### PR TITLE
feat(cli): send --wait — block until the turn settles, return the transcript range

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -26,14 +26,22 @@ struct ControlRequest: Decodable {
     let text: String?
     let lines: Int?
     let agent: String?
+    /// `send`/`answer` only: block until the turn the prompt kicked off settles
+    /// (or the timeout elapses) and report the outcome, instead of replying the
+    /// instant the keystrokes are delivered.
+    let wait: Bool?
+    /// The `--wait` cap in milliseconds; clamped server-side. Nil uses the default.
+    let timeoutMs: Int?
 
     private enum CodingKeys: String, CodingKey {
-        case op, format, target, text, lines, agent
+        case op, format, target, text, lines, agent, wait
         case callerSession = "caller_session"
         case callerCwd = "caller_cwd"
+        case timeoutMs = "timeout_ms"
     }
 
     var wantsJSON: Bool { format == "json" }
+    var wantsWait: Bool { wait == true }
 }
 
 /// A local Unix-domain socket the `termio sessions` CLI connects to. Unlike

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -97,7 +97,8 @@ extension TermioStore {
         switch resolveTarget(token, in: project) {
         case .found(let session):
             let state = surface(for: session, in: project)
-            return await deliver(payload, to: session, state: state, request: request, created: false)
+            return await deliver(payload, to: session, state: state, request: request,
+                                 in: project, created: false)
         case .notFound:
             return controlError(request, "not_found", targetNotFoundMessage(request.target))
         case .ambiguous:
@@ -141,14 +142,15 @@ extension TermioStore {
         }
         let state = surface(for: fresh, in: project)
         await waitForBootSettle(of: state)
-        return await deliver(payload, to: fresh, state: state, request: request, created: true)
+        return await deliver(payload, to: fresh, state: state, request: request,
+                             in: project, created: true)
     }
 
     /// Types `payload` into a session's live surface and submits it. Shared by
     /// the existing-sibling and fresh-spawn paths.
     private func deliver(
         _ payload: String, to session: Session, state: TerminalViewState,
-        request: ControlRequest, created: Bool
+        request: ControlRequest, in project: Project, created: Bool
     ) async -> Data {
         // The libghostty surface attaches lazily on the pane's first render, so a
         // session never shown in the UI has no surface yet. Selecting it adds it to
@@ -172,7 +174,132 @@ extension TermioStore {
         _ = state.send(payload)
         try? await Task.sleep(for: .milliseconds(40))
         Self.pressReturn(on: surfaceHandle)
-        return sentReply(request, session, created: created)
+
+        // Without `--wait`, the reply is the send acknowledgement (the transcript
+        // path + a cursor to read the response from). With it, block until the turn
+        // settles and report the outcome plus the exact transcript range it landed in.
+        guard request.wantsWait else { return sentReply(request, session, created: created) }
+        // The cursor to read the reply from: wherever the transcript stands right
+        // after submitting. A fresh session's transcript often isn't known until its
+        // first hook fires mid-turn, so this is nil for now and re-read after the wait.
+        let cursorAtSend = transcriptPaths[session.id].map(Self.lineCount)
+        return await waitForReply(request, session: session, in: project,
+                                  cursorAtSend: cursorAtSend, created: created)
+    }
+
+    /// Blocks until the session the prompt was sent to finishes its turn — or stops
+    /// to ask the user (`needs-you`) — or the timeout elapses, then reports the
+    /// outcome. This is what lets a caller issue one `send --wait` instead of
+    /// sending and then polling `list` in a loop.
+    ///
+    /// Completion is read primarily from the **status resting**: the turn is done once
+    /// the session, having been seen `working`, drops back off `working` and stays there
+    /// for `settleWindow` (`needs-you` short-circuits immediately). Status is the signal
+    /// every real agent drives — built-ins via hooks, rule-based agents via the screen
+    /// classifier — and unlike a raw screen watch it is immune to a TUI footer that keeps
+    /// animating after the reply. A 300ms poll always catches the `working` span of a real
+    /// turn (an LLM round-trip is far longer). Only a session with no status signal at all
+    /// — a plain terminal driven by `send --wait` — falls back to the screen first changing
+    /// and then going still.
+    private func waitForReply(
+        _ request: ControlRequest, session: Session, in project: Project,
+        cursorAtSend: Int?, created: Bool
+    ) async -> Data {
+        let cap = min(max(request.timeoutMs ?? 300_000, 1_000), 600_000)
+        let deadline = Date().addingTimeInterval(Double(cap) / 1_000)
+        let settleWindow = 1.5
+
+        var sawWorking = false
+        var restingSince: Date?
+        var lastFrame = viewportText(for: session, in: project)
+        var lastChangeAt = Date()
+        var changedSinceSend = false
+        var settled: SessionStatus?
+
+        while Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(300))
+            let current = status(for: session.id)
+            if current == .working {
+                sawWorking = true
+                restingSince = nil
+            } else if restingSince == nil {
+                restingSince = Date()
+            }
+            if current == .needsAttention { settled = .needsAttention; break }
+
+            let now = Date()
+            let frame = viewportText(for: session, in: project)
+            if frame != lastFrame {
+                lastFrame = frame
+                lastChangeAt = now
+                changedSinceSend = true
+            }
+            guard current != .working else { continue }
+            let rested = restingSince.map { now.timeIntervalSince($0) >= settleWindow } ?? false
+            let screenQuiet = now.timeIntervalSince(lastChangeAt) >= settleWindow
+            // Status-tracked agent: seen working, now rested. (Footer animation can't
+            // fool this — it doesn't touch status.)
+            if sawWorking, rested { settled = current; break }
+            // No status signal at all (a plain terminal): the screen changed, then stilled.
+            if !sawWorking, changedSinceSend, screenQuiet { settled = current; break }
+        }
+        return waitReply(request, session: session, in: project,
+                         cursorAtSend: cursorAtSend, created: created, settled: settled)
+    }
+
+    /// The reply for a completed (or timed-out) `send --wait`. Hands back the turn's
+    /// final status and the exact transcript range to read — `cursor` (where the reply
+    /// begins, captured at send) through `cursor_end` (the log's length now) — so the
+    /// caller's own file tools read precisely the new content, no polling. When the
+    /// session is blocked on the user (`needs-you`), the current screen rides along so
+    /// the caller can see the prompt it must `answer`.
+    private func waitReply(
+        _ request: ControlRequest, session: Session, in project: Project,
+        cursorAtSend: Int?, created: Bool, settled: SessionStatus?
+    ) -> Data {
+        let handle = sessionHandle(for: session)
+        let statusToken = Self.statusToken(status(for: session.id))
+        var json: [String: Any] = [
+            "target": handle,
+            "title": displayTitle(for: session),
+            "status": statusToken,
+            "timed_out": settled == nil,
+        ]
+        if created { json["created"] = true }
+
+        let headline: String
+        switch settled {
+        case .needsAttention: headline = "\(handle) is waiting on you"
+        case .some: headline = "\(handle) finished (\(statusToken))"
+        case nil: headline = "\(handle) still \(statusToken) after the wait — timed out"
+        }
+        var text = headline
+
+        // The transcript may only have become known during the wait (a fresh
+        // session's first hook), so re-read it here rather than trusting the
+        // send-time snapshot.
+        if let transcript = transcriptPaths[session.id] {
+            let start = cursorAtSend ?? 0
+            let end = Self.lineCount(of: transcript)
+            json["transcript"] = transcript
+            json["cursor"] = start
+            json["cursor_end"] = end
+            text += "\n  transcript: \(transcript)\n  reply: lines \(start)–\(end) (read this range)"
+        }
+        if settled == .needsAttention, let screen = viewportText(for: session, in: project) {
+            json["screen"] = screen
+            text += "\n  on screen:\n\(screen)"
+        }
+        return control(request, ok: true, text: text, json: json)
+    }
+
+    /// The current viewport text of a session's terminal, or nil when it has no live
+    /// in-memory backend yet (never rendered). Reads through the backend's own lock
+    /// (`readViewportText`), so it's safe from this actor.
+    private func viewportText(for session: Session, in project: Project) -> String? {
+        let state = surfaces[session.id] ?? surface(for: session, in: project)
+        guard case .inMemory(let terminal) = state.configuration.backend else { return nil }
+        return terminal.readViewportText()
     }
 
     /// Waits for a freshly launched agent TUI to finish booting before keystrokes

--- a/scripts/termio
+++ b/scripts/termio
@@ -27,6 +27,8 @@ usage:
   termio sessions list                       sibling sessions in this project + status
   termio sessions send "<prompt>"            start a NEW agent session and send it the prompt
   termio sessions send <agent>@<id> "<prompt>"   send to an existing session
+  termio sessions send --wait <agent>@<id> "<prompt>"  send, then block until the turn
+                                             settles and report the transcript range to read
   termio sessions answer <agent>@<id> "<choice>" answer a session's menu/permission prompt
   termio sessions close <agent>@<id> [...]   close session tabs
   termio sessions focus <agent>@<id>         select the session in the app
@@ -35,6 +37,9 @@ usage:
 
 options:
   --json           machine-readable output (any `sessions` command)
+  --wait           (send/answer) block until the turn settles; reply carries the final
+                   status and the transcript line range the response landed in
+  --timeout <ms>   cap for --wait (default 300000; clamped 1000–600000). implies --wait
   --agent <name>   agent for a new session (send without a handle; default: caller's)
   --help, --version
 
@@ -75,13 +80,20 @@ is_handle() {
 # code — agents check `$?`, not prose.
 request_once() {
     req_op="$1"; req_format="$2"; req_target="$3"; req_agent="$4"; req_text="$5"
-    request=$(printf '{"op":"%s","format":"%s","caller_session":"%s","caller_cwd":"%s","target":"%s","agent":"%s","text":"%s"}' \
+    req_wait="${6:-false}"; req_timeout="${7:-}"
+    # `wait`/`timeout_ms` are optional; append them only when set so older-shaped
+    # callers (and non-send ops) send the same request they always did.
+    extra=""
+    [ "$req_wait" = "true" ] && extra=',"wait":true'
+    [ -n "$req_timeout" ] && extra="$extra,\"timeout_ms\":$req_timeout"
+    request=$(printf '{"op":"%s","format":"%s","caller_session":"%s","caller_cwd":"%s","target":"%s","agent":"%s","text":"%s"%s}' \
         "$req_op" "$req_format" \
         "$(json_escape "${TERMIO_SESSION:-}")" \
         "$(json_escape "$PWD")" \
         "$(json_escape "$req_target")" \
         "$(json_escape "$req_agent")" \
-        "$(json_escape "$req_text")")
+        "$(json_escape "$req_text")" \
+        "$extra")
     response=$(printf '%s' "$request" | nc -U "$SOCKET")
     printf '%s\n' "$response"
     case "$response" in
@@ -113,10 +125,19 @@ sessions() {
     agent=""
     targets=""
     text=""
+    wait=false
+    timeout=""
     seen_positional=0
     while [ $# -gt 0 ]; do
         case "$1" in
             --json) format=json ;;
+            --wait) wait=true ;;
+            --timeout)
+                [ $# -ge 2 ] || { echo "termio: --timeout needs a value in ms" >&2; exit 1; }
+                case "$2" in
+                    ''|*[!0-9]*) echo "termio: --timeout needs whole milliseconds" >&2; exit 1 ;;
+                esac
+                timeout="$2"; wait=true; shift ;;
             --agent)
                 [ $# -ge 2 ] || { echo "termio: --agent needs a value" >&2; exit 1; }
                 agent="$2"; shift ;;
@@ -164,7 +185,7 @@ sessions() {
         exit "$failed"
     fi
 
-    request_once "$op" "$format" "$targets" "$agent" "$text"
+    request_once "$op" "$format" "$targets" "$agent" "$text" "$wait" "$timeout"
 }
 
 # The public hook contract:


### PR DESCRIPTION
Reimplements #67 cleanly against main's current session-control code (the original branch patched `SessionControl.swift`, which main has since deleted/restructured for the `@id` handle system).

## What
`termio sessions send --wait <handle> "<prompt>"` (and `answer --wait`) block until the turn settles, then reply with the final status + the exact transcript line range (`cursor`..`cursor_end`) to read — replacing the send-then-poll-`list` loop with one call. `--timeout <ms>` caps the wait (clamped 1–600s; implies `--wait`).

## How
- Completion is read off the **resting status**: once a session seen `working` drops back off it for ~1.5s (or hits `needs-you`, which short-circuits). Immune to a TUI footer that keeps animating after the reply.
- Plain terminals with no status signal fall back to the screen changing and then going still.
- Reuses the `readViewportText` settling pattern `waitForBootSettle` already relies on; adds a `viewportText` helper (also surfaces the on-screen prompt when the turn ends in `needs-you`).
- Wire: `ControlRequest` gains `wait`/`timeout_ms`; CLI gains `--wait`/`--timeout`. Non-wait sends are byte-for-byte unchanged.

Builds clean (`swift build`). Not yet interactively verified against a live agent.