### PR TITLE
In-editor find bar for open files

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -828,6 +828,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         NotificationCenter.default.post(name: .termioCloseContentOverlay, object: nil)
     }
 
+    /// ⌘F: broadcast so any on-screen file editor opens its find bar.
+    @objc func showEditorFindBar(_ sender: Any?) {
+        NotificationCenter.default.post(name: .termioShowFindBar, object: nil)
+    }
+
     /// Inserts or removes the overlay-close button as a file editor / diff / preview opens and
     /// closes, so it is shown only while there is an overlay to close. It rides the terminal
     /// column's trailing edge: anchored just before the inspector switch's tracking separator when
@@ -1587,6 +1592,13 @@ private func buildMainMenu() -> NSMenu {
     editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
     editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
     editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+    editMenu.addItem(.separator())
+    // ⌘F opens the current file's in-editor find bar. Broadcast via notification so the
+    // shortcut works regardless of first-responder — the terminal receives no find behaviour.
+    let findItem = NSMenuItem(title: "Find…",
+                              action: #selector(AppDelegate.showEditorFindBar(_:)),
+                              keyEquivalent: "f")
+    editMenu.addItem(findItem)
     editItem.submenu = editMenu
 
     let viewItem = NSMenuItem()

--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -45,6 +45,16 @@ struct FileEditorView: View {
     @State private var cursor: EditorCursor?
     /// The pending debounced write, cancelled and rescheduled on each keystroke.
     @State private var saveTask: Task<Void, Never>?
+    @State private var findBarVisible = false
+    @State private var findQuery = ""
+    @State private var findOptions = FindOptions()
+    @State private var findFocusedIndex = 0
+    @State private var findMatchCount = 0
+    /// The query at the last Return press. A second Return on the same query advances to the
+    /// next match (VS Code / Safari convention).
+    @State private var findLastSubmittedQuery = ""
+    /// Bumped on every ⌘F so the find bar re-focuses even when already on screen.
+    @State private var findFocusTrigger = 0
 
     /// Past this size the file renders as plain text: highlight.js parses off-main, but
     /// *applying* its result is thousands of main-thread `setAttributes` calls plus a
@@ -158,9 +168,32 @@ struct FileEditorView: View {
                             currentLineColor: currentLineColor,
                             isEditable: !readOnly,
                             jumpToLine: jumpLine,
+                            findQuery: findBarVisible ? findQuery : "",
+                            findOptions: findOptions,
+                            findFocusedIndex: findFocusedIndex,
+                            onMatchesChanged: { count in
+                                findMatchCount = count
+                                if count > 0, findFocusedIndex >= count { findFocusedIndex = 0 }
+                            },
                             onSave: saveNow
                         )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .overlay(alignment: .top) {
+                            if findBarVisible {
+                                FileFindBar(
+                                    query: $findQuery,
+                                    options: $findOptions,
+                                    currentMatch: findMatchCount == 0 ? 0 : findFocusedIndex + 1,
+                                    totalMatches: findMatchCount,
+                                    onSubmit: submitFind,
+                                    onNext: { advanceFind(by: 1) },
+                                    onPrevious: { advanceFind(by: -1) },
+                                    onClose: closeFindBar,
+                                    focusTrigger: findFocusTrigger
+                                )
+                                .transition(.move(edge: .top).combined(with: .opacity))
+                            }
+                        }
                     }
                     Divider()
                     statusBar
@@ -171,6 +204,9 @@ struct FileEditorView: View {
         // titlebar — no outer `.frame`, which was reserving an empty band above the header.
         .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
         .task { await load() }
+        .onReceive(NotificationCenter.default.publisher(for: .termioShowFindBar)) { _ in
+            openFindBar()
+        }
         // Auto-save: debounce a write after each edit; Escape closes (flushing first). A read-only
         // peek never writes, so neither the debounce nor the exit flush is armed.
         .onChange(of: text) {
@@ -357,6 +393,42 @@ struct FileEditorView: View {
         saveTask?.cancel()
         writeIfNeeded()
         onClose()
+    }
+
+    /// ⌘F: show the find bar. Skipped in Markdown Preview mode — there's no NSTextView to
+    /// search underneath.
+    private func openFindBar() {
+        guard mode == .edit else { return }
+        withAnimation(.easeOut(duration: 0.12)) { findBarVisible = true }
+        // NSTextView keeps first responder otherwise, and SwiftUI's @FocusState can't wrestle
+        // it away — drop it explicitly so the find field can claim the keyboard.
+        NSApp.keyWindow?.makeFirstResponder(nil)
+        findFocusTrigger &+= 1
+    }
+
+    private func closeFindBar() {
+        withAnimation(.easeOut(duration: 0.12)) { findBarVisible = false }
+        findQuery = ""
+        findLastSubmittedQuery = ""
+        findMatchCount = 0
+        findFocusedIndex = 0
+        findOptions = FindOptions()
+    }
+
+    /// Return: fresh query → jump to match 1; same query → next match.
+    private func submitFind() {
+        guard !findQuery.isEmpty else { return }
+        if findQuery == findLastSubmittedQuery, findMatchCount > 0 {
+            advanceFind(by: 1)
+        } else {
+            findLastSubmittedQuery = findQuery
+            findFocusedIndex = 0
+        }
+    }
+
+    private func advanceFind(by offset: Int) {
+        guard findMatchCount > 0 else { return }
+        findFocusedIndex = ((findFocusedIndex + offset) % findMatchCount + findMatchCount) % findMatchCount
     }
 
     /// Reads the file once per opened identity (`.id(url)` on the overlay), off the main

--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -178,7 +178,7 @@ struct FileEditorView: View {
                             onSave: saveNow
                         )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .overlay(alignment: .top) {
+                        .overlay(alignment: .topTrailing) {
                             if findBarVisible {
                                 FileFindBar(
                                     query: $findQuery,
@@ -191,7 +191,7 @@ struct FileEditorView: View {
                                     onClose: closeFindBar,
                                     focusTrigger: findFocusTrigger
                                 )
-                                .transition(.move(edge: .top).combined(with: .opacity))
+                                .transition(.move(edge: .trailing).combined(with: .opacity))
                             }
                         }
                     }

--- a/Sources/termio/Editor/FileFindBar.swift
+++ b/Sources/termio/Editor/FileFindBar.swift
@@ -1,0 +1,131 @@
+import AppKit
+import SwiftUI
+
+/// In-editor find bar. Return re-runs a fresh query or advances on the same query; Esc closes.
+struct FileFindBar: View {
+    @Binding var query: String
+    @Binding var options: FindOptions
+    let currentMatch: Int
+    let totalMatches: Int
+    let onSubmit: () -> Void
+    let onNext: () -> Void
+    let onPrevious: () -> Void
+    let onClose: () -> Void
+    var focusTrigger: Int = 0
+
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            searchFieldGroup
+            countLabel
+            iconButton("chevron.up", disabled: totalMatches == 0, tooltip: "Previous Match", action: onPrevious)
+            iconButton("chevron.down", disabled: totalMatches == 0, tooltip: "Next Match", action: onNext)
+            iconButton("xmark", disabled: false, tooltip: "Close (Esc)", action: onClose)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
+        .padding(.horizontal, 8)
+        .padding(.top, 6)
+        .onExitCommand(perform: onClose)
+        .onAppear { requestFocus() }
+        .onChange(of: focusTrigger) { _, _ in requestFocus() }
+    }
+
+    /// Focus is deferred by a runloop tick so AppKit has time to place the field in the
+    /// responder chain — otherwise the request lands before the view is attached and is dropped.
+    private func requestFocus() {
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(50))
+            focused = true
+        }
+    }
+
+    private var searchFieldGroup: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            TextField("Find", text: $query)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .focused($focused)
+                .onSubmit(onSubmit)
+                .frame(minWidth: 140, maxWidth: 260)
+            optionToggle(label: .symbol("textformat"), active: options.caseSensitive, tooltip: "Match Case") {
+                options.caseSensitive.toggle()
+            }
+            optionToggle(label: .text("ab", underline: true), active: options.wholeWord, tooltip: "Match Whole Word") {
+                options.wholeWord.toggle()
+            }
+            optionToggle(label: .text(".*", underline: false), active: options.regex, tooltip: "Use Regular Expression") {
+                options.regex.toggle()
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(Color(nsColor: .textBackgroundColor).opacity(0.6),
+                    in: RoundedRectangle(cornerRadius: 4))
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
+    }
+
+    private enum ToggleLabel {
+        case symbol(String)
+        case text(String, underline: Bool)
+    }
+
+    private func optionToggle(label: ToggleLabel, active: Bool, tooltip: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Group {
+                switch label {
+                case .symbol(let name):
+                    Image(systemName: name)
+                case .text(let glyphs, let underline):
+                    underline ? AnyView(Text(glyphs).underline()) : AnyView(Text(glyphs))
+                }
+            }
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(active ? Color.accentColor : .secondary)
+            .frame(width: 20, height: 18)
+            .background(
+                active ? Color.accentColor.opacity(0.18) : Color.clear,
+                in: RoundedRectangle(cornerRadius: 3)
+            )
+        }
+        .buttonStyle(.borderless)
+        .help(tooltip)
+    }
+
+    private func iconButton(_ name: String, disabled: Bool, tooltip: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: name).font(.system(size: 11, weight: .semibold))
+        }
+        .buttonStyle(.borderless)
+        .disabled(disabled)
+        .help(tooltip)
+    }
+
+    @ViewBuilder
+    private var countLabel: some View {
+        if query.isEmpty {
+            EmptyView()
+        } else if totalMatches == 0 {
+            Text("No results")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        } else {
+            Text("\(currentMatch) of \(totalMatches)")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+}

--- a/Sources/termio/Editor/FileFindBar.swift
+++ b/Sources/termio/Editor/FileFindBar.swift
@@ -30,7 +30,8 @@ struct FileFindBar: View {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
-        .padding(.horizontal, 8)
+        .fixedSize()
+        .padding(.trailing, 12)
         .padding(.top, 6)
         .onExitCommand(perform: onClose)
         .onAppear { requestFocus() }

--- a/Sources/termio/Editor/FindNotification.swift
+++ b/Sources/termio/Editor/FindNotification.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Notification.Name {
+    /// ⌘F broadcast. Broadcast instead of the responder chain so the menu item stays enabled
+    /// whenever an editor is on screen even if the terminal holds first responder.
+    static let termioShowFindBar = Notification.Name("termio.showFindBar")
+}

--- a/Sources/termio/Editor/FindOptions.swift
+++ b/Sources/termio/Editor/FindOptions.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// VS Code-style find modes: Aa (case), ab (whole word), .* (regex).
+struct FindOptions: Equatable {
+    var caseSensitive = false
+    var wholeWord = false
+    var regex = false
+}

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -24,6 +24,13 @@ struct HighlightedTextView: NSViewRepresentable {
     /// A 1-based line to scroll to and flash (a content-search hit). Applied once on creation and
     /// again whenever the value changes — clicking a different hit in the same file re-scrolls.
     var jumpToLine: Int? = nil
+    /// Search query for the in-editor find bar. Empty string clears highlights.
+    var findQuery: String = ""
+    var findOptions: FindOptions = FindOptions()
+    /// 0-based match to focus; ignored on empty query or empty result.
+    var findFocusedIndex: Int = 0
+    /// Fires with the total match count after any recompute (new query, options, or edit).
+    var onMatchesChanged: ((Int) -> Void)? = nil
     /// Invoked when the user presses ⌘S — flushes the buffer to disk immediately.
     let onSave: () -> Void
 
@@ -57,7 +64,6 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.isAutomaticSpellingCorrectionEnabled = false
         textView.isContinuousSpellCheckingEnabled = false
         textView.isGrammarCheckingEnabled = false
-        textView.usesFindBar = true
         textView.textContainerInset = NSSize(width: 6, height: 10)
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
@@ -154,6 +160,9 @@ struct HighlightedTextView: NSViewRepresentable {
             coordinator.appliedJumpLine = jumpToLine
             if let jumpToLine { Self.reveal(line: jumpToLine, in: textView) }
         }
+
+        coordinator.onMatchesChanged = onMatchesChanged
+        coordinator.updateFind(query: findQuery, options: findOptions, focusedIndex: findFocusedIndex, in: textView)
     }
 
     private func apply(to textView: NSTextView) {
@@ -191,8 +200,13 @@ struct HighlightedTextView: NSViewRepresentable {
         /// The last jump target acted on, so `updateNSView` only re-scrolls on a genuine new hit.
         var appliedJumpLine: Int?
         weak var ruler: LineNumberRulerView?
+        var onMatchesChanged: ((Int) -> Void)?
         private let text: Binding<String>
         private let cursor: Binding<EditorCursor?>
+        private var appliedFindQuery: String = ""
+        private var appliedFindOptions: FindOptions = FindOptions()
+        private var appliedFocusedIndex: Int = -1
+        private var findMatches: [NSRange] = []
 
         init(text: Binding<String>, cursor: Binding<EditorCursor?>) {
             self.text = text
@@ -223,6 +237,11 @@ struct HighlightedTextView: NSViewRepresentable {
             guard let textView = notification.object as? NSTextView else { return }
             text.wrappedValue = textView.string
             ruler?.needsDisplay = true
+            if !appliedFindQuery.isEmpty {
+                recomputeMatches(query: appliedFindQuery, options: appliedFindOptions, in: textView)
+                paintMatches(in: textView, focused: min(appliedFocusedIndex, findMatches.count - 1))
+                notifyMatchCount()
+            }
         }
 
         func textViewDidChangeSelection(_ notification: Notification) {
@@ -233,6 +252,95 @@ struct HighlightedTextView: NSViewRepresentable {
             guard location <= full.length else { return }
             let (line, column) = TextPositions.lineColumn(utf16Offset: location, in: full)
             cursor.wrappedValue = EditorCursor(line: line, column: column)
+        }
+
+        /// Recompute + repaint after a new query, option change, or focus move. Same query
+        /// with a new focused index only re-scrolls.
+        func updateFind(query: String, options: FindOptions, focusedIndex: Int, in textView: NSTextView) {
+            if query != appliedFindQuery || options != appliedFindOptions {
+                appliedFindQuery = query
+                appliedFindOptions = options
+                recomputeMatches(query: query, options: options, in: textView)
+                notifyMatchCount()
+                appliedFocusedIndex = -1
+            }
+            paintMatches(in: textView, focused: focusedIndex)
+            appliedFocusedIndex = focusedIndex
+        }
+
+        /// SwiftUI forbids mutating parent state inside `updateNSView`, so defer the callback
+        /// to the next runloop.
+        private func notifyMatchCount() {
+            let count = findMatches.count
+            let callback = onMatchesChanged
+            DispatchQueue.main.async { callback?(count) }
+        }
+
+        private func recomputeMatches(query: String, options: FindOptions, in textView: NSTextView) {
+            findMatches.removeAll()
+            guard !query.isEmpty else { return }
+            let full = textView.string as NSString
+            let total = full.length
+            guard total > 0 else { return }
+
+            if options.regex {
+                var regexOptions: NSRegularExpression.Options = []
+                if !options.caseSensitive { regexOptions.insert(.caseInsensitive) }
+                guard let regex = try? NSRegularExpression(pattern: query, options: regexOptions) else { return }
+                let matches = regex.matches(in: textView.string, range: NSRange(location: 0, length: total))
+                for match in matches where match.range.length > 0 {
+                    if options.wholeWord, !Self.isWordBoundary(match.range, in: full) { continue }
+                    findMatches.append(match.range)
+                }
+                return
+            }
+
+            var searchOptions: NSString.CompareOptions = []
+            if !options.caseSensitive { searchOptions.insert(.caseInsensitive) }
+            var searchStart = 0
+            while searchStart < total {
+                let searchRange = NSRange(location: searchStart, length: total - searchStart)
+                let hit = full.range(of: query, options: searchOptions, range: searchRange)
+                if hit.location == NSNotFound { break }
+                if !options.wholeWord || Self.isWordBoundary(hit, in: full) {
+                    findMatches.append(hit)
+                }
+                // `hit.length` can be zero for a pathological pattern; step by 1 to guarantee
+                // termination.
+                searchStart = hit.location + max(hit.length, 1)
+            }
+        }
+
+        private static func isWordBoundary(_ range: NSRange, in string: NSString) -> Bool {
+            let letters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
+            if range.location > 0 {
+                let prev = string.character(at: range.location - 1)
+                if let scalar = Unicode.Scalar(prev), letters.contains(scalar) { return false }
+            }
+            let end = range.location + range.length
+            if end < string.length {
+                let next = string.character(at: end)
+                if let scalar = Unicode.Scalar(next), letters.contains(scalar) { return false }
+            }
+            return true
+        }
+
+        private func paintMatches(in textView: NSTextView, focused: Int) {
+            guard let layoutManager = textView.layoutManager else { return }
+            let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
+            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: fullRange)
+
+            let matchColor = NSColor.systemYellow.withAlphaComponent(0.35)
+            let focusedColor = NSColor.systemYellow.withAlphaComponent(0.7)
+            for (index, range) in findMatches.enumerated() {
+                let color = (index == focused) ? focusedColor : matchColor
+                layoutManager.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: range)
+            }
+            if findMatches.indices.contains(focused) {
+                let range = findMatches[focused]
+                textView.scrollRangeToVisible(range)
+                textView.showFindIndicator(for: range)
+            }
         }
     }
 }

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -239,7 +239,10 @@ struct HighlightedTextView: NSViewRepresentable {
             ruler?.needsDisplay = true
             if !appliedFindQuery.isEmpty {
                 recomputeMatches(query: appliedFindQuery, options: appliedFindOptions, in: textView)
-                paintMatches(in: textView, focused: min(appliedFocusedIndex, findMatches.count - 1))
+                // An edit reshuffles the matches, so repaint the highlights — but the user is
+                // typing in the document, not navigating, so don't steal the scroll or re-pulse
+                // the find indicator.
+                paintMatches(in: textView, focused: min(appliedFocusedIndex, findMatches.count - 1), reveal: false)
                 notifyMatchCount()
             }
         }
@@ -257,14 +260,19 @@ struct HighlightedTextView: NSViewRepresentable {
         /// Recompute + repaint after a new query, option change, or focus move. Same query
         /// with a new focused index only re-scrolls.
         func updateFind(query: String, options: FindOptions, focusedIndex: Int, in textView: NSTextView) {
-            if query != appliedFindQuery || options != appliedFindOptions {
+            let queryChanged = query != appliedFindQuery || options != appliedFindOptions
+            if queryChanged {
                 appliedFindQuery = query
                 appliedFindOptions = options
                 recomputeMatches(query: query, options: options, in: textView)
                 notifyMatchCount()
                 appliedFocusedIndex = -1
             }
-            paintMatches(in: textView, focused: focusedIndex)
+            // Every unrelated SwiftUI re-render (caret moves, footer refresh) flows through
+            // `updateNSView` → here. Bail unless the query, options, or focused match actually
+            // moved, so we don't churn the temporary attributes or re-fire the find pulse.
+            guard queryChanged || focusedIndex != appliedFocusedIndex else { return }
+            paintMatches(in: textView, focused: focusedIndex, reveal: true)
             appliedFocusedIndex = focusedIndex
         }
 
@@ -325,7 +333,10 @@ struct HighlightedTextView: NSViewRepresentable {
             return true
         }
 
-        private func paintMatches(in textView: NSTextView, focused: Int) {
+        /// `reveal` scrolls the focused match into view and pulses the find indicator — set only
+        /// when the focus genuinely moved (a new query or a next/prev step), never on a passive
+        /// repaint after an in-document edit.
+        private func paintMatches(in textView: NSTextView, focused: Int, reveal: Bool) {
             guard let layoutManager = textView.layoutManager else { return }
             let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
             layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: fullRange)
@@ -336,7 +347,7 @@ struct HighlightedTextView: NSViewRepresentable {
                 let color = (index == focused) ? focusedColor : matchColor
                 layoutManager.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: range)
             }
-            if findMatches.indices.contains(focused) {
+            if reveal, findMatches.indices.contains(focused) {
                 let range = findMatches[focused]
                 textView.scrollRangeToVisible(range)
                 textView.showFindIndicator(for: range)

--- a/Sources/termio/Git/DiffTextView.swift
+++ b/Sources/termio/Git/DiffTextView.swift
@@ -84,6 +84,11 @@ struct DiffTextPane: NSViewRepresentable {
         context.coordinator.observeFrame(of: textView)
         scrollView.contentView.postsBoundsChangedNotifications = true
         context.coordinator.observeScroll(of: scrollView)
+        // ⌘F now lives on a global Edit-menu item (see App.swift), whose key equivalent
+        // pre-empts the text view before AppKit's find-bar machinery ever sees the event.
+        // Honor the same broadcast the file editor listens for and drive the system find bar
+        // by hand, so ⌘F still opens find in the diff overlay.
+        context.coordinator.observeFindBar(for: textView)
 
         apply(to: textView, layoutManager: layoutManager, ruler: ruler,
               coordinator: context.coordinator)
@@ -97,6 +102,10 @@ struct DiffTextPane: NSViewRepresentable {
             }
         }
         return scrollView
+    }
+
+    static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
+        coordinator.teardown()
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
@@ -163,6 +172,30 @@ struct DiffTextPane: NSViewRepresentable {
         var appliedDocument: DiffDocument?
         var appliedStyled: Int?
         weak var ruler: DiffGutterRulerView?
+        private var findObserver: NSObjectProtocol?
+
+        /// Opens the system find bar on the ⌘F broadcast — the menu item swallows the key
+        /// equivalent, so the text view never gets a chance to open it itself.
+        func observeFindBar(for textView: DiffTextView) {
+            findObserver = NotificationCenter.default.addObserver(
+                forName: .termioShowFindBar, object: nil, queue: .main
+            ) { [weak textView] _ in
+                MainActor.assumeIsolated {
+                    guard let textView, textView.window != nil else { return }
+                    let action = NSMenuItem()
+                    action.tag = NSTextFinder.Action.showFindInterface.rawValue
+                    textView.performTextFinderAction(action)
+                }
+            }
+        }
+
+        /// The find-bar observer is registered with `object: nil`, so unlike the frame/scroll
+        /// observers (scoped to their view) it must be torn down explicitly or it leaks and
+        /// keeps firing for stale diff panes.
+        func teardown() {
+            if let findObserver { NotificationCenter.default.removeObserver(findObserver) }
+            findObserver = nil
+        }
 
         func observeFrame(of textView: NSTextView) {
             NotificationCenter.default.addObserver(


### PR DESCRIPTION
## Summary

- ⌘F opens a find bar over the currently open text/code file.
- Match case (Aa), whole word (ab), regex (.*) toggles inline in the field.
- N of M counter, prev/next chevrons, Return advances on unchanged query.
- Terminal is untouched.

Examples:
<img width="502" height="139" alt="image" src="https://github.com/user-attachments/assets/856c23ae-f043-4a45-88c9-5091c0122c0b" />



## Release Notes

⌘F now opens a find bar over the current file with match-case, whole-word, and regex toggles.