### PR TITLE
Add an SSH settings tab and redesign the Keyboard pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img alt="termio" src="web/landing/public/logo.png" width="88" />
 
-### The native Mac terminal for AI coding agents
+### The Terminal-first Agentic Development Environment
 
 [![Release](https://img.shields.io/github/v/release/termio-sh/termio?style=flat&logo=github)](https://github.com/termio-sh/termio/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
@@ -10,7 +10,7 @@
 
 <br />
 
-Run Claude Code, Codex, and any CLI agent side by side —<br />
+Run Claude Code, Codex, and any CLI agent side by side in a native Mac app —<br />
 every session live in the sidebar, and a menu-bar dot that tells you who needs you.
 
 <br />
@@ -25,9 +25,13 @@ every session live in the sidebar, and a menu-bar dot that tells you who needs y
 
 ## Built for watching agents work
 
-Coding agents live in the terminal, but terminals were built for one shell and
-your full attention. termio is built for the new shape of the work: several
-agents going at once, most of them fine without you, one of them stuck.
+The IDE was built around a person typing code. When agents write most of the
+code, the environment's job changes: it's where agents work and where you
+direct, review, and unblock them. termio is that environment — Terminal-first,
+because that's where the agents already live — built for the new
+shape of the work: several agents going at once, most of them fine without
+you, one of them stuck. (The longer argument:
+[*From IDE to ADE*](docs/essays/from-ide-to-ade.md).)
 
 - **A real terminal, not a web view.** Swift + AppKit on
   [libghostty](https://ghostty.org) (Ghostty's terminal core), rendered with

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -621,7 +621,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         settingsWindow?.contentView = NSHostingView(rootView: SettingsView(
             settings: settings,
             usage: usageMonitor,
-            initialTab: initialTab
+            initialTab: initialTab,
+            onSSHConnect: { [weak self] host in
+                guard let self else { return }
+                self.store.addSSHSession(host: host)
+                // The new session is selected in the store; surface the main
+                // window over Settings so the connection is immediately visible.
+                self.window.makeKeyAndOrderFront(nil)
+            }
         ).frame(minWidth: 640, minHeight: 480))
         settingsWindow?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -344,50 +344,14 @@ final class CompanionServer {
         }
     }
 
-    /// Read the Mac user's `~/.ssh/config` and flatten its concrete `Host`
-    /// blocks for the phone's SSH import. Wildcard patterns (`Host *`, globs)
-    /// are skipped — they're defaults, not connectable destinations. Keys
-    /// (`IdentityFile`) are deliberately not forwarded: they live on the Mac,
-    /// and a phone→server SSH authenticates with a phone-side key or password.
+    /// The Mac user's connectable `~/.ssh/config` hosts (see `SSHConfigFile`),
+    /// flattened for the phone's SSH import. Keys (`IdentityFile`) are
+    /// deliberately not forwarded: they live on the Mac, and a phone→server SSH
+    /// authenticates with a phone-side key or password.
     nonisolated static func parseSSHConfigHosts() -> [WireSSHHost] {
-        let path = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".ssh/config")
-        guard let text = try? String(contentsOf: path, encoding: .utf8) else { return [] }
-
-        var hosts: [WireSSHHost] = []
-        var aliases: [String] = []
-        var hostName = "", user = "", port = 22
-
-        func flush() {
-            for alias in aliases where !alias.contains("*") && !alias.contains("?") {
-                hosts.append(WireSSHHost(
-                    alias: alias, hostName: hostName.isEmpty ? alias : hostName,
-                    user: user, port: port
-                ))
-            }
+        SSHConfigFile.hosts().map {
+            WireSSHHost(alias: $0.alias, hostName: $0.hostName, user: $0.user, port: $0.port)
         }
-
-        for rawLine in text.split(whereSeparator: \.isNewline) {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            guard !line.isEmpty, !line.hasPrefix("#") else { continue }
-            // `Keyword value…` — the keyword match is case-insensitive per ssh_config(5).
-            let parts = line.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "=" })
-                .map(String.init).filter { !$0.isEmpty }
-            guard let keyword = parts.first?.lowercased() else { continue }
-            let values = Array(parts.dropFirst())
-            switch keyword {
-            case "host":
-                flush()
-                aliases = values
-                hostName = ""; user = ""; port = 22
-            case "hostname": hostName = values.first ?? ""
-            case "user": user = values.first ?? ""
-            case "port": port = values.first.flatMap(Int.init) ?? 22
-            default: break
-            }
-        }
-        flush()
-        return hosts
     }
 
     /// Render a session's agent transcript to the same HTML trace the desktop

--- a/Sources/termio/Settings/KeybindingsSettingsTab.swift
+++ b/Sources/termio/Settings/KeybindingsSettingsTab.swift
@@ -18,6 +18,10 @@ struct KeybindingsSettingsTab: View {
     /// per refusal so a repeated attempt re-triggers the recorder's shake even
     /// while the popover is already up.
     @State private var rejection: Rejection?
+    /// Monotonic shake token — never reset, so a row's recorder (which remembers
+    /// the last token it consumed) shakes again on a fresh refusal even after
+    /// the previous rejection was dismissed.
+    @State private var shakeCounter = 0
     /// Auto-dismisses the rejection popover after a beat, cancelled and re-armed
     /// on each refusal.
     @State private var rejectionDismissTask: Task<Void, Never>?
@@ -117,7 +121,8 @@ struct KeybindingsSettingsTab: View {
         }
         if let message = keys.rejection(for: shortcut, assigning: id) {
             NSSound.beep()
-            rejection = Rejection(id: id, message: message, shake: (rejection?.shake ?? 0) + 1)
+            shakeCounter += 1
+            rejection = Rejection(id: id, message: message, shake: shakeCounter)
             rejectionDismissTask?.cancel()
             rejectionDismissTask = Task {
                 try? await Task.sleep(for: .seconds(2.5))

--- a/Sources/termio/Settings/KeybindingsSettingsTab.swift
+++ b/Sources/termio/Settings/KeybindingsSettingsTab.swift
@@ -6,89 +6,87 @@ import SwiftUI
 /// default + user override), so a change here updates the main menu and the
 /// command palette immediately. Only ⌘-based combos are accepted — anything
 /// without Command could shadow a key an agent TUI or the shell needs.
+///
+/// The pane is a single grouped `Form`, System Settings style: search lives in
+/// the window toolbar, the reset-all affordance is the list's last section, and
+/// a refused recording answers with a shake + transient popover instead of an
+/// inline error row that would push the list around.
 struct KeybindingsSettingsTab: View {
     @ObservedObject private var keys = KeybindingStore.shared
     @State private var query = ""
-    /// The command whose last recording was refused, plus why — shown inline.
-    @State private var rejection: (id: KeyCommandID, message: String)?
+    /// The command whose last recording was refused, plus why. `shake` increments
+    /// per refusal so a repeated attempt re-triggers the recorder's shake even
+    /// while the popover is already up.
+    @State private var rejection: Rejection?
+    /// Auto-dismisses the rejection popover after a beat, cancelled and re-armed
+    /// on each refusal.
+    @State private var rejectionDismissTask: Task<Void, Never>?
+
+    private struct Rejection {
+        let id: KeyCommandID
+        let message: String
+        let shake: Int
+    }
 
     var body: some View {
-        VStack(spacing: 0) {
-            searchField
-            Form {
-                ForEach(matchingCategories, id: \.self) { category in
-                    Section {
-                        ForEach(commands(in: category)) { info in
-                            row(info)
-                        }
-                    } header: {
-                        SectionHeaderLabel(title: category)
+        Form {
+            ForEach(matchingCategories, id: \.self) { category in
+                Section {
+                    ForEach(commands(in: category)) { info in
+                        row(info)
                     }
-                }
-                if matchingCategories.isEmpty {
-                    Text("No commands match “\(query)”.")
-                        .foregroundStyle(.secondary)
+                } header: {
+                    SectionHeaderLabel(title: category)
                 }
             }
-            .formStyle(.grouped)
-            Divider()
-            footer
+            if matchingCategories.isEmpty {
+                ContentUnavailableView.search(text: query)
+            } else if query.trimmingCharacters(in: .whitespaces).isEmpty {
+                restoreSection
+            }
         }
+        .formStyle(.grouped)
+        .searchable(text: $query, placement: .toolbar, prompt: "Search commands")
     }
 
     // MARK: - Pieces
 
-    private var searchField: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
-            TextField("Filter commands", text: $query)
-                .textFieldStyle(.plain)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-    }
-
     private func row(_ info: KeyCommandInfo) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
-            LabeledContent(info.title) {
-                HStack(spacing: 6) {
-                    KeyRecorderField(display: keys.display(for: info.id)) { captured in
-                        handle(captured, for: info.id)
-                    }
-                    Button {
-                        keys.reset(info.id)
-                        clearRejection(for: info.id)
-                    } label: {
-                        Image(systemName: "arrow.uturn.backward")
-                    }
-                    .buttonStyle(.borderless)
-                    .help("Reset to default")
-                    .disabled(!keys.isCustomized(info.id))
-                    .opacity(keys.isCustomized(info.id) ? 1 : 0.25)
-                }
-            }
-            if let rejection, rejection.id == info.id {
-                Text(rejection.message)
-                    .font(.caption)
-                    .foregroundStyle(.red)
+        LabeledContent(info.title) {
+            KeyRecorderField(
+                display: keys.display(for: info.id),
+                isCustomized: keys.isCustomized(info.id),
+                shake: rejection?.id == info.id ? (rejection?.shake ?? 0) : 0,
+                onCapture: { handle($0, for: info.id) }
+            )
+            // A representable stretches to whatever width SwiftUI proposes, so
+            // the uniform footprint must be pinned here — the field's intrinsic
+            // size alone doesn't hold against a flexible row.
+            .frame(width: 130)
+            .popover(isPresented: rejectionShown(for: info.id), arrowEdge: .bottom) {
+                Text(rejection?.message ?? "")
+                    .font(.callout)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: 280)
             }
         }
     }
 
-    private var footer: some View {
-        HStack {
-            Text("Press ⌫ while recording to revert a row. Shortcuts must include ⌘.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Spacer()
+    /// The reset-all row, in the list where System Settings keeps such actions —
+    /// with the recording hints as its footer, replacing the old pinned bottom bar.
+    private var restoreSection: some View {
+        Section {
             Button("Restore Defaults") {
                 keys.resetAll()
-                rejection = nil
+                clearRejection()
             }
             .disabled(keys.overrides.isEmpty)
+        } footer: {
+            Text("Shortcuts must include ⌘ so they can't shadow a key an agent or the shell needs. While recording, press ⌫ to remove a shortcut, or esc to cancel.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
     }
 
     // MARK: - Data
@@ -118,124 +116,232 @@ struct KeybindingsSettingsTab: View {
             return
         }
         if let message = keys.rejection(for: shortcut, assigning: id) {
-            rejection = (id, message)
+            NSSound.beep()
+            rejection = Rejection(id: id, message: message, shake: (rejection?.shake ?? 0) + 1)
+            rejectionDismissTask?.cancel()
+            rejectionDismissTask = Task {
+                try? await Task.sleep(for: .seconds(2.5))
+                guard !Task.isCancelled else { return }
+                rejection = nil
+            }
             return
         }
         clearRejection(for: id)
         keys.setShortcut(shortcut, for: id)
     }
 
-    private func clearRejection(for id: KeyCommandID) {
-        if rejection?.id == id { rejection = nil }
+    /// Whether the rejection popover shows on this row; setting it false (the
+    /// user clicking away) clears the rejection early.
+    private func rejectionShown(for id: KeyCommandID) -> Binding<Bool> {
+        Binding(
+            get: { rejection?.id == id },
+            set: { shown in
+                if !shown, rejection?.id == id { clearRejection() }
+            }
+        )
+    }
+
+    private func clearRejection(for id: KeyCommandID? = nil) {
+        guard id == nil || rejection?.id == id else { return }
+        rejectionDismissTask?.cancel()
+        rejection = nil
     }
 }
 
 // MARK: - Recorder
 
-/// A push button that records the next key chord. AppKit, not SwiftUI, because
-/// only a live NSView can intercept ⌘-combos via `performKeyEquivalent` *before*
-/// the main menu claims them — a SwiftUI key handler never sees ⌘D.
+/// The recorder pattern borrowed from the de-facto standard implementation of
+/// this control, sindresorhus/KeyboardShortcuts' `RecorderCocoa`: an
+/// `NSSearchField` dressed as a plain rounded field — centered text, fixed
+/// width, no magnifier, the built-in cancel (⨯) button as the "remove
+/// customization" affordance — recording driven by focus plus a local event
+/// monitor, the only way to see ⌘-combos before the main menu claims them.
+/// Being a real system control, hover/press rendering is AppKit's own — no
+/// hand-rolled tracking areas to go stale when the list scrolls.
 struct KeyRecorderField: NSViewRepresentable {
     /// Current shortcut glyphs (`⌥⌘←`), or nil when the command is unbound.
     let display: String?
-    /// Captured chord, or nil when the user pressed ⌫ to clear.
+    /// Whether the shortcut is a user override — shows the ⨯ (reset) button.
+    let isCustomized: Bool
+    /// A monotonically increasing token; each new value shakes the field once
+    /// (a refused recording). Zero means "no shake pending".
+    let shake: Int
+    /// Captured chord, or nil when the user cleared the customization.
     let onCapture: (Shortcut?) -> Void
 
-    func makeNSView(context: Context) -> RecorderButton {
-        let button = RecorderButton()
-        button.onCapture = onCapture
-        button.refresh(display: display)
-        return button
+    func makeNSView(context: Context) -> RecorderSearchField {
+        let field = RecorderSearchField()
+        field.onCapture = onCapture
+        field.refresh(display: display, isCustomized: isCustomized)
+        return field
     }
 
-    func updateNSView(_ button: RecorderButton, context: Context) {
-        button.onCapture = onCapture
-        button.refresh(display: display)
+    func updateNSView(_ field: RecorderSearchField, context: Context) {
+        field.onCapture = onCapture
+        field.refresh(display: display, isCustomized: isCustomized)
+        if shake > 0, shake != field.lastShake {
+            field.lastShake = shake
+            field.shake()
+        }
     }
 }
 
-final class RecorderButton: NSButton {
+final class RecorderSearchField: NSSearchField, NSSearchFieldDelegate {
     var onCapture: ((Shortcut?) -> Void)?
-    private var currentDisplay: String?
-    private var isRecording = false
+    /// The last shake token consumed, so a SwiftUI re-render doesn't replay it.
+    var lastShake = 0
 
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        bezelStyle = .rounded
-        setButtonType(.momentaryPushIn)
-        target = self
-        action = #selector(toggle)
+    private var currentDisplay: String?
+    private var currentCustomized = false
+    private var isRecording = false
+    private var eventMonitor: Any?
+    private var cancelCell: NSButtonCell?
+    private var windowObserver: NSObjectProtocol?
+
+    init() {
+        super.init(frame: .zero)
+        delegate = self
+        alignment = .center
+        wantsLayer = true
+        placeholderString = "Record Shortcut"
+        // The magnifier and the ⨯ hide via transparency, never by detaching the
+        // cells: macOS 26's accessibility builds this cell's AX children by
+        // inserting both button cells into an array without a nil check, so a
+        // nil'd-out cell crashes the app the moment any AX client (VoiceOver, a
+        // window manager, an input method) walks the focused field.
+        if let cell = cell as? NSSearchFieldCell {
+            cell.searchButtonCell?.isTransparent = true
+            cell.searchButtonCell?.isEnabled = false
+            cancelCell = cell.cancelButtonCell
+        }
+        // The ⨯ resets the row instead of merely emptying the text.
+        cancelCell?.target = self
+        cancelCell?.action = #selector(clearCustomization)
+        setShowsCancel(false)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
 
-    override var acceptsFirstResponder: Bool { true }
+    deinit {
+        if let eventMonitor { NSEvent.removeMonitor(eventMonitor) }
+        if let windowObserver { NotificationCenter.default.removeObserver(windowObserver) }
+    }
 
-    /// Fixed width so the column doesn't jump between "Add Shortcut" and a glyph.
+    /// The upstream control's fixed footprint, one width for every row.
     override var intrinsicContentSize: NSSize {
-        NSSize(width: 128, height: super.intrinsicContentSize.height)
+        var size = super.intrinsicContentSize
+        size.width = 130
+        return size
     }
 
-    func refresh(display: String?) {
+    func refresh(display: String?, isCustomized: Bool) {
         currentDisplay = display
-        updateTitle()
+        currentCustomized = isCustomized
+        guard !isRecording else { return }
+        stringValue = display ?? ""
+        setShowsCancel(isCustomized)
     }
 
-    private func updateTitle() {
-        if isRecording {
-            title = "Type shortcut…"
-            contentTintColor = .controlAccentColor
-        } else {
-            title = currentDisplay ?? "Add Shortcut"
-            contentTintColor = currentDisplay == nil ? .tertiaryLabelColor : nil
-        }
+    /// One bounce left-right — the refused-recording signal, paired with the beep.
+    func shake() {
+        let animation = CAKeyframeAnimation(keyPath: "transform.translation.x")
+        animation.values = [0, -5, 5, -4, 4, -2, 2, 0]
+        animation.duration = 0.35
+        layer?.add(animation, forKey: "shake")
     }
 
-    @objc private func toggle() {
-        isRecording ? endRecording() : beginRecording()
+    // MARK: Recording lifecycle
+
+    override func becomeFirstResponder() -> Bool {
+        let accepted = super.becomeFirstResponder()
+        if accepted { beginRecording() }
+        return accepted
     }
 
     private func beginRecording() {
+        guard !isRecording else { return }
         isRecording = true
-        updateTitle()
-        window?.makeFirstResponder(self)
+        // The current glyphs stay visible while recording (as upstream does) —
+        // writing `stringValue` here would end the just-started editing session,
+        // whose did-end notification tears the recording straight back down.
+        placeholderString = "Press Shortcut…"
+        // The field editor attaches just after focus lands; hide its caret then
+        // (there is nothing to type — the monitor consumes every key).
+        DispatchQueue.main.async { [weak self] in
+            (self?.currentEditor() as? NSTextView)?.insertionPointColor = .clear
+        }
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handle(event)
+        }
+        windowObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification, object: window, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.blur() }
+        }
+    }
+
+    /// Every keystroke while recording routes through here — *before* the main
+    /// menu, which is what lets an already-taken ⌘-combo be captured at all.
+    private func handle(_ event: NSEvent) -> NSEvent? {
+        guard isRecording else { return event }
+        switch event.keyCode {
+        case 53:                       // esc — cancel, binding unchanged
+            blur()
+            return nil
+        case 51, 117:                  // ⌫ / fwd-delete — remove the customization
+            onCapture?(nil)
+            blur()
+            return nil
+        case 48:                       // tab — stop recording, let focus move on
+            blur()
+            return event
+        default: break
+        }
+        guard let shortcut = Shortcut(event: event) else { return nil } // lone modifiers wait
+        onCapture?(shortcut)
+        blur()
+        return nil
+    }
+
+    @objc private func clearCustomization() {
+        onCapture?(nil)
+        blur()
+    }
+
+    private func blur() {
+        endRecording()
+        if window?.firstResponder === currentEditor() || window?.firstResponder === self {
+            window?.makeFirstResponder(nil)
+        }
     }
 
     private func endRecording() {
         guard isRecording else { return }
         isRecording = false
-        updateTitle()
-        if window?.firstResponder === self { window?.makeFirstResponder(nil) }
-    }
-
-    // Intercept ⌘-combos before the menu; only while actively recording.
-    override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        guard isRecording else { return false }
-        capture(event)
-        return true
-    }
-
-    override func keyDown(with event: NSEvent) {
-        guard isRecording else { super.keyDown(with: event); return }
-        capture(event)
-    }
-
-    private func capture(_ event: NSEvent) {
-        switch event.keyCode {
-        case 53: endRecording(); return                        // esc cancels, no change
-        case 51, 117: onCapture?(nil); endRecording(); return  // delete/fwd-delete clears
-        default: break
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitor = nil
         }
-        guard let shortcut = Shortcut(event: event) else { return } // ignore lone modifiers
-        onCapture?(shortcut)
+        if let windowObserver {
+            NotificationCenter.default.removeObserver(windowObserver)
+            self.windowObserver = nil
+        }
+        placeholderString = "Record Shortcut"
+        stringValue = currentDisplay ?? ""
+        setShowsCancel(currentCustomized)
+    }
+
+    /// Clicking away ends the recording (the window's field editor moves on).
+    func controlTextDidEndEditing(_ notification: Notification) {
         endRecording()
     }
 
-    override func resignFirstResponder() -> Bool {
-        if isRecording {
-            isRecording = false
-            updateTitle()
-        }
-        return super.resignFirstResponder()
+    /// A hidden ⨯ stays transparent *and* disabled — a transparent NSButtonCell
+    /// still tracks clicks, which would make an invisible spot of the field
+    /// silently reset the row.
+    private func setShowsCancel(_ shows: Bool) {
+        cancelCell?.isTransparent = !shows
+        cancelCell?.isEnabled = shows
+        needsDisplay = true
     }
 }

--- a/Sources/termio/Settings/SSHConfig.swift
+++ b/Sources/termio/Settings/SSHConfig.swift
@@ -154,11 +154,14 @@ enum SSHConfigFile {
         in url: URL, visited: inout Set<String>, depth: Int, context: inout Block?
     ) -> [Block] {
         let path = url.standardizedFileURL.path
-        // The depth cap breaks Include chains that self-reference through a glob
-        // the visited set can't catch (e.g. re-listing a rewritten temp file).
+        // `visited` is the active recursion *stack*, not a permanent memo: a
+        // shared file legitimately included under several Host blocks parses
+        // once per inclusion; only a file currently being parsed (a cycle) is
+        // refused. The depth cap breaks chains the stack can't catch.
         guard depth <= 3, !visited.contains(path),
               let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
         visited.insert(path)
+        defer { visited.remove(path) }
 
         var blocks: [Block] = []
         // While true, the parse sits inside a Match block: its directives (and

--- a/Sources/termio/Settings/SSHConfig.swift
+++ b/Sources/termio/Settings/SSHConfig.swift
@@ -54,15 +54,68 @@ enum SSHConfigFile {
     /// (and the in-app editor) goes through this.
     static var writableConfigURL: URL { configURL.resolvingSymlinksInPath() }
 
-    /// The connectable hosts from `~/.ssh/config` and any `Include`d files.
-    /// Wildcard patterns (`Host *`, globs, negations) are skipped — they are
-    /// defaults, not destinations.
+    /// The connectable hosts from `~/.ssh/config` and any `Include`d files,
+    /// resolved the way ssh itself resolves them: blocks are replayed in file
+    /// order and the *first obtained* value per key wins, so `Host *` defaults
+    /// and wildcard blocks contribute exactly what a real `ssh <alias>` would
+    /// use. (Known simplifications: `Match` blocks are skipped, and an
+    /// `Include` splices at the top level rather than into a block's context.)
     static func hosts() -> [SSHConfigHost] {
         var visited: Set<String> = []
-        return hosts(in: configURL, visited: &visited, depth: 0)
+        let blocks = blocks(in: configURL, visited: &visited, depth: 0)
+        var results: [SSHConfigHost] = []
+        var seen: Set<String> = []
+        for block in blocks {
+            for alias in block.patterns
+            where !alias.contains("*") && !alias.contains("?") && !alias.hasPrefix("!")
+                && !seen.contains(alias) {
+                seen.insert(alias)
+                var hostName: String?, user: String?, identityFile: String?
+                var port: Int?
+                for candidate in blocks where matches(alias, patterns: candidate.patterns) {
+                    if hostName == nil { hostName = candidate.hostName }
+                    if user == nil { user = candidate.user }
+                    if port == nil { port = candidate.port }
+                    if identityFile == nil { identityFile = candidate.identityFile }
+                }
+                results.append(SSHConfigHost(
+                    alias: alias, hostName: hostName ?? alias, user: user ?? "",
+                    port: port ?? 22, identityFile: identityFile,
+                    file: block.file, line: block.line
+                ))
+            }
+        }
+        return results
     }
 
-    private static func hosts(in url: URL, visited: inout Set<String>, depth: Int) -> [SSHConfigHost] {
+    /// One `Host` block in file order: its patterns plus the values its own
+    /// lines set, kept unresolved so `hosts()` can replay ssh's
+    /// first-obtained-value rule across blocks.
+    private struct Block {
+        var patterns: [String]
+        var hostName: String?
+        var user: String?
+        var port: Int?
+        var identityFile: String?
+        var file: URL
+        var line: Int
+    }
+
+    /// ssh_config pattern-list matching for one alias: any negated (`!`)
+    /// pattern match excludes the block; otherwise any positive match includes.
+    private static func matches(_ alias: String, patterns: [String]) -> Bool {
+        var matched = false
+        for pattern in patterns {
+            if pattern.hasPrefix("!") {
+                if fnmatch(String(pattern.dropFirst()), alias, 0) == 0 { return false }
+            } else if fnmatch(pattern, alias, 0) == 0 {
+                matched = true
+            }
+        }
+        return matched
+    }
+
+    private static func blocks(in url: URL, visited: inout Set<String>, depth: Int) -> [Block] {
         let path = url.standardizedFileURL.path
         // The depth cap breaks Include chains that self-reference through a glob
         // the visited set can't catch (e.g. re-listing a rewritten temp file).
@@ -70,70 +123,73 @@ enum SSHConfigFile {
               let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
         visited.insert(path)
 
-        var hosts: [SSHConfigHost] = []
-        var aliases: [String] = []
-        var hostName = "", user = ""
-        var identityFile: String?
-        var port = 22, portSet = false
-        var blockLine = 0
+        var blocks: [Block] = []
+        // Directives before any Host/Match line apply unconditionally, exactly
+        // as if they sat under `Host *`.
+        var current: Block? = Block(patterns: ["*"], file: url, line: 0)
 
         func flush() {
-            for alias in aliases
-            where !alias.contains("*") && !alias.contains("?") && !alias.hasPrefix("!") {
-                hosts.append(SSHConfigHost(
-                    alias: alias, hostName: hostName.isEmpty ? alias : hostName,
-                    user: user, port: port, identityFile: identityFile,
-                    file: url, line: blockLine
-                ))
-            }
+            if let block = current { blocks.append(block) }
+            current = nil
         }
 
         let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
         for (index, rawLine) in lines.enumerated() {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             guard !line.isEmpty, !line.hasPrefix("#") else { continue }
-            // `Keyword value…` — the keyword match is case-insensitive per
-            // ssh_config(5), and `=` is a valid keyword/value separator.
-            var parts = line.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "=" })
-                .map { String($0).trimmingCharacters(in: CharacterSet(charactersIn: "\"")) }
-                .filter { !$0.isEmpty }
-            // ssh itself has no trailing comments, but a stray `# note` after a
-            // value should degrade to ignoring the note, not to bogus hosts.
-            if let hash = parts.firstIndex(where: { $0.hasPrefix("#") }) {
-                parts = Array(parts[..<hash])
-            }
+            let parts = tokens(of: line)
             guard let keyword = parts.first?.lowercased() else { continue }
             let values = Array(parts.dropFirst())
             switch keyword {
             case "host":
                 flush()
-                aliases = values
-                hostName = ""; user = ""; port = 22; portSet = false; identityFile = nil
-                blockLine = index + 1
+                current = Block(patterns: values, file: url, line: index + 1)
             case "match":
-                // A Match block's settings belong to its condition, not to the
-                // preceding Host — close that block and ignore lines until the
-                // next Host.
+                // A Match block's settings belong to its condition, which this
+                // parser doesn't evaluate — skip lines until the next Host.
                 flush()
-                aliases = []
-            // ssh keeps the *first* obtained value per key; duplicates lose.
-            case "hostname": if hostName.isEmpty { hostName = values.first ?? "" }
-            case "user": if user.isEmpty { user = values.first ?? "" }
-            case "port": if !portSet, let parsed = values.first.flatMap(Int.init) { port = parsed; portSet = true }
-            case "identityfile": if identityFile == nil { identityFile = values.first }
             case "include":
+                flush()
                 for value in values {
                     for included in resolveInclude(value) {
-                        hosts.append(contentsOf: Self.hosts(
+                        blocks.append(contentsOf: Self.blocks(
                             in: included, visited: &visited, depth: depth + 1
                         ))
                     }
                 }
+            case "hostname": if current?.hostName == nil { current?.hostName = values.first }
+            case "user": if current?.user == nil { current?.user = values.first }
+            case "port": if current?.port == nil { current?.port = values.first.flatMap(Int.init) }
+            case "identityfile": if current?.identityFile == nil { current?.identityFile = values.first }
             default: break
             }
         }
         flush()
-        return hosts
+        return blocks
+    }
+
+    /// Splits an ssh_config line into tokens: whitespace/`=` separated, with
+    /// double-quoted segments kept whole (ssh's own quoting for values that
+    /// contain spaces — so the app can read back the blocks it writes). A `#`
+    /// starting a token ends the line: ssh has no trailing comments, but a
+    /// stray note should degrade to being ignored, not to bogus hosts.
+    private static func tokens(of line: String) -> [String] {
+        var tokens: [String] = []
+        var current = ""
+        var inQuotes = false
+        for character in line {
+            if character == "\"" { inQuotes.toggle(); continue }
+            if !inQuotes, character == " " || character == "\t" || character == "=" {
+                if !current.isEmpty { tokens.append(current); current = "" }
+                continue
+            }
+            current.append(character)
+        }
+        if !current.isEmpty { tokens.append(current) }
+        if let hash = tokens.firstIndex(where: { $0.hasPrefix("#") }) {
+            tokens = Array(tokens[..<hash])
+        }
+        return tokens
     }
 
     /// Expands one `Include` operand to concrete files: `~` and relative paths
@@ -182,7 +238,9 @@ enum SSHConfigFile {
         alias: String, hostName: String, user: String, port: String, identityFile: String
     ) throws {
         // ssh_config quotes arguments that contain spaces (a picked key file
-        // under "My Drive" must not split into two tokens).
+        // under "My Drive" must not split into two tokens). Values containing a
+        // double quote are unrepresentable in ssh_config and rejected upstream
+        // in the sheet.
         func quoted(_ value: String) -> String {
             value.contains(" ") ? "\"\(value)\"" : value
         }

--- a/Sources/termio/Settings/SSHConfig.swift
+++ b/Sources/termio/Settings/SSHConfig.swift
@@ -62,7 +62,11 @@ enum SSHConfigFile {
     /// `Include` splices at the top level rather than into a block's context.)
     static func hosts() -> [SSHConfigHost] {
         var visited: Set<String> = []
-        let blocks = blocks(in: configURL, visited: &visited, depth: 0)
+        // Directives before any Host/Match line apply unconditionally, exactly
+        // as if they sat under `Host *`.
+        var context: Block? = Block(patterns: ["*"], file: configURL, line: 0)
+        var blocks = blocks(in: configURL, visited: &visited, depth: 0, context: &context)
+        if let context { blocks.append(context) }
         var results: [SSHConfigHost] = []
         var seen: Set<String> = []
         for block in blocks {
@@ -78,8 +82,14 @@ enum SSHConfigFile {
                     if port == nil { port = candidate.port }
                     if identityFile == nil { identityFile = candidate.identityFile }
                 }
+                // ssh expands %h in HostName to the name given on the command
+                // line (the alias) — `Host *.cloud` + `HostName %h.internal`.
+                let expandedHostName = (hostName ?? alias)
+                    .replacingOccurrences(of: "%%", with: "\u{0}")
+                    .replacingOccurrences(of: "%h", with: alias)
+                    .replacingOccurrences(of: "\u{0}", with: "%")
                 results.append(SSHConfigHost(
-                    alias: alias, hostName: hostName ?? alias, user: user ?? "",
+                    alias: alias, hostName: expandedHostName, user: user ?? "",
                     port: port ?? 22, identityFile: identityFile,
                     file: block.file, line: block.line
                 ))
@@ -107,15 +117,42 @@ enum SSHConfigFile {
         var matched = false
         for pattern in patterns {
             if pattern.hasPrefix("!") {
-                if fnmatch(String(pattern.dropFirst()), alias, 0) == 0 { return false }
-            } else if fnmatch(pattern, alias, 0) == 0 {
+                if wildcardMatches(String(pattern.dropFirst()), alias) { return false }
+            } else if wildcardMatches(pattern, alias) {
                 matched = true
             }
         }
         return matched
     }
 
-    private static func blocks(in url: URL, visited: inout Set<String>, depth: Int) -> [Block] {
+    /// ssh's own pattern language: `*` and `?` only — deliberately not
+    /// `fnmatch`, whose bracket classes would make `web[1-3]` match here while
+    /// a real ssh treats the brackets literally.
+    private static func wildcardMatches(_ pattern: String, _ candidate: String) -> Bool {
+        let p = Array(pattern), c = Array(candidate)
+        var pi = 0, ci = 0, star = -1, mark = 0
+        while ci < c.count {
+            if pi < p.count, p[pi] == "?" || p[pi] == c[ci] {
+                pi += 1; ci += 1
+            } else if pi < p.count, p[pi] == "*" {
+                star = pi; mark = ci; pi += 1
+            } else if star >= 0 {
+                pi = star + 1; mark += 1; ci = mark
+            } else {
+                return false
+            }
+        }
+        while pi < p.count, p[pi] == "*" { pi += 1 }
+        return pi == p.count
+    }
+
+    /// Parses one file into blocks, threading the *current block* through
+    /// `context` the way ssh splices `Include`: an included file's leading
+    /// directives continue the including block, and a block left open at the
+    /// file's end resumes in the includer (the top level flushes the last one).
+    private static func blocks(
+        in url: URL, visited: inout Set<String>, depth: Int, context: inout Block?
+    ) -> [Block] {
         let path = url.standardizedFileURL.path
         // The depth cap breaks Include chains that self-reference through a glob
         // the visited set can't catch (e.g. re-listing a rewritten temp file).
@@ -124,14 +161,10 @@ enum SSHConfigFile {
         visited.insert(path)
 
         var blocks: [Block] = []
-        // Directives before any Host/Match line apply unconditionally, exactly
-        // as if they sat under `Host *`.
-        var current: Block? = Block(patterns: ["*"], file: url, line: 0)
-
-        func flush() {
-            if let block = current { blocks.append(block) }
-            current = nil
-        }
+        // While true, the parse sits inside a Match block: its directives (and
+        // its Includes, which ssh gates on the Match condition) are skipped
+        // until the next Host, since this parser doesn't evaluate conditions.
+        var inMatch = false
 
         let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
         for (index, rawLine) in lines.enumerated() {
@@ -142,29 +175,29 @@ enum SSHConfigFile {
             let values = Array(parts.dropFirst())
             switch keyword {
             case "host":
-                flush()
-                current = Block(patterns: values, file: url, line: index + 1)
+                if let block = context { blocks.append(block) }
+                context = Block(patterns: values, file: url, line: index + 1)
+                inMatch = false
             case "match":
-                // A Match block's settings belong to its condition, which this
-                // parser doesn't evaluate — skip lines until the next Host.
-                flush()
-            case "include":
-                flush()
+                if let block = context { blocks.append(block) }
+                context = nil
+                inMatch = true
+            case "include" where !inMatch:
                 for value in values {
                     for included in resolveInclude(value) {
                         blocks.append(contentsOf: Self.blocks(
-                            in: included, visited: &visited, depth: depth + 1
+                            in: included, visited: &visited, depth: depth + 1,
+                            context: &context
                         ))
                     }
                 }
-            case "hostname": if current?.hostName == nil { current?.hostName = values.first }
-            case "user": if current?.user == nil { current?.user = values.first }
-            case "port": if current?.port == nil { current?.port = values.first.flatMap(Int.init) }
-            case "identityfile": if current?.identityFile == nil { current?.identityFile = values.first }
+            case "hostname": if context?.hostName == nil { context?.hostName = values.first }
+            case "user": if context?.user == nil { context?.user = values.first }
+            case "port": if context?.port == nil { context?.port = values.first.flatMap(Int.init) }
+            case "identityfile": if context?.identityFile == nil { context?.identityFile = values.first }
             default: break
             }
         }
-        flush()
         return blocks
     }
 

--- a/Sources/termio/Settings/SSHConfig.swift
+++ b/Sources/termio/Settings/SSHConfig.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+/// One connectable `Host` block parsed from the user's OpenSSH client config —
+/// the same aliases `ssh <alias>` itself resolves. A block that lists several
+/// aliases yields one entry per alias. `file`/`line` locate the block's `Host`
+/// line so the settings pane can jump straight to it in the editor.
+struct SSHConfigHost: Identifiable, Hashable {
+    let alias: String
+    /// The block's `HostName`, falling back to the alias when the block sets none
+    /// (which is how ssh resolves it too).
+    let hostName: String
+    let user: String
+    let port: Int
+    /// The block's first `IdentityFile`, verbatim (`~` unexpanded), when set.
+    let identityFile: String?
+    let file: URL
+    let line: Int
+
+    var id: String { "\(file.path)#\(line)#\(alias)" }
+
+    /// The row caption under the alias: `user@host`, with the port only when it
+    /// isn't ssh's default.
+    var destinationLabel: String {
+        let base = user.isEmpty ? hostName : "\(user)@\(hostName)"
+        return port == 22 ? base : "\(base):\(port)"
+    }
+}
+
+/// A public key sitting in `~/.ssh`, listed so its text is one click from the
+/// clipboard (for a server's `authorized_keys`). Private keys are never read.
+struct SSHPublicKey: Identifiable, Hashable {
+    let url: URL
+    /// The key's algorithm, prettified from the line's leading token.
+    let algorithm: String
+    /// The trailing comment (usually `user@machine`), empty when absent.
+    let comment: String
+
+    var id: String { url.path }
+    var name: String { url.lastPathComponent }
+}
+
+/// Reads and appends to the user's `~/.ssh/config`. The config file is the
+/// single source of truth for SSH hosts — termio keeps no host database of its
+/// own, so anything another tool (or the user, in any editor) writes there shows
+/// up here, and anything added here works in a bare `ssh` immediately.
+enum SSHConfigFile {
+    static var configURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh/config")
+    }
+
+    /// The connectable hosts from `~/.ssh/config` and any `Include`d files.
+    /// Wildcard patterns (`Host *`, globs, negations) are skipped — they are
+    /// defaults, not destinations.
+    static func hosts() -> [SSHConfigHost] {
+        var visited: Set<String> = []
+        return hosts(in: configURL, visited: &visited, depth: 0)
+    }
+
+    private static func hosts(in url: URL, visited: inout Set<String>, depth: Int) -> [SSHConfigHost] {
+        let path = url.standardizedFileURL.path
+        // The depth cap breaks Include chains that self-reference through a glob
+        // the visited set can't catch (e.g. re-listing a rewritten temp file).
+        guard depth <= 3, !visited.contains(path),
+              let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+        visited.insert(path)
+
+        var hosts: [SSHConfigHost] = []
+        var aliases: [String] = []
+        var hostName = "", user = ""
+        var identityFile: String?
+        var port = 22
+        var blockLine = 0
+
+        func flush() {
+            for alias in aliases
+            where !alias.contains("*") && !alias.contains("?") && !alias.hasPrefix("!") {
+                hosts.append(SSHConfigHost(
+                    alias: alias, hostName: hostName.isEmpty ? alias : hostName,
+                    user: user, port: port, identityFile: identityFile,
+                    file: url, line: blockLine
+                ))
+            }
+        }
+
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        for (index, rawLine) in lines.enumerated() {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, !line.hasPrefix("#") else { continue }
+            // `Keyword value…` — the keyword match is case-insensitive per
+            // ssh_config(5), and `=` is a valid keyword/value separator.
+            let parts = line.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "=" })
+                .map { String($0).trimmingCharacters(in: CharacterSet(charactersIn: "\"")) }
+                .filter { !$0.isEmpty }
+            guard let keyword = parts.first?.lowercased() else { continue }
+            let values = Array(parts.dropFirst())
+            switch keyword {
+            case "host":
+                flush()
+                aliases = values
+                hostName = ""; user = ""; port = 22; identityFile = nil
+                blockLine = index + 1
+            case "hostname": hostName = values.first ?? ""
+            case "user": user = values.first ?? ""
+            case "port": port = values.first.flatMap(Int.init) ?? 22
+            case "identityfile": if identityFile == nil { identityFile = values.first }
+            case "include":
+                for value in values {
+                    for included in resolveInclude(value) {
+                        hosts.append(contentsOf: Self.hosts(
+                            in: included, visited: &visited, depth: depth + 1
+                        ))
+                    }
+                }
+            default: break
+            }
+        }
+        flush()
+        return hosts
+    }
+
+    /// Expands one `Include` operand to concrete files: `~` and relative paths
+    /// resolve per ssh_config(5) (relative means under `~/.ssh`), and a glob in
+    /// the last path component matches directory entries via `fnmatch`.
+    private static func resolveInclude(_ pattern: String) -> [URL] {
+        var expanded = (pattern as NSString).expandingTildeInPath
+        if !expanded.hasPrefix("/") {
+            expanded = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".ssh").appendingPathComponent(expanded).path
+        }
+        let url = URL(fileURLWithPath: expanded)
+        let lastComponent = url.lastPathComponent
+        guard lastComponent.contains("*") || lastComponent.contains("?") else { return [url] }
+        let directory = url.deletingLastPathComponent()
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
+        return names
+            .filter { fnmatch(lastComponent, $0, 0) == 0 }
+            .sorted()
+            .map { directory.appendingPathComponent($0) }
+    }
+
+    /// Creates `~/.ssh` (0700) and an empty config (0600) when missing — the
+    /// permissions ssh itself insists on — so the editor and Add Host always have
+    /// a real file to work with.
+    static func ensureConfigExists() throws {
+        let manager = FileManager.default
+        try manager.createDirectory(
+            at: configURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        if !manager.fileExists(atPath: configURL.path) {
+            manager.createFile(
+                atPath: configURL.path, contents: Data(),
+                attributes: [.posixPermissions: 0o600]
+            )
+        }
+    }
+
+    /// Appends a plain `Host` block to `~/.ssh/config`. Optional fields are
+    /// simply omitted, and the default port is not written — the block stays as
+    /// clean as one written by hand.
+    static func appendHost(
+        alias: String, hostName: String, user: String, port: String, identityFile: String
+    ) throws {
+        var block = "Host \(alias)\n  HostName \(hostName)\n"
+        if !user.isEmpty { block += "  User \(user)\n" }
+        if let portNumber = Int(port), portNumber != 22 { block += "  Port \(portNumber)\n" }
+        if !identityFile.isEmpty { block += "  IdentityFile \(identityFile)\n" }
+
+        try ensureConfigExists()
+        var text = try String(contentsOf: configURL, encoding: .utf8)
+        if !text.isEmpty, !text.hasSuffix("\n") { text += "\n" }
+        if !text.isEmpty { text += "\n" }
+        try (text + block).write(to: configURL, atomically: true, encoding: .utf8)
+        // The atomic write lands as a fresh temp file, so re-assert the 0600 ssh
+        // expects rather than inheriting the process umask.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: configURL.path
+        )
+    }
+
+    /// The `*.pub` keys in `~/.ssh`, sorted by name. Unreadable or non-key files
+    /// are skipped rather than surfaced — this list is a convenience, not an audit.
+    static func publicKeys() -> [SSHPublicKey] {
+        let directory = configURL.deletingLastPathComponent()
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
+        return names.filter { $0.hasSuffix(".pub") }.sorted().compactMap { name in
+            let url = directory.appendingPathComponent(name)
+            guard let line = try? String(contentsOf: url, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines), !line.isEmpty else { return nil }
+            let fields = line.split(separator: " ", maxSplits: 2).map(String.init)
+            let algorithm: String
+            switch fields.first ?? "" {
+            case "ssh-ed25519": algorithm = "ED25519"
+            case "ssh-rsa": algorithm = "RSA"
+            case "ssh-dss": algorithm = "DSA"
+            case let raw where raw.hasPrefix("sk-ssh-ed25519"): algorithm = "ED25519-SK"
+            case let raw where raw.hasPrefix("sk-ecdsa"): algorithm = "ECDSA-SK"
+            case let raw where raw.hasPrefix("ecdsa"): algorithm = "ECDSA"
+            case let raw: algorithm = raw
+            }
+            return SSHPublicKey(
+                url: url, algorithm: algorithm,
+                comment: fields.count > 2 ? fields[2] : ""
+            )
+        }
+    }
+}

--- a/Sources/termio/Settings/SSHConfig.swift
+++ b/Sources/termio/Settings/SSHConfig.swift
@@ -48,6 +48,12 @@ enum SSHConfigFile {
         FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh/config")
     }
 
+    /// The config with symlinks resolved — dotfile managers commonly symlink
+    /// `~/.ssh/config`, and an atomic write aimed at the link path would replace
+    /// the link with a plain file, orphaning the managed target. Every write
+    /// (and the in-app editor) goes through this.
+    static var writableConfigURL: URL { configURL.resolvingSymlinksInPath() }
+
     /// The connectable hosts from `~/.ssh/config` and any `Include`d files.
     /// Wildcard patterns (`Host *`, globs, negations) are skipped — they are
     /// defaults, not destinations.
@@ -68,7 +74,7 @@ enum SSHConfigFile {
         var aliases: [String] = []
         var hostName = "", user = ""
         var identityFile: String?
-        var port = 22
+        var port = 22, portSet = false
         var blockLine = 0
 
         func flush() {
@@ -88,20 +94,32 @@ enum SSHConfigFile {
             guard !line.isEmpty, !line.hasPrefix("#") else { continue }
             // `Keyword value…` — the keyword match is case-insensitive per
             // ssh_config(5), and `=` is a valid keyword/value separator.
-            let parts = line.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "=" })
+            var parts = line.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "=" })
                 .map { String($0).trimmingCharacters(in: CharacterSet(charactersIn: "\"")) }
                 .filter { !$0.isEmpty }
+            // ssh itself has no trailing comments, but a stray `# note` after a
+            // value should degrade to ignoring the note, not to bogus hosts.
+            if let hash = parts.firstIndex(where: { $0.hasPrefix("#") }) {
+                parts = Array(parts[..<hash])
+            }
             guard let keyword = parts.first?.lowercased() else { continue }
             let values = Array(parts.dropFirst())
             switch keyword {
             case "host":
                 flush()
                 aliases = values
-                hostName = ""; user = ""; port = 22; identityFile = nil
+                hostName = ""; user = ""; port = 22; portSet = false; identityFile = nil
                 blockLine = index + 1
-            case "hostname": hostName = values.first ?? ""
-            case "user": user = values.first ?? ""
-            case "port": port = values.first.flatMap(Int.init) ?? 22
+            case "match":
+                // A Match block's settings belong to its condition, not to the
+                // preceding Host — close that block and ignore lines until the
+                // next Host.
+                flush()
+                aliases = []
+            // ssh keeps the *first* obtained value per key; duplicates lose.
+            case "hostname": if hostName.isEmpty { hostName = values.first ?? "" }
+            case "user": if user.isEmpty { user = values.first ?? "" }
+            case "port": if !portSet, let parsed = values.first.flatMap(Int.init) { port = parsed; portSet = true }
             case "identityfile": if identityFile == nil { identityFile = values.first }
             case "include":
                 for value in values {
@@ -148,9 +166,10 @@ enum SSHConfigFile {
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: 0o700]
         )
-        if !manager.fileExists(atPath: configURL.path) {
+        let target = writableConfigURL
+        if !manager.fileExists(atPath: target.path) {
             manager.createFile(
-                atPath: configURL.path, contents: Data(),
+                atPath: target.path, contents: Data(),
                 attributes: [.posixPermissions: 0o600]
             )
         }
@@ -162,20 +181,26 @@ enum SSHConfigFile {
     static func appendHost(
         alias: String, hostName: String, user: String, port: String, identityFile: String
     ) throws {
-        var block = "Host \(alias)\n  HostName \(hostName)\n"
-        if !user.isEmpty { block += "  User \(user)\n" }
+        // ssh_config quotes arguments that contain spaces (a picked key file
+        // under "My Drive" must not split into two tokens).
+        func quoted(_ value: String) -> String {
+            value.contains(" ") ? "\"\(value)\"" : value
+        }
+        var block = "Host \(quoted(alias))\n  HostName \(quoted(hostName))\n"
+        if !user.isEmpty { block += "  User \(quoted(user))\n" }
         if let portNumber = Int(port), portNumber != 22 { block += "  Port \(portNumber)\n" }
-        if !identityFile.isEmpty { block += "  IdentityFile \(identityFile)\n" }
+        if !identityFile.isEmpty { block += "  IdentityFile \(quoted(identityFile))\n" }
 
         try ensureConfigExists()
-        var text = try String(contentsOf: configURL, encoding: .utf8)
+        let target = writableConfigURL
+        var text = try String(contentsOf: target, encoding: .utf8)
         if !text.isEmpty, !text.hasSuffix("\n") { text += "\n" }
         if !text.isEmpty { text += "\n" }
-        try (text + block).write(to: configURL, atomically: true, encoding: .utf8)
+        try (text + block).write(to: target, atomically: true, encoding: .utf8)
         // The atomic write lands as a fresh temp file, so re-assert the 0600 ssh
         // expects rather than inheriting the process umask.
         try FileManager.default.setAttributes(
-            [.posixPermissions: 0o600], ofItemAtPath: configURL.path
+            [.posixPermissions: 0o600], ofItemAtPath: target.path
         )
     }
 
@@ -197,7 +222,9 @@ enum SSHConfigFile {
             case let raw where raw.hasPrefix("sk-ssh-ed25519"): algorithm = "ED25519-SK"
             case let raw where raw.hasPrefix("sk-ecdsa"): algorithm = "ECDSA-SK"
             case let raw where raw.hasPrefix("ecdsa"): algorithm = "ECDSA"
-            case let raw: algorithm = raw
+            // Anything else isn't a public key line — including a `.pub`-named
+            // symlink at a private key, which must never reach the clipboard.
+            default: return nil
             }
             return SSHPublicKey(
                 url: url, algorithm: algorithm,

--- a/Sources/termio/Settings/SSHSettingsTab.swift
+++ b/Sources/termio/Settings/SSHSettingsTab.swift
@@ -119,11 +119,13 @@ struct SSHSettingsTab: View {
     /// `~/.ssh/config` itself. The config is created empty first when missing so
     /// the editor never opens onto a nonexistent file.
     private func presentEditor(for host: SSHConfigHost?) {
+        // Symlinks resolve before the editor opens: its atomic auto-save would
+        // otherwise replace a dotfile-managed link with a plain file.
         if let host {
-            configEditor = ConfigEditorTarget(url: host.file, line: host.line)
+            configEditor = ConfigEditorTarget(url: host.file.resolvingSymlinksInPath(), line: host.line)
         } else {
             try? SSHConfigFile.ensureConfigExists()
-            configEditor = ConfigEditorTarget(url: SSHConfigFile.configURL, line: nil)
+            configEditor = ConfigEditorTarget(url: SSHConfigFile.writableConfigURL, line: nil)
         }
     }
 
@@ -207,7 +209,7 @@ private struct AddSSHHostSheet: View {
         !trimmedAlias.isEmpty && !trimmedAlias.contains(" ")
             && !hostName.trimmingCharacters(in: .whitespaces).isEmpty
             && !aliasTaken
-            && (port.isEmpty || Int(port) != nil)
+            && (port.isEmpty || Int(port).map { (1...65535).contains($0) } == true)
     }
 
     var body: some View {

--- a/Sources/termio/Settings/SSHSettingsTab.swift
+++ b/Sources/termio/Settings/SSHSettingsTab.swift
@@ -210,6 +210,9 @@ private struct AddSSHHostSheet: View {
             && !hostName.trimmingCharacters(in: .whitespaces).isEmpty
             && !aliasTaken
             && (port.isEmpty || Int(port).map { (1...65535).contains($0) } == true)
+            // ssh_config has no escape for a literal double quote — such values
+            // can't be written faithfully, so refuse rather than corrupt.
+            && ![alias, hostName, user, identityFile].contains(where: { $0.contains("\"") })
     }
 
     var body: some View {

--- a/Sources/termio/Settings/SSHSettingsTab.swift
+++ b/Sources/termio/Settings/SSHSettingsTab.swift
@@ -1,0 +1,298 @@
+import AppKit
+import SwiftUI
+
+/// Settings ▸ SSH: the connectable hosts from `~/.ssh/config`, each one click
+/// away from a terminal. The config file stays the single source of truth —
+/// termio reads the same hosts `ssh` itself resolves and writes nothing behind
+/// the user's back: Add Host appends a plain block, Edit opens the raw file.
+struct SSHSettingsTab: View {
+    @ObservedObject var settings: AppSettings
+    /// Opens an SSH terminal to the alias in the main window (wired to
+    /// `TermioStore.addSSHSession` by the app delegate).
+    let onConnect: (String) -> Void
+
+    @State private var hosts: [SSHConfigHost] = []
+    @State private var publicKeys: [SSHPublicKey] = []
+    @State private var addingHost = false
+    @State private var configEditor: ConfigEditorTarget?
+    /// The key whose Copy button is briefly confirming, so the click visibly took.
+    @State private var copiedKeyID: String?
+
+    /// Which file the editor sheet shows — usually `~/.ssh/config`, but a host
+    /// defined in an `Include`d file opens that file, at its `Host` line.
+    private struct ConfigEditorTarget: Identifiable {
+        let url: URL
+        let line: Int?
+        var id: String { "\(url.path)#\(line ?? 0)" }
+    }
+
+    var body: some View {
+        Form {
+            hostsSection
+            configSection
+            if !publicKeys.isEmpty { keysSection }
+        }
+        .formStyle(.grouped)
+        .onAppear(perform: reload)
+        .sheet(isPresented: $addingHost, onDismiss: reload) {
+            AddSSHHostSheet(existingAliases: Set(hosts.map(\.alias)))
+        }
+        .sheet(item: $configEditor, onDismiss: reload) { target in
+            FileEditorView(
+                url: target.url,
+                settings: settings,
+                jumpLine: target.line,
+                onClose: { configEditor = nil }
+            )
+            .frame(minWidth: 640, minHeight: 460)
+        }
+    }
+
+    private var hostsSection: some View {
+        Section {
+            if hosts.isEmpty {
+                Text("No hosts yet — add one, or write a Host block in ~/.ssh/config.")
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(hosts) { host in
+                SSHHostRow(
+                    host: host,
+                    connect: { onConnect(host.alias) },
+                    editInConfig: { presentEditor(for: host) }
+                )
+            }
+            Button { addingHost = true } label: {
+                Label("Add Host", systemImage: "plus")
+            }
+        } header: {
+            SectionHeaderLabel(title: "Hosts")
+        } footer: {
+            Text("The Host blocks from ~/.ssh/config (Include'd files too) — exactly the aliases `ssh` resolves. Connect opens the host as a terminal in the sidebar's Terminals section, same as File ▸ New SSH Connection.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var configSection: some View {
+        Section {
+            LabeledContent {
+                Button("Edit") { presentEditor(for: nil) }
+            } label: {
+                SettingsLabel(
+                    symbol: "doc.text",
+                    title: "~/.ssh/config",
+                    subtext: "The OpenSSH client config is the single source of truth — termio keeps no separate host database. Edits show up here and in plain `ssh` alike."
+                )
+            }
+        } header: {
+            SectionHeaderLabel(title: "Config file")
+        }
+    }
+
+    private var keysSection: some View {
+        Section {
+            ForEach(publicKeys) { key in
+                HStack(spacing: 10) {
+                    IconBadge(.symbol("key"))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(key.name)
+                        Text(key.comment.isEmpty ? key.algorithm : "\(key.algorithm) · \(key.comment)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer(minLength: 8)
+                    Button(copiedKeyID == key.id ? "Copied" : "Copy") { copy(key) }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                }
+            }
+        } header: {
+            SectionHeaderLabel(title: "Public keys")
+        } footer: {
+            Text("The public keys in ~/.ssh. Copy one to paste into a server's authorized_keys — private keys are never read.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Opens the editor sheet on a host's defining file at its `Host` line, or on
+    /// `~/.ssh/config` itself. The config is created empty first when missing so
+    /// the editor never opens onto a nonexistent file.
+    private func presentEditor(for host: SSHConfigHost?) {
+        if let host {
+            configEditor = ConfigEditorTarget(url: host.file, line: host.line)
+        } else {
+            try? SSHConfigFile.ensureConfigExists()
+            configEditor = ConfigEditorTarget(url: SSHConfigFile.configURL, line: nil)
+        }
+    }
+
+    private func reload() {
+        hosts = SSHConfigFile.hosts()
+        publicKeys = SSHConfigFile.publicKeys()
+    }
+
+    private func copy(_ key: SSHPublicKey) {
+        guard let text = try? String(contentsOf: key.url, encoding: .utf8) else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(
+            text.trimmingCharacters(in: .whitespacesAndNewlines), forType: .string
+        )
+        copiedKeyID = key.id
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            if copiedKeyID == key.id { copiedKeyID = nil }
+        }
+    }
+}
+
+/// One host row: alias over its `user@host` destination, a quiet key hint when
+/// the block pins an identity, and a Connect button. The context menu carries
+/// the secondary verbs so the row itself stays scannable.
+private struct SSHHostRow: View {
+    let host: SSHConfigHost
+    let connect: () -> Void
+    let editInConfig: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            IconBadge(.symbol("server.rack"))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(host.alias).font(.headline)
+                Text(host.destinationLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 8)
+            if let identityFile = host.identityFile {
+                Image(systemName: "key.fill")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .help("Uses \(identityFile)")
+            }
+            Button("Connect", action: connect)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+        }
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button("Connect", action: connect)
+            Button("Edit in Config", action: editInConfig)
+            Button("Copy ssh Command") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString("ssh \(host.alias)", forType: .string)
+            }
+        }
+    }
+}
+
+/// The Add Host sheet: the four fields a `Host` block actually needs, appended
+/// to `~/.ssh/config` as a block indistinguishable from a hand-written one.
+private struct AddSSHHostSheet: View {
+    let existingAliases: Set<String>
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var alias = ""
+    @State private var hostName = ""
+    @State private var user = ""
+    @State private var port = ""
+    @State private var identityFile = ""
+    @State private var writeError: String?
+
+    private var trimmedAlias: String { alias.trimmingCharacters(in: .whitespaces) }
+    private var aliasTaken: Bool { existingAliases.contains(trimmedAlias) }
+    private var canAdd: Bool {
+        !trimmedAlias.isEmpty && !trimmedAlias.contains(" ")
+            && !hostName.trimmingCharacters(in: .whitespaces).isEmpty
+            && !aliasTaken
+            && (port.isEmpty || Int(port) != nil)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Form {
+                Section {
+                    TextField("Alias", text: $alias, prompt: Text("myserver"))
+                    TextField("Host", text: $hostName, prompt: Text("server.example.com"))
+                    TextField("User", text: $user, prompt: Text("optional"))
+                    TextField("Port", text: $port, prompt: Text("22"))
+                    LabeledContent("Key file") {
+                        HStack(spacing: 6) {
+                            TextField(
+                                "", text: $identityFile,
+                                prompt: Text("optional — ~/.ssh/id_ed25519")
+                            )
+                            .labelsHidden()
+                            Button("Choose…", action: chooseIdentityFile)
+                        }
+                    }
+                } header: {
+                    SectionHeaderLabel(title: "Add SSH Host")
+                } footer: {
+                    if aliasTaken {
+                        Text("“\(trimmedAlias)” is already in your config.")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    } else {
+                        Text("Appends a Host block to ~/.ssh/config, so the alias works in plain `ssh \(trimmedAlias.isEmpty ? "myserver" : trimmedAlias)` too.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            Divider()
+            HStack {
+                if let writeError {
+                    Text(writeError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                }
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Add", action: add)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canAdd)
+            }
+            .padding(12)
+        }
+        .frame(width: 440, height: 330)
+    }
+
+    private func add() {
+        do {
+            try SSHConfigFile.appendHost(
+                alias: trimmedAlias,
+                hostName: hostName.trimmingCharacters(in: .whitespaces),
+                user: user.trimmingCharacters(in: .whitespaces),
+                port: port.trimmingCharacters(in: .whitespaces),
+                identityFile: identityFile.trimmingCharacters(in: .whitespaces)
+            )
+            dismiss()
+        } catch {
+            writeError = "Couldn't write ~/.ssh/config: \(error.localizedDescription)"
+        }
+    }
+
+    /// A file picker starting in `~/.ssh` with hidden files visible (the whole
+    /// directory is dot-hidden). The chosen path is stored `~`-relative, the way
+    /// ssh configs are conventionally written.
+    private func chooseIdentityFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.showsHiddenFiles = true
+        panel.directoryURL = SSHConfigFile.configURL.deletingLastPathComponent()
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        let path = url.standardizedFileURL.path
+        identityFile = path.hasPrefix(home + "/")
+            ? "~" + path.dropFirst(home.count)
+            : path
+    }
+}

--- a/Sources/termio/Settings/SettingsTab.swift
+++ b/Sources/termio/Settings/SettingsTab.swift
@@ -8,6 +8,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case appearance
     case interface
     case terminal
+    case ssh
     case keyboard
     case agents
     case usage
@@ -21,6 +22,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return "Appearance"
         case .interface: return "Interface"
         case .terminal: return "Terminal"
+        case .ssh: return "SSH"
         case .keyboard: return "Keyboard"
         case .agents: return "Agents"
         case .usage: return "Usage"
@@ -34,6 +36,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return "paintbrush"
         case .interface: return "sidebar.left"
         case .terminal: return "terminal"
+        case .ssh: return "server.rack"
         case .keyboard: return "keyboard"
         case .agents: return "sparkles"
         case .usage: return "gauge.medium"
@@ -49,6 +52,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return "Terminal font, theme, cursor, and window"
         case .interface: return "The app's own sidebar font and density"
         case .terminal: return "Scrollback history and text selection"
+        case .ssh: return "Your ~/.ssh/config hosts, one click away"
         case .keyboard: return "Keyboard shortcuts for every command"
         case .agents: return "Agent presets, live status, and control"
         case .usage: return "Token usage for your connected agents"

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -12,15 +12,21 @@ import SwiftUI
 struct SettingsView: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var usage: UsageMonitor
+    /// Opens an SSH terminal to a `~/.ssh/config` alias in the main window — the
+    /// SSH tab's Connect action, injected by the app delegate so the settings
+    /// window doesn't hold the store.
+    let onSSHConnect: (String) -> Void
     @State private var selection: SettingsTab
 
     init(
         settings: AppSettings,
         usage: UsageMonitor,
-        initialTab: SettingsTab = .appearance
+        initialTab: SettingsTab = .appearance,
+        onSSHConnect: @escaping (String) -> Void
     ) {
         self.settings = settings
         self.usage = usage
+        self.onSSHConnect = onSSHConnect
         _selection = State(initialValue: initialTab)
     }
 
@@ -59,6 +65,7 @@ struct SettingsView: View {
         case .appearance: AppearanceSettingsTab(settings: settings)
         case .interface: InterfaceSettingsTab(settings: settings)
         case .terminal: TerminalSettingsTab(settings: settings)
+        case .ssh: SSHSettingsTab(settings: settings, onConnect: onSSHConnect)
         case .keyboard: KeybindingsSettingsTab()
         case .agents: AgentSettingsTab(settings: settings)
         case .usage: UsageSettingsTab(settings: settings, usage: usage)

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -380,7 +380,7 @@ extension TermioStore {
 
         let combo = NSComboBox(frame: NSRect(x: 0, y: 0, width: 260, height: 26))
         combo.completes = true
-        combo.addItems(withObjectValues: CompanionServer.parseSSHConfigHosts().map(\.alias))
+        combo.addItems(withObjectValues: SSHConfigFile.hosts().map(\.alias))
         alert.accessoryView = combo
         alert.window.initialFirstResponder = combo
 

--- a/web/landing/src/app/layout.tsx
+++ b/web/landing/src/app/layout.tsx
@@ -3,12 +3,12 @@ import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 const siteDescription =
-  "Termio is a native Mac workspace for your AI coding agents — Claude Code, Codex, OpenCode, Pi Agent and more. Run them side by side, each in a real terminal, switch between them instantly, and nothing ever leaves your machine.";
+  "Termio is the Terminal-first Agentic Development Environment — a native Mac app for your AI coding agents: Claude Code, Codex, OpenCode, Pi Agent and more. Run them side by side, each in a real terminal, switch between them instantly, and nothing ever leaves your machine.";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.termio.sh"),
   title: {
-    default: "Termio — the terminal home for your AI coding agents",
+    default: "Termio — the Terminal-first Agentic Development Environment",
     template: "%s — Termio",
   },
   description: siteDescription,
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   openGraph: {
-    title: "Termio — the terminal home for your AI coding agents",
+    title: "Termio — the Terminal-first Agentic Development Environment",
     description: siteDescription,
     type: "website",
     siteName: "Termio",
@@ -44,7 +44,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Termio — the terminal home for your AI coding agents",
+    title: "Termio — the Terminal-first Agentic Development Environment",
     description: siteDescription,
     images: ["/og.webp"],
   },

--- a/web/landing/src/app/llms.txt/route.ts
+++ b/web/landing/src/app/llms.txt/route.ts
@@ -17,7 +17,7 @@ export function GET() {
   const body = [
     "# Termio",
     "",
-    "> Termio is a free, native macOS terminal built for running AI coding agents — Claude Code, Codex, Gemini, and friends — side by side. Sessions are organized by project, each with a live status, a built-in inspector, and an iPhone companion app. No account, no payment.",
+    "> Termio is the Terminal-first Agentic Development Environment — a free, native macOS app for running AI coding agents (Claude Code, Codex, Gemini, and friends) side by side. Sessions are organized by project, each with a live status, a built-in inspector, and an iPhone companion app. No account, no payment.",
     "",
     "## Docs",
     "",

--- a/web/landing/src/app/page.tsx
+++ b/web/landing/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { SiteNav } from "@/components/site-nav";
 import { Hero } from "@/components/sections/hero";
 import { AgentShowcase } from "@/components/sections/agent-showcase";
+import { FeatureGrid } from "@/components/sections/feature-grid";
 import { Faq } from "@/components/sections/faq";
 import { CtaBand } from "@/components/sections/cta-band";
 import { SiteFooter } from "@/components/site-footer";
@@ -34,6 +35,7 @@ export default function Home() {
       <main className="flex-1">
         <Hero />
         <AgentShowcase />
+        <FeatureGrid />
         <Faq />
       </main>
       {/* Shaded outro — mirrors the hero. The CTA band and footer share one slow

--- a/web/landing/src/app/page.tsx
+++ b/web/landing/src/app/page.tsx
@@ -20,7 +20,7 @@ const appJsonLd = {
   downloadUrl,
   image: "https://www.termio.sh/og.webp",
   description:
-    "Termio is a native Mac workspace for your AI coding agents — Claude Code, Codex, OpenCode, Pi Agent and more. Run them side by side, each in a real terminal, and nothing ever leaves your machine.",
+    "Termio is the Terminal-first Agentic Development Environment — a native Mac app for your AI coding agents: Claude Code, Codex, OpenCode, Pi Agent and more. Run them side by side, each in a real terminal, and nothing ever leaves your machine.",
 };
 
 export default function Home() {

--- a/web/landing/src/components/sections/feature-grid.tsx
+++ b/web/landing/src/components/sections/feature-grid.tsx
@@ -1,0 +1,105 @@
+import Image from "next/image";
+import { Reveal } from "@/components/reveal";
+import { SectionLabel } from "@/components/section-label";
+
+// One entry per capture in public/feature/ (native dimensions vary, so each
+// card carries its own intrinsic size and the row stretches to the taller one).
+const features = [
+  {
+    title: "Knows when an agent needs you",
+    blurb:
+      "Session dots show working, idle, or needs-you, aggregated into a menu-bar tray — calm while agents work, ringing the moment one is blocked on you.",
+    src: "/feature/tray.png",
+    alt: "The Termio menu-bar tray listing sessions grouped by project",
+    width: 870,
+    height: 700,
+  },
+  {
+    title: "Command palette",
+    blurb:
+      "Jump to any session, project, or action from one search box.",
+    src: "/feature/pallette.png",
+    alt: "The Termio command palette over a terminal session",
+    width: 1120,
+    height: 800,
+  },
+  {
+    title: "Usage at a glance",
+    blurb:
+      "Your Claude and Codex plan limits in Settings, read locally from your own credentials — no proxy, no account.",
+    src: "/feature/usage.png",
+    alt: "Claude and Codex usage meters in Termio's settings",
+    width: 1150,
+    height: 918,
+  },
+  {
+    title: "Native appearance",
+    blurb:
+      "Light, dark, and a glass look that follows the system — a real Mac app, down to the chrome.",
+    src: "/feature/appearance.png",
+    alt: "Termio's appearance settings with light, dark, and glass modes",
+    width: 1160,
+    height: 926,
+  },
+] as const;
+
+export function FeatureGrid() {
+  return (
+    <section id="features" className="scroll-mt-24">
+      {/* Light top padding — the showcase above already ends with pb-32/40. */}
+      <div className="mx-auto w-full max-w-6xl px-5 pb-32 pt-8 sm:px-8 sm:pb-40 sm:pt-10">
+        <Reveal className="flex flex-col items-center text-center">
+          <SectionLabel accent="pink">What&apos;s inside</SectionLabel>
+          <h2 className="mt-4 text-balance text-3xl font-medium leading-[1.1] tracking-tight text-foreground sm:text-[44px]">
+            Built for watching agents work
+          </h2>
+          <p className="mt-5 max-w-lg text-balance text-base leading-relaxed text-muted-foreground">
+            Several agents going at once, most of them fine without you, one of
+            them stuck — Termio keeps the whole fleet in view.
+          </p>
+        </Reveal>
+
+        <div className="mt-12 grid gap-5 sm:grid-cols-2 sm:gap-6">
+          {features.map((feature, i) => (
+            <Reveal
+              key={feature.src}
+              as="article"
+              delayMs={(i % 2) * 80}
+              className="flex flex-col rounded-3xl bg-card p-6 sm:p-8"
+            >
+              <h3 className="text-xl font-medium tracking-tight text-foreground">
+                {feature.title}
+              </h3>
+              <p className="mt-2 max-w-md text-pretty text-sm leading-relaxed text-muted-foreground">
+                {feature.blurb}
+              </p>
+              <div className="mt-auto pt-6">
+                <Image
+                  src={feature.src}
+                  width={feature.width}
+                  height={feature.height}
+                  alt={feature.alt}
+                  loading="lazy"
+                  // The captures render inside a ~32rem card column; without
+                  // `sizes` the browser downloads the full-width rendition.
+                  sizes="(min-width: 40rem) 32rem, calc(100vw - 5.5rem)"
+                  draggable={false}
+                  className="w-full rounded-xl"
+                />
+              </div>
+            </Reveal>
+          ))}
+        </div>
+
+        <Reveal delayMs={80}>
+          <p className="mx-auto mt-10 max-w-3xl text-balance text-center text-sm leading-relaxed text-muted-foreground">
+            Also in the box: git worktrees nested under each project, a
+            read-only git pane with unified diffs, a click-to-edit file editor,
+            Ghostty-style split panes, and a sessions CLI your agents can drive
+            themselves.
+          </p>
+        </Reveal>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

**Settings ▸ SSH** — a new tab that treats `~/.ssh/config` as the single source of truth: it lists the connectable Host blocks (resolved with ssh's own first-obtained-value semantics — `Host *` defaults, wildcard patterns, `Include` splicing, `%h` expansion), connects to a host as a Terminals-section session in one click, appends new Host blocks via an Add Host sheet (creating `~/.ssh` 0700 / config 0600 when missing, symlink-safe writes), opens the raw config in the in-app editor at the defining line, and offers one-click copy of `~/.ssh` public keys. `CompanionServer`'s inline parser now delegates to the shared `SSHConfigFile`, so the phone's SSH import sees the same correctly-resolved hosts.

**Settings ▸ Keyboard** — redesigned System Settings style: one grouped Form, search in the window toolbar, Restore Defaults as the list's final section, and a beep + shake + transient popover for refused recordings. The recorder follows sindresorhus/KeyboardShortcuts' RecorderCocoa pattern (NSSearchField, focus-driven recording, local key-down monitor), with two macOS 26 fixes: no `stringValue` writes during editing-session establishment (tears recording down), and search/cancel button cells hidden via transparency instead of nil-ing (nil'd cells crash `accessibilityChildrenAttribute`).

Reviewed by a Codex session over five rounds (parser semantics, symlink safety, port/quoting validation, Include recursion-stack cycle guard, recorder lifecycle) — final verdict APPROVE.

## Release Notes

- New Settings ▸ SSH tab: your `~/.ssh/config` hosts with one-click connect, an Add Host form, in-app config editing, and public-key copy.
- The Keyboard settings pane is redesigned in the System Settings style, with toolbar search and a native shortcut recorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)