### PR TITLE
fix(sidebar): draw SSH sessions with the server glyph at column size

### DIFF
--- a/Sources/termio/FileBrowser/ContentSearch.swift
+++ b/Sources/termio/FileBrowser/ContentSearch.swift
@@ -17,7 +17,7 @@ struct ContentMatch: Sendable {
 /// repo. Fixed-string (no regex surprises), smart-case (case-sensitive only
 /// when the query has an uppercase letter), binaries skipped, per-file and
 /// total caps so a one-letter query in a monorepo can't flood the pane.
-/// Blocking — call it off the main thread.
+/// Cancellation-aware: cancelling the surrounding task terminates the grep.
 enum ContentSearch {
     /// Hits per file — past this the file's header row says "in this file",
     /// and the user should sharpen the query.
@@ -25,7 +25,7 @@ enum ContentSearch {
     /// Longest line text kept; minified bundles can put megabytes on one line.
     private static let lineCap = 500
 
-    nonisolated static func search(_ query: String, under root: URL, limit: Int) -> [ContentMatch] {
+    nonisolated static func search(_ query: String, under root: URL, limit: Int) async -> [ContentMatch] {
         guard !query.isEmpty else { return [] }
         // Smart case, the fzf/ripgrep default: all-lowercase queries match
         // insensitively; an uppercase letter opts into exactness.
@@ -36,9 +36,12 @@ enum ContentSearch {
         if insensitive { gitArgs.append("--ignore-case") }
         gitArgs += ["-e", query, "--", "."]
         // Exit 0 = hits, 1 = clean no-hits; ≥2 = not a repo (or git error) → fall back.
-        if let result = run("/usr/bin/git", gitArgs), result.status <= 1 {
+        if let result = await run("/usr/bin/git", gitArgs, maxLines: limit), result.status <= 1 {
             return parse(result.output, root: root, strippingPrefix: nil, limit: limit)
         }
+        // A cancelled git grep dies by signal, which looks like the ≥2 error
+        // path — don't misread it as "not a repo" and launch the fallback scan.
+        guard !Task.isCancelled else { return [] }
 
         var grepArgs = ["-r", "-n", "--fixed-strings", "--binary-files=without-match",
                         "-m", perFileLimit,
@@ -46,7 +49,7 @@ enum ContentSearch {
                         "--exclude-dir=.build", "--exclude-dir=DerivedData"]
         if insensitive { grepArgs.append("-i") }
         grepArgs += ["-e", query, root.path]
-        guard let result = run("/usr/bin/grep", grepArgs), result.status <= 1 else { return [] }
+        guard let result = await run("/usr/bin/grep", grepArgs, maxLines: limit), result.status <= 1 else { return [] }
         return parse(result.output, root: root, strippingPrefix: root.path + "/", limit: limit)
     }
 
@@ -55,8 +58,14 @@ enum ContentSearch {
     /// containing `:` would mis-split; accepted as vanishingly rare.
     private static func parse(_ output: String, root: URL, strippingPrefix: String?, limit: Int) -> [ContentMatch] {
         var out: [ContentMatch] = []
-        for rawLine in output.split(separator: "\n") {
-            if out.count >= limit { break }
+        // Walk lines by index instead of `split`: split materializes every line
+        // of the output up front, paying for the whole array even though this
+        // loop stops at `limit`.
+        var cursor = output.startIndex
+        while cursor < output.endIndex, out.count < limit {
+            let lineEnd = output[cursor...].firstIndex(of: "\n") ?? output.endIndex
+            let rawLine = output[cursor..<lineEnd]
+            cursor = lineEnd == output.endIndex ? output.endIndex : output.index(after: lineEnd)
             guard let firstColon = rawLine.firstIndex(of: ":") else { continue }
             let afterPath = rawLine.index(after: firstColon)
             guard let secondColon = rawLine[afterPath...].firstIndex(of: ":"),
@@ -76,17 +85,48 @@ enum ContentSearch {
         return out
     }
 
-    private static func run(_ executable: String, _ arguments: [String]) -> (status: Int32, output: String)? {
+    /// Runs the tool, draining stdout incrementally. `--max-count` is per FILE,
+    /// so a short query in a monorepo has no global bound — the caller only
+    /// keeps `maxLines` lines, so once that many have arrived the tool is
+    /// terminated instead of letting it flood the pipe. Cancelling the
+    /// surrounding task also terminates it, which unblocks the read via EOF.
+    private static func run(
+        _ executable: String, _ arguments: [String], maxLines: Int
+    ) async -> (status: Int32, output: String)? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
         let stdout = Pipe()
         process.standardOutput = stdout
-        process.standardError = Pipe()
+        // Never attach a pipe that isn't drained: BSD grep can emit 64KB+ of
+        // per-file "Permission denied" noise, filling the buffer and deadlocking
+        // the child against our stdout read. Discard stderr at the kernel.
+        process.standardError = FileHandle.nullDevice
         guard (try? process.run()) != nil else { return nil }
-        let data = stdout.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        guard let output = String(data: data, encoding: .utf8) else { return nil }
-        return (process.terminationStatus, output)
+
+        return await withTaskCancellationHandler {
+            let handle = stdout.fileHandleForReading
+            var data = Data()
+            var newlines = 0
+            var stoppedEarly = false
+            while true {
+                let chunk = handle.availableData
+                if chunk.isEmpty { break }  // EOF: exited, or terminated by cancel
+                for byte in chunk where byte == UInt8(ascii: "\n") { newlines += 1 }
+                data.append(chunk)
+                if newlines >= maxLines {
+                    stoppedEarly = true
+                    process.terminate()
+                    break
+                }
+            }
+            process.waitUntilExit()
+            guard let output = String(data: data, encoding: .utf8) else { return nil }
+            // Self-terminated = success with a full budget of lines; the real
+            // exit status is just the SIGTERM we sent.
+            return (stoppedEarly ? 0 : process.terminationStatus, output)
+        } onCancel: {
+            if process.isRunning { process.terminate() }
+        }
     }
 }

--- a/Sources/termio/FileBrowser/FileSearchView.swift
+++ b/Sources/termio/FileBrowser/FileSearchView.swift
@@ -56,25 +56,44 @@ struct FileSearchView: View {
 
     private var searchField: some View {
         VStack(spacing: 0) {
-            NativeSearchField(
-                text: $query,
-                isFocused: $fieldFocused,
-                focusRequest: focusRequest,
-                placeholder: "Search Project",
-                onSubmit: {
-                    if let first = matches.first { onOpen(first.url, first.line) }
-                },
-                // Esc clears a live query first; a second Esc (empty field)
-                // leaves the pane.
-                onExit: {
-                    if query.isEmpty {
-                        onDismiss()
-                    } else {
-                        query = ""
+            // The magnifier and clear button are drawn here, not by AppKit: the field
+            // is a bare `NSTextField` (see `NativeSearchField`) because a bezel-less
+            // `NSSearchField` misplaces its built-in icons.
+            HStack(spacing: 5) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                NativeSearchField(
+                    text: $query,
+                    isFocused: $fieldFocused,
+                    focusRequest: focusRequest,
+                    placeholder: "Search Project",
+                    onSubmit: {
+                        if let first = matches.first { onOpen(first.url, first.line) }
+                    },
+                    // Esc clears a live query first; a second Esc (empty field)
+                    // leaves the pane.
+                    onExit: {
+                        if query.isEmpty {
+                            onDismiss()
+                        } else {
+                            query = ""
+                        }
                     }
+                )
+                if !query.isEmpty {
+                    Button { query = "" } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Clear")
                 }
-            )
-            .frame(height: 24)
+            }
+            .padding(.horizontal, 9)
+            .frame(height: 28)
+            .background { fieldChrome }
             .padding(.horizontal, 8)
             .padding(.top, 7)
             .padding(.bottom, trimmedQuery.isEmpty ? 7 : 4)
@@ -93,6 +112,20 @@ struct FileSearchView: View {
                 .padding(.horizontal, 10)
                 .padding(.bottom, 5)
             }
+        }
+    }
+
+    /// The field's own chrome, replacing the `NSSearchField` bezel (stripped in
+    /// `makeNSView`): a Liquid Glass capsule on macOS 26 — same material recipe as
+    /// the toolbar's `InspectorTabsToolbar` track — and a flat capsule fill below.
+    @ViewBuilder
+    private var fieldChrome: some View {
+        if #available(macOS 26.0, *) {
+            Capsule()
+                .fill(.clear)
+                .glassEffect(.regular.tint(Color.white.opacity(0.12)), in: .capsule)
+        } else {
+            Capsule(style: .continuous).fill(Color.primary.opacity(0.06))
         }
     }
 
@@ -179,8 +212,11 @@ struct FileSearchView: View {
     // MARK: - Search
 
     /// Debounce + cancel-on-keystroke (Warp's abort pattern): each edit kills
-    /// the in-flight task; only a typing pause reaches the actual grep, which
-    /// runs detached so the field never hitches.
+    /// the in-flight task, and the cancellation reaches all the way down —
+    /// `ContentSearch` terminates its grep subprocess — so a stale search stops
+    /// consuming the machine instead of racing the fresh one. Deliberately NOT
+    /// `Task.detached`: a detached task sits outside this task tree, which is
+    /// exactly what would strand the grep beyond cancellation's reach.
     private func scheduleSearch() {
         searchTask?.cancel()
         let trimmed = trimmedQuery
@@ -195,9 +231,7 @@ struct FileSearchView: View {
             try? await Task.sleep(for: Self.debounce)
             guard !Task.isCancelled else { return }
             isSearching = true
-            let found = await Task.detached(priority: .userInitiated) {
-                ContentSearch.search(trimmed, under: root, limit: limit)
-            }.value
+            let found = await ContentSearch.search(trimmed, under: root, limit: limit)
             guard !Task.isCancelled else { return }
             matches = found
             isSearching = false
@@ -237,7 +271,7 @@ private struct NativeSearchField: NSViewRepresentable {
     /// fade-out — the blue outline you saw hanging over the next pane. Resign first responder
     /// with animations disabled (and drop the ring type) so the outline goes the instant the tab
     /// changes, matching the now-instant content swap.
-    static func dismantleNSView(_ field: NSSearchField, coordinator: Coordinator) {
+    static func dismantleNSView(_ field: NSTextField, coordinator: Coordinator) {
         field.focusRingType = .none
         guard let window = field.window,
               window.firstResponder === field || window.firstResponder === field.currentEditor()
@@ -248,17 +282,29 @@ private struct NativeSearchField: NSViewRepresentable {
         NSAnimationContext.endGrouping()
     }
 
-    func makeNSView(context: Context) -> NSSearchField {
-        let field = NSSearchField()
+    func makeNSView(context: Context) -> NSTextField {
+        // A plain text field, not `NSSearchField`: the SwiftUI wrapper draws the
+        // chrome (glass capsule, magnifier, clear button — see `searchField`), and
+        // a bezel-less `NSSearchField` misplaces its built-in icons. Bare text is
+        // also what sidesteps the field's appearance animations (the focus-ring
+        // bloom and the centered-placeholder slide) that replayed on every
+        // auto-focused appearance of the pane.
+        let field = NSTextField()
         field.delegate = context.coordinator
         field.placeholderString = placeholder
         field.controlSize = .small
         field.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-        field.focusRingType = .default
+        field.focusRingType = .none
+        field.isBezeled = false
+        field.isBordered = false
+        field.drawsBackground = false
+        field.usesSingleLineMode = true
+        field.cell?.wraps = false
+        field.cell?.isScrollable = true
         return field
     }
 
-    func updateNSView(_ field: NSSearchField, context: Context) {
+    func updateNSView(_ field: NSTextField, context: Context) {
         context.coordinator.parent = self
 
         if field.stringValue != text {
@@ -278,7 +324,7 @@ private struct NativeSearchField: NSViewRepresentable {
         }
     }
 
-    final class Coordinator: NSObject, NSSearchFieldDelegate {
+    final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: NativeSearchField
         var lastFocusRequest = -1
 
@@ -286,13 +332,13 @@ private struct NativeSearchField: NSViewRepresentable {
             self.parent = parent
         }
 
-        func submit(_ sender: NSSearchField) {
+        func submit(_ sender: NSTextField) {
             updateText(from: sender)
             parent.onSubmit()
         }
 
         func controlTextDidChange(_ notification: Notification) {
-            guard let field = notification.object as? NSSearchField else { return }
+            guard let field = notification.object as? NSTextField else { return }
             updateText(from: field)
         }
 
@@ -311,7 +357,7 @@ private struct NativeSearchField: NSViewRepresentable {
         ) -> Bool {
             switch commandSelector {
             case #selector(NSResponder.insertNewline(_:)):
-                guard let field = control as? NSSearchField else { return false }
+                guard let field = control as? NSTextField else { return false }
                 submit(field)
                 return true
             case #selector(NSResponder.cancelOperation(_:)):
@@ -322,7 +368,7 @@ private struct NativeSearchField: NSViewRepresentable {
             }
         }
 
-        private func updateText(from field: NSSearchField) {
+        private func updateText(from field: NSTextField) {
             guard parent.text != field.stringValue else { return }
             parent.text = field.stringValue
         }
@@ -373,10 +419,14 @@ private struct FileHeaderRow: View {
                         .truncationMode(.head)
                 }
                 Spacer(minLength: 4)
+                // Count as a capsule badge (VS Code's count badge), so the number
+                // reads as metadata rather than trailing content.
                 Text("\(count)")
                     .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.tertiary)
-                    .frame(minWidth: 18, alignment: .trailing)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 5)
+                    .frame(minWidth: 16, minHeight: 15)
+                    .background(Capsule().fill(.quaternary.opacity(0.6)))
             }
             .contentShape(Rectangle())
             .onTapGesture(perform: open)
@@ -394,9 +444,11 @@ private struct FileHeaderRow: View {
     }
 }
 
-/// One hit line: the dimmed line number in a fixed gutter, then the line's text
-/// with the matched substring tinted accent — enough context to pick the right
-/// hit without opening anything.
+/// One hit line, styled after Xcode's Find navigator: the line's text in the
+/// system font with the context dimmed and the matched substring lifted to
+/// full-strength semibold — the matches are what the eye lands on, not the
+/// context. No line-number gutter (neither Xcode nor VS Code shows one; the
+/// click jumps to the line anyway), so the text aligns under the file name.
 private struct MatchRow: View {
     let match: ContentMatch
     let query: String
@@ -405,22 +457,27 @@ private struct MatchRow: View {
 
     @State private var isHovering = false
 
+    /// Leading context kept before the first hit, cut at a word boundary — VS
+    /// Code's `lcut(…, 26)`: enough to identify the line, short enough that the
+    /// hit stays near the left edge.
+    private static let leadingContextMax = 26
+
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text("\(match.line)")
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(.tertiary)
-                .frame(width: 34, alignment: .trailing)
+        HStack(spacing: 0) {
             Text(highlightedText())
-                .font(.system(size: 11, design: .monospaced))
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 0)
         }
-        .padding(.vertical, 2)
-        .padding(.leading, 27)
+        // Aligns the text's leading edge with the header row's file name
+        // (10 padding + 12 chevron + 4 spacing + 16 icon + 5 spacing).
+        .padding(.leading, 47)
         .padding(.trailing, 8)
-        .frame(minHeight: 21)
+        // One flat row height for every hit (VS Code pins all search rows to
+        // 22px) — the list's rhythm stays even no matter what the text holds.
+        .frame(height: 22)
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
         .background(
@@ -431,23 +488,42 @@ private struct MatchRow: View {
         .onTapGesture(perform: open)
     }
 
-    /// The line trimmed for display, windowed so the hit is visible even when
-    /// it sits deep in a long line (leading context replaced by an ellipsis),
-    /// with the query's first occurrence tinted accent + bold.
+    /// The line trimmed for display: leading context word-boundary-cut to
+    /// `leadingContextMax` chars (with an ellipsis) so the first hit sits near
+    /// the left edge, then every occurrence of the query marked with the
+    /// highlighter treatment — full-strength text on a soft accent wash. The
+    /// context stays `.secondary` (the row's base style), so hits carry the
+    /// row's visual weight even when the match is two characters inside a word.
     private func highlightedText() -> AttributedString {
-        var display = match.text.trimmingCharacters(in: .whitespaces)
-        if let range = display.range(of: query, options: .caseInsensitive) {
-            let offset = display.distance(from: display.startIndex, to: range.lowerBound)
-            if offset > 40 {
-                let start = display.index(range.lowerBound, offsetBy: -20)
-                display = "…" + display[start...]
+        var display = Substring(match.text.trimmingCharacters(in: .whitespaces))
+        if let first = display.range(of: query, options: .caseInsensitive),
+           display.distance(from: display.startIndex, to: first.lowerBound) > Self.leadingContextMax {
+            var start = display.index(first.lowerBound, offsetBy: -Self.leadingContextMax)
+            // Land on the next word boundary so the cut doesn't open mid-word.
+            if let space = display[start..<first.lowerBound].firstIndex(of: " ") {
+                start = display.index(after: space)
             }
+            display = display[start...]
+        } else {
+            return marked(display)
         }
-        var attributed = AttributedString(display)
-        if let range = attributed.range(of: query, options: .caseInsensitive) {
-            attributed[range].foregroundColor = .accentColor
-            attributed[range].inlinePresentationIntent = .stronglyEmphasized
+        return AttributedString("…") + marked(display)
+    }
+
+    /// `display` with every case-insensitive occurrence of the query lifted to
+    /// `.primary` over an accent wash.
+    private func marked(_ display: Substring) -> AttributedString {
+        var attributed = AttributedString()
+        var rest = display
+        while let range = rest.range(of: query, options: .caseInsensitive) {
+            attributed += AttributedString(String(rest[..<range.lowerBound]))
+            var hit = AttributedString(String(rest[range]))
+            hit.foregroundColor = .primary
+            hit.backgroundColor = Color.accentColor.opacity(0.28)
+            attributed += hit
+            rest = rest[range.upperBound...]
         }
+        attributed += AttributedString(String(rest))
         return attributed
     }
 }

--- a/Sources/termio/FileBrowser/FileSearchView.swift
+++ b/Sources/termio/FileBrowser/FileSearchView.swift
@@ -129,39 +129,70 @@ struct FileSearchView: View {
         }
     }
 
+    /// One flat row of the results list, with a globally unique, stable id.
+    /// The list is deliberately a single `ForEach` over these: the previous
+    /// shape — a per-file `ForEach` nesting a per-hit `ForEach` keyed by bare
+    /// line number — mis-diffed inside `LazyVStack` when typing replaced the
+    /// whole match set (line-number ids collide across files, so SwiftUI
+    /// stitched rows from different files under one header, or rendered them
+    /// empty). Flat rows keyed by `path` / `path:line` make the diff
+    /// unambiguous.
+    private enum ResultRow: Identifiable {
+        case header(relative: String, url: URL, count: Int, firstLine: Int, isExpanded: Bool)
+        case match(ContentMatch)
+
+        var id: String {
+            switch self {
+            case .header(let relative, _, _, _, _): return relative
+            case .match(let match): return "\(match.relative):\(match.line)"
+            }
+        }
+    }
+
+    private var rows: [ResultRow] {
+        var out: [ResultRow] = []
+        for group in groups {
+            let isExpanded = !collapsedFiles.contains(group.relative)
+            out.append(.header(relative: group.relative, url: group.url, count: group.items.count,
+                               firstLine: group.items[0].line, isExpanded: isExpanded))
+            if isExpanded {
+                for match in group.items { out.append(.match(match)) }
+            }
+        }
+        return out
+    }
+
     @ViewBuilder
     private var resultList: some View {
-        let grouped = groups
         ScrollView {
             LazyVStack(spacing: 0, pinnedViews: []) {
-                ForEach(grouped, id: \.relative) { group in
-                    let isExpanded = !collapsedFiles.contains(group.relative)
-                    FileHeaderRow(
-                        url: group.url,
-                        relative: group.relative,
-                        count: group.items.count,
-                        isExpanded: isExpanded,
-                        chrome: chrome,
-                        toggleExpanded: {
-                            withAnimation(.easeInOut(duration: 0.12)) {
-                                if isExpanded {
-                                    collapsedFiles.insert(group.relative)
-                                } else {
-                                    collapsedFiles.remove(group.relative)
+                ForEach(rows) { row in
+                    switch row {
+                    case .header(let relative, let url, let count, let firstLine, let isExpanded):
+                        FileHeaderRow(
+                            url: url,
+                            relative: relative,
+                            count: count,
+                            isExpanded: isExpanded,
+                            chrome: chrome,
+                            toggleExpanded: {
+                                withAnimation(.easeInOut(duration: 0.12)) {
+                                    if isExpanded {
+                                        collapsedFiles.insert(relative)
+                                    } else {
+                                        collapsedFiles.remove(relative)
+                                    }
                                 }
-                            }
-                        },
-                        open: { onOpen(group.url, group.items[0].line) }
-                    )
-                    if isExpanded {
-                        ForEach(group.items, id: \.line) { match in
-                            MatchRow(
-                                match: match,
-                                query: trimmedQuery,
-                                chrome: chrome,
-                                open: { onOpen(match.url, match.line) }
-                            )
-                        }
+                            },
+                            open: { onOpen(url, firstLine) }
+                        )
+                    case .match(let match):
+                        MatchRow(
+                            match: match,
+                            query: trimmedQuery,
+                            chrome: chrome,
+                            open: { onOpen(match.url, match.line) }
+                        )
                     }
                 }
             }

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -73,7 +73,11 @@ struct InspectorTabsToolbar: View {
                 let selected = store.inspectorTab == seg.tab
                 // Active glyph lifts to full-strength; the rest stay muted — so the selected
                 // pane is legible even before you notice the pill.
-                HugeIconView(icon: seg.icon, size: 15, color: selected ? .primary : .secondary)
+                // Heavier than the size-derived 1.1pt default: at 15pt the Hugeicons stroke
+                // reads hairline next to the SF Symbol toolbar buttons flanking the track,
+                // so match their optical weight instead.
+                HugeIconView(icon: seg.icon, size: 15, color: selected ? .primary : .secondary,
+                             lineWidthOverride: 1.5)
                     .frame(width: Self.segmentWidth, height: Self.glyphHeight)
                     // Each segment is a matched-geometry *source*; the pill (non-source, below)
                     // snaps to whichever one is selected and animates across on change.

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -954,10 +954,14 @@ private struct SessionRow: View {
             // muted grey from AgentIconView.
             Group {
                 if session.isSSH, store.status(for: session.id) != .working {
-                    // An SSH terminal reads as a remote link — a globe glyph in the
-                    // terminal grey — except while a detected remote agent is working,
-                    // when it falls through to the spinner below.
-                    HugeIconView(icon: .network, size: 11, color: .secondary)
+                    // An SSH terminal is a machine, so it carries the same server
+                    // glyph as its host row in Settings ▸ SSH (a globe reads as
+                    // "web", not "that box") — except while a detected remote
+                    // agent is working, when it falls through to the spinner below.
+                    // Size 15 like the folder and agent marks sharing this
+                    // 16-wide column — HugeIconShape normalizes ink width, so
+                    // equal size is what makes the glyphs read as one family.
+                    HugeIconView(icon: .serverStack, size: 15, color: .secondary)
                 } else if store.status(for: session.id) == .working {
                     // The spinner carries no status color — its motion already
                     // says "working", so color stays reserved for the states


### PR DESCRIPTION
## What

The sidebar's SSH session rows drew a globe at 11pt. Two things wrong: a globe reads as "web", not "that machine" (the row is titled by the host alias), and 11pt was undersized next to the folder and agent marks sharing the same 16-wide icon column at 15pt.

Now the row carries the same `serverStack` glyph as its host row in Settings ▸ SSH — one concept, one symbol — at 15pt, so the glyphs read as one family (`HugeIconShape` normalizes ink width; equal size is what aligns them).

The working-spinner takeover while a remote agent is running is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)