### PR TITLE
Make the sessions CLI fail loud, spawn non-blocking, and watch supervisable

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -110,6 +110,7 @@ final class SessionControlListener {
             Self.log("listen() failed: \(errno)"); close(descriptor); return
         }
         _ = fcntl(descriptor, F_SETFL, fcntl(descriptor, F_GETFL, 0) | O_NONBLOCK)
+        _ = fcntl(descriptor, F_SETFD, FD_CLOEXEC)
 
         let source = DispatchSource.makeReadSource(fileDescriptor: descriptor, queue: queue)
         source.setEventHandler { [weak self] in self?.acceptPending() }
@@ -123,6 +124,13 @@ final class SessionControlListener {
         while true {
             let client = accept(listenDescriptor, nil, nil)
             if client < 0 { break }
+            // A client connection must not leak into spawned PTY children: forkpty
+            // duplicates every open descriptor, and an inherited copy keeps the
+            // socket alive after our close — the CLI then never sees EOF and hangs
+            // until its own timeout. CLOEXEC closes the copies at the child's exec.
+            // (Measured: a spawn burst held every in-flight reply open for the
+            // CLI's full 15s timeout; see sessions-cli-v2.md §4.2 verification.)
+            _ = fcntl(client, F_SETFD, FD_CLOEXEC)
             handle(client)
         }
     }

--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -17,6 +17,8 @@ import Foundation
 ///   bare id / id prefix / title. Empty for `send` means "start a fresh session".
 /// - `text` — the prompt (`send`) or menu answer (`answer`).
 /// - `agent` — the agent for a fresh session (`send` with no target).
+/// - `snapshot` — `watch` only: `false` skips the initial per-session status
+///   snapshot (absent means snapshot on).
 struct ControlRequest: Decodable {
     let op: String
     let format: String?
@@ -26,9 +28,10 @@ struct ControlRequest: Decodable {
     let text: String?
     let lines: Int?
     let agent: String?
+    let snapshot: Bool?
 
     private enum CodingKeys: String, CodingKey {
-        case op, format, target, text, lines, agent
+        case op, format, target, text, lines, agent, snapshot
         case callerSession = "caller_session"
         case callerCwd = "caller_cwd"
     }
@@ -53,16 +56,17 @@ final class SessionControlListener {
 
     private let onRequest: @MainActor (ControlRequest) async -> Data
     /// Resolves a `watch` subscription: returns the caller's project id to scope the
-    /// stream to, or an error payload to write back and hang up. Split from
-    /// `onRequest` because a watch is not one-shot — the connection stays open and is
-    /// handed to `SessionWatchHub` instead of being answered and closed.
-    private let onWatch: @MainActor (ControlRequest) -> (UUID?, Data?)
+    /// stream to (plus the initial status snapshot to emit on attach), or an error
+    /// payload to write back and hang up. Split from `onRequest` because a watch is
+    /// not one-shot — the connection stays open and is handed to `SessionWatchHub`
+    /// instead of being answered and closed.
+    private let onWatch: @MainActor (ControlRequest) -> (UUID?, Data?, [SessionWatchEvent])
     private let queue = DispatchQueue(label: "com.termio.session-control")
     private var source: DispatchSourceRead?
     private var listenDescriptor: Int32 = -1
 
     init(onRequest: @escaping @MainActor (ControlRequest) async -> Data,
-         onWatch: @escaping @MainActor (ControlRequest) -> (UUID?, Data?)) {
+         onWatch: @escaping @MainActor (ControlRequest) -> (UUID?, Data?, [SessionWatchEvent])) {
         self.onRequest = onRequest
         self.onWatch = onWatch
     }
@@ -148,7 +152,7 @@ final class SessionControlListener {
         if decoded.op == "watch" {
             let resolve = onWatch
             Task { @MainActor in
-                let (projectID, errorData) = resolve(decoded)
+                let (projectID, errorData, snapshot) = resolve(decoded)
                 self.queue.async {
                     if let errorData {
                         Self.writeAll(descriptor, errorData)
@@ -158,7 +162,8 @@ final class SessionControlListener {
                     guard let projectID else { close(descriptor); return }
                     SessionWatchHub.shared.subscribe(
                         descriptor: descriptor, projectID: projectID,
-                        states: Self.watchStates(decoded.text), wantsJSON: decoded.wantsJSON)
+                        states: Self.watchStates(decoded.text), wantsJSON: decoded.wantsJSON,
+                        snapshot: snapshot)
                 }
             }
             return
@@ -219,6 +224,9 @@ struct SessionWatchEvent {
     let status: String
     let title: String
     let cwd: String
+    /// Marks the initial current-status lines emitted on subscribe, so a JSON
+    /// consumer can tell "already was" from a live transition.
+    var snapshot = false
 }
 
 /// Holds the open `watch` connections and fans status transitions out to them. A
@@ -239,20 +247,39 @@ final class SessionWatchHub {
         let projectID: UUID
         let states: Set<String>
         let wantsJSON: Bool
+        /// When the hub last successfully wrote to this client — the silence the
+        /// 30s heartbeat measures.
+        var lastWrite: Date
     }
 
     private let queue = DispatchQueue(label: "com.termio.session-watch")
     private var subscribers: [Int32: Subscriber] = [:]
+    private var heartbeatTimer: DispatchSourceTimer?
+    private static let heartbeatInterval: TimeInterval = 30
 
     /// Adopt a client descriptor as a watcher. Ownership of the fd transfers here —
-    /// the hub closes it when the client disconnects.
-    func subscribe(descriptor: Int32, projectID: UUID, states: Set<String>, wantsJSON: Bool) {
+    /// the hub closes it when the client disconnects. `snapshot` is written first:
+    /// one line per scoped session with its *current* status, so a supervisor
+    /// attaching late still learns a session is already `needs-you` (no
+    /// `list`-then-`watch` race). The snapshot ignores the state filter — it is a
+    /// roster, not a transition.
+    func subscribe(
+        descriptor: Int32, projectID: UUID, states: Set<String>, wantsJSON: Bool,
+        snapshot: [SessionWatchEvent]
+    ) {
         queue.async {
             var on: Int32 = 1
             setsockopt(descriptor, SOL_SOCKET, SO_NOSIGPIPE, &on,
                        socklen_t(MemoryLayout<Int32>.size))
+            for event in snapshot {
+                guard Self.write(descriptor, wantsJSON ? event.jsonLine : event.wireLine) else {
+                    close(descriptor)
+                    return
+                }
+            }
             self.subscribers[descriptor] = Subscriber(
-                projectID: projectID, states: states, wantsJSON: wantsJSON)
+                projectID: projectID, states: states, wantsJSON: wantsJSON, lastWrite: Date())
+            self.startHeartbeatIfNeeded()
         }
     }
 
@@ -266,10 +293,47 @@ final class SessionWatchHub {
             for (fd, sub) in self.subscribers {
                 guard sub.projectID == event.projectID, sub.states.contains(event.status)
                 else { continue }
-                if !Self.write(fd, sub.wantsJSON ? jsonLine : line) {
+                if Self.write(fd, sub.wantsJSON ? jsonLine : line) {
+                    self.subscribers[fd]?.lastWrite = Date()
+                } else {
                     self.subscribers.removeValue(forKey: fd)
                     close(fd)
                 }
+            }
+        }
+    }
+
+    /// A `{"heartbeat":true}` line after 30s of silence, JSON subscribers only —
+    /// heartbeats are for programs; a human watching text mode just sees quiet.
+    /// Doubles as proactive dead-reader reaping: a failed heartbeat write reaps the
+    /// subscriber now instead of on the next (possibly far-off) transition.
+    private func startHeartbeatIfNeeded() {
+        guard heartbeatTimer == nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(
+            deadline: .now() + Self.heartbeatInterval, repeating: Self.heartbeatInterval,
+            leeway: .seconds(1))
+        timer.setEventHandler { [weak self] in self?.sendHeartbeats() }
+        heartbeatTimer = timer
+        timer.resume()
+    }
+
+    private func sendHeartbeats() {
+        if subscribers.isEmpty {
+            heartbeatTimer?.cancel()
+            heartbeatTimer = nil
+            return
+        }
+        let line = Data("{\"heartbeat\":true}\n".utf8)
+        let now = Date()
+        for (fd, sub) in subscribers {
+            guard sub.wantsJSON,
+                  now.timeIntervalSince(sub.lastWrite) >= Self.heartbeatInterval else { continue }
+            if Self.write(fd, line) {
+                subscribers[fd]?.lastWrite = now
+            } else {
+                subscribers.removeValue(forKey: fd)
+                close(fd)
             }
         }
     }
@@ -296,10 +360,13 @@ private extension SessionWatchEvent {
         return Data("\(handle)  [\(status)]\(suffix)\n".utf8)
     }
     var jsonLine: Data {
-        let object: [String: Any] = [
-            "schema_version": 1, "handle": handle, "status": status,
-            "title": title, "cwd": cwd,
+        var object: [String: Any] = [
+            "schema_version": 1, "handle": handle, "status": status, "title": title,
         ]
+        // Omitted, not "": the runtime simply hasn't seen an OSC 7 yet, and an
+        // empty string reads like a real (broken) path to a JSON consumer.
+        if !cwd.isEmpty { object["cwd"] = cwd }
+        if snapshot { object["snapshot"] = true }
         let data = (try? JSONSerialization.data(
             withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])) ?? Data()
         return data + Data("\n".utf8)
@@ -346,10 +413,15 @@ enum SessionSkillInstaller {
           idle / needs-you / done)
         - `termio sessions watch` — block and stream one line per sibling status
           change (`done` / `needs-you` by default) until you interrupt it — the push
-          alternative to polling `list`. `--state working,idle,done,needs-you` widens it.
+          alternative to polling `list`. `--state working,idle,done,needs-you` widens
+          it. It opens with one snapshot line per sibling's current status
+          (`"snapshot":true` in `--json`; `--no-snapshot` skips), and in `--json`
+          writes `{"heartbeat":true}` after 30s of silence so a dead stream is
+          detectable. Exits 0 on your Ctrl-C, 2 if termio itself went away.
         - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
-          prompt (`--agent codex` picks the agent; default: your own kind). The
-          reply contains the new session's handle — use it for every follow-up.
+          prompt (`--agent codex` picks the agent; default: your own kind). Replies
+          immediately with the new session's handle — use it for every follow-up;
+          the prompt itself is typed in once the agent finishes booting.
         - `termio sessions send <agent>@<id> "<text>"` — type text into that existing
           sibling and submit it with a real Return keypress. Send a prompt to drive
           it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -43,7 +43,7 @@ extension TermioStore {
                 await self?.handleSessionControl(request) ?? Data()
             },
             onWatch: { [weak self] request in
-                self?.resolveWatchScope(request) ?? (nil, nil)
+                self?.resolveWatchScope(request) ?? (nil, nil, [])
             })
         control.start()
         sessionControl = control

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -2,6 +2,7 @@ import AppKit
 import Foundation
 import GhosttyKit
 import GhosttyTerminal
+import os
 
 /// Handles `termio sessions …` requests from `SessionControlListener`. Every
 /// operation is scoped to the caller's own project (resolved from the caller's
@@ -15,7 +16,21 @@ import GhosttyTerminal
 /// error instead of a silent misdelivery. `send` with *no* handle starts a fresh
 /// agent session — targeting an existing sibling is always an explicit act.
 extension TermioStore {
+    /// Per-op enter/exit timing for control requests, readable via
+    /// `log stream --predicate 'category == "session-control"'`. The exit line's
+    /// elapsed time is how long the op occupied the request path — the number
+    /// that catches head-of-line blocking on the main actor (design doc §4.2).
+    private static let controlTiming = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "sh.termio.app", category: "session-control")
+
     func handleSessionControl(_ request: ControlRequest) async -> Data {
+        let entered = ContinuousClock.now
+        Self.controlTiming.info("enter op=\(request.op, privacy: .public)")
+        defer {
+            let elapsed = entered.duration(to: .now)
+            Self.controlTiming.info(
+                "exit op=\(request.op, privacy: .public) elapsed_ms=\(Int(elapsed.components.seconds) * 1000 + Int(elapsed.components.attoseconds / 1_000_000_000_000_000), privacy: .public)")
+        }
         guard settings.sessionControlEnabled else {
             return controlError(request, "disabled",
                 "Session control is off. Enable it in termio ▸ Settings ▸ Agents.")

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -55,19 +55,30 @@ extension TermioStore {
     }
 
     /// Validates a `watch` subscription and returns the caller's project id to scope
-    /// the stream to, or an error payload to write back before hanging up. The same
-    /// gating as any control op (session control enabled, caller resolves to a
-    /// project); the streaming itself is `SessionWatchHub`'s job.
-    func resolveWatchScope(_ request: ControlRequest) -> (UUID?, Data?) {
+    /// the stream to plus the initial status snapshot (one event per scoped session,
+    /// unless the client opted out), or an error payload to write back before hanging
+    /// up. The same gating as any control op (session control enabled, caller
+    /// resolves to a project); the streaming itself is `SessionWatchHub`'s job.
+    func resolveWatchScope(_ request: ControlRequest) -> (UUID?, Data?, [SessionWatchEvent]) {
         guard settings.sessionControlEnabled else {
             return (nil, controlError(request, "disabled",
-                "Session control is off. Enable it in termio ▸ Settings ▸ Agents."))
+                "Session control is off. Enable it in termio ▸ Settings ▸ Agents."), [])
         }
         guard let project = callerProject(session: request.callerSession, cwd: request.callerCwd) else {
             return (nil, controlError(request, "no_scope",
-                "Couldn't tell which project you're in. Run this from inside a termio session."))
+                "Couldn't tell which project you're in. Run this from inside a termio session."), [])
         }
-        return (project.id, nil)
+        guard request.snapshot != false else { return (project.id, nil, []) }
+        let snapshot = project.sessions.map { session in
+            SessionWatchEvent(
+                projectID: project.id,
+                handle: sessionHandle(for: session),
+                status: Self.statusToken(status(for: session.id)),
+                title: displayTitle(for: session),
+                cwd: runtimes[session.id]?.workingDirectory ?? "",
+                snapshot: true)
+        }
+        return (project.id, nil, snapshot)
     }
 
     /// The address a caller drives a session by. The id half is the stable key
@@ -128,7 +139,7 @@ extension TermioStore {
         switch resolveTarget(token, in: project) {
         case .found(let session):
             let state = surface(for: session, in: project)
-            return await deliver(payload, to: session, state: state, request: request, created: false)
+            return await deliver(payload, to: session, state: state, request: request)
         case .notFound:
             return controlError(request, "not_found", targetNotFoundMessage(request.target))
         case .ambiguous:
@@ -171,16 +182,39 @@ extension TermioStore {
             return controlError(request, "start_failed", "Could not start the session.")
         }
         let state = surface(for: fresh, in: project)
-        await waitForBootSettle(of: state)
-        return await deliver(payload, to: fresh, state: state, request: request, created: true)
+        // Reply with the handle now; boot-settle + prompt delivery continue off the
+        // reply path so no verb silently blocks (§4.2). A delivery failure has no
+        // caller left to tell — it surfaces through the session's own status and
+        // its visibly broken pane, which the caller is about to watch anyway.
+        let handle = sessionHandle(for: fresh)
+        Task { [weak self] in
+            guard let self else { return }
+            await self.waitForBootSettle(of: state)
+            if await !self.performDelivery(payload, to: fresh, state: state) {
+                FileHandle.standardError.write(Data(
+                    "termio: session control could not deliver the queued prompt to \(handle)\n".utf8))
+            }
+        }
+        return spawnQueuedReply(request, fresh)
+    }
+
+    /// Types `payload` into an existing sibling's surface and builds the reply.
+    private func deliver(
+        _ payload: String, to session: Session, state: TerminalViewState,
+        request: ControlRequest
+    ) async -> Data {
+        guard await performDelivery(payload, to: session, state: state) else {
+            return controlError(request, "not_live",
+                "\(displayTitle(for: session)) has no live terminal yet — open it once in termio.")
+        }
+        return sentReply(request, session)
     }
 
     /// Types `payload` into a session's live surface and submits it. Shared by
-    /// the existing-sibling and fresh-spawn paths.
-    private func deliver(
-        _ payload: String, to session: Session, state: TerminalViewState,
-        request: ControlRequest, created: Bool
-    ) async -> Data {
+    /// the existing-sibling reply path and the fresh-spawn detached delivery.
+    private func performDelivery(
+        _ payload: String, to session: Session, state: TerminalViewState
+    ) async -> Bool {
         // The libghostty surface attaches lazily on the pane's first render, so a
         // session never shown in the UI has no surface yet. Selecting it adds it to
         // the mounted set; give the render one cycle. (A session shown even once
@@ -189,10 +223,7 @@ extension TermioStore {
             selectedSessionID = session.id
             try? await Task.sleep(for: .milliseconds(400))
         }
-        guard let surfaceHandle = Self.rawSurface(from: state) else {
-            return controlError(request, "not_live",
-                "\(displayTitle(for: session)) has no live terminal yet — open it once in termio.")
-        }
+        guard let surfaceHandle = Self.rawSurface(from: state) else { return false }
 
         // Type the prompt through the text path (fine for the body), then submit
         // with a real Return *key event*. A trailing "\r" in the text is delivered
@@ -203,7 +234,7 @@ extension TermioStore {
         _ = state.send(payload)
         try? await Task.sleep(for: .milliseconds(40))
         Self.pressReturn(on: surfaceHandle)
-        return sentReply(request, session, created: created)
+        return true
     }
 
     /// Waits for a freshly launched agent TUI to finish booting before keystrokes
@@ -267,27 +298,36 @@ extension TermioStore {
     /// The success reply for a send/answer. Beyond confirming delivery, it hands back
     /// the session's transcript address and a cursor (its line count at send time), so
     /// the caller can read the agent's response straight from its own structured log —
-    /// the caller's file tools resume from `cursor`. The transcript is known only once
-    /// a hook has reported it, so a just-spawned session's reply points the caller at
-    /// `list --json` instead (its whole transcript is this conversation anyway).
-    private func sentReply(_ request: ControlRequest, _ session: Session, created: Bool) -> Data {
+    /// the caller's file tools resume from `cursor`.
+    private func sentReply(_ request: ControlRequest, _ session: Session) -> Data {
         let handle = sessionHandle(for: session)
         var json: [String: Any] = [
             "target": handle,
             "title": displayTitle(for: session),
         ]
-        var text = created
-            ? "started \(handle) and sent the prompt — use this handle for follow-ups"
-            : "sent to \(handle)"
-        if created { json["created"] = true }
+        var text = "sent to \(handle)"
         if let transcript = transcriptPaths[session.id] {
             let cursor = Self.lineCount(of: transcript)
             json["transcript"] = transcript
             json["cursor"] = cursor
             text += "\n  transcript: \(transcript)\n  cursor: \(cursor)  (read the response from here on)"
-        } else if created {
-            text += "\n  (transcript path appears in `termio sessions list --json` once the agent reports it)"
         }
+        return control(request, ok: true, text: text, json: json)
+    }
+
+    /// The immediate reply for a fresh spawn: the handle is the payload, delivery is
+    /// still in flight (`queued`). A just-spawned session has no transcript yet — it
+    /// appears in `list --json` once the agent's hook reports one.
+    private func spawnQueuedReply(_ request: ControlRequest, _ session: Session) -> Data {
+        let handle = sessionHandle(for: session)
+        let json: [String: Any] = [
+            "target": handle,
+            "title": displayTitle(for: session),
+            "created": true,
+            "queued": true,
+        ]
+        let text = "started \(handle) — prompt queued; use this handle for follow-ups"
+            + "\n  (transcript path appears in `termio sessions list --json` once the agent reports it)"
         return control(request, ok: true, text: text, json: json)
     }
 

--- a/scripts/termio
+++ b/scripts/termio
@@ -37,20 +37,92 @@ options:
   --json           machine-readable output (any `sessions` command)
   --agent <id>     agent for `spawn` (e.g. claudeCode, codex, grok, pi; default: caller's kind)
   --state <s,…>    for `watch`: comma-separated states to report (working, idle, done, needs-you)
+  --no-snapshot    for `watch`: skip the initial per-session status snapshot
   --help, --version
 
+`termio sessions <verb> --help` prints focused help for one verb.
 `<agent>@<id>` handles come from `termio sessions list` or a `spawn` reply.
 `answer` is a deprecated alias of `send`; `send` with no handle aliases `spawn`.
+Every one-shot command times out after ${TERMIO_CLI_TIMEOUT:-15}s (TERMIO_CLI_TIMEOUT overrides).
 EOF
+}
+
+# Focused help for one `sessions` verb, printed before the socket is touched —
+# `--help` must work with the app closed.
+verb_usage() {
+    case "$1" in
+        list) cat <<'EOF'
+usage: termio sessions list [--json]
+
+List the sessions in this project with their live status (working / idle /
+done / needs-you). `--json` adds each session's transcript path once its
+agent has reported one.
+EOF
+            ;;
+        watch) cat <<'EOF'
+usage: termio sessions watch [--state <s,…>] [--no-snapshot] [--json]
+
+Block and stream one line per session status transition until interrupted.
+On attach it first prints a snapshot line per session with its current
+status (tagged "snapshot":true in --json); --no-snapshot skips that.
+--state takes a comma-separated filter (working, idle, done, needs-you);
+the default reports the two states a supervisor acts on: done, needs-you.
+In --json mode the app writes {"heartbeat":true} after 30s of silence so a
+dead stream is distinguishable from a quiet one.
+
+exit codes: 0 after Ctrl-C (normal end of supervision), 2 when the stream
+closes from the app side (termio quit or died).
+EOF
+            ;;
+        spawn) cat <<'EOF'
+usage: termio sessions spawn "<prompt>" [--agent <id>] [--json]
+
+Start a NEW agent session on the prompt. Replies immediately with the new
+session's <agent>@<id> handle; the prompt is typed in once the agent
+finishes booting. --agent picks the agent (e.g. claudeCode, codex, grok,
+pi); the default is the calling agent's own kind.
+EOF
+            ;;
+        send|answer) cat <<'EOF'
+usage: termio sessions send <agent>@<id> "<text>" [--json]
+
+Type text into an existing session and submit it with a real Return
+keypress — a prompt to drive it, or a menu choice ("1", "yes") to answer a
+permission prompt. Handles come from `termio sessions list` or a `spawn`
+reply; copy them verbatim.
+
+`answer` is a deprecated alias; `send` without a handle aliases `spawn`.
+EOF
+            ;;
+        close) cat <<'EOF'
+usage: termio sessions close <agent>@<id> [...] [--json]
+
+Close one or more session tabs. Each handle gets its own attempt and reply
+line; any failure fails the whole command.
+EOF
+            ;;
+        focus) cat <<'EOF'
+usage: termio sessions focus <agent>@<id> [--json]
+
+Select the session in the app and bring termio to the front.
+EOF
+            ;;
+        *) usage ;;
+    esac
 }
 
 SOCKET="$HOME/Library/Application Support/$SUPPORT_DIR_NAME/session-control.sock"
 
-# JSON-escape a string for embedding in a request: backslashes, double quotes, and
-# newlines (which would otherwise break the single-line JSON object).
+# JSON-escape a string for embedding in a request: backslashes, double quotes,
+# tabs, and newlines (which would otherwise break the single-line JSON object).
+# Every other C0 control byte is stripped outright — prompts are text for agent
+# TUIs, control bytes in them are never intentional, and one raw byte would make
+# the whole request undecodable.
 json_escape() {
+    tab=$(printf '\t')
     printf '%s' "$1" \
-        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+        | tr -d '\000-\010\013-\037' \
+        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e "s/$tab/\\\\t/g" \
         | awk 'BEGIN { ORS = "" } { if (NR > 1) printf "\\n"; printf "%s", $0 }'
 }
 
@@ -73,22 +145,33 @@ is_handle() {
 }
 
 # The one-line JSON control request shared by the one-shot and streaming paths.
+# An optional 6th argument is raw JSON (`"key":value`) appended verbatim, for the
+# rare per-verb field that doesn't earn a slot in every request.
 build_request() {
-    printf '{"op":"%s","format":"%s","caller_session":"%s","caller_cwd":"%s","target":"%s","agent":"%s","text":"%s"}' \
+    extra=""
+    if [ $# -ge 6 ] && [ -n "$6" ]; then extra=",$6"; fi
+    printf '{"op":"%s","format":"%s","caller_session":"%s","caller_cwd":"%s","target":"%s","agent":"%s","text":"%s"%s}' \
         "$1" "$2" \
         "$(json_escape "${TERMIO_SESSION:-}")" \
         "$(json_escape "$PWD")" \
         "$(json_escape "$3")" \
         "$(json_escape "$4")" \
-        "$(json_escape "$5")"
+        "$(json_escape "$5")" \
+        "$extra"
 }
 
 # One request/response round-trip. Prints the app's reply and returns nonzero when
 # it reports failure, so callers (and `set -e`) surface errors through the exit
-# code — agents check `$?`, not prose.
+# code — agents check `$?`, not prose. `nc -w` bounds the wait when the app is
+# wedged, and an empty reply is a hard error, never a silent success: a control
+# CLI must fail loud.
 request_once() {
     request=$(build_request "$1" "$2" "$3" "$4" "$5")
-    response=$(printf '%s' "$request" | nc -U "$SOCKET")
+    response=$(printf '%s' "$request" | nc -w "${TERMIO_CLI_TIMEOUT:-15}" -U "$SOCKET") || true
+    if [ -z "$response" ]; then
+        echo "termio: no reply from the app within ${TERMIO_CLI_TIMEOUT:-15}s — it may be busy or wedged; check the app, or raise TERMIO_CLI_TIMEOUT" >&2
+        return 1
+    fi
     printf '%s\n' "$response"
     case "$response" in
         error:*|*'"ok":false'*) return 1 ;;
@@ -97,11 +180,6 @@ request_once() {
 }
 
 sessions() {
-    if [ ! -S "$SOCKET" ]; then
-        echo "termio: app is not running (no control socket at $SOCKET)" >&2
-        exit 1
-    fi
-
     op="${1:-list}"
     [ $# -gt 0 ] && shift || true
 
@@ -115,15 +193,29 @@ sessions() {
             ;;
     esac
 
+    # Per-verb help never needs the app: dispatch it before the socket check.
+    for argument in "$@"; do
+        case "$argument" in
+            -h|--help) verb_usage "$op"; exit 0 ;;
+        esac
+    done
+
+    if [ ! -S "$SOCKET" ]; then
+        echo "termio: app is not running (no control socket at $SOCKET)" >&2
+        exit 1
+    fi
+
     format=text
     agent=""
     targets=""
     text=""
     states=""
+    no_snapshot=0
     seen_positional=0
     while [ $# -gt 0 ]; do
         case "$1" in
             --json) format=json ;;
+            --no-snapshot) no_snapshot=1 ;;
             --agent)
                 [ $# -ge 2 ] || { echo "termio: --agent needs a value" >&2; exit 1; }
                 agent="$2"; shift ;;
@@ -179,15 +271,37 @@ sessions() {
         # Streaming: the app holds the connection open and pushes one line per scoped
         # status transition until interrupted (Ctrl-C). `--state` (comma-separated)
         # filters; empty means the two states a supervisor acts on — done, needs-you.
+        # No `nc -w` here: watch is *supposed* to sit open, and its liveness signal is
+        # the app's 30s `{"heartbeat":true}` line (--json mode).
         #
         # Build the request into a variable *first*, then pipe an instant `printf` to
         # `nc`. Piping `build_request` directly (`build_request … | nc`) runs nc
         # concurrently with build_request's json_escape subprocesses, so nc connects
         # and the app's read races the not-yet-written payload — the app then times
         # out on an empty read and reports a malformed request.
-        watch_request=$(build_request watch "$format" "" "" "$states")
-        printf '%s' "$watch_request" | nc -U "$SOCKET"
-        exit 0
+        extra=""
+        [ "$no_snapshot" -eq 1 ] && extra='"snapshot":false'
+        watch_request=$(build_request watch "$format" "" "" "$states" "$extra")
+        # Exit codes tell a supervising agent how the watch ended: Ctrl-C is the
+        # normal end of supervision (0, via the trap); an immediate error reply
+        # (control disabled, no scope) is 1; the stream reaching EOF means the
+        # *app* closed it — 2, "termio died", the case to escalate.
+        trap 'exit 0' INT
+        watch_status=0
+        printf '%s' "$watch_request" | nc -U "$SOCKET" | {
+            if IFS= read -r first_line; then
+                printf '%s\n' "$first_line"
+                case "$first_line" in
+                    error:*|*'"ok":false'*) exit 1 ;;
+                esac
+                cat
+            fi
+            exit 2
+        } || watch_status=$?
+        if [ "$watch_status" -eq 2 ]; then
+            echo "termio: watch stream closed by the app (termio quit or died)" >&2
+        fi
+        exit "$watch_status"
     fi
 
     if [ "$op" = close ]; then

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -52,14 +52,17 @@ for machine-readable output.
 | Command | What it does |
 | --- | --- |
 | `termio sessions list` | List the sessions in this project with their live status. |
-| `termio sessions watch` | Block and stream one line per status change — the push alternative to polling `list`. Defaults to `done` and `needs-you`; widen with `--state working,idle,done,needs-you`. Runs until you interrupt it. |
-| `termio sessions spawn "<prompt>"` | Start a new agent session on the prompt. Add `--agent <id>` (e.g. `codex`, `grok`, `pi`) to choose the agent; it defaults to the caller's own kind. The reply carries the new `<agent>@<id>` handle. |
+| `termio sessions watch` | Block and stream one line per status change — the push alternative to polling `list`. Defaults to `done` and `needs-you`; widen with `--state working,idle,done,needs-you`. On attach it first prints one snapshot line per session with its current status (tagged `"snapshot":true` in `--json`; skip with `--no-snapshot`), and in `--json` mode it writes `{"heartbeat":true}` after 30 seconds of silence so a supervisor can tell a quiet stream from a dead one. Runs until you interrupt it: exits `0` on Ctrl-C, `2` when the stream closed from the app side. |
+| `termio sessions spawn "<prompt>"` | Start a new agent session on the prompt. Add `--agent <id>` (e.g. `codex`, `grok`, `pi`) to choose the agent; it defaults to the caller's own kind. Replies immediately with the new `<agent>@<id>` handle — the prompt is typed in once the agent finishes booting. |
 | `termio sessions send <agent>@<id> "<text>"` | Type text into an existing session and submit it with a real Return keypress — a prompt to drive it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. |
 | `termio sessions close <agent>@<id>` | Close one or more session tabs. |
 | `termio sessions focus <agent>@<id>` | Bring a session to the front in the app. |
 
 `<agent>@<id>` is the handle `list` prints (a bare id or session title also works).
-Commands are scoped to the current project automatically.
+Commands are scoped to the current project automatically. `termio sessions <verb>
+--help` prints focused help for one verb. Every one-shot command fails loud: an
+empty or missing reply exits `1`, bounded by a 15-second client timeout
+(override with the `TERMIO_CLI_TIMEOUT` environment variable).
 
 <Callout type="note">
   `answer` is a deprecated alias of `send`, and `send` with no handle behaves like


### PR DESCRIPTION
Implements Phase 1 + Phase 2 of [docs/design/sessions-cli-v2.md](docs/design/sessions-cli-v2.md) (Sessions CLI v2 — reliability & command design). Phase 3 (`--wait` unification, actionable payloads, contract docs) stays out of scope pending PR #72.

## Phase 1 — reliability floor (shell only, §4.1)

- **Empty reply = exit 1**, with an actionable message. A control CLI must fail loud; silence no longer exits 0.
- **Client read timeout**: every one-shot request runs `nc -w ${TERMIO_CLI_TIMEOUT:-15}`; `watch` is exempt (its liveness comes from the heartbeat).
- **`json_escape` hardening**: tabs escape to `\t`, every other C0 control byte is stripped. Hostile prompt round-trips as valid JSON (verified: tab/CR/ESC/quotes/backslashes).
- **Per-verb help**: `sessions <verb> --help` prints a focused usage block before the socket is touched (works with the app closed).

## Phase 2 — host (§4.2–4.3)

- **Non-blocking `spawn`**: replies immediately with the minted handle (`started <handle> — prompt queued`; JSON adds `created` + `queued`); boot-settle + delivery run in a detached task. Delivery failure logs and surfaces via session status.
- **`watch` snapshot on subscribe**: one line per scoped session with current status, `"snapshot":true` in JSON, same line shape in text; `--no-snapshot` opts out.
- **Heartbeat**: `{"heartbeat":true}` after 30s of write silence, JSON subscribers only; a failed heartbeat write reaps the dead reader proactively.
- **`cwd` omitted** from watch events when the runtime has no OSC 7 yet (was `""`).
- **`watch` exit codes**: `0` on Ctrl-C, `1` on an immediate error reply, `2` when the stream closes from the app side.
- **`FD_CLOEXEC` on listener + accepted fds** — found by the verification below.

## §4.2 head-of-line verification (required experiment)

Instrumented `handleSessionControl` with per-op enter/exit timing (unified log, category `session-control`) and ran 3 concurrent spawns + a `list` latency probe every 500ms, three rounds against dev builds from this worktree (owning pid verified against the socket for every round; several earlier rounds were discarded after stale sibling `termio-dev` builds hijacked the shared bundle id/socket mid-run — the §7 test-infra hazard, reproduced live).

| Round | Build | Spawn reply (client) | Worst `list` probe | Server-side spawn occupancy |
| --- | --- | --- | --- | --- |
| 1 baseline | v1 blocking spawn | 17.96s × 3 | 0.772s | (evicted from log buffer) |
| 2 warm | v2 non-blocking | 15.4–16.0s (!) | 15.79s once, then ≤0.21s | 177–312ms |
| 3 final | v2 + FD_CLOEXEC | **0.07–0.57s** | **0.878s** | 152–260ms |

**Verdict on finding 4 (main-actor head-of-line): not confirmed.** In the baseline, `list` stayed fast (≤0.772s) while three spawns blocked 18s — `Task.sleep` polls yield the actor as §4.2 hypothesized; the starvation seen on 2026-07-24 was the dev-channel bundle-id collision.

**But round 2 exposed the real reply stall**: server handlers exited in 177–312ms, yet every connection in flight during the spawn burst got its reply only after ~15.5s ≈ the CLI's own `nc -w 15` idle timeout. Root cause: `forkpty` children inherit the accepted client descriptors, so the app's `close()` leaves each connection open and `nc` never sees EOF — it delivers the (long-received) reply only when its own timer fires. `FD_CLOEXEC` on the listen + accepted fds closes the copies at the child's exec; round 3 confirms replies in 0.07–0.57s.

## Test evidence

- **Delivery after non-blocking reply**: both spawned Claude transcripts contain `user: Reply with the single word OK…` → `assistant: OK`.
- **Snapshot**: attach prints one `"snapshot":true` line per session; `--no-snapshot` holds the connection ≥4s with zero snapshot lines.
- **Heartbeat cadence**: exactly 2 heartbeats in 70s (t=31.2s, t=61.3s) on a quiet watch; none in text mode.
- **`cwd`**: absent from events when unknown (no `"cwd":""` anywhere).
- **Timeout**: SIGSTOP-equivalent (accepting-but-silent server) + `TERMIO_CLI_TIMEOUT=3` → exit 1 in 3.1s with the actionable message.
- **Ctrl-C**: real `^C` through a pty → exit 0.
- **Server gone**: stream closed mid-watch → prints prior lines, exit 2 + stderr notice.
- **Hostile input**: tab/CR/ESC/quote/backslash prompt → valid JSON request.
- `swift build --target termio` clean; `sh -n scripts/termio` clean; branch rebased onto #82/#83.

Doc surfaces updated: `scripts/termio usage()` + per-verb help, `SessionSkillInstaller.block`, `web/landing/content/docs/session-control.mdx`.

## Known issues left open (pre-existing, out of scope)

- ~1-in-50 concurrent requests get `error: malformed request` (listener read race; observed at the same rate on the v1 baseline). Now at least it fails loud.
- The app's launch window (session restore + main-thread git sync) still stalls the main actor for seconds; the CLI now surfaces that as a bounded timeout instead of an infinite hang.
- Per-worktree dev channels (§7 prerequisite) remain unbuilt; parallel worktree testing still collides on `sh.termio.app.dev`.

## Release Notes:

- The `termio sessions` CLI now fails loud: empty replies exit 1, and every one-shot command has a client timeout (`TERMIO_CLI_TIMEOUT`, default 15s).
- `termio sessions spawn` replies immediately with the new session's handle; the prompt is delivered once the agent finishes booting.
- `termio sessions watch` opens with a status snapshot (`--no-snapshot` to skip), heartbeats every 30s in `--json` mode, and distinguishes Ctrl-C (exit 0) from the app going away (exit 2).
- `termio sessions <verb> --help` prints focused per-verb help.
- Fixed a stall where CLI replies during an agent spawn were held open for the client's full timeout.
