### PR TITLE
Give the sessions CLI --wait, actionable events, a pinned JSON contract, and a caller envelope

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -19,6 +19,9 @@ import Foundation
 /// - `agent` — the agent for a fresh session (`send` with no target).
 /// - `snapshot` — `watch` only: `false` skips the initial per-session status
 ///   snapshot (absent means snapshot on).
+/// - `wait` / `timeoutMs` — `send`/`spawn` only: block until the turn the prompt
+///   kicked off settles (or the timeout elapses) and report the outcome, instead
+///   of replying the instant the keystrokes are delivered.
 struct ControlRequest: Decodable {
     let op: String
     let format: String?
@@ -29,14 +32,19 @@ struct ControlRequest: Decodable {
     let lines: Int?
     let agent: String?
     let snapshot: Bool?
+    let wait: Bool?
+    /// The `--wait` cap in milliseconds; clamped server-side. Nil uses the default.
+    let timeoutMs: Int?
 
     private enum CodingKeys: String, CodingKey {
-        case op, format, target, text, lines, agent, snapshot
+        case op, format, target, text, lines, agent, snapshot, wait
         case callerSession = "caller_session"
         case callerCwd = "caller_cwd"
+        case timeoutMs = "timeout_ms"
     }
 
     var wantsJSON: Bool { format == "json" }
+    var wantsWait: Bool { wait == true }
 }
 
 /// A local Unix-domain socket the `termio sessions` CLI connects to. Unlike
@@ -150,7 +158,11 @@ final class SessionControlListener {
         }
         let decoded = request ?? Self.decode(data)
         guard let decoded else {
-            Self.writeAll(descriptor, Data("error: malformed request\n".utf8))
+            // The request never decoded, so its `format` is unknowable — reply in the
+            // documented JSON error shape, which the text-mode CLI also recognizes
+            // (it matches on `"ok":false`). Only hand-rolled clients ever hit this.
+            Self.writeAll(descriptor, Data(
+                "{\"ok\":false,\"error\":\"bad_request\",\"message\":\"malformed request\",\"schema_version\":1}\n".utf8))
             close(descriptor)
             return
         }
@@ -235,6 +247,13 @@ struct SessionWatchEvent {
     /// Marks the initial current-status lines emitted on subscribe, so a JSON
     /// consumer can tell "already was" from a live transition.
     var snapshot = false
+    /// `needs-you` only: the on-screen question excerpt, so a supervisor can act
+    /// without a round-trip to scrape the viewport (design doc §4.3).
+    var prompt: String? = nil
+    /// `done` only: the transcript address plus its line count now, so the reply
+    /// is readable without another `list --json` round-trip.
+    var transcript: String? = nil
+    var cursorEnd: Int? = nil
 }
 
 /// Holds the open `watch` connections and fans status transitions out to them. A
@@ -375,6 +394,9 @@ private extension SessionWatchEvent {
         // empty string reads like a real (broken) path to a JSON consumer.
         if !cwd.isEmpty { object["cwd"] = cwd }
         if snapshot { object["snapshot"] = true }
+        if let prompt { object["prompt"] = prompt }
+        if let transcript { object["transcript"] = transcript }
+        if let cursorEnd { object["cursor_end"] = cursorEnd }
         let data = (try? JSONSerialization.data(
             withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])) ?? Data()
         return data + Data("\n".utf8)
@@ -433,6 +455,12 @@ enum SessionSkillInstaller {
         - `termio sessions send <agent>@<id> "<text>"` — type text into that existing
           sibling and submit it with a real Return keypress. Send a prompt to drive
           it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
+        - `--wait [--timeout <ms>]` on `send` or `spawn` — block until that turn
+          settles and reply with the final `status`, the `transcript` path, and the
+          `cursor`..`cursor_end` line range holding the response — one call instead
+          of send-then-poll. A sibling that stops to ask you something short-circuits
+          the wait: the reply is `status:"needs-you"` with the on-screen question in
+          `prompt` — answer it with another `send`.
         - `termio sessions close <agent>@<id> …` — close session tabs;
           `termio sessions focus <agent>@<id>` — bring one to the front in the app
 
@@ -461,9 +489,13 @@ enum SessionSkillInstaller {
            after it are the reply. (Each line is a JSON object with a `type`/`role`.)
 
         Workflow: send → wait for `done` via `list` → read the transcript tail. Prefer
-        this over assuming a sibling is finished. Supervising several at once? Block on
+        this over assuming a sibling is finished — or collapse steps 1–2 into one call
+        with `send --wait`, whose reply carries the final status and the exact
+        `cursor`..`cursor_end` range to read. Supervising several at once? Block on
         `termio sessions watch` instead of polling — it prints the handle the moment any
-        sibling turns `done` or `needs-you`, so you act on the transition, not a spin loop.
+        sibling turns `done` or `needs-you`, so you act on the transition, not a spin
+        loop; its `--json` `needs-you` events carry the question in `prompt`, and `done`
+        events carry `transcript` + `cursor_end`, so you can act straight from the event.
         \(endMarker)
         """
     }

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -69,16 +69,36 @@ extension TermioStore {
                 "Couldn't tell which project you're in. Run this from inside a termio session."), [])
         }
         guard request.snapshot != false else { return (project.id, nil, []) }
-        let snapshot = project.sessions.map { session in
-            SessionWatchEvent(
+        let snapshot = project.sessions.map { session -> SessionWatchEvent in
+            var event = SessionWatchEvent(
                 projectID: project.id,
                 handle: sessionHandle(for: session),
                 status: Self.statusToken(status(for: session.id)),
                 title: displayTitle(for: session),
                 cwd: runtimes[session.id]?.workingDirectory ?? "",
                 snapshot: true)
+            attachActionablePayload(to: &event, for: session.id)
+            return event
         }
         return (project.id, nil, snapshot)
+    }
+
+    /// Fills in what makes an event actionable without a second round-trip (design
+    /// doc §4.3): the on-screen question for `needs-you`, the transcript address +
+    /// current length for `done`. Shared by the watch snapshot and the live
+    /// `setStatus` broadcast.
+    func attachActionablePayload(to event: inout SessionWatchEvent, for id: Session.ID) {
+        switch event.status {
+        case "needs-you":
+            event.prompt = promptExcerpt(for: id)
+        case "done":
+            if let transcript = transcriptPaths[id] {
+                event.transcript = transcript
+                event.cursorEnd = Self.lineCount(of: transcript)
+            }
+        default:
+            break
+        }
     }
 
     /// The address a caller drives a session by. The id half is the stable key
@@ -139,7 +159,7 @@ extension TermioStore {
         switch resolveTarget(token, in: project) {
         case .found(let session):
             let state = surface(for: session, in: project)
-            return await deliver(payload, to: session, state: state, request: request)
+            return await deliver(payload, to: session, state: state, request: request, in: project)
         case .notFound:
             return controlError(request, "not_found", targetNotFoundMessage(request.target))
         case .ambiguous:
@@ -182,6 +202,20 @@ extension TermioStore {
             return controlError(request, "start_failed", "Could not start the session.")
         }
         let state = surface(for: fresh, in: project)
+        let delivered = (callerEnvelope(for: request) ?? "") + payload
+        // With `--wait`, the caller opted back into blocking — but for the *outcome*
+        // (§4.4), never just the plumbing: boot-settle, deliver, then hold the reply
+        // until the spawned agent's first turn settles.
+        if request.wantsWait {
+            await waitForBootSettle(of: state)
+            guard await performDelivery(delivered, to: fresh, state: state) else {
+                return controlError(request, "not_live",
+                    "\(displayTitle(for: fresh)) has no live terminal yet — open it once in termio.")
+            }
+            let cursorAtSend = transcriptPaths[fresh.id].map(Self.lineCount)
+            return await waitForReply(request, session: fresh,
+                                      cursorAtSend: cursorAtSend, created: true)
+        }
         // Reply with the handle now; boot-settle + prompt delivery continue off the
         // reply path so no verb silently blocks (§4.2). A delivery failure has no
         // caller left to tell — it surfaces through the session's own status and
@@ -190,7 +224,7 @@ extension TermioStore {
         Task { [weak self] in
             guard let self else { return }
             await self.waitForBootSettle(of: state)
-            if await !self.performDelivery(payload, to: fresh, state: state) {
+            if await !self.performDelivery(delivered, to: fresh, state: state) {
                 FileHandle.standardError.write(Data(
                     "termio: session control could not deliver the queued prompt to \(handle)\n".utf8))
             }
@@ -198,16 +232,52 @@ extension TermioStore {
         return spawnQueuedReply(request, fresh)
     }
 
+    /// The provenance envelope prepended to a spawned session's prompt when the
+    /// spawner is itself a termio session (design doc §4.6) — without it the new
+    /// agent has no idea who spawned it and can only stop as `needs-you` and hope.
+    /// It opens exactly one back-channel: a mid-task question, or a one-line
+    /// completion ping, via `sessions send` to the caller. The hard limits ride in
+    /// the envelope text itself because agent↔agent messaging invites loops and
+    /// injection — no conversation, no delegating work back, and completion stays
+    /// transcript-as-truth (the supervisor's `watch`/transcript path remains the
+    /// reliable backstop). A plain-shell caller resolves no session → no envelope.
+    private func callerEnvelope(for request: ControlRequest) -> String? {
+        guard let callerID = request.callerSession, let uuid = UUID(uuidString: callerID),
+              let caller = session(uuid) else { return nil }
+        let callerHandle = sessionHandle(for: caller)
+        return """
+        [termio] You were spawned by the sibling agent session \(callerHandle). \
+        If you hit a question only they can answer, ask it mid-task with: \
+        termio sessions send \(callerHandle) "QUESTION: <your question>" — and when \
+        you finish you may send at most one line: \
+        termio sessions send \(callerHandle) "DONE: <one line>". \
+        Use this channel for nothing else: no conversation, no status updates, and \
+        never delegate tasks back to them. They read your actual results from your \
+        transcript, so put everything that matters in your normal replies. \
+        Your task follows.
+
+        """
+    }
+
     /// Types `payload` into an existing sibling's surface and builds the reply.
+    /// Without `--wait` the reply is the send acknowledgement (the transcript path
+    /// + a cursor to read the response from); with it, the call blocks until the
+    /// turn settles and reports the outcome plus the transcript range it landed in.
     private func deliver(
         _ payload: String, to session: Session, state: TerminalViewState,
-        request: ControlRequest
+        request: ControlRequest, in project: Project
     ) async -> Data {
         guard await performDelivery(payload, to: session, state: state) else {
             return controlError(request, "not_live",
                 "\(displayTitle(for: session)) has no live terminal yet — open it once in termio.")
         }
-        return sentReply(request, session)
+        guard request.wantsWait else { return sentReply(request, session) }
+        // The cursor to read the reply from: wherever the transcript stands right
+        // after submitting. A session's transcript often isn't known until a hook
+        // fires mid-turn, so this can be nil and is re-read after the wait.
+        let cursorAtSend = transcriptPaths[session.id].map(Self.lineCount)
+        return await waitForReply(request, session: session,
+                                  cursorAtSend: cursorAtSend, created: false)
     }
 
     /// Types `payload` into a session's live surface and submits it. Shared by
@@ -235,6 +305,141 @@ extension TermioStore {
         try? await Task.sleep(for: .milliseconds(40))
         Self.pressReturn(on: surfaceHandle)
         return true
+    }
+
+    /// Blocks until the session the prompt was sent to finishes its turn — or stops
+    /// to ask the user (`needs-you`) — or the timeout elapses, then reports the
+    /// outcome. This is what lets a caller issue one `send --wait` instead of
+    /// sending and then polling `list` in a loop.
+    ///
+    /// Completion is read primarily from the **status resting**: the turn is done once
+    /// the session, having been seen `working`, drops back off `working` and stays there
+    /// for `settleWindow` (`needs-you` short-circuits immediately). Status is the signal
+    /// every real agent drives — built-ins via hooks, rule-based agents via the screen
+    /// classifier — and unlike a raw screen watch it is immune to a TUI footer that keeps
+    /// animating after the reply. A 300ms poll always catches the `working` span of a real
+    /// turn (an LLM round-trip is far longer). Only a session with no status signal at all
+    /// — a plain terminal driven by `send --wait` — falls back to the screen first changing
+    /// and then going still. Each poll awaits off the actor, so a long wait never blocks
+    /// other control requests (§4.2 stays true even mid-wait).
+    private func waitForReply(
+        _ request: ControlRequest, session: Session,
+        cursorAtSend: Int?, created: Bool
+    ) async -> Data {
+        let cap = min(max(request.timeoutMs ?? 300_000, 1_000), 600_000)
+        let deadline = Date().addingTimeInterval(Double(cap) / 1_000)
+        let settleWindow = 1.5
+
+        var sawWorking = false
+        var restingSince: Date?
+        var lastFrame = viewportText(for: session.id)
+        var lastChangeAt = Date()
+        var changedSinceSend = false
+        var settled: SessionStatus?
+
+        while Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(300))
+            let current = status(for: session.id)
+            if current == .working {
+                sawWorking = true
+                restingSince = nil
+            } else if restingSince == nil {
+                restingSince = Date()
+            }
+            if current == .needsAttention { settled = .needsAttention; break }
+
+            let now = Date()
+            let frame = viewportText(for: session.id)
+            if frame != lastFrame {
+                lastFrame = frame
+                lastChangeAt = now
+                changedSinceSend = true
+            }
+            guard current != .working else { continue }
+            let rested = restingSince.map { now.timeIntervalSince($0) >= settleWindow } ?? false
+            let screenQuiet = now.timeIntervalSince(lastChangeAt) >= settleWindow
+            // Status-tracked agent: seen working, now rested. (Footer animation can't
+            // fool this — it doesn't touch status.)
+            if sawWorking, rested { settled = current; break }
+            // No status signal at all (a plain terminal): the screen changed, then stilled.
+            if !sawWorking, changedSinceSend, screenQuiet { settled = current; break }
+        }
+        return waitReply(request, session: session,
+                         cursorAtSend: cursorAtSend, created: created, settled: settled)
+    }
+
+    /// The reply for a completed (or timed-out) `--wait`. Every wait reply — `send`
+    /// or `spawn` — shares one shape (§4.4): the turn's final `status` and the exact
+    /// transcript range to read, `cursor` (where the reply begins, captured at send)
+    /// through `cursor_end` (the log's length now), so the caller's own file tools
+    /// read precisely the new content, no polling. When the session is blocked on
+    /// the user (`needs-you`), the on-screen question rides along as `prompt` so the
+    /// caller can answer without scraping the viewport.
+    private func waitReply(
+        _ request: ControlRequest, session: Session,
+        cursorAtSend: Int?, created: Bool, settled: SessionStatus?
+    ) -> Data {
+        let handle = sessionHandle(for: session)
+        let statusToken = Self.statusToken(status(for: session.id))
+        var json: [String: Any] = [
+            "target": handle,
+            "title": displayTitle(for: session),
+            "status": statusToken,
+            "timed_out": settled == nil,
+        ]
+        if created { json["created"] = true }
+
+        let headline: String
+        switch settled {
+        case .needsAttention: headline = "\(handle) is waiting on you"
+        case .some: headline = "\(handle) finished (\(statusToken))"
+        case nil: headline = "\(handle) still \(statusToken) after the wait — timed out"
+        }
+        var text = headline
+
+        // The transcript may only have become known during the wait (a fresh
+        // session's first hook), so re-read it here rather than trusting the
+        // send-time snapshot.
+        if let transcript = transcriptPaths[session.id] {
+            let start = cursorAtSend ?? 0
+            let end = Self.lineCount(of: transcript)
+            json["transcript"] = transcript
+            json["cursor"] = start
+            json["cursor_end"] = end
+            text += "\n  transcript: \(transcript)\n  reply: lines \(start)–\(end) (read this range)"
+        }
+        if settled == .needsAttention, let prompt = promptExcerpt(for: session.id) {
+            json["prompt"] = prompt
+            text += "\n  on screen:\n\(prompt)"
+        }
+        return control(request, ok: true, text: text, json: json)
+    }
+
+    /// The current viewport text of a session's terminal, or nil when it has no live
+    /// in-memory backend yet (never rendered). Reads only an already-mounted surface —
+    /// deliberately no `surface(for:in:)` fallback, so a status broadcast can never
+    /// create a surface as a side effect. Reads through the backend's own lock
+    /// (`readViewportText`), so it's safe from this actor.
+    func viewportText(for id: Session.ID) -> String? {
+        guard let state = surfaces[id],
+              case .inMemory(let terminal) = state.configuration.backend else { return nil }
+        return terminal.readViewportText()
+    }
+
+    /// The tail of a session's screen — the question or menu the agent stopped on —
+    /// for `needs-you` payloads. The last dozen non-blank rows (right-trimmed, size-
+    /// capped) are enough to answer from; the leading rows are the conversation the
+    /// caller already has via the transcript.
+    func promptExcerpt(for id: Session.ID) -> String? {
+        guard let screen = viewportText(for: id) else { return nil }
+        var lines = screen.components(separatedBy: "\n").map { line -> String in
+            var trimmed = Substring(line)
+            while trimmed.last == " " { trimmed.removeLast() }
+            return String(trimmed)
+        }
+        while lines.last?.isEmpty == true { lines.removeLast() }
+        guard !lines.isEmpty else { return nil }
+        return String(lines.suffix(12).joined(separator: "\n").suffix(1_200))
     }
 
     /// Waits for a freshly launched agent TUI to finish booting before keystrokes
@@ -333,7 +538,7 @@ extension TermioStore {
 
     /// Lines currently in a file, counted cheaply by newline bytes — the cursor a
     /// caller resumes a transcript read from.
-    private static func lineCount(of path: String) -> Int {
+    static func lineCount(of path: String) -> Int {
         guard let data = FileManager.default.contents(atPath: path) else { return 0 }
         return data.reduce(into: 0) { count, byte in if byte == 0x0A { count += 1 } }
     }
@@ -475,6 +680,9 @@ extension TermioStore {
         if request.wantsJSON {
             var object = json
             object["ok"] = ok
+            // Every JSON reply pins the contract it speaks (§4.5) — agents are
+            // coding against these shapes, and versioning them beats breaking them.
+            object["schema_version"] = 1
             let data = (try? JSONSerialization.data(
                 withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])) ?? Data()
             return data + Data("\n".utf8)

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -206,12 +206,17 @@ final class TermioStore: ObservableObject {
         // to this session's project. The hub does the socket writes off the main
         // thread, so a watcher never slows the agent tick that produced the event.
         if let session = session(id), let project = project(for: id) {
-            SessionWatchHub.shared.broadcast(SessionWatchEvent(
+            var event = SessionWatchEvent(
                 projectID: project.id,
                 handle: sessionHandle(for: session),
                 status: Self.statusToken(status),
                 title: displayTitle(for: session),
-                cwd: runtimes[id]?.workingDirectory ?? ""))
+                cwd: runtimes[id]?.workingDirectory ?? "")
+            // A `needs-you` event carries the on-screen question, a `done` event the
+            // transcript cursor — what a supervisor needs to act on the transition
+            // without a second round-trip (design doc §4.3).
+            attachActionablePayload(to: &event, for: id)
+            SessionWatchHub.shared.broadcast(event)
         }
         // A session *entering* `.working` is the "this project is active" signal that
         // floats its project up the Recent-Activity sort. Bumping here, on the genuine

--- a/scripts/termio
+++ b/scripts/termio
@@ -36,6 +36,9 @@ usage:
 options:
   --json           machine-readable output (any `sessions` command)
   --agent <id>     agent for `spawn` (e.g. claudeCode, codex, grok, pi; default: caller's kind)
+  --wait           for `spawn`/`send`: block until the turn settles; the reply carries
+                   the final status and the transcript line range to read
+  --timeout <ms>   cap for --wait (default 300000, clamped 1000–600000); implies --wait
   --state <s,…>    for `watch`: comma-separated states to report (working, idle, done, needs-you)
   --no-snapshot    for `watch`: skip the initial per-session status snapshot
   --help, --version
@@ -75,21 +78,33 @@ closes from the app side (termio quit or died).
 EOF
             ;;
         spawn) cat <<'EOF'
-usage: termio sessions spawn "<prompt>" [--agent <id>] [--json]
+usage: termio sessions spawn "<prompt>" [--agent <id>] [--wait [--timeout <ms>]] [--json]
 
 Start a NEW agent session on the prompt. Replies immediately with the new
 session's <agent>@<id> handle; the prompt is typed in once the agent
 finishes booting. --agent picks the agent (e.g. claudeCode, codex, grok,
 pi); the default is the calling agent's own kind.
+
+--wait holds the reply until the spawned agent's first turn settles (or
+--timeout ms elapse; default 300000, clamped 1000–600000). The reply then
+carries the final status, the transcript path, and the cursor..cursor_end
+line range holding the response. A session that stops to ask you something
+returns immediately as needs-you, with the on-screen question in `prompt`.
 EOF
             ;;
         send|answer) cat <<'EOF'
-usage: termio sessions send <agent>@<id> "<text>" [--json]
+usage: termio sessions send <agent>@<id> "<text>" [--wait [--timeout <ms>]] [--json]
 
 Type text into an existing session and submit it with a real Return
 keypress — a prompt to drive it, or a menu choice ("1", "yes") to answer a
 permission prompt. Handles come from `termio sessions list` or a `spawn`
 reply; copy them verbatim.
+
+--wait holds the reply until the turn the text kicked off settles (or
+--timeout ms elapse; default 300000, clamped 1000–600000). The reply then
+carries the final status, the transcript path, and the cursor..cursor_end
+line range holding the response. A session that stops to ask you something
+returns immediately as needs-you, with the on-screen question in `prompt`.
 
 `answer` is a deprecated alias; `send` without a handle aliases `spawn`.
 EOF
@@ -164,12 +179,15 @@ build_request() {
 # it reports failure, so callers (and `set -e`) surface errors through the exit
 # code — agents check `$?`, not prose. `nc -w` bounds the wait when the app is
 # wedged, and an empty reply is a hard error, never a silent success: a control
-# CLI must fail loud.
+# CLI must fail loud. An optional 6th argument is raw JSON appended to the request
+# (the --wait fields); CLIENT_TIMEOUT is the read bound, widened by `sessions`
+# when a --wait reply is legitimately slow.
+CLIENT_TIMEOUT="${TERMIO_CLI_TIMEOUT:-15}"
 request_once() {
-    request=$(build_request "$1" "$2" "$3" "$4" "$5")
-    response=$(printf '%s' "$request" | nc -w "${TERMIO_CLI_TIMEOUT:-15}" -U "$SOCKET") || true
+    request=$(build_request "$1" "$2" "$3" "$4" "$5" "${6:-}")
+    response=$(printf '%s' "$request" | nc -w "$CLIENT_TIMEOUT" -U "$SOCKET") || true
     if [ -z "$response" ]; then
-        echo "termio: no reply from the app within ${TERMIO_CLI_TIMEOUT:-15}s — it may be busy or wedged; check the app, or raise TERMIO_CLI_TIMEOUT" >&2
+        echo "termio: no reply from the app within ${CLIENT_TIMEOUT}s — it may be busy or wedged; check the app, or raise TERMIO_CLI_TIMEOUT" >&2
         return 1
     fi
     printf '%s\n' "$response"
@@ -211,11 +229,20 @@ sessions() {
     text=""
     states=""
     no_snapshot=0
+    wait=false
+    timeout_ms=""
     seen_positional=0
     while [ $# -gt 0 ]; do
         case "$1" in
             --json) format=json ;;
             --no-snapshot) no_snapshot=1 ;;
+            --wait) wait=true ;;
+            --timeout)
+                [ $# -ge 2 ] || { echo "termio: --timeout needs a value in ms" >&2; exit 1; }
+                case "$2" in
+                    ''|*[!0-9]*) echo "termio: --timeout needs whole milliseconds" >&2; exit 1 ;;
+                esac
+                timeout_ms="$2"; wait=true; shift ;;
             --agent)
                 [ $# -ge 2 ] || { echo "termio: --agent needs a value" >&2; exit 1; }
                 agent="$2"; shift ;;
@@ -266,6 +293,24 @@ sessions() {
             fi
             ;;
     esac
+
+    # One sync vocabulary: --wait/--timeout mean the same thing on every verb that
+    # accepts them (spawn + send), and nothing else silently ignores them.
+    wait_extra=""
+    if [ "$wait" = true ]; then
+        case "$op" in
+            spawn|send|answer) ;;
+            *) echo "termio: --wait applies to spawn and send only" >&2; exit 1 ;;
+        esac
+        wait_extra='"wait":true'
+        [ -n "$timeout_ms" ] && wait_extra="$wait_extra,\"timeout_ms\":$timeout_ms"
+        # The client read bound must outlive the server-side wait (which the app
+        # clamps to 1s–600s), or nc would hang up mid-wait and report a false
+        # timeout. An explicit TERMIO_CLI_TIMEOUT still wins — the escape hatch.
+        if [ -z "${TERMIO_CLI_TIMEOUT:-}" ]; then
+            CLIENT_TIMEOUT=$(( ${timeout_ms:-300000} / 1000 + 30 ))
+        fi
+    fi
 
     if [ "$op" = watch ]; then
         # Streaming: the app holds the connection open and pushes one line per scoped
@@ -322,7 +367,7 @@ sessions() {
     case "$op" in
         spawn|answer) wire_op=send ;;
     esac
-    request_once "$wire_op" "$format" "$targets" "$agent" "$text"
+    request_once "$wire_op" "$format" "$targets" "$agent" "$text" "$wait_extra"
 }
 
 # The public hook contract:

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -74,6 +74,32 @@ and the prompt itself is typed in once the agent finishes booting. Add
 `--agent <id>` (e.g. `codex`, `grok`, `pi`) to choose the agent; it defaults to
 the caller's own kind.
 
+### Waiting for the outcome: `--wait`
+
+Waiting is always explicit, and it means the same thing everywhere: `--wait`
+waits for the *outcome* of the turn, never for plumbing. Both `send` and `spawn`
+accept it (with an optional `--timeout <ms>`, default 300000, clamped
+1000–600000):
+
+```bash
+termio sessions send claude@ab12cd34 "run the tests" --wait
+termio sessions spawn "summarize the failing CI job" --wait --timeout 120000
+```
+
+The call blocks until the turn settles — the session was seen `working` and has
+rested off it — and the reply carries the final `status`, the `transcript` path,
+and the `cursor`..`cursor_end` line range the response landed in, so the caller
+reads exactly the new content with its own file tools. Two special cases:
+
+- A session that stops to ask something short-circuits the wait immediately:
+  the reply is `status: "needs-you"` with the on-screen question in `prompt` —
+  answer it with another `send`.
+- A plain terminal with no status signal falls back to screen settling: the
+  screen changed after the send, then went still.
+
+On timeout the reply still comes back (`timed_out: true`) with whatever the
+current status is; the session keeps running.
+
 ### Supervising with `watch`
 
 `watch` is built so an agent can supervise a fleet without polling:
@@ -85,18 +111,79 @@ the caller's own kind.
 - **Filtered by default.** Live events default to the two states a supervisor
   acts on, `done` and `needs-you`; widen with
   `--state working,idle,done,needs-you`.
+- **Actionable events.** A `needs-you` event carries the on-screen question in
+  `prompt`; a `done` event carries the session's `transcript` path and
+  `cursor_end` — enough to answer, or to read the result, without another
+  round-trip.
 - **Heartbeat.** In `--json` mode the app writes `{"heartbeat":true}` after 30
   seconds of silence, so a quiet stream is distinguishable from a dead one.
 - **Exit codes.** `0` after Ctrl-C (the normal end of supervision), `2` when
   the stream closed from the app side — "I chose to stop" and "termio went
   away" are different outcomes.
 
+### Spawned sessions know their caller
+
+When one termio session spawns another, the delivered prompt opens with a short
+provenance envelope: it names the caller's handle and allows exactly one
+back-channel — a mid-task question, or a one-line completion ping, via
+`termio sessions send <caller-handle> …`. Nothing else travels that way: no
+conversation, no delegating tasks back. Results stay transcript-as-truth — the
+supervisor reads the worker's transcript, with `watch` as the backstop. A
+`spawn` from a plain shell (outside any termio session) gets no envelope.
+
 ### Fail loud
 
 The CLI is built for callers that trust exit codes, not prose. Every one-shot
 command exits `1` on an error or an empty reply, and gives up after a
 15-second client timeout rather than hanging on a busy app (override with the
-`TERMIO_CLI_TIMEOUT` environment variable).
+`TERMIO_CLI_TIMEOUT` environment variable; a `--wait` call widens the client
+timeout automatically to outlive the server-side wait).
+
+## JSON contract
+
+Agents code against `--json` output, so its shapes are pinned, not
+reverse-engineered. Every JSON reply carries `"schema_version": 1`; fields may
+be *added* within a version, never renamed or removed. Optional fields are
+omitted when unknown (never emitted as `""` or `null`).
+
+Every error, on any verb, has one shape — and the exit code is nonzero:
+
+```json
+{"ok": false, "error": "<code>", "message": "<human-readable next step>", "schema_version": 1}
+```
+
+The stable codes: `disabled`, `no_scope`, `bad_op`, `bad_request`, `no_text`,
+`no_target`, `not_found`, `ambiguous`, `wrong_agent`, `bad_agent`, `no_agent`,
+`start_failed`, `not_live`, `read_unavailable`.
+
+Success replies, per verb (`schema_version` and `"ok": true` omitted below for
+brevity):
+
+| Verb | Reply fields |
+| --- | --- |
+| `list` | `project`, `sessions: [{handle, id, title, agent, status, description, transcript?}]` |
+| `spawn` | `target`, `title`, `created: true`, `queued: true` — the prompt is still being delivered |
+| `send` | `target`, `title`, `transcript?`, `cursor?` — read the response from `cursor` onward |
+| `send`/`spawn` `--wait` | `target`, `title`, `status`, `timed_out`, `created?`, `transcript?`, `cursor?`, `cursor_end?`, `prompt?` |
+| `close` | `closed`, `title` |
+| `focus` | `focused` |
+
+The two wait verbs share one reply shape (`--wait` means the same thing
+everywhere): the final `status`, and the transcript line range
+`cursor`..`cursor_end` holding the response. `prompt` appears only on a
+`needs-you` outcome — the question the session is showing on screen.
+
+`watch` streams newline-delimited JSON events rather than one reply:
+
+```json
+{"schema_version": 1, "handle": "claude@ab12cd34", "status": "done", "title": "…",
+ "cwd": "…", "snapshot": true, "prompt": "…", "transcript": "…", "cursor_end": 42}
+```
+
+`cwd` is omitted until the shell reports one; `snapshot` marks the on-attach
+roster lines; `prompt` rides on `needs-you` events and `transcript` +
+`cursor_end` on `done` events, exactly as in wait replies. After 30 seconds of
+silence the app writes `{"heartbeat": true}`.
 
 <Callout type="tip">
   This is what lets one agent hand work to another — `spawn` a task in a sibling


### PR DESCRIPTION
Phase 3 of [Sessions CLI v2](docs/design/sessions-cli-v2.md) (Phases 1+2 shipped in #80/#86). Closes out the design doc's §4.3–§4.6.

## What's in it

**One sync vocabulary (§4.4).** `--wait [--timeout <ms>]` is reimplemented on the v2 base, on *both* `send` and `spawn`. The completion detection is ported from closed PR #72 (the wiring is new): a session seen `working` that rests off it for ~1.5s is settled; `needs-you` short-circuits immediately; a plain terminal with no status signal falls back to screen-changed-then-still (`readViewportText` settling). Every wait reply shares one shape — final `status`, `transcript`, `cursor`..`cursor_end` — and the wait polls off the actor, so a long wait never blocks other control requests. The CLI widens its client read timeout automatically so `nc` outlives the server-side wait.

**Actionable payloads (§4.3).** `needs-you` watch events (and wait replies) carry the on-screen question excerpt in `prompt`; `done` events carry `transcript` + `cursor_end`. Both also ride on the watch snapshot lines, so a late-attaching supervisor can act without a round-trip.

**Pinned contract (§4.5).** `schema_version: 1` on every JSON reply; errors are always `{ok:false, error:<code>, message}` (the malformed-request path included); the landing session-control doc gains a JSON contract section documenting reply shapes per verb.

**Caller envelope (§4.6).** When `spawn`'s `caller_session` resolves to a live termio session, the delivered prompt opens with a provenance envelope naming the caller's handle and allowing exactly one back-channel — a mid-task `QUESTION:` or a one-line `DONE:` ping via `sessions send` — never conversation or task delegation back; completion stays transcript-as-truth. A plain-shell caller gets no envelope.

All three doc surfaces updated: `scripts/termio` usage/per-verb help, the `SessionSkillInstaller` agent skill block, and `web/landing/content/docs/session-control.mdx`.

## Verification

- `swift build` clean; `sh -n scripts/termio` clean.
- Dev-channel build (`TERMIO_CHANNEL=dev`, stale dev apps killed, `lsregister -f`, owning pid confirmed from this worktree) driven end-to-end against a live project:
  - `spawn --wait --json` with Claude Code blocked 6.4s and replied `{"status":"done","cursor":0,"cursor_end":11,"transcript":…,"timed_out":false,"schema_version":1}`; the transcript's assistant entry was the reply.
  - `send --wait` on the existing session returned `cursor:11 → cursor_end:17` (`done`).
  - Plain-terminal fallback: `send terminal@… "echo …" --wait` settled `idle` in 1.9s via screen-changed-then-still, transcript fields correctly omitted.
  - `needs-you` short-circuit: an AskUserQuestion menu returned in 3.2s as `status:"needs-you"` with the exact on-screen menu in `prompt`; answering with `send … "1" --wait` resolved to `done` with the next cursor range.
  - `watch --json` stream showed the snapshot line, a `done` event carrying `transcript`+`cursor_end`, a `needs-you` event carrying `prompt`, and heartbeats.
  - Envelope: `TERMIO_SESSION=<live session uuid> … spawn --wait` delivered the envelope verbatim ahead of the task (verified in the spawned session's transcript); a plain-shell spawn delivered the bare prompt.
  - Error shape: `send nosuch@deadbeef` → `{"ok":false,"error":"not_found",…,"schema_version":1}`, exit 1; `list --wait` rejected client-side.

## Release Notes

- `termio sessions send`/`spawn` accept `--wait [--timeout <ms>]`: block until the turn settles and reply with the final status plus the exact transcript line range to read; a session that stops to ask returns immediately as `needs-you` with the on-screen question.
- `termio sessions watch` events are now actionable: `needs-you` carries the on-screen question, `done` carries the transcript path and cursor.
- Every `--json` reply now carries `schema_version: 1` and errors share one documented shape; the JSON contract is documented on the session-control page.
- A session spawned by another termio session now knows its caller and may send it a mid-task question or a one-line completion ping.