### PR TITLE
feat(git): glass mode switch, aligned headers, single-line history rows

### DIFF
--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -24,6 +24,14 @@ struct GitChangesView: View {
     /// Which of the two tabs is showing.
     @State private var mode: GitPaneMode = .changes
 
+    /// Slides the mode switch's selection pill from the old segment to the new one.
+    @Namespace private var pillNamespace
+
+    /// Fixed height of the pane's top bar, shared with the diff overlay's file header
+    /// (`GitDiffView`) so the two bars — and their bottom hairlines — line up across
+    /// the terminal | inspector split.
+    static let topBarHeight: CGFloat = 34
+
     /// The files a "Discard Changes…" action is waiting to confirm — non-nil while the
     /// destructive alert is up, so the actual `git restore`/delete only fires on "OK".
     @State private var pendingDiscard: [GitChange]?
@@ -86,33 +94,71 @@ struct GitChangesView: View {
 
     // MARK: Chrome
 
-    /// The pane's mode switch, pinned at the top over a hairline: `Changes | History`
-    /// with the active mode lit in the chrome accent — GitHub Desktop's tab placement.
+    /// The pane's mode switch, pinned at the top over a hairline — GitHub Desktop's tab
+    /// placement, drawn as a miniature of `InspectorTabsToolbar`'s segmented track (our
+    /// own capsule track + a sliding Liquid Glass selection pill) so both switches in
+    /// the inspector share one design language.
     private var topBar: some View {
-        HStack(spacing: 8) {
-            switchButton("Changes", .changes)
-            Divider().frame(height: 12)
-            switchButton("History", .history)
+        HStack(spacing: 0) {
+            modeSwitch
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 1)
+        .padding(.horizontal, 8)
+        .frame(height: Self.topBarHeight)
+    }
+
+    private var modeSwitch: some View {
+        HStack(spacing: 0) {
+            segment("Changes", .changes)
+            segment("History", .history)
+        }
+        // The selection pill rides behind the active segment and slides across on switch.
+        .background { selectionPill }
+        .padding(2.5)
+        .background { trackBackground }
+        // Scope the slide to this control so switching modes doesn't animate the pane
+        // content swap below (same reasoning as `InspectorTabsToolbar`).
+        .animation(.snappy(duration: 0.28), value: mode)
+    }
+
+    private func segment(_ title: String, _ value: GitPaneMode) -> some View {
+        let active = mode == value
+        // Constant weight: a semibold-on-select would re-measure the segment and make
+        // the track jitter as the pill lands. Selection reads via .primary + the pill.
+        return Text(title)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(active ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+            .padding(.horizontal, 10)
+            .frame(height: 21)
+            .matchedGeometryEffect(id: value, in: pillNamespace)
+            .contentShape(.capsule)
+            .onTapGesture { mode = value }
+    }
+
+    @ViewBuilder
+    private var selectionPill: some View {
+        if #available(macOS 26.0, *) {
+            Capsule()
+                .fill(.clear)
+                .glassEffect(.regular.interactive(), in: .capsule)
+                .matchedGeometryEffect(id: mode, in: pillNamespace, isSource: false)
+        } else {
+            Capsule(style: .continuous)
+                .fill(Color(nsColor: .controlColor))
+                .shadow(color: .black.opacity(0.18), radius: 0.5, y: 0.5)
+                .matchedGeometryEffect(id: mode, in: pillNamespace, isSource: false)
         }
     }
 
-    private func switchButton(_ title: String, _ value: GitPaneMode) -> some View {
-        let active = mode == value
-        return Button {
-            mode = value
-        } label: {
-            Text(title)
-                .font(.system(size: 11.5, weight: active ? .semibold : .regular))
-                .foregroundStyle(active ? AnyShapeStyle(chrome?.accent ?? Color.accentColor) : AnyShapeStyle(.secondary))
-                .contentShape(Rectangle())
+    @ViewBuilder
+    private var trackBackground: some View {
+        if #available(macOS 26.0, *) {
+            Capsule()
+                .fill(.clear)
+                .glassEffect(.regular.tint(Color.white.opacity(0.12)), in: .capsule)
+        } else {
+            Capsule(style: .continuous).fill(Color.primary.opacity(0.06))
         }
-        .buttonStyle(.plain)
     }
 
     /// Status strip under the content: what the visible list adds up to. There is no

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -36,7 +36,6 @@ struct GitDiffView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-            Divider()
             content
         }
         .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
@@ -113,8 +112,13 @@ struct GitDiffView: View {
             // divider) — see `setCloseOverlayVisible` in App.swift.
         }
         .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        // Fixed height + inset hairline shared with the git pane's mode switch, so this
+        // bar and the inspector's `Changes | History` bar line up across the split.
+        .frame(height: GitChangesView.topBarHeight)
         .background(Color(nsColor: settings.terminalBackgroundColor))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 1)
+        }
     }
 
     // MARK: Content

--- a/Sources/termio/Git/GitHistoryView.swift
+++ b/Sources/termio/Git/GitHistoryView.swift
@@ -35,6 +35,9 @@ struct GitHistoryView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView(.vertical) {
+                    // No separators: fixed-height rows + the hover/selection wash do the
+                    // separating, like a modern SwiftUI List (hairlines between every row
+                    // read as legacy chrome in a narrow pane).
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(model.commits) { commit in
                             CommitRow(commit: commit, isExpanded: expanded == commit.sha, chrome: chrome, font: font) {
@@ -43,14 +46,9 @@ struct GitHistoryView: View {
                             if expanded == commit.sha {
                                 commitFiles(commit)
                             }
-                            // A hairline between commits, inset past the avatar to align under
-                            // the message text — the Xcode / Mail list separator.
-                            Divider()
-                                .padding(.leading, 46)
-                                .opacity(0.5)
                         }
                     }
-                    .padding(.bottom, 10)
+                    .padding(.vertical, 6)
                 }
             }
         }
@@ -66,7 +64,7 @@ struct GitHistoryView: View {
                 Text("No file changes")
                     .font(.system(size: 11))
                     .foregroundStyle(.tertiary)
-                    .padding(.leading, 46)
+                    .padding(.leading, 24)
                     .padding(.vertical, 4)
             } else {
                 ForEach(files) { file in
@@ -84,7 +82,7 @@ struct GitHistoryView: View {
         } else {
             ProgressView()
                 .controlSize(.small)
-                .padding(.leading, 46)
+                .padding(.leading, 24)
                 .padding(.vertical, 4)
         }
     }
@@ -104,11 +102,12 @@ struct GitHistoryView: View {
     }
 }
 
-/// One commit, Xcode-style: the author's initials avatar anchors the row; the subject
-/// reads in the interface font beside it, with `sha · when` muted underneath. A chevron
-/// fades in on hover and turns down when expanded — no permanent glyph cluttering the
-/// leading edge. Hover / expanded lift use the app's shared `SidebarRowHighlight` (the
-/// same accent wash as the sidebar and file tree), not a one-off fill.
+/// One commit, GitHub Desktop-style: the subject on a single truncated line (every row
+/// the same height — a big leading avatar and wrapping subjects made the list ragged),
+/// with a small avatar + `author · when · sha` muted underneath. The sha is tertiary,
+/// not accent: accent is reserved for selection so the list stays quiet. A chevron
+/// fades in on hover and turns down when expanded. Hover / expanded lift use the app's
+/// shared `SidebarRowHighlight` (the same accent wash as the sidebar and file tree).
 private struct CommitRow: View {
     let commit: GitCommit
     let isExpanded: Bool
@@ -120,22 +119,26 @@ private struct CommitRow: View {
 
     var body: some View {
         Button(action: onTap) {
-            HStack(alignment: .top, spacing: 10) {
-                CommitAvatar(author: commit.author, chrome: chrome)
-                    .padding(.top, 1)
+            HStack(alignment: .center, spacing: 8) {
                 VStack(alignment: .leading, spacing: 3) {
                     Text(commit.subject)
                         .font(font)
                         .foregroundStyle(.primary)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                     HStack(spacing: 5) {
-                        Text(commit.shortSHA)
-                            .font(.system(size: 10.5, design: .monospaced))
-                            .foregroundStyle(chrome?.accent ?? .accentColor)
+                        CommitAvatar(author: commit.author, chrome: chrome)
+                        Text(commit.author)
+                            .lineLimit(1)
                         Text("·").foregroundStyle(.tertiary)
                         Text(commit.relativeDate)
                             .lineLimit(1)
+                            .layoutPriority(1)
+                        Text("·").foregroundStyle(.tertiary)
+                        Text(commit.shortSHA)
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                            .layoutPriority(1)
                     }
                     .font(.system(size: 10.5))
                     .foregroundStyle(.secondary)
@@ -143,12 +146,9 @@ private struct CommitRow: View {
                 Spacer(minLength: 4)
                 Image(systemName: "chevron.right")
                     .font(.system(size: 9, weight: .semibold))
-                    // Match the commit subject's color (`.primary`) rather than a muted
-                    // tertiary, so the expand affordance reads as strong as the message.
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(.secondary)
                     .rotationEffect(.degrees(isExpanded ? 90 : 0))
                     .opacity(isHovering || isExpanded ? 1 : 0)
-                    .padding(.top, 4)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 7)
@@ -158,12 +158,15 @@ private struct CommitRow: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
+        .help(commit.subject)
     }
 }
 
-/// A circular initials avatar — the Xcode source-control row anchor — filled in the chrome
-/// accent so it derives from the terminal theme like the rest of termio's chrome (one
-/// source of color truth) rather than a per-author rainbow hue.
+/// A small circular initials avatar riding in the metadata line (GitHub Desktop's
+/// placement — a 24pt leading avatar column read as a loud repeated stripe when one
+/// author dominates). Filled in the chrome accent so it derives from the terminal theme
+/// like the rest of termio's chrome (one source of color truth) rather than a per-author
+/// rainbow hue.
 private struct CommitAvatar: View {
     let author: String
     let chrome: ChromeTheme?
@@ -171,10 +174,10 @@ private struct CommitAvatar: View {
     var body: some View {
         Circle()
             .fill((chrome?.accent ?? .accentColor).gradient)
-            .frame(width: 24, height: 24)
+            .frame(width: 15, height: 15)
             .overlay(
                 Text(initials)
-                    .font(.system(size: 9.5, weight: .semibold))
+                    .font(.system(size: 6.5, weight: .semibold))
                     .foregroundStyle(.white)
             )
             .help(author)
@@ -215,7 +218,7 @@ private struct CommitFileRow: View {
                 if change.deletions > 0 { Text("−\(change.deletions)").foregroundStyle(.red) }
             }
             .font(.system(size: 10.5, weight: .medium, design: .monospaced))
-            .padding(.leading, 46)
+            .padding(.leading, 24)
             .padding(.trailing, 14)
             .padding(.vertical, 3)
             .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Polish pass on the git pane after the #36→#42→#41 stack, from visual review of the running app.

## Changes

- **Changes | History switch → Liquid Glass segments**: the text-link tabs are replaced with a miniature of `InspectorTabsToolbar`'s hand-drawn segmented track — our own capsule track + a sliding selection pill (`glassEffect` on macOS 26, flat capsule fills below), so both switches in the inspector share one design language.
- **Header alignment across the split**: the diff overlay's file header and the git pane's mode switch now share one fixed 34pt height (`GitChangesView.topBarHeight`), so the two bars line up across the terminal | inspector divider. The hairline under the mode switch is removed; the diff header keeps its own inset hairline since content scrolls beneath it.
- **History rows after GitHub Desktop**: subject on a single truncated line (equal-height rows), the 24pt leading avatar column replaced by a 15pt avatar riding in the metadata line (`author · when · sha`), sha demoted from accent to tertiary so accent stays reserved for selection, per-row hairline separators dropped in favor of the shared hover/selection wash, expanded file-row indent tightened from 46 to 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)