### PR TITLE
feat(issues): open PR/issue detail in the center with inline file diffs

### DIFF
--- a/Shared/Sources/TermioShared/BrandIcons.swift
+++ b/Shared/Sources/TermioShared/BrandIcons.swift
@@ -485,6 +485,74 @@ public struct BrandLogoShape: Shape {
     }
 }
 
+// MARK: - GitHub state octicons
+
+/// GitHub's own Octicons for issue / pull-request lifecycle state, stored as
+/// their official 16×16 fill paths (primer/octicons, MIT). The Issues pane shows
+/// GitHub data, so it shows GitHub's exact state marks — the shapes users already
+/// read on github.com — rather than an approximation. Drawn *filled* (even-odd,
+/// so the rings and node holes carve correctly) and tinted by the caller, they
+/// live in the colored-status register, distinct from the monochrome Hugeicons
+/// chrome — the same status-vs-navigation split GitHub itself draws.
+public enum StateOcticon: Hashable, Sendable {
+    case issueOpened, issueClosed
+    case pullOpen, pullMerged, pullClosed, pullDraft
+
+    /// Side length of the octicon square viewBox (the 16px grid).
+    public var viewBox: CGFloat { 16 }
+
+    public var pathData: String {
+        switch self {
+        case .issueOpened:
+            return "M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
+        case .issueClosed:
+            return "M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+        case .pullOpen:
+            return "M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"
+        case .pullMerged:
+            return "M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0 0 .005V3.25Z"
+        case .pullClosed:
+            return "M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 5.5a.75.75 0 0 1 .75.75v3.378a2.251 2.251 0 1 1-1.5 0V7.25a.75.75 0 0 1 .75-.75Zm-2.03-5.273a.75.75 0 0 1 1.06 0l.97.97.97-.97a.748.748 0 0 1 1.265.332.75.75 0 0 1-.205.729l-.97.97.97.97a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-.97-.97-.97.97a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l.97-.97-.97-.97a.75.75 0 0 1 0-1.06ZM2.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z"
+        case .pullDraft:
+            return "M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 14a2.25 2.25 0 1 1 0-4.5 2.25 2.25 0 0 1 0 4.5ZM2.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM14 7.5a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm0-4.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z"
+        }
+    }
+}
+
+/// Renders a `StateOcticon` as a filled, tinted glyph on the 16px grid.
+public struct OcticonView: View {
+    let icon: StateOcticon
+    let size: CGFloat
+    let color: Color
+
+    public init(icon: StateOcticon, size: CGFloat, color: Color) {
+        self.icon = icon
+        self.size = size
+        self.color = color
+    }
+
+    public var body: some View {
+        OcticonShape(icon: icon)
+            .fill(color, style: FillStyle(eoFill: true))
+            .frame(width: size, height: size)
+    }
+}
+
+/// A `Shape` that draws a `StateOcticon`'s SVG fill path, scaled from its 16px
+/// viewBox to fit the rect. Octicons are optically sized on that grid, so plain
+/// viewBox-fitting (unlike Hugeicons) already lines them up.
+public struct OcticonShape: Shape {
+    let icon: StateOcticon
+
+    public init(icon: StateOcticon) {
+        self.icon = icon
+    }
+
+    public func path(in rect: CGRect) -> Path {
+        scaledVectorPath(SVGPath(icon.pathData).cgPath, viewBox: icon.viewBox, in: rect)
+    }
+}
+
 /// Renders a `HugeIcon` as a rounded stroke in the given color. The stroke
 /// width tracks the source's 1.5px-on-24 ratio with a small floor so the
 /// line never thins to a hairline at list sizes.

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -122,6 +122,10 @@ typealias HugeIcon = TermioShared.HugeIcon
 typealias HugeIconView = TermioShared.HugeIconView
 typealias HugeIconShape = TermioShared.HugeIconShape
 
+/// GitHub's Octicons for issue/PR state, shared with iOS from `TermioShared`.
+typealias StateOcticon = TermioShared.StateOcticon
+typealias OcticonView = TermioShared.OcticonView
+
 /// A vendor brand mark, stored as its official SVG path so it renders crisp at any
 /// size without shipping binary image assets. Rendered in the vendor's brand color
 /// by `BrandLogoShape`; see `BrandLogo.tint`. Pi and OpenCode are not here — their

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -642,20 +642,6 @@ enum GitService {
         return value.isEmpty ? nil : value
     }
 
-    /// Fetches a pull request's head (`refs/pull/N/head` — GitHub serves every PR
-    /// there, fork or not) into `origin/pr/N`, plus the PR's base branch, so the
-    /// Files tab can show three-dot merge-base diffs without any checkout. Returns
-    /// the `base...head` range string to diff with, or `nil` when the fetch failed.
-    static func fetchPullRequestRef(number: Int, baseRef: String, in repoRoot: String) async -> String? {
-        await offMain {
-            guard run(["fetch", "--no-tags", "origin", baseRef,
-                       "+refs/pull/\(number)/head:refs/remotes/origin/pr/\(number)"],
-                      in: repoRoot) != nil
-            else { return nil }
-            return "origin/\(baseRef)...origin/pr/\(number)"
-        }
-    }
-
     /// Checks the PR's branch out: a same-repo PR switches to its real head branch
     /// (tracking `origin`); a fork PR materializes the pull ref as local `pr/N`.
     /// Returns an error description, or `nil` on success.

--- a/Sources/termio/Git/PRFilesDiffView.swift
+++ b/Sources/termio/Git/PRFilesDiffView.swift
@@ -1,0 +1,289 @@
+import AppKit
+import SwiftUI
+
+// MARK: - PR files (master-detail)
+
+/// GitHub Desktop's "Files changed": a file list on the left, the selected file's diff
+/// on the right. Diffs come from the GitHub API's inline `patch` (no checkout, no git),
+/// rendered by the single-file diff renderer (`DiffDocument` / `DiffTextPane`), so the
+/// list stays put while you review and you always see where you are in the PR.
+struct PRFilesSplitView: View {
+    let files: [GitChange]
+    /// Each file's inline unified-diff `patch` from the GitHub API, keyed by path.
+    let patches: [String: String]
+    /// Only used to resolve each file's language for syntax coloring.
+    let repoRoot: String
+    @ObservedObject var settings: AppSettings
+    /// Esc closes the whole PR detail (there's no per-file overlay to pop back to).
+    let onClose: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var selection: String?
+
+    /// The list rail's width — the changed-files column, a touch wider than the sidebar
+    /// since PR paths run deep.
+    private static let listWidth: CGFloat = 260
+
+    var body: some View {
+        HStack(spacing: 0) {
+            fileList
+                .frame(width: Self.listWidth)
+                .background(Color(nsColor: settings.terminalBackgroundColor).opacity(0.4))
+            Rectangle()
+                .fill(Color.primary.opacity(0.08))
+                .frame(width: 1)
+            detail
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
+        .onExitCommand(perform: onClose)
+        // Select the first file on open (and if the set changes under us).
+        .onAppear { if selection == nil { selection = files.first?.path } }
+    }
+
+    // MARK: List rail
+
+    private var fileList: some View {
+        List(files, selection: $selection) { change in
+            PRFileRow(
+                change: change,
+                font: settings.interfaceFont,
+                chrome: settings.chromeTheme(for: colorScheme),
+                isSelected: selection == change.path
+            )
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .environment(\.defaultMinListRowHeight, 1)
+    }
+
+    // MARK: Detail
+
+    @ViewBuilder
+    private var detail: some View {
+        if let selection, let change = files.first(where: { $0.path == selection }) {
+            PRFileDiffBody(
+                change: change,
+                patch: patches[change.path],
+                repoRoot: repoRoot,
+                settings: settings,
+                onClose: onClose,
+                onWalk: walk
+            )
+            // Rebuild for each file so the diff, syntax colors, and scroll reset cleanly.
+            .id(change.path)
+        } else {
+            ContentUnavailableView(
+                "No File Selected",
+                huge: .fileDoc,
+                description: Text("Pick a file on the left to see its changes.")
+            )
+        }
+    }
+
+    /// Left/right arrow (from the diff) steps the selected file — Quick Look's walk.
+    private func walk(_ delta: Int) -> Bool {
+        guard let current = selection,
+              let index = files.firstIndex(where: { $0.path == current }) else {
+            return false
+        }
+        let next = index + delta
+        guard next >= 0, next < files.count else { return false }
+        selection = files[next].path
+        return true
+    }
+}
+
+// MARK: - One file's diff (from an API patch)
+
+/// The right pane: one file's diff, parsed from the GitHub API `patch` (no git) and
+/// rendered by the shared `DiffTextPane`. A compact header names the file; a binary or
+/// oversized file (no patch) shows a note instead.
+private struct PRFileDiffBody: View {
+    let change: GitChange
+    let patch: String?
+    let repoRoot: String
+    @ObservedObject var settings: AppSettings
+    let onClose: () -> Void
+    let onWalk: (Int) -> Bool
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var rows: [DiffRow] = []
+    @State private var document: DiffDocument?
+    @State private var styledLines: [Int: NSAttributedString] = [:]
+    @State private var expanded: Set<Int> = []
+    @State private var isLoading = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            content
+        }
+        .background(Color(nsColor: settings.terminalBackgroundColor))
+        // The diff view owns the keys once mounted; these cover the loading / note states.
+        .focusable()
+        .focusEffectDisabled()
+        .onExitCommand(perform: onClose)
+        .onKeyPress(.leftArrow) { onWalk(-1) ? .handled : .ignored }
+        .onKeyPress(.rightArrow) { onWalk(+1) ? .handled : .ignored }
+        .task(id: change.path) { await load() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text(change.status.letter)
+                .font(.system(size: 12, weight: .bold, design: .monospaced))
+                .foregroundStyle(change.status.tint)
+                .frame(width: 16)
+            Text(change.name)
+                .font(.system(size: 12.5, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            if !change.directory.isEmpty {
+                Text(change.directory)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.head)
+            }
+            Spacer(minLength: 8)
+            HStack(spacing: 5) {
+                if change.additions > 0 { Text("+\(change.additions)").foregroundStyle(.green) }
+                if change.deletions > 0 { Text("−\(change.deletions)").foregroundStyle(.red) }
+            }
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .fixedSize()
+        }
+        .padding(.horizontal, 12)
+        .frame(height: GitChangesView.topBarHeight)
+        .background(Color(nsColor: settings.terminalBackgroundColor))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 1)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let document {
+            DiffTextPane(
+                document: document,
+                styled: styledLines,
+                font: settings.resolvedTerminalFont(),
+                backgroundColor: settings.terminalBackgroundColor,
+                numberColor: settings.gutterInk(for: colorScheme),
+                onExpand: { id in
+                    expanded.insert(id)
+                    self.document = DiffDocument.build(
+                        rows: rows, expanded: expanded,
+                        codeFont: settings.resolvedTerminalFont())
+                },
+                onWalk: onWalk,
+                onClose: onClose
+            )
+        } else {
+            ContentUnavailableView(
+                change.isBinary ? "Binary File" : "No Diff",
+                huge: .fileDoc,
+                description: Text(change.isBinary
+                    ? "This file is binary — open it on GitHub to view."
+                    : "This diff is too large to show here — open the file on GitHub.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func load() async {
+        guard let patch, !patch.isEmpty else {
+            rows = []
+            document = nil
+            isLoading = false
+            return
+        }
+        let parsed = await GitService.parseDiffText(patch)
+        rows = parsed
+        document = parsed.isEmpty
+            ? nil
+            : DiffDocument.build(rows: parsed, expanded: expanded,
+                                 codeFont: settings.resolvedTerminalFont())
+        isLoading = false
+        await buildStyledLines(parsed)
+    }
+
+    private func buildStyledLines(_ rows: [DiffRow]) async {
+        let url = URL(fileURLWithPath: repoRoot).appendingPathComponent(change.path)
+        guard let language = FileEditorView.highlightLanguage(for: url) else { return }
+        let code = rows.filter { $0.kind != .hunk }
+        guard code.count <= 8000, code.reduce(0, { $0 + $1.text.count }) <= 600_000 else { return }
+
+        let styled = await DiffHighlighter.shared.styledLines(
+            newSide: code.filter { $0.kind == .context || $0.kind == .addition },
+            oldSide: code.filter { $0.kind == .context || $0.kind == .deletion },
+            language: language,
+            theme: colorScheme == .dark ? "xcode-dark" : "xcode",
+            font: settings.resolvedTerminalFont()
+        )
+        guard !Task.isCancelled else { return }
+        styledLines = styled
+    }
+}
+
+// MARK: - File row
+
+/// A PR file row: the Changes list's visual language (status letter, name, dimmed
+/// directory, `+A −D`) without the working-tree affordances — the files aren't local.
+private struct PRFileRow: View {
+    let change: GitChange
+    let font: Font
+    let chrome: ChromeTheme?
+    let isSelected: Bool
+
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(change.status.letter)
+                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                .foregroundStyle(change.status.tint)
+                .frame(width: 14)
+            Text(change.name)
+                .font(font)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .layoutPriority(1)
+            if !change.directory.isEmpty {
+                Text(change.directory)
+                    .font(font)
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer(minLength: 6)
+            HStack(spacing: 5) {
+                if change.additions > 0 { Text("+\(change.additions)").foregroundStyle(.green) }
+                if change.deletions > 0 { Text("−\(change.deletions)").foregroundStyle(.red) }
+            }
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .opacity(0.85)
+            .fixedSize()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .background(OutlineSelectionStyleStripper())
+        .listRowInsets(EdgeInsets())
+        .listRowSeparator(.hidden)
+        .listRowBackground(
+            SidebarRowHighlight(isSelected: isSelected, isHovering: isHovering, chrome: chrome)
+                .animation(.easeInOut(duration: 0.12), value: isSelected)
+                .animation(.easeInOut(duration: 0.12), value: isHovering)
+        )
+        .onHover { isHovering = $0 }
+        .help(change.originalPath.map { "\($0) → \(change.path)" } ?? change.path)
+    }
+}

--- a/Sources/termio/Issues/GitHubIssueProvider.swift
+++ b/Sources/termio/Issues/GitHubIssueProvider.swift
@@ -103,21 +103,25 @@ struct GitHubIssueProvider: IssueProvider {
             URL(string: "https://api.github.com/repos/\(container.id)/pulls/\(number)")!)
         return PullRequestGitInfo(
             headRef: raw.head.ref,
-            baseRef: raw.base.ref,
             // A deleted fork leaves `head.repo` null — only the pull ref remains.
             crossRepository: raw.head.repo?.fullName != raw.base.repo?.fullName
         )
     }
 
-    /// The PR's changed files as `GitChange` rows (the git pane's own model), so
-    /// the Files tab and the diff overlay's sibling walk reuse everything.
-    func pullRequestFiles(_ number: Int, in container: IssueContainer) async throws -> [GitChange] {
+    /// The PR's changed files as `GitChange` rows (the git pane's own model) *with the
+    /// diff inline*: the `/pulls/{n}/files` response already carries each file's unified
+    /// `patch`, so the Files tab renders straight from this one call — no `git fetch` of
+    /// the PR refs, no per-file `git diff`, and it works for cross-fork PRs with nothing
+    /// checked out locally. GitHub omits `patch` for binaries and diffs too large to
+    /// inline; those arrive as `nil` and the UI shows a note instead.
+    func pullRequestFiles(_ number: Int, in container: IssueContainer) async throws -> [PullRequestFile] {
         struct RawFile: Decodable {
             let filename: String
             let status: String
             let additions: Int
             let deletions: Int
             let previousFilename: String?
+            let patch: String?
         }
         let raw: [RawFile] = try await get(
             URL(string: "https://api.github.com/repos/\(container.id)/pulls/\(number)/files?per_page=100")!)
@@ -134,7 +138,9 @@ struct GitHubIssueProvider: IssueProvider {
             change.additions = file.additions
             change.deletions = file.deletions
             change.originalPath = file.previousFilename
-            return change
+            // No `patch` on a binary file; GitHub also drops it past its inline-size cap.
+            change.isBinary = file.patch == nil && file.additions == 0 && file.deletions == 0
+            return PullRequestFile(change: change, patch: file.patch)
         }
     }
 

--- a/Sources/termio/Issues/IssueModels.swift
+++ b/Sources/termio/Issues/IssueModels.swift
@@ -44,6 +44,19 @@ enum IssueItemState: Hashable, Sendable {
         }
     }
 
+    /// The state glyph: GitHub's own Octicon for this lifecycle state, so a row
+    /// shows the exact mark users read on github.com. Shape carries the state on
+    /// its own — open issue and closed PR are a red/green pair that colorblind
+    /// users can't separate by hue, but the shapes stay distinct.
+    func octicon(for kind: IssueKind) -> StateOcticon {
+        switch self {
+        case .open: return kind == .pullRequest ? .pullOpen : .issueOpened
+        case .closed: return kind == .pullRequest ? .pullClosed : .issueClosed
+        case .merged: return .pullMerged
+        case .draft: return .pullDraft
+        }
+    }
+
     var label: String {
         switch self {
         case .open: return "Open"
@@ -126,13 +139,20 @@ struct IssueDetail: Sendable {
     let comments: [IssueComment]
 }
 
-/// The branch facts the Files tab and Checkout need from a pull request —
-/// which refs to fetch and diff, and whether the head lives in a fork (a fork's
-/// branch is only reachable through the `refs/pull/N/head` ref).
+/// The branch facts Checkout needs from a pull request — which head ref to fetch,
+/// and whether it lives in a fork (a fork's branch is only reachable through the
+/// `refs/pull/N/head` ref).
 struct PullRequestGitInfo: Sendable {
     let headRef: String
-    let baseRef: String
     let crossRepository: Bool
+}
+
+/// One PR file with its unified-diff `patch` straight from the GitHub API — the Files
+/// tab renders from this without a local checkout or extra fetch. `patch` is `nil` when
+/// GitHub omits it (a binary file, or a diff too large to inline).
+struct PullRequestFile: Sendable {
+    let change: GitChange
+    let patch: String?
 }
 
 // MARK: - Provider protocol

--- a/Sources/termio/Issues/IssuesPanelModel.swift
+++ b/Sources/termio/Issues/IssuesPanelModel.swift
@@ -135,18 +135,29 @@ final class IssuesPanelModel: ObservableObject {
 
     func loadDetail(for item: IssueSummary) async {
         guard let provider, let container else { return }
+        // The model's own record of which item is open, independent of what drives the
+        // UI — `checkout` keys off it.
+        openItem = item
         detail = nil
         detailError = nil
         prFiles = []
+        prFilePatches = [:]
         prInfo = nil
-        prDiffRange = nil
         checkoutError = nil
         do {
             if item.kind == .pullRequest {
                 async let loadedDetail = provider.detail(item.number, in: container)
                 async let info = provider.pullRequestGitInfo(item.number, in: container)
                 async let files = provider.pullRequestFiles(item.number, in: container)
-                (detail, prInfo, prFiles) = try await (loadedDetail, info, files)
+                let loadedFiles = try await files
+                (detail, prInfo) = try await (loadedDetail, info)
+                prFiles = loadedFiles.map(\.change)
+                // The diff arrives inline with the file list — key each file's patch by
+                // path so the Files tab renders with no further network or git work.
+                prFilePatches = Dictionary(
+                    uniqueKeysWithValues: loadedFiles.compactMap { file in
+                        file.patch.map { (file.change.path, $0) }
+                    })
             } else {
                 detail = try await provider.detail(item.number, in: container)
             }
@@ -159,25 +170,12 @@ final class IssuesPanelModel: ObservableObject {
 
     /// The PR's changed files (empty for issues) and branch facts.
     @Published private(set) var prFiles: [GitChange] = []
+    /// Each file's inline unified-diff patch from the API, keyed by path — what the Files
+    /// tab renders. Absent keys are files GitHub gave no patch for (binary / too large).
+    @Published private(set) var prFilePatches: [String: String] = [:]
     @Published private(set) var prInfo: PullRequestGitInfo?
-    /// The `base...head` range diffs run over, set once the refs are fetched —
-    /// the Files tab shows a spinner until this lands.
-    @Published private(set) var prDiffRange: String?
-    @Published private(set) var isFetchingDiffRefs = false
     @Published private(set) var isCheckingOut = false
     @Published var checkoutError: String?
-
-    /// Fetches the PR's refs once per opened detail, so file rows diff locally
-    /// (JetBrains' trick: read the code without checking anything out).
-    func prepareDiffRefs() async {
-        guard prDiffRange == nil, !isFetchingDiffRefs,
-              let item = openItem, let info = prInfo
-        else { return }
-        isFetchingDiffRefs = true
-        prDiffRange = await GitService.fetchPullRequestRef(
-            number: item.number, baseRef: info.baseRef, in: repoRoot)
-        isFetchingDiffRefs = false
-    }
 
     func checkout() async {
         guard let item = openItem, let info = prInfo, !isCheckingOut else { return }

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -28,17 +28,24 @@ struct IssuesView: View {
     private var chrome: ChromeTheme? { settings.chromeTheme(for: colorScheme) }
 
     var body: some View {
-        Group {
-            if let item = model.openItem {
-                IssueDetailView(item: item, model: model, settings: settings) {
-                    model.openItem = nil
-                    selection = nil
-                }
-            } else {
-                listPane
+        // List only — the detail opens in the center over the terminal (like the file
+        // editor and diff), driven by `store.openIssueDetail`, not pushed in here.
+        listPane
+            .task(id: repoRoot) {
+                store.issuesModel = model
+                await model.start()
             }
-        }
-        .task(id: repoRoot) { await model.start() }
+            // Selection IS the open gesture; route it to the center overlay. Follow the
+            // overlay back: when it closes, release the selection so the same row reopens.
+            .onChange(of: selection) { _, selected in
+                guard let selected,
+                      let item = model.items.first(where: { $0.number == selected })
+                else { return }
+                store.openIssueDetail = item
+            }
+            .onChange(of: store.openIssueDetail) { _, item in
+                if item == nil { selection = nil }
+            }
     }
 
     // MARK: List pane
@@ -202,7 +209,7 @@ struct IssuesView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             // Native `List` selection as the click handler, like the changes list —
-            // a selected row pushes in its detail.
+            // a selected row opens its detail in the center (see `body`'s onChange).
             List(model.items, selection: $selection) { item in
                 IssueRow(
                     item: item,
@@ -214,11 +221,6 @@ struct IssuesView: View {
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .environment(\.defaultMinListRowHeight, 1)
-            .onChange(of: selection) { _, selected in
-                if let selected, let item = model.items.first(where: { $0.number == selected }) {
-                    model.openItem = item
-                }
-            }
         }
     }
 
@@ -230,10 +232,12 @@ struct IssuesView: View {
 
 // MARK: - Row
 
-/// One list row: state dot, monospace identifier, title (the flexible element).
-/// The trailing metadata — label chips and the updated age — appears on hover
-/// (the GitChangeRow pattern): bare color dots at rest carried no meaning, so
-/// the resting row is clean and the hover answers "what is this, how fresh".
+/// One list row: state icon, monospace identifier, title (the flexible element).
+/// The icon is shape-distinct per state (GitHub's octicon convention), so the
+/// resting row reads without hover and without leaning on hue alone. The trailing
+/// metadata — label chips and the updated age — still appears on hover (the
+/// GitChangeRow pattern), so the resting row stays clean and the hover answers
+/// "what labels, how fresh".
 private struct IssueRow: View {
     let item: IssueSummary
     let font: Font
@@ -244,10 +248,13 @@ private struct IssueRow: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            Circle()
-                .fill(item.state.tint(for: item.kind))
-                .frame(width: 7, height: 7)
-                .help(item.state.label)
+            OcticonView(
+                icon: item.state.octicon(for: item.kind),
+                size: 13,
+                color: item.state.tint(for: item.kind)
+            )
+            .frame(width: 14)
+            .help(item.state.label)
             // Never wraps or compresses — without this, a narrow pane stacks the
             // identifier one character per line and the row balloons.
             Text(item.identifier)
@@ -301,27 +308,25 @@ private struct IssueRow: View {
     }
 }
 
-// MARK: - Detail (pushed in)
+// MARK: - Detail (center overlay)
 
-/// The pushed-in detail: a native header (back, identifier, checkout for PRs,
-/// open-in-browser) over the content. An issue shows the conversation (body +
-/// comments through `MarkdownHTML` in a themed web view); a pull request adds
-/// the Conversation | Files switch — files diff natively in the `GitDiffView`
-/// overlay against the fetched PR refs, JetBrains-style, no checkout needed.
-private struct IssueDetailView: View {
+/// The item detail, shown over the terminal in the center (by `TerminalPane`,
+/// driven by `store.openIssueDetail`) — the editor/diff pattern, not the narrow
+/// inspector. A native header (back, identifier, checkout for PRs, open-in-browser)
+/// over the content: an issue shows the conversation (body + comments through
+/// `MarkdownHTML` in a themed web view); a pull request adds the Conversation |
+/// Files switch — files diff natively in the `GitDiffView` overlay (which stacks
+/// on top of this one) against the fetched PR refs, JetBrains-style, no checkout needed.
+struct IssueDetailView: View {
     let item: IssueSummary
     @ObservedObject var model: IssuesPanelModel
     @ObservedObject var settings: AppSettings
     let onBack: () -> Void
 
-    @EnvironmentObject var store: TermioStore
     @Environment(\.colorScheme) private var colorScheme
 
     private enum Tab: Hashable { case conversation, files }
     @State private var tab: Tab = .conversation
-    /// The Files list's selected row, by path — selection IS the open gesture,
-    /// like the Changes list.
-    @State private var fileSelection: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -334,14 +339,6 @@ private struct IssueDetailView: View {
         }
         .task(id: item.number) { await model.loadDetail(for: item) }
         .onExitCommand(perform: onBack)
-        // Follow the overlay both ways, like the Changes list: walking with ← / →
-        // chases the selection; closing releases it so the same row reopens.
-        .onChange(of: store.openDiff) { _, request in
-            if let request, request.range != nil, fileSelection != request.change.path {
-                fileSelection = request.change.path
-            }
-            if request == nil { fileSelection = nil }
-        }
         .alert(
             "Couldn’t Check Out",
             isPresented: Binding(
@@ -362,9 +359,12 @@ private struct IssueDetailView: View {
     private var header: some View {
         HStack(spacing: 6) {
             TreeHeaderButton(huge: .chevronLeft, help: "Back", action: onBack)
-            Circle()
-                .fill(item.state.tint(for: item.kind))
-                .frame(width: 7, height: 7)
+            OcticonView(
+                icon: item.state.octicon(for: item.kind),
+                size: 14,
+                color: item.state.tint(for: item.kind)
+            )
+            .frame(width: 15)
             Text(item.identifier)
                 .font(.system(size: 11, weight: .medium, design: .monospaced))
                 .foregroundStyle(.secondary)
@@ -439,108 +439,25 @@ private struct IssueDetailView: View {
 
     @ViewBuilder
     private var filesBody: some View {
-        if model.prFiles.isEmpty {
+        if !model.prFiles.isEmpty {
+            // GitHub Desktop's "Files changed": file list on the left, the selected file's
+            // diff on the right, rendered from the API's inline patches (no fetch, no git).
+            PRFilesSplitView(
+                files: model.prFiles, patches: model.prFilePatches,
+                repoRoot: model.repoRoot, settings: settings, onClose: onBack
+            )
+        } else if model.detail == nil, model.detailError == nil {
+            // The file list arrives with the detail; show a spinner until it lands.
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
             ContentUnavailableView(
                 "No Files", huge: .fileDoc,
                 description: Text("This pull request changes no files.")
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            List(model.prFiles, selection: $fileSelection) { change in
-                PRFileRow(
-                    change: change,
-                    font: settings.interfaceFont,
-                    chrome: settings.chromeTheme(for: colorScheme),
-                    isSelected: fileSelection == change.path
-                )
-            }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .environment(\.defaultMinListRowHeight, 1)
-            // Diffs need the fetched refs; a brief overlay spinner covers the fetch
-            // kicked off when the tab first appears.
-            .overlay {
-                if model.isFetchingDiffRefs {
-                    ProgressView().controlSize(.small)
-                }
-            }
-            .task { await model.prepareDiffRefs() }
-            .onChange(of: fileSelection) { _, selected in
-                guard let selected,
-                      let change = model.prFiles.first(where: { $0.path == selected })
-                else { return }
-                openDiff(change)
-            }
-            .onKeyPress(.leftArrow) { walkOverlay(-1) }
-            .onKeyPress(.rightArrow) { walkOverlay(+1) }
         }
-    }
-
-    private func openDiff(_ change: GitChange) {
-        guard let range = model.prDiffRange else { return }
-        store.openDiff = GitDiffRequest(
-            repoRoot: model.repoRoot, change: change, range: range, siblings: model.prFiles)
-    }
-
-    private func walkOverlay(_ delta: Int) -> KeyPress.Result {
-        guard let next = store.openDiff?.neighbor(delta) else { return .ignored }
-        store.openDiff = next
-        return .handled
-    }
-}
-
-/// A PR file row: the Changes list's visual language (status letter, name,
-/// dimmed directory, `+A −D`) without the working-tree affordances (no drag,
-/// no discard — the files aren't local).
-private struct PRFileRow: View {
-    let change: GitChange
-    let font: Font
-    let chrome: ChromeTheme?
-    let isSelected: Bool
-
-    @State private var isHovering = false
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Text(change.status.letter)
-                .font(.system(size: 11, weight: .bold, design: .monospaced))
-                .foregroundStyle(change.status.tint)
-                .frame(width: 14)
-            Text(change.name)
-                .font(font)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .layoutPriority(1)
-            if !change.directory.isEmpty {
-                Text(change.directory)
-                    .font(font)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .foregroundStyle(.tertiary)
-            }
-            Spacer(minLength: 6)
-            HStack(spacing: 5) {
-                if change.additions > 0 { Text("+\(change.additions)").foregroundStyle(.green) }
-                if change.deletions > 0 { Text("−\(change.deletions)").foregroundStyle(.red) }
-            }
-            .font(.system(size: 10.5, weight: .medium, design: .monospaced))
-            .opacity(0.85)
-            .fixedSize()
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 5)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
-        .background(OutlineSelectionStyleStripper())
-        .listRowInsets(EdgeInsets())
-        .listRowSeparator(.hidden)
-        .listRowBackground(
-            SidebarRowHighlight(isSelected: isSelected, isHovering: isHovering, chrome: chrome)
-                .animation(.easeInOut(duration: 0.12), value: isSelected)
-                .animation(.easeInOut(duration: 0.12), value: isHovering)
-        )
-        .onHover { isHovering = $0 }
-        .help(change.originalPath.map { "\($0) → \(change.path)" } ?? change.path)
     }
 }
 

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -115,6 +115,23 @@ struct TerminalPane: View {
             }
         }
         .animation(.easeOut(duration: 0.12), value: store.openFileURL != nil)
+        // Clicking a row in the inspector's Issues pane covers the terminal with that item's
+        // detail — the conversation (and, for a PR, its Files), opened in the center like the
+        // editor and diff rather than cramped in the narrow inspector. Ordered BEFORE the diff
+        // overlay below so a PR's file diff stacks on top: closing the diff returns here, not to
+        // the terminal. Escape or the back button clears it.
+        .overlay {
+            if let item = store.openIssueDetail, let model = store.issuesModel {
+                IssueDetailView(item: item, model: model, settings: settings) {
+                    store.openIssueDetail = nil
+                    requestSelectedTerminalFocus(reason: .overlayClosed)
+                }
+                .background(paneBackground)
+                .id(item.number)
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.12), value: store.openIssueDetail != nil)
         // Clicking a row in the inspector's Changes pane covers the terminal with that file's
         // unified diff (the surface keeps running underneath), the git counterpart of the editor
         // overlay above. Escape or the close button clears it.
@@ -183,14 +200,21 @@ struct TerminalPane: View {
             store.openFileURL = nil
             store.openDiff = nil
             store.openTrace = nil
+            store.openIssueDetail = nil
             requestSelectedTerminalFocus(reason: .selectionChanged)
         }
         // The toolbar's close button posts this; tear the overlay down the same way the overlay's
         // own Esc / close does (clear the store, return focus to the selected session's terminal).
         .onReceive(NotificationCenter.default.publisher(for: .termioCloseContentOverlay)) { _ in
-            store.openFileURL = nil
-            store.openDiff = nil
-            store.openTrace = nil
+            // Tear down top-down: a stacked PR file diff closes first, revealing the detail;
+            // a second press then closes the detail (matching the overlay's own Esc handling).
+            if store.openDiff != nil {
+                store.openDiff = nil
+            } else {
+                store.openFileURL = nil
+                store.openTrace = nil
+                store.openIssueDetail = nil
+            }
             requestSelectedTerminalFocus(reason: .overlayClosed)
         }
         // Dev-only: perform the real AppKit failure while the main window stays key.

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -113,7 +113,7 @@ final class TermioStore: ObservableObject {
     /// Opening a file dismisses any open diff — the two overlays are mutually exclusive.
     @Published var openFileURL: URL? {
         didSet {
-            if openFileURL != nil { openDiff = nil; openTrace = nil }
+            if openFileURL != nil { openDiff = nil; openTrace = nil; openIssueDetail = nil }
             // Closing always returns to the editable default; a read-only open re-asserts the flag
             // immediately before setting the URL (see `openTerminalLink`). The jump line clears too,
             // so a later plain open of the same file doesn't scroll to a stale hit.
@@ -158,8 +158,26 @@ final class TermioStore: ObservableObject {
     /// "View Trace" sets it, and `TerminalPane` covers itself with `TraceView` while
     /// it is non-nil. Mutually exclusive with the other two.
     @Published var openTrace: TraceRequest? {
-        didSet { if openTrace != nil { openFileURL = nil; openDiff = nil } }
+        didSet { if openTrace != nil { openFileURL = nil; openDiff = nil; openIssueDetail = nil } }
     }
+
+    /// The GitHub issue / pull request whose detail is shown over the terminal, or `nil`
+    /// when none is. The fourth content overlay: clicking a row in the inspector's Issues
+    /// pane sets it, and `TerminalPane` covers itself with the detail — the conversation /
+    /// PR files opened in the center like the editor and diff, not cramped in the narrow
+    /// inspector. Unlike the others it deliberately COEXISTS with `openDiff`: a PR's file
+    /// diff stacks on top of the detail (`TerminalPane` orders the diff overlay above this
+    /// one), so closing the diff returns to the PR rather than the terminal.
+    @Published var openIssueDetail: IssueSummary? {
+        didSet { if openIssueDetail != nil { openFileURL = nil; openDiff = nil; openTrace = nil } }
+    }
+
+    /// The Issues pane's model, held here (in addition to the inspector view that owns it)
+    /// so an open PR/issue detail in the center keeps its data — conversation, PR files,
+    /// checkout — even when the inspector switches to another tab or collapses and its view
+    /// is torn down. `IssuesView` points this at its model on appear; `TerminalPane`'s
+    /// detail overlay reads it.
+    @Published var issuesModel: IssuesPanelModel?
 
     /// Which pane the trailing inspector shows — the file tree or git changes. Set by the toolbar's
     /// segmented switch and read by `FileBrowserView`. (The inspector's open/closed state is owned by


### PR DESCRIPTION
## What

Clicking a row in the inspector's Issues pane now covers the terminal with that item's detail — the conversation, and for a PR its changed files — opened in the **center** like the editor and diff, rather than cramped in the narrow inspector.

## Highlights

- **Inline PR diffs, no checkout.** PR file diffs render straight from the GitHub API's inline `patch` (`/pulls/{n}/files`), so review needs no `git fetch` of the PR refs and no local checkout — and it works for cross-fork PRs with nothing checked out. Binary / too-large files arrive with no patch and show a note instead.
- **GitHub Desktop's Files layout.** A changed-files rail on the left, the selected file's diff on the right (`PRFilesSplitView`), reusing the existing single-file diff renderer (`DiffDocument` / `DiffTextPane`).
- **Octicon state glyphs.** Rows carry GitHub's own Octicons (open / closed / merged / draft); shape distinguishes the lifecycle state without relying on hue (colorblind-safe).
- **Center overlay coexists with the diff.** `openIssueDetail` is a fourth content overlay in `TermioStore`; a PR's file diff deliberately stacks on top, so closing the diff returns to the PR detail, not the terminal.

## Notes

- Scope is the feature only; unrelated in-flight changes (Homebrew cask bump, PTY stray-reap `tty` refinement, iOS app icon) were intentionally left out of this branch.
- `swift build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)