### PR TITLE
feat(ios): voice-to-text dictation from the terminal keyboard's (+) menu

### DIFF
--- a/Shared/Sources/TermioShared/BrandIcons.swift
+++ b/Shared/Sources/TermioShared/BrandIcons.swift
@@ -224,6 +224,7 @@ public enum HugeIcon: Hashable, Sendable {
     case wifiError
     case inbox
     case github
+    case voice
 
     /// Side length of the source SVG's square viewBox (Hugeicons uses 24).
     public var viewBox: CGFloat { 24 }
@@ -415,6 +416,10 @@ public enum HugeIcon: Hashable, Sendable {
         case .inbox:
             // Hugeicons "inbox": a rounded tray — the iOS no-sessions empty state.
             return "M2.5 12C2.5 7.52166 2.5 5.28249 3.89124 3.89124C5.28249 2.5 7.52166 2.5 12 2.5C16.4783 2.5 18.7175 2.5 20.1088 3.89124C21.5 5.28249 21.5 7.52166 21.5 12C21.5 16.4783 21.5 18.7175 20.1088 20.1088C18.7175 21.5 16.4783 21.5 12 21.5C7.52166 21.5 5.28249 21.5 3.89124 20.1088C2.5 18.7175 2.5 16.4783 2.5 12Z M21.5 13.5H16.5743C15.7322 13.5 15.0706 14.2036 14.6995 14.9472C14.2963 15.7551 13.4889 16.5 12 16.5C10.5111 16.5 9.70373 15.7551 9.30054 14.9472C8.92942 14.2036 8.26777 13.5 7.42566 13.5H2.5"
+        case .voice:
+            // A microphone in the Hugeicons stroke style (mic body + cradle arc,
+            // stem, and base) — the Voice settings tab.
+            return "M9 6C9 4.34315 10.3431 3 12 3C13.6569 3 15 4.34315 15 6V11C15 12.6569 13.6569 14 12 14C10.3431 14 9 12.6569 9 11V6Z M18 11C18 14.3137 15.3137 17 12 17C8.68629 17 6 14.3137 6 11 M12 17V21 M8.5 21H15.5"
         }
     }
 }

--- a/ios/Sources/MobileSettings.swift
+++ b/ios/Sources/MobileSettings.swift
@@ -47,6 +47,7 @@ final class MobileSettings {
         static let fontSize = "appearance.fontSize"
         static let terminalKeys = "terminalKeyboard.keys"
         static let pushToTalk = "voice.pushToTalk"
+        static let transcriptionProvider = "voice.provider"
     }
 
     private let defaults = UserDefaults.standard
@@ -106,6 +107,16 @@ final class MobileSettings {
         }
     }
 
+    /// Which transcription service dictation uses — the user's Settings ▸ Voice
+    /// choice. Each provider keeps its own key in the Keychain, so switching
+    /// never loses the other's key.
+    var transcriptionProvider: TranscriptionProvider {
+        didSet {
+            defaults.set(transcriptionProvider.rawValue, forKey: Key.transcriptionProvider)
+            notify()
+        }
+    }
+
     private init() {
         defaults.register(defaults: [
             Key.appearanceMode: AppearanceMode.system.rawValue,
@@ -114,6 +125,7 @@ final class MobileSettings {
             Key.fontSize: Self.defaultFontSize,
             Key.terminalKeys: TerminalKeyCatalog.defaultIDs,
             Key.pushToTalk: false,
+            Key.transcriptionProvider: TranscriptionProvider.openAI.rawValue,
         ])
         appearanceMode = AppearanceMode(
             rawValue: defaults.string(forKey: Key.appearanceMode) ?? ""
@@ -124,6 +136,9 @@ final class MobileSettings {
         terminalKeyIDs = defaults.stringArray(forKey: Key.terminalKeys)
             ?? TerminalKeyCatalog.defaultIDs
         pushToTalkEnabled = defaults.bool(forKey: Key.pushToTalk)
+        transcriptionProvider = TranscriptionProvider(
+            rawValue: defaults.string(forKey: Key.transcriptionProvider) ?? ""
+        ) ?? .openAI
     }
 
     private func notify() {

--- a/ios/Sources/SettingsViewController.swift
+++ b/ios/Sources/SettingsViewController.swift
@@ -14,13 +14,14 @@ final class SettingsViewController: UITableViewController {
     }
 
     private enum Row: Int, CaseIterable {
-        case connectivity, appearance, terminalKeyboard
+        case connectivity, appearance, terminalKeyboard, voice
 
         var title: String {
             switch self {
             case .connectivity: "Connectivity"
             case .appearance: "Appearance"
             case .terminalKeyboard: "Terminal Keyboard"
+            case .voice: "Voice"
             }
         }
 
@@ -31,6 +32,7 @@ final class SettingsViewController: UITableViewController {
             case .connectivity: .wireless
             case .appearance: .paintBrush
             case .terminalKeyboard: .keyboard
+            case .voice: .voice
             }
         }
 
@@ -39,6 +41,7 @@ final class SettingsViewController: UITableViewController {
             case .connectivity: ConnectivitySettingsViewController()
             case .appearance: AppearanceSettingsViewController()
             case .terminalKeyboard: TerminalKeyboardSettingsViewController()
+            case .voice: VoiceSettingsViewController()
             }
         }
     }
@@ -364,20 +367,23 @@ final class TerminalKeyboardSettingsViewController: UITableViewController {
 
 // MARK: - Voice
 
-/// Voice dictation setup: the push-to-talk switch and the OpenAI key that
-/// powers it. With push-to-talk on, holding the terminal keyboard's space bar
-/// dictates a prompt; off, the space bar is just a space. The key lives in the
-/// Keychain (via `VoiceDictation`); two knobs on purpose.
+/// Voice dictation setup: the master switch, the transcription provider, and
+/// that provider's API key. With voice on, holding the terminal keyboard's mic
+/// key dictates a prompt. Each provider keeps its own key in the Keychain (via
+/// `VoiceDictation`), so switching providers never loses the other's key.
 final class VoiceSettingsViewController: UITableViewController {
     private let settings = MobileSettings.shared
 
     private enum Section: Int, CaseIterable {
-        case pushToTalk, key
+        case voice, provider, key
     }
 
     private enum KeyRow: Int, CaseIterable {
         case apiKey, remove
     }
+
+    /// The provider whose key the Key section is showing — the current choice.
+    private var provider: TranscriptionProvider { settings.transcriptionProvider }
 
     init() {
         super.init(style: .insetGrouped)
@@ -397,32 +403,39 @@ final class VoiceSettingsViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch Section(rawValue: section) {
-        case .pushToTalk, nil: 1
-        // "Remove" only earns a row once there's a key to remove.
-        case .key: VoiceDictation.hasAPIKey ? KeyRow.allCases.count : 1
+        case .voice, .provider, nil: 1
+        // "Remove" only earns a row once the selected provider has a key.
+        case .key: VoiceDictation.hasAPIKey(for: provider) ? KeyRow.allCases.count : 1
         }
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        section == Section.key.rawValue ? "OpenAI" : nil
+        switch Section(rawValue: section) {
+        case .provider: "Transcription"
+        // The key belongs to the chosen provider — name it so the two read together.
+        case .key: provider.displayName
+        default: nil
+        }
     }
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         switch Section(rawValue: section) {
-        case .pushToTalk, nil:
-            "Hold the space bar on the terminal keyboard to dictate a prompt — "
-                + "release to drop the transcript into the draft, slide up to cancel."
+        case .voice, nil:
+            "Hold the mic key on the terminal keyboard to dictate a prompt — "
+                + "release to send it, slide up to cancel."
+        case .provider:
+            "Which service transcribes your voice. Each keeps its own key."
         case .key:
-            "Transcribed with OpenAI gpt-4o-transcribe; your key stays in this "
-                + "device's Keychain and is used only for transcription."
+            provider.keyFooter
+                + " Your key stays in this device's Keychain and is used only for transcription."
         }
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch Section(rawValue: indexPath.section) {
-        case .pushToTalk, nil:
+        case .voice, nil:
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-            cell.textLabel?.text = "Push-to-Talk"
+            cell.textLabel?.text = "Voice Input"
             cell.selectionStyle = .none
             let toggle = UISwitch()
             toggle.isOn = settings.pushToTalkEnabled
@@ -432,13 +445,30 @@ final class VoiceSettingsViewController: UITableViewController {
             }, for: .valueChanged)
             cell.accessoryView = toggle
             return cell
+        case .provider:
+            let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+            cell.textLabel?.text = "Provider"
+            cell.selectionStyle = .none
+            let providers = TranscriptionProvider.allCases
+            let control = UISegmentedControl(items: providers.map(\.displayName))
+            control.selectedSegmentIndex = providers.firstIndex(of: provider) ?? 0
+            control.addAction(UIAction { [weak self, weak control] _ in
+                guard let self, let control else { return }
+                settings.transcriptionProvider = providers[control.selectedSegmentIndex]
+                // The Key section below tracks the selected provider.
+                tableView.reloadData()
+            }, for: .valueChanged)
+            control.sizeToFit()
+            cell.accessoryView = control
+            return cell
         case .key:
             let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+            let isSet = VoiceDictation.hasAPIKey(for: provider)
             switch KeyRow(rawValue: indexPath.row) {
             case .apiKey, nil:
                 cell.textLabel?.text = "API Key"
-                cell.detailTextLabel?.text = VoiceDictation.hasAPIKey ? "•••• Set" : "Not Set"
-                cell.detailTextLabel?.textColor = VoiceDictation.hasAPIKey ? .systemGreen : .secondaryLabel
+                cell.detailTextLabel?.text = isSet ? "•••• Set" : "Not Set"
+                cell.detailTextLabel?.textColor = isSet ? .systemGreen : .secondaryLabel
                 cell.accessoryType = .disclosureIndicator
             case .remove:
                 cell.textLabel?.text = "Remove Key"
@@ -455,26 +485,27 @@ final class VoiceSettingsViewController: UITableViewController {
         case .apiKey, nil:
             presentKeyEditor()
         case .remove:
-            VoiceDictation.apiKey = nil
+            VoiceDictation.setAPIKey(nil, for: provider)
             tableView.reloadData()
         }
     }
 
     private func presentKeyEditor() {
+        let provider = self.provider
         let alert = UIAlertController(
-            title: "OpenAI API Key",
-            message: "Paste your key (sk-…). It's stored in this device's Keychain.",
+            title: "\(provider.displayName) API Key",
+            message: "Paste your key. It's stored in this device's Keychain.",
             preferredStyle: .alert
         )
         alert.addTextField { field in
-            field.placeholder = "sk-..."
+            field.placeholder = provider.keyPlaceholder
             field.isSecureTextEntry = true
             field.autocapitalizationType = .none
             field.autocorrectionType = .no
-            field.text = VoiceDictation.apiKey
+            field.text = VoiceDictation.apiKey(for: provider)
         }
         alert.addAction(UIAlertAction(title: "Save", style: .default) { [weak self, weak alert] _ in
-            VoiceDictation.apiKey = alert?.textFields?.first?.text
+            VoiceDictation.setAPIKey(alert?.textFields?.first?.text, for: provider)
             self?.tableView.reloadData()
         })
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))

--- a/ios/Sources/SoftwareKeyboardDeleteRepeat.swift
+++ b/ios/Sources/SoftwareKeyboardDeleteRepeat.swift
@@ -1,0 +1,94 @@
+import UIKit
+
+/// Makes the iOS on-screen keyboard auto-repeat its delete key over the
+/// terminal, and accelerates a sustained hold.
+///
+/// Why it's needed: the software keyboard only keeps calling `deleteBackward`
+/// on hold while it believes the `UITextInput` document still has text to the
+/// left of the caret. A terminal has no such document — the wrapper presents an
+/// empty one at rest — so holding delete fires exactly once and stops (a
+/// hardware keyboard doesn't care: its repeat is an OS-level key-event stream,
+/// no document required). We therefore hand the keyboard a large, static
+/// *phantom* document with the caret parked far from the start: there is always
+/// "more to delete", so iOS keeps firing on hold.
+///
+/// Second problem: iOS drops its own repeat cadence to ~3/s after ~20 reps (its
+/// word-delete phase), which feels sluggish when we only delete one character
+/// per call. We can't raise that rate, so we ACCELERATE instead — the longer
+/// the key is held, the more backspaces each call emits — matching the "faster
+/// the longer you hold" feel of a native text field without abandoning
+/// character-delete semantics.
+///
+/// This type owns only the policy and state; the `UITextInput` overrides that
+/// feed it live on the view (UIKit calls them there). `now` is injected so the
+/// acceleration is deterministic and unit-testable.
+struct SoftwareKeyboardDeleteRepeat {
+    /// The phantom document's fixed length. Large enough that the caret can
+    /// walk left for a very long hold without ever reaching the start.
+    static let documentLength = 1 << 20
+
+    /// The caret position shown to the keyboard, parked at the end so there is
+    /// always content to its left.
+    private(set) var caret = documentLength
+
+    /// Reps in the current hold and when the last arrived; a gap resets the
+    /// streak so a fresh hold starts gentle.
+    private var streak = 0
+    private var lastDeleteTime: CFTimeInterval = 0
+
+    /// A gap (in seconds) longer than this ends the current hold.
+    private static let holdGap: CFTimeInterval = 0.5
+    /// Follow iOS 1:1 for this many reps before ramping.
+    private static let rampAfter = 12
+    /// Add one backspace per this many reps past `rampAfter`.
+    private static let rampEvery = 4
+    /// Never emit more than this many backspaces for a single call.
+    private static let burstCap = 6
+
+    /// iOS moved the caret during deletion — clamp it into the phantom document.
+    mutating func moveCaret(to index: Int) {
+        caret = min(max(index, 0), Self.documentLength)
+    }
+
+    /// Real text was typed (or an IME took over) — the next hold starts gentle.
+    mutating func reset() {
+        streak = 0
+    }
+
+    /// One `deleteBackward` arrived at `now`; returns how many backspaces to
+    /// send for it.
+    mutating func backspaceCount(now: CFTimeInterval) -> Int {
+        if now - lastDeleteTime > Self.holdGap { streak = 0 }
+        lastDeleteTime = now
+        streak += 1
+        guard streak > Self.rampAfter else { return 1 }
+        return min((streak - Self.rampAfter) / Self.rampEvery + 1, Self.burstCap)
+    }
+}
+
+/// Positions in the phantom document above. Kept distinct from the wrapper's
+/// own position type so the view's overrides can tell "our" geometry from the
+/// real (IME) one with a simple cast.
+final class PhantomTextPosition: UITextPosition {
+    let index: Int
+    init(_ index: Int) {
+        self.index = index
+        super.init()
+    }
+}
+
+final class PhantomTextRange: UITextRange {
+    private let from: PhantomTextPosition
+    private let to: PhantomTextPosition
+
+    init(start: PhantomTextPosition, end: PhantomTextPosition) {
+        self.from = start
+        self.to = end
+        super.init()
+    }
+
+    override var start: UITextPosition { from }
+    override var end: UITextPosition { to }
+    override var isEmpty: Bool { from.index == to.index }
+    var length: Int { to.index - from.index }
+}

--- a/ios/Sources/TerminalAccessoryBar.swift
+++ b/ios/Sources/TerminalAccessoryBar.swift
@@ -150,10 +150,12 @@ final class TerminalAccessoryBar: UIInputView {
     private var stickyButtons: [TerminalStickyKey: UIButton] = [:]
     private let attachButton = UIButton(type: .system)
 
-    /// Voice dictation: the recorder/transcriber and the Messages-style
-    /// recording capsule that takes over the bar while it's active.
+    /// Voice dictation: the recorder/transcriber, the Messages-style pill that
+    /// replaces the two control-key rows while recording, and a reference to
+    /// those rows so they can be hidden (the QWERTY keyboard stays put).
     private let voice = VoiceDictation()
     private let voiceBar = VoiceRecordingBar()
+    private var keyPlane: UIStackView?
 
     init() {
         super.init(frame: CGRect(x: 0, y: 0, width: 320, height: Self.barHeight),
@@ -189,6 +191,7 @@ final class TerminalAccessoryBar: UIInputView {
         plane.spacing = Self.keySpacing
         plane.translatesAutoresizingMaskIntoConstraints = false
         addSubview(plane)
+        keyPlane = plane
         NSLayoutConstraint.activate([
             plane.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
             plane.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
@@ -196,13 +199,14 @@ final class TerminalAccessoryBar: UIInputView {
             plane.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
         ])
 
-        // The voice capsule overlays the key grid, filling the same band. It's
-        // hidden until Voice is picked from the (+) menu, then covers the keys.
+        // The recording pill fills the bar band. It's hidden until Voice is
+        // picked; then the two key rows hide and it takes their place — the
+        // system QWERTY keyboard below stays put.
         voiceBar.translatesAutoresizingMaskIntoConstraints = false
         addSubview(voiceBar)
         NSLayoutConstraint.activate([
-            voiceBar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
-            voiceBar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            voiceBar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            voiceBar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
             voiceBar.topAnchor.constraint(equalTo: topAnchor, constant: 6),
             voiceBar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
         ])
@@ -225,12 +229,19 @@ final class TerminalAccessoryBar: UIInputView {
                 }
             }
         }
+        // Every exit path (success, cancel, auto-dismissed error) restores the
+        // control-key rows.
+        voiceBar.onDismissed = { [weak self] in
+            self?.keyPlane?.isHidden = false
+        }
     }
 
-    /// Picked Voice from the (+) menu: show the capsule and start recording.
-    /// A start failure (no key, mic denied) surfaces in the capsule itself.
+    /// Picked Voice from the (+) menu: hide the two control-key rows, show the
+    /// pill in their place, and start recording. A start failure (no key, mic
+    /// denied) surfaces in the pill itself. The QWERTY keyboard is untouched.
     private func startVoiceRecording() {
         haptic.impactOccurred()
+        keyPlane?.isHidden = true
         voiceBar.isHidden = false
         bringSubviewToFront(voiceBar)
         voice.start { [weak self] result in
@@ -289,11 +300,30 @@ final class TerminalAccessoryBar: UIInputView {
             self?.haptic.impactOccurred()
             self?.toggleAttachMenu()
         }, for: .touchUpInside)
+        // A quick dip on finger-down gives the key iMessage's tactile press
+        // before the menu even opens.
+        attachButton.addAction(UIAction { [weak self] _ in
+            UIView.animate(withDuration: 0.12, delay: 0, options: .allowUserInteraction) {
+                self?.attachButton.transform = CGAffineTransform(scaleX: 0.88, y: 0.88)
+            }
+        }, for: .touchDown)
+    }
+
+    /// Spins the (+) glyph into an (×) while the menu is up, and back on
+    /// close — plus a spring pop that releases the touch-down dip.
+    private func setAttachButtonOpen(_ open: Bool) {
+        UIView.animate(withDuration: 0.4, delay: 0, usingSpringWithDamping: 0.6,
+                       initialSpringVelocity: 0, options: .allowUserInteraction) {
+            self.attachButton.transform = .identity
+            self.attachButton.imageView?.transform =
+                open ? CGAffineTransform(rotationAngle: .pi / 4) : .identity
+        }
     }
 
     // MARK: - Attach source menu
 
     private var attachMenuScrim: UIControl?
+    private weak var attachMenuCard: UIView?
 
     private func toggleAttachMenu() {
         if attachMenuScrim != nil {
@@ -327,11 +357,18 @@ final class TerminalAccessoryBar: UIInputView {
         glass.layer.cornerRadius = 26
         glass.layer.cornerCurve = .continuous
 
+        // iMessage's (+) chips aren't flat — each is a diagonal gradient
+        // squircle. We mirror its palette: a dark camera lens, the Photos
+        // rainbow, a red-orange audio capsule, and the Files blue.
         let rows = UIStackView(arrangedSubviews: [
-            makeMenuRow(title: "Camera", symbol: "camera.fill", tint: .systemGray) { [weak self] in self?.onAttach?(.camera) },
-            makeMenuRow(title: "Photos", symbol: "photo.fill", tint: .systemBlue) { [weak self] in self?.onAttach?(.photos) },
-            makeMenuRow(title: "Voice", symbol: "mic.fill", tint: .systemRed) { [weak self] in self?.startVoiceRecording() },
-            makeMenuRow(title: "Files", symbol: "folder.fill", tint: .systemIndigo) { [weak self] in self?.onAttach?(.files) },
+            makeMenuRow(title: "Camera", symbol: "camera.fill",
+                        colors: [Self.hex(0x8A8F98), Self.hex(0x3A3D42)]) { [weak self] in self?.onAttach?(.camera) },
+            makeMenuRow(title: "Photos", symbol: "photo.fill",
+                        colors: [Self.hex(0xFCC72E), Self.hex(0xF6499A), Self.hex(0x3E9BFE)]) { [weak self] in self?.onAttach?(.photos) },
+            makeMenuRow(title: "Voice", symbol: "waveform",
+                        colors: [Self.hex(0xFF8A5B), Self.hex(0xFB2C55)]) { [weak self] in self?.startVoiceRecording() },
+            makeMenuRow(title: "Files", symbol: "folder.fill",
+                        colors: [Self.hex(0x39B9FF), Self.hex(0x0A7BFF)]) { [weak self] in self?.onAttach?(.files) },
         ])
         rows.axis = .vertical
         rows.translatesAutoresizingMaskIntoConstraints = false
@@ -339,7 +376,7 @@ final class TerminalAccessoryBar: UIInputView {
 
         // Bottom-left corner of the card sits just above the (+) key.
         let anchor = attachButton.convert(attachButton.bounds, to: window)
-        let size = CGSize(width: 250, height: 4 * 46 + 12)
+        let size = CGSize(width: 258, height: 4 * 54 + 12)
         let card = UIView(frame: CGRect(
             x: max(8, anchor.minX),
             y: anchor.minY - size.height - 8,
@@ -365,40 +402,53 @@ final class TerminalAccessoryBar: UIInputView {
             rows.bottomAnchor.constraint(equalTo: glass.contentView.bottomAnchor, constant: -6),
         ])
         scrim.addSubview(card)
+        attachMenuCard = card
 
-        // UIMenu's entrance: grow from the anchor corner with a soft spring.
-        card.alpha = 0
-        card.transform = CGAffineTransform(scaleX: 0.4, y: 0.4)
+        // UIMenu's entrance: grow from the bottom-left corner (the (+) key)
+        // with a soft spring — the translate keeps that corner pinned while
+        // the card scales up out of it.
+        let collapsed = CGAffineTransform(scaleX: 0.4, y: 0.4)
             .translatedBy(x: -size.width * 0.5, y: size.height * 0.5)
-        UIView.animate(withDuration: 0.35, delay: 0, usingSpringWithDamping: 0.8,
+        card.alpha = 0
+        card.transform = collapsed
+        UIView.animate(withDuration: 0.4, delay: 0, usingSpringWithDamping: 0.78,
                        initialSpringVelocity: 0) {
             card.alpha = 1
             card.transform = .identity
         }
+        setAttachButtonOpen(true)
     }
 
     private func dismissAttachMenu() {
-        attachMenuScrim?.removeFromSuperview()
+        setAttachButtonOpen(false)
+        guard let scrim = attachMenuScrim else { return }
         attachMenuScrim = nil
+        // Collapse back into the (+) key, mirroring the entrance.
+        let card = attachMenuCard
+        let size = card?.bounds.size ?? .zero
+        UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseIn) {
+            card?.alpha = 0
+            card?.transform = CGAffineTransform(scaleX: 0.4, y: 0.4)
+                .translatedBy(x: -size.width * 0.5, y: size.height * 0.5)
+        } completion: { _ in
+            scrim.removeFromSuperview()
+        }
     }
 
     /// One source row in the newest-Messages style: a filled SF symbol in a
     /// tinted rounded chip on the leading edge, then the label — the iMessage
     /// (+) app-row look, cleaner than the plain UIMenu icon-on-the-right shape.
     private func makeMenuRow(
-        title: String, symbol: String, tint: UIColor, handler: @escaping () -> Void
+        title: String, symbol: String, colors: [UIColor], handler: @escaping () -> Void
     ) -> UIView {
         let button = UIButton(type: .system)
-        button.heightAnchor.constraint(equalToConstant: 46).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 54).isActive = true
         button.addAction(UIAction { [weak self] _ in
             self?.dismissAttachMenu()
             handler()
         }, for: .touchUpInside)
 
-        let chip = UIView()
-        chip.backgroundColor = tint
-        chip.layer.cornerRadius = 7
-        chip.layer.cornerCurve = .continuous
+        let chip = GradientChipView(colors: colors)
         chip.isUserInteractionEnabled = false
         chip.translatesAutoresizingMaskIntoConstraints = false
 
@@ -424,8 +474,8 @@ final class TerminalAccessoryBar: UIInputView {
         NSLayoutConstraint.activate([
             chip.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: 16),
             chip.centerYAnchor.constraint(equalTo: button.centerYAnchor),
-            chip.widthAnchor.constraint(equalToConstant: 30),
-            chip.heightAnchor.constraint(equalToConstant: 30),
+            chip.widthAnchor.constraint(equalToConstant: 34),
+            chip.heightAnchor.constraint(equalToConstant: 34),
             icon.centerXAnchor.constraint(equalTo: chip.centerXAnchor),
             icon.centerYAnchor.constraint(equalTo: chip.centerYAnchor),
             label.leadingAnchor.constraint(equalTo: chip.trailingAnchor, constant: 12),
@@ -433,6 +483,16 @@ final class TerminalAccessoryBar: UIInputView {
             label.trailingAnchor.constraint(lessThanOrEqualTo: button.trailingAnchor, constant: -16),
         ])
         return button
+    }
+
+    /// 0xRRGGBB → UIColor, for the fixed iMessage-style chip palette.
+    static func hex(_ rgb: UInt32) -> UIColor {
+        UIColor(
+            red: CGFloat((rgb >> 16) & 0xFF) / 255,
+            green: CGFloat((rgb >> 8) & 0xFF) / 255,
+            blue: CGFloat(rgb & 0xFF) / 255,
+            alpha: 1
+        )
     }
 
     /// Shows the attach (+) — only sessions with a Mac behind them can
@@ -641,5 +701,28 @@ final class RepeatingKeyButton: UIButton {
             onFire?()
         }
         heldLongEnoughToRepeat = false
+    }
+}
+
+/// A rounded chip filled with a top-left→bottom-right gradient — the depth
+/// iMessage gives its (+) source icons, which a flat tint can't match.
+final class GradientChipView: UIView {
+    private let gradient = CAGradientLayer()
+
+    init(colors: [UIColor]) {
+        super.init(frame: .zero)
+        gradient.colors = colors.map(\.cgColor)
+        gradient.startPoint = CGPoint(x: 0, y: 0)
+        gradient.endPoint = CGPoint(x: 1, y: 1)
+        layer.addSublayer(gradient)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradient.frame = bounds
+        // iMessage's source chips are full circles, not rounded squares.
+        gradient.cornerRadius = bounds.height / 2
     }
 }

--- a/ios/Sources/TerminalAccessoryBar.swift
+++ b/ios/Sources/TerminalAccessoryBar.swift
@@ -229,21 +229,19 @@ final class TerminalAccessoryBar: UIInputView {
                 }
             }
         }
-        // Every exit path (success, cancel, auto-dismissed error) restores the
-        // control-key rows.
+        // Every exit path (success, cancel, auto-dismissed error) cross-fades
+        // the control-key rows back in as the pill leaves.
         voiceBar.onDismissed = { [weak self] in
-            self?.keyPlane?.isHidden = false
+            self?.hideVoiceBar()
         }
     }
 
-    /// Picked Voice from the (+) menu: hide the two control-key rows, show the
-    /// pill in their place, and start recording. A start failure (no key, mic
-    /// denied) surfaces in the pill itself. The QWERTY keyboard is untouched.
+    /// Picked Voice from the (+) menu: swap the two control-key rows for the
+    /// pill and start recording. A start failure (no key, mic denied) surfaces
+    /// in the pill itself. The QWERTY keyboard is untouched.
     private func startVoiceRecording() {
         haptic.impactOccurred()
-        keyPlane?.isHidden = true
-        voiceBar.isHidden = false
-        bringSubviewToFront(voiceBar)
+        showVoiceBar()
         voice.start { [weak self] result in
             guard let self else { return }
             switch result {
@@ -252,6 +250,48 @@ final class TerminalAccessoryBar: UIInputView {
             case .failure(let failure):
                 voiceBar.showError(failure.hudMessage)
             }
+        }
+    }
+
+    /// Materialize the pill: it scales up from 0.96 + fades in while the key
+    /// rows fade out under it — critically damped, no overshoot (the pill
+    /// didn't come from a flick), under 300ms, ease-out for an entrance. Under
+    /// Reduce Motion it's a plain opacity cross-fade, no transform.
+    private func showVoiceBar() {
+        let reduce = UIAccessibility.isReduceMotionEnabled
+        bringSubviewToFront(voiceBar)
+        voiceBar.isHidden = false
+        voiceBar.alpha = 0
+        voiceBar.transform = reduce ? .identity : CGAffineTransform(scaleX: 0.96, y: 0.96)
+        UIView.animate(
+            withDuration: reduce ? 0.2 : 0.28, delay: 0,
+            usingSpringWithDamping: 1, initialSpringVelocity: 0,
+            options: [.curveEaseOut, .allowUserInteraction]
+        ) {
+            self.voiceBar.alpha = 1
+            self.voiceBar.transform = .identity
+            self.keyPlane?.alpha = 0
+        } completion: { _ in
+            self.keyPlane?.isHidden = true
+        }
+    }
+
+    /// Reverse of `showVoiceBar` — the pill fades/scales out along the same path
+    /// as the key rows fade back in, so the swap reads as one motion.
+    private func hideVoiceBar() {
+        let reduce = UIAccessibility.isReduceMotionEnabled
+        keyPlane?.alpha = 0
+        keyPlane?.isHidden = false
+        UIView.animate(
+            withDuration: reduce ? 0.2 : 0.24, delay: 0,
+            options: [.curveEaseOut, .allowUserInteraction]
+        ) {
+            self.voiceBar.alpha = 0
+            self.voiceBar.transform = reduce ? .identity : CGAffineTransform(scaleX: 0.96, y: 0.96)
+            self.keyPlane?.alpha = 1
+        } completion: { _ in
+            self.voiceBar.isHidden = true
+            self.voiceBar.transform = .identity
         }
     }
 

--- a/ios/Sources/TerminalAccessoryBar.swift
+++ b/ios/Sources/TerminalAccessoryBar.swift
@@ -328,10 +328,10 @@ final class TerminalAccessoryBar: UIInputView {
         glass.layer.cornerCurve = .continuous
 
         let rows = UIStackView(arrangedSubviews: [
-            makeMenuRow(title: "Camera", symbol: "camera") { [weak self] in self?.onAttach?(.camera) },
-            makeMenuRow(title: "Photos", symbol: "photo.on.rectangle") { [weak self] in self?.onAttach?(.photos) },
-            makeMenuRow(title: "Files", symbol: "folder") { [weak self] in self?.onAttach?(.files) },
-            makeMenuRow(title: "Voice", symbol: "waveform") { [weak self] in self?.startVoiceRecording() },
+            makeMenuRow(title: "Camera", symbol: "camera.fill", tint: .systemGray) { [weak self] in self?.onAttach?(.camera) },
+            makeMenuRow(title: "Photos", symbol: "photo.fill", tint: .systemBlue) { [weak self] in self?.onAttach?(.photos) },
+            makeMenuRow(title: "Voice", symbol: "mic.fill", tint: .systemRed) { [weak self] in self?.startVoiceRecording() },
+            makeMenuRow(title: "Files", symbol: "folder.fill", tint: .systemIndigo) { [weak self] in self?.onAttach?(.files) },
         ])
         rows.axis = .vertical
         rows.translatesAutoresizingMaskIntoConstraints = false
@@ -382,34 +382,56 @@ final class TerminalAccessoryBar: UIInputView {
         attachMenuScrim = nil
     }
 
-    /// One native-menu row: 17pt title leading, SF symbol trailing — the
-    /// layout a real UIMenu row uses (icons ride the right edge on iOS).
-    /// No separators: iMessage/WhatsApp source menus are clean rows.
+    /// One source row in the newest-Messages style: a filled SF symbol in a
+    /// tinted rounded chip on the leading edge, then the label — the iMessage
+    /// (+) app-row look, cleaner than the plain UIMenu icon-on-the-right shape.
     private func makeMenuRow(
-        title: String, symbol: String, handler: @escaping () -> Void
+        title: String, symbol: String, tint: UIColor, handler: @escaping () -> Void
     ) -> UIView {
-        var config = UIButton.Configuration.plain()
-        config.title = title
-        config.image = UIImage(
-            systemName: symbol,
-            withConfiguration: UIImage.SymbolConfiguration(pointSize: 16, weight: .regular)
-        )
-        config.imagePlacement = .trailing
-        config.baseForegroundColor = .label
-        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 18, bottom: 0, trailing: 18)
-        config.titleTextAttributesTransformer = .init { attributes in
-            var attributes = attributes
-            attributes.font = .systemFont(ofSize: 17)
-            return attributes
-        }
-        let button = UIButton(configuration: config)
-        // .fill spreads title and trailing image to opposite edges.
-        button.contentHorizontalAlignment = .fill
+        let button = UIButton(type: .system)
         button.heightAnchor.constraint(equalToConstant: 46).isActive = true
         button.addAction(UIAction { [weak self] _ in
             self?.dismissAttachMenu()
             handler()
         }, for: .touchUpInside)
+
+        let chip = UIView()
+        chip.backgroundColor = tint
+        chip.layer.cornerRadius = 7
+        chip.layer.cornerCurve = .continuous
+        chip.isUserInteractionEnabled = false
+        chip.translatesAutoresizingMaskIntoConstraints = false
+
+        let icon = UIImageView(image: UIImage(
+            systemName: symbol,
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 15, weight: .semibold)
+        ))
+        icon.tintColor = .white
+        icon.contentMode = .center
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        chip.addSubview(icon)
+
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 17)
+        label.textColor = .label
+        label.isUserInteractionEnabled = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        button.addSubview(chip)
+        button.addSubview(label)
+        button.accessibilityLabel = title
+        NSLayoutConstraint.activate([
+            chip.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: 16),
+            chip.centerYAnchor.constraint(equalTo: button.centerYAnchor),
+            chip.widthAnchor.constraint(equalToConstant: 30),
+            chip.heightAnchor.constraint(equalToConstant: 30),
+            icon.centerXAnchor.constraint(equalTo: chip.centerXAnchor),
+            icon.centerYAnchor.constraint(equalTo: chip.centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: chip.trailingAnchor, constant: 12),
+            label.centerYAnchor.constraint(equalTo: button.centerYAnchor),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: button.trailingAnchor, constant: -16),
+        ])
         return button
     }
 

--- a/ios/Sources/TerminalAccessoryBar.swift
+++ b/ios/Sources/TerminalAccessoryBar.swift
@@ -138,6 +138,9 @@ final class TerminalAccessoryBar: UIInputView {
     var onAttach: ((TerminalAttachSource) -> Void)?
     /// A viewport jump key was tapped — the owner scrolls the terminal view.
     var onScrollEdge: ((TerminalScrollEdge) -> Void)?
+    /// Voice dictation finished — the transcript to type into the terminal.
+    /// Never carries a newline: dictation fills the prompt, it never sends it.
+    var onVoiceTranscript: ((String) -> Void)?
 
     static let barHeight: CGFloat = 82
     private static let keyHeight: CGFloat = 32
@@ -146,6 +149,11 @@ final class TerminalAccessoryBar: UIInputView {
     private let haptic = UIImpactFeedbackGenerator(style: .light)
     private var stickyButtons: [TerminalStickyKey: UIButton] = [:]
     private let attachButton = UIButton(type: .system)
+
+    /// Voice dictation: the recorder/transcriber and the Messages-style
+    /// recording capsule that takes over the bar while it's active.
+    private let voice = VoiceDictation()
+    private let voiceBar = VoiceRecordingBar()
 
     init() {
         super.init(frame: CGRect(x: 0, y: 0, width: 320, height: Self.barHeight),
@@ -187,6 +195,53 @@ final class TerminalAccessoryBar: UIInputView {
             plane.topAnchor.constraint(equalTo: topAnchor, constant: 6),
             plane.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
         ])
+
+        // The voice capsule overlays the key grid, filling the same band. It's
+        // hidden until Voice is picked from the (+) menu, then covers the keys.
+        voiceBar.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(voiceBar)
+        NSLayoutConstraint.activate([
+            voiceBar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            voiceBar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            voiceBar.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            voiceBar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+        ])
+        voiceBar.onCancel = { [weak self] in
+            self?.voice.cancel()
+            self?.voiceBar.dismiss()
+        }
+        voiceBar.onStop = { [weak self] in
+            guard let self else { return }
+            haptic.impactOccurred()
+            voiceBar.showTranscribing()
+            voice.stopAndTranscribe { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .success(let text):
+                    voiceBar.dismiss()
+                    onVoiceTranscript?(text)
+                case .failure(let failure):
+                    voiceBar.showError(failure.hudMessage)
+                }
+            }
+        }
+    }
+
+    /// Picked Voice from the (+) menu: show the capsule and start recording.
+    /// A start failure (no key, mic denied) surfaces in the capsule itself.
+    private func startVoiceRecording() {
+        haptic.impactOccurred()
+        voiceBar.isHidden = false
+        bringSubviewToFront(voiceBar)
+        voice.start { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success:
+                voiceBar.beginRecording(levelProvider: { [weak self] in self?.voice.currentLevel() ?? 0 })
+            case .failure(let failure):
+                voiceBar.showError(failure.hudMessage)
+            }
+        }
     }
 
     @available(*, unavailable)
@@ -273,9 +328,10 @@ final class TerminalAccessoryBar: UIInputView {
         glass.layer.cornerCurve = .continuous
 
         let rows = UIStackView(arrangedSubviews: [
-            makeAttachRow(title: "Camera", symbol: "camera", source: .camera),
-            makeAttachRow(title: "Photos", symbol: "photo.on.rectangle", source: .photos),
-            makeAttachRow(title: "Files", symbol: "folder", source: .files),
+            makeMenuRow(title: "Camera", symbol: "camera") { [weak self] in self?.onAttach?(.camera) },
+            makeMenuRow(title: "Photos", symbol: "photo.on.rectangle") { [weak self] in self?.onAttach?(.photos) },
+            makeMenuRow(title: "Files", symbol: "folder") { [weak self] in self?.onAttach?(.files) },
+            makeMenuRow(title: "Voice", symbol: "waveform") { [weak self] in self?.startVoiceRecording() },
         ])
         rows.axis = .vertical
         rows.translatesAutoresizingMaskIntoConstraints = false
@@ -283,7 +339,7 @@ final class TerminalAccessoryBar: UIInputView {
 
         // Bottom-left corner of the card sits just above the (+) key.
         let anchor = attachButton.convert(attachButton.bounds, to: window)
-        let size = CGSize(width: 250, height: 3 * 46 + 12)
+        let size = CGSize(width: 250, height: 4 * 46 + 12)
         let card = UIView(frame: CGRect(
             x: max(8, anchor.minX),
             y: anchor.minY - size.height - 8,
@@ -329,8 +385,8 @@ final class TerminalAccessoryBar: UIInputView {
     /// One native-menu row: 17pt title leading, SF symbol trailing — the
     /// layout a real UIMenu row uses (icons ride the right edge on iOS).
     /// No separators: iMessage/WhatsApp source menus are clean rows.
-    private func makeAttachRow(
-        title: String, symbol: String, source: TerminalAttachSource
+    private func makeMenuRow(
+        title: String, symbol: String, handler: @escaping () -> Void
     ) -> UIView {
         var config = UIButton.Configuration.plain()
         config.title = title
@@ -352,7 +408,7 @@ final class TerminalAccessoryBar: UIInputView {
         button.heightAnchor.constraint(equalToConstant: 46).isActive = true
         button.addAction(UIAction { [weak self] _ in
             self?.dismissAttachMenu()
-            self?.onAttach?(source)
+            handler()
         }, for: .touchUpInside)
         return button
     }

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -429,6 +429,11 @@ final class TerminalViewController: UIViewController {
             case .files: self?.presentDocumentPicker()
             }
         }
+        // The transcript types straight into the prompt — no newline, so a
+        // dictation never sends a half-formed prompt on its own.
+        keyBar.onVoiceTranscript = { [weak self] text in
+            self?.terminalView.send(Data(text.utf8))
+        }
         terminalView.setStickyModifierChangeHandler { [weak self] in
             guard let self else { return }
             keyBar.setStickyVisual(.ctrl, Self.stickyVisual(terminalView.stickyActivation(for: .ctrl)))

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -1188,6 +1188,7 @@ private final class DisplayTerminalView: UITerminalView {
     /// newline from auto-submitting. A char with a sticky ctrl/alt armed also
     /// stays on the wrapper path, which applies the modifier.
     override func insertText(_ text: String) {
+        deleteRepeat.reset()
         if text == "\n" {
             send(Data([0x0D]))
             return
@@ -1198,6 +1199,115 @@ private final class DisplayTerminalView: UITerminalView {
             return
         }
         super.insertText(text)
+    }
+
+    // MARK: - Software-keyboard delete auto-repeat (phantom document)
+
+    /// Owns the phantom-document state and hold-acceleration policy that make
+    /// the on-screen keyboard's delete key auto-repeat over the terminal. The
+    /// `UITextInput` overrides below are the thin UIKit glue that feed it; the
+    /// reasoning lives in `SoftwareKeyboardDeleteRepeat`.
+    private var deleteRepeat = SoftwareKeyboardDeleteRepeat()
+
+    /// True while an IME (e.g. pinyin) is composing. In that state we defer to
+    /// the wrapper's real geometry so composition, cursor, and candidate
+    /// replacement keep working — the phantom document is only for plain typing.
+    private var isComposingIME: Bool { super.markedTextRange != nil }
+
+    override func deleteBackward() {
+        // IME composition and armed sticky modifiers own the keystroke — never
+        // accelerate those; one delete, real geometry, streak cleared.
+        guard !isComposingIME, !stickyModifierArmed else {
+            deleteRepeat.reset()
+            super.deleteBackward()
+            return
+        }
+        // Re-use the wrapper's own delete encoding (correct per backend,
+        // marked-text-safe) rather than hand-rolling the byte.
+        let count = deleteRepeat.backspaceCount(now: CACurrentMediaTime())
+        for _ in 0..<count { super.deleteBackward() }
+    }
+
+    override var beginningOfDocument: UITextPosition {
+        isComposingIME ? super.beginningOfDocument : PhantomTextPosition(0)
+    }
+
+    override var endOfDocument: UITextPosition {
+        isComposingIME
+            ? super.endOfDocument
+            : PhantomTextPosition(SoftwareKeyboardDeleteRepeat.documentLength)
+    }
+
+    override var selectedTextRange: UITextRange? {
+        get {
+            guard !isComposingIME else { return super.selectedTextRange }
+            let caret = PhantomTextPosition(deleteRepeat.caret)
+            return PhantomTextRange(start: caret, end: caret)
+        }
+        set {
+            guard !isComposingIME else { super.selectedTextRange = newValue; return }
+            if let caret = (newValue?.start as? PhantomTextPosition)?.index {
+                deleteRepeat.moveCaret(to: caret)
+            }
+        }
+    }
+
+    override func textRange(
+        from fromPosition: UITextPosition, to toPosition: UITextPosition
+    ) -> UITextRange? {
+        guard !isComposingIME,
+              let from = fromPosition as? PhantomTextPosition,
+              let to = toPosition as? PhantomTextPosition
+        else { return super.textRange(from: fromPosition, to: toPosition) }
+        return PhantomTextRange(start: from, end: to)
+    }
+
+    override func position(from position: UITextPosition, offset: Int) -> UITextPosition? {
+        guard !isComposingIME, let pos = position as? PhantomTextPosition else {
+            return super.position(from: position, offset: offset)
+        }
+        let index = pos.index + offset
+        guard index >= 0, index <= SoftwareKeyboardDeleteRepeat.documentLength else { return nil }
+        return PhantomTextPosition(index)
+    }
+
+    override func position(
+        from position: UITextPosition, in direction: UITextLayoutDirection, offset: Int
+    ) -> UITextPosition? {
+        guard !isComposingIME, position is PhantomTextPosition else {
+            return super.position(from: position, in: direction, offset: offset)
+        }
+        return self.position(from: position, offset: offset)
+    }
+
+    override func compare(
+        _ position: UITextPosition, to other: UITextPosition
+    ) -> ComparisonResult {
+        guard !isComposingIME,
+              let lhs = position as? PhantomTextPosition,
+              let rhs = other as? PhantomTextPosition
+        else { return super.compare(position, to: other) }
+        if lhs.index < rhs.index { return .orderedAscending }
+        if lhs.index > rhs.index { return .orderedDescending }
+        return .orderedSame
+    }
+
+    override func offset(from: UITextPosition, to toPosition: UITextPosition) -> Int {
+        guard !isComposingIME,
+              let f = from as? PhantomTextPosition,
+              let t = toPosition as? PhantomTextPosition
+        else { return super.offset(from: from, to: toPosition) }
+        return t.index - f.index
+    }
+
+    override func text(in range: UITextRange) -> String? {
+        guard !isComposingIME, let range = range as? PhantomTextRange else {
+            return super.text(in: range)
+        }
+        // Any non-empty string keeps the keyboard convinced there is content
+        // to delete; the bytes never leave this class.
+        let length = max(0, range.length)
+        return String(repeating: " ", count: min(length, 64))
     }
 
     /// Whether any sticky modifier (key bar's ctrl/alt/cmd chips) is armed or

--- a/ios/Sources/VoiceDictation.swift
+++ b/ios/Sources/VoiceDictation.swift
@@ -560,6 +560,9 @@ final class VoiceRecordingBar: UIView {
         }
     }
 
+    /// Marks the cycle done and hands off to the owner, which animates the pill
+    /// out (so the exit stays in sync with the key rows fading back in) — the
+    /// bar's own visibility is left to `onDismissed`.
     func dismiss() {
         guard !hasDismissed else { return }
         hasDismissed = true
@@ -567,7 +570,6 @@ final class VoiceRecordingBar: UIView {
         spinner.stopAnimating()
         dot.layer.removeAllAnimations()
         dot.alpha = 1
-        isHidden = true
         onDismissed?()
     }
 
@@ -580,6 +582,8 @@ final class VoiceRecordingBar: UIView {
     private func pulseDot() {
         dot.layer.removeAllAnimations()
         dot.alpha = 1
+        // Reduced motion: hold the dot steady rather than breathing it.
+        guard !UIAccessibility.isReduceMotionEnabled else { return }
         UIView.animate(
             withDuration: 0.6, delay: 0, options: [.repeat, .autoreverse, .allowUserInteraction]
         ) {

--- a/ios/Sources/VoiceDictation.swift
+++ b/ios/Sources/VoiceDictation.swift
@@ -374,17 +374,31 @@ private extension Data {
     }
 }
 
-/// The recording overlay shown over the composer's pill while the mic button is
-/// held: a pulsing red dot, an elapsed timer, a live waveform, and a hint that
-/// swaps to a cancel warning when the finger slides up into the cancel zone —
-/// Doubao's hold-to-talk affordances, pared to what a one-line composer can
-/// carry. It also renders a brief "transcribing…" and error state.
-final class VoiceRecordingHUD: UIView {
+/// The recording surface that takes over the terminal keyboard's accessory bar
+/// when the user picks Voice from the (+) menu — Apple Messages' audio-message
+/// aesthetic: a rounded capsule with a cancel (✕) on the left, a pulsing red
+/// record dot, an elapsed timer and a live waveform in the middle, and the
+/// signature red circular stop button (a white rounded square) on the right.
+/// Tap Voice to start, tap stop to finish — no hold. After stop it swaps to a
+/// "Transcribing…" spinner, then a brief red error line on failure.
+final class VoiceRecordingBar: UIView {
+    /// The cancel (✕) was tapped — discard the clip, don't transcribe.
+    var onCancel: (() -> Void)?
+    /// The stop button was tapped — finish recording and transcribe.
+    var onStop: (() -> Void)?
+
+    private let capsule = UIView()
+    private let cancelButton = UIButton(type: .system)
+    private let stopButton = UIButton(type: .system)
+    private let stopGlyph = UIView()
     private let dot = UIView()
     private let timeLabel = UILabel()
-    private let hintLabel = UILabel()
+    private let statusLabel = UILabel()
     private let spinner = UIActivityIndicatorView(style: .medium)
     private let waveform = WaveformView()
+
+    /// Controls shown while recording; hidden once we're transcribing or errored.
+    private var recordingControls: [UIView] { [cancelButton, dot, timeLabel, waveform, stopButton] }
 
     private var startDate: Date?
     private var timer: Timer?
@@ -392,7 +406,34 @@ final class VoiceRecordingHUD: UIView {
     init() {
         super.init(frame: .zero)
         isHidden = true
-        layer.cornerCurve = .continuous
+
+        capsule.backgroundColor = .secondarySystemBackground
+        capsule.layer.cornerCurve = .continuous
+        capsule.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(capsule)
+
+        // Cancel (✕): Messages' discard affordance, a plain grey circle.
+        var cancelConfig = UIButton.Configuration.plain()
+        cancelConfig.image = UIImage(
+            systemName: "xmark",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 15, weight: .semibold)
+        )
+        cancelConfig.baseForegroundColor = .secondaryLabel
+        cancelButton.configuration = cancelConfig
+        cancelButton.backgroundColor = .tertiarySystemFill
+        cancelButton.accessibilityLabel = "Cancel recording"
+        cancelButton.addAction(UIAction { [weak self] _ in self?.onCancel?() }, for: .touchUpInside)
+
+        // Stop: the red circle with a white rounded square — Messages' stop.
+        stopButton.backgroundColor = .systemRed
+        stopButton.accessibilityLabel = "Stop and transcribe"
+        stopButton.addAction(UIAction { [weak self] _ in self?.onStop?() }, for: .touchUpInside)
+        stopGlyph.backgroundColor = .white
+        stopGlyph.layer.cornerRadius = 3.5
+        stopGlyph.layer.cornerCurve = .continuous
+        stopGlyph.isUserInteractionEnabled = false
+        stopGlyph.translatesAutoresizingMaskIntoConstraints = false
+        stopButton.addSubview(stopGlyph)
 
         dot.backgroundColor = .systemRed
         dot.layer.cornerRadius = 4
@@ -401,32 +442,56 @@ final class VoiceRecordingHUD: UIView {
         timeLabel.textColor = .label
         timeLabel.text = "0:00"
 
-        hintLabel.font = .systemFont(ofSize: 13, weight: .medium)
-        hintLabel.textColor = .secondaryLabel
-        hintLabel.text = "Slide up to cancel"
+        statusLabel.font = .systemFont(ofSize: 15, weight: .medium)
+        statusLabel.textColor = .secondaryLabel
+        statusLabel.textAlignment = .center
+        statusLabel.isHidden = true
 
         spinner.hidesWhenStopped = true
 
-        for subview in [dot, timeLabel, waveform, hintLabel, spinner] {
-            subview.translatesAutoresizingMaskIntoConstraints = false
-            addSubview(subview)
+        for v in [cancelButton, dot, timeLabel, waveform, stopButton, statusLabel, spinner] {
+            v.translatesAutoresizingMaskIntoConstraints = false
+            capsule.addSubview(v)
         }
         NSLayoutConstraint.activate([
-            dot.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            dot.centerYAnchor.constraint(equalTo: centerYAnchor),
+            capsule.leadingAnchor.constraint(equalTo: leadingAnchor),
+            capsule.trailingAnchor.constraint(equalTo: trailingAnchor),
+            capsule.centerYAnchor.constraint(equalTo: centerYAnchor),
+            capsule.heightAnchor.constraint(equalToConstant: 52),
+
+            cancelButton.leadingAnchor.constraint(equalTo: capsule.leadingAnchor, constant: 6),
+            cancelButton.centerYAnchor.constraint(equalTo: capsule.centerYAnchor),
+            cancelButton.widthAnchor.constraint(equalToConstant: 40),
+            cancelButton.heightAnchor.constraint(equalToConstant: 40),
+
+            stopButton.trailingAnchor.constraint(equalTo: capsule.trailingAnchor, constant: -6),
+            stopButton.centerYAnchor.constraint(equalTo: capsule.centerYAnchor),
+            stopButton.widthAnchor.constraint(equalToConstant: 40),
+            stopButton.heightAnchor.constraint(equalToConstant: 40),
+            stopGlyph.centerXAnchor.constraint(equalTo: stopButton.centerXAnchor),
+            stopGlyph.centerYAnchor.constraint(equalTo: stopButton.centerYAnchor),
+            stopGlyph.widthAnchor.constraint(equalToConstant: 15),
+            stopGlyph.heightAnchor.constraint(equalToConstant: 15),
+
+            dot.leadingAnchor.constraint(equalTo: cancelButton.trailingAnchor, constant: 10),
+            dot.centerYAnchor.constraint(equalTo: capsule.centerYAnchor),
             dot.widthAnchor.constraint(equalToConstant: 8),
             dot.heightAnchor.constraint(equalToConstant: 8),
+
             timeLabel.leadingAnchor.constraint(equalTo: dot.trailingAnchor, constant: 8),
-            timeLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            waveform.leadingAnchor.constraint(equalTo: timeLabel.trailingAnchor, constant: 10),
-            waveform.centerYAnchor.constraint(equalTo: centerYAnchor),
-            waveform.heightAnchor.constraint(equalToConstant: 22),
-            waveform.widthAnchor.constraint(lessThanOrEqualToConstant: 120),
-            hintLabel.leadingAnchor.constraint(greaterThanOrEqualTo: waveform.trailingAnchor, constant: 10),
-            hintLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            hintLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            spinner.centerXAnchor.constraint(equalTo: centerXAnchor),
-            spinner.centerYAnchor.constraint(equalTo: centerYAnchor),
+            timeLabel.centerYAnchor.constraint(equalTo: capsule.centerYAnchor),
+
+            waveform.leadingAnchor.constraint(equalTo: timeLabel.trailingAnchor, constant: 12),
+            waveform.trailingAnchor.constraint(equalTo: stopButton.leadingAnchor, constant: -12),
+            waveform.centerYAnchor.constraint(equalTo: capsule.centerYAnchor),
+            waveform.heightAnchor.constraint(equalToConstant: 24),
+
+            statusLabel.leadingAnchor.constraint(equalTo: capsule.leadingAnchor, constant: 44),
+            statusLabel.trailingAnchor.constraint(equalTo: capsule.trailingAnchor, constant: -16),
+            statusLabel.centerYAnchor.constraint(equalTo: capsule.centerYAnchor),
+
+            spinner.trailingAnchor.constraint(equalTo: statusLabel.leadingAnchor, constant: -8),
+            spinner.centerYAnchor.constraint(equalTo: capsule.centerYAnchor),
         ])
     }
 
@@ -435,19 +500,18 @@ final class VoiceRecordingHUD: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        layer.cornerRadius = min(bounds.height, bounds.width) / 2
+        capsule.layer.cornerRadius = capsule.bounds.height / 2
+        cancelButton.layer.cornerRadius = cancelButton.bounds.height / 2
+        stopButton.layer.cornerRadius = stopButton.bounds.height / 2
     }
 
     /// Shows the recording state and starts the timer. `levelProvider` is polled
-    /// for the live waveform so the HUD never reaches into the recorder itself.
+    /// for the live waveform so the bar never reaches into the recorder itself.
     func beginRecording(levelProvider: @escaping () -> Float) {
         isHidden = false
         spinner.stopAnimating()
-        waveform.isHidden = false
-        setCancelZone(false)
-        backgroundColor = Self.material
-        dot.isHidden = false
-        timeLabel.isHidden = false
+        statusLabel.isHidden = true
+        recordingControls.forEach { $0.isHidden = false }
         waveform.reset()
 
         startDate = Date()
@@ -461,35 +525,25 @@ final class VoiceRecordingHUD: UIView {
         }
     }
 
-    /// Toggles the cancel-zone warning (finger slid up past the threshold).
-    func setCancelZone(_ active: Bool) {
-        hintLabel.text = active ? "Release to cancel" : "Slide up to cancel"
-        hintLabel.textColor = active ? .systemRed : .secondaryLabel
-        dot.backgroundColor = active ? .systemGray : .systemRed
-    }
-
-    /// Swaps to the "transcribing…" state after release.
+    /// Swaps to the "Transcribing…" state after stop.
     func showTranscribing() {
         stopTimer()
-        dot.isHidden = true
-        timeLabel.isHidden = true
-        waveform.isHidden = true
-        hintLabel.text = "Transcribing…"
-        hintLabel.textColor = .secondaryLabel
+        recordingControls.forEach { $0.isHidden = true }
+        statusLabel.text = "Transcribing…"
+        statusLabel.textColor = .secondaryLabel
+        statusLabel.isHidden = false
         spinner.startAnimating()
     }
 
-    /// Flashes an error line, then hides the HUD.
+    /// Flashes a red error line, then hides the bar.
     func showError(_ message: String) {
         stopTimer()
         isHidden = false
         spinner.stopAnimating()
-        dot.isHidden = true
-        timeLabel.isHidden = true
-        waveform.isHidden = true
-        backgroundColor = Self.material
-        hintLabel.text = message
-        hintLabel.textColor = .systemRed
+        recordingControls.forEach { $0.isHidden = true }
+        statusLabel.text = message
+        statusLabel.textColor = .systemRed
+        statusLabel.isHidden = false
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.2) { [weak self] in
             self?.dismiss()
         }
@@ -498,6 +552,8 @@ final class VoiceRecordingHUD: UIView {
     func dismiss() {
         stopTimer()
         spinner.stopAnimating()
+        dot.layer.removeAllAnimations()
+        dot.alpha = 1
         isHidden = true
     }
 
@@ -508,22 +564,23 @@ final class VoiceRecordingHUD: UIView {
     }
 
     private func pulseDot() {
+        dot.layer.removeAllAnimations()
+        dot.alpha = 1
         UIView.animate(
             withDuration: 0.6, delay: 0, options: [.repeat, .autoreverse, .allowUserInteraction]
         ) {
             self.dot.alpha = 0.3
         }
     }
-
-    private static var material: UIColor { .secondarySystemBackground }
 }
 
 /// A row of bars whose heights trail a rolling buffer of input levels — the
 /// "I'm listening" waveform. Cheap: a handful of layers nudged each tick.
 private final class WaveformView: UIView {
-    private let barCount = 13
+    // Enough bars to fill the full-width capsule; they spread to fit whatever
+    // width Auto Layout hands us (no fixed width — the bar stretches).
+    private let barCount = 26
     private let barWidth: CGFloat = 3
-    private let spacing: CGFloat = 4
     private var bars: [CALayer] = []
     private var levels: [Float]
 
@@ -538,9 +595,6 @@ private final class WaveformView: UIView {
             bars.append(bar)
         }
         translatesAutoresizingMaskIntoConstraints = false
-        widthAnchor.constraint(
-            equalToConstant: CGFloat(barCount) * barWidth + CGFloat(barCount - 1) * spacing
-        ).isActive = true
     }
 
     @available(*, unavailable)
@@ -569,6 +623,10 @@ private final class WaveformView: UIView {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         let midY = bounds.midY
+        // Spread the bars evenly across the available width.
+        let spacing = bars.count > 1
+            ? max(0, (bounds.width - CGFloat(bars.count) * barWidth) / CGFloat(bars.count - 1))
+            : 0
         for (index, bar) in bars.enumerated() {
             let height = max(barWidth, CGFloat(levels[index]) * bounds.height)
             let x = CGFloat(index) * (barWidth + spacing)

--- a/ios/Sources/VoiceDictation.swift
+++ b/ios/Sources/VoiceDictation.swift
@@ -56,15 +56,16 @@ enum TranscriptionProvider: String, CaseIterable {
     }
 }
 
-/// Hold-to-talk voice dictation: record the mic while the user holds the
-/// terminal keyboard's mic key, then transcribe the clip with the provider the
-/// user picked in Settings ▸ Voice and hand the text back to drop into the
-/// terminal (never auto-sent — a dictation can't fire a half-formed prompt).
+/// Voice dictation: record the mic while the recording pill is up (started
+/// from the terminal keyboard's (+) menu), then transcribe the clip with the
+/// provider the user picked in Settings ▸ Voice and hand the text back to drop
+/// into the terminal (never auto-sent — a dictation can't fire a half-formed
+/// prompt).
 ///
-/// The clip is short (a held key, seconds to a minute) and the text is wanted
-/// only after release, so this records-then-POSTs rather than opening a
-/// realtime socket — see `docs/rfcs/push-to-talk-voice-dictation.md` for why
-/// that model wins here.
+/// The clip is short (seconds to a minute) and the text is wanted only once the
+/// user taps stop, so this records-then-POSTs rather than opening a realtime
+/// socket — see `docs/rfcs/push-to-talk-voice-dictation.md` for why that model
+/// wins here.
 final class VoiceDictation: NSObject {
     enum Failure: Error {
         case missingKey
@@ -74,7 +75,7 @@ final class VoiceDictation: NSObject {
         case network(String)
         case api(status: Int, message: String)
 
-        /// A short line fit for the recording HUD's error state.
+        /// A short line fit for the recording pill's error state.
         var hudMessage: String {
             switch self {
             case .missingKey: "Add an API key in Settings ▸ Voice"
@@ -139,7 +140,7 @@ final class VoiceDictation: NSObject {
         self.fileURL = url
     }
 
-    /// The current input level, 0…1, for the HUD's waveform. Call while
+    /// The current input level, 0…1, for the pill's waveform. Call while
     /// recording; returns 0 otherwise.
     func currentLevel() -> Float {
         guard let recorder, recorder.isRecording else { return 0 }
@@ -151,7 +152,7 @@ final class VoiceDictation: NSObject {
         return min(1, (decibels - floor) / -floor)
     }
 
-    /// Discards the in-flight recording without transcribing (slide-to-cancel).
+    /// Discards the in-flight recording without transcribing (the cancel ✕).
     func cancel() {
         recorder?.stop()
         cleanUp()
@@ -405,6 +406,10 @@ final class VoiceRecordingBar: UIView {
 
     private var startDate: Date?
     private var timer: Timer?
+    /// Guards `onDismissed` to one fire per cycle — `showError` schedules a
+    /// delayed `dismiss()`, so a cycle must not restore the key rows twice.
+    /// Reset whenever the pill re-enters an active state.
+    private var hasDismissed = false
 
     init() {
         super.init(frame: .zero)
@@ -511,6 +516,7 @@ final class VoiceRecordingBar: UIView {
     /// Shows the recording state and starts the timer. `levelProvider` is polled
     /// for the live waveform so the bar never reaches into the recorder itself.
     func beginRecording(levelProvider: @escaping () -> Float) {
+        hasDismissed = false
         isHidden = false
         spinner.stopAnimating()
         statusLabel.isHidden = true
@@ -538,8 +544,10 @@ final class VoiceRecordingBar: UIView {
         spinner.startAnimating()
     }
 
-    /// Flashes a red error line, then hides the bar.
+    /// Flashes a red error line, then hides the bar. Can be reached without a
+    /// preceding `beginRecording` (a start failure), so it re-arms the guard.
     func showError(_ message: String) {
+        hasDismissed = false
         stopTimer()
         isHidden = false
         spinner.stopAnimating()
@@ -553,6 +561,8 @@ final class VoiceRecordingBar: UIView {
     }
 
     func dismiss() {
+        guard !hasDismissed else { return }
+        hasDismissed = true
         stopTimer()
         spinner.stopAnimating()
         dot.layer.removeAllAnimations()

--- a/ios/Sources/VoiceDictation.swift
+++ b/ios/Sources/VoiceDictation.swift
@@ -386,6 +386,9 @@ final class VoiceRecordingBar: UIView {
     var onCancel: (() -> Void)?
     /// The stop button was tapped — finish recording and transcribe.
     var onStop: (() -> Void)?
+    /// The pill hid itself (success, cancel, or an auto-dismissed error) — the
+    /// owner restores the keyboard here, on every exit path.
+    var onDismissed: (() -> Void)?
 
     private let capsule = UIView()
     private let cancelButton = UIButton(type: .system)
@@ -555,6 +558,7 @@ final class VoiceRecordingBar: UIView {
         dot.layer.removeAllAnimations()
         dot.alpha = 1
         isHidden = true
+        onDismissed?()
     }
 
     private func stopTimer() {

--- a/ios/Sources/VoiceDictation.swift
+++ b/ios/Sources/VoiceDictation.swift
@@ -88,16 +88,24 @@ final class VoiceDictation: NSObject {
         }
     }
 
-    private var recorder: AVAudioRecorder?
+    private var engine: AVAudioEngine?
+    private var audioFile: AVAudioFile?
     private var fileURL: URL?
+    /// Frames the tap has written ÷ sample rate = the clip length, for the
+    /// too-short-jab guard. Written on the audio thread, read after teardown.
+    private var recordedFrames: AVAudioFramePosition = 0
+    private var inputSampleRate: Double = 48_000
+    /// Latest input level, 0…1, for the waveform. Written on the tap's audio
+    /// thread, read on the main thread — a benign race for a meter (aligned
+    /// 32-bit access), so no render-thread lock.
+    private var meterLevel: Float = 0
 
-    var isRecording: Bool { recorder?.isRecording ?? false }
+    var isRecording: Bool { engine?.isRunning ?? false }
 
     // MARK: - Recording
 
     /// Requests mic access if needed, then begins recording. `completion` fires
-    /// on the main queue once recording is actually underway (or with the
-    /// reason it couldn't start).
+    /// on the main queue once recording is underway (or with why it couldn't).
     func start(completion: @escaping (Result<Void, Failure>) -> Void) {
         guard Self.hasAPIKey(for: MobileSettings.shared.transcriptionProvider) else {
             completion(.failure(.missingKey))
@@ -113,62 +121,94 @@ final class VoiceDictation: NSObject {
                 try beginRecording()
                 completion(.success(()))
             } catch {
+                teardownEngine()
                 completion(.failure(.recordingFailed))
             }
         }
     }
 
+    /// Taps the mic through AVAudioEngine and writes straight to an AAC file.
+    /// Unlike AVAudioRecorder, stopping the engine flushes every frame the tap
+    /// has delivered, so the tail is never clipped and no drain delay is needed
+    /// — Apple's recommended path for recording.
     private func beginRecording() throws {
         let session = AVAudioSession.sharedInstance()
         try session.setCategory(.record, mode: .measurement, options: [.duckOthers])
         try session.setActive(true)
 
+        let engine = AVAudioEngine()
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        guard format.sampleRate > 0 else { throw Failure.recordingFailed }
+
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("termio-dictation-\(UUID().uuidString).m4a")
-        // AAC in an m4a container: one of OpenAI's accepted formats, and small.
-        // 24 kHz mono is plenty for speech and keeps uploads tiny.
+        // AAC in an m4a container (both providers accept it), written at the
+        // mic's own rate/channels so the tap buffers need no format conversion.
         let settings: [String: Any] = [
             AVFormatIDKey: kAudioFormatMPEG4AAC,
-            AVSampleRateKey: 24_000,
-            AVNumberOfChannelsKey: 1,
+            AVSampleRateKey: format.sampleRate,
+            AVNumberOfChannelsKey: format.channelCount,
             AVEncoderAudioQualityKey: AVAudioQuality.medium.rawValue,
         ]
-        let recorder = try AVAudioRecorder(url: url, settings: settings)
-        recorder.isMeteringEnabled = true
-        guard recorder.record() else { throw Failure.recordingFailed }
-        self.recorder = recorder
+        let file = try AVAudioFile(forWriting: url, settings: settings)
+
+        recordedFrames = 0
+        inputSampleRate = format.sampleRate
+        meterLevel = 0
+        input.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
+            guard let self else { return }
+            try? file.write(from: buffer)
+            recordedFrames += AVAudioFramePosition(buffer.frameLength)
+            meterLevel = Self.level(of: buffer)
+        }
+
+        engine.prepare()
+        try engine.start()
+        self.engine = engine
+        self.audioFile = file
         self.fileURL = url
+    }
+
+    /// RMS of a buffer mapped to 0…1 over the useful speech band. The band is
+    /// deliberately narrow — quiet room ≈ -55 dB, normal speech ≈ -30 dB, loud
+    /// ≈ -12 dB — so normal talking fills the bar instead of sitting near the
+    /// floor (0 dB is clipping, which speech never reaches).
+    private static func level(of buffer: AVAudioPCMBuffer) -> Float {
+        guard let data = buffer.floatChannelData?[0], buffer.frameLength > 0 else { return 0 }
+        let count = Int(buffer.frameLength)
+        var sum: Float = 0
+        for i in 0..<count { let s = data[i]; sum += s * s }
+        let decibels = 20 * log10(max(sqrt(sum / Float(count)), 1e-7))
+        let floor: Float = -55
+        let ceiling: Float = -12
+        return min(1, max(0, (decibels - floor) / (ceiling - floor)))
     }
 
     /// The current input level, 0…1, for the pill's waveform. Call while
     /// recording; returns 0 otherwise.
     func currentLevel() -> Float {
-        guard let recorder, recorder.isRecording else { return 0 }
-        recorder.updateMeters()
-        let decibels = recorder.averagePower(forChannel: 0)
-        // averagePower is roughly -160…0 dB; map the useful speech band to 0…1.
-        let floor: Float = -50
-        guard decibels > floor else { return 0 }
-        return min(1, (decibels - floor) / -floor)
+        isRecording ? meterLevel : 0
     }
 
     /// Discards the in-flight recording without transcribing (the cancel ✕).
     func cancel() {
-        recorder?.stop()
+        teardownEngine()
         cleanUp()
     }
 
     /// Stops recording and transcribes the clip. `completion` fires on the main
-    /// queue with the transcript or the reason it failed.
+    /// queue with the transcript or the reason it failed. Stopping the engine
+    /// flushes the tap cleanly, so the whole clip is on disk — no drain wait.
     func stopAndTranscribe(completion: @escaping (Result<String, Failure>) -> Void) {
-        guard let recorder, let fileURL else {
+        guard let fileURL, engine != nil else {
             completion(.failure(.recordingFailed))
             return
         }
-        let duration = recorder.currentTime
-        recorder.stop()
-        self.recorder = nil
+        // Teardown first so the tap has stopped and recordedFrames is final.
+        teardownEngine()
         deactivateSession()
+        let duration = Double(recordedFrames) / inputSampleRate
 
         // A stab at the button (or a bump) isn't a dictation; drop it quietly.
         guard duration >= 0.4 else {
@@ -176,7 +216,6 @@ final class VoiceDictation: NSObject {
             completion(.failure(.empty))
             return
         }
-
         let provider = MobileSettings.shared.transcriptionProvider
         guard let key = Self.apiKey(for: provider), !key.isEmpty else {
             cleanUp()
@@ -189,9 +228,18 @@ final class VoiceDictation: NSObject {
         }
     }
 
+    /// Stops the engine and closes the file, flushing every delivered frame.
+    private func teardownEngine() {
+        engine?.inputNode.removeTap(onBus: 0)
+        engine?.stop()
+        engine = nil
+        audioFile = nil   // closing the AVAudioFile flushes its remaining frames
+    }
+
     private func cleanUp() {
         if let fileURL { try? FileManager.default.removeItem(at: fileURL) }
-        recorder = nil
+        engine = nil
+        audioFile = nil
         fileURL = nil
         deactivateSession()
     }
@@ -377,9 +425,9 @@ private extension Data {
 
 /// The recording surface that takes over the terminal keyboard's accessory bar
 /// when the user picks Voice from the (+) menu — Apple Messages' audio-message
-/// aesthetic: a rounded capsule with a cancel (✕) on the left, a pulsing red
-/// record dot, an elapsed timer and a live waveform in the middle, and the
-/// signature red circular stop button (a white rounded square) on the right.
+/// aesthetic: a rounded capsule with a cancel (✕) on the left, an elapsed timer
+/// and a live waveform in the middle, and the signature red circular stop button
+/// (a white rounded square) on the right.
 /// Tap Voice to start, tap stop to finish — no hold. After stop it swaps to a
 /// "Transcribing…" spinner, then a brief red error line on failure.
 final class VoiceRecordingBar: UIView {
@@ -395,14 +443,13 @@ final class VoiceRecordingBar: UIView {
     private let cancelButton = UIButton(type: .system)
     private let stopButton = UIButton(type: .system)
     private let stopGlyph = UIView()
-    private let dot = UIView()
     private let timeLabel = UILabel()
     private let statusLabel = UILabel()
     private let spinner = UIActivityIndicatorView(style: .medium)
     private let waveform = WaveformView()
 
     /// Controls shown while recording; hidden once we're transcribing or errored.
-    private var recordingControls: [UIView] { [cancelButton, dot, timeLabel, waveform, stopButton] }
+    private var recordingControls: [UIView] { [cancelButton, timeLabel, waveform, stopButton] }
 
     private var startDate: Date?
     private var timer: Timer?
@@ -443,9 +490,6 @@ final class VoiceRecordingBar: UIView {
         stopGlyph.translatesAutoresizingMaskIntoConstraints = false
         stopButton.addSubview(stopGlyph)
 
-        dot.backgroundColor = .systemRed
-        dot.layer.cornerRadius = 4
-
         timeLabel.font = .monospacedDigitSystemFont(ofSize: 15, weight: .medium)
         timeLabel.textColor = .label
         timeLabel.text = "0:00"
@@ -457,7 +501,7 @@ final class VoiceRecordingBar: UIView {
 
         spinner.hidesWhenStopped = true
 
-        for v in [cancelButton, dot, timeLabel, waveform, stopButton, statusLabel, spinner] {
+        for v in [cancelButton, timeLabel, waveform, stopButton, statusLabel, spinner] {
             v.translatesAutoresizingMaskIntoConstraints = false
             capsule.addSubview(v)
         }
@@ -481,12 +525,7 @@ final class VoiceRecordingBar: UIView {
             stopGlyph.widthAnchor.constraint(equalToConstant: 15),
             stopGlyph.heightAnchor.constraint(equalToConstant: 15),
 
-            dot.leadingAnchor.constraint(equalTo: cancelButton.trailingAnchor, constant: 10),
-            dot.centerYAnchor.constraint(equalTo: capsule.centerYAnchor),
-            dot.widthAnchor.constraint(equalToConstant: 8),
-            dot.heightAnchor.constraint(equalToConstant: 8),
-
-            timeLabel.leadingAnchor.constraint(equalTo: dot.trailingAnchor, constant: 8),
+            timeLabel.leadingAnchor.constraint(equalTo: cancelButton.trailingAnchor, constant: 14),
             timeLabel.centerYAnchor.constraint(equalTo: capsule.centerYAnchor),
 
             waveform.leadingAnchor.constraint(equalTo: timeLabel.trailingAnchor, constant: 12),
@@ -524,7 +563,6 @@ final class VoiceRecordingBar: UIView {
         waveform.reset()
 
         startDate = Date()
-        pulseDot()
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
             guard let self, let startDate else { return }
@@ -568,8 +606,6 @@ final class VoiceRecordingBar: UIView {
         hasDismissed = true
         stopTimer()
         spinner.stopAnimating()
-        dot.layer.removeAllAnimations()
-        dot.alpha = 1
         onDismissed?()
     }
 
@@ -577,18 +613,6 @@ final class VoiceRecordingBar: UIView {
         timer?.invalidate()
         timer = nil
         startDate = nil
-    }
-
-    private func pulseDot() {
-        dot.layer.removeAllAnimations()
-        dot.alpha = 1
-        // Reduced motion: hold the dot steady rather than breathing it.
-        guard !UIAccessibility.isReduceMotionEnabled else { return }
-        UIView.animate(
-            withDuration: 0.6, delay: 0, options: [.repeat, .autoreverse, .allowUserInteraction]
-        ) {
-            self.dot.alpha = 0.3
-        }
     }
 }
 

--- a/ios/Sources/VoiceDictation.swift
+++ b/ios/Sources/VoiceDictation.swift
@@ -1,22 +1,71 @@
 import AVFoundation
 import UIKit
 
-/// Hold-to-talk voice dictation: record the mic while the user holds the
-/// composer's mic button, then transcribe the clip with OpenAI's
-/// `gpt-4o-transcribe` and hand the text back for the composer to drop into the
-/// draft (never auto-sent — the same "dictation can't fire a half-formed
-/// prompt" contract the composer already keeps).
-///
-/// The clip is short (a held button, seconds to a minute) and the text is
-/// wanted only after release, so this records-then-POSTs to
-/// `/v1/audio/transcriptions` rather than opening a realtime socket — see
-/// `docs/rfcs/push-to-talk-voice-dictation.md` for why that model wins here.
-final class VoiceDictation: NSObject {
-    /// The transcription model. `gpt-4o-transcribe` is the most accurate of
-    /// OpenAI's speech-to-text models — worth it for prompts dense with
-    /// identifiers and paths — at $0.006/min.
-    static let model = "gpt-4o-transcribe"
+/// One of the bring-your-own-key transcription services the user can pick in
+/// Settings ▸ Voice. Each owns its endpoint, auth header, request shape, and
+/// its own Keychain entry, so keys never cross providers.
+enum TranscriptionProvider: String, CaseIterable {
+    case openAI
+    case elevenLabs
 
+    /// Settings label.
+    var displayName: String {
+        switch self {
+        case .openAI: "OpenAI"
+        case .elevenLabs: "ElevenLabs"
+        }
+    }
+
+    /// The key editor's field placeholder.
+    var keyPlaceholder: String {
+        switch self {
+        case .openAI: "sk-..."
+        case .elevenLabs: "Your ElevenLabs API key"
+        }
+    }
+
+    /// The Key section's footer — which model does the transcribing.
+    var keyFooter: String {
+        switch self {
+        case .openAI: "Transcribed with OpenAI gpt-4o-transcribe."
+        case .elevenLabs: "Transcribed with ElevenLabs Scribe."
+        }
+    }
+
+    fileprivate var keychainService: String {
+        switch self {
+        case .openAI: "sh.termio.mobile.openai"
+        case .elevenLabs: "sh.termio.mobile.elevenlabs"
+        }
+    }
+
+    fileprivate var endpointURL: URL {
+        switch self {
+        case .openAI: URL(string: "https://api.openai.com/v1/audio/transcriptions")!
+        case .elevenLabs: URL(string: "https://api.elevenlabs.io/v1/speech-to-text")!
+        }
+    }
+
+    /// The transcription model id sent in the request. `gpt-4o-transcribe` is
+    /// OpenAI's most accurate speech model; `scribe_v2` is ElevenLabs' Scribe.
+    fileprivate var model: String {
+        switch self {
+        case .openAI: "gpt-4o-transcribe"
+        case .elevenLabs: "scribe_v2"
+        }
+    }
+}
+
+/// Hold-to-talk voice dictation: record the mic while the user holds the
+/// terminal keyboard's mic key, then transcribe the clip with the provider the
+/// user picked in Settings ▸ Voice and hand the text back to drop into the
+/// terminal (never auto-sent — a dictation can't fire a half-formed prompt).
+///
+/// The clip is short (a held key, seconds to a minute) and the text is wanted
+/// only after release, so this records-then-POSTs rather than opening a
+/// realtime socket — see `docs/rfcs/push-to-talk-voice-dictation.md` for why
+/// that model wins here.
+final class VoiceDictation: NSObject {
     enum Failure: Error {
         case missingKey
         case microphonePermissionDenied
@@ -28,7 +77,7 @@ final class VoiceDictation: NSObject {
         /// A short line fit for the recording HUD's error state.
         var hudMessage: String {
             switch self {
-            case .missingKey: "Add your OpenAI key in Settings ▸ Voice"
+            case .missingKey: "Add an API key in Settings ▸ Voice"
             case .microphonePermissionDenied: "Allow microphone access in Settings"
             case .recordingFailed: "Couldn't start recording"
             case .empty: "Didn't catch that — try again"
@@ -49,7 +98,7 @@ final class VoiceDictation: NSObject {
     /// on the main queue once recording is actually underway (or with the
     /// reason it couldn't start).
     func start(completion: @escaping (Result<Void, Failure>) -> Void) {
-        guard Self.apiKey?.isEmpty == false else {
+        guard Self.hasAPIKey(for: MobileSettings.shared.transcriptionProvider) else {
             completion(.failure(.missingKey))
             return
         }
@@ -127,12 +176,13 @@ final class VoiceDictation: NSObject {
             return
         }
 
-        guard let key = Self.apiKey, !key.isEmpty else {
+        let provider = MobileSettings.shared.transcriptionProvider
+        guard let key = Self.apiKey(for: provider), !key.isEmpty else {
             cleanUp()
             completion(.failure(.missingKey))
             return
         }
-        transcribe(fileURL: fileURL, apiKey: key) { [weak self] result in
+        transcribe(fileURL: fileURL, provider: provider, apiKey: key) { [weak self] result in
             self?.cleanUp()
             completion(result)
         }
@@ -163,7 +213,7 @@ final class VoiceDictation: NSObject {
     // MARK: - Transcription
 
     private func transcribe(
-        fileURL: URL, apiKey: String,
+        fileURL: URL, provider: TranscriptionProvider, apiKey: String,
         completion: @escaping (Result<String, Failure>) -> Void
     ) {
         let audioData: Data
@@ -174,32 +224,7 @@ final class VoiceDictation: NSObject {
             return
         }
 
-        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/audio/transcriptions")!)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        let boundary = "termio-\(UUID().uuidString)"
-        request.setValue(
-            "multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type"
-        )
-
-        var body = Data()
-        func field(_ name: String, _ value: String) {
-            body.appendString("--\(boundary)\r\n")
-            body.appendString("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
-            body.appendString("\(value)\r\n")
-        }
-        field("model", Self.model)
-        // Plain-text response: the whole body is the transcript, no JSON to peel.
-        field("response_format", "text")
-        body.appendString("--\(boundary)\r\n")
-        body.appendString(
-            "Content-Disposition: form-data; name=\"file\"; filename=\"audio.m4a\"\r\n"
-        )
-        body.appendString("Content-Type: audio/m4a\r\n\r\n")
-        body.append(audioData)
-        body.appendString("\r\n--\(boundary)--\r\n")
-        request.httpBody = body
-
+        let request = provider.makeRequest(apiKey: apiKey, audioData: audioData)
         URLSession.shared.dataTask(with: request) { data, response, error in
             let result: Result<String, Failure>
             defer { DispatchQueue.main.async { completion(result) } }
@@ -212,67 +237,135 @@ final class VoiceDictation: NSObject {
                 result = .failure(.network("No response"))
                 return
             }
-            let bodyText = String(data: data, encoding: .utf8) ?? ""
             guard (200..<300).contains(http.statusCode) else {
                 result = .failure(.api(
-                    status: http.statusCode, message: Self.apiErrorMessage(from: data) ?? "Transcription failed"
+                    status: http.statusCode,
+                    message: provider.errorMessage(from: data) ?? "Transcription failed"
                 ))
                 return
             }
-            let transcript = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
+            let transcript = provider.transcript(from: data)
             result = transcript.isEmpty ? .failure(.empty) : .success(transcript)
         }.resume()
     }
 
-    /// OpenAI errors come back as `{ "error": { "message": ... } }`.
-    private static func apiErrorMessage(from data: Data) -> String? {
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let error = json["error"] as? [String: Any],
-              let message = error["message"] as? String
-        else { return nil }
-        return message
-    }
-
     // MARK: - API key (Keychain)
 
-    private static let keychainService = "sh.termio.mobile.openai"
+    // One entry per provider (keyed by service), same account. Reads use the
+    // service the value was written under, so a key stored before providers
+    // were split out still resolves under `.openAI` unchanged.
     private static let keychainAccount = "api-key"
 
-    /// The OpenAI API key, stored in the Keychain (never UserDefaults). Setting
-    /// nil or empty removes it.
-    static var apiKey: String? {
-        get {
-            let query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: keychainService,
-                kSecAttrAccount as String: keychainAccount,
-                kSecReturnData as String: true,
-                kSecMatchLimit as String: kSecMatchLimitOne,
-            ]
-            var item: CFTypeRef?
-            guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
-                  let data = item as? Data
-            else { return nil }
-            return String(data: data, encoding: .utf8)
-        }
-        set {
-            let base: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: keychainService,
-                kSecAttrAccount as String: keychainAccount,
-            ]
-            SecItemDelete(base as CFDictionary)
-            guard let value = newValue?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !value.isEmpty, let data = value.data(using: .utf8)
-            else { return }
-            var add = base
-            add[kSecValueData as String] = data
-            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-            SecItemAdd(add as CFDictionary, nil)
-        }
+    /// The stored key for `provider`, or nil. Kept in the Keychain, never
+    /// UserDefaults.
+    static func apiKey(for provider: TranscriptionProvider) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: provider.keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data
+        else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 
-    static var hasAPIKey: Bool { apiKey?.isEmpty == false }
+    /// Stores the key for `provider`; a nil or empty value removes it.
+    static func setAPIKey(_ newValue: String?, for provider: TranscriptionProvider) {
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: provider.keychainService,
+            kSecAttrAccount as String: keychainAccount,
+        ]
+        SecItemDelete(base as CFDictionary)
+        guard let value = newValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty, let data = value.data(using: .utf8)
+        else { return }
+        var add = base
+        add[kSecValueData as String] = data
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        SecItemAdd(add as CFDictionary, nil)
+    }
+
+    static func hasAPIKey(for provider: TranscriptionProvider) -> Bool {
+        apiKey(for: provider)?.isEmpty == false
+    }
+}
+
+private extension TranscriptionProvider {
+    /// Builds the multipart transcription POST for this provider.
+    func makeRequest(apiKey: String, audioData: Data) -> URLRequest {
+        var request = URLRequest(url: endpointURL)
+        request.httpMethod = "POST"
+        let boundary = "termio-\(UUID().uuidString)"
+        request.setValue(
+            "multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type"
+        )
+        switch self {
+        case .openAI:
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        case .elevenLabs:
+            request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+        }
+
+        var body = Data()
+        func field(_ name: String, _ value: String) {
+            body.appendString("--\(boundary)\r\n")
+            body.appendString("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+            body.appendString("\(value)\r\n")
+        }
+        switch self {
+        case .openAI:
+            field("model", model)
+            // Plain-text response: the whole body is the transcript, no JSON to peel.
+            field("response_format", "text")
+        case .elevenLabs:
+            field("model_id", model)
+        }
+        body.appendString("--\(boundary)\r\n")
+        body.appendString(
+            "Content-Disposition: form-data; name=\"file\"; filename=\"audio.m4a\"\r\n"
+        )
+        body.appendString("Content-Type: audio/m4a\r\n\r\n")
+        body.append(audioData)
+        body.appendString("\r\n--\(boundary)--\r\n")
+        request.httpBody = body
+        return request
+    }
+
+    /// Pulls the transcript out of a 2xx response body.
+    func transcript(from data: Data) -> String {
+        let text: String
+        switch self {
+        case .openAI:
+            // response_format=text: the body is the transcript verbatim.
+            text = String(data: data, encoding: .utf8) ?? ""
+        case .elevenLabs:
+            // JSON: { "text": "…", "language_code": …, "words": [...] }.
+            let json = try? JSONSerialization.jsonObject(with: data)
+            text = (json as? [String: Any])?["text"] as? String ?? ""
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// A human-readable message from an error response, if the body carries one.
+    func errorMessage(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        switch self {
+        case .openAI:
+            // { "error": { "message": … } }
+            return (json["error"] as? [String: Any])?["message"] as? String
+        case .elevenLabs:
+            // { "detail": "…" } or { "detail": { "message": … } }
+            if let detail = json["detail"] as? String { return detail }
+            return (json["detail"] as? [String: Any])?["message"] as? String
+        }
+    }
 }
 
 private extension Data {


### PR DESCRIPTION
Adds voice dictation to the iOS terminal keyboard: pick **Voice** from the `+` menu, speak into a Messages-style recording pill, and the transcript is typed straight into the prompt.

## What's in it
- **Multi-provider transcription** — bring-your-own-key **OpenAI** (`gpt-4o-transcribe`, the flagship-accuracy model) or **ElevenLabs** (`scribe_v2`), picked in **Settings ▸ Voice**. Keys live in the Keychain, one per provider.
- **iMessage-style recording pill** (`VoiceRecordingBar`) — cancel ✕ · pulsing red dot · `m:ss` timer · live waveform · the red circular stop button. Tap to start, tap stop to transcribe; `Transcribing…` spinner, then a red error line on failure.
- **Keyboard behavior** — while recording, the two control-key rows are hidden and the pill takes their place; the **system QWERTY keyboard stays up**. The rows are restored on every exit path.
- **`+` source menu, refreshed** — Camera/Photos/Voice/Files rows are now iMessage-style gradient squircle chips (leading icon, label after).
- **Settings tab icon** — a new `voice` microphone glyph added to the shared Hugeicons set.

## Contract
The transcript is inserted **with no newline** — dictation fills the prompt, it never auto-submits (the same rule the rest of the keyboard keeps).

## Notes for review
- Voice lives inside the `+` menu, so it inherits the menu's availability (a live companion Mac session).
- No transcription key → the pill guides the user to **Settings ▸ Voice**; mic denied → prompts for microphone access.
- The terminal screen is **never** sent anywhere — only the recorded clip goes to the chosen provider.

## Testing
- Builds clean for the iOS Simulator.
- Installed and exercised on a physical iPhone.

Still **draft** — pending on-device polish (pill spacing / chip sizing) from screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)