### PR TITLE
feat(git): tag chips and unpushed markers in History, drop the commit-count bar

### DIFF
--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -55,7 +55,9 @@ struct GitChangesView: View {
             case .changes: changesBody
             case .history: GitHistoryView(model: model, repoRoot: repoRoot, chrome: chrome, font: settings.interfaceFont)
             }
-            bottomBar
+            // Only Changes has a real total to report ("N files +A −D"). History's
+            // count would just echo the fetch limit — meaningless, so no bar.
+            if mode == .changes { bottomBar }
         }
         .task(id: repoRoot) { await model.load() }
         .task(id: mode) { if mode == .history { await model.loadHistory() } }
@@ -180,20 +182,13 @@ struct GitChangesView: View {
 
     @ViewBuilder
     private var summary: some View {
-        switch mode {
-        case .changes:
-            if !model.changes.isEmpty {
-                let additions = model.changes.reduce(0) { $0 + $1.additions }
-                let deletions = model.changes.reduce(0) { $0 + $1.deletions }
-                Text("\(model.changes.count) \(model.changes.count == 1 ? "file" : "files")")
-                    .foregroundStyle(.secondary)
-                if additions > 0 { Text("+\(additions)").foregroundStyle(.green) }
-                if deletions > 0 { Text("−\(deletions)").foregroundStyle(.red) }
-            }
-        case .history:
-            if !model.commits.isEmpty {
-                Text("\(model.commits.count) commits").foregroundStyle(.secondary)
-            }
+        if !model.changes.isEmpty {
+            let additions = model.changes.reduce(0) { $0 + $1.additions }
+            let deletions = model.changes.reduce(0) { $0 + $1.deletions }
+            Text("\(model.changes.count) \(model.changes.count == 1 ? "file" : "files")")
+                .foregroundStyle(.secondary)
+            if additions > 0 { Text("+\(additions)").foregroundStyle(.green) }
+            if deletions > 0 { Text("−\(deletions)").foregroundStyle(.red) }
         }
     }
 

--- a/Sources/termio/Git/GitHistoryView.swift
+++ b/Sources/termio/Git/GitHistoryView.swift
@@ -121,11 +121,19 @@ private struct CommitRow: View {
         Button(action: onTap) {
             HStack(alignment: .center, spacing: 8) {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(commit.subject)
-                        .font(font)
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+                    HStack(spacing: 6) {
+                        Text(commit.subject)
+                            .font(font)
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        // Tag chips mark release boundaries (termio releases by tagging
+                        // main); rare enough that they may squeeze the subject.
+                        ForEach(commit.tags, id: \.self) { tag in
+                            TagChip(name: tag)
+                                .layoutPriority(1)
+                        }
+                    }
                     HStack(spacing: 5) {
                         CommitAvatar(author: commit.author, chrome: chrome)
                         Text(commit.author)
@@ -139,6 +147,13 @@ private struct CommitRow: View {
                             .font(.system(size: 10, design: .monospaced))
                             .foregroundStyle(.tertiary)
                             .layoutPriority(1)
+                        if commit.isUnpushed {
+                            Image(systemName: "arrow.up")
+                                .font(.system(size: 8, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                                .layoutPriority(1)
+                                .help("Not pushed to upstream")
+                        }
                     }
                     .font(.system(size: 10.5))
                     .foregroundStyle(.secondary)
@@ -159,6 +174,21 @@ private struct CommitRow: View {
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
         .help(commit.subject)
+    }
+}
+
+/// A quiet outlined capsule naming a tag that points at the commit — a release
+/// boundary in the history, since termio cuts releases by tagging main.
+private struct TagChip: View {
+    let name: String
+
+    var body: some View {
+        Text(name)
+            .font(.system(size: 9, weight: .medium, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1.5)
+            .background(Capsule().strokeBorder(Color.primary.opacity(0.18), lineWidth: 1))
     }
 }
 

--- a/Sources/termio/Git/GitModels.swift
+++ b/Sources/termio/Git/GitModels.swift
@@ -51,6 +51,13 @@ struct GitCommit: Identifiable, Hashable, Sendable {
     let author: String
     /// Human "3 hours ago" string straight from `git log --date=relative`.
     let relativeDate: String
+    /// Tags pointing at this commit — release boundaries in termio's tag-is-the-release
+    /// flow, shown as chips on the row.
+    let tags: [String]
+    /// True when the commit hasn't reached the branch's upstream (`@{u}..HEAD`).
+    /// False everywhere when the branch has no upstream, so a purely local branch
+    /// doesn't mark every row.
+    let isUnpushed: Bool
 
     var id: String { sha }
 }

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -85,9 +85,17 @@ enum GitService {
     }
 
     /// Parses `git log` into commit rows. Fields are joined by US (`\u{1f}`) and records
-    /// by RS (`\u{1e}`), so subjects with spaces/tabs survive intact.
+    /// by RS (`\u{1e}`), so subjects with spaces/tabs survive intact. `%D` carries the
+    /// commit's decorations, from which only tags are kept (branch refs would restate
+    /// what the pane's scope and the sidebar already say).
     private static func loadLog(_ repoRoot: String, _ limit: Int) -> [GitCommit] {
-        let format = ["%H", "%h", "%s", "%an", "%ad"].joined(separator: "\u{1f}") + "\u{1e}"
+        // Commits the upstream doesn't have yet. `run` returns nil on a non-zero exit,
+        // so a branch with no upstream yields an empty set — no rows marked.
+        let unpushed = Set(
+            (run(["rev-list", "@{upstream}..HEAD"], in: repoRoot) ?? "")
+                .split(separator: "\n").map(String.init)
+        )
+        let format = ["%H", "%h", "%s", "%an", "%ad", "%D"].joined(separator: "\u{1f}") + "\u{1e}"
         guard let out = run(
             ["log", "-n", String(limit), "--date=relative", "--pretty=format:\(format)"],
             in: repoRoot
@@ -95,9 +103,13 @@ enum GitService {
         return out.components(separatedBy: "\u{1e}").compactMap { record in
             let fields = record.trimmingCharacters(in: .whitespacesAndNewlines)
                 .components(separatedBy: "\u{1f}")
-            guard fields.count == 5, !fields[0].isEmpty else { return nil }
+            guard fields.count == 6, !fields[0].isEmpty else { return nil }
+            let tags = fields[5].components(separatedBy: ", ")
+                .filter { $0.hasPrefix("tag: ") }
+                .map { String($0.dropFirst("tag: ".count)) }
             return GitCommit(sha: fields[0], shortSHA: fields[1], subject: fields[2],
-                             author: fields[3], relativeDate: fields[4])
+                             author: fields[3], relativeDate: fields[4],
+                             tags: tags, isUnpushed: unpushed.contains(fields[0]))
         }
     }
 


### PR DESCRIPTION
Follow-up to #43, completing the History decoration pass.

- **Tag chips**: `%D` decorations parsed from `git log`, keeping only `tag:` entries (branch refs would restate the pane's scope and the sidebar's worktree tree). Rendered as quiet outlined monospaced capsules beside the subject — in termio's tag-is-the-release flow these mark version boundaries right in the list.
- **Unpushed marker**: SHAs from `git rev-list @{upstream}..HEAD` get a small ↑ after the sha (tooltip "Not pushed to upstream"). No upstream → empty set, so purely local branches don't mark every row.
- **Footer removed in History**: "100 commits" just echoed the `-n 100` fetch limit. The Changes bar stays — `N files +A −D` is a real total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)