### PR TITLE
perf(git): stop the git subprocess storm behind branch/worktree watching

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -69,6 +69,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // KVO on the sidebar's collapse state, so every collapse path (toolbar toggle, View menu,
     // divider drag) empties/refills the sidebar's toolbar region (see `setNavigatorItemsVisible`).
     private var sidebarCollapseObserver: NSKeyValueObservation?
+    // KVO on the inspector's collapse state, mirrored onto `store.inspectorVisible` so
+    // hosted panes (the git pane's auto-refresh) can stand down while hidden.
+    private var inspectorCollapseObserver: NSKeyValueObservation?
     // KVO on the window's effective appearance, so a *system-driven* light↔dark flip (macOS auto
     // day/night, Control Center) re-resolves the window background. In `.system` appearance mode
     // nothing else re-runs `applyWindowTransparency` on an OS flip — the settings never change —
@@ -162,6 +165,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // divider drag). No `.initial`: the launch-time sync below runs after the autosave restore.
         sidebarCollapseObserver = sidebarSplitItem?.observe(\.isCollapsed, options: [.new]) { [weak self] item, _ in
             MainActor.assumeIsolated { self?.setNavigatorItemsVisible(!item.isCollapsed) }
+        }
+        // Mirror the inspector's live collapse state onto the store, so panes it hosts
+        // can idle while hidden (a collapsed item keeps its view hierarchy alive — the
+        // git pane's watcher would otherwise keep spawning `git status` unseen). KVO
+        // catches every collapse path; `.initial` seeds the restored autosave state.
+        inspectorCollapseObserver = filesInspectorItem?.observe(
+            \.isCollapsed, options: [.initial, .new]
+        ) { [weak self] item, _ in
+            let visible = !item.isCollapsed
+            MainActor.assumeIsolated {
+                guard let store = self?.store, store.inspectorVisible != visible else { return }
+                store.inspectorVisible = visible
+            }
         }
         // Re-resolve the window background whenever the OS flips light↔dark under `.system` mode
         // (see `appearanceObserver`). Pinned Light/Dark modes never see the effective appearance

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -65,8 +65,15 @@ struct FileBrowserView: View {
                 if let repoRoot = projectPath {
                     // Fresh identity per repo, so the panel model (selection, draft message,
                     // PR status) resets cleanly when the selected project moves.
-                    GitChangesView(repoRoot: repoRoot, changeCount: $store.gitChangeCount)
-                        .id(repoRoot)
+                    // The visibility closure reads the store live (weakly — the model may
+                    // outlive a closing window), so a collapsed inspector parks the pane's
+                    // auto-refresh even while this view stays in the hierarchy.
+                    GitChangesView(
+                        repoRoot: repoRoot,
+                        changeCount: $store.gitChangeCount,
+                        isPaneVisible: { [weak store] in store?.inspectorVisible ?? true }
+                    )
+                    .id(repoRoot)
                 } else {
                     content
                 }

--- a/Sources/termio/Git/BranchModel.swift
+++ b/Sources/termio/Git/BranchModel.swift
@@ -11,11 +11,20 @@ import Combine
 /// attribute read from that folder's `HEAD`. A folder is watched by observing the
 /// directory that contains its `HEAD` file — for the primary checkout that is
 /// `<repo>/.git`, for a linked worktree it is `<repo>/.git/worktrees/<name>`. Git
-/// resolves the right one via `rev-parse --git-path HEAD`. Watching the *directory*
+/// resolves the right one via `rev-parse --git-path HEAD` (the one git spawn left
+/// here, once per folder when the watch is armed). Watching the *directory*
 /// (not the file) survives git's atomic replace-on-write of `HEAD`, where the file
 /// inode is swapped out from under a file-level watch.
 ///
-/// All git work runs off the main thread; `branches` is only ever mutated on main,
+/// The state itself is read **in-process** — `HEAD` is a one-line text file and the
+/// linked worktrees are a directory listing. The previous shape spawned 2–3 `git
+/// rev-parse` processes per event, and the watched directory is `.git` itself, whose
+/// busiest file by far is `index`: every `git status` run by *anyone* (an agent's
+/// shell loop, the git pane's own reload) rewrites it and fired this watch. With a
+/// fleet of agent sessions that added up to a machine-wide process storm — dozens of
+/// short-lived `git` spawns a second, with trustd/tccd re-validating each one.
+///
+/// All reads run off the main thread; `branches` is only ever mutated on main,
 /// so SwiftUI observers stay safe.
 final class BranchModel: ObservableObject {
     /// Folder path → branch label (the branch name, or a short commit SHA when the
@@ -27,15 +36,24 @@ final class BranchModel: ObservableObject {
     /// and keeps that SHA for the tooltip.
     @Published private(set) var detachedFolders: Set<String> = []
 
-    /// Fired on the main thread after a watched folder's git directory changes. The store
-    /// uses it to re-scan for worktrees created/removed outside the app — a `git worktree
-    /// add` in a terminal writes into the primary checkout's `.git`, which this watch sees.
-    var onGitDirectoryChange: (() -> Void)?
+    /// Fired on the main thread when a watched folder's git state *actually changed*:
+    /// its HEAD moved (checkout, commit, rebase) or its linked-worktree set gained or
+    /// lost an entry. Deliberately not fired for every `.git` directory event — index
+    /// refreshes are the overwhelming majority and mean nothing to the worktree list.
+    /// Carries the folder so the store can reconcile just that project, not all of them.
+    var onGitStateChange: ((String) -> Void)?
 
     private let queue = DispatchQueue(label: "sh.termio.branch", qos: .utility)
     private var watchers: [String: Watcher] = [:]
+    /// The currently wanted watch set and the folders whose HEAD-directory resolution
+    /// is in flight — both main-only, so an overlapping `setWatched` can't double-arm.
+    private var wanted: Set<String> = []
+    private var arming: Set<String> = []
     /// Pending debounce work items per folder, touched only on `queue`.
     private var pending: [String: DispatchWorkItem] = [:]
+    /// The last state read per folder, touched only on `queue` — the change gate for
+    /// `onGitStateChange`.
+    private var lastStates: [String: GitState] = [:]
 
     /// A live file-system observer on the directory holding a folder's `HEAD`.
     private final class Watcher {
@@ -57,24 +75,42 @@ final class BranchModel: ObservableObject {
     /// newly present folder and stops watching any that has gone. Idempotent, so the
     /// store can call it after every change to the project tree. Main-actor only.
     func setWatched(_ folders: Set<String>) {
-        let wanted = Set(folders.map(Self.standardized))
+        wanted = Set(folders.map(Self.standardized))
 
         for (folder, watcher) in watchers where !wanted.contains(folder) {
             watcher.source.cancel()
             watchers[folder] = nil
             branches[folder] = nil
             detachedFolders.remove(folder)
+            queue.async { [weak self] in self?.lastStates[folder] = nil }
         }
-        for folder in wanted where watchers[folder] == nil {
-            arm(folder)
-            resolve(folder)
+        for folder in wanted where watchers[folder] == nil && !arming.contains(folder) {
+            arming.insert(folder)
+            // Resolve the HEAD directory off the main thread: it is the one git spawn
+            // left in this model, and launch-time git has hung in the kernel before
+            // (post-rebuild code-sign stall) — that must stall a utility queue, never
+            // app startup. The watch is then armed back on main, where `watchers` lives.
+            queue.async { [weak self] in
+                let headDirectory = self?.headDirectory(for: folder)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    self.arming.remove(folder)
+                    // The wanted set may have moved while git ran; arm only if current.
+                    guard let headDirectory, self.wanted.contains(folder),
+                          self.watchers[folder] == nil else { return }
+                    self.arm(folder, headDirectory: headDirectory)
+                    // Seed the state without notifying: the store reconciles everything
+                    // at launch anyway; the seed makes the first *event* comparable.
+                    self.queue.async { [weak self] in
+                        self?.refresh(folder, headDirectory: headDirectory, notify: false)
+                    }
+                }
+            }
         }
     }
 
-    /// Opens a directory-level watch on the folder's `HEAD` container. A folder that
-    /// is not a git repo simply gets no watcher (and no branch entry).
-    private func arm(_ folder: String) {
-        guard let headDirectory = headDirectory(for: folder) else { return }
+    /// Opens a directory-level watch on the folder's already-resolved `HEAD` container.
+    private func arm(_ folder: String, headDirectory: String) {
         let descriptor = open(headDirectory, O_EVTONLY)
         guard descriptor >= 0 else { return }
 
@@ -83,32 +119,35 @@ final class BranchModel: ObservableObject {
             eventMask: [.write, .delete, .rename, .extend, .link, .revoke],
             queue: queue
         )
-        source.setEventHandler { [weak self] in self?.scheduleResolve(folder) }
+        source.setEventHandler { [weak self] in
+            self?.scheduleRefresh(folder, headDirectory: headDirectory)
+        }
         source.setCancelHandler { close(descriptor) }
         watchers[folder] = Watcher(source: source)
         source.resume()
     }
 
     /// Coalesces a burst of file-system events (a checkout rewrites several refs)
-    /// into a single re-resolve. Runs on `queue`, where `pending` lives.
-    private func scheduleResolve(_ folder: String) {
+    /// into a single re-read. Runs on `queue`, where `pending` lives.
+    private func scheduleRefresh(_ folder: String, headDirectory: String) {
         pending[folder]?.cancel()
         let item = DispatchWorkItem { [weak self] in
             self?.pending[folder] = nil
-            self?.publish(folder, state: self?.currentBranchState(for: folder))
-            // A ref change is often also a worktree-tree change (add/remove touches the
-            // primary checkout's .git); let the store reconcile its worktree list.
-            DispatchQueue.main.async { self?.onGitDirectoryChange?() }
+            self?.refresh(folder, headDirectory: headDirectory, notify: true)
         }
         pending[folder] = item
         queue.asyncAfter(deadline: .now() + 0.12, execute: item)
     }
 
-    /// Reads the branch off the main thread and publishes it.
-    private func resolve(_ folder: String) {
-        queue.async { [weak self] in
-            self?.publish(folder, state: self?.currentBranchState(for: folder))
-        }
+    /// Re-reads a folder's git state, publishes the branch label, and — when notifying
+    /// and something really moved — reports the change. Runs on `queue`.
+    private func refresh(_ folder: String, headDirectory: String, notify: Bool) {
+        let state = readGitState(headDirectory: headDirectory)
+        let changed = lastStates[folder] != state
+        lastStates[folder] = state
+        publish(folder, state: state.branch)
+        guard notify, changed else { return }
+        DispatchQueue.main.async { [weak self] in self?.onGitStateChange?(folder) }
     }
 
     private func publish(_ folder: String, state: BranchState?) {
@@ -124,30 +163,62 @@ final class BranchModel: ObservableObject {
         }
     }
 
-    // MARK: - Git
+    // MARK: - In-process git state
 
-    private struct BranchState {
+    private struct BranchState: Equatable {
         var label: String
         var isDetached: Bool
     }
 
-    /// The folder's current branch name, or its short SHA plus detached state when
-    /// no branch owns HEAD. Returns `nil` when the folder is not a git work tree.
-    private func currentBranchState(for folder: String) -> BranchState? {
-        guard git(["rev-parse", "--is-inside-work-tree"], in: folder) == "true" else { return nil }
-        let head = git(["rev-parse", "--abbrev-ref", "HEAD"], in: folder)
-        if let head, head != "HEAD", !head.isEmpty {
-            return BranchState(label: head, isDetached: false)
+    /// Everything a git-dir event can meaningfully change for us: where HEAD points,
+    /// and which linked worktrees exist. Equatable so an `index` refresh — same HEAD,
+    /// same worktrees — is recognized as the no-op it is.
+    private struct GitState: Equatable {
+        var branch: BranchState?
+        var worktreeNames: [String]
+    }
+
+    private func readGitState(headDirectory: String) -> GitState {
+        GitState(branch: readBranch(headDirectory: headDirectory),
+                 worktreeNames: readWorktreeNames(headDirectory: headDirectory))
+    }
+
+    /// Parses `HEAD` directly instead of spawning `git rev-parse`: the file is either
+    /// `ref: refs/heads/<branch>` or a bare commit hash (detached). The label matches
+    /// what `--abbrev-ref` printed, except a detached SHA is always 7 chars (git may
+    /// lengthen its abbreviation for ambiguity; for a display chip that nicety isn't
+    /// worth a process per event).
+    private func readBranch(headDirectory: String) -> BranchState? {
+        guard let raw = try? String(
+            contentsOfFile: headDirectory + "/HEAD", encoding: .utf8) else { return nil }
+        let head = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if head.hasPrefix("ref: ") {
+            let ref = head.dropFirst("ref: ".count)
+            let label = ref.hasPrefix("refs/heads/") ? ref.dropFirst("refs/heads/".count) : ref
+            guard !label.isEmpty else { return nil }
+            return BranchState(label: String(label), isDetached: false)
         }
         // Detached HEAD (rebase in progress, or checked out at a bare commit): show
         // the short SHA so the node still reads as "somewhere specific".
-        guard let commit = git(["rev-parse", "--short", "HEAD"], in: folder) else { return nil }
-        return BranchState(label: commit, isDetached: true)
+        guard head.count >= 7, head.allSatisfy(\.isHexDigit) else { return nil }
+        return BranchState(label: String(head.prefix(7)), isDetached: true)
     }
+
+    /// The linked-worktree entry names under the primary checkout's git dir. Empty for
+    /// a linked worktree's own HEAD directory (which has no `worktrees` child) and for
+    /// a repo with no linked worktrees — both fine, the value only has to be *stable*
+    /// so a change in it is a real add/remove.
+    private func readWorktreeNames(headDirectory: String) -> [String] {
+        ((try? FileManager.default.contentsOfDirectory(atPath: headDirectory + "/worktrees")) ?? [])
+            .sorted()
+    }
+
+    // MARK: - Git (watch setup only)
 
     /// The directory that contains the folder's `HEAD` file. `git-path` resolves the
     /// linked-worktree case (`…/.git/worktrees/<name>/HEAD`) as well as the primary
-    /// checkout (`…/.git/HEAD`). Returns `nil` for a non-repo.
+    /// checkout (`…/.git/HEAD`). Returns `nil` for a non-repo. The one place this
+    /// model still runs git — once per folder, when its watch is armed.
     private func headDirectory(for folder: String) -> String? {
         guard let headPath = git(["rev-parse", "--git-path", "HEAD"], in: folder) else { return nil }
         let absolute = headPath.hasPrefix("/")
@@ -156,9 +227,9 @@ final class BranchModel: ObservableObject {
         return (absolute as NSString).deletingLastPathComponent
     }
 
-    /// Runs `git -C <folder> <arguments…>` synchronously (callers are already off the
-    /// main thread), returning trimmed stdout on success or `nil` on any failure —
-    /// the same no-trap, degrade-gracefully stance the rest of the app takes.
+    /// Runs `git -C <folder> <arguments…>` synchronously, returning trimmed stdout on
+    /// success or `nil` on any failure — the same no-trap, degrade-gracefully stance
+    /// the rest of the app takes.
     private func git(_ arguments: [String], in folder: String) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")

--- a/Sources/termio/Git/BranchModel.swift
+++ b/Sources/termio/Git/BranchModel.swift
@@ -175,12 +175,12 @@ final class BranchModel: ObservableObject {
     /// same worktrees — is recognized as the no-op it is.
     private struct GitState: Equatable {
         var branch: BranchState?
-        var worktreeNames: [String]
+        var worktreeEntries: [String]
     }
 
     private func readGitState(headDirectory: String) -> GitState {
         GitState(branch: readBranch(headDirectory: headDirectory),
-                 worktreeNames: readWorktreeNames(headDirectory: headDirectory))
+                 worktreeEntries: readWorktreeEntries(headDirectory: headDirectory))
     }
 
     /// Parses `HEAD` directly instead of spawning `git rev-parse`: the file is either
@@ -204,13 +204,38 @@ final class BranchModel: ObservableObject {
         return BranchState(label: String(head.prefix(7)), isDetached: true)
     }
 
-    /// The linked-worktree entry names under the primary checkout's git dir. Empty for
-    /// a linked worktree's own HEAD directory (which has no `worktrees` child) and for
-    /// a repo with no linked worktrees — both fine, the value only has to be *stable*
-    /// so a change in it is a real add/remove.
-    private func readWorktreeNames(headDirectory: String) -> [String] {
-        ((try? FileManager.default.contentsOfDirectory(atPath: headDirectory + "/worktrees")) ?? [])
-            .sorted()
+    /// The primary checkout's git directory — where the `worktrees` listing lives.
+    /// A linked worktree's HEAD directory (`<common>/worktrees/<name>`) carries a
+    /// `commondir` file pointing back, usually relatively, at the common dir; the
+    /// primary checkout has no such file and is its own common dir.
+    private func commonDirectory(for headDirectory: String) -> String {
+        guard let raw = try? String(
+            contentsOfFile: headDirectory + "/commondir", encoding: .utf8) else {
+            return headDirectory
+        }
+        let path = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else { return headDirectory }
+        if path.hasPrefix("/") { return path }
+        return URL(fileURLWithPath: headDirectory)
+            .appendingPathComponent(path).standardizedFileURL.path
+    }
+
+    /// One line per linked worktree: the entry name plus its admin `gitdir` contents,
+    /// so an add, a remove, *and* a `git worktree move` (same name, new checkout path)
+    /// all read as changes. Resolved through the common dir, so a linked checkout's
+    /// events see the same listing the primary one does — its own HEAD directory has
+    /// no `worktrees` child. Empty for a repo with no linked worktrees.
+    private func readWorktreeEntries(headDirectory: String) -> [String] {
+        let root = commonDirectory(for: headDirectory) + "/worktrees"
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: root) else {
+            return []
+        }
+        return names.sorted().map { name in
+            let gitdir = (try? String(
+                contentsOfFile: root + "/" + name + "/gitdir", encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return name + "\u{0}" + gitdir
+        }
     }
 
     // MARK: - Git (watch setup only)

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -43,10 +43,11 @@ struct GitChangesView: View {
     /// several become the targets of the batch context-menu actions.
     @State private var selection = Set<String>()
 
-    init(repoRoot: String, changeCount: Binding<Int>) {
+    init(repoRoot: String, changeCount: Binding<Int>, isPaneVisible: (() -> Bool)? = nil) {
         self.repoRoot = repoRoot
         self._changeCount = changeCount
-        self._model = StateObject(wrappedValue: GitPanelModel(repoRoot: repoRoot))
+        self._model = StateObject(
+            wrappedValue: GitPanelModel(repoRoot: repoRoot, isPaneVisible: isPaneVisible))
     }
 
     private var chrome: ChromeTheme? { settings.chromeTheme(for: colorScheme) }
@@ -64,6 +65,13 @@ struct GitChangesView: View {
         }
         .task(id: repoRoot) { await model.load() }
         .task(id: mode) { if mode == .history { await model.loadHistory() } }
+        // Replay any refresh that arrived while the inspector was collapsed, the
+        // moment the pane is actually shown again (either signal can fire first
+        // depending on how the view was re-attached).
+        .onAppear { model.flushDeferredRefresh() }
+        .onChange(of: store.inspectorVisible) { _, visible in
+            if visible { model.flushDeferredRefresh() }
+        }
         .onChange(of: model.changes.count) { _, count in changeCount = count }
         .onChange(of: selection) { _, selected in
             if selected.count == 1, let change = model.changes.first(where: { $0.path == selected.first }) {

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -30,8 +30,29 @@ final class GitPanelModel: ObservableObject {
     /// Monotonic ticket for `load()` — only the newest pass may publish.
     private var loadGeneration = 0
 
-    init(repoRoot: String) {
+    /// Whether the pane is actually on screen, read live at refresh time. A collapsed
+    /// inspector keeps this model alive (the hosting view stays in the hierarchy), and
+    /// before this gate the file-system watch kept re-running `git status` — four git
+    /// spawns a burst — for a pane nobody could see. `nil` when the caller has no
+    /// visibility signal; treated as visible.
+    private let isPaneVisible: (() -> Bool)?
+    /// A refresh that arrived while hidden, replayed on the next `flushDeferredRefresh`.
+    /// Deferred, not dropped — the pane must be correct the moment it shows.
+    private var deferredRefreshIncludesHistory: Bool?
+
+    /// Directory names whose events can't change what the pane shows: build products
+    /// and package caches that are gitignored in practice. An agent's `swift build`
+    /// writes thousands of files under `.build`, and every burst was a full change-list
+    /// pass; dropping these keeps the watch quiet through builds. A repo that actually
+    /// tracks one of these still stays honest — any event outside the list, and app
+    /// re-activation, reload from git, the source of truth.
+    private static let ignoredEventComponents: Set<String> = [
+        ".build", "node_modules", "DerivedData", ".venv", ".gradle", ".turbo", ".next",
+    ]
+
+    init(repoRoot: String, isPaneVisible: (() -> Bool)? = nil) {
         self.repoRoot = repoRoot
+        self.isPaneVisible = isPaneVisible
         // Re-activation catches whatever happened while termio was in the background
         // (a rebase in another app, a pull on another machine's shared folder…).
         appActiveObserver = NotificationCenter.default
@@ -67,6 +88,14 @@ final class GitPanelModel: ObservableObject {
         isLoadingHistory = false
     }
 
+    /// Replays a refresh that was deferred while the pane was hidden. Called by the
+    /// view when the pane (re)appears, so the shown list is never stale.
+    func flushDeferredRefresh() {
+        guard let includeHistory = deferredRefreshIncludesHistory else { return }
+        deferredRefreshIncludesHistory = nil
+        scheduleRefresh(includeHistory: includeHistory)
+    }
+
     // MARK: Auto-refresh
 
     /// The pane has no refresh button for the same reason IDEs don't: an invalidation
@@ -85,7 +114,13 @@ final class GitPanelModel: ObservableObject {
             paths: paths, latency: 0.4,
             queue: DispatchQueue(label: "sh.termio.gitpane.fsevents", qos: .utility)
         ) { [weak self] eventPaths in
-            let touchesGitDir = eventPaths.contains { path in
+            // Build-product churn can't change the pane; don't let it spawn git.
+            let relevant = eventPaths.filter { path in
+                !path.split(separator: "/")
+                    .contains { Self.ignoredEventComponents.contains(String($0)) }
+            }
+            guard !relevant.isEmpty else { return }
+            let touchesGitDir = relevant.contains { path in
                 gitDirs.contains { path.hasPrefix($0) } || path.contains("/.git/") || path.hasSuffix("/.git")
             }
             Task { @MainActor [weak self] in
@@ -97,7 +132,12 @@ final class GitPanelModel: ObservableObject {
     /// Coalesces a burst of events (FSEvents latency already batches most) into one
     /// reload a beat later. `git status` itself may refresh the index once, which
     /// echoes back as a git-dir event — the second pass reads clean and the chain ends.
+    /// While the pane is hidden the reload is parked instead (see `flushDeferredRefresh`).
     private func scheduleRefresh(includeHistory: Bool) {
+        if let isPaneVisible, !isPaneVisible() {
+            deferredRefreshIncludesHistory = (deferredRefreshIncludesHistory ?? false) || includeHistory
+            return
+        }
         refreshDebounce?.cancel()
         refreshDebounce = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 150_000_000)

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -43,12 +43,26 @@ final class GitPanelModel: ObservableObject {
     /// Directory names whose events can't change what the pane shows: build products
     /// and package caches that are gitignored in practice. An agent's `swift build`
     /// writes thousands of files under `.build`, and every burst was a full change-list
-    /// pass; dropping these keeps the watch quiet through builds. A repo that actually
-    /// tracks one of these still stays honest — any event outside the list, and app
-    /// re-activation, reload from git, the source of truth.
+    /// pass; dropping these keeps the watch quiet through builds. Only components
+    /// *below a watched root* count — a repo that itself lives under a directory
+    /// named like a build product must not go deaf to every event. A repo that
+    /// actually tracks one of these still stays honest — any event outside the list,
+    /// and app re-activation, reload from git, the source of truth.
     private static let ignoredEventComponents: Set<String> = [
         ".build", "node_modules", "DerivedData", ".venv", ".gradle", ".turbo", ".next",
     ]
+
+    /// Whether an event path sits under a build-product directory *inside* one of the
+    /// watched roots. The roots' own ancestry is deliberately not inspected.
+    private static func isBuildProductEvent(_ path: String, underAny roots: [String]) -> Bool {
+        for root in roots where path == root || path.hasPrefix(root + "/") {
+            return path.dropFirst(root.count).split(separator: "/")
+                .contains { ignoredEventComponents.contains(String($0)) }
+        }
+        // An event outside every watched root (FSEvents shouldn't produce one)
+        // stays relevant rather than being silently swallowed.
+        return false
+    }
 
     init(repoRoot: String, isPaneVisible: (() -> Bool)? = nil) {
         self.repoRoot = repoRoot
@@ -116,8 +130,7 @@ final class GitPanelModel: ObservableObject {
         ) { [weak self] eventPaths in
             // Build-product churn can't change the pane; don't let it spawn git.
             let relevant = eventPaths.filter { path in
-                !path.split(separator: "/")
-                    .contains { Self.ignoredEventComponents.contains(String($0)) }
+                !Self.isBuildProductEvent(path, underAny: paths)
             }
             guard !relevant.isEmpty else { return }
             let touchesGitDir = relevant.contains { path in

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -143,6 +143,13 @@ final class TermioStore: ObservableObject {
     /// changes" without the inspector being open.
     @Published var gitChangeCount = 0
 
+    /// Whether the trailing inspector panel is expanded. Mirrored from the AppKit
+    /// split item — the owner of collapse state — via KVO in `App.swift`, so hosted
+    /// panes can stand down while hidden: a collapsed item keeps its view hierarchy
+    /// (and any `@StateObject` in it) alive, which left the git pane's auto-refresh
+    /// spawning `git status` for a pane nobody could see.
+    @Published var inspectorVisible = false
+
     /// Per-session high-frequency live state (status, running tool, live title, cwd),
     /// each held in its own `@Observable` `SessionRuntime` so a change re-renders only
     /// the owning sidebar row rather than the whole tree. Deliberately **not**
@@ -339,6 +346,12 @@ final class TermioStore: ObservableObject {
     /// Debounces the worktree re-scan so a burst of git-dir events (a rebase, a fetch)
     /// coalesces into one `git worktree list`.
     private var worktreeReconcileWork: DispatchWorkItem?
+    /// The folders whose git state changed since the last reconcile pass, plus whether
+    /// a full pass (app activation) was requested meanwhile. One `.git` change used to
+    /// re-scan *every* folder project — N git spawns for one repo's event; scoping the
+    /// pass to the projects that own the changed folder removes that amplification.
+    private var pendingReconcileFolders: Set<String> = []
+    private var reconcileAllPending = false
     private var linkClickMonitor: Any?
     private let stateFile = StateFile()
     /// Coalesces the ratio-drag flood of `splitGroups` writes into one save.
@@ -505,10 +518,13 @@ final class TermioStore: ObservableObject {
         syncWatchedFolders()
 
         // Keep the worktree list honest against git, so worktrees made on the CLI show up
-        // and ones removed drop out. Re-scan when the app regains focus (covers a `git
-        // worktree add` run in another terminal) and when a watched git dir changes (covers
-        // one run inside termio). See `reconcileWorktrees`.
-        branchModel.onGitDirectoryChange = { [weak self] in self?.scheduleWorktreeReconcile() }
+        // and ones removed drop out. Re-scan the affected project when a watched folder's
+        // git *state* changes (covers a `git worktree add` run inside termio), and
+        // everything when the app regains focus (covers one run in another terminal
+        // while termio was in the background). See `reconcileWorktrees`.
+        branchModel.onGitStateChange = { [weak self] folder in
+            self?.scheduleWorktreeReconcile(for: folder)
+        }
         appActiveObserver = NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in self?.scheduleWorktreeReconcile() }
         reconcileWorktrees()
@@ -543,20 +559,36 @@ final class TermioStore: ObservableObject {
         branchModel.setWatched(folders)
     }
 
-    /// Coalesces a burst of git-directory events into a single re-scan a beat later.
-    private func scheduleWorktreeReconcile() {
+    /// Coalesces a burst of git-state events into a single re-scan a beat later,
+    /// remembering *which* folders moved so the pass stays scoped. No folder means
+    /// "everything" (app activation).
+    private func scheduleWorktreeReconcile(for folder: String? = nil) {
+        if let folder {
+            pendingReconcileFolders.insert(folder)
+        } else {
+            reconcileAllPending = true
+        }
         worktreeReconcileWork?.cancel()
-        let item = DispatchWorkItem { [weak self] in self?.reconcileWorktrees() }
+        let item = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            let folders = self.reconcileAllPending ? nil : self.pendingReconcileFolders
+            self.reconcileAllPending = false
+            self.pendingReconcileFolders = []
+            self.reconcileWorktrees(limitedTo: folders)
+        }
         worktreeReconcileWork = item
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: item)
     }
 
-    /// Reconciles every folder project's `worktrees` with what git actually reports:
+    /// Reconciles folder projects' `worktrees` with what git actually reports:
     /// worktrees created outside termio (`git worktree add` on the CLI) get added, ones
     /// removed on the CLI drop out, and termio's own keep their id/metadata. Git is the
     /// source of truth — the sidebar mirrors the repo rather than a private list.
-    func reconcileWorktrees() {
+    /// `limitedTo` scopes the pass to the projects owning those folders (a project
+    /// path or one of its worktree paths); `nil` re-scans every folder project.
+    func reconcileWorktrees(limitedTo folders: Set<String>? = nil) {
         for project in projects where project.kind == .folder {
+            if let folders, !projectOwns(project, anyOf: folders) { continue }
             let id = project.id
             let path = project.path
             Task { [weak self] in
@@ -565,6 +597,20 @@ final class TermioStore: ObservableObject {
                 await MainActor.run { self?.applyDiscoveredWorktrees(discovered, to: id) }
             }
         }
+    }
+
+    /// Whether any of `folders` (standardized paths from the branch watcher) is this
+    /// project's checkout or one of its worktrees — i.e. whether a git change there
+    /// can alter this project's worktree list.
+    private func projectOwns(_ project: Project, anyOf folders: Set<String>) -> Bool {
+        if folders.contains(Self.standardizedPath(project.path)) { return true }
+        for worktree in project.worktrees
+        where folders.contains(Self.standardizedPath(worktree.path)) { return true }
+        for session in project.sessions {
+            if let path = session.worktreePath,
+               folders.contains(Self.standardizedPath(path)) { return true }
+        }
+        return false
     }
 
     /// Merges git's linked-worktree paths into one project's `worktrees`, in git's order.

--- a/scripts/bench-git-spawns.sh
+++ b/scripts/bench-git-spawns.sh
@@ -1,0 +1,57 @@
+#!/bin/zsh
+# Measures how many git subprocesses the running termio-dev app spawns while a
+# synthetic agent workload (file appends + `git status` index rewrites + periodic
+# commits) hammers a scratch repo the app watches. The regression harness for the
+# git-spawn-storm fix: run it against two builds and compare the exact counts.
+#
+# Exact counting works via GIT_TRACE2_EVENT: set it in the launchd GUI domain
+# BEFORE launching the app, so every git the app spawns appends a "start" event
+# (with argv) to the trace file. Remember to unset it afterwards:
+#
+#   launchctl setenv GIT_TRACE2_EVENT /tmp/git-trace.jsonl
+#   open <bundle>/termio-dev.app
+#   scripts/bench-git-spawns.sh /path/to/scratch-repo 45
+#   launchctl unsetenv GIT_TRACE2_EVENT
+#   python3 -c 'import json,collections,sys; c=collections.Counter(
+#       " ".join(e["argv"][1:4]) for e in map(json.loads, open("/tmp/git-trace.jsonl"))
+#       if e.get("event")=="start"); [print(v,k) for k,v in c.most_common(12)]'
+#
+# The scratch repo must already be one of the app's projects (open it once via
+# `open -b sh.termio.app.dev <repo>`), or nothing will be watching it.
+zmodload zsh/datetime
+set -u
+REPO=${1:?usage: bench-git-spawns.sh <scratch-repo> [seconds]}
+DURATION=${2:-45}
+
+APP_PID=$(pgrep -f "termio-dev.app/Contents/MacOS/termio" | head -1)
+[[ -z "$APP_PID" ]] && { echo "dev app not running"; exit 1; }
+echo "app: $(ps -o args= -p "$APP_PID")"
+
+( # workload: appends + index rewrites + a real commit every ~4s
+  cd "$REPO" || exit 1
+  i=0
+  end=$((EPOCHSECONDS + DURATION))
+  while (( EPOCHSECONDS < end )); do
+    i=$((i + 1))
+    echo "tick $i" >> "$(( i % 5 )).work.txt"
+    (( i % 3 == 0 )) && git status --porcelain >/dev/null 2>&1
+    (( i % 15 == 0 )) && { git add -A >/dev/null 2>&1; git commit -qm "bench $i" >/dev/null 2>&1; }
+    sleep 0.25
+  done
+) &
+WORKLOAD=$!
+
+# coarse sampler alongside the exact trace: git-child sightings + app CPU
+ticks=0; hits=0; cpu_total=0
+end=$((EPOCHSECONDS + DURATION))
+while (( EPOCHSECONDS < end )); do
+  n=$(ps -axo ppid=,comm= 2>/dev/null | awk -v p="$APP_PID" '$1==p && $2 ~ /git/' | wc -l)
+  hits=$((hits + n))
+  cpu=$(ps -o pcpu= -p "$APP_PID" 2>/dev/null | tr -d ' ')
+  cpu_total=$(( cpu_total + ${cpu:-0} ))
+  ticks=$((ticks + 1))
+  sleep 0.06
+done
+wait $WORKLOAD 2>/dev/null
+
+echo "samples=$ticks git-child-sightings=$hits avg-app-cpu=$(( cpu_total / (ticks > 0 ? ticks : 1) ))%"

--- a/scripts/bench-git-spawns.sh
+++ b/scripts/bench-git-spawns.sh
@@ -27,7 +27,15 @@ APP_PID=$(pgrep -f "termio-dev.app/Contents/MacOS/termio" | head -1)
 [[ -z "$APP_PID" ]] && { echo "dev app not running"; exit 1; }
 echo "app: $(ps -o args= -p "$APP_PID")"
 
+# The trace file counts every traced git, not just the app's — so start each run
+# from the current line offset and report the delta, and keep this script's own
+# workload out of the trace even when run from a traced shell.
+TRACE_FILE=$(launchctl getenv GIT_TRACE2_EVENT 2>/dev/null || true)
+trace_start=0
+[[ -n "$TRACE_FILE" && -f "$TRACE_FILE" ]] && trace_start=$(wc -l < "$TRACE_FILE")
+
 ( # workload: appends + index rewrites + a real commit every ~4s
+  unset GIT_TRACE2_EVENT
   cd "$REPO" || exit 1
   i=0
   end=$((EPOCHSECONDS + DURATION))
@@ -55,3 +63,7 @@ done
 wait $WORKLOAD 2>/dev/null
 
 echo "samples=$ticks git-child-sightings=$hits avg-app-cpu=$(( cpu_total / (ticks > 0 ? ticks : 1) ))%"
+if [[ -n "$TRACE_FILE" && -f "$TRACE_FILE" ]]; then
+  trace_end=$(wc -l < "$TRACE_FILE")
+  echo "trace-lines-this-run=$(( trace_end - trace_start ))  (analyze from line $(( trace_start + 1 )) of $TRACE_FILE)"
+fi


### PR DESCRIPTION
## Problem

The machine ran hot with agent fleets active. `sample` + child-process sampling of the live app showed a continuous storm of short-lived `git` subprocesses (100 samples over 15s caught 104 zombie `git` children), with `tccd` at 66% and `trustd` at 31% revalidating every spawn.

Three compounding causes:

1. **BranchModel** watched the whole `.git` directory — whose busiest file is `index`, rewritten by every `git status` run by *anyone* (agents, the git pane itself) — and answered each event by spawning 2–3 `git rev-parse` processes.
2. Every event also fired an **unconditional worktree reconcile across all folder projects**: N × `git worktree list` for one repo's index refresh.
3. **The git pane's FSEvents watch** covered the whole worktree including `.build` (an agent's `swift build` = refresh storm, 4 spawns per pass), and kept refreshing while the inspector was **collapsed** — the split item keeps the hosted view (and its `@StateObject` model) alive, confirmed live: `git status --porcelain=v2` passes with no pane on screen.

## Fix

- BranchModel reads `HEAD` + the `worktrees` listing **in-process** (zero spawns per event) and reports downstream only when HEAD or the linked-worktree set actually changed. Its one remaining spawn (HEAD-dir resolution, once per watch) moves off the main thread — closing the recorded BranchModel launch-freeze path too.
- Worktree reconcile is scoped to the project owning the changed folder; app activation still re-scans everything.
- The git pane drops FSEvents from build-product dirs (`.build`, `node_modules`, …) and parks auto-refresh while the inspector is collapsed (new `store.inspectorVisible`, KVO-mirrored from the split item); deferred refreshes replay on next show.

## Verification

- `swift build` clean.
- Before: 40 ps samples in 10s → 19 caught live git children; argv showed `status --porcelain=v2`, `diff --numstat --cached`, `rev-parse --is-inside-work-tree` under the app with the inspector collapsed.
- After: pending a rebuilt dev-channel run under the same agent load (kept the release app untouched for comparison).