### PR TITLE
perf(ui): keep project-open and sidebar renders off blocking I/O

### DIFF
--- a/Sources/termio/App/BrandIcons.swift
+++ b/Sources/termio/App/BrandIcons.swift
@@ -46,8 +46,22 @@ struct AgentImageView: View {
     let url: URL
     var size: CGFloat
 
+    /// Decoded icons, keyed by file URL. A working session's sidebar row re-renders
+    /// about once a second (spinner/liveness), and without this every pass re-reads
+    /// and re-decodes the icon file from disk — synchronous I/O inside `body`. An
+    /// icon *swap* re-keys by URL and shows immediately; editing the file in place
+    /// shows its new art on the next launch.
+    private static let decoded = NSCache<NSURL, NSImage>()
+
+    private static func image(at url: URL) -> NSImage? {
+        if let hit = decoded.object(forKey: url as NSURL) { return hit }
+        guard let loaded = NSImage(contentsOf: url) else { return nil }
+        decoded.setObject(loaded, forKey: url as NSURL)
+        return loaded
+    }
+
     var body: some View {
-        if let image = NSImage(contentsOf: url) {
+        if let image = Self.image(at: url) {
             Image(nsImage: image)
                 .resizable()
                 .interpolation(.high)

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -291,12 +291,13 @@ extension TermioStore {
         let project = Project(
             name: agent == .terminal ? "Terminals" : "Chats",
             path: path,
-            branch: currentBranch(in: path) ?? "—",
+            branch: "—",
             sessions: [session],
             kind: containerKind
         )
         projects.append(project)
         selectedSessionID = session.id
+        resolveBranchLabel(for: project.id, at: path)
     }
 
     /// Opens an **SSH terminal** to `host` — a loose terminal that launches
@@ -467,11 +468,12 @@ extension TermioStore {
         let project = Project(
             name: url.lastPathComponent,
             path: path,
-            branch: currentBranch(in: path) ?? "—",
+            branch: "—",
             sessions: [session]
         )
         projects.append(project)
         selectedSessionID = project.sessions.first?.id
+        resolveBranchLabel(for: project.id, at: path)
     }
 
     /// Removes a project from the sidebar: tears down every session's live surface
@@ -603,10 +605,22 @@ extension TermioStore {
         relaunchSession(id)
     }
 
-    /// The checked-out branch of the git repository at `directory`, or `nil` when
-    /// it is not a repo (rendered as "—", matching the seed projects).
-    private func currentBranch(in directory: String) -> String? {
-        runGit(["rev-parse", "--abbrev-ref", "HEAD"], in: directory)
+    /// Fills in a just-created project's branch label off the main thread. Creation
+    /// seeds the label with "—" (the non-repo rendering) because resolving it means
+    /// spawning a `git rev-parse` subprocess and blocking on its exit — a visible
+    /// hitch to pay on the main thread just for sidebar chrome. The patch keys on
+    /// the project id, so a project closed before git answers is simply a no-op.
+    private func resolveBranchLabel(for projectID: Project.ID, at path: String) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let branch = Self.gitOutput(["rev-parse", "--abbrev-ref", "HEAD"], in: path),
+                  !branch.isEmpty else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      let index = self.projects.firstIndex(where: { $0.id == projectID })
+                else { return }
+                self.projects[index].branch = branch
+            }
+        }
     }
 
     /// Runs `git -C <directory> <arguments…>` synchronously, returning trimmed
@@ -614,6 +628,12 @@ extension TermioStore {
     /// treat `nil` as "couldn't do it" and fall back rather than trapping.
     @discardableResult
     private func runGit(_ arguments: [String], in directory: String) -> String? {
+        Self.gitOutput(arguments, in: directory)
+    }
+
+    /// The blocking body behind `runGit`, isolation-free so background work (the
+    /// branch-label resolve) can call it without hopping through the main actor.
+    private nonisolated static func gitOutput(_ arguments: [String], in directory: String) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
         process.arguments = ["-C", directory] + arguments


### PR DESCRIPTION
## What

Two main-thread I/O eliminations found while re-auditing the terminal-open hot path:

- **Async branch label.** `addProject` / `addScratchSession` spawned a synchronous `git rev-parse` (`Process` + `waitUntilExit`) on the main thread just to fill the sidebar branch label. The label now seeds `—` and a background resolve patches it in, keyed by project id so a project closed before git answers is a no-op. `runGit` keeps its signature; its body moved to a `nonisolated static gitOutput` both paths share.
- **Agent icon cache.** `AgentImageView.body` re-read and re-decoded its icon file from disk on every render — and a working session's sidebar row re-renders about once a second, so file-icon agents (OpenCode, Gemini, user agents) paid a disk read + PNG decode per second per row. Decoded images are now cached in an `NSCache` keyed by URL.

## What was audited and deliberately left alone

- **`warmUpRendering` 60 Hz pump**: `ghostty_app_tick` is no-op-cheap when idle, hidden panes still lay out (so the 6 s no-size backstop basically never runs), and the 2 s floor is what papers over the edge-triggered-wakeup drops during OpenCode's reply-gated startup handshake. Not a real cost; shortening it risks re-breaking the OpenCode blank-screen fix.
- **`surface(for:)` inside `TerminalPane.body`**: first-call-only (cached), intentional.
- Worktree creation still runs `git worktree add` synchronously on the main thread — real but rare and user-prompted; left as a follow-up.

## Testing

`swift build` clean. Not runtime-verified: relaunching the dev app would kill live sessions; behavior changes are label-fill timing and icon caching only.