### PR TITLE
Adopt herdr's fail-fast wait semantics: stalled prompts, vanished sessions, timeout exit code

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -460,7 +460,10 @@ enum SessionSkillInstaller {
           `cursor`..`cursor_end` line range holding the response — one call instead
           of send-then-poll. A sibling that stops to ask you something short-circuits
           the wait: the reply is `status:"needs-you"` with the on-screen question in
-          `prompt` — answer it with another `send`.
+          `prompt` — answer it with another `send`. Exit codes: 0 settled, 1 error
+          (`prompt_stalled` = the input showed no effect within 5s; `session_closed`
+          / `agent_gone` = the target vanished mid-wait), 3 timed out (session still
+          running — re-arm or read its transcript).
         - `termio sessions close <agent>@<id> …` — close session tabs;
           `termio sessions focus <agent>@<id>` — bring one to the front in the app
 

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -322,23 +322,54 @@ extension TermioStore {
     /// — a plain terminal driven by `send --wait` — falls back to the screen first changing
     /// and then going still. Each poll awaits off the actor, so a long wait never blocks
     /// other control requests (§4.2 stays true even mid-wait).
+    ///
+    /// Two failure modes end the wait early instead of burning the whole timeout,
+    /// both adopted from herdr's agent-wait design:
+    /// - **Stalled prompt**: from a non-`working` start, *some* effect — a status
+    ///   move or a screen change — must appear within `stallWindow`, or the
+    ///   keystrokes were eaten (a half-booted TUI, a program that ignores typed
+    ///   text) and no turn is coming: `prompt_stalled`, immediately. A `--timeout`
+    ///   at or under the window keeps the plain timeout reply instead.
+    /// - **Occupant gone**: the wait is pinned to the session and agent it started
+    ///   on. The session closing mid-wait is `session_closed`; its agent exiting
+    ///   back to a plain shell is `agent_gone`. (A plain-terminal target is exempt
+    ///   from the pin — a sent command line may legitimately start an agent in the
+    ///   pane, which is progress, not replacement.)
     private func waitForReply(
         _ request: ControlRequest, session: Session,
         cursorAtSend: Int?, created: Bool
     ) async -> Data {
         let cap = min(max(request.timeoutMs ?? 300_000, 1_000), 600_000)
-        let deadline = Date().addingTimeInterval(Double(cap) / 1_000)
+        let started = Date()
+        let deadline = started.addingTimeInterval(Double(cap) / 1_000)
         let settleWindow = 1.5
+        let stallWindow = 5.0
 
+        let statusAtSend = status(for: session.id)
+        let occupantAtSend = effectiveAgent(for: session)
         var sawWorking = false
         var restingSince: Date?
         var lastFrame = viewportText(for: session.id)
-        var lastChangeAt = Date()
+        var lastChangeAt = started
         var changedSinceSend = false
         var settled: SessionStatus?
 
         while Date() < deadline {
             try? await Task.sleep(for: .milliseconds(300))
+            guard let live = self.session(session.id) else {
+                return controlError(request, "session_closed",
+                    "\(sessionHandle(for: session)) was closed while waiting on it.")
+            }
+            let occupant = effectiveAgent(for: live)
+            if occupantAtSend != .terminal, occupant.id != occupantAtSend.id {
+                var message = "The \(occupantAtSend.displayName) agent in "
+                    + "\(sessionHandle(for: session)) exited mid-wait; no reply is coming."
+                if let transcript = transcriptPaths[session.id] {
+                    message += " Its transcript (\(transcript)) holds whatever it did first."
+                }
+                return controlError(request, "agent_gone", message)
+            }
+
             let current = status(for: session.id)
             if current == .working {
                 sawWorking = true
@@ -346,7 +377,6 @@ extension TermioStore {
             } else if restingSince == nil {
                 restingSince = Date()
             }
-            if current == .needsAttention { settled = .needsAttention; break }
 
             let now = Date()
             let frame = viewportText(for: session.id)
@@ -355,6 +385,28 @@ extension TermioStore {
                 lastChangeAt = now
                 changedSinceSend = true
             }
+
+            // needs-you settles the wait immediately — but only as *new* evidence.
+            // A session already blocked at send time (the caller is answering its
+            // menu) must not read as "still waiting on you" on the first poll,
+            // before the agent has had a chance to react to the answer.
+            if current == .needsAttention,
+               statusAtSend != .needsAttention || sawWorking || changedSinceSend {
+                settled = .needsAttention
+                break
+            }
+
+            if statusAtSend != .working, !sawWorking, !changedSinceSend,
+               current == statusAtSend,
+               Double(cap) / 1_000 > stallWindow,
+               now.timeIntervalSince(started) >= stallWindow {
+                return controlError(request, "prompt_stalled",
+                    "The prompt showed no effect in \(sessionHandle(for: session)) within "
+                    + "\(Int(stallWindow))s — no status change, no screen change. The input "
+                    + "was likely eaten (agent still booting, or a program that ignores "
+                    + "typed text); check the pane before resending.")
+            }
+
             guard current != .working else { continue }
             let rested = restingSince.map { now.timeIntervalSince($0) >= settleWindow } ?? false
             let screenQuiet = now.timeIntervalSince(lastChangeAt) >= settleWindow

--- a/scripts/termio
+++ b/scripts/termio
@@ -38,6 +38,7 @@ options:
   --agent <id>     agent for `spawn` (e.g. claudeCode, codex, grok, pi; default: caller's kind)
   --wait           for `spawn`/`send`: block until the turn settles; the reply carries
                    the final status and the transcript line range to read
+                   (exit 0 settled, 1 error — including a stalled/vanished session, 3 timed out)
   --timeout <ms>   cap for --wait (default 300000, clamped 1000–600000); implies --wait
   --state <s,…>    for `watch`: comma-separated states to report (working, idle, done, needs-you)
   --no-snapshot    for `watch`: skip the initial per-session status snapshot
@@ -90,6 +91,12 @@ pi); the default is the calling agent's own kind.
 carries the final status, the transcript path, and the cursor..cursor_end
 line range holding the response. A session that stops to ask you something
 returns immediately as needs-you, with the on-screen question in `prompt`.
+
+A prompt that shows no effect within 5s fails fast as prompt_stalled (the
+input was eaten) rather than burning the timeout; a session that closes or
+whose agent exits mid-wait fails as session_closed / agent_gone.
+
+exit codes: 0 settled, 1 error (including stalled/vanished), 3 timed out.
 EOF
             ;;
         send|answer) cat <<'EOF'
@@ -105,6 +112,12 @@ reply; copy them verbatim.
 carries the final status, the transcript path, and the cursor..cursor_end
 line range holding the response. A session that stops to ask you something
 returns immediately as needs-you, with the on-screen question in `prompt`.
+
+A prompt that shows no effect within 5s fails fast as prompt_stalled (the
+input was eaten) rather than burning the timeout; a session that closes or
+whose agent exits mid-wait fails as session_closed / agent_gone.
+
+exit codes: 0 settled, 1 error (including stalled/vanished), 3 timed out.
 
 `answer` is a deprecated alias; `send` without a handle aliases `spawn`.
 EOF
@@ -194,6 +207,22 @@ request_once() {
     case "$response" in
         error:*|*'"ok":false'*) return 1 ;;
     esac
+    # A --wait that expired is its own outcome, on its own exit code (3): the
+    # session is still running and the caller decides whether to re-arm — distinct
+    # from success (0) and from hard errors (1), so scripts can branch without
+    # parsing. JSON mode keys off the contract field, text mode off the headline;
+    # both checks are scoped to wait requests so no other reply can trip them.
+    if [ -n "${6:-}" ]; then
+        if [ "$2" = json ]; then
+            case "$response" in
+                *'"timed_out":true'*) return 3 ;;
+            esac
+        else
+            case "$(printf '%s\n' "$response" | head -1)" in
+                *'— timed out'*) return 3 ;;
+            esac
+        fi
+    fi
     return 0
 }
 

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -97,8 +97,19 @@ reads exactly the new content with its own file tools. Two special cases:
 - A plain terminal with no status signal falls back to screen settling: the
   screen changed after the send, then went still.
 
+Waits also **fail fast instead of burning the timeout** when no outcome can
+come:
+
+- A prompt that shows no effect within 5 seconds — no status move, no screen
+  change — errors as `prompt_stalled`: the input was eaten (an agent still
+  booting, a program that ignores typed text), and no turn is coming.
+- A session that closes mid-wait errors as `session_closed`; an agent that
+  exits back to its shell mid-wait errors as `agent_gone`.
+
 On timeout the reply still comes back (`timed_out: true`) with whatever the
-current status is; the session keeps running.
+current status is; the session keeps running. The exit code splits the three
+outcomes so scripts can branch without parsing: **0** settled, **1** error
+(including stalled/vanished), **3** timed out.
 
 ### Supervising with `watch`
 
@@ -154,7 +165,8 @@ Every error, on any verb, has one shape — and the exit code is nonzero:
 
 The stable codes: `disabled`, `no_scope`, `bad_op`, `bad_request`, `no_text`,
 `no_target`, `not_found`, `ambiguous`, `wrong_agent`, `bad_agent`, `no_agent`,
-`start_failed`, `not_live`, `read_unavailable`.
+`start_failed`, `not_live`, `read_unavailable` — plus, on `--wait` only,
+`prompt_stalled`, `session_closed`, and `agent_gone`.
 
 Success replies, per verb (`schema_version` and `"ok": true` omitted below for
 brevity):


### PR DESCRIPTION
Stacked on #87 (Phase 3). Reproduces the wait-failure semantics from herdr's agent-automation design ([`herdr agent prompt --wait` / `agent wait`](https://github.com/ogulcancelik/herdr)) on termio's `--wait`, so a wait that can never succeed fails in seconds instead of burning its timeout. Verified against herdr's source (`AGENT_PROMPT_EFFECT_TIMEOUT_MS = 5_000` in `src/api/wait.rs`) and its agent-automation docs before porting.

> **Merge order note:** retarget this PR to `main` after #87 merges, *before* deleting the base branch (stacked-PR auto-close gotcha).

## What changes

- **`prompt_stalled`** (herdr: `agent_prompt_stalled`): from a non-`working` start, the prompt must show *some* effect — a status move or a screen change — within 5s, else the wait errors immediately: the input was eaten (half-booted TUI, a program that ignores typed text) and no turn is coming. herdr parity: a `--timeout` at or under the stall window keeps the plain timeout reply.
- **`session_closed` / `agent_gone`** (herdr: `agent_not_running`): the wait is pinned to the session and agent it started on. A session closed mid-wait, or an agent that exited back to its shell, ends the wait immediately. Plain-terminal targets are exempt from the pin — a sent command line may legitimately start an agent in the pane.
- **Timeout exit code 3** (gh-style, deliberate divergence from herdr's exit-1-on-timeout): `--wait` exits 0 settled / 1 error / 3 timed out, so scripts branch without parsing. Detection is scoped to wait requests only; JSON mode keys off `"timed_out":true`, text mode off the reply headline.
- **needs-you race fix**: a session already `needs-you` at send time (the caller answering its menu) no longer reads as "still waiting on you" on the first poll before the agent reacts — needs-you now settles the wait only as *new* evidence (a transition, or after observed activity). Latent in #87's port of the #72 detection.

All three doc surfaces updated (CLI usage/per-verb help, agent skill block, landing `session-control.mdx`: new error codes + exit-code contract).

## Verification

`swift build` and `sh -n` clean. Live against a dev build from this worktree (each passing reply carries the new codes/fields, which only this build has):

- `prompt_stalled`: `send --wait "ping"` into a `stty -echo; sleep 300` terminal errored in **5.3s** (vs its 30s timeout) with the documented message, exit 1.
- Timeout: a 3s cap on a live Claude turn returned `{"status":"working","timed_out":true,…}` at 3.16s, **exit 3**; the session kept running.
- `session_closed`: closing the session 4s into a 60s wait returned `{"error":"session_closed",…}` immediately, exit 1.
- Regression: `spawn --wait` (pong) unchanged — `done`, correct cursor range, exit 0.
- `agent_gone`: **not live-reproduced** — it shares the same per-poll guard block and error path as the live-verified `session_closed` (one `if` apart), but staging a real mid-wait agent exit was defeated by the dev-channel environment: a foreign rebuild loop kept re-registering and SIGKILLing `sh.termio.app.dev` out from under the test app (the §7 test-infra hazard in sessions-cli-v2.md; log-verified `SIGKILL(9)` from outside this session). The deterministic repro needs the per-worktree dev channel that doc calls the prerequisite.

## Release Notes

- `termio sessions send/spawn --wait` now fails fast when no outcome can come: a prompt with no visible effect within 5s (`prompt_stalled`), a session closed mid-wait (`session_closed`), or an agent that exited mid-wait (`agent_gone`).
- A timed-out `--wait` exits with code 3 (settled = 0, errors = 1) so scripts can branch without parsing the reply.
- Answering a session's menu with `--wait` no longer risks an instant false "still waiting on you" reply.