### PR TITLE
fix(agents): make working status survive hook loss

### DIFF
--- a/Sources/termio/PTYProcess.swift
+++ b/Sources/termio/PTYProcess.swift
@@ -465,6 +465,7 @@ final class PTYProcess: @unchecked Sendable {
         writeLock.lock()
         defer { writeLock.unlock() }
         guard !writerTornDown else { return }
+        lastInputAtLocked = Date()
         // Once a backlog exists every write must append behind it, or these
         // bytes would overtake the queued remainder and reorder the stream.
         guard pendingWrite.isEmpty else {
@@ -477,6 +478,22 @@ final class PTYProcess: @unchecked Sendable {
         case .blocked(let resumeAt):
             appendBacklogLocked(data.subdata(in: resumeAt ..< data.count))
         }
+    }
+
+    /// Instant of the last stdin write. Every input path funnels through
+    /// `write(_:)` — Mac keystrokes via the surface's write callback, phone
+    /// keystrokes via the companion bridge, synthetic `sessions send` text — so
+    /// this is the one place input can be timestamped for all of them. Guarded
+    /// by `writeLock` like the rest of the writer state.
+    private var lastInputAtLocked = Date.distantPast
+
+    /// Thread-safe read of the last stdin-write instant. The status tap reads it
+    /// each poke to tell input echo apart from agent-driven output (see
+    /// `TermioStore.noteUserInput`).
+    var lastInputAt: Date {
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        return lastInputAtLocked
     }
 
     /// Result of pushing bytes at the non-blocking write fd.

--- a/Sources/termio/Resources/agents/claude.json
+++ b/Sources/termio/Resources/agents/claude.json
@@ -18,8 +18,7 @@
       { "on": "PreToolUse", "state": "working", "matcher": "*" },
       { "on": "PostToolUse", "state": "working", "matcher": "*" },
       { "on": "PermissionRequest", "state": "attention", "matcher": "*" },
-      { "on": "Stop", "state": "done" },
-      { "on": "SubagentStop", "state": "working" }
+      { "on": "Stop", "state": "done" }
     ]
   }
 }

--- a/Sources/termio/Resources/agents/codex.json
+++ b/Sources/termio/Resources/agents/codex.json
@@ -17,8 +17,7 @@
       { "on": "PreToolUse", "state": "working" },
       { "on": "PostToolUse", "state": "working" },
       { "on": "PermissionRequest", "state": "attention" },
-      { "on": "Stop", "state": "done" },
-      { "on": "SubagentStop", "state": "working" }
+      { "on": "Stop", "state": "done" }
     ]
   }
 }

--- a/Sources/termio/Resources/agents/grok.json
+++ b/Sources/termio/Resources/agents/grok.json
@@ -16,8 +16,7 @@
       { "on": "UserPromptSubmit", "state": "working" },
       { "on": "PreToolUse", "state": "working" },
       { "on": "PostToolUse", "state": "working" },
-      { "on": "Stop", "state": "done" },
-      { "on": "SubagentStop", "state": "working" }
+      { "on": "Stop", "state": "done" }
     ]
   }
 }

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -78,6 +78,11 @@ extension TermioStore {
             // same result as Claude's hook-carried path, just discovered.
             transcriptPaths[id] = path
         }
+        // Any recognized report proves this session's hooks are alive and speaking,
+        // which tells the screen-driven promotion to stand down (`hookQuietWindow`).
+        if ["working", "done", "attention", "idle"].contains(report.state) {
+            lastHookReportAt[id] = Date()
+        }
         switch report.state {
         case "working":
             // Spin a row only when it's genuinely an agent: a declared agent session,
@@ -120,22 +125,78 @@ extension TermioStore {
     private func clearWorking(_ id: Session.ID) {
         currentTool[id] = nil
         lastWorkingAt[id] = nil
+        promotionStreak[id] = nil
     }
 
-    /// Refreshes a working session's activity timestamp when the rendered screen
-    /// changed. A genuinely working agent repaints changing content (its ticking
-    /// spinner, streaming tokens) every second, so a changing viewport means the
-    /// turn is still live; the moment the screen goes static (the agent is back at
-    /// its prompt), the timestamp stops advancing and `sweepStaleWorking` can clear
-    /// the spinner. Keying on the *screen* rather than raw bytes is what closes the
-    /// gap for a finished agent that keeps dribbling output at an idle prompt (a
-    /// redraw, a blinking cursor) — the stuck-spinner failure. No-op unless the
-    /// session is actually spinning, so idle sessions cost nothing. Fed by a
-    /// throttled tap on the PTY stream (see `surface(for:in:)`).
-    func noteOutputActivity(_ id: Session.ID, screenChanged: Bool) {
-        guard statuses[id] == .working else { return }
-        guard screenChanged else { return }
-        lastWorkingAt[id] = Date()
+    /// Marks the moment of live user input into a session's terminal (fed by the
+    /// surface's PTY write path). Keystroke echo and mouse-mode scrolling repaint
+    /// the screen exactly like agent output, so promotion holds off while the
+    /// human is the one causing the changes.
+    func noteUserInput(_ id: Session.ID) {
+        lastUserInputAt[id] = Date()
+    }
+
+    /// Keeps a session's status honest against its live output, in both directions.
+    ///
+    /// *Sustain*: while `.working`, a changed rendered screen (streaming tokens, a
+    /// ticking spinner) refreshes `lastWorkingAt` so `sweepStaleWorking` leaves the
+    /// turn alone; a static screen lets the timestamp age out — the recovery for a
+    /// turn that ended without a `Stop` hook. The screen, not raw bytes, is the
+    /// primary key: a finished agent still dribbles output at an idle prompt (a
+    /// redraw, a blinking cursor), which is exactly the stuck-spinner failure. The
+    /// byte-rate floor is the one exception — a viewport the user scrolled away
+    /// from stops changing even mid-stream (`readViewportText` follows the scroll),
+    /// so a genuinely streaming byte volume also counts as liveness.
+    ///
+    /// *Promote*: a session whose hooks have gone quiet can also come back the
+    /// other way. Hooks miss turns in the wild — an uninstalled/broken hook file, a
+    /// turn the sweep cleared mid-stream, an agent whose TUI never fires them — and
+    /// historically nothing could re-light the spinner until the next hook event.
+    /// Two consecutive changed ticks promote `.idle` back to `.working`, guarded
+    /// so precision states are never guessed over: never out of `.done` or
+    /// `.needsAttention`, not while recent hooks are speaking for the session
+    /// (`hookQuietWindow`), not right after launch (the banner painting), not right
+    /// after user input (keystroke echo), and never for a plain terminal or an
+    /// agent whose declared screen rules already own its status.
+    ///
+    /// Fed by a throttled once-a-second tap on the PTY stream (see
+    /// `surface(for:in:)`); no-ops cost a dictionary lookup.
+    func noteOutputActivity(_ id: Session.ID, screenChanged: Bool, bytes: Int) {
+        if statuses[id] == .working {
+            promotionStreak[id] = nil
+            if screenChanged || bytes >= streamingByteFloor {
+                lastWorkingAt[id] = Date()
+            }
+            return
+        }
+        guard screenChanged else {
+            promotionStreak[id] = nil
+            return
+        }
+        guard status(for: id) == .idle,
+              let session = session(id),
+              effectiveAgent(for: session) != .terminal,
+              effectiveAgent(for: session).statusRules == nil
+        else { return }
+        let now = Date()
+        if let launched = session.launchedAt, now.timeIntervalSince(launched) < launchGraceWindow {
+            return
+        }
+        if let input = lastUserInputAt[id], now.timeIntervalSince(input) < userInputQuietWindow {
+            return
+        }
+        if let report = lastHookReportAt[id], now.timeIntervalSince(report) < hookQuietWindow {
+            return
+        }
+        let streak = (promotionStreak[id] ?? 0) + 1
+        guard streak >= 2 else {
+            promotionStreak[id] = streak
+            return
+        }
+        promotionStreak[id] = nil
+        statuses[id] = .working
+        lastWorkingAt[id] = now
+        if let pid = project(for: id)?.id { liveActivity[pid] = now }
     }
 
     /// Drives status from an agent's own screen when it ships no hook system — the path

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -128,12 +128,16 @@ extension TermioStore {
         promotionStreak[id] = nil
     }
 
-    /// Marks the moment of live user input into a session's terminal (fed by the
-    /// surface's PTY write path). Keystroke echo and mouse-mode scrolling repaint
-    /// the screen exactly like agent output, so promotion holds off while the
-    /// human is the one causing the changes.
-    func noteUserInput(_ id: Session.ID) {
-        lastUserInputAt[id] = Date()
+    /// Marks the moment of live user input into a session's terminal. Keystroke
+    /// echo and mouse-mode scrolling repaint the screen exactly like agent
+    /// output, so promotion holds off while the human is the one causing the
+    /// changes. Fed each status poke from `PTYProcess.lastInputAt` — the choke
+    /// point every input path crosses (Mac surface, phone companion bridge,
+    /// synthetic `sessions send`) — hence the monotonic guard: a poke can only
+    /// carry the timestamp forward.
+    func noteUserInput(_ id: Session.ID, at instant: Date) {
+        if let existing = lastUserInputAt[id], existing >= instant { return }
+        lastUserInputAt[id] = instant
     }
 
     /// Keeps a session's status honest against its live output, in both directions.

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -494,6 +494,9 @@ extension TermioStore {
             liveTitles[sessionID] = nil
             detectedAgents[sessionID] = nil
             lastWorkingAt[sessionID] = nil
+            lastHookReportAt[sessionID] = nil
+            lastUserInputAt[sessionID] = nil
+            promotionStreak[sessionID] = nil
         }
         projects.remove(at: projectIndex)
 
@@ -555,6 +558,9 @@ extension TermioStore {
         liveTitles[id] = nil
         detectedAgents[id] = nil
         lastWorkingAt[id] = nil
+        lastHookReportAt[id] = nil
+        lastUserInputAt[id] = nil
+        promotionStreak[id] = nil
 
         // If the session held a split pane, collapse that pane; when it was also
         // the focused pane the prune moves the selection to its layout neighbor,

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -152,11 +152,15 @@ extension TermioStore {
         let pty = PTYProcess(argv: argv, cwd: workspacePath, env: env,
                              cols: lastHostGridColumns, rows: lastHostGridRows)
         let inMemory = InMemoryTerminalSession(
-            write: { data in
+            write: { [weak self] data in
                 // Typing on the Mac reclaims the winsize from an attached
                 // phone — the size follows the device being used.
                 pty?.claimHostOwnership()
                 pty?.write(data)
+                // Live input (keystrokes, mouse-mode scrolling) repaints the
+                // screen just like agent output, so the status promotion in
+                // `noteOutputActivity` holds off while the human is typing.
+                DispatchQueue.main.async { self?.noteUserInput(session.id) }
             },
             resize: { [weak self] viewport in
                 let columns = Int(viewport.columns)
@@ -168,20 +172,21 @@ extension TermioStore {
         )
         if let pty {
             pty.addSink { [weak inMemory] data in inMemory?.receive(data) }
-            // Tap the same stream as a working-liveness signal: while an agent is
-            // mid-turn its TUI repaints changing content (a ticking spinner,
-            // streaming tokens), so a *changing* screen keeps `lastWorkingAt`
-            // fresh and a screen that goes static lets the stale sweep clear the
-            // spinner — the recovery path for a turn that ends without a `Stop`
-            // hook. Liveness is judged on the rendered viewport, not raw bytes:
-            // an agent parked at an idle prompt still dribbles output (a redraw, a
-            // blinking cursor) that the byte stream alone reads as activity, which
-            // is what pins a finished agent's spinner on forever. `readViewportText`
-            // is thread-safe (its own lock), so the compare runs on the read pump;
-            // only the changed-flag hops to the main actor. Throttled to once a
-            // second and cheap when the session isn't spinning
-            // (`noteOutputActivity` no-ops). The read pump calls sinks serially, so
-            // the captured `lastPoke` / `lastScreenSignature` need no lock.
+            // Tap the same stream as a working-status signal (see
+            // `noteOutputActivity` for the full model): a *changing* rendered
+            // screen keeps a working session's `lastWorkingAt` fresh — and, when
+            // hooks have gone quiet, can promote an idle session back to working —
+            // while a static screen lets the stale sweep clear the spinner. The
+            // screen, not raw bytes, is the primary key: an agent parked at an
+            // idle prompt still dribbles output (a redraw, a blinking cursor) that
+            // the byte stream alone reads as activity, which is what pins a
+            // finished agent's spinner on forever. The per-tick byte count rides
+            // along as a secondary liveness signal for a viewport the user
+            // scrolled away from the live tail. `readViewportText` is thread-safe
+            // (its own lock), so the compare runs on the read pump; only the
+            // changed-flag and byte count hop to the main actor. Throttled to once
+            // a second. The read pump calls sinks serially, so the captured
+            // `lastPoke` / `lastScreenSignature` / `pendingBytes` need no lock.
             // A user agent may declare `status` regex rules in its `agent.json`; the
             // same viewport read that feeds the liveness sweep is classified against
             // them to drive working / needs-attention / done for agents that ship no
@@ -190,8 +195,9 @@ extension TermioStore {
             //
             // Caveat: `readViewportText` returns the *displayed* viewport, which follows
             // the user's scrollback — so scrolling an inline agent's pane up feeds stale
-            // rows to the classifier until it snaps back to the bottom (self-healing).
-            // herdr avoids this by reading the live bottom (active) buffer; the clean fix
+            // rows to the classifier until it snaps back to the bottom (self-healing;
+            // the byte-count signal covers working-liveness meanwhile). herdr avoids
+            // this by reading the live bottom (active) buffer; the clean fix
             // here needs a `readActiveText()` on the libghostty wrapper (its blessed read
             // serializes against the PTY write under a private lock we can't hold, and a
             // raw unsynchronized `GHOSTTY_POINT_ACTIVE` read from this pump thread would
@@ -202,10 +208,17 @@ extension TermioStore {
             let statusTrace = ProcessInfo.processInfo.environment["TERMIO_STATUS_TRACE"] != nil
             var lastPoke = Date.distantPast
             var lastScreenSignature: Int?
-            pty.addSink { [weak self, weak inMemory] _ in
+            // Bytes seen since the last poke, so the throttled tick can report the
+            // stream's volume alongside the screen compare — the scroll-frozen-
+            // viewport liveness signal (see `noteOutputActivity`).
+            var pendingBytes = 0
+            pty.addSink { [weak self, weak inMemory] data in
+                pendingBytes += data.count
                 let now = Date()
                 guard now.timeIntervalSince(lastPoke) >= 1 else { return }
                 lastPoke = now
+                let bytes = pendingBytes
+                pendingBytes = 0
                 let text = inMemory?.readViewportText()
                 let screenChanged: Bool
                 if let text {
@@ -229,7 +242,7 @@ extension TermioStore {
                     detected = nil
                 }
                 DispatchQueue.main.async {
-                    self?.noteOutputActivity(session.id, screenChanged: screenChanged)
+                    self?.noteOutputActivity(session.id, screenChanged: screenChanged, bytes: bytes)
                     if let detected {
                         self?.applyScreenDetectedActivity(detected, for: session.id)
                     }

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -152,15 +152,11 @@ extension TermioStore {
         let pty = PTYProcess(argv: argv, cwd: workspacePath, env: env,
                              cols: lastHostGridColumns, rows: lastHostGridRows)
         let inMemory = InMemoryTerminalSession(
-            write: { [weak self] data in
+            write: { data in
                 // Typing on the Mac reclaims the winsize from an attached
                 // phone — the size follows the device being used.
                 pty?.claimHostOwnership()
                 pty?.write(data)
-                // Live input (keystrokes, mouse-mode scrolling) repaints the
-                // screen just like agent output, so the status promotion in
-                // `noteOutputActivity` holds off while the human is typing.
-                DispatchQueue.main.async { self?.noteUserInput(session.id) }
             },
             resize: { [weak self] viewport in
                 let columns = Int(viewport.columns)
@@ -212,13 +208,20 @@ extension TermioStore {
             // stream's volume alongside the screen compare — the scroll-frozen-
             // viewport liveness signal (see `noteOutputActivity`).
             var pendingBytes = 0
-            pty.addSink { [weak self, weak inMemory] data in
+            pty.addSink { [weak self, weak inMemory, weak pty] data in
                 pendingBytes += data.count
                 let now = Date()
                 guard now.timeIntervalSince(lastPoke) >= 1 else { return }
                 lastPoke = now
                 let bytes = pendingBytes
                 pendingBytes = 0
+                // The PTY timestamps every stdin write (Mac keystrokes, phone
+                // input over the companion bridge, synthetic `sessions send`
+                // text), so sampling it here — instead of tapping only the Mac
+                // surface's write callback — keeps promotion quiet after input
+                // from any device. Input echo repaints the screen just like
+                // agent output does.
+                let inputAt = pty?.lastInputAt
                 let text = inMemory?.readViewportText()
                 let screenChanged: Bool
                 if let text {
@@ -242,6 +245,7 @@ extension TermioStore {
                     detected = nil
                 }
                 DispatchQueue.main.async {
+                    if let inputAt { self?.noteUserInput(session.id, at: inputAt) }
                     self?.noteOutputActivity(session.id, screenChanged: screenChanged, bytes: bytes)
                     if let detected {
                         self?.applyScreenDetectedActivity(detected, for: session.id)

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -263,6 +263,37 @@ final class TermioStore: ObservableObject {
     /// or a hook that never correlated) instead of spinning forever.
     let staleWorkingTimeout: TimeInterval = 12
 
+    /// When a session's hooks last applied any state, so the screen-driven
+    /// promotion in `noteOutputActivity` can defer to live hooks: a session whose
+    /// hooks just spoke doesn't need the screen to guess for them.
+    var lastHookReportAt: [Session.ID: Date] = [:]
+    /// When the user last typed (or scrolled) into a session's terminal. Keystroke
+    /// echo repaints the screen exactly like streaming output does, so promotion
+    /// stays quiet for a beat after any input.
+    var lastUserInputAt: [Session.ID: Date] = [:]
+    /// Consecutive changed-screen ticks observed for a non-working session — the
+    /// debounce counter behind promotion (see `noteOutputActivity`).
+    var promotionStreak: [Session.ID: Int] = [:]
+    /// Hooks are trusted for this long after their last report before the screen
+    /// may promote a session to working on its own. Just above
+    /// `staleWorkingTimeout`, so a live turn the sweep mistakenly cleared becomes
+    /// recoverable the moment it repaints, while the repaint burst right after a
+    /// `Stop` hook (the final answer rendering) can never re-light the spinner.
+    let hookQuietWindow: TimeInterval = 15
+    /// How long after user input the screen must settle before promotion; typing a
+    /// long prompt repaints the input box every keystroke.
+    let userInputQuietWindow: TimeInterval = 3
+    /// No promotion this soon after launch: an agent's banner and first prompt
+    /// paint across several ticks while it is simply starting up.
+    let launchGraceWindow: TimeInterval = 10
+    /// PTY bytes per throttle tick that read as genuine streaming for the
+    /// *sustain* path in `noteOutputActivity` — enough to keep a working session
+    /// alive while the user has scrolled its viewport away from the live tail
+    /// (a frozen viewport stops the screen-change signal), yet above the trickle
+    /// an idle prompt emits (a cursor-park sequence, a redraw) so a finished turn
+    /// still goes static and gets swept.
+    let streamingByteFloor = 512
+
     /// Records the host surface's live grid so the next session's PTY is spawned
     /// at a size that matches the window, avoiding the first-prompt reflow. Only
     /// meaningful sizes are kept, and only when they change, so this is cheap to


### PR DESCRIPTION
## Scope (rebased after #21)

The delivery-layer half of this PR (stable CLI path + status broadcast) merged separately as #21; this branch was rebased onto dev with that commit dropped. What remains is the status-model half, plus one improvement ported from #19 (now closed as superseded).

## Problem

A session whose hooks go quiet had no way back to `.working`: `noteOutputActivity` could only sustain an existing spinner, never start one, so a missed `working` report pinned the row calm forever while output streamed. Separately, liveness was keyed on the displayed viewport, so scrolling away froze the signal and the 12s sweep killed live turns.

## Fix

- **Promotion**: two consecutive changed-screen ticks promote `.idle` → `.working`, guarded: never out of `.done`/`.needsAttention`, not while hooks spoke within 15s (`hookQuietWindow` > 12s sweep, so a swept live turn recovers on the next repaint but the post-`Stop` render burst cannot re-light), not within 10s of launch (banner paint), not within 3s of user input, never for plain terminals or screen-rule agents.
- **Input timestamp at the PTY choke point** (ported from #19): `PTYProcess.write` stamps `lastInputAt`, covering Mac keystrokes, phone input via the companion bridge, and synthetic `sessions send` alike; the status tap samples it each poke. The Mac-only surface-callback stamp it replaces missed phone typing, whose echo could false-promote.
- **Scroll-proof sustain**: per-tick PTY byte volume (≥512B) rides along as a secondary liveness signal so a streaming turn survives the sweep while its viewport is scrolled away.
- **Dropped `SubagentStop → working`** from the Claude/Codex/Grok manifests (fires after turn end — herdr filters it for the same reason); installers strip stale entries on next launch.

## Verification

- `swift build` clean after the rebase and the port.
- Live runs pre-rebase per the original body; the rebase changed no delivery behavior (that code now comes from #21).