### PR TITLE
fix(github): resolve SSH host aliases when detecting a github.com remote

### DIFF
--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -589,10 +589,49 @@ enum GitService {
             guard let remote = run(["remote", "get-url", "origin"], in: dir)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                 let (host, path) = parseRemote(remote),
-                host == "github.com" || host == "www.github.com"
+                isGitHubHost(host)
             else { return nil }
             return path
         }
+    }
+
+    /// Whether `host` is github.com — directly, or through an SSH `~/.ssh/config`
+    /// alias (`Host github-work` → `HostName github.com`), the standard trick for
+    /// juggling two GitHub accounts with different keys. We ask ssh itself to
+    /// expand the alias (`ssh -G`) rather than parse the config by hand, so
+    /// Include / Match directives all resolve correctly; this mirrors how `gh`
+    /// (go-gh's SSH translator) handles the same case. Results are cached — the
+    /// ssh config rarely changes within a run.
+    private static func isGitHubHost(_ host: String) -> Bool {
+        let lower = host.lowercased()
+        if lower == "github.com" || lower == "www.github.com" { return true }
+        return resolveSSHHostName(lower) == "github.com"
+    }
+
+    private nonisolated(unsafe) static var sshHostNameCache: [String: String] = [:]
+    private static let sshHostNameLock = NSLock()
+
+    /// The real hostname `ssh` resolves `host` to (after alias / Include / Match
+    /// expansion), or `nil` when ssh can't be run or reports nothing. An empty
+    /// string is cached for "no answer" so a missing ssh isn't retried per repo.
+    private static func resolveSSHHostName(_ host: String) -> String? {
+        sshHostNameLock.lock()
+        if let cached = sshHostNameCache[host] {
+            sshHostNameLock.unlock()
+            return cached.isEmpty ? nil : cached
+        }
+        sshHostNameLock.unlock()
+        // `ssh -G <host>` prints the fully-resolved effective config; its
+        // `hostname <value>` line is the destination the alias points at.
+        let resolved = output(of: "/usr/bin/ssh", ["-G", host])?
+            .split(separator: "\n")
+            .first { $0.lowercased().hasPrefix("hostname ") }
+            .map { String($0.dropFirst("hostname ".count)).trimmingCharacters(in: .whitespaces) }
+        let value = resolved?.lowercased() ?? ""
+        sshHostNameLock.lock()
+        sshHostNameCache[host] = value
+        sshHostNameLock.unlock()
+        return value.isEmpty ? nil : value
     }
 
     /// Fetches a pull request's head (`refs/pull/N/head` — GitHub serves every PR
@@ -699,6 +738,23 @@ enum GitService {
         let data = out.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
         if !ignoreStatus, process.terminationStatus != 0 { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Runs an arbitrary executable and returns stdout on a clean exit — the same
+    /// drain-before-wait discipline as `run`, for the non-git tools (ssh) the
+    /// service shells out to. Inherits the environment so ssh finds `~/.ssh/config`.
+    private static func output(of executable: String, _ args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = args
+        let out = Pipe()
+        process.standardOutput = out
+        process.standardError = FileHandle.nullDevice
+        do { try process.run() } catch { return nil }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 { return nil }
         return String(data: data, encoding: .utf8)
     }
 }

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -575,9 +575,9 @@ enum GitService {
     private static func resolveRemotePage(_ dir: String) -> RemotePage? {
         guard let remote = run(["remote", "get-url", "origin"], in: dir)?
             .trimmingCharacters(in: .whitespacesAndNewlines),
-            let (host, path) = parseRemote(remote),
-            let forge = Forge(host: host),
-            let repo = URL(string: "https://\(host)/\(path)") else { return nil }
+            let parsed = parseRemote(remote),
+            let forge = Forge(host: parsed.host),
+            let repo = URL(string: "https://\(parsed.host)/\(parsed.path)") else { return nil }
         guard run(["rev-parse", "--abbrev-ref", "@{upstream}"], in: dir) != nil,
               let branch = run(["rev-parse", "--abbrev-ref", "HEAD"], in: dir)?
                   .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -595,43 +595,26 @@ enum GitService {
         await offMain {
             guard let remote = run(["remote", "get-url", "origin"], in: dir)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
-                let (host, path) = parseRemote(remote)
+                let parsed = parseRemote(remote)
             else { return nil }
             // A literal github.com host binds directly, whatever the transport.
-            if isGitHubHostName(host) { return path }
+            if isGitHubHostName(parsed.host) { return parsed.path }
             // Otherwise it may be an SSH `~/.ssh/config` alias (`Host github-work`
             // → `HostName github.com`, the standard trick for juggling accounts).
-            // Only expand for remotes git actually reaches over SSH: running
-            // `ssh -G` on an HTTPS host is pointless and could fire a `Match exec`
-            // or falsely bind an unrelated repo to public GitHub. Feed ssh the
-            // exact `[user@]host`, original case, so `Host` patterns and
-            // `Match user` / `%r` rules resolve as git's own ssh would.
-            guard let target = sshTarget(remote),
+            // `sshTarget` is non-nil only for SSH remotes, so an HTTPS host never
+            // triggers `ssh -G` — which would be pointless and could fire a
+            // `Match exec` or falsely bind an unrelated repo to public GitHub.
+            guard let target = parsed.sshTarget,
                   let resolved = resolveSSHHostName(target),
                   isGitHubHostName(resolved)
             else { return nil }
-            return path
+            return parsed.path
         }
     }
 
     private static func isGitHubHostName(_ host: String) -> Bool {
         let lower = host.lowercased()
         return lower == "github.com" || lower == "www.github.com"
-    }
-
-    /// The `[user@]host` to hand `ssh -G`, or `nil` when the remote isn't an SSH
-    /// URL (HTTPS / git:// never touch ssh). Case and userinfo are preserved.
-    private static func sshTarget(_ remote: String) -> String? {
-        if !remote.contains("://") {
-            // scp-style `user@host:path` — the only no-scheme form git treats as SSH.
-            guard remote.contains("@"), let colon = remote.firstIndex(of: ":") else { return nil }
-            let target = String(remote[..<colon])
-            return target.isEmpty ? nil : target
-        }
-        guard remote.hasPrefix("ssh://"), let url = URL(string: remote),
-              let host = url.host, !host.isEmpty else { return nil }
-        if let user = url.user, !user.isEmpty { return "\(user)@\(host)" }
-        return host
     }
 
     private nonisolated(unsafe) static var sshHostNameCache: [String: String] = [:]
@@ -644,22 +627,18 @@ enum GitService {
     /// repo. The cache key keeps the target's case (OpenSSH matching is
     /// case-sensitive), so `github-work` and `GitHub-Work` stay distinct.
     private static func resolveSSHHostName(_ target: String) -> String? {
-        sshHostNameLock.lock()
-        if let cached = sshHostNameCache[target] {
-            sshHostNameLock.unlock()
+        // The subprocess runs *outside* the lock (never hold a lock across a fork);
+        // a rare duplicate lookup just recomputes the same value.
+        if let cached = sshHostNameLock.withLock({ sshHostNameCache[target] }) {
             return cached.isEmpty ? nil : cached
         }
-        sshHostNameLock.unlock()
         // `ssh -G <target>` prints the fully-resolved effective config; its
         // `hostname <value>` line is the destination the alias points at.
-        let resolved = output(of: "/usr/bin/ssh", ["-G", target])?
+        let value = output(of: "/usr/bin/ssh", ["-G", target])?
             .split(separator: "\n")
             .first { $0.lowercased().hasPrefix("hostname ") }
-            .map { String($0.dropFirst("hostname ".count)).trimmingCharacters(in: .whitespaces) }
-        let value = resolved ?? ""
-        sshHostNameLock.lock()
-        sshHostNameCache[target] = value
-        sshHostNameLock.unlock()
+            .map { String($0.dropFirst("hostname ".count)).trimmingCharacters(in: .whitespaces) } ?? ""
+        sshHostNameLock.withLock { sshHostNameCache[target] = value }
         return value.isEmpty ? nil : value
     }
 
@@ -704,26 +683,42 @@ enum GitService {
         }
     }
 
-    /// Splits a remote into web-addressable host + repo path, from either the scp-like
-    /// form (`git@host:owner/repo.git`) or a real URL (`https://…`, `ssh://…`). Ports
-    /// and userinfo are dropped — the web UI lives on plain https.
-    private static func parseRemote(_ remote: String) -> (host: String, path: String)? {
-        var host: String
+    /// A git remote split into its web-addressable host + repo path, plus the
+    /// `[user@]host` to hand `ssh -G` when git reaches it over SSH.
+    private struct ParsedRemote {
+        let host: String
+        let path: String
+        /// Present only for SSH remotes (scp-like or `ssh://`); `nil` for HTTPS /
+        /// git://. Case and userinfo are preserved so `Host` patterns and
+        /// `Match user` / `%r` rules resolve as git's own ssh would.
+        let sshTarget: String?
+    }
+
+    /// Splits a remote from either the scp-like form (`git@host:owner/repo.git`) or a
+    /// real URL (`https://…`, `ssh://…`). Ports and userinfo are dropped from `host` /
+    /// `path` — the web UI lives on plain https — but kept in `sshTarget`.
+    private static func parseRemote(_ remote: String) -> ParsedRemote? {
+        let host: String
         var path: String
+        var sshTarget: String?
         if !remote.contains("://"), remote.contains("@"), let colon = remote.firstIndex(of: ":") {
-            let hostPart = String(remote[..<colon])
+            let hostPart = String(remote[..<colon])   // user@host, original case
             host = hostPart.components(separatedBy: "@").last ?? hostPart
             path = String(remote[remote.index(after: colon)...])
+            sshTarget = hostPart
         } else if let url = URL(string: remote), let urlHost = url.host {
             host = urlHost
             path = url.path
+            if url.scheme == "ssh" {
+                sshTarget = url.user.map { "\($0)@\(urlHost)" } ?? urlHost
+            }
         } else {
             return nil
         }
         path = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         if path.hasSuffix(".git") { path = String(path.dropLast(4)) }
         guard !host.isEmpty, !path.isEmpty else { return nil }
-        return (host, path)
+        return ParsedRemote(host: host, path: path, sshTarget: sshTarget)
     }
 
     // MARK: Stall detection
@@ -752,28 +747,18 @@ enum GitService {
         }
     }
 
-    /// Runs `git -C <dir> <args>` and returns stdout, or `nil` on launch failure (or a
-    /// non-zero exit unless `ignoreStatus`). stdout is drained *before* `waitUntilExit`
-    /// because a diff can exceed the 64 KB pipe buffer and otherwise deadlock the child;
-    /// stderr is sent to the null device so it can never fill either.
+    /// Runs `git -C <dir> <args>` and returns stdout, or `nil` on launch failure or a
+    /// non-zero exit (unless `ignoreStatus`).
     private static func run(_ args: [String], in dir: String, ignoreStatus: Bool = false) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-        process.arguments = ["-C", dir] + args
-        let out = Pipe()
-        process.standardOutput = out
-        process.standardError = FileHandle.nullDevice
-        do { try process.run() } catch { return nil }
-        let data = out.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        if !ignoreStatus, process.terminationStatus != 0 { return nil }
-        return String(data: data, encoding: .utf8)
+        output(of: "/usr/bin/git", ["-C", dir] + args, ignoreStatus: ignoreStatus)
     }
 
-    /// Runs an arbitrary executable and returns stdout on a clean exit — the same
-    /// drain-before-wait discipline as `run`, for the non-git tools (ssh) the
-    /// service shells out to. Inherits the environment so ssh finds `~/.ssh/config`.
-    private static func output(of executable: String, _ args: [String]) -> String? {
+    /// Runs an executable and returns stdout, or `nil` on launch failure or a non-zero
+    /// exit (unless `ignoreStatus`). stdout is drained *before* `waitUntilExit` because
+    /// output can exceed the 64 KB pipe buffer and otherwise deadlock the child; stderr
+    /// is sent to the null device so it can never fill either. The environment is
+    /// inherited, so ssh finds `~/.ssh/config`.
+    private static func output(of executable: String, _ args: [String], ignoreStatus: Bool = false) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = args
@@ -783,7 +768,7 @@ enum GitService {
         do { try process.run() } catch { return nil }
         let data = out.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
-        if process.terminationStatus != 0 { return nil }
+        if !ignoreStatus, process.terminationStatus != 0 { return nil }
         return String(data: data, encoding: .utf8)
     }
 }

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -43,6 +43,13 @@ enum GitService {
         await offMain { loadDiffText(change, repoRoot) }
     }
 
+    /// Parses ready-made unified-diff text (GitHub's inline PR `patch`) into rows off the
+    /// main thread — the same parser the local `git diff` path uses, so a PR file diffed
+    /// from the API renders identically without a subprocess or a checkout.
+    static func parseDiffText(_ text: String) async -> [DiffRow] {
+        await offMain { parseDiff(text) }
+    }
+
     /// Discards a whole selection in one confirmed action — the multi-select's
     /// "Discard N Files…". Sequential and best-effort per file, like the single form.
     static func discard(_ changes: [GitChange], in repoRoot: String) async {
@@ -588,48 +595,70 @@ enum GitService {
         await offMain {
             guard let remote = run(["remote", "get-url", "origin"], in: dir)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
-                let (host, path) = parseRemote(remote),
-                isGitHubHost(host)
+                let (host, path) = parseRemote(remote)
+            else { return nil }
+            // A literal github.com host binds directly, whatever the transport.
+            if isGitHubHostName(host) { return path }
+            // Otherwise it may be an SSH `~/.ssh/config` alias (`Host github-work`
+            // → `HostName github.com`, the standard trick for juggling accounts).
+            // Only expand for remotes git actually reaches over SSH: running
+            // `ssh -G` on an HTTPS host is pointless and could fire a `Match exec`
+            // or falsely bind an unrelated repo to public GitHub. Feed ssh the
+            // exact `[user@]host`, original case, so `Host` patterns and
+            // `Match user` / `%r` rules resolve as git's own ssh would.
+            guard let target = sshTarget(remote),
+                  let resolved = resolveSSHHostName(target),
+                  isGitHubHostName(resolved)
             else { return nil }
             return path
         }
     }
 
-    /// Whether `host` is github.com — directly, or through an SSH `~/.ssh/config`
-    /// alias (`Host github-work` → `HostName github.com`), the standard trick for
-    /// juggling two GitHub accounts with different keys. We ask ssh itself to
-    /// expand the alias (`ssh -G`) rather than parse the config by hand, so
-    /// Include / Match directives all resolve correctly; this mirrors how `gh`
-    /// (go-gh's SSH translator) handles the same case. Results are cached — the
-    /// ssh config rarely changes within a run.
-    private static func isGitHubHost(_ host: String) -> Bool {
+    private static func isGitHubHostName(_ host: String) -> Bool {
         let lower = host.lowercased()
-        if lower == "github.com" || lower == "www.github.com" { return true }
-        return resolveSSHHostName(lower) == "github.com"
+        return lower == "github.com" || lower == "www.github.com"
+    }
+
+    /// The `[user@]host` to hand `ssh -G`, or `nil` when the remote isn't an SSH
+    /// URL (HTTPS / git:// never touch ssh). Case and userinfo are preserved.
+    private static func sshTarget(_ remote: String) -> String? {
+        if !remote.contains("://") {
+            // scp-style `user@host:path` — the only no-scheme form git treats as SSH.
+            guard remote.contains("@"), let colon = remote.firstIndex(of: ":") else { return nil }
+            let target = String(remote[..<colon])
+            return target.isEmpty ? nil : target
+        }
+        guard remote.hasPrefix("ssh://"), let url = URL(string: remote),
+              let host = url.host, !host.isEmpty else { return nil }
+        if let user = url.user, !user.isEmpty { return "\(user)@\(host)" }
+        return host
     }
 
     private nonisolated(unsafe) static var sshHostNameCache: [String: String] = [:]
     private static let sshHostNameLock = NSLock()
 
-    /// The real hostname `ssh` resolves `host` to (after alias / Include / Match
-    /// expansion), or `nil` when ssh can't be run or reports nothing. An empty
-    /// string is cached for "no answer" so a missing ssh isn't retried per repo.
-    private static func resolveSSHHostName(_ host: String) -> String? {
+    /// The real hostname `ssh` resolves `target` (`[user@]host`) to, after alias /
+    /// Include / Match expansion — mirrors how `gh` (go-gh's SSH translator)
+    /// resolves the same case. `nil` when ssh can't be run or reports nothing; an
+    /// empty string is cached for "no answer" so a missing ssh isn't retried per
+    /// repo. The cache key keeps the target's case (OpenSSH matching is
+    /// case-sensitive), so `github-work` and `GitHub-Work` stay distinct.
+    private static func resolveSSHHostName(_ target: String) -> String? {
         sshHostNameLock.lock()
-        if let cached = sshHostNameCache[host] {
+        if let cached = sshHostNameCache[target] {
             sshHostNameLock.unlock()
             return cached.isEmpty ? nil : cached
         }
         sshHostNameLock.unlock()
-        // `ssh -G <host>` prints the fully-resolved effective config; its
+        // `ssh -G <target>` prints the fully-resolved effective config; its
         // `hostname <value>` line is the destination the alias points at.
-        let resolved = output(of: "/usr/bin/ssh", ["-G", host])?
+        let resolved = output(of: "/usr/bin/ssh", ["-G", target])?
             .split(separator: "\n")
             .first { $0.lowercased().hasPrefix("hostname ") }
             .map { String($0.dropFirst("hostname ".count)).trimmingCharacters(in: .whitespaces) }
-        let value = resolved?.lowercased() ?? ""
+        let value = resolved ?? ""
         sshHostNameLock.lock()
-        sshHostNameCache[host] = value
+        sshHostNameCache[target] = value
         sshHostNameLock.unlock()
         return value.isEmpty ? nil : value
     }


### PR DESCRIPTION
## What

The Issues pane binds only when the origin remote's host is *literally* `github.com`. A remote that goes through an SSH config alias — `git@github-work:owner/repo.git`, the standard trick for juggling multiple keys/accounts — resolved to host `github-work`, so `gitHubRepoSlug` returned `nil` and the Issues segment never appeared for that repo.

## Fix

`gitHubRepoSlug`'s host check moves from a literal `github.com` compare to `isGitHubHost`, which for a non-`github.com` host asks ssh to expand the alias — `ssh -G <host>` and read its resolved `hostname` line — rather than parsing `~/.ssh/config` by hand, so `Include` / `Match` directives all resolve. Results are cached behind an `NSLock` (an empty string memoises "no answer" so a missing ssh isn't retried per repo). This mirrors how `gh` (go-gh's SSH translator) handles the same case.

Adds a small private `output(of:_:)` process runner alongside `run`, with the same drain-before-wait discipline, for the non-git tools the service shells out to.

## Scope

Single, self-contained change to `GitService.swift`. No behavior change for remotes that already use a literal `github.com` host (HTTPS or plain SSH).

## Test

- `swift build` passes.
- Manual: an origin remote via an `~/.ssh/config` alias mapping to `github.com` now shows the Issues pane; a non-GitHub remote still doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)