### PR TITLE
feat(cli): send --wait — block until the turn settles, return the transcript cursor range

### DIFF
--- a/Sources/termio/SessionControl.swift
+++ b/Sources/termio/SessionControl.swift
@@ -17,6 +17,10 @@ import Foundation
 ///   bare id / id prefix / title. Empty for `send` means "start a fresh session".
 /// - `text` — the prompt (`send`) or menu answer (`answer`).
 /// - `agent` — the agent for a fresh session (`send` with no target).
+/// - `wait` — for `send`: block until the driven session finishes its turn (or
+///   blocks on the user) before replying, instead of returning the instant the
+///   prompt is typed. Collapses the "send then poll `list`" loop into one call.
+/// - `timeoutMs` — the `wait` cap in milliseconds; server-clamped.
 struct ControlRequest: Decodable {
     let op: String
     let format: String?
@@ -26,14 +30,18 @@ struct ControlRequest: Decodable {
     let text: String?
     let lines: Int?
     let agent: String?
+    let wait: Bool?
+    let timeoutMs: Int?
 
     private enum CodingKeys: String, CodingKey {
-        case op, format, target, text, lines, agent
+        case op, format, target, text, lines, agent, wait
         case callerSession = "caller_session"
         case callerCwd = "caller_cwd"
+        case timeoutMs = "timeout_ms"
     }
 
     var wantsJSON: Bool { format == "json" }
+    var wantsWait: Bool { wait == true }
 }
 
 /// A local Unix-domain socket the `termio sessions` CLI connects to. Unlike
@@ -218,9 +226,12 @@ enum SessionSkillInstaller {
           the prompt (`--agent codex` picks the agent; default: your own kind). The
           reply contains the new session's handle — use it for every follow-up.
         - `termio sessions send <agent>@<id> "<prompt>"` — type a prompt into that
-          existing sibling and submit it (a real Return keypress, so it actually runs)
+          existing sibling and submit it (a real Return keypress, so it actually runs).
+          Add `--wait` to block until it finishes and get the reply pointer back.
         - `termio sessions answer <agent>@<id> "<choice>"` — answer a sibling's
           menu/permission prompt (e.g. `"1"`, `"yes"`)
+        - `termio sessions read <agent>@<id>` — print what's on that session's screen
+          right now (look before you `answer`)
         - `termio sessions close <agent>@<id> …` — close session tabs;
           `termio sessions focus <agent>@<id>` — bring one to the front in the app
 
@@ -236,20 +247,21 @@ enum SessionSkillInstaller {
 
         ### Reading a sibling's response
 
-        Don't scrape the terminal. `send` returns the sibling's **transcript** — the
-        agent's own structured Q&A log (Claude Code: a JSONL file) — plus a **cursor**
-        (its line count at send time). To read the reply:
+        Don't scrape the terminal. The reply lives in the sibling's **transcript** —
+        the agent's own structured Q&A log (Claude Code: a JSONL file). Two ways in:
 
-        1. `send` and note `transcript` + `cursor` from the output. (A just-started
-           session has no transcript yet; it appears in `list --json` once the agent
-           reports it — read that file from the start.)
-        2. Poll `termio sessions list` until that session's status is `done` (or
-           `needs-you` if it's blocked waiting on input — then `answer` it).
-        3. Read the transcript file from line `cursor` onward; the `assistant` entries
-           after it are the reply. (Each line is a JSON object with a `type`/`role`.)
+        - **Preferred: `send --wait`.** It blocks until the turn ends and returns the
+          final `status` plus the exact transcript range to read (`cursor`→`cursor_end`).
+          Read just that line range; the `assistant` entries are the reply. If `status`
+          is `needs-you`, the reply includes the on-screen prompt — `answer` it, then
+          `send --wait` again to continue.
+        - **Manual:** plain `send` returns `transcript` + `cursor`; poll
+          `termio sessions list` until the session is `done` (or `needs-you`), then read
+          the transcript from `cursor` onward. (A just-started session's transcript path
+          only appears in `list --json` once its first hook fires — read it from line 0.)
 
-        Workflow: send → wait for `done` via `list` → read the transcript tail. Prefer
-        this over assuming a sibling is finished.
+        Each transcript line is a JSON object with a `type`/`role`. Prefer `--wait` over
+        assuming a sibling is finished.
         \(endMarker)
         """
     }

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -28,12 +28,9 @@ extension TermioStore {
         switch request.op {
         case "list": return listSessions(in: project, request: request)
         case "send", "answer": return await sendText(request, in: project)
+        case "read": return await readScreen(request, in: project)
         case "close": return closeTab(request, in: project)
         case "focus": return focusSession(request, in: project)
-        case "read":
-            return controlError(request, "read_unavailable",
-                "Reading a session's output isn't available in this build yet — it needs a "
-                + "terminal-core buffer API. list / send / answer / close / focus work today.")
         default:
             return controlError(request, "bad_op", "Unknown op '\(request.op)'.")
         }
@@ -103,7 +100,8 @@ extension TermioStore {
                     "\(displayTitle(for: session)) is a browser pane — it accepts no input.")
             }
             let state = surface(for: session, in: project)
-            return await deliver(payload, to: session, state: state, request: request, created: false)
+            return await deliverAndReply(payload, to: session, state: state,
+                                         request: request, in: project, created: false)
         case .notFound:
             return controlError(request, "not_found", targetNotFoundMessage(request.target))
         case .ambiguous:
@@ -144,14 +142,17 @@ extension TermioStore {
         }
         let state = surface(for: fresh, in: project)
         await waitForBootSettle(of: state)
-        return await deliver(payload, to: fresh, state: state, request: request, created: true)
+        return await deliverAndReply(payload, to: fresh, state: state,
+                                     request: request, in: project, created: true)
     }
 
-    /// Types `payload` into a session's live surface and submits it. Shared by
-    /// the existing-sibling and fresh-spawn paths.
-    private func deliver(
+    /// Types `payload` into a session's live surface and submits it, then builds
+    /// the reply — either the immediate "sent" acknowledgement or, when the caller
+    /// passed `--wait`, the outcome of the turn it kicked off. Shared by the
+    /// existing-sibling and fresh-spawn paths.
+    private func deliverAndReply(
         _ payload: String, to session: Session, state: TerminalViewState,
-        request: ControlRequest, created: Bool
+        request: ControlRequest, in project: Project, created: Bool
     ) async -> Data {
         // The libghostty surface attaches lazily on the pane's first render, so a
         // session never shown in the UI has no surface yet. Selecting it adds it to
@@ -175,7 +176,83 @@ extension TermioStore {
         _ = state.send(payload)
         try? await Task.sleep(for: .milliseconds(40))
         Self.pressReturn(on: surfaceHandle)
-        return sentReply(request, session, created: created)
+
+        guard request.wantsWait else { return sentReply(request, session, created: created) }
+        // The cursor to read the reply from: wherever the transcript stands right
+        // after submitting, before the agent has answered. A fresh session's
+        // transcript often isn't known until its first hook fires mid-turn, so this
+        // is nil for now and filled in after the wait.
+        let cursorAtSend = transcriptPaths[session.id].map(Self.lineCount)
+        return await waitForReply(request, session: session, in: project,
+                                  cursorAtSend: cursorAtSend, created: created)
+    }
+
+    /// Blocks until the session the prompt was sent to finishes its turn — or stops
+    /// to ask the user (`needs-you`) — or the timeout elapses, then reports the
+    /// outcome. This is what lets a caller issue one `send --wait` instead of
+    /// sending and then polling `list` in a loop.
+    ///
+    /// Completion is read primarily from the **status resting**: the turn is done once
+    /// the session, having been seen `working`, drops back off `working` and stays there
+    /// for `settleWindow` (`needs-you` short-circuits immediately). Status is the signal
+    /// every real agent drives — built-ins via hooks, rule-based agents via the screen
+    /// classifier — and unlike a raw screen watch it is immune to a TUI footer that keeps
+    /// animating after the reply (Claude Code's hint line), which otherwise never "goes
+    /// quiet". A poll every 300ms always catches the `working` span of a real turn (an
+    /// LLM round-trip is far longer), so the fast-turn blip that defeats a pure status
+    /// *edge* watch isn't a problem for a status *rest* watch. Only a session with no
+    /// status signal at all — a plain terminal driven by `send --wait` — falls back to
+    /// the screen going still after it first changed.
+    private func waitForReply(
+        _ request: ControlRequest, session: Session, in project: Project,
+        cursorAtSend: Int?, created: Bool
+    ) async -> Data {
+        let cap = min(max(request.timeoutMs ?? 300_000, 1_000), 600_000)
+        let deadline = Date().addingTimeInterval(Double(cap) / 1_000)
+        let settleWindow = 1.5
+
+        let backend: InMemoryTerminalSession? = {
+            guard case .inMemory(let terminal) = surface(for: session, in: project).configuration.backend
+            else { return nil }
+            return terminal
+        }()
+
+        var sawWorking = false
+        var restingSince: Date?
+        var lastFrame = backend?.readViewportText()
+        var lastChangeAt = Date()
+        var changedSinceSend = false
+        var settled: SessionStatus?
+
+        while Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(300))
+            let current = status(for: session.id)
+            if current == .working {
+                sawWorking = true
+                restingSince = nil
+            } else if restingSince == nil {
+                restingSince = Date()
+            }
+            if current == .needsAttention { settled = .needsAttention; break }
+
+            let now = Date()
+            let frame = backend?.readViewportText()
+            if frame != lastFrame {
+                lastFrame = frame
+                lastChangeAt = now
+                changedSinceSend = true
+            }
+            guard current != .working else { continue }
+            let rested = restingSince.map { now.timeIntervalSince($0) >= settleWindow } ?? false
+            let screenQuiet = now.timeIntervalSince(lastChangeAt) >= settleWindow
+            // Status-tracked agent: seen working, now rested. (Footer animation can't
+            // fool this — it doesn't touch status.)
+            if sawWorking, rested { settled = current; break }
+            // No status signal at all (a plain terminal): the screen changed, then stilled.
+            if !sawWorking, changedSinceSend, screenQuiet { settled = current; break }
+        }
+        return waitReply(request, session: session, in: project,
+                         cursorAtSend: cursorAtSend, created: created, settled: settled)
     }
 
     /// Waits for a freshly launched agent TUI to finish booting before keystrokes
@@ -261,6 +338,96 @@ extension TermioStore {
             text += "\n  (transcript path appears in `termio sessions list --json` once the agent reports it)"
         }
         return control(request, ok: true, text: text, json: json)
+    }
+
+    /// The reply for a completed (or timed-out) `send --wait`. Hands back the turn's
+    /// final status and the exact transcript range to read — `cursor` (where the reply
+    /// begins, captured at send) through `cursor_end` (the log's length now) — so the
+    /// caller's own file tools read precisely the new content, no polling. When the
+    /// session is blocked on the user (`needs-you`), the current screen rides along so
+    /// the caller can see the prompt it must `answer`.
+    private func waitReply(
+        _ request: ControlRequest, session: Session, in project: Project,
+        cursorAtSend: Int?, created: Bool, settled: SessionStatus?
+    ) -> Data {
+        let handle = sessionHandle(for: session)
+        let statusToken = Self.statusToken(status(for: session.id))
+        var json: [String: Any] = [
+            "target": handle,
+            "title": displayTitle(for: session),
+            "status": statusToken,
+            "timed_out": settled == nil,
+        ]
+        if created { json["created"] = true }
+
+        let headline: String
+        switch settled {
+        case .needsAttention: headline = "\(handle) is waiting on you"
+        case .some: headline = "\(handle) finished (\(statusToken))"
+        case nil: headline = "\(handle) still \(statusToken) after the wait — timed out"
+        }
+        var text = headline
+
+        // The transcript may only have become known during the wait (a fresh
+        // session's first hook), so re-read it here rather than trusting the
+        // send-time snapshot.
+        if let transcript = transcriptPaths[session.id] {
+            let start = cursorAtSend ?? 0
+            let end = Self.lineCount(of: transcript)
+            json["transcript"] = transcript
+            json["cursor"] = start
+            json["cursor_end"] = end
+            text += "\n  transcript: \(transcript)\n  reply: lines \(start)–\(end) (read this range)"
+        }
+        if settled == .needsAttention, let screen = viewportText(for: session, in: project) {
+            json["screen"] = screen
+            text += "\n  on screen:\n\(screen)"
+        }
+        return control(request, ok: true, text: text, json: json)
+    }
+
+    /// `read`: hands back what is currently on a session's screen — the live viewport
+    /// (visible rows, following the user's scroll). Its first purpose is looking at a
+    /// menu or free-text prompt *before* `answer`ing it, so a caller isn't answering
+    /// blind; it also works for a plain terminal, which has no transcript to read.
+    private func readScreen(_ request: ControlRequest, in project: Project) async -> Data {
+        switch resolveTarget(request.target, in: project) {
+        case .found(let session):
+            if session.isBrowser {
+                return controlError(request, "not_terminal",
+                    "\(displayTitle(for: session)) is a browser pane — it has no text screen.")
+            }
+            // Mount the surface if this session has never been shown, and give a
+            // never-rendered one a cycle to paint before the read (mirrors `send`).
+            let state = surface(for: session, in: project)
+            if state.surface == nil {
+                selectedSessionID = session.id
+                try? await Task.sleep(for: .milliseconds(400))
+            }
+            guard let screen = viewportText(for: session, in: project) else {
+                return controlError(request, "not_live",
+                    "\(displayTitle(for: session)) has no live terminal yet — open it once in termio.")
+            }
+            return control(request, ok: true, text: screen,
+                json: ["handle": sessionHandle(for: session), "screen": screen])
+        case .notFound:
+            return controlError(request, "not_found", targetNotFoundMessage(request.target))
+        case .ambiguous:
+            return controlError(request, "ambiguous",
+                "'\(request.target ?? "")' matches more than one session; use a longer id.")
+        case .mismatch(let expected):
+            return controlError(request, "wrong_agent",
+                "That id belongs to \(expected) — use that handle (copied verbatim from `list`).")
+        }
+    }
+
+    /// The current viewport text of a session's terminal, or nil when it has no
+    /// live in-memory backend yet (never rendered). Reads through the backend's own
+    /// lock (`readViewportText`), so it's safe from this actor.
+    private func viewportText(for session: Session, in project: Project) -> String? {
+        let state = surfaces[session.id] ?? surface(for: session, in: project)
+        guard case .inMemory(let terminal) = state.configuration.backend else { return nil }
+        return terminal.readViewportText()
     }
 
     /// Lines currently in a file, counted cheaply by newline bytes — the cursor a

--- a/scripts/termio
+++ b/scripts/termio
@@ -27,15 +27,19 @@ usage:
   termio sessions list                       sibling sessions in this project + status
   termio sessions send "<prompt>"            start a NEW agent session and send it the prompt
   termio sessions send <agent>@<id> "<prompt>"   send to an existing session
+  termio sessions send --wait "<prompt>"     send, then block until the turn ends + report
   termio sessions answer <agent>@<id> "<choice>" answer a session's menu/permission prompt
+  termio sessions read <agent>@<id>          print what's on a session's screen right now
   termio sessions close <agent>@<id> [...]   close session tabs
   termio sessions focus <agent>@<id>         select the session in the app
 
   termio agent report <state>                report this agent's activity (hook contract)
 
 options:
-  --json           machine-readable output (any `sessions` command)
-  --agent <name>   agent for a new session (send without a handle; default: caller's)
+  --json            machine-readable output (any `sessions` command)
+  --agent <name>    agent for a new session (send without a handle; default: caller's)
+  --wait            send: block until the session finishes its turn (or blocks on you)
+  --timeout <secs>  cap for --wait (default 300)
   --help, --version
 
 `<agent>@<id>` handles come from `termio sessions list` or a `send` reply.
@@ -70,19 +74,46 @@ is_handle() {
     printf '%s' "$1" | grep -qE '^[A-Za-z][A-Za-z0-9._-]*@[0-9a-fA-F]{4,32}$'
 }
 
+# Send one request to the control socket and echo the app's reply. Feeds the
+# request through a FIFO whose write end we hold open until `nc` exits, rather than
+# `printf | nc`: piping closes nc's stdin immediately, and on that EOF nc half-closes
+# the socket — which drops a reply the app sends seconds later (a `send --wait` turn),
+# and also races a SIGPIPE on a fast error reply. Holding the write end open keeps the
+# socket full-duplex until the app closes it after replying, so both the instant and
+# the delayed responses arrive intact.
+socket_roundtrip() {
+    fifo=$(mktemp -u "${TMPDIR:-/tmp}/termio.XXXXXX") || return 1
+    mkfifo "$fifo" 2>/dev/null || return 1
+    nc -U "$SOCKET" < "$fifo" &
+    ncpid=$!
+    # Opening the write end blocks until nc (the reader) opens its end — no race.
+    exec 3>"$fifo"
+    printf '%s' "$1" >&3
+    wait "$ncpid"; rc=$?
+    exec 3>&-
+    rm -f "$fifo"
+    return $rc
+}
+
 # One request/response round-trip. Prints the app's reply and returns nonzero when
 # it reports failure, so callers (and `set -e`) surface errors through the exit
-# code — agents check `$?`, not prose.
+# code — agents check `$?`, not prose. `req_wait` ("true"/"") and `req_timeout`
+# (milliseconds/"") are appended only when set, so ordinary commands send the same
+# object as before.
 request_once() {
     req_op="$1"; req_format="$2"; req_target="$3"; req_agent="$4"; req_text="$5"
-    request=$(printf '{"op":"%s","format":"%s","caller_session":"%s","caller_cwd":"%s","target":"%s","agent":"%s","text":"%s"}' \
+    req_wait="${6:-}"; req_timeout="${7:-}"
+    request=$(printf '{"op":"%s","format":"%s","caller_session":"%s","caller_cwd":"%s","target":"%s","agent":"%s","text":"%s"' \
         "$req_op" "$req_format" \
         "$(json_escape "${TERMIO_SESSION:-}")" \
         "$(json_escape "$PWD")" \
         "$(json_escape "$req_target")" \
         "$(json_escape "$req_agent")" \
         "$(json_escape "$req_text")")
-    response=$(printf '%s' "$request" | nc -U "$SOCKET")
+    [ "$req_wait" = "true" ] && request="$request,\"wait\":true"
+    [ -n "$req_timeout" ] && request="$request,\"timeout_ms\":$req_timeout"
+    request="$request}"
+    response=$(socket_roundtrip "$request")
     printf '%s\n' "$response"
     case "$response" in
         error:*|*'"ok":false'*) return 1 ;;
@@ -100,7 +131,7 @@ sessions() {
     [ $# -gt 0 ] && shift || true
 
     case "$op" in
-        list|send|answer|close|focus) ;;
+        list|send|answer|read|close|focus) ;;
         -h|--help|help) usage; exit 0 ;;
         *)
             echo "termio: unknown sessions command '$op'" >&2
@@ -113,10 +144,19 @@ sessions() {
     agent=""
     targets=""
     text=""
+    wait=""
+    timeout=""
     seen_positional=0
     while [ $# -gt 0 ]; do
         case "$1" in
             --json) format=json ;;
+            --wait) wait=true ;;
+            --timeout)
+                [ $# -ge 2 ] || { echo "termio: --timeout needs seconds" >&2; exit 1; }
+                case "$2" in
+                    ''|*[!0-9]*) echo "termio: --timeout needs a whole number of seconds" >&2; exit 1 ;;
+                esac
+                timeout=$(( $2 * 1000 )); shift ;;
             --agent)
                 [ $# -ge 2 ] || { echo "termio: --agent needs a value" >&2; exit 1; }
                 agent="$2"; shift ;;
@@ -124,7 +164,8 @@ sessions() {
                 if [ "$op" = close ]; then
                     # Every positional is a tab to close.
                     targets="${targets:+$targets }$1"
-                elif [ "$seen_positional" -eq 0 ] && { [ "$op" = answer ] || [ "$op" = focus ]; }; then
+                elif [ "$seen_positional" -eq 0 ] && \
+                    { [ "$op" = answer ] || [ "$op" = focus ] || [ "$op" = read ]; }; then
                     targets="$1"
                 elif [ "$seen_positional" -eq 0 ] && [ "$op" = send ] && is_handle "$1"; then
                     # `send` alone takes an *optional* leading handle — absent, the
@@ -139,8 +180,14 @@ sessions() {
         shift
     done
 
+    # `--wait`/`--timeout` only mean anything to `send`.
+    if [ "$op" != send ] && { [ -n "$wait" ] || [ -n "$timeout" ]; }; then
+        echo "termio: --wait/--timeout apply to \`send\` only" >&2
+        exit 1
+    fi
+
     case "$op" in
-        answer|focus)
+        answer|focus|read)
             if [ -z "$targets" ]; then
                 echo "termio: $op needs a session handle (see \`termio sessions list\`)" >&2
                 exit 1
@@ -164,7 +211,7 @@ sessions() {
         exit "$failed"
     fi
 
-    request_once "$op" "$format" "$targets" "$agent" "$text"
+    request_once "$op" "$format" "$targets" "$agent" "$text" "$wait" "$timeout"
 }
 
 # The public hook contract:


### PR DESCRIPTION
One `send --wait` replaces the send-then-poll-`list` loop: it waits for the session's status to rest (done / needs-you) or the timeout, then reports the turn outcome plus the exact transcript range (`cursor`..`cursor_end`) to read the reply from. Falls back to viewport-frame settling for plain terminals with no status signal.

Recovered from an uncommitted worktree; branch is behind main and will need a rebase before merge.