### PR TITLE
feat(files): expand explorer row menu + auto-refresh the tree

### DIFF
--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -21,6 +21,9 @@ struct FileBrowserView: View {
     /// Bumped to collapse the whole tree: it is the file list's `.id`, so changing it
     /// rebuilds the list fresh — and a fresh `List(children:)` starts fully collapsed.
     @State private var treeGeneration = 0
+    /// Watches the project root on disk and bumps its `changeToken` when anything under
+    /// it changes, so the tree stays live with an agent's edits (see `onChange` below).
+    @StateObject private var watcher = FileTreeWatcher()
 
     /// The directory the tree is rooted at: the selected session's worktree if it
     /// has one, otherwise its project folder. `nil` when nothing is selected.
@@ -96,10 +99,19 @@ struct FileBrowserView: View {
             guard let projectPath else { return false }
             return receive(urls, into: URL(fileURLWithPath: projectPath))
         }
-        .onAppear { refresh(); seedChangeCount() }
+        .onAppear { refresh(); seedChangeCount(); watcher.watch(projectPath) }
+        .onDisappear { watcher.watch(nil) }
         .onChange(of: projectPath) {
             refresh()
             seedChangeCount()
+            watcher.watch(projectPath)
+        }
+        // The project root changed on disk (an agent wrote, renamed, or removed a
+        // file): rebuild the tree from disk. Keep the Changes badge fresh too, unless
+        // the Changes pane is open — it owns the count live while visible.
+        .onChange(of: watcher.changeToken) {
+            refresh()
+            if store.inspectorTab != .changes { seedChangeCount() }
         }
         .onChange(of: browserState.selection) {
             // The table fires native selection on a clean click — reliably, unlike a
@@ -296,6 +308,7 @@ struct FileBrowserView: View {
         FileTreeActions(
             newFile: { createFile(in: $0) },
             newFolder: { createFolder(in: $0) },
+            rename: { rename($0) },
             delete: { delete($0) }
         )
     }
@@ -327,6 +340,35 @@ struct FileBrowserView: View {
         }
     }
 
+    /// Prompts for a new name (pre-filled with the current one) and renames `url` in
+    /// place. If the renamed file was selected — and so open in the editor — the
+    /// selection moves to the new URL and it is re-activated, so the editor follows
+    /// the rename instead of holding (and auto-saving back) the old path.
+    private func rename(_ url: URL) {
+        guard let name = promptForName(title: "Rename “\(url.lastPathComponent)”", defaultName: url.lastPathComponent, buttonTitle: "Rename"),
+              name != url.lastPathComponent
+        else { return }
+        let target = url.deletingLastPathComponent().appendingPathComponent(name)
+        guard !FileManager.default.fileExists(atPath: target.path) else {
+            let alert = NSAlert()
+            alert.messageText = "“\(name)” already exists."
+            alert.informativeText = "Choose a different name."
+            alert.runModal()
+            return
+        }
+        do {
+            let wasSelected = browserState.selection == url
+            try FileManager.default.moveItem(at: url, to: target)
+            refresh()
+            if wasSelected {
+                browserState.selection = target
+                if !isDirectory(target) { onActivate(target) }
+            }
+        } catch {
+            Log.files.error("failed to rename \(url.path, privacy: .public) to \(target.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     /// Moves `url` to the Trash after a confirm — recoverable, not an unlink — clears
     /// it from the selection, and refreshes.
     private func delete(_ url: URL) {
@@ -347,10 +389,10 @@ struct FileBrowserView: View {
 
     /// A modal name prompt — one text field in an `NSAlert`, pre-filled with
     /// `defaultName`. Returns the trimmed entry, or `nil` if cancelled or emptied.
-    private func promptForName(title: String, defaultName: String) -> String? {
+    private func promptForName(title: String, defaultName: String, buttonTitle: String = "Create") -> String? {
         let alert = NSAlert()
         alert.messageText = title
-        alert.addButton(withTitle: "Create")
+        alert.addButton(withTitle: buttonTitle)
         alert.addButton(withTitle: "Cancel")
         let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
         field.stringValue = defaultName

--- a/Sources/termio/FileBrowser/FileTreeControls.swift
+++ b/Sources/termio/FileBrowser/FileTreeControls.swift
@@ -60,11 +60,14 @@ struct TreeHeaderButton: View {
 }
 
 /// The right-click menu actions the tree's rows invoke: `newFile`/`newFolder`
-/// (created inside the given directory) and `delete`. Bundled so `FileRow` carries
-/// one value rather than three closures. (Single-click open is driven by the List's
-/// native selection, not a row action — see `FileBrowserView`.)
+/// (created inside the given directory), `rename`, and `delete`. Bundled so
+/// `FileRow` carries one value rather than a fistful of closures. (Single-click
+/// open is driven by the List's native selection, not a row action — see
+/// `FileBrowserView`. Reveal in Finder / Copy Path need no view state, so they
+/// live directly in the row menu.)
 struct FileTreeActions {
     let newFile: (_ directory: URL) -> Void
     let newFolder: (_ directory: URL) -> Void
+    let rename: (URL) -> Void
     let delete: (URL) -> Void
 }

--- a/Sources/termio/FileBrowser/FileTreeList.swift
+++ b/Sources/termio/FileBrowser/FileTreeList.swift
@@ -28,7 +28,7 @@ struct FileTreeList: View {
         // outline view's `selectionHighlightStyle = .none` (see `FileRow`), leaving our
         // own `SidebarRowHighlight` as the sole, left-sidebar-matching selection cue.
         List(nodes, children: \.children, selection: $selection) { node in
-            FileRow(node: node, font: font, isSelected: selection == node.url, onDrop: onDrop, actions: actions, captureOutline: captureOutline)
+            FileRow(node: node, font: font, isSelected: selection == node.url, onDrop: onDrop, rootURL: rootURL, actions: actions, captureOutline: captureOutline)
                 .listRowSeparator(.hidden)
         }
         .listStyle(.plain)
@@ -57,6 +57,8 @@ private struct FileRow: View {
     let font: Font
     let isSelected: Bool
     let onDrop: (_ sources: [URL], _ destination: URL) -> Bool
+    /// The project root — the base "Copy Relative Path" resolves against.
+    let rootURL: URL
     let actions: FileTreeActions
     /// Reports the hosting outline view up to `FileBrowserView` (see `FileTreeList`).
     let captureOutline: (NSOutlineView?) -> Void
@@ -134,11 +136,13 @@ private struct FileRow: View {
         // Right-click menu via an AppKit `NSMenu`, NOT SwiftUI's `.contextMenu` —
         // the latter paints an accent highlight ring around the targeted row that
         // can't be styled off. New File / New Folder appear only for a folder (they
-        // create inside it); a file gets just Delete. The empty area below the rows
-        // has its own root menu (see `EmptyAreaContextMenu`).
+        // create inside it); every row gets Reveal in Finder, Copy Path, Rename,
+        // Delete. The empty area below the rows has its own root menu (see
+        // `EmptyAreaContextMenu`).
         .background(RowContextMenu(
             isDirectory: node.isDirectory,
             target: node.url,
+            rootURL: rootURL,
             actions: actions
         ))
 
@@ -160,10 +164,12 @@ private struct FileRow: View {
 /// `.contextMenu` — the latter rings the targeted row with an un-styleable accent
 /// highlight. A secondary-click recognizer on the row's own view pops the menu up,
 /// so nothing emphasizes the row. New File / New Folder appear only for a folder
-/// (created inside it); a file gets just Delete.
+/// (created inside it); every row gets Reveal in Finder, Copy Path / Copy Relative
+/// Path, Rename, and Delete.
 private struct RowContextMenu: NSViewRepresentable {
     let isDirectory: Bool
     let target: URL
+    let rootURL: URL
     let actions: FileTreeActions
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -171,13 +177,13 @@ private struct RowContextMenu: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
         context.coordinator.owner = view
-        context.coordinator.configure(isDirectory: isDirectory, target: target, actions: actions)
+        context.coordinator.configure(isDirectory: isDirectory, target: target, rootURL: rootURL, actions: actions)
         context.coordinator.attach()
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        context.coordinator.configure(isDirectory: isDirectory, target: target, actions: actions)
+        context.coordinator.configure(isDirectory: isDirectory, target: target, rootURL: rootURL, actions: actions)
         context.coordinator.attach()
     }
 
@@ -190,13 +196,15 @@ private struct RowContextMenu: NSViewRepresentable {
         weak var owner: NSView?
         private var isDirectory = false
         private var target = URL(fileURLWithPath: "/")
+        private var rootURL = URL(fileURLWithPath: "/")
         private var actions: FileTreeActions?
         private weak var hostView: NSView?
         private var recognizer: NSClickGestureRecognizer?
 
-        func configure(isDirectory: Bool, target: URL, actions: FileTreeActions) {
+        func configure(isDirectory: Bool, target: URL, rootURL: URL, actions: FileTreeActions) {
             self.isDirectory = isDirectory
             self.target = target
+            self.rootURL = rootURL
             self.actions = actions
         }
 
@@ -228,6 +236,12 @@ private struct RowContextMenu: NSViewRepresentable {
                 menu.addItem(menuItem("New Folder", #selector(newFolder)))
                 menu.addItem(.separator())
             }
+            menu.addItem(menuItem("Reveal in Finder", #selector(revealInFinder)))
+            menu.addItem(.separator())
+            menu.addItem(menuItem("Copy Path", #selector(copyPath)))
+            menu.addItem(menuItem("Copy Relative Path", #selector(copyRelativePath)))
+            menu.addItem(.separator())
+            menu.addItem(menuItem("Rename…", #selector(rename)))
             menu.addItem(menuItem("Delete", #selector(deleteItem)))
             menu.popUp(positioning: nil, at: recognizer.location(in: hostView), in: hostView)
         }
@@ -240,7 +254,34 @@ private struct RowContextMenu: NSViewRepresentable {
 
         @objc private func newFile() { actions?.newFile(target) }
         @objc private func newFolder() { actions?.newFolder(target) }
+        @objc private func rename() { actions?.rename(target) }
         @objc private func deleteItem() { actions?.delete(target) }
+
+        @objc private func revealInFinder() {
+            NSWorkspace.shared.activateFileViewerSelecting([target])
+        }
+
+        @objc private func copyPath() {
+            setPasteboard(target.path)
+        }
+
+        /// The path relative to the project root — the form agents and build tools
+        /// take; falls back to the absolute path for anything outside the root.
+        @objc private func copyRelativePath() {
+            let rootPath = rootURL.standardizedFileURL.path
+            let path = target.standardizedFileURL.path
+            if path.hasPrefix(rootPath + "/") {
+                setPasteboard(String(path.dropFirst(rootPath.count + 1)))
+            } else {
+                setPasteboard(path)
+            }
+        }
+
+        private func setPasteboard(_ string: String) {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(string, forType: .string)
+        }
 
         private static func rowView(above view: NSView) -> NSView? {
             var ancestor = view.superview

--- a/Sources/termio/FileBrowser/FileTreeWatcher.swift
+++ b/Sources/termio/FileBrowser/FileTreeWatcher.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// A recursive filesystem watch over the file tree's root, so the explorer picks up
+/// files an agent (or any outside tool) creates, renames, or deletes without waiting
+/// for the manual Refresh button. Owns one `FolderEventStream` at a time, restarting
+/// it when the root moves, and coalesces bursts into a single `changeToken` bump — the
+/// view rebuilds the whole tree from disk on each bump, so *which* path changed doesn't
+/// matter, only that something did.
+@MainActor
+final class FileTreeWatcher: ObservableObject {
+    /// Bumped once per settled change; observed by `FileBrowserView` to rebuild.
+    @Published private(set) var changeToken = 0
+
+    private var stream: FolderEventStream?
+    private var watchedPath: String?
+    private var debounce: DispatchWorkItem?
+
+    /// (Re)starts the recursive watch on `path`, tearing down any prior watch. A nil
+    /// path (nothing selected) just stops watching. A no-op when the path is unchanged,
+    /// so the every-render `onChange`/`onAppear` calls don't churn the stream.
+    func watch(_ path: String?) {
+        guard path != watchedPath else { return }
+        watchedPath = path
+        debounce?.cancel()
+        stream = nil
+        guard let path else { return }
+        // Deliver on the main queue so `scheduleTick` can safely touch this main-actor
+        // object; FSEvents' own latency window gives a first coalescing pass.
+        stream = FolderEventStream(paths: [path], latency: 0.3, queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.scheduleTick() }
+        }
+    }
+
+    /// A second, short coalescing step beyond FSEvents' latency, so a storm of
+    /// callbacks (a git checkout, an npm install) collapses into one tree rebuild
+    /// shortly after the disk settles rather than one per callback.
+    private func scheduleTick() {
+        debounce?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.changeToken += 1 }
+        debounce = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
+    }
+}


### PR DESCRIPTION
## What

Two additions to the inspector file explorer.

**Row context menu** — a file previously had only **Delete**. Now every row also gets:
- **Reveal in Finder**
- **Copy Path** / **Copy Relative Path** (relative resolves against the project root — the form you'd hand an agent)
- **Rename…** — reuses the existing name-prompt alert, refuses to clobber an existing name, and re-selects the renamed URL so an open editor follows the move instead of auto-saving the old path back into existence.

**Auto-refresh** — a new `FileTreeWatcher` owns a recursive FSEvents watch over the project root (reusing the git pane's `FolderEventStream`) and rebuilds the tree when files change on disk. So files an agent creates/renames/deletes in the terminal appear on their own, without the manual Refresh button. Bursts (git checkout, npm install) are coalesced by FSEvents' latency window plus a short debounce into a single rebuild; the watch restarts when the project moves and stops when the inspector disappears. Outline expansion state survives the rebuild (node identity is the URL).

## Notes
- Folder rows keep New File / New Folder above the shared items.
- The Changes badge is re-seeded on disk changes, except while the Changes pane is open (it owns the count live there).

## Test
- Built clean against `origin/main` (`swift build`).
- Manually: right-click files/folders for the new menu; create/rename/delete a file from the terminal and watch the tree update itself.