### PR TITLE
Emit stalled watch events from loop-level stall detection

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -240,7 +240,9 @@ final class SessionControlListener {
 struct SessionWatchEvent {
     let projectID: UUID
     let handle: String
-    /// Wire status token (`working` / `idle` / `done` / `needs-you`).
+    /// Wire status token (`working` / `idle` / `done` / `needs-you`), or the
+    /// watch-plane `stalled` — a supervision judgment broadcast without ever
+    /// becoming the session's real status.
     let status: String
     let title: String
     let cwd: String
@@ -254,6 +256,11 @@ struct SessionWatchEvent {
     /// is readable without another `list --json` round-trip.
     var transcript: String? = nil
     var cursorEnd: Int? = nil
+    /// `stalled` only: the stall detector's reasoning ("working 42m, no repo
+    /// change, transcript +3 lines"). `stalled` is a watch-plane signal, never a
+    /// session's real status — see the loop-level stall detection in
+    /// `TermioStore+AgentStatus` (design doc §4.7).
+    var evidence: String? = nil
 }
 
 /// Holds the open `watch` connections and fans status transitions out to them. A
@@ -384,7 +391,8 @@ final class SessionWatchHub {
 private extension SessionWatchEvent {
     var wireLine: Data {
         let suffix = title.isEmpty ? "" : "  \(title)"
-        return Data("\(handle)  [\(status)]\(suffix)\n".utf8)
+        let detail = evidence.map { "  — \($0)" } ?? ""
+        return Data("\(handle)  [\(status)]\(suffix)\(detail)\n".utf8)
     }
     var jsonLine: Data {
         var object: [String: Any] = [
@@ -397,6 +405,7 @@ private extension SessionWatchEvent {
         if let prompt { object["prompt"] = prompt }
         if let transcript { object["transcript"] = transcript }
         if let cursorEnd { object["cursor_end"] = cursorEnd }
+        if let evidence { object["evidence"] = evidence }
         let data = (try? JSONSerialization.data(
             withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])) ?? Data()
         return data + Data("\n".utf8)
@@ -444,7 +453,11 @@ enum SessionSkillInstaller {
         - `termio sessions watch` — block and stream one line per sibling status
           change (`done` / `needs-you` by default) until you interrupt it — the push
           alternative to polling `list`. `--state working,idle,done,needs-you` widens
-          it. It opens with one snapshot line per sibling's current status
+          it, and `--state stalled` adds the runaway signal: a sibling still
+          `working` that has made no repo or transcript progress for 20+ minutes
+          (long builds streaming output don't trip it). A stalled event says why in
+          `evidence`, fires once, and re-arms when progress resumes. It opens with
+          one snapshot line per sibling's current status
           (`"snapshot":true` in `--json`; `--no-snapshot` skips), and in `--json`
           writes `{"heartbeat":true}` after 30s of silence so a dead stream is
           detectable. Exits 0 on your Ctrl-C, 2 if termio itself went away.

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -593,6 +593,22 @@ enum GitService {
         return (host, path)
     }
 
+    // MARK: Stall detection
+
+    /// A cheap identity of a working tree for the stall detector (sessions-cli-v2
+    /// §4.7 probe 2): the HEAD commit plus a digest of the porcelain status, so
+    /// both a new commit and any tree change move it. The digest is process-local
+    /// (`hashValue` is seeded per launch), which is all the detector compares
+    /// across. Synchronous and blocking — callers must run it off the main thread
+    /// (the BranchModel main-thread-git freeze). A non-repo directory fingerprints
+    /// as a stable empty value, which still compares correctly across a window.
+    static func stallFingerprint(in repoRoot: String) -> String {
+        let head = run(["rev-parse", "HEAD"], in: repoRoot)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let status = run(["status", "--porcelain"], in: repoRoot) ?? ""
+        return "\(head)#\(status.hashValue)"
+    }
+
     // MARK: Process
 
     private static func offMain<T: Sendable>(_ work: @escaping @Sendable () -> T) async -> T {

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -1,6 +1,15 @@
 import Foundation
+import os
 
 extension TermioStore {
+    /// Probe-level trace for the stall detector, readable via
+    /// `log stream --predicate 'category == "stall-detection"' --level info`.
+    /// The thresholds ship untuned against real fleets (design doc §4.7 keeps
+    /// `stalled` out of the default watch filter for exactly that reason), and
+    /// this is the evidence stream tuning needs: which windows slid on output
+    /// volume, and what each probe measured when one fired or held.
+    private static let stallTrace = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "sh.termio.app", category: "stall-detection")
     /// Brings up the hook socket and aligns `~/.claude/settings.json` with the
     /// current setting. The listener always runs (it is harmless when no hooks are
     /// installed); only the settings-file side is toggled.
@@ -17,7 +26,10 @@ extension TermioStore {
         // "turn ended" signal), so the sweep has to tick at that granularity to
         // clear a stuck spinner promptly. A 2s repeating timer is negligible.
         staleWorkingSweep = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
-            MainActor.assumeIsolated { self?.sweepStaleWorking() }
+            MainActor.assumeIsolated {
+                self?.sweepStaleWorking()
+                self?.sweepStalledSessions()
+            }
         }
     }
 
@@ -185,6 +197,7 @@ extension TermioStore {
         promotionStreak[id] = nil
         lastTitleActivity[id] = nil
         lastScreenActivity[id] = nil
+        stallProbes[id] = nil
     }
 
     /// Marks the moment of live user input into a session's terminal. Keystroke
@@ -230,6 +243,11 @@ extension TermioStore {
             if screenChanged || bytes >= streamingByteFloor {
                 lastWorkingAt[id] = Date()
             }
+            // Feed the stall detector's output-rate suppressor (§4.7 probe 4)
+            // with the raw byte volume. The rate over the whole window is what
+            // discriminates: build logs scrolling through a TUI repaint far more
+            // bytes per second than an idle spinner's frame updates.
+            stallProbes[id]?.streamedBytes += bytes
             return
         }
         guard screenChanged else {
@@ -458,6 +476,183 @@ extension TermioStore {
         }
     }
 
+    // MARK: Loop-level stall detection (design doc §4.7)
+
+    /// How long a session must be continuously `.working` with no progress marker
+    /// before it reads as stalled — probe 1's window, and the span every other
+    /// probe compares across.
+    nonisolated static let stallWindow: TimeInterval =
+        stallOverride("TERMIO_STALL_WINDOW_SECONDS", default: 20 * 60)
+    /// Transcript lines the window must add to count as progress (probe 3's K).
+    nonisolated static let stallTranscriptLineFloor: Int =
+        Int(stallOverride("TERMIO_STALL_TRANSCRIPT_LINES", default: 5))
+    /// The average PTY output rate (bytes/second across the window) at or above
+    /// which probe 4 suppresses the alert: the agent is visibly producing —
+    /// output genuinely scrolling through the terminal. Calibrated against
+    /// measured Claude Code rates (2026-07): parked on a spinner ~1.4 KB/s,
+    /// a tool call with collapsed output ~1.1 KB/s, streaming a text response
+    /// ~1.5 KB/s averaged across its thinking pauses — while full-screen output
+    /// scrolls run tens of KB/s. The default sits above every measured idle mode.
+    /// Note the flip side: a TUI that collapses tool output (Claude) keeps a
+    /// legitimate long build *under* this rate, so a window-length quiet build
+    /// still signals — from outside the agent the two are indistinguishable,
+    /// which is exactly why this plane signals and never kills (§4.7); the
+    /// transcript-tail awareness of phase 4b is the planned refinement.
+    nonisolated static let stallStreamByteRate: Double =
+        stallOverride("TERMIO_STALL_STREAM_BYTES_PER_SECOND", default: 4096)
+    /// How often the expensive probes may re-run per session once its window has
+    /// elapsed. Scaled with the window so a shortened testing window still probes
+    /// promptly; the 2s floor is the sweep's own tick.
+    nonisolated static let stallProbeInterval: TimeInterval = max(2, stallWindow / 40)
+
+    /// Testing-only override for the stall thresholds, so live verification does
+    /// not take 20 minutes: the environment variable when a dev launch exports
+    /// one, else a `defaults` key of the same name, else the shipped default.
+    /// Read once at first use; deliberately not a setting.
+    nonisolated private static func stallOverride(_ key: String, default value: Double) -> Double {
+        if let raw = ProcessInfo.processInfo.environment[key],
+           let overridden = Double(raw), overridden > 0 { return overridden }
+        let stored = UserDefaults.standard.double(forKey: key)
+        return stored > 0 ? stored : value
+    }
+
+    /// The stall sweep, riding the same 2s timer as `sweepStaleWorking`. The four
+    /// probes are evaluated lazily, cheapest first: the clock (probe 1) and the
+    /// output-rate suppressor (probe 4) are plain arithmetic and gate everything;
+    /// only a fully-elapsed, unsuppressed window pays for the off-main git +
+    /// transcript measurement (probes 2 and 3). Verdict `1 AND 2 AND 3 AND NOT 4`
+    /// emits one `stalled` watch event, then holds until a progress marker
+    /// re-arms the window.
+    func sweepStalledSessions() {
+        let now = Date()
+        for (id, probe) in stallProbes {
+            guard status(for: id) == .working else { stallProbes[id] = nil; continue }
+            guard !probe.measuring else { continue }
+            guard probe.baseline != nil else {
+                launchStallMeasurement(for: id, capture: true)
+                continue
+            }
+            guard now.timeIntervalSince(probe.windowStart) >= Self.stallWindow,
+                  now.timeIntervalSince(probe.lastProbeAt) >= Self.stallProbeInterval
+            else { continue }
+            if probe.isStreamSuppressed(at: now, bytesPerSecond: Self.stallStreamByteRate) {
+                // Sustained output is progress in itself: slide the window instead
+                // of alerting, and drop the baseline so the next capture compares
+                // against the world as of now.
+                Self.stallTrace.info(
+                    "suppressed session=\(id, privacy: .public) streamed_bytes=\(probe.streamedBytes, privacy: .public) elapsed_s=\(Int(now.timeIntervalSince(probe.windowStart)), privacy: .public)")
+                var slid = probe
+                slid.slideWindow(to: now, baseline: nil)
+                stallProbes[id] = slid
+                continue
+            }
+            launchStallMeasurement(for: id, capture: false)
+        }
+    }
+
+    /// Opens the stall window for a session that just entered `.working`: stamps
+    /// `workingSince` now; the first sweep tick captures the baseline. Called
+    /// only from `setStatus`, the single status choke point.
+    func beginStallWatch(for id: Session.ID) {
+        let now = Date()
+        stallProbes[id] = StallProbe(workingSince: now, windowStart: now)
+    }
+
+    /// Runs the expensive probes off the main actor — the BranchModel
+    /// main-thread-git freeze is the documented hazard — and applies the result
+    /// back on it. With `capture` the result seeds a fresh window's baseline;
+    /// otherwise it is judged against the existing one.
+    private func launchStallMeasurement(for id: Session.ID, capture: Bool) {
+        guard var probe = stallProbes[id] else { return }
+        probe.measuring = true
+        if !capture { probe.lastProbeAt = Date() }
+        stallProbes[id] = probe
+        let generation = probe.generation
+        let baseline = probe.baseline
+        // The baseline's directory is reused for the whole window, so an agent
+        // `cd`-ing between repos can't masquerade as repo progress.
+        let directory = capture ? stallProbeDirectory(for: id) : baseline?.directory
+        let transcript = transcriptPaths[id] ?? resolveTranscriptPath(for: id)
+        Task { [weak self] in
+            let measured = await Self.measureStallEvidence(
+                directory: directory, transcript: transcript, known: baseline)
+            guard let self, var probe = self.stallProbes[id],
+                  probe.generation == generation else { return }
+            probe.measuring = false
+            if capture {
+                probe.baseline = StallProbe.Baseline(directory: directory, measured: measured)
+                self.stallProbes[id] = probe
+                return
+            }
+            let assessment = probe.assess(
+                measured, at: Date(), transcriptLineFloor: Self.stallTranscriptLineFloor)
+            self.stallProbes[id] = probe
+            Self.stallTrace.info(
+                "probe session=\(id, privacy: .public) verdict=\(String(describing: assessment), privacy: .public) fingerprint=\(measured.repoFingerprint, privacy: .public) transcript_lines=\(measured.transcriptLines, privacy: .public) streamed_bytes=\(probe.streamedBytes, privacy: .public)")
+            if case .stalled(let linesGrown) = assessment {
+                self.emitStalled(
+                    id, workingSince: probe.workingSince, transcriptLinesGrown: linesGrown)
+            }
+        }
+    }
+
+    /// Where probe 2 fingerprints: the session's own worktree when it has one,
+    /// else the live shell cwd, else the project checkout.
+    private func stallProbeDirectory(for id: Session.ID) -> String? {
+        guard let session = session(id) else { return nil }
+        return session.worktreePath ?? runtimes[id]?.workingDirectory ?? project(for: id)?.path
+    }
+
+    /// One off-main reading of probes 2 and 3. The transcript's full line count is
+    /// only paid for when its size moved (or nothing is known yet) — an unchanged
+    /// `stat` answers "grew < K lines" by itself.
+    nonisolated private static func measureStallEvidence(
+        directory: String?, transcript: String?, known: StallProbe.Baseline?
+    ) async -> StallMeasurement {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                let fingerprint = directory.map { GitService.stallFingerprint(in: $0) } ?? ""
+                guard let transcript else {
+                    return continuation.resume(returning: StallMeasurement(
+                        repoFingerprint: fingerprint, transcriptPath: nil,
+                        transcriptLines: 0, transcriptSize: 0))
+                }
+                let attributes = try? FileManager.default.attributesOfItem(atPath: transcript)
+                let size = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+                let lines: Int
+                if let known, known.transcriptPath == transcript, known.transcriptSize == size {
+                    lines = known.transcriptLines
+                } else {
+                    lines = lineCount(of: transcript)
+                }
+                continuation.resume(returning: StallMeasurement(
+                    repoFingerprint: fingerprint, transcriptPath: transcript,
+                    transcriptLines: lines, transcriptSize: size))
+            }
+        }
+    }
+
+    /// Broadcasts the one `stalled` event. Watch-plane only (§4.7): the session's
+    /// real status stays `.working` — no new `SessionStatus` case, the sidebar and
+    /// menu bar are untouched — and the default watch filter (done, needs-you)
+    /// keeps the signal opt-in via `--state stalled`.
+    private func emitStalled(
+        _ id: Session.ID, workingSince: Date, transcriptLinesGrown: Int
+    ) {
+        guard let session = session(id), let project = project(for: id) else { return }
+        let minutes = max(1, Int(Date().timeIntervalSince(workingSince) / 60))
+        let growth = "transcript +\(transcriptLinesGrown) line"
+            + (transcriptLinesGrown == 1 ? "" : "s")
+        var event = SessionWatchEvent(
+            projectID: project.id,
+            handle: sessionHandle(for: session),
+            status: "stalled",
+            title: displayTitle(for: session),
+            cwd: runtimes[id]?.workingDirectory ?? "")
+        event.evidence = "working \(minutes)m, no repo change, \(growth)"
+        SessionWatchHub.shared.broadcast(event)
+    }
+
     /// Resolves a status report back to its session. The exact key is the
     /// `TERMIO_SESSION` id termio stamped into the PTY and the agent echoed back, so
     /// this is unambiguous even when several sessions share one project directory.
@@ -507,4 +702,105 @@ extension TermioStore {
             return "Waiting for you"
         }
     }
+}
+
+/// Per-session state for loop-level stall detection (design doc §4.7). One value
+/// exists per continuously-working session, created on the `.working` transition
+/// and dropped on the way out. The window slides forward on every progress
+/// marker; `alerted` is the edge-trigger latch — one `stalled` event per quiet
+/// window, re-armed only by progress. A plain value type so the verdict logic is
+/// testable without the store.
+struct StallProbe {
+    /// When the session entered `.working` — probe 1's clock, and the duration the
+    /// evidence string reports.
+    let workingSince: Date
+    /// Start of the current no-progress window; slides to "now" on any progress.
+    var windowStart: Date
+    /// PTY output bytes seen since `windowStart` — probe 4's numerator, fed by
+    /// `noteOutputActivity`. Volume, not tick counting: an idle agent's spinner
+    /// repaints on every tick too, so only the byte *rate* separates "parked on a
+    /// spinner" from "build logs scrolling through the TUI".
+    var streamedBytes = 0
+    /// What the window's probes compare against, captured off-main just after
+    /// `windowStart`. `nil` while a capture is pending.
+    var baseline: Baseline?
+    /// An off-main capture or probe is in flight; the sweep must not stack another.
+    var measuring = false
+    /// Ties an in-flight off-main measurement back to this exact probe value, so a
+    /// result landing after the session left and re-entered `.working` is
+    /// discarded instead of judged against the wrong window.
+    let generation = UUID()
+    var lastProbeAt = Date.distantPast
+    var alerted = false
+
+    struct Baseline {
+        /// The directory fingerprinted at capture, reused for the whole window.
+        let directory: String?
+        let repoFingerprint: String
+        let transcriptPath: String?
+        let transcriptLines: Int
+        let transcriptSize: Int64
+
+        init(directory: String?, measured: StallMeasurement) {
+            self.directory = directory
+            repoFingerprint = measured.repoFingerprint
+            transcriptPath = measured.transcriptPath
+            transcriptLines = measured.transcriptLines
+            transcriptSize = measured.transcriptSize
+        }
+    }
+
+    enum Assessment: Equatable {
+        /// A progress marker landed — the window slid forward and re-armed.
+        case progress
+        /// Every probe agrees: emit the one `stalled` event.
+        case stalled(transcriptLinesGrown: Int)
+        /// No progress, but the alert already fired — keep holding.
+        case hold
+    }
+
+    /// Whether probe 4 suppresses the alert: the window's average output rate
+    /// says the agent is visibly producing.
+    func isStreamSuppressed(at now: Date, bytesPerSecond: Double) -> Bool {
+        let elapsed = now.timeIntervalSince(windowStart)
+        guard elapsed > 0 else { return false }
+        return Double(streamedBytes) >= elapsed * bytesPerSecond
+    }
+
+    /// Judges a fresh measurement against the baseline (probes 2 and 3) and
+    /// applies the verdict: progress slides the window and re-arms; the first
+    /// all-probes-agree verdict latches `alerted` so the event fires exactly once.
+    mutating func assess(
+        _ measured: StallMeasurement, at now: Date, transcriptLineFloor: Int
+    ) -> Assessment {
+        guard let baseline else { return .hold }
+        let linesGrown = max(0, measured.transcriptLines - baseline.transcriptLines)
+        if measured.repoFingerprint != baseline.repoFingerprint
+            || linesGrown >= transcriptLineFloor {
+            slideWindow(to: now, baseline: Baseline(
+                directory: baseline.directory, measured: measured))
+            return .progress
+        }
+        if alerted { return .hold }
+        alerted = true
+        return .stalled(transcriptLinesGrown: linesGrown)
+    }
+
+    /// Restarts the no-progress window at `now` and re-arms the alert. A `nil`
+    /// baseline makes the next sweep tick capture a fresh one.
+    mutating func slideWindow(to now: Date, baseline newBaseline: Baseline?) {
+        windowStart = now
+        streamedBytes = 0
+        baseline = newBaseline
+        alerted = false
+    }
+}
+
+/// One off-main reading of a session's progress evidence: the repo fingerprint
+/// plus the transcript's current extent.
+struct StallMeasurement {
+    let repoFingerprint: String
+    let transcriptPath: String?
+    let transcriptLines: Int
+    let transcriptSize: Int64
 }

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -641,7 +641,7 @@ extension TermioStore {
 
     /// Lines currently in a file, counted cheaply by newline bytes — the cursor a
     /// caller resumes a transcript read from.
-    static func lineCount(of path: String) -> Int {
+    nonisolated static func lineCount(of path: String) -> Int {
         guard let data = FileManager.default.contents(atPath: path) else { return 0 }
         return data.reduce(into: 0) { count, byte in if byte == 0x0A { count += 1 } }
     }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -199,7 +199,17 @@ final class TermioStore: ObservableObject {
     func setStatus(_ status: SessionStatus, for id: Session.ID) -> Bool {
         let runtime = runtime(for: id)
         guard runtime.status != status else { return false }
+        let previous = runtime.status
         runtime.status = status
+        // Stall detection (§4.7) keys off continuous time spent `.working`, so the
+        // window opens on the genuine transition in — this method is the single
+        // status choke point — and closes on the way out: a session that stopped
+        // working can no longer be stalled.
+        if status == .working {
+            beginStallWatch(for: id)
+        } else if previous == .working {
+            stallProbes[id] = nil
+        }
         // The tray and window title present status, so a real change pings them.
         sessionRuntimeDidChange.send()
         // Push the genuine transition to any `termio sessions watch` clients scoped
@@ -366,6 +376,13 @@ final class TermioStore: ObservableObject {
     /// Refreshed both by working hooks and by a *changed* rendered screen
     /// (`noteOutputActivity`).
     var lastWorkingAt: [Session.ID: Date] = [:]
+    /// Loop-level stall-detection state per continuously-working session (design
+    /// doc §4.7): when it entered `.working`, the current no-progress window, the
+    /// output-rate ticks, and the repo/transcript baseline the sweep compares
+    /// against. Created on the transition into `.working`, dropped on the way out
+    /// (both in `setStatus`); probed by `sweepStalledSessions` in
+    /// `TermioStore+AgentStatus`.
+    var stallProbes: [Session.ID: StallProbe] = [:]
     /// The last activity a screen-scrape-configured agent's viewport was classified
     /// into (see `AgentStatusRules` / `applyScreenDetectedActivity`), so status is only
     /// re-driven on a transition — not re-emitted every tick the screen sits idle.

--- a/Tests/termioTests/StallProbeTests.swift
+++ b/Tests/termioTests/StallProbeTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import termio
+
+/// The stall detector's verdict logic (design doc §4.7), pinned as a pure state
+/// machine: the edge trigger must fire exactly once per quiet window, every
+/// progress marker must slide the window and re-arm it, and the output-rate
+/// suppressor must read sustained streams — not spinner dribble — as progress.
+final class StallProbeTests: XCTestCase {
+    private let start = Date(timeIntervalSinceReferenceDate: 0)
+
+    private func measurement(
+        fingerprint: String = "abc#1", lines: Int = 100, size: Int64 = 1000
+    ) -> StallMeasurement {
+        StallMeasurement(
+            repoFingerprint: fingerprint, transcriptPath: "/tmp/t.jsonl",
+            transcriptLines: lines, transcriptSize: size)
+    }
+
+    private func probeWithBaseline() -> StallProbe {
+        var probe = StallProbe(workingSince: start, windowStart: start)
+        probe.baseline = StallProbe.Baseline(directory: "/repo", measured: measurement())
+        return probe
+    }
+
+    func testUnchangedEvidenceAlertsOnceThenHolds() {
+        var probe = probeWithBaseline()
+        let later = start.addingTimeInterval(1200)
+        XCTAssertEqual(
+            probe.assess(measurement(lines: 103), at: later, transcriptLineFloor: 5),
+            .stalled(transcriptLinesGrown: 3))
+        XCTAssertTrue(probe.alerted)
+        // The next quiet probe holds — edge-triggered, never spam.
+        XCTAssertEqual(
+            probe.assess(measurement(lines: 104), at: later.addingTimeInterval(30),
+                         transcriptLineFloor: 5),
+            .hold)
+    }
+
+    func testRepoChangeIsProgressAndReArms() {
+        var probe = probeWithBaseline()
+        let later = start.addingTimeInterval(1200)
+        XCTAssertEqual(
+            probe.assess(measurement(), at: later, transcriptLineFloor: 5),
+            .stalled(transcriptLinesGrown: 0))
+        // A commit moves the fingerprint: the window slides, the latch re-arms.
+        let afterCommit = later.addingTimeInterval(60)
+        XCTAssertEqual(
+            probe.assess(measurement(fingerprint: "def#2"), at: afterCommit,
+                         transcriptLineFloor: 5),
+            .progress)
+        XCTAssertFalse(probe.alerted)
+        XCTAssertEqual(probe.windowStart, afterCommit)
+        XCTAssertEqual(probe.baseline?.repoFingerprint, "def#2")
+        // A later quiet stretch may alert again — one event per window, not per turn.
+        XCTAssertEqual(
+            probe.assess(measurement(fingerprint: "def#2"),
+                         at: afterCommit.addingTimeInterval(1200), transcriptLineFloor: 5),
+            .stalled(transcriptLinesGrown: 0))
+    }
+
+    func testTranscriptBurstIsProgress() {
+        var probe = probeWithBaseline()
+        let later = start.addingTimeInterval(1200)
+        XCTAssertEqual(
+            probe.assess(measurement(lines: 100 + 5, size: 2000), at: later,
+                         transcriptLineFloor: 5),
+            .progress)
+        XCTAssertEqual(probe.baseline?.transcriptLines, 105)
+    }
+
+    func testStreamSuppressorReadsSustainedVolumeOnly() {
+        var probe = StallProbe(workingSince: start, windowStart: start)
+        let later = start.addingTimeInterval(1000)
+        // A spinner's frame repaints average ~2 KB/s — under the rate threshold.
+        probe.streamedBytes = 2048 * 1000
+        XCTAssertFalse(probe.isStreamSuppressed(at: later, bytesPerSecond: 4096))
+        // A build scrolling logs through the TUI is an order of magnitude louder.
+        probe.streamedBytes = 20_000 * 1000
+        XCTAssertTrue(probe.isStreamSuppressed(at: later, bytesPerSecond: 4096))
+    }
+
+    func testSlideWindowWithoutBaselineForcesRecapture() {
+        var probe = probeWithBaseline()
+        probe.alerted = true
+        probe.streamedBytes = 300_000
+        let now = start.addingTimeInterval(1200)
+        probe.slideWindow(to: now, baseline: nil)
+        XCTAssertNil(probe.baseline)
+        XCTAssertFalse(probe.alerted)
+        XCTAssertEqual(probe.streamedBytes, 0)
+        XCTAssertEqual(probe.windowStart, now)
+        // With no baseline the assessment cannot judge — it holds until recapture.
+        XCTAssertEqual(
+            probe.assess(measurement(), at: now.addingTimeInterval(1200),
+                         transcriptLineFloor: 5),
+            .hold)
+    }
+}

--- a/scripts/termio
+++ b/scripts/termio
@@ -43,7 +43,8 @@ options:
                    (exit 0 settled, 1 error — including a stalled/vanished session, 3 timed out)
   --timeout <ms>   cap for --wait (default 300000, clamped 1000–600000); implies --wait
   --lines <n>      for `read`: keep only the last n screen rows
-  --state <s,…>    for `watch`: comma-separated states to report (working, idle, done, needs-you)
+  --state <s,…>    for `watch`: comma-separated states to report (working, idle, done,
+                   needs-you, stalled; default done,needs-you)
   --no-snapshot    for `watch`: skip the initial per-session status snapshot
   --help, --version
 
@@ -72,10 +73,19 @@ usage: termio sessions watch [--state <s,…>] [--no-snapshot] [--json]
 Block and stream one line per session status transition until interrupted.
 On attach it first prints a snapshot line per session with its current
 status (tagged "snapshot":true in --json); --no-snapshot skips that.
---state takes a comma-separated filter (working, idle, done, needs-you);
-the default reports the two states a supervisor acts on: done, needs-you.
+--state takes a comma-separated filter (working, idle, done, needs-you,
+stalled); the default reports the two states a supervisor acts on: done,
+needs-you.
 In --json mode the app writes {"heartbeat":true} after 30s of silence so a
 dead stream is distinguishable from a quiet one.
+
+`stalled` is a watch-plane signal, not a real status: the session is still
+working, but for 20+ minutes has made no repo change and next-to-no
+transcript growth — the unattended-runaway pattern. Sustained output (a
+long build streaming logs) suppresses it. The event carries the reasoning
+in `evidence` ("working 42m, no repo change, transcript +3 lines"), fires
+once per quiet stretch, and re-arms when progress resumes. Opt in with
+--state stalled; it is not in the default filter.
 
 exit codes: 0 after Ctrl-C (normal end of supervision), 2 when the stream
 closes from the app side (termio quit or died).

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -137,6 +137,14 @@ outcomes so scripts can branch without parsing: **0** settled, **1** error
 - **Filtered by default.** Live events default to the two states a supervisor
   acts on, `done` and `needs-you`; widen with
   `--state working,idle,done,needs-you`.
+- **Stall alarm, opt-in.** `--state stalled` adds a watch-plane signal for the
+  unattended runaway: a session still `working` that has made **no repo change
+  and next-to-no transcript growth for 20+ minutes**. Sustained output — a long
+  build streaming logs — suppresses it. The event carries the detector's
+  reasoning in `evidence` (`"working 42m, no repo change, transcript +3
+  lines"`), fires once per quiet stretch, and re-arms when progress resumes.
+  Termio only signals; it never kills — the session's real status stays
+  `working` and the sidebar is untouched. Not in the default filter.
 - **Actionable events.** A `needs-you` event carries the on-screen question in
   `prompt`; a `done` event carries the session's `transcript` path and
   `cursor_end` — enough to answer, or to read the result, without another
@@ -209,9 +217,12 @@ everywhere): the final `status`, and the transcript line range
 ```
 
 `cwd` is omitted until the shell reports one; `snapshot` marks the on-attach
-roster lines; `prompt` rides on `needs-you` events and `transcript` +
-`cursor_end` on `done` events, exactly as in wait replies. After 30 seconds of
-silence the app writes `{"heartbeat": true}`.
+roster lines; `prompt` rides on `needs-you` events, `transcript` +
+`cursor_end` on `done` events (exactly as in wait replies), and `evidence` on
+`stalled` events — the stall detector's reasoning, e.g.
+`"working 42m, no repo change, transcript +3 lines"`. `stalled` appears only
+on the watch stream, never as a session's `status` in `list` or wait replies.
+After 30 seconds of silence the app writes `{"heartbeat": true}`.
 
 <Callout type="tip">
   This is what lets one agent hand work to another — `spawn` a task in a sibling


### PR DESCRIPTION
Phase 4a of the Sessions CLI v2 design ([§4.7](../blob/main/docs/design/sessions-cli-v2.md)) — the supervision plane's answer to the unattended runaway: a session `working` for tens of minutes while producing nothing. Phases 1–3 shipped in #80/#86/#87/#88.

## What it does

- `setStatus` stamps the working window on the genuine transition into `.working` (the single status choke point) and drops it on the way out.
- A sweep riding the existing 2s stale-working timer evaluates four probes lazily, cheapest first:
  1. continuously `working` ≥ 20 min (timestamp compare)
  2. repo fingerprint unchanged — `rev-parse HEAD` + porcelain digest in the session's worktree/cwd, run **off the main actor** (the BranchModel main-thread-git freeze is the documented hazard)
  3. transcript grew < K lines over the window (`stat` first; the full line count is only paid when the size moved)
  4. suppressor: sustained PTY output byte-rate (fed by the existing per-tick byte stamps) reads as visible progress
- Verdict `1 AND 2 AND 3 AND NOT 4` → **one** `stalled` event through `SessionWatchHub` with an evidence string (`"working 42m, no repo change, transcript +3 lines"`), then hold until a progress marker (commit, tree change, transcript burst, sustained output) slides the window and re-arms. Edge-triggered, never spam.
- `stalled` is a **watch-plane event only**: no fifth `SessionStatus`, the session's real status stays `working`, sidebar/menubar untouched, and it stays **out of the default watch filter** (`--state stalled` opts in). Signal only — no kill switch.
- Window/thresholds are internally overridable for testing (`TERMIO_STALL_WINDOW_SECONDS`, `TERMIO_STALL_TRANSCRIPT_LINES`, `TERMIO_STALL_STREAM_BYTES_PER_SECOND` — env var or defaults key, read at startup, documented as testing-only).
- A `stall-detection` os_log category traces every suppress/probe verdict with the measured rates — the evidence stream threshold tuning needs before `stalled` graduates into the default filter.
- Docs updated on all three surfaces: CLI usage + `watch` per-verb help, the installed agent skill block, and `web/landing/content/docs/session-control.mdx` (watch states, `evidence` field, JSON contract).

## Verification (dev build, 45s test window)

Unit: `StallProbeTests` pins the verdict state machine (alert-once-then-hold, progress re-arms, transcript burst, suppressor rate math) — 5/5 pass.

Live, driving a spawned Claude session in a scratch repo via the `termio-dev` CLI:

- **(a) real stall** — a turn parked inside one long quiet tool call: exactly one event, correct evidence, real status stayed `working`:
  ```json
  {"evidence":"working 1m, no repo change, transcript +3 lines","handle":"claude@2aa6359e","schema_version":1,"status":"stalled","title":"…"}
  ```
  Follow-up probes traced `verdict=hold` — no repeat event.
- **(c) reset & re-arm** — a `git commit` mid-stall traced `verdict=progress` within one probe interval; a fresh quiet window then produced a second event (`"working 2m, no repo change, transcript +0 lines"`), proving the window reset and the latch re-armed.
- **(b) suppression** — with the rate override set below the measured spinner rate, two consecutive expired windows traced `suppressed streamed_bytes=55500 elapsed_s=45` / `49151/46` and emitted **zero** events while the window slid — the suppressor path works end-to-end.

Calibration honesty, from measured rates: Claude Code renders thriftily (spinner ~1.4 KB/s, collapsed tool output ~1.1 KB/s, streaming text ~1.5 KB/s averaged), so the shipped 4 KB/s default sits above every idle mode and suppresses only genuinely scrolling output. The flip side is documented in the code: a TUI that collapses tool output keeps a legitimate window-length build under the rate, so it will signal — from outside the agent the two are indistinguishable, which is exactly why this plane signals and never kills, and why 4b (transcript-tail tool-signature awareness) is the planned refinement. This is also why `stalled` stays out of the default filter until tuned.

Release Notes:
- `termio sessions watch --state stalled` now flags runaway sessions: still `working`, but no repo change and next-to-no transcript growth for 20+ minutes. Events carry the reasoning in `evidence`, fire once per quiet stretch, and re-arm when progress resumes. Termio only signals — nothing is killed, and the session's status in the sidebar is unchanged.