### PR TITLE
perf(sidebar): per-session runtime state so scrolling stays smooth

### DIFF
--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -179,6 +179,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
         updateWindowTitle()
         // Keep the native title/subtitle in step with the selected session and its live branch.
+        // The title reads only the selected session's working-directory/project path (see
+        // `updateWindowTitle`), both of which live on the structural store, so plain
+        // `objectWillChange` covers it — no per-session runtime ping needed here.
         titleObserver = store.objectWillChange
             .receive(on: RunLoop.main)
             .sink { [weak self] in

--- a/Sources/termio/CompanionServer.swift
+++ b/Sources/termio/CompanionServer.swift
@@ -951,10 +951,12 @@ extension TermioStore {
         // Without this, permission prompts answered through the raw PTY can stay
         // orange forever because menu keystrokes don't necessarily produce a new
         // agent hook event to overwrite the old attention state.
-        if statuses[session.id] == .needsAttention || statuses[session.id] == .done {
-            statuses[session.id] = .idle
+        let current = status(for: session.id)
+        if current == .needsAttention || current == .done {
+            setStatus(.idle, for: session.id)
         }
-        liveActivity[project.id] = Date()
+        // A deliberate attach from the phone, like desktop selection — float it now.
+        noteProjectActivity(project.id, force: true)
         if let pty = ptyProcesses[session.id] { return pty }
         _ = surface(for: session, in: project)
         return ptyProcesses[session.id]

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -34,7 +34,7 @@ struct FileBrowserView: View {
     private var projectPath: String? {
         guard let id = store.selectedSessionID, let project = store.project(for: id) else { return nil }
         if project.kind == .terminals {
-            return store.workingDirectories[id]
+            return store.workingDirectory(for: id)
                 ?? store.session(id)?.lastWorkingDirectory
                 ?? project.path
         }

--- a/Sources/termio/Info/SessionInfoView.swift
+++ b/Sources/termio/Info/SessionInfoView.swift
@@ -23,7 +23,7 @@ struct SessionInfoView: View {
     private var workingDirectory: String? {
         guard let project else { return nil }
         if project.kind == .terminals, let id = store.selectedSessionID {
-            return store.workingDirectories[id]
+            return store.workingDirectory(for: id)
                 ?? session?.lastWorkingDirectory
                 ?? project.path
         }

--- a/Sources/termio/MenuBarController.swift
+++ b/Sources/termio/MenuBarController.swift
@@ -39,8 +39,18 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         // backs the working-state pulse animation.
         statusItem.button?.wantsLayer = true
 
+        // Structural changes (a session opened/closed, a rename) come over the store's
+        // own `objectWillChange`.
         store.objectWillChange
             .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.refresh() }
+            .store(in: &cancellables)
+        // Per-session status/title churn no longer rides `objectWillChange` (it moved to
+        // per-session `SessionRuntime`s so the sidebar stops rebuilding on every tick),
+        // so the tray subscribes to the dedicated runtime ping instead. Throttled: the
+        // menu only needs to catch up a few times a second, not on every hook event.
+        store.sessionRuntimeDidChange
+            .throttle(for: .milliseconds(250), scheduler: RunLoop.main, latest: true)
             .sink { [weak self] in self?.refresh() }
             .store(in: &cancellables)
         refresh()

--- a/Sources/termio/TermioStore/SessionRuntime.swift
+++ b/Sources/termio/TermioStore/SessionRuntime.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Observation
+
+/// Per-session live state that changes at agent-tick frequency: the agent's
+/// status, the tool it is running, its live `OSC 0/2` title, and the shell's
+/// working directory.
+///
+/// These four fields used to be `@Published` dictionaries on `TermioStore`. That
+/// made them share the store's single `objectWillChange`, so one session's status
+/// flipping (which happens several times a second while an agent works) invalidated
+/// *every* view holding the store — the whole sidebar tree rebuilt on each tick,
+/// which is what made scrolling stutter once a few projects were open.
+///
+/// Splitting them into a per-session `@Observable` fixes that at the root: a
+/// `SessionRow` that reads `runtime.status` takes an Observation dependency on *that
+/// session's* runtime alone, so a status change re-renders only the owning row and
+/// never touches the container or its siblings. The store keeps its `ObservableObject`
+/// role for the structural spine (projects, selection, overlays); only this
+/// high-frequency state lives here, one object per session.
+@MainActor
+@Observable
+final class SessionRuntime {
+    /// Live status, driven by agent hooks / screen detection (see `TermioStore+AgentStatus`).
+    var status: SessionStatus = .idle
+    /// The tool a `.working` session is currently running (`PreToolUse.tool_name`),
+    /// shown in the status tooltip; `nil` once the turn ends.
+    var currentTool: String?
+    /// The running program's live terminal title (`OSC 0/2`), used as an agent
+    /// session's display label so two sessions of the same agent stay distinguishable.
+    var liveTitle: String?
+    /// The live working directory (shell `OSC 7`); for loose terminals this *is* the
+    /// entity's path — it labels the row and roots the inspector.
+    var workingDirectory: String?
+}

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -121,31 +121,29 @@ extension TermioStore {
             // stays calm, so only real agent rows show the thinking spinner.
             guard let session = session(id), effectiveAgent(for: session) != .terminal
             else { break }
-            statuses[id] = .working
-            currentTool[id] = report.tool
+            setStatus(.working, for: id)
+            setCurrentTool(report.tool, for: id)
             // Remember when work was last seen, so a turn that ends abnormally
             // (the agent crashed and never sent `done`) can be swept back to calm
             // instead of spinning forever — the failure mode cmux's own tracker
-            // suffers from (issue #3749).
+            // suffers from (issue #3749). (Floating the project up the Recent-Activity
+            // sort is handled by `setStatus`'s working transition.)
             lastWorkingAt[id] = Date()
-            // A working agent is the strongest "this project is active" signal, so
-            // float its project up under the "Recent Activity" sort (see `orderedProjects`).
-            if let pid = project(for: id)?.id { liveActivity[pid] = Date() }
         case "done":
             // The turn finished. If the user is looking at it, calm; otherwise a
             // gentle "ready for you" cue — distinct from `needsAttention`, which is
             // reserved for the agent actually being blocked on the user.
             clearWorking(id)
-            statuses[id] = (selectedSessionID == id) ? .idle : .done
+            setStatus(selectedSessionID == id ? .idle : .done, for: id)
         case "attention":
             // The agent is blocked waiting on the user (a permission prompt or a
             // free-text answer). Mirror the bell path: only flag a session the user
             // isn't already looking at.
             clearWorking(id)
-            if selectedSessionID != id { statuses[id] = .needsAttention }
+            if selectedSessionID != id { setStatus(.needsAttention, for: id) }
         case "idle":
             clearWorking(id)
-            statuses[id] = .idle
+            setStatus(.idle, for: id)
         default:
             break
         }
@@ -163,7 +161,7 @@ extension TermioStore {
     }
 
     private func clearWorking(_ id: Session.ID) {
-        currentTool[id] = nil
+        setCurrentTool(nil, for: id)
         lastWorkingAt[id] = nil
         promotionStreak[id] = nil
     }
@@ -206,7 +204,7 @@ extension TermioStore {
     /// Fed by a throttled once-a-second tap on the PTY stream (see
     /// `surface(for:in:)`); no-ops cost a dictionary lookup.
     func noteOutputActivity(_ id: Session.ID, screenChanged: Bool, bytes: Int) {
-        if statuses[id] == .working {
+        if status(for: id) == .working {
             promotionStreak[id] = nil
             if screenChanged || bytes >= streamingByteFloor {
                 lastWorkingAt[id] = Date()
@@ -238,9 +236,8 @@ extension TermioStore {
             return
         }
         promotionStreak[id] = nil
-        statuses[id] = .working
+        setStatus(.working, for: id)
         lastWorkingAt[id] = now
-        if let pid = project(for: id)?.id { liveActivity[pid] = now }
     }
 
     /// Drives status from an agent's own screen when it ships no hook system — the path
@@ -259,17 +256,16 @@ extension TermioStore {
         lastScreenActivity[id] = activity
         switch activity {
         case .working:
-            statuses[id] = .working
-            if let pid = project(for: id)?.id { liveActivity[pid] = Date() }
+            setStatus(.working, for: id)
         case .attention:
             clearWorking(id)
-            if selectedSessionID != id { statuses[id] = .needsAttention }
+            if selectedSessionID != id { setStatus(.needsAttention, for: id) }
         case .idle:
             clearWorking(id)
             if previous == .working || previous == .attention {
-                statuses[id] = (selectedSessionID == id) ? .idle : .done
+                setStatus(selectedSessionID == id ? .idle : .done, for: id)
             } else {
-                statuses[id] = .idle
+                setStatus(.idle, for: id)
             }
         }
     }
@@ -291,19 +287,18 @@ extension TermioStore {
         lastTitleActivity[id] = activity
         switch activity {
         case .working:
-            guard statuses[id] != .needsAttention else { return }
+            guard status(for: id) != .needsAttention else { return }
             guard let session = session(id), effectiveAgent(for: session) != .terminal
             else { return }
-            statuses[id] = .working
+            setStatus(.working, for: id)
             lastWorkingAt[id] = Date()
-            if let pid = project(for: id)?.id { liveActivity[pid] = Date() }
         case .attention:
             clearWorking(id)
-            if selectedSessionID != id { statuses[id] = .needsAttention }
+            if selectedSessionID != id { setStatus(.needsAttention, for: id) }
         case .idle:
-            guard previous == .working, statuses[id] == .working else { return }
+            guard previous == .working, status(for: id) == .working else { return }
             clearWorking(id)
-            statuses[id] = (selectedSessionID == id) ? .idle : .done
+            setStatus(selectedSessionID == id ? .idle : .done, for: id)
         }
     }
 
@@ -360,10 +355,11 @@ extension TermioStore {
         session.agent = .terminal
         session.liveTitle = nil
         projects[location.project].sessions[location.session] = session
-        liveTitles[id] = nil
+        setLiveTitle(nil, for: id)
         lastTitleActivity[id] = nil
         clearWorking(id)
-        if statuses[id] == .working || statuses[id] == .done { statuses[id] = .idle }
+        let current = status(for: id)
+        if current == .working || current == .done { setStatus(.idle, for: id) }
     }
 
     /// Resolves a session's transcript file from disk when its hook hasn't handed
@@ -397,7 +393,7 @@ extension TermioStore {
     private func sweepStaleWorking() {
         let now = Date()
         for (id, since) in lastWorkingAt where now.timeIntervalSince(since) > staleWorkingTimeout {
-            if statuses[id] == .working { statuses[id] = .idle }
+            if status(for: id) == .working { setStatus(.idle, for: id) }
             clearWorking(id)
         }
     }
@@ -443,7 +439,7 @@ extension TermioStore {
         case .idle:
             return ""
         case .working:
-            if let tool = currentTool[sessionID] { return "Working — \(tool)" }
+            if let tool = runtimes[sessionID]?.currentTool { return "Working — \(tool)" }
             return "Working…"
         case .done:
             return "Done"

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -489,9 +489,7 @@ extension TermioStore {
             surfaces[sessionID] = nil
             browserPanes[sessionID] = nil
             monitors[sessionID] = nil
-            statuses[sessionID] = nil
-            currentTool[sessionID] = nil
-            liveTitles[sessionID] = nil
+            removeRuntime(for: sessionID)
             processSpawnedAt[sessionID] = nil
             lastWorkingAt[sessionID] = nil
             lastHookReportAt[sessionID] = nil
@@ -554,9 +552,7 @@ extension TermioStore {
         surfaces[id] = nil
         browserPanes[id] = nil
         monitors[id] = nil
-        statuses[id] = nil
-        currentTool[id] = nil
-        liveTitles[id] = nil
+        removeRuntime(for: id)
         processSpawnedAt[id] = nil
         lastWorkingAt[id] = nil
         lastHookReportAt[id] = nil

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -584,7 +584,7 @@ extension TermioStore {
         // agent name until the new conversation earns a topic. Status and
         // `lastTitleActivity` are separate channels — leave them alone.
         if session.resumeID != nil {
-            liveTitles[id] = nil
+            setLiveTitle(nil, for: id)
             session.liveTitle = nil
         }
         session.resumeID = conversationID
@@ -840,9 +840,9 @@ extension TermioStore {
     /// state, so "Action Required" after a turn ends is a real question to you.
     private func monitor(_ state: TerminalViewState, for id: Session.ID) {
         let flag: () -> Void = { [weak self] in
-            guard let self, self.selectedSessionID != id, self.statuses[id] != .done
+            guard let self, self.selectedSessionID != id, self.status(for: id) != .done
             else { return }
-            self.statuses[id] = .needsAttention
+            self.setStatus(.needsAttention, for: id)
         }
         monitors[id] = [
             state.$lastBellAt.dropFirst().compactMap { $0 }.sink { _ in flag() },
@@ -869,8 +869,8 @@ extension TermioStore {
                 }
                 let cleaned = self.sanitizedLiveTitle(title)
                 guard self.isMeaningfulLiveTitle(cleaned, for: session),
-                      self.liveTitles[id] != cleaned else { return }
-                self.liveTitles[id] = cleaned
+                      self.runtimes[id]?.liveTitle != cleaned else { return }
+                self.setLiveTitle(cleaned, for: id)
                 // Also record it on the session itself, so the label survives an
                 // app restart (the agent won't re-emit a title until it next works).
                 // Declared agent sessions only: a plain terminal's adopted title
@@ -896,7 +896,7 @@ extension TermioStore {
     /// it on the session itself, since the cwd is that entity's own path (the
     /// shell respawns there next launch; see docs/design/loose-terminal-entity.md).
     func noteWorkingDirectory(_ cwd: String, for id: Session.ID) {
-        if workingDirectories[id] != cwd { workingDirectories[id] = cwd }
+        setWorkingDirectory(cwd, for: id)
         guard let location = locate(id),
               projects[location.project].kind == .terminals,
               projects[location.project].sessions[location.session]

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -16,6 +16,7 @@ final class TermioStore: ObservableObject {
         didSet {
             persist()
             syncWatchedFolders()
+            syncRuntimes()
         }
     }
     @Published var selectedSessionID: Session.ID? {
@@ -26,12 +27,14 @@ final class TermioStore: ObservableObject {
             if let id = selectedSessionID {
                 // A mid-turn `.working` keeps its spinner; only the resting
                 // "your turn" states are answered by looking.
-                if statuses[id] == .needsAttention || statuses[id] == .done {
-                    statuses[id] = .idle
+                let current = status(for: id)
+                if current == .needsAttention || current == .done {
+                    setStatus(.idle, for: id)
                 }
                 // Switching to a session counts as activity for its project, so the
-                // "Recent Activity" sort floats a project the moment you focus it.
-                if let pid = project(for: id)?.id { liveActivity[pid] = Date() }
+                // "Recent Activity" sort floats a project the moment you focus it —
+                // forced past the coalesce window since it's a deliberate user action.
+                if let pid = project(for: id)?.id { noteProjectActivity(pid, force: true) }
             }
             persist()
         }
@@ -136,25 +139,126 @@ final class TermioStore: ObservableObject {
     /// changes" without the inspector being open.
     @Published var gitChangeCount = 0
 
-    /// Per-session activity, driven by terminal signals and, when enabled, agent hooks.
-    /// A session with no entry (never opened, so no surface yet) reads as `.idle`.
-    @Published var statuses: [Session.ID: SessionStatus] = [:]
+    /// Per-session high-frequency live state (status, running tool, live title, cwd),
+    /// each held in its own `@Observable` `SessionRuntime` so a change re-renders only
+    /// the owning sidebar row rather than the whole tree. Deliberately **not**
+    /// `@Published`: the map's identity is stable (an entry is created when a session
+    /// enters the tree — see `syncRuntimes` — and dropped when it leaves), and the
+    /// reactive signal lives on each `SessionRuntime`, not on the store. Read through
+    /// the accessors (`status(for:)`, `displayTitle(for:)`, …) so callers never couple
+    /// to the storage; mutate through the private setters below, which guard against
+    /// no-op writes and ping `sessionRuntimeDidChange` for the non-SwiftUI observers.
+    private(set) var runtimes: [Session.ID: SessionRuntime] = [:]
 
-    /// The tool a working session is currently running (`PreToolUse.tool_name`),
-    /// shown in the session's status tooltip. Cleared when the turn ends.
-    @Published var currentTool: [Session.ID: String] = [:]
+    /// A coarse "some session's runtime changed" ping for observers that can't
+    /// subscribe to a per-session `@Observable` — the menu-bar tray and the window
+    /// title bar (both plain AppKit). The sidebar deliberately ignores this: its rows
+    /// track their own `SessionRuntime`, so this signal never rebuilds the tree. The
+    /// companion server doesn't need it either (it polls the store once a second).
+    let sessionRuntimeDidChange = PassthroughSubject<Void, Never>()
 
-    /// The running program's live terminal title (`OSC 0/2`) per session, used as
-    /// an agent session's display label so two sessions of the same agent stay
-    /// distinguishable. The stored `Session.title` is never touched.
-    @Published var liveTitles: [Session.ID: String] = [:]
+    /// The runtime for a session, created on first touch. Callers that mutate state go
+    /// through this; read-only paths use `runtimes[id]?` so a bare read never allocates.
+    func runtime(for id: Session.ID) -> SessionRuntime {
+        if let existing = runtimes[id] { return existing }
+        let created = SessionRuntime()
+        runtimes[id] = created
+        return created
+    }
 
-    /// The live working directory per session, from the shell's OSC 7 reports
-    /// (surfaced by `TerminalViewState.workingDirectory`, subscribed in
-    /// `monitor(_:for:)`). For loose terminals this *is* the entity's path: it
-    /// labels the sidebar row and roots the inspector (file tree / search /
-    /// changes), so the app follows a `cd` instead of staying parked at `$HOME`.
-    @Published var workingDirectories: [Session.ID: String] = [:]
+    /// Drops a closed session's runtime. Called from the session/project teardown
+    /// paths; `syncRuntimes` would also reap it on the next `projects` change, but the
+    /// teardown sites clear the rest of a session's caches inline, so this keeps them
+    /// in one place. (A dedicated method because `runtimes` is `private(set)`, so its
+    /// setter is unreachable from the store's other-file extensions.)
+    func removeRuntime(for id: Session.ID) {
+        runtimes.removeValue(forKey: id)
+    }
+
+    /// Reconciles the runtime map with the live session set: creates a runtime for any
+    /// session that lacks one (so its row has a stable object to observe from its very
+    /// first render — an on-demand create during view update would both miss the
+    /// dependency and warn about mutating state mid-render) and drops runtimes for
+    /// sessions that have closed. Called from `projects.didSet` and once after load, so
+    /// every add/remove/restore keeps the map in step without per-site bookkeeping.
+    func syncRuntimes() {
+        let live = Set(projects.flatMap(\.sessions).map(\.id))
+        for id in live where runtimes[id] == nil { runtimes[id] = SessionRuntime() }
+        for id in runtimes.keys where !live.contains(id) { runtimes.removeValue(forKey: id) }
+    }
+
+    /// Sets a session's status, no-op-guarded so a redundant same-value write (the hook
+    /// path re-asserts `.working` on every tool event) neither re-renders the row nor
+    /// pings the tray. Returns whether it actually changed, for callers that gate
+    /// follow-on work on a real transition.
+    @discardableResult
+    func setStatus(_ status: SessionStatus, for id: Session.ID) -> Bool {
+        let runtime = runtime(for: id)
+        guard runtime.status != status else { return false }
+        runtime.status = status
+        // The tray and window title present status, so a real change pings them.
+        sessionRuntimeDidChange.send()
+        // A session *entering* `.working` is the "this project is active" signal that
+        // floats its project up the Recent-Activity sort. Bumping here, on the genuine
+        // transition, means one write per turn instead of one per hook/screen tick — the
+        // callers no longer poke activity themselves (they used to fire it every tick).
+        if status == .working, let pid = project(for: id)?.id { noteProjectActivity(pid) }
+        return true
+    }
+
+    /// Sets the running tool for a session (`nil` clears it), guarded like `setStatus`.
+    /// No runtime ping: the tool shows only in the sidebar row's own tooltip, which
+    /// tracks its session's runtime directly — no AppKit observer reads it.
+    func setCurrentTool(_ tool: String?, for id: Session.ID) {
+        let runtime = runtime(for: id)
+        guard runtime.currentTool != tool else { return }
+        runtime.currentTool = tool
+    }
+
+    /// Sets a session's live `OSC 0/2` title (`nil` clears it), guarded like `setStatus`.
+    /// Pings: the title feeds the tray roster label and the selected row, so a change
+    /// must reach the AppKit tray.
+    func setLiveTitle(_ title: String?, for id: Session.ID) {
+        let runtime = runtime(for: id)
+        guard runtime.liveTitle != title else { return }
+        runtime.liveTitle = title
+        sessionRuntimeDidChange.send()
+    }
+
+    /// Sets a session's live working directory (shell `OSC 7`), guarded like `setStatus`.
+    /// No runtime ping: the cwd shows only in SwiftUI (the loose-terminal row label and
+    /// the cwd-following inspector), which track the runtime directly.
+    func setWorkingDirectory(_ path: String?, for id: Session.ID) {
+        let runtime = runtime(for: id)
+        guard runtime.workingDirectory != path else { return }
+        runtime.workingDirectory = path
+    }
+
+    /// Window within which repeated activity pokes for the same project coalesce into a
+    /// single `liveActivity` write. A working agent re-pokes its project several times a
+    /// second (every hook tool event, every screen tick); each poke used to write a
+    /// fresh `Date`, and because `liveActivity` is `@Published` that re-sorted and
+    /// rebuilt the entire sidebar at agent-tick frequency — a second churn source
+    /// alongside the status dictionaries. The "Recent Activity" order only needs coarse
+    /// freshness, so collapsing pokes to one write every few seconds ends the churn
+    /// while still floating a newly-active project up promptly.
+    private let activityCoalesceWindow: TimeInterval = 4
+
+    /// Floats a project up the "Recent Activity" sort (see `orderedProjects`).
+    ///
+    /// Background agent activity is coalesced — a project bumped within
+    /// `activityCoalesceWindow` is left alone, so a working agent that flaps
+    /// working→idle→working doesn't re-sort the sidebar every tick. Deliberate user
+    /// actions (focusing a session, attaching from the phone) pass `force: true` to
+    /// bypass the window: selecting a session must float it *now*, even if a background
+    /// tick bumped the same project a moment ago — otherwise a just-selected project can
+    /// sit below a more-recently-active one, contradicting "float the moment you focus it".
+    func noteProjectActivity(_ pid: Project.ID, force: Bool = false) {
+        let now = Date()
+        if !force, let last = liveActivity[pid],
+           now.timeIntervalSince(last) < activityCoalesceWindow { return }
+        liveActivity[pid] = now
+    }
 
     /// User preferences (appearance, agent commands, worktree behaviour). Held so
     /// surfaces can be configured on creation and re-styled live when settings
@@ -316,6 +420,10 @@ final class TermioStore: ObservableObject {
         let storedRows = UserDefaults.standard.integer(forKey: Self.hostGridRowsKey)
         self.lastHostGridColumns = storedColumns > 0 ? storedColumns : 80
         self.lastHostGridRows = storedRows > 0 ? storedRows : 24
+        // The initial `projects` assignment above runs before `didSet` is armed, so
+        // seed the runtime map for the restored tree explicitly (later add/remove goes
+        // through `projects.didSet`).
+        syncRuntimes()
 
         // Re-style already-open terminals whenever appearance settings change.
         // `objectWillChange` fires *before* the new value lands, so we hop to the
@@ -561,7 +669,14 @@ final class TermioStore: ObservableObject {
     }
 
     func status(for sessionID: Session.ID) -> SessionStatus {
-        statuses[sessionID] ?? .idle
+        runtimes[sessionID]?.status ?? .idle
+    }
+
+    /// The live working directory a session last reported (shell `OSC 7`), or `nil`.
+    /// A thin accessor over the runtime so the inspector / file browser read the same
+    /// place the sidebar label does, without touching the storage directly.
+    func workingDirectory(for sessionID: Session.ID) -> String? {
+        runtimes[sessionID]?.workingDirectory
     }
 
     /// The agent a session *presents* as. Since identity became persistent this is
@@ -592,7 +707,7 @@ final class TermioStore: ObservableObject {
             if session.title != session.agent.displayName {
                 return session.title
             }
-            return liveTitles[session.id] ?? session.liveTitle ?? session.title
+            return runtimes[session.id]?.liveTitle ?? session.liveTitle ?? session.title
         }
         guard Self.isAutoTerminalName(session.title) else {
             return session.title
@@ -604,7 +719,7 @@ final class TermioStore: ObservableObject {
         // shell's first OSC 7 report. Project terminals keep the plain label —
         // their place is the project, not wherever they've wandered.
         if project(for: session.id)?.kind == .terminals,
-           let cwd = workingDirectories[session.id] ?? session.lastWorkingDirectory {
+           let cwd = runtimes[session.id]?.workingDirectory ?? session.lastWorkingDirectory {
             return Self.terminalLabel(forPath: cwd)
         }
         return "Terminal"

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ from the real front matter).
 | draft | design | [Remote Projects (open an SSH/VPS box like a local project)](design/remote-projects.md) |
 | draft | design | [Session Daemon Architecture (termiod — one model for local, remote, mobile)](design/session-daemon-architecture.md) |
 | draft | design | [远程访问与中转策略（tunelo / BYO-tunnel）](design/remote-access-relay-strategy.md) |
+| draft | design | [Sidebar scroll performance — per-session runtime state](design/sidebar-scroll-performance.md) |
 | draft | rfc | ["RFC: Per-project agent sandbox (Apple Seatbelt)"](design/sandbox-seatbelt.md) |
 | draft | rfc | [Automation — scheduled agent runs](rfcs/automation-scheduled-agent-runs.md) |
 | draft | rfc | [Fork libghostty-spm — own the wrapper, rent the engine?](rfcs/fork-libghostty-spm.md) |

--- a/docs/design/sidebar-scroll-performance.md
+++ b/docs/design/sidebar-scroll-performance.md
@@ -1,0 +1,136 @@
+---
+title: Sidebar scroll performance — per-session runtime state
+status: draft
+type: design
+created: 2026-07-24
+updated: 2026-07-24
+related:
+  - loose-terminal-entity.md
+---
+
+# Sidebar scroll performance — per-session runtime state
+
+## Symptom
+
+With more than a handful of projects open, scrolling the sidebar stutters while
+an agent is working. It is smooth when everything is idle.
+
+## Root cause
+
+Not the `List` control. `List(.sidebar)` is backed by `NSTableView` and already
+virtualizes rows; painting a hundred rows is not the problem.
+
+The problem is **observation granularity**. `SidebarView`, `SessionRow`, and
+`ProjectHeader` all hold `@EnvironmentObject var store: TermioStore`, and
+`TermioStore` is an `ObservableObject`. `ObservableObject` invalidation is
+*object-level*: any `@Published` change fires one `objectWillChange`, which
+re-runs **every** view that observes the store — the whole sidebar tree.
+
+Four `@Published` dictionaries changed at agent-tick frequency:
+
+- `statuses` — flipped on every hook event / screen tick
+- `currentTool` — changed per tool call
+- `liveTitles` — rewritten on every frame of a ticking title spinner
+- `workingDirectories` — on every `cd`
+
+Plus a fifth churn source: `liveActivity[pid] = Date()` was written on *every*
+working report (a fresh `Date` each time → always a real change), re-sorting and
+rebuilding the container roughly once a second per active agent.
+
+So during agent work the entire `SidebarView.body` re-ran several times a second
+— recomputing `orderedProjects` (a sort), the pinned partition (flatMaps + Sets),
+and rebuilding every row struct — and that competed with the scroll gesture for
+the main thread.
+
+## Fix
+
+Move the four high-frequency fields off the store's single `objectWillChange` and
+onto a **per-session `@Observable`**, so a change invalidates only the one row
+that owns it.
+
+### `SessionRuntime`
+
+A tiny `@MainActor @Observable final class` holding `status`, `currentTool`,
+`liveTitle`, `workingDirectory`. The store keeps a stable `runtimes:
+[Session.ID: SessionRuntime]` map (**not** `@Published` — the map's identity is
+stable; only each runtime's fields change). `syncRuntimes()`, called from
+`projects.didSet` and once after load, creates a runtime when a session enters the
+tree and drops it when the session closes, so every row has a stable object to
+observe from its first render.
+
+A `SessionRow` reads `store.status(for: id)` → `runtimes[id]?.status`. Because the
+row body is evaluated under SwiftUI's observation tracking, accessing that
+`@Observable` property — even through a store method — registers a dependency on
+*that session's* runtime alone. A status flip on session A now re-renders row A
+and nothing else: not the container, not sibling rows.
+
+The public accessors (`status(for:)`, `statusDescription(for:)`,
+`displayTitle(for:)`, plus a new `workingDirectory(for:)`) keep their signatures
+and are reimplemented over `runtimes`, so the non-SwiftUI readers (companion
+server, `termio sessions` CLI, menu-bar tray) are unaffected. Writes go through
+no-op-guarded setters (`setStatus`, `setCurrentTool`, `setLiveTitle`,
+`setWorkingDirectory`) so a redundant same-value write neither re-renders a row
+nor pings observers.
+
+### `liveActivity` coalescing
+
+`liveActivity` stays `@Published` (a sort-order change genuinely must re-render
+the container), but it now fires far less. The agent-side bump moved into
+`setStatus`'s **transition into `.working`**, so a turn floats its project up once
+at turn start rather than on every hook/screen tick. `noteProjectActivity(_:force:)`
+still coalesces background bumps within a 4 s window as a flap backstop; deliberate
+user actions (selecting a session, attaching from the phone) pass `force: true` so
+they float the project *immediately*, never suppressed by a recent background bump
+(the ordering regression an unconditional coalescer introduced).
+
+Residual: with many *independently* active projects, `liveActivity` still triggers
+one store-wide invalidation per project turn-start — bounded and infrequent, but
+not zero. Eliminating it entirely would mean publishing only when the displayed
+order actually changes; deferred as not worth the complexity for the common case.
+
+### Non-SwiftUI push consumers
+
+The menu-bar tray is plain AppKit and can't subscribe to a per-session
+`@Observable`, yet it previously relied on the store's `objectWillChange` firing on
+status/title changes. It now subscribes to a dedicated `sessionRuntimeDidChange`
+`PassthroughSubject` (throttled 250 ms), fired only by `setStatus` and
+`setLiveTitle` — the two fields the tray presents. `setCurrentTool` and
+`setWorkingDirectory` don't ping: those show only in SwiftUI (a row tooltip, the
+loose-terminal label, the cwd-following inspector), which track the runtime
+directly. The window title bar needs nothing new either — `updateWindowTitle`
+reads only the selected session's path, which lives on the structural store, so its
+plain `objectWillChange` subscription already covers it. The companion server also
+needs nothing — it polls the store once a second and broadcasts on change.
+
+## Why not migrate the whole store to `@Observable`
+
+Considered and rejected for this change. It would fix the container-rebuild path
+too, but it also deletes `objectWillChange`, breaking the three subscribers that
+depend on it (window title, overlay chrome, tray) and forcing every
+`@EnvironmentObject`/`.environmentObject` site to move to
+`@Environment`/`@Bindable`. Larger blast radius, higher regression risk, no extra
+win for the sidebar over the surgical fix above. The migration remains a sensible
+later cleanup, not a prerequisite.
+
+## Caveat — runtime presence is load-bearing
+
+A row reads `runtimes[id]?.status ?? .idle`. If a live session ever lacked a
+runtime, that read observes nothing, and a later lazy `runtime(for:)` create
+wouldn't fire any invalidation, so the row could stay stale until an unrelated
+redraw. `syncRuntimes()` (from `init` and `projects.didSet`) keeps the invariant on
+every add/remove/restore path, and no current path renders a live row before its
+runtime exists — but the invariant is worth an assertion/test if this grows.
+
+## Verification
+
+- `swift build` clean.
+- Independent review (a Codex sibling) confirmed the core claim by local
+  `withObservationTracking` experiment: a dictionary lookup followed by a
+  method-mediated `@Observable` read does establish the per-session dependency, and
+  `@EnvironmentObject` does not defeat it. It also flagged, and this revision fixed:
+  a user-focus activity-ordering regression (the `force` path), an over-broad
+  runtime ping (now scoped to status/title), and a dead window-title subscription
+  (reverted). 18 existing tests pass; none cover this refactor.
+- Runtime (pending, needs a busy tree): open many projects, run an agent, scroll
+  while it works — the tree should stay smooth; the working row's spinner, the tray
+  badge, and the window title should still update live.


### PR DESCRIPTION
## Problem
The sidebar stutters when scrolling while agents work. `TermioStore` is an `ObservableObject`, so its object-level `objectWillChange` fired on every change to the high-frequency `statuses`/`currentTool`/`liveTitles`/`workingDirectories` dicts — and to `liveActivity`, written with a fresh `Date` on every working tick — re-running the whole `SidebarView.body` (sort + flatMaps + full `List` rebuild) several times a second, competing with the scroll gesture.

## Fix
Move those four fields into a per-session `@Observable` `SessionRuntime` held in a plain (non-`@Published`) `runtimes` map. A `SessionRow` now takes an Observation dependency on only its own session's state, so a status change re-renders one row, not the tree. Accessors (`status(for:)`/`displayTitle(for:)`/…) keep their signatures over the new storage, so the non-SwiftUI readers (companion, CLI, tray) are untouched; writes go through no-op-guarded setters; `syncRuntimes()` reconciles the map on every add/remove/restore.

Also cut the `liveActivity` churn: the Recent-Activity bump now fires only on the genuine idle→working transition (coalesced, with a force path for deliberate user focus / phone attach), and the AppKit tray ping (`sessionRuntimeDidChange`) is scoped to status/title changes only.

## Review
Independently reviewed by a Codex sibling, which confirmed the per-session Observation dependency holds (verified via `withObservationTracking`) and flagged an activity-ordering regression, an over-broad ping, and a dead title subscription — all fixed here.

## Known / out of scope
- Under many *independently* active projects, `liveActivity` still triggers one whole-tree invalidation per turn-start — bounded, documented, deferred.
- Pre-existing `reentrant operation in its NSTableView delegate` warning is unrelated to this change (reproduces on other branches); tracked separately.

## Verification
`swift build` clean; `swift test` 18/18. Live scroll verification pending a busy tree.

Design: `docs/design/sidebar-scroll-performance.md`