### PR TITLE
feat(git): keyboard diff walk and intraline word-level highlight

### DIFF
--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -325,7 +325,8 @@ struct FileEditorView: View {
     /// actually ships (e.g. it has no `toml`/`jsonc` — those fold into `ini`/`json`). The whole file
     /// name is checked first (so `Dockerfile`, `Cargo.lock`, `yarn.lock`, … resolve by name, not
     /// extension), then the extension. Unknown files return `nil` to let highlight.js auto-detect.
-    private static func highlightLanguage(for url: URL) -> String? {
+    /// Shared with `GitDiffView`, which colors diff lines through the same grammar set.
+    static func highlightLanguage(for url: URL) -> String? {
         // Extension-less or specially-named files, keyed by the whole (lowercased) name.
         switch url.lastPathComponent.lowercased() {
         case "dockerfile", "containerfile": return "dockerfile"

--- a/Sources/termio/Git/DiffHighlighter.swift
+++ b/Sources/termio/Git/DiffHighlighter.swift
@@ -1,0 +1,102 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+// MARK: - Diff syntax coloring
+
+/// One reusable Highlightr behind an actor. Building its JavaScriptCore context and
+/// parsing highlight.min.js costs on the order of 100 ms — far too much to pay per
+/// file switch — and the context is not safe to share across concurrent tasks. The
+/// actor amortizes the setup, serializes requests (rapid arrow-key walking queues
+/// instead of racing), and re-themes only when the theme or font actually changes.
+actor DiffHighlighter {
+    static let shared = DiffHighlighter()
+
+    private var highlightr: Highlightr?
+    private var appliedTheme: String?
+    private var appliedFont: NSFont?
+
+    /// Syntax-colors a diff, one side at a time: each side is highlighted as a single
+    /// text so multi-line constructs (block comments, raw strings) keep their true
+    /// state — per-line coloring can't do that. Context lines take the new side's
+    /// colors; the old side contributes only its deletions. Returns SwiftUI-scope
+    /// attributed lines by row id, with the intraline emphasis layered back on top.
+    func styledLines(newSide: [DiffRow], oldSide: [DiffRow], language: String,
+                     theme: String, font: NSFont) -> [Int: AttributedString] {
+        guard let highlightr = prepared(theme: theme, font: font) else { return [:] }
+        var result: [Int: AttributedString] = [:]
+        apply(newSide, keeping: [.context, .addition], highlightr, language, into: &result)
+        apply(oldSide, keeping: [.deletion], highlightr, language, into: &result)
+        return result
+    }
+
+    private func prepared(theme: String, font: NSFont) -> Highlightr? {
+        if highlightr == nil { highlightr = Highlightr() }
+        guard let highlightr else { return nil }
+        if appliedTheme != theme {
+            guard highlightr.setTheme(to: theme) else { return nil }
+            appliedTheme = theme
+            appliedFont = nil
+        }
+        if appliedFont != font {
+            highlightr.theme.setCodeFont(font)
+            appliedFont = font
+        }
+        return highlightr
+    }
+
+    private func apply(_ side: [DiffRow], keeping kinds: Set<DiffRow.Kind>,
+                       _ highlightr: Highlightr, _ language: String,
+                       into result: inout [Int: AttributedString]) {
+        let joined = side.map(\.text).joined(separator: "\n")
+        // The colored text must round-trip exactly, or the per-line offsets below
+        // would attribute the wrong spans — bail to plain rendering instead.
+        guard let colored = highlightr.highlight(joined, as: language, fastRender: true),
+              colored.string == joined else { return }
+        var location = 0
+        for row in side {
+            let length = (row.text as NSString).length
+            defer { location += length + 1 }
+            guard kinds.contains(row.kind), length > 0 else { continue }
+            let line = colored.attributedSubstring(from: NSRange(location: location, length: length))
+            var attributed = Self.swiftUIAttributed(line)
+            attributed.applyDiffEmphasis(row.emphasis, kind: row.kind)
+            result[row.id] = attributed
+        }
+    }
+
+    /// Re-emits an AppKit attributed line as SwiftUI attributes. `Text` only honors
+    /// the SwiftUI attribute scope, so the theme's `NSColor`/`NSFont` runs must be
+    /// translated, not just bridged; the theme's background never carries over — the
+    /// row's add/delete wash owns that layer.
+    private static func swiftUIAttributed(_ line: NSAttributedString) -> AttributedString {
+        var attributed = AttributedString("")
+        line.enumerateAttributes(in: NSRange(location: 0, length: line.length)) { attributes, range, _ in
+            var piece = AttributedString(line.attributedSubstring(from: range).string)
+            if let color = attributes[.foregroundColor] as? NSColor {
+                piece.foregroundColor = Color(nsColor: color)
+            }
+            if let font = attributes[.font] as? NSFont {
+                piece.font = Font(font)
+            }
+            attributed += piece
+        }
+        return attributed
+    }
+}
+
+extension AttributedString {
+    /// Lays a diff row's intraline emphasis span over the line — the deeper second
+    /// shade of the row's own tint. Shared by the syntax-colored path and the plain
+    /// fallback so the two can never drift apart.
+    mutating func applyDiffEmphasis(_ emphasis: Range<Int>?, kind: DiffRow.Kind) {
+        guard let emphasis, !emphasis.isEmpty else { return }
+        guard let start = characters.index(characters.startIndex, offsetBy: emphasis.lowerBound,
+                                           limitedBy: characters.endIndex),
+              let end = characters.index(characters.startIndex, offsetBy: emphasis.upperBound,
+                                         limitedBy: characters.endIndex),
+              start < end else { return }
+        self[start..<end].backgroundColor =
+            kind == .addition ? Color.green.opacity(0.28) : Color.red.opacity(0.28)
+    }
+}

--- a/Sources/termio/Git/FolderEventStream.swift
+++ b/Sources/termio/Git/FolderEventStream.swift
@@ -1,0 +1,50 @@
+import CoreServices
+import Foundation
+
+/// A recursive FSEvents watch over one or more directory trees. `BranchModel`'s
+/// `DispatchSourceFileSystemObject` watches a single directory's own entries; the git
+/// pane needs "anything under the worktree (or its git dir) changed", which is exactly
+/// what FSEvents provides. Events are coalesced by the stream's own latency window and
+/// delivered on `queue` as the raw changed paths.
+final class FolderEventStream {
+    private var stream: FSEventStreamRef?
+
+    /// Retained by the stream context so the C callback can reach the Swift closure;
+    /// released by the context's `release` hook when the stream is invalidated.
+    private final class Handler {
+        let fire: ([String]) -> Void
+        init(_ fire: @escaping ([String]) -> Void) { self.fire = fire }
+    }
+
+    init?(paths: [String], latency: TimeInterval, queue: DispatchQueue,
+          handler: @escaping ([String]) -> Void) {
+        var context = FSEventStreamContext()
+        context.info = Unmanaged.passRetained(Handler(handler)).toOpaque()
+        context.release = { info in
+            guard let info else { return }
+            Unmanaged<Handler>.fromOpaque(info).release()
+        }
+        let callback: FSEventStreamCallback = { _, info, count, eventPaths, _, _ in
+            guard let info else { return }
+            let handler = Unmanaged<Handler>.fromOpaque(info).takeUnretainedValue()
+            let raw = eventPaths.assumingMemoryBound(to: UnsafeMutablePointer<CChar>.self)
+            handler.fire((0..<count).map { String(cString: raw[$0]) })
+        }
+        guard let stream = FSEventStreamCreate(
+            nil, callback, &context, paths as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            latency,
+            FSEventStreamCreateFlags(kFSEventStreamCreateFlagNone)
+        ) else { return nil }
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
+    }
+
+    deinit {
+        guard let stream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+    }
+}

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -60,16 +60,21 @@ struct GitChangesView: View {
                 store.openDiff = nil
             }
         }
-        // Re-read when a diff overlay closes — the user may have just acted on it. A
-        // lone selection is released too, so clicking the same row reopens its diff.
+        // Follow the overlay both ways: ← / → walks inside it, so the list's selection
+        // chases the shown file; on close, re-read (the user may have just acted on it)
+        // and release a lone selection so clicking the same row reopens its diff. The
+        // `openFileURL` guards keep a diff↔preview hand-off from reading as a close.
         .onChange(of: store.openDiff) { _, request in
-            if request == nil {
+            if let request, request.commit == nil, selection != [request.change.path] {
+                selection = [request.change.path]
+            }
+            if request == nil, store.openFileURL == nil {
                 Task { await model.load() }
                 if selection.count == 1 { selection.removeAll() }
             }
         }
         .onChange(of: store.openFileURL) { _, url in
-            if url == nil, selection.count == 1 { selection.removeAll() }
+            if url == nil, store.openDiff == nil, selection.count == 1 { selection.removeAll() }
         }
         .alert("Discard Changes?", isPresented: discardAlertPresented, presenting: pendingDiscard) { changes in
             Button("Discard Changes", role: .destructive) { performDiscard(changes) }
@@ -230,12 +235,12 @@ struct GitChangesView: View {
     private func open(_ change: GitChange) {
         // An image/SVG/PDF has no meaningful text diff, so show the file itself in the preview
         // overlay. A deleted file is gone from disk, so fall back to the diff (its empty result
-        // is the honest one).
+        // is the honest one). The store's overlay didSets keep the two mutually exclusive.
         let url = fileURL(for: change)
         if FileActivation.previewsRatherThanDiff(url), FileManager.default.fileExists(atPath: url.path) {
             store.openFileInEditor(url)
         } else {
-            store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: change)
+            store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: change, siblings: model.changes)
         }
     }
 

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -115,21 +115,17 @@ struct GitChangesView: View {
         .buttonStyle(.plain)
     }
 
-    /// Status strip under the content: what the visible list adds up to, and refresh.
+    /// Status strip under the content: what the visible list adds up to. There is no
+    /// refresh control — the model watches the worktree and git dir and re-reads on
+    /// its own (see `GitPanelModel.armWatcher`), the same invariant that lets IDEs
+    /// ship without one.
     private var bottomBar: some View {
         HStack(spacing: 5) {
             summary
             Spacer(minLength: 8)
-            TreeHeaderButton(systemName: "arrow.clockwise", help: "Refresh") {
-                Task {
-                    if mode == .changes { await model.load() }
-                    else { await model.loadHistory(force: true) }
-                }
-            }
         }
         .font(.system(size: 10.5, weight: .medium, design: .monospaced))
-        .padding(.leading, 12)
-        .padding(.trailing, 8)
+        .padding(.horizontal, 12)
         .padding(.vertical, 6)
         .overlay(alignment: .top) {
             Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 1)

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -194,6 +194,16 @@ struct GitChangesView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .environment(\.defaultMinListRowHeight, 1)
+        // ← / → walk the open diff from here too — the list usually holds focus
+        // (↑ ↓ walk via selection), so the overlay's own keys alone wouldn't fire.
+        .onKeyPress(.leftArrow) { walkOverlay(-1) }
+        .onKeyPress(.rightArrow) { walkOverlay(+1) }
+    }
+
+    private func walkOverlay(_ delta: Int) -> KeyPress.Result {
+        guard let next = store.openDiff?.neighbor(delta) else { return .ignored }
+        store.openDiff = next
+        return .handled
     }
 
     /// The row's menu acts on the whole selection when the clicked row is part of it,

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -375,6 +375,9 @@ private struct GitChangeRow: View {
                 }
                 .font(.system(size: 10.5, weight: .medium, design: .monospaced))
                 .opacity(0.85)
+                // Counts never wrap or compress — when the row runs out of width the
+                // dimmed directory is the one flexible element that gives way.
+                .fixedSize()
             }
         }
         .padding(.horizontal, 14)

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -239,8 +239,17 @@ struct GitDiffView: View {
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
-            .environment(\.defaultMinListRowHeight, 1)
+            // A realistic per-line estimate, NOT 1: the table uses this to size its
+            // viewport, and a 1 pt estimate on a full-context diff (thousands of rows)
+            // makes it materialize them all at once — a seconds-long main-thread stall.
+            .environment(\.defaultMinListRowHeight, lineHeightEstimate)
         }
+    }
+
+    /// Approximate single-line row height (font line box + the row's 1 pt paddings).
+    private var lineHeightEstimate: CGFloat {
+        let font = settings.resolvedTerminalFont()
+        return (font.ascender - font.descender + font.leading).rounded(.up) + 2
     }
 
     /// Whether any code row carries an old/new line number (hunk rows don't count —

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -126,15 +126,22 @@ struct GitDiffView: View {
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            ScrollView(.vertical) {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(rows) { row in
-                        DiffLineRow(row: row, font: diffFont, gutterFont: gutterFont,
-                                    showOldGutter: hasOldLines, showNewGutter: hasNewLines)
-                    }
-                }
-                .padding(.bottom, 12)
+            // A `List` (NSTableView underneath), not a `ScrollView`+`LazyVStack`: the rows
+            // soft-wrap, so their heights vary, and LazyVStack only *estimates* heights for
+            // off-screen content — scrolling fights the estimates (visible jitter) and rows
+            // laid out at an old width keep their stale wrap after the inspector resizes.
+            // NSTableView measures and caches real row heights and re-lays them out on
+            // width changes, which is why the Changes list built on it holds steady.
+            List(rows) { row in
+                DiffLineRow(row: row, font: diffFont, gutterFont: gutterFont,
+                            showOldGutter: hasOldLines, showNewGutter: hasNewLines)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .environment(\.defaultMinListRowHeight, 1)
         }
     }
 

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -13,6 +13,10 @@ struct GitDiffView: View {
     let request: GitDiffRequest
     @ObservedObject var settings: AppSettings
     let onClose: () -> Void
+    /// Replaces the overlay's request in place — ← / → walk through `request.siblings`
+    /// without dropping back to the list (Quick Look's arrow-key walk; ↑ ↓ stay with
+    /// scrolling, and the same keys in the focused Changes list walk via selection).
+    var onNavigate: ((GitDiffRequest) -> Void)? = nil
 
     @State private var rows: [DiffRow] = []
     @State private var isLoading = true
@@ -24,8 +28,37 @@ struct GitDiffView: View {
             content
         }
         .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
+        .focusable()
+        .focusEffectDisabled()
+        .onKeyPress(.leftArrow) { walk(-1) ? .handled : .ignored }
+        .onKeyPress(.rightArrow) { walk(+1) ? .handled : .ignored }
         .onExitCommand(perform: onClose)
         .task(id: request) { await load() }
+    }
+
+    // MARK: Walking
+
+    private var walkIndex: Int? {
+        request.siblings.firstIndex { $0.path == request.change.path }
+    }
+
+    /// Steps to the previous/next sibling that has a textual diff, skipping the
+    /// image/PDF kind the preview overlay owns. Returns false at either end so the
+    /// key press falls through instead of pretending to act.
+    private func walk(_ delta: Int) -> Bool {
+        guard let onNavigate, let index = walkIndex else { return false }
+        var next = index + delta
+        while next >= 0, next < request.siblings.count {
+            let candidate = request.siblings[next]
+            let url = URL(fileURLWithPath: request.repoRoot).appendingPathComponent(candidate.path)
+            if !FileActivation.previewsRatherThanDiff(url) {
+                onNavigate(GitDiffRequest(repoRoot: request.repoRoot, change: candidate,
+                                          commit: request.commit, siblings: request.siblings))
+                return true
+            }
+            next += delta
+        }
+        return false
     }
 
     private var header: some View {
@@ -47,6 +80,13 @@ struct GitDiffView: View {
                     .truncationMode(.head)
             }
             Spacer(minLength: 8)
+            // "n of m" (Mail's message-walk wording) whenever there is a set to walk.
+            if request.siblings.count > 1, let index = walkIndex {
+                Text("\(index + 1) of \(request.siblings.count)")
+                    .font(.system(size: 10.5, weight: .medium).monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .padding(.trailing, 2)
+            }
             // For a history diff, tag the header with the commit it belongs to.
             if let commit = request.commit {
                 Text("@ \(commit.prefix(7))")
@@ -151,7 +191,7 @@ private struct DiffLineRow: View {
                     .font(font)
                     .foregroundStyle(signColor)
                     .frame(width: 16)
-                Text(row.text.isEmpty ? " " : row.text)
+                codeText
                     .font(font)
                     .foregroundStyle(.primary)
                     .textSelection(.enabled)
@@ -163,6 +203,25 @@ private struct DiffLineRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(background)
         }
+    }
+
+    /// The code line, with the intraline changed span (if any) on a deeper tint of
+    /// the row's own color — the second, stronger shade Xcode's comparison view uses.
+    private var codeText: Text {
+        guard let emphasis = row.emphasis, !emphasis.isEmpty, !row.text.isEmpty else {
+            return Text(row.text.isEmpty ? " " : row.text)
+        }
+        var attributed = AttributedString(row.text)
+        let characters = attributed.characters
+        if let start = characters.index(characters.startIndex, offsetBy: emphasis.lowerBound,
+                                        limitedBy: characters.endIndex),
+           let end = characters.index(characters.startIndex, offsetBy: emphasis.upperBound,
+                                      limitedBy: characters.endIndex),
+           start < end {
+            attributed[start..<end].backgroundColor =
+                row.kind == .addition ? Color.green.opacity(0.28) : Color.red.opacity(0.28)
+        }
+        return Text(attributed)
     }
 
     private func gutter(_ number: Int?) -> some View {

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -53,23 +53,12 @@ struct GitDiffView: View {
         request.siblings.firstIndex { $0.path == request.change.path }
     }
 
-    /// Steps to the previous/next sibling that has a textual diff, skipping the
-    /// image/PDF kind the preview overlay owns. Returns false at either end so the
-    /// key press falls through instead of pretending to act.
+    /// Steps to the previous/next diffable sibling. Returns false at either end so
+    /// the key press falls through instead of pretending to act.
     private func walk(_ delta: Int) -> Bool {
-        guard let onNavigate, let index = walkIndex else { return false }
-        var next = index + delta
-        while next >= 0, next < request.siblings.count {
-            let candidate = request.siblings[next]
-            let url = URL(fileURLWithPath: request.repoRoot).appendingPathComponent(candidate.path)
-            if !FileActivation.previewsRatherThanDiff(url) {
-                onNavigate(GitDiffRequest(repoRoot: request.repoRoot, change: candidate,
-                                          commit: request.commit, siblings: request.siblings))
-                return true
-            }
-            next += delta
-        }
-        return false
+        guard let onNavigate, let next = request.neighbor(delta) else { return false }
+        onNavigate(next)
+        return true
     }
 
     // MARK: Header
@@ -280,86 +269,44 @@ struct GitDiffView: View {
         await buildStyledLines(parsed)
     }
 
-    /// Colors the code through the editor's Highlightr pipeline. Each *side* of the
-    /// file is reconstructed as one text (context + additions = new file, context +
-    /// deletions = old file) and highlighted whole, so multi-line constructs — block
-    /// comments, raw strings — keep their true state; per-line highlighting can't do
-    /// that. The theme's own foreground/font attributes are re-emitted as SwiftUI
-    /// attributes (Text ignores AppKit-scope ones) and the add/delete emphasis span
-    /// is layered back on top. Oversized diffs skip coloring rather than stall.
+    /// Colors the code through `DiffHighlighter` (the editor's Highlightr pipeline
+    /// behind a shared actor). Oversized diffs skip coloring rather than stall; a
+    /// result that lands after the user has walked on is dropped, not applied.
     private func buildStyledLines(_ rows: [DiffRow]) async {
         let url = URL(fileURLWithPath: request.repoRoot).appendingPathComponent(request.change.path)
         guard let language = FileEditorView.highlightLanguage(for: url) else { return }
         let code = rows.filter { $0.kind != .hunk }
         guard code.count <= 8000, code.reduce(0, { $0 + $1.text.count }) <= 600_000 else { return }
 
-        let theme = colorScheme == .dark ? "xcode-dark" : "xcode"
-        let font = settings.resolvedTerminalFont()
-        let newSide = code.filter { $0.kind == .context || $0.kind == .addition }
-        let oldSide = code.filter { $0.kind == .context || $0.kind == .deletion }
-
-        let styled = await Task.detached(priority: .userInitiated) { () -> [Int: AttributedString] in
-            guard let highlightr = Highlightr(), highlightr.setTheme(to: theme) else { return [:] }
-            highlightr.theme.setCodeFont(font)
-            var result: [Int: AttributedString] = [:]
-
-            func apply(_ side: [DiffRow], keeping kinds: Set<DiffRow.Kind>) {
-                let joined = side.map(\.text).joined(separator: "\n")
-                guard let colored = highlightr.highlight(joined, as: language, fastRender: true),
-                      colored.string == joined else { return }
-                var location = 0
-                for row in side {
-                    let length = (row.text as NSString).length
-                    defer { location += length + 1 }
-                    guard kinds.contains(row.kind), length > 0 else { continue }
-                    let sub = colored.attributedSubstring(from: NSRange(location: location, length: length))
-                    result[row.id] = swiftUIAttributed(sub, emphasis: row.emphasis, kind: row.kind)
-                }
-            }
-            // Context lines take the new side's colors; the old side only contributes
-            // its deletions (the context would be identical, so skip the overwrite).
-            apply(newSide, keeping: [.context, .addition])
-            apply(oldSide, keeping: [.deletion])
-            return result
-        }.value
+        let styled = await DiffHighlighter.shared.styledLines(
+            newSide: code.filter { $0.kind == .context || $0.kind == .addition },
+            oldSide: code.filter { $0.kind == .context || $0.kind == .deletion },
+            language: language,
+            theme: colorScheme == .dark ? "xcode-dark" : "xcode",
+            font: settings.resolvedTerminalFont()
+        )
+        guard !Task.isCancelled else { return }
         styledLines = styled
     }
+}
 
-    /// Re-emits an AppKit attributed line as SwiftUI attributes and lays the intraline
-    /// emphasis back over it. `Text` only honors the SwiftUI attribute scope, so the
-    /// theme's `NSColor`/`NSFont` runs must be translated, not just bridged.
-    private nonisolated static func swiftUIAttributed(
-        _ line: NSAttributedString, emphasis: Range<Int>?, kind: DiffRow.Kind
-    ) -> AttributedString {
-        var attributed = AttributedString("")
-        line.enumerateAttributes(in: NSRange(location: 0, length: line.length)) { attributes, range, _ in
-            var piece = AttributedString(line.attributedSubstring(from: range).string)
-            if let color = attributes[.foregroundColor] as? NSColor {
-                piece.foregroundColor = Color(nsColor: color)
+extension GitDiffRequest {
+    /// The nearest sibling in `delta`'s direction that has a textual diff —
+    /// image/PDF siblings belong to the preview overlay and are skipped. The one
+    /// walking rule, shared by the overlay's own ← / → and the Changes list's.
+    func neighbor(_ delta: Int) -> GitDiffRequest? {
+        guard let index = siblings.firstIndex(where: { $0.path == change.path }) else { return nil }
+        var next = index + delta
+        while next >= 0, next < siblings.count {
+            let candidate = siblings[next]
+            let url = URL(fileURLWithPath: repoRoot).appendingPathComponent(candidate.path)
+            if !FileActivation.previewsRatherThanDiff(url) {
+                return GitDiffRequest(repoRoot: repoRoot, change: candidate,
+                                      commit: commit, siblings: siblings)
             }
-            if let pieceFont = attributes[.font] as? NSFont {
-                piece.font = Font(pieceFont)
-            }
-            attributed += piece
+            next += delta
         }
-        if let emphasis, !emphasis.isEmpty {
-            let characters = attributed.characters
-            if let start = characters.index(characters.startIndex, offsetBy: emphasis.lowerBound,
-                                            limitedBy: characters.endIndex),
-               let end = characters.index(characters.startIndex, offsetBy: emphasis.upperBound,
-                                          limitedBy: characters.endIndex),
-               start < end {
-                attributed[start..<end].backgroundColor =
-                    kind == .addition ? Color.green.opacity(0.28) : Color.red.opacity(0.28)
-            }
-        }
-        return attributed
-    }
-
-    private nonisolated func swiftUIAttributed(
-        _ line: NSAttributedString, emphasis: Range<Int>?, kind: DiffRow.Kind
-    ) -> AttributedString {
-        Self.swiftUIAttributed(line, emphasis: emphasis, kind: kind)
+        return nil
     }
 }
 
@@ -399,19 +346,9 @@ private struct DiffLineRow: View {
 
     private var codeText: Text {
         if let styled, !styled.characters.isEmpty { return Text(styled) }
-        guard let emphasis = row.emphasis, !emphasis.isEmpty, !row.text.isEmpty else {
-            return Text(row.text.isEmpty ? " " : row.text)
-        }
+        guard !row.text.isEmpty else { return Text(" ") }
         var attributed = AttributedString(row.text)
-        let characters = attributed.characters
-        if let start = characters.index(characters.startIndex, offsetBy: emphasis.lowerBound,
-                                        limitedBy: characters.endIndex),
-           let end = characters.index(characters.startIndex, offsetBy: emphasis.upperBound,
-                                      limitedBy: characters.endIndex),
-           start < end {
-            attributed[start..<end].backgroundColor =
-                row.kind == .addition ? Color.green.opacity(0.28) : Color.red.opacity(0.28)
-        }
+        attributed.applyDiffEmphasis(row.emphasis, kind: row.kind)
         return Text(attributed)
     }
 

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -20,6 +20,9 @@ struct GitDiffView: View {
 
     @State private var rows: [DiffRow] = []
     @State private var isLoading = true
+    /// The spinner waits 0.15 s before appearing, so a fast file-to-file walk swaps
+    /// content with no intermediate flash; only a genuinely slow diff shows it.
+    @State private var showsSpinner = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -118,6 +121,11 @@ struct GitDiffView: View {
             ProgressView()
                 .controlSize(.small)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .opacity(showsSpinner ? 1 : 0)
+                .task {
+                    try? await Task.sleep(nanoseconds: 150_000_000)
+                    showsSpinner = true
+                }
         } else if rows.isEmpty {
             ContentUnavailableView(
                 "No Diff",

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -4,11 +4,12 @@ import SwiftUI
 // MARK: - Diff overlay
 
 /// A read-only unified diff that covers the terminal pane — the git counterpart of
-/// `FilePreviewView`/`FileEditorView`, driven by `store.openDiff`. Rendered as native
-/// SwiftUI rows (the Xcode / CodeEdit / gitdiff pattern — parse the diff, draw line
-/// rows with a line-number gutter and per-line green/red backgrounds) rather than a
-/// web view, so it needs no syntax-highlighting dependency. Escape or the close
-/// button dismisses it back to the terminal.
+/// `FilePreviewView`/`FileEditorView`, driven by `store.openDiff`. Native SwiftUI rows
+/// in a `List` (NSTableView underneath, for stable variable-height scrolling), styled
+/// after the current generation of diff readers: code keeps its syntax colors (the
+/// editor's Highlightr pipeline) with the add/delete tint as a wash underneath, raw
+/// `@@` plumbing never appears — unchanged runs collapse into expandable "n lines"
+/// bands — and the gutter chrome recedes. Escape or the close button dismisses it.
 struct GitDiffView: View {
     let request: GitDiffRequest
     @ObservedObject var settings: AppSettings
@@ -18,11 +19,18 @@ struct GitDiffView: View {
     /// scrolling, and the same keys in the focused Changes list walk via selection).
     var onNavigate: ((GitDiffRequest) -> Void)? = nil
 
+    @Environment(\.colorScheme) private var colorScheme
+
     @State private var rows: [DiffRow] = []
     @State private var isLoading = true
     /// The spinner waits 0.15 s before appearing, so a fast file-to-file walk swaps
     /// content with no intermediate flash; only a genuinely slow diff shows it.
     @State private var showsSpinner = false
+    /// Syntax-colored line content per row id (emphasis merged in), filled by a
+    /// background pass after the rows land; rows render plain until then.
+    @State private var styledLines: [Int: AttributedString] = [:]
+    /// Ids (first hidden row) of the collapsed bands the user has expanded.
+    @State private var expanded: Set<Int> = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -64,6 +72,8 @@ struct GitDiffView: View {
         return false
     }
 
+    // MARK: Header
+
     private var header: some View {
         HStack(spacing: 8) {
             Text(request.change.status.letter)
@@ -97,22 +107,94 @@ struct GitDiffView: View {
                     .foregroundStyle(.secondary)
                     .padding(.trailing, 2)
             }
-            if request.change.additions > 0 {
-                Text("+\(request.change.additions)")
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(.green)
+            HStack(spacing: 5) {
+                if request.change.additions > 0 {
+                    Text("+\(request.change.additions)").foregroundStyle(.green)
+                }
+                if request.change.deletions > 0 {
+                    Text("−\(request.change.deletions)").foregroundStyle(.red)
+                }
             }
-            if request.change.deletions > 0 {
-                Text("−\(request.change.deletions)")
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(.red)
-            }
-            // Close lives in the toolbar now (a bordered, Liquid Glass button hugging the
-            // terminal|inspector divider) — see `setCloseOverlayVisible` in App.swift.
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .fixedSize()
+            // Close lives in the toolbar (a bordered button hugging the terminal|inspector
+            // divider) — see `setCloseOverlayVisible` in App.swift.
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .background(Color(nsColor: settings.terminalBackgroundColor))
+    }
+
+    // MARK: Content
+
+    /// One renderable element: a code line, or a collapsed band standing in for a run
+    /// of unchanged lines. A band with rows expands in place when clicked; a band with
+    /// none (the default-context fallback, where the hidden lines were never fetched)
+    /// is a fixed marker sized from the hunk-boundary arithmetic.
+    private enum DisplayItem: Identifiable {
+        case line(DiffRow)
+        case band(id: Int, count: Int, expandable: Bool)
+
+        var id: Int {
+            switch self {
+            case .line(let row): return row.id
+            case .band(let id, _, _): return -id - 1
+            }
+        }
+    }
+
+    /// Folds the raw rows into the display list: hunk plumbing disappears (its gap
+    /// becomes a band), and unchanged runs longer than a handful of lines collapse to
+    /// a band keeping 3 lines of context on the side(s) that face a change.
+    private var displayItems: [DisplayItem] {
+        var items: [DisplayItem] = []
+        var run: [DiffRow] = []
+        var sawChange = false
+        var lastNewLine = 0
+
+        func flush(isLast: Bool) {
+            defer { run = [] }
+            guard !run.isEmpty else { return }
+            let head = sawChange ? 3 : 0
+            let tail = isLast ? 0 : 3
+            let hidden = run.count - head - tail
+            guard hidden >= 10 else {
+                items += run.map(DisplayItem.line)
+                return
+            }
+            items += run.prefix(head).map(DisplayItem.line)
+            let hiddenRows = Array(run.dropFirst(head).dropLast(tail))
+            if expanded.contains(hiddenRows[0].id) {
+                items += hiddenRows.map(DisplayItem.line)
+            } else {
+                items.append(.band(id: hiddenRows[0].id, count: hiddenRows.count, expandable: true))
+            }
+            items += run.suffix(tail).map(DisplayItem.line)
+        }
+
+        for row in rows {
+            switch row.kind {
+            case .hunk:
+                flush(isLast: false)
+                if let start = row.newLine, start > lastNewLine + 1 {
+                    items.append(.band(id: row.id, count: start - lastNewLine - 1, expandable: false))
+                }
+            case .context:
+                run.append(row)
+                lastNewLine = row.newLine ?? lastNewLine
+            case .addition:
+                flush(isLast: false)
+                sawChange = true
+                items.append(.line(row))
+                lastNewLine = row.newLine ?? lastNewLine
+            case .deletion:
+                flush(isLast: false)
+                sawChange = true
+                items.append(.line(row))
+            }
+        }
+        flush(isLast: true)
+        return items
     }
 
     @ViewBuilder
@@ -138,14 +220,22 @@ struct GitDiffView: View {
             // soft-wrap, so their heights vary, and LazyVStack only *estimates* heights for
             // off-screen content — scrolling fights the estimates (visible jitter) and rows
             // laid out at an old width keep their stale wrap after the inspector resizes.
-            // NSTableView measures and caches real row heights and re-lays them out on
-            // width changes, which is why the Changes list built on it holds steady.
-            List(rows) { row in
-                DiffLineRow(row: row, font: diffFont, gutterFont: gutterFont,
-                            showOldGutter: hasOldLines, showNewGutter: hasNewLines)
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
+            List(displayItems) { item in
+                Group {
+                    switch item {
+                    case .line(let row):
+                        DiffLineRow(row: row, styled: styledLines[row.id],
+                                    font: diffFont, gutterFont: gutterFont,
+                                    showOldGutter: hasOldLines, showNewGutter: hasNewLines)
+                    case .band(let id, let count, let expandable):
+                        CollapsedBand(count: count, expandable: expandable) {
+                            expanded.insert(id)
+                        }
+                    }
+                }
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
@@ -153,11 +243,12 @@ struct GitDiffView: View {
         }
     }
 
-    /// Whether any row carries an old/new line number. A pure-addition file (new file)
-    /// has no old numbers, so we collapse that empty gutter rather than show a blank band;
-    /// likewise a pure deletion collapses the new gutter.
-    private var hasOldLines: Bool { rows.contains { $0.oldLine != nil } }
-    private var hasNewLines: Bool { rows.contains { $0.newLine != nil } }
+    /// Whether any code row carries an old/new line number (hunk rows don't count —
+    /// they hold start offsets). A pure-addition file has no old numbers, so that
+    /// empty gutter collapses rather than showing a blank band; likewise a pure
+    /// deletion collapses the new gutter.
+    private var hasOldLines: Bool { rows.contains { $0.kind != .hunk && $0.oldLine != nil } }
+    private var hasNewLines: Bool { rows.contains { $0.kind != .hunk && $0.newLine != nil } }
 
     /// The terminal font, so the diff reads in the same face as the agent's output
     /// and the file editor.
@@ -171,58 +262,134 @@ struct GitDiffView: View {
         return Font(NSFont.monospacedDigitSystemFont(ofSize: size, weight: .regular))
     }
 
+    // MARK: Loading + syntax colors
+
     private func load() async {
         let parsed = await GitService.diffRows(for: request.change, in: request.repoRoot, commit: request.commit)
         rows = parsed
         isLoading = false
+        await buildStyledLines(parsed)
+    }
+
+    /// Colors the code through the editor's Highlightr pipeline. Each *side* of the
+    /// file is reconstructed as one text (context + additions = new file, context +
+    /// deletions = old file) and highlighted whole, so multi-line constructs — block
+    /// comments, raw strings — keep their true state; per-line highlighting can't do
+    /// that. The theme's own foreground/font attributes are re-emitted as SwiftUI
+    /// attributes (Text ignores AppKit-scope ones) and the add/delete emphasis span
+    /// is layered back on top. Oversized diffs skip coloring rather than stall.
+    private func buildStyledLines(_ rows: [DiffRow]) async {
+        let url = URL(fileURLWithPath: request.repoRoot).appendingPathComponent(request.change.path)
+        guard let language = FileEditorView.highlightLanguage(for: url) else { return }
+        let code = rows.filter { $0.kind != .hunk }
+        guard code.count <= 8000, code.reduce(0, { $0 + $1.text.count }) <= 600_000 else { return }
+
+        let theme = colorScheme == .dark ? "xcode-dark" : "xcode"
+        let font = settings.resolvedTerminalFont()
+        let newSide = code.filter { $0.kind == .context || $0.kind == .addition }
+        let oldSide = code.filter { $0.kind == .context || $0.kind == .deletion }
+
+        let styled = await Task.detached(priority: .userInitiated) { () -> [Int: AttributedString] in
+            guard let highlightr = Highlightr(), highlightr.setTheme(to: theme) else { return [:] }
+            highlightr.theme.setCodeFont(font)
+            var result: [Int: AttributedString] = [:]
+
+            func apply(_ side: [DiffRow], keeping kinds: Set<DiffRow.Kind>) {
+                let joined = side.map(\.text).joined(separator: "\n")
+                guard let colored = highlightr.highlight(joined, as: language, fastRender: true),
+                      colored.string == joined else { return }
+                var location = 0
+                for row in side {
+                    let length = (row.text as NSString).length
+                    defer { location += length + 1 }
+                    guard kinds.contains(row.kind), length > 0 else { continue }
+                    let sub = colored.attributedSubstring(from: NSRange(location: location, length: length))
+                    result[row.id] = swiftUIAttributed(sub, emphasis: row.emphasis, kind: row.kind)
+                }
+            }
+            // Context lines take the new side's colors; the old side only contributes
+            // its deletions (the context would be identical, so skip the overwrite).
+            apply(newSide, keeping: [.context, .addition])
+            apply(oldSide, keeping: [.deletion])
+            return result
+        }.value
+        styledLines = styled
+    }
+
+    /// Re-emits an AppKit attributed line as SwiftUI attributes and lays the intraline
+    /// emphasis back over it. `Text` only honors the SwiftUI attribute scope, so the
+    /// theme's `NSColor`/`NSFont` runs must be translated, not just bridged.
+    private nonisolated static func swiftUIAttributed(
+        _ line: NSAttributedString, emphasis: Range<Int>?, kind: DiffRow.Kind
+    ) -> AttributedString {
+        var attributed = AttributedString("")
+        line.enumerateAttributes(in: NSRange(location: 0, length: line.length)) { attributes, range, _ in
+            var piece = AttributedString(line.attributedSubstring(from: range).string)
+            if let color = attributes[.foregroundColor] as? NSColor {
+                piece.foregroundColor = Color(nsColor: color)
+            }
+            if let pieceFont = attributes[.font] as? NSFont {
+                piece.font = Font(pieceFont)
+            }
+            attributed += piece
+        }
+        if let emphasis, !emphasis.isEmpty {
+            let characters = attributed.characters
+            if let start = characters.index(characters.startIndex, offsetBy: emphasis.lowerBound,
+                                            limitedBy: characters.endIndex),
+               let end = characters.index(characters.startIndex, offsetBy: emphasis.upperBound,
+                                          limitedBy: characters.endIndex),
+               start < end {
+                attributed[start..<end].backgroundColor =
+                    kind == .addition ? Color.green.opacity(0.28) : Color.red.opacity(0.28)
+            }
+        }
+        return attributed
+    }
+
+    private nonisolated func swiftUIAttributed(
+        _ line: NSAttributedString, emphasis: Range<Int>?, kind: DiffRow.Kind
+    ) -> AttributedString {
+        Self.swiftUIAttributed(line, emphasis: emphasis, kind: kind)
     }
 }
 
-/// One line of the diff: a hunk header on a faint accent band, or a code line with an
-/// old/new line-number gutter, a `+`/`−`/space sign, and a green/red/clear background.
-/// Long lines soft-wrap (the panel is fixed-width) rather than scroll horizontally,
-/// which keeps each line's background spanning the full width.
+// MARK: - Rows
+
+/// One code line of the diff: old/new line-number gutter (quiet, quaternary ink), a
+/// `+`/`−`/space sign, and the code — syntax-colored when the styled pass has landed,
+/// plain until then — over a green/red/clear wash. Long lines soft-wrap (the panel is
+/// fixed-width), which keeps each line's background spanning the full width.
 private struct DiffLineRow: View {
     let row: DiffRow
+    let styled: AttributedString?
     let font: Font
     let gutterFont: Font
     var showOldGutter = true
     var showNewGutter = true
 
     var body: some View {
-        if row.kind == .hunk {
-            Text(row.text)
+        HStack(alignment: .top, spacing: 0) {
+            if showOldGutter { gutter(row.oldLine) }
+            if showNewGutter { gutter(row.newLine) }
+            Text(sign)
                 .font(font)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(signColor)
+                .frame(width: 14)
+            codeText
+                .font(font)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, 3)
-                .padding(.horizontal, 10)
-                .background(Color.accentColor.opacity(0.10))
-        } else {
-            HStack(alignment: .top, spacing: 0) {
-                if showOldGutter { gutter(row.oldLine) }
-                if showNewGutter { gutter(row.newLine) }
-                Text(sign)
-                    .font(font)
-                    .foregroundStyle(signColor)
-                    .frame(width: 16)
-                codeText
-                    .font(font)
-                    .foregroundStyle(.primary)
-                    .textSelection(.enabled)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.trailing, 10)
-            }
-            .padding(.vertical, 1)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(background)
+                .padding(.trailing, 10)
         }
+        .padding(.vertical, 1)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(background)
     }
 
-    /// The code line, with the intraline changed span (if any) on a deeper tint of
-    /// the row's own color — the second, stronger shade Xcode's comparison view uses.
     private var codeText: Text {
+        if let styled, !styled.characters.isEmpty { return Text(styled) }
         guard let emphasis = row.emphasis, !emphasis.isEmpty, !row.text.isEmpty else {
             return Text(row.text.isEmpty ? " " : row.text)
         }
@@ -242,8 +409,8 @@ private struct DiffLineRow: View {
     private func gutter(_ number: Int?) -> some View {
         Text(number.map(String.init) ?? "")
             .font(gutterFont)
-            .foregroundStyle(.tertiary)
-            .frame(width: 36, alignment: .trailing)
+            .foregroundStyle(.quaternary)
+            .frame(width: 34, alignment: .trailing)
             .padding(.trailing, 6)
     }
 
@@ -269,5 +436,46 @@ private struct DiffLineRow: View {
         case .deletion: return Color.red.opacity(0.13)
         default: return .clear
         }
+    }
+}
+
+/// The stand-in for a run of unchanged lines — the raw `@@` hunk header never appears.
+/// Expandable bands (full-context loads) splice their lines back in on click; fixed
+/// bands (the oversized-diff fallback) just mark the gap. Meta information, so it
+/// speaks in the UI font, not the code font.
+private struct CollapsedBand: View {
+    let count: Int
+    let expandable: Bool
+    let onExpand: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Group {
+            if expandable {
+                Button(action: onExpand) { label }
+                    .buttonStyle(.plain)
+                    .onHover { isHovering = $0 }
+            } else {
+                label
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 4)
+        .background(Color.primary.opacity(isHovering ? 0.07 : 0.04))
+        .contentShape(Rectangle())
+    }
+
+    private var label: some View {
+        HStack(spacing: 6) {
+            if expandable {
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 8.5, weight: .semibold))
+            }
+            Text("\(count) unchanged \(count == 1 ? "line" : "lines")")
+        }
+        .font(.system(size: 10.5, weight: .medium))
+        .foregroundStyle(isHovering ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
+        .frame(maxWidth: .infinity)
     }
 }

--- a/Sources/termio/Git/GitHistoryView.swift
+++ b/Sources/termio/Git/GitHistoryView.swift
@@ -76,7 +76,8 @@ struct GitHistoryView: View {
                         chrome: chrome,
                         isSelected: store.openDiff?.commit == commit.sha && store.openDiff?.change.path == file.path
                     ) {
-                        store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: file, commit: commit.sha)
+                        store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: file,
+                                                        commit: commit.sha, siblings: files)
                     }
                 }
             }

--- a/Sources/termio/Git/GitModels.swift
+++ b/Sources/termio/Git/GitModels.swift
@@ -111,6 +111,9 @@ struct GitDiffRequest: Hashable, Sendable {
     /// (`git show <sha>`) rather than the working-tree diff — the History tab's
     /// file rows carry the commit they belong to.
     var commit: String? = nil
+    /// The ordered set the overlay walks with ← / → — the whole Changes list, or
+    /// the files of the commit being read. Also feeds the header's "n of m".
+    var siblings: [GitChange] = []
 
     var name: String { change.name }
 }
@@ -125,4 +128,9 @@ struct DiffRow: Identifiable, Sendable {
     let text: String
     let oldLine: Int?
     let newLine: Int?
+    /// The changed span within a paired deletion/addition line, in `Character`
+    /// offsets — rendered with a stronger background so a one-word edit in a long
+    /// line reads at a glance. `nil` when the line has no counterpart or the two
+    /// sides share too little for a span to mean anything.
+    var emphasis: Range<Int>? = nil
 }

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Combine
 import SwiftUI
 
 // MARK: - Git-pane state
@@ -22,23 +24,78 @@ final class GitPanelModel: ObservableObject {
     @Published var isLoadingHistory = false
     private var didLoadHistory = false
 
-    init(repoRoot: String) { self.repoRoot = repoRoot }
+    private var watcher: FolderEventStream?
+    private var appActiveObserver: AnyCancellable?
+    private var refreshDebounce: Task<Void, Never>?
+
+    init(repoRoot: String) {
+        self.repoRoot = repoRoot
+        // Re-activation catches whatever happened while termio was in the background
+        // (a rebase in another app, a pull on another machine's shared folder…).
+        appActiveObserver = NotificationCenter.default
+            .publisher(for: NSApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in self?.scheduleRefresh(includeHistory: true) }
+    }
+
+    deinit { refreshDebounce?.cancel() }
 
     // MARK: Loading
 
-    /// Reloads the working-tree change list.
+    /// Reloads the working-tree change list. The first successful pass also arms the
+    /// file-system watch, so from then on the pane refreshes itself.
     func load() async {
         changes = await GitService.changes(in: repoRoot)
         isLoading = false
+        if watcher == nil { await armWatcher() }
     }
 
-    /// Loads the commit history on demand (first time the History tab opens), and can be
-    /// re-run by the refresh button.
+    /// Loads the commit history on demand (first time the History tab opens); re-run
+    /// with `force` when the git dir reports a change.
     func loadHistory(force: Bool = false) async {
         guard force || !didLoadHistory else { return }
         didLoadHistory = true
-        isLoadingHistory = true
+        isLoadingHistory = commits.isEmpty
         commits = await GitService.log(in: repoRoot)
         isLoadingHistory = false
+    }
+
+    // MARK: Auto-refresh
+
+    /// The pane has no refresh button for the same reason IDEs don't: an invalidation
+    /// chain keeps it fresh instead. Any write under the worktree re-reads the changes
+    /// list; a write under the git dir (the terminal committing, the agent staging,
+    /// a branch flip) also re-reads history; app re-activation is the catch-all. The
+    /// git dirs are watched separately because a linked worktree's metadata lives
+    /// outside the checkout — see `GitService.watchPaths`.
+    private func armWatcher() async {
+        let (tree, gitDirs) = await GitService.watchPaths(for: repoRoot)
+        guard watcher == nil, !gitDirs.isEmpty else { return }
+        // The primary checkout's `.git` sits inside the tree and needs no second watch.
+        var paths = [tree]
+        paths += gitDirs.filter { !$0.hasPrefix(tree + "/") }
+        watcher = FolderEventStream(
+            paths: paths, latency: 0.4,
+            queue: DispatchQueue(label: "sh.termio.gitpane.fsevents", qos: .utility)
+        ) { [weak self] eventPaths in
+            let touchesGitDir = eventPaths.contains { path in
+                gitDirs.contains { path.hasPrefix($0) } || path.contains("/.git/") || path.hasSuffix("/.git")
+            }
+            Task { @MainActor [weak self] in
+                self?.scheduleRefresh(includeHistory: touchesGitDir)
+            }
+        }
+    }
+
+    /// Coalesces a burst of events (FSEvents latency already batches most) into one
+    /// reload a beat later. `git status` itself may refresh the index once, which
+    /// echoes back as a git-dir event — the second pass reads clean and the chain ends.
+    private func scheduleRefresh(includeHistory: Bool) {
+        refreshDebounce?.cancel()
+        refreshDebounce = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard let self, !Task.isCancelled else { return }
+            await self.load()
+            if includeHistory, self.didLoadHistory { await self.loadHistory(force: true) }
+        }
     }
 }

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -273,7 +273,64 @@ enum GitService {
                 continue
             }
         }
+        applyIntraline(&rows)
         return rows
+    }
+
+    /// Marks the changed span inside modified lines (Critique/Xcode's intraline
+    /// highlight): within each hunk, a run of deletions immediately followed by a run
+    /// of additions is paired index-wise, and each pair gets its common prefix/suffix
+    /// stripped to leave the span that actually changed.
+    private static func applyIntraline(_ rows: inout [DiffRow]) {
+        var i = 0
+        while i < rows.count {
+            guard rows[i].kind == .deletion else { i += 1; continue }
+            let delStart = i
+            while i < rows.count, rows[i].kind == .deletion { i += 1 }
+            let addStart = i
+            while i < rows.count, rows[i].kind == .addition { i += 1 }
+            for k in 0..<min(addStart - delStart, i - addStart) {
+                guard let (old, new) = emphasisRanges(rows[delStart + k].text, rows[addStart + k].text)
+                else { continue }
+                rows[delStart + k].emphasis = old
+                rows[addStart + k].emphasis = new
+            }
+        }
+    }
+
+    /// The changed spans of a deletion/addition line pair: common prefix and suffix
+    /// are peeled off, then the boundaries snap outward to whole words so renaming
+    /// `newValue` → `oldValue` highlights the identifiers, not a `ldValue` tail.
+    /// Returns `nil` when the sides share under a fifth of the shorter line — a
+    /// rewrite, where span-highlighting the whole line would just be noise.
+    private static func emphasisRanges(_ oldText: String, _ newText: String) -> (Range<Int>, Range<Int>)? {
+        guard oldText != newText, oldText.count <= 2000, newText.count <= 2000 else { return nil }
+        let o = Array(oldText), n = Array(newText)
+        var prefix = 0
+        while prefix < o.count, prefix < n.count, o[prefix] == n[prefix] { prefix += 1 }
+        var suffix = 0
+        while suffix < o.count - prefix, suffix < n.count - prefix,
+              o[o.count - 1 - suffix] == n[n.count - 1 - suffix] { suffix += 1 }
+        guard (prefix + suffix) * 5 >= min(o.count, n.count) else { return nil }
+
+        // CJK scripts have no intra-word boundaries, so snapping there would swallow
+        // the whole run — every ideograph/kana counts as its own boundary instead.
+        func isWord(_ c: Character) -> Bool {
+            guard c.isLetter || c.isNumber || c == "_" else { return false }
+            guard let scalar = c.unicodeScalars.first else { return false }
+            return scalar.value < 0x2E80
+        }
+        while prefix > 0, isWord(o[prefix - 1]),
+              (prefix < o.count - suffix && isWord(o[prefix]))
+                || (prefix < n.count - suffix && isWord(n[prefix])) {
+            prefix -= 1
+        }
+        while suffix > 0, isWord(o[o.count - suffix]),
+              (o.count - suffix > prefix && isWord(o[o.count - suffix - 1]))
+                || (n.count - suffix > prefix && isWord(n[n.count - suffix - 1])) {
+            suffix -= 1
+        }
+        return (prefix..<(o.count - suffix), prefix..<(n.count - suffix))
     }
 
     private static func isFileHeader(_ line: String) -> Bool {

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -22,9 +22,11 @@ enum GitService {
     /// then shows the inter-hunk gaps as fixed, non-expandable bands).
     static func diffRows(for change: GitChange, in repoRoot: String, commit: String? = nil) async -> [DiffRow] {
         await offMain {
-            let full = parseDiff(loadDiffText(change, repoRoot, commit: commit, context: 999_999))
-            guard full.count > 20_000 else { return full }
-            return parseDiff(loadDiffText(change, repoRoot, commit: commit))
+            let full = loadDiffText(change, repoRoot, commit: commit, context: 999_999)
+            // ~20k lines of average code ≈ 1.5 MB. Beyond that, re-fetch at git's
+            // default 3-line context rather than parse (and render) a whole huge file.
+            let text = full.count <= 1_500_000 ? full : loadDiffText(change, repoRoot, commit: commit)
+            return parseDiff(text)
         }
     }
 

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -15,8 +15,17 @@ enum GitService {
     /// The unified-diff rows for one changed file (staged + unstaged vs `HEAD`, or the
     /// whole file for an untracked one). With `commit` set, the file's diff *at that
     /// commit* instead — the History tab's per-file view.
+    ///
+    /// Rows are fetched with *full* context (`-U999999`) so the whole file is present
+    /// and the overlay can collapse unchanged runs into expandable bands client-side;
+    /// a pathological row count falls back to git's default 3-line context (the view
+    /// then shows the inter-hunk gaps as fixed, non-expandable bands).
     static func diffRows(for change: GitChange, in repoRoot: String, commit: String? = nil) async -> [DiffRow] {
-        await offMain { parseDiff(loadDiffText(change, repoRoot, commit: commit)) }
+        await offMain {
+            let full = parseDiff(loadDiffText(change, repoRoot, commit: commit, context: 999_999))
+            guard full.count > 20_000 else { return full }
+            return parseDiff(loadDiffText(change, repoRoot, commit: commit))
+        }
     }
 
     /// The raw unified-diff text for one changed file — what "Copy Diff" puts on the
@@ -244,25 +253,28 @@ enum GitService {
         }
     }
 
-    private static func loadDiffText(_ change: GitChange, _ repoRoot: String, commit: String? = nil) -> String {
+    private static func loadDiffText(_ change: GitChange, _ repoRoot: String,
+                                     commit: String? = nil, context: Int? = nil) -> String {
+        let contextArguments = context.map { ["-U\($0)"] } ?? []
         // History file row: the file's change within one commit. `--format=` strips the
         // commit header so parseDiff sees only the unified diff.
         if let commit {
-            return run(["show", "--format=", "-M", commit, "--", change.path],
+            return run(["show", "--format=", "-M"] + contextArguments + [commit, "--", change.path],
                        in: repoRoot, ignoreStatus: true) ?? ""
         }
         if change.isUntracked {
             // `--no-index` exits non-zero when the files differ, which is the normal
             // case here, so the status is ignored.
-            return run(["diff", "--no-index", "--", "/dev/null", change.path],
+            return run(["diff", "--no-index"] + contextArguments + ["--", "/dev/null", change.path],
                        in: repoRoot, ignoreStatus: true) ?? ""
         }
         // `diff HEAD` shows staged and unstaged together. Fall back to the split views
         // for a repo with no commit yet, or a fully-staged change.
-        if let d = run(["diff", "HEAD", "--", change.path], in: repoRoot), !d.isEmpty { return d }
-        let unstaged = run(["diff", "--", change.path], in: repoRoot) ?? ""
+        if let d = run(["diff"] + contextArguments + ["HEAD", "--", change.path], in: repoRoot),
+           !d.isEmpty { return d }
+        let unstaged = run(["diff"] + contextArguments + ["--", change.path], in: repoRoot) ?? ""
         if !unstaged.isEmpty { return unstaged }
-        return run(["diff", "--cached", "--", change.path], in: repoRoot) ?? ""
+        return run(["diff"] + contextArguments + ["--cached", "--", change.path], in: repoRoot) ?? ""
     }
 
     /// Parses unified-diff text into rows, tracking old/new line numbers from each
@@ -276,7 +288,9 @@ enum GitService {
             let line = String(raw)
             if line.hasPrefix("@@") {
                 if let (o, n) = parseHunkHeader(line) { oldNo = o; newNo = n }
-                rows.append(DiffRow(id: id, kind: .hunk, text: line, oldLine: nil, newLine: nil)); id += 1
+                // Hunk rows carry their start numbers so the overlay can size the gap
+                // to the previous hunk when it renders the boundary as a "⋯ n lines" band.
+                rows.append(DiffRow(id: id, kind: .hunk, text: line, oldLine: oldNo, newLine: newNo)); id += 1
                 continue
             }
             if isFileHeader(line) { continue }

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -40,6 +40,26 @@ enum GitService {
         await offMain { for change in changes { _ = discardChanges(change, repoRoot) } }
     }
 
+    /// The directories whose file-system events invalidate the git pane: the worktree
+    /// itself, plus the resolved git dir(s). For a linked worktree the metadata lives
+    /// *outside* the checkout (`.git` there is a pointer file; commits write into the
+    /// primary checkout's `.git/worktrees/<name>` and `refs`), so watching the tree
+    /// alone would miss commits made in the terminal. `gitDirs` is empty for a non-repo.
+    static func watchPaths(for repoRoot: String) async -> (worktree: String, gitDirs: [String]) {
+        await offMain {
+            var dirs: [String] = []
+            for args in [["rev-parse", "--absolute-git-dir"], ["rev-parse", "--git-common-dir"]] {
+                guard let out = run(args, in: repoRoot)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines), !out.isEmpty else { continue }
+                let absolute = out.hasPrefix("/")
+                    ? out : (repoRoot as NSString).appendingPathComponent(out)
+                let standardized = URL(fileURLWithPath: absolute).standardizedFileURL.path
+                if !dirs.contains(standardized) { dirs.append(standardized) }
+            }
+            return (repoRoot, dirs)
+        }
+    }
+
     // MARK: History
 
     /// The most recent commits on the current branch (newest first), for the History tab.

--- a/Sources/termio/TerminalPane.swift
+++ b/Sources/termio/TerminalPane.swift
@@ -171,7 +171,7 @@ struct TerminalPane: View {
                 GitDiffView(request: request, settings: settings, onClose: {
                     store.openDiff = nil
                     requestSelectedTerminalFocus(reason: .overlayClosed)
-                })
+                }, onNavigate: { store.openDiff = $0 })
                 .id(request)
                 .transition(.opacity)
             }

--- a/Sources/termio/TerminalPane.swift
+++ b/Sources/termio/TerminalPane.swift
@@ -162,7 +162,11 @@ struct TerminalPane: View {
                 .transition(.opacity)
             }
         }
-        .animation(.easeOut(duration: 0.12), value: store.openFileURL)
+        // The fade is tied to presence (nil ↔ non-nil), NOT to the value: animating the
+        // value would crossfade content-to-content switches (arrow-key walking, clicking
+        // file after file), stacking two translucent copies — visible ghosting. Switching
+        // swaps instantly, Quick Look style; only open and close fade.
+        .animation(.easeOut(duration: 0.12), value: store.openFileURL != nil)
         // Clicking a row in the inspector's Changes pane covers the terminal with that file's
         // unified diff (the surface keeps running underneath), the git counterpart of the editor
         // overlay above. Escape or the close button clears it.
@@ -176,7 +180,7 @@ struct TerminalPane: View {
                 .transition(.opacity)
             }
         }
-        .animation(.easeOut(duration: 0.12), value: store.openDiff)
+        .animation(.easeOut(duration: 0.12), value: store.openDiff != nil)
         // The Info pane's "View Trace" covers the terminal with the session's rendered agent trace
         // (dashboard + collapsible conversation), themed to match termio. Escape or the close button
         // clears it, like the editor and diff overlays.
@@ -190,7 +194,7 @@ struct TerminalPane: View {
                 .transition(.opacity)
             }
         }
-        .animation(.easeOut(duration: 0.12), value: store.openTrace)
+        .animation(.easeOut(duration: 0.12), value: store.openTrace != nil)
         // The ⌘⇧O/⌘⇧P palette lives in its own floating NSPanel (owned by
         // the app delegate — a SwiftUI overlay would render *under* the NSView
         // terminal surfaces); this only hands focus back to the terminal when


### PR DESCRIPTION
## What

Second PR of the git-pane reading work, **stacked on #36** (retarget to `main` after #36 merges).

Reading a PR/branch is a *traversal* problem — this turns the per-file diff peek into a walkable reading flow:

- **← / → walks the diff overlay** through its sibling set (the Changes list, or a commit's files in History) without closing — Quick Look's arrow-key pattern, per HIG. ↑ ↓ stay with scrolling; in the focused Changes list ↑ ↓ already walk via selection (native List behavior). Preview-only files (images/PDF) are skipped; header shows **"n of m"** (Mail's wording); the list selection follows the overlay both ways. File switches reuse the existing 0.12 s opacity crossfade — no new animation vocabulary.
- **Intraline word-level highlight**: deletion/addition runs are paired index-wise; common prefix/suffix is peeled and snapped outward to whole identifiers (`newValue` → `oldValue` highlights the tokens, not a `ldValue` tail). CJK scalars count as their own boundaries so a run of ideographs isn't swallowed. Pairs sharing <20 % of the shorter line get no span — a full rewrite highlighted end-to-end is noise. Rendered as a deeper tint of the row's own green/red (Xcode's second-shade pattern).

## Verification

`swift build` passes; the range algorithm was exercised standalone against five edge cases (identifier swap, pure insertion, full rewrite → nil, nested string, CJK) — all correct.

## Design lineage

Walk = the universal pattern of keyboard-first review tools (CodeRabbit/Octo.nvim/gh-dash); intraline = Critique's top-cited readability feature. Groundwork for the Review tab (viewed state will hook into the same walk).