### PR TITLE
docs(design): issue-tracker integration draft + feedback-to-issue skill

### DIFF
--- a/.claude/skills/feedback-to-issue/SKILL.md
+++ b/.claude/skills/feedback-to-issue/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: feedback-to-issue
+description: "Turn vague customer or user feedback from pasted text, chat excerpts, or screenshots into a clear, evidence-backed GitHub issue without inventing requirements. Use when the user says 'create an issue for this', 'turn this user request into an issue', 'file this feedback', '用户反馈建 issue', '把这个模糊需求变成 issue', '把这段聊天/截图建成 GitHub issue', or invokes /feedback-to-issue."
+---
+
+# Vague user request → actionable GitHub issue
+
+Preserve the user's voice, identify the underlying problem, add only grounded
+repository context, and create the smallest honest issue that moves the work
+forward. Never turn missing information into confident requirements.
+
+## Workflow
+
+### 1. Normalize the raw input
+
+Handle all three input modes:
+
+- **Pasted text:** preserve the most useful original sentence verbatim.
+- **Screenshot:** inspect both visible text and UI context. Transcribe only what
+  is legible and mark uncertainty. Keep the original image for `Evidence`.
+- **Mixed:** treat the pasted explanation as context and the screenshot as
+  primary evidence unless they conflict; surface any conflict.
+
+Build a private scratch intake before drafting:
+
+| Field | Extract |
+|---|---|
+| Actor | Who experiences this? |
+| Situation | When and where does it happen? |
+| Friction | What is hard, broken, or missing now? |
+| Desired outcome | What should the user be able to achieve? |
+| Impact | Why does it matter? |
+| Explicit constraints | What did the user actually require? |
+| Unknowns | What remains unclear? |
+
+Do not force the request into “As a user, I want…” language. Preserve a direct
+quote when it expresses the pain better than a summary.
+
+If the message is phrased as a question, identify the latent need but first
+check whether existing behavior or documentation already answers it. Do not file
+a feature request for something the product already supports.
+
+### 2. Resolve repository conventions
+
+Use an explicitly named repository; otherwise resolve the current checkout:
+
+```bash
+gh auth status
+gh repo view --json nameWithOwner,defaultBranchRef,visibility,hasIssuesEnabled
+gh issue list --state all --limit 10 --json number,title,state,url
+rg --files -g 'CONTRIBUTING*' -g '.github/ISSUE_TEMPLATE/**'
+```
+
+Read any relevant issue template or contributing guide. Match the repository's
+language, headings, title style, and metadata conventions. Do not invent labels,
+types, milestones, or assignees.
+
+### 3. Ground the request in the product
+
+Do light, targeted exploration using nouns, UI labels, errors, and capability
+names from the intake. Search README/docs first, then likely code:
+
+```bash
+rg -n -i 'user phrase|normalized capability|visible UI label' \
+  README.md docs Sources Shared ios web 2>/dev/null
+```
+
+Stop when there is enough context to name the affected area, identify existing
+behavior, or determine that this is a product-level discovery request. Code
+exploration is context gathering, not implementation planning.
+
+### 4. Apply the clarification gate
+
+Ask at most three focused questions, and only when an answer would change one of:
+
+- whether an issue should exist;
+- bug vs feature/discovery classification;
+- the core problem or desired outcome;
+- reproduction of a bug;
+- a material scope boundary;
+- whether evidence is safe to publish.
+
+First try to answer gaps from the screenshot, repository, docs, and related
+issues. Do not ask the user to design the solution or manufacture acceptance
+criteria. Put non-blocking uncertainty in `Open questions` and continue.
+
+### 5. Classify honestly
+
+| Type | Use when |
+|---|---|
+| Bug | Existing behavior contradicts expected or documented behavior |
+| Feature/usability | A clear user outcome is unsupported or unnecessarily hard |
+| Discovery | The need is real but the right behavior or scope still requires investigation |
+| No new issue | Existing behavior/docs solve it, or a strong duplicate already tracks it |
+
+When feedback is too broad for an implementation issue, create a bounded
+discovery issue such as “Define task-completion notification behavior” instead
+of inventing a complete solution.
+
+### 6. Search for duplicates
+
+Run separate searches using:
+
+1. the user's exact phrase;
+2. the normalized product capability;
+3. the symptom or desired outcome.
+
+```bash
+gh issue list --repo OWNER/REPO --state all \
+  --search 'query in:title,body' --limit 20 \
+  --json number,title,state,url
+```
+
+If a strong duplicate exists, return it instead of creating another issue. If
+the overlap is partial, create the new issue and link the related one.
+
+### 7. Draft a problem-first issue
+
+Read [references/templates.md](references/templates.md), choose the matching
+template, and omit empty sections.
+
+Follow these rules:
+
+- Write a direct, scannable title under 72 characters.
+- Separate original evidence, verified facts, and inference.
+- Describe the problem and desired outcome before any possible solution.
+- Include the user's original words as a short quote when useful.
+- Add file/component references only when verified by repository exploration.
+- Write acceptance criteria only for observable behavior supported by the
+  request or established product conventions.
+- Put unresolved product decisions under `Open questions`.
+- Keep one issue focused on one outcome; split independent requests.
+
+### 8. Attach evidence when present
+
+If the input includes one or more images, read
+[references/images.md](references/images.md) and follow its privacy, upload, and
+verification workflow. Do not silently drop an image.
+
+### 9. Create and verify
+
+Before any GitHub write, state the exact repository, proposed title, and any
+image asset path. Prepare the final Markdown body outside the repository, then:
+
+```bash
+gh issue create --repo OWNER/REPO \
+  --title 'Concise problem or outcome' \
+  --body-file /absolute/path/to/temporary-issue-body.md
+```
+
+Use an existing issue type or label only after confirming it exists. Then verify
+the returned issue:
+
+```bash
+gh issue view ISSUE_NUMBER --repo OWNER/REPO \
+  --json number,title,state,url,body,labels
+```
+
+Confirm the intended repository, title, body, evidence links, and metadata.
+Return the issue URL plus any assumptions or open questions retained in it.
+
+## Quality gate
+
+Do not create the issue until all applicable checks pass:
+
+- The original request is represented faithfully.
+- The core problem and desired outcome are understandable.
+- Facts and inference are distinguishable.
+- No behavior, scope, or acceptance criterion was invented.
+- Existing docs/code and likely duplicate issues were checked.
+- The issue is actionable, or explicitly scoped as discovery.
+- Supplied evidence is embedded and safe for the repository's visibility.
+- The issue follows repository templates and conventions.

--- a/.claude/skills/feedback-to-issue/references/images.md
+++ b/.claude/skills/feedback-to-issue/references/images.md
@@ -1,0 +1,96 @@
+# Images in GitHub issues
+
+Read this reference only when the user supplies an image.
+
+## 1. Inspect and protect
+
+Inspect both textual and visual evidence. Record:
+
+- legible text, preserving the original language;
+- relevant UI state, error messages, and visible controls;
+- uncertainty where text is cropped or unreadable.
+
+Check repository visibility before uploading. For a public repository, stop and
+ask before publishing names, account details, tokens, private URLs, customer
+identifiers, or confidential conversations.
+
+If the image is visible in the conversation but has no accessible local file,
+use a browser attachment flow if available. Otherwise ask the user for a saved
+file path; do not silently omit the evidence.
+
+## 2. Choose an upload method
+
+Prefer these methods in order:
+
+1. **GitHub browser attachment:** paste or upload into the issue editor to get a
+   permanent `github.com/user-attachments/assets/...` URL.
+2. **Contents API fallback:** upload to the same repository's dedicated
+   `issue-assets` branch without touching the default branch or current
+   worktree.
+
+Standard `gh issue create` cannot upload a local attachment. Do not use a local
+filesystem path, `data:` URI, third-party image host, temporary API
+`download_url`, or `raw.githubusercontent.com` URL for a private repository.
+
+## 3. Upload through the Contents API
+
+Before writing, state the exact repository, asset branch, and unique ASCII asset
+path. Reuse `issue-assets`; never overwrite existing evidence.
+
+```bash
+request_repo='OWNER/REPO'
+request_asset_branch='issue-assets'
+request_image='/absolute/path/to/evidence.png'
+request_asset_path='.github/issue-assets/YYYYMMDD-unique-description.png'
+
+request_default_branch=$(
+  gh repo view "$request_repo" --json defaultBranchRef \
+    --jq '.defaultBranchRef.name'
+)
+
+if ! gh api \
+  "repos/$request_repo/git/ref/heads/$request_asset_branch" >/dev/null 2>&1
+then
+  request_default_sha=$(
+    gh api "repos/$request_repo/git/ref/heads/$request_default_branch" \
+      --jq '.object.sha'
+  )
+  gh api --method POST "repos/$request_repo/git/refs" \
+    -f ref="refs/heads/$request_asset_branch" \
+    -f sha="$request_default_sha"
+fi
+
+base64 < "$request_image" | tr -d '\n' |
+  jq -Rs \
+    --arg message "docs: add feedback-to-issue evidence" \
+    --arg branch "$request_asset_branch" \
+    '{message:$message, content:., branch:$branch}' |
+  gh api --method PUT \
+    "repos/$request_repo/contents/$request_asset_path" --input -
+```
+
+Embed the stable authenticated repository URL:
+
+```markdown
+![User request](https://github.com/OWNER/REPO/raw/issue-assets/.github/issue-assets/YYYYMMDD-unique-description.png)
+```
+
+For a private repository, viewers must have repository access. Such images may
+not render in email notifications.
+
+## 4. Verify
+
+Verify remote and local hashes:
+
+```bash
+gh api \
+  "repos/$request_repo/contents/$request_asset_path?ref=$request_asset_branch" \
+  --jq .content |
+  tr -d '\n' | base64 -d | shasum -a 256
+
+shasum -a 256 "$request_image"
+```
+
+After issue creation, confirm that every supplied image appears in the Markdown
+body. If upload succeeds but issue creation fails, retry or report the orphan
+asset path explicitly.

--- a/.claude/skills/feedback-to-issue/references/templates.md
+++ b/.claude/skills/feedback-to-issue/references/templates.md
@@ -1,0 +1,133 @@
+# Issue drafting templates
+
+Choose the smallest template that communicates the work. Omit headings that
+would contain guesses or filler.
+
+## Feature or usability request
+
+```markdown
+## Problem
+
+<Who encounters what friction, in what situation, and with what impact?>
+
+## Original request
+
+> <Short verbatim quote or faithful transcription>
+
+## Context
+
+<Verified product/repository context. Separate inference explicitly.>
+
+## Desired outcome
+
+<Observable user outcome, without prescribing an internal implementation.>
+
+## Acceptance criteria
+
+- [ ] <Grounded, testable behavior>
+
+## Open questions
+
+- <Product decision or non-blocking unknown>
+
+## Evidence
+
+<Embedded images and source links>
+```
+
+Do not include `Acceptance criteria` when the desired behavior is still a
+product decision. Use a discovery issue instead.
+
+## Bug report
+
+```markdown
+## Problem
+
+<Concise description of what fails and where.>
+
+## Original report
+
+> <Short verbatim quote or faithful transcription>
+
+## Steps to reproduce
+
+1. <Verified or user-provided step>
+
+## Expected behavior
+
+<Expected result grounded in docs, existing behavior, or the report.>
+
+## Actual behavior
+
+<Observed result.>
+
+## Environment
+
+- Version:
+- OS/device:
+- Relevant configuration:
+
+## Affected area
+
+<Verified component, file, or workflow.>
+
+## Evidence
+
+<Embedded screenshots, logs, or links.>
+
+## Open questions
+
+- <Missing but non-blocking diagnostic detail>
+```
+
+If reproduction or actual-vs-expected behavior is unknowable, ask a focused
+question rather than manufacturing steps.
+
+## Discovery issue
+
+```markdown
+## Problem
+
+<The validated user need or ambiguity worth resolving.>
+
+## Original request
+
+> <Short verbatim quote or faithful transcription>
+
+## Known context
+
+- <Verified fact>
+
+## Questions to resolve
+
+- <Behavior, scope, or feasibility question>
+
+## Done when
+
+- [ ] <A decision, prototype, or specification exists>
+- [ ] <Follow-up implementation work can be scoped honestly>
+
+## Evidence
+
+<Embedded images and source links>
+```
+
+## Normalization example
+
+Raw feedback:
+
+> 如果任务完成以后能主动发通知，这个需要配置终端，还是可以集成到软件里？
+
+Grounded transformation:
+
+- **Fact:** the user wants to know when a long-running task has completed.
+- **Likely friction (inference):** they may leave the app while waiting and miss
+  completion.
+- **Desired outcome:** receive a reliable completion signal without monitoring
+  the session continuously.
+- **Do not assume:** native macOS notification, supported agent list, sounds,
+  click-to-focus behavior, or settings UI unless repository context establishes
+  those decisions.
+- **Possible issue:** use a discovery issue if the notification surface and
+  completion signal are still undecided; use a feature issue only when the
+  product behavior is already clear.

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ from the real front matter).
 | draft | design | [调研：下一批 AgentAdapter 的落盘格式（OpenCode / Pi / Amp / Cursor / Kimi）](design/agent-transcript-survey.md) |
 | draft | design | ["Markdown preview — Apple-grade reading typography"](design/markdown-preview-reading-typography.md) |
 | draft | design | [Issue Triage → 本地 agent（GitHub / Linear 事件驱动 termio session）](design/issue-triage-local-agent.md) |
+| draft | design | [Issue tracker 集成：inspector Issues tab（GitHub / Linear，per-project provider）](design/issue-tracker-integration.md) |
 | draft | design | [Mac retention analytics (no app changes)](design/mac-retention-analytics.md) |
 | draft | design | [Remote Projects (open an SSH/VPS box like a local project)](design/remote-projects.md) |
 | draft | design | [Session Daemon Architecture (termiod — one model for local, remote, mobile)](design/session-daemon-architecture.md) |

--- a/docs/design/issue-tracker-integration.md
+++ b/docs/design/issue-tracker-integration.md
@@ -1,0 +1,87 @@
+---
+title: "Issue tracker 集成：inspector Issues tab（GitHub / Linear，per-project provider）"
+status: draft
+type: design
+created: 2026-07-26
+updated: 2026-07-26
+related:
+  - issue-triage-local-agent.md
+  - worktree-information-architecture.md
+---
+
+# 设计：Issue tracker 集成（inspector Issues tab）
+
+> 在 inspector 加第五个 pane：当前项目的 issue 列表 + 详情 + 完整交互（reaction / label / 评论），tracker 按项目绑定（GitHub Issues 或 Linear，协议留好 Jira 的位置），核心出口是把 issue 一键派给本地 agent session。
+
+## 1. 为什么做 / 边界
+
+- 用户在 termio 里看着 repo、开着 agent，但查 issue 要回浏览器。原生 macOS 的 issue 阅读器这个位置是空的（GitHub Desktop 只做 PR；Trailer/Gitify 是通知聚合器；GitHawk 死了且是 iOS）。
+- termio 的差异点不是"更好看的 issue 列表"，而是**读完直接派活**：issue → send to agent，接上 [issue-triage-local-agent.md](issue-triage-local-agent.md) 的出站半场（那篇是事件*进来*自动触发，本篇是人*看着*手动派）。
+- **第一版不做**：通知（badge / 系统通知都不做）、建 issue、关闭/改状态、Jira provider、PR 列表。协议为它们留缝，但不实现。
+
+## 2. 核心问题：不同项目用不同 tracker
+
+同一个用户，A 项目用 GitHub Issues，B 项目用 Linear，C 项目用 Jira。解法是把三个概念拆开：
+
+| 概念 | 作用域 | 存哪 | 内容 |
+| --- | --- | --- | --- |
+| **Connection** | 全局，每 provider 一个 | 凭证进 Keychain，元数据进 UserDefaults | "我登录了 GitHub"、"我登录了 Linear" |
+| **Provider** | 代码 | app 内置 | `IssueProvider` 协议的一个实现（GitHub、Linear；未来 Jira = 再写一个 conformance） |
+| **Binding** | 每 project 一个 | `Project` 持久化字段 | 这个项目用哪个 provider + 哪个远端容器（GitHub 的 `owner/repo`，Linear 的 team） |
+
+Binding 的解析顺序：
+
+1. 项目已手动绑定 → 用它。
+2. 未绑定且 origin remote 是 `github.com` → 自动绑 GitHub Issues 的那个 repo（零配置，多数用户到此为止）。
+3. 否则（或用户想改）→ Issues tab 零态里选：GitHub repo 选择器 / Linear team 选择器。Linear 与本地 repo 没有可推导的对应关系，必选一次，选完记住。
+
+这就是"extension 形式"的落点：**内置 provider 注册表 + per-project binding**，不是对外插件系统。加 Jira 是一天的 conformance 工作，不是平台工程。
+
+## 3. IssueProvider 协议
+
+归一化模型 + capability 声明，UI 只认协议不认 provider：
+
+```swift
+protocol IssueProvider: Sendable {
+    var id: ProviderID { get }                 // .github / .linear
+    var capabilities: IssueCapabilities { get } // reactions? labelEdit? comment?
+
+    func containers() async throws -> [IssueContainer]   // repos / teams，绑定用
+    func issues(in c: IssueContainer, query: IssueQuery) async throws -> [IssueSummary]
+    func detail(_ ref: IssueRef) async throws -> IssueDetail
+
+    func setReaction(_ r: Reaction, on target: ReactionTarget, add: Bool) async throws
+    func setLabels(_ labels: [Label], on ref: IssueRef) async throws
+    func availableLabels(in c: IssueContainer) async throws -> [Label]
+    func comment(_ markdown: String, on ref: IssueRef) async throws
+}
+```
+
+- `IssueSummary`：`identifier`（GH 的 `#95` / Linear 的 `TER-123`）、title、state、labels（name+color）、assignees、updatedAt。
+- `IssueDetail`：+ body（markdown）、comment 线程（author/时间/body/reactions）。
+- `IssueCapabilities` 让 UI 按 provider 收缩：Linear 没有 GitHub 式 emoji reaction 全集，就只显示它支持的。
+- GitHub 走 REST（`URLSession`，不引 SDK），Linear 走 GraphQL（同样裸 `URLSession`，query 手写）。
+
+## 4. 认证
+
+| Provider | 流程 | 为什么 |
+| --- | --- | --- |
+| GitHub | **OAuth Device Flow**：Connect → 显示 8 位码 + 自动开 `github.com/login/device` → 轮询换 token。scope `repo`（写 label/评论需要）。 | 只需公开 client_id，无 secret 无回调服务器——termio 开源，secret 不能进仓库。需在 GitHub 注册 OAuth App 并勾选 Enable Device Flow（发布前的一次性人工步骤）。 |
+| Linear | **Personal API key 粘贴**：Connect → 开 `linear.app/settings/api` → 用户粘贴 key。 | Linear OAuth2 强制 client secret，开源 app 用不了；API key 是 Linear 给本地工具的正路（linear-cli 同款）。 |
+
+凭证一律进 Keychain（service `sh.termio.app.issues`，account = provider id）。断开 = 删 Keychain 项 + 清 binding。Usage tab 已有读 OAuth 凭证的先例，模式一致。
+
+## 5. UI
+
+- **入口**：`InspectorTab` 加 `.issues`，`InspectorTabsToolbar` 第五个 segment（HugeIcon 需新增一个 issue/task 玻璃线框图标，现有 30 个 case 里没有合适的）。tab 常显；未连接/未绑定时显示零态而不是藏 tab（可发现性优先）。
+- **零态**：未连接 → "Connect GitHub / Connect Linear" 两个按钮；已连接未绑定 → 容器选择器。
+- **列表**：一行式 row——state 圆点（open 绿 / closed 紫，Linear 用状态色）、`identifier` 等宽、title、右侧 label 色点 chips。默认 open + 按 updated 排序；顶部一个轻量 filter（open/closed、assigned to me）。
+- **详情**：推入式（沿用 git pane 文件→diff 的导航模式）。body 与 comment 用现成 `MarkdownHTML` 渲染（session trace 同款）；底部评论输入框；每条 comment/body 挂 reaction bar；toolbar 上 label 编辑 popover（`availableLabels` 勾选）。
+- **Send to Agent**：详情页首要按钮。生成 prompt（`Work on <identifier>: <title>\n\n<body>` + issue URL），走 `TermioStore+SessionControl` 现成的 deliver/spawn 路径：有活跃 session 就送入，没有就 spawn。这是本功能存在的理由，位置必须最显眼。
+
+## 6. 里程碑
+
+1. **M1 读**：协议 + GitHub provider（device flow、列表、详情）、tab + 零态 + 列表 + 详情渲染。
+2. **M2 写**：reaction、label 编辑、评论（GitHub）。
+3. **M3 Linear**：API key connect、GraphQL provider、binding 选择器。
+4. **M4 派活**：Send to Agent 打磨（prompt 模板、目标 session 选择）。

--- a/docs/design/issue-tracker-integration.md
+++ b/docs/design/issue-tracker-integration.md
@@ -11,13 +11,14 @@ related:
 
 # 设计：Issue tracker 集成（inspector Issues tab）
 
-> 在 inspector 加第五个 pane：当前项目的 issue 列表 + 详情 + 完整交互（reaction / label / 评论），tracker 按项目绑定（GitHub Issues 或 Linear，协议留好 Jira 的位置），核心出口是把 issue 一键派给本地 agent session。
+> 在 inspector 加第五个 pane：当前项目的 issue + PR 列表 + 详情 + 完整交互（reaction / label / 评论），tracker 按项目绑定（GitHub Issues 或 Linear，协议留好 Jira 的位置），核心出口是把 issue / PR 一键派给本地 agent session。
 
 ## 1. 为什么做 / 边界
 
-- 用户在 termio 里看着 repo、开着 agent，但查 issue 要回浏览器。原生 macOS 的 issue 阅读器这个位置是空的（GitHub Desktop 只做 PR；Trailer/Gitify 是通知聚合器；GitHawk 死了且是 iOS）。
-- termio 的差异点不是"更好看的 issue 列表"，而是**读完直接派活**：issue → send to agent，接上 [issue-triage-local-agent.md](issue-triage-local-agent.md) 的出站半场（那篇是事件*进来*自动触发，本篇是人*看着*手动派）。
-- **第一版不做**：通知（badge / 系统通知都不做）、建 issue、关闭/改状态、Jira provider、PR 列表。协议为它们留缝，但不实现。
+- 用户在 termio 里看着 repo、开着 agent，但查 issue / PR 要回浏览器。原生 macOS 的阅读器这个位置是空的（GitHub Desktop 的 PR 只在 branch 下拉里；Trailer/Gitify 是通知聚合器；GitHawk 死了且是 iOS）。
+- termio 的差异点不是"更好看的 issue 列表"，而是**读完直接派活**：issue / PR → send to agent，接上 [issue-triage-local-agent.md](issue-triage-local-agent.md) 的出站半场（那篇是事件*进来*自动触发，本篇是人*看着*手动派）。
+- **PR 从第一版就在读的范围内**：读是每日高频动作，PR 是 agent 干活的产物；而且 GitHub API 里 PR 就是带附加字段的 issue（同一个 list endpoint），issue 读通了 PR 读几乎免费。PR 读 = 标题/正文/评论线 + 状态，到此为止。
+- **第一版不做**：通知（badge / 系统通知都不做）、建 issue、关闭/改状态、Jira provider、PR review 线程 / 本地 diff / checks 详情 / merge 操作（PR 本地 diff 属于 git pane 的 Review mode，后续单独接）。协议为它们留缝，但不实现。
 
 ## 2. 核心问题：不同项目用不同 tracker
 
@@ -57,9 +58,10 @@ protocol IssueProvider: Sendable {
 }
 ```
 
-- `IssueSummary`：`identifier`（GH 的 `#95` / Linear 的 `TER-123`）、title、state、labels（name+color）、assignees、updatedAt。
+- `IssueQuery` 带 `kind`（`.issue` / `.pullRequest`）：GitHub 里 PR 就是 issue，同一套模型直接覆盖。
+- `IssueSummary`：`identifier`（GH 的 `#95` / Linear 的 `TER-123`）、title、state（PR 多 merged / draft 两态）、labels（name+color）、assignees、updatedAt。
 - `IssueDetail`：+ body（markdown）、comment 线程（author/时间/body/reactions）。
-- `IssueCapabilities` 让 UI 按 provider 收缩：Linear 没有 GitHub 式 emoji reaction 全集，就只显示它支持的。
+- `IssueCapabilities` 让 UI 按 provider 收缩：Linear 没有 GitHub 式 emoji reaction 全集，就只显示它支持的；也没有 PR——`pullRequests` capability 关掉，kind filter 整个消失。
 - GitHub 走 REST（`URLSession`，不引 SDK），Linear 走 GraphQL（同样裸 `URLSession`，query 手写）。
 
 ## 4. 认证
@@ -75,13 +77,15 @@ protocol IssueProvider: Sendable {
 
 - **入口**：`InspectorTab` 加 `.issues`，`InspectorTabsToolbar` 第五个 segment（HugeIcon 需新增一个 issue/task 玻璃线框图标，现有 30 个 case 里没有合适的）。tab 常显；未连接/未绑定时显示零态而不是藏 tab（可发现性优先）。
 - **零态**：未连接 → "Connect GitHub / Connect Linear" 两个按钮；已连接未绑定 → 容器选择器。
-- **列表**：一行式 row——state 圆点（open 绿 / closed 紫，Linear 用状态色）、`identifier` 等宽、title、右侧 label 色点 chips。默认 open + 按 updated 排序；顶部一个轻量 filter（open/closed、assigned to me）。
+- **列表**：顶部 Issues / Pull Requests kind filter（沿用 Changes/History 的迷你 segmented 样式，provider 无 PR 则不显示）；一行式 row——state 圆点（open 绿 / closed & merged 紫 / draft 灰，Linear 用状态色）、`identifier` 等宽、title、右侧 label 色点 chips。默认 open + 按 updated 排序；旁边一个轻量 filter（open/closed、assigned to me）。
 - **详情**：推入式（沿用 git pane 文件→diff 的导航模式）。body 与 comment 用现成 `MarkdownHTML` 渲染（session trace 同款）；底部评论输入框；每条 comment/body 挂 reaction bar；toolbar 上 label 编辑 popover（`availableLabels` 勾选）。
 - **Send to Agent**：详情页首要按钮。生成 prompt（`Work on <identifier>: <title>\n\n<body>` + issue URL），走 `TermioStore+SessionControl` 现成的 deliver/spawn 路径：有活跃 session 就送入，没有就 spawn。这是本功能存在的理由，位置必须最显眼。
 
 ## 6. 里程碑
 
-1. **M1 读**：协议 + GitHub provider（device flow、列表、详情）、tab + 零态 + 列表 + 详情渲染。
-2. **M2 写**：reaction、label 编辑、评论（GitHub）。
-3. **M3 Linear**：API key connect、GraphQL provider、binding 选择器。
-4. **M4 派活**：Send to Agent 打磨（prompt 模板、目标 session 选择）。
+读 + 派活在前（每日高频 + 差异点，且派活只是「拼 prompt + 现成 deliver 路径」的小步）；写在后（每个写操作都有浏览器兜底）；Linear 收尾（协议从第一天就管住它，conformance 不急）。
+
+1. **M1 读（issues + PRs）**：协议 + GitHub provider（device flow、列表、详情、kind filter）、tab + 零态 + 列表 + 详情渲染。→ [#99](https://github.com/jiweiyuan/termio/issues/99)
+2. **M2 派活**：Send to Agent（prompt 模板、目标 session 选择），issue 与 PR 同一条路径。→ [#102](https://github.com/jiweiyuan/termio/issues/102)
+3. **M3 写**：reaction、label 编辑、评论（GitHub，issue 与 PR 通用）。→ [#100](https://github.com/jiweiyuan/termio/issues/100)
+4. **M4 Linear**：API key connect、GraphQL provider、binding 选择器。→ [#101](https://github.com/jiweiyuan/termio/issues/101)


### PR DESCRIPTION
Two working-tree strays committed:

- `docs/design/issue-tracker-integration.md` — draft design for the inspector Issues tab (GitHub / Linear, per-project provider), plus its `docs/README.md` wiki-index row
- `.claude/skills/feedback-to-issue/` — the skill that turns vague user feedback (text/screenshots) into evidence-backed GitHub issues (used to file #106)

🤖 Generated with [Claude Code](https://claude.com/claude-code)