### PR TITLE
Follow in-process conversation rotation for Codex, OpenCode, Pi, and Grok

### DIFF
--- a/Sources/termio/AgentDefinition.swift
+++ b/Sources/termio/AgentDefinition.swift
@@ -446,6 +446,12 @@ struct AgentHookSpec: Hashable {
     let directory: String?
     let dialect: HookDialect
     let capturesTranscript: Bool
+    /// Where the hook host exposes the live conversation id, so reports can carry
+    /// it and termio can follow an in-process `/new` rotation. Dialect-interpreted:
+    /// a stdin JSON field name for shell hooks (`session_id`, `sessionId`), a dot
+    /// key path in the event object for the OpenCode plugin, or the named
+    /// `context` mechanism for the Pi plugin. `nil` for identity-blind hooks.
+    let conversation: String?
     let events: [AgentHookEvent]
 }
 
@@ -889,6 +895,9 @@ struct AgentManifest: Decodable {
         var dir: String?
         var dialect: String?
         var capturesTranscript: Bool?
+        /// Dialect-interpreted locator of the live conversation id (see
+        /// `AgentHookSpec.conversation`).
+        var conversation: String?
         var events: [Event]
         struct Event: Decodable {
             var on: String?
@@ -1021,6 +1030,41 @@ struct AgentManifest: Decodable {
             throw ManifestError.invalid("\(id): \(typeName) hooks require 'file'")
         }
 
+        // The conversation locator is embedded in generated hook commands and plugin
+        // source, so it must be a bare token: a JSON field name for shell hooks, a
+        // dot path of JS identifiers for the OpenCode plugin, or the one named
+        // mechanism (`context`) for the Pi plugin. Anything else is a manifest error,
+        // never rendered.
+        var conversation: String?
+        if let raw = hooks.conversation?.trimmingCharacters(in: .whitespaces), !raw.isEmpty {
+            func isIdentifier(_ value: Substring) -> Bool {
+                guard let first = value.first, first.isLetter || first == "_" else { return false }
+                return value.dropFirst().allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+            }
+            switch dialect {
+            case .claudeNested, .cursorFlat:
+                guard isIdentifier(raw[...]) else {
+                    throw ManifestError.invalid(
+                        "\(id): hook conversation must name a stdin JSON field, not '\(raw)'")
+                }
+            case .openCodePlugin:
+                let components = raw.split(separator: ".", omittingEmptySubsequences: false)
+                guard !components.isEmpty, components.allSatisfy(isIdentifier) else {
+                    throw ManifestError.invalid(
+                        "\(id): hook conversation must be a dot key path, not '\(raw)'")
+                }
+            case .piPlugin:
+                guard raw == "context" else {
+                    throw ManifestError.invalid(
+                        "\(id): hook conversation for this dialect must be 'context', not '\(raw)'")
+                }
+            case .kimiTOML, .ampPlugin:
+                throw ManifestError.invalid(
+                    "\(id): hook conversation is not supported for this dialect")
+            }
+            conversation = raw
+        }
+
         let validStates: Set<String> = ["working", "attention", "done", "idle"]
         let events = try hooks.events.map { event -> AgentHookEvent in
             guard let name = event.on ?? event.event, !name.isEmpty else {
@@ -1037,6 +1081,7 @@ struct AgentManifest: Decodable {
             directory: hooks.dir,
             dialect: dialect,
             capturesTranscript: hooks.capturesTranscript ?? false,
+            conversation: conversation,
             events: events)
     }
 

--- a/Sources/termio/AgentSessionStore.swift
+++ b/Sources/termio/AgentSessionStore.swift
@@ -31,6 +31,28 @@ enum AgentSessionStore {
         return match(agent: agent, directory: directory, after: launchedAt)?.url.path
     }
 
+    /// The transcript for a *known* conversation id: the record whose id field matches,
+    /// regardless of creation time — once a session's pin is established (or rotated),
+    /// the trace must follow that exact conversation, not whichever record a time-based
+    /// match happens to find. Returns the first hit (ids are unique in every agent's
+    /// store), and only for `jsonl` records, which double as the transcript.
+    static func transcript(agent: AgentPreset, id: String) -> String? {
+        guard let spec = agent.resumeSpec.discover, spec.format == .jsonl else { return nil }
+        let root = URL(fileURLWithPath: (spec.root as NSString).expandingTildeInPath)
+        let keys: [URLResourceKey] = [.isRegularFileKey]
+        guard let enumerator = FileManager.default.enumerator(
+            at: root, includingPropertiesForKeys: keys) else { return nil }
+        for case let url as URL in enumerator {
+            guard url.pathExtension == spec.format.fileExtension,
+                  (try? url.resourceValues(forKeys: Set(keys)))?.isRegularFile == true,
+                  let object = record(at: url, format: spec.format),
+                  value(at: spec.id, in: object) == id
+            else { continue }
+            return url.path
+        }
+        return nil
+    }
+
     /// Re-discovery at a turn boundary: the *newest* record born in this directory
     /// since launch is the conversation the agent is writing right now. Where
     /// `discover` binds to the record created at launch (earliest match), this

--- a/Sources/termio/AgentSessionStore.swift
+++ b/Sources/termio/AgentSessionStore.swift
@@ -31,15 +31,30 @@ enum AgentSessionStore {
         return match(agent: agent, directory: directory, after: launchedAt)?.url.path
     }
 
+    /// Re-discovery at a turn boundary: the *newest* record born in this directory
+    /// since launch is the conversation the agent is writing right now. Where
+    /// `discover` binds to the record created at launch (earliest match), this
+    /// follows the agent through an in-process rotation (`/new`) that minted a newer
+    /// one. Returns the id plus the record path when the record doubles as the
+    /// transcript (`jsonl`).
+    static func rediscover(agent: AgentPreset, directory: String, after launchedAt: Date?)
+        -> (id: String, transcriptPath: String?)? {
+        guard let hit = match(agent: agent, directory: directory, after: launchedAt, newest: true)
+        else { return nil }
+        let isTranscript = agent.resumeSpec.discover?.format == .jsonl
+        return (hit.id, isTranscript ? hit.url.path : nil)
+    }
+
     /// The session record for this agent — its URL and the session id parsed from it.
     /// Both `discover` (id, for resume) and `discoverTranscript` (path, for the trace
     /// viewer) read from the same scan.
-    private static func match(agent: AgentPreset, directory: String, after launchedAt: Date?)
-        -> (url: URL, id: String)? {
+    private static func match(agent: AgentPreset, directory: String, after launchedAt: Date?,
+                              newest: Bool = false) -> (url: URL, id: String)? {
         guard let launchedAt, let spec = agent.resumeSpec.discover else { return nil }
         let root = URL(fileURLWithPath: (spec.root as NSString).expandingTildeInPath)
         let target = canonical(directory)
-        return bestMatch(in: root, ext: spec.format.fileExtension, after: launchedAt) { url in
+        return bestMatch(in: root, ext: spec.format.fileExtension, after: launchedAt,
+                         newest: newest) { url in
             guard let object = record(at: url, format: spec.format),
                   let id = value(at: spec.id, in: object),
                   let cwd = value(at: spec.cwd, in: object),
@@ -80,7 +95,10 @@ enum AgentSessionStore {
     /// Walks `root` for `ext` files created at/after `launchedAt`, runs `identify` (which
     /// confirms the working directory and returns the session id), and returns the URL and
     /// id of the *earliest-created* match — the session born when we launched this one.
+    /// With `newest`, the *latest-created* match instead — the session the agent most
+    /// recently rotated to (see `rediscover`).
     private static func bestMatch(in root: URL, ext: String, after launchedAt: Date,
+                                  newest: Bool = false,
                                   identify: (URL) -> String?) -> (url: URL, id: String)? {
         let keys: [URLResourceKey] = [.creationDateKey, .isRegularFileKey]
         guard let enumerator = FileManager.default.enumerator(
@@ -93,7 +111,7 @@ enum AgentSessionStore {
                   let values = try? url.resourceValues(forKeys: Set(keys)),
                   values.isRegularFile == true,
                   let created = values.creationDate, created >= threshold,
-                  best == nil || created < best!.created,
+                  best.map({ newest ? created > $0.created : created < $0.created }) ?? true,
                   let id = identify(url)
             else { continue }
             best = (url, id, created)

--- a/Sources/termio/HookListener.swift
+++ b/Sources/termio/HookListener.swift
@@ -22,6 +22,12 @@ struct StatusReport: Decodable {
     /// address of the raw Q&A instead of scraping the terminal. Absent for agents
     /// whose hook doesn't carry it.
     let transcriptPath: String?
+    /// The agent's own id for the conversation this session is currently writing,
+    /// forwarded by hooks/plugins whose host exposes it (the manifest's
+    /// `hooks.conversation` locator). Lets termio advance the resume pin the moment
+    /// the agent rotates conversations in-process (`/new`), without needing the id
+    /// to be encoded in a transcript filename. Absent for identity-blind hooks.
+    let conversationID: String?
 
     private enum CodingKeys: String, CodingKey {
         case termioSession = "termio_session"
@@ -29,6 +35,7 @@ struct StatusReport: Decodable {
         case tool
         case cwd
         case transcriptPath = "transcript_path"
+        case conversationID = "conversation_id"
     }
 }
 
@@ -261,13 +268,20 @@ enum AgentStatusHooks {
     /// silent no-op if the copy is missing, instead of spamming every agent turn with
     /// hook-failure noise.
     static func reportCommand(
-        state: String, withTranscript: Bool = false, dialect: HookDialect = .claudeNested
+        state: String, withTranscript: Bool = false, conversationField: String? = nil,
+        dialect: HookDialect = .claudeNested
     ) -> String {
         var command = "\(shellQuote(cliPath)) agent report \(state)"
         // Claude feeds each hook a JSON blob on stdin carrying `transcript_path`; the
         // CLI mines it out (jq-free) so termio can address the raw Q&A log. Only enabled
         // for agents that reliably provide stdin, so the CLI's `cat` can't block.
         if withTranscript { command += " --transcript" }
+        // Some agents' stdin blob also names the live conversation id (Codex
+        // `session_id`, Grok `sessionId`); the manifest declares the field and the CLI
+        // mines it, so termio can follow an in-process `/new` rotation. Same stdin
+        // caveat as `--transcript`. The field name is validated at manifest load to be
+        // a bare identifier, so it embeds safely.
+        if let conversationField { command += " --conversation-from \(conversationField)" }
         // Cursor reads the hook's stdout as its JSON reply, so the CLI must stay silent
         // and print a benign `{}`. (Claude/Codex ignore hook stdout, so they don't.)
         // The fallback keeps that contract even when the CLI itself couldn't run.
@@ -334,9 +348,13 @@ private struct JSONHookFile: AgentStatusInstaller {
     let events: [AgentHookEvent]
     let label: String
     /// Whether this agent's hooks pass a JSON payload on stdin we can mine for the
-    /// session's `transcript_path`. Only Claude Code is known to (and to always
-    /// supply stdin, so the capturing `cat` can't block); others stay off.
+    /// session's `transcript_path`. Only enabled for agents verified to always
+    /// supply stdin (Claude Code, Codex), so the capturing `cat` can't block.
     var capturesTranscript: Bool = false
+    /// The stdin JSON field naming the live conversation id (`hooks.conversation`
+    /// in the manifest), or `nil` for identity-blind hooks. Same stdin caveat as
+    /// `capturesTranscript`.
+    var conversationField: String?
     /// The file's structural shape (see `HookDialect`). Defaults to Claude's, which
     /// Codex also uses; Cursor overrides it.
     var dialect: HookDialect = .claudeNested
@@ -362,6 +380,7 @@ private struct JSONHookFile: AgentStatusInstaller {
             events: spec.events,
             label: id,
             capturesTranscript: spec.capturesTranscript,
+            conversationField: spec.conversation,
             dialect: spec.dialect,
             removesFileWhenEmpty: isDedicatedTermioFile,
             legacyURLs: legacyURLs)
@@ -395,7 +414,8 @@ private struct JSONHookFile: AgentStatusInstaller {
         for event in events {
             var groups = hooks[event.name] as? [[String: Any]] ?? []
             let command = AgentStatusHooks.reportCommand(
-                state: event.state, withTranscript: capturesTranscript, dialect: dialect)
+                state: event.state, withTranscript: capturesTranscript,
+                conversationField: conversationField, dialect: dialect)
             let group: [String: Any]
             if dialect == .cursorFlat {
                 group = ["command": command]
@@ -526,11 +546,11 @@ private struct PluginFile: AgentStatusInstaller {
         case .openCodePlugin:
             filename = "termio.js"
             legacyFilename = "termio-status.js"
-            contents = openCodeSource(events: spec.events)
+            contents = openCodeSource(events: spec.events, conversationPath: spec.conversation)
         case .piPlugin:
             filename = "termio.js"
             legacyFilename = "termio-status.js"
-            contents = piSource(events: spec.events)
+            contents = piSource(events: spec.events, conversation: spec.conversation)
         case .ampPlugin:
             filename = "termio.ts"
             legacyFilename = "termio-status.ts"
@@ -604,26 +624,59 @@ private struct PluginFile: AgentStatusInstaller {
     /// when the turn ends; `permission.updated` means it's waiting on the user. Each
     /// maps to the public report contract shelled out via Bun's `$`. The session id
     /// comes from `TERMIO_SESSION`, which the PTY carries into the in-process plugin.
-    private static func openCodeSource(events: [AgentHookEvent]) -> String {
+    ///
+    /// `conversationPath` (the manifest's `hooks.conversation`) is the dot key path
+    /// in the event object naming OpenCode's own conversation id; when set, each
+    /// report also carries it so termio can follow an in-process new-session
+    /// rotation. Subagent child sessions share this event bus, and adopting a
+    /// child's id would mis-pin the tab, so the plugin learns which ids are
+    /// top-level from `session.created`/`session.updated` (child sessions carry
+    /// `parentID`) and forwards only those.
+    private static func openCodeSource(events: [AgentHookEvent], conversationPath: String?) -> String {
+        let conversationExpression = conversationPath.map { path in
+            "event" + path.split(separator: ".").map { "?.\($0)" }.joined()
+        }
         let branches = events.map { event in
             let eventName = jsString(event.name)
             let state = jsString(event.state)
+            let arguments = conversationExpression.map { "\(state), \($0)" } ?? state
             if let matcher = event.matcher {
-                return "      if (event.type === \(eventName) && event.properties?.status?.type === \(jsString(matcher))) return report(\(state));"
+                return "      if (event.type === \(eventName) && event.properties?.status?.type === \(jsString(matcher))) return report(\(arguments));"
             }
-            return "      if (event.type === \(eventName)) return report(\(state));"
+            return "      if (event.type === \(eventName)) return report(\(arguments));"
         }.joined(separator: "\n")
+        let identity = conversationExpression == nil ? "" : """
+
+          const roots = new Set();
+          const note = (info) => {
+            if (!info?.id) return;
+            if (info.parentID) roots.delete(info.id); else roots.add(info.id);
+          };
+        """
+        let identityBranches = conversationExpression == nil ? "" : """
+              if (event.type === "session.created" || event.type === "session.updated") return note(event.properties?.info);
+
+        """
+        let reportBody = conversationExpression == nil ? """
+            return $`${cli} agent report ${state}`.quiet().nothrow();
+        """ : """
+            if (conversation && roots.has(conversation)) {
+              return $`${cli} agent report ${state} --conversation ${conversation}`.quiet().nothrow();
+            }
+            return $`${cli} agent report ${state}`.quiet().nothrow();
+        """
+        let reportParameters = conversationExpression == nil ? "(state)" : "(state, conversation)"
         return """
         // termio agent status — reports OpenCode session lifecycle to termio.
         // Socket marker: \(AgentStatusHooks.marker)
         export const TermioStatus = async ({ $ }) => {
-          const cli = \(jsString(cliPath));
-          const report = (state) => {
-            return $`${cli} agent report ${state}`.quiet().nothrow();
+          const cli = \(jsString(cliPath));\(identity)
+          const report = \(reportParameters) => {
+        \(reportBody)
           };
           return {
             event: async ({ event }) => {
-        \(branches)
+        \(identityBranches)\(branches)
             },
           };
         };
@@ -633,15 +686,40 @@ private struct PluginFile: AgentStatusInstaller {
     /// Pi extension: `agent_start` fires when a turn begins, `agent_end` when it
     /// returns to the user. Pi has no shell-hook config, so the extension itself
     /// shells out via `pi.exec`; the session id rides in on `TERMIO_SESSION`.
-    private static func piSource(events: [AgentHookEvent]) -> String {
+    ///
+    /// `conversation == "context"` (the manifest's `hooks.conversation`) means Pi's
+    /// own conversation id is read from the extension context's session manager and
+    /// forwarded with each report, so termio can follow an in-process `/new`
+    /// rotation (Pi reloads extensions with a fresh context when it switches
+    /// sessions). The id is embedded in a shell command, so it is forwarded only
+    /// when it looks like a bare token — Pi's uuidv7 ids always do.
+    private static func piSource(events: [AgentHookEvent], conversation: String?) -> String {
+        guard conversation != nil else {
+            let listeners = events.map { event in
+                let command = AgentStatusHooks.reportCommand(state: event.state)
+                return "  pi.on(\(jsString(event.name)), () => pi.exec(\"sh\", [\"-c\", \(jsString(command))]));"
+            }.joined(separator: "\n")
+            return """
+            // termio agent status — reports Pi turn lifecycle to termio.
+            // Socket marker: \(AgentStatusHooks.marker)
+            export default (pi) => {
+            \(listeners)
+            };
+            """
+        }
         let listeners = events.map { event in
-            let command = AgentStatusHooks.reportCommand(state: event.state)
-            return "  pi.on(\(jsString(event.name)), () => pi.exec(\"sh\", [\"-c\", \(jsString(command))]));"
+            "  pi.on(\(jsString(event.name)), (_event, context) => report(\(jsString(event.state)), context));"
         }.joined(separator: "\n")
         return """
         // termio agent status — reports Pi turn lifecycle to termio.
         // Socket marker: \(AgentStatusHooks.marker)
         export default (pi) => {
+          const cli = \(jsString(AgentStatusHooks.shellQuote(cliPath)));
+          const report = (state, context) => {
+            const id = context?.sessionManager?.getSessionId?.();
+            const conversation = id && /^[A-Za-z0-9._-]+$/.test(id) ? ` --conversation ${id}` : "";
+            pi.exec("sh", ["-c", `${cli} agent report ${state}${conversation} 2>/dev/null || true`]);
+          };
         \(listeners)
         };
         """

--- a/Sources/termio/HookListener.swift
+++ b/Sources/termio/HookListener.swift
@@ -655,6 +655,7 @@ private struct PluginFile: AgentStatusInstaller {
         """
         let identityBranches = conversationExpression == nil ? "" : """
               if (event.type === "session.created" || event.type === "session.updated") return note(event.properties?.info);
+              if (event.type === "session.deleted") return roots.delete(event.properties?.info?.id);
 
         """
         let reportBody = conversationExpression == nil ? """

--- a/Sources/termio/Resources/agents/codex.json
+++ b/Sources/termio/Resources/agents/codex.json
@@ -24,7 +24,10 @@
     "type": "json",
     "file": "~/.codex/hooks.json",
     "dialect": "codex",
+    "capturesTranscript": true,
+    "conversation": "session_id",
     "events": [
+      { "on": "SessionStart", "state": "idle" },
       { "on": "UserPromptSubmit", "state": "working" },
       { "on": "PreToolUse", "state": "working" },
       { "on": "PostToolUse", "state": "working" },

--- a/Sources/termio/Resources/agents/grok.json
+++ b/Sources/termio/Resources/agents/grok.json
@@ -20,7 +20,9 @@
     "type": "json",
     "file": "~/.grok/hooks/termio.json",
     "dialect": "grok",
+    "conversation": "sessionId",
     "events": [
+      { "on": "SessionStart", "state": "idle" },
       { "on": "UserPromptSubmit", "state": "working" },
       { "on": "PreToolUse", "state": "working" },
       { "on": "PostToolUse", "state": "working" },

--- a/Sources/termio/Resources/agents/opencode.json
+++ b/Sources/termio/Resources/agents/opencode.json
@@ -19,6 +19,7 @@
     "type": "plugin",
     "dir": "~/.config/opencode/plugin",
     "dialect": "opencode",
+    "conversation": "properties.sessionID",
     "events": [
       { "on": "session.status", "state": "working", "matcher": "busy" },
       { "on": "session.idle", "state": "done" },

--- a/Sources/termio/Resources/agents/pi.json
+++ b/Sources/termio/Resources/agents/pi.json
@@ -17,7 +17,9 @@
     "type": "plugin",
     "dir": "~/.pi/agent/extensions",
     "dialect": "pi",
+    "conversation": "context",
     "events": [
+      { "on": "session_start", "state": "idle" },
       { "on": "agent_start", "state": "working" },
       { "on": "agent_end", "state": "done" }
     ]

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -69,24 +69,37 @@ extension TermioStore {
         let carriedTranscript = report.transcriptPath.flatMap { $0.isEmpty ? nil : $0 }
         if let path = carriedTranscript {
             transcriptPaths[id] = path
-            // A hook-carried path can name a *new* conversation id in its filename
-            // (after `/clear`), so advance the resume pin to match — a no-op unless it
-            // actually rotated. See docs/design/agent-resume-identity.md.
-            reconcileResumeID(id, transcriptPath: path)
         }
-        if let conversation = report.conversationID, !conversation.isEmpty {
-            // An identity-bearing report names the live conversation outright — the
-            // rotation signal for agents whose hook host exposes the id (the
-            // manifest's `hooks.conversation`). On a rotation without a hook-carried
-            // transcript, re-resolve it from the agent's store; nil clears a stale
-            // path that described the discarded conversation.
-            if adoptConversationID(conversation, for: id), carriedTranscript == nil {
-                transcriptPaths[id] = resolveTranscriptPath(for: id)
+        // Conversation identity may only move on an *exactly-stamped* report — the
+        // hook files are global, so every same-agent process on the machine reports
+        // here, and a cwd-guessed match must never re-pin this tab to an outside
+        // run's conversation. And only at a turn boundary: a working-state payload
+        // embeds prompt/tool content on stdin, where a colliding field name could be
+        // mined as the id by mistake; SessionStart/Stop payloads are the agent's own
+        // minimal envelope. (`sessionID(for:)` already validated the stamp maps to a
+        // session this app owns.)
+        let stamped = report.termioSession.map { !$0.isEmpty } ?? false
+        if stamped, report.state != "working" {
+            if let path = carriedTranscript {
+                // A hook-carried path can name a *new* conversation id in its filename
+                // (after `/clear`), so advance the resume pin to match — a no-op unless
+                // it actually rotated. See docs/design/agent-resume-identity.md.
+                reconcileResumeID(id, transcriptPath: path)
             }
-        } else if report.state == "done" {
-            // Identity-blind turn end: for a discovered-id agent, re-scan its store in
-            // case the conversation rotated in-process (`/new`) since discovery.
-            rediscoverConversation(for: id)
+            if let conversation = conversationToken(report.conversationID) {
+                // An identity-bearing report names the live conversation outright — the
+                // rotation signal for agents whose hook host exposes the id (the
+                // manifest's `hooks.conversation`). On a rotation without a hook-carried
+                // transcript, drop the stale path that described the discarded
+                // conversation; the shared resolve below re-learns it against the new pin.
+                if adoptConversationID(conversation, for: id), carriedTranscript == nil {
+                    transcriptPaths[id] = nil
+                }
+            } else if report.state == "done" {
+                // Identity-blind turn end: for a discovered-id agent, re-scan its store
+                // in case the conversation rotated in-process (`/new`) since discovery.
+                rediscoverConversation(for: id)
+            }
         }
         if transcriptPaths[id] == nil, let path = resolveTranscriptPath(for: id) {
             // The hook didn't carry a path (a pre-hook Claude session never will), so
@@ -136,6 +149,17 @@ extension TermioStore {
         default:
             break
         }
+    }
+
+    /// A reported conversation id, accepted only when it is a bare token — the ids
+    /// every agent mints (UUIDs, `ses_…`) always are. The shell-hook path mines the
+    /// value out of an arbitrary stdin blob, so anything else (pasted JSON, a path,
+    /// whitespace) is treated as no identity rather than adopted into the pin.
+    private func conversationToken(_ raw: String?) -> String? {
+        guard let raw, !raw.isEmpty, raw.count <= 128,
+              raw.allSatisfy({ $0.isLetter || $0.isNumber || "._-".contains($0) })
+        else { return nil }
+        return raw
     }
 
     private func clearWorking(_ id: Session.ID) {
@@ -307,15 +331,20 @@ extension TermioStore {
     /// Resolves a session's transcript file from disk when its hook hasn't handed
     /// termio one — the source of truth for the Info pane's trace when no hook fired.
     /// A pinned-id agent whose store is a file-per-conversation (Claude Code) names its
-    /// transcript by the id termio pinned (`Session.resumeID`), so it's located directly;
-    /// Codex/OpenCode fall back to the launch-time file match (`AgentSessionStore`). `nil`
-    /// until a matching transcript exists on disk.
+    /// transcript by the id termio pinned (`Session.resumeID`), so it's located directly.
+    /// A discovered-id agent with a known pin is likewise looked up by that exact id —
+    /// the launch-time earliest-match below would drift back to a rotated-away record —
+    /// and only an unpinned session falls back to the launch-time file match
+    /// (`AgentSessionStore`). `nil` until a matching transcript exists on disk.
     func resolveTranscriptPath(for id: Session.ID) -> String? {
         guard let session = session(id), session.launched else { return nil }
         if let store = session.agent.resumeSpec.store, !store.isDirectory,
            let resumeID = session.resumeID,
            let path = SessionStore.locate(store, id: resumeID) {
             return path
+        }
+        if session.agent.resumeSpec.discover != nil, let resumeID = session.resumeID {
+            return AgentSessionStore.transcript(agent: session.agent, id: resumeID)
         }
         guard let directory = session.worktreePath ?? project(for: id)?.path else { return nil }
         return AgentSessionStore.discoverTranscript(

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -66,16 +66,32 @@ extension TermioStore {
         guard let id = sessionID(for: report) else { return }
         // Remember the session's transcript address whenever a hook carries it, so
         // `sessions send` can hand it back as the place to read the response.
-        if let path = report.transcriptPath, !path.isEmpty {
+        let carriedTranscript = report.transcriptPath.flatMap { $0.isEmpty ? nil : $0 }
+        if let path = carriedTranscript {
             transcriptPaths[id] = path
-            // The hook path is the one signal that can carry a *new* conversation id
+            // A hook-carried path can name a *new* conversation id in its filename
             // (after `/clear`), so advance the resume pin to match — a no-op unless it
             // actually rotated. See docs/design/agent-resume-identity.md.
             reconcileResumeID(id, transcriptPath: path)
-        } else if transcriptPaths[id] == nil, let path = resolveTranscriptPath(for: id) {
-            // The hook didn't carry a path (Codex never does; a pre-hook Claude session
-            // never will), so learn it from the agent's own on-disk transcript instead —
-            // same result as Claude's hook-carried path, just discovered.
+        }
+        if let conversation = report.conversationID, !conversation.isEmpty {
+            // An identity-bearing report names the live conversation outright — the
+            // rotation signal for agents whose hook host exposes the id (the
+            // manifest's `hooks.conversation`). On a rotation without a hook-carried
+            // transcript, re-resolve it from the agent's store; nil clears a stale
+            // path that described the discarded conversation.
+            if adoptConversationID(conversation, for: id), carriedTranscript == nil {
+                transcriptPaths[id] = resolveTranscriptPath(for: id)
+            }
+        } else if report.state == "done" {
+            // Identity-blind turn end: for a discovered-id agent, re-scan its store in
+            // case the conversation rotated in-process (`/new`) since discovery.
+            rediscoverConversation(for: id)
+        }
+        if transcriptPaths[id] == nil, let path = resolveTranscriptPath(for: id) {
+            // The hook didn't carry a path (a pre-hook Claude session never will), so
+            // learn it from the agent's own on-disk transcript instead — same result
+            // as Claude's hook-carried path, just discovered.
             transcriptPaths[id] = path
         }
         // Any recognized report proves this session's hooks are alive and speaking,

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -558,6 +558,7 @@ extension TermioStore {
         currentTool[id] = nil
         liveTitles[id] = nil
         detectedAgents[id] = nil
+        processSpawnedAt[id] = nil
         lastWorkingAt[id] = nil
         lastHookReportAt[id] = nil
         lastUserInputAt[id] = nil

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -493,6 +493,7 @@ extension TermioStore {
             currentTool[sessionID] = nil
             liveTitles[sessionID] = nil
             detectedAgents[sessionID] = nil
+            processSpawnedAt[sessionID] = nil
             lastWorkingAt[sessionID] = nil
             lastHookReportAt[sessionID] = nil
             lastUserInputAt[sessionID] = nil

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -363,6 +363,7 @@ extension TermioStore {
 
         state.configuration = TerminalSurfaceOptions(backend: .inMemory(inMemory))
         surfaces[session.id] = state
+        processSpawnedAt[session.id] = Date()
         monitor(state, for: session.id)
         warmUpRendering(state)
         // Record that this session has now launched (and its pinned resume id) so the
@@ -524,15 +525,29 @@ extension TermioStore {
     /// transcript and orphans the old file; the once-pinned id (`recordLaunch` writes
     /// it only while nil) would otherwise resume the cleared conversation. A no-op
     /// unless the live transcript names a different id than the pin, and only for
-    /// styles whose filename *is* the id — discovered-id agents advance through
-    /// re-discovery instead. Fed by the hook-carried transcript path in
+    /// styles whose filename *is* the id — other agents advance through an
+    /// identity-bearing report or turn-boundary re-discovery, which land in the same
+    /// `adoptConversationID`. Fed by the hook-carried transcript path in
     /// `applyStatusReport`. See docs/design/agent-resume-identity.md.
     func reconcileResumeID(_ id: Session.ID, transcriptPath: String) {
-        guard let location = locate(id) else { return }
-        var session = projects[location.project].sessions[location.session]
-        guard let liveID = session.agent.resumeSpec.conversationID(fromTranscriptPath: transcriptPath),
-              liveID != session.resumeID
+        guard let session = session(id),
+              let liveID = session.agent.resumeSpec.conversationID(fromTranscriptPath: transcriptPath)
         else { return }
+        adoptConversationID(liveID, for: id)
+    }
+
+    /// The one point where a session's conversation identity changes, shared by every
+    /// rotation signal (transcript-filename reconcile, identity-bearing reports,
+    /// turn-boundary re-discovery). Returns whether the pin actually advanced.
+    @discardableResult
+    func adoptConversationID(_ conversationID: String, for id: Session.ID) -> Bool {
+        guard let location = locate(id) else { return false }
+        var session = projects[location.project].sessions[location.session]
+        // Only a session whose declared agent can resume by id has a pin to keep
+        // honest. A plain terminal that merely *runs* an agent (cwd-correlated
+        // report) relaunches as a shell, so adopting an id there is pure noise.
+        guard session.agent.resumeSpec.resume != nil else { return false }
+        guard conversationID != session.resumeID else { return false }
         // A genuine rotation (the pin already named a conversation and it changed —
         // not the first-report adoption of an unpinned session) also orphans the
         // sidebar topic title: it describes the discarded conversation. Drop both
@@ -543,8 +558,61 @@ extension TermioStore {
             liveTitles[id] = nil
             session.liveTitle = nil
         }
-        session.resumeID = liveID
+        session.resumeID = conversationID
         projects[location.project].sessions[location.session] = session
+        return true
+    }
+
+    /// Turn-boundary re-discovery for a discovered-id agent whose reports carry no
+    /// conversation identity: at each turn end, re-scan the agent's own session store
+    /// for a record born in this session's directory since launch. The newest such
+    /// record is the conversation the agent is writing *now*, so a changed id means
+    /// an in-process rotation (`/new`) — advance the pin and transcript through the
+    /// shared adoption path. Guarded by the no-guessing rule: when two same-agent
+    /// sessions share the directory, a newer record can't be attributed and nothing
+    /// moves. The scan runs only on `done` reports, so its cost lands at turn end,
+    /// not on a timer.
+    func rediscoverConversation(for id: Session.ID) {
+        guard let session = session(id),
+              session.agent.resumeSpec.discover != nil,
+              session.launched,
+              let directory = session.worktreePath ?? project(for: id)?.path
+        else { return }
+        // An agent whose manifest declares an identity locator reports the id
+        // whenever it is attributable; a report *without* one is deliberate (an
+        // OpenCode subagent's turn end, say), and its store record — same agent,
+        // same directory, newer — is exactly the false match this scan must not
+        // adopt. Re-discovery is only for manifests with no identity channel.
+        guard session.agent.hookSpec?.conversation == nil else { return }
+        guard soleAgentSession(session.agent, in: directory, is: id) else { return }
+        // Bound the scan to this app run's process, not the persisted first-ever
+        // `launchedAt` — a resumed tab's window would otherwise span days and swallow
+        // records the agent minted in runs (or outside termio) in between.
+        guard let spawnedAt = processSpawnedAt[id] else { return }
+        guard let found = AgentSessionStore.rediscover(
+            agent: session.agent, directory: directory, after: spawnedAt)
+        else { return }
+        if adoptConversationID(found.id, for: id) {
+            transcriptPaths[id] = found.transcriptPath
+        }
+    }
+
+    /// Whether `id` is the only session of this agent working in `directory` — the
+    /// precondition for attributing a store record to it without guessing.
+    private func soleAgentSession(_ agent: AgentDefinition, in directory: String,
+                                  is id: Session.ID) -> Bool {
+        let target = URL(fileURLWithPath: directory).standardizedFileURL.path
+        var count = 0
+        for project in projects {
+            for peer in project.sessions where peer.agent == agent {
+                let peerDirectory = peer.worktreePath ?? project.path
+                guard URL(fileURLWithPath: peerDirectory).standardizedFileURL.path == target
+                else { continue }
+                if peer.id != id { return false }
+                count += 1
+            }
+        }
+        return count == 1
     }
 
     /// The position of a session in the project tree, for an in-place edit.

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -543,10 +543,12 @@ extension TermioStore {
     func adoptConversationID(_ conversationID: String, for id: Session.ID) -> Bool {
         guard let location = locate(id) else { return false }
         var session = projects[location.project].sessions[location.session]
-        // Only a session whose declared agent can resume by id has a pin to keep
-        // honest. A plain terminal that merely *runs* an agent (cwd-correlated
-        // report) relaunches as a shell, so adopting an id there is pure noise.
-        guard session.agent.resumeSpec.resume != nil else { return false }
+        // Only a session whose declared agent participates in conversation identity
+        // (a pinned, discovered, or resumable id) has a pin to keep honest. A plain
+        // terminal that merely *runs* an agent relaunches as a shell, so adopting an
+        // id there is pure noise.
+        let spec = session.agent.resumeSpec
+        guard spec.pinsID || spec.discoversID || spec.resume != nil else { return false }
         guard conversationID != session.resumeID else { return false }
         // A genuine rotation (the pin already named a conversation and it changed —
         // not the first-report adoption of an unpinned session) also orphans the
@@ -584,11 +586,11 @@ extension TermioStore {
         // same directory, newer — is exactly the false match this scan must not
         // adopt. Re-discovery is only for manifests with no identity channel.
         guard session.agent.hookSpec?.conversation == nil else { return }
-        guard soleAgentSession(session.agent, in: directory, is: id) else { return }
         // Bound the scan to this app run's process, not the persisted first-ever
         // `launchedAt` — a resumed tab's window would otherwise span days and swallow
         // records the agent minted in runs (or outside termio) in between.
         guard let spawnedAt = processSpawnedAt[id] else { return }
+        guard soleAgentSession(session.agent, in: directory, is: id) else { return }
         guard let found = AgentSessionStore.rediscover(
             agent: session.agent, directory: directory, after: spawnedAt)
         else { return }
@@ -598,21 +600,21 @@ extension TermioStore {
     }
 
     /// Whether `id` is the only session of this agent working in `directory` — the
-    /// precondition for attributing a store record to it without guessing.
+    /// precondition for attributing a store record to it without guessing. Paths are
+    /// compared symlink-resolved, matching how the store scan canonicalizes the
+    /// agent's recorded cwd (`/tmp` vs `/private/tmp` must count as the same place).
     private func soleAgentSession(_ agent: AgentDefinition, in directory: String,
                                   is id: Session.ID) -> Bool {
-        let target = URL(fileURLWithPath: directory).standardizedFileURL.path
-        var count = 0
+        func canonical(_ path: String) -> String {
+            URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+        }
+        let target = canonical(directory)
         for project in projects {
-            for peer in project.sessions where peer.agent == agent {
-                let peerDirectory = peer.worktreePath ?? project.path
-                guard URL(fileURLWithPath: peerDirectory).standardizedFileURL.path == target
-                else { continue }
-                if peer.id != id { return false }
-                count += 1
+            for peer in project.sessions where peer.agent == agent && peer.id != id {
+                if canonical(peer.worktreePath ?? project.path) == target { return false }
             }
         }
-        return count == 1
+        return true
     }
 
     /// The position of a session in the project tree, for an in-place edit.

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -244,6 +244,12 @@ final class TermioStore: ObservableObject {
     /// structured log instead of scraping the terminal.
     @Published var transcriptPaths: [Session.ID: String] = [:]
 
+    /// When each session's agent process was spawned in *this* app run — unlike the
+    /// persisted `Session.launchedAt` (stamped once, at the session's first launch
+    /// ever), this bounds turn-boundary re-discovery to store records the current
+    /// process could actually have created (see `rediscoverConversation`).
+    var processSpawnedAt: [Session.ID: Date] = [:]
+
     /// When each currently-working session last reported activity, used to recover
     /// a session whose turn ended without a `done` hook (see `sweepStaleWorking`).
     /// Refreshed both by working hooks and by a *changed* rendered screen

--- a/docs/design/clear-conversation-rotation.md
+++ b/docs/design/clear-conversation-rotation.md
@@ -175,6 +175,19 @@ dialect-interpreted, mechanism-named, never agent-named:
 | opencode plugin | dot key path in the event object | `properties.sessionID` |
 | pi plugin | the `context` mechanism — the extension context's session manager | `context` |
 
+Identity adoption is deliberately narrower than status adoption. It requires an
+*exactly-stamped* report (`TERMIO_SESSION` echoed back — the hook files are
+global, so a same-directory agent run outside termio also reports, and a
+cwd-guessed match must never re-pin a tab), fires only at a **turn boundary**
+(`state != working` — a working-state payload embeds prompt/tool content on
+stdin, where a colliding field name could be mined as the id; SessionStart/Stop
+payloads are the agent's own minimal envelope), and accepts only bare-token ids
+(the shell miner reads an arbitrary blob; anything that isn't UUID-shaped is
+treated as no identity). On rotation, the transcript follows the *pinned id
+exactly*: `resolveTranscriptPath` looks a discovered-id conversation up by its
+id in the store rather than by launch-time file matching, which would drift
+back to the rotated-away record.
+
 ### Mechanism 2 — turn-boundary re-discovery
 
 For a discovered-id agent whose reports carry no identity, discovery no longer

--- a/docs/design/clear-conversation-rotation.md
+++ b/docs/design/clear-conversation-rotation.md
@@ -146,3 +146,82 @@ smallest spot that makes it graceful.
    auto-compact mid-turn does not flick status (matcher excludes it);
    quit-and-relaunch right after `/clear` opens a working fresh session, not a
    resume error.
+
+## Phase 2 — rotation signals for the other agents
+
+Phase 1's three downstream mechanisms — advance `transcriptPaths`, advance the
+resume pin, invalidate the stale topic title — were already agent-generic; only
+the *signal* (Claude's hook-carried `transcript_path`) was Claude-specific.
+Phase 2 gives every other rotating agent a signal, through two new ATP manifest
+mechanisms. All three consequences now flow through one shared adoption point
+(`TermioStore.adoptConversationID`), so title invalidation comes for free
+regardless of which signal fired.
+
+### Mechanism 1 — identity-bearing reports (`hooks.conversation`)
+
+The manifest's `hooks` object gains a `conversation` locator: where the hook
+host exposes the agent's own id for the conversation it is currently writing.
+`termio agent report` grew matching flags (`--conversation <id>` for plugins
+that hold the id in-process, `--conversation-from <field>` to mine it out of
+the JSON blob shell hooks receive on stdin), and the report payload carries it
+as `conversation_id`. A report whose conversation id differs from the session's
+pin *is* the rotation — `applyStatusReport` adopts it exactly the way a
+hook-carried transcript path is adopted today. The locator is
+dialect-interpreted, mechanism-named, never agent-named:
+
+| dialect | locator meaning | example |
+| --- | --- | --- |
+| json (shell hooks) | stdin JSON field name | `session_id` (Codex), `sessionId` (Grok) |
+| opencode plugin | dot key path in the event object | `properties.sessionID` |
+| pi plugin | the `context` mechanism — the extension context's session manager | `context` |
+
+### Mechanism 2 — turn-boundary re-discovery
+
+For a discovered-id agent whose reports carry no identity, discovery no longer
+runs at most once: on each `done` report that arrived without a
+`conversation_id`, `AgentSessionStore.rediscover` re-scans the agent's declared
+`discover` store for the **newest** record born in the session's directory
+since this app run spawned the process (the original discovery binds to the
+*earliest* record after the persisted first-ever launch; re-discovery bounds
+itself to the live process so a resumed tab's window can't span days and
+swallow records from runs in between). A newer record with a different id is
+an in-process rotation;
+adopt it. The no-guessing rule holds: when two same-agent sessions share the
+directory, a newer record can't be attributed and nothing moves. The scan runs
+only at turn end, never on a timer, and is skipped entirely for agents whose
+manifest declares an identity locator — from such an agent, a report *without*
+an id is deliberate (an OpenCode subagent's turn end), and its store record
+would be exactly the false match the scan must not adopt.
+
+### What each agent ships
+
+| Agent | signal | rotation command | verified against |
+| --- | --- | --- | --- |
+| Codex | `conversation: session_id` + `capturesTranscript` (its hook stdin carries `session_id` and `transcript_path` = the live rollout); `SessionStart` event added so rotation lands at `/new` time; mechanism 2 covers it only when a user-override manifest drops the locator | `/new` | codex-cli 0.144.6 binary + openai/codex hook schemas |
+| OpenCode | plugin passes `event.properties.sessionID` on `session.status` / `session.idle` / `permission.updated`. Subagent child sessions share the plugin bus, so the template learns top-level ids from `session.created`/`session.updated` (children carry `parentID`) and forwards only those | `session.new` (`<leader>n`) | opencode 1.17.20 bundled schemas + SDK types |
+| Pi | extension reads `context.sessionManager.getSessionId()` (Pi reloads extensions with a fresh context after a session switch); `session_start` event added so rotation lands at `/new` time, before the lazily-created session file exists | `/new` | pi 0.80.6 shipped source |
+| Grok | `conversation: sessionId` mined from hook stdin (Grok's payload is camelCase); `SessionStart` event added | `/new` (alias `/clear`) | grok 0.2.106 local docs (`~/.grok/docs/user-guide/10-hooks.md`, `17-sessions.md`) |
+| Claude Code | unchanged — Phase 1's transcript-filename reconcile, now routed through the shared adoption point | `/clear` | — |
+
+Notes: Codex's and Grok's `SessionStart` subscriptions also fire at process
+start, where the reported id equals the pin — a no-op by construction (`state:
+idle` matches a freshly started session). Pi's and Grok's rotated pins point at
+conversations the pinned-store probe resolves on relaunch (create-vs-resume
+stays existence-gated, so quitting before the new conversation's first message
+correctly re-creates under the adopted id). A plain terminal running a
+hand-started agent never adopts an id — the tab relaunches as a shell, so
+there is no pin to keep honest.
+
+### Phase 2 test plan
+
+Per agent: start a session in termio, chat until the trace/title reflect the
+conversation, run the rotation command, then verify (a) the resume pin
+(`Session.resumeID`) advances to the agent's new id, (b) the sidebar title
+falls back to the agent name, (c) View Trace follows for agents with a
+transcript (Claude, Codex, Pi — Codex's arrives with the next hook event, Pi's
+once the new session file materializes on the first assistant reply), and (d)
+quit-and-relaunch resumes the *new* conversation. For OpenCode, additionally
+run a subagent-spawning prompt and confirm the pin never moves to a child
+session id. For Codex, verify mechanism 2 by the same steps with
+`capturesTranscript`/`conversation` removed from a user-override manifest —
+rotation must then land on the `done` report at turn end.

--- a/scripts/termio
+++ b/scripts/termio
@@ -37,6 +37,16 @@ json_escape() {
         | awk 'BEGIN { ORS = "" } { if (NR > 1) printf "\\n"; printf "%s", $0 }'
 }
 
+# Mine a string field out of a JSON blob, jq-free: the first `"field":"value"`
+# occurrence, whitespace-tolerant around the colon. `head -1` closes the pipe so
+# the pipeline's exit status is sed's (0), keeping `set -e` happy even when grep
+# matches nothing.
+mine_field() {
+    printf '%s' "$2" \
+        | grep -o "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 \
+        | sed 's/^"[^"]*"[[:space:]]*:[[:space:]]*"//;s/"$//'
+}
+
 sessions() {
     if [ ! -S "$SOCKET" ]; then
         echo "termio: app is not running (no control socket at $SOCKET)" >&2
@@ -136,23 +146,21 @@ agent() {
     session=$(json_escape "${TERMIO_SESSION:-}")
     cwd=$(json_escape "$PWD")
 
-    # Read stdin once when any flag mines it. `head -1` closes the pipe so the
-    # pipeline's exit status is sed's (0), keeping `set -e` happy even when grep
-    # matches nothing.
+    # Read stdin once when any flag mines it — but never from a tty: an agent that
+    # ran the hook without piping its payload would leave `cat` waiting on the
+    # terminal forever, while a closed/absent stdin still reads instantly as empty.
     input=""
     if [ "$with_transcript" -eq 1 ] || [ -n "$conversation_from" ]; then
-        input=$(cat)
+        if [ ! -t 0 ]; then input=$(cat); fi
     fi
     if [ -z "$conversation" ] && [ -n "$conversation_from" ]; then
-        conversation=$(printf '%s' "$input" \
-            | grep -o "\"$conversation_from\":\"[^\"]*\"" | head -1 | sed 's/.*:"//;s/"$//')
+        conversation=$(mine_field "$conversation_from" "$input")
     fi
 
     payload=$(printf '{"termio_session":"%s","state":"%s","cwd":"%s"' \
         "$session" "$state" "$cwd")
     if [ "$with_transcript" -eq 1 ]; then
-        # Mirror the old hook: mine transcript_path out of the JSON on stdin, jq-free.
-        tp=$(printf '%s' "$input" | grep -o '"transcript_path":"[^"]*"' | head -1 | sed 's/.*:"//;s/"$//')
+        tp=$(mine_field transcript_path "$input")
         payload=$(printf '%s,"transcript_path":"%s"' "$payload" "$(json_escape "$tp")")
     fi
     if [ -n "$conversation" ]; then

--- a/scripts/termio
+++ b/scripts/termio
@@ -79,7 +79,9 @@ sessions() {
     printf '%s' "$request" | nc -U "$SOCKET"
 }
 
-# The public hook contract: `termio agent report <state> [--transcript] [--reply]`.
+# The public hook contract:
+#   `termio agent report <state> [--transcript] [--conversation <id>]
+#                                [--conversation-from <field>] [--reply]`
 # An agent's status hook runs this instead of a hand-rolled `printf | nc`; termio
 # stamps the absolute path to this script into the hook file at install time. It reads
 # the session id from $TERMIO_SESSION (which the PTY carries) and the cwd from $PWD,
@@ -88,29 +90,43 @@ sessions() {
 # global hook file per agent, so a single report fans out to both; each app keeps only
 # the reports whose session id it stamped and ignores the rest (`TermioStore.sessionID`).
 # A missing socket (app not running) is a silent no-op — hooks fire constantly.
-#   --transcript  slurp stdin (Claude feeds hooks a JSON blob) and forward its
-#                 transcript_path so termio can address the raw Q&A log.
-#   --reply       stay silent on stdout and print `{}` at the end, for agents (Cursor)
-#                 that read the hook's stdout as its JSON reply.
+#   --transcript          slurp stdin (Claude feeds hooks a JSON blob) and forward its
+#                         transcript_path so termio can address the raw Q&A log.
+#   --conversation        forward this agent-reported conversation id verbatim, for
+#                         in-process plugins that already hold the live id.
+#   --conversation-from   mine the conversation id out of the named string field of
+#                         the JSON on stdin (agents disagree on the field name:
+#                         Codex `session_id`, Grok `sessionId`).
+#   --reply               stay silent on stdout and print `{}` at the end, for agents
+#                         (Cursor) that read the hook's stdout as its JSON reply.
 agent() {
     op="${1:-}"
     [ $# -gt 0 ] && shift || true
     if [ "$op" != "report" ]; then
         echo "termio: unknown agent command '${op:-}'" >&2
-        echo "usage: termio agent report <working|attention|done|idle> [--transcript] [--reply]" >&2
+        echo "usage: termio agent report <working|attention|done|idle> [--transcript] [--conversation <id>] [--conversation-from <field>] [--reply]" >&2
         exit 1
     fi
 
     state=""
     with_transcript=0
     reply=0
-    for arg in "$@"; do
-        case "$arg" in
+    conversation=""
+    conversation_from=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
             --transcript) with_transcript=1 ;;
             --reply) reply=1 ;;
-            working|attention|done|idle) state="$arg" ;;
-            *) echo "termio: unknown agent report argument '$arg'" >&2; exit 1 ;;
+            --conversation)
+                [ $# -ge 2 ] || { echo "termio: --conversation needs a value" >&2; exit 1; }
+                conversation="$2"; shift ;;
+            --conversation-from)
+                [ $# -ge 2 ] || { echo "termio: --conversation-from needs a field name" >&2; exit 1; }
+                conversation_from="$2"; shift ;;
+            working|attention|done|idle) state="$1" ;;
+            *) echo "termio: unknown agent report argument '$1'" >&2; exit 1 ;;
         esac
+        shift
     done
     if [ -z "$state" ]; then
         echo "termio: agent report needs a state (working|attention|done|idle)" >&2
@@ -120,18 +136,29 @@ agent() {
     session=$(json_escape "${TERMIO_SESSION:-}")
     cwd=$(json_escape "$PWD")
 
+    # Read stdin once when any flag mines it. `head -1` closes the pipe so the
+    # pipeline's exit status is sed's (0), keeping `set -e` happy even when grep
+    # matches nothing.
+    input=""
+    if [ "$with_transcript" -eq 1 ] || [ -n "$conversation_from" ]; then
+        input=$(cat)
+    fi
+    if [ -z "$conversation" ] && [ -n "$conversation_from" ]; then
+        conversation=$(printf '%s' "$input" \
+            | grep -o "\"$conversation_from\":\"[^\"]*\"" | head -1 | sed 's/.*:"//;s/"$//')
+    fi
+
+    payload=$(printf '{"termio_session":"%s","state":"%s","cwd":"%s"' \
+        "$session" "$state" "$cwd")
     if [ "$with_transcript" -eq 1 ]; then
         # Mirror the old hook: mine transcript_path out of the JSON on stdin, jq-free.
-        # `head -1` closes the pipe so the pipeline's exit status is sed's (0), keeping
-        # `set -e` happy even when grep matches nothing.
-        input=$(cat)
         tp=$(printf '%s' "$input" | grep -o '"transcript_path":"[^"]*"' | head -1 | sed 's/.*:"//;s/"$//')
-        payload=$(printf '{"termio_session":"%s","state":"%s","cwd":"%s","transcript_path":"%s"}' \
-            "$session" "$state" "$cwd" "$(json_escape "$tp")")
-    else
-        payload=$(printf '{"termio_session":"%s","state":"%s","cwd":"%s"}' \
-            "$session" "$state" "$cwd")
+        payload=$(printf '%s,"transcript_path":"%s"' "$payload" "$(json_escape "$tp")")
     fi
+    if [ -n "$conversation" ]; then
+        payload=$(printf '%s,"conversation_id":"%s"' "$payload" "$(json_escape "$conversation")")
+    fi
+    payload="$payload}"
 
     # Fan out to every channel's status socket, not just this binary's own: the
     # report is self-identifying (the session id routes it), so broadcasting is


### PR DESCRIPTION
Phase 2 of [docs/design/clear-conversation-rotation.md](https://github.com/jiweiyuan/termio/blob/feat/agent-rotation-signals/docs/design/clear-conversation-rotation.md): PR #34 made the rotation *consequences* (transcript path, resume pin, stale-title invalidation) agent-generic but the *signal* was Claude-only. This PR gives the other rotating agents a signal, via two new ATP manifest mechanisms — no agent-name switches in store code.

> Stacked on #34 (`feat/clear-conversation-rotation`), which is still open — this PR targets that branch so its diff shows only phase 2. Retarget to `main` when #34 merges.

## Mechanism 1 — identity-bearing reports (`hooks.conversation`)

The manifest's `hooks` object gains a `conversation` locator naming where the hook host exposes the agent's own live conversation id. Dialect-interpreted, mechanism-named: a stdin JSON field for shell hooks, an event key path for the OpenCode plugin, the extension context for the Pi plugin. `termio agent report` grew `--conversation <id>` / `--conversation-from <field>`, the payload carries `conversation_id`, and `applyStatusReport` adopts a changed id exactly the way a hook-carried transcript path is adopted today.

## Mechanism 2 — turn-boundary re-discovery

For a discovered-id agent whose manifest declares **no** identity locator, each identity-less `done` report re-scans the declared `discover` store for the newest record born in the session's directory during this process's lifetime; a different id is an in-process rotation. No-guessing guards: two same-agent sessions sharing a directory → no move; agents *with* a locator are excluded (an identity-less report from them is deliberate — an OpenCode subagent's turn end — and its store record is exactly the false match to avoid). Scan runs at turn end only, never on a timer.

Both signals land in one shared adoption point (`TermioStore.adoptConversationID`), so title invalidation comes for free per mechanism.

## Per-agent outcome

| Agent | Outcome | Signal | Verified against |
| --- | --- | --- | --- |
| Codex | ✅ supported | `conversation: session_id` + `capturesTranscript: true` (hook stdin carries `session_id` and `transcript_path` = live rollout; verified in the 0.144.6 binary + openai/codex hook schemas) + `SessionStart` event | codex-cli 0.144.6 |
| OpenCode | ✅ supported | plugin forwards `event.properties.sessionID` on status/idle/permission events, filtered to top-level sessions via a `session.created`/`session.updated` `parentID` cache (child subagent sessions share the plugin bus and must never be adopted) | opencode 1.17.20 bundled schemas + SDK types |
| Pi | ✅ supported | `conversation: context` — extension reads `ctx.sessionManager.getSessionId()`; Pi has in-process `/new` (mints a new uuidv7 + file) and reloads extensions with a fresh context after the switch; `session_start` event added so rotation lands at `/new` time | pi 0.80.6 shipped source |
| Grok | ✅ supported | `conversation: sessionId` mined from hook stdin (camelCase payload, documented in `~/.grok/docs/user-guide/10-hooks.md`); Grok has in-process `/new` (alias `/clear`) that mints a new session id; `SessionStart` event added | grok 0.2.106 local docs + binary |
| Claude Code | unchanged | phase 1 transcript-filename reconcile, now routed through the shared adoption point | — |
| Amp / Cursor / Kimi / Antigravity / Hermes | skipped | no `resume` capability declared — no pin to rotate | — |

## Manual test plan

Per agent — start a session in termio, chat until title + trace reflect the conversation, then:

| Agent | Rotate with | Expect |
| --- | --- | --- |
| Codex | `/new` | pin → new rollout id at `SessionStart`/next hook event; trace follows via hook-carried rollout path; title falls back to "Codex"; quit+relaunch runs `codex resume <new id>` |
| OpenCode | `session.new` (`ctrl+x n`) | pin → new `ses_…` id at first busy/idle of the new session; title falls back; relaunch runs `opencode --session <new id>`. Also: run a subagent-spawning prompt — pin must NOT move to a child session id |
| Pi | `/new` | pin → pi-minted uuidv7 at `session_start` (before the session file exists); title falls back; relaunch `--session-id <new id>` (seed pre-creates the file if no message was sent) |
| Grok | `/new` or `/clear` | pin → new id at `SessionStart`/first prompt of the new conversation; title falls back; relaunch runs `grok --resume <new id>` |
| Claude | `/clear` | regression — unchanged phase 1 behavior |
| Codex (mechanism 2) | user-override manifest with `conversation`/`capturesTranscript` removed, then `/new` + one full turn | rotation lands on the `done` report at turn end |

Hooks re-install on next app launch (`AgentStatusHooks.sync`); already-running agent processes keep their old hook snapshot until relaunched.

## Notes / follow-ups

- `SessionStart` for Codex/Grok is schema-verified but not live-fired here; if a version doesn't emit it, rotation still lands on the next subscribed event — the extra event is purely earlier, never wrong (at process start the reported id equals the pin → no-op).
- Watch item: if Codex/Grok ever fire tool hooks *inside* subagents with the subagent's own `session_id` (Claude keeps the main session's id there; Codex's schema suggests the same), adoption could flap mid-turn — the fix would be a one-line state gate on adoption.
- The ATP landing page's example manifest (`web/landing/src/app/docs/atp/page.tsx`) doesn't yet show `hooks.conversation` — small follow-up.
- `docs/README.md` index unchanged: the doc's title/status front matter didn't change, so the generated table is identical.

Release Notes:
- Termio now follows Codex, OpenCode, Pi, and Grok when they start a new conversation in place (`/new`): the tab's resume pin, trace, and sidebar title move to the new conversation instead of sticking to the discarded one.