### PR TITLE
fix(github): render raw HTML in issue and PR comments like GitHub does

### DIFF
--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -603,8 +603,10 @@ private struct CapsuleSwitch<Value: Hashable>: View {
 // MARK: - Detail HTML
 
 /// Assembles the self-contained detail page: title + meta header, the body,
-/// then each comment as a panel — all markdown through `MarkdownHTML` (escaped;
-/// tracker content is untrusted), colored from the live `TraceTheme`.
+/// then each comment as a panel — all markdown through `MarkdownHTML` in
+/// `documentMode`, so raw HTML (bot comments, `<picture>`/`<img>`/tables) renders
+/// through the GitHub-mirroring `HTMLSanitizer` whitelist the way GitHub itself
+/// does, colored from the live `TraceTheme`.
 private enum IssueDetailHTML {
     static func page(_ detail: IssueDetail, theme: TraceTheme) -> String {
         let s = detail.summary
@@ -613,12 +615,12 @@ private enum IssueDetailHTML {
         }.joined()
         let body = detail.bodyMarkdown.isEmpty
             ? "<p class=\"empty\">No description provided.</p>"
-            : MarkdownHTML.html(detail.bodyMarkdown)
+            : MarkdownHTML.html(detail.bodyMarkdown, documentMode: true)
         let comments = detail.comments.map { comment in
             """
             <section class="comment">
             <div class="who">\(avatar(comment.avatarURL))<b>\(escape(comment.author))</b> · \(relative(comment.createdAt))</div>
-            \(MarkdownHTML.html(comment.bodyMarkdown))
+            \(MarkdownHTML.html(comment.bodyMarkdown, documentMode: true))
             </section>
             """
         }.joined()


### PR DESCRIPTION
## Problem

Issue/PR bodies and comments in the Issues pane render through `MarkdownHTML` with `documentMode` **off** — the mode built for untrusted agent transcripts, which escapes any raw HTML into visible text. GitHub comments (especially bot comments) routinely contain raw HTML blocks, so they leaked through as literal tags.

Concretely, on PR #125 the Vercel bot comment showed up as raw `<a href="…"><picture><source …>…</picture></a>` text instead of the rendered "Request Review" badge, and its deployment table didn't render.

## Fix

Render issue/PR bodies and comments with `documentMode: true`. In that mode raw HTML passes through `HTMLSanitizer`, whose whitelist mirrors GitHub's own `html-pipeline` `SanitizationFilter`:

- `a`, `picture`, `source`, `img`, `table`, `details`… render as markup
- `script` / `style` / inline `style` / `class` / `id` / `on*` handlers are still stripped
- images become real `<img>` tags (the page CSS already caps them at `max-width: 100%`)

Net effect: termio renders GitHub content the way GitHub itself renders it.

## Scope

Two call sites in `IssuesView.swift` (`IssueDetailHTML.page`) — the body and each comment. No other behavior change. `swift build` passes and the dev app renders PR #125's Vercel comment correctly.

## Note

`documentMode` also enables loading remote content images (matching GitHub's behavior). If we'd rather keep the pane fully offline / no third-party fetches, images can be gated separately as a follow-up.