### PR TITLE
feat(terminal): Group navigator toolbar actions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,5 +64,10 @@ let package = Package(
                 .swiftLanguageMode(.v5),
             ]
         ),
+        .testTarget(
+            name: "termioTests",
+            dependencies: ["termio"],
+            path: "Tests/termioTests"
+        ),
     ]
 )

--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -925,6 +925,7 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     /// inspector's left edge (divider 1, between the terminal and the file column).
     private weak var splitViewController: NSSplitViewController?
     private weak var branchPickerHostingView: NSView?
+    private weak var navigatorActionsControl: NSSegmentedControl?
     private var branchPickerWidthConstraint: NSLayoutConstraint?
     private var terminalPaneFrameObserver: NSObjectProtocol?
 
@@ -978,9 +979,9 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
         }
     }
 
-    /// Builds the project-sort pull-down for the `.sortProjects` toolbar item: one
-    /// entry per `ProjectSortOrder`, each setting `AppSettings.projectSortOrder`. The
-    /// checkmark on the active order is refreshed on open via `menuNeedsUpdate`.
+    /// Builds the sidebar grouping pull-down for the `.sortProjects` toolbar item. Its
+    /// neutral choice leaves the stored project order alone; the other choices activate
+    /// a visible grouping rule.
     func makeProjectSortMenu() -> NSMenu {
         let menu = NSMenu()
         menu.delegate = self
@@ -997,6 +998,30 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
         guard let raw = sender.representedObject as? String,
               let order = ProjectSortOrder(rawValue: raw) else { return }
         settings.projectSortOrder = order
+        updateNavigatorActionsSelection()
+    }
+
+    @objc private func showNavigatorActionsMenu(_ sender: NSSegmentedControl) {
+        let eventSegment: Int
+        if let event = NSApp.currentEvent {
+            let point = sender.convert(event.locationInWindow, from: nil)
+            eventSegment = point.x < sender.width(forSegment: 0) ? 0 : 1
+        } else {
+            eventSegment = -1
+        }
+        let segment = eventSegment >= 0 ? eventSegment : sender.selectedSegment
+        guard segment >= 0 else {
+            updateNavigatorActionsSelection()
+            return
+        }
+        let menu = segment == 0 ? makeProjectSortMenu() : makeNewSessionMenu()
+        menu.popUp(positioning: nil, at: CGPoint(x: 0, y: sender.bounds.height), in: sender)
+        updateNavigatorActionsSelection()
+    }
+
+    private func updateNavigatorActionsSelection() {
+        navigatorActionsControl?.setSelected(settings.projectSortOrder != .none, forSegment: 0)
+        navigatorActionsControl?.setSelected(false, forSegment: 1)
     }
 
     /// Builds the `+` pull-down for the `.newTerminal` toolbar item: exactly the
@@ -1107,20 +1132,22 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             let item = NSToolbarItem(itemIdentifier: .sortProjects)
             item.label = "Navigator Actions"
             item.toolTip = "Sort projects or create a terminal"
-            let control = NSSegmentedControl(frame: NSRect(x: 0, y: 0, width: 80, height: 28))
+            let control = NSSegmentedControl(frame: NSRect(x: 0, y: 0, width: 66, height: 28))
             control.segmentCount = 2
             control.segmentStyle = .capsule
-            control.trackingMode = .momentary
+            control.trackingMode = .selectAny
+            control.target = self
+            control.action = #selector(showNavigatorActionsMenu(_:))
             control.setImage(NSImage(systemSymbolName: "line.3.horizontal.decrease", accessibilityDescription: "Sort projects"), forSegment: 0)
             control.setToolTip("Choose how projects are ordered", forSegment: 0)
-            control.setShowsMenuIndicator(true, forSegment: 0)
-            control.setMenu(makeProjectSortMenu(), forSegment: 0)
-            control.setWidth(44, forSegment: 0)
+            control.setShowsMenuIndicator(false, forSegment: 0)
+            control.setWidth(30, forSegment: 0)
             control.setImage(NSImage(systemSymbolName: "plus", accessibilityDescription: "New"), forSegment: 1)
             control.setToolTip("New terminal or project", forSegment: 1)
-            control.setMenu(makeNewSessionMenu(), forSegment: 1)
             control.setWidth(36, forSegment: 1)
             item.view = control
+            navigatorActionsControl = control
+            updateNavigatorActionsSelection()
             return item
         case .inspectorTabs:
             // The native segmented switch (Files / Changes), pinned to the inspector's left edge by

--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -925,7 +925,8 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     /// inspector's left edge (divider 1, between the terminal and the file column).
     private weak var splitViewController: NSSplitViewController?
     private weak var branchPickerHostingView: NSView?
-    private weak var navigatorActionsControl: NSSegmentedControl?
+    private weak var navigatorSortButton: NSButton?
+    private weak var navigatorNewButton: NSButton?
     private var branchPickerWidthConstraint: NSLayoutConstraint?
     private var terminalPaneFrameObserver: NSObjectProtocol?
 
@@ -1001,27 +1002,46 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
         updateNavigatorActionsSelection()
     }
 
-    @objc private func showNavigatorActionsMenu(_ sender: NSSegmentedControl) {
-        let eventSegment: Int
-        if let event = NSApp.currentEvent {
-            let point = sender.convert(event.locationInWindow, from: nil)
-            eventSegment = point.x < sender.width(forSegment: 0) ? 0 : 1
-        } else {
-            eventSegment = -1
-        }
-        let segment = eventSegment >= 0 ? eventSegment : sender.selectedSegment
-        guard segment >= 0 else {
-            updateNavigatorActionsSelection()
-            return
-        }
-        let menu = segment == 0 ? makeProjectSortMenu() : makeNewSessionMenu()
-        menu.popUp(positioning: nil, at: CGPoint(x: 0, y: sender.bounds.height), in: sender)
+    @objc private func showProjectSortMenu(_ sender: NSButton) {
+        popUpToolbarMenu(makeProjectSortMenu(), from: sender)
+    }
+
+    @objc private func showNewSessionMenu(_ sender: NSButton) {
+        popUpToolbarMenu(makeNewSessionMenu(), from: sender)
+    }
+
+    private func popUpToolbarMenu(_ menu: NSMenu, from button: NSButton) {
+        menu.popUp(positioning: nil, at: CGPoint(x: 0, y: button.bounds.height), in: button)
         updateNavigatorActionsSelection()
     }
 
     private func updateNavigatorActionsSelection() {
-        navigatorActionsControl?.setSelected(settings.projectSortOrder != .none, forSegment: 0)
-        navigatorActionsControl?.setSelected(false, forSegment: 1)
+        navigatorSortButton?.state = settings.projectSortOrder == .none ? .off : .on
+        navigatorNewButton?.state = .off
+    }
+
+    private func makeNavigatorActionButton(
+        symbol: String,
+        accessibilityDescription: String,
+        toolTip: String,
+        action: Selector,
+        toggles: Bool = false
+    ) -> NSButton {
+        let button = NSButton()
+        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: accessibilityDescription)
+        button.imagePosition = .imageOnly
+        button.bezelStyle = .toolbar
+        button.controlSize = .regular
+        button.setButtonType(toggles ? .pushOnPushOff : .momentaryPushIn)
+        button.target = self
+        button.action = action
+        button.toolTip = toolTip
+        button.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            button.widthAnchor.constraint(equalToConstant: 32),
+            button.heightAnchor.constraint(equalToConstant: 32),
+        ])
+        return button
     }
 
     /// Builds the `+` pull-down for the `.newTerminal` toolbar item: exactly the
@@ -1126,27 +1146,32 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             item.action = #selector(NSSplitViewController.toggleSidebar(_:))
             return item
         case .sortProjects:
-            // `NSToolbarItemGroup` still renders its child items as separate glass capsules on
-            // macOS 26. A native segmented control supplies the shared outer capsule and divider
-            // that Mail uses, while each segment keeps its own pull-down menu.
+            // Keep these as two compact toolbar buttons rather than an NSSegmentedControl: the
+            // latter always draws a centre divider, while this pairing preserves two clear click
+            // targets without implying a mutually-exclusive segmented choice.
             let item = NSToolbarItem(itemIdentifier: .sortProjects)
             item.label = "Navigator Actions"
             item.toolTip = "Sort projects or create a terminal"
-            let control = NSSegmentedControl(frame: NSRect(x: 0, y: 0, width: 66, height: 28))
-            control.segmentCount = 2
-            control.segmentStyle = .capsule
-            control.trackingMode = .selectAny
-            control.target = self
-            control.action = #selector(showNavigatorActionsMenu(_:))
-            control.setImage(NSImage(systemSymbolName: "line.3.horizontal.decrease", accessibilityDescription: "Sort projects"), forSegment: 0)
-            control.setToolTip("Choose how projects are ordered", forSegment: 0)
-            control.setShowsMenuIndicator(false, forSegment: 0)
-            control.setWidth(30, forSegment: 0)
-            control.setImage(NSImage(systemSymbolName: "plus", accessibilityDescription: "New"), forSegment: 1)
-            control.setToolTip("New terminal or project", forSegment: 1)
-            control.setWidth(36, forSegment: 1)
-            item.view = control
-            navigatorActionsControl = control
+            let sort = makeNavigatorActionButton(
+                symbol: "line.3.horizontal.decrease",
+                accessibilityDescription: "Sort projects",
+                toolTip: "Choose how projects are ordered",
+                action: #selector(showProjectSortMenu(_:)),
+                toggles: true
+            )
+            let new = makeNavigatorActionButton(
+                symbol: "plus",
+                accessibilityDescription: "New",
+                toolTip: "New terminal or project",
+                action: #selector(showNewSessionMenu(_:))
+            )
+            let actions = NSStackView(views: [sort, new])
+            actions.orientation = .horizontal
+            actions.alignment = .centerY
+            actions.spacing = 2
+            item.view = actions
+            navigatorSortButton = sort
+            navigatorNewButton = new
             updateNavigatorActionsSelection()
             return item
         case .inspectorTabs:

--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -678,13 +678,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         setNavigatorItemsVisible(!item.isCollapsed)
     }
 
-    /// Inserts or removes the sidebar's own toolbar actions (the sort pull-down and the `+`
-    /// new-terminal button) as the navigator opens/closes, so the sidebar's toolbar region empties
+    /// Inserts or removes the sidebar's grouped toolbar actions as the navigator opens/closes, so
+    /// the sidebar's toolbar region empties
     /// when the sidebar is collapsed — matching Finder/Xcode, which drop their sidebar buttons with
     /// the sidebar, and freeing the horizontal room that otherwise forces NSToolbar's `»` overflow.
-    /// The paired flexible space (which right-aligns the two against the sidebar divider) is inserted
-    /// and removed *with* them. When open the region reads `toggleNavigator, flex, sortProjects,
-    /// newTerminal | sidebarTrackingSeparator`. Mirrors `setInspectorSwitchVisible`.
+    /// The paired flexible space (which right-aligns the group against the sidebar divider) is inserted
+    /// and removed *with* it. When open the region reads `toggleNavigator, flex, sortProjects
+    /// | sidebarTrackingSeparator`. Mirrors `setInspectorSwitchVisible`.
     private func setNavigatorItemsVisible(_ visible: Bool) {
         guard let toolbar = window?.toolbar else { return }
         func index(of id: NSToolbarItem.Identifier) -> Int? {
@@ -697,16 +697,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         defer { NSAnimationContext.endGrouping() }
         if visible {
             guard index(of: .sortProjects) == nil, let sep = index(of: .sidebarTrackingSeparator) else { return }
-            // Insert in reverse at the separator's index so the final order is flex, sortProjects, newTerminal.
-            toolbar.insertItem(withItemIdentifier: .newTerminal, at: sep)
+            // Reuse the sort identifier so existing toolbar configurations migrate to the group.
             toolbar.insertItem(withItemIdentifier: .sortProjects, at: sep)
             toolbar.insertItem(withItemIdentifier: .flexibleSpace, at: sep)
         } else {
-            // Only clean up when the buttons are actually present (nothing to remove at launch with
+            // Only clean up when the group is actually present (nothing to remove at launch with
             // the sidebar already collapsed). Re-find each id after every removal — indices shift.
-            guard let sortIdx = index(of: .sortProjects) else { return }
-            toolbar.removeItem(at: sortIdx)
-            if let i = index(of: .newTerminal) { toolbar.removeItem(at: i) }
+            guard let actionsIdx = index(of: .sortProjects) else { return }
+            toolbar.removeItem(at: actionsIdx)
+            // Discard the pre-group `+` item if an existing saved toolbar layout still has it.
+            if let legacyNewIdx = index(of: .newTerminal) { toolbar.removeItem(at: legacyNewIdx) }
             // Drop the flexible space that right-aligned them (the one just before the sidebar separator).
             if let sep = index(of: .sidebarTrackingSeparator), sep > 0,
                toolbar.items[sep - 1].itemIdentifier == .flexibleSpace {
@@ -1067,7 +1067,7 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     // open (see `setInspectorSwitchVisible`) — keeping the separator in the default set would draw a
     // stray divider line in the toolbar while the panel is collapsed.
     // Sidebar-collapsed baseline: just the navigator toggle, the branch title, and the inspector
-    // toggle. The sidebar's own actions (`sortProjects` + `newTerminal`) and their right-aligning
+    // toggle. The sidebar's grouped actions and their right-aligning
     // flexible space are inserted by the app delegate only while the navigator is open (see
     // `setNavigatorItemsVisible`) — keeping them in the default set is what over-packed the row and
     // forced NSToolbar's `»` overflow when the sidebar was collapsed.
@@ -1101,35 +1101,26 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             item.action = #selector(NSSplitViewController.toggleSidebar(_:))
             return item
         case .sortProjects:
-            // A pull-down that sets how the sidebar orders projects (Recent Activity /
-            // Name). Sits just left of the `+`, at the trailing edge of the sidebar's
-            // toolbar region. Native `NSMenuToolbarItem` so it carries the standard
-            // menu chevron and free Liquid Glass bordered look, matching the toggles.
-            let item = NSMenuToolbarItem(itemIdentifier: .sortProjects)
-            item.label = "Sort"
-            item.toolTip = "Choose how projects are ordered"
-            item.image = NSImage(systemSymbolName: "line.3.horizontal.decrease", accessibilityDescription: "Sort projects")
-            item.isBordered = true
-            item.showsIndicator = true
-            item.menu = makeProjectSortMenu()
-            return item
-        case .newTerminal:
-            // Pinned to the trailing edge of the sidebar's toolbar region (just before the
-            // tracking separator), so it reads as the navigator's own "new" action — like the
-            // `+` at the foot of Finder's sidebar: a plain `+` that pops a menu on click. It
-            // still carries a pull-down (the two ways something new enters the sidebar — a loose
-            // terminal or a project), but with `showsIndicator = false` it keeps the exact width
-            // of the single-action `+` it replaced, so the sidebar's `minimumThickness` (240)
-            // stays valid and the button never grows the chevron that would push it toward the
-            // NSToolbar `»` overflow. Finder's sidebar `+` shows no chevron either — a `+` reads
-            // as "add" on its own, unlike the sort item, whose glyph does keep its indicator.
-            let item = NSMenuToolbarItem(itemIdentifier: .newTerminal)
-            item.label = "New"
-            item.toolTip = "New terminal or project"
-            item.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "New")
-            item.isBordered = true
-            item.showsIndicator = false
-            item.menu = makeNewSessionMenu()
+            // `NSToolbarItemGroup` still renders its child items as separate glass capsules on
+            // macOS 26. A native segmented control supplies the shared outer capsule and divider
+            // that Mail uses, while each segment keeps its own pull-down menu.
+            let item = NSToolbarItem(itemIdentifier: .sortProjects)
+            item.label = "Navigator Actions"
+            item.toolTip = "Sort projects or create a terminal"
+            let control = NSSegmentedControl(frame: NSRect(x: 0, y: 0, width: 80, height: 28))
+            control.segmentCount = 2
+            control.segmentStyle = .capsule
+            control.trackingMode = .momentary
+            control.setImage(NSImage(systemSymbolName: "line.3.horizontal.decrease", accessibilityDescription: "Sort projects"), forSegment: 0)
+            control.setToolTip("Choose how projects are ordered", forSegment: 0)
+            control.setShowsMenuIndicator(true, forSegment: 0)
+            control.setMenu(makeProjectSortMenu(), forSegment: 0)
+            control.setWidth(44, forSegment: 0)
+            control.setImage(NSImage(systemSymbolName: "plus", accessibilityDescription: "New"), forSegment: 1)
+            control.setToolTip("New terminal or project", forSegment: 1)
+            control.setMenu(makeNewSessionMenu(), forSegment: 1)
+            control.setWidth(36, forSegment: 1)
+            item.view = control
             return item
         case .inspectorTabs:
             // The native segmented switch (Files / Changes), pinned to the inspector's left edge by

--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -1016,8 +1016,11 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     }
 
     private func updateNavigatorActionsSelection() {
-        navigatorSortButton?.state = settings.projectSortOrder == .none ? .off : .on
+        let groupingIsActive = settings.projectSortOrder != .none
+        navigatorSortButton?.state = groupingIsActive ? .on : .off
+        navigatorSortButton?.contentTintColor = groupingIsActive ? .controlAccentColor : .secondaryLabelColor
         navigatorNewButton?.state = .off
+        navigatorNewButton?.contentTintColor = .secondaryLabelColor
     }
 
     private func makeNavigatorActionButton(
@@ -1029,6 +1032,7 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     ) -> NSButton {
         let button = NSButton()
         button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: accessibilityDescription)
+        button.image?.isTemplate = true
         button.imagePosition = .imageOnly
         button.bezelStyle = .toolbar
         button.controlSize = .regular

--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -913,112 +913,6 @@ private final class KeyBorderlessPanel: NSPanel {
     override var canBecomeKey: Bool { true }
 }
 
-/// The neutral pressed-state plate inside one segment of the navigator-actions
-/// capsule. It mirrors the standard segmented-control selection: a soft inset
-/// rounded rectangle, not an accent-coloured toggle.
-private final class NavigatorActionSelectionView: NSView {
-    override func draw(_ dirtyRect: NSRect) {
-        let plate = bounds.insetBy(dx: 2, dy: 3)
-        NSColor.labelColor.withAlphaComponent(0.13).setFill()
-        NSBezierPath(roundedRect: plate, xRadius: plate.height / 2, yRadius: plate.height / 2).fill()
-    }
-}
-
-/// Two actions sharing one glass track. Native segmented controls always paint a
-/// centre divider, while two independent toolbar buttons paint their own bezels.
-/// This view keeps one undivided capsule and draws the same neutral inset selection
-/// plate used by standard segmented controls.
-private final class NavigatorActionsToolbarView: NSView {
-    private static let segmentWidth: CGFloat = 36
-    private static let controlHeight: CGFloat = 36
-
-    private let material = NSVisualEffectView()
-    private let selection = NavigatorActionSelectionView()
-    let sortButton = NSButton()
-    let newButton = NSButton()
-
-    var groupingIsActive = false {
-        didSet { updateAppearance() }
-    }
-
-    init(target: AnyObject?, sortAction: Selector, newAction: Selector) {
-        super.init(frame: .zero)
-        material.material = .headerView
-        material.blendingMode = .withinWindow
-        material.state = .active
-        material.wantsLayer = true
-        material.layer?.masksToBounds = true
-        material.layer?.borderWidth = 1
-        material.layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.35).cgColor
-        addSubview(material)
-
-        selection.isHidden = true
-        material.addSubview(selection)
-
-        configure(sortButton,
-                  symbol: "line.3.horizontal.decrease",
-                  accessibilityDescription: "Sort projects",
-                  toolTip: "Choose how projects are ordered",
-                  target: target,
-                  action: sortAction)
-        configure(newButton,
-                  symbol: "plus",
-                  accessibilityDescription: "New",
-                  toolTip: "New terminal or project",
-                  target: target,
-                  action: newAction)
-        material.addSubview(sortButton)
-        material.addSubview(newButton)
-        updateAppearance()
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    override var intrinsicContentSize: NSSize {
-        NSSize(width: Self.segmentWidth * 2, height: Self.controlHeight)
-    }
-
-    override func layout() {
-        super.layout()
-        material.frame = bounds
-        material.layer?.cornerRadius = bounds.height / 2
-        let leadingWidth = min(Self.segmentWidth, bounds.width / 2)
-        selection.frame = NSRect(x: 0, y: 0, width: leadingWidth, height: bounds.height)
-        sortButton.frame = selection.frame
-        newButton.frame = NSRect(
-            x: leadingWidth,
-            y: 0,
-            width: bounds.width - leadingWidth,
-            height: bounds.height
-        )
-    }
-
-    private func configure(
-        _ button: NSButton,
-        symbol: String,
-        accessibilityDescription: String,
-        toolTip: String,
-        target: AnyObject?,
-        action: Selector
-    ) {
-        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: accessibilityDescription)
-        button.image?.isTemplate = true
-        button.imagePosition = .imageOnly
-        button.isBordered = false
-        button.setButtonType(.momentaryPushIn)
-        button.target = target
-        button.action = action
-        button.toolTip = toolTip
-    }
-
-    private func updateAppearance() {
-        selection.isHidden = !groupingIsActive
-        sortButton.contentTintColor = .labelColor
-        newButton.contentTintColor = .labelColor
-    }
-}
-
 /// Delegate for the window's real toolbar, mirroring CodeEdit's chrome. It declares a leading
 /// navigator toggle, the AppKit-provided sidebar tracking separator (bound to the sidebar
 /// divider), the custom branch-picker title item, and a trailing inspector toggle. The store and
@@ -1031,7 +925,8 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     /// inspector's left edge (divider 1, between the terminal and the file column).
     private weak var splitViewController: NSSplitViewController?
     private weak var branchPickerHostingView: NSView?
-    private weak var navigatorActionsView: NavigatorActionsToolbarView?
+    private var navigatorActionsState: NavigatorToolbarActionsState?
+    private var navigatorActionsHandler: NavigatorToolbarActionHandler?
     private var branchPickerWidthConstraint: NSLayoutConstraint?
     private var terminalPaneFrameObserver: NSObjectProtocol?
 
@@ -1107,21 +1002,21 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
         updateNavigatorActionsSelection()
     }
 
-    @objc private func showProjectSortMenu(_ sender: NSButton) {
-        popUpToolbarMenu(makeProjectSortMenu(), from: sender)
+    private func showProjectSortMenu(from anchor: NSView) {
+        popUpToolbarMenu(makeProjectSortMenu(), from: anchor)
     }
 
-    @objc private func showNewSessionMenu(_ sender: NSButton) {
-        popUpToolbarMenu(makeNewSessionMenu(), from: sender)
+    private func showNewSessionMenu(from anchor: NSView) {
+        popUpToolbarMenu(makeNewSessionMenu(), from: anchor)
     }
 
-    private func popUpToolbarMenu(_ menu: NSMenu, from button: NSButton) {
-        menu.popUp(positioning: nil, at: CGPoint(x: 0, y: button.bounds.height), in: button)
+    private func popUpToolbarMenu(_ menu: NSMenu, from anchor: NSView) {
+        menu.popUp(positioning: nil, at: CGPoint(x: 0, y: anchor.bounds.height), in: anchor)
         updateNavigatorActionsSelection()
     }
 
     private func updateNavigatorActionsSelection() {
-        navigatorActionsView?.groupingIsActive = settings.projectSortOrder != .none
+        navigatorActionsState?.groupingIsActive = settings.projectSortOrder != .none
     }
 
     /// Builds the `+` pull-down for the `.newTerminal` toolbar item: exactly the
@@ -1226,18 +1121,23 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             item.action = #selector(NSSplitViewController.toggleSidebar(_:))
             return item
         case .sortProjects:
-            // Use one undivided capsule rather than AppKit's segmented or paired button styles:
-            // they respectively add a centre divider or draw their own separate pressed bezels.
             let item = NSToolbarItem(itemIdentifier: .sortProjects)
             item.label = "Navigator Actions"
             item.toolTip = "Sort projects or create a terminal"
-            let actions = NavigatorActionsToolbarView(
-                target: self,
-                sortAction: #selector(showProjectSortMenu(_:)),
-                newAction: #selector(showNewSessionMenu(_:))
-            )
+            let state = NavigatorToolbarActionsState()
+            let handler = NavigatorToolbarActionHandler()
+            let actions = NSHostingView(rootView: NavigatorActionsToolbar(
+                state: state,
+                actionHandler: handler
+            ))
+            handler.anchorView = actions
+            handler.showSortMenu = { [weak self] anchor in self?.showProjectSortMenu(from: anchor) }
+            handler.showNewMenu = { [weak self] anchor in self?.showNewSessionMenu(from: anchor) }
+            actions.sizingOptions = [.intrinsicContentSize]
             item.view = actions
-            navigatorActionsView = actions
+            item.isBordered = false
+            navigatorActionsState = state
+            navigatorActionsHandler = handler
             updateNavigatorActionsSelection()
             return item
         case .inspectorTabs:

--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -926,7 +926,6 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     private weak var splitViewController: NSSplitViewController?
     private weak var branchPickerHostingView: NSView?
     private var navigatorActionsState: NavigatorToolbarActionsState?
-    private var navigatorActionsHandler: NavigatorToolbarActionHandler?
     private var branchPickerWidthConstraint: NSLayoutConstraint?
     private var terminalPaneFrameObserver: NSObjectProtocol?
 
@@ -1012,7 +1011,6 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
 
     private func popUpToolbarMenu(_ menu: NSMenu, from anchor: NSView) {
         menu.popUp(positioning: nil, at: CGPoint(x: 0, y: anchor.bounds.height), in: anchor)
-        updateNavigatorActionsSelection()
     }
 
     private func updateNavigatorActionsSelection() {
@@ -1137,7 +1135,6 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             item.view = actions
             item.isBordered = false
             navigatorActionsState = state
-            navigatorActionsHandler = handler
             updateNavigatorActionsSelection()
             return item
         case .inspectorTabs:

--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -913,6 +913,112 @@ private final class KeyBorderlessPanel: NSPanel {
     override var canBecomeKey: Bool { true }
 }
 
+/// The neutral pressed-state plate inside one segment of the navigator-actions
+/// capsule. It mirrors the standard segmented-control selection: a soft inset
+/// rounded rectangle, not an accent-coloured toggle.
+private final class NavigatorActionSelectionView: NSView {
+    override func draw(_ dirtyRect: NSRect) {
+        let plate = bounds.insetBy(dx: 2, dy: 3)
+        NSColor.labelColor.withAlphaComponent(0.13).setFill()
+        NSBezierPath(roundedRect: plate, xRadius: plate.height / 2, yRadius: plate.height / 2).fill()
+    }
+}
+
+/// Two actions sharing one glass track. Native segmented controls always paint a
+/// centre divider, while two independent toolbar buttons paint their own bezels.
+/// This view keeps one undivided capsule and draws the same neutral inset selection
+/// plate used by standard segmented controls.
+private final class NavigatorActionsToolbarView: NSView {
+    private static let segmentWidth: CGFloat = 36
+    private static let controlHeight: CGFloat = 36
+
+    private let material = NSVisualEffectView()
+    private let selection = NavigatorActionSelectionView()
+    let sortButton = NSButton()
+    let newButton = NSButton()
+
+    var groupingIsActive = false {
+        didSet { updateAppearance() }
+    }
+
+    init(target: AnyObject?, sortAction: Selector, newAction: Selector) {
+        super.init(frame: .zero)
+        material.material = .headerView
+        material.blendingMode = .withinWindow
+        material.state = .active
+        material.wantsLayer = true
+        material.layer?.masksToBounds = true
+        material.layer?.borderWidth = 1
+        material.layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.35).cgColor
+        addSubview(material)
+
+        selection.isHidden = true
+        material.addSubview(selection)
+
+        configure(sortButton,
+                  symbol: "line.3.horizontal.decrease",
+                  accessibilityDescription: "Sort projects",
+                  toolTip: "Choose how projects are ordered",
+                  target: target,
+                  action: sortAction)
+        configure(newButton,
+                  symbol: "plus",
+                  accessibilityDescription: "New",
+                  toolTip: "New terminal or project",
+                  target: target,
+                  action: newAction)
+        material.addSubview(sortButton)
+        material.addSubview(newButton)
+        updateAppearance()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: Self.segmentWidth * 2, height: Self.controlHeight)
+    }
+
+    override func layout() {
+        super.layout()
+        material.frame = bounds
+        material.layer?.cornerRadius = bounds.height / 2
+        let leadingWidth = min(Self.segmentWidth, bounds.width / 2)
+        selection.frame = NSRect(x: 0, y: 0, width: leadingWidth, height: bounds.height)
+        sortButton.frame = selection.frame
+        newButton.frame = NSRect(
+            x: leadingWidth,
+            y: 0,
+            width: bounds.width - leadingWidth,
+            height: bounds.height
+        )
+    }
+
+    private func configure(
+        _ button: NSButton,
+        symbol: String,
+        accessibilityDescription: String,
+        toolTip: String,
+        target: AnyObject?,
+        action: Selector
+    ) {
+        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: accessibilityDescription)
+        button.image?.isTemplate = true
+        button.imagePosition = .imageOnly
+        button.isBordered = false
+        button.setButtonType(.momentaryPushIn)
+        button.target = target
+        button.action = action
+        button.toolTip = toolTip
+    }
+
+    private func updateAppearance() {
+        selection.isHidden = !groupingIsActive
+        sortButton.contentTintColor = .labelColor
+        newButton.contentTintColor = .labelColor
+    }
+}
+
 /// Delegate for the window's real toolbar, mirroring CodeEdit's chrome. It declares a leading
 /// navigator toggle, the AppKit-provided sidebar tracking separator (bound to the sidebar
 /// divider), the custom branch-picker title item, and a trailing inspector toggle. The store and
@@ -925,8 +1031,7 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     /// inspector's left edge (divider 1, between the terminal and the file column).
     private weak var splitViewController: NSSplitViewController?
     private weak var branchPickerHostingView: NSView?
-    private weak var navigatorSortButton: NSButton?
-    private weak var navigatorNewButton: NSButton?
+    private weak var navigatorActionsView: NavigatorActionsToolbarView?
     private var branchPickerWidthConstraint: NSLayoutConstraint?
     private var terminalPaneFrameObserver: NSObjectProtocol?
 
@@ -1016,36 +1121,7 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     }
 
     private func updateNavigatorActionsSelection() {
-        let groupingIsActive = settings.projectSortOrder != .none
-        navigatorSortButton?.state = groupingIsActive ? .on : .off
-        navigatorSortButton?.contentTintColor = groupingIsActive ? .controlAccentColor : .secondaryLabelColor
-        navigatorNewButton?.state = .off
-        navigatorNewButton?.contentTintColor = .secondaryLabelColor
-    }
-
-    private func makeNavigatorActionButton(
-        symbol: String,
-        accessibilityDescription: String,
-        toolTip: String,
-        action: Selector,
-        toggles: Bool = false
-    ) -> NSButton {
-        let button = NSButton()
-        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: accessibilityDescription)
-        button.image?.isTemplate = true
-        button.imagePosition = .imageOnly
-        button.bezelStyle = .toolbar
-        button.controlSize = .regular
-        button.setButtonType(toggles ? .pushOnPushOff : .momentaryPushIn)
-        button.target = self
-        button.action = action
-        button.toolTip = toolTip
-        button.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            button.widthAnchor.constraint(equalToConstant: 32),
-            button.heightAnchor.constraint(equalToConstant: 32),
-        ])
-        return button
+        navigatorActionsView?.groupingIsActive = settings.projectSortOrder != .none
     }
 
     /// Builds the `+` pull-down for the `.newTerminal` toolbar item: exactly the
@@ -1150,32 +1226,18 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             item.action = #selector(NSSplitViewController.toggleSidebar(_:))
             return item
         case .sortProjects:
-            // Keep these as two compact toolbar buttons rather than an NSSegmentedControl: the
-            // latter always draws a centre divider, while this pairing preserves two clear click
-            // targets without implying a mutually-exclusive segmented choice.
+            // Use one undivided capsule rather than AppKit's segmented or paired button styles:
+            // they respectively add a centre divider or draw their own separate pressed bezels.
             let item = NSToolbarItem(itemIdentifier: .sortProjects)
             item.label = "Navigator Actions"
             item.toolTip = "Sort projects or create a terminal"
-            let sort = makeNavigatorActionButton(
-                symbol: "line.3.horizontal.decrease",
-                accessibilityDescription: "Sort projects",
-                toolTip: "Choose how projects are ordered",
-                action: #selector(showProjectSortMenu(_:)),
-                toggles: true
+            let actions = NavigatorActionsToolbarView(
+                target: self,
+                sortAction: #selector(showProjectSortMenu(_:)),
+                newAction: #selector(showNewSessionMenu(_:))
             )
-            let new = makeNavigatorActionButton(
-                symbol: "plus",
-                accessibilityDescription: "New",
-                toolTip: "New terminal or project",
-                action: #selector(showNewSessionMenu(_:))
-            )
-            let actions = NSStackView(views: [sort, new])
-            actions.orientation = .horizontal
-            actions.alignment = .centerY
-            actions.spacing = 2
             item.view = actions
-            navigatorSortButton = sort
-            navigatorNewButton = new
+            navigatorActionsView = actions
             updateNavigatorActionsSelection()
             return item
         case .inspectorTabs:

--- a/Sources/termio/CompanionServer.swift
+++ b/Sources/termio/CompanionServer.swift
@@ -928,6 +928,7 @@ extension TermioStore {
             statuses[session.id] = .idle
         }
         liveActivity[project.id] = Date()
+        sessionActivity[session.id] = Date()
         if let pty = ptyProcesses[session.id] { return pty }
         _ = surface(for: session, in: project)
         return ptyProcesses[session.id]

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -26,10 +26,10 @@ struct InspectorTabsToolbar: View {
     /// fires on every open.
     @State private var appeared = false
 
-    /// Outer height of the glass track, matched to the native bordered toolbar buttons either
+    /// Outer height of the glass track, matched to the native bordered toolbar controls either
     /// side of it so all the toolbar backgrounds line up. The track is built bottom-up as
     /// `glyphHeight + 2 * trackPadding`, so those two derive from this single number.
-    static let toolbarControlHeight: CGFloat = 30
+    static let toolbarControlHeight: CGFloat = 28
     private static let trackPadding: CGFloat = 3
     private static var glyphHeight: CGFloat { toolbarControlHeight - 2 * trackPadding }
 

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -12,8 +12,8 @@ import SwiftUI
 /// segmented control: a glass track holding both segments, with the selected segment lifted
 /// on its own pill that fluidly morphs across as you switch panes.
 ///
-/// The track is tinted lighter (whiter) so it never sits darker than the borderless system
-/// collapse button at the inspector's other edge. Both glyphs keep the same neutral
+/// The track uses the same regular material as the native single collapse button at the inspector's
+/// other edge. Both glyphs keep the same neutral
 /// `.secondary` tone — matching the neighbouring toolbar buttons — and selection is shown
 /// purely by the brighter, raised pill, never by recolouring or tinting a glyph.
 struct InspectorTabsToolbar: View {
@@ -29,9 +29,7 @@ struct InspectorTabsToolbar: View {
     /// Outer height of the glass track, matched to the native bordered toolbar controls either
     /// side of it so all the toolbar backgrounds line up. The track is built bottom-up as
     /// `glyphHeight + 2 * trackPadding`, so those two derive from this single number.
-    static let toolbarControlHeight: CGFloat = 36
-    private static let trackPadding: CGFloat = 3
-    private static var glyphHeight: CGFloat { toolbarControlHeight - 2 * trackPadding }
+    static let toolbarControlHeight: CGFloat = ToolbarGlassMetrics.controlHeight
 
     private let segments: [(tab: InspectorTab, icon: String, help: String)] = [
         (.files, "list.bullet.indent", "Project Files"),
@@ -67,8 +65,8 @@ struct InspectorTabsToolbar: View {
 
     @available(macOS 26.0, *)
     private var glassControl: some View {
-        GlassEffectContainer(spacing: 4) {
-            HStack(spacing: 2) {
+        GlassEffectContainer(spacing: ToolbarGlassMetrics.containerSpacing) {
+            HStack(spacing: ToolbarGlassMetrics.itemSpacing) {
                 ForEach(segments, id: \.tab) { seg in
                     let selected = store.inspectorTab == seg.tab
                     icon(seg)
@@ -90,17 +88,17 @@ struct InspectorTabsToolbar: View {
                         .help(seg.help)
                 }
             }
-            .padding(Self.trackPadding)
-            // The shared track: a faint, slightly-whitened glass so it stays lighter than the
-            // system collapse button and lets the brighter selected pill read as raised.
-            .glassEffect(.regular.tint(Color.white.opacity(0.12)), in: .capsule)
+            .padding(ToolbarGlassMetrics.trackPadding)
+            // The shared track matches the native single button's regular material;
+            // only the selected pill is brighter and raised.
+            .glassEffect(.regular, in: .capsule)
         }
     }
 
     // MARK: Fallback (macOS < 26)
 
     private var legacyControl: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: ToolbarGlassMetrics.itemSpacing) {
             ForEach(segments, id: \.tab) { seg in
                 let selected = store.inspectorTab == seg.tab
                 Button { store.inspectorTab = seg.tab } label: {
@@ -116,7 +114,7 @@ struct InspectorTabsToolbar: View {
                 .help(seg.help)
             }
         }
-        .padding(Self.trackPadding)
+        .padding(ToolbarGlassMetrics.trackPadding)
         .background(Capsule(style: .continuous).fill(Color.primary.opacity(0.06)))
     }
 
@@ -130,6 +128,6 @@ struct InspectorTabsToolbar: View {
             // it (and Files) comparable visual mass.
             .font(.system(size: 17, weight: .medium))
             .foregroundStyle(.secondary)
-            .frame(width: 34, height: Self.glyphHeight)
+            .frame(width: ToolbarGlassMetrics.segmentWidth, height: ToolbarGlassMetrics.glyphHeight)
     }
 }

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -29,7 +29,7 @@ struct InspectorTabsToolbar: View {
     /// Outer height of the glass track, matched to the native bordered toolbar controls either
     /// side of it so all the toolbar backgrounds line up. The track is built bottom-up as
     /// `glyphHeight + 2 * trackPadding`, so those two derive from this single number.
-    static let toolbarControlHeight: CGFloat = 42
+    static let toolbarControlHeight: CGFloat = 36
     private static let trackPadding: CGFloat = 3
     private static var glyphHeight: CGFloat { toolbarControlHeight - 2 * trackPadding }
 

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -29,7 +29,7 @@ struct InspectorTabsToolbar: View {
     /// Outer height of the glass track, matched to the native bordered toolbar controls either
     /// side of it so all the toolbar backgrounds line up. The track is built bottom-up as
     /// `glyphHeight + 2 * trackPadding`, so those two derive from this single number.
-    static let toolbarControlHeight: CGFloat = 28
+    static let toolbarControlHeight: CGFloat = 32
     private static let trackPadding: CGFloat = 3
     private static var glyphHeight: CGFloat { toolbarControlHeight - 2 * trackPadding }
 

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -29,8 +29,6 @@ struct InspectorTabsToolbar: View {
     /// Outer height of the glass track, matched to the native bordered toolbar controls either
     /// side of it so all the toolbar backgrounds line up. The track is built bottom-up as
     /// `glyphHeight + 2 * trackPadding`, so those two derive from this single number.
-    static let toolbarControlHeight: CGFloat = ToolbarGlassMetrics.controlHeight
-
     private let segments: [(tab: InspectorTab, icon: String, help: String)] = [
         (.files, "list.bullet.indent", "Project Files"),
         (.search, "magnifyingglass", "Search Files"),
@@ -51,7 +49,7 @@ struct InspectorTabsToolbar: View {
         // background reads at one consistent height. An unconstrained control can also report a
         // tall intrinsic height that grows the unified toolbar (and, with `.fullSizeContentView`,
         // nudges the window frame) when the item is inserted, so the clamp stays.
-        .frame(height: Self.toolbarControlHeight)
+        .frame(height: ToolbarGlassMetrics.controlHeight)
         .fixedSize()
         // Fade in over the same ~0.25s the split view takes to slide the inspector open, so
         // the cluster and the pane read as one motion instead of a snap followed by a slide.

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -29,7 +29,7 @@ struct InspectorTabsToolbar: View {
     /// Outer height of the glass track, matched to the native bordered toolbar controls either
     /// side of it so all the toolbar backgrounds line up. The track is built bottom-up as
     /// `glyphHeight + 2 * trackPadding`, so those two derive from this single number.
-    static let toolbarControlHeight: CGFloat = 32
+    static let toolbarControlHeight: CGFloat = 42
     private static let trackPadding: CGFloat = 3
     private static var glyphHeight: CGFloat { toolbarControlHeight - 2 * trackPadding }
 

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -39,16 +39,17 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
     }
 }
 
-/// Whether the sidebar groups its projects by an ordering rule. Pinned projects always
-/// stay above the unpinned projects (see `TermioStore.orderedProjects`).
+/// How the sidebar presents its projects or shells. Pinned projects stay above the
+/// unpinned projects whenever the project hierarchy itself is visible (see
+/// `TermioStore.orderedProjects`).
 enum ProjectSortOrder: String, CaseIterable, Identifiable {
     /// Keep the stored project order. This is the neutral default, so the toolbar
     /// filter stays inactive until the user explicitly selects a grouping rule.
     case none
-    /// Most recently active project first — a project rises whenever one of its
-    /// agents reports work (or the user switches to one of its sessions).
+    /// Flatten all shells into three time folders: within one day, within seven days,
+    /// and older sessions.
     case recentActivity
-    /// Stable A→Z by project name.
+    /// Stable A→Z by project name, without adding letter headers to the sidebar.
     case name
 
     var id: String { rawValue }

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -39,10 +39,12 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
     }
 }
 
-/// How the sidebar orders its projects. Raw values persist. Pinned projects always
-/// sort ahead of the rest (see `TermioStore.orderedProjects`); this decides the order
-/// within each group.
+/// Whether the sidebar groups its projects by an ordering rule. Pinned projects always
+/// stay above the unpinned projects (see `TermioStore.orderedProjects`).
 enum ProjectSortOrder: String, CaseIterable, Identifiable {
+    /// Keep the stored project order. This is the neutral default, so the toolbar
+    /// filter stays inactive until the user explicitly selects a grouping rule.
+    case none
     /// Most recently active project first — a project rises whenever one of its
     /// agents reports work (or the user switches to one of its sessions).
     case recentActivity
@@ -53,8 +55,9 @@ enum ProjectSortOrder: String, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
-        case .recentActivity: return "Recent Activity"
-        case .name: return "Name"
+        case .none: return "No Grouping"
+        case .recentActivity: return "Group by Recent Activity"
+        case .name: return "Group by Name"
         }
     }
 }
@@ -101,6 +104,7 @@ final class AppSettings: ObservableObject {
         static let usageAuthorizedAgents = "usage.authorizedAgents"
         static let claudeKeychainDeclined = "usage.claudeKeychainDeclined"
         static let projectSortOrder = "sidebar.projectSortOrder"
+        static let projectSortOrderMigrated = "sidebar.projectSortOrderMigrated"
         static let recentProjects = "welcome.recentProjects"
     }
 
@@ -351,7 +355,7 @@ final class AppSettings: ObservableObject {
             Key.interfaceRowPadding: 2.0,
             Key.agentHooksEnabled: false,
             Key.sessionControlEnabled: false,
-            Key.projectSortOrder: "recentActivity",
+            Key.projectSortOrder: "none",
         ])
 
         fontFamily = defaults.string(forKey: Key.fontFamily) ?? ""
@@ -377,7 +381,17 @@ final class AppSettings: ObservableObject {
         sessionControlEnabled = defaults.bool(forKey: Key.sessionControlEnabled)
         usageAuthorizedAgents = Set(defaults.stringArray(forKey: Key.usageAuthorizedAgents) ?? [])
         claudeKeychainDeclined = defaults.bool(forKey: Key.claudeKeychainDeclined)
-        projectSortOrder = defaults.string(forKey: Key.projectSortOrder).flatMap(ProjectSortOrder.init) ?? .recentActivity
+        // The old default was Recent Activity, so treat that legacy value as the new
+        // neutral mode on first launch after this migration. An explicit Name choice
+        // remains active, and future user choices are left untouched.
+        if defaults.bool(forKey: Key.projectSortOrderMigrated) {
+            projectSortOrder = defaults.string(forKey: Key.projectSortOrder).flatMap(ProjectSortOrder.init) ?? .none
+        } else {
+            projectSortOrder = defaults.string(forKey: Key.projectSortOrder).flatMap(ProjectSortOrder.init) == .name
+                ? .name
+                : .none
+            defaults.set(true, forKey: Key.projectSortOrderMigrated)
+        }
         recentProjects = defaults.data(forKey: Key.recentProjects)
             .flatMap { try? JSONDecoder().decode([RecentProject].self, from: $0) } ?? []
     }

--- a/Sources/termio/SidebarActivityGrouping.swift
+++ b/Sources/termio/SidebarActivityGrouping.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// The fixed, scannable time windows used when the sidebar is grouped by recent
+/// activity. A missing timestamp intentionally lands in the oldest bucket: an
+/// unlaunched session must remain visible, but should not look recently active.
+enum SidebarActivityBucket: CaseIterable, Hashable, Identifiable {
+    case withinOneDay
+    case withinSevenDays
+    case olderSessions
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .withinOneDay: return "WITHIN 1 DAY"
+        case .withinSevenDays: return "WITHIN 7 DAYS"
+        case .olderSessions: return "OLDER SESSIONS"
+        }
+    }
+
+    static func bucket(for timestamp: Date?, now: Date = Date()) -> Self {
+        guard let timestamp else { return .olderSessions }
+        if timestamp >= now.addingTimeInterval(-24 * 60 * 60) {
+            return .withinOneDay
+        }
+        if timestamp >= now.addingTimeInterval(-7 * 24 * 60 * 60) {
+            return .withinSevenDays
+        }
+        return .olderSessions
+    }
+}

--- a/Sources/termio/SidebarView.swift
+++ b/Sources/termio/SidebarView.swift
@@ -39,23 +39,26 @@ struct SidebarView: View {
         // macOS has no `listSectionSpacing`. The header carries its own grouping
         // weight (small-caps label + folder mark), so folded projects stack tight.
         List {
-            // A flat list of projects (each opened folder, including any git worktree
-            // the user opened, is just a project), in display order: pinned first, then
-            // the rest ordered by the sidebar toolbar's sort (Recent Activity / Name).
-            // A project can be pinned from its right-click menu below. See
-            // `TermioStore.orderedProjects` — the stored tree keeps its own order.
-            ForEach(store.orderedProjects) { project in
-                ProjectHeader(
-                    project: project,
-                    isCollapsed: collapsedProjects.contains(project.id),
-                    toggleCollapsed: { toggleCollapsed(project.id) },
-                    chrome: chrome
-                )
-                if !collapsedProjects.contains(project.id) {
-                    let splitMarks = splitLinkMarks(for: project)
-                    ForEach(project.sessions) { session in
-                        SessionRow(session: session, chrome: chrome,
-                                   splitLink: splitMarks[session.id])
+            // A flat list rather than SwiftUI Sections, with small injected labels when
+            // a grouping rule is active. This keeps the sidebar rhythm tight while making
+            // the chosen grouping visible instead of silently applying only a sort order.
+            ForEach(projectGroups) { group in
+                if let title = group.title {
+                    ProjectGroupLabel(title: title, chrome: chrome)
+                }
+                ForEach(group.projects) { project in
+                    ProjectHeader(
+                        project: project,
+                        isCollapsed: collapsedProjects.contains(project.id),
+                        toggleCollapsed: { toggleCollapsed(project.id) },
+                        chrome: chrome
+                    )
+                    if !collapsedProjects.contains(project.id) {
+                        let splitMarks = splitLinkMarks(for: project)
+                        ForEach(project.sessions) { session in
+                            SessionRow(session: session, chrome: chrome,
+                                       splitLink: splitMarks[session.id])
+                        }
                     }
                 }
             }
@@ -89,6 +92,92 @@ struct SidebarView: View {
                 collapsedProjects.insert(id)
             }
         }
+    }
+
+    private struct ProjectGroup: Identifiable {
+        let id: String
+        let title: String?
+        let projects: [Project]
+    }
+
+    private var projectGroups: [ProjectGroup] {
+        let ordered = store.orderedProjects
+        let terminals = ordered.filter { $0.kind == .terminals }
+        let folders = ordered.filter { $0.kind != .terminals }
+        var groups: [ProjectGroup] = []
+
+        // The Terminals section already carries its own recognisable header, so it
+        // remains above any user-selected project grouping.
+        if !terminals.isEmpty {
+            groups.append(ProjectGroup(id: "terminals", title: nil, projects: terminals))
+        }
+
+        switch settings.projectSortOrder {
+        case .none:
+            if !folders.isEmpty {
+                groups.append(ProjectGroup(id: "projects", title: nil, projects: folders))
+            }
+        case .name:
+            groups.append(contentsOf: groupedFolders(folders) { project in
+                let initial = project.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                    .uppercased().first
+                return initial.map(String.init) ?? "#"
+            })
+        case .recentActivity:
+            groups.append(contentsOf: activityGroups(folders))
+        }
+        return groups
+    }
+
+    private func groupedFolders(
+        _ folders: [Project],
+        key: (Project) -> String
+    ) -> [ProjectGroup] {
+        var result: [ProjectGroup] = []
+        for (pinned, prefix) in [(true, "PINNED · "), (false, "")] {
+            let projects = folders.filter { $0.pinned == pinned }
+            var buckets: [String: [Project]] = [:]
+            var order: [String] = []
+            for project in projects {
+                let groupKey = key(project)
+                if buckets[groupKey] == nil { order.append(groupKey) }
+                buckets[groupKey, default: []].append(project)
+            }
+            for groupKey in order {
+                guard let projects = buckets[groupKey] else { continue }
+                result.append(ProjectGroup(
+                    id: "\(pinned ? "pinned" : "projects")-\(groupKey)",
+                    title: prefix + groupKey,
+                    projects: projects
+                ))
+            }
+        }
+        return result
+    }
+
+    private func activityGroups(_ folders: [Project]) -> [ProjectGroup] {
+        let titles = ["ACTIVE NOW", "RECENT ACTIVITY", "OTHER PROJECTS"]
+        func activityTitle(for project: Project) -> String {
+            if project.sessions.contains(where: { store.statuses[$0.id] == .working }) {
+                return titles[0]
+            }
+            return store.liveActivity[project.id] == nil ? titles[2] : titles[1]
+        }
+
+        var result: [ProjectGroup] = []
+        for (pinned, prefix) in [(true, "PINNED · "), (false, "")] {
+            let projects = folders.filter { $0.pinned == pinned }
+            for title in titles {
+                let bucket = projects.filter { activityTitle(for: $0) == title }
+                guard !bucket.isEmpty else { continue }
+                result.append(ProjectGroup(
+                    id: "\(pinned ? "pinned" : "projects")-\(title)",
+                    title: prefix + title,
+                    projects: bucket
+                ))
+            }
+        }
+        return result
     }
 
     /// Which sessions of `project` get a split-group bracket, and which segment of
@@ -126,6 +215,25 @@ struct SidebarView: View {
         }
         closeRun()
         return marks
+    }
+}
+
+/// A small in-list label makes active project grouping scannable without bringing
+/// back List section spacing or a full-width card treatment.
+private struct ProjectGroupLabel: View {
+    let title: String
+    let chrome: ChromeTheme?
+
+    var body: some View {
+        Text(title)
+            .font(.system(size: 10, weight: .semibold))
+            .tracking(0.7)
+            .foregroundStyle(chrome.map { AnyShapeStyle($0.foreground.opacity(0.55)) }
+                ?? AnyShapeStyle(.secondary))
+            .padding(.top, 8)
+            .padding(.bottom, 2)
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 8))
     }
 }
 

--- a/Sources/termio/SidebarView.swift
+++ b/Sources/termio/SidebarView.swift
@@ -39,25 +39,52 @@ struct SidebarView: View {
         // macOS has no `listSectionSpacing`. The header carries its own grouping
         // weight (small-caps label + folder mark), so folded projects stack tight.
         List {
-            // A flat list rather than SwiftUI Sections, with small injected labels when
-            // a grouping rule is active. This keeps the sidebar rhythm tight while making
-            // the chosen grouping visible instead of silently applying only a sort order.
-            ForEach(projectGroups) { group in
-                if let title = group.title {
-                    ProjectGroupLabel(title: title, chrome: chrome)
-                }
-                ForEach(group.projects) { project in
-                    ProjectHeader(
-                        project: project,
-                        isCollapsed: collapsedProjects.contains(project.id),
-                        toggleCollapsed: { toggleCollapsed(project.id) },
-                        chrome: chrome
+            if settings.projectSortOrder == .none {
+                // The neutral mode is intentionally a plain session switcher: no
+                // project folders or Terminals container, just every open shell at
+                // the same source-list depth.
+                ForEach(flattenedSessionRows) { row in
+                    SessionRow(
+                        session: row.session,
+                        chrome: chrome,
+                        projectName: row.projectName,
+                        leadingIndent: 0
                     )
-                    if !collapsedProjects.contains(project.id) {
-                        let splitMarks = splitLinkMarks(for: project)
-                        ForEach(project.sessions) { session in
-                            SessionRow(session: session, chrome: chrome,
-                                       splitLink: splitMarks[session.id])
+                }
+            } else if settings.projectSortOrder == .recentActivity {
+                // Recent activity deliberately flattens every shell across every
+                // project. The time folders, not project headers, own this hierarchy.
+                ForEach(activitySessionGroups) { group in
+                    ActivitySessionGroupLabel(title: group.bucket.title, chrome: chrome)
+                    ForEach(group.rows) { row in
+                        SessionRow(
+                            session: row.session,
+                            chrome: chrome,
+                            projectName: row.projectName
+                        )
+                    }
+                }
+            } else {
+                // A flat list rather than SwiftUI Sections, with small injected labels
+                // when name grouping is active. This keeps the sidebar rhythm tight
+                // while making the chosen grouping visible instead of silently sorting.
+                ForEach(projectGroups) { group in
+                    if let title = group.title {
+                        ProjectGroupLabel(title: title, chrome: chrome)
+                    }
+                    ForEach(group.projects) { project in
+                        ProjectHeader(
+                            project: project,
+                            isCollapsed: collapsedProjects.contains(project.id),
+                            toggleCollapsed: { toggleCollapsed(project.id) },
+                            chrome: chrome
+                        )
+                        if !collapsedProjects.contains(project.id) {
+                            let splitMarks = splitLinkMarks(for: project)
+                            ForEach(project.sessions) { session in
+                                SessionRow(session: session, chrome: chrome,
+                                           splitLink: splitMarks[session.id])
+                            }
                         }
                     }
                 }
@@ -100,6 +127,28 @@ struct SidebarView: View {
         let projects: [Project]
     }
 
+    private struct ActivitySessionRow: Identifiable {
+        let session: Session
+        let projectName: String
+        let activityAt: Date
+
+        var id: Session.ID { session.id }
+    }
+
+    private struct FlattenedSessionRow: Identifiable {
+        let session: Session
+        let projectName: String
+
+        var id: Session.ID { session.id }
+    }
+
+    private struct ActivitySessionGroup: Identifiable {
+        let bucket: SidebarActivityBucket
+        let rows: [ActivitySessionRow]
+
+        var id: SidebarActivityBucket { bucket }
+    }
+
     private var projectGroups: [ProjectGroup] {
         let ordered = store.orderedProjects
         let terminals = ordered.filter { $0.kind == .terminals }
@@ -118,66 +167,55 @@ struct SidebarView: View {
                 groups.append(ProjectGroup(id: "projects", title: nil, projects: folders))
             }
         case .name:
-            groups.append(contentsOf: groupedFolders(folders) { project in
-                let initial = project.name.trimmingCharacters(in: .whitespacesAndNewlines)
-                    .uppercased().first
-                return initial.map(String.init) ?? "#"
-            })
+            // Name grouping is deliberately just a direct A→Z ordering. Keeping the
+            // existing project rows (without injected A/B/C headers) preserves the
+            // normal sidebar hierarchy and avoids turning each initial into a folder.
+            if !folders.isEmpty {
+                groups.append(ProjectGroup(id: "projects-by-name", title: nil, projects: folders))
+            }
         case .recentActivity:
-            groups.append(contentsOf: activityGroups(folders))
+            // This presentation bypasses the project tree entirely; see
+            // `activitySessionGroups` above the List.
+            break
         }
         return groups
     }
 
-    private func groupedFolders(
-        _ folders: [Project],
-        key: (Project) -> String
-    ) -> [ProjectGroup] {
-        var result: [ProjectGroup] = []
-        for (pinned, prefix) in [(true, "PINNED · "), (false, "")] {
-            let projects = folders.filter { $0.pinned == pinned }
-            var buckets: [String: [Project]] = [:]
-            var order: [String] = []
-            for project in projects {
-                let groupKey = key(project)
-                if buckets[groupKey] == nil { order.append(groupKey) }
-                buckets[groupKey, default: []].append(project)
-            }
-            for groupKey in order {
-                guard let projects = buckets[groupKey] else { continue }
-                result.append(ProjectGroup(
-                    id: "\(pinned ? "pinned" : "projects")-\(groupKey)",
-                    title: prefix + groupKey,
-                    projects: projects
-                ))
+    private var flattenedSessionRows: [FlattenedSessionRow] {
+        store.orderedProjects.flatMap { project in
+            project.sessions.map { session in
+                FlattenedSessionRow(session: session, projectName: project.name)
             }
         }
-        return result
     }
 
-    private func activityGroups(_ folders: [Project]) -> [ProjectGroup] {
-        let titles = ["ACTIVE NOW", "RECENT ACTIVITY", "OTHER PROJECTS"]
-        func activityTitle(for project: Project) -> String {
-            if project.sessions.contains(where: { store.statuses[$0.id] == .working }) {
-                return titles[0]
+    private var activitySessionGroups: [ActivitySessionGroup] {
+        let now = Date()
+        let rows = store.projects.flatMap { project in
+            project.sessions.map { session in
+                ActivitySessionRow(
+                    session: session,
+                    projectName: project.name,
+                    activityAt: store.sessionActivity[session.id]
+                        ?? store.lastWorkingAt[session.id]
+                        ?? session.launchedAt
+                        ?? session.createdAt
+                )
             }
-            return store.liveActivity[project.id] == nil ? titles[2] : titles[1]
         }
 
-        var result: [ProjectGroup] = []
-        for (pinned, prefix) in [(true, "PINNED · "), (false, "")] {
-            let projects = folders.filter { $0.pinned == pinned }
-            for title in titles {
-                let bucket = projects.filter { activityTitle(for: $0) == title }
-                guard !bucket.isEmpty else { continue }
-                result.append(ProjectGroup(
-                    id: "\(pinned ? "pinned" : "projects")-\(title)",
-                    title: prefix + title,
-                    projects: bucket
-                ))
-            }
+        return SidebarActivityBucket.allCases.map { bucket in
+            let bucketRows = rows
+                .filter { SidebarActivityBucket.bucket(for: $0.activityAt, now: now) == bucket }
+                .sorted {
+                    if $0.activityAt != $1.activityAt { return $0.activityAt > $1.activityAt }
+                    if $0.projectName != $1.projectName {
+                        return $0.projectName.localizedCaseInsensitiveCompare($1.projectName) == .orderedAscending
+                    }
+                    return $0.session.title.localizedCaseInsensitiveCompare($1.session.title) == .orderedAscending
+                }
+            return ActivitySessionGroup(bucket: bucket, rows: bucketRows)
         }
-        return result
     }
 
     /// Which sessions of `project` get a split-group bracket, and which segment of
@@ -234,6 +272,29 @@ private struct ProjectGroupLabel: View {
             .padding(.bottom, 2)
             .listRowSeparator(.hidden)
             .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 8))
+    }
+}
+
+/// Recent-activity buckets are virtual folders rather than project headers: they
+/// contain individual shells gathered across the whole sidebar tree.
+private struct ActivitySessionGroupLabel: View {
+    let title: String
+    let chrome: ChromeTheme?
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "folder")
+                .font(.system(size: 12, weight: .medium))
+            Text(title)
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.7)
+        }
+        .foregroundStyle(chrome.map { AnyShapeStyle($0.foreground.opacity(0.55)) }
+            ?? AnyShapeStyle(.secondary))
+        .padding(.top, 8)
+        .padding(.bottom, 2)
+        .listRowSeparator(.hidden)
+        .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 8))
     }
 }
 
@@ -648,6 +709,9 @@ private struct SessionRow: View {
     @EnvironmentObject var settings: AppSettings
     let session: Session
     let chrome: ChromeTheme?
+    /// When time grouping flattens the project hierarchy, retain the shell's source
+    /// project in its title so otherwise-identical "Terminal" rows stay distinct.
+    var projectName: String? = nil
     /// Leading inset for the row's content. Sessions sit at 16 under a project, or a
     /// step deeper (32) when nested under a worktree folder node.
     var leadingIndent: CGFloat = 16
@@ -681,7 +745,7 @@ private struct SessionRow: View {
             }
             .frame(width: 16)
             .help(store.statusDescription(for: session.id))
-            Text(store.displayTitle(for: session))
+            Text(groupedDisplayTitle)
                 .font(settings.interfaceFont)
                 .foregroundStyle(chrome.map { AnyShapeStyle($0.foreground) } ?? AnyShapeStyle(.primary))
                 .lineLimit(1)
@@ -747,6 +811,11 @@ private struct SessionRow: View {
                 .animation(.easeInOut(duration: 0.12), value: isHovering)
         )
         .animation(.easeInOut(duration: 0.12), value: isHovering)
+    }
+
+    private var groupedDisplayTitle: String {
+        guard let projectName else { return store.displayTitle(for: session) }
+        return "\(projectName) — \(store.displayTitle(for: session))"
     }
 }
 

--- a/Sources/termio/SidebarView.swift
+++ b/Sources/termio/SidebarView.swift
@@ -43,13 +43,15 @@ struct SidebarView: View {
                 // The neutral mode is intentionally a plain session switcher: no
                 // project folders or Terminals container, just every open shell at
                 // the same source-list depth.
-                ForEach(flattenedSessionRows) { row in
-                    SessionRow(
-                        session: row.session,
-                        chrome: chrome,
-                        projectName: row.projectName,
-                        leadingIndent: 0
-                    )
+                ForEach(store.orderedProjects) { project in
+                    ForEach(project.sessions) { session in
+                        SessionRow(
+                            session: session,
+                            chrome: chrome,
+                            projectName: project.name,
+                            leadingIndent: 0
+                        )
+                    }
                 }
             } else if settings.projectSortOrder == .recentActivity {
                 // Recent activity deliberately flattens every shell across every
@@ -65,26 +67,18 @@ struct SidebarView: View {
                     }
                 }
             } else {
-                // A flat list rather than SwiftUI Sections, with small injected labels
-                // when name grouping is active. This keeps the sidebar rhythm tight
-                // while making the chosen grouping visible instead of silently sorting.
-                ForEach(projectGroups) { group in
-                    if let title = group.title {
-                        ProjectGroupLabel(title: title, chrome: chrome)
-                    }
-                    ForEach(group.projects) { project in
-                        ProjectHeader(
-                            project: project,
-                            isCollapsed: collapsedProjects.contains(project.id),
-                            toggleCollapsed: { toggleCollapsed(project.id) },
-                            chrome: chrome
-                        )
-                        if !collapsedProjects.contains(project.id) {
-                            let splitMarks = splitLinkMarks(for: project)
-                            ForEach(project.sessions) { session in
-                                SessionRow(session: session, chrome: chrome,
-                                           splitLink: splitMarks[session.id])
-                            }
+                ForEach(store.orderedProjects) { project in
+                    ProjectHeader(
+                        project: project,
+                        isCollapsed: collapsedProjects.contains(project.id),
+                        toggleCollapsed: { toggleCollapsed(project.id) },
+                        chrome: chrome
+                    )
+                    if !collapsedProjects.contains(project.id) {
+                        let splitMarks = splitLinkMarks(for: project)
+                        ForEach(project.sessions) { session in
+                            SessionRow(session: session, chrome: chrome,
+                                       splitLink: splitMarks[session.id])
                         }
                     }
                 }
@@ -121,23 +115,10 @@ struct SidebarView: View {
         }
     }
 
-    private struct ProjectGroup: Identifiable {
-        let id: String
-        let title: String?
-        let projects: [Project]
-    }
-
     private struct ActivitySessionRow: Identifiable {
         let session: Session
         let projectName: String
         let activityAt: Date
-
-        var id: Session.ID { session.id }
-    }
-
-    private struct FlattenedSessionRow: Identifiable {
-        let session: Session
-        let projectName: String
 
         var id: Session.ID { session.id }
     }
@@ -147,46 +128,6 @@ struct SidebarView: View {
         let rows: [ActivitySessionRow]
 
         var id: SidebarActivityBucket { bucket }
-    }
-
-    private var projectGroups: [ProjectGroup] {
-        let ordered = store.orderedProjects
-        let terminals = ordered.filter { $0.kind == .terminals }
-        let folders = ordered.filter { $0.kind != .terminals }
-        var groups: [ProjectGroup] = []
-
-        // The Terminals section already carries its own recognisable header, so it
-        // remains above any user-selected project grouping.
-        if !terminals.isEmpty {
-            groups.append(ProjectGroup(id: "terminals", title: nil, projects: terminals))
-        }
-
-        switch settings.projectSortOrder {
-        case .none:
-            if !folders.isEmpty {
-                groups.append(ProjectGroup(id: "projects", title: nil, projects: folders))
-            }
-        case .name:
-            // Name grouping is deliberately just a direct A→Z ordering. Keeping the
-            // existing project rows (without injected A/B/C headers) preserves the
-            // normal sidebar hierarchy and avoids turning each initial into a folder.
-            if !folders.isEmpty {
-                groups.append(ProjectGroup(id: "projects-by-name", title: nil, projects: folders))
-            }
-        case .recentActivity:
-            // This presentation bypasses the project tree entirely; see
-            // `activitySessionGroups` above the List.
-            break
-        }
-        return groups
-    }
-
-    private var flattenedSessionRows: [FlattenedSessionRow] {
-        store.orderedProjects.flatMap { project in
-            project.sessions.map { session in
-                FlattenedSessionRow(session: session, projectName: project.name)
-            }
-        }
     }
 
     private var activitySessionGroups: [ActivitySessionGroup] {
@@ -253,25 +194,6 @@ struct SidebarView: View {
         }
         closeRun()
         return marks
-    }
-}
-
-/// A small in-list label makes active project grouping scannable without bringing
-/// back List section spacing or a full-width card treatment.
-private struct ProjectGroupLabel: View {
-    let title: String
-    let chrome: ChromeTheme?
-
-    var body: some View {
-        Text(title)
-            .font(.system(size: 10, weight: .semibold))
-            .tracking(0.7)
-            .foregroundStyle(chrome.map { AnyShapeStyle($0.foreground.opacity(0.55)) }
-                ?? AnyShapeStyle(.secondary))
-            .padding(.top, 8)
-            .padding(.bottom, 2)
-            .listRowSeparator(.hidden)
-            .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 8))
     }
 }
 

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -87,6 +87,7 @@ extension TermioStore {
             // instead of spinning forever — the failure mode cmux's own tracker
             // suffers from (issue #3749).
             lastWorkingAt[id] = Date()
+            sessionActivity[id] = Date()
             // A working agent is the strongest "this project is active" signal, so
             // float its project up under the "Recent Activity" sort (see `orderedProjects`).
             if let pid = project(for: id)?.id { liveActivity[pid] = Date() }

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -247,12 +247,16 @@ extension TermioStore {
         }
     }
 
-    /// The projects in sidebar display order: pinned ones first, then the rest, each
-    /// group ordered by the user's chosen sort (`AppSettings.projectSortOrder`). A
-    /// computed view over `projects` — the stored array keeps its own insertion order,
-    /// so ordering is a presentation concern that never mutates (or persists) the tree.
+    /// The projects in sidebar display order. Without grouping this preserves the stored
+    /// order; active grouping orders each pinned/unpinned set. The computed view never
+    /// mutates (or persists) the stored tree.
     var orderedProjects: [Project] {
         let order = settings.projectSortOrder
+        if order == .none {
+            // Keep the original insertion order while retaining the existing pinned
+            // section at the top of the navigator.
+            return projects.filter(\.pinned) + projects.filter { !$0.pinned }
+        }
         return projects.sorted { a, b in
             // The Terminals section is the entry funnel, so it sits above every
             // project — ahead even of pinned ones, whichever sort is active.
@@ -260,6 +264,8 @@ extension TermioStore {
             // Pinned projects always float to the top, whichever sort is active.
             if a.pinned != b.pinned { return a.pinned }
             switch order {
+            case .none:
+                return false
             case .name:
                 return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
             case .recentActivity:

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -253,9 +253,11 @@ extension TermioStore {
     var orderedProjects: [Project] {
         let order = settings.projectSortOrder
         if order == .none {
-            // Keep the original insertion order while retaining the existing pinned
-            // section at the top of the navigator.
-            return projects.filter(\.pinned) + projects.filter { !$0.pinned }
+            // Keep the original insertion order while retaining the existing Terminals
+            // and pinned sections at the top of the navigator.
+            let terminals = projects.filter { $0.kind == .terminals }
+            let folders = projects.filter { $0.kind != .terminals }
+            return terminals + folders.filter(\.pinned) + folders.filter { !$0.pinned }
         }
         return projects.sorted { a, b in
             // The Terminals section is the entry funnel, so it sits above every

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -32,6 +32,9 @@ final class TermioStore: ObservableObject {
                 // Switching to a session counts as activity for its project, so the
                 // "Recent Activity" sort floats a project the moment you focus it.
                 if let pid = project(for: id)?.id { liveActivity[pid] = Date() }
+                // Keep the same signal at shell granularity for the sidebar's
+                // time-window grouping. It remains transient like `liveActivity`.
+                sessionActivity[id] = Date()
             }
             persist()
         }
@@ -78,6 +81,9 @@ final class TermioStore: ObservableObject {
     /// falls back to the stored project order until activity resumes), which keeps the
     /// high-frequency working-event updates off the disk-writing `projects` array.
     @Published var liveActivity: [Project.ID: Date] = [:]
+
+    /// Per-shell counterpart to `liveActivity`, used by the sidebar's time buckets.
+    @Published var sessionActivity: [Session.ID: Date] = [:]
 
     /// The project whose Security panel is open, or `nil` when none is. Transient UI
     /// state (not persisted) driving the sandbox-configuration sheet.

--- a/Sources/termio/ToolbarGlassControls.swift
+++ b/Sources/termio/ToolbarGlassControls.swift
@@ -87,13 +87,13 @@ struct NavigatorActionsToolbar: View {
 
     private var legacyControl: some View {
         HStack(spacing: ToolbarGlassMetrics.itemSpacing) {
-            legacyActionButton(
+            actionButton(
                 symbol: "line.3.horizontal.decrease",
                 help: "Choose how projects are ordered",
                 selected: state.groupingIsActive,
                 action: actionHandler.presentSortMenu
             )
-            legacyActionButton(
+            actionButton(
                 symbol: "plus",
                 help: "New terminal or project",
                 selected: false,
@@ -104,7 +104,6 @@ struct NavigatorActionsToolbar: View {
         .background(Capsule(style: .continuous).fill(Color.primary.opacity(0.06)))
     }
 
-    @available(macOS 26.0, *)
     private func actionButton(
         symbol: String,
         help: String,
@@ -114,36 +113,28 @@ struct NavigatorActionsToolbar: View {
         Button(action: action) {
             icon(symbol)
                 .background {
-                    if selected {
-                        Capsule()
-                            .fill(.clear)
-                            .glassEffect(.regular.interactive(), in: .capsule)
-                            .glassEffectID("navigatorSelection", in: glassNamespace)
-                    }
+                    selectionBackground(selected: selected)
                 }
-                .contentShape(.capsule)
+                .contentShape(Capsule())
         }
         .buttonStyle(.plain)
         .help(help)
     }
 
-    private func legacyActionButton(
-        symbol: String,
-        help: String,
-        selected: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            icon(symbol)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(selected ? Color(nsColor: .controlColor) : .clear)
-                        .shadow(color: selected ? .black.opacity(0.18) : .clear, radius: 0.5, y: 0.5)
-                )
-                .contentShape(Capsule())
+    @ViewBuilder
+    private func selectionBackground(selected: Bool) -> some View {
+        if #available(macOS 26.0, *) {
+            if selected {
+                Capsule()
+                    .fill(.clear)
+                    .glassEffect(.regular.interactive(), in: .capsule)
+                    .glassEffectID("navigatorSelection", in: glassNamespace)
+            }
+        } else {
+            Capsule(style: .continuous)
+                .fill(selected ? Color(nsColor: .controlColor) : .clear)
+                .shadow(color: selected ? .black.opacity(0.18) : .clear, radius: 0.5, y: 0.5)
         }
-        .buttonStyle(.plain)
-        .help(help)
     }
 
     private func icon(_ symbol: String) -> some View {

--- a/Sources/termio/ToolbarGlassControls.swift
+++ b/Sources/termio/ToolbarGlassControls.swift
@@ -1,0 +1,155 @@
+import AppKit
+import Combine
+import SwiftUI
+
+/// Geometry shared by every custom glass control in the unified toolbar. Keeping
+/// the metrics here prevents an AppKit-hosted group from drifting away from the
+/// SwiftUI inspector group by a pixel or two.
+enum ToolbarGlassMetrics {
+    static let controlHeight: CGFloat = 36
+    static let trackPadding: CGFloat = 3
+    static let itemSpacing: CGFloat = 2
+    static let segmentWidth: CGFloat = 34
+    static let containerSpacing: CGFloat = 4
+
+    static var glyphHeight: CGFloat { controlHeight - 2 * trackPadding }
+}
+
+@MainActor
+final class NavigatorToolbarActionsState: ObservableObject {
+    @Published var groupingIsActive = false
+}
+
+/// AppKit owns the menus, while this SwiftUI control owns their shared glass
+/// appearance. The handler keeps the menu anchored to the hosting view without
+/// making the SwiftUI view aware of `NSToolbar` implementation details.
+@MainActor
+final class NavigatorToolbarActionHandler {
+    weak var anchorView: NSView?
+    var showSortMenu: ((NSView) -> Void)?
+    var showNewMenu: ((NSView) -> Void)?
+
+    func presentSortMenu() {
+        guard let anchorView else { return }
+        showSortMenu?(anchorView)
+    }
+
+    func presentNewMenu() {
+        guard let anchorView else { return }
+        showNewMenu?(anchorView)
+    }
+}
+
+/// The navigator's two actions rendered with the exact glass-track vocabulary
+/// used by the inspector control: a shared regular-material capsule, 2pt icon rhythm, and
+/// a raised interactive pill for the active grouping state.
+struct NavigatorActionsToolbar: View {
+    @ObservedObject var state: NavigatorToolbarActionsState
+    let actionHandler: NavigatorToolbarActionHandler
+    @Namespace private var glassNamespace
+
+    var body: some View {
+        Group {
+            if #available(macOS 26.0, *) {
+                glassControl
+            } else {
+                legacyControl
+            }
+        }
+        .frame(height: ToolbarGlassMetrics.controlHeight)
+        .fixedSize()
+    }
+
+    @available(macOS 26.0, *)
+    private var glassControl: some View {
+        GlassEffectContainer(spacing: ToolbarGlassMetrics.containerSpacing) {
+            HStack(spacing: ToolbarGlassMetrics.itemSpacing) {
+                actionButton(
+                    symbol: "line.3.horizontal.decrease",
+                    help: "Choose how projects are ordered",
+                    selected: state.groupingIsActive,
+                    action: actionHandler.presentSortMenu
+                )
+                actionButton(
+                    symbol: "plus",
+                    help: "New terminal or project",
+                    selected: false,
+                    action: actionHandler.presentNewMenu
+                )
+            }
+            .padding(ToolbarGlassMetrics.trackPadding)
+            // Match native single toolbar buttons' base material. The selected pill
+            // below supplies the elevated state; a white tint here made the whole
+            // multi-button track look heavier and more opaque than its neighbour.
+            .glassEffect(.regular, in: .capsule)
+        }
+    }
+
+    private var legacyControl: some View {
+        HStack(spacing: ToolbarGlassMetrics.itemSpacing) {
+            legacyActionButton(
+                symbol: "line.3.horizontal.decrease",
+                help: "Choose how projects are ordered",
+                selected: state.groupingIsActive,
+                action: actionHandler.presentSortMenu
+            )
+            legacyActionButton(
+                symbol: "plus",
+                help: "New terminal or project",
+                selected: false,
+                action: actionHandler.presentNewMenu
+            )
+        }
+        .padding(ToolbarGlassMetrics.trackPadding)
+        .background(Capsule(style: .continuous).fill(Color.primary.opacity(0.06)))
+    }
+
+    @available(macOS 26.0, *)
+    private func actionButton(
+        symbol: String,
+        help: String,
+        selected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            icon(symbol)
+                .background {
+                    if selected {
+                        Capsule()
+                            .fill(.clear)
+                            .glassEffect(.regular.interactive(), in: .capsule)
+                            .glassEffectID("navigatorSelection", in: glassNamespace)
+                    }
+                }
+                .contentShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
+    private func legacyActionButton(
+        symbol: String,
+        help: String,
+        selected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            icon(symbol)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(selected ? Color(nsColor: .controlColor) : .clear)
+                        .shadow(color: selected ? .black.opacity(0.18) : .clear, radius: 0.5, y: 0.5)
+                )
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
+    private func icon(_ symbol: String) -> some View {
+        Image(systemName: symbol)
+            .font(.system(size: 17, weight: .medium))
+            .foregroundStyle(.secondary)
+            .frame(width: ToolbarGlassMetrics.segmentWidth, height: ToolbarGlassMetrics.glyphHeight)
+    }
+}

--- a/Tests/termioTests/SidebarActivityGroupingTests.swift
+++ b/Tests/termioTests/SidebarActivityGroupingTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import termio
+
+final class SidebarActivityGroupingTests: XCTestCase {
+    func testClassifiesSessionsIntoTheThreeRecentActivityBuckets() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+        XCTAssertEqual(
+            SidebarActivityBucket.bucket(for: now.addingTimeInterval(-23 * 60 * 60), now: now),
+            .withinOneDay
+        )
+        XCTAssertEqual(
+            SidebarActivityBucket.bucket(for: now.addingTimeInterval(-24 * 60 * 60), now: now),
+            .withinOneDay
+        )
+        XCTAssertEqual(
+            SidebarActivityBucket.bucket(for: now.addingTimeInterval(-6 * 24 * 60 * 60), now: now),
+            .withinSevenDays
+        )
+        XCTAssertEqual(
+            SidebarActivityBucket.bucket(for: now.addingTimeInterval(-7 * 24 * 60 * 60), now: now),
+            .withinSevenDays
+        )
+        XCTAssertEqual(
+            SidebarActivityBucket.bucket(for: now.addingTimeInterval(-8 * 24 * 60 * 60), now: now),
+            .olderSessions
+        )
+        XCTAssertEqual(SidebarActivityBucket.bucket(for: nil, now: now), .olderSessions)
+    }
+}

--- a/Tests/termioTests/SidebarActivityGroupingTests.swift
+++ b/Tests/termioTests/SidebarActivityGroupingTests.swift
@@ -2,6 +2,12 @@ import XCTest
 @testable import termio
 
 final class SidebarActivityGroupingTests: XCTestCase {
+    func testToolbarGlassMetricsMatchTheSharedToolbarControlGeometry() {
+        XCTAssertEqual(ToolbarGlassMetrics.controlHeight, 36)
+        XCTAssertEqual(ToolbarGlassMetrics.trackPadding, 3)
+        XCTAssertEqual(ToolbarGlassMetrics.itemSpacing, 2)
+    }
+
     func testClassifiesSessionsIntoTheThreeRecentActivityBuckets() {
         let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
 


### PR DESCRIPTION
## 概要

优化侧边栏的分组体验与工具栏一致性。

- 将侧边栏的 Filter 与 Add 合并为无分隔符的玻璃按钮组，并与右侧 Inspector 工具栏共用尺寸与材质。
- Filter 点击后提供三种模式：
  - No Grouping：所有终端平铺在同一层级。
  - Group by Name：项目按名称 A–Z 排序，不额外添加字母文件夹。
  - Group by Recent Activity：按 Within 1 Day、Within 7 Days、Older Sessions 三个时间段归类终端。
- 有分组时 Filter 显示激活态；Add 菜单保留 New Terminal 与 Open Project。
- 移除重复的侧边栏分组包装与工具栏按钮实现，收敛为共享的玻璃控件逻辑。

## 验证

- `swift test --filter SidebarActivityGroupingTests`
- Dev app 构建及签名校验
- 实际验证 Filter 与 Add 菜单可正常打开


这个PR其实我无所谓怎么设计这个order和groupby，我觉得可以以你的思路为主，我只是想统一一下那个按钮组和单个按钮的样式，目前看起来高度没对齐材质好像有不一致

另外我截图是在macOS 27下的样式，macOS 26下的情况得看你那边build的结果

<img width="1422" height="1089" alt="image" src="https://github.com/user-attachments/assets/fe345aac-e80f-4219-bbbe-4848ed43f7fb" />

