### PR TITLE
spike(tabs): native NSWindow tabbing (Ghostty-style) — Route A prototype

### DIFF
--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -29,9 +29,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// elsewhere in the app (`TerminalPane` filters key-window notifications with it,
     /// so the settings window never triggers the terminal refocus rescue).
     static let mainWindowFrameAutosaveName = "TermioMainWindow"
-    private var window: NSWindow!
-    private let settings = AppSettings()
-    private lazy var store = TermioStore.restored(settings: settings)
+    var window: NSWindow! // SPIKE: relaxed from private so NativeTabsSpike.swift can opt it into tabbing.
+    let settings = AppSettings() // SPIKE: relaxed from private for NativeTabsSpike.swift.
+    lazy var store = TermioStore.restored(settings: settings) // SPIKE: relaxed from private.
     private lazy var usageMonitor = UsageMonitor(settings: settings)
     private var menuBar: MenuBarController?
     private var companionServer: CompanionServer?
@@ -78,6 +78,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // The window's real toolbar delegate (must be retained); it carries the native
     // sidebar toggle (see `installToolbar`).
     private var toolbarDelegate: MainToolbarDelegate?
+    // SPIKE (spike/native-window-tabs): extra tabbed windows + their toolbar delegates, held
+    // for the app's lifetime so they aren't deallocated. See `NativeTabsSpike.swift`.
+    var spikeWindows: [NSWindow] = []
+    var spikeToolbarDelegates: [MainToolbarDelegate] = []
     // Keeps the native window title (path) and subtitle (git branch) in step with the
     // selected session — NetNewsWire's approach, no custom title-bar views.
     private var titleObserver: AnyCancellable?
@@ -147,6 +151,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         applyWindowTransparency()
         applyChromeAppearance()
         installToolbar()
+        enableNativeSessionTabbing() // SPIKE: opt this window into native NSWindow tabbing.
         // Empty the sidebar's toolbar region (sort + new-terminal) whenever the navigator collapses
         // and restore it when it reopens — the sidebar's own buttons ride with the sidebar, the way
         // Finder/Xcode drop theirs. KVO catches every collapse path (toolbar toggle, View menu,
@@ -476,7 +481,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// effective appearance. `AppSettings.terminalBackgroundColor` is a dynamic color that picks
     /// light/dark per drawing context; the window (and especially its fullscreen title-bar
     /// overlay) needs a fixed color so it can't resolve to the wrong side.
-    private func resolvedTerminalBackground() -> NSColor {
+    func resolvedTerminalBackground() -> NSColor {
         let dynamic = settings.terminalBackgroundColor
         // Resolve against the appearance the window is pinned to (not its current
         // `effectiveAppearance`, which can lag `applyChromeAppearance` depending on call order).
@@ -934,7 +939,7 @@ private final class KeyBorderlessPanel: NSPanel {
 /// divider), the custom branch-picker title item, and a trailing inspector toggle. The store and
 /// settings drive the branch picker.
 @MainActor
-private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDelegate {
+final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDelegate {
     private let store: TermioStore
     private let settings: AppSettings
     /// Used to build the inspector tracking separator, which pins the pane switch to the
@@ -1331,9 +1336,12 @@ private func buildMainMenu() -> NSMenu {
     // Keeps the `+` new-terminal action reachable when the navigator is collapsed and its toolbar
     // button is hidden (see `setNavigatorItemsVisible`). ⌘T is safe: TUI programs drive off Ctrl,
     // never Cmd, so it can't shadow a key a terminal app wants.
+    // SPIKE (spike/native-window-tabs): ⌘T opens a NEW native tab (a separate NSWindow grouped
+    // via addTabbedWindow), so macOS draws its own tab bar — the Ghostty model. Repointed from
+    // `newScratchTerminal` for this spike so the native tab bar is easy to exercise.
     fileMenu.addItem(
-        withTitle: "New Terminal",
-        action: #selector(AppDelegate.newScratchTerminal(_:)),
+        withTitle: "New Tab",
+        action: #selector(AppDelegate.newWindowForTab(_:)),
         keyEquivalent: "t"
     )
     fileMenu.addItem(.separator())

--- a/Sources/termio/NativeTabsSpike.swift
+++ b/Sources/termio/NativeTabsSpike.swift
@@ -1,0 +1,121 @@
+import AppKit
+import SwiftUI
+
+// MARK: - SPIKE: native NSWindow tabbing (Ghostty's model)
+//
+// Branch: spike/native-window-tabs. Purpose: let us *feel* Route A — one real NSWindow per tab,
+// grouped with `addTabbedWindow` so macOS draws its own native tab bar (the same widget Ghostty
+// relocates into its titlebar). This is throwaway exploration, not a merge candidate.
+//
+// WHAT THIS DEMONSTRATES (honestly):
+//   • The native tab bar chrome: the system `+`, drag-to-reorder, compression when the window
+//     narrows, the overflow menu, ⌃⇥ cycling, ⌘⇧\ to show all tabs — all free from AppKit.
+//   • The unavoidable consequence: every tab is a whole window, so each carries its OWN sidebar.
+//     Collapse the sidebar in one tab and the other tab keeps its own — proof they're separate.
+//
+// WHAT THIS FAKES (the part that would be the real rewrite):
+//   • Content follows the store's single GLOBAL `selectedSessionID`, so every tab shows the same
+//     session. Real per-tab content needs selection to become per-window — that refactor (plus
+//     the fact native tabs can't nest into Safari tab-groups) is exactly what this spike prices.
+
+extension AppDelegate {
+    private static let sessionTabbingIdentifier = NSWindow.TabbingIdentifier("termio.session")
+
+    /// Opt the main window into native tabbing so new windows with the same tabbing identifier
+    /// merge into one native tab group instead of opening standalone.
+    func enableNativeSessionTabbing() {
+        guard let window else { return }
+        window.tabbingMode = .preferred
+        window.tabbingIdentifier = Self.sessionTabbingIdentifier
+    }
+
+    /// AppKit's hook for the tab bar's `+` button and our repointed ⌘T. Creates a fresh session
+    /// window and tabs it into the sender window's group.
+    @objc func newWindowForTab(_ sender: Any?) {
+        let parent = (sender as? NSWindow)
+            ?? NSApp.keyWindow
+            ?? NSApp.mainWindow
+        let newWindow = makeSpikeSessionWindow()
+        if let parent, parent.tabbingIdentifier == Self.sessionTabbingIdentifier {
+            parent.addTabbedWindow(newWindow, ordered: .above)
+        }
+        newWindow.makeKeyAndOrderFront(nil)
+    }
+
+    /// Builds a window that mirrors the main window's chrome — same style mask, transparent
+    /// terminal-tinted titlebar, full-height sidebar, and a real toolbar (branch picker) bound to
+    /// this window's own split. Retained in `spikeWindows` / `spikeToolbarDelegates`.
+    private func makeSpikeSessionWindow() -> NSWindow {
+        let w = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1100, height: 720),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        w.title = "Termio"
+        w.contentMinSize = NSSize(width: 640, height: 420)
+        w.titleVisibility = .hidden
+        w.titlebarSeparatorStyle = .automatic
+        w.tabbingMode = .preferred
+        w.tabbingIdentifier = Self.sessionTabbingIdentifier
+        w.isReleasedWhenClosed = false
+
+        let split = makeSpikeContentSplit()
+        w.contentViewController = split
+
+        // A real toolbar bound to THIS window's split, so the branch picker + sidebar toggle work
+        // per tab exactly like the main window.
+        let delegate = MainToolbarDelegate(store: store, settings: settings, splitViewController: split)
+        spikeToolbarDelegates.append(delegate)
+        let toolbar = NSToolbar(identifier: "TermioSpikeToolbar")
+        toolbar.delegate = delegate
+        toolbar.displayMode = .iconOnly
+        toolbar.allowsUserCustomization = false
+        toolbar.showsBaselineSeparator = false
+        if #available(macOS 26, *) {
+            w.toolbarStyle = .automatic
+        } else {
+            w.toolbarStyle = .unifiedCompact
+        }
+        w.toolbar = toolbar
+
+        // Match the main window's transparent, terminal-tinted titlebar (statically resolved).
+        let translucent = settings.backgroundOpacity < 1.0 || settings.backgroundBlur > 0
+        w.isOpaque = !translucent
+        w.backgroundColor = translucent ? .clear : resolvedTerminalBackground()
+        w.titlebarAppearsTransparent = !w.styleMask.contains(.fullScreen)
+
+        spikeWindows.append(w)
+        return w
+    }
+
+    /// A standalone copy of the main content split ([sidebar | terminal]) bound to the shared
+    /// store. Mirrors `makeContentSplitViewController` but touches no `AppDelegate` singleton state
+    /// so it can be built once per window.
+    private func makeSpikeContentSplit() -> NSSplitViewController {
+        let sidebar = NSHostingController(rootView: SidebarView()
+            .environmentObject(store)
+            .environmentObject(settings))
+        let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebar)
+        sidebarItem.minimumThickness = 240
+        sidebarItem.maximumThickness = 400
+        sidebarItem.canCollapse = true
+        sidebarItem.allowsFullHeightLayout = true
+        if #unavailable(macOS 26) {
+            sidebarItem.titlebarSeparatorStyle = .none
+        }
+
+        let detail = NSHostingController(rootView: TerminalPane()
+            .environmentObject(store)
+            .environmentObject(settings))
+        detail.sizingOptions = []
+        let detailItem = NSSplitViewItem(viewController: detail)
+        detailItem.minimumThickness = 280
+        detailItem.titlebarSeparatorStyle = .line
+
+        let split = NSSplitViewController()
+        split.addSplitViewItem(sidebarItem)
+        split.addSplitViewItem(detailItem)
+        return split
+    }
+}


### PR DESCRIPTION
## What this is

A **throwaway spike** (not for merge) pricing **Route A** for session tabs: real
native macOS window tabbing like Ghostty, instead of a custom title-bar strip.

Each ⌘T / native `+` creates a separate `NSWindow` and merges it with
`addTabbedWindow`, so macOS draws its own `NSTabBar` — the exact widget Ghostty
relocates into its titlebar.

## What it demonstrates

- The native tab-bar chrome for free: drag-reorder, compression + overflow `»`
  menu, ⌃⇥ cycling, ⌘⇧\ show-all-tabs.
- The unavoidable cost: **every tab is a whole window, so each carries its own
  sidebar** (collapse one tab's sidebar — the others keep theirs).

## What it fakes (the real rewrite)

Content still follows the store's single **global** `selectedSessionID`, so all
tabs show the same session. True per-tab content needs selection to become
**per-window**, and native tabs **can't nest into Safari-style tab groups**
(they're flat). That tradeoff is exactly what this spike measures.

## Files

- `Sources/termio/NativeTabsSpike.swift` — tabbing setup + per-window content/toolbar build
- `Sources/termio/App.swift` — enable tabbing, repoint ⌘T → New Tab, relax a few
  private members so the spike extension can reach them

## Decision

Recommendation from the exploration: **keep the custom strip**, not Route A —
native tabs drop tab-groups and force a per-window-selection rewrite for a bar
that compresses rather than scrolls anyway. This branch preserves the prototype
for reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)