### PR TITLE
Refresh session identity when Claude Code /clear rotates the conversation

### DIFF
--- a/Sources/termio/Info/SessionTraceRenderer.swift
+++ b/Sources/termio/Info/SessionTraceRenderer.swift
@@ -23,6 +23,13 @@ enum SessionTraceRenderer {
     /// Reads the JSONL at `jsonlPath` and returns a full HTML document string, themed
     /// with `theme`. The caller hands the string to a `WKWebView`.
     static func html(jsonlPath: String, title: String, theme: TraceTheme) throws -> String {
+        // A conversation rotation (Claude Code's `/clear`) advances the transcript
+        // pointer before the agent writes the new file — it appears on the first
+        // message. Until then an absent file means "new conversation", not an error.
+        guard FileManager.default.fileExists(atPath: jsonlPath) else {
+            return placeholder(message: "New conversation — no messages yet.",
+                               theme: theme, title: title)
+        }
         guard let data = FileManager.default.contents(atPath: jsonlPath),
               let text = String(data: data, encoding: .utf8) else {
             throw RenderError.unreadable(jsonlPath)
@@ -49,9 +56,9 @@ enum SessionTraceRenderer {
     /// A themed one-line page for when there is nothing to render yet — used by
     /// the companion server so a trace request always returns a valid document
     /// (never a fatal `.error` on the PTY-bridge socket).
-    static func placeholder(message: String, theme: TraceTheme) -> String {
+    static func placeholder(message: String, theme: TraceTheme, title: String = "Trace") -> String {
         let body = "<div class=\"turn\"><div class=\"text\">\(escaped(message))</div></div>"
-        return document(title: "Trace", stats: Stats(), body: body, theme: theme)
+        return document(title: title, stats: Stats(), body: body, theme: theme)
     }
 
     // MARK: Stats

--- a/Sources/termio/Resources/agents/claude.json
+++ b/Sources/termio/Resources/agents/claude.json
@@ -22,6 +22,7 @@
     "dialect": "claude",
     "capturesTranscript": true,
     "events": [
+      { "on": "SessionStart", "state": "idle", "matcher": "clear" },
       { "on": "UserPromptSubmit", "state": "working" },
       { "on": "PreToolUse", "state": "working", "matcher": "*" },
       { "on": "PostToolUse", "state": "working", "matcher": "*" },

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -533,6 +533,16 @@ extension TermioStore {
         guard let liveID = session.agent.resumeSpec.conversationID(fromTranscriptPath: transcriptPath),
               liveID != session.resumeID
         else { return }
+        // A genuine rotation (the pin already named a conversation and it changed —
+        // not the first-report adoption of an unpinned session) also orphans the
+        // sidebar topic title: it describes the discarded conversation. Drop both
+        // the in-memory and the persisted copy so `displayTitle` falls back to the
+        // agent name until the new conversation earns a topic. Status and
+        // `lastTitleActivity` are separate channels — leave them alone.
+        if session.resumeID != nil {
+            liveTitles[id] = nil
+            session.liveTitle = nil
+        }
         session.resumeID = liveID
         projects[location.project].sessions[location.session] = session
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ from the real front matter).
 | approved | design | [会话历史 · 搜索 · 恢复（Session History / Search / Resume）](design/session-history-search-resume.md) |
 | approved | design | [Agent Resume Identity — keeping the resume pin on the live conversation](design/agent-resume-identity.md) |
 | approved | design | [Git worktree creation & lifecycle (Codex-aligned)](design/worktree-creation-lifecycle.md) |
+| approved | design | [Refresh session identity when Claude Code /clear rotates the conversation](design/clear-conversation-rotation.md) |
 | approved | design | [Worktree information architecture](design/worktree-information-architecture.md) |
 | archived | design | [iOS scroll-draw coalescing (vsync-capped surface draws)](design/ios-scroll-renderer-health.md) |
 | archived | design | [Sandbox VM —— 原生 per-project 容器（Apple Containerization）](design/sandbox-vm.md) |

--- a/docs/design/clear-conversation-rotation.md
+++ b/docs/design/clear-conversation-rotation.md
@@ -1,0 +1,148 @@
+---
+title: Refresh session identity when Claude Code /clear rotates the conversation
+status: approved
+type: design
+created: 2026-07-20
+updated: 2026-07-20
+related:
+  - agent-resume-identity.md
+  - config-driven-agent-resume.md
+---
+
+# Refresh session identity when Claude Code `/clear` rotates the conversation
+
+> Close the blind window between `/clear` and the next user prompt: advance the
+> transcript path and resume pin the moment the conversation rotates, and drop
+> the stale sidebar topic title that belongs to the discarded conversation.
+
+## Symptom
+
+After the user runs `/clear` inside a Claude Code session:
+
+- **View Trace** (Info pane) still renders the *old* conversation's JSONL.
+- The **sidebar row title** still shows the *old* conversation's topic
+  (e.g. "Review Markdown preview feature on t…").
+- The **resume pin** (`Session.resumeID`) still points at the cleared
+  conversation, so quitting termio in this window would resume a conversation
+  the user deliberately discarded.
+
+Everything self-heals on the *first prompt of the new conversation* — but until
+then termio is blind, and the Info pane actively shows wrong data.
+
+## Root cause
+
+The event model assumes "conversation identity only changes when a subscribed
+hook fires." `/clear` breaks that assumption: the one event Claude Code fires
+at that moment — `SessionStart` with `source: "clear"` — is not in the
+manifest's event list (`Sources/termio/Resources/agents/claude.json`), which
+subscribes only to `UserPromptSubmit` / `PreToolUse` / `PostToolUse` /
+`PermissionRequest` / `Stop`.
+
+Two mechanisms downstream are starved by that missing subscription:
+
+1. **Transcript + resume pin.** `applyStatusReport`
+   (`TermioStore+AgentStatus.swift:65-80`) updates `transcriptPaths[id]` and
+   calls `reconcileResumeID` on any report carrying a `transcript_path`. The
+   mechanism was built precisely for the `/clear` rotation (the comment says
+   so) — it is just wired to a signal that arrives one user-action too late.
+2. **Sidebar title.** `liveTitles` only advances on a *meaningful* OSC title
+   (`TermioStore+TerminalSurface.swift:751-764`). After `/clear` Claude resets
+   its title to the agent/folder name, which `isMeaningfulLiveTitle`
+   deliberately rejects as startup noise — good default, but there is no
+   "the conversation ended, the old topic is now wrong" invalidation signal.
+
+## Design
+
+Three small pieces. No new subsystems — the fix is one manifest entry plus
+teaching the existing rotation point to invalidate the title.
+
+### 1. Subscribe to `SessionStart(source: clear)` in the Claude manifest
+
+Add to `claude.json` `hooks.events`:
+
+```json
+{ "on": "SessionStart", "state": "idle", "matcher": "clear" }
+```
+
+- Claude Code's `SessionStart` hook supports a source matcher
+  (`startup` / `resume` / `clear` / `compact`); matching only `clear` keeps
+  startup/resume/compact from firing this hook at all, so there is no risk of
+  clobbering a mid-turn status during auto-compact.
+- The installer already writes per-event matchers into the nested Claude
+  settings shape (`HookListener.swift` `JSONHookFile.install`, ~line 395-408),
+  and `capturesTranscript: true` means the hook command carries
+  `--transcript`, so the report arrives with the **new** `session_id`'s
+  `transcript_path`.
+- `state: "idle"` flows through the existing `applyStatusReport` switch
+  (`case "idle"` → `clearWorking` + `.idle`) — correct, since a
+  just-cleared session *is* idle. No state-machine changes needed.
+
+With this alone, `transcriptPaths[id]` and `reconcileResumeID` advance at
+`/clear` time instead of first-prompt time.
+
+### 2. Invalidate the stale topic title on conversation rotation
+
+`reconcileResumeID` (`TermioStore+TerminalSurface.swift:530-538`) is the single
+point that *knows* the conversation rotated (extracted id ≠ pinned id). When it
+detects a rotation, additionally:
+
+- clear `liveTitles[id]` (the in-memory topic),
+- clear the persisted `session.liveTitle`,
+
+so `displayTitle(for:)` falls back to the agent display name ("Claude Code")
+until the new conversation earns a topic. Do **not** touch `lastTitleActivity`
+or the status dictionaries — title-driven status is a separate channel and the
+`idle` report already handles status.
+
+Rotation is a safe trigger: on normal launch/resume the hook-carried id equals
+the pinned id (create pre-pins via `--session-id {id}`), so this fires only
+when the conversation genuinely changed.
+
+### 3. Graceful trace for a not-yet-materialized transcript
+
+At `/clear` time the new JSONL does not exist yet — Claude Code creates it on
+the first message. After piece 1, `transcriptPaths[id]` points at a
+nonexistent file until then. The Info pane / View Trace path must handle this:
+render an honest empty state ("New conversation — no messages yet" or simply
+the trace with zero entries) rather than an error. Check how the trace
+renderer (`Sources/termio/Info/`) behaves on a missing file and patch the
+smallest spot that makes it graceful.
+
+## Things to verify while implementing
+
+- **Launch-time resume with a file-less pin.** After rotation, if the user
+  quits before the first prompt, `Session.resumeID` names a conversation with
+  no on-disk file. Confirm the launch path (resume spec resolution) checks
+  store existence to decide `--resume {id}` vs create `--session-id {id}` — if
+  it does an exact-file check, a file-less pin degrades to *creating* a fresh
+  session under that id, which is exactly right. If it blindly passes
+  `--resume`, fix that decision to be existence-gated. (Resume is
+  exact-or-nothing per [[agent-resume-identity]]; resurrecting the cleared
+  conversation would be wrong.)
+- **`SessionStart` payload shape.** Confirm the hook stdin JSON carries
+  `transcript_path` for `source: "clear"` (it should — same payload family as
+  the other events). The report CLI already mines stdin when `--transcript`
+  is set.
+- **Hook install refresh.** `AgentStatusHooks.sync` rewrites
+  `~/.claude/settings.json` at app launch, so the new event installs on next
+  termio start. Note: an *already-running* Claude session snapshots its hook
+  config at startup and won't fire the new hook until relaunched — expected,
+  document nothing.
+- **Other agents.** This is Claude-manifest-only. Codex/OpenCode use
+  discovered ids ([[config-driven-agent-resume]]) and have no `/clear`
+  equivalent wired to hooks; leave them alone.
+
+## Test plan
+
+1. Rebuild dev app, start a Claude session, chat until a topic title appears
+   and a trace renders.
+2. `/clear` (no further input). Expect, within a beat: sidebar title falls
+   back to "Claude Code"; Info pane View Trace shows the empty new
+   conversation (no error); `Session.resumeID` equals the new id (check via
+   the persisted store or a debug print).
+3. Type a first prompt. Expect: trace fills with the new conversation, title
+   reappears once Claude emits a topic.
+4. Regression: plain launch and `--resume` of an existing session still work;
+   auto-compact mid-turn does not flick status (matcher excludes it);
+   quit-and-relaunch right after `/clear` opens a working fresh session, not a
+   resume error.


### PR DESCRIPTION
After `/clear` in a Claude Code session, termio stayed blind until the first prompt of the new conversation: View Trace rendered the discarded conversation's JSONL, the sidebar kept the old topic title, and the resume pin still named the cleared conversation (so quitting in that window would resume it).

Design doc (travels with this PR): [docs/design/clear-conversation-rotation.md](docs/design/clear-conversation-rotation.md)

## What changed

- **Subscribe to `SessionStart(source: clear)`** in the Claude manifest (`claude.json`): the one event Claude Code fires at `/clear` time. The matcher excludes `startup`/`resume`/`compact`, so auto-compact can't clobber a mid-turn status; `state: "idle"` flows through the existing `applyStatusReport` switch unchanged. With `capturesTranscript` the report carries the **new** conversation's `transcript_path`, so `transcriptPaths` and `reconcileResumeID` advance at `/clear` time instead of first-prompt time.
- **Invalidate the stale topic title on rotation**: `reconcileResumeID` — the single point that knows the conversation rotated — now also clears `liveTitles[id]` and the persisted `session.liveTitle` when a non-nil pin changes, so `displayTitle` falls back to "Claude Code" until the new conversation earns a topic. Status channels are untouched.
- **Graceful trace for a not-yet-materialized transcript**: Claude creates the new JSONL on the first message, so until then the transcript pointer names a nonexistent file. `SessionTraceRenderer.html` now returns a themed "New conversation — no messages yet." page for an absent file instead of throwing; a file that exists but can't be read still errors.

## Verified

- Launch resume with a file-less pin already degrades to create: `resolveLaunch` gates `--resume` on `SessionStore.exists` (exact on-disk check), so quitting right after `/clear` relaunches a fresh session under the pinned id — resume is exact-or-nothing per agent-resume-identity.
- The installer already writes per-event matchers into the nested Claude settings shape; `AgentStatusHooks.sync` installs the new event on next app launch.
- Claude-manifest-only; Codex/OpenCode (discovered ids, no `/clear` hook equivalent) untouched.
- `swift build` passes; no test target exists in the package (manual test plan is in the design doc).

Release Notes:
- Running `/clear` in a Claude Code session now immediately updates the session's trace, sidebar title, and resume pin to the new conversation, instead of showing the discarded one until the next prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)