### PR TITLE
fix(sessions): anchor CLI spawns beside the calling agent, not the watched pane

### DIFF
--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -197,6 +197,14 @@ struct TerminalPane: View {
                 activated.append(id)
             }
         }
+        // A background-driven session (a sibling spawn, a `send` to a pane never
+        // shown) mounts invisibly so its surface attaches without the selection
+        // moving; the focus paths all gate on visibility, so it stays silent.
+        .onChange(of: store.backgroundActivationIDs, initial: true) { _, ids in
+            for id in ids where !activated.contains(id) {
+                activated.append(id)
+            }
+        }
         .onChange(of: store.selectedSessionID, initial: true) { _, id in
             if let id, !activated.contains(id) {
                 activated.append(id)

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -4,12 +4,14 @@ import Foundation
 extension TermioStore {
     /// Adds a session to a project, optionally running in one of its linked
     /// worktree folders while remaining in the project's flat session roster.
+    @discardableResult
     func addSession(
         to projectID: Project.ID,
         agent: AgentPreset = .terminal,
-        worktreePath: String? = nil
-    ) {
-        guard let index = projects.firstIndex(where: { $0.id == projectID }) else { return }
+        worktreePath: String? = nil,
+        takeFocus: Bool = true
+    ) -> Session.ID? {
+        guard let index = projects.firstIndex(where: { $0.id == projectID }) else { return nil }
         let project = projects[index]
         let terminalCount = project.sessions.filter { $0.agent == .terminal }.count
         let title = agent == .terminal
@@ -18,7 +20,12 @@ extension TermioStore {
         var session = Session(title: title, agent: agent)
         session.worktreePath = worktreePath
         projects[index].sessions.append(session)
-        selectedSessionID = session.id
+        if takeFocus {
+            selectedSessionID = session.id
+        } else {
+            activateInBackground(session.id)
+        }
+        return session.id
     }
 
     /// Whether `moved` may be drag-reordered next to `target`: both must live in the

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -173,6 +173,13 @@ extension TermioStore {
     /// help gets a Claude), then to the user's preferred chat agent; `--agent`
     /// overrides both.
     private func spawnAndSend(_ request: ControlRequest, in project: Project, payload: String) async -> Data {
+        // Who is asking, resolved against this project's roster: a sibling agent
+        // spawning from inside termio, or nil for a spawn from an outside shell.
+        // Drives both defaults below — the new agent's kind and where its pane lands.
+        let caller = request.callerSession
+            .flatMap(UUID.init(uuidString:))
+            .flatMap { id in project.sessions.first { $0.id == id } }
+
         let preset: AgentDefinition
         if let name = request.agent, !name.isEmpty {
             // An explicit name may be the plain shell — that is `run`, a terminal
@@ -184,8 +191,7 @@ extension TermioStore {
                     "Unknown agent '\(name)'. Try one of: \(names), or terminal.")
             }
             preset = resolved
-        } else if let callerID = request.callerSession, let uuid = UUID(uuidString: callerID),
-                  let caller = session(uuid), !effectiveAgent(for: caller).isShell {
+        } else if let caller, !effectiveAgent(for: caller).isShell {
             preset = effectiveAgent(for: caller)
         } else if let fallback = defaultChatAgent() {
             preset = fallback
@@ -194,11 +200,14 @@ extension TermioStore {
                 "No coding agent is enabled — pass --agent <name>.")
         }
 
-        // Drop the new agent in beside the pane you were watching (a split), not
-        // as a full-screen swap that hides the caller — the whole reason to spawn
-        // a sibling from the CLI is to see them side by side.
-        addSplitSession(to: project.id, agent: preset)
-        guard let id = selectedSessionID, let fresh = session(id) else {
+        // Beside the caller's pane as a split, not a full-screen swap — the whole
+        // reason to spawn a sibling is to see them side by side. Anchoring and
+        // focus policy are documented on `addSplitSession`; the selection only
+        // moves when the caller is the pane the user is already watching.
+        let freshID = addSplitSession(
+            to: project.id, agent: preset, anchor: caller?.id,
+            takeFocus: caller == nil || caller?.id == selectedSessionID)
+        guard let freshID, let fresh = session(freshID) else {
             return controlError(request, "start_failed", "Could not start the session.")
         }
         let state = surface(for: fresh, in: project)
@@ -290,13 +299,15 @@ extension TermioStore {
         _ payload: String, to session: Session, state: TerminalViewState
     ) async -> Bool {
         // The libghostty surface attaches lazily on the pane's first render, so a
-        // session never shown in the UI has no surface yet. Selecting it adds it to
-        // the mounted set, then poll for the attach rather than betting on one
-        // render cycle: right after app launch several panes render at once and one
-        // cycle isn't enough — a `run` session's near-instant boot-settle hit that
-        // window as a spurious not_live. (A session shown even once stays mounted,
-        // so this only foregrounds on the very first drive.)
-        if state.surface == nil { selectedSessionID = session.id }
+        // session never shown in the UI has no surface yet. A background mount adds
+        // it to the mounted set *without* moving the user's selection (a sibling
+        // driving a pane the user isn't watching must stay silent), then poll for
+        // the attach rather than betting on one render cycle: right after app
+        // launch several panes render at once and one cycle isn't enough — a `run`
+        // session's near-instant boot-settle hit that window as a spurious
+        // not_live. (A session mounted even once stays mounted, so this only fires
+        // on the very first drive.)
+        if state.surface == nil { activateInBackground(session.id) }
         let attachDeadline = Date().addingTimeInterval(3)
         while state.surface == nil, Date() < attachDeadline {
             try? await Task.sleep(for: .milliseconds(150))

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -58,21 +58,33 @@ extension TermioStore {
 
     /// Adds a session to a project and drops it in **beside** a visible pane as a
     /// split, instead of replacing the view the way `addSession` does. This is the
-    /// path the CLI / an agent spawning a sibling takes (`termio sessions start`):
+    /// path the CLI / an agent spawning a sibling takes (`termio sessions spawn`):
     /// there the whole point is to *see* the new agent next to the one you were
     /// watching, not to have it hijack the terminal area and push its predecessor
     /// off to a sidebar row.
     ///
-    /// The anchor is the pane you're looking at when it belongs to this project,
-    /// else the project's last session (a cross-project selection is ignored, so a
+    /// The anchor is the caller's own pane when one is passed (a CLI spawn from a
+    /// sibling agent lands beside that agent, wherever the user is looking), else
+    /// the pane you're looking at when it belongs to this project, else the
+    /// project's last session (a cross-project selection is ignored, so a
     /// background agent's sibling never gets dragged into another project's group).
     /// The split axis alternates across the anchor's current one, tiling-WM style —
     /// a lone anchor opens side by side. With no pane to anchor to (an empty
     /// project) it falls back to a plain `addSession`.
-    func addSplitSession(to projectID: Project.ID, agent: AgentPreset = .terminal) {
-        guard let projectIndex = projects.firstIndex(where: { $0.id == projectID }) else { return }
+    ///
+    /// With `takeFocus` false the selection stays where the user put it: the new
+    /// pane is mounted invisibly instead (see `activateInBackground`), so its
+    /// surface still attaches and can take a queued prompt.
+    @discardableResult
+    func addSplitSession(
+        to projectID: Project.ID, agent: AgentPreset = .terminal,
+        anchor: Session.ID? = nil, takeFocus: Bool = true
+    ) -> Session.ID? {
+        guard let projectIndex = projects.firstIndex(where: { $0.id == projectID }) else { return nil }
 
-        let anchorID = selectedSessionID.flatMap { id in
+        let anchorID = anchor.flatMap { id in
+            projects[projectIndex].sessions.contains { $0.id == id } ? id : nil
+        } ?? selectedSessionID.flatMap { id in
             projects[projectIndex].sessions.contains { $0.id == id } ? id : nil
         } ?? projects[projectIndex].sessions.last?.id
 
@@ -80,8 +92,7 @@ extension TermioStore {
               let anchorIndex = projects[projectIndex].sessions.firstIndex(where: { $0.id == anchorID })
         else {
             // Empty project — nothing to split against; behave like a normal add.
-            addSession(to: projectID, agent: agent)
-            return
+            return addSession(to: projectID, agent: agent, takeFocus: takeFocus)
         }
 
         let project = projects[projectIndex]
@@ -114,8 +125,13 @@ extension TermioStore {
                                                   first: .leaf(anchorID),
                                                   second: .leaf(newSession.id))))
         }
-        selectedSessionID = newSession.id
-        isPaneZoomed = false
+        if takeFocus {
+            selectedSessionID = newSession.id
+            isPaneZoomed = false
+        } else {
+            activateInBackground(newSession.id)
+        }
+        return newSession.id
     }
 
     // MARK: - Type switching (联合 ⇄ 独立)

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -77,6 +77,21 @@ final class TermioStore: ObservableObject {
     /// pane. `TerminalPane` honours it only while a split is on screen.
     @Published var isPaneZoomed = false
 
+    /// Activation *requests* for sessions that are neither selected nor in the
+    /// visible group: a background spawn's fresh pane, a `send` target never
+    /// shown. `TerminalPane` folds these into its own `activated` list — the
+    /// actual mounted set — so the pane mounts invisibly at full size, which is
+    /// what attaches the libghostty surface: the queued prompt can then be
+    /// delivered without yanking the user's selection over to the new pane.
+    /// Transient and not persisted — on relaunch the pane mounts the normal way.
+    @Published private(set) var backgroundActivationIDs: [Session.ID] = []
+
+    /// Requests an invisible mount for `id` (see `backgroundActivationIDs`).
+    func activateInBackground(_ id: Session.ID) {
+        guard !backgroundActivationIDs.contains(id) else { return }
+        backgroundActivationIDs.append(id)
+    }
+
     /// The session currently being drag-reordered in the sidebar, recorded when a row
     /// drag begins so a hovered row can ask `canReorder` whether it's a legal drop
     /// target (same project + worktree bucket) and light its background only then.


### PR DESCRIPTION
## Problem

An agent in session A calls `termio sessions spawn` while the user has switched to session B — the new pane splits **B** (the pane the user happens to be watching) instead of **A** (the agent that asked), and the selection is yanked over to the fresh pane.

Root cause: `spawnAndSend` → `addSplitSession` anchored solely on `selectedSessionID`, and prompt delivery to an unmounted pane forced the selection over as its mount fallback.

## Fix

- **Caller-anchored placement**: `spawnAndSend` resolves the caller (`TERMIO_SESSION`) once against the project roster and passes it to `addSplitSession` as the split anchor — the sibling lands beside the agent that spawned it, wherever the user is looking.
- **No focus steal**: the selection only moves when the caller *is* the watched pane, or the spawn came from an outside shell (no caller). A background spawn leaves the user's selection and zoom untouched.
- **Background activation** (`activateInBackground` / `backgroundActivationIDs`): the store publishes activation requests and `TerminalPane` folds them into its mounted set, so an invisible pane still mounts, attaches its libghostty surface, and takes the queued prompt silently. This also replaces the focus-steal fallback in `performDelivery`, fixing `send` to a never-shown session the same way.

`addSplitSession`/`addSession` now return the new session id (`@discardableResult`) instead of the spawn path recovering it from global selection.

## Verified

Dev-app end-to-end: impersonated a background caller (`TERMIO_SESSION=<Terminal 1>` while Claude Code was selected in the same project) and ran `termio-dev sessions run "echo …"` —

- new pane inserted directly after Terminal 1, split group = Terminal 1 + new pane
- `selectedSessionID` stayed on Claude Code throughout
- the command executed in the invisible pane (background mount attached the surface)

Reviewed by a Codex sibling session for cleanliness; its three polish items (single caller resolution, comment dedup + stale `sessions start` doc fix, `backgroundActivationIDs` rename with `private(set)`) are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)