### PR TITLE
feat(agents): promote working status from sustained screen activity

### DIFF
--- a/Sources/termio/PTYProcess.swift
+++ b/Sources/termio/PTYProcess.swift
@@ -465,6 +465,7 @@ final class PTYProcess: @unchecked Sendable {
         writeLock.lock()
         defer { writeLock.unlock() }
         guard !writerTornDown else { return }
+        lastInputAtLocked = Date()
         // Once a backlog exists every write must append behind it, or these
         // bytes would overtake the queued remainder and reorder the stream.
         guard pendingWrite.isEmpty else {
@@ -477,6 +478,21 @@ final class PTYProcess: @unchecked Sendable {
         case .blocked(let resumeAt):
             appendBacklogLocked(data.subdata(in: resumeAt ..< data.count))
         }
+    }
+
+    /// Instant of the last stdin write — every keystroke, paste, and synthetic
+    /// `sessions send` from the Mac *or* the phone funnels through `write(_:)`,
+    /// so this is the one place input can be timestamped for both devices.
+    /// Guarded by `writeLock` like the rest of the writer state.
+    private var lastInputAtLocked = Date.distantPast
+
+    /// Thread-safe read of the last stdin-write instant. The status tap uses it
+    /// to tell input echo apart from agent-driven output (see
+    /// `TermioStore.noteOutputActivity`).
+    var lastInputAt: Date {
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        return lastInputAtLocked
     }
 
     /// Result of pushing bytes at the non-blocking write fd.

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -120,22 +120,71 @@ extension TermioStore {
     private func clearWorking(_ id: Session.ID) {
         currentTool[id] = nil
         lastWorkingAt[id] = nil
+        promotionStreaks[id] = nil
     }
 
-    /// Refreshes a working session's activity timestamp when the rendered screen
-    /// changed. A genuinely working agent repaints changing content (its ticking
-    /// spinner, streaming tokens) every second, so a changing viewport means the
-    /// turn is still live; the moment the screen goes static (the agent is back at
-    /// its prompt), the timestamp stops advancing and `sweepStaleWorking` can clear
-    /// the spinner. Keying on the *screen* rather than raw bytes is what closes the
+    /// How many consecutive changed-screen pokes (at the tap's ~1s cadence) an
+    /// un-working agent session must show before it is promoted back to
+    /// `.working`, and how large a gap between pokes breaks the run. Three
+    /// pokes ≈ 3s of sustained repaint — long enough to skip one-off redraws
+    /// (a resize, a settled prompt), short enough that a missed hook shows a
+    /// spinner within a few seconds of real streaming.
+    private var promotionStreakThreshold: Int { 3 }
+    private var promotionStreakMaxGap: TimeInterval { 5 }
+
+    /// Judges a session's liveness — and, when the evidence is sustained, its
+    /// working-ness — from the rendered screen. Two directions share this tap:
+    ///
+    /// **Sustain** — while `.working`, a changing viewport keeps `lastWorkingAt`
+    /// fresh; the moment the screen goes static (the agent is back at its
+    /// prompt), the timestamp stops advancing and `sweepStaleWorking` clears the
+    /// spinner. Keying on the *screen* rather than raw bytes is what closes the
     /// gap for a finished agent that keeps dribbling output at an idle prompt (a
-    /// redraw, a blinking cursor) — the stuck-spinner failure. No-op unless the
-    /// session is actually spinning, so idle sessions cost nothing. Fed by a
-    /// throttled tap on the PTY stream (see `surface(for:in:)`).
-    func noteOutputActivity(_ id: Session.ID, screenChanged: Bool) {
-        guard statuses[id] == .working else { return }
-        guard screenChanged else { return }
-        lastWorkingAt[id] = Date()
+    /// redraw, a blinking cursor) — the stuck-spinner failure.
+    ///
+    /// **Promote** — hooks are the primary working authority, but a single
+    /// missed `working` report (a failed hook script, an early `Stop` on a
+    /// continued turn) used to pin the row calm forever while output streamed:
+    /// this tap could only sustain, never start, a spinner. A sustained run of
+    /// changed-screen pokes now flips an agent row back to `.working`, behind
+    /// four guards: only agent sessions (a bare terminal never spins), never
+    /// while `needsAttention` is asserted (a blocked prompt repaints too — the
+    /// hook keeps sole authority over attention), never within the input-echo
+    /// window (typing a prompt repaints the composer sub-second), and only
+    /// after `promotionStreakThreshold` consecutive pokes (a one-off redraw is
+    /// not a turn). Downgrades still come only from hooks and the stale sweep,
+    /// so hooks remain the one authority for attention/done.
+    ///
+    /// Fed by a throttled tap on the PTY stream (see `surface(for:in:)`);
+    /// `inputRecently` derives from `PTYProcess.lastInputAt`, which both the
+    /// Mac and phone input paths stamp.
+    func noteOutputActivity(_ id: Session.ID, screenChanged: Bool, inputRecently: Bool) {
+        if statuses[id] == .working {
+            promotionStreaks[id] = nil
+            guard screenChanged else { return }
+            lastWorkingAt[id] = Date()
+            return
+        }
+        guard screenChanged, !inputRecently else {
+            promotionStreaks[id] = nil
+            return
+        }
+        guard statuses[id] != .needsAttention else { return }
+        guard let session = session(id), effectiveAgent(for: session) != .terminal else { return }
+        let now = Date()
+        var streak = promotionStreaks[id] ?? (count: 0, last: now)
+        if now.timeIntervalSince(streak.last) > promotionStreakMaxGap {
+            streak = (count: 0, last: now)
+        }
+        streak = (count: streak.count + 1, last: now)
+        guard streak.count >= promotionStreakThreshold else {
+            promotionStreaks[id] = streak
+            return
+        }
+        promotionStreaks[id] = nil
+        statuses[id] = .working
+        lastWorkingAt[id] = now
+        if let pid = project(for: id)?.id { liveActivity[pid] = now }
     }
 
     /// Drives status from an agent's own screen when it ships no hook system — the path

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -494,6 +494,7 @@ extension TermioStore {
             liveTitles[sessionID] = nil
             detectedAgents[sessionID] = nil
             lastWorkingAt[sessionID] = nil
+            promotionStreaks[sessionID] = nil
         }
         projects.remove(at: projectIndex)
 
@@ -555,6 +556,7 @@ extension TermioStore {
         liveTitles[id] = nil
         detectedAgents[id] = nil
         lastWorkingAt[id] = nil
+        promotionStreaks[id] = nil
 
         // If the session held a split pane, collapse that pane; when it was also
         // the focused pane the prune moves the selection to its layout neighbor,

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -202,10 +202,15 @@ extension TermioStore {
             let statusTrace = ProcessInfo.processInfo.environment["TERMIO_STATUS_TRACE"] != nil
             var lastPoke = Date.distantPast
             var lastScreenSignature: Int?
-            pty.addSink { [weak self, weak inMemory] _ in
+            pty.addSink { [weak self, weak inMemory, weak pty] _ in
                 let now = Date()
                 guard now.timeIntervalSince(lastPoke) >= 1 else { return }
                 lastPoke = now
+                // Freshly-typed input repaints the composer too; the promotion
+                // path in `noteOutputActivity` must not read that echo as a
+                // working turn. 1.5s outlasts the echo of the final keystroke
+                // while barely delaying promotion once real streaming starts.
+                let inputRecently = now.timeIntervalSince(pty?.lastInputAt ?? .distantPast) < 1.5
                 let text = inMemory?.readViewportText()
                 let screenChanged: Bool
                 if let text {
@@ -229,7 +234,8 @@ extension TermioStore {
                     detected = nil
                 }
                 DispatchQueue.main.async {
-                    self?.noteOutputActivity(session.id, screenChanged: screenChanged)
+                    self?.noteOutputActivity(
+                        session.id, screenChanged: screenChanged, inputRecently: inputRecently)
                     if let detected {
                         self?.applyScreenDetectedActivity(detected, for: session.id)
                     }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -249,6 +249,11 @@ final class TermioStore: ObservableObject {
     /// Refreshed both by working hooks and by a *changed* rendered screen
     /// (`noteOutputActivity`).
     var lastWorkingAt: [Session.ID: Date] = [:]
+    /// Consecutive changed-screen pokes seen for an agent session that is *not*
+    /// `.working` — the evidence meter behind hook-miss promotion (see
+    /// `noteOutputActivity`). Reset the moment the run of pokes breaks, so only
+    /// a genuinely sustained repaint can flip a session back to `.working`.
+    var promotionStreaks: [Session.ID: (count: Int, last: Date)] = [:]
     /// The last activity a screen-scrape-configured agent's viewport was classified
     /// into (see `AgentStatusRules` / `applyScreenDetectedActivity`), so status is only
     /// re-driven on a transition — not re-emitted every tick the screen sits idle.


### PR DESCRIPTION
## Problem

A missed `working` hook left a session's sidebar dot stuck at calm while output streamed. `noteOutputActivity` had a one-way guard — it could **sustain** an existing `.working` but never **start** one — so a single lost hook report (failed hook script, early `Stop` on a continued turn) had no self-healing path. Today's stale-CLI outage made the whole class visible at once.

## Fix

Let the existing 1s screen tap promote an agent row back to `.working` when repaint evidence is sustained, behind four guards:

1. **Agent sessions only** — same `effectiveAgent != .terminal` check the hook path uses; a bare terminal never spins.
2. **Never over `needsAttention`** — a blocked permission prompt repaints too; hooks keep sole authority over attention.
3. **Input-echo window** — `PTYProcess.write` now timestamps every stdin write (one choke point covers Mac keyboard, phone companion, and `sessions send`); pokes within 1.5s of input don't count, so typing a prompt can't fake a turn.
4. **Streak threshold** — three consecutive changed-screen pokes (~3s of real streaming); a one-off redraw or resize is not a turn, and a >5s gap breaks the run.

Downgrades are untouched: only hooks and `sweepStaleWorking` ever clear the spinner, so hooks remain the one authority for `attention`/`done` (one-authority-per-pane holds).

## Known edges (accepted)

- A TUI that *continuously animates while idle* would false-promote — no built-in agent does this today (Claude/Codex idle screens are static).
- Viewport-follows-scrollback staleness is pre-existing (documented in `TermioStore+TerminalSurface.swift`) and orthogonal; scroll alone can't trigger the tap since the sink only fires on PTY output.

## Testing

- `swift build` clean.
- Manual: hooks disabled → start a Claude turn → row spins within ~4s of streaming; typing a long prompt does not spin; blocked permission prompt stays `needsAttention`.