### PR TITLE
Make agent resume config-driven via a flat manifest object

### DIFF
--- a/Sources/termio/AgentDefinition.swift
+++ b/Sources/termio/AgentDefinition.swift
@@ -123,12 +123,10 @@ struct AgentDefinition: Identifiable {
 
     /// How a relaunch continues (or doesn't) this agent's prior conversation, parsed
     /// straight from the manifest's `resume` object. Everything here is data — argument
-    /// templates with an `{id}` placeholder plus a description of the agent's on-disk
-    /// session store — so a new agent in the common "pin an id, create-then-resume"
-    /// family needs no Swift at all. The two things that can't be data (recovering an
-    /// id the agent minted itself, and pre-seeding a session file so a pinned id
-    /// resolves quietly) name a built-in strategy instead of inlining the agent's
-    /// private file format. See docs/design/agent-resume-identity.md.
+    /// templates with an `{id}` placeholder plus descriptions of the agent's on-disk
+    /// session store — so a new agent needs no Swift at all. Strategies describe
+    /// *mechanisms* (file formats, field paths), never agent identities. See
+    /// docs/design/agent-resume-identity.md.
     struct ResumeSpec: Hashable, Sendable {
         /// Launch template for a fresh, termio-pinned id (e.g. `--session-id {id}`). Its
         /// presence means the id is pinned up front; its absence means the id is
@@ -141,11 +139,11 @@ struct AgentDefinition: Identifiable {
         /// flag errors on a duplicate id; also backs the Info-pane transcript fallback
         /// and `/clear` id-rotation for file-per-conversation stores.
         var store: Store?
-        /// Names the built-in matcher that reads this agent's own store to recover an
-        /// id it minted itself (`codex`, `opencode`). Set iff `create` is nil.
-        var discover: String?
-        /// Names the built-in that pre-creates the session file so a pinned id resolves
-        /// silently on first launch (`pi`).
+        /// How to read the id out of the agent's own session records after launch, for
+        /// agents that mint the id themselves. Set iff `create` is nil.
+        var discover: Discover?
+        /// Names the built-in mechanism that pre-creates the session file so a pinned id
+        /// resolves silently on first launch (`session-file`).
         var seed: String?
 
         /// A declarative description of where an agent keeps its conversations on disk.
@@ -159,6 +157,31 @@ struct AgentDefinition: Identifiable {
             /// `root`; termio searches across the buckets rather than reconstruct each
             /// agent's private cwd encoding.
             var name: String
+        }
+
+        /// A declarative description of how to recover an agent-minted session id from
+        /// the agent's own records: where they live, how a record is read, and which
+        /// fields carry the id and the working directory. All mechanism, no agent names —
+        /// `AgentSessionStore` interprets this generically.
+        struct Discover: Hashable, Sendable {
+            /// Tilde-expandable root the records live under, e.g. `~/.codex/sessions`.
+            var root: String
+            /// How a record file is read.
+            var format: Format
+            /// Dot-separated key path to the session id, e.g. `payload.id`.
+            var id: String
+            /// Dot-separated key path to the recorded working directory, e.g. `payload.cwd`.
+            var cwd: String
+
+            enum Format: String, Hashable, Sendable {
+                /// A `.jsonl` log whose first line is a JSON header — the log itself is
+                /// the conversation transcript.
+                case jsonl
+                /// A standalone `.json` metadata record (not a transcript).
+                case json
+
+                var fileExtension: String { rawValue }
+            }
         }
 
         static let none = ResumeSpec()
@@ -828,8 +851,19 @@ struct AgentManifest: Decodable {
             /// `dir:<pattern>` or `file:<pattern>`, where `<pattern>` contains `{id}` and
             /// may contain a `*` glob (e.g. `dir:{id}`, `file:{id}.jsonl`, `file:*_{id}.jsonl`).
             var storeMatch: String?
-            var discover: String?
+            var discover: DiscoverFields?
             var seed: String?
+
+            /// Mechanism description for recovering an agent-minted id — a record
+            /// location plus field paths, never an agent name.
+            struct DiscoverFields: Decodable {
+                var root: String
+                /// `jsonl` (first line of a `.jsonl` log is the record; the log is the
+                /// transcript) or `json` (a standalone `.json` metadata record).
+                var format: String
+                var id: String
+                var cwd: String
+            }
         }
 
         init(from decoder: Decoder) throws {
@@ -881,11 +915,15 @@ struct AgentManifest: Decodable {
             case "pi":
                 return .init(create: "--session-id {id}", resume: "--session-id {id}",
                              store: .init(root: "~/.pi/agent/sessions", isDirectory: false,
-                                          name: "*_{id}.jsonl"), seed: "pi")
+                                          name: "*_{id}.jsonl"), seed: "session-file")
             case "codex":
-                return .init(resume: "resume {id}", discover: "codex")
+                return .init(resume: "resume {id}",
+                             discover: .init(root: "~/.codex/sessions", format: .jsonl,
+                                             id: "payload.id", cwd: "payload.cwd"))
             case "opencode":
-                return .init(resume: "--session {id}", discover: "opencode")
+                return .init(resume: "--session {id}",
+                             discover: .init(root: "~/.local/share/opencode/storage/session",
+                                             format: .json, id: "id", cwd: "directory"))
             case let other:
                 throw ManifestError.invalid("\(id): unknown resume preset '\(other)'")
             }
@@ -915,19 +953,28 @@ struct AgentManifest: Decodable {
             default:
                 throw ManifestError.invalid("\(id): storeRoot and storeMatch must be set together")
             }
-            if let discover = fields.discover, !["codex", "opencode"].contains(discover) {
-                throw ManifestError.invalid("\(id): unknown resume discover strategy '\(discover)'")
+            var discover: AgentDefinition.ResumeSpec.Discover?
+            if let fields = fields.discover {
+                guard let format = AgentDefinition.ResumeSpec.Discover.Format(
+                    rawValue: fields.format.lowercased()) else {
+                    throw ManifestError.invalid(
+                        "\(id): discover format must be 'jsonl' or 'json', not '\(fields.format)'")
+                }
+                guard !fields.root.isEmpty, !fields.id.isEmpty, !fields.cwd.isEmpty else {
+                    throw ManifestError.invalid("\(id): discover requires root, format, id, cwd")
+                }
+                discover = .init(root: fields.root, format: format, id: fields.id, cwd: fields.cwd)
             }
-            if let seed = fields.seed, seed != "pi" {
-                throw ManifestError.invalid("\(id): unknown resume seed strategy '\(seed)'")
+            if let seed = fields.seed, seed != "session-file" {
+                throw ManifestError.invalid("\(id): unknown resume seed mechanism '\(seed)'")
             }
-            if fields.create != nil, fields.discover != nil {
+            if fields.create != nil, discover != nil {
                 throw ManifestError.invalid(
                     "\(id): resume 'create' (pinned id) and 'discover' (found id) are mutually exclusive")
             }
             return .init(
                 create: fields.create, resume: fields.resume,
-                store: store, discover: fields.discover, seed: fields.seed)
+                store: store, discover: discover, seed: fields.seed)
         }
     }
 

--- a/Sources/termio/AgentDefinition.swift
+++ b/Sources/termio/AgentDefinition.swift
@@ -136,9 +136,6 @@ struct AgentDefinition: Identifiable {
         var create: String?
         /// Template to continue a known conversation id (e.g. `--resume {id}`).
         var resume: String?
-        /// Template to continue the most-recent conversation when no id is known yet —
-        /// discovered-id agents, before the first discovery (e.g. `--continue`).
-        var continueLast: String?
         /// The agent's on-disk session store. Lets termio tell an already-saved
         /// conversation (→ `resume`) from a brand-new one (→ `create`), since a create
         /// flag errors on a duplicate id; also backs the Info-pane transcript fallback
@@ -183,10 +180,10 @@ struct AgentDefinition: Identifiable {
                 return context.pinnedConversationExists ? fill(resume) : fill(create)
             }
             if discoversID {
-                // Resume the exact session once its id has been discovered; until then
-                // continue the most recent recorded session in this directory.
-                if !context.resumeID.isEmpty { return fill(resume) }
-                return context.launchedBefore ? continueLast : nil
+                // Resume the exact session once its id has been discovered and saved
+                // (`Session.resumeID`); until then launch fresh — no approximate
+                // "continue whatever is most recent" fallback.
+                return context.resumeID.isEmpty ? nil : fill(resume)
             }
             return nil
         }
@@ -209,8 +206,6 @@ struct AgentDefinition: Identifiable {
         /// The stable id termio pinned for this session (meaningful only when
         /// `usesPinnedResumeID`).
         var resumeID: String
-        /// Whether this session's agent has been launched in a prior app run.
-        var launchedBefore: Bool
         /// Whether the agent already has a saved conversation under `resumeID`. Resuming
         /// one that doesn't exist errors, so a pinned-but-never-used session is
         /// (re)created with the `create` flag instead.
@@ -828,7 +823,6 @@ struct AgentManifest: Decodable {
         struct Fields: Decodable {
             var create: String?
             var resume: String?
-            var continueLast: String?
             /// Tilde-expandable root of the agent's on-disk session store.
             var storeRoot: String?
             /// `dir:<pattern>` or `file:<pattern>`, where `<pattern>` contains `{id}` and
@@ -889,9 +883,9 @@ struct AgentManifest: Decodable {
                              store: .init(root: "~/.pi/agent/sessions", isDirectory: false,
                                           name: "*_{id}.jsonl"), seed: "pi")
             case "codex":
-                return .init(resume: "resume {id}", continueLast: "resume --last", discover: "codex")
+                return .init(resume: "resume {id}", discover: "codex")
             case "opencode":
-                return .init(resume: "--session {id}", continueLast: "--continue", discover: "opencode")
+                return .init(resume: "--session {id}", discover: "opencode")
             case let other:
                 throw ManifestError.invalid("\(id): unknown resume preset '\(other)'")
             }
@@ -932,7 +926,7 @@ struct AgentManifest: Decodable {
                     "\(id): resume 'create' (pinned id) and 'discover' (found id) are mutually exclusive")
             }
             return .init(
-                create: fields.create, resume: fields.resume, continueLast: fields.continueLast,
+                create: fields.create, resume: fields.resume,
                 store: store, discover: fields.discover, seed: fields.seed)
         }
     }

--- a/Sources/termio/AgentDefinition.swift
+++ b/Sources/termio/AgentDefinition.swift
@@ -29,7 +29,7 @@ struct AgentDefinition: Identifiable {
     /// still accepts any flag). Composed on by `AppSettings.command(for:)`.
     let permissionBypassFlag: String?
     /// How (and whether) a relaunch resumes this agent's prior conversation.
-    let resumeStyle: ResumeStyle
+    let resumeSpec: ResumeSpec
     let icon: AgentIcon
     /// Portable form sent to the companion. Bundled assets stay name references;
     /// user image paths are rasterized once at catalog load into inline PNG bytes.
@@ -73,7 +73,7 @@ struct AgentDefinition: Identifiable {
     init(
         id: String, order: Int = Self.unorderedRank, displayName: String, command: String?,
         permissionBypassFlag: String?,
-        resumeStyle: ResumeStyle, icon: AgentIcon,
+        resumeSpec: ResumeSpec, icon: AgentIcon,
         iconRef: TermioShared.IconRef, tint: Color, tintHex: String?, installURL: URL?, wireName: String,
         statusRules: AgentStatusRules? = nil, titleRules: AgentStatusRules? = nil,
         hookSpec: AgentHookSpec? = nil
@@ -83,7 +83,7 @@ struct AgentDefinition: Identifiable {
         self.displayName = displayName
         self.command = command
         self.permissionBypassFlag = permissionBypassFlag
-        self.resumeStyle = resumeStyle
+        self.resumeSpec = resumeSpec
         self.icon = icon
         self.iconRef = iconRef
         self.tint = tint
@@ -114,47 +114,93 @@ struct AgentDefinition: Identifiable {
     var tintColor: Color { tint }
 
     /// Whether this agent lets termio pin its conversation id up front so a relaunch
-    /// resumes the exact prior session (Claude Code, Pi).
-    var usesPinnedResumeID: Bool { resumeStyle == .claudeStyle || resumeStyle == .piStyle }
+    /// resumes the exact prior session (Claude Code, Grok, Pi).
+    var usesPinnedResumeID: Bool { resumeSpec.pinsID }
 
     /// Whether this agent's id can't be set up front but *can* be discovered from its
     /// own session store afterward and resumed by id (Codex, OpenCode).
-    var usesDiscoveredResumeID: Bool { resumeStyle == .codexStyle || resumeStyle == .openCodeStyle }
+    var usesDiscoveredResumeID: Bool { resumeSpec.discoversID }
 
-    /// How a relaunch continues (or doesn't) this agent's prior conversation.
-    enum ResumeStyle: Hashable {
-        case none
-        case claudeStyle
-        case piStyle
-        case codexStyle
-        case openCodeStyle
+    /// How a relaunch continues (or doesn't) this agent's prior conversation, parsed
+    /// straight from the manifest's `resume` object. Everything here is data — argument
+    /// templates with an `{id}` placeholder plus a description of the agent's on-disk
+    /// session store — so a new agent in the common "pin an id, create-then-resume"
+    /// family needs no Swift at all. The two things that can't be data (recovering an
+    /// id the agent minted itself, and pre-seeding a session file so a pinned id
+    /// resolves quietly) name a built-in strategy instead of inlining the agent's
+    /// private file format. See docs/design/agent-resume-identity.md.
+    struct ResumeSpec: Hashable, Sendable {
+        /// Launch template for a fresh, termio-pinned id (e.g. `--session-id {id}`). Its
+        /// presence means the id is pinned up front; its absence means the id is
+        /// discovered after launch, or the agent doesn't resume.
+        var create: String?
+        /// Template to continue a known conversation id (e.g. `--resume {id}`).
+        var resume: String?
+        /// Template to continue the most-recent conversation when no id is known yet —
+        /// discovered-id agents, before the first discovery (e.g. `--continue`).
+        var continueLast: String?
+        /// The agent's on-disk session store. Lets termio tell an already-saved
+        /// conversation (→ `resume`) from a brand-new one (→ `create`), since a create
+        /// flag errors on a duplicate id; also backs the Info-pane transcript fallback
+        /// and `/clear` id-rotation for file-per-conversation stores.
+        var store: Store?
+        /// Names the built-in matcher that reads this agent's own store to recover an
+        /// id it minted itself (`codex`, `opencode`). Set iff `create` is nil.
+        var discover: String?
+        /// Names the built-in that pre-creates the session file so a pinned id resolves
+        /// silently on first launch (`pi`).
+        var seed: String?
 
-        /// The agent's conversation id read from its live transcript *path*, for
-        /// styles whose filename encodes the id. termio uses this to advance a
-        /// session's pinned `resumeID` after the agent rotates its conversation
-        /// mid-session — Claude Code's `/clear` mints a new id and transcript and
-        /// orphans the old file, which the once-pinned id would otherwise keep
-        /// resuming. Returns nil when the id is not in the filename (Codex/OpenCode
-        /// carry it *inside* the file, so advancing those is re-discovery's job, not
-        /// path parsing) or the style does not resume. See
-        /// docs/design/agent-resume-identity.md.
-        func conversationID(fromTranscriptPath path: String) -> String? {
-            switch self {
-            case .claudeStyle:
-                // Claude names the transcript exactly `<conversation-id>.jsonl`; strip
-                // the suffix directly rather than via `deletingPathExtension`, which
-                // mishandles a leading-dot name (a stray `.jsonl` would survive as an id).
-                let file = (path as NSString).lastPathComponent
-                guard file.hasSuffix(".jsonl") else { return nil }
-                let id = String(file.dropLast(".jsonl".count))
-                return id.isEmpty ? nil : id
-            case .piStyle, .codexStyle, .openCodeStyle, .none:
-                // Pi encodes the id in the filename too (`<timestamp>_<id>.jsonl`),
-                // but its transcript discovery isn't wired yet; Codex/OpenCode keep
-                // the id inside the file. All advance via re-discovery (Phase 3),
-                // not here — see the design doc.
-                return nil
+        /// A declarative description of where an agent keeps its conversations on disk.
+        struct Store: Hashable, Sendable {
+            /// Tilde-expandable root, e.g. `~/.grok/sessions`.
+            var root: String
+            /// Whether a conversation is a directory (Grok) or a file (Claude, Pi).
+            var isDirectory: Bool
+            /// The entry name with `{id}` substituted — `{id}` (dir), `{id}.jsonl`, or
+            /// `*_{id}.jsonl` (a `*` globs). Sessions bucket per working directory under
+            /// `root`; termio searches across the buckets rather than reconstruct each
+            /// agent's private cwd encoding.
+            var name: String
+        }
+
+        static let none = ResumeSpec()
+
+        var pinsID: Bool { create != nil }
+        var discoversID: Bool { discover != nil }
+
+        /// The argument fragment to append to the base command so this session continues
+        /// its prior conversation on relaunch, or `nil` to launch fresh.
+        func arguments(_ context: ResumeContext) -> String? {
+            func fill(_ template: String?) -> String? {
+                template?.replacingOccurrences(of: "{id}", with: context.resumeID)
             }
+            if pinsID {
+                // The create flag errors if the id already exists and the resume flag
+                // errors if it doesn't, so create until the agent has saved a
+                // conversation and resume once it has. (When both templates are equal —
+                // Pi — the branch is a no-op either way.)
+                return context.pinnedConversationExists ? fill(resume) : fill(create)
+            }
+            if discoversID {
+                // Resume the exact session once its id has been discovered; until then
+                // continue the most recent recorded session in this directory.
+                if !context.resumeID.isEmpty { return fill(resume) }
+                return context.launchedBefore ? continueLast : nil
+            }
+            return nil
+        }
+
+        /// The conversation id encoded in a transcript *path*, for a file-per-conversation
+        /// store whose filename carries the id. termio uses this to advance a session's
+        /// pinned `resumeID` after the agent rotates its conversation mid-session (Claude
+        /// Code's `/clear` mints a new id and transcript and orphans the old file, which
+        /// the once-pinned id would otherwise keep resuming). Nil for directory stores,
+        /// discovered-id agents (the id lives inside the file), or no declared store.
+        func conversationID(fromTranscriptPath path: String) -> String? {
+            guard let store, !store.isDirectory else { return nil }
+            return SessionStore.id(fromEntryName: (path as NSString).lastPathComponent,
+                                   pattern: store.name)
         }
     }
 
@@ -165,38 +211,16 @@ struct AgentDefinition: Identifiable {
         var resumeID: String
         /// Whether this session's agent has been launched in a prior app run.
         var launchedBefore: Bool
-        /// Whether Claude Code already has a saved conversation under `resumeID`.
-        /// Resuming one that doesn't exist errors, so a pinned-but-never-used session
-        /// is (re)created with `--session-id` instead.
+        /// Whether the agent already has a saved conversation under `resumeID`. Resuming
+        /// one that doesn't exist errors, so a pinned-but-never-used session is
+        /// (re)created with the `create` flag instead.
         var pinnedConversationExists: Bool
     }
 
     /// The argument fragment to append to the resolved base command so this session
     /// continues its prior conversation on relaunch, or `nil` to launch fresh.
     func resumeArguments(_ context: ResumeContext) -> String? {
-        switch resumeStyle {
-        case .none:
-            return nil
-        case .claudeStyle:
-            // `--session-id` creates a session with our id (and errors if it already
-            // exists); `--resume` resumes it (and errors if it doesn't). So create
-            // until a conversation has been saved, and resume once one exists.
-            return context.pinnedConversationExists
-                ? "--resume \(context.resumeID)"
-                : "--session-id \(context.resumeID)"
-        case .piStyle:
-            // Pi's `--session-id` creates the session when missing and resumes it
-            // otherwise, so the same flag is correct on every launch.
-            return "--session-id \(context.resumeID)"
-        case .codexStyle:
-            // Resume the exact session once its id has been discovered; until then
-            // continue the most recent recorded session in this directory.
-            if !context.resumeID.isEmpty { return "resume \(context.resumeID)" }
-            return context.launchedBefore ? "resume --last" : nil
-        case .openCodeStyle:
-            if !context.resumeID.isEmpty { return "--session \(context.resumeID)" }
-            return context.launchedBefore ? "--continue" : nil
-        }
+        resumeSpec.arguments(context)
     }
 }
 
@@ -231,7 +255,7 @@ extension AgentDefinition {
     static func fallback(id: String) -> AgentDefinition {
         AgentDefinition(
             id: id, displayName: id, command: nil, permissionBypassFlag: nil,
-            resumeStyle: .none,
+            resumeSpec: .none,
             icon: .symbol("questionmark.app"),
             iconRef: TermioShared.IconRef(symbol: "questionmark.app"),
             tint: .monochromeInk, tintHex: nil,
@@ -773,7 +797,7 @@ struct AgentManifest: Decodable {
     var wire: String?
     var command: String?
     var permissionBypassFlag: String?
-    var resume: String?
+    var resume: ResumeConfig?
     var install: String?
     /// Accepted while Cut 4 migrates manifests written against the earlier RFC.
     var installURL: String?
@@ -792,6 +816,35 @@ struct AgentManifest: Decodable {
         var symbol: String?
         var tint: String?
         var path: String?
+    }
+
+    /// The manifest's `resume`. The flat object is the interface; a bare string is
+    /// accepted only as backward-compatibility for manifests written against the older
+    /// preset names (`"claude"`, `"codex"`, `"pi"`, `"opencode"`, `"none"`).
+    enum ResumeConfig: Decodable {
+        case legacyPreset(String)
+        case spec(Fields)
+
+        struct Fields: Decodable {
+            var create: String?
+            var resume: String?
+            var continueLast: String?
+            /// Tilde-expandable root of the agent's on-disk session store.
+            var storeRoot: String?
+            /// `dir:<pattern>` or `file:<pattern>`, where `<pattern>` contains `{id}` and
+            /// may contain a `*` glob (e.g. `dir:{id}`, `file:{id}.jsonl`, `file:*_{id}.jsonl`).
+            var storeMatch: String?
+            var discover: String?
+            var seed: String?
+        }
+
+        init(from decoder: Decoder) throws {
+            if let preset = try? decoder.singleValueContainer().decode(String.self) {
+                self = .legacyPreset(preset)
+            } else {
+                self = .spec(try Fields(from: decoder))
+            }
+        }
     }
 
     /// Regex lists that classify the agent's rendered screen. `working` → the spinner
@@ -815,6 +868,72 @@ struct AgentManifest: Decodable {
             var event: String?
             var state: String
             var matcher: String?
+        }
+    }
+
+    /// Turns the manifest's `resume` into the runtime `ResumeSpec`, validating the store
+    /// descriptor and the named strategies. The legacy preset strings map onto the same
+    /// objects the bundled manifests now declare, so old user manifests keep working.
+    private func resolvedResumeSpec() throws -> AgentDefinition.ResumeSpec {
+        guard let resume else { return .none }
+        switch resume {
+        case .legacyPreset(let preset):
+            switch preset.lowercased() {
+            case "none": return .none
+            case "claude":
+                return .init(create: "--session-id {id}", resume: "--resume {id}",
+                             store: .init(root: "~/.claude/projects", isDirectory: false,
+                                          name: "{id}.jsonl"))
+            case "pi":
+                return .init(create: "--session-id {id}", resume: "--session-id {id}",
+                             store: .init(root: "~/.pi/agent/sessions", isDirectory: false,
+                                          name: "*_{id}.jsonl"), seed: "pi")
+            case "codex":
+                return .init(resume: "resume {id}", continueLast: "resume --last", discover: "codex")
+            case "opencode":
+                return .init(resume: "--session {id}", continueLast: "--continue", discover: "opencode")
+            case let other:
+                throw ManifestError.invalid("\(id): unknown resume preset '\(other)'")
+            }
+        case .spec(let fields):
+            var store: AgentDefinition.ResumeSpec.Store?
+            switch (fields.storeRoot, fields.storeMatch) {
+            case (nil, nil):
+                store = nil
+            case let (root?, match?):
+                let parts = match.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+                guard parts.count == 2, !parts[1].isEmpty else {
+                    throw ManifestError.invalid(
+                        "\(id): storeMatch must be 'dir:<pattern>' or 'file:<pattern>'")
+                }
+                let isDirectory: Bool
+                switch parts[0] {
+                case "dir": isDirectory = true
+                case "file": isDirectory = false
+                default:
+                    throw ManifestError.invalid(
+                        "\(id): storeMatch must start with 'dir:' or 'file:'")
+                }
+                guard parts[1].contains("{id}") else {
+                    throw ManifestError.invalid("\(id): storeMatch pattern must contain '{id}'")
+                }
+                store = .init(root: root, isDirectory: isDirectory, name: String(parts[1]))
+            default:
+                throw ManifestError.invalid("\(id): storeRoot and storeMatch must be set together")
+            }
+            if let discover = fields.discover, !["codex", "opencode"].contains(discover) {
+                throw ManifestError.invalid("\(id): unknown resume discover strategy '\(discover)'")
+            }
+            if let seed = fields.seed, seed != "pi" {
+                throw ManifestError.invalid("\(id): unknown resume seed strategy '\(seed)'")
+            }
+            if fields.create != nil, fields.discover != nil {
+                throw ManifestError.invalid(
+                    "\(id): resume 'create' (pinned id) and 'discover' (found id) are mutually exclusive")
+            }
+            return .init(
+                create: fields.create, resume: fields.resume, continueLast: fields.continueLast,
+                store: store, discover: fields.discover, seed: fields.seed)
         }
     }
 
@@ -945,21 +1064,13 @@ struct AgentManifest: Decodable {
             working: titleStatus?.working, attention: titleStatus?.attention,
             label: "\(id).title")
 
-        let resumeStyle: AgentDefinition.ResumeStyle
-        switch resume?.lowercased() ?? "none" {
-        case "none": resumeStyle = .none
-        case "claude": resumeStyle = .claudeStyle
-        case "codex": resumeStyle = .codexStyle
-        case "opencode": resumeStyle = .openCodeStyle
-        case "pi": resumeStyle = .piStyle
-        case let value: throw ManifestError.invalid("\(id): unknown resume strategy '\(value)'")
-        }
+        let resumeSpec = try resolvedResumeSpec()
 
         return AgentDefinition(
             id: id, order: order ?? AgentDefinition.unorderedRank,
             displayName: name, command: command,
             permissionBypassFlag: permissionBypassFlag,
-            resumeStyle: resumeStyle, icon: resolvedIcon, iconRef: resolvedIconRef,
+            resumeSpec: resumeSpec, icon: resolvedIcon, iconRef: resolvedIconRef,
             tint: resolvedTint, tintHex: resolvedTintHex,
             installURL: (install ?? installURL).flatMap(URL.init(string:)), wireName: wire ?? id,
             statusRules: statusRules, titleRules: titleRules, hookSpec: hookSpec)

--- a/Sources/termio/AgentSessionStore.swift
+++ b/Sources/termio/AgentSessionStore.swift
@@ -11,40 +11,41 @@ import Foundation
 /// `launchedAt`, and (unlike modification time) it doesn't move as the conversation
 /// grows — so the record created right when we launched is the one we bind to.
 ///
-/// This reads each agent's *private* on-disk layout (Codex's `~/.codex/sessions`
-/// rollout files, OpenCode's `~/.local/share/opencode/storage/session` records), which
-/// is undocumented and can change between agent versions. Every read is therefore
-/// best-effort: any miss returns `nil`, and the caller falls back to continuing the
-/// most recent session in the directory.
+/// The record locations and field paths come from the manifest's `resume.discover`
+/// descriptor — pure mechanism (a root, a format, two key paths), interpreted
+/// generically here with no agent identities. The layouts described are each agent's
+/// *private* on-disk format, undocumented and free to change between agent versions,
+/// so every read is best-effort: any miss returns `nil` and the session launches fresh.
 enum AgentSessionStore {
     static func discover(agent: AgentPreset, directory: String, after launchedAt: Date?) -> String? {
         match(agent: agent, directory: directory, after: launchedAt)?.id
     }
 
     /// The on-disk conversation transcript for an agent that doesn't hand termio a
-    /// transcript path through its hooks the way Claude Code does. Codex writes a
-    /// rollout JSONL per session under `~/.codex/sessions`; that file *is* the
-    /// transcript, so the Info pane can render a trace from it. Returns the file path,
-    /// or `nil` when none matches (yet) or the agent has no readable transcript.
-    /// Only Codex is supported: OpenCode's session record is metadata, not a transcript.
+    /// transcript path through its hooks the way Claude Code does. A `jsonl` record is
+    /// the agent's session log itself (Codex's rollout file), so the Info pane can
+    /// render a trace from it; a `json` record is metadata only (OpenCode). Returns the
+    /// file path, or `nil` when none matches (yet) or the record isn't a transcript.
     static func discoverTranscript(agent: AgentPreset, directory: String, after launchedAt: Date?) -> String? {
-        // Only Codex's store record is itself the transcript; OpenCode's is metadata.
-        guard agent.resumeSpec.discover == "codex" else { return nil }
+        guard agent.resumeSpec.discover?.format == .jsonl else { return nil }
         return match(agent: agent, directory: directory, after: launchedAt)?.url.path
     }
 
-    /// The session file for this agent — its URL (the transcript) and the session id
-    /// parsed from it. Both `discover` (id, for resume) and `discoverTranscript` (path,
-    /// for the trace viewer) read from the same scan. Keyed on the manifest's declared
-    /// `resume.discover` strategy rather than agent identity, so the matcher a new agent
-    /// reuses is named in its config.
+    /// The session record for this agent — its URL and the session id parsed from it.
+    /// Both `discover` (id, for resume) and `discoverTranscript` (path, for the trace
+    /// viewer) read from the same scan.
     private static func match(agent: AgentPreset, directory: String, after launchedAt: Date?)
         -> (url: URL, id: String)? {
-        guard let launchedAt else { return nil }
-        switch agent.resumeSpec.discover {
-        case "codex": return matchCodex(directory: directory, after: launchedAt)
-        case "opencode": return matchOpenCode(directory: directory, after: launchedAt)
-        default: return nil
+        guard let launchedAt, let spec = agent.resumeSpec.discover else { return nil }
+        let root = URL(fileURLWithPath: (spec.root as NSString).expandingTildeInPath)
+        let target = canonical(directory)
+        return bestMatch(in: root, ext: spec.format.fileExtension, after: launchedAt) { url in
+            guard let object = record(at: url, format: spec.format),
+                  let id = value(at: spec.id, in: object),
+                  let cwd = value(at: spec.cwd, in: object),
+                  canonical(cwd) == target
+            else { return nil }
+            return id
         }
     }
 
@@ -52,41 +53,28 @@ enum AgentSessionStore {
     /// so its creation time should be ≥ `launchedAt`, but allow for clock granularity.
     private static let tolerance: TimeInterval = 2
 
-    /// Codex writes one rollout file per session at `~/.codex/sessions/YYYY/MM/DD/`,
-    /// whose first line is a `session_meta` event carrying the session `id` and `cwd`.
-    private static func matchCodex(directory: String, after launchedAt: Date) -> (url: URL, id: String)? {
-        let root = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".codex/sessions", isDirectory: true)
-        let target = canonical(directory)
-        return bestMatch(in: root, ext: "jsonl", after: launchedAt) { url in
-            guard let line = firstLine(of: url),
-                  let object = json(line),
-                  object["type"] as? String == "session_meta",
-                  let payload = object["payload"] as? [String: Any],
-                  let id = payload["id"] as? String,
-                  let cwd = payload["cwd"] as? String,
-                  canonical(cwd) == target
-            else { return nil }
-            return id
+    /// One session record as a JSON object: for `jsonl`, the log's first line (the
+    /// header event); for `json`, the whole file.
+    private static func record(at url: URL,
+                               format: AgentDefinition.ResumeSpec.Discover.Format) -> [String: Any]? {
+        switch format {
+        case .jsonl:
+            return firstLine(of: url).flatMap(json)
+        case .json:
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         }
     }
 
-    /// OpenCode stores one JSON record per session under
-    /// `~/.local/share/opencode/storage/session/<projectID>/<id>.json`, carrying the
-    /// `id` and the absolute `directory` the session ran in.
-    private static func matchOpenCode(directory: String, after launchedAt: Date) -> (url: URL, id: String)? {
-        let root = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".local/share/opencode/storage/session", isDirectory: true)
-        let target = canonical(directory)
-        return bestMatch(in: root, ext: "json", after: launchedAt) { url in
-            guard let data = try? Data(contentsOf: url),
-                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let id = object["id"] as? String,
-                  let dir = object["directory"] as? String,
-                  canonical(dir) == target
-            else { return nil }
-            return id
+    /// The string at a dot-separated key path (e.g. `payload.id`) in a JSON object.
+    private static func value(at keyPath: String, in object: [String: Any]) -> String? {
+        var current: Any = object
+        for key in keyPath.split(separator: ".") {
+            guard let dictionary = current as? [String: Any],
+                  let next = dictionary[String(key)] else { return nil }
+            current = next
         }
+        return current as? String
     }
 
     /// Walks `root` for `ext` files created at/after `launchedAt`, runs `identify` (which

--- a/Sources/termio/AgentSessionStore.swift
+++ b/Sources/termio/AgentSessionStore.swift
@@ -28,23 +28,24 @@ enum AgentSessionStore {
     /// or `nil` when none matches (yet) or the agent has no readable transcript.
     /// Only Codex is supported: OpenCode's session record is metadata, not a transcript.
     static func discoverTranscript(agent: AgentPreset, directory: String, after launchedAt: Date?) -> String? {
-        guard agent == .codex else { return nil }
+        // Only Codex's store record is itself the transcript; OpenCode's is metadata.
+        guard agent.resumeSpec.discover == "codex" else { return nil }
         return match(agent: agent, directory: directory, after: launchedAt)?.url.path
     }
 
     /// The session file for this agent — its URL (the transcript) and the session id
     /// parsed from it. Both `discover` (id, for resume) and `discoverTranscript` (path,
-    /// for the trace viewer) read from the same scan.
+    /// for the trace viewer) read from the same scan. Keyed on the manifest's declared
+    /// `resume.discover` strategy rather than agent identity, so the matcher a new agent
+    /// reuses is named in its config.
     private static func match(agent: AgentPreset, directory: String, after launchedAt: Date?)
         -> (url: URL, id: String)? {
         guard let launchedAt else { return nil }
-        if agent == .codex {
-            return matchCodex(directory: directory, after: launchedAt)
+        switch agent.resumeSpec.discover {
+        case "codex": return matchCodex(directory: directory, after: launchedAt)
+        case "opencode": return matchOpenCode(directory: directory, after: launchedAt)
+        default: return nil
         }
-        if agent == .opencode {
-            return matchOpenCode(directory: directory, after: launchedAt)
-        }
-        return nil
     }
 
     /// A small negative tolerance: the agent writes its record just after we launch it,

--- a/Sources/termio/Models.swift
+++ b/Sources/termio/Models.swift
@@ -246,7 +246,7 @@ struct Session: Identifiable, Hashable, Codable {
 
     /// The stable id termio hands the agent so a relaunch resumes *this exact*
     /// conversation rather than starting a new one. Assigned on first launch for
-    /// agents that can pin their session id (Claude Code, Pi — see
+    /// agents that can pin their session id (Claude Code, Grok, Pi — see
     /// `AgentPreset.usesPinnedResumeID`) and `nil` otherwise; Codex/OpenCode resume the
     /// most recent session in the directory and never need one. Persisted, so it
     /// survives the app quitting.

--- a/Sources/termio/Resources/agents/amp.json
+++ b/Sources/termio/Resources/agents/amp.json
@@ -4,7 +4,6 @@
   "name": "Amp",
   "wire": "amp",
   "command": "amp",
-  "resume": "none",
   "icon": { "asset": "amp-favicon" },
   "install": "https://ampcode.com/manual",
   "hooks": {

--- a/Sources/termio/Resources/agents/antigravity.json
+++ b/Sources/termio/Resources/agents/antigravity.json
@@ -4,7 +4,6 @@
   "name": "Antigravity",
   "wire": "antigravity",
   "command": "agy",
-  "resume": "none",
   "icon": { "asset": "antigravity-favicon" },
   "install": "https://antigravity.google/product/antigravity-cli"
 }

--- a/Sources/termio/Resources/agents/claude.json
+++ b/Sources/termio/Resources/agents/claude.json
@@ -5,7 +5,12 @@
   "wire": "claude",
   "command": "claude",
   "permissionBypassFlag": "--dangerously-skip-permissions",
-  "resume": "claude",
+  "resume": {
+    "create": "--session-id {id}",
+    "resume": "--resume {id}",
+    "storeRoot": "~/.claude/projects",
+    "storeMatch": "file:{id}.jsonl"
+  },
   "icon": { "vector": "claude" },
   "install": "https://claude.com/claude-code",
   "titleStatus": {

--- a/Sources/termio/Resources/agents/codex.json
+++ b/Sources/termio/Resources/agents/codex.json
@@ -7,7 +7,12 @@
   "permissionBypassFlag": "--dangerously-bypass-approvals-and-sandbox",
   "resume": {
     "resume": "resume {id}",
-    "discover": "codex"
+    "discover": {
+      "root": "~/.codex/sessions",
+      "format": "jsonl",
+      "id": "payload.id",
+      "cwd": "payload.cwd"
+    }
   },
   "icon": { "vector": "codex" },
   "install": "https://developers.openai.com/codex/cli",

--- a/Sources/termio/Resources/agents/codex.json
+++ b/Sources/termio/Resources/agents/codex.json
@@ -5,7 +5,11 @@
   "wire": "codex",
   "command": "codex",
   "permissionBypassFlag": "--dangerously-bypass-approvals-and-sandbox",
-  "resume": "codex",
+  "resume": {
+    "resume": "resume {id}",
+    "continueLast": "resume --last",
+    "discover": "codex"
+  },
   "icon": { "vector": "codex" },
   "install": "https://developers.openai.com/codex/cli",
   "titleStatus": {

--- a/Sources/termio/Resources/agents/codex.json
+++ b/Sources/termio/Resources/agents/codex.json
@@ -7,7 +7,6 @@
   "permissionBypassFlag": "--dangerously-bypass-approvals-and-sandbox",
   "resume": {
     "resume": "resume {id}",
-    "continueLast": "resume --last",
     "discover": "codex"
   },
   "icon": { "vector": "codex" },

--- a/Sources/termio/Resources/agents/cursor.json
+++ b/Sources/termio/Resources/agents/cursor.json
@@ -4,7 +4,6 @@
   "name": "Cursor",
   "wire": "cursor",
   "command": "cursor-agent",
-  "resume": "none",
   "icon": { "asset": "cursor-favicon" },
   "install": "https://cursor.com/docs/cli",
   "hooks": {

--- a/Sources/termio/Resources/agents/grok.json
+++ b/Sources/termio/Resources/agents/grok.json
@@ -5,7 +5,12 @@
   "wire": "grok",
   "command": "grok",
   "permissionBypassFlag": "--yolo",
-  "resume": "claude",
+  "resume": {
+    "create": "--session-id {id}",
+    "resume": "--resume {id}",
+    "storeRoot": "~/.grok/sessions",
+    "storeMatch": "dir:{id}"
+  },
   "icon": { "vector": "grok" },
   "install": "https://x.ai/cli",
   "titleStatus": {

--- a/Sources/termio/Resources/agents/hermes.json
+++ b/Sources/termio/Resources/agents/hermes.json
@@ -4,7 +4,6 @@
   "name": "Hermes",
   "wire": "hermes",
   "command": "hermes",
-  "resume": "none",
   "icon": { "asset": "hermes-favicon" },
   "install": "https://hermes-agent.nousresearch.com/#downloads"
 }

--- a/Sources/termio/Resources/agents/kimi.json
+++ b/Sources/termio/Resources/agents/kimi.json
@@ -4,7 +4,6 @@
   "name": "Kimi",
   "wire": "kimi",
   "command": "kimi",
-  "resume": "none",
   "icon": { "asset": "kimi-favicon" },
   "install": "https://moonshotai.github.io/kimi-code",
   "hooks": {

--- a/Sources/termio/Resources/agents/opencode.json
+++ b/Sources/termio/Resources/agents/opencode.json
@@ -6,7 +6,6 @@
   "command": "opencode",
   "resume": {
     "resume": "--session {id}",
-    "continueLast": "--continue",
     "discover": "opencode"
   },
   "icon": { "asset": "opencode-favicon" },

--- a/Sources/termio/Resources/agents/opencode.json
+++ b/Sources/termio/Resources/agents/opencode.json
@@ -4,7 +4,11 @@
   "name": "OpenCode",
   "wire": "opencode",
   "command": "opencode",
-  "resume": "opencode",
+  "resume": {
+    "resume": "--session {id}",
+    "continueLast": "--continue",
+    "discover": "opencode"
+  },
   "icon": { "asset": "opencode-favicon" },
   "install": "https://opencode.ai",
   "hooks": {

--- a/Sources/termio/Resources/agents/opencode.json
+++ b/Sources/termio/Resources/agents/opencode.json
@@ -6,7 +6,12 @@
   "command": "opencode",
   "resume": {
     "resume": "--session {id}",
-    "discover": "opencode"
+    "discover": {
+      "root": "~/.local/share/opencode/storage/session",
+      "format": "json",
+      "id": "id",
+      "cwd": "directory"
+    }
   },
   "icon": { "asset": "opencode-favicon" },
   "install": "https://opencode.ai",

--- a/Sources/termio/Resources/agents/pi.json
+++ b/Sources/termio/Resources/agents/pi.json
@@ -9,7 +9,7 @@
     "resume": "--session-id {id}",
     "storeRoot": "~/.pi/agent/sessions",
     "storeMatch": "file:*_{id}.jsonl",
-    "seed": "pi"
+    "seed": "session-file"
   },
   "icon": { "asset": "pi-favicon" },
   "install": "https://pi.dev",

--- a/Sources/termio/Resources/agents/pi.json
+++ b/Sources/termio/Resources/agents/pi.json
@@ -4,7 +4,13 @@
   "name": "Pi",
   "wire": "pi",
   "command": "pi",
-  "resume": "pi",
+  "resume": {
+    "create": "--session-id {id}",
+    "resume": "--session-id {id}",
+    "storeRoot": "~/.pi/agent/sessions",
+    "storeMatch": "file:*_{id}.jsonl",
+    "seed": "pi"
+  },
   "icon": { "asset": "pi-favicon" },
   "install": "https://pi.dev",
   "hooks": {

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -290,13 +290,16 @@ extension TermioStore {
 
     /// Resolves a session's transcript file from disk when its hook hasn't handed
     /// termio one — the source of truth for the Info pane's trace when no hook fired.
-    /// Claude Code names its transcript by the id termio pinned (`Session.resumeID`),
-    /// so it's located directly; Codex/OpenCode fall back to the launch-time file
-    /// match (`AgentSessionStore`). `nil` until a matching transcript exists on disk.
+    /// A pinned-id agent whose store is a file-per-conversation (Claude Code) names its
+    /// transcript by the id termio pinned (`Session.resumeID`), so it's located directly;
+    /// Codex/OpenCode fall back to the launch-time file match (`AgentSessionStore`). `nil`
+    /// until a matching transcript exists on disk.
     func resolveTranscriptPath(for id: Session.ID) -> String? {
         guard let session = session(id), session.launched else { return nil }
-        if session.agent == .claudeCode {
-            return session.resumeID.flatMap(ClaudeConversation.transcriptPath)
+        if let store = session.agent.resumeSpec.store, !store.isDirectory,
+           let resumeID = session.resumeID,
+           let path = SessionStore.locate(store, id: resumeID) {
+            return path
         }
         guard let directory = session.worktreePath ?? project(for: id)?.path else { return nil }
         return AgentSessionStore.discoverTranscript(

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -491,7 +491,6 @@ extension TermioStore {
         }
         let context = AgentPreset.ResumeContext(
             resumeID: resumeID ?? "",
-            launchedBefore: session.launched,
             pinnedConversationExists: pinnedConversationExists
         )
         guard let arguments = agent.resumeArguments(context) else {

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -3,31 +3,69 @@ import Foundation
 import GhosttyTerminal
 import GhosttyTheme
 
-/// Looks up whether Claude Code has a saved conversation for a given session id.
-/// Claude stores each conversation at `~/.claude/projects/<encoded-cwd>/<id>.jsonl`;
-/// we glob across the project folders by id rather than reconstruct Claude's cwd
-/// encoding (which is its private detail). Used to decide between `--session-id`
-/// (create) and `--resume` (resume) — resuming an id with no saved conversation errors.
-enum ClaudeConversation {
-    static func exists(id: String) -> Bool { transcriptPath(id: id) != nil }
+/// Resolves an agent's on-disk conversation entries from the declarative store
+/// descriptor its manifest supplies (`ResumeSpec.Store`) — one probe for every agent,
+/// replacing the per-agent lookups. Agents bucket sessions per working directory under
+/// `root`; termio globs the immediate buckets for the entry whose name matches the
+/// pattern (`{id}` the session id, `*` a wildcard) rather than reconstruct each agent's
+/// private cwd encoding. Used to decide create-vs-resume (a create flag errors on a
+/// duplicate id), to back the Info-pane transcript fallback, and to follow a `/clear`
+/// that rotates the id mid-session.
+enum SessionStore {
+    static func exists(_ store: AgentDefinition.ResumeSpec.Store, id: String) -> Bool {
+        locate(store, id: id) != nil
+    }
 
-    /// The transcript file for a saved conversation `id`, or `nil` if none exists.
-    /// Globs the project folders for `<id>.jsonl` rather than reconstructing Claude's
-    /// cwd encoding. Because termio pins Claude's id (`Session.resumeID`) up front, this
-    /// resolves a session's transcript directly — the fallback the Info pane uses when
-    /// the hook never delivered a `transcript_path` (a session started before the
-    /// transcript-capturing hook was installed; Claude reads hooks only at startup).
-    static func transcriptPath(id: String) -> String? {
-        let projects = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/projects", isDirectory: true)
-        guard let folders = try? FileManager.default.contentsOfDirectory(
-            at: projects, includingPropertiesForKeys: nil) else { return nil }
-        let transcript = "\(id).jsonl"
-        for folder in folders {
-            let candidate = folder.appendingPathComponent(transcript)
-            if FileManager.default.fileExists(atPath: candidate.path) { return candidate.path }
+    /// The path of the on-disk entry for `id`, or `nil` if the agent hasn't saved it yet.
+    static func locate(_ store: AgentDefinition.ResumeSpec.Store, id: String) -> String? {
+        let root = URL(fileURLWithPath: (store.root as NSString).expandingTildeInPath)
+        guard let buckets = try? FileManager.default.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: nil) else { return nil }
+        let target = store.name.replacingOccurrences(of: "{id}", with: id)
+        let fileManager = FileManager.default
+        for bucket in buckets {
+            if !target.contains("*") {
+                // Exact name (the common case) — a direct existence check, kind-matched
+                // so a file store never matches a stray directory and vice versa.
+                let candidate = bucket.appendingPathComponent(target)
+                var isDirectory: ObjCBool = false
+                if fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory),
+                   isDirectory.boolValue == store.isDirectory { return candidate.path }
+            } else if let entries = try? fileManager.contentsOfDirectory(atPath: bucket.path),
+                      let hit = entries.first(where: { glob(target, matches: $0) }) {
+                return bucket.appendingPathComponent(hit).path
+            }
         }
         return nil
+    }
+
+    /// Recovers `{id}` from a concrete entry name given the store's `{id}`/`*` pattern —
+    /// e.g. `<uuid>.jsonl` against `{id}.jsonl`, or `170_<uuid>.jsonl` against `*_{id}.jsonl`.
+    static func id(fromEntryName name: String, pattern: String) -> String? {
+        guard let idRange = pattern.range(of: "{id}") else { return nil }
+        let prefix = pattern[..<idRange.lowerBound].replacingOccurrences(of: "*", with: "")
+        let suffix = pattern[idRange.upperBound...].replacingOccurrences(of: "*", with: "")
+        var core = Substring(name)
+        if !suffix.isEmpty {
+            guard core.hasSuffix(suffix) else { return nil }
+            core = core.dropLast(suffix.count)
+        }
+        if !prefix.isEmpty, let r = core.range(of: prefix) { core = core[r.upperBound...] }
+        return core.isEmpty ? nil : String(core)
+    }
+
+    /// A minimal `*`-only glob: the non-empty fragments must appear in order, anchored at
+    /// both ends. (Enough for the session-file patterns; not a full shell glob.)
+    private static func glob(_ pattern: String, matches name: String) -> Bool {
+        let fragments = pattern.components(separatedBy: "*")
+        var cursor = name.startIndex
+        for (index, fragment) in fragments.enumerated() where !fragment.isEmpty {
+            guard let range = name.range(of: fragment, range: cursor..<name.endIndex) else { return false }
+            if index == 0, range.lowerBound != name.startIndex { return false }
+            cursor = range.upperBound
+        }
+        if let last = fragments.last, !last.isEmpty { return name.hasSuffix(last) }
+        return true
     }
 }
 
@@ -110,7 +148,8 @@ extension TermioStore {
 
         // Pi checks the pinned `--session-id` against its session store at startup
         // and warns when no file exists yet; pre-creating it keeps the launch silent.
-        if session.agent == .pi, let pinnedID = launch.resumeID {
+        // The manifest opts in via `resume.seed`, so no agent is named here.
+        if session.agent.resumeSpec.seed == "pi", let pinnedID = launch.resumeID {
             PiSession.ensureExists(id: pinnedID, cwd: workspacePath)
         }
 
@@ -440,11 +479,20 @@ extension TermioStore {
         } else {
             resumeID = nil
         }
+        // Does the agent already have a saved conversation under this id? Probe its
+        // declared store — the create flag errors on a duplicate id, so we switch to the
+        // resume flag once the agent has persisted it. Fully manifest-driven: no agent is
+        // named here.
+        let pinnedConversationExists: Bool
+        if let store = agent.resumeSpec.store, let id = resumeID {
+            pinnedConversationExists = SessionStore.exists(store, id: id)
+        } else {
+            pinnedConversationExists = false
+        }
         let context = AgentPreset.ResumeContext(
             resumeID: resumeID ?? "",
             launchedBefore: session.launched,
-            pinnedConversationExists: agent == .claudeCode
-                && resumeID.map(ClaudeConversation.exists) == true
+            pinnedConversationExists: pinnedConversationExists
         )
         guard let arguments = agent.resumeArguments(context) else {
             return (base, resumeID)
@@ -483,7 +531,7 @@ extension TermioStore {
     func reconcileResumeID(_ id: Session.ID, transcriptPath: String) {
         guard let location = locate(id) else { return }
         var session = projects[location.project].sessions[location.session]
-        guard let liveID = session.agent.resumeStyle.conversationID(fromTranscriptPath: transcriptPath),
+        guard let liveID = session.agent.resumeSpec.conversationID(fromTranscriptPath: transcriptPath),
               liveID != session.resumeID
         else { return }
         session.resumeID = liveID

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -149,7 +149,7 @@ extension TermioStore {
         // Pi checks the pinned `--session-id` against its session store at startup
         // and warns when no file exists yet; pre-creating it keeps the launch silent.
         // The manifest opts in via `resume.seed`, so no agent is named here.
-        if session.agent.resumeSpec.seed == "pi", let pinnedID = launch.resumeID {
+        if session.agent.resumeSpec.seed == "session-file", let pinnedID = launch.resumeID {
             PiSession.ensureExists(id: pinnedID, cwd: workspacePath)
         }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,9 @@ from the real front matter).
 | done | bug | ["HANDOFF: terminal content does not reflow on window resize"](bug/terminal-resize-no-reflow-HANDOFF.md) |
 | done | bug | [Agent welcome banner frozen into a narrow column when a session opens in a wide window](bug/terminal-narrow-grid-frozen-banner-on-open.md) |
 | done | design | ["Sandbox removal & restoration (Apple Seatbelt subsystem)"](design/sandbox-removal-and-restoration.md) |
+| done | design | [Agent Abstraction & Configuration](design/agent-abstraction-and-configuration.md) |
+| done | design | [Config-driven agent resume](design/config-driven-agent-resume.md) |
+| done | design | [Vibe Island 式 Agent 状态层（Claude Code hooks）](design/vibe-island-status.md) |
 | done | marketing | [从 IDE 到 ADE：开发环境六十年，以及它为什么正在终结](maketing/blog-ide-to-ade.md) |
 | done | research | ["ADE 赛道全景表（2026-07）：开源 + 闭源一张表，termio 亮点"](competitive-analysis/10-landscape-table-2026-07.md) |
 | done | research | ["Competitive analysis: claude-squad"](competitive-analysis/05-claude-squad.md) |
@@ -68,7 +71,6 @@ from the real front matter).
 | draft | design | [Remote Projects (open an SSH/VPS box like a local project)](design/remote-projects.md) |
 | draft | design | [Session Daemon Architecture (termiod — one model for local, remote, mobile)](design/session-daemon-architecture.md) |
 | draft | design | [远程访问与中转策略（tunelo / BYO-tunnel）](design/remote-access-relay-strategy.md) |
-| draft | design | [Vibe Island 式 Agent 状态层（Claude Code hooks）](design/vibe-island-status.md) |
 | draft | marketing | [OG image & landing copy](maketing/og-image-and-messaging.md) |
 | draft | rfc | ["RFC: Per-project agent sandbox (Apple Seatbelt)"](design/sandbox-seatbelt.md) |
 | draft | rfc | [Automation — scheduled agent runs](rfcs/automation-scheduled-agent-runs.md) |

--- a/docs/design/config-driven-agent-resume.md
+++ b/docs/design/config-driven-agent-resume.md
@@ -46,13 +46,12 @@ pinned family needs is data:
 
 ```jsonc
 "resume": {
-  "create":       "--session-id {id}",   // launch fresh with a termio-pinned id
-  "resume":       "--resume {id}",        // continue a known conversation id
-  "continueLast": "--continue",           // continue most-recent when id unknown
-  "storeRoot":    "~/.grok/sessions",     // root of the agent's on-disk store
-  "storeMatch":   "dir:{id}",             // how a conversation is named on disk
-  "discover":     "codex",                // named strategy: recover an agent-minted id
-  "seed":         "pi"                    // named strategy: pre-create the session file
+  "create":     "--session-id {id}",   // launch fresh with a termio-pinned id
+  "resume":     "--resume {id}",        // continue a known conversation id
+  "storeRoot":  "~/.grok/sessions",     // root of the agent's on-disk store
+  "storeMatch": "dir:{id}",             // how a conversation is named on disk
+  "discover":   "codex",                // named strategy: recover an agent-minted id
+  "seed":       "pi"                    // named strategy: pre-create the session file
 }
 ```
 
@@ -68,7 +67,7 @@ Rules, all inferred from which fields are present — no `kind`/`style` tag:
 `{id}` is the only placeholder; the rendered fragment is appended to the base
 command.
 
-### The discovered-id lifecycle (and why `continueLast` exists)
+### The discovered-id lifecycle
 
 For a discovered-id agent the tab↔conversation connection is *established once,
 then saved* — after which resume is exactly as precise as the pinned family:
@@ -81,19 +80,13 @@ then saved* — after which resume is exactly as precise as the pinned family:
    runs at most once per session; from here on the saved id wins.
 3. **Every later relaunch** — `resume {id}` with the saved id. Exact.
 
-`continueLast` covers only the failure window in step 2: discovery is inference
-(the agent wrote its record late; the match was ambiguous because two sessions
-share a directory; the app quit before a scan ran), and when it misses there is
-no saved id to resume. The alternatives in that state are silently starting a
-*new* conversation — data loss from the user's perspective — or continuing the
-most-recent conversation in this directory via the agent's own flag. The
-`launchedBefore` guard keeps this honest: a tab that never ran launches fresh
-rather than hijacking some unrelated recent session.
-
-Pinned agents never consult `continueLast` — their connection is guaranteed at
-mint time, so they are always exact. If a discovered-id agent ever grows a
-`--session-id`-style flag, it moves to the pinned family and its `continueLast`
-falls away.
+Resume is deliberately exact-or-nothing: if discovery misses (no saved id), the
+session launches fresh rather than approximately continuing "whatever is most
+recent in this directory" — the prior conversation stays reachable in the
+agent's own session picker. An earlier draft carried a `continueLast` fallback
+flag for that window; it was cut as surplus. If a discovered-id agent ever grows
+a `--session-id`-style flag, it moves to the pinned family and discovery falls
+away entirely.
 
 ### The store descriptor
 
@@ -137,17 +130,19 @@ their implementation is code — the wiring stays visible in the manifest.
 
 ## What each built-in declares
 
-| Agent | create | resume | continueLast | store | discover | seed |
-| --- | --- | --- | --- | --- | --- | --- |
-| Claude | `--session-id {id}` | `--resume {id}` | — | `file:{id}.jsonl` | — | — |
-| Grok | `--session-id {id}` | `--resume {id}` | — | `dir:{id}` | — | — |
-| Pi | `--session-id {id}` | `--session-id {id}` | — | `file:*_{id}.jsonl` | — | `pi` |
-| Codex | — | `resume {id}` | `resume --last` | — | `codex` | — |
-| OpenCode | — | `--session {id}` | `--continue` | — | `opencode` | — |
-| Amp, Cursor, Kimi, Antigravity, Hermes | *(no `resume` field)* | | | | | |
+| Agent | create | resume | store | discover | seed |
+| --- | --- | --- | --- | --- | --- |
+| Claude | `--session-id {id}` | `--resume {id}` | `file:{id}.jsonl` | — | — |
+| Grok | `--session-id {id}` | `--resume {id}` | `dir:{id}` | — | — |
+| Pi | `--session-id {id}` | `--session-id {id}` | `file:*_{id}.jsonl` | — | `pi` |
+| Codex | — | `resume {id}` | — | `codex` | — |
+| OpenCode | — | `--session {id}` | — | `opencode` | — |
+| Amp, Cursor, Kimi, Antigravity, Hermes | *(no `resume` field)* | | | | |
 
 The five migrated agents produce byte-identical launch arguments to the old
-`ResumeStyle`, verified case-by-case.
+`ResumeStyle`, verified case-by-case — with one deliberate exception: the old
+`resume --last` / `--continue` fallback (Codex/OpenCode with no discovered id)
+now launches fresh instead of approximately continuing.
 
 ## Why this shape
 

--- a/docs/design/config-driven-agent-resume.md
+++ b/docs/design/config-driven-agent-resume.md
@@ -62,12 +62,38 @@ Rules, all inferred from which fields are present — no `kind`/`style` tag:
   with `create` the first time and `resume` on every relaunch. The switch is driven
   by probing the store (below), because the create flag errors on a duplicate id.
 - **`discover` present ⇒ the id is minted by the agent and recovered afterward.**
-  Used before the id is known: `continueLast`; once discovered: `resume`. `create`
-  and `discover` are mutually exclusive.
+  `create` and `discover` are mutually exclusive.
 - **Neither ⇒ the agent doesn't resume** (omit `resume` entirely, or `"none"`).
 
 `{id}` is the only placeholder; the rendered fragment is appended to the base
 command.
+
+### The discovered-id lifecycle (and why `continueLast` exists)
+
+For a discovered-id agent the tab↔conversation connection is *established once,
+then saved* — after which resume is exactly as precise as the pinned family:
+
+1. **First launch** — no id exists yet, so the session launches fresh and termio
+   stamps `Session.launchedAt`. The agent mints its own id internally.
+2. **Discovery** — on the next resolve, `AgentSessionStore` scans the agent's
+   store for the session record born at that launch (cwd + creation-time match)
+   and `recordLaunch` persists the found id into `Session.resumeID`. Discovery
+   runs at most once per session; from here on the saved id wins.
+3. **Every later relaunch** — `resume {id}` with the saved id. Exact.
+
+`continueLast` covers only the failure window in step 2: discovery is inference
+(the agent wrote its record late; the match was ambiguous because two sessions
+share a directory; the app quit before a scan ran), and when it misses there is
+no saved id to resume. The alternatives in that state are silently starting a
+*new* conversation — data loss from the user's perspective — or continuing the
+most-recent conversation in this directory via the agent's own flag. The
+`launchedBefore` guard keeps this honest: a tab that never ran launches fresh
+rather than hijacking some unrelated recent session.
+
+Pinned agents never consult `continueLast` — their connection is guaranteed at
+mint time, so they are always exact. If a discovered-id agent ever grows a
+`--session-id`-style flag, it moves to the pinned family and its `continueLast`
+falls away.
 
 ### The store descriptor
 

--- a/docs/design/config-driven-agent-resume.md
+++ b/docs/design/config-driven-agent-resume.md
@@ -50,8 +50,13 @@ pinned family needs is data:
   "resume":     "--resume {id}",        // continue a known conversation id
   "storeRoot":  "~/.grok/sessions",     // root of the agent's on-disk store
   "storeMatch": "dir:{id}",             // how a conversation is named on disk
-  "discover":   "codex",                // named strategy: recover an agent-minted id
-  "seed":       "pi"                    // named strategy: pre-create the session file
+  "discover": {                          // how to recover an agent-minted id
+    "root":   "~/.codex/sessions",       //   where the agent's records live
+    "format": "jsonl",                   //   jsonl (header line) | json (whole file)
+    "id":     "payload.id",              //   key path to the session id
+    "cwd":    "payload.cwd"              //   key path to the working directory
+  },
+  "seed":       "session-file"          // pre-create the session file at launch
 }
 ```
 
@@ -113,20 +118,25 @@ encoding. The same descriptor backs three consumers:
    transcript filename to re-pin the live conversation (see
    [agent-resume-identity.md](agent-resume-identity.md)).
 
-### The two named strategies
+### The discover descriptor
 
-Some behavior genuinely can't be data, because it requires parsing or writing an
-agent's private file format. Rather than inline that, the config *names* a
-built-in strategy:
+For agents that mint the id themselves, the id lives *inside* their session
+records. `discover` describes how to read it — pure mechanism, no agent names:
+`root` (where records live), `format` (`jsonl`: the first line of a `.jsonl` log
+is the record and the log itself is the transcript; `json`: a standalone
+metadata file), and two dot-separated key paths (`id`, `cwd`). One generic
+reader in `AgentSessionStore` walks `root` for records created at this session's
+launch whose `cwd` matches, and extracts the id — a new record shape is new
+config, not new code. The `format` also answers whether the matched file can
+feed the Info-pane trace (`jsonl` yes, `json` no).
 
-- **`discover`** (`codex`, `opencode`) — the id lives *inside* the session file
-  (Codex's `session_meta.payload.id`, OpenCode's record), so recovering it means
-  reading that format. `AgentSessionStore` holds the matchers, keyed on this name.
-- **`seed`** (`pi`) — Pi warns on first launch unless its session file already
-  exists, so termio pre-writes pi's exact header. `PiSession` holds the writer.
+### The seed mechanism
 
-These are the only two escape hatches, and they're declared in config even though
-their implementation is code — the wiring stays visible in the manifest.
+`seed: "session-file"` names the one behavior that stays code: pre-creating the
+agent's session file so a pinned id resolves silently on first launch (Pi warns
+otherwise). It can't be data because it must write the agent's private header
+format and cwd encoding. It's still declared in the manifest so the wiring is
+visible; strategies are named for what they *do*, never for an agent.
 
 ## What each built-in declares
 
@@ -134,9 +144,9 @@ their implementation is code — the wiring stays visible in the manifest.
 | --- | --- | --- | --- | --- | --- |
 | Claude | `--session-id {id}` | `--resume {id}` | `file:{id}.jsonl` | — | — |
 | Grok | `--session-id {id}` | `--resume {id}` | `dir:{id}` | — | — |
-| Pi | `--session-id {id}` | `--session-id {id}` | `file:*_{id}.jsonl` | — | `pi` |
-| Codex | — | `resume {id}` | — | `codex` | — |
-| OpenCode | — | `--session {id}` | — | `opencode` | — |
+| Pi | `--session-id {id}` | `--session-id {id}` | `file:*_{id}.jsonl` | — | `session-file` |
+| Codex | — | `resume {id}` | — | `jsonl` · `payload.id` | — |
+| OpenCode | — | `--session {id}` | — | `json` · `id` | — |
 | Amp, Cursor, Kimi, Antigravity, Hermes | *(no `resume` field)* | | | | |
 
 The five migrated agents produce byte-identical launch arguments to the old
@@ -147,12 +157,13 @@ now launches fresh instead of approximately continuing.
 ## Why this shape
 
 - **No presets, no inheritance.** Each agent's config is self-contained and
-  explicit; there are no magic strings to learn beyond the two strategy names.
-  (The old preset strings still decode, as backward-compatibility for existing
-  user manifests, but aren't the documented interface.)
-- **Identity leaves the runtime.** `agent == .claudeCode` / `== .pi` / `== .codex`
-  special-casing is gone from the launch, probe, transcript, and discovery paths;
-  they all read `agent.resumeSpec`.
-- **The common case is code-free.** A new claude-like CLI is four lines of JSON.
-  Only genuinely new *mechanisms* (a third discovery format, a new seed) touch
-  Swift — and then only to add a named strategy the config points at.
+  explicit; the only magic string is the one seed name. (The old preset strings
+  still decode, as backward-compatibility for existing user manifests, but
+  aren't the documented interface.)
+- **Mechanisms, not identities.** Strategies describe *how* (a format, a key
+  path, a file to pre-create), never *who* — there is no `"discover": "codex"`
+  pointing at agent-named code. Agent identity is gone from the launch, probe,
+  transcript, and discovery paths; they all read `agent.resumeSpec`.
+- **The common case is code-free.** A new claude-like CLI is four lines of JSON;
+  a new discovered-id CLI is a `discover` object. Only a genuinely new mechanism
+  (a third record format, a second seed) touches Swift.

--- a/docs/design/config-driven-agent-resume.md
+++ b/docs/design/config-driven-agent-resume.md
@@ -1,0 +1,137 @@
+---
+title: Config-driven agent resume
+status: done
+type: design
+created: 2026-07-20
+updated: 2026-07-20
+related:
+  - agent-resume-identity.md
+  - agent-extensibility.md
+---
+
+# Config-driven agent resume
+
+> Move an agent's resume behavior out of a hardcoded Swift enum and into its
+> manifest, so adding an agent in the common "pin an id, create-then-resume"
+> family is JSON alone — no code.
+
+## The problem
+
+Resume behavior used to live in a five-case `ResumeStyle` enum
+(`claudeStyle` / `piStyle` / `codexStyle` / `openCodeStyle` / `none`). The
+argument strings, the create-vs-resume switch, and the on-disk session-store
+lookups were all hardcoded and keyed on agent *identity* — `agent == .claudeCode`,
+`agent == .pi`, and so on.
+
+That surfaced as a real bug when Grok was added purely through its manifest
+(`grok.json`). Grok's CLI is Claude-shaped — `--session-id <uuid>` creates (and
+errors if the id already exists), `--resume <uuid>` continues — so `resume:
+"claude"` gave it the right *arguments*. But the create-vs-resume switch asked
+"does this conversation already exist on disk?" through a probe hardcoded to
+Claude's store (`~/.claude/projects`). For Grok it was always false, so termio
+re-sent `--session-id` on every relaunch for an id Grok had already saved under
+`~/.grok/sessions`, and Grok rejected the duplicate:
+
+```
+Error: Session ID <uuid> is already in use. Process exited.
+```
+
+Grok couldn't resume — not because its CLI lacked support, but because the store
+probe wasn't expressible in config.
+
+## The interface
+
+`resume` in the manifest becomes a flat object. Everything an agent in the
+pinned family needs is data:
+
+```jsonc
+"resume": {
+  "create":       "--session-id {id}",   // launch fresh with a termio-pinned id
+  "resume":       "--resume {id}",        // continue a known conversation id
+  "continueLast": "--continue",           // continue most-recent when id unknown
+  "storeRoot":    "~/.grok/sessions",     // root of the agent's on-disk store
+  "storeMatch":   "dir:{id}",             // how a conversation is named on disk
+  "discover":     "codex",                // named strategy: recover an agent-minted id
+  "seed":         "pi"                    // named strategy: pre-create the session file
+}
+```
+
+Rules, all inferred from which fields are present — no `kind`/`style` tag:
+
+- **`create` present ⇒ the id is pinned up front.** termio mints the UUID, launches
+  with `create` the first time and `resume` on every relaunch. The switch is driven
+  by probing the store (below), because the create flag errors on a duplicate id.
+- **`discover` present ⇒ the id is minted by the agent and recovered afterward.**
+  Used before the id is known: `continueLast`; once discovered: `resume`. `create`
+  and `discover` are mutually exclusive.
+- **Neither ⇒ the agent doesn't resume** (omit `resume` entirely, or `"none"`).
+
+`{id}` is the only placeholder; the rendered fragment is appended to the base
+command.
+
+### The store descriptor
+
+`storeRoot` + `storeMatch` describe where the agent keeps conversations, so one
+generic probe replaces every per-agent lookup. `storeMatch` is
+`dir:<pattern>` or `file:<pattern>`, where `<pattern>` contains `{id}` and may
+contain a `*` glob:
+
+| Agent | `storeMatch` | on disk |
+| --- | --- | --- |
+| Claude | `file:{id}.jsonl` | `~/.claude/projects/<cwd>/<id>.jsonl` |
+| Grok | `dir:{id}` | `~/.grok/sessions/<cwd>/<id>/` |
+| Pi | `file:*_{id}.jsonl` | `~/.pi/agent/sessions/--<cwd>--/<ts>_<id>.jsonl` |
+
+Agents bucket sessions per working directory under `storeRoot`; the probe
+(`SessionStore` in `TermioStore+TerminalSurface.swift`) globs the immediate
+buckets for the matching entry rather than reconstruct each agent's private cwd
+encoding. The same descriptor backs three consumers:
+
+1. **create-vs-resume** — does an entry for `{id}` exist yet?
+2. **Info-pane transcript fallback** — for a `file:` store, the matched path *is*
+   the transcript (Claude), when no hook delivered one.
+3. **`/clear` id-rotation** — for a `file:` store, `{id}` is recovered back out of a
+   transcript filename to re-pin the live conversation (see
+   [agent-resume-identity.md](agent-resume-identity.md)).
+
+### The two named strategies
+
+Some behavior genuinely can't be data, because it requires parsing or writing an
+agent's private file format. Rather than inline that, the config *names* a
+built-in strategy:
+
+- **`discover`** (`codex`, `opencode`) — the id lives *inside* the session file
+  (Codex's `session_meta.payload.id`, OpenCode's record), so recovering it means
+  reading that format. `AgentSessionStore` holds the matchers, keyed on this name.
+- **`seed`** (`pi`) — Pi warns on first launch unless its session file already
+  exists, so termio pre-writes pi's exact header. `PiSession` holds the writer.
+
+These are the only two escape hatches, and they're declared in config even though
+their implementation is code — the wiring stays visible in the manifest.
+
+## What each built-in declares
+
+| Agent | create | resume | continueLast | store | discover | seed |
+| --- | --- | --- | --- | --- | --- | --- |
+| Claude | `--session-id {id}` | `--resume {id}` | — | `file:{id}.jsonl` | — | — |
+| Grok | `--session-id {id}` | `--resume {id}` | — | `dir:{id}` | — | — |
+| Pi | `--session-id {id}` | `--session-id {id}` | — | `file:*_{id}.jsonl` | — | `pi` |
+| Codex | — | `resume {id}` | `resume --last` | — | `codex` | — |
+| OpenCode | — | `--session {id}` | `--continue` | — | `opencode` | — |
+| Amp, Cursor, Kimi, Antigravity, Hermes | *(no `resume` field)* | | | | | |
+
+The five migrated agents produce byte-identical launch arguments to the old
+`ResumeStyle`, verified case-by-case.
+
+## Why this shape
+
+- **No presets, no inheritance.** Each agent's config is self-contained and
+  explicit; there are no magic strings to learn beyond the two strategy names.
+  (The old preset strings still decode, as backward-compatibility for existing
+  user manifests, but aren't the documented interface.)
+- **Identity leaves the runtime.** `agent == .claudeCode` / `== .pi` / `== .codex`
+  special-casing is gone from the launch, probe, transcript, and discovery paths;
+  they all read `agent.resumeSpec`.
+- **The common case is code-free.** A new claude-like CLI is four lines of JSON.
+  Only genuinely new *mechanisms* (a third discovery format, a new seed) touch
+  Swift — and then only to add a named strategy the config points at.

--- a/web/landing/src/app/docs/atp/page.tsx
+++ b/web/landing/src/app/docs/atp/page.tsx
@@ -1,0 +1,250 @@
+import type { Metadata } from "next";
+import { SiteNav } from "@/components/site-nav";
+import { SiteFooter } from "@/components/site-footer";
+import { SectionLabel } from "@/components/section-label";
+import { Reveal } from "@/components/reveal";
+
+export const metadata: Metadata = {
+  title: "Agent Terminal Protocol",
+  description:
+    "The Agent Terminal Protocol (ATP) is how Termio hosts any agent CLI: one JSON manifest declaring how to launch it, how it reports status, and how to resume its exact conversation.",
+  alternates: {
+    canonical: "/docs/atp",
+  },
+  openGraph: {
+    title: "Agent Terminal Protocol — Termio",
+    description:
+      "One JSON manifest per agent: launch, live status, exact resume. The agent's own TUI stays in a real terminal.",
+    url: "/docs/atp",
+  },
+};
+
+// A spec code block: monospace, hairline border, horizontally scrollable on
+// small screens. Content is a plain string so the JSON reads exactly as the
+// file on disk would.
+function CodeBlock({ children }: { children: string }) {
+  return (
+    <pre className="overflow-x-auto rounded-xl border border-border bg-white/[0.03] p-5 font-mono text-[13px] leading-relaxed text-foreground/90">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+// A two-column field reference row: name (mono) on the left, description on the
+// right, separated by hairlines like the changelog ledger.
+function FieldRow({ name, children }: { name: string; children: React.ReactNode }) {
+  return (
+    <div className="grid gap-1 border-t border-border py-4 first:border-t-0 sm:grid-cols-[200px_minmax(0,1fr)] sm:gap-6">
+      <code className="font-mono text-[13px] text-foreground">{name}</code>
+      <p className="text-sm leading-relaxed text-muted-foreground">{children}</p>
+    </div>
+  );
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mt-16 text-2xl font-medium tracking-tight text-foreground">
+      {children}
+    </h2>
+  );
+}
+
+const exampleManifest = `{
+  "id": "grok",
+  "name": "Grok",
+  "command": "grok",
+  "permissionBypassFlag": "--yolo",
+  "icon": { "vector": "grok" },
+  "install": "https://x.ai/cli",
+  "resume": {
+    "create": "--session-id {id}",
+    "resume": "--resume {id}",
+    "storeRoot": "~/.grok/sessions",
+    "storeMatch": "dir:{id}"
+  },
+  "titleStatus": {
+    "attention": ["Action Required"]
+  },
+  "hooks": {
+    "type": "json",
+    "file": "~/.grok/hooks/termio.json",
+    "dialect": "grok",
+    "events": [
+      { "on": "UserPromptSubmit", "state": "working" },
+      { "on": "PreToolUse", "state": "working" },
+      { "on": "PostToolUse", "state": "working" },
+      { "on": "Stop", "state": "done" }
+    ]
+  }
+}`;
+
+const discoverExample = `"resume": {
+  "resume": "resume {id}",
+  "discover": {
+    "root": "~/.codex/sessions",
+    "format": "jsonl",
+    "id": "payload.id",
+    "cwd": "payload.cwd"
+  }
+}`;
+
+export default function AtpPage() {
+  return (
+    <>
+      <SiteNav />
+      <main className="flex-1">
+        <section className="scroll-mt-24">
+          <div className="mx-auto w-full px-5 pb-32 pt-36 sm:px-8 sm:pb-40 sm:pt-44">
+            <Reveal className="mx-auto mb-14 w-full max-w-[680px] text-center sm:mb-16">
+              <SectionLabel accent="muted">Docs</SectionLabel>
+              <h1 className="mt-4 text-balance text-4xl font-medium leading-[1.1] tracking-tight text-foreground sm:text-5xl">
+                Agent Terminal Protocol
+              </h1>
+              <p className="mx-auto mt-5 max-w-lg text-base leading-relaxed text-muted-foreground">
+                ATP is how a terminal hosts an agent CLI: one JSON manifest
+                declaring how to launch it, how it reports status, and how to
+                resume its exact conversation.
+              </p>
+            </Reveal>
+
+            <Reveal className="mx-auto w-full max-w-[640px]">
+              <p className="text-base leading-relaxed text-muted-foreground">
+                Editor protocols re-render your agent inside an editor pane. ATP
+                takes the opposite bet: the agent&apos;s own TUI already is the
+                interface, so it stays in a real terminal, and the protocol
+                standardizes only the thin layer around it —{" "}
+                <span className="text-foreground">launch</span>,{" "}
+                <span className="text-foreground">live status</span>, and{" "}
+                <span className="text-foreground">exact resume</span>. Every
+                agent Termio ships is defined by this same manifest; there is no
+                privileged internal API.
+              </p>
+
+              <SectionHeading>The manifest</SectionHeading>
+              <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+                One JSON file per agent. This is Termio&apos;s bundled Grok
+                manifest, verbatim:
+              </p>
+              <div className="mt-6">
+                <CodeBlock>{exampleManifest}</CodeBlock>
+              </div>
+
+              <div className="mt-8">
+                <FieldRow name="id">
+                  Stable identifier. Sessions persist it, so it never changes
+                  once shipped.
+                </FieldRow>
+                <FieldRow name="name">Display name in the picker and sidebar.</FieldRow>
+                <FieldRow name="command">
+                  The CLI to launch, resolved on your login shell&apos;s PATH.
+                </FieldRow>
+                <FieldRow name="permissionBypassFlag">
+                  The vendor&apos;s skip-permissions flag, wired to a one-click
+                  toggle. Optional.
+                </FieldRow>
+                <FieldRow name="icon">
+                  <code className="font-mono text-[13px]">vector</code> (a
+                  built-in brand mark), <code className="font-mono text-[13px]">path</code>{" "}
+                  (your PNG/SVG file), or{" "}
+                  <code className="font-mono text-[13px]">symbol</code> (an SF
+                  Symbol), with an optional{" "}
+                  <code className="font-mono text-[13px]">tint</code>.
+                </FieldRow>
+                <FieldRow name="install">
+                  The vendor&apos;s install page, offered when the command
+                  isn&apos;t found. Optional.
+                </FieldRow>
+                <FieldRow name="order">
+                  Position in the agent picker. Optional; omitted manifests sort
+                  last.
+                </FieldRow>
+              </div>
+
+              <SectionHeading>Status</SectionHeading>
+              <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+                A session is always in one of four states —{" "}
+                <code className="font-mono text-[13px]">working</code>,{" "}
+                <code className="font-mono text-[13px]">attention</code>{" "}
+                (blocked on you),{" "}
+                <code className="font-mono text-[13px]">done</code>, or{" "}
+                <code className="font-mono text-[13px]">idle</code> — shown in
+                the sidebar, the menu bar, and on your phone. The manifest
+                declares how the agent reports them:
+              </p>
+              <div className="mt-8">
+                <FieldRow name="hooks">
+                  The precise channel: Termio installs the agent&apos;s own hook
+                  configuration (JSON, TOML, or a plugin, per{" "}
+                  <code className="font-mono text-[13px]">dialect</code>) so the
+                  agent itself reports each{" "}
+                  <code className="font-mono text-[13px]">on → state</code>{" "}
+                  event. When hooks are declared they are the single source of
+                  truth.
+                </FieldRow>
+                <FieldRow name="titleStatus">
+                  Regex rules over the agent&apos;s live terminal title (OSC
+                  0/2) — the in-band signal some agents broadcast. Coexists with
+                  hooks and corrects a missed event the instant the title flips.
+                </FieldRow>
+                <FieldRow name="status">
+                  Screen-classification regexes for agents with no hook system
+                  at all. Ignored when hooks are declared.
+                </FieldRow>
+              </div>
+
+              <SectionHeading>Resume</SectionHeading>
+              <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+                Reopening a session relaunches the agent into the same
+                conversation. Resume is exact-or-nothing: Termio either resumes
+                the precise conversation a tab is bound to, or launches fresh —
+                it never guesses. Two families, inferred from which fields are
+                present:
+              </p>
+              <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+                <span className="text-foreground">Pinned id</span> — the CLI
+                accepts a session id at launch.{" "}
+                <code className="font-mono text-[13px]">create</code> starts a
+                fresh conversation under a Termio-minted id and{" "}
+                <code className="font-mono text-[13px]">resume</code> continues
+                it; <code className="font-mono text-[13px]">storeRoot</code> +{" "}
+                <code className="font-mono text-[13px]">storeMatch</code>{" "}
+                describe the agent&apos;s on-disk session store so Termio can
+                tell the two apart (creating a duplicate id errors, as does
+                resuming a missing one).
+              </p>
+              <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+                <span className="text-foreground">Discovered id</span> — the
+                agent mints the id itself.{" "}
+                <code className="font-mono text-[13px]">discover</code>{" "}
+                describes the mechanism, never an agent: where session records
+                live, how a record is read (
+                <code className="font-mono text-[13px]">jsonl</code> — the first
+                line of a log that is itself the transcript, or{" "}
+                <code className="font-mono text-[13px]">json</code> — a
+                standalone metadata file), and key paths to the id and working
+                directory. Termio recovers the id once, binds it to the tab, and
+                resumes exactly from then on.
+              </p>
+              <div className="mt-6">
+                <CodeBlock>{discoverExample}</CodeBlock>
+              </div>
+
+              <SectionHeading>Add your own agent</SectionHeading>
+              <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+                Drop a manifest at{" "}
+                <code className="font-mono text-[13px]">
+                  ~/.termio/config/agents/&lt;id&gt;.json
+                </code>{" "}
+                and restart Termio — it appears in the picker alongside the
+                built-ins, with the same status dots and resume behavior. A
+                minimal manifest is just an id, a name, and a command; add
+                status and resume as the CLI supports them.
+              </p>
+            </Reveal>
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/web/landing/src/app/sitemap.ts
+++ b/web/landing/src/app/sitemap.ts
@@ -19,6 +19,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: "https://www.termio.sh/docs/atp",
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
       url: "https://www.termio.sh/privacy",
       changeFrequency: "yearly",
       priority: 0.3,

--- a/web/landing/src/components/site-footer.tsx
+++ b/web/landing/src/components/site-footer.tsx
@@ -1,5 +1,6 @@
 const footerLinks: { label: string; href: string }[] = [
   { label: "Changelog", href: "/changelog" },
+  { label: "Docs", href: "/docs/atp" },
   { label: "Privacy", href: "/privacy" },
   { label: "Terms", href: "/terms" },
 ];

--- a/web/landing/src/lib/site.ts
+++ b/web/landing/src/lib/site.ts
@@ -15,6 +15,7 @@ export const supportedAgents = [
 
 export const navLinks = [
   { label: "Changelog", href: "/changelog" },
+  { label: "Docs", href: "/docs/atp" },
 ] as const;
 
 // Community Discord invite, surfaced in the site nav.


### PR DESCRIPTION
## Why

Resume behavior lived in a hardcoded five-case `ResumeStyle` enum whose argument strings, create-vs-resume switch, and on-disk session-store lookups were all keyed on **agent identity** (`agent == .claudeCode`, `== .pi`, `== .codex`). So an agent added through its manifest alone couldn't fully resume: Grok (added via `grok.json`) launched fine but failed on relaunch with `Session ID <uuid> is already in use`, because the create-vs-resume probe was wired to Claude's store (`~/.claude/projects`) and never saw Grok's (`~/.grok/sessions`).

This makes resume **data**, per the design in `docs/design/config-driven-agent-resume.md`.

## The interface

`resume` in the manifest becomes a flat object:

```jsonc
"resume": {
  "create":     "--session-id {id}",   // launch fresh with a termio-pinned id
  "resume":     "--resume {id}",        // continue a known id
  "storeRoot":  "~/.grok/sessions",     // root of the agent's on-disk store
  "storeMatch": "dir:{id}",             // file:<pat> | dir:<pat>, {id} + optional *
  "discover":   "codex",                // named strategy: recover an agent-minted id
  "seed":       "pi"                    // named strategy: pre-create the session file
}
```

Rules are inferred from which fields are present (no `style`/`kind` tag): `create` ⇒ id pinned up front; `discover` ⇒ id minted by the agent, recovered once after launch and saved onto the tab (`Session.resumeID`); neither ⇒ no resume. `create`/`discover` are mutually exclusive.

Resume is **exact-or-nothing**: a discovered-id agent with no saved id launches fresh — there is no approximate "continue most-recent" fallback (an earlier revision carried a `continueLast` flag; it was cut as surplus).

## What changed

- New `ResumeSpec` (parsed from the manifest) replaces the `ResumeStyle` enum.
- One generic `SessionStore` probe driven by `storeRoot`/`storeMatch` replaces the per-agent `ClaudeConversation`/`GrokConversation` lookups; it also backs the Info-pane transcript fallback and the `/clear` id-rotation.
- `AgentSessionStore` discovery and the Pi seed are keyed on the manifest's `discover`/`seed` names, not agent identity.
- All ten bundled manifests migrated to the new shape.

Agent identity no longer appears in the launch, probe, transcript, or discovery paths. A new claude-like CLI is now four lines of JSON.

## Verification

- `swift build` passes.
- The five resuming agents produce **byte-identical** launch arguments to the old enum (verified case-by-case), with one deliberate behavior change: Codex/OpenCode with no discovered id launch fresh instead of `resume --last` / `--continue`.
- `SessionStore` glob + id-extraction and the `storeMatch` parser unit-checked against Claude/Grok/Pi patterns and malformed input.

## Notes

- Supersedes #26 (the Grok-specific `GrokConversation` fix) — that special-case is subsumed by the generic probe here. #26 is closed.
- Legacy `"resume": "claude"`-style strings still decode (backward-compat for existing user manifests) but aren't the documented interface.

Release Notes: Grok sessions now resume correctly instead of failing with "Session ID is already in use".