### PR TITLE
fix(hooks): stamp channel-stable CLI path and broadcast status reports

### DIFF
--- a/Sources/termio/HookListener.swift
+++ b/Sources/termio/HookListener.swift
@@ -207,6 +207,9 @@ enum AgentStatusHooks {
 
     /// Re-applies every agent's integration (or removes them all) to match `enabled`.
     static func sync(enabled: Bool) {
+        // Every hook references the channel-stable CLI copy, so make sure it carries
+        // this build's content before (re)stamping its path anywhere.
+        CommandLineTool.refreshSupportCopy()
         if enabled {
             // A full user override may intentionally remove/redirect a shipped hook.
             // Remove that old managed wiring before installing the merged catalog.
@@ -250,10 +253,13 @@ enum AgentStatusHooks {
     /// stamped into the plugin agents' JavaScript too, so every installer converges on
     /// the same contract.
     ///
-    /// The CLI path is *stamped absolute* so the hook resolves to this exact channel's
-    /// binary — a dev app's hooks call `termio-dev` (its own socket), a release app's
-    /// call `termio` — mirroring how the PTY stamps TERMIO_SESSION. Getting this wrong
-    /// would make dev hooks report into the release app or vice versa.
+    /// The stamped path is the channel-stable CLI copy — never the bundle, whose
+    /// location can vanish (a dev build launched from a deleted git worktree). The CLI
+    /// broadcasts each report to every channel's status socket, so which channel's copy
+    /// a hook happens to invoke doesn't matter; the receiving apps route by session id.
+    /// Status reporting stays best-effort either way: the whole command degrades to a
+    /// silent no-op if the copy is missing, instead of spamming every agent turn with
+    /// hook-failure noise.
     static func reportCommand(
         state: String, withTranscript: Bool = false, dialect: HookDialect = .claudeNested
     ) -> String {
@@ -264,17 +270,21 @@ enum AgentStatusHooks {
         if withTranscript { command += " --transcript" }
         // Cursor reads the hook's stdout as its JSON reply, so the CLI must stay silent
         // and print a benign `{}`. (Claude/Codex ignore hook stdout, so they don't.)
-        if dialect == .cursorFlat { command += " --reply" }
+        // The fallback keeps that contract even when the CLI itself couldn't run.
+        if dialect == .cursorFlat {
+            command += " --reply 2>/dev/null || printf '{}'"
+        } else {
+            command += " 2>/dev/null || true"
+        }
         return command
     }
 
-    /// Absolute path to *this channel's* bundled `termio`/`termio-dev` CLI, stamped into
-    /// each hook command so it drives the right app+socket regardless of PATH or whether
-    /// the user installed the `/usr/local/bin` symlink. A plain SwiftPM binary has no
-    /// bundled tool, so use the channel-specific install location; it remains absolute
-    /// and surfaces a missing CLI as a normal hook command failure.
+    /// Absolute path to this channel's stable `termio`/`termio-dev` CLI copy under
+    /// Application Support (see `CommandLineTool.supportCopyURL`), stamped into each
+    /// hook command so it resolves regardless of PATH, the `/usr/local/bin` symlink,
+    /// or where the app bundle happens to live.
     static var cliPath: String {
-        CommandLineTool.bundledURL?.path ?? CommandLineTool.installURL.path
+        CommandLineTool.supportCopyURL.path
     }
 
     /// Single-quotes a path for safe embedding in a hook shell command (the bundle path

--- a/Sources/termio/SessionControl.swift
+++ b/Sources/termio/SessionControl.swift
@@ -294,9 +294,12 @@ enum SessionSkillInstaller {
 
 /// Installs and audits the `termio` command-line tool — the bundled script the
 /// app symlinks onto the user's PATH so any shell (and any agent's shell tool)
-/// can run `termio sessions …` and `termio .`. Modeled on VS Code's `code` tool:
-/// the binary lives inside the app bundle, so the symlink keeps pointing at the
-/// current version across updates, and the audit surfaces a moved/old install.
+/// can run `termio sessions …` and `termio .`. Modeled on VS Code's `code` tool,
+/// with one twist: the symlink (and every agent hook) points at a channel-stable
+/// *copy* under Application Support, not into the bundle, because the bundle's
+/// location is transient — a dev build launched from a since-deleted git worktree
+/// once took every hook that referenced its path down with it. The copy's path
+/// never changes; each launch refreshes its content from the running bundle.
 enum CommandLineTool {
     /// The tool's name on PATH and inside the bundle: `termio` for a release build,
     /// `termio-dev` for the side-by-side dev channel, so the dev app links its own
@@ -309,16 +312,17 @@ enum CommandLineTool {
     static var installURL: URL { URL(fileURLWithPath: "/usr/local/bin/\(toolName)") }
 
     enum Status: Equatable {
-        /// Linked to this build's bundled tool — nothing to do.
+        /// Linked to this channel's stable tool copy — nothing to do.
         case installed
-        /// Linked to a `termio` tool at a different bundle path (the app moved or
-        /// this is an older install); offer to update the link.
+        /// Linked to an old-style bundle path, or the copy behind the link is
+        /// missing; offer to update the install.
         case stale(String)
         /// Nothing occupies the PATH location yet.
         case notInstalled
         /// A file that termio did not create sits at the location; never clobber it.
         case conflict
-        /// Running as a bare dev binary with no bundle, so there is nothing to link.
+        /// No bundled tool and no previously installed copy (a bare `swift run`
+        /// binary on a fresh machine), so there is nothing to link.
         case unavailable
     }
 
@@ -328,9 +332,43 @@ enum CommandLineTool {
         Bundle.main.url(forResource: toolName, withExtension: nil)
     }
 
-    static func audit() -> Status {
-        guard let bundled = bundledURL else { return .unavailable }
+    /// The channel-stable copy of the tool (`…/Application Support/termio[-dev]/bin/`)
+    /// — the only path hook files and the PATH symlink ever reference.
+    static var supportCopyURL: URL {
+        AppChannel.supportDirectory.appendingPathComponent("bin/\(toolName)")
+    }
+
+    /// Aligns the support copy's content with the bundled tool. A bare `swift run`
+    /// binary has no bundle to copy from, so an existing copy (from the last real
+    /// app build) is left serving. Returns whether a usable copy exists afterwards.
+    @discardableResult
+    static func refreshSupportCopy() -> Bool {
         let fileManager = FileManager.default
+        let copy = supportCopyURL
+        guard let bundled = bundledURL, let content = try? Data(contentsOf: bundled) else {
+            return fileManager.isExecutableFile(atPath: copy.path)
+        }
+        if (try? Data(contentsOf: copy)) != content {
+            do {
+                try fileManager.createDirectory(
+                    at: copy.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try content.write(to: copy, options: .atomic)
+            } catch {
+                FileHandle.standardError.write(
+                    Data("termio: command-line tool copy failed: \(error)\n".utf8))
+                return fileManager.isExecutableFile(atPath: copy.path)
+            }
+        }
+        // An atomic write lands with default (non-executable) permissions, and hooks
+        // exec the copy directly, so re-assert the mode even on the unchanged path.
+        try? fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: copy.path)
+        return true
+    }
+
+    static func audit() -> Status {
+        let fileManager = FileManager.default
+        let copyUsable = fileManager.isExecutableFile(atPath: supportCopyURL.path)
+        guard copyUsable || bundledURL != nil else { return .unavailable }
         let path = installURL.path
         guard let attributes = try? fileManager.attributesOfItem(atPath: path) else {
             return fileManager.fileExists(atPath: path) ? .conflict : .notInstalled
@@ -341,20 +379,23 @@ enum CommandLineTool {
             return .conflict
         }
         let resolved = URL(fileURLWithPath: destination).standardizedFileURL.path
-        if resolved == bundled.standardizedFileURL.path { return .installed }
+        if resolved == supportCopyURL.standardizedFileURL.path {
+            return copyUsable ? .installed : .stale(resolved)
+        }
+        // A link into any app bundle is a pre-copy install (or a moved app); update it.
         if resolved.hasSuffix("/Contents/Resources/\(toolName)") { return .stale(resolved) }
         return .conflict
     }
 
-    /// Links the bundled tool onto PATH and returns the fresh audit. Replaces our
-    /// own stale link; refuses to overwrite a file we did not create.
+    /// Links the stable tool copy onto PATH and returns the fresh audit. Replaces
+    /// our own stale link; refuses to overwrite a file we did not create.
     @discardableResult
     static func install() -> Status {
-        guard let bundled = bundledURL else { return .unavailable }
+        guard refreshSupportCopy() else { return .unavailable }
         if case .conflict = audit() { return .conflict }
         let target = installURL.path
-        if linkWithoutPrivileges(from: bundled.path, to: target) { return audit() }
-        linkWithAdminPrompt(from: bundled.path, to: target)
+        if linkWithoutPrivileges(from: supportCopyURL.path, to: target) { return audit() }
+        linkWithAdminPrompt(from: supportCopyURL.path, to: target)
         return audit()
     }
 

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -220,12 +220,15 @@ extension TermioStore {
     /// Resolves a status report back to its session. The exact key is the
     /// `TERMIO_SESSION` id termio stamped into the PTY and the agent echoed back, so
     /// this is unambiguous even when several sessions share one project directory.
+    /// A report that *carries* an id this app didn't stamp is another channel's
+    /// session (the CLI broadcasts each report to both the release and dev app's
+    /// sockets) and must be dropped, not cwd-guessed — that guess is exactly how a
+    /// prod session's activity would light up a dev session sharing its directory.
     /// `cwd` is only a fallback for an agent whose environment didn't carry the id
-    /// through to the hook.
+    /// through to the hook at all (an agent hand-started outside termio).
     private func sessionID(for report: StatusReport) -> Session.ID? {
-        if let token = report.termioSession,
-           let id = UUID(uuidString: token),
-           session(id) != nil {
+        if let token = report.termioSession, !token.isEmpty {
+            guard let id = UUID(uuidString: token), session(id) != nil else { return nil }
             return id
         }
         return sessionID(forCwd: report.cwd)

--- a/docs/design/vibe-island-status.md
+++ b/docs/design/vibe-island-status.md
@@ -2,7 +2,7 @@
 title: Vibe Island 式 Agent 状态层（Claude Code hooks）
 status: done
 type: design
-updated: 2026-07-18
+updated: 2026-07-19
 ---
 
 # 设计：Vibe Island 式 Agent 状态层（Claude Code hooks）
@@ -56,6 +56,21 @@ TermioStore.applyHookEvent(_:)  (reducer)  ──写──▶  statuses[id]
 既有 UI：SidebarView.StatusDot / MenuBarController（无需改）
 ```
 
+> **更新（2026-07-19，channel-stable CLI path + 广播）**：修复一个真实事故——worktree 里
+> 构建/启动的 dev app 把**自己 bundle 内的 CLI 绝对路径**盖进了所有 agent 的全局 hook 文件，
+> worktree merge 后删除，路径失效，每个 agent 的每次工具调用都刷 hook 报错。三点修正：
+> - **hook 只引用 channel 稳定路径**：app 每次启动把打包的 CLI **拷贝**到
+>   `~/Library/Application Support/termio[-dev]/bin/termio[-dev]`
+>   （`CommandLineTool.refreshSupportCopy`，内容比对 + 原子写 + 0755），hook 与
+>   `/usr/local/bin` symlink 一律指向该拷贝。路径永不变；worktree 删除后拷贝仍在，零失效窗口。
+> - **CLI 广播**：`agent report` 不再只写本 channel 的 socket，而是向 `termio` 与
+>   `termio-dev` 两个 support 目录的 `agent-status.sock` 都发（缺失即跳过）。dev/prod 两个
+>   app 共存共享同一份全局 hook 文件时，不论最后由谁安装，两边都收到报告。
+> - **收端按 id 路由，杜绝串台**：`sessionID(for:)` 对"带 session id 但本 app 不认识"的
+>   报告直接丢弃（那是另一 channel 的会话），cwd 兜底只服务完全没带 id 的手动启动 agent。
+>   hook 命令尾部加 `2>/dev/null || true`（Cursor 为 `|| printf '{}'`），路径万一损坏时
+>   静默降级而非刷屏。
+>
 > **更新（2026-07-18，final as-built，多 agent）**：下面 §1 的 cwd 方案已被
 > **env-id 注入**取代为主关联键，并从单一 Claude 扩展到声明 hooks 的全部内置 agent。要点：
 > - **注入**：`TermioStore.surface` 给每个 PTY 设 `builder.withCustom("env", "TERMIO_SESSION=<session.id>")`

--- a/scripts/termio
+++ b/scripts/termio
@@ -28,9 +28,6 @@ SUPPORT_DIR_NAME="termio"
 BUNDLE_ID="sh.termio.app"
 
 SOCKET="$HOME/Library/Application Support/$SUPPORT_DIR_NAME/session-control.sock"
-# The agent-status socket `HookListener` binds — same channel-scoped directory as the
-# control socket, so a dev app's hooks report into the dev app, not the release one.
-STATUS_SOCKET="$HOME/Library/Application Support/$SUPPORT_DIR_NAME/agent-status.sock"
 
 # JSON-escape a string for embedding in a request: backslashes, double quotes, and
 # newlines (which would otherwise break the single-line JSON object).
@@ -86,7 +83,10 @@ sessions() {
 # An agent's status hook runs this instead of a hand-rolled `printf | nc`; termio
 # stamps the absolute path to this script into the hook file at install time. It reads
 # the session id from $TERMIO_SESSION (which the PTY carries) and the cwd from $PWD,
-# then writes the normalized `{termio_session,state,cwd}` report to the status socket.
+# then writes the normalized `{termio_session,state,cwd}` report to the status socket
+# of *every* channel (release and dev). The two apps can run side by side sharing one
+# global hook file per agent, so a single report fans out to both; each app keeps only
+# the reports whose session id it stamped and ignores the rest (`TermioStore.sessionID`).
 # A missing socket (app not running) is a silent no-op — hooks fire constantly.
 #   --transcript  slurp stdin (Claude feeds hooks a JSON blob) and forward its
 #                 transcript_path so termio can address the raw Q&A log.
@@ -133,12 +133,15 @@ agent() {
             "$session" "$state" "$cwd")
     fi
 
-    if [ "$reply" -eq 1 ]; then
-        printf '%s' "$payload" | nc -w 1 -U "$STATUS_SOCKET" >/dev/null 2>&1 || true
-        printf '{}'
-    else
-        printf '%s' "$payload" | nc -w 1 -U "$STATUS_SOCKET" 2>/dev/null || true
-    fi
+    # Fan out to every channel's status socket, not just this binary's own: the
+    # report is self-identifying (the session id routes it), so broadcasting is
+    # what lets one installed hook serve a release app and a dev app at once.
+    for channel_dir in "termio" "termio-dev"; do
+        status_socket="$HOME/Library/Application Support/$channel_dir/agent-status.sock"
+        [ -S "$status_socket" ] || continue
+        printf '%s' "$payload" | nc -w 1 -U "$status_socket" >/dev/null 2>&1 || true
+    done
+    if [ "$reply" -eq 1 ]; then printf '{}'; fi
 }
 
 if [ "${1:-}" = "sessions" ]; then


### PR DESCRIPTION
## Problem

A dev build launched from a git worktree stamped **its own bundle path** into every agent's global hook config (`~/.claude/settings.json`, `~/.codex/hooks.json`, OpenCode/Amp plugins). After the worktree was merged and deleted, every hook on every agent failed with *No such file or directory* / exit 127 on **every tool call**.

Two more latent bugs in the same area:
- dev and prod apps fight over the shared hook files (last launch wins), so the losing channel's app misses all status reports.
- `sessionID(for:)` falls back to cwd matching when a report's session id is unknown — the exact path by which one channel's report could light up the other channel's session in the same directory.

## Fix

1. **Channel-stable CLI copy** — each launch copies the bundled CLI to `~/Library/Application Support/termio[-dev]/bin/termio[-dev]` (content-compare, atomic write, 0755). Hooks and the `/usr/local/bin` symlink reference only this path. It never changes, so deleting a worktree leaves hooks working with **zero failure window** (a copy, unlike a symlink, can't dangle).
2. **Broadcast reports** — `termio agent report` now writes to both channels' `agent-status.sock` (skipping missing sockets), so one installed hook file serves prod and dev side by side regardless of which app wrote it last.
3. **Route by id, never guess across channels** — a report carrying a session id this app didn't stamp is dropped; cwd fallback only serves reports with no id at all (hand-started agents).
4. **Failure-silent hooks** — commands end in `2>/dev/null || true` (Cursor: `|| printf '{}'` to keep its stdout contract), so any residual path breakage degrades silently instead of spamming every agent turn.

Design log updated in `docs/design/vibe-island-status.md`.

## Testing
- `swift build` passes in the worktree.
- `sh -n scripts/termio` + live run: plain report exits 0, `--transcript --reply` prints `{}` and exits 0, report observed arriving at the running dev app's socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)