### PR TITLE
feat(landing): serve llms.txt and raw-Markdown docs routes for agents

### DIFF
--- a/web/landing/next.config.ts
+++ b/web/landing/next.config.ts
@@ -5,6 +5,12 @@ const nextConfig: NextConfig = {
   // Emit a self-contained server bundle so the Docker runtime image only needs
   // the standalone output plus static assets, not the full node_modules tree.
   output: "standalone",
+  // /docs/<slug>.md serves a page's raw Markdown for agents (llms.txt links
+  // here). The handler lives at /docs-md because a route.ts can't sit beside
+  // the docs page.tsx.
+  async rewrites() {
+    return [{ source: "/docs/:slug.md", destination: "/docs-md/:slug" }];
+  },
 };
 
 // Wire Fumadocs MDX into the build: this generates the `.source` folder from

--- a/web/landing/src/app/docs-md/[...slug]/route.ts
+++ b/web/landing/src/app/docs-md/[...slug]/route.ts
@@ -1,0 +1,18 @@
+import { source } from "@/lib/source";
+
+// Serves a doc page's raw Markdown. Reached as /docs/<slug>.md via the rewrite
+// in next.config.ts — a route handler can't sit beside the docs page.tsx, so
+// the real path is /docs-md/<slug>. The docs index answers to /docs/index.md.
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string[] }> },
+) {
+  const { slug } = await params;
+  const page = source.getPage(slug.join("/") === "index" ? [] : slug);
+  if (!page) return new Response("Not found", { status: 404 });
+
+  const raw = await page.data.getText("raw");
+  return new Response(raw, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/web/landing/src/app/llms-full.txt/route.ts
+++ b/web/landing/src/app/llms-full.txt/route.ts
@@ -1,0 +1,29 @@
+import {
+  markdownUrl,
+  orderedDocPages,
+  siteUrl,
+  stripFrontmatter,
+} from "@/lib/docs-llms";
+
+// /llms-full.txt — the entire docs corpus as one Markdown document, in sidebar
+// order. Small enough to fit any model's context, so a single fetch gives an
+// agent the complete picture. Statically generated at build time.
+export async function GET() {
+  const sections = await Promise.all(
+    orderedDocPages().map(async (page) => {
+      const raw = await page.data.getText("raw");
+      return [
+        `# ${page.data.title}`,
+        "",
+        `URL: ${siteUrl}${page.url}`,
+        `Markdown: ${markdownUrl(page)}`,
+        "",
+        stripFrontmatter(raw),
+      ].join("\n");
+    }),
+  );
+
+  return new Response(`${sections.join("\n\n---\n\n")}\n`, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/web/landing/src/app/llms.txt/route.ts
+++ b/web/landing/src/app/llms.txt/route.ts
@@ -1,0 +1,33 @@
+import { markdownUrl, orderedDocPages, siteUrl } from "@/lib/docs-llms";
+
+// /llms.txt — the llmstxt.org index for agents: what Termio is, plus every doc
+// page linked in its raw-Markdown form so an agent never has to parse the HTML
+// shell. Statically generated at build time.
+export function GET() {
+  const docLines = orderedDocPages().map((page) => {
+    const description = page.data.description
+      ? `: ${page.data.description}`
+      : "";
+    return `- [${page.data.title}](${markdownUrl(page)})${description}`;
+  });
+
+  const body = [
+    "# Termio",
+    "",
+    "> Termio is a free, native macOS terminal built for running AI coding agents — Claude Code, Codex, Gemini, and friends — side by side. Sessions are organized by project, each with a live status, a built-in inspector, and an iPhone companion app. No account, no payment.",
+    "",
+    "## Docs",
+    "",
+    ...docLines,
+    "",
+    "## Optional",
+    "",
+    `- [Changelog](${siteUrl}/changelog): release history`,
+    `- [Full docs in one file](${siteUrl}/llms-full.txt): every page above, concatenated`,
+    `- Programmatic docs search: \`GET ${siteUrl}/api/search?query=<terms>\` returns JSON results with page URLs`,
+  ].join("\n");
+
+  return new Response(`${body}\n`, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/web/landing/src/app/sitemap.ts
+++ b/web/landing/src/app/sitemap.ts
@@ -1,11 +1,19 @@
 import type { MetadataRoute } from "next";
 import { changelog } from "@/data/changelog";
+import { source } from "@/lib/source";
 
 // /colors is a design scratch page and is deliberately left out (it is also
 // noindexed via its own layout).
 export default function sitemap(): MetadataRoute.Sitemap {
   const latestRelease = new Date(`${changelog[0].date}T12:00:00Z`);
+  const docPages: MetadataRoute.Sitemap = source.getPages().map((page) => ({
+    url: `https://www.termio.sh${page.url}`,
+    lastModified: latestRelease,
+    changeFrequency: "weekly",
+    priority: 0.6,
+  }));
   return [
+    ...docPages,
     {
       url: "https://www.termio.sh/",
       lastModified: latestRelease,

--- a/web/landing/src/lib/docs-llms.ts
+++ b/web/landing/src/lib/docs-llms.ts
@@ -1,0 +1,44 @@
+import { source } from "@/lib/source";
+
+export const siteUrl = "https://www.termio.sh";
+
+type DocPage = NonNullable<ReturnType<typeof source.getPage>>;
+
+// Doc pages in sidebar (meta.json) order, resolved to full page objects so
+// callers get frontmatter and raw Markdown, not just tree nodes. Shared by the
+// llms.txt / llms-full.txt routes.
+export function orderedDocPages(): DocPage[] {
+  const byUrl = new Map(source.getPages().map((page) => [page.url, page]));
+  const out: DocPage[] = [];
+  const walk = (nodes: ReturnType<typeof source.getPageTree>["children"]) => {
+    for (const node of nodes) {
+      if (node.type === "page") {
+        const page = byUrl.get(String(node.url));
+        if (page) out.push(page);
+      } else if (node.type === "folder") {
+        if (node.index) {
+          const page = byUrl.get(String(node.index.url));
+          if (page) out.push(page);
+        }
+        walk(node.children);
+      }
+    }
+  };
+  walk(source.getPageTree().children);
+  return out;
+}
+
+// The absolute URL of a page's raw-Markdown twin — /docs/<slug>.md, served by
+// the app/docs-md handler via the rewrite in next.config.ts. The docs index has
+// no slug of its own, so it lives at /docs/index.md.
+export function markdownUrl(page: DocPage): string {
+  return page.url === "/docs"
+    ? `${siteUrl}/docs/index.md`
+    : `${siteUrl}${page.url}.md`;
+}
+
+// Strip the YAML frontmatter block getText("raw") includes; llms-full.txt
+// renders its own title/URL header instead.
+export function stripFrontmatter(raw: string): string {
+  return raw.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
+}


### PR DESCRIPTION
## What

Make the docs site legible to LLMs and agents without parsing the HTML shell:

- **`/llms.txt`** — [llmstxt.org](https://llmstxt.org) index: one-paragraph site summary, every doc page linked in its raw-Markdown form with its frontmatter description, plus the programmatic search endpoint (`GET /api/search?query=…`) documented for agents.
- **`/docs/<slug>.md`** — any page's raw Markdown (`text/markdown`), served by `app/docs-md` via a rewrite since a route handler can't sit beside the docs `page.tsx`. Docs index lives at `/docs/index.md`.
- **`/llms-full.txt`** — the entire 13-page corpus as one sidebar-ordered Markdown document (frontmatter stripped, per-page title + canonical URL headers), so one fetch gives an agent everything.
- **Sitemap fix** — `sitemap.xml` previously omitted every docs page; they're now listed.

All three routes reuse the existing fumadocs `source` loader and `getText("raw")` (already powering the "Copy for LLM" button). Zero new dependencies.

## Verification

Against local `next dev` + `next build`:
- `/llms.txt` valid llmstxt format; all 13 `.md` links return 200 `text/markdown`
- bogus slug → 404; `/docs/index.md` serves the index
- `/llms-full.txt` contains all 13 page titles, zero leaked frontmatter
- `/sitemap.xml` lists all docs URLs; `tsc --noEmit` + eslint clean; production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)