### PR TITLE
fix(ios): reflow slow agent TUIs (Grok) on alt-screen entry

### DIFF
--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -664,7 +664,27 @@ final class TerminalViewController: UIViewController {
             )
             transport.onOutput = { [weak terminalSession, weak self] data in
                 terminalSession?.receive(data)
-                DispatchQueue.main.async { self?.altScreenSniffer.consume(data) }
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    let wasAlternate = self.altScreenSniffer.isAlternate
+                    self.altScreenSniffer.consume(data)
+                    // A slow-starting full-screen agent (Grok) switches into its
+                    // alt-screen TUI only after the phone's on-attach grid claim
+                    // has gone stale, and the Mac won't re-SIGWINCH an unchanged
+                    // winsize — so the TUI first paints at the wrong grid and only
+                    // a tap (which changes the keyboard geometry) forces a reflow.
+                    // Re-claim the grid the instant the TUI appears; the Mac
+                    // jiggles when the size is unchanged, so the agent reflows on
+                    // its own. Twice, mirroring the on-connect reassert, in case
+                    // the first lands before the agent finishes its opening paint.
+                    if !wasAlternate, self.altScreenSniffer.isAlternate, case .companion = self.backend {
+                        self.companion?.reassertGrid()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+                            guard let self, case .companion = backend else { return }
+                            companion?.reassertGrid()
+                        }
+                    }
+                }
             }
             transport.onState = { [weak self] state in
                 self?.companionStateChanged(state)


### PR DESCRIPTION
Follow-up to #71 (which already merged). Second Grok-on-phone layout bug.

## Problem

On the phone, a slow-starting full-screen agent (Grok) opens with its input box floating mid-screen and dead space above; the layout only "shrinks to normal" after you tap the terminal.

**Root cause — a resize/reflow race during the agent's startup:** the phone claims its grid early (on attach + when the keyboard raises), but Grok switches into its alt-screen TUI only *after* its slow init (session_start hook, model load). By then the phone's grid claim is stale, and the Mac won't re-SIGWINCH an unchanged winsize — so the TUI first paints at the wrong grid. A tap changes the keyboard geometry, producing a fresh resize that finally reflows it.

## Fix

The app already has an `AlternateScreenSniffer` watching the output for DECSET 1049/1047/47. Wire its *enter* transition to `companion.reassertGrid()`: the instant the TUI appears, re-claim the grid (the Mac's `jiggleResize` forces a redraw when the size is unchanged), so the agent reflows on its own — no tap. Reassert twice, mirroring the on-connect path, in case the first lands before the opening paint finishes.

## Scope / testing

- Companion path only; no effect on the demo shell.
- Built + installed on a physical iPhone. **Pending on-device confirmation** that a fresh Grok session now lays out correctly without a tap.