### PR TITLE
fix(sessions): retire per-session state with the session

### DIFF
--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -288,7 +288,11 @@ final class CompanionServer {
             let bridge = PTYBridge(pty: pty, connection: connection)
             bridges[id] = bridge
             bridge.start()
-            pty.addExitObserver { [weak self, weak connection] code in
+            // The bridge owns the token so `stop()` retires the observer with the
+            // attach: without that, a phone that re-attaches to another session
+            // would still hear THIS pty's exit — a spurious exit banner and a
+            // dropped connection while it's viewing a session that's fine.
+            bridge.exitToken = pty.addExitObserver { [weak self, weak connection] code in
                 guard let connection else { return }
                 Task { @MainActor in
                     self?.sendControl(.exit(code: code), to: connection)
@@ -794,6 +798,9 @@ private final class PTYBridge: @unchecked Sendable {
     private let queue = DispatchQueue(label: "termio.companion.bridge")
     private var sinkToken: UUID?
     private var resizeToken: UUID?
+    /// Set by the attach handler (the observer's body needs the server, which the
+    /// bridge doesn't know); cleared here in `stop()` like the other two tokens.
+    var exitToken: UUID?
     private let lock = NSLock()
     private var pendingBytes = 0
     private var behind = false
@@ -900,6 +907,8 @@ private final class PTYBridge: @unchecked Sendable {
         sinkToken = nil
         if let token = resizeToken { pty.removeResizeObserver(token) }
         resizeToken = nil
+        if let token = exitToken { pty.removeExitObserver(token) }
+        exitToken = nil
     }
 
     private func send(_ data: Data) {

--- a/Sources/termio/Terminal/Ghostty/PTYProcess.swift
+++ b/Sources/termio/Terminal/Ghostty/PTYProcess.swift
@@ -102,7 +102,7 @@ final class PTYProcess: @unchecked Sendable {
     private var companionCols = 0
     private var companionRows = 0
     private var resizeObservers: [UUID: (Int, Int) -> Void] = [:]
-    private var exitObservers: [(Int32) -> Void] = []
+    private var exitObservers: [UUID: (Int32) -> Void] = [:]
     private var terminated = false
     /// Set (under `lock`) the moment `waitpid` reaps the child, after which its
     /// pid may be recycled — the escalation kill checks this so a delayed
@@ -217,7 +217,7 @@ final class PTYProcess: @unchecked Sendable {
                 let runtimeMs = UInt64(max(0, Date().timeIntervalSince(self.startedAt) * 1000))
                 self.onExit?(Int32(code), runtimeMs)
                 self.lock.lock()
-                let observers = self.exitObservers
+                let observers = Array(self.exitObservers.values)
                 self.lock.unlock()
                 for observer in observers { observer(Int32(code)) }
             }
@@ -448,10 +448,22 @@ final class PTYProcess: @unchecked Sendable {
     }
 
     /// Observe child exit (in addition to `onExit`, which the store owns).
-    /// Fired on the main queue.
-    func addExitObserver(_ observer: @escaping (Int32) -> Void) {
+    /// Fired on the main queue. The token unregisters it — an observer tied to
+    /// something shorter-lived than the PTY (a phone attach, outlived when the
+    /// same connection re-attaches to another session) must be removed on that
+    /// teardown, or the dead pairing still hears this PTY's exit.
+    @discardableResult
+    func addExitObserver(_ observer: @escaping (Int32) -> Void) -> UUID {
+        let id = UUID()
         lock.lock()
-        exitObservers.append(observer)
+        exitObservers[id] = observer
+        lock.unlock()
+        return id
+    }
+
+    func removeExitObserver(_ id: UUID) {
+        lock.lock()
+        exitObservers[id] = nil
         lock.unlock()
     }
 

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -173,6 +173,20 @@ extension TermioStore {
         promotionStreak[id] = nil
     }
 
+    /// Drops every per-session activity-tracking entry — the one place that
+    /// enumerates these dictionaries, so the teardown paths (close, project
+    /// removal, relaunch) can't drift out of step when a new tracker is added.
+    /// `transcriptPaths` is deliberately not here: a relaunch resumes the same
+    /// conversation, so only the close/remove paths clear it (inline).
+    func clearActivityTracking(for id: Session.ID) {
+        lastWorkingAt[id] = nil
+        lastHookReportAt[id] = nil
+        lastUserInputAt[id] = nil
+        promotionStreak[id] = nil
+        lastTitleActivity[id] = nil
+        lastScreenActivity[id] = nil
+    }
+
     /// Marks the moment of live user input into a session's terminal. Keystroke
     /// echo and mouse-mode scrolling repaint the screen exactly like agent
     /// output, so promotion holds off while the human is the one causing the

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -490,11 +490,8 @@ extension TermioStore {
             monitors[sessionID] = nil
             removeRuntime(for: sessionID)
             processSpawnedAt[sessionID] = nil
-            lastWorkingAt[sessionID] = nil
-            lastHookReportAt[sessionID] = nil
-            lastUserInputAt[sessionID] = nil
-            promotionStreak[sessionID] = nil
-            lastTitleActivity[sessionID] = nil
+            transcriptPaths[sessionID] = nil
+            clearActivityTracking(for: sessionID)
         }
         projects.remove(at: projectIndex)
 
@@ -552,11 +549,8 @@ extension TermioStore {
         monitors[id] = nil
         removeRuntime(for: id)
         processSpawnedAt[id] = nil
-        lastWorkingAt[id] = nil
-        lastHookReportAt[id] = nil
-        lastUserInputAt[id] = nil
-        promotionStreak[id] = nil
-        lastTitleActivity[id] = nil
+        transcriptPaths[id] = nil
+        clearActivityTracking(for: id)
 
         // If the session held a split pane, collapse that pane; when it was also
         // the focused pane the prune moves the selection to its layout neighbor,
@@ -587,6 +581,15 @@ extension TermioStore {
         surfaces[id] = nil
         monitors[id] = nil
         processSpawnedAt[id] = nil
+        // The dead child's status must not carry into the respawn: a leftover
+        // spinner would read as the new process already working (and with the
+        // trackers cleared below, the stale-working sweep — which only visits
+        // sessions present in `lastWorkingAt` — could never correct it).
+        setStatus(.idle, for: id)
+        setCurrentTool(nil, for: id)
+        clearActivityTracking(for: id)
+        // `transcriptPaths` deliberately survives: the respawn resumes the same
+        // conversation, so the Info pane's trace should keep pointing at it.
         // `surfaces` is a plain cache, not `@Published` — nothing re-renders on
         // its own, so poke observers; the pane then rebuilds via `surface(for:)`.
         objectWillChange.send()


### PR DESCRIPTION
Three lifecycle bugs from a bug-hunt across the PTY/session/companion subsystems (follow-up to #82's audit):

## 1. Closed sessions leaked two tracker dictionaries

`closeSession` / `removeProject` cleaned ten `Session.ID`-keyed caches but missed `lastScreenActivity` and `transcriptPaths` (both added after the cleanup lists were written), so every closed session left entries behind for the app's lifetime. The per-session activity trackers now retire through one shared `clearActivityTracking(for:)` — the single place that enumerates them, so the next tracker can't drift out of step with the teardown paths.

## 2. `relaunchSession` carried the dead child's status into the respawn

A self-update relaunch (or /quit revert-to-shell) kept the old process's `.working` status and trackers. The relaunch now resets status to `.idle`, clears the current tool, and drops the trackers. `transcriptPaths` deliberately survives — the respawn resumes the same conversation, so the Info pane's trace keeps pointing at it. (Note: clearing the trackers *without* the status reset would have wedged the spinner forever, since the stale-working sweep only visits sessions present in `lastWorkingAt`.)

## 3. Phone re-attach left the old session's exit observer alive

`PTYProcess.addExitObserver` had no removal API, and the companion attach handler adds an observer per attach. A phone that re-attached to another session on the same connection still heard the old pty's exit — a spurious exit banner and a dropped connection while viewing a session that's fine. `addExitObserver` now returns a token (same shape as `addSink`/`addResizeObserver`), the bridge owns it, and `PTYBridge.stop()` retires it with the attach.

## Testing

`swift build` clean (the Sendable warnings in CompanionServer are pre-existing, on untouched lines). Not runtime-verified — relaunching the dev app would kill live sessions; the phone re-attach scenario (bug 3) is worth exercising when convenient: attach to session A, switch to session B, exit A's shell, confirm the phone stays connected.