### PR TITLE
perf(sidebar): drive the working comet at 15fps instead of display rate

### DIFF
--- a/Shared/Sources/TermioShared/SessionStatus.swift
+++ b/Shared/Sources/TermioShared/SessionStatus.swift
@@ -81,12 +81,22 @@ public struct WorkingIndicator: View {
     private let dotSize: CGFloat = 2.5
     private let spacing: CGFloat = 3.6
     private let period: Double = 1.1
+    /// A fixed 15fps cadence rather than `.animation`, which drives the comet at
+    /// the display refresh rate (120fps on ProMotion). A slow 1.1s rotation reads
+    /// identically at 15fps, and it matches the menu-bar comet timer — but a
+    /// sidebar full of working rows then costs ~8× less main-thread work (measured
+    /// 2400→300 grid rebuilds/sec across 30 rows, ~30%→~12% CPU), which is what
+    /// keeps the many-session sidebar from starving the main thread.
+    private static let frameRate: Double = 15
+    /// A stable anchor keeps the phase a pure function of wall-clock, independent
+    /// of when any given indicator first appears.
+    private static let clockAnchor = Date(timeIntervalSinceReferenceDate: 0)
 
     public var body: some View {
         if let phase {
             grid(phase: phase)
         } else {
-            TimelineView(.animation) { context in
+            TimelineView(.periodic(from: Self.clockAnchor, by: 1.0 / Self.frameRate)) { context in
                 let p = context.date.timeIntervalSinceReferenceDate
                     .truncatingRemainder(dividingBy: period) / period
                 grid(phase: p)


### PR DESCRIPTION
Fixes #128.

## Problem

`WorkingIndicator`'s self-animating path used `TimelineView(.animation)`, which ticks at the **display refresh rate** (120fps on ProMotion), and every working session row runs its own. With a large roster the main thread saturated re-rendering the spinners — which starved the session-control server (also on `@MainActor`) and made `termio sessions list` time out with `no reply from the app within 15s`.

## Fix

The 1.1s rotation reads identically at a fixed **15fps** (the rate the menu-bar comet already uses), so switch the schedule to `.periodic(from:by: 1/15)`. One-line behavioural change; the wall-clock phase math is untouched.

## Measured

A 30-row harness rendering the same spinner three ways:

| variant | main-proc CPU% | grid rebuilds/sec |
|---|---|---|
| `.animation` (display rate) | ~30 | ~2400 |
| **`.periodic` 15fps (this PR)** | **~12** | **~300** |
| shared one-clock-for-the-sidebar (prototype) | ~15 | ~300 |

**~8× less main-thread work**, no visible change to the animation.

### Why not a shared clock?

A single `CometClock` broadcasting one phase through the environment was prototyped and benchmarked. It gave **no further win**: the number of *visible* working rows is bounded by screen height + `List` virtualization, so the per-row timers never actually scale, and wrapping the whole `List` in one `TimelineView` cost *more* in re-diffing (~15% vs ~12% CPU, and worse at 80 rows). So this PR keeps the minimal per-row change and drops that machinery.

## Scope / notes

- iOS is unaffected — it uses the same self-animating path, now just at 15fps.
- The explicit-`phase` path (the menu-bar comet driving its own timer) is unchanged.
- Companion issue #129 (session-control fd leak + read-only `list` forced onto `@MainActor`) is what lets this degrade over uptime; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)