### PR TITLE
feat(trace): add Grok transcript and trace rendering support

### DIFF
--- a/Sources/termio/Agents/AgentDefinition.swift
+++ b/Sources/termio/Agents/AgentDefinition.swift
@@ -157,6 +157,12 @@ struct AgentDefinition: Identifiable {
             /// `root`; termio searches across the buckets rather than reconstruct each
             /// agent's private cwd encoding.
             var name: String
+            /// For a directory-based store: the filename of the transcript inside the
+            /// session directory, e.g. `"conversation.jsonl"`. When set,
+            /// `resolveTranscriptPath` looks for this exact file. `nil` (the default)
+            /// falls back to scanning for a single `.jsonl` file in the directory.
+            /// Only meaningful when `isDirectory` is true.
+            var transcriptName: String? = nil
         }
 
         /// A declarative description of how to recover an agent-minted session id from
@@ -843,6 +849,9 @@ struct AgentManifest: Decodable {
             /// `dir:<pattern>` or `file:<pattern>`, where `<pattern>` contains `{id}` and
             /// may contain a `*` glob (e.g. `dir:{id}`, `file:{id}.jsonl`, `file:*_{id}.jsonl`).
             var storeMatch: String?
+            /// For a directory-based store: the name of the transcript file inside the
+            /// session directory, e.g. `"conversation.jsonl"`.
+            var transcriptName: String?
             var discover: DiscoverFields?
             var seed: String?
 
@@ -944,7 +953,8 @@ struct AgentManifest: Decodable {
                 guard parts[1].contains("{id}") else {
                     throw ManifestError.invalid("\(id): storeMatch pattern must contain '{id}'")
                 }
-                store = .init(root: root, isDirectory: isDirectory, name: String(parts[1]))
+                store = .init(root: root, isDirectory: isDirectory, name: String(parts[1]),
+                              transcriptName: fields.transcriptName)
             default:
                 throw ManifestError.invalid("\(id): storeRoot and storeMatch must be set together")
             }

--- a/Sources/termio/Agents/AgentDefinition.swift
+++ b/Sources/termio/Agents/AgentDefinition.swift
@@ -158,10 +158,12 @@ struct AgentDefinition: Identifiable {
             /// agent's private cwd encoding.
             var name: String
             /// For a directory-based store: the filename of the transcript inside the
-            /// session directory, e.g. `"conversation.jsonl"`. When set,
-            /// `resolveTranscriptPath` looks for this exact file. `nil` (the default)
-            /// falls back to scanning for a single `.jsonl` file in the directory.
-            /// Only meaningful when `isDirectory` is true.
+            /// session directory, e.g. `"chat_history.jsonl"`. When set,
+            /// `resolveTranscriptPath` looks for this exact file and returns `nil` if
+            /// it is absent (no sole-jsonl guess — multi-file session dirs would pin
+            /// the wrong sibling). `nil` (the default) falls back to scanning for a
+            /// single `.jsonl` file in the directory. Only meaningful when
+            /// `isDirectory` is true.
             var transcriptName: String? = nil
         }
 
@@ -850,7 +852,8 @@ struct AgentManifest: Decodable {
             /// may contain a `*` glob (e.g. `dir:{id}`, `file:{id}.jsonl`, `file:*_{id}.jsonl`).
             var storeMatch: String?
             /// For a directory-based store: the name of the transcript file inside the
-            /// session directory, e.g. `"conversation.jsonl"`.
+            /// session directory, e.g. `"chat_history.jsonl"`. When present, path
+            /// resolution is exact-name only (no sole-jsonl fallback).
             var transcriptName: String?
             var discover: DiscoverFields?
             var seed: String?

--- a/Sources/termio/Info/SessionTraceRenderer.swift
+++ b/Sources/termio/Info/SessionTraceRenderer.swift
@@ -44,12 +44,11 @@ enum SessionTraceRenderer {
                 return obj
             }
 
-        // Codex rollouts open with a `session_meta` header; Grok's chat_history
-        // carries `model_id` at the top level (not nested under `message`). The
-        // first assistant-type entry picks the parser — the three schemas share
-        // nothing below the header.
+        // Codex rollouts open with a `session_meta` header. Grok is detected without
+        // waiting for an assistant row (early sessions are system + synthetic users
+        // only) — see `isGrokTranscript`. Everything else falls through to Claude.
         let isCodex = rows.first?["type"] as? String == "session_meta"
-        let isGrok = !isCodex && (rows.first(where: { ($0["type"] as? String) == "assistant" })?["model_id"] != nil)
+        let isGrok = !isCodex && isGrokTranscript(rows: rows, jsonlPath: jsonlPath)
         // Grok's chat_history.jsonl has no cwd/version/timestamps — those live in
         // the sibling `summary.json` in the same session directory.
         let grokMeta = isGrok ? grokSessionMeta(jsonlPath: jsonlPath) : nil
@@ -151,6 +150,37 @@ enum SessionTraceRenderer {
 
     // MARK: Grok
 
+    /// Whether `jsonlPath` / `rows` look like a Grok `chat_history.jsonl`.
+    /// Prefer path and sibling metadata over waiting for an assistant with
+    /// `model_id` — real sessions open with `system` + synthetic `user` rows
+    /// and only later append an assistant.
+    private static func isGrokTranscript(rows: [[String: Any]], jsonlPath: String) -> Bool {
+        // Manifest-declared transcript name (and the only name Grok writes).
+        if (jsonlPath as NSString).lastPathComponent == "chat_history.jsonl" {
+            return true
+        }
+        // Sibling `summary.json` with Grok session fields.
+        if grokSessionMeta(jsonlPath: jsonlPath) != nil {
+            return true
+        }
+        // Row heuristics for paths that are not the declared name (e.g. a
+        // hand-copied file): top-level assistant `model_id`, or ConversationItem
+        // shape (user/assistant with top-level `content`, no Claude `message`
+        // envelope) plus a system row.
+        if rows.contains(where: {
+            ($0["type"] as? String) == "assistant" && $0["model_id"] != nil
+        }) {
+            return true
+        }
+        let hasSystem = rows.contains { ($0["type"] as? String) == "system" }
+        let hasFlatUser = rows.contains {
+            ($0["type"] as? String) == "user"
+                && $0["message"] == nil
+                && $0["content"] != nil
+        }
+        return hasSystem && hasFlatUser
+    }
+
     /// Grok's `chat_history.jsonl` schema: no `message` wrapper, `model_id` at
     /// top level, standalone `tool_result`/`reasoning` entries, and no token usage
     /// or timestamp fields — so the dashboard omits Tokens and Duration when
@@ -187,19 +217,21 @@ enum SessionTraceRenderer {
                 // The system prompt is huge and not useful as metadata — skip.
                 break
             case "user":
-                // Only count turns that carry user-visible content (a `<user_query>`
-                // or non-system text). Pure system-injection blocks don't count.
-                if let blocks = entry["content"] as? [[String: Any]] {
-                    let fullText = blocks.compactMap { b -> String? in
-                        guard (b["type"] as? String) == "text" else { return nil }
-                        return b["text"] as? String
-                    }.joined()
-                    if !grokExtractUserQuery(fullText).isEmpty {
-                        s.userTurns += 1
-                    }
+                // Runtime injections carry `synthetic_reason`; skip them for the
+                // turn counter. Genuine turns (and the untagged `<user_info>`
+                // preamble) are filtered by visible-content extraction below.
+                if entry["synthetic_reason"] != nil { break }
+                if let fullText = grokUserText(entry),
+                   !grokExtractUserQuery(fullText).isEmpty {
+                    s.userTurns += 1
                 }
             case "assistant":
-                s.assistantTurns += 1
+                // Mirror Claude: only text-bearing assistant rows count as turns.
+                // Tool-only steps (empty `content` + `tool_calls`) still contribute
+                // to the tool-call chart below.
+                let text = (entry["content"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if !text.isEmpty { s.assistantTurns += 1 }
                 if let toolCalls = entry["tool_calls"] as? [[String: Any]] {
                     for tc in toolCalls {
                         let name = tc["name"] as? String ?? "tool"
@@ -207,7 +239,9 @@ enum SessionTraceRenderer {
                     }
                 }
             case "tool_result":
-                break
+                if let content = entry["content"] as? String, grokToolResultFailed(content) {
+                    s.toolErrors += 1
+                }
             case "reasoning":
                 break
             default:
@@ -540,24 +574,31 @@ enum SessionTraceRenderer {
         case "user": return renderGrokUser(entry)
         case "assistant": return renderGrokAssistant(entry)
         case "tool_result": return renderGrokToolResult(entry)
-        case "reasoning": return "" // internal reasoning — not part of the conversation
+        case "reasoning": return renderGrokReasoning(entry)
         default: return ""
         }
     }
 
     private static func renderGrokUser(_ entry: [String: Any]) -> String {
-        guard let blocks = entry["content"] as? [[String: Any]] else { return "" }
-        // Join all text blocks and extract the user-visible content. Grok injects
-        // system-level context (`<user_info>`, `<system-reminder>`, `<git_status>`)
-        // as separate text blocks alongside the actual `<user_query>`; only the
-        // query (or, when there isn't one, any non-system text) belongs in the trace.
+        // Prefer the structured flag Grok writes for runtime injections
+        // (`project_instructions`, `system_reminder`, …). Untagged preambles
+        // such as `<user_info>` still fall through to tag stripping below.
+        if entry["synthetic_reason"] != nil { return "" }
+        guard let fullText = grokUserText(entry) else { return "" }
+        let visible = grokExtractUserQuery(fullText)
+        guard !visible.isEmpty else { return "" }
+        return turnCard(role: "user", label: "You", body: textBlock(visible))
+    }
+
+    /// Joined text of a Grok user entry's content blocks (ConversationItem
+    /// `UserItem.content: Vec<ContentPart>`).
+    private static func grokUserText(_ entry: [String: Any]) -> String? {
+        guard let blocks = entry["content"] as? [[String: Any]] else { return nil }
         let fullText = blocks.compactMap { b -> String? in
             guard (b["type"] as? String) == "text" else { return nil }
             return b["text"] as? String
         }.joined()
-        let visible = grokExtractUserQuery(fullText)
-        guard !visible.isEmpty else { return "" }
-        return turnCard(role: "user", label: "You", body: textBlock(visible))
+        return fullText.isEmpty ? nil : fullText
     }
 
     /// Extracts the user-visible content from a Grok user turn's concatenated text.
@@ -567,6 +608,7 @@ enum SessionTraceRenderer {
     private static func grokExtractUserQuery(_ text: String) -> String {
         // First, strip every known system-injection block — tags AND content — from
         // the joined text, regardless of whether they span multiple original blocks.
+        // Covers the untagged `<user_info>` preamble (synthetic_reason is nil there).
         let systemTags = ["user_info", "system-reminder", "git_status",
                           "action_safety", "tool_calling", "background_tasks",
                           "output_efficiency", "formatting", "user_guide"]
@@ -580,9 +622,8 @@ enum SessionTraceRenderer {
                 cleaned = regex.stringByReplacingMatches(in: cleaned, range: NSRange(location: 0, length: ns.length), withTemplate: "")
             }
         }
-        // Now extract the user-visible query. When `<user_query>…</user_query>` is
-        // present, only its inner content is returned (the tags themselves are stripped
-        // by the loop above, but the content remains — so extract only that).
+        // `<user_query>` is intentionally not in `systemTags` so the delimiters remain
+        // for this range extraction; only the inner text is returned.
         if let start = cleaned.range(of: "<user_query>"),
            let end = cleaned.range(of: "</user_query>", range: start.upperBound..<cleaned.endIndex) {
             return String(cleaned[start.upperBound..<end.lowerBound])
@@ -620,7 +661,16 @@ enum SessionTraceRenderer {
     private static func renderGrokToolResult(_ entry: [String: Any]) -> String {
         let out = entry["content"] as? String ?? ""
         guard !out.isEmpty else { return "" }
-        return "<details class=\"tool-result\"><summary>◀ result</summary><pre>\(escaped(out))</pre></details>"
+        // Grok's ToolResultItem has no `is_error` flag; failed tools typically
+        // prefix the content with `Error:` (mirrors what the model sees).
+        let failed = grokToolResultFailed(out)
+        return "<details class=\"tool-result\(failed ? " error" : "")\"><summary>\(failed ? "⚠ result" : "◀ result")</summary><pre>\(escaped(out))</pre></details>"
+    }
+
+    /// Heuristic for Grok tool failures — content often begins with `Error:`.
+    private static func grokToolResultFailed(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix("Error:") || trimmed.hasPrefix("error:")
     }
 
     private static func renderGrokReasoning(_ entry: [String: Any]) -> String {

--- a/Sources/termio/Info/SessionTraceRenderer.swift
+++ b/Sources/termio/Info/SessionTraceRenderer.swift
@@ -44,11 +44,17 @@ enum SessionTraceRenderer {
                 return obj
             }
 
-        // Codex rollouts open with a `session_meta` header; Claude transcripts don't.
-        // The header picks the parser — the two schemas share nothing below it.
+        // Codex rollouts open with a `session_meta` header; Grok's chat_history
+        // carries `model_id` at the top level (not nested under `message`). The
+        // first assistant-type entry picks the parser — the three schemas share
+        // nothing below the header.
         let isCodex = rows.first?["type"] as? String == "session_meta"
-        let stats = isCodex ? analyzeCodex(rows) : analyze(rows)
-        let renderEntry = isCodex ? renderCodexEntry : renderEntry
+        let isGrok = !isCodex && (rows.first(where: { ($0["type"] as? String) == "assistant" })?["model_id"] != nil)
+        // Grok's chat_history.jsonl has no cwd/version/timestamps — those live in
+        // the sibling `summary.json` in the same session directory.
+        let grokMeta = isGrok ? grokSessionMeta(jsonlPath: jsonlPath) : nil
+        let stats = isCodex ? analyzeCodex(rows) : isGrok ? analyzeGrok(rows, meta: grokMeta) : analyze(rows)
+        let renderEntry = isCodex ? renderCodexEntry : isGrok ? renderGrokEntry : renderEntry
         let body = rows.map(renderEntry).filter { !$0.isEmpty }.joined(separator: "\n")
         return document(title: title, stats: stats, body: body, theme: theme)
     }
@@ -141,6 +147,150 @@ enum SessionTraceRenderer {
             }
         }
         return s
+    }
+
+    // MARK: Grok
+
+    /// Grok's `chat_history.jsonl` schema: no `message` wrapper, `model_id` at
+    /// top level, standalone `tool_result`/`reasoning` entries, and no token usage
+    /// or timestamp fields — so the dashboard omits Tokens and Duration when
+    /// those aren't available. Tool calls live on the assistant entry's
+    /// `tool_calls` array rather than inside content blocks.
+    /// `meta` is the sibling `summary.json` carrying cwd, model, git branch,
+    /// and timestamps the chat history itself lacks.
+    private static func analyzeGrok(_ rows: [[String: Any]], meta: GrokSessionMeta?) -> Stats {
+        var s = Stats()
+
+        // Session-level metadata from summary.json.
+        if let meta {
+            s.cwd = meta.cwd
+            s.gitBranch = meta.gitBranch
+            s.version = meta.version
+            s.firstTimestamp = meta.createdAt
+            s.lastTimestamp = meta.updatedAt
+            if let model = meta.model { s.models.insert(model) }
+            if let usage = meta.usage {
+                s.inputTokens = usage.inputTokens
+                s.outputTokens = usage.outputTokens
+                s.cacheTokens = usage.cacheTokens
+            }
+        }
+
+        for entry in rows {
+            let type = entry["type"] as? String
+
+            // Per-message model_id (may differ from the session-level model).
+            if let model = entry["model_id"] as? String { s.models.insert(model) }
+
+            switch type {
+            case "system":
+                // The system prompt is huge and not useful as metadata — skip.
+                break
+            case "user":
+                // Only count turns that carry user-visible content (a `<user_query>`
+                // or non-system text). Pure system-injection blocks don't count.
+                if let blocks = entry["content"] as? [[String: Any]] {
+                    let fullText = blocks.compactMap { b -> String? in
+                        guard (b["type"] as? String) == "text" else { return nil }
+                        return b["text"] as? String
+                    }.joined()
+                    if !grokExtractUserQuery(fullText).isEmpty {
+                        s.userTurns += 1
+                    }
+                }
+            case "assistant":
+                s.assistantTurns += 1
+                if let toolCalls = entry["tool_calls"] as? [[String: Any]] {
+                    for tc in toolCalls {
+                        let name = tc["name"] as? String ?? "tool"
+                        s.toolCounts[name, default: 0] += 1
+                    }
+                }
+            case "tool_result":
+                break
+            case "reasoning":
+                break
+            default:
+                break
+            }
+        }
+        return s
+    }
+
+    /// Metadata mined from Grok's `summary.json` (sibling of `chat_history.jsonl`
+    /// in the session directory), filling the cwd/version/timestamps the chat
+    /// history itself doesn't carry.
+    private struct GrokSessionMeta {
+        var cwd: String?
+        var gitBranch: String?
+        var version: String?
+        var model: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        /// Token counts from the last `turn_completed` event in `updates.jsonl`.
+        var usage: GrokUsage?
+    }
+
+    /// Token usage from Grok's `updates.jsonl` `turn_completed` events — cumulative
+    /// per turn, so the last occurrence is the session total.
+    private struct GrokUsage {
+        var inputTokens: Int
+        var outputTokens: Int
+        var cacheTokens: Int
+    }
+
+    /// Reads the `summary.json` next to `jsonlPath` plus `~/.grok/version.json`
+    /// and `updates.jsonl`, returning whatever metadata Grok recorded for this session.
+    private static func grokSessionMeta(jsonlPath: String) -> GrokSessionMeta? {
+        let dir = URL(fileURLWithPath: jsonlPath).deletingLastPathComponent()
+        let summaryURL = dir.appendingPathComponent("summary.json")
+        guard let data = try? Data(contentsOf: summaryURL),
+              let summary = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        var meta = GrokSessionMeta()
+        if let info = summary["info"] as? [String: Any] {
+            meta.cwd = info["cwd"] as? String
+        }
+        meta.gitBranch = summary["head_branch"] as? String
+        meta.model = summary["current_model_id"] as? String
+        if let ts = summary["created_at"] as? String { meta.createdAt = date(from: ts) }
+        if let ts = summary["updated_at"] as? String { meta.updatedAt = date(from: ts) }
+
+        // Grok CLI version lives in ~/.grok/version.json, not per-session.
+        let versionURL = URL(fileURLWithPath: ("~/.grok/version.json" as NSString).expandingTildeInPath)
+        if let vData = try? Data(contentsOf: versionURL),
+           let version = try? JSONSerialization.jsonObject(with: vData) as? [String: Any] {
+            meta.version = version["version"] as? String
+        }
+
+        // Token counts: scan updates.jsonl for the last turn_completed event.
+        // Grok reports cumulative usage per turn, so the last one is the total.
+        meta.usage = grokSessionUsage(in: dir)
+        return meta
+    }
+
+    /// Scans `updates.jsonl` in the session directory for the last `turn_completed`
+    /// event and returns its cumulative token counts. Each turn_completed carries
+    /// `inputTokens`, `outputTokens`, and `cachedReadTokens` — the running total.
+    private static func grokSessionUsage(in dir: URL) -> GrokUsage? {
+        let updatesURL = dir.appendingPathComponent("updates.jsonl")
+        guard let text = try? String(contentsOf: updatesURL, encoding: .utf8) else { return nil }
+        var last: GrokUsage?
+        for line in text.split(whereSeparator: \.isNewline) {
+            guard let d = line.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
+                  let params = obj["params"] as? [String: Any],
+                  let update = params["update"] as? [String: Any],
+                  update["sessionUpdate"] as? String == "turn_completed",
+                  let usage = update["usage"] as? [String: Any]
+            else { continue }
+            last = GrokUsage(
+                inputTokens: (usage["inputTokens"] as? Int) ?? 0,
+                outputTokens: (usage["outputTokens"] as? Int) ?? 0,
+                cacheTokens: (usage["cachedReadTokens"] as? Int) ?? 0)
+        }
+        return last
     }
 
     // MARK: Dashboard
@@ -380,6 +530,105 @@ enum SessionTraceRenderer {
         guard !out.isEmpty else { return "" }
         let isError = (b["is_error"] as? Bool) ?? false
         return "<details class=\"tool-result\(isError ? " error" : "")\"><summary>\(isError ? "⚠ result" : "◀ result")</summary><pre>\(escaped(out))</pre></details>"
+    }
+
+    /// Grok entry renderer: dispatches on the top-level `type` field and shapes
+    /// content that is unwrapped (no `message` envelope).
+    private static func renderGrokEntry(_ entry: [String: Any]) -> String {
+        switch entry["type"] as? String {
+        case "system": return "" // shown in dashboard metadata, not the trace body
+        case "user": return renderGrokUser(entry)
+        case "assistant": return renderGrokAssistant(entry)
+        case "tool_result": return renderGrokToolResult(entry)
+        case "reasoning": return "" // internal reasoning — not part of the conversation
+        default: return ""
+        }
+    }
+
+    private static func renderGrokUser(_ entry: [String: Any]) -> String {
+        guard let blocks = entry["content"] as? [[String: Any]] else { return "" }
+        // Join all text blocks and extract the user-visible content. Grok injects
+        // system-level context (`<user_info>`, `<system-reminder>`, `<git_status>`)
+        // as separate text blocks alongside the actual `<user_query>`; only the
+        // query (or, when there isn't one, any non-system text) belongs in the trace.
+        let fullText = blocks.compactMap { b -> String? in
+            guard (b["type"] as? String) == "text" else { return nil }
+            return b["text"] as? String
+        }.joined()
+        let visible = grokExtractUserQuery(fullText)
+        guard !visible.isEmpty else { return "" }
+        return turnCard(role: "user", label: "You", body: textBlock(visible))
+    }
+
+    /// Extracts the user-visible content from a Grok user turn's concatenated text.
+    /// When `<user_query>…</user_query>` is present, only its inner content is shown;
+    /// otherwise, all known system-injection tags (and their content) are stripped, and
+    /// the remainder — the user's own words — is returned.
+    private static func grokExtractUserQuery(_ text: String) -> String {
+        // First, strip every known system-injection block — tags AND content — from
+        // the joined text, regardless of whether they span multiple original blocks.
+        let systemTags = ["user_info", "system-reminder", "git_status",
+                          "action_safety", "tool_calling", "background_tasks",
+                          "output_efficiency", "formatting", "user_guide"]
+        var cleaned = text
+        for tag in systemTags {
+            // Match `<tag>…</tag>` across newlines (dot matches line separators off by
+            // default in ICU regex, so use (?s) to make `.` match newlines too).
+            let pattern = "<" + NSRegularExpression.escapedPattern(for: tag) + ">.*?</" + NSRegularExpression.escapedPattern(for: tag) + ">"
+            if let regex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]) {
+                let ns = cleaned as NSString
+                cleaned = regex.stringByReplacingMatches(in: cleaned, range: NSRange(location: 0, length: ns.length), withTemplate: "")
+            }
+        }
+        // Now extract the user-visible query. When `<user_query>…</user_query>` is
+        // present, only its inner content is returned (the tags themselves are stripped
+        // by the loop above, but the content remains — so extract only that).
+        if let start = cleaned.range(of: "<user_query>"),
+           let end = cleaned.range(of: "</user_query>", range: start.upperBound..<cleaned.endIndex) {
+            return String(cleaned[start.upperBound..<end.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        // No `<user_query>`: after stripping system tags, whatever is left is the user's
+        // own text. Collapse multiple blank lines into one.
+        let lines = cleaned.components(separatedBy: "\n")
+        let nonEmpty = lines.drop(while: { $0.trimmingCharacters(in: .whitespaces).isEmpty })
+        let result = nonEmpty.joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Normalize runs of blank lines.
+        return result.replacingOccurrences(of: "\n{3,}", with: "\n\n", options: .regularExpression)
+    }
+
+    private static func renderGrokAssistant(_ entry: [String: Any]) -> String {
+        var parts: [String] = []
+        // Text content — a plain string, not a block array.
+        if let text = entry["content"] as? String, !text.isEmpty {
+            parts.append(textBlock(text, markdown: true))
+        }
+        // Tool calls from the `tool_calls` array.
+        if let toolCalls = entry["tool_calls"] as? [[String: Any]] {
+            for tc in toolCalls {
+                let name = tc["name"] as? String ?? "tool"
+                let args = tc["arguments"] as? String ?? ""
+                let prettyArgs = codexArguments(args) // reuses Codex arg-prettifier (JSON string → pretty)
+                let pre = prettyArgs.isEmpty ? "" : "<pre>\(escaped(prettyArgs))</pre>"
+                parts.append("<details class=\"tool-use\"><summary>▶ \(escaped(name))</summary>\(pre)</details>")
+            }
+        }
+        return parts.isEmpty ? "" : turnCard(role: "assistant", label: "Agent", body: parts.joined(separator: "\n"))
+    }
+
+    private static func renderGrokToolResult(_ entry: [String: Any]) -> String {
+        let out = entry["content"] as? String ?? ""
+        guard !out.isEmpty else { return "" }
+        return "<details class=\"tool-result\"><summary>◀ result</summary><pre>\(escaped(out))</pre></details>"
+    }
+
+    private static func renderGrokReasoning(_ entry: [String: Any]) -> String {
+        // Summaries are `[{type: "summary_text", text: "..."}]`.
+        let summaries = entry["summary"] as? [[String: Any]] ?? []
+        let text = summaries.compactMap { $0["text"] as? String }.joined(separator: "\n")
+        guard !text.isEmpty else { return "" }
+        return "<details class=\"thinking\"><summary>Thinking</summary><div>\(escaped(text))</div></details>"
     }
 
     private static func renderSummary(_ entry: [String: Any]) -> String {

--- a/Sources/termio/Resources/agents/grok.json
+++ b/Sources/termio/Resources/agents/grok.json
@@ -9,7 +9,8 @@
     "create": "--session-id {id}",
     "resume": "--resume {id}",
     "storeRoot": "~/.grok/sessions",
-    "storeMatch": "dir:{id}"
+    "storeMatch": "dir:{id}",
+    "transcriptName": "chat_history.jsonl"
   },
   "icon": { "vector": "grok" },
   "install": "https://x.ai/cli",
@@ -20,6 +21,7 @@
     "type": "json",
     "file": "~/.grok/hooks/termio.json",
     "dialect": "grok",
+    "capturesTranscript": true,
     "conversation": "sessionId",
     "events": [
       { "on": "SessionStart", "state": "idle" },

--- a/Sources/termio/Resources/agents/grok.json
+++ b/Sources/termio/Resources/agents/grok.json
@@ -21,7 +21,6 @@
     "type": "json",
     "file": "~/.grok/hooks/termio.json",
     "dialect": "grok",
-    "capturesTranscript": true,
     "conversation": "sessionId",
     "events": [
       { "on": "SessionStart", "state": "idle" },

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -372,7 +372,9 @@ extension TermioStore {
     /// A discovered-id agent with a known pin is likewise looked up by that exact id —
     /// the launch-time earliest-match below would drift back to a rotated-away record —
     /// and only an unpinned session falls back to the launch-time file match
-    /// (`AgentSessionStore`). `nil` until a matching transcript exists on disk.
+    /// (`AgentSessionStore`). For a directory-based store (Grok: `dir:{id}`), the
+    /// directory itself is located and its contents scanned for a transcript file.
+    /// `nil` until a matching transcript exists on disk.
     func resolveTranscriptPath(for id: Session.ID) -> String? {
         guard let session = session(id), session.launched else { return nil }
         if let store = session.agent.resumeSpec.store, !store.isDirectory,
@@ -380,12 +382,50 @@ extension TermioStore {
            let path = SessionStore.locate(store, id: resumeID) {
             return path
         }
+        if let store = session.agent.resumeSpec.store, store.isDirectory,
+           let resumeID = session.resumeID,
+           let dirPath = SessionStore.locate(store, id: resumeID) {
+            // Directory-based store: scan the session directory for a transcript file.
+            // The manifest may declare a specific filename via `transcriptName`;
+            // otherwise, look for any `.jsonl` file — but only when there is exactly
+            // one, to avoid guessing.
+            if let name = store.transcriptName,
+               let candidate = transcriptFile(in: dirPath, named: name) {
+                return candidate
+            }
+            if let candidate = soleJSONLFile(in: dirPath) {
+                return candidate
+            }
+        }
         if session.agent.resumeSpec.discover != nil, let resumeID = session.resumeID {
             return AgentSessionStore.transcript(agent: session.agent, id: resumeID)
         }
         guard let directory = session.worktreePath ?? project(for: id)?.path else { return nil }
         return AgentSessionStore.discoverTranscript(
             agent: session.agent, directory: directory, after: session.launchedAt)
+    }
+
+    /// Returns the path to a named file inside a directory, or `nil` if it doesn't exist.
+    private func transcriptFile(in directory: String, named name: String) -> String? {
+        let candidate = URL(fileURLWithPath: directory).appendingPathComponent(name).path
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: candidate, isDirectory: &isDir),
+              !isDir.boolValue else { return nil }
+        return candidate
+    }
+
+    /// Returns the path to the single `.jsonl` file in a directory, or `nil` when there
+    /// are zero or more than one — the transcript is ambiguous with multiple candidates.
+    private func soleJSONLFile(in directory: String) -> String? {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: URL(fileURLWithPath: directory), includingPropertiesForKeys: nil)
+        else { return nil }
+        let jsonlFiles = entries.filter {
+            $0.pathExtension.lowercased() == "jsonl"
+                && (try? $0.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+        }
+        guard jsonlFiles.count == 1 else { return nil }
+        return jsonlFiles[0].path
     }
 
     /// Sweeps sessions stuck in `.working` with no activity for a generous window

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -385,17 +385,16 @@ extension TermioStore {
         if let store = session.agent.resumeSpec.store, store.isDirectory,
            let resumeID = session.resumeID,
            let dirPath = SessionStore.locate(store, id: resumeID) {
-            // Directory-based store: scan the session directory for a transcript file.
-            // The manifest may declare a specific filename via `transcriptName`;
-            // otherwise, look for any `.jsonl` file — but only when there is exactly
-            // one, to avoid guessing.
-            if let name = store.transcriptName,
-               let candidate = transcriptFile(in: dirPath, named: name) {
-                return candidate
+            // Directory-based store: the session is a directory of files. Prefer the
+            // manifest's `transcriptName` when set (Grok: `chat_history.jsonl`). Do not
+            // fall through to sole-jsonl when a name is declared — Grok dirs routinely
+            // hold several `.jsonl` files (`updates.jsonl`, `events.jsonl`, …), and a
+            // briefly-missing named file must not pin a sibling. Sole-jsonl is only for
+            // undeclared names where exactly one candidate exists.
+            if let name = store.transcriptName {
+                return transcriptFile(in: dirPath, named: name)
             }
-            if let candidate = soleJSONLFile(in: dirPath) {
-                return candidate
-            }
+            return soleJSONLFile(in: dirPath)
         }
         if session.agent.resumeSpec.discover != nil, let resumeID = session.resumeID {
             return AgentSessionStore.transcript(agent: session.agent, id: resumeID)


### PR DESCRIPTION
## What

Wires Grok into termio's transcript discovery and Info-pane trace rendering, so a Grok session can **View Trace** the same way Claude and Codex already can.

## Why

Grok keeps conversations as a **directory** under `~/.grok/sessions/<cwd>/<id>/` (`chat_history.jsonl` + sibling `summary.json` / `updates.jsonl`), not a single Claude-style `.jsonl` file. The existing Claude/Codex parsers can't read that layout or ConversationItem schema, so the Info pane had no path and no usable HTML.

## How

**Discovery**
- `ResumeSpec.Store.transcriptName` names the file inside a directory store (`chat_history.jsonl` for Grok).
- `resolveTranscriptPath` locates `dir:{id}` across cwd buckets, then resolves that exact name (no sole-jsonl guess when a name is declared — Grok dirs hold several `.jsonl` siblings).
- Grok hooks keep `conversation: sessionId` for rotation. `capturesTranscript` is **off**: Grok's hook `transcriptPath` points at `updates.jsonl` (event stream), not the chat log, and is camelCase while the CLI mines snake_case.

**Rendering** (`SessionTraceRenderer`)
- Detect Grok without waiting for the first assistant+`model_id` (path name, sibling `summary.json`, then row heuristics) so early/first-turn traces don't fall through to Claude and render blank.
- Parse ConversationItem rows: top-level `content` / `model_id` / `tool_calls`, standalone `tool_result` + `reasoning`.
- Dashboard meta from `summary.json` + `~/.grok/version.json`; token totals from the last `turn_completed` in `updates.jsonl`.
- User rows: skip `synthetic_reason` injections; strip untagged `<user_info>` / system tags; extract `<user_query>`.
- Reasoning cards, `Error:` tool-result styling, and Claude-style turn counting (text-bearing assistants only).

## Files

- `Sources/termio/Resources/agents/grok.json` — `transcriptName`, hooks (`sessionId`, no `capturesTranscript`)
- `Sources/termio/Agents/AgentDefinition.swift` — `transcriptName` on directory stores
- `Sources/termio/TermioStore/TermioStore+AgentStatus.swift` — directory transcript resolution
- `Sources/termio/Info/SessionTraceRenderer.swift` — Grok detect / analyze / render

## Verification

- ✅ `swift build --target termio` clean
- ✅ Schema/path assumptions checked against grok-build (`xai-chat-state` ConversationItem, hook envelope, `get_transcript_path` → `updates.jsonl`) and real `~/.grok/sessions/…/chat_history.jsonl` samples


<img width="2426" height="1818" alt="image" src="https://github.com/user-attachments/assets/998b7e2e-48ef-4cf8-919c-2004c98faacb" />
