### PR TITLE
fix(git): show images from the Changes pane instead of an empty diff

### DIFF
--- a/Sources/termio/Editor/FileActivation.swift
+++ b/Sources/termio/Editor/FileActivation.swift
@@ -10,6 +10,15 @@ enum FileActivation {
         previewExtensions.contains(url.pathExtension.lowercased())
     }
 
+    /// Previewable files whose git diff isn't useful: image rasters, SVG art, and PDFs are
+    /// binary or opaque, so the Changes pane opens the file itself rather than a "binary files
+    /// differ" / empty diff. HTML keeps its (meaningful) text diff.
+    static func previewsRatherThanDiff(_ url: URL) -> Bool {
+        guard isPreviewable(url) else { return false }
+        let ext = url.pathExtension.lowercased()
+        return ext != "html" && ext != "htm"
+    }
+
     private static let previewExtensions: Set<String> = [
         "png", "jpg", "jpeg", "gif", "webp", "heic", "heif", "tiff", "bmp", "icns", "svg",
         "pdf", "html", "htm",

--- a/Sources/termio/FilePreview.swift
+++ b/Sources/termio/FilePreview.swift
@@ -64,15 +64,14 @@ struct FilePreviewView: View {
             WebPreview(url: url)
         case .image:
             // NSImage decodes the raster formats; anything it can't (e.g. some SVGs) falls back to
-            // the web view, which renders vector art reliably.
+            // the web view, which renders vector art reliably. The image fits the pane by default —
+            // large images scale down to fit rather than overflow, small ones center.
             if let image = NSImage(contentsOf: url) {
-                ScrollView([.horizontal, .vertical]) {
-                    Image(nsImage: image)
-                        .resizable()
-                        .scaledToFit()
-                        .padding(24)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .padding(24)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 WebPreview(url: url)
             }

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -150,7 +150,15 @@ struct GitChangesView: View {
     }
 
     private func open(_ change: GitChange) {
-        store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: change)
+        // An image/SVG/PDF has no meaningful text diff, so show the file itself in the preview
+        // overlay. A deleted file is gone from disk, so fall back to the diff (its empty result
+        // is the honest one).
+        let url = fileURL(for: change)
+        if FileActivation.previewsRatherThanDiff(url), FileManager.default.fileExists(atPath: url.path) {
+            store.openFileInEditor(url)
+        } else {
+            store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: change)
+        }
     }
 
     // MARK: Row actions
@@ -207,7 +215,16 @@ struct GitChangesView: View {
     /// never fires. Deselection is ignored — closing the diff is the overlay's own job.
     private var selectedPath: Binding<String?> {
         Binding(
-            get: { store.openDiff?.commit == nil ? store.openDiff?.change.path : nil },
+            get: {
+                if let diff = store.openDiff, diff.commit == nil { return diff.change.path }
+                // Image/SVG/PDF changes open in the preview overlay, not the diff — match the
+                // open file back to its row so the selection stays put while it's up.
+                if let open = store.openFileURL?.standardizedFileURL,
+                   let change = model.changes.first(where: { fileURL(for: $0).standardizedFileURL == open }) {
+                    return change.path
+                }
+                return nil
+            },
             set: { path in
                 if let change = model.changes.first(where: { $0.path == path }) { open(change) }
             }


### PR DESCRIPTION
## Problem

Clicking an image (PNG/JPEG/SVG) in the git **Changes** pane opened a text diff. Git reports images as binary, so the diff came back empty — you got the **"No Diff"** state instead of the image.

## Fix

- Route image/SVG/PDF changes to the **preview overlay** (the same viewer the file browser uses) instead of a text diff. Deleted files keep the diff, and the row stays selected while the image is open.
- Fit previewed images to the pane **by default** — drop the bidirectional scroll wrapper so large images scale down instead of overflowing.

HTML changes are untouched (their text diff is still useful).
