### PR TITLE
Size file-type icons to the sidebar's optical width

### DIFF
--- a/Sources/termio/FileBrowser/FileTreeList.swift
+++ b/Sources/termio/FileBrowser/FileTreeList.swift
@@ -84,8 +84,12 @@ private struct FileRow: View {
                     .frame(width: 16, alignment: .leading)
             } else {
                 // The file's real language/tool logo (a Devicon mark) when bundled,
-                // else a tinted SF Symbol — see `FileIconView`.
-                FileIconView(url: node.url, size: 15, symbolSize: 13)
+                // else a tinted SF Symbol — see `FileIconView`. Boxed below the folder's
+                // nominal 15: Devicon marks fill their box edge-to-edge while HugeIcons
+                // ink only ~75% of theirs (the left sidebar's shared-column rule), so an
+                // equal nominal size made every file icon read a step LARGER than the
+                // folder and sidebar family — 12 brings their ink widths level.
+                FileIconView(url: node.url, size: 12, symbolSize: 11)
                     .frame(width: 16, alignment: .leading)
             }
             Text(node.name)


### PR DESCRIPTION
## Summary

Devicon file logos fill their box edge-to-edge while HugeIcons (the folder glyph, the whole left sidebar) ink only ~75% of theirs, so at an equal nominal 15 every file icon read a step larger than the folder rows and the sidebar family. File logos now box at 12 (SF Symbol fallback 11), bringing their ink widths level with the folder's; the 16-wide icon column is unchanged so names keep lining up.

## Release Notes

- File-type icons in the file tree now match the folder and sidebar icons' visual size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)