### PR TITLE
Remove the search pane's background seam

### DIFF
--- a/Sources/termio/FileBrowser/FileSearchView.swift
+++ b/Sources/termio/FileBrowser/FileSearchView.swift
@@ -94,7 +94,6 @@ struct FileSearchView: View {
                 .padding(.bottom, 5)
             }
         }
-        .background(Color(nsColor: .windowBackgroundColor))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

The inspector Search pane's field strip painted its own `windowBackgroundColor` while the result list below stays transparent over the inspector's themed background, leaving a visible color seam under the search field. Dropping the extra background gives the whole pane one continuous surface.

## Release Notes

- The inspector's Search pane no longer shows a background seam under the search field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)