### PR TITLE
feat(settings): availability-gated Add Agent menu replaces the More-agents drawer

### DIFF
--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -226,7 +226,7 @@ private struct AgentManagerRow: View {
             // the padding and the Spacer are holes in the Form row's hit test.
             .contentShape(Rectangle())
             .contextMenu {
-                Button("Remove Agent") { settings.removeAgent(preset) }
+                Button("Remove from List") { settings.removeAgent(preset) }
             }
 
             if isExpanded {
@@ -264,16 +264,14 @@ private struct AgentManagerRow: View {
                     }
 
                     // The visible twin of the row's right-click item — a drawer-only
-                    // action so the scannable list stays clean. A real bordered
-                    // button (the macOS settings shape for destructive row actions,
-                    // red on the text only), not an iOS-style bare red row. No
-                    // confirmation: the agent is one "Add Agent" pick away from
-                    // coming back.
-                    Button("Remove Agent", role: .destructive) {
+                    // action so the scannable list stays clean. Deliberately not
+                    // red: nothing is destroyed — the row folds back into the "Add
+                    // Agent" menu with its overrides intact, so no confirmation
+                    // either.
+                    Button("Remove from List") {
                         settings.removeAgent(preset)
                     }
                     .buttonStyle(.bordered)
-                    .tint(.red)
                     .controlSize(.small)
                 }
                 // Indent to the title's column (icon 22 + spacing 10) so the drawer

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -264,14 +264,17 @@ private struct AgentManagerRow: View {
                     }
 
                     // The visible twin of the row's right-click item — a drawer-only
-                    // action so the scannable list stays clean. No confirmation: the
-                    // agent is one "Add Agent" pick away from coming back.
-                    Button(role: .destructive) {
+                    // action so the scannable list stays clean. A real bordered
+                    // button (the macOS settings shape for destructive row actions,
+                    // red on the text only), not an iOS-style bare red row. No
+                    // confirmation: the agent is one "Add Agent" pick away from
+                    // coming back.
+                    Button("Remove Agent", role: .destructive) {
                         settings.removeAgent(preset)
-                    } label: {
-                        Text("Remove Agent").foregroundStyle(.red)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.bordered)
+                    .tint(.red)
+                    .controlSize(.small)
                 }
                 // Indent to the title's column (icon 22 + spacing 10) so the drawer
                 // reads as the row's children, not more agents.

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -182,9 +182,10 @@ private struct AgentManagerRow: View {
     @State private var available: Bool?
 
     var body: some View {
-        // `Group` is transparent inside a Form (its children each become a row), so the
-        // header and the disclosed controls read as sibling rows while sharing one probe.
-        Group {
+        // One VStack = one Form row, so the header and its disclosed controls share a
+        // single cell — separators fall only between agents, and the drawer can't be
+        // mistaken for top-level rows (as `Group`'s sibling rows were).
+        VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 10) {
                 IconBadge(preset.icon)
                 VStack(alignment: .leading, spacing: 2) {
@@ -229,43 +230,53 @@ private struct AgentManagerRow: View {
             }
 
             if isExpanded {
-                TextField(
-                    "Command",
-                    text: Binding(
-                        get: { settings.agentCommandOverrides[preset.rawValue] ?? "" },
-                        set: { settings.agentCommandOverrides[preset.rawValue] = $0 }
-                    ),
-                    prompt: Text(preset.command ?? "")
-                )
-
-                if available == false, let url = preset.installURL {
-                    Link(destination: url) {
-                        Label("Install \(preset.displayName)", systemImage: "arrow.down.circle")
-                    }
-                }
-
-                if let flag = preset.permissionBypassFlag {
-                    Toggle(isOn: Binding(
-                        get: { settings.bypassesPermissions(preset) },
-                        set: { settings.setBypassPermissions(preset, enabled: $0) }
-                    )) {
-                        SettingsLabel(
-                            title: "Skip permission prompts",
-                            subtext: "Runs with `\(flag)`. The agent won't ask before editing files or running commands."
+                VStack(alignment: .leading, spacing: 12) {
+                    LabeledContent("Command") {
+                        TextField(
+                            "",
+                            text: Binding(
+                                get: { settings.agentCommandOverrides[preset.rawValue] ?? "" },
+                                set: { settings.agentCommandOverrides[preset.rawValue] = $0 }
+                            ),
+                            prompt: Text(preset.command ?? "")
                         )
+                        .textFieldStyle(.plain)
+                        .labelsHidden()
                     }
-                    .toggleStyle(.switch)
-                }
 
-                // The visible twin of the row's right-click item — a drawer-only
-                // action so the scannable list stays clean. No confirmation: the
-                // agent is one "Add Agent" pick away from coming back.
-                Button(role: .destructive) {
-                    settings.removeAgent(preset)
-                } label: {
-                    Text("Remove Agent").foregroundStyle(.red)
+                    if available == false, let url = preset.installURL {
+                        Link(destination: url) {
+                            Label("Install \(preset.displayName)", systemImage: "arrow.down.circle")
+                        }
+                    }
+
+                    if let flag = preset.permissionBypassFlag {
+                        Toggle(isOn: Binding(
+                            get: { settings.bypassesPermissions(preset) },
+                            set: { settings.setBypassPermissions(preset, enabled: $0) }
+                        )) {
+                            SettingsLabel(
+                                title: "Skip permission prompts",
+                                subtext: "Runs with `\(flag)`. The agent won't ask before editing files or running commands."
+                            )
+                        }
+                        .toggleStyle(.switch)
+                    }
+
+                    // The visible twin of the row's right-click item — a drawer-only
+                    // action so the scannable list stays clean. No confirmation: the
+                    // agent is one "Add Agent" pick away from coming back.
+                    Button(role: .destructive) {
+                        settings.removeAgent(preset)
+                    } label: {
+                        Text("Remove Agent").foregroundStyle(.red)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
+                // Indent to the title's column (icon 22 + spacing 10) so the drawer
+                // reads as the row's children, not more agents.
+                .padding(.leading, 32)
+                .padding(.top, 12)
             }
         }
         // Re-checks whenever the effective command changes, so typing a valid path

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -3,20 +3,18 @@ import SwiftUI
 struct AgentSettingsTab: View {
     @ObservedObject var settings: AppSettings
 
-    /// Which enabled agents have their configuration drawer open. Keyed by id so the
+    /// Which listed agents have their configuration drawer open. Keyed by id so the
     /// set survives reordering and enable/disable without stale indices.
     @State private var expanded: Set<String> = []
-    /// Whether the collapsed "More agents" drawer (the disabled agents) is open.
-    @State private var showingMore = false
 
     /// The agents the user actually manages, in the user's arrangement. The plain
     /// Terminal is not here — it's the login shell, configured on the Terminal tab and
     /// always available, so it's never an enable/reorder row (see `AgentDefinition.isShell`).
-    private var enabledAgents: [AgentPreset] {
-        settings.orderedAgents(AgentPreset.codingAgents.filter(settings.isAgentEnabled))
+    private var listedAgents: [AgentPreset] {
+        settings.orderedAgents(AgentPreset.codingAgents.filter(settings.isAgentListed))
     }
-    private var disabledAgents: [AgentPreset] {
-        settings.orderedAgents(AgentPreset.codingAgents.filter { !settings.isAgentEnabled($0) })
+    private var addableAgents: [AgentPreset] {
+        settings.orderedAgents(AgentPreset.codingAgents.filter { !settings.isAgentListed($0) })
     }
 
     var body: some View {
@@ -63,12 +61,13 @@ struct AgentSettingsTab: View {
         .formStyle(.grouped)
     }
 
-    /// The one section that replaced a full-height card per agent: the enabled agents
+    /// The one section that replaced a full-height card per agent: the user's agents
     /// as a compact, reorderable list whose per-agent config hides behind a disclosure,
-    /// and the long tail of disabled agents folded into a "More agents" drawer.
+    /// and the rest of the catalog behind an "Add Agent" pull-down at the bottom —
+    /// the System Settings shape for "curated list + pool to add from".
     private var agentsSection: some View {
         Section {
-            ForEach(enabledAgents) { preset in
+            ForEach(listedAgents) { preset in
                 AgentManagerRow(
                     settings: settings,
                     preset: preset,
@@ -76,27 +75,39 @@ struct AgentSettingsTab: View {
                     toggleExpanded: { toggleExpanded(preset) }
                 )
             }
-            .onMove(perform: moveEnabled)
+            .onMove(perform: moveListed)
 
-            if !disabledAgents.isEmpty {
-                DisclosureGroup(isExpanded: $showingMore) {
-                    ForEach(disabledAgents) { preset in
-                        DisabledAgentRow(settings: settings, preset: preset)
+            if !addableAgents.isEmpty {
+                Menu {
+                    ForEach(addableAgents) { preset in
+                        Button { add(preset) } label: {
+                            Label { Text(preset.displayName) } icon: { IconBadge(preset.icon) }
+                        }
                     }
                 } label: {
-                    HStack {
-                        Text("More agents").font(.headline)
-                        Spacer()
-                        Text("\(disabledAgents.count)").foregroundStyle(.secondary)
-                    }
+                    Label("Add Agent", systemImage: "plus")
                 }
             }
         } header: {
             SectionHeaderLabel(title: "Agents")
         } footer: {
-            Text("The agents offered in the new-session menu and the sidebar's quick-add row, in this order — drag to reorder. Open a row to set a custom command or skip its permission prompts.")
+            Text("The agents offered in the new-session menu and the sidebar's quick-add row, in this order — drag to reorder, right-click to remove. Open a row to set a custom command or skip its permission prompts. An agent whose CLI isn't installed stays off until it is.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Adds the agent's row immediately, then lets the availability probe decide the
+    /// switch: an installed CLI turns it on; a missing one leaves it off with its
+    /// drawer opened onto the install link. The row never blocks on the probe.
+    private func add(_ preset: AgentPreset) {
+        settings.addAgent(preset)
+        Task { @MainActor in
+            if await AgentAvailability.isCommandAvailable(settings.command(for: preset) ?? "") {
+                settings.setAgent(preset, enabled: true)
+            } else {
+                expanded.insert(preset.id)
+            }
         }
     }
 
@@ -104,10 +115,10 @@ struct AgentSettingsTab: View {
         if expanded.contains(preset.id) { expanded.remove(preset.id) } else { expanded.insert(preset.id) }
     }
 
-    /// Persists a drag as the new enabled arrangement; `setEnabledOrder` keeps every
+    /// Persists a drag as the new arrangement; `setEnabledOrder` keeps every
     /// other id ranked behind it so the ordering stays total.
-    private func moveEnabled(from source: IndexSet, to destination: Int) {
-        var ids = enabledAgents.map(\.id)
+    private func moveListed(from source: IndexSet, to destination: Int) {
+        var ids = listedAgents.map(\.id)
         ids.move(fromOffsets: source, toOffset: destination)
         settings.setEnabledOrder(ids)
     }
@@ -206,6 +217,12 @@ private struct AgentManagerRow: View {
                 ))
                 .labelsHidden()
                 .toggleStyle(.switch)
+                // A missing CLI can't be launched, so it can't be switched on — only
+                // off (an already-on agent stays revocable while the hint shows).
+                .disabled(available == false && !settings.isAgentEnabled(preset))
+            }
+            .contextMenu {
+                Button("Remove Agent") { settings.removeAgent(preset) }
             }
 
             if isExpanded {
@@ -250,26 +267,4 @@ private struct AgentManagerRow: View {
     }
 
     private var effectiveCommand: String { settings.command(for: preset) ?? "" }
-}
-
-/// A disabled agent in the "More agents" drawer: just its identity and the enable
-/// switch. There's nothing to configure until it's on, so it carries no drawer —
-/// enabling it lifts it into the reorderable list above, where its config lives.
-private struct DisabledAgentRow: View {
-    @ObservedObject var settings: AppSettings
-    let preset: AgentPreset
-
-    var body: some View {
-        Toggle(isOn: Binding(
-            get: { settings.isAgentEnabled(preset) },
-            set: { settings.setAgent(preset, enabled: $0) }
-        )) {
-            SettingsLabel(
-                preset.icon,
-                title: preset.displayName,
-                subtext: preset.command ?? "Login shell"
-            )
-        }
-        .toggleStyle(.switch)
-    }
 }

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -221,6 +221,9 @@ private struct AgentManagerRow: View {
                 // off (an already-on agent stays revocable while the hint shows).
                 .disabled(available == false && !settings.isAgentEnabled(preset))
             }
+            // Without an explicit shape only the row's glyphs are right-clickable —
+            // the padding and the Spacer are holes in the Form row's hit test.
+            .contentShape(Rectangle())
             .contextMenu {
                 Button("Remove Agent") { settings.removeAgent(preset) }
             }
@@ -253,6 +256,16 @@ private struct AgentManagerRow: View {
                     }
                     .toggleStyle(.switch)
                 }
+
+                // The visible twin of the row's right-click item — a drawer-only
+                // action so the scannable list stays clean. No confirmation: the
+                // agent is one "Add Agent" pick away from coming back.
+                Button(role: .destructive) {
+                    settings.removeAgent(preset)
+                } label: {
+                    Text("Remove Agent").foregroundStyle(.red)
+                }
+                .buttonStyle(.plain)
             }
         }
         // Re-checks whenever the effective command changes, so typing a valid path

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -95,6 +95,7 @@ final class AppSettings: ObservableObject {
         static let agentCommands = "agents.commandOverrides"
         static let bypassPermissionAgents = "agents.bypassPermissions"
         static let disabledAgents = "agents.disabled"
+        static let addedAgents = "agents.added"
         static let agentOrder = "agents.order"
         static let agentHooksEnabled = "agents.hooksEnabled"
         static let sessionControlEnabled = "agents.sessionControlEnabled"
@@ -281,6 +282,15 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(Array(disabledAgents), forKey: Key.disabledAgents) }
     }
 
+    /// Agents pinned to the Agents settings list even while switched off, by
+    /// `rawValue`. A row on that list means added-or-enabled (`isAgentListed`); the
+    /// rest wait behind its "Add Agent" menu. `setAgent` keeps any agent the user
+    /// flips in here, so switching one off leaves its row in place — only
+    /// `removeAgent` drops a row back into the menu.
+    @Published var addedAgents: Set<String> {
+        didSet { defaults.set(Array(addedAgents), forKey: Key.addedAgents) }
+    }
+
     /// The user's own agent arrangement, as an ordered list of `rawValue`s — the
     /// runtime layer that overrides each manifest's default `order` (the VSCode
     /// model: shipped defaults, user settings on top). Empty until the user drags a
@@ -404,6 +414,7 @@ final class AppSettings: ObservableObject {
         agentCommandOverrides = defaults.dictionary(forKey: Key.agentCommands) as? [String: String] ?? [:]
         bypassPermissionAgents = Set(defaults.stringArray(forKey: Key.bypassPermissionAgents) ?? [])
         disabledAgents = Set(defaults.stringArray(forKey: Key.disabledAgents) ?? [])
+        addedAgents = Set(defaults.stringArray(forKey: Key.addedAgents) ?? [])
         agentOrder = defaults.stringArray(forKey: Key.agentOrder) ?? []
         agentHooksEnabled = defaults.bool(forKey: Key.agentHooksEnabled)
         sessionControlEnabled = defaults.bool(forKey: Key.sessionControlEnabled)
@@ -459,11 +470,36 @@ final class AppSettings: ObservableObject {
     }
 
     func setAgent(_ agent: AgentPreset, enabled: Bool) {
+        // Either flip pins the row: enabling implies one, and disabling must not
+        // silently drop one — only `removeAgent` does that. Also catches agents
+        // that were never explicitly added (enabled by default or by manifest).
+        addedAgents.insert(agent.rawValue)
         if enabled {
             disabledAgents.remove(agent.rawValue)
         } else {
             disabledAgents.insert(agent.rawValue)
         }
+    }
+
+    /// Whether the agent occupies a row on the Agents settings tab: explicitly
+    /// added, or enabled (a default-enabled agent has a row without ever being
+    /// added, so enabled ⊆ listed holds by construction).
+    func isAgentListed(_ agent: AgentPreset) -> Bool {
+        addedAgents.contains(agent.rawValue) || isAgentEnabled(agent)
+    }
+
+    /// Puts the agent's row on the Agents settings list without enabling it —
+    /// enabling is a separate, availability-gated step (see `AgentSettingsTab`).
+    func addAgent(_ agent: AgentPreset) {
+        addedAgents.insert(agent.rawValue)
+    }
+
+    /// Drops the agent's row from the settings list back into the "Add Agent"
+    /// menu. Also disables it: an unlisted agent must not linger in the session
+    /// pickers. Written directly (not via `setAgent`), which would re-pin the row.
+    func removeAgent(_ agent: AgentPreset) {
+        addedAgents.remove(agent.rawValue)
+        disabledAgents.insert(agent.rawValue)
     }
 
     /// Applies the user's `agentOrder` on top of the catalog's default order. The


### PR DESCRIPTION
## What

Reworks the Agents settings tab's bottom edge. The collapsible **More agents** drawer — which read as a section header and mixed disabled rows into the enabled list — is gone. In its place, the System Settings shape for "curated list + pool":

- The list shows only the agents the user manages (added or enabled), drag-reorderable as before.
- A native **⊕ Add Agent** pull-down at the bottom lists the rest of the catalog (icon + name); picking one adds it.
- The button disappears when the whole catalog is listed.

## Availability gating

Listing and enabling are now separate states (`agents.added` on top of the existing `agents.disabled`):

- Adding an agent probes its CLI on the login-shell PATH (existing `AgentAvailability`). Installed → switched on. Missing → the row lands in the list **off**, its drawer auto-opens onto the install link, and the switch is locked until the CLI resolves (an already-on agent stays revocable).
- Switching a row off keeps it in the list; **right-click → Remove Agent** returns it to the Add menu and disables it.
- Enabled ⊆ listed holds by construction, so default-enabled or manifest-enabled agents always surface without migration.

## Notes

- Downstream consumers (`enabledAgentPresets`, session pickers, usage tab, companion) are untouched — they keep reading the enabled state.
- Existing users: previously-disabled agents move from the drawer into the Add menu; enabled ones keep their rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)