### PR TITLE
feat(sidebar): default project sort to Name

### DIFF
--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -370,7 +370,7 @@ final class AppSettings: ObservableObject {
             Key.interfaceRowPadding: 2.0,
             Key.agentHooksEnabled: false,
             Key.sessionControlEnabled: false,
-            Key.projectSortOrder: "recentActivity",
+            Key.projectSortOrder: "name",
         ])
 
         fontFamily = defaults.string(forKey: Key.fontFamily) ?? ""
@@ -396,7 +396,7 @@ final class AppSettings: ObservableObject {
         sessionControlEnabled = defaults.bool(forKey: Key.sessionControlEnabled)
         usageAuthorizedAgents = Set(defaults.stringArray(forKey: Key.usageAuthorizedAgents) ?? [])
         claudeKeychainDeclined = defaults.bool(forKey: Key.claudeKeychainDeclined)
-        projectSortOrder = defaults.string(forKey: Key.projectSortOrder).flatMap(ProjectSortOrder.init) ?? .recentActivity
+        projectSortOrder = defaults.string(forKey: Key.projectSortOrder).flatMap(ProjectSortOrder.init) ?? .name
         recentProjects = defaults.data(forKey: Key.recentProjects)
             .flatMap { try? JSONDecoder().decode([RecentProject].self, from: $0) } ?? []
         lastChatAgentID = defaults.string(forKey: Key.lastChatAgent)


### PR DESCRIPTION
## Problem

The sidebar's default sort was **Recent Activity**, which floats the active project to the top. `liveActivity[project]` gets stamped whenever you focus one of a project's sessions (or one of its agents changes status), so **selecting or switching a project reshuffled the whole list on every focus** — the order was never stable, and spatial/muscle memory never worked.

## Fix

- Change the default `projectSortOrder` from `recentActivity` to **`name`** (both the registered default and the decode fallback).
- `name` is a stable A→Z sort that never depends on activity, so the sidebar holds still and you can locate a project by first letter.
- **Recent Activity** and **Name** both remain selectable — this only changes the default.

Two-line change; no new sort mode, no new UI, no migration.

## Context / follow-up

This supersedes #10, which added a `Fixed` (insertion-order) sort as the default. `Fixed` relied on the persisted `projects` array order, which our worktree/discovery reconciliation can perturb, and `Project` has no `createdAt` to anchor it. `name` fixes the same reshuffle problem with zero new state.

A proper **manual ordering** (an explicit per-project order index + drag-to-reorder, the Xcode/Finder/Dock model) is the fuller answer and is worth doing later — but it's a separate, larger change. For now this just makes the default stable.