### PR TITLE
feat(panes): unify split verbs as Group/Ungroup and always offer Close Session

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -998,14 +998,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.splitSelectedPane(.vertical)
     }
 
-    /// View ▸ Close Pane (⌘W) — collapses the focused pane out of the layout,
-    /// terminal-style. The session itself stays alive in the sidebar (killing it
-    /// remains the sidebar's explicit close). With no split on screen there is no
-    /// pane to peel off, so ⌘W falls through to closing the window, matching
-    /// iTerm2 where the last pane's ⌘W closes its container.
-    @objc func closeSplitPane(_ sender: Any?) {
+    /// View ▸ Ungroup (⌘W) — collapses the focused pane out of the layout.
+    /// The session itself stays alive in the sidebar (killing it remains the
+    /// explicit "Close Session"). With no split on screen there is no pane to
+    /// peel off, so ⌘W falls through to closing the window, matching iTerm2
+    /// where the last pane's ⌘W closes its container.
+    @objc func ungroupPane(_ sender: Any?) {
         if store.splitRoot != nil {
-            store.closeSelectedPane()
+            store.ungroupSelectedPane()
         } else {
             window?.performClose(sender)
         }
@@ -1570,7 +1570,7 @@ private func buildMainMenu() -> NSMenu {
         command: .openProject
     )
     fileMenu.addItem(.separator())
-    // ⌘⇧W closes the whole window (⌘W is Close Pane, terminal-style — see View menu).
+    // ⌘⇧W closes the whole window (⌘W is Ungroup, terminal-style — see View menu).
     fileMenu.addItem(
         withTitle: "Close Window",
         action: #selector(AppDelegate.closeMainWindow(_:)),
@@ -1625,13 +1625,13 @@ private func buildMainMenu() -> NSMenu {
         action: #selector(AppDelegate.toggleSplitZoom(_:)),
         command: .splitZoom
     )
-    // ⌘W closes the focused *pane* (the layout slot), not the session, matching
-    // terminal convention; the last pane's ⌘W falls through to the window. The
+    // ⌘W ungroups the focused *pane* (the layout slot) — the session survives
+    // in the sidebar; the last pane's ⌘W falls through to the window. The
     // whole window is ⌘⇧W (File ▸ Close Window).
     viewMenu.addItem(
-        withTitle: "Close Pane",
-        action: #selector(AppDelegate.closeSplitPane(_:)),
-        command: .closePane
+        withTitle: "Ungroup",
+        action: #selector(AppDelegate.ungroupPane(_:)),
+        command: .ungroup
     )
     viewMenu.addItem(.separator())
     // ⌥⌘ arrows move focus between panes, scored on the split geometry.

--- a/Sources/termio/CommandPalette/CommandPalette.swift
+++ b/Sources/termio/CommandPalette/CommandPalette.swift
@@ -227,9 +227,9 @@ struct CommandPaletteView: View {
                                  shortcut: keys.display(for: .splitZoom)) {
                 $0.toggleSelectedPaneZoom()
             })
-            actions.append(.init(id: "close-pane", title: "Close Pane",
-                                 icon: .square, shortcut: keys.display(for: .closePane)) {
-                $0.closeSelectedPane()
+            actions.append(.init(id: "ungroup", title: "Ungroup",
+                                 icon: .square, shortcut: keys.display(for: .ungroup)) {
+                $0.ungroupSelectedPane()
             })
             for (id, command, selector) in [
                 ("focus-left", KeyCommandID.focusPaneLeft, #selector(AppDelegate.focusPaneLeft(_:))),

--- a/Sources/termio/Keybindings/KeyCommand.swift
+++ b/Sources/termio/Keybindings/KeyCommand.swift
@@ -15,7 +15,8 @@ enum KeyCommandID: String, CaseIterable, Identifiable {
     case splitRight = "pane.split-right"
     case splitDown = "pane.split-down"
     case splitZoom = "pane.zoom"
-    case closePane = "pane.close"
+    // Raw value predates the Ungroup rename — kept so saved keybindings resolve.
+    case ungroup = "pane.close"
     case focusPaneLeft = "pane.focus-left"
     case focusPaneRight = "pane.focus-right"
     case focusPaneUp = "pane.focus-up"
@@ -72,7 +73,7 @@ enum KeyCommandCatalog {
               defaultShortcut: .init(modifiers: [.command, .shift], key: .char("d"))),
         .init(id: .splitZoom, category: "Panes", title: "Zoom Split",
               defaultShortcut: .init(modifiers: [.command, .shift], key: .return)),
-        .init(id: .closePane, category: "Panes", title: "Close Pane",
+        .init(id: .ungroup, category: "Panes", title: "Ungroup",
               defaultShortcut: .init(modifiers: [.command], key: .char("w"))),
         .init(id: .focusPaneLeft, category: "Panes", title: "Focus Pane Left",
               defaultShortcut: .init(modifiers: [.command, .option], key: .left)),

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -915,8 +915,8 @@ private struct SessionRow: View {
 
     private var isSelected: Bool { store.selectedSessionID == session.id }
 
-    /// The row's right-click menu. Rename/Pin/Close are always present; the two
-    /// split "type switch" items appear conditionally — "Unsplit" only when the
+    /// The row's right-click menu. Rename/Pin/Close Session are always present; the two
+    /// split "type switch" items appear conditionally — "Ungroup" only when the
     /// session is already in a group (联合 → 独立), and "Group with ▸" only when
     /// there is a sibling to combine it with (独立 → 联合).
     private var menuItems: [SidebarMenuItem] {
@@ -926,7 +926,7 @@ private struct SessionRow: View {
         let targets = store.groupableTargets(for: session.id)
         if store.isInSplitGroup(session.id) || !targets.isEmpty { items.append(.separator) }
         if store.isInSplitGroup(session.id) {
-            items.append(.action("Unsplit") { store.detachFromSplit(session.id) })
+            items.append(.action("Ungroup") { store.detachFromSplit(session.id) })
         }
         if !targets.isEmpty {
             items.append(.submenu("Group with", targets.map { target in
@@ -939,7 +939,7 @@ private struct SessionRow: View {
             .separator,
             .action(session.pinned ? "Unpin" : "Pin") { store.toggleSessionPinned(session.id) },
             .separator,
-            .action("Close") { store.closeSession(session.id) },
+            .action("Close Session") { store.closeSession(session.id) },
         ])
         return items
     }

--- a/Sources/termio/Terminal/TerminalContextMenu.swift
+++ b/Sources/termio/Terminal/TerminalContextMenu.swift
@@ -97,13 +97,15 @@ final class TerminalContextMenu: NSObject {
         menu.addItem(.separator())
         menu.addItem(storeItem("Split Right", action: #selector(splitRight), symbol: "rectangle.split.2x1"))
         menu.addItem(storeItem("Split Down", action: #selector(splitDown), symbol: "rectangle.split.1x2"))
-        // A split pane leaves the layout but keeps its session alive ("Close
-        // Pane"); a lone terminal has no pane to leave, so the only close that
-        // means anything kills the session outright — same action and label as
-        // the sidebar row's "Close Session".
+        // "Ungroup" is the layout half: the pane leaves the split group but its
+        // session stays alive in the sidebar — the same action the sidebar row
+        // names "Ungroup" (the inverse of "Group with"). "Close Session" is the destructive half and is
+        // always offered; closing a split session prunes its pane on the way
+        // out, so the layout needs no separate cleanup.
         if store?.splitRoot != nil {
-            menu.addItem(storeItem("Close Pane", action: #selector(closePane), symbol: "rectangle"))
-        } else if clickedSessionID != nil {
+            menu.addItem(storeItem("Ungroup", action: #selector(ungroup), symbol: "rectangle"))
+        }
+        if clickedSessionID != nil {
             menu.addItem(storeItem("Close Session", action: #selector(closeSession), symbol: "xmark"))
         }
         return menu
@@ -130,7 +132,7 @@ final class TerminalContextMenu: NSObject {
 
     @objc private func splitRight() { store?.splitSelectedPane(.horizontal) }
     @objc private func splitDown() { store?.splitSelectedPane(.vertical) }
-    @objc private func closePane() { store?.closeSelectedPane() }
+    @objc private func ungroup() { store?.ungroupSelectedPane() }
     @objc private func closeSession() {
         guard let id = clickedSessionID else { return }
         store?.closeSession(id)

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -157,12 +157,12 @@ extension TermioStore {
         }
     }
 
-    /// Pulls a pane out of its split group into a standalone session — VS Code's
-    /// "Unsplit Terminal" (联合 → 独立). The session itself is untouched (its shell
+    /// Pulls a pane out of its split group into a standalone session — the
+    /// sidebar's "Ungroup" (联合 → 独立). The session itself is untouched (its shell
     /// keeps running, its surface stays cached); it just leaves the tree, the
     /// group dissolves when a lone pane is left, and the selection *follows* the
     /// detached pane so you see it come up on its own (the difference from
-    /// `closeSelectedPane`, which hands focus to the neighbour it leaves behind).
+    /// `ungroupSelectedPane`, which hands focus to the neighbour it leaves behind).
     func detachFromSplit(_ id: Session.ID) {
         guard let group = groupIndex(containing: id) else { return }
         setGroup(at: group, to: splitGroups[group].removing(leaf: id))
@@ -234,12 +234,12 @@ extension TermioStore {
         projects[projectIndex].sessions.insert(row, at: anchorIndex + 1)
     }
 
-    /// Closes the focused *pane* — the layout operation, not the session one.
+    /// Ungroups the focused *pane* — the layout operation, not the session one.
     /// The session stays alive in the sidebar (its shell keeps running, its
     /// surface stays cached); it just leaves its group, and focus moves to its
-    /// layout neighbour. Killing the session outright remains the sidebar's
-    /// close, which prunes the groups through `pruneSessionsFromSplit`.
-    func closeSelectedPane() {
+    /// layout neighbour. Killing the session outright remains "Close Session",
+    /// which prunes the groups through `pruneSessionsFromSplit`.
+    func ungroupSelectedPane() {
         guard let focusedID = selectedSessionID,
               let group = groupIndex(containing: focusedID) else { return }
         let neighbor = neighborPane(of: focusedID, in: splitGroups[group])


### PR DESCRIPTION
## Why

"Close Pane" (⌘W, terminal context menu, palette, keybindings) never killed the session — it only removed the pane from its split group. The sidebar named the very same operation "Unsplit". One operation, two names, and a "Close" label on a non-destructive action.

## What

- **Ungroup** is now the one name for layout removal, the symmetric inverse of **Group with** (Finder/Keynote convention; matches `splitGroups`/`groupSession` in the model). Applied to the terminal context menu, View menu (⌘W), command palette, keybindings settings, and the sidebar row (was "Unsplit").
- **Close Session** is the only destructive verb: sidebar row renamed from bare "Close", and the terminal context menu now offers it inside a split too — a split pane's menu reads `Split Right / Split Down / Ungroup / Close Session`.
- Internal identifiers follow: `closeSplitPane`→`ungroupPane`, `closeSelectedPane`→`ungroupSelectedPane`, `KeyCommandID.closePane`→`.ungroup`, palette id `close-pane`→`ungroup`.
- The keybinding raw value `"pane.close"` is kept (persisted in saved keybindings) with a comment.

"Split Right / Split Down" stay: they are directional creation (iTerm2 muscle memory); their inverse is Ungroup.

No behavior changes beyond the always-visible Close Session menu item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)