### PR TITLE
Redact account identifiers from the release docs before open-sourcing

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -51,7 +51,7 @@ and records a GitHub Release for the changelog.
 ## One-time setup: GitHub secrets
 
 Set these with the `gh` CLI from the repo root (`gh auth login` first). Team ID
-is `5Y27G7B6D8` (Jiwei Yuan).
+is `<TEAM_ID>` (your Apple Developer team).
 
 ### Cloudflare R2 (artifact hosting)
 

--- a/docs/runbook/macos-release-runbook.md
+++ b/docs/runbook/macos-release-runbook.md
@@ -45,14 +45,14 @@ website Download button), and existing installs auto-update via Sparkle from
 | Thing | Value |
 | --- | --- |
 | Repo | `jiweiyuan/termio` (private) |
-| Apple Team ID | `5Y27G7B6D8` (Jiwei Yuan) |
-| Developer ID Application | `Jiwei Yuan (5Y27G7B6D8)` — SHA-1 `7E3F98DC984CE82B7F58A71AC4548F6C766F2657` |
-| ASC API key (Team key "termio") | Key ID `YC4MR9DW4Q`, Issuer ID `5242c966-78e9-46ac-96f4-c90f9117c419`, role **Developer** |
-| ASC `.p8` backup | `~/.appstoreconnect/private_keys/AuthKey_YC4MR9DW4Q.p8` (also `~/credentials/`) |
+| Apple Team ID | `<TEAM_ID>` (<YOUR_NAME>) |
+| Developer ID Application | `<YOUR_NAME> (<TEAM_ID>)` — SHA-1 `<CERT_SHA1>` |
+| ASC API key (Team key "termio") | Key ID `<ASC_KEY_ID>`, Issuer ID `<ASC_ISSUER_ID>`, role **Developer** |
+| ASC `.p8` backup | `~/.appstoreconnect/private_keys/AuthKey_<ASC_KEY_ID>.p8` (also `~/credentials/`) |
 | Sparkle public key | `SUPublicEDKey = zm3UpFrDf8tFcctK2vkEhrms6oFTp50AUb824lP9BAw=` (shared with oakreader) |
-| Cloudflare account ID | `a22b80fa365fb7cf04d194272379b669` |
+| Cloudflare account ID | `<CF_ACCOUNT_ID>` |
 | R2 bucket | `termio-downloads` (custom domain `downloads.termio.sh`) |
-| R2 S3 endpoint | `https://a22b80fa365fb7cf04d194272379b669.r2.cloudflarestorage.com` |
+| R2 S3 endpoint | `https://<CF_ACCOUNT_ID>.r2.cloudflarestorage.com` |
 
 These are identifiers, not secrets — the real secrets (the `.p8` bytes, the cert
 password, the R2 secret access key) live only in GitHub Secrets and your vault.
@@ -74,7 +74,7 @@ injects `GITHUB_TOKEN` automatically. Check state with
 | `DEVELOPER_ID_CERT_P12` | base64 of the Developer ID `.p12` (cert + key) | ✅ |
 | `DEVELOPER_ID_CERT_PASSWORD` | that `.p12`'s password | ✅ |
 | `ASC_API_KEY` | base64 of the App Store Connect `.p8` | ✅ |
-| `ASC_KEY_ID` | 10-char key ID (`YC4MR9DW4Q`) | ✅ |
+| `ASC_KEY_ID` | 10-char key ID (`<ASC_KEY_ID>`) | ✅ |
 | `ASC_ISSUER_ID` | account issuer UUID | ✅ |
 | `SPARKLE_ED_KEY` | Sparkle EdDSA private key (shared w/ oakreader) | ✅ |
 | `R2_ACCESS_KEY_ID` | R2 S3 access key ID | ✅ |
@@ -159,7 +159,7 @@ notarization). Download the `.p8` **once** (`AuthKey_<KEYID>.p8`). The **Issuer
 ID** is shown above the key list — one per account, shared across all keys.
 
 ```sh
-KEYID=YC4MR9DW4Q                                  # filename = AuthKey_<KEYID>.p8
+KEYID=<ASC_KEY_ID>                                  # filename = AuthKey_<KEYID>.p8
 base64 -i ~/Downloads/AuthKey_$KEYID.p8 | gh secret set ASC_API_KEY --repo jiweiyuan/termio
 printf '%s' "$KEYID"                              | gh secret set ASC_KEY_ID    --repo jiweiyuan/termio
 gh secret set ASC_ISSUER_ID --repo jiweiyuan/termio   # prompts; paste the issuer UUID


### PR DESCRIPTION
Replaces real operational identifiers in the release docs with placeholders ahead of open-sourcing the repo.

Redacted in `docs/runbook/macos-release-runbook.md` and `docs/RELEASING.md`: Apple Team ID, Developer ID certificate SHA-1, App Store Connect Key ID and Issuer ID, Cloudflare account ID, and personal name — all now `<PLACEHOLDER>` form. These are identifiers, not credentials (the real secrets live only in GitHub Secrets), but there's no reason to publish account coordinates once the repo is public.

The Sparkle public key is kept verbatim: it's public by design (embedded in every shipped app's Info.plist) and the verification step references its exact value.

A full `gitleaks` scan of all 604 commits found no real secrets in history — the only hits were false positives (SSH format strings in comments, a license-key alphabet constant, and the Sparkle public key).

## Release Notes

None (documentation only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)