### PR TITLE
fix(git): stop the git-pane refresh storm (GIT_OPTIONAL_LOCKS everywhere)

### DIFF
--- a/Sources/termio/CommandPalette/FuzzySearch.swift
+++ b/Sources/termio/CommandPalette/FuzzySearch.swift
@@ -45,6 +45,7 @@ enum FuzzySearch {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
         process.arguments = ["-C", root.path, "ls-files", "--cached", "--others", "--exclude-standard"]
+        process.environment = GitEnvironment.optionalLocksDisabled
         let stdout = Pipe()
         process.standardOutput = stdout
         process.standardError = Pipe()

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -442,6 +442,7 @@ final class CompanionServer {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
         process.arguments = ["ls-files", "--cached", "--others", "--exclude-standard", "-z"]
+        process.environment = GitEnvironment.optionalLocksDisabled
         process.currentDirectoryURL = URL(fileURLWithPath: root)
         let pipe = Pipe()
         process.standardOutput = pipe
@@ -634,6 +635,7 @@ final class CompanionServer {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
         process.arguments = ["status", "--porcelain", "--no-renames", "-z", "--untracked-files=all"]
+        process.environment = GitEnvironment.optionalLocksDisabled
         process.currentDirectoryURL = URL(fileURLWithPath: root)
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/Sources/termio/FileBrowser/ContentSearch.swift
+++ b/Sources/termio/FileBrowser/ContentSearch.swift
@@ -100,6 +100,11 @@ enum ContentSearch {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
+        // See `GitEnvironment`: keep `git grep` from touching the index; the BSD
+        // `grep` fallback ignores it.
+        if executable.hasSuffix("/git") {
+            process.environment = GitEnvironment.optionalLocksDisabled
+        }
         let stdout = Pipe()
         process.standardOutput = stdout
         // Never attach a pipe that isn't drained: BSD grep can emit 64KB+ of

--- a/Sources/termio/Git/BranchModel.swift
+++ b/Sources/termio/Git/BranchModel.swift
@@ -259,6 +259,7 @@ final class BranchModel: ObservableObject {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
         process.arguments = ["-C", folder] + arguments
+        process.environment = GitEnvironment.optionalLocksDisabled
         let output = Pipe()
         process.standardOutput = output
         process.standardError = Pipe()

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -29,6 +29,13 @@ final class GitPanelModel: ObservableObject {
     private var refreshDebounce: Task<Void, Never>?
     /// Monotonic ticket for `load()` — only the newest pass may publish.
     private var loadGeneration = 0
+    /// One `git status` in flight at a time: `load()` sets `loading` while it runs,
+    /// and any call that lands mid-pass (the FSEvents debounce *or* a direct
+    /// `model.load()` from the view) sets `loadReentered` to request a single
+    /// replay instead of spawning an overlapping, expensive status — the way VS
+    /// Code serializes its own status.
+    private var loading = false
+    private var loadReentered = false
 
     /// Whether the pane is actually on screen, read live at refresh time. A collapsed
     /// inspector keeps this model alive (the hosting view stays in the hierarchy), and
@@ -80,16 +87,42 @@ final class GitPanelModel: ObservableObject {
 
     /// Reloads the working-tree change list. The first successful pass also arms the
     /// file-system watch, so from then on the pane refreshes itself.
+    ///
+    /// Serialized: only one `git status` runs at a time. Every refresh path funnels
+    /// through here — the watcher and the view's direct `model.load()` calls alike —
+    /// so a call that arrives mid-pass flags a replay rather than spawning an
+    /// overlapping status. (Runs on the main actor, so the flags need no lock.)
+    ///
+    /// Immediate replays are capped at one. The first pass is suppressed if a reentry
+    /// superseded it (its snapshot predates whatever change triggered the reentry —
+    /// a discard, ignore, checkout); the single replay always publishes best-effort.
+    /// If events *still* arrive through that replay — a continuously churning tree —
+    /// we publish anyway and hand off to a debounced refresh instead of looping here,
+    /// so the pane can never livelock (spinning `git status`, `isLoading` stuck on).
     func load() async {
-        // Loads overlap (explicit reload racing the FSEvents debounce); the generation
-        // guard keeps a slow older pass from publishing a stale snapshot over a newer one.
-        loadGeneration += 1
-        let generation = loadGeneration
-        let loaded = await GitService.changes(in: repoRoot)
-        guard generation == loadGeneration else { return }
-        changes = loaded
-        isLoading = false
-        if watcher == nil { await armWatcher() }
+        if loading {
+            loadReentered = true
+            loadGeneration += 1   // supersede the in-flight pass's stale snapshot
+            return
+        }
+        loading = true
+        defer { loading = false }
+        for attempt in 0...1 {
+            loadReentered = false
+            loadGeneration += 1
+            let generation = loadGeneration
+            let loaded = await GitService.changes(in: repoRoot)
+            if generation == loadGeneration || attempt == 1 {
+                changes = loaded
+                isLoading = false
+            }
+            if watcher == nil { await armWatcher() }
+            if !loadReentered { break }
+        }
+        if loadReentered {
+            loadReentered = false
+            scheduleRefresh(includeHistory: false)   // still churning: catch up off-stack
+        }
     }
 
     /// Loads the commit history on demand (first time the History tab opens); re-run
@@ -143,9 +176,10 @@ final class GitPanelModel: ObservableObject {
     }
 
     /// Coalesces a burst of events (FSEvents latency already batches most) into one
-    /// reload a beat later. `git status` itself may refresh the index once, which
-    /// echoes back as a git-dir event — the second pass reads clean and the chain ends.
-    /// While the pane is hidden the reload is parked instead (see `flushDeferredRefresh`).
+    /// reload a beat later. `git status` no longer echoes back as a git-dir event —
+    /// `GIT_OPTIONAL_LOCKS=0` keeps it from writing the index — so the chain ends
+    /// after one pass. While the pane is hidden the reload is parked instead (see
+    /// `flushDeferredRefresh`).
     private func scheduleRefresh(includeHistory: Bool) {
         if let isPaneVisible, !isPaneVisible() {
             deferredRefreshIncludesHistory = (deferredRefreshIncludesHistory ?? false) || includeHistory

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -1,6 +1,30 @@
 import Darwin
 import Foundation
 
+/// The environment for **every** app-side `git` subprocess. `GIT_OPTIONAL_LOCKS=0`
+/// stops read-only git — notably `git status` — from taking the index lock and
+/// rewriting `.git/index` to refresh its stat/untracked cache. That write fires an
+/// FSEvent under `.git`, which the git pane's watcher treats as a change and
+/// re-reads: a `status → index-write → status` loop that never settles while the
+/// working tree keeps changing (a live dev server, a busy agent) and pegged a
+/// long-running app at ~20% CPU, starving the main actor until `sessions list`
+/// timed out.
+///
+/// It is applied at *every* git spawn site (GitService, BranchModel,
+/// WorktreeService, CommandPalette, CompanionServer), not just the pane's, so no
+/// path can reintroduce the loop — the same reason VS Code's git extension sets it
+/// globally rather than per-command. Safe for writes too: `--no-optional-locks`
+/// only skips *optional* locks, never the ones a real mutation needs. The inherited
+/// environment is preserved (git still finds config/credentials), and it is scoped
+/// to the app's own subprocesses — terminal sessions are never touched.
+enum GitEnvironment {
+    static let optionalLocksDisabled: [String: String] = {
+        var env = ProcessInfo.processInfo.environment
+        env["GIT_OPTIONAL_LOCKS"] = "0"
+        return env
+    }()
+}
+
 // MARK: - Git
 
 /// Thin wrapper over the `git` CLI for the changes list and diff overlay. Every call
@@ -748,6 +772,11 @@ enum GitService {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = args
+        // See `GitEnvironment`: keeps `git status` from rewriting `.git/index` and
+        // re-triggering the pane watcher. `ssh` (the other caller) ignores it.
+        if executable.hasSuffix("/git") {
+            process.environment = GitEnvironment.optionalLocksDisabled
+        }
         let out = Pipe()
         process.standardOutput = out
         process.standardError = FileHandle.nullDevice

--- a/Sources/termio/Git/WorktreeService.swift
+++ b/Sources/termio/Git/WorktreeService.swift
@@ -59,6 +59,7 @@ enum WorktreeService {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
         process.arguments = ["-C", dir] + args
+        process.environment = GitEnvironment.optionalLocksDisabled
         let out = Pipe()
         process.standardOutput = out
         process.standardError = FileHandle.nullDevice

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -690,6 +690,7 @@ extension TermioStore {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
         process.arguments = ["-C", directory] + arguments
+        process.environment = GitEnvironment.optionalLocksDisabled
         let output = Pipe()
         process.standardOutput = output
         process.standardError = Pipe()


### PR DESCRIPTION
Relates to #129 — fixes the CPU/storm root cause behind the `sessions list` timeout.

## Root cause (profiled)

~20% sustained CPU in the git-pane auto-refresh pipeline (`GitPanelModel → GitService.changes → git status --untracked-files=all`), starving the main actor until `termio sessions list` timed out. A **self-sustaining loop**: a read-only `git status` rewrites `.git/index` (stat/untracked cache) → that write fires an FSEvent under `.git` → the pane watcher re-reads → status → … Never settles while the working tree keeps changing (a live dev server, a busy agent).

## Fix — modelled on VS Code's git extension

1. **`GIT_OPTIONAL_LOCKS=0` for every git read** via a shared `GitEnvironment.optionalLocksDisabled`, so `git status` never writes the index. Loop broken at the source. Verified deterministically: `git status --untracked-files=all` rewrites `.git/index` without the flag, leaves it untouched with it.
2. **Applied at all 8 app-side git spawns** — GitService, BranchModel, WorktreeService, TermioStore (worktree cleanliness), CommandPalette (`ls-files`), FileBrowser content search (`git grep`), and CompanionServer ×2 (runs the same `git status --untracked-files=all` for the phone). No path can reintroduce the loop; terminal sessions are untouched.
3. **`GitPanelModel.load()` serialized** — one `git status` in flight. A call arriving mid-pass (watcher debounce *or* a direct `model.load()` from the view) coalesces into a replay and supersedes the stale in-flight snapshot. Immediate replays are **capped at one**: a continuously churning tree publishes a best-effort snapshot and hands off to a debounced refresh instead of livelocking (spinning status / `isLoading` stuck).

## Scope / notes

- Filename-based `.git/index`/`index.lock` watcher filters were tried and dropped — `FolderEventStream` requests directory-level FSEvents, so the event path is `<repo>/.git`, not the filename; the filters can't match without switching to noisier file-level events, and (1) already cures the loop.
- The complementary structural fix — read-only `list` off the `@MainActor` — is separate and optional now that the storm is gone.

## Review

Iterated under `codex` review — five passes, each surfacing a real gap, all fixed:
- a P1-adjacent gap where the serializer missed direct `load()` callers,
- a missed 6th spawn (`TermioStore.gitOutput`),
- a stale-snapshot publish on reentry (a discarded file could flash back),
- a missed 8th spawn (`ContentSearch` `git grep`, via a generic runner),
- a livelock in the replay loop under continuous churn.

Final pass clean; full test suite (32) passes. 8 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)