### PR TITLE
fix(landing): prerender the llms.txt and docs Markdown routes

### DIFF
--- a/web/landing/src/app/docs-md/[...slug]/route.ts
+++ b/web/landing/src/app/docs-md/[...slug]/route.ts
@@ -3,6 +3,17 @@ import { source } from "@/lib/source";
 // Serves a doc page's raw Markdown. Reached as /docs/<slug>.md via the rewrite
 // in next.config.ts — a route handler can't sit beside the docs page.tsx, so
 // the real path is /docs-md/<slug>. The docs index answers to /docs/index.md.
+// Every page prerenders at build time: getText("raw") reads the content/docs
+// sources from disk, which aren't in the serverless bundle at request time.
+export const dynamic = "force-static";
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return source.getPages().map((page) => ({
+    slug: page.slugs.length ? page.slugs : ["index"],
+  }));
+}
+
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ slug: string[] }> },

--- a/web/landing/src/app/llms-full.txt/route.ts
+++ b/web/landing/src/app/llms-full.txt/route.ts
@@ -7,7 +7,10 @@ import {
 
 // /llms-full.txt — the entire docs corpus as one Markdown document, in sidebar
 // order. Small enough to fit any model's context, so a single fetch gives an
-// agent the complete picture. Statically generated at build time.
+// agent the complete picture. Must render at build time: getText("raw") reads
+// the content/docs sources from disk, which aren't in the serverless bundle.
+export const dynamic = "force-static";
+
 export async function GET() {
   const sections = await Promise.all(
     orderedDocPages().map(async (page) => {

--- a/web/landing/src/app/llms.txt/route.ts
+++ b/web/landing/src/app/llms.txt/route.ts
@@ -2,7 +2,10 @@ import { markdownUrl, orderedDocPages, siteUrl } from "@/lib/docs-llms";
 
 // /llms.txt — the llmstxt.org index for agents: what Termio is, plus every doc
 // page linked in its raw-Markdown form so an agent never has to parse the HTML
-// shell. Statically generated at build time.
+// shell. Must render at build time: route handlers are dynamic by default, and
+// at request time the content/docs sources aren't in the serverless bundle.
+export const dynamic = "force-static";
+
 export function GET() {
   const docLines = orderedDocPages().map((page) => {
     const description = page.data.description


### PR DESCRIPTION
## Problem

After #32 deployed, `/docs/<slug>.md` and `/llms-full.txt` returned **500 in production** (they worked in local dev and build). Next 16 route handlers are dynamic by default, and `getText("raw")` reads the `content/docs` source files from disk at request time — those files aren't included in Vercel's serverless bundle. `/llms.txt` survived only because it reads nothing but compiled frontmatter.

## Fix

Force all three routes static (`dynamic = "force-static"`), and give the per-page route `generateStaticParams` + `dynamicParams = false` so every page prerenders at build time — where the content files exist — exactly like the docs pages themselves.

## Verification

`next build` now shows ○/● for all three routes (was ƒ). Against local `next start` (prod server): all 13 `.md` pages 200 `text/markdown`, `/llms-full.txt` has 13 titles, bogus slug 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)