### PR TITLE
refactor(settings): move agent integrations to General, trim copy to one-liners

### DIFF
--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -20,38 +20,6 @@ struct AgentSettingsTab: View {
     var body: some View {
         Form {
             Section {
-                Toggle(isOn: $settings.agentHooksEnabled) {
-                    SettingsLabel(
-                        .huge(.wireless),
-                        title: "Live agent status",
-                        subtext: "Installs hooks for Claude Code, Codex, OpenCode, and Pi so termio can tell when an agent is working or waiting on you — shown as the spinning sidebar icon and the menu-bar pulse. Adds termio's own entries to each agent's config; turning this off removes them. (Codex needs a one-time /hooks trust.)"
-                    )
-                }
-                .toggleStyle(.switch)
-                if settings.agentHooksEnabled {
-                    // For re-applying after the user (or another tool) has edited
-                    // ~/.claude/settings.json; install is idempotent.
-                    Button("Reinstall hooks") { AgentStatusHooks.sync(enabled: true) }
-                }
-            } header: {
-                SectionHeaderLabel(title: "Status")
-            }
-            Section {
-                Toggle(isOn: $settings.sessionControlEnabled) {
-                    SettingsLabel(
-                        .huge(.gitBranch),
-                        title: "Session control",
-                        subtext: "Lets an agent see and drive its sibling sessions in the same project with the `termio sessions` command (list, send a prompt, answer a menu, start, stop). Scoped to the current project. Adds a short awareness note to the agents' instruction files; turning this off removes it."
-                    )
-                }
-                .toggleStyle(.switch)
-                if settings.sessionControlEnabled {
-                    Button("Reinstall note") { SessionSkillInstaller.sync(enabled: true) }
-                }
-            } header: {
-                SectionHeaderLabel(title: "Orchestration")
-            }
-            Section {
                 DefaultChatAgentRow(settings: settings)
             } header: {
                 SectionHeaderLabel(title: "New chat")
@@ -91,7 +59,7 @@ struct AgentSettingsTab: View {
         } header: {
             SectionHeaderLabel(title: "Agents")
         } footer: {
-            Text("The agents offered in the new-session menu and the sidebar's quick-add row, in this order — drag to reorder, right-click to remove. Open a row to set a custom command or skip its permission prompts. An agent whose CLI isn't installed stays off until it is.")
+            Text("The agents offered when starting a new session, in this order — drag to reorder, right-click to remove.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/termio/Settings/GeneralSettingsTab.swift
+++ b/Sources/termio/Settings/GeneralSettingsTab.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 import UserNotifications
 
-/// App-level settings that aren't about a specific surface: the `termio`
-/// command-line tool (an app integration, not an agent feature, so it lives here
-/// rather than in the Agents tab) and task-completion notifications.
+/// App-level settings that aren't about a specific surface: task-completion
+/// notifications, the `termio` command-line tool, and the machine-wide agent
+/// integrations (status hooks, session control). The latter three install termio's
+/// wiring outside the app — PATH, agent configs, instruction files — rather than
+/// configure a particular agent, so they live here rather than in the Agents tab.
 struct GeneralSettingsTab: View {
     @ObservedObject var settings: AppSettings
 
@@ -14,7 +16,7 @@ struct GeneralSettingsTab: View {
                     SettingsLabel(
                         .huge(.checkCircle),
                         title: "Task completion",
-                        subtext: "Posts a macOS notification when an agent finishes a task — or stops to ask you something — while termio is in the background. Quick replies and answer-only turns that ran no tools stay quiet; a blocked agent always notifies. Click the notification to jump to that session. macOS asks for permission the first time."
+                        subtext: "Posts a notification when an agent finishes or needs you while termio is in the background."
                     )
                 }
                 .toggleStyle(.switch)
@@ -29,6 +31,38 @@ struct GeneralSettingsTab: View {
                 CommandLineToolRow()
             } header: {
                 SectionHeaderLabel(title: "Command line")
+            }
+            Section {
+                Toggle(isOn: $settings.agentHooksEnabled) {
+                    SettingsLabel(
+                        .huge(.wireless),
+                        title: "Live agent status",
+                        subtext: "Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse. Installs termio's hooks into each agent's config."
+                    )
+                }
+                .toggleStyle(.switch)
+                if settings.agentHooksEnabled {
+                    // For re-applying after the user (or another tool) has edited
+                    // ~/.claude/settings.json; install is idempotent.
+                    Button("Reinstall hooks") { AgentStatusHooks.sync(enabled: true) }
+                }
+            } header: {
+                SectionHeaderLabel(title: "Status")
+            }
+            Section {
+                Toggle(isOn: $settings.sessionControlEnabled) {
+                    SettingsLabel(
+                        .huge(.gitBranch),
+                        title: "Session control",
+                        subtext: "Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command."
+                    )
+                }
+                .toggleStyle(.switch)
+                if settings.sessionControlEnabled {
+                    Button("Reinstall note") { SessionSkillInstaller.sync(enabled: true) }
+                }
+            } header: {
+                SectionHeaderLabel(title: "Orchestration")
             }
         }
         .formStyle(.grouped)

--- a/Sources/termio/Settings/MobileSettingsTab.swift
+++ b/Sources/termio/Settings/MobileSettingsTab.swift
@@ -38,7 +38,7 @@ struct MobileSettingsTab: View {
             Section {
                 Toggle("Mobile Access", isOn: $mobile.isEnabled)
             } footer: {
-                Text("When off, this Mac stops listening and your iPhone disconnects — but stays paired. Turn it back on to reconnect; no new QR needed.")
+                Text("Turn off to disconnect your iPhone; pairing is kept.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }
@@ -86,7 +86,7 @@ struct MobileSettingsTab: View {
                 } header: {
                     SectionHeaderLabel(title: "Remote Access")
                 } footer: {
-                    Text("Fronts this Mac with a public URL so the iPhone can connect away from home. The QR above switches to the tunnel address while one is running; every connection still has to present this Mac's pairing token.")
+                    Text("Gives this Mac a public URL so your iPhone can connect away from home; connections still require this Mac's pairing token.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/termio/Settings/SSHSettingsTab.swift
+++ b/Sources/termio/Settings/SSHSettingsTab.swift
@@ -83,7 +83,7 @@ struct SSHSettingsTab: View {
         } header: {
             SectionHeaderLabel(title: "Hosts")
         } footer: {
-            Text("The Host blocks from ~/.ssh/config (Include'd files too) — exactly the aliases `ssh` resolves. Test Connection probes reachability and auth without opening a session; right-click a host to Connect it as a terminal in the sidebar, same as File ▸ New SSH Connection.")
+            Text("Your Host entries from ~/.ssh/config — the same aliases `ssh` resolves. Right-click a host to connect.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -97,7 +97,7 @@ struct SSHSettingsTab: View {
                 SettingsLabel(
                     .huge(.fileDoc),
                     title: "~/.ssh/config",
-                    subtext: "The OpenSSH client config is the single source of truth — termio keeps no separate host database. Edits show up here and in plain `ssh` alike."
+                    subtext: "Reads ~/.ssh/config directly — termio keeps no separate host list."
                 )
             }
         } header: {


### PR DESCRIPTION
## Summary
- Move the **Status** (Live agent status) and **Orchestration** (Session control) sections from the Agents tab to the General tab. Both install machine-wide wiring — agent configs and instruction files — rather than configure a particular agent, so they sit beside the command-line tool. General now reads: Notifications → Command line → Status → Orchestration; Agents keeps only New chat and the agents list.
- Trim over-long settings copy to the Apple/Xcode convention (one sentence on what the control does) across General, Agents, SSH, and Mobile. Consent text (Usage), pairing steps (Mobile QR), and the keybinding-recording hint keep their fuller wording deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)