### PR TITLE
fix(terminal): Align inspector toolbar height

### DIFF
--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -29,7 +29,7 @@ struct InspectorTabsToolbar: View {
     /// Outer height of the glass track, matched to the native bordered toolbar buttons either
     /// side of it so all the toolbar backgrounds line up. The track is built bottom-up as
     /// `glyphHeight + 2 * trackPadding`, so those two derive from this single number.
-    static let toolbarControlHeight: CGFloat = 30
+    static let toolbarControlHeight: CGFloat = 36
     private static let trackPadding: CGFloat = 3
     private static var glyphHeight: CGFloat { toolbarControlHeight - 2 * trackPadding }
 


### PR DESCRIPTION
## 概要

将右侧 Inspector 的玻璃标签组高度从 30pt 调整为 36pt，使其与同一工具栏中的原生单按钮外框对齐。

不改变图标、材质、动画或标签切换行为。

## 验证

- `TERMIO_CHANNEL=dev ./scripts/build-app.sh`
- `codesign --verify --deep --strict ./termio-dev.app`
- 已启动新构建的 dev app，确认右侧 Inspector 工具栏高度对齐。

备注：`swift test` 会完成项目编译，但当前 `main` 没有 Swift 测试 target，最终输出为 `no tests found`。