### PR TITLE
feat(settings): probe SSH hosts with Test Connection instead of launching

### DIFF
--- a/Sources/termio/Settings/SSHConfig.swift
+++ b/Sources/termio/Settings/SSHConfig.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+/// The outcome of a non-interactive SSH reachability + auth probe (the Settings
+/// "Test Connection" action). Deliberately coarse: enough to tell "it works"
+/// from "the network's the problem" from "auth's the problem", each with a short
+/// human line for the row and the raw detail in a tooltip.
+enum SSHProbeResult: Equatable {
+    case reachable
+    case authFailed(String)
+    case unreachable(String)
+}
+
 /// One connectable `Host` block parsed from the user's OpenSSH client config —
 /// the same aliases `ssh <alias>` itself resolves. A block that lists several
 /// aliases yields one entry per alias. `file`/`line` locate the block's `Host`
@@ -325,5 +335,69 @@ enum SSHConfigFile {
                 comment: fields.count > 2 ? fields[2] : ""
             )
         }
+    }
+
+    /// Probes an alias non-interactively: connect, authenticate, run `true`,
+    /// exit — it never opens a shell or a prompt. `BatchMode=yes` blocks any
+    /// password/passphrase ask (so it can't hang waiting on stdin),
+    /// `ConnectTimeout` bounds the network wait, and running `true` makes a clean
+    /// exit mean "authenticated and the remote executed a command". Runs off the
+    /// main thread; the exact ssh resolution matches a real `ssh <alias>`.
+    static func testConnection(alias: String) async -> SSHProbeResult {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+                process.arguments = [
+                    "-o", "BatchMode=yes",
+                    "-o", "ConnectTimeout=6",
+                    // A never-seen host would otherwise fail the probe on the
+                    // host-key prompt BatchMode suppresses; accept-new records it
+                    // exactly as a first real connect would.
+                    "-o", "StrictHostKeyChecking=accept-new",
+                    alias, "true",
+                ]
+                let errorPipe = Pipe()
+                process.standardError = errorPipe
+                process.standardOutput = Pipe()
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(returning: .unreachable("ssh unavailable"))
+                    return
+                }
+                // Drain before wait: a full stderr pipe would deadlock a process
+                // we're blocking on. EOF arrives when ssh exits and closes it.
+                let stderr = String(
+                    data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8
+                ) ?? ""
+                process.waitUntilExit()
+                continuation.resume(
+                    returning: process.terminationStatus == 0 ? .reachable : classify(stderr)
+                )
+            }
+        }
+    }
+
+    /// Buckets ssh's stderr into the probe outcomes, keeping the clearest line as
+    /// the detail. Auth failures (including BatchMode's "we won't ask for a
+    /// password") are told apart from the host being unreachable.
+    private static func classify(_ stderr: String) -> SSHProbeResult {
+        let lower = stderr.lowercased()
+        let lastLine = stderr
+            .split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+            .last(where: { !$0.isEmpty }) ?? "Connection failed"
+        if lower.contains("permission denied")
+            || lower.contains("too many authentication failures")
+            || lower.contains("no supported authentication methods") {
+            return .authFailed(lastLine)
+        }
+        if lower.contains("could not resolve") || lower.contains("name or service not known") {
+            return .unreachable("Host not found")
+        }
+        if lower.contains("connection refused") { return .unreachable("Connection refused") }
+        if lower.contains("no route to host") { return .unreachable("No route to host") }
+        if lower.contains("timed out") { return .unreachable("Timed out") }
+        return .unreachable(lastLine)
     }
 }

--- a/Sources/termio/Settings/SSHSettingsTab.swift
+++ b/Sources/termio/Settings/SSHSettingsTab.swift
@@ -45,6 +45,22 @@ struct SSHSettingsTab: View {
                 onClose: { configEditor = nil }
             )
             .frame(minWidth: 640, minHeight: 460)
+            // FileEditorView delegates its close to an external toolbar that only
+            // exists over the terminal pane — in a sheet there's none, so supply
+            // one. Escape closes too; the visible button is the guaranteed way out.
+            .overlay(alignment: .topTrailing) {
+                Button { configEditor = nil } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24, height: 24)
+                        .background(.thinMaterial, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.cancelAction)
+                .help("Close (Esc)")
+                .padding(8)
+            }
         }
     }
 
@@ -67,7 +83,7 @@ struct SSHSettingsTab: View {
         } header: {
             SectionHeaderLabel(title: "Hosts")
         } footer: {
-            Text("The Host blocks from ~/.ssh/config (Include'd files too) — exactly the aliases `ssh` resolves. Connect opens the host as a terminal in the sidebar's Terminals section, same as File ▸ New SSH Connection.")
+            Text("The Host blocks from ~/.ssh/config (Include'd files too) — exactly the aliases `ssh` resolves. Test Connection probes reachability and auth without opening a session; right-click a host to Connect it as a terminal in the sidebar, same as File ▸ New SSH Connection.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -149,12 +165,16 @@ struct SSHSettingsTab: View {
 }
 
 /// One host row: alias over its `user@host` destination, a quiet key hint when
-/// the block pins an identity, and a Connect button. The context menu carries
-/// the secondary verbs so the row itself stays scannable.
+/// the block pins an identity, and a Test Connection probe. Live connecting is a
+/// launch, not a setting — it lives in the context menu (and the sidebar / File
+/// menu), keeping this pane about configuring and verifying hosts.
 private struct SSHHostRow: View {
     let host: SSHConfigHost
     let connect: () -> Void
     let editInConfig: () -> Void
+
+    private enum ProbeState { case idle, running, result(SSHProbeResult) }
+    @State private var probe: ProbeState = .idle
 
     var body: some View {
         HStack(spacing: 10) {
@@ -174,18 +194,86 @@ private struct SSHHostRow: View {
                     .foregroundStyle(.tertiary)
                     .help("Uses \(identityFile)")
             }
-            Button("Connect", action: connect)
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+            probeControl
         }
         .contentShape(Rectangle())
         .contextMenu {
             Button("Connect", action: connect)
+            Button("Test Connection", action: runProbe)
             Button("Edit in Config", action: editInConfig)
             Button("Copy ssh Command") {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString("ssh \(host.alias)", forType: .string)
             }
+        }
+    }
+
+    /// The trailing control: a Test button that turns into a spinner while the
+    /// probe runs, then a tinted result badge that re-tests on click.
+    @ViewBuilder
+    private var probeControl: some View {
+        switch probe {
+        case .idle:
+            Button("Test", action: runProbe)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+        case .running:
+            ProgressView()
+                .controlSize(.small)
+                .frame(minWidth: 44)
+        case .result(let outcome):
+            Button(action: runProbe) {
+                Label(outcome.label, systemImage: outcome.symbol)
+                    .foregroundStyle(outcome.tint)
+                    .lineLimit(1)
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help("\(outcome.detail) — click to re-test")
+        }
+    }
+
+    /// Runs the non-interactive probe off the main thread, hopping back to update
+    /// the badge. A fresh click just re-arms it.
+    private func runProbe() {
+        probe = .running
+        Task { @MainActor in
+            probe = .result(await SSHConfigFile.testConnection(alias: host.alias))
+        }
+    }
+}
+
+/// How each probe outcome reads in the row: a short label + tinted glyph (never
+/// color alone), with the raw ssh detail in the tooltip.
+private extension SSHProbeResult {
+    var label: String {
+        switch self {
+        case .reachable: return "Reachable"
+        case .authFailed: return "Auth failed"
+        case .unreachable(let reason): return reason
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .reachable: return "checkmark.circle.fill"
+        case .authFailed: return "xmark.circle.fill"
+        case .unreachable: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .reachable: return .green
+        case .authFailed: return .orange
+        case .unreachable: return .red
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .reachable: return "Connected and authenticated"
+        case .authFailed(let message), .unreachable(let message): return message
         }
     }
 }

--- a/Sources/termio/Settings/SSHSettingsTab.swift
+++ b/Sources/termio/Settings/SSHSettingsTab.swift
@@ -95,7 +95,7 @@ struct SSHSettingsTab: View {
                 Button("Edit") { presentEditor(for: nil) }
             } label: {
                 SettingsLabel(
-                    symbol: "doc.text",
+                    .huge(.fileDoc),
                     title: "~/.ssh/config",
                     subtext: "The OpenSSH client config is the single source of truth — termio keeps no separate host database. Edits show up here and in plain `ssh` alike."
                 )
@@ -109,7 +109,7 @@ struct SSHSettingsTab: View {
         Section {
             ForEach(publicKeys) { key in
                 HStack(spacing: 10) {
-                    IconBadge(.symbol("key"))
+                    IconBadge(.huge(.key))
                     VStack(alignment: .leading, spacing: 2) {
                         Text(key.name)
                         Text(key.comment.isEmpty ? key.algorithm : "\(key.algorithm) · \(key.comment)")
@@ -178,7 +178,7 @@ private struct SSHHostRow: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            IconBadge(.symbol("server.rack"))
+            IconBadge(.huge(.serverStack))
             VStack(alignment: .leading, spacing: 2) {
                 Text(host.alias).font(.headline)
                 Text(host.destinationLabel)
@@ -189,9 +189,7 @@ private struct SSHHostRow: View {
             }
             Spacer(minLength: 8)
             if let identityFile = host.identityFile {
-                Image(systemName: "key.fill")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+                HugeIconView(icon: .key, size: 11, color: Color(nsColor: .tertiaryLabelColor))
                     .help("Uses \(identityFile)")
             }
             probeControl


### PR DESCRIPTION
The Settings ▸ SSH pane is for **configuring and verifying** hosts — launching a live session belongs elsewhere. This reworks the per-host action accordingly, and fixes a trap in the config editor found alongside it.

### Test Connection (was: Connect)
- The primary button now runs a **non-interactive probe**: `ssh -o BatchMode=yes -o ConnectTimeout=6 -o StrictHostKeyChecking=accept-new <alias> true` — connect, authenticate, run a no-op, exit. `BatchMode` blocks any password/passphrase prompt so it can't hang.
- Result reads **inline, never color-alone**: ✓ **Reachable** / ✗ **Auth failed** / ⚠ **&lt;reason&gt;** (Host not found, Connection refused, Timed out, …), with the raw ssh stderr in the tooltip. Click the badge to re-test.
- **Live connecting moves to the row's right-click menu** (and remains in the sidebar and `File ▸ New SSH Connection`).

### Fix: the config editor couldn't be closed
`FileEditorView` delegates its close to a toolbar that only exists when it covers the terminal pane — presented as a Settings `.sheet`, there was **no way out**. Added a visible close button (top-trailing) + Escape.

Probe logic lives in `SSHConfig.swift`; the row UI and close button in `SSHSettingsTab.swift`. Sits cleanly on top of the Hugeicons refactor (#93).

🤖 Generated with [Claude Code](https://claude.com/claude-code)