### PR TITLE
feat(keybindings): customizable shortcuts + conventional terminal binds

### DIFF
--- a/Sources/termio/App.swift
+++ b/Sources/termio/App.swift
@@ -34,6 +34,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private lazy var store = TermioStore.restored(settings: settings)
     private lazy var usageMonitor = UsageMonitor(settings: settings)
     private var menuBar: MenuBarController?
+    /// Rebuilds the main menu when the user rebinds a shortcut in Settings.
+    private var keybindingsObserver: NSObjectProtocol?
     private var companionServer: CompanionServer?
     private var settingsWindow: NSWindow?
     private var settingsObserver: AnyCancellable?
@@ -104,6 +106,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Sweep up session processes a previous instance stranded (crash,
         // force-quit, dev rebuild's kill -9) before this run adds its own.
         PTYProcess.reapStrayOrphans()
+        // Menu items cache their key equivalents at build time, so rebuild the
+        // whole main menu whenever a user rebinds a shortcut in Settings.
+        keybindingsObserver = NotificationCenter.default.addObserver(
+            forName: .termioKeybindingsChanged, object: nil, queue: .main
+        ) { _ in
+            MainActor.assumeIsolated { NSApp.mainMenu = buildMainMenu() }
+        }
         window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1100, height: 720),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
@@ -894,11 +903,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.splitSelectedPane(.vertical)
     }
 
-    /// View ▸ Close Pane (⌥⌘W) — collapses the focused pane out of the layout.
-    /// The session itself stays alive in the sidebar; killing it remains the
-    /// sidebar's explicit close.
+    /// View ▸ Close Pane (⌘W) — collapses the focused pane out of the layout,
+    /// terminal-style. The session itself stays alive in the sidebar (killing it
+    /// remains the sidebar's explicit close). With no split on screen there is no
+    /// pane to peel off, so ⌘W falls through to closing the window, matching
+    /// iTerm2 where the last pane's ⌘W closes its container.
     @objc func closeSplitPane(_ sender: Any?) {
-        store.closeSelectedPane()
+        if store.splitRoot != nil {
+            store.closeSelectedPane()
+        } else {
+            window?.performClose(sender)
+        }
+    }
+
+    /// Window ▸ Close Window (⌘⇧W) — closes the whole window regardless of splits.
+    @objc func closeMainWindow(_ sender: Any?) {
+        window?.performClose(sender)
+    }
+
+    /// View ▸ Zoom Split (⌘⇧↩) — maximise the focused pane, or restore the split.
+    @objc func toggleSplitZoom(_ sender: Any?) {
+        store.toggleSelectedPaneZoom()
+    }
+
+    // Font size drives the persisted `fontSize` setting, so a bump survives
+    // relaunch and re-styles every open surface at once (the store's settings
+    // observer reapplies appearance). Clamped to the Appearance stepper's range.
+    @objc func increaseFontSize(_ sender: Any?) {
+        settings.fontSize = min(32, (settings.fontSize + 1).rounded())
+    }
+
+    @objc func decreaseFontSize(_ sender: Any?) {
+        settings.fontSize = max(8, (settings.fontSize - 1).rounded())
+    }
+
+    @objc func resetFontSize(_ sender: Any?) {
+        settings.fontSize = 13
     }
 
     @objc func focusPaneLeft(_ sender: Any?) { store.focusPane(.left) }
@@ -1318,13 +1358,20 @@ private func buildMainMenu() -> NSMenu {
     fileMenu.addItem(
         withTitle: "New Terminal",
         action: #selector(AppDelegate.newScratchTerminal(_:)),
-        keyEquivalent: "t"
+        command: .newTerminal
     )
     fileMenu.addItem(.separator())
     fileMenu.addItem(
         withTitle: "Open Project…",
         action: #selector(AppDelegate.openProject(_:)),
-        keyEquivalent: "o"
+        command: .openProject
+    )
+    fileMenu.addItem(.separator())
+    // ⌘⇧W closes the whole window (⌘W is Close Pane, terminal-style — see View menu).
+    fileMenu.addItem(
+        withTitle: "Close Window",
+        action: #selector(AppDelegate.closeMainWindow(_:)),
+        command: .closeWindow
     )
     fileItem.submenu = fileMenu
 
@@ -1346,63 +1393,83 @@ private func buildMainMenu() -> NSMenu {
     // surface, so the key never reaches the menu. Both shortcuts are
     // additionally unbound in the surface config (see `applyAppearance`) so
     // they can't be swallowed either.
-    let openQuickly = viewMenu.addItem(
+    viewMenu.addItem(
         withTitle: "Open Quickly…",
         action: #selector(AppDelegate.toggleOpenQuickly(_:)),
-        keyEquivalent: "o"
+        command: .openQuickly
     )
-    openQuickly.keyEquivalentModifierMask = [.command, .shift]
-    let palette = viewMenu.addItem(
+    viewMenu.addItem(
         withTitle: "Command Palette…",
         action: #selector(AppDelegate.toggleCommandPalette(_:)),
-        keyEquivalent: "p"
+        command: .commandPalette
     )
-    palette.keyEquivalentModifierMask = [.command, .shift]
     viewMenu.addItem(.separator())
     // iTerm2's split shortcuts: ⌘D right, ⌘⇧D down. The new pane opens a plain
     // terminal in the focused session's project (see `splitSelectedPane`).
     viewMenu.addItem(
         withTitle: "Split Right",
         action: #selector(AppDelegate.splitPaneRight(_:)),
-        keyEquivalent: "d"
+        command: .splitRight
     )
-    let splitDown = viewMenu.addItem(
+    viewMenu.addItem(
         withTitle: "Split Down",
         action: #selector(AppDelegate.splitPaneDown(_:)),
-        keyEquivalent: "d"
+        command: .splitDown
     )
-    splitDown.keyEquivalentModifierMask = [.command, .shift]
-    // ⌥⌘W: closes the *pane* (the layout slot), not the session — ⌘W stays
-    // unbound so the window's own close keeps its meaning.
-    let closePane = viewMenu.addItem(
+    // ⌘⇧↩ maximises the focused pane (tmux/iTerm2 zoom), toggling back to the split.
+    viewMenu.addItem(
+        withTitle: "Zoom Split",
+        action: #selector(AppDelegate.toggleSplitZoom(_:)),
+        command: .splitZoom
+    )
+    // ⌘W closes the focused *pane* (the layout slot), not the session, matching
+    // terminal convention; the last pane's ⌘W falls through to the window. The
+    // whole window is ⌘⇧W (File ▸ Close Window).
+    viewMenu.addItem(
         withTitle: "Close Pane",
         action: #selector(AppDelegate.closeSplitPane(_:)),
-        keyEquivalent: "w"
+        command: .closePane
     )
-    closePane.keyEquivalentModifierMask = [.command, .option]
     viewMenu.addItem(.separator())
     // ⌥⌘ arrows move focus between panes, scored on the split geometry.
-    for (title, action, key) in [
-        ("Focus Pane Left", #selector(AppDelegate.focusPaneLeft(_:)), NSLeftArrowFunctionKey),
-        ("Focus Pane Right", #selector(AppDelegate.focusPaneRight(_:)), NSRightArrowFunctionKey),
-        ("Focus Pane Up", #selector(AppDelegate.focusPaneUp(_:)), NSUpArrowFunctionKey),
-        ("Focus Pane Down", #selector(AppDelegate.focusPaneDown(_:)), NSDownArrowFunctionKey),
+    for (command, action) in [
+        (KeyCommandID.focusPaneLeft, #selector(AppDelegate.focusPaneLeft(_:))),
+        (.focusPaneRight, #selector(AppDelegate.focusPaneRight(_:))),
+        (.focusPaneUp, #selector(AppDelegate.focusPaneUp(_:))),
+        (.focusPaneDown, #selector(AppDelegate.focusPaneDown(_:))),
     ] {
-        let item = viewMenu.addItem(
-            withTitle: title,
+        viewMenu.addItem(
+            withTitle: KeyCommandCatalog.info(command).title,
             action: action,
-            keyEquivalent: String(UnicodeScalar(UInt16(key))!)
+            command: command
         )
-        item.keyEquivalentModifierMask = [.command, .option]
     }
     viewMenu.addItem(.separator())
     // Mirrors Xcode's inspector shortcut (⌥⌘0) for the trailing file-tree panel.
-    let toggleFiles = viewMenu.addItem(
+    viewMenu.addItem(
         withTitle: "Show Project Files",
         action: #selector(AppDelegate.toggleFilesInspector(_:)),
-        keyEquivalent: "0"
+        command: .toggleProjectFiles
     )
-    toggleFiles.keyEquivalentModifierMask = [.command, .option]
+    viewMenu.addItem(.separator())
+    // Safari-style terminal font size: ⌘= bigger, ⌘- smaller, ⌘0 default. Drives
+    // the persisted Appearance font size (ghostty's own binds are unbound in the
+    // surface — see `applyAppearance`) so it survives relaunch and all panes match.
+    viewMenu.addItem(
+        withTitle: "Increase Font Size",
+        action: #selector(AppDelegate.increaseFontSize(_:)),
+        command: .increaseFontSize
+    )
+    viewMenu.addItem(
+        withTitle: "Decrease Font Size",
+        action: #selector(AppDelegate.decreaseFontSize(_:)),
+        command: .decreaseFontSize
+    )
+    viewMenu.addItem(
+        withTitle: "Reset Font Size",
+        action: #selector(AppDelegate.resetFontSize(_:)),
+        command: .resetFontSize
+    )
     viewItem.submenu = viewMenu
 
     return mainMenu

--- a/Sources/termio/CommandPalette.swift
+++ b/Sources/termio/CommandPalette.swift
@@ -210,35 +210,42 @@ struct CommandPaletteView: View {
     /// pane verbs need a pane), so the list never advertises dead rows.
     private var availableActions: [PaletteAction] {
         var actions: [PaletteAction] = []
+        let keys = KeybindingStore.shared
         if store.selectedSessionID != nil {
             actions.append(.init(id: "split-right", title: "Split Right",
-                                 symbol: "rectangle.split.2x1", shortcut: "⌘D") {
+                                 symbol: "rectangle.split.2x1", shortcut: keys.display(for: .splitRight)) {
                 $0.splitSelectedPane(.horizontal)
             })
             actions.append(.init(id: "split-down", title: "Split Down",
-                                 symbol: "rectangle.split.1x2", shortcut: "⇧⌘D") {
+                                 symbol: "rectangle.split.1x2", shortcut: keys.display(for: .splitDown)) {
                 $0.splitSelectedPane(.vertical)
             })
         }
         if store.splitRoot != nil {
+            actions.append(.init(id: "zoom-split", title: "Zoom Split",
+                                 symbol: "arrow.up.left.and.arrow.down.right",
+                                 shortcut: keys.display(for: .splitZoom)) {
+                $0.toggleSelectedPaneZoom()
+            })
             actions.append(.init(id: "close-pane", title: "Close Pane",
-                                 symbol: "rectangle", shortcut: "⌥⌘W") {
+                                 symbol: "rectangle", shortcut: keys.display(for: .closePane)) {
                 $0.closeSelectedPane()
             })
-            for (id, title, arrow, selector) in [
-                ("focus-left", "Focus Pane Left", "←", #selector(AppDelegate.focusPaneLeft(_:))),
-                ("focus-right", "Focus Pane Right", "→", #selector(AppDelegate.focusPaneRight(_:))),
-                ("focus-up", "Focus Pane Up", "↑", #selector(AppDelegate.focusPaneUp(_:))),
-                ("focus-down", "Focus Pane Down", "↓", #selector(AppDelegate.focusPaneDown(_:))),
+            for (id, command, selector) in [
+                ("focus-left", KeyCommandID.focusPaneLeft, #selector(AppDelegate.focusPaneLeft(_:))),
+                ("focus-right", .focusPaneRight, #selector(AppDelegate.focusPaneRight(_:))),
+                ("focus-up", .focusPaneUp, #selector(AppDelegate.focusPaneUp(_:))),
+                ("focus-down", .focusPaneDown, #selector(AppDelegate.focusPaneDown(_:))),
             ] {
-                actions.append(.init(id: id, title: title,
-                                     symbol: "arrow.left.and.right.square", shortcut: "⌥⌘\(arrow)") { _ in
+                actions.append(.init(id: id, title: KeyCommandCatalog.info(command).title,
+                                     symbol: "arrow.left.and.right.square",
+                                     shortcut: keys.display(for: command)) { _ in
                     NSApp.sendAction(selector, to: nil, from: nil)
                 })
             }
         }
         actions.append(.init(id: "new-terminal", title: "New Terminal",
-                             symbol: "plus.rectangle", shortcut: "⌘T") {
+                             symbol: "plus.rectangle", shortcut: keys.display(for: .newTerminal)) {
             $0.addScratchTerminal()
         })
         // One "New … Session" verb per enabled agent — in the selected
@@ -256,15 +263,28 @@ struct CommandPaletteView: View {
             })
         }
         actions.append(.init(id: "open-project", title: "Open Project…",
-                             symbol: "folder", shortcut: "⌘O") {
+                             symbol: "folder", shortcut: keys.display(for: .openProject)) {
             $0.presentOpenProjectPanel()
         })
+        for (id, title, symbol, command, selector) in [
+            ("font-increase", "Increase Font Size", "textformat.size.larger",
+             KeyCommandID.increaseFontSize, #selector(AppDelegate.increaseFontSize(_:))),
+            ("font-decrease", "Decrease Font Size", "textformat.size.smaller",
+             .decreaseFontSize, #selector(AppDelegate.decreaseFontSize(_:))),
+            ("font-reset", "Reset Font Size", "textformat.size",
+             .resetFontSize, #selector(AppDelegate.resetFontSize(_:))),
+        ] {
+            actions.append(.init(id: id, title: title, symbol: symbol,
+                                 shortcut: keys.display(for: command)) { _ in
+                NSApp.sendAction(selector, to: nil, from: nil)
+            })
+        }
         actions.append(.init(id: "toggle-sidebar", title: "Toggle Sidebar",
                              symbol: "sidebar.leading", shortcut: nil) { _ in
             NSApp.sendAction(#selector(NSSplitViewController.toggleSidebar(_:)), to: nil, from: nil)
         })
         actions.append(.init(id: "toggle-files", title: "Toggle Project Files",
-                             symbol: "sidebar.trailing", shortcut: "⌥⌘0") { _ in
+                             symbol: "sidebar.trailing", shortcut: keys.display(for: .toggleProjectFiles)) { _ in
             NSApp.sendAction(#selector(AppDelegate.toggleFilesInspector(_:)), to: nil, from: nil)
         })
         actions.append(.init(id: "settings", title: "Settings…",

--- a/Sources/termio/Keybindings/KeyCommand.swift
+++ b/Sources/termio/Keybindings/KeyCommand.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Stable identifier for every rebindable app command. The raw string is the key
+/// used both in `keybindings.json` and to look a shortcut up from the menu and
+/// the palette, so these values are API — don't rename them once shipped.
+enum KeyCommandID: String, CaseIterable, Identifiable {
+    // File
+    case newTerminal = "file.new-terminal"
+    case openProject = "file.open-project"
+    // Navigation
+    case openQuickly = "nav.open-quickly"
+    case commandPalette = "nav.command-palette"
+    // Panes
+    case splitRight = "pane.split-right"
+    case splitDown = "pane.split-down"
+    case splitZoom = "pane.zoom"
+    case closePane = "pane.close"
+    case focusPaneLeft = "pane.focus-left"
+    case focusPaneRight = "pane.focus-right"
+    case focusPaneUp = "pane.focus-up"
+    case focusPaneDown = "pane.focus-down"
+    // Font
+    case increaseFontSize = "font.increase"
+    case decreaseFontSize = "font.decrease"
+    case resetFontSize = "font.reset"
+    // Window
+    case closeWindow = "window.close"
+    // Interface
+    case toggleProjectFiles = "ui.toggle-project-files"
+
+    var id: String { rawValue }
+}
+
+/// One row in the command catalog: everything the menu, the palette, and the
+/// Settings ▸ Keyboard list need to *describe* a command, independent of how it
+/// is invoked (menus keep their `#selector`s; the palette keeps its closures).
+/// Bindings live here; invocation stays at the call sites. That split is why the
+/// catalog can be a plain value table.
+struct KeyCommandInfo: Identifiable {
+    let id: KeyCommandID
+    /// Grouping header in the Settings list (e.g. "Panes").
+    let category: String
+    /// Human title, matching the menu item wording.
+    let title: String
+    /// The shipped shortcut, before any user override. `nil` = no default binding.
+    let defaultShortcut: Shortcut?
+}
+
+/// The single source of truth for command metadata + default shortcuts. Both the
+/// AppKit menu (`buildMainMenu`) and the command palette read their shortcuts
+/// from here via `KeybindingStore`, so a binding is written in exactly one place.
+enum KeyCommandCatalog {
+    /// Order here is the display order in the Settings list.
+    static let all: [KeyCommandInfo] = [
+        // File
+        .init(id: .newTerminal, category: "File", title: "New Terminal",
+              defaultShortcut: .init(modifiers: [.command], key: .char("t"))),
+        .init(id: .openProject, category: "File", title: "Open Project…",
+              defaultShortcut: .init(modifiers: [.command], key: .char("o"))),
+        // Navigation
+        .init(id: .openQuickly, category: "Navigation", title: "Open Quickly…",
+              defaultShortcut: .init(modifiers: [.command, .shift], key: .char("o"))),
+        .init(id: .commandPalette, category: "Navigation", title: "Command Palette…",
+              defaultShortcut: .init(modifiers: [.command, .shift], key: .char("p"))),
+        // Panes
+        .init(id: .splitRight, category: "Panes", title: "Split Right",
+              defaultShortcut: .init(modifiers: [.command], key: .char("d"))),
+        .init(id: .splitDown, category: "Panes", title: "Split Down",
+              defaultShortcut: .init(modifiers: [.command, .shift], key: .char("d"))),
+        .init(id: .splitZoom, category: "Panes", title: "Zoom Split",
+              defaultShortcut: .init(modifiers: [.command, .shift], key: .return)),
+        .init(id: .closePane, category: "Panes", title: "Close Pane",
+              defaultShortcut: .init(modifiers: [.command], key: .char("w"))),
+        .init(id: .focusPaneLeft, category: "Panes", title: "Focus Pane Left",
+              defaultShortcut: .init(modifiers: [.command, .option], key: .left)),
+        .init(id: .focusPaneRight, category: "Panes", title: "Focus Pane Right",
+              defaultShortcut: .init(modifiers: [.command, .option], key: .right)),
+        .init(id: .focusPaneUp, category: "Panes", title: "Focus Pane Up",
+              defaultShortcut: .init(modifiers: [.command, .option], key: .up)),
+        .init(id: .focusPaneDown, category: "Panes", title: "Focus Pane Down",
+              defaultShortcut: .init(modifiers: [.command, .option], key: .down)),
+        // Font
+        .init(id: .increaseFontSize, category: "Font", title: "Increase Font Size",
+              defaultShortcut: .init(modifiers: [.command], key: .char("="))),
+        .init(id: .decreaseFontSize, category: "Font", title: "Decrease Font Size",
+              defaultShortcut: .init(modifiers: [.command], key: .char("-"))),
+        .init(id: .resetFontSize, category: "Font", title: "Reset Font Size",
+              defaultShortcut: .init(modifiers: [.command], key: .char("0"))),
+        // Window
+        .init(id: .closeWindow, category: "Window", title: "Close Window",
+              defaultShortcut: .init(modifiers: [.command, .shift], key: .char("w"))),
+        // Interface
+        .init(id: .toggleProjectFiles, category: "Interface", title: "Show Project Files",
+              defaultShortcut: .init(modifiers: [.command, .option], key: .char("0"))),
+    ]
+
+    static let byID: [KeyCommandID: KeyCommandInfo] =
+        Dictionary(uniqueKeysWithValues: all.map { ($0.id, $0) })
+
+    static func info(_ id: KeyCommandID) -> KeyCommandInfo { byID[id]! }
+
+    /// Category headers in display order, de-duplicated.
+    static var categories: [String] {
+        var seen = Set<String>()
+        return all.compactMap { seen.insert($0.category).inserted ? $0.category : nil }
+    }
+}

--- a/Sources/termio/Keybindings/KeybindingMenu.swift
+++ b/Sources/termio/Keybindings/KeybindingMenu.swift
@@ -1,0 +1,30 @@
+import AppKit
+
+/// Bridges the command catalog to AppKit menus so a menu item's key equivalent
+/// is never hardcoded — it is resolved from `KeybindingStore` by command id.
+/// `buildMainMenu` runs again on `.termioKeybindingsChanged`, so re-reading the
+/// store here is all that's needed to reflect a user's rebinding.
+@MainActor
+extension NSMenu {
+    /// Add an item whose key equivalent comes from the resolved binding for `id`.
+    @discardableResult
+    func addItem(withTitle title: String, action: Selector, command id: KeyCommandID) -> NSMenuItem {
+        let item = addItem(withTitle: title, action: action, keyEquivalent: "")
+        item.applyShortcut(for: id)
+        return item
+    }
+}
+
+@MainActor
+extension NSMenuItem {
+    /// Apply the currently-effective shortcut for `id` (or clear it if unbound).
+    func applyShortcut(for id: KeyCommandID) {
+        if let shortcut = KeybindingStore.shared.shortcut(for: id) {
+            keyEquivalent = shortcut.keyEquivalent
+            keyEquivalentModifierMask = shortcut.keyEquivalentModifierMask
+        } else {
+            keyEquivalent = ""
+            keyEquivalentModifierMask = []
+        }
+    }
+}

--- a/Sources/termio/Keybindings/KeybindingStore.swift
+++ b/Sources/termio/Keybindings/KeybindingStore.swift
@@ -1,0 +1,147 @@
+import AppKit
+import Combine
+
+extension Notification.Name {
+    /// Posted whenever an effective binding changes so `AppDelegate` can rebuild
+    /// the main menu (menu items cache their key equivalents at build time).
+    static let termioKeybindingsChanged = Notification.Name("termioKeybindingsChanged")
+}
+
+/// The effective keybinding table: catalog defaults with a thin layer of user
+/// overrides on top. Only the *diffs* are persisted, to
+/// `~/.termio[-dev]/keybindings.json` (`{ "pane.split-down": "cmd+shift+k" }`),
+/// mirroring how Xcode stores a user set as deltas over the built-in defaults.
+///
+/// A singleton so the menu builder, the palette, and the Settings pane all read
+/// one source of truth; an `ObservableObject` so the Settings UI re-renders on
+/// edit.
+@MainActor
+final class KeybindingStore: ObservableObject {
+    static let shared = KeybindingStore()
+
+    /// id → user override. Absent id = use the catalog default.
+    @Published private(set) var overrides: [KeyCommandID: Shortcut] = [:]
+
+    private let fileURL = AppChannel.homeConfigDirectory
+        .appendingPathComponent("keybindings.json", isDirectory: false)
+
+    private init() {
+        load()
+    }
+
+    // MARK: - Lookup
+
+    /// The effective shortcut for a command: override if present, else the
+    /// shipped default (which may itself be nil = unbound).
+    func shortcut(for id: KeyCommandID) -> Shortcut? {
+        if let override = overrides[id] { return override }
+        return KeyCommandCatalog.info(id).defaultShortcut
+    }
+
+    /// Convenience for the palette's display strings (`⌥⌘←`).
+    func display(for id: KeyCommandID) -> String? { shortcut(for: id)?.display }
+
+    /// True when the command currently differs from its shipped default.
+    func isCustomized(_ id: KeyCommandID) -> Bool { overrides[id] != nil }
+
+    // MARK: - Editing
+
+    /// Bind `id` to `shortcut`, or clear the override (revert to default) with
+    /// `nil`. Persists and broadcasts so menu + palette pick it up.
+    func setShortcut(_ shortcut: Shortcut?, for id: KeyCommandID) {
+        if let shortcut, shortcut != KeyCommandCatalog.info(id).defaultShortcut {
+            overrides[id] = shortcut
+        } else {
+            // Matching the default is stored as "no override" so the JSON stays
+            // minimal and a later default change still reaches the user.
+            overrides.removeValue(forKey: id)
+        }
+        save()
+        NotificationCenter.default.post(name: .termioKeybindingsChanged, object: nil)
+    }
+
+    /// Revert a single command to its shipped default.
+    func reset(_ id: KeyCommandID) { setShortcut(nil, for: id) }
+
+    /// Revert every command to its shipped default.
+    func resetAll() {
+        guard !overrides.isEmpty else { return }
+        overrides.removeAll()
+        save()
+        NotificationCenter.default.post(name: .termioKeybindingsChanged, object: nil)
+    }
+
+    // MARK: - Validation
+
+    /// Why a candidate shortcut can't be assigned, or nil if it's fine. Two
+    /// rules: it must not collide with another command (or a reserved system
+    /// shortcut), and it must include ⌘ so it can never shadow a key an agent
+    /// TUI or the shell wants (those live in Ctrl / plain-key space).
+    func rejection(for shortcut: Shortcut, assigning id: KeyCommandID) -> String? {
+        guard shortcut.modifiers.contains(.command) else {
+            return "Add ⌘ — shortcuts without Command would collide with the terminal."
+        }
+        if let other = conflict(for: shortcut, excluding: id) {
+            return "Already used by \(other)."
+        }
+        return nil
+    }
+
+    /// The human label of whatever already owns `shortcut`, or nil if it's free.
+    /// Checks both the rebindable catalog and the fixed system shortcuts.
+    func conflict(for shortcut: Shortcut, excluding id: KeyCommandID?) -> String? {
+        for info in KeyCommandCatalog.all where info.id != id {
+            if self.shortcut(for: info.id) == shortcut { return info.title }
+        }
+        for reserved in Self.reserved where reserved.shortcut == shortcut {
+            return reserved.label
+        }
+        return nil
+    }
+
+    /// Fixed shortcuts termio does not expose for rebinding but must still guard
+    /// against, so the recorder can warn instead of silently double-binding.
+    private static let reserved: [(label: String, shortcut: Shortcut)] = [
+        ("Settings…", .init(modifiers: [.command], key: .char(","))),
+        ("Quit Termio", .init(modifiers: [.command], key: .char("q"))),
+        ("Copy", .init(modifiers: [.command], key: .char("c"))),
+        ("Paste", .init(modifiers: [.command], key: .char("v"))),
+        ("Select All", .init(modifiers: [.command], key: .char("a"))),
+    ]
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }  // absent = all defaults
+        guard let raw = try? JSONDecoder().decode([String: String].self, from: data) else {
+            Log.app.error("keybindings: could not decode \(self.fileURL.path, privacy: .public); using defaults")
+            return
+        }
+        for (key, token) in raw {
+            guard let id = KeyCommandID(rawValue: key), let sc = Shortcut(encoded: token) else { continue }
+            overrides[id] = sc
+        }
+    }
+
+    private func save() {
+        let raw = Dictionary(uniqueKeysWithValues: overrides.map { ($0.key.rawValue, $0.value.encoded) })
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let data = try JSONEncoder.sortedPretty.encode(raw)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            Log.app.error("keybindings: failed to write \(self.fileURL.path): \(error.localizedDescription)")
+        }
+    }
+}
+
+private extension JSONEncoder {
+    /// Stable key order + pretty printing so the file reads cleanly and diffs
+    /// don't churn when overrides are added or removed.
+    static var sortedPretty: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+}

--- a/Sources/termio/Keybindings/Shortcut.swift
+++ b/Sources/termio/Keybindings/Shortcut.swift
@@ -1,0 +1,169 @@
+import AppKit
+
+/// One keyboard shortcut — a set of modifiers plus a single key — in the one
+/// representation the whole app shares. It is the bridge between three worlds
+/// that otherwise each spell shortcuts their own way:
+///
+///  - **AppKit menus** want a `keyEquivalent` string + a `keyEquivalentModifierMask`.
+///  - **The command palette** wants a display string like `⌥⌘←`.
+///  - **On-disk config** (`~/.termio/keybindings.json`) wants a stable, hand-editable
+///    token like `opt+cmd+left`.
+///
+/// Keeping all three in one value type means a shortcut is defined once (in the
+/// command catalog) and every surface renders it consistently. Parsing is
+/// lenient on input aliases (`cmd`/`command`/`super`) but `encoded` always emits
+/// one canonical form so the JSON stays diff-stable.
+struct Shortcut: Equatable {
+    /// The non-modifier key. Arrows are special-cased because AppKit encodes them
+    /// as private-use function-key scalars, not characters.
+    enum Key: Equatable {
+        case char(String)   // a single lowercase character or punctuation ("d", ",", "]", "0")
+        case left, right, up, down
+        case `return`
+    }
+
+    var modifiers: NSEvent.ModifierFlags
+    var key: Key
+
+    init(modifiers: NSEvent.ModifierFlags, key: Key) {
+        // Only the four device-independent modifiers we bind against; strip caps
+        // lock / function / numeric-pad noise so equality and conflict checks
+        // compare like with like.
+        self.modifiers = modifiers.intersection([.command, .option, .control, .shift])
+        self.key = key
+    }
+}
+
+// MARK: - Encoding (config token: "opt+cmd+left")
+
+extension Shortcut {
+    /// Canonical order matches how macOS itself renders modifiers: ⌃⌥⇧⌘.
+    private static let modifierOrder: [(NSEvent.ModifierFlags, token: String, glyph: String)] = [
+        (.control, "ctrl", "⌃"),
+        (.option, "opt", "⌥"),
+        (.shift, "shift", "⇧"),
+        (.command, "cmd", "⌘"),
+    ]
+
+    /// The stable token written to `keybindings.json`, e.g. `opt+cmd+left`.
+    var encoded: String {
+        var parts = Self.modifierOrder.filter { modifiers.contains($0.0) }.map(\.token)
+        parts.append(key.token)
+        return parts.joined(separator: "+")
+    }
+
+    /// Parse a config token. Returns nil on anything unrecognised so a corrupt
+    /// file degrades to the default binding rather than crashing.
+    init?(encoded: String) {
+        var mods: NSEvent.ModifierFlags = []
+        var parsedKey: Key?
+        for raw in encoded.lowercased().split(separator: "+") {
+            let token = raw.trimmingCharacters(in: .whitespaces)
+            switch token {
+            case "cmd", "command", "super", "meta": mods.insert(.command)
+            case "opt", "option", "alt": mods.insert(.option)
+            case "ctrl", "control": mods.insert(.control)
+            case "shift": mods.insert(.shift)
+            default:
+                guard let k = Key(token: token) else { return nil }
+                parsedKey = k
+            }
+        }
+        guard let parsedKey else { return nil }
+        self.init(modifiers: mods, key: parsedKey)
+    }
+}
+
+// MARK: - Display (menu glyphs: "⌥⌘←")
+
+extension Shortcut {
+    /// The glyph string shown in menus and the palette.
+    var display: String {
+        let mods = Self.modifierOrder.filter { modifiers.contains($0.0) }.map(\.glyph).joined()
+        return mods + key.displayGlyph
+    }
+}
+
+// MARK: - AppKit menu bridging
+
+extension Shortcut {
+    /// The `NSMenuItem.keyEquivalent` character (lowercase; arrows become their
+    /// private-use function-key scalar).
+    var keyEquivalent: String { key.keyEquivalent }
+
+    /// The mask for `NSMenuItem.keyEquivalentModifierMask`.
+    var keyEquivalentModifierMask: NSEvent.ModifierFlags { modifiers }
+}
+
+// MARK: - Live capture from a key event (the recorder)
+
+extension Shortcut {
+    /// Build a shortcut from a `keyDown` event as the recorder sees it. Returns
+    /// nil for modifier-only presses (nothing to bind yet).
+    init?(event: NSEvent) {
+        let mods = event.modifierFlags.intersection([.command, .option, .control, .shift])
+        // Arrows arrive as key codes, not characters.
+        switch event.keyCode {
+        case 123: self.init(modifiers: mods, key: .left); return
+        case 124: self.init(modifiers: mods, key: .right); return
+        case 125: self.init(modifiers: mods, key: .down); return
+        case 126: self.init(modifiers: mods, key: .up); return
+        case 36, 76: self.init(modifiers: mods, key: .return); return  // return / keypad enter
+        default: break
+        }
+        guard let chars = event.charactersIgnoringModifiers, let first = chars.first else { return nil }
+        // Ignore bare modifier / function keys that produce no printable base key.
+        guard first.isLetter || first.isNumber || first.isPunctuation || first.isSymbol else { return nil }
+        self.init(modifiers: mods, key: .char(String(first).lowercased()))
+    }
+}
+
+// MARK: - Key token/glyph tables
+
+private extension Shortcut.Key {
+    init?(token: String) {
+        switch token {
+        case "left": self = .left
+        case "right": self = .right
+        case "up": self = .up
+        case "down": self = .down
+        case "return", "enter": self = .return
+        default:
+            guard token.count == 1 else { return nil }
+            self = .char(token)
+        }
+    }
+
+    var token: String {
+        switch self {
+        case .char(let c): return c
+        case .left: return "left"
+        case .right: return "right"
+        case .up: return "up"
+        case .down: return "down"
+        case .return: return "return"
+        }
+    }
+
+    var displayGlyph: String {
+        switch self {
+        case .char(let c): return c.uppercased()
+        case .left: return "←"
+        case .right: return "→"
+        case .up: return "↑"
+        case .down: return "↓"
+        case .return: return "↩"
+        }
+    }
+
+    var keyEquivalent: String {
+        switch self {
+        case .char(let c): return c
+        case .left: return String(UnicodeScalar(UInt16(NSLeftArrowFunctionKey))!)
+        case .right: return String(UnicodeScalar(UInt16(NSRightArrowFunctionKey))!)
+        case .up: return String(UnicodeScalar(UInt16(NSUpArrowFunctionKey))!)
+        case .down: return String(UnicodeScalar(UInt16(NSDownArrowFunctionKey))!)
+        case .return: return "\r"
+        }
+    }
+}

--- a/Sources/termio/Log.swift
+++ b/Sources/termio/Log.swift
@@ -22,4 +22,5 @@ enum Log {
     static let companion = Logger(subsystem: subsystem, category: "companion")
     static let files = Logger(subsystem: subsystem, category: "files")
     static let focus = Logger(subsystem: subsystem, category: "focus")
+    static let app = Logger(subsystem: subsystem, category: "app")
 }

--- a/Sources/termio/Settings/KeybindingsSettingsTab.swift
+++ b/Sources/termio/Settings/KeybindingsSettingsTab.swift
@@ -1,0 +1,241 @@
+import AppKit
+import SwiftUI
+
+/// The Keyboard settings pane: every rebindable command grouped by category, each
+/// with a live recorder. Bindings resolve through `KeybindingStore` (catalog
+/// default + user override), so a change here updates the main menu and the
+/// command palette immediately. Only ⌘-based combos are accepted — anything
+/// without Command could shadow a key an agent TUI or the shell needs.
+struct KeybindingsSettingsTab: View {
+    @ObservedObject private var keys = KeybindingStore.shared
+    @State private var query = ""
+    /// The command whose last recording was refused, plus why — shown inline.
+    @State private var rejection: (id: KeyCommandID, message: String)?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            Form {
+                ForEach(matchingCategories, id: \.self) { category in
+                    Section {
+                        ForEach(commands(in: category)) { info in
+                            row(info)
+                        }
+                    } header: {
+                        SectionHeaderLabel(title: category)
+                    }
+                }
+                if matchingCategories.isEmpty {
+                    Text("No commands match “\(query)”.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+            Divider()
+            footer
+        }
+    }
+
+    // MARK: - Pieces
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+            TextField("Filter commands", text: $query)
+                .textFieldStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private func row(_ info: KeyCommandInfo) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            LabeledContent(info.title) {
+                HStack(spacing: 6) {
+                    KeyRecorderField(display: keys.display(for: info.id)) { captured in
+                        handle(captured, for: info.id)
+                    }
+                    Button {
+                        keys.reset(info.id)
+                        clearRejection(for: info.id)
+                    } label: {
+                        Image(systemName: "arrow.uturn.backward")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Reset to default")
+                    .disabled(!keys.isCustomized(info.id))
+                    .opacity(keys.isCustomized(info.id) ? 1 : 0.25)
+                }
+            }
+            if let rejection, rejection.id == info.id {
+                Text(rejection.message)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Text("Press ⌫ while recording to revert a row. Shortcuts must include ⌘.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button("Restore Defaults") {
+                keys.resetAll()
+                rejection = nil
+            }
+            .disabled(keys.overrides.isEmpty)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Data
+
+    private var matchingCategories: [String] {
+        KeyCommandCatalog.categories.filter { !commands(in: $0).isEmpty }
+    }
+
+    private func commands(in category: String) -> [KeyCommandInfo] {
+        KeyCommandCatalog.all.filter { info in
+            info.category == category && matches(info)
+        }
+    }
+
+    private func matches(_ info: KeyCommandInfo) -> Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return true }
+        return info.title.localizedCaseInsensitiveContains(trimmed)
+    }
+
+    // MARK: - Editing
+
+    private func handle(_ shortcut: Shortcut?, for id: KeyCommandID) {
+        guard let shortcut else {           // ⌫ while recording = revert to default
+            keys.reset(id)
+            clearRejection(for: id)
+            return
+        }
+        if let message = keys.rejection(for: shortcut, assigning: id) {
+            rejection = (id, message)
+            return
+        }
+        clearRejection(for: id)
+        keys.setShortcut(shortcut, for: id)
+    }
+
+    private func clearRejection(for id: KeyCommandID) {
+        if rejection?.id == id { rejection = nil }
+    }
+}
+
+// MARK: - Recorder
+
+/// A push button that records the next key chord. AppKit, not SwiftUI, because
+/// only a live NSView can intercept ⌘-combos via `performKeyEquivalent` *before*
+/// the main menu claims them — a SwiftUI key handler never sees ⌘D.
+struct KeyRecorderField: NSViewRepresentable {
+    /// Current shortcut glyphs (`⌥⌘←`), or nil when the command is unbound.
+    let display: String?
+    /// Captured chord, or nil when the user pressed ⌫ to clear.
+    let onCapture: (Shortcut?) -> Void
+
+    func makeNSView(context: Context) -> RecorderButton {
+        let button = RecorderButton()
+        button.onCapture = onCapture
+        button.refresh(display: display)
+        return button
+    }
+
+    func updateNSView(_ button: RecorderButton, context: Context) {
+        button.onCapture = onCapture
+        button.refresh(display: display)
+    }
+}
+
+final class RecorderButton: NSButton {
+    var onCapture: ((Shortcut?) -> Void)?
+    private var currentDisplay: String?
+    private var isRecording = false
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        bezelStyle = .rounded
+        setButtonType(.momentaryPushIn)
+        target = self
+        action = #selector(toggle)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    /// Fixed width so the column doesn't jump between "Add Shortcut" and a glyph.
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: 128, height: super.intrinsicContentSize.height)
+    }
+
+    func refresh(display: String?) {
+        currentDisplay = display
+        updateTitle()
+    }
+
+    private func updateTitle() {
+        if isRecording {
+            title = "Type shortcut…"
+            contentTintColor = .controlAccentColor
+        } else {
+            title = currentDisplay ?? "Add Shortcut"
+            contentTintColor = currentDisplay == nil ? .tertiaryLabelColor : nil
+        }
+    }
+
+    @objc private func toggle() {
+        isRecording ? endRecording() : beginRecording()
+    }
+
+    private func beginRecording() {
+        isRecording = true
+        updateTitle()
+        window?.makeFirstResponder(self)
+    }
+
+    private func endRecording() {
+        guard isRecording else { return }
+        isRecording = false
+        updateTitle()
+        if window?.firstResponder === self { window?.makeFirstResponder(nil) }
+    }
+
+    // Intercept ⌘-combos before the menu; only while actively recording.
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard isRecording else { return false }
+        capture(event)
+        return true
+    }
+
+    override func keyDown(with event: NSEvent) {
+        guard isRecording else { super.keyDown(with: event); return }
+        capture(event)
+    }
+
+    private func capture(_ event: NSEvent) {
+        switch event.keyCode {
+        case 53: endRecording(); return                        // esc cancels, no change
+        case 51, 117: onCapture?(nil); endRecording(); return  // delete/fwd-delete clears
+        default: break
+        }
+        guard let shortcut = Shortcut(event: event) else { return } // ignore lone modifiers
+        onCapture?(shortcut)
+        endRecording()
+    }
+
+    override func resignFirstResponder() -> Bool {
+        if isRecording {
+            isRecording = false
+            updateTitle()
+        }
+        return super.resignFirstResponder()
+    }
+}

--- a/Sources/termio/Settings/SettingsTab.swift
+++ b/Sources/termio/Settings/SettingsTab.swift
@@ -7,6 +7,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case appearance
     case interface
     case terminal
+    case keyboard
     case agents
     case usage
     case mobile
@@ -18,6 +19,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return "Appearance"
         case .interface: return "Interface"
         case .terminal: return "Terminal"
+        case .keyboard: return "Keyboard"
         case .agents: return "Agents"
         case .usage: return "Usage"
         case .mobile: return "Mobile"
@@ -29,6 +31,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return "paintbrush"
         case .interface: return "sidebar.left"
         case .terminal: return "terminal"
+        case .keyboard: return "keyboard"
         case .agents: return "sparkles"
         case .usage: return "gauge.medium"
         case .mobile: return "iphone"

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -33,6 +33,7 @@ struct SettingsView: View {
                 case .appearance: AppearanceSettingsTab(settings: settings)
                 case .interface: InterfaceSettingsTab(settings: settings)
                 case .terminal: TerminalSettingsTab(settings: settings)
+                case .keyboard: KeybindingsSettingsTab()
                 case .agents: AgentSettingsTab(settings: settings)
                 case .usage: UsageSettingsTab(settings: settings, usage: usage)
                 case .mobile: MobileSettingsTab()
@@ -40,6 +41,8 @@ struct SettingsView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(width: 580, height: 520)
+        // Wide enough for the seven-tab bar (7 × 84 + spacing/padding) and the
+        // Keyboard pane's shortcut column.
+        .frame(width: 660, height: 540)
     }
 }

--- a/Sources/termio/TerminalPane.swift
+++ b/Sources/termio/TerminalPane.swift
@@ -61,13 +61,19 @@ struct TerminalPane: View {
             // guarantee with an NSView registry; termio's surface cache plus
             // frame-driven layout is the equivalent with the existing pattern.
             let layout = store.splitRoot?.layout(in: bounds)
+            // Zoom collapses the split to just the selected pane at full size
+            // and hides the dividers — the layout is otherwise untouched, so
+            // un-zooming snaps straight back to the same ratios.
+            let zoomed = store.isPaneZoomed && layout != nil
             ZStack {
                 if mounted.isEmpty {
                     WelcomeView()
                 }
                 ForEach(mounted, id: \.session.id) { item in
                     let id = item.session.id
-                    let paneFrame = layout?.frames[id]
+                    let paneFrame = zoomed
+                        ? (id == store.selectedSessionID ? bounds : nil)
+                        : layout?.frames[id]
                     let isVisible = paneFrame != nil
                         || (layout == nil && store.selectedSessionID == id)
                     // Hidden sessions keep the full pane size, so returning to
@@ -103,7 +109,7 @@ struct TerminalPane: View {
                     .opacity(closing ? 0 : (isVisible ? 1 : 0))
                     .allowsHitTesting(isVisible && !closing)
                 }
-                if let layout {
+                if let layout, !zoomed {
                     // Identified by the (stable) branch id, so a divider keeps its
                     // view identity — and its in-flight drag anchor — while its own
                     // drag rewrites the ratio underneath it.

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -53,6 +53,7 @@ extension TermioStore {
         // The new pane takes focus; it is a member of the (possibly new) group,
         // so the derived `splitRoot` keeps showing this layout.
         selectedSessionID = newSession.id
+        isPaneZoomed = false
     }
 
     /// Splits the focused pane with a **browser pane** — the "terminal left,
@@ -99,6 +100,15 @@ extension TermioStore {
         let neighbor = neighborPane(of: focusedID, in: splitGroups[group])
         setGroup(at: group, to: splitGroups[group].removing(leaf: focusedID))
         if let neighbor { selectedSessionID = neighbor }
+        isPaneZoomed = false
+    }
+
+    /// Toggles zoom on the focused pane (⌘⇧↩) — maximise it to fill the terminal
+    /// area, or restore the split. A no-op with no split on screen, matching
+    /// tmux/iTerm2 where zoom only means something inside a group.
+    func toggleSelectedPaneZoom() {
+        guard splitRoot != nil else { return }
+        isPaneZoomed.toggle()
     }
 
     /// Moves pane focus directionally (⌥⌘ arrows), scored on the visible

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -567,6 +567,17 @@ extension TermioStore {
         // shortcuts always reach termio's menu.
         builder.withCustom("keybind", "super+shift+p=unbind")
         builder.withCustom("keybind", "super+shift+o=unbind")
+        // Font size and split zoom are termio menu actions too: font size is
+        // driven from the persisted `fontSize` setting (so it survives relaunch
+        // and applies to every surface), and zoom is a host SplitTree operation
+        // (ghostty has no splits in embedded mode). Unbind ghostty's built-in
+        // versions so ⌘=/⌘-/⌘0 and ⌘⇧↩ reach `buildMainMenu` instead of being
+        // swallowed by the surface.
+        builder.withCustom("keybind", "super+equal=unbind")
+        builder.withCustom("keybind", "super+plus=unbind")
+        builder.withCustom("keybind", "super+minus=unbind")
+        builder.withCustom("keybind", "super+zero=unbind")
+        builder.withCustom("keybind", "super+shift+enter=unbind")
     }
 
     /// The light/dark theme pair libghostty switches between as the system

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -71,6 +71,12 @@ final class TermioStore: ObservableObject {
     /// (not persisted), toggled by the View menu and cleared by the palette.
     @Published var paletteMode: PaletteMode?
 
+    /// Whether the focused pane is zoomed to fill the terminal area (⌘⇧↩,
+    /// tmux/iTerm2 style). Transient and not persisted; the zoom always targets
+    /// the *selected* pane, so navigating focus while zoomed moves the full-size
+    /// pane. `TerminalPane` honours it only while a split is on screen.
+    @Published var isPaneZoomed = false
+
     /// When each project was last active — the moment one of its agents last reported
     /// work, or the user last switched to one of its sessions. Drives the sidebar's
     /// "Recent Activity" sort (see `orderedProjects`). In-memory and `@Published` so a


### PR DESCRIPTION
Adds KeybindingStore for user-customizable shortcuts plus conventional terminal bindings. Aligns with the keybindings-help direction.

Recovered from an uncommitted worktree; branch is behind main and will need a rebase before merge.