### PR TITLE
feat(files): 紧凑文件浏览器布局，隐藏分割线并支持显示隐藏文件

### DIFF
--- a/Sources/termio/FileBrowser/FileBrowserState.swift
+++ b/Sources/termio/FileBrowser/FileBrowserState.swift
@@ -8,6 +8,4 @@ import Foundation
 @MainActor
 final class FileBrowserState: ObservableObject {
     @Published var selection: URL?
-    @Published var showHiddenFiles: Bool = false
 }
-

--- a/Sources/termio/FileBrowser/FileBrowserState.swift
+++ b/Sources/termio/FileBrowser/FileBrowserState.swift
@@ -8,4 +8,6 @@ import Foundation
 @MainActor
 final class FileBrowserState: ObservableObject {
     @Published var selection: URL?
+    @Published var showHiddenFiles: Bool = false
 }
+

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -38,13 +38,6 @@ struct FileBrowserView: View {
         return store.session(id)?.worktreePath ?? project.path
     }
 
-    private var compactFont: Font {
-        let size = max(10.0, settings.interfaceFontSize - 1.5)
-        return settings.interfaceFontFamily.isEmpty
-            ? .system(size: size)
-            : .custom(settings.interfaceFontFamily, size: size)
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             switch store.inspectorTab {
@@ -118,9 +111,6 @@ struct FileBrowserView: View {
                 QLPreviewPanel.shared().reloadData()
             }
         }
-        .onChange(of: browserState.showHiddenFiles) {
-            refresh()
-        }
     }
 
     /// Whether `url` points at a directory — used to open only files on selection.
@@ -135,7 +125,7 @@ struct FileBrowserView: View {
             FileTreeList(
                 nodes: root.children ?? [],
                 selection: $browserState.selection,
-                font: compactFont,
+                font: settings.interfaceFont,
                 onDrop: { sources, destination in receive(sources, into: destination) },
                 rootURL: root.url,
                 actions: treeActions
@@ -180,12 +170,6 @@ struct FileBrowserView: View {
             TreeHeaderButton(codicon: .newFolder, help: "New Folder") {
                 createFolder(in: root.url)
             }
-            TreeHeaderButton(
-                systemName: browserState.showHiddenFiles ? "eye" : "eye.slash",
-                help: browserState.showHiddenFiles ? "Hide Hidden Files" : "Show Hidden Files"
-            ) {
-                browserState.showHiddenFiles.toggle()
-            }
             TreeHeaderButton(codicon: .refresh, help: "Refresh") {
                 refresh()
             }
@@ -215,7 +199,7 @@ struct FileBrowserView: View {
             root = nil
             return
         }
-        root = FileNode(url: URL(fileURLWithPath: projectPath), isDirectory: true, showHidden: browserState.showHiddenFiles)
+        root = FileNode(url: URL(fileURLWithPath: projectPath), isDirectory: true)
     }
 
     /// Places each dropped file into `destination` (a folder inside the tree, or the

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -38,6 +38,13 @@ struct FileBrowserView: View {
         return store.session(id)?.worktreePath ?? project.path
     }
 
+    private var compactFont: Font {
+        let size = max(10.0, settings.interfaceFontSize - 1.5)
+        return settings.interfaceFontFamily.isEmpty
+            ? .system(size: size)
+            : .custom(settings.interfaceFontFamily, size: size)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             switch store.inspectorTab {
@@ -111,6 +118,9 @@ struct FileBrowserView: View {
                 QLPreviewPanel.shared().reloadData()
             }
         }
+        .onChange(of: browserState.showHiddenFiles) {
+            refresh()
+        }
     }
 
     /// Whether `url` points at a directory — used to open only files on selection.
@@ -125,7 +135,7 @@ struct FileBrowserView: View {
             FileTreeList(
                 nodes: root.children ?? [],
                 selection: $browserState.selection,
-                font: settings.interfaceFont,
+                font: compactFont,
                 onDrop: { sources, destination in receive(sources, into: destination) },
                 rootURL: root.url,
                 actions: treeActions
@@ -170,6 +180,12 @@ struct FileBrowserView: View {
             TreeHeaderButton(codicon: .newFolder, help: "New Folder") {
                 createFolder(in: root.url)
             }
+            TreeHeaderButton(
+                systemName: browserState.showHiddenFiles ? "eye" : "eye.slash",
+                help: browserState.showHiddenFiles ? "Hide Hidden Files" : "Show Hidden Files"
+            ) {
+                browserState.showHiddenFiles.toggle()
+            }
             TreeHeaderButton(codicon: .refresh, help: "Refresh") {
                 refresh()
             }
@@ -179,7 +195,7 @@ struct FileBrowserView: View {
         }
         .padding(.leading, 14)
         .padding(.trailing, 8)
-        .padding(.vertical, 6)
+        .padding(.vertical, 3)
     }
 
     /// Seeds the switcher's Changes badge with the repo's dirty-file count, so it is
@@ -199,7 +215,7 @@ struct FileBrowserView: View {
             root = nil
             return
         }
-        root = FileNode(url: URL(fileURLWithPath: projectPath), isDirectory: true)
+        root = FileNode(url: URL(fileURLWithPath: projectPath), isDirectory: true, showHidden: browserState.showHiddenFiles)
     }
 
     /// Places each dropped file into `destination` (a folder inside the tree, or the

--- a/Sources/termio/FileBrowser/FileNode.swift
+++ b/Sources/termio/FileBrowser/FileNode.swift
@@ -9,16 +9,14 @@ import Foundation
 final class FileNode: Identifiable {
     let url: URL
     let isDirectory: Bool
-    let showHidden: Bool
     var id: URL { url }
     var name: String { url.lastPathComponent }
 
     private var loadedChildren: [FileNode]?
 
-    init(url: URL, isDirectory: Bool, showHidden: Bool) {
+    init(url: URL, isDirectory: Bool) {
         self.url = url
         self.isDirectory = isDirectory
-        self.showHidden = showHidden
     }
 
     /// `nil` for a file (so the outline draws no disclosure triangle); a folder's
@@ -27,32 +25,28 @@ final class FileNode: Identifiable {
     var children: [FileNode]? {
         guard isDirectory else { return nil }
         if let loadedChildren { return loadedChildren }
-        let contents = FileNode.readContents(of: url, showHidden: showHidden)
+        let contents = FileNode.readContents(of: url)
         loadedChildren = contents
         return contents
     }
 
     /// Directory entries, folders first then files, each alphabetized the way the
-    /// Finder orders names. Hidden entries are dropped (`.git`, dotfiles), as are a
-    /// few heavy build directories that would only bloat the tree.
-    private static func readContents(of url: URL, showHidden: Bool) -> [FileNode] {
+    /// Finder orders names. Dotfiles are shown (the VS Code explorer default); only the
+    /// VCS/OS metadata in `ignoredNames` is dropped — matching VS Code's own default
+    /// `files.exclude`, which likewise leaves `node_modules`/build folders visible.
+    private static func readContents(of url: URL) -> [FileNode] {
         let manager = FileManager.default
-        let options: FileManager.DirectoryEnumerationOptions = showHidden ? [] : [.skipsHiddenFiles]
         guard let entries = try? manager.contentsOfDirectory(
             at: url,
             includingPropertiesForKeys: [.isDirectoryKey],
-            options: options
+            options: []
         ) else { return [] }
 
         return entries
-            .filter { entry in
-                let name = entry.lastPathComponent
-                if alwaysIgnored.contains(name) { return false }
-                return !ignoredNames.contains(name)
-            }
+            .filter { !ignoredNames.contains($0.lastPathComponent) }
             .map { entry in
                 let isDirectory = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-                return FileNode(url: entry, isDirectory: isDirectory, showHidden: showHidden)
+                return FileNode(url: entry, isDirectory: isDirectory)
             }
             .sorted { left, right in
                 if left.isDirectory != right.isDirectory { return left.isDirectory }
@@ -60,10 +54,9 @@ final class FileNode: Identifiable {
             }
     }
 
-    /// Hidden directories that are always noise and should not be shown even if showing hidden files.
-    private static let alwaysIgnored: Set<String> = [".git", ".DS_Store"]
-
-    /// Non-hidden directories that are noise in a project tree (the hidden ones —
-    /// `.git`, `.DS_Store` — are already excluded by `.skipsHiddenFiles`).
-    private static let ignoredNames: Set<String> = ["node_modules", ".build", "DerivedData"]
+    /// VCS and OS metadata that is always noise, dropped even though dotfiles are
+    /// otherwise shown. Mirrors VS Code's default `files.exclude`
+    /// (`.git`/`.svn`/`.hg`/`.DS_Store`/`Thumbs.db`); like VS Code it does *not* hide
+    /// `node_modules` or build output — those stay visible, loaded lazily on expand.
+    private static let ignoredNames: Set<String> = [".git", ".svn", ".hg", ".DS_Store", "Thumbs.db"]
 }

--- a/Sources/termio/FileBrowser/FileNode.swift
+++ b/Sources/termio/FileBrowser/FileNode.swift
@@ -9,14 +9,16 @@ import Foundation
 final class FileNode: Identifiable {
     let url: URL
     let isDirectory: Bool
+    let showHidden: Bool
     var id: URL { url }
     var name: String { url.lastPathComponent }
 
     private var loadedChildren: [FileNode]?
 
-    init(url: URL, isDirectory: Bool) {
+    init(url: URL, isDirectory: Bool, showHidden: Bool) {
         self.url = url
         self.isDirectory = isDirectory
+        self.showHidden = showHidden
     }
 
     /// `nil` for a file (so the outline draws no disclosure triangle); a folder's
@@ -25,7 +27,7 @@ final class FileNode: Identifiable {
     var children: [FileNode]? {
         guard isDirectory else { return nil }
         if let loadedChildren { return loadedChildren }
-        let contents = FileNode.readContents(of: url)
+        let contents = FileNode.readContents(of: url, showHidden: showHidden)
         loadedChildren = contents
         return contents
     }
@@ -33,25 +35,33 @@ final class FileNode: Identifiable {
     /// Directory entries, folders first then files, each alphabetized the way the
     /// Finder orders names. Hidden entries are dropped (`.git`, dotfiles), as are a
     /// few heavy build directories that would only bloat the tree.
-    private static func readContents(of url: URL) -> [FileNode] {
+    private static func readContents(of url: URL, showHidden: Bool) -> [FileNode] {
         let manager = FileManager.default
+        let options: FileManager.DirectoryEnumerationOptions = showHidden ? [] : [.skipsHiddenFiles]
         guard let entries = try? manager.contentsOfDirectory(
             at: url,
             includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
+            options: options
         ) else { return [] }
 
         return entries
-            .filter { !ignoredNames.contains($0.lastPathComponent) }
+            .filter { entry in
+                let name = entry.lastPathComponent
+                if alwaysIgnored.contains(name) { return false }
+                return !ignoredNames.contains(name)
+            }
             .map { entry in
                 let isDirectory = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-                return FileNode(url: entry, isDirectory: isDirectory)
+                return FileNode(url: entry, isDirectory: isDirectory, showHidden: showHidden)
             }
             .sorted { left, right in
                 if left.isDirectory != right.isDirectory { return left.isDirectory }
                 return left.name.localizedStandardCompare(right.name) == .orderedAscending
             }
     }
+
+    /// Hidden directories that are always noise and should not be shown even if showing hidden files.
+    private static let alwaysIgnored: Set<String> = [".git", ".DS_Store"]
 
     /// Non-hidden directories that are noise in a project tree (the hidden ones —
     /// `.git`, `.DS_Store` — are already excluded by `.skipsHiddenFiles`).

--- a/Sources/termio/FileBrowser/FileTreeList.swift
+++ b/Sources/termio/FileBrowser/FileTreeList.swift
@@ -33,6 +33,9 @@ struct FileTreeList: View {
         // `FileBrowserView.body`) shows through — the file column lives in a plain split item, not
         // a panel item, so it carries no system vibrant background of its own.
         .scrollContentBackground(.hidden)
+        // Let each row size to its own content (icon/text + the row's vertical padding)
+        // rather than forcing a tall minimum — a large min height paints an empty
+        // highlight band above/below the label on hover/selection.
         .environment(\.defaultMinListRowHeight, 1)
         // A right-click in the empty area below the rows offers New File / New Folder
         // at the project root — the rows' own menus take the clicks that land on them.
@@ -62,9 +65,9 @@ private struct FileRow: View {
     var body: some View {
         // One explicit HStack for both kinds (not `Label`, whose internal insets shift
         // the title): a folder is just its name pulled flush to the disclosure chevron
-        // (VS Code, no glyph); a file leads with its type icon. Because both start at
-        // the HStack's leading edge, a folder's name lines up exactly under the file
-        // icons below it.
+        // (VS Code, no glyph — cleaner without a folder icon); a file leads with its
+        // type icon. Because both start at the HStack's leading edge, a folder's name
+        // lines up exactly under the file icons below it.
         let row = HStack(spacing: 5) {
             if !node.isDirectory {
                 // The file's real language/tool logo (a Devicon mark) when bundled,
@@ -77,12 +80,14 @@ private struct FileRow: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
         }
-        // Tighten the generous default sidebar-row height into a denser tree, the
-        // way the project sidebar floors its own rows.
-        .padding(.vertical, 0)
-        // Tight padding (2) to minimize the gap between the folder chevron and name,
-        // aligning the child chevron at X=20 directly under the parent text.
-        .padding(.leading, 2)
+        // A denser tree than the system default, but with enough vertical breathing
+        // room that rows aren't cramped (paired with `defaultMinListRowHeight` below).
+        .padding(.vertical, 2)
+        // Pull the row left toward the disclosure chevron — SwiftUI's default
+        // chevron-to-content gap is wider than VS Code / Xcode, which sit the label
+        // tight to the arrow. Applied to both kinds so folder names and file icons
+        // share one column.
+        .padding(.leading, -6)
         // Fill the row so the tap target — and any folder drop target — spans its
         // full width, not just the label's footprint.
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/termio/FileBrowser/FileTreeList.swift
+++ b/Sources/termio/FileBrowser/FileTreeList.swift
@@ -25,8 +25,10 @@ struct FileTreeList: View {
         // own `SidebarRowHighlight` as the sole, left-sidebar-matching selection cue.
         List(nodes, children: \.children, selection: $selection) { node in
             FileRow(node: node, font: font, isSelected: selection == node.url, onDrop: onDrop, actions: actions)
+                .listRowSeparator(.hidden)
         }
-        .listStyle(.sidebar)
+        .listStyle(.plain)
+        .padding(.leading, 12)
         // Drop the list's own backing so the terminal-colored background behind it (see
         // `FileBrowserView.body`) shows through — the file column lives in a plain split item, not
         // a panel item, so it carries no system vibrant background of its own.
@@ -77,11 +79,10 @@ private struct FileRow: View {
         }
         // Tighten the generous default sidebar-row height into a denser tree, the
         // way the project sidebar floors its own rows.
-        .padding(.vertical, 1)
-        // Nudge the whole row off the disclosure chevron so a folder name isn't
-        // crowded against the arrow. Applied to both kinds, so folder names and file
-        // icons stay in the same column.
-        .padding(.leading, 6)
+        .padding(.vertical, 0)
+        // Tight padding (2) to minimize the gap between the folder chevron and name,
+        // aligning the child chevron at X=20 directly under the parent text.
+        .padding(.leading, 2)
         // Fill the row so the tap target — and any folder drop target — spans its
         // full width, not just the label's footprint.
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## 简介
这个 PR 实现了用户对 Files 标签页的紧凑布局、对齐优化、移除分割线以及支持显示/隐藏隐藏文件功能。

## 改动内容

1. **更紧凑且对齐的列表布局**:
   - 将 `FileTreeList` 切换为 `.listStyle(.plain)`，天然实现更紧凑的行高，移除了可能导致 `AttributeGraph` 崩溃的运行时 AppKit 布局强行修改。
   - 整体 List 容器增加左侧 `12pt` 边距，使文件夹展开箭头与顶部 `ADSBAO` 标题在 **X=14** 位置完美对齐。
   - 优化 `FileRow` 单元格间距为 `.padding(.leading, 2)`，使文件夹名称与文件名称在 **X=35** 完美对齐，文件夹 chevron 箭头与文件图标在 **X=14** 完美对齐。
   - 移除了自定义 `indentation` 覆盖，使用系统默认的 16pt 缩进，层级间的 chevron 在父级文本正下方对齐。
   - 使用 `.listRowSeparator(.hidden)` 隐藏了平铺列表下的水平分割线。

2. **支持显示/隐藏隐藏文件**:
   - 在 `FileBrowserState` 中新增 `showHiddenFiles` 状态。
   - 在 Files 面板右上角增加眼睛图标按钮（`eye` / `eye.slash`），支持一键切换隐藏文件显示状态。
   - 过滤掉无关的项目噪音（如 `.git` 和 `.DS_Store`），其余隐藏文件/文件夹在切换显示时能正常渲染并展开。

<img width="2752" height="2086" alt="image" src="https://github.com/user-attachments/assets/937dfe11-5893-45e1-a695-f5c2d8ffb173" />

