### PR TITLE
fix(sessions): spare daemonized tools from the stray-orphan reaper

### DIFF
--- a/Sources/termio/Terminal/Ghostty/PTYProcess.swift
+++ b/Sources/termio/Terminal/Ghostty/PTYProcess.swift
@@ -926,8 +926,9 @@ final class PTYProcess: @unchecked Sendable {
             let ps = Process()
             ps.executableURL = URL(fileURLWithPath: "/bin/ps")
             // -E appends each process's environment to the command column
-            // (own-user processes only, which is exactly the scope wanted).
-            ps.arguments = ["-axEww", "-o", "pid=,ppid=,command="]
+            // (own-user processes only, which is exactly the scope wanted);
+            // `tty` gates out daemons — see the guard below.
+            ps.arguments = ["-axEww", "-o", "pid=,ppid=,tty=,command="]
             let out = Pipe()
             ps.standardOutput = out
             do { try ps.run() } catch {
@@ -941,9 +942,16 @@ final class PTYProcess: @unchecked Sendable {
                 guard line.contains("TERMIO_SESSION="),
                       line.contains("TERM_PROGRAM=termio") else { continue }
                 let fields = line.split(separator: " ", omittingEmptySubsequences: true)
-                guard fields.count >= 2,
+                // fields: pid, ppid, tty, command… — `ppid == 1` alone can't
+                // tell a stranded agent from a tool that daemonized off the
+                // pane (a tmux/screen server, or termio itself): both
+                // re-parent to launchd carrying the stamps. The tell is the
+                // tty — a stray still holds its dead PTY (`ttysNNN`), which is
+                // why it leaks; a daemon shed it (`??`).
+                guard fields.count >= 3,
                       let pid = pid_t(fields[0]), let ppid = pid_t(fields[1]),
-                      ppid == 1, pid != getpid()
+                      ppid == 1, pid != getpid(),
+                      fields[2] != "??"
                 else { continue }
                 Log.pty.info("reaping stray session process pid=\(pid, privacy: .public)")
                 // The group first (the leader's tree), then the pid itself —


### PR DESCRIPTION
## Problem

A user (pylon, via WeChat) reported that a `tmux` session started inside a termio pane gets **killed after a while**, repeatedly — closes #127.

Root cause: `PTYProcess.reapStrayOrphans()` runs on every launch and `SIGKILL`s any process carrying termio's env stamps (`TERMIO_SESSION` + `TERM_PROGRAM=termio`) with `ppid == 1`, to sweep up agent shells a dead termio stranded. But tmux's **server daemonizes** — it re-parents to launchd (`ppid == 1`) *by design* and inherits the pane's env stamps. So a live tmux server is indistinguishable from a leaked orphan, and the next termio launch reaps it, taking the whole session with it. The same defect can make one termio instance kill another (the app binary also has `ppid == 1` + the stamps).

## Fix

Add one condition to the reap predicate: **the process must still hold a controlling terminal** (`tty != "??"`).

This is the exact semantic of the leak: a stranded agent still holds its now-dead PTY (`ttysNNN`) — which is *why* it idles forever — while a daemon (tmux/screen/dtach) or a GUI app has deliberately shed its controlling terminal (`??`). No blocklist, no new env var, no persisted state — just the process property that already separates the two.

```
guard fields.count >= 3,
      let pid = pid_t(fields[0]), let ppid = pid_t(fields[1]),
      ppid == 1, pid != getpid(),
      fields[2] != "??"          // still bound to its orphaned PTY
else { continue }
```

Fixes both the tmux case and the termio-kills-sibling-termio case at once.

## Verification (end-to-end, against the built app)

Relaunched the app with both targets present:

| target | shape | result |
|---|---|---|
| tmux server (must spare) | `ppid=1`, `tty=??` | **survives ✅** (old build SIGKILL'd it) |
| genuine orphan agent (must reap) | `ppid=1`, `tty=pts` | **still reaped ✅** |

The orphan still dying proves the reaper wasn't disabled — only narrowed.

### One nuance worth knowing

macOS only exposes env in `ps` for non-platform binaries, but that covers every agent we spawn (`claude`/`node`/`codex`); a bare orphaned `/bin/zsh` is invisible to the reaper yet takes the SIGHUP and dies on its own, so it never leaks. (This required rebuilding the test kill-target from `node` rather than `/bin/sleep` — early "passing" runs were false positives.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
