### PR TITLE
feat(git): show real GitHub avatars in commit history

### DIFF
--- a/Sources/termio/Git/CommitAvatarStore.swift
+++ b/Sources/termio/Git/CommitAvatarStore.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Resolves commit-author emails to real GitHub avatars for the History rows — the
+/// GitHub Desktop treatment. The lookup is GitHub's unauthenticated avatar-by-email
+/// CDN endpoint (`avatars.githubusercontent.com/u/e?email=…`), which covers normal
+/// emails and the `id+login@users.noreply.github.com` form alike, so one code path
+/// serves both. No Gravatar fallback by design: avatars come from GitHub, initials
+/// otherwise — no account, no token, and the only data leaving the machine is the
+/// author email already public in the repo's history.
+///
+/// The endpoint answers an *unknown* email with `200` and one shared placeholder
+/// image rather than a 404. A real avatar is told apart by fetching that placeholder
+/// once per run (via a sentinel address no account can claim) and comparing bytes;
+/// placeholder matches are cached as misses so those rows keep their initials.
+///
+/// Caching is per-launch and in-memory: a repo's history has a handful of distinct
+/// authors, so this is a few ~1 KB fetches per run — not worth a disk cache. Fetch
+/// failures are also cached as misses for the session; the feature is cosmetic, and
+/// an offline launch shouldn't retry per row while scrolling.
+actor CommitAvatarStore {
+    static let shared = CommitAvatarStore()
+
+    /// Email (lowercased) → avatar image bytes, with `nil` for a known miss.
+    private var cache: [String: Data?] = [:]
+    private var inFlight: [String: Task<Data?, Never>] = [:]
+    private var placeholderTask: Task<Data?, Never>?
+
+    /// The avatar image bytes for a commit author, or `nil` when the email has no
+    /// GitHub account (or the network is down). Coalesces concurrent requests for
+    /// the same email so a burst of appearing rows costs one fetch per author.
+    func imageData(for email: String) async -> Data? {
+        let key = email.lowercased()
+        if let cached = cache[key] { return cached }
+        if let running = inFlight[key] { return await running.value }
+        let task = Task { await self.fetch(key) }
+        inFlight[key] = task
+        let data = await task.value
+        cache[key] = data
+        inFlight[key] = nil
+        return data
+    }
+
+    private func fetch(_ email: String) async -> Data? {
+        guard email.contains("@"), let url = Self.avatarURL(email),
+              let data = await Self.download(url) else { return nil }
+        if let placeholder = await placeholder(), data == placeholder { return nil }
+        return data
+    }
+
+    /// GitHub's shared unknown-email image, fetched lazily once per run using an
+    /// address in a reserved domain no account can hold. `nil` (fetch failed) means
+    /// real avatars can't be told from the placeholder — but in that case the real
+    /// fetches are failing too, so nothing is misclassified in practice.
+    private func placeholder() async -> Data? {
+        if let placeholderTask { return await placeholderTask.value }
+        let task = Task<Data?, Never> {
+            guard let url = Self.avatarURL("no-such-user@avatar.invalid") else { return nil }
+            return await Self.download(url)
+        }
+        placeholderTask = task
+        return await task.value
+    }
+
+    /// `s=64` covers the 15 pt row circle on a 3× display with headroom.
+    private static func avatarURL(_ email: String) -> URL? {
+        var components = URLComponents(string: "https://avatars.githubusercontent.com/u/e")
+        components?.queryItems = [
+            URLQueryItem(name: "email", value: email),
+            URLQueryItem(name: "s", value: "64"),
+        ]
+        return components?.url
+    }
+
+    private static func download(_ url: URL) async -> Data? {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200, !data.isEmpty
+        else { return nil }
+        return data
+    }
+}

--- a/Sources/termio/Git/GitHistoryView.swift
+++ b/Sources/termio/Git/GitHistoryView.swift
@@ -135,7 +135,7 @@ private struct CommitRow: View {
                         }
                     }
                     HStack(spacing: 5) {
-                        CommitAvatar(author: commit.author, chrome: chrome)
+                        CommitAvatar(author: commit.author, email: commit.authorEmail, chrome: chrome)
                         Text(commit.author)
                             .lineLimit(1)
                         Text("·").foregroundStyle(.tertiary)
@@ -192,25 +192,44 @@ private struct TagChip: View {
     }
 }
 
-/// A small circular initials avatar riding in the metadata line (GitHub Desktop's
-/// placement — a 24pt leading avatar column read as a loud repeated stripe when one
-/// author dominates). Filled in the chrome accent so it derives from the terminal theme
-/// like the rest of termio's chrome (one source of color truth) rather than a per-author
-/// rainbow hue.
+/// A small circular avatar riding in the metadata line (GitHub Desktop's placement —
+/// a 24pt leading avatar column read as a loud repeated stripe when one author
+/// dominates). The author's real GitHub avatar when `CommitAvatarStore` resolves one
+/// from the commit email; otherwise an initials circle filled in the chrome accent so
+/// it derives from the terminal theme like the rest of termio's chrome (one source of
+/// color truth) rather than a per-author rainbow hue.
 private struct CommitAvatar: View {
     let author: String
+    let email: String
     let chrome: ChromeTheme?
 
+    @State private var avatar: NSImage?
+
     var body: some View {
-        Circle()
-            .fill((chrome?.accent ?? .accentColor).gradient)
-            .frame(width: 15, height: 15)
-            .overlay(
-                Text(initials)
-                    .font(.system(size: 6.5, weight: .semibold))
-                    .foregroundStyle(.white)
-            )
-            .help(author)
+        Group {
+            if let avatar {
+                Image(nsImage: avatar)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 15, height: 15)
+                    .clipShape(Circle())
+            } else {
+                Circle()
+                    .fill((chrome?.accent ?? .accentColor).gradient)
+                    .frame(width: 15, height: 15)
+                    .overlay(
+                        Text(initials)
+                            .font(.system(size: 6.5, weight: .semibold))
+                            .foregroundStyle(.white)
+                    )
+            }
+        }
+        .help(author)
+        .task(id: email) {
+            guard avatar == nil,
+                  let data = await CommitAvatarStore.shared.imageData(for: email) else { return }
+            avatar = NSImage(data: data)
+        }
     }
 
     private var initials: String {

--- a/Sources/termio/Git/GitModels.swift
+++ b/Sources/termio/Git/GitModels.swift
@@ -49,6 +49,8 @@ struct GitCommit: Identifiable, Hashable, Sendable {
     let shortSHA: String
     let subject: String
     let author: String
+    /// Author email, the key `CommitAvatarStore` resolves to a GitHub avatar.
+    let authorEmail: String
     /// Human "3 hours ago" string straight from `git log --date=relative`.
     let relativeDate: String
     /// Tags pointing at this commit — release boundaries in termio's tag-is-the-release

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -95,7 +95,7 @@ enum GitService {
             (run(["rev-list", "@{upstream}..HEAD"], in: repoRoot) ?? "")
                 .split(separator: "\n").map(String.init)
         )
-        let format = ["%H", "%h", "%s", "%an", "%ad", "%D"].joined(separator: "\u{1f}") + "\u{1e}"
+        let format = ["%H", "%h", "%s", "%an", "%ae", "%ad", "%D"].joined(separator: "\u{1f}") + "\u{1e}"
         guard let out = run(
             ["log", "-n", String(limit), "--date=relative", "--pretty=format:\(format)"],
             in: repoRoot
@@ -103,12 +103,12 @@ enum GitService {
         return out.components(separatedBy: "\u{1e}").compactMap { record in
             let fields = record.trimmingCharacters(in: .whitespacesAndNewlines)
                 .components(separatedBy: "\u{1f}")
-            guard fields.count == 6, !fields[0].isEmpty else { return nil }
-            let tags = fields[5].components(separatedBy: ", ")
+            guard fields.count == 7, !fields[0].isEmpty else { return nil }
+            let tags = fields[6].components(separatedBy: ", ")
                 .filter { $0.hasPrefix("tag: ") }
                 .map { String($0.dropFirst("tag: ".count)) }
             return GitCommit(sha: fields[0], shortSHA: fields[1], subject: fields[2],
-                             author: fields[3], relativeDate: fields[4],
+                             author: fields[3], authorEmail: fields[4], relativeDate: fields[5],
                              tags: tags, isUnpushed: unpushed.contains(fields[0]))
         }
     }


### PR DESCRIPTION
## What

The History tab's commit rows now show the author's real GitHub avatar (the GitHub Desktop treatment) instead of always the initials circle. Initials remain the fallback while loading, offline, or for authors with no GitHub account.

## How

- `git log` now also asks for `%ae`, carried as `GitCommit.authorEmail`.
- New `CommitAvatarStore` actor resolves emails via GitHub's unauthenticated avatar-by-email CDN endpoint (`avatars.githubusercontent.com/u/e?email=…`), which covers both normal emails and `id+login@users.noreply.github.com` — one code path, no token, no Gravatar.
- The endpoint answers unknown emails with `200` + one shared placeholder image; a once-per-run sentinel fetch identifies that image by byte-compare so those rows keep their initials.
- Lookups are coalesced per email and cached in memory for the session (a repo's history has few distinct authors, so this is a handful of ~1 KB fetches per launch).

## Privacy note

The only data leaving the machine is the commit author email — already public in the repo's history — sent to GitHub's avatar CDN. No Gravatar fallback by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)