### PR TITLE
feat(editor): Xcode-feel pass on the LSP gestures

### DIFF
--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -49,6 +49,9 @@ struct FileEditorView: View {
     /// A registered-but-not-installed server for this file's language: the header shows its
     /// install command once (Zed's meet-the-file-where-it-is pattern, minus the store).
     @State private var installHint: LSPServerDescriptor?
+    /// A transient footer line for slow LSP work ("Starting sourcekit-lsp…") — silence reads
+    /// as broken during a cold server start.
+    @State private var lspActivity: String?
 
     /// The highlight.js language id, sniffed once from the file extension (`nil` lets highlight.js
     /// auto-detect). Stable for the lifetime of the open file.
@@ -158,6 +161,11 @@ struct FileEditorView: View {
                             onDefinitionRequest: lsp == nil ? nil : jumpToDefinition,
                             hoverProvider: lsp == nil ? nil : { [self] offset in
                                 await lsp?.hover(at: offset, in: text)
+                            },
+                            linkResolver: lsp == nil ? nil : { [self] offset in
+                                // The probe result is memoized in the client, so the click that
+                                // follows a lit link costs no second request.
+                                await lsp?.definition(at: offset, in: text) != nil
                             }
                         )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -188,7 +196,15 @@ struct FileEditorView: View {
         .task {
             guard !loadFailed else { return }
             let opened = text
-            guard let client = await LSPEditorClient.attach(url: url, text: opened) else {
+            // Xcode-style activity whisper: only a slow start earns a footer line — a warm
+            // server attaches in milliseconds and should stay invisible.
+            let notice = slowActivityNotice(
+                LSPRegistry.descriptor(for: url).map { "Starting \($0.descriptor.id)…" }
+            )
+            let client = await LSPEditorClient.attach(url: url, text: opened)
+            notice.cancel()
+            lspActivity = nil
+            guard let client else {
                 // No server came up. If one is registered but just not installed, surface its
                 // install command — only in an editable open; a read-only peek stays silent.
                 if !readOnly { installHint = await LSPManager.shared.missingServer(for: url) }
@@ -339,6 +355,13 @@ struct FileEditorView: View {
                 // Mark the peek so the absent caret/typing doesn't read as the editor being broken.
                 statusItem("Read-Only")
             }
+            // The LSP activity whisper — "Starting sourcekit-lsp…", "Looking up definition…" —
+            // shown only when the work is actually slow, gone the moment it lands.
+            if let lspActivity {
+                statusItem(lspActivity)
+                    .foregroundStyle(.tertiary)
+                    .transition(.opacity)
+            }
             Spacer()
             if isMarkdown && mode == .preview {
                 // No caret in the rendered view — name the mode so the missing Ln/Col reads right.
@@ -392,13 +415,28 @@ struct FileEditorView: View {
         onClose()
     }
 
+    /// Arms a delayed footer status line: fast work never shows it (cancel before the delay),
+    /// slow work earns a quiet whisper instead of dead silence. Caller cancels + clears.
+    private func slowActivityNotice(_ message: String?, after delay: UInt64 = 400_000_000) -> Task<Void, Never> {
+        Task { @MainActor in
+            guard let message else { return }
+            try? await Task.sleep(nanoseconds: delay)
+            if Task.isCancelled { return }
+            withAnimation(.easeIn(duration: 0.15)) { lspActivity = message }
+        }
+    }
+
     /// Resolves the symbol at `utf16Offset` through the language server. A same-file hit reuses
     /// the reveal plumbing in place; a cross-file hit hands the target to the host, which swaps
     /// the overlay (`.id(url)`) exactly like clicking another search result. No answer → a beep,
     /// the quietest possible "nothing there".
     private func jumpToDefinition(at utf16Offset: Int) {
         Task { @MainActor in
-            guard let lsp, let hit = await lsp.definition(at: utf16Offset, in: text) else {
+            let notice = slowActivityNotice("Looking up definition…")
+            let hit = await lsp?.definition(at: utf16Offset, in: text)
+            notice.cancel()
+            lspActivity = nil
+            guard let hit else {
                 NSSound.beep()
                 return
             }

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -33,6 +33,10 @@ struct HighlightedTextView: NSViewRepresentable {
     /// Hover documentation: given the UTF-16 offset under a dwelling ⌘-hover, returns the
     /// markdown to show in a popover (`nil` shows nothing).
     var hoverProvider: ((Int) async -> String?)? = nil
+    /// The honest-underline probe: does the symbol at this offset actually resolve to a
+    /// definition? The ⌘-hover link only lights when this answers true, so an underline is a
+    /// promise a click can keep — Xcode's contract. `nil` falls back to lexical underlining.
+    var linkResolver: ((Int) async -> Bool)? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator(text: $text, cursor: $cursor) }
 
@@ -55,6 +59,7 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.onSave = onSave
         textView.onDefinitionRequest = onDefinitionRequest
         textView.hoverProvider = hoverProvider
+        textView.linkResolver = linkResolver
         textView.delegate = context.coordinator
         textView.isEditable = isEditable
         textView.isSelectable = true
@@ -126,6 +131,7 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.onSave = onSave
         textView.onDefinitionRequest = onDefinitionRequest
         textView.hoverProvider = hoverProvider
+        textView.linkResolver = linkResolver
         if textView.isEditable != isEditable { textView.isEditable = isEditable }
         let coordinator = context.coordinator
         let storage = coordinator.textStorage
@@ -173,8 +179,10 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.insertionPointColor = caretColor
         if let saving = textView as? SavingTextView {
             saving.currentLineColor = currentLineColor
-            // The matched pair glows in the caret's own accent, dimmed to a wash.
+            // The matched pair glows in the caret's own accent, dimmed to a wash; a lit
+            // ⌘-hover link takes the accent at full strength — Xcode's symbol-turns-blue.
             saving.bracketHighlightColor = caretColor.withAlphaComponent(0.28)
+            saving.linkColor = caretColor
         }
     }
 
@@ -234,6 +242,8 @@ struct HighlightedTextView: NSViewRepresentable {
             guard let textView = notification.object as? NSTextView else { return }
             text.wrappedValue = textView.string
             ruler?.needsDisplay = true
+            // Every cached link-probe answer keyed on the old text is stale now.
+            (textView as? SavingTextView)?.bufferChanged()
         }
 
         func textViewDidChangeSelection(_ notification: Notification) {
@@ -267,6 +277,9 @@ private final class SavingTextView: NSTextView {
         didSet { if (onDefinitionRequest == nil) != (oldValue == nil) { updateTrackingAreas() } }
     }
     var hoverProvider: ((Int) async -> String?)?
+    /// Does the symbol at this offset resolve to a definition? Confirms a candidate before it
+    /// lights up (`nil` = light lexically, the pre-probe behavior).
+    var linkResolver: ((Int) async -> Bool)?
     /// Full-width wash under the caret's line; `.clear` (or a read-only buffer) draws nothing.
     var currentLineColor: NSColor = .clear { didSet { needsDisplay = true } }
     /// Background wash on a bracket pair when the caret sits against one of them.
@@ -282,6 +295,14 @@ private final class SavingTextView: NSTextView {
     /// The armed dwell → hover-popover chain, cancelled whenever the target changes.
     private var hoverTask: Task<Void, Never>?
     private var hoverPopover: NSPopover?
+    /// The hovered identifier whose definition probe is still in flight.
+    private var candidateRange: NSRange?
+    private var resolveTask: Task<Void, Never>?
+    /// Probe answers for the current buffer version (cleared on every edit), so re-hovering a
+    /// word doesn't re-ask the server.
+    private var linkCache: [NSRange: Bool] = [:]
+    /// The accent a confirmed link lights up in (set alongside the caret color).
+    var linkColor: NSColor = .linkColor
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -408,6 +429,11 @@ private final class SavingTextView: NSTextView {
         ))
     }
 
+    /// The honest-underline flow: hovering an identifier under ⌘ makes it a *candidate*; a short
+    /// debounce later the resolver confirms a definition actually exists, and only then does the
+    /// word light up in the accent (color + underline + hand) — so, like Xcode, a lit link is a
+    /// promise the click can keep. ⌘-click itself still *attempts* anywhere (a cold server may
+    /// not have resolved the probe yet); the light is honesty, not a gate.
     override func mouseMoved(with event: NSEvent) {
         super.mouseMoved(with: event)
         guard onDefinitionRequest != nil,
@@ -418,14 +444,43 @@ private final class SavingTextView: NSTextView {
             clearLink()
             return
         }
-        guard range != linkRange else { return }
+        if range == linkRange || range == candidateRange { return }
         clearLink()
+        candidateRange = range
+        armHover(for: range)
+        guard let linkResolver else { light(range); return } // no probe → lexical fallback
+        if let known = linkCache[range] {
+            if known { light(range) }
+            return
+        }
+        resolveTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 90_000_000) // let the cursor travel settle
+            if Task.isCancelled { return }
+            let resolved = await linkResolver(range.location)
+            if Task.isCancelled { return }
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.linkCache[range] = resolved
+                guard resolved, self.candidateRange == range,
+                      NSEvent.modifierFlags.contains(.command) else { return }
+                self.light(range)
+            }
+        }
+    }
+
+    /// Turns the confirmed identifier into a link: accent ink, accent underline, hand cursor —
+    /// all temporary attributes, so the Highlightr storage never notices.
+    private func light(_ range: NSRange) {
         linkRange = range
         layoutManager?.addTemporaryAttributes(
-            [.underlineStyle: NSUnderlineStyle.single.rawValue, .cursor: NSCursor.pointingHand],
+            [
+                .underlineStyle: NSUnderlineStyle.single.rawValue,
+                .underlineColor: linkColor,
+                .foregroundColor: linkColor,
+                .cursor: NSCursor.pointingHand,
+            ],
             forCharacterRange: range
         )
-        armHover(for: range)
     }
 
     override func mouseExited(with event: NSEvent) {
@@ -441,11 +496,10 @@ private final class SavingTextView: NSTextView {
     override func mouseDown(with event: NSEvent) {
         if event.modifierFlags.contains(.command),
            let onDefinitionRequest,
-           let range = linkRange,
            let index = characterIndex(at: event.locationInWindow),
-           NSLocationInRange(index, range) {
+           let range = identifierRange(at: index) {
             // Swallow the click: stock ⌘-click starts a discontiguous selection, which would
-            // fight the jump.
+            // fight the jump. The jump is attempted even if the probe hasn't lit the word yet.
             clearLink()
             onDefinitionRequest(range.location)
             return
@@ -459,15 +513,26 @@ private final class SavingTextView: NSTextView {
         super.scrollWheel(with: event)
     }
 
+    /// The buffer changed: every cached probe answer and lit range is stale.
+    func bufferChanged() {
+        linkCache.removeAll()
+        clearLink()
+    }
+
     private func clearLink() {
         hoverTask?.cancel()
         hoverTask = nil
+        resolveTask?.cancel()
+        resolveTask = nil
+        candidateRange = nil
         hoverPopover?.close()
         hoverPopover = nil
         guard let range = linkRange else { return }
         linkRange = nil
         guard let clamped = Self.clamp(range, to: (string as NSString).length) else { return }
         layoutManager?.removeTemporaryAttribute(.underlineStyle, forCharacterRange: clamped)
+        layoutManager?.removeTemporaryAttribute(.underlineColor, forCharacterRange: clamped)
+        layoutManager?.removeTemporaryAttribute(.foregroundColor, forCharacterRange: clamped)
         layoutManager?.removeTemporaryAttribute(.cursor, forCharacterRange: clamped)
     }
 
@@ -551,7 +616,7 @@ private final class SavingTextView: NSTextView {
 
         let popover = NSPopover()
         popover.behavior = .transient
-        popover.animates = false
+        popover.animates = true // the soft system fade Quick Help has
         let controller = NSViewController()
         controller.view = NSHostingView(rootView: LSPHoverContent(markdown: markdown))
         popover.contentViewController = controller
@@ -560,15 +625,34 @@ private final class SavingTextView: NSTextView {
     }
 }
 
-/// The hover popover's body: the server's markdown, code-styled where fenced, capped to a
-/// readable column and height. Deliberately plain — a tooltip, not a browser.
+/// The hover popover's body, shaped like Xcode's Quick Help: the declaration (the leading fenced
+/// code block, which is how every mainstream server opens its hover) sits in a monospaced chip,
+/// a divider separates it from the documentation prose, further code blocks stay monospaced.
+/// Still a tooltip, not a browser.
 private struct LSPHoverContent: View {
     let markdown: String
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 6) {
-                ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+        let segments = segments
+        let declaration = segments.first?.isCode == true ? segments[0].text : nil
+        let rest = declaration == nil ? segments : Array(segments.dropFirst())
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                if let declaration {
+                    Text(declaration)
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .textSelection(.enabled)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(Color.primary.opacity(0.05))
+                        )
+                }
+                if declaration != nil, !rest.isEmpty {
+                    Divider()
+                }
+                ForEach(Array(rest.enumerated()), id: \.offset) { _, segment in
                     if segment.isCode {
                         Text(segment.text)
                             .font(.system(size: 11.5, design: .monospaced))
@@ -576,6 +660,7 @@ private struct LSPHoverContent: View {
                     } else {
                         Text(attributed(segment.text))
                             .font(.system(size: 12))
+                            .foregroundStyle(.primary.opacity(0.85))
                             .textSelection(.enabled)
                     }
                 }

--- a/Sources/termio/Editor/LSP/LSPEditorClient.swift
+++ b/Sources/termio/Editor/LSP/LSPEditorClient.swift
@@ -15,6 +15,9 @@ final class LSPEditorClient {
     /// flush first, so a jump right after typing still resolves against the current text.
     private var unsentText: String?
     private var changeTask: Task<Void, Never>?
+    /// The last definition answer, keyed by offset and invalidated on every edit — the ⌘-hover
+    /// probe and the click that follows it become one server request instead of two.
+    private var definitionMemo: (offset: Int, target: (url: URL, line: Int)?)?
 
     /// Opens `url` against its project's server. `nil` when no server owns the file — the caller
     /// leaves every LSP hook dormant.
@@ -43,6 +46,7 @@ final class LSPEditorClient {
     /// (a rangeless change event is a full replace — every mainstream server accepts it, and it
     /// sidesteps incremental-diff bookkeeping entirely).
     func noteChange(fullText: String) {
+        definitionMemo = nil
         unsentText = fullText
         changeTask?.cancel()
         changeTask = Task {
@@ -72,6 +76,7 @@ final class LSPEditorClient {
     /// when the server has no answer. Multiple candidates collapse to the first — good enough for
     /// a jump, and menus can come later if it ever matters.
     func definition(at utf16Offset: Int, in text: String) async -> (url: URL, line: Int)? {
+        if let memo = definitionMemo, memo.offset == utf16Offset { return memo.target }
         await flushPendingChange()
         let position = TextPositions.position(utf16Offset: utf16Offset, in: text as NSString)
         let response: DefinitionResponse
@@ -81,9 +86,15 @@ final class LSPEditorClient {
             Log.lsp.error("definition failed: \(String(describing: error), privacy: .public)")
             return nil
         }
-        guard let hit = Self.firstTarget(in: response) else { return nil }
-        guard let url = URL(string: hit.uri), url.isFileURL else { return nil }
-        return (url.standardizedFileURL, hit.range.start.line + 1)
+        let target: (url: URL, line: Int)?
+        if let hit = Self.firstTarget(in: response),
+           let url = URL(string: hit.uri), url.isFileURL {
+            target = (url.standardizedFileURL, hit.range.start.line + 1)
+        } else {
+            target = nil
+        }
+        definitionMemo = (utf16Offset, target)
+        return target
     }
 
     private static func firstTarget(in response: DefinitionResponse) -> (uri: DocumentUri, range: LSPRange)? {


### PR DESCRIPTION
The three Apple-feel gaps from the PR #47 retrospective (Go Back deliberately excluded by user choice):

1. **Honest underline** — ⌘-hover now probes `textDocument/definition` (90ms debounce, cached per buffer version) and only lights the identifier — accent color + underline + hand — when a definition actually exists. Xcode's contract: a lit link is a promise the click can keep. Previously any identifier-shaped word (keywords, comment words) underlined lexically and clicking could just beep. The probe result is memoized in the client, so the click following a lit link costs no second server request. ⌘-click still *attempts* anywhere — the light is honesty, not a gate — so first-click-on-cold-server keeps working.
2. **Cold-start feedback** — slow LSP work shows a quiet tertiary footer line (`Starting sourcekit-lsp…` / `Looking up definition…`) that only appears past 400ms and clears when the work lands. Warm paths never see it.
3. **Quick Help-shaped hover** — the leading fenced code block renders as a monospaced declaration chip, divider, then documentation prose; popover uses the system fade.

Verified: `swift build` clean, 18/18 tests pass, dev bundle rebuilt and running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)