### PR TITLE
fix(status): keep a finished turn green when a turn-complete notification trails it

### DIFF
--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -800,9 +800,21 @@ extension TermioStore {
     /// notification while the user is looking elsewhere. (Claude Code emits
     /// OSC 9/99 notifications natively inside Ghostty, so this works with no
     /// per-agent configuration.) Selecting the session clears the flag.
+    ///
+    /// A `.done` session is never downgraded here. Bell and notification are
+    /// *edge* events — "something happened", not "this is my state" — and agents
+    /// fire them for turn completion as much as for being blocked: Grok posts an
+    /// OSC 777 turn-complete notification a few seconds *after* its Stop hook
+    /// (its unfocused-delay default), which would repaint the green "finished"
+    /// as the orange "waiting for you" on every tool-using turn. Once a turn has
+    /// ended, nothing can be blocked on the user, so the flag is meaningless.
+    /// The title channel keeps its right to override `done` (see
+    /// `applyTitleActivity`): a title is a *level* signal of the agent's current
+    /// state, so "Action Required" after a turn ends is a real question to you.
     private func monitor(_ state: TerminalViewState, for id: Session.ID) {
         let flag: () -> Void = { [weak self] in
-            guard let self, self.selectedSessionID != id else { return }
+            guard let self, self.selectedSessionID != id, self.statuses[id] != .done
+            else { return }
             self.statuses[id] = .needsAttention
         }
         monitors[id] = [


### PR DESCRIPTION
## Problem

A Grok session that finishes a tool-using task shows the **orange** "waiting for you" dot instead of the **green** "done" dot that Claude Code sessions get.

## Root cause

Grok's notification defaults (`[ui.notifications]`) include the `turn_complete` event, and on Ghostty its `method = auto` selects **OSC 777**. The notification is focus-gated (`condition = unfocused`, `idle_threshold_secs = 3`), so it lands a few seconds **after** the Stop hook already reported `done`:

1. Turn ends → Stop hook → `done` → green dot
2. ~3s later → OSC 777 turn-complete notification → ghostty `desktop_notification` action
3. The bell/notification monitor maps every notification to `needsAttention` → green repainted orange

Short turns stay green (they finish under the 3s unfocused threshold); every tool-using turn goes orange. Claude Code is unaffected because it doesn't notify on turn completion.

Verified empirically: PTY probes of Grok's escape output (it emits no bell, no OSC 9/99, no "Action Required" title on normal completion — only the OSC 777 under a ghostty TERM), plus a live repro via `sessions send` (working → needs-you at turn end).

## Fix

One guard in the monitor: a session that already reads `.done` is never downgraded to `needsAttention` by a bell or notification. The design line, now documented on `monitor(_:for:)`:

- **Bell/notification are edge events** — "something happened", fired for completion as much as for being blocked. Once a turn has ended, nothing can be blocked on the user, so the flag is meaningless.
- **The title channel stays senior** — a title is a level signal of the agent's current state, so "Action Required" after a turn ends is a real question and keeps its right to override `done`.

Genuinely blocked agents are unaffected: approval notifications arrive mid-turn while the session reads `working`, where the guard doesn't apply.

## Verification

Rebuilt the dev app with the fix; a tool-using Grok turn now lands green (user-confirmed in the running app).