### PR TITLE
feat(agents): classify agent OSC titles into status

### DIFF
--- a/Sources/termio/AgentDefinition.swift
+++ b/Sources/termio/AgentDefinition.swift
@@ -53,6 +53,14 @@ struct AgentDefinition: Identifiable {
     /// no `status` block (or that declared `hooks`, which take authority). See
     /// `AgentStatusRules`.
     let statusRules: AgentStatusRules?
+    /// Rules over the agent's live `OSC 0/2` *title* — the in-band state broadcast
+    /// some agents ship (Claude prefixes a braille spinner while working, Codex and
+    /// Grok flip to "Action Required" when blocked). Unlike `statusRules` this
+    /// coexists with hooks rather than replacing them: the title is the agent's own
+    /// deliberate signal on a channel that cannot break (no hook file, no external
+    /// script, no socket), so it corrects a missed or late hook the instant the
+    /// title flips. See `TermioStore.applyTitleActivity` for the arbitration.
+    let titleRules: AgentStatusRules?
     /// A manifest's declarative hook integration: the destination owned by the agent,
     /// a closed installer/dialect, and its event→state mapping.
     /// When present it is installed by `AgentStatusHooks` and becomes the session's
@@ -67,7 +75,8 @@ struct AgentDefinition: Identifiable {
         permissionBypassFlag: String?,
         resumeStyle: ResumeStyle, icon: AgentIcon,
         iconRef: TermioShared.IconRef, tint: Color, tintHex: String?, installURL: URL?, wireName: String,
-        statusRules: AgentStatusRules? = nil, hookSpec: AgentHookSpec? = nil
+        statusRules: AgentStatusRules? = nil, titleRules: AgentStatusRules? = nil,
+        hookSpec: AgentHookSpec? = nil
     ) {
         self.id = id
         self.order = order
@@ -82,6 +91,7 @@ struct AgentDefinition: Identifiable {
         self.installURL = installURL
         self.wireName = wireName
         self.statusRules = statusRules
+        self.titleRules = titleRules
         self.hookSpec = hookSpec
     }
 
@@ -769,6 +779,11 @@ struct AgentManifest: Decodable {
     var installURL: String?
     var icon: IconSpec?
     var status: StatusSpec?
+    /// Same regex shape as `status`, matched against the agent's live OSC 0/2
+    /// title instead of the rendered screen. Coexists with `hooks` (the title is a
+    /// correction channel, not a competing authority), so it is not gated the way
+    /// `status` is.
+    var titleStatus: StatusSpec?
     var hooks: HookSpec?
 
     struct IconSpec: Decodable {
@@ -923,6 +938,9 @@ struct AgentManifest: Decodable {
         let statusRules = hookSpec == nil
             ? AgentStatusRules.from(working: status?.working, attention: status?.attention, label: id)
             : nil
+        let titleRules = AgentStatusRules.from(
+            working: titleStatus?.working, attention: titleStatus?.attention,
+            label: "\(id).title")
 
         let resumeStyle: AgentDefinition.ResumeStyle
         switch resume?.lowercased() ?? "none" {
@@ -941,7 +959,7 @@ struct AgentManifest: Decodable {
             resumeStyle: resumeStyle, icon: resolvedIcon, iconRef: resolvedIconRef,
             tint: resolvedTint, tintHex: resolvedTintHex,
             installURL: (install ?? installURL).flatMap(URL.init(string:)), wireName: wire ?? id,
-            statusRules: statusRules, hookSpec: hookSpec)
+            statusRules: statusRules, titleRules: titleRules, hookSpec: hookSpec)
     }
 
     private static func bundledAsset(named name: String, in bundle: Bundle) -> URL? {

--- a/Sources/termio/Resources/agents/claude.json
+++ b/Sources/termio/Resources/agents/claude.json
@@ -8,6 +8,9 @@
   "resume": "claude",
   "icon": { "vector": "claude" },
   "install": "https://claude.com/claude-code",
+  "titleStatus": {
+    "working": ["^[⠀-⣿] "]
+  },
   "hooks": {
     "type": "json",
     "file": "~/.claude/settings.json",

--- a/Sources/termio/Resources/agents/codex.json
+++ b/Sources/termio/Resources/agents/codex.json
@@ -8,6 +8,10 @@
   "resume": "codex",
   "icon": { "vector": "codex" },
   "install": "https://developers.openai.com/codex/cli",
+  "titleStatus": {
+    "working": ["(?:^| )[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏](?: |$)"],
+    "attention": ["Action Required"]
+  },
   "hooks": {
     "type": "json",
     "file": "~/.codex/hooks.json",

--- a/Sources/termio/Resources/agents/grok.json
+++ b/Sources/termio/Resources/agents/grok.json
@@ -8,6 +8,9 @@
   "resume": "claude",
   "icon": { "asset": "grok-favicon" },
   "install": "https://x.ai/cli",
+  "titleStatus": {
+    "attention": ["Action Required"]
+  },
   "hooks": {
     "type": "json",
     "file": "~/.grok/hooks/termio.json",

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -234,6 +234,39 @@ extension TermioStore {
         }
     }
 
+    /// Drives status from the agent's live `OSC 0/2` title — the in-band state
+    /// broadcast some agents ship (Claude prefixes a braille spinner mid-turn,
+    /// Codex/Grok flip to "Action Required" when blocked). Unlike the screen path
+    /// this *coexists* with hooks: the title is the agent's own deliberate signal
+    /// on a channel that cannot break, so it corrects a missed `working` hook the
+    /// instant the turn starts and ends a lost turn the instant the title calms —
+    /// no 12s sweep wait, no promotion evidence-gathering. Transitions only
+    /// (`lastTitleActivity`), with hooks kept senior where they are more precise:
+    /// a title-working never overrides `needsAttention` (a blocked agent's title
+    /// can keep spinning), and a title-idle only ends a turn — an arbitrary title
+    /// (which classifies idle by no-match) must not clear hook-set states.
+    func applyTitleActivity(_ activity: AgentStatusRules.Activity, for id: Session.ID) {
+        guard lastTitleActivity[id] != activity else { return }
+        let previous = lastTitleActivity[id]
+        lastTitleActivity[id] = activity
+        switch activity {
+        case .working:
+            guard statuses[id] != .needsAttention else { return }
+            guard let session = session(id), effectiveAgent(for: session) != .terminal
+            else { return }
+            statuses[id] = .working
+            lastWorkingAt[id] = Date()
+            if let pid = project(for: id)?.id { liveActivity[pid] = Date() }
+        case .attention:
+            clearWorking(id)
+            if selectedSessionID != id { statuses[id] = .needsAttention }
+        case .idle:
+            guard previous == .working, statuses[id] == .working else { return }
+            clearWorking(id)
+            statuses[id] = (selectedSessionID == id) ? .idle : .done
+        }
+    }
+
     /// Records (or clears) the agent detected running in a plain terminal's
     /// foreground, upgrading the row to a first-class agent while it runs (brand icon,
     /// adopted live title, working spinner) and reverting it to a plain terminal when
@@ -249,6 +282,7 @@ extension TermioStore {
         } else {
             detectedAgents[id] = nil
             liveTitles[id] = nil
+            lastTitleActivity[id] = nil
             clearWorking(id)
             if statuses[id] == .working || statuses[id] == .done { statuses[id] = .idle }
         }

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -497,6 +497,7 @@ extension TermioStore {
             lastHookReportAt[sessionID] = nil
             lastUserInputAt[sessionID] = nil
             promotionStreak[sessionID] = nil
+            lastTitleActivity[sessionID] = nil
         }
         projects.remove(at: projectIndex)
 
@@ -561,6 +562,7 @@ extension TermioStore {
         lastHookReportAt[id] = nil
         lastUserInputAt[id] = nil
         promotionStreak[id] = nil
+        lastTitleActivity[id] = nil
 
         // If the session held a split pane, collapse that pane; when it was also
         // the focused pane the prune moves the selection to its layout neighbor,

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -682,9 +682,25 @@ extension TermioStore {
             state.$lastBellAt.dropFirst().compactMap { $0 }.sink { _ in flag() },
             state.$lastDesktopNotificationAt.dropFirst().compactMap { $0 }.sink { _ in flag() },
             // The surface already publishes the program's live `OSC 0/2` title;
-            // adopt the meaningful values as the agent session's display label.
+            // classify it as a status signal, then adopt the meaningful values as
+            // the agent session's display label. Classification sees the RAW
+            // title — the working/idle marks (Claude's braille spinner prefix,
+            // Codex's "Action Required") are exactly what the label sanitizer
+            // strips as noise. Every frame of a ticking title spinner republishes
+            // here; `applyTitleActivity` collapses them on its own transition
+            // guard, so per-frame work is one regex over a short string.
             state.$title.removeDuplicates().sink { [weak self] title in
                 guard let self, let session = self.session(id) else { return }
+                let agent = self.effectiveAgent(for: session)
+                if let rules = agent.titleRules {
+                    let (activity, matched) = rules.explain(title)
+                    if ProcessInfo.processInfo.environment["TERMIO_STATUS_TRACE"] != nil {
+                        AgentStatusRules.trace(
+                            agent: "\(agent.id).title", session: id,
+                            activity: activity, matched: matched)
+                    }
+                    self.applyTitleActivity(activity, for: id)
+                }
                 let cleaned = self.sanitizedLiveTitle(title)
                 guard self.isMeaningfulLiveTitle(cleaned, for: session),
                       self.liveTitles[id] != cleaned else { return }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -253,6 +253,11 @@ final class TermioStore: ObservableObject {
     /// into (see `AgentStatusRules` / `applyScreenDetectedActivity`), so status is only
     /// re-driven on a transition — not re-emitted every tick the screen sits idle.
     var lastScreenActivity: [Session.ID: AgentStatusRules.Activity] = [:]
+    /// The last activity an agent's live OSC title was classified into (see
+    /// `applyTitleActivity`), so title-driven status also moves only on
+    /// transitions — a spinner frame change re-classifies as the same `working`
+    /// and is dropped here.
+    var lastTitleActivity: [Session.ID: AgentStatusRules.Activity] = [:]
     var staleWorkingSweep: Timer?
     /// How long a `.working` session may go with *no screen change and no working
     /// hook* before the sweep flips it back to idle. A working agent's TUI repaints


### PR DESCRIPTION
## What

A third status signal source, senior to screen-guessing and complementary to hooks: the agent's own live `OSC 0/2` title. Verified against herdr's battle-tested manifests (its **top-priority** signal for all three agents) and live titles:

| Agent | Title while working | Title when blocked |
|---|---|---|
| Claude Code | braille spinner prefix (`⠹ …`), `✳` at rest | — (hook covers it) |
| Codex | spaced braille spinner glyph | `Action Required` |
| Grok | — (splash logo is braille art, unsafe) | `Action Required` |

## Why

- The title is the agent's **deliberate, in-band** state broadcast — no hook file, no external script, no socket; nothing on the path can break (this week's outage class cannot touch it).
- It corrects a missed `working` hook the instant the turn starts, and ends a lost turn the instant the title calms — ahead of the 12s sweep and the 2-tick promotion evidence window.
- **Codex and Grok gain their first `attention` signal**: Grok's hook dialect has no attention event at all.

## How

- Manifests may declare `titleStatus` (same regex shape as `status`). Unlike screen rules it is **not** gated on the absence of hooks — it's a correction channel, not a competing authority. User agents get it for free.
- `applyTitleActivity` fires on classification transitions only (spinner frames collapse), with hooks kept senior where they're more precise: title-working never overrides `needsAttention`; title-idle only ends a turn (no-match classifies idle, so an arbitrary title must not clear hook-set states).
- Classification reads the **raw** title in the `$title` sink — the status marks are exactly what the display-label sanitizer strips.
- `TERMIO_STATUS_TRACE` traces title classifications alongside screen ones.

## Not in this PR

OSC 9;4 progress parsing (Claude 2.0's `terminalProgressBarEnabled`, Grok's native busy/idle) — needs a byte-stream OSC hook in the libghostty wrapper, tracked as follow-up.

## Verification

- `swift build` clean.
- Regex behavior pinned by 11 sample-title assertions (Claude braille/✳ prefixes, Codex spaced spinner + "Action Required", case-insensitivity) — all pass.
- The animation/spinner rendering is untouched — this changes only *when* status flips, not how it draws.