### PR TITLE
feat(cli): sessions supervision verbs — spawn/send merge + watch

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -52,12 +52,19 @@ final class SessionControlListener {
     }
 
     private let onRequest: @MainActor (ControlRequest) async -> Data
+    /// Resolves a `watch` subscription: returns the caller's project id to scope the
+    /// stream to, or an error payload to write back and hang up. Split from
+    /// `onRequest` because a watch is not one-shot — the connection stays open and is
+    /// handed to `SessionWatchHub` instead of being answered and closed.
+    private let onWatch: @MainActor (ControlRequest) -> (UUID?, Data?)
     private let queue = DispatchQueue(label: "com.termio.session-control")
     private var source: DispatchSourceRead?
     private var listenDescriptor: Int32 = -1
 
-    init(onRequest: @escaping @MainActor (ControlRequest) async -> Data) {
+    init(onRequest: @escaping @MainActor (ControlRequest) async -> Data,
+         onWatch: @escaping @MainActor (ControlRequest) -> (UUID?, Data?)) {
         self.onRequest = onRequest
+        self.onWatch = onWatch
     }
 
     func start() {
@@ -135,6 +142,27 @@ final class SessionControlListener {
             close(descriptor)
             return
         }
+        // `watch` is the one streaming op: the connection is not answered and closed
+        // but handed to `SessionWatchHub`, which pushes a line per status transition
+        // until the client disconnects. Everything else is one-shot request/response.
+        if decoded.op == "watch" {
+            let resolve = onWatch
+            Task { @MainActor in
+                let (projectID, errorData) = resolve(decoded)
+                self.queue.async {
+                    if let errorData {
+                        Self.writeAll(descriptor, errorData)
+                        close(descriptor)
+                        return
+                    }
+                    guard let projectID else { close(descriptor); return }
+                    SessionWatchHub.shared.subscribe(
+                        descriptor: descriptor, projectID: projectID,
+                        states: Self.watchStates(decoded.text), wantsJSON: decoded.wantsJSON)
+                }
+            }
+            return
+        }
         // The handler touches `TermioStore`, so it must run on the main actor; the
         // reply is written back on this private queue so the socket work stays off
         // the main thread.
@@ -146,6 +174,17 @@ final class SessionControlListener {
                 close(descriptor)
             }
         }
+    }
+
+    /// The status filter a `watch` client asked for, carried in the request's `text`
+    /// field as a comma-separated list. Empty means the two states a supervisor acts
+    /// on — a session finishing (`done`) or stopping to ask (`needs-you`).
+    private static func watchStates(_ text: String?) -> Set<String> {
+        let raw = text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !raw.isEmpty else { return ["done", "needs-you"] }
+        return Set(raw.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty })
     }
 
     private static func writeAll(_ descriptor: Int32, _ data: Data) {
@@ -166,6 +205,104 @@ final class SessionControlListener {
 
     private static func log(_ message: String) {
         FileHandle.standardError.write(Data("termio: session control \(message)\n".utf8))
+    }
+}
+
+/// One status transition, pushed to every `termio sessions watch` client scoped to
+/// the session's project and interested in the new state. Built on the main actor
+/// (where `setStatus` lives) and handed to `SessionWatchHub`, which does the socket
+/// writes off the main thread.
+struct SessionWatchEvent {
+    let projectID: UUID
+    let handle: String
+    /// Wire status token (`working` / `idle` / `done` / `needs-you`).
+    let status: String
+    let title: String
+    let cwd: String
+}
+
+/// Holds the open `watch` connections and fans status transitions out to them. A
+/// `watch` is the one long-lived control connection: unlike request/response, the
+/// socket stays open and this hub pushes a line whenever a scoped session changes
+/// state, until the client goes away.
+///
+/// Everything runs on a private serial queue so a slow or dead reader never blocks
+/// the agent tick that produced the event. A dead client is detected lazily — on the
+/// next write that fails — rather than by watching the socket for EOF: a piped CLI
+/// client (`… | nc -U`) half-closes its write side as soon as it has sent the
+/// request, which would look like a disconnect while the client is very much still
+/// reading. `SO_NOSIGPIPE` keeps that failing write from signalling the whole app.
+final class SessionWatchHub {
+    static let shared = SessionWatchHub()
+
+    private struct Subscriber {
+        let projectID: UUID
+        let states: Set<String>
+        let wantsJSON: Bool
+    }
+
+    private let queue = DispatchQueue(label: "com.termio.session-watch")
+    private var subscribers: [Int32: Subscriber] = [:]
+
+    /// Adopt a client descriptor as a watcher. Ownership of the fd transfers here —
+    /// the hub closes it when the client disconnects.
+    func subscribe(descriptor: Int32, projectID: UUID, states: Set<String>, wantsJSON: Bool) {
+        queue.async {
+            var on: Int32 = 1
+            setsockopt(descriptor, SOL_SOCKET, SO_NOSIGPIPE, &on,
+                       socklen_t(MemoryLayout<Int32>.size))
+            self.subscribers[descriptor] = Subscriber(
+                projectID: projectID, states: states, wantsJSON: wantsJSON)
+        }
+    }
+
+    /// Push an event to every matching subscriber. Called from the main actor via
+    /// `TermioStore.setStatus`; the work hops onto the hub's queue immediately.
+    func broadcast(_ event: SessionWatchEvent) {
+        queue.async {
+            guard !self.subscribers.isEmpty else { return }
+            let line = event.wireLine
+            let jsonLine = event.jsonLine
+            for (fd, sub) in self.subscribers {
+                guard sub.projectID == event.projectID, sub.states.contains(event.status)
+                else { continue }
+                if !Self.write(fd, sub.wantsJSON ? jsonLine : line) {
+                    self.subscribers.removeValue(forKey: fd)
+                    close(fd)
+                }
+            }
+        }
+    }
+
+    /// Best-effort full write; returns false when the reader is gone (so the caller
+    /// reaps the subscriber).
+    private static func write(_ fd: Int32, _ data: Data) -> Bool {
+        data.withUnsafeBytes { raw -> Bool in
+            guard let base = raw.baseAddress else { return true }
+            var offset = 0
+            while offset < data.count {
+                let n = Darwin.write(fd, base + offset, data.count - offset)
+                if n <= 0 { return false }
+                offset += n
+            }
+            return true
+        }
+    }
+}
+
+private extension SessionWatchEvent {
+    var wireLine: Data {
+        let suffix = title.isEmpty ? "" : "  \(title)"
+        return Data("\(handle)  [\(status)]\(suffix)\n".utf8)
+    }
+    var jsonLine: Data {
+        let object: [String: Any] = [
+            "schema_version": 1, "handle": handle, "status": status,
+            "title": title, "cwd": cwd,
+        ]
+        let data = (try? JSONSerialization.data(
+            withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])) ?? Data()
+        return data + Data("\n".utf8)
     }
 }
 
@@ -207,6 +344,9 @@ enum SessionSkillInstaller {
 
         - `termio sessions list` — siblings in this project, with status (working /
           idle / needs-you / done)
+        - `termio sessions watch` — block and stream one line per sibling status
+          change (`done` / `needs-you` by default) until you interrupt it — the push
+          alternative to polling `list`. `--state working,idle,done,needs-you` widens it.
         - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
           prompt (`--agent codex` picks the agent; default: your own kind). The
           reply contains the new session's handle — use it for every follow-up.
@@ -241,7 +381,9 @@ enum SessionSkillInstaller {
            after it are the reply. (Each line is a JSON object with a `type`/`role`.)
 
         Workflow: send → wait for `done` via `list` → read the transcript tail. Prefer
-        this over assuming a sibling is finished.
+        this over assuming a sibling is finished. Supervising several at once? Block on
+        `termio sessions watch` instead of polling — it prints the handle the moment any
+        sibling turns `done` or `needs-you`, so you act on the transition, not a spin loop.
         \(endMarker)
         """
     }

--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -207,13 +207,12 @@ enum SessionSkillInstaller {
 
         - `termio sessions list` — siblings in this project, with status (working /
           idle / needs-you / done)
-        - `termio sessions send "<prompt>"` — start a NEW agent session and give it
-          the prompt (`--agent codex` picks the agent; default: your own kind). The
+        - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
+          prompt (`--agent codex` picks the agent; default: your own kind). The
           reply contains the new session's handle — use it for every follow-up.
-        - `termio sessions send <agent>@<id> "<prompt>"` — type a prompt into that
-          existing sibling and submit it (a real Return keypress, so it actually runs)
-        - `termio sessions answer <agent>@<id> "<choice>"` — answer a sibling's
-          menu/permission prompt (e.g. `"1"`, `"yes"`)
+        - `termio sessions send <agent>@<id> "<text>"` — type text into that existing
+          sibling and submit it with a real Return keypress. Send a prompt to drive
+          it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
         - `termio sessions close <agent>@<id> …` — close session tabs;
           `termio sessions focus <agent>@<id>` — bring one to the front in the app
 
@@ -225,19 +224,19 @@ enum SessionSkillInstaller {
           and never run multiple `send` commands in parallel — delegate to ONE
           session.
         - Unsure which sibling the user means? Ask them, or start a fresh session
-          with a plain `send` — don't broadcast.
+          with `spawn` — don't broadcast.
 
         ### Reading a sibling's response
 
-        Don't scrape the terminal. `send` returns the sibling's **transcript** — the
-        agent's own structured Q&A log (Claude Code: a JSONL file) — plus a **cursor**
-        (its line count at send time). To read the reply:
+        Don't scrape the terminal. `spawn`/`send` returns the sibling's **transcript**
+        — the agent's own structured Q&A log (Claude Code: a JSONL file) — plus a
+        **cursor** (its line count at send time). To read the reply:
 
-        1. `send` and note `transcript` + `cursor` from the output. (A just-started
-           session has no transcript yet; it appears in `list --json` once the agent
-           reports it — read that file from the start.)
+        1. `spawn`/`send` and note `transcript` + `cursor` from the output. (A just-
+           started session has no transcript yet; it appears in `list --json` once the
+           agent reports it — read that file from the start.)
         2. Poll `termio sessions list` until that session's status is `done` (or
-           `needs-you` if it's blocked waiting on input — then `answer` it).
+           `needs-you` if it's blocked waiting on input — then `send` its answer).
         3. Read the transcript file from line `cursor` onward; the `assistant` entries
            after it are the reply. (Each line is a JSON object with a `type`/`role`.)
 

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -38,9 +38,13 @@ extension TermioStore {
     /// current setting. Like the hook listener, the socket always runs; only the
     /// note written into the agent instruction files is toggled.
     func startSessionControl() {
-        let control = SessionControlListener { [weak self] request in
-            await self?.handleSessionControl(request) ?? Data()
-        }
+        let control = SessionControlListener(
+            onRequest: { [weak self] request in
+                await self?.handleSessionControl(request) ?? Data()
+            },
+            onWatch: { [weak self] request in
+                self?.resolveWatchScope(request) ?? (nil, nil)
+            })
         control.start()
         sessionControl = control
         installedSessionControlEnabled = settings.sessionControlEnabled

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -39,6 +39,22 @@ extension TermioStore {
         }
     }
 
+    /// Validates a `watch` subscription and returns the caller's project id to scope
+    /// the stream to, or an error payload to write back before hanging up. The same
+    /// gating as any control op (session control enabled, caller resolves to a
+    /// project); the streaming itself is `SessionWatchHub`'s job.
+    func resolveWatchScope(_ request: ControlRequest) -> (UUID?, Data?) {
+        guard settings.sessionControlEnabled else {
+            return (nil, controlError(request, "disabled",
+                "Session control is off. Enable it in termio ▸ Settings ▸ Agents."))
+        }
+        guard let project = callerProject(session: request.callerSession, cwd: request.callerCwd) else {
+            return (nil, controlError(request, "no_scope",
+                "Couldn't tell which project you're in. Run this from inside a termio session."))
+        }
+        return (project.id, nil)
+    }
+
     /// The address a caller drives a session by. The id half is the stable key
     /// (minted at creation, never renumbered — unlike the sidebar's live labels);
     /// the agent half makes the handle self-describing in logs and lets the
@@ -419,7 +435,7 @@ extension TermioStore {
         String(id.uuidString.prefix(8)).lowercased()
     }
 
-    private static func statusToken(_ status: SessionStatus) -> String {
+    static func statusToken(_ status: SessionStatus) -> String {
         switch status {
         case .idle: return "idle"
         case .working: return "working"

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -195,6 +195,17 @@ final class TermioStore: ObservableObject {
         runtime.status = status
         // The tray and window title present status, so a real change pings them.
         sessionRuntimeDidChange.send()
+        // Push the genuine transition to any `termio sessions watch` clients scoped
+        // to this session's project. The hub does the socket writes off the main
+        // thread, so a watcher never slows the agent tick that produced the event.
+        if let session = session(id), let project = project(for: id) {
+            SessionWatchHub.shared.broadcast(SessionWatchEvent(
+                projectID: project.id,
+                handle: sessionHandle(for: session),
+                status: Self.statusToken(status),
+                title: displayTitle(for: session),
+                cwd: runtimes[id]?.workingDirectory ?? ""))
+        }
         // A session *entering* `.working` is the "this project is active" signal that
         // floats its project up the Recent-Activity sort. Bumping here, on the genuine
         // transition, means one write per turn instead of one per hook/screen tick — the

--- a/scripts/termio
+++ b/scripts/termio
@@ -24,10 +24,9 @@ usage:
   termio open [DIR]                          open DIR (default: cwd) as a project
   termio [DIR]                               shorthand for `termio open DIR`
 
-  termio sessions list                       sibling sessions in this project + status
-  termio sessions send "<prompt>"            start a NEW agent session and send it the prompt
-  termio sessions send <agent>@<id> "<prompt>"   send to an existing session
-  termio sessions answer <agent>@<id> "<choice>" answer a session's menu/permission prompt
+  termio sessions list                       sessions in this project + status
+  termio sessions spawn "<prompt>"           start a NEW agent session on the prompt
+  termio sessions send <agent>@<id> "<text>"     type a prompt (or menu answer) into a session
   termio sessions close <agent>@<id> [...]   close session tabs
   termio sessions focus <agent>@<id>         select the session in the app
 
@@ -35,10 +34,11 @@ usage:
 
 options:
   --json           machine-readable output (any `sessions` command)
-  --agent <name>   agent for a new session (send without a handle; default: caller's)
+  --agent <id>     agent for `spawn` (e.g. claudeCode, codex, grok, pi; default: caller's kind)
   --help, --version
 
-`<agent>@<id>` handles come from `termio sessions list` or a `send` reply.
+`<agent>@<id>` handles come from `termio sessions list` or a `spawn` reply.
+`answer` is a deprecated alias of `send`; `send` with no handle aliases `spawn`.
 EOF
 }
 
@@ -100,7 +100,7 @@ sessions() {
     [ $# -gt 0 ] && shift || true
 
     case "$op" in
-        list|send|answer|close|focus) ;;
+        list|spawn|send|answer|close|focus) ;;
         -h|--help|help) usage; exit 0 ;;
         *)
             echo "termio: unknown sessions command '$op'" >&2
@@ -124,11 +124,16 @@ sessions() {
                 if [ "$op" = close ]; then
                     # Every positional is a tab to close.
                     targets="${targets:+$targets }$1"
+                elif [ "$op" = spawn ]; then
+                    # `spawn` takes no handle — every positional is the prompt.
+                    text="${text:+$text }$1"
                 elif [ "$seen_positional" -eq 0 ] && { [ "$op" = answer ] || [ "$op" = focus ]; }; then
                     targets="$1"
                 elif [ "$seen_positional" -eq 0 ] && [ "$op" = send ] && is_handle "$1"; then
-                    # `send` alone takes an *optional* leading handle — absent, the
-                    # app starts a new agent session for the prompt.
+                    # A leading handle targets an existing session. Without one, `send`
+                    # is a back-compat alias for `spawn` (see dispatch below); the strict
+                    # is_handle shape keeps a prompt that merely opens with a word from
+                    # being mistaken for a handle.
                     targets="$1"
                 else
                     text="${text:+$text }$1"
@@ -152,6 +157,12 @@ sessions() {
                 exit 1
             fi
             ;;
+        spawn)
+            if [ -z "$text" ]; then
+                echo "termio: spawn needs a prompt (e.g. \`termio sessions spawn \"fix the build\" --agent codex\`)" >&2
+                exit 1
+            fi
+            ;;
     esac
 
     if [ "$op" = close ]; then
@@ -164,7 +175,15 @@ sessions() {
         exit "$failed"
     fi
 
-    request_once "$op" "$format" "$targets" "$agent" "$text"
+    # `spawn` and the no-handle `send` alias both start a fresh session: the app
+    # spawns whenever a `send` request carries an empty target. `answer` is a thin
+    # alias for sending to an existing session. So both fold onto the wire `send`;
+    # every other verb maps straight through.
+    wire_op="$op"
+    case "$op" in
+        spawn|answer) wire_op=send ;;
+    esac
+    request_once "$wire_op" "$format" "$targets" "$agent" "$text"
 }
 
 # The public hook contract:

--- a/scripts/termio
+++ b/scripts/termio
@@ -25,6 +25,7 @@ usage:
   termio [DIR]                               shorthand for `termio open DIR`
 
   termio sessions list                       sessions in this project + status
+  termio sessions watch [--state <s,…>]      stream status transitions until Ctrl-C (default: done,needs-you)
   termio sessions spawn "<prompt>"           start a NEW agent session on the prompt
   termio sessions send <agent>@<id> "<text>"     type a prompt (or menu answer) into a session
   termio sessions close <agent>@<id> [...]   close session tabs
@@ -35,6 +36,7 @@ usage:
 options:
   --json           machine-readable output (any `sessions` command)
   --agent <id>     agent for `spawn` (e.g. claudeCode, codex, grok, pi; default: caller's kind)
+  --state <s,…>    for `watch`: comma-separated states to report (working, idle, done, needs-you)
   --help, --version
 
 `<agent>@<id>` handles come from `termio sessions list` or a `spawn` reply.
@@ -70,18 +72,22 @@ is_handle() {
     printf '%s' "$1" | grep -qE '^[A-Za-z][A-Za-z0-9._-]*@[0-9a-fA-F]{4,32}$'
 }
 
+# The one-line JSON control request shared by the one-shot and streaming paths.
+build_request() {
+    printf '{"op":"%s","format":"%s","caller_session":"%s","caller_cwd":"%s","target":"%s","agent":"%s","text":"%s"}' \
+        "$1" "$2" \
+        "$(json_escape "${TERMIO_SESSION:-}")" \
+        "$(json_escape "$PWD")" \
+        "$(json_escape "$3")" \
+        "$(json_escape "$4")" \
+        "$(json_escape "$5")"
+}
+
 # One request/response round-trip. Prints the app's reply and returns nonzero when
 # it reports failure, so callers (and `set -e`) surface errors through the exit
 # code — agents check `$?`, not prose.
 request_once() {
-    req_op="$1"; req_format="$2"; req_target="$3"; req_agent="$4"; req_text="$5"
-    request=$(printf '{"op":"%s","format":"%s","caller_session":"%s","caller_cwd":"%s","target":"%s","agent":"%s","text":"%s"}' \
-        "$req_op" "$req_format" \
-        "$(json_escape "${TERMIO_SESSION:-}")" \
-        "$(json_escape "$PWD")" \
-        "$(json_escape "$req_target")" \
-        "$(json_escape "$req_agent")" \
-        "$(json_escape "$req_text")")
+    request=$(build_request "$1" "$2" "$3" "$4" "$5")
     response=$(printf '%s' "$request" | nc -U "$SOCKET")
     printf '%s\n' "$response"
     case "$response" in
@@ -100,7 +106,7 @@ sessions() {
     [ $# -gt 0 ] && shift || true
 
     case "$op" in
-        list|spawn|send|answer|close|focus) ;;
+        list|watch|spawn|send|answer|close|focus) ;;
         -h|--help|help) usage; exit 0 ;;
         *)
             echo "termio: unknown sessions command '$op'" >&2
@@ -113,6 +119,7 @@ sessions() {
     agent=""
     targets=""
     text=""
+    states=""
     seen_positional=0
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -120,6 +127,9 @@ sessions() {
             --agent)
                 [ $# -ge 2 ] || { echo "termio: --agent needs a value" >&2; exit 1; }
                 agent="$2"; shift ;;
+            --state)
+                [ $# -ge 2 ] || { echo "termio: --state needs a value" >&2; exit 1; }
+                states="$2"; shift ;;
             *)
                 if [ "$op" = close ]; then
                     # Every positional is a tab to close.
@@ -164,6 +174,21 @@ sessions() {
             fi
             ;;
     esac
+
+    if [ "$op" = watch ]; then
+        # Streaming: the app holds the connection open and pushes one line per scoped
+        # status transition until interrupted (Ctrl-C). `--state` (comma-separated)
+        # filters; empty means the two states a supervisor acts on — done, needs-you.
+        #
+        # Build the request into a variable *first*, then pipe an instant `printf` to
+        # `nc`. Piping `build_request` directly (`build_request … | nc`) runs nc
+        # concurrently with build_request's json_escape subprocesses, so nc connects
+        # and the app's read races the not-yet-written payload — the app then times
+        # out on an empty read and reports a malformed request.
+        watch_request=$(build_request watch "$format" "" "" "$states")
+        printf '%s' "$watch_request" | nc -U "$SOCKET"
+        exit 0
+    fi
 
     if [ "$op" = close ]; then
         # One request per tab; any failure fails the whole command, but every

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -52,6 +52,7 @@ for machine-readable output.
 | Command | What it does |
 | --- | --- |
 | `termio sessions list` | List the sessions in this project with their live status. |
+| `termio sessions watch` | Block and stream one line per status change — the push alternative to polling `list`. Defaults to `done` and `needs-you`; widen with `--state working,idle,done,needs-you`. Runs until you interrupt it. |
 | `termio sessions spawn "<prompt>"` | Start a new agent session on the prompt. Add `--agent <id>` (e.g. `codex`, `grok`, `pi`) to choose the agent; it defaults to the caller's own kind. The reply carries the new `<agent>@<id>` handle. |
 | `termio sessions send <agent>@<id> "<text>"` | Type text into an existing session and submit it with a real Return keypress — a prompt to drive it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. |
 | `termio sessions close <agent>@<id>` | Close one or more session tabs. |
@@ -67,6 +68,8 @@ Commands are scoped to the current project automatically.
 
 <Callout type="tip">
   This is what lets one agent hand work to another — `spawn` a task in a sibling
-  session, then poll `termio sessions list` until it reports **done** and read the
-  result. An agent orchestrating other agents, all on your own machine.
+  session, then `watch` (or poll `list`) until it reports **done** and read the
+  result. Watching several at once, `termio sessions watch` prints the handle the
+  moment any of them turns **done** or **needs-you** — one agent supervising a
+  fleet, all on your own machine.
 </Callout>

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -52,16 +52,21 @@ for machine-readable output.
 | Command | What it does |
 | --- | --- |
 | `termio sessions list` | List the sessions in this project with their live status. |
-| `termio sessions send <id> "<text>"` | Type a prompt into a session and submit it. |
-| `termio sessions answer <id> "<text>"` | Answer a session's menu or permission prompt. |
-| `termio sessions start <agent>` | Start a new session with the named agent. |
-| `termio sessions stop <id>` | Close a session. |
+| `termio sessions spawn "<prompt>"` | Start a new agent session on the prompt. Add `--agent <id>` (e.g. `codex`, `grok`, `pi`) to choose the agent; it defaults to the caller's own kind. The reply carries the new `<agent>@<id>` handle. |
+| `termio sessions send <agent>@<id> "<text>"` | Type text into an existing session and submit it with a real Return keypress — a prompt to drive it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. |
+| `termio sessions close <agent>@<id>` | Close one or more session tabs. |
+| `termio sessions focus <agent>@<id>` | Bring a session to the front in the app. |
 
-`<id>` is the short id from `list` (a session title also works). Commands are
-scoped to the current project automatically.
+`<agent>@<id>` is the handle `list` prints (a bare id or session title also works).
+Commands are scoped to the current project automatically.
+
+<Callout type="note">
+  `answer` is a deprecated alias of `send`, and `send` with no handle behaves like
+  `spawn` — both kept so existing scripts keep working. Prefer `spawn` and `send`.
+</Callout>
 
 <Callout type="tip">
-  This is what lets one agent hand work to another — kick off a task in a sibling
+  This is what lets one agent hand work to another — `spawn` a task in a sibling
   session, then poll `termio sessions list` until it reports **done** and read the
   result. An agent orchestrating other agents, all on your own machine.
 </Callout>


### PR DESCRIPTION
Reworks the `termio sessions` CLI surface so each verb does one job, and adds the missing **push** primitive for supervising a fleet of agents.

## Why

The CLI had two design smells:
- **`send` was overloaded** — it messaged an existing session *or* (with no handle) spawned a fresh one, disambiguated only by the shape of a positional.
- **`answer` was a pure synonym for `send`** — same wire op, same code path, same "type text + Return" mechanism.

And there was no push side to the loop: an agent supervising siblings could only **poll** `list` to notice one finishing or stopping to ask.

## What

Final verb set:

```
list · watch [--state …] · spawn "<prompt>" [--agent <id>] · send <handle> "<text>" · close <handle>… · focus <handle>
```

### 1. Split `spawn` from `send`, fold `answer` into `send` (`27a99d9`)
- **`spawn "<prompt>" [--agent <id>]`** is now the only creating verb — no handle, prompt is the sole positional, so the `is_handle` guess is gone from the clean path. The app already validates the agent id, so a typo fails with the valid list.
- **`send <agent>@<id> "<text>"`** only talks to something that exists — a prompt to drive it, or a menu choice (`"1"`/`"yes"`) to answer a permission prompt (absorbing what `answer` did).
- **`answer`**, and **`send` with no handle**, stay as silent back-compat aliases (both fold onto the wire `send`, which the app already routes to spawn on an empty target) so existing scripts keep working.
- **No host behavior change** here: `send`/`answer` already shared one handler, and empty-target `send` already spawned.

### 2. `sessions watch` — stream status transitions, push not poll (`342e0c6`)
`send --wait` waits on the one session you poked; `watch` waits on *any* of them. It blocks and streams one line per scoped status change until interrupted.

- **`SessionWatchHub`** holds the open watch connections and fans a `SessionWatchEvent` to every subscriber scoped to the session's project and interested in the new state. All socket writes run off the main thread; a dead reader is reaped on the next failed write (not by watching for EOF — a piped `… | nc` client half-closes its write side immediately, which would look like a disconnect), with `SO_NOSIGPIPE` so that failing write can't signal the app.
- **`SessionControlListener`** gains a streaming path: the `watch` op isn't answered and closed but handed to the hub via a new `onWatch` scope-resolver.
- **`setStatus`** — the one guarded transition choke point — broadcasts the event.
- **`--state`** (carried in the request text) filters; empty means `done` + `needs-you`.

## Docs

Updated in all three places the CLI is documented: the shell `usage()`, the in-app injected agent block (`SessionSkillInstaller.block`, written into `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md`), and the landing `session-control.mdx` — which was stale, listing never-implemented `start`/`stop` verbs.

## Verification

`swift build` + full `build-app.sh` clean. Exercised end-to-end against a dev build:

```
JSON (all states):  {"status":"working",...,"handle":"claude@96187e1f","schema_version":1}
                    {"status":"done",...}
TEXT (default):     claude@96187e1f  [done]  Respond with greeting message   ← 'working' correctly filtered out
```

`spawn`, `send`-to-existing, agent validation, project scoping, JSON/text modes, and the default-filter all confirmed; the app stayed healthy across subscriber churn.

One client-side bug found and fixed during verification: `build_request | nc` runs `nc` concurrently with the `json_escape` subprocesses, so `nc` connects before the payload is ready and the app reads empty → `malformed request`. Fixed by building the request into a variable first, then `printf | nc`.

## Notes

- Independent of #72. `watch` events carry `handle`/`status`/`title` today; enriching each event with the on-screen prompt / transcript cursor is a small follow-up once #72's `viewportText` lands on main.
- `--key` (raw keypress, no Return) was considered for menus but left out — every built-in agent's permission prompt already accepts text+Return, which is why `answer` folded cleanly into `send`.