### PR TITLE
feat(sidebar): add Fixed project sort order and expose sort in Settings

### DIFF
--- a/Sources/termio/Settings/InterfaceSettingsTab.swift
+++ b/Sources/termio/Settings/InterfaceSettingsTab.swift
@@ -41,6 +41,19 @@ struct InterfaceSettingsTab: View {
             } header: {
                 SectionHeaderLabel(title: "Density")
             }
+            Section {
+                Picker("Sort", selection: $settings.projectSortOrder) {
+                    ForEach(ProjectSortOrder.allCases) { order in
+                        Text(order.displayName).tag(order)
+                    }
+                }
+            } header: {
+                SectionHeaderLabel(title: "Project order")
+            } footer: {
+                Text("How the sidebar orders projects (pinned always first). Fixed holds the order you added them; Recent Activity floats the active project to the top.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
     }

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -43,6 +43,7 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
 /// sort ahead of the rest (see `TermioStore.orderedProjects`); this decides the order
 /// within each group.
 enum ProjectSortOrder: String, CaseIterable, Identifiable {
+    case fixed
     /// Most recently active project first — a project rises whenever one of its
     /// agents reports work (or the user switches to one of its sessions).
     case recentActivity
@@ -53,6 +54,7 @@ enum ProjectSortOrder: String, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
+        case .fixed: return "Fixed"
         case .recentActivity: return "Recent Activity"
         case .name: return "Name"
         }
@@ -370,7 +372,7 @@ final class AppSettings: ObservableObject {
             Key.interfaceRowPadding: 2.0,
             Key.agentHooksEnabled: false,
             Key.sessionControlEnabled: false,
-            Key.projectSortOrder: "recentActivity",
+            Key.projectSortOrder: "fixed",
         ])
 
         fontFamily = defaults.string(forKey: Key.fontFamily) ?? ""
@@ -396,7 +398,7 @@ final class AppSettings: ObservableObject {
         sessionControlEnabled = defaults.bool(forKey: Key.sessionControlEnabled)
         usageAuthorizedAgents = Set(defaults.stringArray(forKey: Key.usageAuthorizedAgents) ?? [])
         claudeKeychainDeclined = defaults.bool(forKey: Key.claudeKeychainDeclined)
-        projectSortOrder = defaults.string(forKey: Key.projectSortOrder).flatMap(ProjectSortOrder.init) ?? .recentActivity
+        projectSortOrder = defaults.string(forKey: Key.projectSortOrder).flatMap(ProjectSortOrder.init) ?? .fixed
         recentProjects = defaults.data(forKey: Key.recentProjects)
             .flatMap { try? JSONDecoder().decode([RecentProject].self, from: $0) } ?? []
         lastChatAgentID = defaults.string(forKey: Key.lastChatAgent)

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -397,6 +397,8 @@ extension TermioStore {
             // Pinned projects always float to the top, whichever sort is active.
             if a.pinned != b.pinned { return a.pinned }
             switch order {
+            case .fixed:
+                return false
             case .name:
                 return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
             case .recentActivity:


### PR DESCRIPTION
## Problem

The sidebar's default (and only meaningful) sort was **Recent Activity**, which floats the active project to the top. So selecting or switching a project reshuffled the whole list on every focus — the order was never stable.

## Fix

- Add a **Fixed** sort order that keeps projects in the order they were added — nothing floats on activity or selection — and make it the new default.
- Expose the sort as a picker in **Settings › Interface**, kept in sync with the sidebar's existing sort menu.
- **Recent Activity** and **Name** remain available.

<img width="737" height="541" alt="image" src="https://github.com/user-attachments/assets/cb3fe448-6330-48ef-ae2b-68e9b3d5176c" />

