### PR TITLE
fix(landing): anchor .vercelignore so docs site isn't stripped from the build

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,14 +1,19 @@
 # Only web/landing is deployed (Vercel project root directory = web/landing).
 # Keep the upload to sources: exclude the Swift app, build artifacts and deps.
-.build/
-.swiftpm/
-Sources/
-Tests/
-termio.app/
-packaging/
-scripts/
-tools/
-docs/
-web/docs/
-web/landing/node_modules/
-web/landing/.next/
+#
+# NOTE: every pattern is anchored with a leading "/" so it matches ONLY the
+# repo-root entry. An unanchored "docs/" would (gitignore semantics) also match
+# web/landing/content/docs and web/landing/src/app/docs and silently strip the
+# docs site from the build — which is exactly what happened once. Keep the slash.
+/.build/
+/.swiftpm/
+/Sources/
+/Tests/
+/termio.app/
+/packaging/
+/scripts/
+/tools/
+/docs/
+/web/docs/
+/web/landing/node_modules/
+/web/landing/.next/


### PR DESCRIPTION
## Problem

After #29 merged, `www.termio.sh/docs` returned **404** even though the Vercel production deploy was green and built from the right commit (`ca2dbd8`, `main`, READY).

## Root cause

The repo-root `.vercelignore` had an **unanchored** pattern:

```
docs/
```

With gitignore semantics that matches *any* directory named `docs` at any depth — so Vercel stripped `web/landing/content/docs/` (the MDX content) **and** `web/landing/src/app/docs/` (the route) from the upload, along with the intended repo-root `docs/` design docs. The build then compiled **no `/docs` routes** (confirmed in the build log's Route table) and every `/docs/*` path fell through to the 404 page.

## Fix

Anchor every `.vercelignore` pattern to the repo root with a leading `/`, so each excludes only its top-level entry (`/docs/` no longer touches the nested `web/landing/.../docs`). Added a comment explaining why the slash matters.

Vercel will redeploy on merge; `/docs` should then serve on production.