### PR TITLE
Add highlight annotations and find-in-document to the PDF reader

### DIFF
--- a/Sources/termio/Browser/FilePreview.swift
+++ b/Sources/termio/Browser/FilePreview.swift
@@ -1,5 +1,4 @@
 import AppKit
-import PDFKit
 import SwiftUI
 import WebKit
 
@@ -26,12 +25,14 @@ struct FilePreviewView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            header
-            Divider()
+            // The PDF reader draws its own toolbar with the filename inline (Preview.app style),
+            // so skip the outer header there to avoid two stacked title rows.
+            if kind != .pdf {
+                header
+                Divider()
+            }
             content
         }
-        // Opaque terminal-colored fill so the overlay fully covers the terminal, running up under
-        // the toolbar like the terminal itself.
         .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
         .onExitCommand(perform: onClose)
     }
@@ -59,7 +60,7 @@ struct FilePreviewView: View {
     private var content: some View {
         switch kind {
         case .pdf:
-            PDFPreview(url: url)
+            PDFReaderView(url: url)
         case .web:
             WebPreview(url: url)
         case .image:
@@ -75,25 +76,6 @@ struct FilePreviewView: View {
             } else {
                 WebPreview(url: url)
             }
-        }
-    }
-}
-
-/// A `PDFView` over a file URL, scaled to fit on the terminal background.
-private struct PDFPreview: NSViewRepresentable {
-    let url: URL
-
-    func makeNSView(context: Context) -> PDFView {
-        let view = PDFView()
-        view.document = PDFDocument(url: url)
-        view.autoScales = true
-        view.backgroundColor = .clear
-        return view
-    }
-
-    func updateNSView(_ view: PDFView, context: Context) {
-        if view.document?.documentURL != url {
-            view.document = PDFDocument(url: url)
         }
     }
 }

--- a/Sources/termio/Browser/PDFAnnotationStore.swift
+++ b/Sources/termio/Browser/PDFAnnotationStore.swift
@@ -1,0 +1,124 @@
+import Foundation
+import PDFKit
+import CryptoKit
+
+/// Persists user-added PDF annotations in a per-document sidecar keyed by the file's content
+/// hash — moving or renaming the PDF keeps its annotations attached and the original file is
+/// never modified.
+enum PDFAnnotationStore {
+    static let userName = "termio"
+
+    private static var directory: URL {
+        AppChannel.supportDirectory.appendingPathComponent("pdf-annotations", isDirectory: true)
+    }
+
+    private static func sidecarURL(for hash: String) -> URL {
+        directory.appendingPathComponent(hash + ".json")
+    }
+
+    static func hash(for url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url, options: [.mappedIfSafe]) else { return nil }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func load(into document: PDFDocument, hash: String) {
+        guard let data = try? Data(contentsOf: sidecarURL(for: hash)),
+              let records = try? JSONDecoder().decode([Record].self, from: data) else { return }
+        for record in records {
+            guard record.page >= 0, record.page < document.pageCount,
+                  let page = document.page(at: record.page),
+                  let subtype = PDFAnnotationSubtype.fromString(record.subtype) else { continue }
+            let bounds = CGRect(x: record.x, y: record.y, width: record.width, height: record.height)
+            let annotation = PDFAnnotation(bounds: bounds, forType: subtype, withProperties: nil)
+            annotation.color = NSColor(hex: record.colorHex) ?? .systemYellow
+            annotation.userName = userName
+            page.addAnnotation(annotation)
+        }
+    }
+
+    static func save(_ document: PDFDocument, hash: String) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        var records: [Record] = []
+        for pageIndex in 0..<document.pageCount {
+            guard let page = document.page(at: pageIndex) else { continue }
+            for annotation in page.annotations where annotation.userName == userName {
+                guard let rawType = annotation.type,
+                      let subtype = PDFAnnotationSubtype.toString(fromRawType: rawType) else { continue }
+                let bounds = annotation.bounds
+                records.append(Record(
+                    page: pageIndex,
+                    x: bounds.origin.x, y: bounds.origin.y,
+                    width: bounds.size.width, height: bounds.size.height,
+                    subtype: subtype,
+                    colorHex: annotation.color.hexString
+                ))
+            }
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(records).write(to: sidecarURL(for: hash), options: [.atomic])
+    }
+
+    private struct Record: Codable {
+        let page: Int
+        let x, y, width, height: Double
+        let subtype: String
+        let colorHex: String
+    }
+}
+
+private extension PDFAnnotationSubtype {
+    static func fromString(_ string: String) -> PDFAnnotationSubtype? {
+        switch string {
+        case "highlight": return .highlight
+        case "underline": return .underline
+        case "strikeOut": return .strikeOut
+        default: return nil
+        }
+    }
+
+    // `PDFAnnotation.type` returns a raw PDF spec name (may or may not carry a leading slash),
+    // not a `PDFAnnotationSubtype`, so map by string.
+    static func toString(fromRawType raw: String) -> String? {
+        let cleaned = raw.hasPrefix("/") ? String(raw.dropFirst()) : raw
+        switch cleaned {
+        case "Highlight": return "highlight"
+        case "Underline": return "underline"
+        case "StrikeOut": return "strikeOut"
+        default: return nil
+        }
+    }
+}
+
+private extension NSColor {
+    convenience init?(hex: String) {
+        var s = hex
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard s.count == 6 || s.count == 8, let value = UInt64(s, radix: 16) else { return nil }
+        let r, g, b, a: CGFloat
+        if s.count == 6 {
+            r = CGFloat((value >> 16) & 0xff) / 255
+            g = CGFloat((value >> 8) & 0xff) / 255
+            b = CGFloat(value & 0xff) / 255
+            a = 1
+        } else {
+            r = CGFloat((value >> 24) & 0xff) / 255
+            g = CGFloat((value >> 16) & 0xff) / 255
+            b = CGFloat((value >> 8) & 0xff) / 255
+            a = CGFloat(value & 0xff) / 255
+        }
+        self.init(srgbRed: r, green: g, blue: b, alpha: a)
+    }
+
+    var hexString: String {
+        // `redComponent`/`greenComponent`/`blueComponent` trap on non-RGB color spaces
+        // (grayscale, CMYK, and some P3 displays), so fall back to opaque black on failure —
+        // the sidecar keeps loading, just without an exact color for that record.
+        guard let converted = usingColorSpace(.sRGB) else { return "#000000ff" }
+        let r = Int((converted.redComponent * 255).rounded())
+        let g = Int((converted.greenComponent * 255).rounded())
+        let b = Int((converted.blueComponent * 255).rounded())
+        let a = Int((converted.alphaComponent * 255).rounded())
+        return String(format: "#%02x%02x%02x%02x", r, g, b, a)
+    }
+}

--- a/Sources/termio/Browser/PDFReaderView.swift
+++ b/Sources/termio/Browser/PDFReaderView.swift
@@ -1,0 +1,571 @@
+import AppKit
+import PDFKit
+import SwiftUI
+
+/// PDF reader with a Preview.app-style highlight toolbar and find-in-document field.
+struct PDFReaderView: NSViewRepresentable {
+    let url: URL
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> Container {
+        let pdfView = PDFReaderPDFView()
+        pdfView.translatesAutoresizingMaskIntoConstraints = false
+        pdfView.autoScales = true
+        pdfView.backgroundColor = .clear
+        pdfView.displayMode = .singlePageContinuous
+        pdfView.displayDirection = .vertical
+        pdfView.contextMenuProvider = { [weak coordinator = context.coordinator] point in
+            coordinator?.contextMenu(at: point, in: pdfView)
+        }
+
+        context.coordinator.attach(pdfView: pdfView, url: url)
+
+        let toolbar = NSHostingView(rootView: makeToolbar(coordinator: context.coordinator))
+        toolbar.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = Container(toolbar: toolbar, pdfView: pdfView)
+        container.addSubview(toolbar)
+        container.addSubview(pdfView)
+        NSLayoutConstraint.activate([
+            toolbar.topAnchor.constraint(equalTo: container.topAnchor),
+            toolbar.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            toolbar.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            pdfView.topAnchor.constraint(equalTo: toolbar.bottomAnchor),
+            pdfView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            pdfView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            pdfView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        return container
+    }
+
+    func updateNSView(_ view: Container, context: Context) {
+        guard context.coordinator.url != url else { return }
+        context.coordinator.attach(pdfView: view.pdfView, url: url)
+        // The hosted SwiftUI toolbar caches its @State (query, armed) across reconciliations,
+        // so refresh the root view whenever the URL changes to reset those to a clean start.
+        view.toolbar.rootView = makeToolbar(coordinator: context.coordinator)
+    }
+
+    private func makeToolbar(coordinator: Coordinator) -> PDFReaderToolbar {
+        PDFReaderToolbar(
+            title: url.lastPathComponent,
+            hasSelection: { [weak coordinator] in coordinator?.hasSelection ?? false },
+            armToggle: { [weak coordinator] subtype, color in
+                coordinator?.setArmed(subtype: subtype, color: color)
+            },
+            disarm: { [weak coordinator] in coordinator?.setArmed(subtype: nil, color: nil) },
+            applyOnce: { [weak coordinator] subtype, color in
+                coordinator?.applyOnce(subtype: subtype, color: color)
+            },
+            search: { [weak coordinator] in coordinator?.search(query: $0) },
+            gotoNext: { [weak coordinator] in coordinator?.gotoMatch(offset: 1) },
+            gotoPrevious: { [weak coordinator] in coordinator?.gotoMatch(offset: -1) },
+            matchCount: { [weak coordinator] in coordinator?.matchCount ?? 0 },
+            currentMatchIndex: { [weak coordinator] in coordinator?.currentMatchIndex ?? 0 }
+        )
+    }
+
+    final class Container: NSView {
+        let toolbar: NSHostingView<PDFReaderToolbar>
+        let pdfView: PDFReaderPDFView
+        init(toolbar: NSHostingView<PDFReaderToolbar>, pdfView: PDFReaderPDFView) {
+            self.toolbar = toolbar
+            self.pdfView = pdfView
+            super.init(frame: .zero)
+        }
+        required init?(coder: NSCoder) { nil }
+    }
+
+    final class Coordinator: NSObject {
+        weak var pdfView: PDFReaderPDFView?
+        private(set) var url: URL?
+        private var documentHash: String?
+        private var findMatches: [PDFSelection] = []
+        private var findCursor: Int = 0
+        private var armedMark: (subtype: PDFAnnotationSubtype, color: NSColor)?
+        private var selectionObserver: NSObjectProtocol?
+        private var mouseUpMonitor: Any?
+        // The last non-empty selection observed on the PDFView. Toolbar buttons can steal
+        // first-responder focus and drop the live selection between the click and the coordinator
+        // callback, so the mark actions fall back to this cache when the live one is empty.
+        private var lastSelection: PDFSelection?
+        // Set while `setCurrentSelection` navigates search hits, so the armed listener doesn't
+        // annotate a search jump.
+        private var suppressAutoMark = false
+
+        var matchCount: Int { findMatches.count }
+        var currentMatchIndex: Int { findMatches.isEmpty ? 0 : findCursor + 1 }
+        var hasSelection: Bool {
+            if let sel = pdfView?.currentSelection, !sel.pages.isEmpty { return true }
+            return lastSelection.map { !$0.pages.isEmpty } ?? false
+        }
+
+        deinit {
+            if let selectionObserver { NotificationCenter.default.removeObserver(selectionObserver) }
+            if let mouseUpMonitor { NSEvent.removeMonitor(mouseUpMonitor) }
+        }
+
+        func attach(pdfView: PDFReaderPDFView, url: URL) {
+            self.pdfView = pdfView
+            self.url = url
+            documentHash = nil
+            findMatches.removeAll()
+            findCursor = 0
+            armedMark = nil
+            lastSelection = nil
+
+            let document = PDFDocument(url: url)
+            pdfView.document = document
+            if let document, let hash = PDFAnnotationStore.hash(for: url) {
+                documentHash = hash
+                PDFAnnotationStore.load(into: document, hash: hash)
+            }
+
+            if let selectionObserver { NotificationCenter.default.removeObserver(selectionObserver) }
+            selectionObserver = NotificationCenter.default.addObserver(
+                forName: .PDFViewSelectionChanged,
+                object: pdfView,
+                queue: .main
+            ) { [weak self] _ in self?.selectionChanged() }
+
+            if mouseUpMonitor == nil {
+                // `.PDFViewSelectionChanged` fires continuously during a drag, so armed annotation
+                // needs to wait for the drag to end. The local monitor fires exactly once per
+                // mouse-up and never sees synthetic selections from search navigation.
+                mouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
+                    self?.mouseUp(event)
+                    return event
+                }
+            }
+
+            fitToWidthWhenLaidOut(pdfView: pdfView)
+        }
+
+        /// Interaction B: mark the current (or last cached) selection once.
+        func applyOnce(subtype: PDFAnnotationSubtype, color: NSColor) {
+            guard let pdfView, let selection = liveOrCachedSelection() else { return }
+            markSelection(selection, subtype: subtype, color: color)
+            pdfView.clearSelection()
+            lastSelection = nil
+        }
+
+        /// Interaction A: arm (subtype+color non-nil) or disarm (both nil).
+        func setArmed(subtype: PDFAnnotationSubtype?, color: NSColor?) {
+            if let subtype, let color { armedMark = (subtype, color) }
+            else { armedMark = nil }
+        }
+
+        func search(query: String) {
+            guard let pdfView, let document = pdfView.document else { return }
+            let trimmed = query.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else {
+                pdfView.highlightedSelections = nil
+                pdfView.clearSelection()
+                findMatches.removeAll()
+                findCursor = 0
+                return
+            }
+            let matches = document.findString(trimmed, withOptions: [.caseInsensitive])
+            // `highlightedSelections` requires each selection to carry an explicit color; the
+            // default alpha is 0, so matches render invisible without this.
+            for match in matches { match.color = .systemYellow.withAlphaComponent(0.55) }
+            findMatches = matches
+            findCursor = 0
+            pdfView.highlightedSelections = matches
+            if let first = matches.first { goto(first) }
+        }
+
+        func gotoMatch(offset: Int) {
+            guard !findMatches.isEmpty else { return }
+            let count = findMatches.count
+            findCursor = ((findCursor + offset) % count + count) % count
+            goto(findMatches[findCursor])
+        }
+
+        func contextMenu(at point: NSPoint, in pdfView: PDFReaderPDFView) -> NSMenu? {
+            guard let page = pdfView.page(for: point, nearest: false) else { return nil }
+            let pagePoint = pdfView.convert(point, to: page)
+            guard let annotation = page.annotation(at: pagePoint),
+                  annotation.userName == PDFAnnotationStore.userName else { return nil }
+            let menu = NSMenu()
+            let item = NSMenuItem(title: "Delete Annotation",
+                                  action: #selector(deleteAnnotation), keyEquivalent: "")
+            item.target = self
+            item.representedObject = AnnotationRef(annotation: annotation, page: page)
+            menu.addItem(item)
+            return menu
+        }
+
+        @objc private func deleteAnnotation(_ sender: NSMenuItem) {
+            guard let ref = sender.representedObject as? AnnotationRef else { return }
+            ref.page.removeAnnotation(ref.annotation)
+            persist()
+        }
+
+        private func mouseUp(_ event: NSEvent) {
+            guard let pdfView, event.window === pdfView.window,
+                  armedMark != nil, !suppressAutoMark else { return }
+            let locationInPDFView = pdfView.convert(event.locationInWindow, from: nil)
+            guard pdfView.bounds.contains(locationInPDFView) else { return }
+            guard let armed = armedMark,
+                  let selection = pdfView.currentSelection, !selection.pages.isEmpty else { return }
+            markSelection(selection, subtype: armed.subtype, color: armed.color)
+            pdfView.clearSelection()
+            lastSelection = nil
+        }
+
+        private func selectionChanged() {
+            guard let pdfView else { return }
+            if let sel = pdfView.currentSelection, !sel.pages.isEmpty { lastSelection = sel }
+        }
+
+        private func liveOrCachedSelection() -> PDFSelection? {
+            if let sel = pdfView?.currentSelection, !sel.pages.isEmpty { return sel }
+            return lastSelection.flatMap { $0.pages.isEmpty ? nil : $0 }
+        }
+
+        private func markSelection(_ selection: PDFSelection, subtype: PDFAnnotationSubtype, color: NSColor) {
+            for line in selection.selectionsByLine() {
+                for page in line.pages {
+                    let annotation = PDFAnnotation(bounds: line.bounds(for: page),
+                                                   forType: subtype, withProperties: nil)
+                    annotation.color = color
+                    annotation.userName = PDFAnnotationStore.userName
+                    page.addAnnotation(annotation)
+                }
+            }
+            persist()
+        }
+
+        private func goto(_ selection: PDFSelection) {
+            guard let pdfView else { return }
+            suppressAutoMark = true
+            pdfView.setCurrentSelection(selection, animate: false)
+            pdfView.scrollSelectionToVisible(nil)
+            DispatchQueue.main.async { [weak self] in self?.suppressAutoMark = false }
+        }
+
+        private func persist() {
+            guard let document = pdfView?.document, let hash = documentHash else { return }
+            do { try PDFAnnotationStore.save(document, hash: hash) }
+            catch { NSLog("PDFReaderView: failed to persist annotations: \(error)") }
+        }
+
+        /// `autoScales` leaves the initial scale at 1.0 until the container has a non-zero frame,
+        /// so a fresh PDF paints at native size (tiny). Retry the fit computation for a few
+        /// runloop ticks until the frame settles.
+        private func fitToWidthWhenLaidOut(pdfView: PDFView, attempt: Int = 0) {
+            DispatchQueue.main.async { [weak pdfView] in
+                guard let pdfView else { return }
+                let fit = pdfView.scaleFactorForSizeToFit
+                if fit > 0 {
+                    pdfView.scaleFactor = fit
+                    pdfView.minScaleFactor = fit * 0.25
+                    pdfView.maxScaleFactor = fit * 4.0
+                    return
+                }
+                if attempt < 8 {
+                    self.fitToWidthWhenLaidOut(pdfView: pdfView, attempt: attempt + 1)
+                }
+            }
+        }
+
+        // NSMenuItem.representedObject must be a class, so box the pair.
+        private final class AnnotationRef {
+            let annotation: PDFAnnotation
+            let page: PDFPage
+            init(annotation: PDFAnnotation, page: PDFPage) {
+                self.annotation = annotation
+                self.page = page
+            }
+        }
+    }
+}
+
+/// PDFView subclass that lets a caller supply the context menu instead of hard-replacing the
+/// `menu` property, which would strip PDFKit's own copy/lookup/selection actions.
+final class PDFReaderPDFView: PDFView {
+    var contextMenuProvider: ((NSPoint) -> NSMenu?)?
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let point = convert(event.locationInWindow, from: nil)
+        if let custom = contextMenuProvider?(point) { return custom }
+        return super.menu(for: event)
+    }
+}
+
+struct PDFReaderToolbar: View {
+    let title: String
+    let hasSelection: () -> Bool
+    let armToggle: (PDFAnnotationSubtype, NSColor) -> Void
+    let disarm: () -> Void
+    let applyOnce: (PDFAnnotationSubtype, NSColor) -> Void
+    let search: (String) -> Void
+    let gotoNext: () -> Void
+    let gotoPrevious: () -> Void
+    let matchCount: () -> Int
+    let currentMatchIndex: () -> Int
+
+    @State private var currentColor: HighlightColor = .yellow
+    @State private var currentSubtype: MarkSubtype = .highlight
+    @State private var armed: Bool = false
+    @State private var showPopover: Bool = false
+    @State private var query: String = ""
+    @State private var lastQuery: String = ""
+    @State private var lastMatchCount: Int = 0
+    @State private var lastMatchIndex: Int = 0
+
+    var body: some View {
+        HStack(spacing: 10) {
+            titleLabel
+            Spacer(minLength: 8)
+            markSplitButton
+            searchField
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color(nsColor: .separatorColor)).frame(height: 1)
+        }
+    }
+
+    private var titleLabel: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "doc.richtext")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.system(size: 12.5, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    private var markSplitButton: some View {
+        HStack(spacing: 0) {
+            Button(action: pencilTapped) {
+                Image(systemName: currentSubtype.iconName)
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(currentColor.swatch, .primary)
+                    .font(.system(size: 15))
+                    .frame(width: 26, height: 22)
+                    .background(
+                        armed ? currentColor.swatch.opacity(0.28) : Color.clear,
+                        in: RoundedRectangle(cornerRadius: 5)
+                    )
+            }
+            .buttonStyle(.borderless)
+            .help(armed ? "Cancel Highlighting" : "Highlight")
+
+            Button { showPopover.toggle() } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16, height: 22)
+            }
+            .buttonStyle(.borderless)
+            .popover(isPresented: $showPopover, arrowEdge: .bottom) {
+                popoverBody
+                    .padding(.vertical, 6)
+                    .frame(width: 180)
+            }
+        }
+        .padding(.horizontal, 3)
+        .padding(.vertical, 2)
+        .background(Color(nsColor: .quaternaryLabelColor).opacity(0.35),
+                    in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    /// Pencil click: mark the current selection once (B) if present, otherwise toggle armed (A).
+    private func pencilTapped() {
+        let color = currentColor.nsColor
+        let subtype = currentSubtype.pdfSubtype
+        if hasSelection() {
+            applyOnce(subtype, color)
+        } else if armed {
+            armed = false
+            disarm()
+        } else {
+            armed = true
+            armToggle(subtype, color)
+        }
+    }
+
+    private var popoverBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(HighlightColor.allCases) { color in
+                popoverRow(
+                    selected: color == currentColor && currentSubtype == .highlight,
+                    leading: Circle().fill(color.swatch).frame(width: 12, height: 12)
+                ) {
+                    Text(color.name)
+                } onTap: {
+                    currentColor = color
+                    currentSubtype = .highlight
+                    pickedStyle(subtype: .highlight, color: color.nsColor)
+                }
+            }
+            Divider().padding(.vertical, 4)
+            popoverRow(
+                selected: currentSubtype == .underline,
+                leading: Text("U").font(.system(size: 12, weight: .semibold)).underline().frame(width: 14)
+            ) {
+                Text("Underline")
+            } onTap: {
+                currentSubtype = .underline
+                pickedStyle(subtype: .underline, color: currentColor.nsColor)
+            }
+            popoverRow(
+                selected: currentSubtype == .strikethrough,
+                leading: Text("S").font(.system(size: 12, weight: .semibold)).strikethrough().frame(width: 14)
+            ) {
+                Text("Strikethrough")
+            } onTap: {
+                currentSubtype = .strikethrough
+                pickedStyle(subtype: .strikeOut, color: currentColor.nsColor)
+            }
+        }
+    }
+
+    private func pickedStyle(subtype: PDFAnnotationSubtype, color: NSColor) {
+        if hasSelection() {
+            applyOnce(subtype, color)
+            if armed { armed = false; disarm() }
+        } else {
+            armed = true
+            armToggle(subtype, color)
+        }
+        showPopover = false
+    }
+
+    @ViewBuilder
+    private func popoverRow<Leading: View, Label: View>(
+        selected: Bool,
+        leading: Leading,
+        @ViewBuilder label: () -> Label,
+        onTap: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 10, weight: .bold))
+                .frame(width: 12)
+                .opacity(selected ? 1 : 0)
+            leading
+            label()
+                .font(.system(size: 12.5))
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .font(.system(size: 11))
+            TextField("Search", text: $query)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .onSubmit(runSearch)
+                .onChange(of: query) { _, newValue in
+                    if newValue.isEmpty { clearSearch() }
+                }
+                .frame(minWidth: 120, maxWidth: 220)
+            if !query.isEmpty {
+                Text(lastMatchCount == 0 ? "no matches" : "\(lastMatchIndex) of \(lastMatchCount)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                Button { gotoPrevious(); lastMatchIndex = currentMatchIndex() } label: {
+                    Image(systemName: "chevron.up")
+                }
+                .buttonStyle(.borderless)
+                .disabled(lastMatchCount == 0)
+                Button { gotoNext(); lastMatchIndex = currentMatchIndex() } label: {
+                    Image(systemName: "chevron.down")
+                }
+                .buttonStyle(.borderless)
+                .disabled(lastMatchCount == 0)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(Color(nsColor: .quaternaryLabelColor).opacity(0.35),
+                    in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    /// Return re-runs a fresh query, or advances to the next hit when the query is unchanged —
+    /// matches Preview.app and Safari.
+    private func runSearch() {
+        if query == lastQuery, lastMatchCount > 0 {
+            gotoNext()
+            lastMatchIndex = currentMatchIndex()
+        } else {
+            search(query)
+            lastQuery = query
+            lastMatchCount = matchCount()
+            lastMatchIndex = currentMatchIndex()
+        }
+    }
+
+    private func clearSearch() {
+        search("")
+        lastQuery = ""
+        lastMatchCount = 0
+        lastMatchIndex = 0
+    }
+}
+
+private enum MarkSubtype: Hashable {
+    case highlight, underline, strikethrough
+
+    var pdfSubtype: PDFAnnotationSubtype {
+        switch self {
+        case .highlight: return .highlight
+        case .underline: return .underline
+        case .strikethrough: return .strikeOut
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .highlight: return "highlighter"
+        case .underline: return "underline"
+        case .strikethrough: return "strikethrough"
+        }
+    }
+}
+
+enum HighlightColor: String, CaseIterable, Identifiable {
+    case yellow, green, blue, pink, purple
+
+    var id: String { rawValue }
+    var name: String { rawValue.capitalized }
+
+    var nsColor: NSColor {
+        let base: NSColor
+        switch self {
+        case .yellow: base = .systemYellow
+        case .green:  base = .systemGreen
+        case .blue:   base = .systemBlue
+        case .pink:   base = .systemPink
+        case .purple: base = .systemPurple
+        }
+        return base.withAlphaComponent(0.35)
+    }
+
+    var swatch: Color {
+        switch self {
+        case .yellow: .yellow
+        case .green:  .green
+        case .blue:   .blue
+        case .pink:   .pink
+        case .purple: .purple
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The PDF reader (opened via **Open in Right Panel** or the full-window overlay) now sports a Preview.app-style toolbar with a highlight split-button, a color/style popover, and a find-in-document field.
- User-created highlights, underlines, and strikethroughs persist to a per-document sidecar under Application Support, keyed by the PDF's content hash. The original PDF is never modified.
- Search runs \`PDFDocument.findString\` with case-insensitive matching, highlights every hit, and offers Return-to-next / prev / next navigation with an \"N of M\" counter.

<img width="423" height="401" alt="image" src="https://github.com/user-attachments/assets/11698188-e8fb-447f-822f-36723b819fba" />


## Design

- **Sidecar over embedded annotations.** Sidecar JSON at \`~/Library/Application Support/termio[-dev]/pdf-annotations/<sha256>.json\`, keyed by the PDF's content hash so moves/renames keep annotations attached. Read misses are silently \"no annotations\", not an error. Every add/delete triggers a full re-serialize + atomic write.
- **Two interaction paths matching Preview.**
  - Interaction A (armed): click the pencil with nothing selected → the tool enters an armed state (visible fill in the current color). Any subsequent completed text selection is auto-annotated. Click again to disarm.
  - Interaction B (one-shot): drag to select text, then click the pencil or pick a style. That one selection is annotated; armed state is not entered.
- **Custom \`.popover\`, not \`Menu\`.** SwiftUI \`Menu\` coerces label icons to template symbols, dropping swatch colors. The popover renders full-color swatches, a Preview-style checkmark rail, plus Underline and Strikethrough rows.
- **Mouse-up-driven armed annotation.** \`.PDFViewSelectionChanged\` fires continuously during a drag, so armed annotation listens on a local \`NSEvent\` monitor for \`.leftMouseUp\` instead. That gives exactly one annotation per drag.
- **Selection cache.** Toolbar buttons steal first-responder focus and can clear \`PDFView.currentSelection\` between the click and the coordinator callback. The coordinator caches the last non-empty selection so the mark actions fall back to it.
- **PDFView subclass for context menu.** Overrides \`menu(for:)\` so we can add \"Delete Annotation\" for termio-owned annotations without stripping PDFKit's own Copy/Look Up/Zoom items.
- **Initial fit.** \`autoScales\` leaves the scale at 1.0 until first layout, so we retry \`scaleFactorForSizeToFit\` for a few runloop ticks until it returns a non-zero factor, then also set \`minScaleFactor\` and \`maxScaleFactor\`.

## Non-goals

- No zoom controls, keyboard shortcuts, undo/redo, ink/free-form drawing, sticky notes, or export-annotated-PDF. Those are follow-up work if the reader proves useful.

## Review

Codex reviewed an earlier revision of this branch. Applied fixes:

- \`documentHash\` now cleared at the start of every \`attach\` and only reassigned after a successful hash, so a hash failure on a new URL cannot corrupt the previous sidecar.
- \`updateNSView\` refreshes the hosted toolbar's \`rootView\` on URL change, resetting the query/armed \`@State\` for a new PDF.
- Search field clears highlights on empty query via \`.onChange\`, not only on Return.
- Armed annotation is driven by a \`.leftMouseUp\` local event monitor instead of a debounce over \`.PDFViewSelectionChanged\`.
- The \`.PDFViewSelectionChanged\` observer is re-registered on every \`attach\`, so a coordinator paired with a new \`PDFView\` still receives notifications.
- \`hasSelection\` and \`applyOnce\` fall back to a cached last-non-empty \`PDFSelection\` when the live one has been cleared by focus loss.
- \`pdfView.menu\` is no longer replaced; a \`PDFView\` subclass overrides \`menu(for:)\` and appends the delete item only for termio-owned annotations.
- Toolbar background switched to \`NSColor.windowBackgroundColor\` + a separator hairline; the \`.thinMaterial\` was illegible in the dark termio theme.
- \`NSColor.hexString\` gracefully handles non-sRGB color spaces instead of trapping on \`redComponent\`.
- \`scaleFactorForSizeToFit\` retries up to 8 runloop ticks in case the initial hop still runs before final layout.

## Test plan

- [x] Open a PDF in the right panel — toolbar renders inline, filename left-aligned, controls right-aligned.
- [x] Click pencil with nothing selected → armed (color fill behind the pencil). Drag to select → auto-highlighted on release. Click pencil → disarms.
- [x] Drag to select text → click pencil → that selection is highlighted, armed state stays off.
- [x] Popover shows five color rows (Yellow / Green / Blue / Pink / Purple) with real color swatches, plus Underline and Strikethrough.
- [x] Right-click a termio highlight → \"Delete Annotation\" removes it; the sidecar updates immediately.
- [x] Right-click a link inside the PDF → PDFKit's own menu still fires (Copy, Look Up, etc.).
- [x] Type a search query → Return jumps to the first match with visible yellow highlight; up/down chevrons walk matches circularly; Return on the same query advances to the next match; clearing the field clears all highlights.
- [x] Open a different PDF in the same panel — the reader re-fits, the sidecar for the new document loads (or is silent if none), and the search field / armed state reset.
- [x] Annotations survive relaunching the app.
- [x] \`swift build\` clean.

## Release Notes

The PDF reader now supports highlight, underline, and strikethrough annotations in five colors (yellow, green, blue, pink, purple), plus a find-in-document field with Return-to-next navigation. Annotations persist per-PDF and never modify the original file.