### PR TITLE
feat(split-panes): auto-split CLI-started agents + manual group/ungroup

### DIFF
--- a/Sources/termio/SidebarView.swift
+++ b/Sources/termio/SidebarView.swift
@@ -694,9 +694,11 @@ func headerSessionPresets(_ settings: AppSettings) -> [AgentPreset] {
     [.terminal] + enabledAgentPresets(settings).filter { $0 != .terminal }
 }
 
-/// One entry in a sidebar row's right-click menu — a titled action or a separator.
+/// One entry in a sidebar row's right-click menu — a titled action, a titled
+/// submenu of further entries, or a separator.
 enum SidebarMenuItem {
     case action(String, () -> Void)
+    indirect case submenu(String, [SidebarMenuItem])
     case separator
 }
 
@@ -763,8 +765,14 @@ private struct SidebarRowContextMenu: NSViewRepresentable {
 
         @objc private func showMenu(_ recognizer: NSClickGestureRecognizer) {
             guard let hostView else { return }
-            let menu = NSMenu()
+            let menu = build(items)
             menu.delegate = self
+            menu.popUp(positioning: nil, at: recognizer.location(in: hostView), in: hostView)
+        }
+
+        /// Builds an `NSMenu` from the spec, recursing for submenus.
+        private func build(_ items: [SidebarMenuItem]) -> NSMenu {
+            let menu = NSMenu()
             for item in items {
                 switch item {
                 case .separator:
@@ -774,9 +782,16 @@ private struct SidebarRowContextMenu: NSViewRepresentable {
                     menuItem.target = self
                     menuItem.representedObject = Handler(handler)
                     menu.addItem(menuItem)
+                case let .submenu(title, children):
+                    let menuItem = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+                    // An empty submenu (e.g. nothing to group with) reads as a
+                    // disabled, un-openable parent rather than a dead-end click.
+                    menuItem.isEnabled = !children.isEmpty
+                    menuItem.submenu = children.isEmpty ? nil : build(children)
+                    menu.addItem(menuItem)
                 }
             }
-            menu.popUp(positioning: nil, at: recognizer.location(in: hostView), in: hostView)
+            return menu
         }
 
         @objc private func invoke(_ sender: NSMenuItem) {
@@ -888,8 +903,44 @@ private struct SessionRow: View {
     /// lives. `nil` for a row in its normal tree spot.
     var breadcrumb: String? = nil
     @State private var isHovering = false
+    /// A same-project session is being dragged over this row — highlight it as the
+    /// grouping target (VS Code's blue pane-drop cue).
+    @State private var isDropTarget = false
+
+    /// The drag pasteboard payload identifying a session by id. Namespaced so the
+    /// row's `.dropDestination` accepts only a session drag, never arbitrary text.
+    private static let dragPrefix = "termio-session:"
 
     private var isSelected: Bool { store.selectedSessionID == session.id }
+
+    /// The row's right-click menu. Rename/Pin/Close are always present; the two
+    /// split "type switch" items appear conditionally — "Unsplit" only when the
+    /// session is already in a group (联合 → 独立), and "Group with ▸" only when
+    /// there is a sibling to combine it with (独立 → 联合).
+    private var menuItems: [SidebarMenuItem] {
+        var items: [SidebarMenuItem] = [
+            .action("Rename…") { store.renameSession(session.id) }
+        ]
+        let targets = store.groupableTargets(for: session.id)
+        if store.isInSplitGroup(session.id) || !targets.isEmpty { items.append(.separator) }
+        if store.isInSplitGroup(session.id) {
+            items.append(.action("Unsplit") { store.detachFromSplit(session.id) })
+        }
+        if !targets.isEmpty {
+            items.append(.submenu("Group with", targets.map { target in
+                .action(store.displayTitle(for: target)) {
+                    store.groupSession(session.id, with: target.id)
+                }
+            }))
+        }
+        items.append(contentsOf: [
+            .separator,
+            .action(session.pinned ? "Unpin" : "Pin") { store.toggleSessionPinned(session.id) },
+            .separator,
+            .action("Close") { store.closeSession(session.id) },
+        ])
+        return items
+    }
 
     var body: some View {
         HStack(spacing: 6) {
@@ -960,12 +1011,25 @@ private struct SessionRow: View {
         // is a folder-level action now (the project header's "New worktree" button),
         // so a session row carries only its close button.
         .overlay(alignment: .trailing) {
-            SessionRowActionButton(
-                systemImage: "xmark.circle.fill",
-                help: "Close session",
-                chrome: chrome
-            ) {
-                store.closeSession(session.id)
+            HStack(spacing: 0) {
+                // The drag handle (独立 → 联合): grab it and drop onto another
+                // session's row to combine the two into one split group. It lives on
+                // its own subview with no tap gesture so `.draggable` isn't preempted
+                // by the row's selection tap — the conflict noted in the file browser.
+                Image(systemName: "line.3.horizontal")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 22)
+                    .contentShape(Rectangle())
+                    .help("Drag onto another session to split them together")
+                    .draggable(Self.dragPrefix + session.id.uuidString)
+                SessionRowActionButton(
+                    systemImage: "xmark.circle.fill",
+                    help: "Close session",
+                    chrome: chrome
+                ) {
+                    store.closeSession(session.id)
+                }
             }
             .opacity(isHovering ? 1 : 0)
             .allowsHitTesting(isHovering)
@@ -988,6 +1052,25 @@ private struct SessionRow: View {
             }
         }
         .contentShape(Rectangle())
+        // Accept a session drag dropped onto this row: combine the dragged session
+        // with this one into a split group. A String payload (not a custom type) so
+        // it rides the same pasteboard SwiftUI drop reads; the prefix filter rejects
+        // any non-session text, and a self-drop is ignored.
+        .dropDestination(for: String.self) { payloads, _ in
+            guard let payload = payloads.first(where: { $0.hasPrefix(Self.dragPrefix) }),
+                  let moved = UUID(uuidString: String(payload.dropFirst(Self.dragPrefix.count))),
+                  moved != session.id
+            else { return false }
+            store.groupSession(moved, with: session.id)
+            return true
+        } isTargeted: { isDropTarget = $0 }
+        .overlay {
+            if isDropTarget {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .strokeBorder(Color.accentColor, lineWidth: 2)
+                    .padding(.horizontal, 4)
+            }
+        }
         .onHover { isHovering = $0 }
         .onTapGesture {
             // Tapping a session in the sidebar always returns to its terminal — close the file
@@ -997,13 +1080,7 @@ private struct SessionRow: View {
         }
         // NSMenu rather than SwiftUI's `.contextMenu` so right-click leaves no blue
         // accent ring on the row (see `SidebarRowContextMenu`).
-        .background(SidebarRowContextMenu(items: [
-            .action("Rename…") { store.renameSession(session.id) },
-            .separator,
-            .action(session.pinned ? "Unpin" : "Pin") { store.toggleSessionPinned(session.id) },
-            .separator,
-            .action("Close") { store.closeSession(session.id) }
-        ]))
+        .background(SidebarRowContextMenu(items: menuItems))
         .listRowBackground(
             SidebarRowHighlight(isSelected: isSelected, isHovering: isHovering, chrome: chrome)
                 .animation(.easeInOut(duration: 0.12), value: isSelected)

--- a/Sources/termio/SplitTree.swift
+++ b/Sources/termio/SplitTree.swift
@@ -59,6 +59,23 @@ indirect enum SplitNode: Codable, Hashable {
         }
     }
 
+    /// The axis of the branch that has `id` as a direct child — the direction the
+    /// pane is currently divided along. Used to add a neighbour on the *cross*
+    /// axis so splits alternate the way a tiling window manager does. `nil` when
+    /// `id` is a lone pane with no enclosing branch.
+    func branchDirection(childLeaf id: Session.ID) -> SplitDirection? {
+        switch self {
+        case .leaf:
+            return nil
+        case .split(let branch):
+            if branch.first == .leaf(id) || branch.second == .leaf(id) {
+                return branch.direction
+            }
+            return branch.first.branchDirection(childLeaf: id)
+                ?? branch.second.branchDirection(childLeaf: id)
+        }
+    }
+
     /// Replaces the `target` leaf with a split of it and `newLeaf` (the new pane
     /// takes the second/trailing slot, matching "Split Right"/"Split Down").
     /// A miss returns the tree unchanged.

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -165,7 +165,10 @@ extension TermioStore {
             return controlError(request, "bad_agent",
                 "Unknown agent '\(request.agent ?? "")'. Try one of: \(names).")
         }
-        addSession(to: project.id, agent: preset)
+        // Drop the new agent in beside the pane you were watching (a split), not
+        // as a full-screen swap that hides the caller — the whole reason to start
+        // a sibling from the CLI is to see them side by side.
+        addSplitSession(to: project.id, agent: preset)
         guard let id = selectedSessionID, let session = self.session(id) else {
             return controlError(request, "start_failed", "Could not start the session.")
         }

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -89,6 +89,168 @@ extension TermioStore {
         selectedSessionID = newSession.id
     }
 
+    /// Adds a session to a project and drops it in **beside** a visible pane as a
+    /// split, instead of replacing the view the way `addSession` does. This is the
+    /// path the CLI / an agent spawning a sibling takes (`termio sessions start`):
+    /// there the whole point is to *see* the new agent next to the one you were
+    /// watching, not to have it hijack the terminal area and push its predecessor
+    /// off to a sidebar row.
+    ///
+    /// The anchor is the pane you're looking at when it belongs to this project,
+    /// else the project's last session (a cross-project selection is ignored, so a
+    /// background agent's sibling never gets dragged into another project's group).
+    /// The split axis alternates across the anchor's current one, tiling-WM style —
+    /// a lone anchor opens side by side. With no pane to anchor to (an empty
+    /// project) it falls back to a plain `addSession`.
+    func addSplitSession(to projectID: Project.ID, agent: AgentPreset = .terminal) {
+        guard let projectIndex = projects.firstIndex(where: { $0.id == projectID }) else { return }
+
+        let anchorID = selectedSessionID.flatMap { id in
+            projects[projectIndex].sessions.contains { $0.id == id } ? id : nil
+        } ?? projects[projectIndex].sessions.last?.id
+
+        guard let anchorID,
+              let anchorIndex = projects[projectIndex].sessions.firstIndex(where: { $0.id == anchorID })
+        else {
+            // Empty project — nothing to split against; behave like a normal add.
+            addSession(to: projectID, agent: agent)
+            return
+        }
+
+        let project = projects[projectIndex]
+        let title = agent == .terminal
+            ? "Terminal \(project.sessions.filter { $0.agent == .terminal }.count + 1)"
+            : agent.displayName
+        var newSession = Session(title: title, agent: agent)
+        // Share the anchor's working directory so a worktree agent's sibling lands
+        // in the same checkout — the same courtesy `splitSelectedPane` extends.
+        newSession.worktreePath = session(anchorID)?.worktreePath
+        // Adjacent to the anchor, so the sidebar reads the group as neighbouring
+        // rows and draws its ┌/└ bracket (see `splitLinkMarks`).
+        projects[projectIndex].sessions.insert(newSession, at: anchorIndex + 1)
+
+        // Alternate the split axis across the anchor's current one; a lone anchor
+        // (no enclosing branch) opens side by side.
+        let group = groupIndex(containing: anchorID)
+        let direction: SplitDirection
+        if let group, let current = splitGroups[group].branchDirection(childLeaf: anchorID) {
+            direction = current == .horizontal ? .vertical : .horizontal
+        } else {
+            direction = .horizontal
+        }
+
+        if let group {
+            splitGroups[group] = splitGroups[group]
+                .splitting(leaf: anchorID, direction: direction, adding: newSession.id)
+        } else {
+            splitGroups.append(.split(SplitBranch(direction: direction, ratio: 0.5,
+                                                  first: .leaf(anchorID),
+                                                  second: .leaf(newSession.id))))
+        }
+        selectedSessionID = newSession.id
+        isPaneZoomed = false
+    }
+
+    // MARK: - Type switching (联合 ⇄ 独立)
+
+    /// Whether `id` is currently part of a split group (联合) rather than a
+    /// standalone session (独立). Drives which switch action the sidebar offers.
+    func isInSplitGroup(_ id: Session.ID) -> Bool {
+        groupIndex(containing: id) != nil
+    }
+
+    /// The sessions `id` can be grouped *with* — same project, same working
+    /// bucket (root vs a given worktree, keyed by `worktreePath`), and not
+    /// already grouped with `id`. The bucket match is what keeps the resulting
+    /// group a single adjacent run in the sidebar, so its ┌/└ bracket draws.
+    func groupableTargets(for id: Session.ID) -> [Session] {
+        guard let project = projects.first(where: { $0.sessions.contains { $0.id == id } }),
+              let me = session(id) else { return [] }
+        let myGroup = groupIndex(containing: id)
+        return project.sessions.filter { other in
+            other.id != id
+                && other.worktreePath == me.worktreePath
+                && !(myGroup != nil && groupIndex(containing: other.id) == myGroup)
+        }
+    }
+
+    /// Pulls a pane out of its split group into a standalone session — VS Code's
+    /// "Unsplit Terminal" (联合 → 独立). The session itself is untouched (its shell
+    /// keeps running, its surface stays cached); it just leaves the tree, the
+    /// group dissolves when a lone pane is left, and the selection *follows* the
+    /// detached pane so you see it come up on its own (the difference from
+    /// `closeSelectedPane`, which hands focus to the neighbour it leaves behind).
+    func detachFromSplit(_ id: Session.ID) {
+        guard let group = groupIndex(containing: id) else { return }
+        setGroup(at: group, to: splitGroups[group].removing(leaf: id))
+        selectedSessionID = id
+        isPaneZoomed = false
+    }
+
+    /// Groups an existing `moved` session in beside `anchor` (独立 → 联合) — VS
+    /// Code's drag-a-tab-into-a-pane / "Move to Group". Unlike `splitSelectedPane`
+    /// this reuses a session already in the sidebar instead of spawning a fresh
+    /// one, so it's how two scattered sessions become one combined split.
+    ///
+    /// `moved` is first detached from any prior group (a session is a leaf in at
+    /// most one tree, so it can never appear twice), then spliced beside the
+    /// anchor with the axis alternated across the anchor's current one — the same
+    /// tiling-WM rule `addSplitSession` uses. Finally the sidebar rows are
+    /// reordered so the group reads as an adjacent run, which is what lets
+    /// `splitLinkMarks` draw its bracket over them.
+    func groupSession(_ moved: Session.ID, with anchor: Session.ID) {
+        guard moved != anchor,
+              let projectIndex = projects.firstIndex(where: { $0.sessions.contains { $0.id == anchor } }),
+              projects[projectIndex].sessions.contains(where: { $0.id == moved })
+        else { return }
+        // Already sharing the anchor's group — nothing to switch.
+        if let anchorGroup = groupIndex(containing: anchor),
+           groupIndex(containing: moved) == anchorGroup { return }
+
+        // 1. Detach `moved` from any prior group, keeping the "one leaf, one tree"
+        //    invariant. This may dissolve that group and shift `splitGroups`
+        //    indices, so the anchor's group is (re)resolved only afterwards.
+        if let previous = groupIndex(containing: moved) {
+            setGroup(at: previous, to: splitGroups[previous].removing(leaf: moved))
+        }
+
+        // 2. Splice beside the anchor, alternating the split axis across its
+        //    current one; a lone anchor (no branch yet) opens side by side.
+        let anchorGroup = groupIndex(containing: anchor)
+        let direction: SplitDirection
+        if let group = anchorGroup, let current = splitGroups[group].branchDirection(childLeaf: anchor) {
+            direction = current == .horizontal ? .vertical : .horizontal
+        } else {
+            direction = .horizontal
+        }
+        if let group = anchorGroup {
+            splitGroups[group] = splitGroups[group]
+                .splitting(leaf: anchor, direction: direction, adding: moved)
+        } else {
+            splitGroups.append(.split(SplitBranch(direction: direction, ratio: 0.5,
+                                                  first: .leaf(anchor), second: .leaf(moved))))
+        }
+
+        // 3. Sit `moved`'s row right after the anchor's so the sidebar reads the
+        //    group as a contiguous run (see `splitLinkMarks`).
+        moveSessionRow(moved, besideAnchor: anchor, in: projectIndex)
+        selectedSessionID = moved
+        isPaneZoomed = false
+    }
+
+    /// Moves `moved`'s row to immediately follow the anchor's within the project,
+    /// keeping a split group's sidebar rows adjacent. The anchor index is read
+    /// *after* the removal so it stays valid regardless of which row came first.
+    private func moveSessionRow(_ moved: Session.ID, besideAnchor anchor: Session.ID,
+                                in projectIndex: Int) {
+        guard let from = projects[projectIndex].sessions.firstIndex(where: { $0.id == moved })
+        else { return }
+        let row = projects[projectIndex].sessions.remove(at: from)
+        let anchorIndex = projects[projectIndex].sessions.firstIndex { $0.id == anchor }
+            ?? projects[projectIndex].sessions.count - 1
+        projects[projectIndex].sessions.insert(row, at: anchorIndex + 1)
+    }
+
     /// Closes the focused *pane* — the layout operation, not the session one.
     /// The session stays alive in the sidebar (its shell keeps running, its
     /// surface stays cached); it just leaves its group, and focus moves to its


### PR DESCRIPTION
## What

Two complementary split-pane changes that landed together (co-developed in parallel sessions), unified by one rule.

### 1. CLI-started agents open as a split panel, not a full-screen swap
`termio sessions start <agent>` (an agent spawning a sibling, or you from a shell) used to run `addSession` — appending the new session and **selecting it full-screen**, hiding the agent you were watching behind a sidebar row. It now drops the new agent in **beside** the pane you were on, as a split.

- **Only the CLI/socket path** auto-splits. The sidebar's own add and the phone keep their full-screen add unchanged.
- Anchor = the pane you're looking at when it's in this project, else the project's last session (a cross-project selection is ignored, so a background agent's sibling never gets dragged into another project's group).
- Axis **alternates** across the anchor's current split, tiling-WM style; a lone anchor opens side by side.
- Empty project falls back to a plain `addSession`.

### 2. Manual group / ungroup in the sidebar
- **Group (独立 → 联合):** drag one session's grip onto another to splice them into one split — `groupSession(_:with:)`, reusing an existing session instead of spawning one.
- **Ungroup (联合 → 独立):** an Unsplit action detaches a pane back to a standalone session (`detachFromSplit`); selection follows the detached pane.
- Sidebar gains a drag grip + drop target, and the context menu grows a nested submenu.

Both reuse the same alternating-axis rule via the new `SplitNode.branchDirection(childLeaf:)`, so auto-split and manual group compose identically. Ungroup also doubles as the escape hatch for anyone who doesn't want an auto-split.

## Files
- `SplitTree.swift` — `branchDirection(childLeaf:)` (the shared alternating-axis primitive)
- `TermioStore+SplitPanes.swift` — `addSplitSession` (auto-split) + `groupSession`/`detachFromSplit`/`groupableTargets`/`isInSplitGroup`/`moveSessionRow` (manual)
- `TermioStore+SessionControl.swift` — CLI `start` → `addSplitSession`
- `SidebarView.swift` — drag grip, drop target, nested submenu

## Verified
- `swift build` clean off `main`.
- Dev app: `sessions start claude` on a lone terminal → horizontal split; a second `start codex` → the anchor (in a horizontal branch) splits **vertical** (alternating). Confirmed via the persisted split tree.