### PR TITLE
refactor: remove dead code found by periphery

### DIFF
--- a/Sources/termio/Agents/AgentDefinition.swift
+++ b/Sources/termio/Agents/AgentDefinition.swift
@@ -305,18 +305,6 @@ extension AgentDefinition {
     static var claudeCode: AgentDefinition { AgentCatalog.shared.definition(for: "claudeCode") }
     static var codex: AgentDefinition { AgentCatalog.shared.definition(for: "codex") }
     static var opencode: AgentDefinition { AgentCatalog.shared.definition(for: "opencode") }
-    static var pi: AgentDefinition { AgentCatalog.shared.definition(for: "pi") }
-    static var amp: AgentDefinition { AgentCatalog.shared.definition(for: "amp") }
-    static var cursor: AgentDefinition { AgentCatalog.shared.definition(for: "cursor") }
-    static var kimi: AgentDefinition { AgentCatalog.shared.definition(for: "kimi") }
-    static var antigravity: AgentDefinition { AgentCatalog.shared.definition(for: "antigravity") }
-    static var hermes: AgentDefinition { AgentCatalog.shared.definition(for: "hermes") }
-    static var grok: AgentDefinition { AgentCatalog.shared.definition(for: "grok") }
-
-    init?(rawValue: String) {
-        guard let definition = AgentCatalog.shared.find(id: rawValue) else { return nil }
-        self = definition
-    }
 
     /// Resolves a free-text agent name from the CLI (`termio sessions start claude`)
     /// to a definition, accepting the id, the display name, and common aliases.
@@ -364,8 +352,6 @@ struct AgentStatusRules {
         case attention
         case idle
     }
-
-    func classify(_ screen: String) -> Activity { explain(screen).activity }
 
     /// Like `classify`, but also returns the source pattern that decided the state
     /// (or `nil` when nothing matched → idle). Feeds the `TERMIO_STATUS_TRACE`

--- a/Sources/termio/Agents/HookListener.swift
+++ b/Sources/termio/Agents/HookListener.swift
@@ -71,13 +71,6 @@ final class HookListener {
         queue.async { [weak self] in self?.bindAndListen() }
     }
 
-    func stop() {
-        queue.async { [weak self] in
-            self?.source?.cancel()
-            self?.source = nil
-        }
-    }
-
     private func bindAndListen() {
         let url = Self.socketURL
         try? FileManager.default.createDirectory(

--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -64,13 +64,6 @@ final class SessionControlListener {
         queue.async { [weak self] in self?.bindAndListen() }
     }
 
-    func stop() {
-        queue.async { [weak self] in
-            self?.source?.cancel()
-            self?.source = nil
-        }
-    }
-
     private func bindAndListen() {
         let url = Self.socketURL
         try? FileManager.default.createDirectory(

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -216,17 +216,6 @@ enum SessionStatus: Hashable {
     /// The agent is blocked waiting on the user (permission prompt, or a bell /
     /// desktop notification it raised). The one state that demands attention.
     case needsAttention
-
-    /// SF Symbol drawn as the status dot in the sidebar and the per-session row
-    /// in the menu-bar roster.
-    var symbolName: String {
-        switch self {
-        case .idle: return "circle.fill"
-        case .working: return "circle.dotted"
-        case .done: return "circle.fill"
-        case .needsAttention: return "exclamationmark.circle.fill"
-        }
-    }
 }
 
 /// A single terminal session within a project. Each session owns one live
@@ -306,11 +295,6 @@ struct Session: Identifiable, Hashable, Codable {
     /// record created at this moment (see `AgentSessionStore.discover`). `nil` until
     /// first launch, and unused by the pinned-id agents (Claude Code, Pi).
     var launchedAt: Date?
-
-    /// Program passed to libghostty's `command` config; derived from `agent`.
-    /// User overrides and the resume arguments are resolved in `TermioStore` via
-    /// `AppSettings.command(for:)` and `AgentPreset.resumeArguments(_:)`.
-    var command: String? { agent.command }
 
     init(title: String, agent: AgentPreset = .terminal, createdAt: Date = Date()) {
         self.title = title

--- a/Sources/termio/Companion/UsageMonitor.swift
+++ b/Sources/termio/Companion/UsageMonitor.swift
@@ -22,11 +22,6 @@ struct UsageWindow: Identifiable, Hashable, Sendable {
 /// never interrupt a session.
 struct AgentUsage: Hashable, Sendable {
     var windows: [UsageWindow]
-    /// The tightest window (highest utilization), used for the one-line summaries
-    /// in the sidebar footer and the tray.
-    var tightest: UsageWindow? {
-        windows.max { $0.usedPercent < $1.usedPercent }
-    }
 }
 
 /// Reads the usage limits of the coding agents termio runs, on demand.

--- a/Sources/termio/FileBrowser/FileTreeControls.swift
+++ b/Sources/termio/FileBrowser/FileTreeControls.swift
@@ -18,12 +18,6 @@ struct TreeHeaderButton: View {
     let action: () -> Void
     @State private var isHovering = false
 
-    init(systemName: String, help: String, action: @escaping () -> Void) {
-        self.source = .symbol(systemName)
-        self.help = help
-        self.action = action
-    }
-
     init(codicon: Codicon, help: String, action: @escaping () -> Void) {
         self.source = .codicon(codicon)
         self.help = help

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -40,15 +40,6 @@ enum GitService {
         await offMain { loadDiffText(change, repoRoot) }
     }
 
-    /// Throws away every change to a single file, restoring it to its clean state:
-    /// modified/deleted files reset to `HEAD` (index *and* worktree), a newly-added file
-    /// is unstaged and removed, and an untracked file is deleted from disk. Best-effort —
-    /// the caller reloads the changes list afterwards regardless of the return.
-    @discardableResult
-    static func discard(_ change: GitChange, in repoRoot: String) async -> Bool {
-        await offMain { discardChanges(change, repoRoot) }
-    }
-
     /// Discards a whole selection in one confirmed action — the multi-select's
     /// "Discard N Files…". Sequential and best-effort per file, like the single form.
     static func discard(_ changes: [GitChange], in repoRoot: String) async {

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -8,7 +8,6 @@ struct IconBadge: View {
     let icon: AgentIcon
 
     init(_ icon: AgentIcon) { self.icon = icon }
-    init(symbol: String) { self.icon = .symbol(symbol) }
 
     var body: some View {
         glyph

--- a/Sources/termio/Theme/ThemeLibrary.swift
+++ b/Sources/termio/Theme/ThemeLibrary.swift
@@ -48,10 +48,6 @@ enum ThemeLibrary {
         userThemes.first { $0.name == name } ?? GhosttyThemeCatalog.theme(named: name)
     }
 
-    /// Every bundled theme name, sorted — the picker's full "All Themes" list.
-    /// Enumerating the catalog is not free, so it is computed once for the process.
-    static let bundledThemeNames: [String] = GhosttyThemeCatalog.search("").map(\.name).sorted()
-
     /// The bundled catalog partitioned by brightness, computed once. The picker shows
     /// only the slot-appropriate half — dark themes in the Dark slot, light in the
     /// Light slot — so a slot can never offer a theme that renders the wrong way.


### PR DESCRIPTION
Ran `periphery` (index-based, builds the target) over `termio` + `termioTests` and removed the unused declarations that are **self-contained with zero callers**. The false-positive categories were deliberately left untouched.

## Removed (69 lines, pure deletion)
- **AgentDefinition** — 7 unused catalog-shim accessors (`pi`/`amp`/`cursor`/`kimi`/`antigravity`/`hermes`/`grok`), the vestigial `init(rawValue:)`, and `AgentStatusRules.classify` (superseded by `explain`).
- **GitService** — the single-file `discard(_ change:)` overload (the git write side was removed; the multi-select array overload and the `discardChanges` helper stay).
- **Models** — `SessionStatus.symbolName` and `Session.command`, orphaned computed helpers.
- **ThemeLibrary.bundledThemeNames**, **AgentUsage.tightest** — unused computed / constants.
- **HookListener.stop()** / **SessionControl.stop()** — never called; the listeners run for the app's lifetime.
- **FileTreeIconButton.init(systemName:)**, **IconBadge.init(symbol:)** — unused convenience inits.

## Deliberately NOT removed (periphery false positives)
- **Retention-keeper properties** held only to stay alive (deleting them deallocates the observer/timer/listener and breaks the feature): `App.menuBar`, the `*Observer`s, `TermioStore.hookListener`/`sessionControl`/`linkClickMonitor`/`staleWorkingSweep`, `FileTreeWatcher.stream`, `UsageMonitor.scanTask`, etc. (removing the two `stop()`s makes their `source` properties newly flagged for the same reason — kept.)
- **Vendored Highlightr** (`Editor/Highlightr/*`) — left to ease upstream syncing.
- **Codable / wire model fields** like `Session.createdAt` — part of the persisted/companion schema.
- **`@objc` action `sender:` params** — required by the AppKit selector signature.

## Verification
`swift build` clean; `swift test` 26/26. No behavior change — every removal had zero callers.