### PR TITLE
feat(git): render the diff in a single TextKit view

### DIFF
--- a/Sources/termio/Git/DiffDocument.swift
+++ b/Sources/termio/Git/DiffDocument.swift
@@ -1,0 +1,242 @@
+import AppKit
+
+// MARK: - Diff document
+
+/// The whole diff as one immutable text document: an attributed string (one paragraph
+/// per rendered element) plus per-paragraph metadata the layout manager and gutter
+/// read at draw time. Built once per (rows, expanded) pair; the text view swaps it
+/// in wholesale — TextKit owns layout, wrapping, selection, and the find bar from
+/// there, which is what buys continuous multi-line selection and ⌘F.
+final class DiffDocument {
+    /// One paragraph of the document — a code line, or a collapsed band standing in
+    /// for a run of unchanged lines.
+    struct Line {
+        enum Role {
+            case code(DiffRow.Kind)
+            /// `expandable` bands (full-context loads) splice their hidden lines back
+            /// in on click; fixed bands (the default-context fallback, where the
+            /// hidden lines were never fetched) just mark the gap.
+            case band(count: Int, expandable: Bool)
+        }
+
+        let role: Role
+        /// The paragraph's range in the document, including its trailing newline.
+        let range: NSRange
+        /// `DiffRow.id` for a code line (keys the syntax-color pass); the first hidden
+        /// row's id for a band (keys the expand action).
+        let rowId: Int
+        let oldLine: Int?
+        let newLine: Int?
+
+        var isBand: Bool {
+            if case .band = role { return true }
+            return false
+        }
+    }
+
+    let attributed: NSAttributedString
+    let lines: [Line]
+    /// Whether any code line carries an old/new number. A pure-addition file has no
+    /// old numbers, so that gutter column collapses rather than showing a blank band;
+    /// likewise a pure deletion collapses the new column.
+    let hasOldGutter: Bool
+    let hasNewGutter: Bool
+    /// The largest line number shown, sizing the gutter columns.
+    let maxLineNumber: Int
+
+    private init(attributed: NSAttributedString, lines: [Line],
+                 hasOldGutter: Bool, hasNewGutter: Bool, maxLineNumber: Int) {
+        self.attributed = attributed
+        self.lines = lines
+        self.hasOldGutter = hasOldGutter
+        self.hasNewGutter = hasNewGutter
+        self.maxLineNumber = maxLineNumber
+    }
+
+    /// Meta text (band labels) speaks in the UI font; code speaks in the terminal font.
+    static let bandFont = NSFont.systemFont(ofSize: 10.5, weight: .medium)
+    /// Extra breathing room drawn around a band row (the fill is expanded to match).
+    static let bandPadding: CGFloat = 3
+
+    // MARK: Building
+
+    /// Folds the parsed rows into the display list and lays it down as one attributed
+    /// string. Hunk plumbing disappears (its gap becomes a band), unchanged runs longer
+    /// than a handful of lines collapse to a band keeping 3 lines of context on the
+    /// side(s) that face a change, and `expanded` bands splice their lines back in.
+    static func build(rows: [DiffRow], expanded: Set<Int>, codeFont: NSFont) -> DiffDocument {
+        let items = displayItems(rows: rows, expanded: expanded)
+
+        var text = String()
+        text.reserveCapacity(items.reduce(0) { $0 + $1.textLength + 1 })
+        var lines: [Line] = []
+        lines.reserveCapacity(items.count)
+        var maxLineNumber = 0
+
+        for item in items {
+            let location = (text as NSString).length
+            switch item {
+            case .line(let row):
+                text += row.text
+                text += "\n"
+                let length = (row.text as NSString).length + 1
+                lines.append(Line(role: .code(row.kind), range: NSRange(location: location, length: length),
+                                  rowId: row.id, oldLine: row.oldLine, newLine: row.newLine))
+                maxLineNumber = max(maxLineNumber, row.oldLine ?? 0, row.newLine ?? 0)
+            case .band(let id, let count, let expandable):
+                let label = "⋯ \(count) unchanged \(count == 1 ? "line" : "lines")"
+                text += label
+                text += "\n"
+                let length = (label as NSString).length + 1
+                lines.append(Line(role: .band(count: count, expandable: expandable),
+                                  range: NSRange(location: location, length: length),
+                                  rowId: id, oldLine: nil, newLine: nil))
+            }
+        }
+
+        let attributed = NSMutableAttributedString(string: text, attributes: [
+            .font: codeFont,
+            .foregroundColor: NSColor.labelColor,
+        ])
+        styleBandsAndEmphasis(attributed, items: items, lines: lines)
+
+        return DiffDocument(
+            attributed: attributed,
+            lines: lines,
+            hasOldGutter: rows.contains { $0.kind != .hunk && $0.oldLine != nil },
+            hasNewGutter: rows.contains { $0.kind != .hunk && $0.newLine != nil },
+            maxLineNumber: maxLineNumber
+        )
+    }
+
+    /// The index of the first line whose paragraph ends past `location` — the entry
+    /// point for draw-time walks, so painting only ever touches the visible lines.
+    func lineIndex(at location: Int) -> Int {
+        var low = 0, high = lines.count
+        while low < high {
+            let mid = (low + high) / 2
+            if NSMaxRange(lines[mid].range) <= location { low = mid + 1 } else { high = mid }
+        }
+        return low
+    }
+
+    /// The line containing the character at `location`, if any.
+    func line(at location: Int) -> Line? {
+        let index = lineIndex(at: location)
+        guard index < lines.count, NSLocationInRange(location, lines[index].range) else { return nil }
+        return lines[index]
+    }
+
+    // MARK: Attributes
+
+    /// Bands restyle to the UI font (centered, tertiary ink, pointing-hand cursor when
+    /// expandable); intraline emphasis lands as a `.backgroundColor` attribute — the
+    /// layout manager's washes paint underneath, and TextKit's own background pass
+    /// composites the deeper tint on top.
+    private static func styleBandsAndEmphasis(_ attributed: NSMutableAttributedString,
+                                              items: [DisplayItem], lines: [Line]) {
+        let bandStyle = NSMutableParagraphStyle()
+        bandStyle.alignment = .center
+        bandStyle.paragraphSpacingBefore = bandPadding
+        bandStyle.paragraphSpacing = bandPadding
+
+        for (item, line) in zip(items, lines) {
+            switch item {
+            case .band(_, _, let expandable):
+                var attrs: [NSAttributedString.Key: Any] = [
+                    .font: bandFont,
+                    .foregroundColor: NSColor.tertiaryLabelColor,
+                    .paragraphStyle: bandStyle,
+                ]
+                if expandable { attrs[.cursor] = NSCursor.pointingHand }
+                attributed.addAttributes(attrs, range: line.range)
+            case .line(let row):
+                guard let emphasis = row.emphasis, !emphasis.isEmpty,
+                      let range = utf16Range(of: emphasis, in: row.text) else { continue }
+                let color = row.kind == .addition
+                    ? NSColor.systemGreen.withAlphaComponent(0.28)
+                    : NSColor.systemRed.withAlphaComponent(0.28)
+                attributed.addAttribute(
+                    .backgroundColor, value: color,
+                    range: NSRange(location: line.range.location + range.location, length: range.length)
+                )
+            }
+        }
+    }
+
+    /// `DiffRow.emphasis` is in `Character` offsets (the intraline pass is CJK-aware);
+    /// attributed-string ranges are UTF-16. Bail rather than misplace the span.
+    private static func utf16Range(of emphasis: Range<Int>, in text: String) -> NSRange? {
+        guard let lower = text.index(text.startIndex, offsetBy: emphasis.lowerBound,
+                                     limitedBy: text.endIndex),
+              let upper = text.index(text.startIndex, offsetBy: emphasis.upperBound,
+                                     limitedBy: text.endIndex),
+              lower < upper else { return nil }
+        return NSRange(lower..<upper, in: text)
+    }
+
+    // MARK: Display fold
+
+    private enum DisplayItem {
+        case line(DiffRow)
+        case band(id: Int, count: Int, expandable: Bool)
+
+        var textLength: Int {
+            switch self {
+            case .line(let row): return (row.text as NSString).length
+            case .band: return 24
+            }
+        }
+    }
+
+    private static func displayItems(rows: [DiffRow], expanded: Set<Int>) -> [DisplayItem] {
+        var items: [DisplayItem] = []
+        var run: [DiffRow] = []
+        var sawChange = false
+        var lastNewLine = 0
+
+        func flush(isLast: Bool) {
+            defer { run = [] }
+            guard !run.isEmpty else { return }
+            let head = sawChange ? 3 : 0
+            let tail = isLast ? 0 : 3
+            let hidden = run.count - head - tail
+            guard hidden >= 10 else {
+                items += run.map(DisplayItem.line)
+                return
+            }
+            items += run.prefix(head).map(DisplayItem.line)
+            let hiddenRows = Array(run.dropFirst(head).dropLast(tail))
+            if expanded.contains(hiddenRows[0].id) {
+                items += hiddenRows.map(DisplayItem.line)
+            } else {
+                items.append(.band(id: hiddenRows[0].id, count: hiddenRows.count, expandable: true))
+            }
+            items += run.suffix(tail).map(DisplayItem.line)
+        }
+
+        for row in rows {
+            switch row.kind {
+            case .hunk:
+                flush(isLast: false)
+                if let start = row.newLine, start > lastNewLine + 1 {
+                    items.append(.band(id: row.id, count: start - lastNewLine - 1, expandable: false))
+                }
+            case .context:
+                run.append(row)
+                lastNewLine = row.newLine ?? lastNewLine
+            case .addition:
+                flush(isLast: false)
+                sawChange = true
+                items.append(.line(row))
+                lastNewLine = row.newLine ?? lastNewLine
+            case .deletion:
+                flush(isLast: false)
+                sawChange = true
+                items.append(.line(row))
+            }
+        }
+        flush(isLast: true)
+        return items
+    }
+}

--- a/Sources/termio/Git/DiffGutterRulerView.swift
+++ b/Sources/termio/Git/DiffGutterRulerView.swift
@@ -1,0 +1,149 @@
+import AppKit
+
+/// The diff's gutter, following `LineNumberRulerView`'s ruler precedent (including its
+/// hard-won full-redraw-on-scroll invalidation, wired up by the pane's coordinator):
+/// old and new line-number columns in quaternary ink plus the `+`/`−` sign, drawn at
+/// each paragraph's first line fragment. Living in the ruler — outside the text view —
+/// is what keeps the numbers out of selection and the clipboard. The add/delete washes
+/// and band fills continue across it so each row reads as one full-width band.
+final class DiffGutterRulerView: NSRulerView {
+    private var document: DiffDocument?
+    private var numberFont: NSFont = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+    private var signFont: NSFont = .monospacedSystemFont(ofSize: 12, weight: .regular)
+    private var gutterColor: NSColor = .textBackgroundColor
+    private var oldColumnWidth: CGFloat = 0
+    private var newColumnWidth: CGFloat = 0
+
+    private static let leadingPad: CGFloat = 8
+    private static let columnGap: CGFloat = 8
+    private static let signWidth: CGFloat = 12
+    private static let trailingPad: CGFloat = 2
+
+    override var isOpaque: Bool { true }
+
+    init(scrollView: NSScrollView, codeFont: NSFont, gutterColor: NSColor) {
+        super.init(scrollView: scrollView, orientation: .verticalRuler)
+        clientView = scrollView.documentView
+        self.gutterColor = gutterColor
+        restyle(codeFont: codeFont)
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) { fatalError("init(coder:) is not used") }
+
+    func configure(document: DiffDocument, codeFont: NSFont, gutterColor: NSColor) {
+        self.document = document
+        self.gutterColor = gutterColor
+        restyle(codeFont: codeFont)
+    }
+
+    /// Line numbers step down from the code the same way the editor's gutter does.
+    private func restyle(codeFont: NSFont) {
+        numberFont = .monospacedDigitSystemFont(ofSize: max(9, codeFont.pointSize - 1.5),
+                                                weight: .regular)
+        signFont = codeFont
+        let digits = max(2, String(max(document?.maxLineNumber ?? 0, 1)).count)
+        let digitWidth = ("8" as NSString).size(withAttributes: [.font: numberFont]).width
+        let columnWidth = (digitWidth * CGFloat(digits)).rounded(.up)
+        oldColumnWidth = document?.hasOldGutter == false ? 0 : columnWidth
+        newColumnWidth = document?.hasNewGutter == false ? 0 : columnWidth
+        var thickness = Self.leadingPad + Self.signWidth + Self.trailingPad
+        if oldColumnWidth > 0 { thickness += oldColumnWidth + Self.columnGap }
+        if newColumnWidth > 0 { thickness += newColumnWidth + Self.columnGap }
+        ruleThickness = thickness
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        gutterColor.setFill()
+        bounds.fill()
+        drawGutter()
+    }
+
+    override func drawHashMarksAndLabels(in rect: NSRect) {
+        // The full ruler is drawn in `draw(_:)` so AppKit never paints its default chrome.
+    }
+
+    private func drawGutter() {
+        guard let document,
+              let textView = clientView as? NSTextView,
+              let layoutManager = textView.layoutManager,
+              let container = textView.textContainer else { return }
+
+        let inset = textView.textContainerInset.height
+        // Maps the text view's y-coordinates into the ruler's (carries the scroll offset).
+        let yOffset = convert(NSPoint.zero, from: textView).y
+        let numberAttrs: [NSAttributedString.Key: Any] = [
+            .font: numberFont, .foregroundColor: NSColor.quaternaryLabelColor,
+        ]
+        // Numbers stranded in the strip above the content clip would ghost over the
+        // header; anything at or above the ruler's top edge stays undrawn.
+        let topClipInset = window.map { 1 / $0.backingScaleFactor } ?? 0
+
+        let visibleGlyphs = layoutManager.glyphRange(forBoundingRect: textView.visibleRect,
+                                                     in: container)
+        let visibleChars = layoutManager.characterRange(forGlyphRange: visibleGlyphs,
+                                                        actualGlyphRange: nil)
+
+        var index = document.lineIndex(at: visibleChars.location)
+        while index < document.lines.count {
+            let line = document.lines[index]
+            index += 1
+            if line.range.location >= NSMaxRange(visibleChars) { break }
+            let glyphs = layoutManager.glyphRange(forCharacterRange: line.range,
+                                                  actualCharacterRange: nil)
+
+            // Continue the row's wash/band fill across the gutter, over every wrapped
+            // fragment of the paragraph, so the tint reads edge-to-edge.
+            if let fill = DiffWashLayoutManager.fill(for: line.role) {
+                var band = layoutManager.boundingRect(forGlyphRange: glyphs, in: container)
+                band.origin.y += inset + yOffset
+                band.origin.x = 0
+                band.size.width = ruleThickness
+                if line.isBand { band = band.insetBy(dx: 0, dy: -DiffDocument.bandPadding) }
+                fill.setFill()
+                band.fill()
+            }
+
+            guard case .code(let kind) = line.role else { continue }
+            let fragment = layoutManager.lineFragmentRect(forGlyphAt: glyphs.location,
+                                                          effectiveRange: nil)
+            let y = fragment.minY + inset + yOffset
+            guard y > bounds.minY + topClipInset else { continue }
+
+            var x = Self.leadingPad
+            if oldColumnWidth > 0 {
+                if let number = line.oldLine {
+                    drawNumber(number, rightEdge: x + oldColumnWidth, y: y, attrs: numberAttrs)
+                }
+                x += oldColumnWidth + Self.columnGap
+            }
+            if newColumnWidth > 0 {
+                if let number = line.newLine {
+                    drawNumber(number, rightEdge: x + newColumnWidth, y: y, attrs: numberAttrs)
+                }
+                x += newColumnWidth + Self.columnGap
+            }
+            if let sign = Self.sign(for: kind) {
+                sign.text.draw(at: NSPoint(x: x, y: y), withAttributes: [
+                    .font: signFont, .foregroundColor: sign.color,
+                ])
+            }
+        }
+    }
+
+    private func drawNumber(_ number: Int, rightEdge: CGFloat, y: CGFloat,
+                            attrs: [NSAttributedString.Key: Any]) {
+        let string = "\(number)" as NSString
+        let width = string.size(withAttributes: attrs).width
+        string.draw(at: NSPoint(x: rightEdge - width, y: y), withAttributes: attrs)
+    }
+
+    private static func sign(for kind: DiffRow.Kind) -> (text: NSString, color: NSColor)? {
+        switch kind {
+        case .addition: return ("+", .systemGreen)
+        case .deletion: return ("−", .systemRed)
+        case .context, .hunk: return nil
+        }
+    }
+}

--- a/Sources/termio/Git/DiffHighlighter.swift
+++ b/Sources/termio/Git/DiffHighlighter.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Foundation
-import SwiftUI
 
 // MARK: - Diff syntax coloring
 
@@ -19,12 +18,13 @@ actor DiffHighlighter {
     /// Syntax-colors a diff, one side at a time: each side is highlighted as a single
     /// text so multi-line constructs (block comments, raw strings) keep their true
     /// state — per-line coloring can't do that. Context lines take the new side's
-    /// colors; the old side contributes only its deletions. Returns SwiftUI-scope
-    /// attributed lines by row id, with the intraline emphasis layered back on top.
+    /// colors; the old side contributes only its deletions. Returns Highlightr's
+    /// attributed lines by row id, used directly by the TextKit pane — the theme's
+    /// background never carries over; the wash and emphasis layers own that.
     func styledLines(newSide: [DiffRow], oldSide: [DiffRow], language: String,
-                     theme: String, font: NSFont) -> [Int: AttributedString] {
+                     theme: String, font: NSFont) -> [Int: NSAttributedString] {
         guard let highlightr = prepared(theme: theme, font: font) else { return [:] }
-        var result: [Int: AttributedString] = [:]
+        var result: [Int: NSAttributedString] = [:]
         apply(newSide, keeping: [.context, .addition], highlightr, language, into: &result)
         apply(oldSide, keeping: [.deletion], highlightr, language, into: &result)
         return result
@@ -47,7 +47,7 @@ actor DiffHighlighter {
 
     private func apply(_ side: [DiffRow], keeping kinds: Set<DiffRow.Kind>,
                        _ highlightr: Highlightr, _ language: String,
-                       into result: inout [Int: AttributedString]) {
+                       into result: inout [Int: NSAttributedString]) {
         let joined = side.map(\.text).joined(separator: "\n")
         // The colored text must round-trip exactly, or the per-line offsets below
         // would attribute the wrong spans — bail to plain rendering instead.
@@ -58,45 +58,8 @@ actor DiffHighlighter {
             let length = (row.text as NSString).length
             defer { location += length + 1 }
             guard kinds.contains(row.kind), length > 0 else { continue }
-            let line = colored.attributedSubstring(from: NSRange(location: location, length: length))
-            var attributed = Self.swiftUIAttributed(line)
-            attributed.applyDiffEmphasis(row.emphasis, kind: row.kind)
-            result[row.id] = attributed
+            result[row.id] = colored.attributedSubstring(
+                from: NSRange(location: location, length: length))
         }
-    }
-
-    /// Re-emits an AppKit attributed line as SwiftUI attributes. `Text` only honors
-    /// the SwiftUI attribute scope, so the theme's `NSColor`/`NSFont` runs must be
-    /// translated, not just bridged; the theme's background never carries over — the
-    /// row's add/delete wash owns that layer.
-    private static func swiftUIAttributed(_ line: NSAttributedString) -> AttributedString {
-        var attributed = AttributedString("")
-        line.enumerateAttributes(in: NSRange(location: 0, length: line.length)) { attributes, range, _ in
-            var piece = AttributedString(line.attributedSubstring(from: range).string)
-            if let color = attributes[.foregroundColor] as? NSColor {
-                piece.foregroundColor = Color(nsColor: color)
-            }
-            if let font = attributes[.font] as? NSFont {
-                piece.font = Font(font)
-            }
-            attributed += piece
-        }
-        return attributed
-    }
-}
-
-extension AttributedString {
-    /// Lays a diff row's intraline emphasis span over the line — the deeper second
-    /// shade of the row's own tint. Shared by the syntax-colored path and the plain
-    /// fallback so the two can never drift apart.
-    mutating func applyDiffEmphasis(_ emphasis: Range<Int>?, kind: DiffRow.Kind) {
-        guard let emphasis, !emphasis.isEmpty else { return }
-        guard let start = characters.index(characters.startIndex, offsetBy: emphasis.lowerBound,
-                                           limitedBy: characters.endIndex),
-              let end = characters.index(characters.startIndex, offsetBy: emphasis.upperBound,
-                                         limitedBy: characters.endIndex),
-              start < end else { return }
-        self[start..<end].backgroundColor =
-            kind == .addition ? Color.green.opacity(0.28) : Color.red.opacity(0.28)
     }
 }

--- a/Sources/termio/Git/DiffTextView.swift
+++ b/Sources/termio/Git/DiffTextView.swift
@@ -1,0 +1,311 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Diff text pane
+
+/// The diff overlay's content: one non-editable `NSTextView` (TextKit 1, matching the
+/// editor) holding the whole `DiffDocument`. Line semantics are painted, not stacked —
+/// `DiffWashLayoutManager` fills the add/delete washes and band fills behind the text,
+/// the gutter ruler draws line numbers and the `+`/`−` signs *outside* the selectable
+/// text — so selection runs continuously across lines, copies pure code, and ⌘F is
+/// the system find bar.
+struct DiffTextPane: NSViewRepresentable {
+    let document: DiffDocument
+    /// Syntax-colored lines by row id (the `DiffHighlighter` pass), applied in place
+    /// once they land; the document renders plain until then.
+    let styled: [Int: NSAttributedString]
+    let font: NSFont
+    let backgroundColor: NSColor
+    /// Splices a clicked band's hidden lines back in (rebuilds the document upstream).
+    let onExpand: (Int) -> Void
+    /// ← / → sibling walk; returns false at either end so the press dies quietly.
+    let onWalk: (Int) -> Bool
+    let onClose: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let storage = NSTextStorage()
+        let layoutManager = DiffWashLayoutManager()
+        storage.addLayoutManager(layoutManager)
+        let container = NSTextContainer()
+        container.widthTracksTextView = true          // soft-wrap to the panel width
+        layoutManager.addTextContainer(container)
+
+        let textView = DiffTextView(frame: .zero, textContainer: container)
+        textView.onExpand = onExpand
+        textView.onWalk = onWalk
+        textView.onClose = onClose
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.usesFindBar = true
+        textView.isIncrementalSearchingEnabled = true
+        textView.textContainerInset = NSSize(width: 6, height: 8)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                  height: CGFloat.greatestFiniteMagnitude)
+
+        let scrollView = NSScrollView()
+        scrollView.documentView = textView
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = backgroundColor
+        // Paint the clip view the same color so the ruler/text seam can never show as a hairline.
+        scrollView.contentView.drawsBackground = true
+        scrollView.contentView.backgroundColor = backgroundColor
+
+        let ruler = DiffGutterRulerView(scrollView: scrollView, codeFont: font,
+                                        gutterColor: backgroundColor)
+        scrollView.verticalRulerView = ruler
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = true
+        context.coordinator.ruler = ruler
+
+        // The ruler must fully redraw on three events: content changes and the view
+        // re-wrapping on resize (both via the text view's frame changes), and —
+        // crucially — *scrolling*. AppKit's copy-on-scroll only repaints the newly
+        // exposed strip, so without a full invalidation the gutter's absolutely
+        // positioned numbers desync into a garbled smear (the editor's ruler learned
+        // this the hard way).
+        textView.postsFrameChangedNotifications = true
+        context.coordinator.observeFrame(of: textView)
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        context.coordinator.observeScroll(of: scrollView)
+
+        apply(to: textView, layoutManager: layoutManager, ruler: ruler,
+              coordinator: context.coordinator)
+
+        // Keys (← → walk, Esc, ⌘F) should work the moment the overlay lands, without
+        // a click first. Deferred one turn — at make time the view has no window yet.
+        DispatchQueue.main.async { [weak textView] in
+            guard let textView, let window = textView.window else { return }
+            if window.firstResponder === window || window.firstResponder is NSTextView == false {
+                window.makeFirstResponder(textView)
+            }
+        }
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? DiffTextView,
+              let layoutManager = textView.layoutManager as? DiffWashLayoutManager,
+              let ruler = context.coordinator.ruler else { return }
+        textView.onExpand = onExpand
+        textView.onWalk = onWalk
+        textView.onClose = onClose
+        scrollView.backgroundColor = backgroundColor
+        scrollView.contentView.backgroundColor = backgroundColor
+        textView.backgroundColor = backgroundColor
+        apply(to: textView, layoutManager: layoutManager, ruler: ruler,
+              coordinator: context.coordinator)
+    }
+
+    /// Swaps the document in when it changed (initial load, band expand) and lays the
+    /// syntax colors over it when they land — both idempotent against re-renders.
+    private func apply(to textView: DiffTextView, layoutManager: DiffWashLayoutManager,
+                       ruler: DiffGutterRulerView, coordinator: Coordinator) {
+        textView.backgroundColor = backgroundColor
+        if coordinator.appliedDocument !== document {
+            coordinator.appliedDocument = document
+            coordinator.appliedStyled = nil
+            layoutManager.document = document
+            textView.document = document
+            textView.textStorage?.setAttributedString(document.attributed)
+            ruler.configure(document: document, codeFont: font, gutterColor: backgroundColor)
+        }
+        // A dictionary identity check, not equality: the highlight pass lands at most
+        // once per load, so pointer-style diffing by count is enough and O(1).
+        if !styled.isEmpty, coordinator.appliedStyled != styled.count {
+            coordinator.appliedStyled = styled.count
+            applyStyled(to: textView)
+        }
+    }
+
+    /// Lays the highlighter's colors (and any bold/italic trait fonts) over the plain
+    /// document in place — geometry-stable for same-width fonts, so the scroll
+    /// position holds while the colors fade in.
+    private func applyStyled(to textView: DiffTextView) {
+        guard let storage = textView.textStorage else { return }
+        storage.beginEditing()
+        for line in document.lines where !line.isBand {
+            guard let colored = styled[line.rowId],
+                  colored.length == line.range.length - 1 else { continue }
+            colored.enumerateAttributes(in: NSRange(location: 0, length: colored.length)) { attrs, range, _ in
+                var overlay: [NSAttributedString.Key: Any] = [:]
+                if let color = attrs[.foregroundColor] as? NSColor { overlay[.foregroundColor] = color }
+                if let font = attrs[.font] as? NSFont { overlay[.font] = font }
+                guard !overlay.isEmpty else { return }
+                storage.addAttributes(overlay, range: NSRange(
+                    location: line.range.location + range.location, length: range.length))
+            }
+        }
+        storage.endEditing()
+    }
+
+    @MainActor
+    final class Coordinator {
+        var appliedDocument: DiffDocument?
+        var appliedStyled: Int?
+        weak var ruler: DiffGutterRulerView?
+
+        func observeFrame(of textView: NSTextView) {
+            NotificationCenter.default.addObserver(
+                forName: NSView.frameDidChangeNotification, object: textView, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.ruler?.needsDisplay = true }
+            }
+        }
+
+        func observeScroll(of scrollView: NSScrollView) {
+            NotificationCenter.default.addObserver(
+                forName: NSView.boundsDidChangeNotification, object: scrollView.contentView, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.ruler?.needsDisplay = true }
+            }
+        }
+    }
+}
+
+// MARK: - Text view
+
+/// The diff's text view: read-only but selectable, with the overlay's keys folded in —
+/// ← / → walk the sibling files, Esc closes, ↑ / ↓ stay with scrolling (there is no
+/// caret to move), and a click on an expandable band splices its lines back in.
+final class DiffTextView: NSTextView {
+    var document: DiffDocument?
+    var onExpand: ((Int) -> Void)?
+    var onWalk: ((Int) -> Bool)?
+    var onClose: (() -> Void)?
+
+    override func keyDown(with event: NSEvent) {
+        let hasModifiers = !event.modifierFlags
+            .intersection([.command, .option, .control, .shift]).isEmpty
+        if !hasModifiers {
+            switch event.keyCode {
+            case 123: _ = onWalk?(-1); return    // ← — dies quietly at either end
+            case 124: _ = onWalk?(+1); return    // →
+            case 125: scroll(byLines: +3); return
+            case 126: scroll(byLines: -3); return
+            case 53: onClose?(); return          // Esc (find bar handles its own first)
+            default: break
+            }
+        }
+        super.keyDown(with: event)
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        onClose?()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        if let anchor = expandableBand(at: event) {
+            onExpand?(anchor)
+            return
+        }
+        super.mouseDown(with: event)
+    }
+
+    /// The band under a click, hit anywhere across the row (the nearest-glyph mapping
+    /// clamps horizontally; the fragment-rect check rejects clicks past the last line).
+    private func expandableBand(at event: NSEvent) -> Int? {
+        guard let document, let layoutManager, let textContainer else { return nil }
+        let point = convert(event.locationInWindow, from: nil)
+        let local = NSPoint(x: point.x - textContainerOrigin.x, y: point.y - textContainerOrigin.y)
+        let glyph = layoutManager.glyphIndex(for: local, in: textContainer)
+        let fragment = layoutManager.lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil)
+        let padding = DiffDocument.bandPadding
+        guard local.y >= fragment.minY - padding, local.y <= fragment.maxY + padding else { return nil }
+        let character = layoutManager.characterIndexForGlyph(at: glyph)
+        guard let line = document.line(at: character),
+              case .band(_, expandable: true) = line.role else { return nil }
+        return line.rowId
+    }
+
+    /// ⌘C copies the selected *code* — band labels are chrome, not content, so a
+    /// selection sweeping across one drops the "n unchanged lines" text on the way
+    /// to the pasteboard. (The gutter never needs stripping; it lives in the ruler.)
+    override func copy(_ sender: Any?) {
+        guard let document else { return super.copy(sender) }
+        let content = string as NSString
+        var pieces: [String] = []
+        for value in selectedRanges {
+            let selection = value.rangeValue
+            guard selection.length > 0 else { continue }
+            var kept = ""
+            var index = document.lineIndex(at: selection.location)
+            while index < document.lines.count {
+                let line = document.lines[index]
+                let overlap = NSIntersectionRange(line.range, selection)
+                if overlap.length == 0, line.range.location >= NSMaxRange(selection) { break }
+                if overlap.length > 0, !line.isBand {
+                    kept += content.substring(with: overlap)
+                }
+                index += 1
+            }
+            if !kept.isEmpty { pieces.append(kept) }
+        }
+        guard !pieces.isEmpty else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(pieces.joined(separator: "\n"), forType: .string)
+    }
+
+    private func scroll(byLines delta: CGFloat) {
+        guard let clip = enclosingScrollView?.contentView else { return }
+        let lineHeight = layoutManager?.defaultLineHeight(for: font ?? .systemFont(ofSize: 12)) ?? 14
+        var origin = clip.bounds.origin
+        origin.y += delta * lineHeight
+        clip.scroll(to: clip.constrainBoundsRect(
+            NSRect(origin: origin, size: clip.bounds.size)).origin)
+        enclosingScrollView?.reflectScrolledClipView(clip)
+    }
+}
+
+// MARK: - Layout manager
+
+/// Paints the diff's line semantics behind the text: full-width add/delete washes and
+/// the bands' faint fills. Runs before `super.drawBackground`, so TextKit's own pass
+/// (the intraline-emphasis `.backgroundColor` spans, the selection highlight) always
+/// composites on top.
+final class DiffWashLayoutManager: NSLayoutManager {
+    var document: DiffDocument?
+
+    override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: NSPoint) {
+        if let document, let container = textContainers.first {
+            let charRange = characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
+            // Washes span the full panel width, not just the laid-out text.
+            let width = max(usedRect(for: container).width + origin.x,
+                            container.textView?.bounds.width ?? 0)
+            var index = document.lineIndex(at: charRange.location)
+            while index < document.lines.count {
+                let line = document.lines[index]
+                index += 1
+                if line.range.location >= NSMaxRange(charRange) { break }
+                guard let fill = Self.fill(for: line.role) else { continue }
+                let glyphs = glyphRange(forCharacterRange: line.range, actualCharacterRange: nil)
+                var rect = boundingRect(forGlyphRange: glyphs, in: container)
+                rect.origin.x = 0
+                rect.size.width = width
+                rect.origin.y += origin.y
+                if line.isBand { rect = rect.insetBy(dx: 0, dy: -DiffDocument.bandPadding) }
+                fill.setFill()
+                rect.fill()
+            }
+        }
+        super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
+    }
+
+    static func fill(for role: DiffDocument.Line.Role) -> NSColor? {
+        switch role {
+        case .code(.addition): return NSColor.systemGreen.withAlphaComponent(0.13)
+        case .code(.deletion): return NSColor.systemRed.withAlphaComponent(0.13)
+        case .band: return NSColor.labelColor.withAlphaComponent(0.045)
+        case .code: return nil
+        }
+    }
+}

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -4,12 +4,12 @@ import SwiftUI
 // MARK: - Diff overlay
 
 /// A read-only unified diff that covers the terminal pane — the git counterpart of
-/// `FilePreviewView`/`FileEditorView`, driven by `store.openDiff`. Native SwiftUI rows
-/// in a `List` (NSTableView underneath, for stable variable-height scrolling), styled
-/// after the current generation of diff readers: code keeps its syntax colors (the
-/// editor's Highlightr pipeline) with the add/delete tint as a wash underneath, raw
-/// `@@` plumbing never appears — unchanged runs collapse into expandable "n lines"
-/// bands — and the gutter chrome recedes. Escape or the close button dismisses it.
+/// `FilePreviewView`/`FileEditorView`, driven by `store.openDiff`. The content is one
+/// TextKit view holding the whole diff (`DiffTextPane`): code keeps its syntax colors
+/// (the editor's Highlightr pipeline) with the add/delete tint painted as a full-width
+/// wash underneath, raw `@@` plumbing never appears — unchanged runs collapse into
+/// expandable "n lines" bands — selection runs continuously across lines, and ⌘F is
+/// the system find bar. Escape or the close button dismisses it.
 struct GitDiffView: View {
     let request: GitDiffRequest
     @ObservedObject var settings: AppSettings
@@ -22,13 +22,14 @@ struct GitDiffView: View {
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var rows: [DiffRow] = []
+    @State private var document: DiffDocument?
     @State private var isLoading = true
     /// The spinner waits 0.15 s before appearing, so a fast file-to-file walk swaps
     /// content with no intermediate flash; only a genuinely slow diff shows it.
     @State private var showsSpinner = false
-    /// Syntax-colored line content per row id (emphasis merged in), filled by a
-    /// background pass after the rows land; rows render plain until then.
-    @State private var styledLines: [Int: AttributedString] = [:]
+    /// Syntax-colored line content per row id, filled by a background pass after the
+    /// rows land; the document renders plain until then.
+    @State private var styledLines: [Int: NSAttributedString] = [:]
     /// Ids (first hidden row) of the collapsed bands the user has expanded.
     @State private var expanded: Set<Int> = []
 
@@ -39,6 +40,8 @@ struct GitDiffView: View {
             content
         }
         .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
+        // The pane's text view owns the keys once mounted; these cover the loading
+        // and empty states, where there is no text view to hold first responder.
         .focusable()
         .focusEffectDisabled()
         .onKeyPress(.leftArrow) { walk(-1) ? .handled : .ignored }
@@ -116,76 +119,6 @@ struct GitDiffView: View {
 
     // MARK: Content
 
-    /// One renderable element: a code line, or a collapsed band standing in for a run
-    /// of unchanged lines. A band with rows expands in place when clicked; a band with
-    /// none (the default-context fallback, where the hidden lines were never fetched)
-    /// is a fixed marker sized from the hunk-boundary arithmetic.
-    private enum DisplayItem: Identifiable {
-        case line(DiffRow)
-        case band(id: Int, count: Int, expandable: Bool)
-
-        var id: Int {
-            switch self {
-            case .line(let row): return row.id
-            case .band(let id, _, _): return -id - 1
-            }
-        }
-    }
-
-    /// Folds the raw rows into the display list: hunk plumbing disappears (its gap
-    /// becomes a band), and unchanged runs longer than a handful of lines collapse to
-    /// a band keeping 3 lines of context on the side(s) that face a change.
-    private var displayItems: [DisplayItem] {
-        var items: [DisplayItem] = []
-        var run: [DiffRow] = []
-        var sawChange = false
-        var lastNewLine = 0
-
-        func flush(isLast: Bool) {
-            defer { run = [] }
-            guard !run.isEmpty else { return }
-            let head = sawChange ? 3 : 0
-            let tail = isLast ? 0 : 3
-            let hidden = run.count - head - tail
-            guard hidden >= 10 else {
-                items += run.map(DisplayItem.line)
-                return
-            }
-            items += run.prefix(head).map(DisplayItem.line)
-            let hiddenRows = Array(run.dropFirst(head).dropLast(tail))
-            if expanded.contains(hiddenRows[0].id) {
-                items += hiddenRows.map(DisplayItem.line)
-            } else {
-                items.append(.band(id: hiddenRows[0].id, count: hiddenRows.count, expandable: true))
-            }
-            items += run.suffix(tail).map(DisplayItem.line)
-        }
-
-        for row in rows {
-            switch row.kind {
-            case .hunk:
-                flush(isLast: false)
-                if let start = row.newLine, start > lastNewLine + 1 {
-                    items.append(.band(id: row.id, count: start - lastNewLine - 1, expandable: false))
-                }
-            case .context:
-                run.append(row)
-                lastNewLine = row.newLine ?? lastNewLine
-            case .addition:
-                flush(isLast: false)
-                sawChange = true
-                items.append(.line(row))
-                lastNewLine = row.newLine ?? lastNewLine
-            case .deletion:
-                flush(isLast: false)
-                sawChange = true
-                items.append(.line(row))
-            }
-        }
-        flush(isLast: true)
-        return items
-    }
-
     @ViewBuilder
     private var content: some View {
         if isLoading {
@@ -197,67 +130,29 @@ struct GitDiffView: View {
                     try? await Task.sleep(nanoseconds: 150_000_000)
                     showsSpinner = true
                 }
-        } else if rows.isEmpty {
+        } else if let document {
+            DiffTextPane(
+                document: document,
+                styled: styledLines,
+                font: settings.resolvedTerminalFont(),
+                backgroundColor: settings.terminalBackgroundColor,
+                onExpand: { id in
+                    expanded.insert(id)
+                    self.document = DiffDocument.build(
+                        rows: rows, expanded: expanded,
+                        codeFont: settings.resolvedTerminalFont())
+                },
+                onWalk: { walk($0) },
+                onClose: onClose
+            )
+        } else {
             ContentUnavailableView(
                 "No Diff",
                 systemImage: "doc",
                 description: Text("No textual changes to show.")
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            // A `List` (NSTableView underneath), not a `ScrollView`+`LazyVStack`: the rows
-            // soft-wrap, so their heights vary, and LazyVStack only *estimates* heights for
-            // off-screen content — scrolling fights the estimates (visible jitter) and rows
-            // laid out at an old width keep their stale wrap after the inspector resizes.
-            List(displayItems) { item in
-                Group {
-                    switch item {
-                    case .line(let row):
-                        DiffLineRow(row: row, styled: styledLines[row.id],
-                                    font: diffFont, gutterFont: gutterFont,
-                                    showOldGutter: hasOldLines, showNewGutter: hasNewLines)
-                    case .band(let id, let count, let expandable):
-                        CollapsedBand(count: count, expandable: expandable) {
-                            expanded.insert(id)
-                        }
-                    }
-                }
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
-            }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            // A realistic per-line estimate, NOT 1: the table uses this to size its
-            // viewport, and a 1 pt estimate on a full-context diff (thousands of rows)
-            // makes it materialize them all at once — a seconds-long main-thread stall.
-            .environment(\.defaultMinListRowHeight, lineHeightEstimate)
         }
-    }
-
-    /// Approximate single-line row height (font line box + the row's 1 pt paddings).
-    private var lineHeightEstimate: CGFloat {
-        let font = settings.resolvedTerminalFont()
-        return (font.ascender - font.descender + font.leading).rounded(.up) + 2
-    }
-
-    /// Whether any code row carries an old/new line number (hunk rows don't count —
-    /// they hold start offsets). A pure-addition file has no old numbers, so that
-    /// empty gutter collapses rather than showing a blank band; likewise a pure
-    /// deletion collapses the new gutter.
-    private var hasOldLines: Bool { rows.contains { $0.kind != .hunk && $0.oldLine != nil } }
-    private var hasNewLines: Bool { rows.contains { $0.kind != .hunk && $0.newLine != nil } }
-
-    /// The terminal font, so the diff reads in the same face as the agent's output
-    /// and the file editor.
-    private var diffFont: Font {
-        Font(settings.resolvedTerminalFont())
-    }
-
-    /// Line numbers step down from the code the same way the editor's gutter does.
-    private var gutterFont: Font {
-        let size = max(9, settings.resolvedTerminalFont().pointSize - 1.5)
-        return Font(NSFont.monospacedDigitSystemFont(ofSize: size, weight: .regular))
     }
 
     // MARK: Loading + syntax colors
@@ -265,6 +160,10 @@ struct GitDiffView: View {
     private func load() async {
         let parsed = await GitService.diffRows(for: request.change, in: request.repoRoot, commit: request.commit)
         rows = parsed
+        document = parsed.isEmpty
+            ? nil
+            : DiffDocument.build(rows: parsed, expanded: expanded,
+                                 codeFont: settings.resolvedTerminalFont())
         isLoading = false
         await buildStyledLines(parsed)
     }
@@ -307,121 +206,5 @@ extension GitDiffRequest {
             next += delta
         }
         return nil
-    }
-}
-
-// MARK: - Rows
-
-/// One code line of the diff: old/new line-number gutter (quiet, quaternary ink), a
-/// `+`/`−`/space sign, and the code — syntax-colored when the styled pass has landed,
-/// plain until then — over a green/red/clear wash. Long lines soft-wrap (the panel is
-/// fixed-width), which keeps each line's background spanning the full width.
-private struct DiffLineRow: View {
-    let row: DiffRow
-    let styled: AttributedString?
-    let font: Font
-    let gutterFont: Font
-    var showOldGutter = true
-    var showNewGutter = true
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 0) {
-            if showOldGutter { gutter(row.oldLine) }
-            if showNewGutter { gutter(row.newLine) }
-            Text(sign)
-                .font(font)
-                .foregroundStyle(signColor)
-                .frame(width: 14)
-            codeText
-                .font(font)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.trailing, 10)
-        }
-        .padding(.vertical, 1)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(background)
-    }
-
-    private var codeText: Text {
-        if let styled, !styled.characters.isEmpty { return Text(styled) }
-        guard !row.text.isEmpty else { return Text(" ") }
-        var attributed = AttributedString(row.text)
-        attributed.applyDiffEmphasis(row.emphasis, kind: row.kind)
-        return Text(attributed)
-    }
-
-    private func gutter(_ number: Int?) -> some View {
-        Text(number.map(String.init) ?? "")
-            .font(gutterFont)
-            .foregroundStyle(.quaternary)
-            .frame(width: 34, alignment: .trailing)
-            .padding(.trailing, 6)
-    }
-
-    private var sign: String {
-        switch row.kind {
-        case .addition: return "+"
-        case .deletion: return "-"
-        default: return " "
-        }
-    }
-
-    private var signColor: Color {
-        switch row.kind {
-        case .addition: return .green
-        case .deletion: return .red
-        default: return .secondary
-        }
-    }
-
-    private var background: Color {
-        switch row.kind {
-        case .addition: return Color.green.opacity(0.13)
-        case .deletion: return Color.red.opacity(0.13)
-        default: return .clear
-        }
-    }
-}
-
-/// The stand-in for a run of unchanged lines — the raw `@@` hunk header never appears.
-/// Expandable bands (full-context loads) splice their lines back in on click; fixed
-/// bands (the oversized-diff fallback) just mark the gap. Meta information, so it
-/// speaks in the UI font, not the code font.
-private struct CollapsedBand: View {
-    let count: Int
-    let expandable: Bool
-    let onExpand: () -> Void
-
-    @State private var isHovering = false
-
-    var body: some View {
-        Group {
-            if expandable {
-                Button(action: onExpand) { label }
-                    .buttonStyle(.plain)
-                    .onHover { isHovering = $0 }
-            } else {
-                label
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 4)
-        .background(Color.primary.opacity(isHovering ? 0.07 : 0.04))
-        .contentShape(Rectangle())
-    }
-
-    private var label: some View {
-        HStack(spacing: 6) {
-            if expandable {
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 8.5, weight: .semibold))
-            }
-            Text("\(count) unchanged \(count == 1 ? "line" : "lines")")
-        }
-        .font(.system(size: 10.5, weight: .medium))
-        .foregroundStyle(isHovering ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
-        .frame(maxWidth: .infinity)
     }
 }


### PR DESCRIPTION
## What changed

The diff overlay's rendering layer moves from a SwiftUI \`List\` of per-line rows to the architecture the top-tier native diff viewers use: **one non-editable \`NSTextView\` (TextKit 1) holding the whole diff**, with line semantics painted rather than stacked.

- **\`DiffDocument\`** — the folded display list (code lines + collapsed bands) laid down as one attributed string, with per-paragraph metadata (kind, line numbers, band anchors) the draw passes read via binary search. The collapse/expand semantics (≥10-line unchanged runs, 3 context lines, fixed bands in the default-context fallback) are unchanged.
- **\`DiffWashLayoutManager\`** — \`drawBackground(forGlyphRange:at:)\` fills the full-width green/red washes (0.13) and the bands' faint fills before \`super\` runs, so TextKit's own background pass (intraline emphasis spans at 0.28, painted as a \`.backgroundColor\` attribute, and the selection highlight) always composites on top.
- **\`DiffGutterRulerView\`** — old/new line numbers (quaternary ink) **and the +/− signs** live in the ruler, on the \`LineNumberRulerView\` precedent including its full-redraw-on-scroll invalidation. Washes continue across the gutter so each row reads edge-to-edge.
- **\`DiffHighlighter\`** now hands its \`NSAttributedString\` lines to the pane directly; the SwiftUI-attribute translation step is deleted. Colors are applied in place when they land — no relayout, no scroll jump.
- Band clicks hit-test through the document metadata and splice the hidden lines back in; expandable bands get a pointing-hand cursor. ← / → walk, "n of m" header, Esc, the delayed spinner, and the presence-keyed fade are all unchanged.

## The two big wins

1. **Continuous multi-line selection** — selection sweeps across lines like any text view. Copy yields pure code: the gutter was never in the text (it lives in the ruler), and \`copy(_:)\` drops band labels on the way to the pasteboard.
2. **The system find bar** — \`usesFindBar\` gives ⌘F with incremental search for free.

## Verification

- \`swift build\` passes; dev app rebuilt from the worktree and running (process path verified).
- Interactive checks (wash/emphasis rendering, band expand, ⌘F, drag-select + copy, rapid ←/→ walk, inspector resize re-wrap) pending a visual pass — being verified in the dev build now.

Stacked on #37 (\`feat/diff-reading\`); retarget to \`main\` after the stack below merges.