### PR TITLE
Add run and read: plain-command terminal sessions and screen reads

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -452,10 +452,18 @@ enum SessionSkillInstaller {
           prompt (`--agent codex` picks the agent; default: your own kind). Replies
           immediately with the new session's handle — use it for every follow-up;
           the prompt itself is typed in once the agent finishes booting.
+        - `termio sessions run "<command>"` — start a NEW plain terminal session
+          typing that shell command (a dev server, a test run) into a visible pane —
+          no LLM. Use it instead of your own background shell when the user should
+          be able to see and take over the process.
         - `termio sessions send <agent>@<id> "<text>"` — type text into that existing
           sibling and submit it with a real Return keypress. Send a prompt to drive
           it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
-        - `--wait [--timeout <ms>]` on `send` or `spawn` — block until that turn
+        - `termio sessions read <agent>@<id> [--lines N]` — the session's current
+          screen. The result channel for `run` sessions (a plain command has no
+          transcript; its screen is the result) — for agent replies keep using the
+          transcript, not the screen.
+        - `--wait [--timeout <ms>]` on `send`, `spawn`, or `run` — block until that turn
           settles and reply with the final `status`, the `transcript` path, and the
           `cursor`..`cursor_end` line range holding the response — one call instead
           of send-then-poll. A sibling that stops to ask you something short-circuits

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -45,10 +45,7 @@ extension TermioStore {
         case "send", "answer": return await sendText(request, in: project)
         case "close": return closeTab(request, in: project)
         case "focus": return focusSession(request, in: project)
-        case "read":
-            return controlError(request, "read_unavailable",
-                "Reading a session's output isn't available in this build yet — it needs a "
-                + "terminal-core buffer API. list / send / answer / close / focus work today.")
+        case "read": return readScreen(request, in: project)
         default:
             return controlError(request, "bad_op", "Unknown op '\(request.op)'.")
         }
@@ -178,10 +175,13 @@ extension TermioStore {
     private func spawnAndSend(_ request: ControlRequest, in project: Project, payload: String) async -> Data {
         let preset: AgentDefinition
         if let name = request.agent, !name.isEmpty {
-            guard let resolved = AgentPreset.resolve(name), !resolved.isShell else {
+            // An explicit name may be the plain shell — that is `run`, a terminal
+            // session typing a command. Only the *defaults* below are agent-only:
+            // nobody asks for a shell by omission.
+            guard let resolved = AgentPreset.resolve(name) else {
                 let names = AgentPreset.codingAgents.map(\.rawValue).joined(separator: ", ")
                 return controlError(request, "bad_agent",
-                    "Unknown agent '\(name)'. Try one of: \(names).")
+                    "Unknown agent '\(name)'. Try one of: \(names), or terminal.")
             }
             preset = resolved
         } else if let callerID = request.callerSession, let uuid = UUID(uuidString: callerID),
@@ -202,7 +202,11 @@ extension TermioStore {
             return controlError(request, "start_failed", "Could not start the session.")
         }
         let state = surface(for: fresh, in: project)
-        let delivered = (callerEnvelope(for: request) ?? "") + payload
+        // The envelope is agent guidance — typed into a shell it would *execute*
+        // as commands, so a `run` session gets the bare command line only.
+        let delivered = preset.isShell
+            ? payload
+            : (callerEnvelope(for: request) ?? "") + payload
         // With `--wait`, the caller opted back into blocking — but for the *outcome*
         // (§4.4), never just the plumbing: boot-settle, deliver, then hold the reply
         // until the spawned agent's first turn settles.
@@ -287,11 +291,15 @@ extension TermioStore {
     ) async -> Bool {
         // The libghostty surface attaches lazily on the pane's first render, so a
         // session never shown in the UI has no surface yet. Selecting it adds it to
-        // the mounted set; give the render one cycle. (A session shown even once
-        // stays mounted, so this only foregrounds on the very first drive.)
-        if state.surface == nil {
-            selectedSessionID = session.id
-            try? await Task.sleep(for: .milliseconds(400))
+        // the mounted set, then poll for the attach rather than betting on one
+        // render cycle: right after app launch several panes render at once and one
+        // cycle isn't enough — a `run` session's near-instant boot-settle hit that
+        // window as a spurious not_live. (A session shown even once stays mounted,
+        // so this only foregrounds on the very first drive.)
+        if state.surface == nil { selectedSessionID = session.id }
+        let attachDeadline = Date().addingTimeInterval(3)
+        while state.surface == nil, Date() < attachDeadline {
+            try? await Task.sleep(for: .milliseconds(150))
         }
         guard let surfaceHandle = Self.rawSurface(from: state) else { return false }
 
@@ -483,6 +491,14 @@ extension TermioStore {
     /// capped) are enough to answer from; the leading rows are the conversation the
     /// caller already has via the transcript.
     func promptExcerpt(for id: Session.ID) -> String? {
+        guard let lines = screenLines(for: id), !lines.isEmpty else { return nil }
+        return String(lines.suffix(12).joined(separator: "\n").suffix(1_200))
+    }
+
+    /// A session's viewport as display rows — right-trimmed, trailing blank rows
+    /// dropped — or nil when it has no live surface. The shared source for the
+    /// `needs-you` excerpt and the `read` verb.
+    private func screenLines(for id: Session.ID) -> [String]? {
         guard let screen = viewportText(for: id) else { return nil }
         var lines = screen.components(separatedBy: "\n").map { line -> String in
             var trimmed = Substring(line)
@@ -490,8 +506,36 @@ extension TermioStore {
             return String(trimmed)
         }
         while lines.last?.isEmpty == true { lines.removeLast() }
-        guard !lines.isEmpty else { return nil }
-        return String(lines.suffix(12).joined(separator: "\n").suffix(1_200))
+        return lines
+    }
+
+    /// `read`: a sibling's current screen. This is the result channel for a `run`
+    /// session — a plain command has no transcript, its output *is* the screen —
+    /// and a focus-free peek at any agent's live TUI. Viewport only (what a glance
+    /// at the pane would show); scrollback needs a terminal-core buffer API this
+    /// build doesn't have. `--lines` keeps just the tail.
+    private func readScreen(_ request: ControlRequest, in project: Project) -> Data {
+        switch resolveTarget(request.target, in: project) {
+        case .found(let session):
+            guard var lines = screenLines(for: session.id) else {
+                return controlError(request, "not_live",
+                    "\(displayTitle(for: session)) has no live terminal yet — open it once in termio.")
+            }
+            if let cap = request.lines, cap > 0 { lines = Array(lines.suffix(cap)) }
+            let screen = lines.joined(separator: "\n")
+            let handle = sessionHandle(for: session)
+            return control(request, ok: true,
+                text: screen.isEmpty ? "(blank screen)" : screen,
+                json: ["target": handle, "title": displayTitle(for: session), "screen": screen])
+        case .notFound:
+            return controlError(request, "not_found", targetNotFoundMessage(request.target))
+        case .ambiguous:
+            return controlError(request, "ambiguous",
+                "'\(request.target ?? "")' matches more than one session; use a longer id.")
+        case .mismatch(let expected):
+            return controlError(request, "wrong_agent",
+                "That id belongs to \(expected) — use that handle (copied verbatim from `list`).")
+        }
     }
 
     /// Waits for a freshly launched agent TUI to finish booting before keystrokes
@@ -574,7 +618,8 @@ extension TermioStore {
 
     /// The immediate reply for a fresh spawn: the handle is the payload, delivery is
     /// still in flight (`queued`). A just-spawned session has no transcript yet — it
-    /// appears in `list --json` once the agent's hook reports one.
+    /// appears in `list --json` once the agent's hook reports one. A `run` session
+    /// never will: a plain command's results are read off its screen (`read`).
     private func spawnQueuedReply(_ request: ControlRequest, _ session: Session) -> Data {
         let handle = sessionHandle(for: session)
         let json: [String: Any] = [
@@ -583,8 +628,14 @@ extension TermioStore {
             "created": true,
             "queued": true,
         ]
-        let text = "started \(handle) — prompt queued; use this handle for follow-ups"
-            + "\n  (transcript path appears in `termio sessions list --json` once the agent reports it)"
+        let text: String
+        if effectiveAgent(for: session).isShell {
+            text = "started \(handle) — command queued; use this handle for follow-ups"
+                + "\n  (read its output with `termio sessions read \(handle)`)"
+        } else {
+            text = "started \(handle) — prompt queued; use this handle for follow-ups"
+                + "\n  (transcript path appears in `termio sessions list --json` once the agent reports it)"
+        }
         return control(request, ok: true, text: text, json: json)
     }
 

--- a/scripts/termio
+++ b/scripts/termio
@@ -27,7 +27,9 @@ usage:
   termio sessions list                       sessions in this project + status
   termio sessions watch [--state <s,…>]      stream status transitions until Ctrl-C (default: done,needs-you)
   termio sessions spawn "<prompt>"           start a NEW agent session on the prompt
+  termio sessions run "<command>"            start a NEW terminal session running a shell command
   termio sessions send <agent>@<id> "<text>"     type a prompt (or menu answer) into a session
+  termio sessions read <agent>@<id> [--lines N]  print a session's current screen
   termio sessions close <agent>@<id> [...]   close session tabs
   termio sessions focus <agent>@<id>         select the session in the app
 
@@ -36,10 +38,11 @@ usage:
 options:
   --json           machine-readable output (any `sessions` command)
   --agent <id>     agent for `spawn` (e.g. claudeCode, codex, grok, pi; default: caller's kind)
-  --wait           for `spawn`/`send`: block until the turn settles; the reply carries
+  --wait           for `spawn`/`run`/`send`: block until the turn settles; the reply carries
                    the final status and the transcript line range to read
                    (exit 0 settled, 1 error — including a stalled/vanished session, 3 timed out)
   --timeout <ms>   cap for --wait (default 300000, clamped 1000–600000); implies --wait
+  --lines <n>      for `read`: keep only the last n screen rows
   --state <s,…>    for `watch`: comma-separated states to report (working, idle, done, needs-you)
   --no-snapshot    for `watch`: skip the initial per-session status snapshot
   --help, --version
@@ -97,6 +100,30 @@ input was eaten) rather than burning the timeout; a session that closes or
 whose agent exits mid-wait fails as session_closed / agent_gone.
 
 exit codes: 0 settled, 1 error (including stalled/vanished), 3 timed out.
+EOF
+            ;;
+        run) cat <<'EOF'
+usage: termio sessions run "<command>" [--wait [--timeout <ms>]] [--json]
+
+Start a NEW plain terminal session and type the shell command into it — a
+dev server, a test run, a build — visible in a split pane, no LLM involved.
+Replies immediately with the session's terminal@<id> handle; drive it
+further with `send`, read its output with `read` (a plain command has no
+transcript; its screen is the result), close it with `close`.
+
+--wait settles when the screen goes still after the command's output (or
+returns needs-you / times out, exactly as with send).
+
+exit codes: 0 settled, 1 error (including stalled/vanished), 3 timed out.
+EOF
+            ;;
+        read) cat <<'EOF'
+usage: termio sessions read <agent>@<id> [--lines N] [--json]
+
+Print the session's current screen (its viewport, right-trimmed, trailing
+blank rows dropped) without focusing it. The result channel for `run`
+sessions, and a quick peek at any agent's live TUI. --lines keeps only
+the last N rows. Scrollback is not included.
 EOF
             ;;
         send|answer) cat <<'EOF'
@@ -211,8 +238,9 @@ request_once() {
     # session is still running and the caller decides whether to re-arm — distinct
     # from success (0) and from hard errors (1), so scripts can branch without
     # parsing. JSON mode keys off the contract field, text mode off the headline;
-    # both checks are scoped to wait requests so no other reply can trip them.
-    if [ -n "${6:-}" ]; then
+    # both checks are scoped to wait requests (never `read`, whose payload is an
+    # arbitrary screen) so no other reply can trip them.
+    case "${6:-}" in *'"wait":true'*)
         if [ "$2" = json ]; then
             case "$response" in
                 *'"timed_out":true'*) return 3 ;;
@@ -222,7 +250,7 @@ request_once() {
                 *'— timed out'*) return 3 ;;
             esac
         fi
-    fi
+    ;; esac
     return 0
 }
 
@@ -231,7 +259,7 @@ sessions() {
     [ $# -gt 0 ] && shift || true
 
     case "$op" in
-        list|watch|spawn|send|answer|close|focus) ;;
+        list|watch|spawn|run|send|answer|read|close|focus) ;;
         -h|--help|help) usage; exit 0 ;;
         *)
             echo "termio: unknown sessions command '$op'" >&2
@@ -260,6 +288,7 @@ sessions() {
     no_snapshot=0
     wait=false
     timeout_ms=""
+    lines=""
     seen_positional=0
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -278,14 +307,20 @@ sessions() {
             --state)
                 [ $# -ge 2 ] || { echo "termio: --state needs a value" >&2; exit 1; }
                 states="$2"; shift ;;
+            --lines)
+                [ $# -ge 2 ] || { echo "termio: --lines needs a value" >&2; exit 1; }
+                case "$2" in
+                    ''|*[!0-9]*) echo "termio: --lines needs a whole number" >&2; exit 1 ;;
+                esac
+                lines="$2"; shift ;;
             *)
                 if [ "$op" = close ]; then
                     # Every positional is a tab to close.
                     targets="${targets:+$targets }$1"
-                elif [ "$op" = spawn ]; then
-                    # `spawn` takes no handle — every positional is the prompt.
+                elif [ "$op" = spawn ] || [ "$op" = run ]; then
+                    # `spawn`/`run` take no handle — every positional is the payload.
                     text="${text:+$text }$1"
-                elif [ "$seen_positional" -eq 0 ] && { [ "$op" = answer ] || [ "$op" = focus ]; }; then
+                elif [ "$seen_positional" -eq 0 ] && { [ "$op" = answer ] || [ "$op" = focus ] || [ "$op" = read ]; }; then
                     targets="$1"
                 elif [ "$seen_positional" -eq 0 ] && [ "$op" = send ] && is_handle "$1"; then
                     # A leading handle targets an existing session. Without one, `send`
@@ -303,7 +338,7 @@ sessions() {
     done
 
     case "$op" in
-        answer|focus)
+        answer|focus|read)
             if [ -z "$targets" ]; then
                 echo "termio: $op needs a session handle (see \`termio sessions list\`)" >&2
                 exit 1
@@ -321,18 +356,24 @@ sessions() {
                 exit 1
             fi
             ;;
+        run)
+            if [ -z "$text" ]; then
+                echo "termio: run needs a command (e.g. \`termio sessions run \"pnpm dev\"\`)" >&2
+                exit 1
+            fi
+            ;;
     esac
 
     # One sync vocabulary: --wait/--timeout mean the same thing on every verb that
-    # accepts them (spawn + send), and nothing else silently ignores them.
-    wait_extra=""
+    # accepts them (spawn/run + send), and nothing else silently ignores them.
+    extra_json=""
     if [ "$wait" = true ]; then
         case "$op" in
-            spawn|send|answer) ;;
-            *) echo "termio: --wait applies to spawn and send only" >&2; exit 1 ;;
+            spawn|run|send|answer) ;;
+            *) echo "termio: --wait applies to spawn, run, and send only" >&2; exit 1 ;;
         esac
-        wait_extra='"wait":true'
-        [ -n "$timeout_ms" ] && wait_extra="$wait_extra,\"timeout_ms\":$timeout_ms"
+        extra_json='"wait":true'
+        [ -n "$timeout_ms" ] && extra_json="$extra_json,\"timeout_ms\":$timeout_ms"
         # The client read bound must outlive the server-side wait (which the app
         # clamps to 1s–600s), or nc would hang up mid-wait and report a false
         # timeout. An explicit TERMIO_CLI_TIMEOUT still wins — the escape hatch.
@@ -389,14 +430,17 @@ sessions() {
     fi
 
     # `spawn` and the no-handle `send` alias both start a fresh session: the app
-    # spawns whenever a `send` request carries an empty target. `answer` is a thin
-    # alias for sending to an existing session. So both fold onto the wire `send`;
-    # every other verb maps straight through.
+    # spawns whenever a `send` request carries an empty target. `run` is the same
+    # spawn with the agent pinned to the plain shell — the payload is a command
+    # line, not a prompt. `answer` is a thin alias for sending to an existing
+    # session. All fold onto the wire `send`; every other verb maps straight through.
     wire_op="$op"
     case "$op" in
         spawn|answer) wire_op=send ;;
+        run) wire_op=send; agent="terminal" ;;
+        read) [ -n "$lines" ] && extra_json="\"lines\":$lines" ;;
     esac
-    request_once "$wire_op" "$format" "$targets" "$agent" "$text" "$wait_extra"
+    request_once "$wire_op" "$format" "$targets" "$agent" "$text" "$extra_json"
 }
 
 # The public hook contract:

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -54,7 +54,9 @@ for machine-readable output.
 | `termio sessions list` | List the sessions in this project with their live status. |
 | `termio sessions watch` | Block and stream one line per status change — the push alternative to polling `list`. |
 | `termio sessions spawn "<prompt>"` | Start a new agent session on the prompt; replies immediately with its `<agent>@<id>` handle. |
+| `termio sessions run "<command>"` | Start a new plain terminal session typing that shell command — a dev server, a test run — in a visible pane, no LLM. |
 | `termio sessions send <agent>@<id> "<text>"` | Type text into an existing session and submit it with a real Return keypress — a prompt to drive it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. |
+| `termio sessions read <agent>@<id>` | Print the session's current screen without focusing it (`--lines N` keeps the tail) — the result channel for `run` sessions. |
 | `termio sessions close <agent>@<id>` | Close one or more session tabs. |
 | `termio sessions focus <agent>@<id>` | Bring a session to the front in the app. |
 
@@ -73,6 +75,19 @@ Commands are scoped to the current project automatically, and `termio sessions
 and the prompt itself is typed in once the agent finishes booting. Add
 `--agent <id>` (e.g. `codex`, `grok`, `pi`) to choose the agent; it defaults to
 the caller's own kind.
+
+### Running plain commands
+
+Not everything in a fleet is an agent. `run` starts a *terminal* session on a
+shell command — a dev server, a test watcher, a build — in a visible pane you
+can watch and take over, and `read` prints any session's current screen
+without focusing it. A plain command has no transcript, so its screen is its
+result channel; agent results keep flowing through transcripts.
+
+```bash
+termio sessions run "pnpm test"
+termio sessions read terminal@1a2b3c4d --lines 40
+```
 
 ### Waiting for the outcome: `--wait`
 
@@ -165,8 +180,8 @@ Every error, on any verb, has one shape — and the exit code is nonzero:
 
 The stable codes: `disabled`, `no_scope`, `bad_op`, `bad_request`, `no_text`,
 `no_target`, `not_found`, `ambiguous`, `wrong_agent`, `bad_agent`, `no_agent`,
-`start_failed`, `not_live`, `read_unavailable` — plus, on `--wait` only,
-`prompt_stalled`, `session_closed`, and `agent_gone`.
+`start_failed`, `not_live` — plus, on `--wait` only, `prompt_stalled`,
+`session_closed`, and `agent_gone`.
 
 Success replies, per verb (`schema_version` and `"ok": true` omitted below for
 brevity):
@@ -174,9 +189,10 @@ brevity):
 | Verb | Reply fields |
 | --- | --- |
 | `list` | `project`, `sessions: [{handle, id, title, agent, status, description, transcript?}]` |
-| `spawn` | `target`, `title`, `created: true`, `queued: true` — the prompt is still being delivered |
+| `spawn` / `run` | `target`, `title`, `created: true`, `queued: true` — the payload is still being delivered |
 | `send` | `target`, `title`, `transcript?`, `cursor?` — read the response from `cursor` onward |
-| `send`/`spawn` `--wait` | `target`, `title`, `status`, `timed_out`, `created?`, `transcript?`, `cursor?`, `cursor_end?`, `prompt?` |
+| `read` | `target`, `title`, `screen` — the current viewport, right-trimmed, trailing blank rows dropped |
+| `send`/`spawn`/`run` `--wait` | `target`, `title`, `status`, `timed_out`, `created?`, `transcript?`, `cursor?`, `cursor_end?`, `prompt?` |
 | `close` | `closed`, `title` |
 | `focus` | `focused` |
 


### PR DESCRIPTION
Adopts the one genuinely missing primitive from the herdr comparison — running plain commands — translated into termio's session model instead of herdr's pane model: a terminal running a command is already a first-class session, so no workspace/tab/pane topology is needed. Two artificial gaps close:

- **`termio sessions run "<command>"`** — start a plain **terminal** session (a dev server, a test run, a build) typing the command into a visible split pane, no LLM. Wire-wise it is `spawn` with the agent pinned to the shell (the CLI's `resolve` already knew `terminal`; only `spawnAndSend`'s blanket shell rejection stood in the way). Same immediate-handle reply, same `--wait` vocabulary (screen-settle fallback, `prompt_stalled`, exit 3 on timeout), same `watch`/`send`/`close` afterwards.
- **`termio sessions read <handle> [--lines N]`** — the protocol's reserved `read` op, implemented: the session's current screen, right-trimmed, trailing blank rows dropped. A plain command has no transcript — its screen *is* the result channel; for agents it's a focus-free peek while their real results stay in the transcript.

Safety rule that falls out of §4.6: the **caller envelope is never prepended to a shell payload** — typed into a shell it would *execute* as commands.

Robustness fix found live: `performDelivery` now polls up to 3s for the lazy surface attach instead of betting on a single 400ms render cycle. A `run` session's near-instant boot-settle reached delivery before the pane's first render right after app launch, surfacing as a spurious `not_live`; agent spawns just never hit the window because their banners take seconds to settle.

Deliberately **not** adopted from herdr: `wait-output --regex`, `send-keys`, pane addressing — `--wait` + `read` covers the supervision workflows without growing an expect-style automation surface.

All three doc surfaces updated (CLI usage/per-verb help, agent skill block, landing `session-control.mdx`: verbs, contract rows, `read_unavailable` retired from the error codes).

## Verification

`swift build` + `sh -n` clean. Live against a dev build from this worktree:

- `run` (fire-and-forget) returned `{"created":true,"queued":true,…}` instantly; `read --lines 8` showed the executed command and its output; `read --json --lines 4` returned the same as a `screen` field.
- `run --wait` settled `idle` with `timed_out:false`, exit 0.
- Envelope suppression: `run` with a real `TERMIO_SESSION` caller delivered the bare command — `read` of the pane shows zero `[termio]` content.
- Live-testing also flushed out an unrelated dev-channel launch hang (main thread stuck in `applicationDidFinishLaunching` → `_setFrameAutosaveName` layout recursion on macOS 26.5, cleared by deleting the `NSWindow Frame` autosave defaults) — worth its own investigation, not part of this change.

## Release Notes

- `termio sessions run "<command>"` starts a plain terminal session on a shell command in a visible pane — the fleet primitive for dev servers, builds, and test runs, with the same handle/`--wait` semantics as `spawn`.
- `termio sessions read <handle> [--lines N]` prints a session's current screen without focusing it — the result channel for `run` sessions.
- Fixed a race where driving a freshly created session immediately after app launch could fail with `not_live`.