### PR TITLE
Add custom user agents with an editor in the Agents settings pane

### DIFF
--- a/Sources/termio/Agents/AgentDefinition.swift
+++ b/Sources/termio/Agents/AgentDefinition.swift
@@ -457,9 +457,23 @@ struct AgentHookSpec: Hashable {
 
 /// Owns the merged set of agent definitions. Both sources decode through
 /// `AgentManifest`; only their directory layout differs until Cut 4 migrates the
-/// legacy user folders. Loaded once, with no hot reload.
+/// legacy user folders. Each instance is immutable; `reload()` swaps in a fresh
+/// one after Settings writes or deletes a user manifest.
 final class AgentCatalog {
-    static let shared = AgentCatalog()
+    private static let sharedLock = NSLock()
+    private static var _shared = AgentCatalog()
+
+    static var shared: AgentCatalog {
+        sharedLock.withLock { _shared }
+    }
+
+    /// Re-reads bundled + user manifests. Readers pick up the fresh instance on
+    /// their next `shared` access; definitions already handed out keep their old
+    /// values (equality is by id, so live sessions are unaffected).
+    static func reload() {
+        let fresh = AgentCatalog()
+        sharedLock.withLock { _shared = fresh }
+    }
 
     let all: [AgentDefinition]
     /// Retained so a user override that removes or redirects a shipped hook can
@@ -496,6 +510,14 @@ final class AgentCatalog {
 
     func find(id: String) -> AgentDefinition? {
         all.first { $0.id == id }
+    }
+
+    /// Whether this id came from a user manifest rather than the bundle — i.e. the
+    /// Settings editor may rewrite or delete its file. A user *override* of a
+    /// bundled id is deliberately excluded: deleting it would resurrect the
+    /// bundled agent, which "Delete" does not promise.
+    func isUserDefined(_ id: String) -> Bool {
+        find(id: id) != nil && !bundled.contains { $0.id == id }
     }
 
     /// Language runtimes an agent's CLI may be executed through, so a `node …/cli.js`
@@ -577,7 +599,9 @@ final class AgentCatalog {
     }
 
     /// The channel-scoped flat manifest directory (`~/.termio[-dev]/config/agents`).
-    private static var userAgentsDirectory: URL {
+    /// Internal so the Settings custom-agent editor writes to the same place the
+    /// catalog reads from.
+    static var userAgentsDirectory: URL {
         AppChannel.homeConfigDirectory
             .appendingPathComponent("config", isDirectory: true)
             .appendingPathComponent("agents", isDirectory: true)

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1368,7 +1368,9 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             let item = NSToolbarItem(itemIdentifier: .inspectorTabs)
             item.label = "Inspector"
             item.toolTip = "Switch between project files, search, changes, and info"
-            let host = NSHostingView(rootView: InspectorTabsToolbar().environmentObject(store))
+            let host = NSHostingView(rootView: InspectorTabsToolbar()
+                .environmentObject(store)
+                .environmentObject(store.settings))
             host.sizingOptions = [.intrinsicContentSize]
             item.view = host
             item.isBordered = false

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -25,21 +25,8 @@ struct FileBrowserView: View {
     /// it changes, so the tree stays live with an agent's edits (see `onChange` below).
     @StateObject private var watcher = FileTreeWatcher()
 
-    /// The directory the tree is rooted at: the selected session's worktree if it
-    /// has one, otherwise its project folder. `nil` when nothing is selected.
-    /// A loose terminal roots at its *live* cwd instead (falling back to the cwd
-    /// persisted from the last run, then `$HOME`) — the session owns its path, so
-    /// the tree, search, and changes panes all follow a `cd`. Real projects keep
-    /// their stable root; the anchor is the point of a project.
-    private var projectPath: String? {
-        guard let id = store.selectedSessionID, let project = store.project(for: id) else { return nil }
-        if project.kind == .terminals {
-            return store.workingDirectory(for: id)
-                ?? store.session(id)?.lastWorkingDirectory
-                ?? project.path
-        }
-        return store.session(id)?.worktreePath ?? project.path
-    }
+    /// The directory the tree is rooted at — see `TermioStore.inspectorProjectPath`.
+    private var projectPath: String? { store.inspectorProjectPath }
 
     var body: some View {
         VStack(spacing: 0) {

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -22,6 +22,11 @@ import SwiftUI
 /// reads unambiguously even where the glass pill is subtle.
 struct InspectorTabsToolbar: View {
     @EnvironmentObject var store: TermioStore
+    @EnvironmentObject var settings: AppSettings
+    /// Whether the current project's origin remote points at github.com — probed
+    /// async per selection change; gates the Issues segment together with the
+    /// General "GitHub" setting.
+    @State private var hasGitHubRemote = false
     /// Slides the selection pill from the old segment to the new one.
     @Namespace private var pillNamespace
     /// Drives the fade-in that syncs the cluster with the inspector pane's slide. The toolbar item
@@ -51,6 +56,13 @@ struct InspectorTabsToolbar: View {
         (.info, .infoCircle, "Info"),
     ]
 
+    /// Issues only exists for a project that actually lives on GitHub (and with the
+    /// integration left on in General) — for anything else the segment disappears
+    /// rather than leading to a dead pane.
+    private var visibleSegments: [(tab: InspectorTab, icon: HugeIcon, help: String)] {
+        segments.filter { $0.tab != .issues || (settings.githubIntegrationEnabled && hasGitHubRemote) }
+    }
+
     var body: some View {
         segmentedTrack
             // Clamp the hosting view to a fixed height matching the native bordered toolbar buttons
@@ -63,6 +75,21 @@ struct InspectorTabsToolbar: View {
             // cluster and the pane read as one motion instead of a snap followed by a slide.
             .opacity(appeared ? 1 : 0)
             .onAppear { withAnimation(.easeOut(duration: 0.25)) { appeared = true } }
+            // Re-probe when the selection moves or the General switch flips; keyed so
+            // the check doesn't rerun on unrelated store churn.
+            .task(id: "\(settings.githubIntegrationEnabled)|\(store.inspectorProjectPath ?? "")") {
+                if let path = store.inspectorProjectPath, settings.githubIntegrationEnabled {
+                    hasGitHubRemote = await GitService.gitHubRepoSlug(in: path) != nil
+                } else {
+                    hasGitHubRemote = false
+                }
+                // The pane someone was on can vanish out from under them (setting
+                // turned off, selection moved to a non-GitHub project) — land on Files.
+                if store.inspectorTab == .issues,
+                   !(settings.githubIntegrationEnabled && hasGitHubRemote) {
+                    store.inspectorTab = .files
+                }
+            }
     }
 
     /// The row of segments with the sliding selection pill behind the active one, all inside our own
@@ -70,7 +97,7 @@ struct InspectorTabsToolbar: View {
     /// macOS 26, flat capsule fills on macOS 15 / earlier).
     private var segmentedTrack: some View {
         HStack(spacing: 0) {
-            ForEach(segments, id: \.tab) { seg in
+            ForEach(visibleSegments, id: \.tab) { seg in
                 let selected = store.inspectorTab == seg.tab
                 // Active glyph lifts to full-strength; the rest stay muted — so the selected
                 // pane is legible even before you notice the pill.

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -1,11 +1,33 @@
 import SwiftUI
 
+/// The Agents tab as a master–detail split: a left column listing the user's
+/// agents (drag to reorder, switch to enable) plus a pinned General row, and a
+/// right pane carrying the selected agent's configuration — replacing the old
+/// single-column list whose per-agent config hid behind disclosure drawers.
 struct AgentSettingsTab: View {
     @ObservedObject var settings: AppSettings
 
-    /// Which listed agents have their configuration drawer open. Keyed by id so the
-    /// set survives reordering and enable/disable without stale indices.
-    @State private var expanded: Set<String> = []
+    /// What the detail pane shows. `general` carries the tab's non-per-agent
+    /// settings (the default chat agent) so they keep a home in the split
+    /// without a second tab.
+    private enum Pane: Hashable {
+        case general
+        case agent(String)
+    }
+
+    @State private var selection: Pane = .general
+
+    /// What the custom-agent sheet is doing; `nil` existing means "create".
+    private struct EditorTarget: Identifiable {
+        let existing: AgentPreset?
+        var id: String { existing?.id ?? "new" }
+    }
+    @State private var editorTarget: EditorTarget?
+
+    /// Bumped after every catalog reload. `AgentDefinition` equality is by id, so
+    /// without this a rename would leave stale rows on screen; referencing the
+    /// version in `body` forces a recompute from the fresh catalog.
+    @State private var catalogVersion = 0
 
     /// The agents the user actually manages, in the user's arrangement. The plain
     /// Terminal is not here — it's the login shell, configured on the Terminal tab and
@@ -18,69 +40,159 @@ struct AgentSettingsTab: View {
     }
 
     var body: some View {
+        let _ = catalogVersion
+        HStack(spacing: 0) {
+            sidebar
+                .frame(width: 230)
+            Divider()
+            detail
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .sheet(item: $editorTarget) { target in
+            CustomAgentEditorSheet(existing: target.existing) { id in
+                agentSaved(id)
+            }
+        }
+    }
+
+    // MARK: Left column
+
+    private var sidebar: some View {
+        VStack(spacing: 0) {
+            List(selection: $selection) {
+                Label {
+                    Text("General")
+                } icon: {
+                    IconBadge(.symbol("gearshape"))
+                }
+                .tag(Pane.general)
+
+                Section("Agents") {
+                    ForEach(listedAgents) { preset in
+                        AgentListRow(settings: settings, preset: preset)
+                            .tag(Pane.agent(preset.id))
+                            .contextMenu {
+                                Button("Remove from List") { remove(preset) }
+                            }
+                    }
+                    .onMove(perform: moveListed)
+                }
+            }
+            .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
+
+            Divider()
+            Menu {
+                ForEach(addableAgents) { preset in
+                    Button { add(preset) } label: {
+                        Label { Text(preset.displayName) } icon: { IconBadge(preset.icon) }
+                    }
+                }
+                if !addableAgents.isEmpty { Divider() }
+                Button("Custom Agent…") { editorTarget = EditorTarget(existing: nil) }
+            } label: {
+                Label("Add Agent", systemImage: "plus")
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: Detail pane
+
+    @ViewBuilder
+    private var detail: some View {
+        switch selection {
+        case .general:
+            generalPane
+        case .agent(let id):
+            if let preset = listedAgents.first(where: { $0.id == id }) {
+                AgentDetailPane(
+                    settings: settings,
+                    preset: preset,
+                    onRemove: { remove(preset) },
+                    // Editing and deletion exist only for agents backed by a user
+                    // manifest; bundled agents just leave the list.
+                    onEdit: AgentCatalog.shared.isUserDefined(preset.id)
+                        ? { editorTarget = EditorTarget(existing: preset) } : nil,
+                    onDelete: AgentCatalog.shared.isUserDefined(preset.id)
+                        ? { deleteCustom(preset) } : nil
+                )
+                // Distinct identity per agent — and per catalog generation, so a
+                // rename rebuilds the pane (definitions compare equal by id).
+                .id("\(preset.id)#\(catalogVersion)")
+            } else {
+                // The selected agent was removed out from under us; fall back.
+                generalPane.onAppear { selection = .general }
+            }
+        }
+    }
+
+    /// The tab's non-per-agent settings — just the default chat agent now that
+    /// agent integrations live on the General tab.
+    private var generalPane: some View {
         Form {
             Section {
                 DefaultChatAgentRow(settings: settings)
             } header: {
                 SectionHeaderLabel(title: "New chat")
+            } footer: {
+                Text("The agents in the list are offered when starting a new session, in that order — drag to reorder, select one to configure it.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-            agentsSection
         }
         .formStyle(.grouped)
     }
 
-    /// The one section that replaced a full-height card per agent: the user's agents
-    /// as a compact, reorderable list whose per-agent config hides behind a disclosure,
-    /// and the rest of the catalog behind an "Add Agent" pull-down at the bottom —
-    /// the System Settings shape for "curated list + pool to add from".
-    private var agentsSection: some View {
-        Section {
-            ForEach(listedAgents) { preset in
-                AgentManagerRow(
-                    settings: settings,
-                    preset: preset,
-                    isExpanded: expanded.contains(preset.id),
-                    toggleExpanded: { toggleExpanded(preset) }
-                )
-            }
-            .onMove(perform: moveListed)
-
-            if !addableAgents.isEmpty {
-                Menu {
-                    ForEach(addableAgents) { preset in
-                        Button { add(preset) } label: {
-                            Label { Text(preset.displayName) } icon: { IconBadge(preset.icon) }
-                        }
-                    }
-                } label: {
-                    Label("Add Agent", systemImage: "plus")
-                }
-            }
-        } header: {
-            SectionHeaderLabel(title: "Agents")
-        } footer: {
-            Text("The agents offered when starting a new session, in this order — drag to reorder, right-click to remove.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    /// Adds the agent's row immediately, then lets the availability probe decide the
-    /// switch: an installed CLI turns it on; a missing one leaves it off with its
-    /// drawer opened onto the install link. The row never blocks on the probe.
+    /// Adds the agent's row immediately and selects it, then lets the availability
+    /// probe decide the switch: an installed CLI turns it on; a missing one leaves
+    /// it off with the detail pane already showing the install link.
     private func add(_ preset: AgentPreset) {
         settings.addAgent(preset)
+        selection = .agent(preset.id)
         Task { @MainActor in
             if await AgentAvailability.isCommandAvailable(settings.command(for: preset) ?? "") {
                 settings.setAgent(preset, enabled: true)
-            } else {
-                expanded.insert(preset.id)
             }
         }
     }
 
-    private func toggleExpanded(_ preset: AgentPreset) {
-        if expanded.contains(preset.id) { expanded.remove(preset.id) } else { expanded.insert(preset.id) }
+    private func remove(_ preset: AgentPreset) {
+        if selection == .agent(preset.id) { selection = .general }
+        settings.removeAgent(preset)
+    }
+
+    /// After the sheet writes a manifest: refresh the catalog, make sure the agent
+    /// is on the list, select it, and let the availability probe decide its switch
+    /// (same contract as `add`).
+    private func agentSaved(_ id: String) {
+        AgentCatalog.reload()
+        catalogVersion += 1
+        let definition = AgentCatalog.shared.definition(for: id)
+        settings.addAgent(definition)
+        selection = .agent(id)
+        Task { @MainActor in
+            if await AgentAvailability.isCommandAvailable(settings.command(for: definition) ?? "") {
+                settings.setAgent(definition, enabled: true)
+            }
+        }
+    }
+
+    /// Deletes a user agent's manifest file (its sessions survive via the id-only
+    /// fallback definition). Confirmation lives on the button in the detail pane.
+    private func deleteCustom(_ preset: AgentPreset) {
+        do {
+            try UserAgentStore.delete(id: preset.id)
+        } catch {
+            AgentCatalog.log("could not delete \(preset.id): \(error)")
+            return
+        }
+        remove(preset)
+        AgentCatalog.reload()
+        catalogVersion += 1
     }
 
     /// Persists a drag as the new arrangement; `setEnabledOrder` keeps every
@@ -90,6 +202,173 @@ struct AgentSettingsTab: View {
         ids.move(fromOffsets: source, toOffset: destination)
         settings.setEnabledOrder(ids)
     }
+}
+
+/// A left-column agent row: brand mark, name, and the enable switch — kept to one
+/// line so the column stays a scannable roster. The heavier config lives in the
+/// detail pane.
+private struct AgentListRow: View {
+    @ObservedObject var settings: AppSettings
+    let preset: AgentPreset
+
+    /// `nil` while the PATH probe is still running (show nothing rather than a
+    /// premature warning); `false` once we've confirmed the command isn't resolvable.
+    @State private var available: Bool?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            IconBadge(preset.icon)
+            Text(preset.displayName)
+            Spacer(minLength: 4)
+            if available == false {
+                Image(systemName: "exclamationmark.circle")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .help("\(preset.displayName) isn’t on your PATH")
+            }
+            Toggle("", isOn: Binding(
+                get: { settings.isAgentEnabled(preset) },
+                set: { settings.setAgent(preset, enabled: $0) }
+            ))
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.mini)
+            // A missing CLI can't be launched, so it can't be switched on — only
+            // off (an already-on agent stays revocable while the hint shows).
+            .disabled(available == false && !settings.isAgentEnabled(preset))
+        }
+        .task(id: settings.command(for: preset) ?? "") {
+            available = await AgentAvailability.isCommandAvailable(
+                settings.command(for: preset) ?? "")
+        }
+    }
+}
+
+/// The selected agent's configuration: an identity header above a grouped form —
+/// command override, install link when the CLI is missing, the permission-bypass
+/// switch, and removal.
+private struct AgentDetailPane: View {
+    @ObservedObject var settings: AppSettings
+    let preset: AgentPreset
+    let onRemove: () -> Void
+    /// Set only for user-manifest agents: reopens the creation form prefilled.
+    var onEdit: (() -> Void)?
+    /// Set only for user-manifest agents: deletes the manifest file.
+    var onDelete: (() -> Void)?
+
+    /// Same probe semantics as the list row (see `AgentListRow.available`).
+    @State private var available: Bool?
+    @State private var confirmingDelete = false
+
+    var body: some View {
+        Form {
+            Section {
+                HStack(spacing: 12) {
+                    IconBadge(preset.icon)
+                        .scaleEffect(1.4)
+                        .frame(width: 30, height: 30)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(preset.displayName)
+                            .font(.title3.weight(.semibold))
+                        Text(settings.command(for: preset) ?? "Login shell")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if let onEdit {
+                        Spacer(minLength: 8)
+                        Button("Edit…") { onEdit() }
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+
+            Section {
+                LabeledContent("Command") {
+                    TextField(
+                        "",
+                        text: Binding(
+                            get: { settings.agentCommandOverrides[preset.rawValue] ?? "" },
+                            set: { settings.agentCommandOverrides[preset.rawValue] = $0 }
+                        ),
+                        prompt: Text(preset.command ?? "")
+                    )
+                    .textFieldStyle(.plain)
+                    .multilineTextAlignment(.trailing)
+                    .labelsHidden()
+                }
+                if available == false, let url = preset.installURL {
+                    Link(destination: url) {
+                        Label("Install \(preset.displayName)", systemImage: "arrow.down.circle")
+                    }
+                }
+            } header: {
+                SectionHeaderLabel(title: "Launch")
+            }
+
+            if let flag = preset.permissionBypassFlag {
+                Section {
+                    Toggle(isOn: Binding(
+                        get: { settings.bypassesPermissions(preset) },
+                        set: { settings.setBypassPermissions(preset, enabled: $0) }
+                    )) {
+                        SettingsLabel(
+                            title: "Skip permission prompts",
+                            subtext: "Runs with `\(flag)`. The agent won't ask before editing files or running commands."
+                        )
+                    }
+                    .toggleStyle(.switch)
+                } header: {
+                    SectionHeaderLabel(title: "Permissions")
+                }
+            }
+
+            Section {
+                // Deliberately not red: nothing is destroyed — the agent folds back
+                // into the "Add Agent" menu with its overrides intact, so no
+                // confirmation either.
+                LabeledContent {
+                    Button("Remove") { onRemove() }
+                } label: {
+                    SettingsLabel(
+                        title: "Remove from List",
+                        subtext: "Takes \(preset.displayName) out of the new-session menu. Its settings are kept."
+                    )
+                }
+                if let onDelete {
+                    // Red and confirmed, unlike Remove: this one erases the
+                    // manifest file the agent is made of.
+                    LabeledContent {
+                        Button("Delete…", role: .destructive) { confirmingDelete = true }
+                            .confirmationDialog(
+                                "Delete \(preset.displayName)?",
+                                isPresented: $confirmingDelete
+                            ) {
+                                Button("Delete", role: .destructive) { onDelete() }
+                            } message: {
+                                Text("Removes this custom agent and its configuration file. Existing sessions keep running.")
+                            }
+                    } label: {
+                        SettingsLabel(
+                            title: "Delete Agent",
+                            subtext: "Deletes the custom agent's manifest from this Mac."
+                        )
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        // Re-checks whenever the effective command changes, so typing a valid path
+        // clears the install link. The PATH probe runs once (cached); each check is
+        // an in-memory lookup. The leading sleep debounces per-keystroke edits into
+        // one probe once the user pauses.
+        .task(id: effectiveCommand) {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            available = await AgentAvailability.isCommandAvailable(effectiveCommand)
+        }
+    }
+
+    private var effectiveCommand: String { settings.command(for: preset) ?? "" }
 }
 
 /// The "New chat" default-agent picker: which agent the single New Chat action
@@ -133,135 +412,4 @@ private struct DefaultChatAgentRow: View {
             set: { settings.defaultChatAgentID = $0 == lastUsedTag ? nil : $0 }
         )
     }
-}
-
-/// An enabled agent's management row: a compact header (icon, name, effective
-/// command, an unavailable hint, the enable switch) with the heavier config —
-/// command override, install link, permission bypass — tucked behind a disclosure so
-/// the list stays scannable. Draggable to reorder (the enclosing `ForEach.onMove`).
-private struct AgentManagerRow: View {
-    @ObservedObject var settings: AppSettings
-    let preset: AgentPreset
-    let isExpanded: Bool
-    let toggleExpanded: () -> Void
-
-    /// `nil` while the PATH probe is still running (show nothing rather than a
-    /// premature warning); `false` once we've confirmed the command isn't resolvable.
-    @State private var available: Bool?
-
-    var body: some View {
-        // One VStack = one Form row, so the header and its disclosed controls share a
-        // single cell — separators fall only between agents, and the drawer can't be
-        // mistaken for top-level rows (as `Group`'s sibling rows were).
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 10) {
-                IconBadge(preset.icon)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(preset.displayName).font(.headline)
-                    Text(settings.command(for: preset) ?? "Login shell")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: 8)
-                // A quiet, uncolored hint — matching the tab's calm tone — rather than
-                // an alarm; the install link lives inside the drawer.
-                if available == false {
-                    Image(systemName: "exclamationmark.circle")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .help("\(preset.displayName) isn’t on your PATH")
-                }
-                Button(action: toggleExpanded) {
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                        .contentShape(Rectangle())
-                        .frame(width: 16, height: 16)
-                }
-                .buttonStyle(.plain)
-                Toggle("", isOn: Binding(
-                    get: { settings.isAgentEnabled(preset) },
-                    set: { settings.setAgent(preset, enabled: $0) }
-                ))
-                .labelsHidden()
-                .toggleStyle(.switch)
-                // A missing CLI can't be launched, so it can't be switched on — only
-                // off (an already-on agent stays revocable while the hint shows).
-                .disabled(available == false && !settings.isAgentEnabled(preset))
-            }
-            // Without an explicit shape only the row's glyphs are right-clickable —
-            // the padding and the Spacer are holes in the Form row's hit test.
-            .contentShape(Rectangle())
-            .contextMenu {
-                Button("Remove from List") { settings.removeAgent(preset) }
-            }
-
-            if isExpanded {
-                VStack(alignment: .leading, spacing: 12) {
-                    LabeledContent("Command") {
-                        TextField(
-                            "",
-                            text: Binding(
-                                get: { settings.agentCommandOverrides[preset.rawValue] ?? "" },
-                                set: { settings.agentCommandOverrides[preset.rawValue] = $0 }
-                            ),
-                            prompt: Text(preset.command ?? "")
-                        )
-                        .textFieldStyle(.plain)
-                        .labelsHidden()
-                    }
-
-                    if available == false, let url = preset.installURL {
-                        Link(destination: url) {
-                            Label {
-                                Text("Install \(preset.displayName)")
-                            } icon: {
-                                HugeIconView(icon: .download, size: 13, color: .accentColor)
-                            }
-                        }
-                    }
-
-                    if let flag = preset.permissionBypassFlag {
-                        Toggle(isOn: Binding(
-                            get: { settings.bypassesPermissions(preset) },
-                            set: { settings.setBypassPermissions(preset, enabled: $0) }
-                        )) {
-                            SettingsLabel(
-                                title: "Skip permission prompts",
-                                subtext: "Runs with `\(flag)`. The agent won't ask before editing files or running commands."
-                            )
-                        }
-                        .toggleStyle(.switch)
-                    }
-
-                    // The visible twin of the row's right-click item — a drawer-only
-                    // action so the scannable list stays clean. Deliberately not
-                    // red: nothing is destroyed — the row folds back into the "Add
-                    // Agent" menu with its overrides intact, so no confirmation
-                    // either.
-                    Button("Remove from List") {
-                        settings.removeAgent(preset)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                }
-                // Indent to the title's column (icon 22 + spacing 10) so the drawer
-                // reads as the row's children, not more agents.
-                .padding(.leading, 32)
-                .padding(.top, 12)
-            }
-        }
-        // Re-checks whenever the effective command changes, so typing a valid path
-        // clears the hint. The PATH probe runs once (cached); each row does an
-        // in-memory lookup. The leading sleep debounces per-keystroke edits into one
-        // probe once the user pauses.
-        .task(id: effectiveCommand) {
-            try? await Task.sleep(for: .milliseconds(300))
-            guard !Task.isCancelled else { return }
-            available = await AgentAvailability.isCommandAvailable(effectiveCommand)
-        }
-    }
-
-    private var effectiveCommand: String { settings.command(for: preset) ?? "" }
 }

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -83,10 +83,10 @@ struct AgentSettingsTab: View {
 
             Divider()
             Menu {
+                // Plain text rows: AppKit menus rasterize custom SwiftUI icon views
+                // at their natural image size, not the badge frame.
                 ForEach(addableAgents) { preset in
-                    Button { add(preset) } label: {
-                        Label { Text(preset.displayName) } icon: { IconBadge(preset.icon) }
-                    }
+                    Button(preset.displayName) { add(preset) }
                 }
                 if !addableAgents.isEmpty { Divider() }
                 Button("Custom Agent…") { editorTarget = EditorTarget(existing: nil) }

--- a/Sources/termio/Settings/AppearanceSettingsTab.swift
+++ b/Sources/termio/Settings/AppearanceSettingsTab.swift
@@ -21,6 +21,26 @@ struct AppearanceSettingsTab: View {
                     .foregroundStyle(.secondary)
             }
             Section {
+                ThemePickerField(title: "Light", selection: $settings.lightThemeName, userThemeNames: userThemeNames)
+                ThemePickerField(title: "Dark", selection: $settings.darkThemeName, userThemeNames: userThemeNames)
+                HStack {
+                    Button("Open Themes Folder…", action: openThemesFolder)
+                    Spacer()
+                    if !userThemeNames.isEmpty {
+                        Text("\(userThemeNames.count) custom")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Button("Reload", action: reloadUserThemes)
+                }
+            } header: {
+                SectionHeaderLabel(title: "Theme")
+            } footer: {
+                Text("termio switches between these as macOS changes appearance; leave a slot on the default for termio's own canvas. Drop Ghostty-format theme files into the Themes folder to add your own — they appear under “Custom.”")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Section {
                 FontFamilyField(
                     title: "Family",
                     prompt: "System monospace",
@@ -68,26 +88,6 @@ struct AppearanceSettingsTab: View {
                 SectionHeaderLabel(title: "Window")
             } footer: {
                 Text("Opacity below 100% lets the desktop show through; blur softens it. The window stays solid at full opacity.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Section {
-                ThemePickerField(title: "Light", selection: $settings.lightThemeName, userThemeNames: userThemeNames)
-                ThemePickerField(title: "Dark", selection: $settings.darkThemeName, userThemeNames: userThemeNames)
-                HStack {
-                    Button("Open Themes Folder…", action: openThemesFolder)
-                    Spacer()
-                    if !userThemeNames.isEmpty {
-                        Text("\(userThemeNames.count) custom")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    Button("Reload", action: reloadUserThemes)
-                }
-            } header: {
-                SectionHeaderLabel(title: "Theme")
-            } footer: {
-                Text("termio switches between these as macOS changes appearance; leave a slot on the default for termio's own canvas. Drop Ghostty-format theme files into the Themes folder to add your own — they appear under “Custom.”")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/termio/Settings/CustomAgentEditor.swift
+++ b/Sources/termio/Settings/CustomAgentEditor.swift
@@ -1,0 +1,205 @@
+import AppKit
+import SwiftUI
+
+/// Reads and writes user agent manifests (`~/.termio[-dev]/config/agents/<id>.json`)
+/// on behalf of the Settings form. The form covers the everyday fields (name,
+/// command, icon symbol, bypass flag); a hand-written manifest's other keys
+/// (status, hooks, resume, …) are preserved verbatim on rewrite.
+enum UserAgentStore {
+    struct Draft {
+        var name = ""
+        var command = ""
+        /// SF Symbol name; empty means the default terminal glyph.
+        var symbol = ""
+        var permissionBypassFlag = ""
+
+        init() {}
+
+        /// Prefills the form from an existing definition for edit mode.
+        init(_ definition: AgentDefinition) {
+            name = definition.displayName
+            command = definition.command ?? ""
+            if case .symbol(let name) = definition.icon { symbol = name }
+            permissionBypassFlag = definition.permissionBypassFlag ?? ""
+        }
+
+        var isValid: Bool {
+            !name.trimmingCharacters(in: .whitespaces).isEmpty
+                && !command.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+    }
+
+    /// Writes the draft as a manifest and returns its id — the existing id when
+    /// editing, else a fresh slug derived from the name. Editing loads the current
+    /// JSON first and only replaces the form's keys, so hand-authored extras
+    /// survive a rename.
+    static func save(_ draft: Draft, existingID: String?) throws -> String {
+        let id = existingID ?? uniqueID(for: draft.name)
+        let directory = AgentCatalog.userAgentsDirectory
+        let file = directory.appendingPathComponent("\(id).json")
+
+        var object: [String: Any] = [:]
+        if let data = try? Data(contentsOf: file),
+           let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            object = existing
+        }
+        object["id"] = id
+        object["name"] = draft.name.trimmingCharacters(in: .whitespaces)
+        object["command"] = draft.command.trimmingCharacters(in: .whitespaces)
+
+        let flag = draft.permissionBypassFlag.trimmingCharacters(in: .whitespaces)
+        object["permissionBypassFlag"] = flag.isEmpty ? nil : flag
+
+        let symbol = draft.symbol.trimmingCharacters(in: .whitespaces)
+        if !symbol.isEmpty {
+            object["icon"] = ["symbol": symbol]
+        } else if let icon = object["icon"] as? [String: Any], icon["symbol"] != nil {
+            // Clearing the field removes a symbol icon (back to the default glyph),
+            // but never touches a hand-authored path/vector/asset icon.
+            object["icon"] = nil
+        }
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+        try data.write(to: file, options: .atomic)
+        return id
+    }
+
+    static func delete(id: String) throws {
+        let file = AgentCatalog.userAgentsDirectory.appendingPathComponent("\(id).json")
+        try FileManager.default.removeItem(at: file)
+    }
+
+    /// A filename-safe slug from the display name, suffixed until it collides with
+    /// no known agent id (bundled or user).
+    private static func uniqueID(for name: String) -> String {
+        let allowed = CharacterSet.alphanumerics
+        var slug = name.lowercased()
+            .map { character -> Character in
+                character.unicodeScalars.allSatisfy(allowed.contains) ? character : "-"
+            }
+            .reduce(into: "") { partial, character in
+                // Collapse runs of separators so "My  Agent!" → "my-agent".
+                if character == "-" && partial.hasSuffix("-") { return }
+                partial.append(character)
+            }
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        if slug.isEmpty { slug = "agent" }
+        let taken = Set(AgentDefinition.allCases.map(\.id))
+        if !taken.contains(slug) { return slug }
+        for counter in 2... where !taken.contains("\(slug)-\(counter)") {
+            return "\(slug)-\(counter)"
+        }
+        fatalError("unreachable: the counter loop always returns")
+    }
+}
+
+/// The create/edit form for a user agent — the everyday subset of the manifest.
+/// Anything richer (status regexes, hooks, resume) stays a hand-written JSON
+/// affair; this form round-trips those keys untouched.
+struct CustomAgentEditorSheet: View {
+    /// `nil` creates a new agent; a definition edits its manifest in place.
+    let existing: AgentDefinition?
+    /// Called with the saved agent's id after the manifest is written.
+    let onSave: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft: UserAgentStore.Draft
+    @State private var saveError: String?
+
+    init(existing: AgentDefinition?, onSave: @escaping (String) -> Void) {
+        self.existing = existing
+        self.onSave = onSave
+        _draft = State(initialValue: existing.map(UserAgentStore.Draft.init) ?? UserAgentStore.Draft())
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Form {
+                Section {
+                    TextField("Name", text: $draft.name, prompt: Text("My Agent"))
+                    LabeledContent("Command") {
+                        TextField(
+                            "", text: $draft.command,
+                            prompt: Text("my-agent --flag"))
+                        .textFieldStyle(.plain)
+                        .multilineTextAlignment(.trailing)
+                        .fontDesign(.monospaced)
+                        .labelsHidden()
+                    }
+                } header: {
+                    SectionHeaderLabel(title: existing == nil ? "New Agent" : "Edit Agent")
+                } footer: {
+                    Text("The command is run in a login shell, so anything on your PATH works.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section {
+                    LabeledContent("Icon") {
+                        HStack(spacing: 8) {
+                            TextField("", text: $draft.symbol, prompt: Text("SF Symbol name"))
+                                .textFieldStyle(.plain)
+                                .multilineTextAlignment(.trailing)
+                                .labelsHidden()
+                            IconBadge(iconPreview)
+                        }
+                    }
+                    LabeledContent("Skip-permissions flag") {
+                        TextField("", text: $draft.permissionBypassFlag, prompt: Text("--yolo"))
+                            .textFieldStyle(.plain)
+                            .multilineTextAlignment(.trailing)
+                            .fontDesign(.monospaced)
+                            .labelsHidden()
+                    }
+                } footer: {
+                    Text("Both optional. The flag powers the agent's “Skip permission prompts” switch; leave it empty if the CLI has none.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let saveError {
+                    Section {
+                        Label(saveError, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button(existing == nil ? "Add" : "Save") { save() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!draft.isValid)
+            }
+            .padding(12)
+        }
+        .frame(width: 440, height: 380)
+    }
+
+    /// The badge the agent will actually get: the typed symbol when the system
+    /// resolves it, else the default terminal glyph — so the preview never lies.
+    private var iconPreview: AgentIcon {
+        let symbol = draft.symbol.trimmingCharacters(in: .whitespaces)
+        guard !symbol.isEmpty,
+              NSImage(systemSymbolName: symbol, accessibilityDescription: nil) != nil
+        else { return .terminalGlyph }
+        return .symbol(symbol)
+    }
+
+    private func save() {
+        do {
+            let id = try UserAgentStore.save(draft, existingID: existing?.id)
+            dismiss()
+            onSave(id)
+        } catch {
+            saveError = error.localizedDescription
+        }
+    }
+}

--- a/Sources/termio/Settings/GeneralSettingsTab.swift
+++ b/Sources/termio/Settings/GeneralSettingsTab.swift
@@ -64,6 +64,18 @@ struct GeneralSettingsTab: View {
             } header: {
                 SectionHeaderLabel(title: "Orchestration")
             }
+            Section {
+                Toggle(isOn: $settings.githubIntegrationEnabled) {
+                    SettingsLabel(
+                        .huge(.github),
+                        title: "GitHub",
+                        subtext: "Shows the Issues pane in the inspector for projects whose remote is on GitHub."
+                    )
+                }
+                .toggleStyle(.switch)
+            } header: {
+                SectionHeaderLabel(title: "Integrations")
+            }
         }
         .formStyle(.grouped)
     }

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -102,6 +102,7 @@ final class AppSettings: ObservableObject {
         static let sessionControlPrompted = "agents.sessionControlPrompted"
         static let usageAuthorizedAgents = "usage.authorizedAgents"
         static let claudeKeychainDeclined = "usage.claudeKeychainDeclined"
+        static let githubIntegrationEnabled = "github.integrationEnabled"
         static let notifyTaskCompletion = "notifications.taskCompletion"
         static let notificationSound = "notifications.sound"
         static let projectSortOrder = "sidebar.projectSortOrder"
@@ -332,6 +333,13 @@ final class AppSettings: ObservableObject {
         set { defaults.set(newValue, forKey: Key.sessionControlPrompted) }
     }
 
+    /// Gates the GitHub side of the app — today the inspector's Issues pane. The
+    /// pane additionally only appears for projects whose origin remote points at
+    /// github.com, so this switch is for opting out of GitHub entirely.
+    @Published var githubIntegrationEnabled: Bool {
+        didSet { defaults.set(githubIntegrationEnabled, forKey: Key.githubIntegrationEnabled) }
+    }
+
     /// Agents whose usage data the user has allowed termio to read, by `rawValue`.
     /// The Usage tab is opt-in per agent: until the user clicks Allow there, none
     /// of that agent's data is touched — not its local session logs and not its
@@ -410,6 +418,9 @@ final class AppSettings: ObservableObject {
             Key.interfaceRowPadding: 2.0,
             Key.agentHooksEnabled: false,
             Key.sessionControlEnabled: false,
+            // On by default: the pane is read-only and only appears for projects
+            // with a GitHub remote, so there is nothing to opt into until then.
+            Key.githubIntegrationEnabled: true,
             Key.projectSortOrder: "name",
             // Notifications ship on (macOS's own permission prompt is the real
             // gate); the sound stays opt-in so a finishing agent is never noisy
@@ -441,6 +452,7 @@ final class AppSettings: ObservableObject {
         agentOrder = defaults.stringArray(forKey: Key.agentOrder) ?? []
         agentHooksEnabled = defaults.bool(forKey: Key.agentHooksEnabled)
         sessionControlEnabled = defaults.bool(forKey: Key.sessionControlEnabled)
+        githubIntegrationEnabled = defaults.bool(forKey: Key.githubIntegrationEnabled)
         usageAuthorizedAgents = Set(defaults.stringArray(forKey: Key.usageAuthorizedAgents) ?? [])
         claudeKeychainDeclined = defaults.bool(forKey: Key.claudeKeychainDeclined)
         notifyOnTaskCompletion = defaults.bool(forKey: Key.notifyTaskCompletion)

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -158,6 +158,22 @@ final class TermioStore: ObservableObject {
     /// changes" without the inspector being open.
     @Published var gitChangeCount = 0
 
+    /// The directory the inspector panes root at: the selected session's worktree if it
+    /// has one, otherwise its project folder. `nil` when nothing is selected.
+    /// A loose terminal roots at its *live* cwd instead (falling back to the cwd
+    /// persisted from the last run, then `$HOME`) — the session owns its path, so
+    /// the tree, search, and changes panes all follow a `cd`. Real projects keep
+    /// their stable root; the anchor is the point of a project.
+    var inspectorProjectPath: String? {
+        guard let id = selectedSessionID, let project = project(for: id) else { return nil }
+        if project.kind == .terminals {
+            return workingDirectory(for: id)
+                ?? session(id)?.lastWorkingDirectory
+                ?? project.path
+        }
+        return session(id)?.worktreePath ?? project.path
+    }
+
     /// Whether the trailing inspector panel is expanded. Mirrored from the AppKit
     /// split item — the owner of collapse state — via KVO in `App.swift`, so hosted
     /// panes can stand down while hidden: a collapsed item keeps its view hierarchy


### PR DESCRIPTION
## Summary

Rescued from a parked worktree (`agent-settings-two-column`) and rebased onto current main. Two pieces:

- **`UserAgentStore`** — reads/writes user agent manifests under `~/.termio[-dev]/config/agents/<id>.json`. The editor form covers the everyday fields (name, command, SF Symbol icon, permission-bypass flag); any other keys in a hand-authored manifest (status, hooks, resume, …) are preserved verbatim on rewrite, so editing never destroys advanced config.
- **Restructured Agents pane** — per-agent management moves into an editor sheet; the inline `AgentManagerRow` disclosure is retired.

**Draft on purpose**: this was parked mid-development. It compiles against current main (post-Hugeicons), but the flow hasn't been exercised end to end — needs a design pass on the pane layout and a live test of manifest round-tripping before it's review-ready.

## Release Notes

- N/A (draft experiment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)