### PR TITLE
Bump the Homebrew cask on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,36 @@ jobs:
             --title "${APP_NAME} v${VERSION} — $DOWNLOAD_BASE_URL/v${VERSION}/${APP_NAME}.dmg" \
             --generate-notes
 
+      # Point the Homebrew tap (termio-sh/homebrew-tap) at this release so
+      # `brew install --cask termio-sh/tap/termio` serves it. Auth is a write
+      # deploy key on the tap repo. No-ops (with a notice) until the secret is set.
+      - name: Bump Homebrew cask
+        env:
+          TAP_DEPLOY_KEY: ${{ secrets.TAP_DEPLOY_KEY }}
+        run: |
+          if [ -z "$TAP_DEPLOY_KEY" ]; then
+            echo "::notice::TAP_DEPLOY_KEY not set — skipping Homebrew cask bump."
+            exit 0
+          fi
+          VERSION="${{ steps.meta.outputs.version }}"
+          SHA256=$(shasum -a 256 "$DMG_PATH" | cut -d' ' -f1)
+
+          KEY_FILE="$RUNNER_TEMP/tap_deploy_key"
+          echo "$TAP_DEPLOY_KEY" > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+          export GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new"
+
+          git clone --depth 1 git@github.com:termio-sh/homebrew-tap.git "$RUNNER_TEMP/tap"
+          cd "$RUNNER_TEMP/tap"
+          sed -i '' \
+            -e "s/^  version .*/  version \"${VERSION}\"/" \
+            -e "s/^  sha256 .*/  sha256 \"${SHA256}\"/" \
+            Casks/termio.rb
+          git -c user.name="termio-release" -c user.email="release@termio.sh" \
+            commit -am "termio ${VERSION}"
+          git push
+          echo "Bumped cask to ${VERSION} (${SHA256})"
+
       - name: Cleanup keychain
         if: always()
         run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ push-to-talk voice input — is on its way to the App Store.
 **[Download termio for macOS](https://downloads.termio.sh/termio.dmg)** — free,
 no account. Requires macOS 14+.
 
+Or install with [Homebrew](https://brew.sh):
+
+```sh
+brew install --cask termio-sh/tap/termio
+```
+
 ## Build from source
 
 ```sh

--- a/docs/runbook/macos-release-runbook.md
+++ b/docs/runbook/macos-release-runbook.md
@@ -35,10 +35,14 @@ runner, which:
 7. Purges the stable DMG + appcast from Cloudflare's edge (if the purge token is
    set — otherwise skips with a notice).
 8. Records a GitHub Release for the tag + auto-generated changelog.
+9. Bumps the Homebrew cask in `termio-sh/homebrew-tap` (version + sha256 in
+   `Casks/termio.rb`), pushed with the `TAP_DEPLOY_KEY` secret — a write deploy
+   key on the tap repo. Skips with a notice if the secret is unset.
 
 Result: `https://downloads.termio.sh/termio.dmg` serves the notarized build (the
-website Download button), and existing installs auto-update via Sparkle from
-`https://downloads.termio.sh/appcast.xml` (the app's `SUFeedURL`).
+website Download button), existing installs auto-update via Sparkle from
+`https://downloads.termio.sh/appcast.xml` (the app's `SUFeedURL`), and
+`brew install --cask termio-sh/tap/termio` serves the new version.
 
 ## Fixed facts (this project)
 
@@ -65,7 +69,7 @@ password, the R2 secret access key) live only in GitHub Secrets and your vault.
 
 ## GitHub secrets inventory
 
-The workflow reads these ten secrets. **None is a GitHub token** — Actions
+The workflow reads these eleven secrets. **None is a GitHub token** — Actions
 injects `GITHUB_TOKEN` automatically. Check state with
 `gh secret list --repo jiweiyuan/termio`.
 
@@ -82,10 +86,13 @@ injects `GITHUB_TOKEN` automatically. Check state with
 | `R2_ENDPOINT` | `https://<accountid>.r2.cloudflarestorage.com` | ✅ |
 | `CLOUDFLARE_ZONE_ID` | termio.sh zone ID (for cache purge) | ⚪ |
 | `CLOUDFLARE_API_TOKEN` | Zone→Cache Purge token | ⚪ |
+| `TAP_DEPLOY_KEY` | write deploy key for `termio-sh/homebrew-tap` (cask bump) | ⚪ |
 
 ⚪ = optional. Without the two Cloudflare cache secrets the release still
-succeeds; the purge step just skips. The stable copies are uploaded with
-`Cache-Control: no-cache`, so they mostly aren't edge-cached anyway.
+succeeds; the purge step just skips. Without `TAP_DEPLOY_KEY` the Homebrew cask
+bump skips too (the tap still serves the previous version). The stable copies
+are uploaded with `Cache-Control: no-cache`, so they mostly aren't edge-cached
+anyway.
 
 ### Gotcha: setting secret values from the shell
 

--- a/web/landing/content/docs/installation.mdx
+++ b/web/landing/content/docs/installation.mdx
@@ -20,6 +20,17 @@ Termio runs on Apple Silicon Macs. Installation is a normal drag-to-Applications
 3. Launch it from Applications. Because the app is notarized by Apple, it opens
    without a Gatekeeper warning.
 
+## Install with Homebrew
+
+Prefer the command line? Termio is a [Homebrew](https://brew.sh) cask:
+
+```sh
+brew install --cask termio-sh/tap/termio
+```
+
+This installs the same notarized build. Termio still updates itself through
+Sparkle, so `brew upgrade` leaves it alone unless you pass `--greedy`.
+
 ## Staying up to date
 
 Termio updates itself through Sparkle. It periodically checks the download


### PR DESCRIPTION
Wires the release workflow to update the `termio-sh/homebrew-tap` cask automatically, so `brew install --cask termio-sh/tap/termio` always serves the latest build.

After the GitHub Release step, the workflow clones the tap, rewrites `version` + `sha256` in `Casks/termio.rb`, and pushes. Auth is the `TAP_DEPLOY_KEY` secret (a write deploy key on the tap repo); the step skips with a notice when the secret is unset, matching the optional Cloudflare purge step. The runbook's step list and secrets inventory are updated to match.

The tap repo itself is already live and installable; this only automates the per-release version bump.

## Release Notes

Homebrew: `brew install --cask termio-sh/tap/termio` now tracks each release automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)