### PR TITLE
feat(ios): context-aware ＋ across the three tabs (#145)

### DIFF
--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -47,11 +47,6 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     /// gathers in the `.terminals` funnel and needs no project. Answered with
     /// `.started`.
     case startSSH(host: String)
-    /// The Projects tab's ＋: reopen a folder from the Mac's recent-projects
-    /// list (see `.recentProjects`) as a project. The phone is sandboxed and
-    /// can't browse the Mac's disk, so it can only reopen a path the Mac already
-    /// knows. No reply — the next roster push carries the new project row.
-    case openProject(path: String)
     /// The client asks the Mac to close a session (the phone's swipe-to-remove).
     /// No success reply — the next roster push drops the row everywhere.
     case stop(sessionID: String)
@@ -113,15 +108,6 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     /// Mac → phone: the parsed `~/.ssh/config` host blocks.
     case sshConfigList(hosts: [WireSSHHost])
 
-    /// Phone → Mac: list the Mac's recent projects (the last folders opened in
-    /// termio). The phone can't browse the Mac's disk, so this is how the
-    /// Projects tab's ＋ offers something to reopen. Answered with
-    /// `.recentProjectList`.
-    case recentProjects
-
-    /// Mac → phone: the Mac's recent-project entries, most-recent first.
-    case recentProjectList(projects: [WireRecentProject])
-
     case error(message: String)
 
     public func encoded() -> String {
@@ -145,8 +131,6 @@ public enum CompanionControl: Codable, Sendable, Equatable {
             return #"{"t":"startTerminal"}"#
         case .startSSH(let host):
             return Self.json(["t": "startSSH", "host": host])
-        case .openProject(let path):
-            return Self.json(["t": "openProject", "path": path])
         case .stop(let sessionID):
             return #"{"t":"stop","session":"\#(sessionID)"}"#
         case .resize(let cols, let rows):
@@ -204,13 +188,6 @@ public enum CompanionControl: Codable, Sendable, Equatable {
                     ["alias": $0.alias, "hostName": $0.hostName, "user": $0.user, "port": $0.port]
                 },
             ])
-        case .recentProjects:
-            return #"{"t":"recentProjects"}"#
-        case .recentProjectList(let projects):
-            return Self.json([
-                "t": "recentProjectList",
-                "projects": projects.map { ["name": $0.name, "path": $0.path] },
-            ])
         case .error(let message):
             let escaped = message
                 .replacingOccurrences(of: "\\", with: "\\\\")
@@ -244,9 +221,6 @@ public enum CompanionControl: Codable, Sendable, Equatable {
         case "startSSH":
             guard let host = obj["host"] as? String else { return nil }
             return .startSSH(host: host)
-        case "openProject":
-            guard let path = obj["path"] as? String else { return nil }
-            return .openProject(path: path)
         case "stop":
             guard let sessionID = obj["session"] as? String else { return nil }
             return .stop(sessionID: sessionID)
@@ -343,16 +317,6 @@ public enum CompanionControl: Codable, Sendable, Equatable {
                 )
             }
             return .sshConfigList(hosts: hosts)
-        case "recentProjects":
-            return .recentProjects
-        case "recentProjectList":
-            let raw = obj["projects"] as? [[String: Any]] ?? []
-            let projects = raw.compactMap { entry -> WireRecentProject? in
-                guard let name = entry["name"] as? String,
-                      let path = entry["path"] as? String else { return nil }
-                return WireRecentProject(name: name, path: path)
-            }
-            return .recentProjectList(projects: projects)
         case "error":
             guard let message = obj["message"] as? String else { return nil }
             return .error(message: message)
@@ -397,20 +361,6 @@ public struct WireSSHHost: Codable, Sendable, Equatable {
         self.hostName = hostName
         self.user = user
         self.port = port
-    }
-}
-
-/// One entry from the Mac's recent-projects list, flattened for the phone's
-/// "reopen a project" menu: the folder name the row shows, and the absolute Mac
-/// path `.openProject` reopens. The phone never touches the path itself — it
-/// only echoes it back, the same contract as an SSH alias.
-public struct WireRecentProject: Codable, Sendable, Equatable {
-    public let name: String
-    public let path: String
-
-    public init(name: String, path: String) {
-        self.name = name
-        self.path = path
     }
 }
 

--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -35,6 +35,23 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     /// it for an agent-less start until the next roster push. nil from an
     /// older Mac; the client falls back to the agent it asked for.
     case started(sessionID: String, agent: String?)
+    /// The Terminals tab's ＋ → "New Terminal": open a plain login shell in the
+    /// Mac's loose `.terminals` funnel, the shell twin of the agent-less
+    /// `.start`. It carries no project because the funnel is found-or-created by
+    /// kind on the Mac (like ⌘T), so — unlike `.start` — the phone can seed the
+    /// very first terminal too. Answered with `.started` (agent `"terminal"`).
+    case startTerminal
+    /// The Terminals tab's ＋ → "New SSH": open a loose terminal that runs
+    /// `ssh <host>` instead of a local shell. `host` is a `~/.ssh/config` alias
+    /// (see `.sshConfigHosts`) or a bare `user@host`. Like `.startTerminal` it
+    /// gathers in the `.terminals` funnel and needs no project. Answered with
+    /// `.started`.
+    case startSSH(host: String)
+    /// The Projects tab's ＋: reopen a folder from the Mac's recent-projects
+    /// list (see `.recentProjects`) as a project. The phone is sandboxed and
+    /// can't browse the Mac's disk, so it can only reopen a path the Mac already
+    /// knows. No reply — the next roster push carries the new project row.
+    case openProject(path: String)
     /// The client asks the Mac to close a session (the phone's swipe-to-remove).
     /// No success reply — the next roster push drops the row everywhere.
     case stop(sessionID: String)
@@ -96,6 +113,15 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     /// Mac → phone: the parsed `~/.ssh/config` host blocks.
     case sshConfigList(hosts: [WireSSHHost])
 
+    /// Phone → Mac: list the Mac's recent projects (the last folders opened in
+    /// termio). The phone can't browse the Mac's disk, so this is how the
+    /// Projects tab's ＋ offers something to reopen. Answered with
+    /// `.recentProjectList`.
+    case recentProjects
+
+    /// Mac → phone: the Mac's recent-project entries, most-recent first.
+    case recentProjectList(projects: [WireRecentProject])
+
     case error(message: String)
 
     public func encoded() -> String {
@@ -115,6 +141,12 @@ public enum CompanionControl: Codable, Sendable, Equatable {
             var fields: [String: Any] = ["t": "started", "session": sessionID]
             if let agent { fields["agent"] = agent }
             return Self.json(fields)
+        case .startTerminal:
+            return #"{"t":"startTerminal"}"#
+        case .startSSH(let host):
+            return Self.json(["t": "startSSH", "host": host])
+        case .openProject(let path):
+            return Self.json(["t": "openProject", "path": path])
         case .stop(let sessionID):
             return #"{"t":"stop","session":"\#(sessionID)"}"#
         case .resize(let cols, let rows):
@@ -172,6 +204,13 @@ public enum CompanionControl: Codable, Sendable, Equatable {
                     ["alias": $0.alias, "hostName": $0.hostName, "user": $0.user, "port": $0.port]
                 },
             ])
+        case .recentProjects:
+            return #"{"t":"recentProjects"}"#
+        case .recentProjectList(let projects):
+            return Self.json([
+                "t": "recentProjectList",
+                "projects": projects.map { ["name": $0.name, "path": $0.path] },
+            ])
         case .error(let message):
             let escaped = message
                 .replacingOccurrences(of: "\\", with: "\\\\")
@@ -200,6 +239,14 @@ public enum CompanionControl: Codable, Sendable, Equatable {
         case "started":
             guard let sessionID = obj["session"] as? String else { return nil }
             return .started(sessionID: sessionID, agent: obj["agent"] as? String)
+        case "startTerminal":
+            return .startTerminal
+        case "startSSH":
+            guard let host = obj["host"] as? String else { return nil }
+            return .startSSH(host: host)
+        case "openProject":
+            guard let path = obj["path"] as? String else { return nil }
+            return .openProject(path: path)
         case "stop":
             guard let sessionID = obj["session"] as? String else { return nil }
             return .stop(sessionID: sessionID)
@@ -296,6 +343,16 @@ public enum CompanionControl: Codable, Sendable, Equatable {
                 )
             }
             return .sshConfigList(hosts: hosts)
+        case "recentProjects":
+            return .recentProjects
+        case "recentProjectList":
+            let raw = obj["projects"] as? [[String: Any]] ?? []
+            let projects = raw.compactMap { entry -> WireRecentProject? in
+                guard let name = entry["name"] as? String,
+                      let path = entry["path"] as? String else { return nil }
+                return WireRecentProject(name: name, path: path)
+            }
+            return .recentProjectList(projects: projects)
         case "error":
             guard let message = obj["message"] as? String else { return nil }
             return .error(message: message)
@@ -340,6 +397,20 @@ public struct WireSSHHost: Codable, Sendable, Equatable {
         self.hostName = hostName
         self.user = user
         self.port = port
+    }
+}
+
+/// One entry from the Mac's recent-projects list, flattened for the phone's
+/// "reopen a project" menu: the folder name the row shows, and the absolute Mac
+/// path `.openProject` reopens. The phone never touches the path itself — it
+/// only echoes it back, the same contract as an SSH alias.
+public struct WireRecentProject: Codable, Sendable, Equatable {
+    public let name: String
+    public let path: String
+
+    public init(name: String, path: String) {
+        self.name = name
+        self.path = path
     }
 }
 

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -286,12 +286,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             startSSHSession: { [weak store] host in
                 store?.companionStartSSHSession(host: host)
             },
-            openProject: { [weak store] path in
-                store?.companionOpenProject(path: path)
-            },
-            recentProjects: { [weak store] in
-                store?.companionRecentProjects() ?? []
-            },
             traceProvider: { [weak store] sessionID in
                 store?.companionTrace(for: sessionID)
             }

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -280,6 +280,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             stopSession: { [weak store] sessionID in
                 store?.companionStopSession(sessionID: sessionID) ?? false
             },
+            startScratchTerminal: { [weak store] in
+                store?.companionStartScratchTerminal()
+            },
+            startSSHSession: { [weak store] host in
+                store?.companionStartSSHSession(host: host)
+            },
+            openProject: { [weak store] path in
+                store?.companionOpenProject(path: path)
+            },
+            recentProjects: { [weak store] in
+                store?.companionRecentProjects() ?? []
+            },
             traceProvider: { [weak store] sessionID in
                 store?.companionTrace(for: sessionID)
             }

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -90,11 +90,6 @@ final class CompanionServer {
     /// Opens an `ssh <host>` terminal for the phone's Terminals ＋ → SSH
     /// (`.startSSH`); returns the `.started` echo, or nil on failure.
     private let startSSHSession: (String) -> (sessionID: String, agentID: String)?
-    /// Reopens a recent project by path for the phone's Projects ＋
-    /// (`.openProject`). Fire-and-forget: the roster poll announces the result.
-    private let openProject: (String) -> Void
-    /// The Mac's recent projects for the phone's Projects ＋ (`.recentProjects`).
-    private let recentProjects: () -> [WireRecentProject]
     /// Resolves a session's transcript path and display title for a `trace`
     /// request, or nil when the session has no readable transcript yet.
     private let traceProvider: (String) -> (path: String, title: String)?
@@ -123,8 +118,6 @@ final class CompanionServer {
         stopSession: @escaping (String) -> Bool,
         startScratchTerminal: @escaping () -> (sessionID: String, agentID: String)?,
         startSSHSession: @escaping (String) -> (sessionID: String, agentID: String)?,
-        openProject: @escaping (String) -> Void,
-        recentProjects: @escaping () -> [WireRecentProject],
         traceProvider: @escaping (String) -> (path: String, title: String)?
     ) {
         self.port = port
@@ -134,8 +127,6 @@ final class CompanionServer {
         self.stopSession = stopSession
         self.startScratchTerminal = startScratchTerminal
         self.startSSHSession = startSSHSession
-        self.openProject = openProject
-        self.recentProjects = recentProjects
         self.traceProvider = traceProvider
     }
 
@@ -352,12 +343,6 @@ final class CompanionServer {
             } else {
                 sendControl(.error(message: "could not open an SSH session"), to: connection)
             }
-        case .openProject(let path):
-            // Reopen a recent project; the roster poll carries the new row back —
-            // no direct reply, mirroring how a desktop Open-folder just appears.
-            openProject(path)
-        case .recentProjects:
-            sendControl(.recentProjectList(projects: recentProjects()), to: connection)
         case .stop(let sessionID):
             // Close on the Mac; the roster push drops the row on every phone.
             if !stopSession(sessionID) {
@@ -386,7 +371,7 @@ final class CompanionServer {
         case .sshConfigHosts:
             sendControl(.sshConfigList(hosts: Self.parseSSHConfigHosts()), to: connection)
         case .auth, .exit, .error, .started, .fileList, .file, .written, .uploaded,
-             .searchResults, .traceHTML, .sshConfigList, .recentProjectList:
+             .searchResults, .traceHTML, .sshConfigList:
             break
         }
     }
@@ -1040,24 +1025,6 @@ extension TermioStore {
         addSSHSession(host: host)
         guard let sessionID = selectedSessionID?.uuidString else { return nil }
         return (sessionID, AgentPreset.terminal.wireName)
-    }
-
-    /// Reopen `path` as a project for the phone's Projects-tab ＋ (`.openProject`)
-    /// — the same `addProject` the desktop's Open-folder picker feeds. The phone
-    /// only ever sends a path the Mac already handed it via `.recentProjectList`,
-    /// so there's nothing to browse or validate here beyond `addProject`'s own
-    /// dedupe. No reply: the roster poll carries the new project to every phone.
-    func companionOpenProject(path: String) {
-        let path = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !path.isEmpty else { return }
-        addProject(at: URL(fileURLWithPath: path))
-    }
-
-    /// The Mac's recent-projects list for the phone's Projects-tab ＋
-    /// (`.recentProjects`) — the last folders opened in termio, most-recent
-    /// first, flattened to name + path.
-    func companionRecentProjects() -> [WireRecentProject] {
-        settings.recentProjects.map { WireRecentProject(name: $0.name, path: $0.path) }
     }
 
     /// Close a session for a phone `stop` request — the same `closeSession`

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -83,6 +83,18 @@ final class CompanionServer {
     /// session before the next roster push), or nil when the start failed.
     private let startSession: (String, String?) -> (sessionID: String, agentID: String)?
     private let stopSession: (String) -> Bool
+    /// Opens a plain shell in the loose terminals funnel for the phone's
+    /// Terminals ＋ (`.startTerminal`); returns the `.started` echo, or nil on
+    /// failure. Project-less: the funnel is found-or-created on the Mac.
+    private let startScratchTerminal: () -> (sessionID: String, agentID: String)?
+    /// Opens an `ssh <host>` terminal for the phone's Terminals ＋ → SSH
+    /// (`.startSSH`); returns the `.started` echo, or nil on failure.
+    private let startSSHSession: (String) -> (sessionID: String, agentID: String)?
+    /// Reopens a recent project by path for the phone's Projects ＋
+    /// (`.openProject`). Fire-and-forget: the roster poll announces the result.
+    private let openProject: (String) -> Void
+    /// The Mac's recent projects for the phone's Projects ＋ (`.recentProjects`).
+    private let recentProjects: () -> [WireRecentProject]
     /// Resolves a session's transcript path and display title for a `trace`
     /// request, or nil when the session has no readable transcript yet.
     private let traceProvider: (String) -> (path: String, title: String)?
@@ -109,6 +121,10 @@ final class CompanionServer {
         ptyForSession: @escaping (String) -> PTYProcess?,
         startSession: @escaping (String, String?) -> (sessionID: String, agentID: String)?,
         stopSession: @escaping (String) -> Bool,
+        startScratchTerminal: @escaping () -> (sessionID: String, agentID: String)?,
+        startSSHSession: @escaping (String) -> (sessionID: String, agentID: String)?,
+        openProject: @escaping (String) -> Void,
+        recentProjects: @escaping () -> [WireRecentProject],
         traceProvider: @escaping (String) -> (path: String, title: String)?
     ) {
         self.port = port
@@ -116,6 +132,10 @@ final class CompanionServer {
         self.ptyForSession = ptyForSession
         self.startSession = startSession
         self.stopSession = stopSession
+        self.startScratchTerminal = startScratchTerminal
+        self.startSSHSession = startSSHSession
+        self.openProject = openProject
+        self.recentProjects = recentProjects
         self.traceProvider = traceProvider
     }
 
@@ -311,6 +331,33 @@ final class CompanionServer {
             } else {
                 sendControl(.error(message: "could not start a session there"), to: connection)
             }
+        case .startTerminal:
+            // "New Terminal": a plain shell in the loose terminals funnel, seeded
+            // on the Mac even if the phone has never seen one there yet.
+            if let started = startScratchTerminal() {
+                sendControl(
+                    .started(sessionID: started.sessionID, agent: started.agentID),
+                    to: connection
+                )
+            } else {
+                sendControl(.error(message: "could not open a terminal"), to: connection)
+            }
+        case .startSSH(let host):
+            // "New SSH": a terminal running `ssh <host>` in that same funnel.
+            if let started = startSSHSession(host) {
+                sendControl(
+                    .started(sessionID: started.sessionID, agent: started.agentID),
+                    to: connection
+                )
+            } else {
+                sendControl(.error(message: "could not open an SSH session"), to: connection)
+            }
+        case .openProject(let path):
+            // Reopen a recent project; the roster poll carries the new row back —
+            // no direct reply, mirroring how a desktop Open-folder just appears.
+            openProject(path)
+        case .recentProjects:
+            sendControl(.recentProjectList(projects: recentProjects()), to: connection)
         case .stop(let sessionID):
             // Close on the Mac; the roster push drops the row on every phone.
             if !stopSession(sessionID) {
@@ -339,7 +386,7 @@ final class CompanionServer {
         case .sshConfigHosts:
             sendControl(.sshConfigList(hosts: Self.parseSSHConfigHosts()), to: connection)
         case .auth, .exit, .error, .started, .fileList, .file, .written, .uploaded,
-             .searchResults, .traceHTML, .sshConfigList:
+             .searchResults, .traceHTML, .sshConfigList, .recentProjectList:
             break
         }
     }
@@ -970,6 +1017,47 @@ extension TermioStore {
         addSession(to: project.id, agent: preset)
         guard let sessionID = selectedSessionID?.uuidString else { return nil }
         return (sessionID, preset.wireName)
+    }
+
+    /// Open a plain login shell in the loose `.terminals` funnel for the phone's
+    /// Terminals-tab ＋ → "New Terminal" (`.startTerminal`). Unlike `.start` this
+    /// carries no project: `addScratchSession` finds-or-creates the funnel by
+    /// kind, so the phone can seed the very first terminal too. Returns the new
+    /// session's wire id and the `"terminal"` echo.
+    func companionStartScratchTerminal() -> (sessionID: String, agentID: String)? {
+        addScratchSession(agent: .terminal)
+        guard let sessionID = selectedSessionID?.uuidString else { return nil }
+        return (sessionID, AgentPreset.terminal.wireName)
+    }
+
+    /// Open an SSH terminal to `host` for the phone's Terminals-tab ＋ → "New
+    /// SSH" (`.startSSH`) — the same `addSSHSession` the desktop's SSH picker
+    /// uses. It lands in the `.terminals` funnel too, so it needs no project.
+    /// Returns the new session's wire id and the `"terminal"` echo.
+    func companionStartSSHSession(host: String) -> (sessionID: String, agentID: String)? {
+        let host = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !host.isEmpty else { return nil }
+        addSSHSession(host: host)
+        guard let sessionID = selectedSessionID?.uuidString else { return nil }
+        return (sessionID, AgentPreset.terminal.wireName)
+    }
+
+    /// Reopen `path` as a project for the phone's Projects-tab ＋ (`.openProject`)
+    /// — the same `addProject` the desktop's Open-folder picker feeds. The phone
+    /// only ever sends a path the Mac already handed it via `.recentProjectList`,
+    /// so there's nothing to browse or validate here beyond `addProject`'s own
+    /// dedupe. No reply: the roster poll carries the new project to every phone.
+    func companionOpenProject(path: String) {
+        let path = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else { return }
+        addProject(at: URL(fileURLWithPath: path))
+    }
+
+    /// The Mac's recent-projects list for the phone's Projects-tab ＋
+    /// (`.recentProjects`) — the last folders opened in termio, most-recent
+    /// first, flattened to name + path.
+    func companionRecentProjects() -> [WireRecentProject] {
+        settings.recentProjects.map { WireRecentProject(name: $0.name, path: $0.path) }
     }
 
     /// Close a session for a phone `stop` request — the same `closeSession`

--- a/ios/Sources/ChatListViewController.swift
+++ b/ios/Sources/ChatListViewController.swift
@@ -76,20 +76,15 @@ final class ChatListViewController: UIViewController {
     }
 
     /// ＋ floats bottom-right, opposite the home tab pill — the compose corner.
-    /// A TAP is one New Chat, no questions asked: the Mac resolves the agent
-    /// through its ⌘N default policy (`startDefaultChat`), so composing costs
-    /// zero choices. The per-agent menu survives on LONG-PRESS as the
-    /// pick-a-specific-agent escape hatch — `menu` stays set, it's just no
-    /// longer the primary action. Deferred so it always reflects the roster's
-    /// current agent list (and the button hides while unpaired).
+    /// A TAP presents the agent picker directly: choosing which agent to start
+    /// IS the primary action, not a default hidden behind a long-press. Deferred
+    /// so it always reflects the roster's current enabled agents (and the button
+    /// hides while unpaired).
     private func configureNewChatButton() {
         newChatButton.applyGlassIcon(.add, boxSize: 26)
         newChatButton.tintColor = .label
         newChatButton.accessibilityLabel = "New Chat"
-        newChatButton.addAction(
-            UIAction { [weak self] _ in self?.store.startDefaultChat() },
-            for: .touchUpInside
-        )
+        newChatButton.showsMenuAsPrimaryAction = true
         newChatButton.menu = UIMenu(children: [
             UIDeferredMenuElement.uncached { [weak self] completion in
                 guard let self, let chatsProject = store.chatsProject else {

--- a/ios/Sources/CompanionClient.swift
+++ b/ios/Sources/CompanionClient.swift
@@ -45,6 +45,10 @@ final class CompanionClient: NSObject {
     var onSearchResults: ((String, [String], Bool) -> Void)?
     /// The server rejected a request (e.g. a failed `start`).
     var onError: ((String) -> Void)?
+    /// The Mac's parsed `~/.ssh/config` host blocks, answering a
+    /// `.sshConfigHosts` request — the read-only menu the Terminals ＋ → New SSH
+    /// picks from (the phone never authors a host, only chooses a known alias).
+    var onSSHConfig: (([WireSSHHost]) -> Void)?
 
     /// Controls sent before the socket is open wait here — auth must ride
     /// the wire first on every connect, so a `.upload` fired right after
@@ -194,6 +198,7 @@ final class CompanionClient: NSObject {
                         case .searchResults(let query, let paths, let truncated):
                             onSearchResults?(query, paths, truncated)
                         case .error(let reason): onError?(reason)
+                        case .sshConfigList(let hosts): onSSHConfig?(hosts)
                         default: break
                         }
                     }

--- a/ios/Sources/Models.swift
+++ b/ios/Sources/Models.swift
@@ -56,6 +56,11 @@ struct MockProject: Identifiable {
     var kind: String?
     let sessions: [MockSession]
 
+    /// A stand-in for the Mac's loose-terminals container before it has opened
+    /// one, so a phone-seeded first terminal can open attached right away; the
+    /// next roster push swaps in the real container.
+    static let terminalsPlaceholder = MockProject(name: "Terminals", path: "", sessions: [])
+
     /// Projects keep their order; within a project, attention floats up.
     static let samples: [MockProject] = {
         var order: [String] = []

--- a/ios/Sources/ProjectListViewController.swift
+++ b/ios/Sources/ProjectListViewController.swift
@@ -27,7 +27,6 @@ final class ProjectListViewController: UIViewController {
     private var sortByName = UserDefaults.standard.string(forKey: "sessions.sortOrder") == "name"
 
     private let filterButton = UIButton(type: .system)
-    private let newSessionButton = UIButton(type: .system)
     private let tableView = UITableView(frame: .zero, style: .grouped)
     /// The Telegram/iMessage-style zero state shown when there are no projects
     /// to list — never fake rows. Its copy tracks `CompanionLink.state`.
@@ -54,8 +53,6 @@ final class ProjectListViewController: UIViewController {
         let topBar = configureTopBar()
         configureTable(below: topBar)
         configureEmptyState(below: topBar)
-        // Added last so it floats over the list, opposite the home tab pill.
-        configureNewSessionButton()
         refilter()
         rosterObserver = NotificationCenter.default.addObserver(
             forName: RosterStore.didChange, object: nil, queue: .main
@@ -141,42 +138,6 @@ final class ProjectListViewController: UIViewController {
         refilter()
     }
 
-    // MARK: - New-session button (the floating ＋)
-
-    /// ＋ floats bottom-right like Slack's compose button — the same corner as
-    /// the Chats tab's ＋, so "start something new" always lives in one place.
-    /// A project must be picked first, so the menu is one submenu per project
-    /// with the agents inside (the long-press menu, made discoverable);
-    /// deferred so it always reflects the live roster, hidden while unpaired.
-    private func configureNewSessionButton() {
-        newSessionButton.applyGlassIcon(.add, boxSize: 26)
-        newSessionButton.tintColor = .label
-        newSessionButton.accessibilityLabel = "New Session"
-        newSessionButton.showsMenuAsPrimaryAction = true
-        newSessionButton.menu = UIMenu(children: [
-            UIDeferredMenuElement.uncached { [weak self] completion in
-                guard let self else { return completion([]) }
-                completion(visible.filter { $0.rosterID != nil }.map { project in
-                    UIMenu(
-                        title: project.name,
-                        image: UIImage(systemName: "folder"),
-                        children: self.store.newSessionActions(in: project)
-                    )
-                })
-            },
-        ])
-        newSessionButton.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(newSessionButton)
-        NSLayoutConstraint.activate([
-            newSessionButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
-            // The tab pill's own scale (64pt, 8pt above the safe area), so the
-            // two ends of the bottom edge read as one balanced bar.
-            newSessionButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8),
-            newSessionButton.widthAnchor.constraint(equalToConstant: 64),
-            newSessionButton.heightAnchor.constraint(equalToConstant: 64),
-        ])
-    }
-
     private func presentSettings() {
         // The sheet inherits the window's app-wide Appearance override, same
         // as every other screen.
@@ -231,8 +192,6 @@ final class ProjectListViewController: UIViewController {
             : store.projects
         visible = ordered.filter { $0.kind != "chats" && $0.kind != "terminals" }
         sections = (attention.isEmpty ? [] : [.needsYou]) + [.projects]
-        newSessionButton.isHidden = store.companionURL == nil
-            || !visible.contains { $0.rosterID != nil }
         tableView.reloadData()
         updateEmptyState()
     }

--- a/ios/Sources/RosterStore.swift
+++ b/ios/Sources/RosterStore.swift
@@ -138,17 +138,6 @@ final class RosterStore {
         client?.send(.start(projectID: projectID, agent: agent.id))
     }
 
-    /// The Chats tab's one-tap ＋: start a chat with no agent named, so the
-    /// Mac resolves its default (pinned → last used → first enabled — the
-    /// exact ⌘N policy, which also keeps updating "last used"). The phone
-    /// deliberately owns none of that policy; the per-agent menu behind
-    /// long-press stays the escape hatch for picking a specific one.
-    func startDefaultChat() {
-        guard let project = chatsProject, let projectID = project.rosterID else { return }
-        pendingStart = (project, nil)
-        client?.send(.start(projectID: projectID, agent: nil))
-    }
-
     /// The Terminals tab's ＋: open a plain login shell at `~` in the loose
     /// `.terminals` funnel. The wire agent token `"terminal"` maps to the Mac's
     /// The Terminals tab's ＋ → "New Terminal": a plain login shell in the Mac's

--- a/ios/Sources/RosterStore.swift
+++ b/ios/Sources/RosterStore.swift
@@ -21,6 +21,12 @@ final class RosterStore {
     /// roster. New-session menus mirror this so the phone never offers an
     /// agent the desktop has turned off.
     private(set) var enabledAgents: [RosterAgent] = []
+    /// The Mac's `~/.ssh/config` host aliases, requested on connect. The
+    /// Terminals ＋ → New SSH menu is a read-only pick from these — the phone
+    /// never types a host, it only chooses one the Mac already knows (the SSH
+    /// twin of Projects ＋ reopening a known folder). Empty until the Mac
+    /// answers, or when the config has no hosts.
+    private(set) var sshHosts: [WireSSHHost] = []
     private(set) var companionURL: URL?
     /// `MockSession.key` of the session filling the screen — its row gets the
     /// current-chat pill wherever session rows render.
@@ -145,13 +151,25 @@ final class RosterStore {
 
     /// The Terminals tab's ＋: open a plain login shell at `~` in the loose
     /// `.terminals` funnel. The wire agent token `"terminal"` maps to the Mac's
-    /// `.terminal` preset (an unknown token also falls back to it), so the Mac
-    /// starts a shell — not the default chat agent an agent-less start would.
-    /// Needs an existing terminals container to land in; the ＋ hides until then.
-    func startDefaultTerminal() {
-        guard let project = terminalsProject, let projectID = project.rosterID else { return }
-        pendingStart = (project, nil)
-        client?.send(.start(projectID: projectID, agent: "terminal"))
+    /// The Terminals tab's ＋ → "New Terminal": a plain login shell in the Mac's
+    /// loose `.terminals` funnel. Project-less on the wire (`.startTerminal`), so
+    /// — unlike the old `.start` path — it can seed the very first terminal too,
+    /// no container need pre-exist. Opens attached on the `.started` echo, so a
+    /// placeholder stands in until the roster push carries the real container.
+    func startNewTerminal() {
+        pendingStart = (terminalsProject ?? .terminalsPlaceholder, nil)
+        client?.send(.startTerminal)
+    }
+
+    /// The Terminals tab's ＋ → "New SSH": an `ssh <host>` terminal in that same
+    /// funnel. `host` is always a `~/.ssh/config` alias the Mac handed us (see
+    /// `sshHosts`) — the phone only picks a host the Mac already knows, it never
+    /// authors one. Lands project-less like New Terminal.
+    func startSSH(host: String) {
+        let host = host.trimmingCharacters(in: .whitespaces)
+        guard !host.isEmpty else { return }
+        pendingStart = (terminalsProject ?? .terminalsPlaceholder, nil)
+        client?.send(.startSSH(host: host))
     }
 
     /// Close on the Mac; the next roster push drops the row everywhere.
@@ -189,8 +207,16 @@ final class RosterStore {
         companionURL = url
         CompanionLink.state = .connecting
         let client = CompanionClient(url: url)
-        client.onConnected = { connected in
+        client.onConnected = { [weak self] connected in
             CompanionLink.state = connected ? .connected : .connecting
+            // Refresh the SSH host list on every (re)connect so New SSH reflects
+            // the Mac's current ~/.ssh/config without a manual pull.
+            if connected { self?.client?.send(.sshConfigHosts) }
+        }
+        client.onSSHConfig = { [weak self] hosts in
+            guard let self else { return }
+            sshHosts = hosts
+            NotificationCenter.default.post(name: Self.didChange, object: nil)
         }
         client.onRoster = { [weak self] roster in
             guard let self else { return }
@@ -235,6 +261,7 @@ final class RosterStore {
         CompanionLink.state = .unpaired
         projects = []
         enabledAgents = []
+        sshHosts = []
         NotificationCenter.default.post(name: Self.didChange, object: nil)
     }
 

--- a/ios/Sources/TerminalListViewController.swift
+++ b/ios/Sources/TerminalListViewController.swift
@@ -78,18 +78,26 @@ final class TerminalListViewController: UIViewController {
     }
 
     /// ＋ floats bottom-right, opposite the home tab pill — the compose corner.
-    /// A TAP is one new terminal: a plain login shell at `~`, which the Mac
-    /// gathers into the loose `.terminals` funnel. There is no agent to choose,
-    /// so — unlike the Chats ＋ — no long-press menu. Hidden until the Mac has a
-    /// terminals container to land in (mirrors the Chats ＋), and while unpaired.
+    /// A TAP presents the menu the issue asks for: New Terminal (a plain login
+    /// shell the Mac gathers into the loose `.terminals` funnel) and New SSH (an
+    /// `ssh <host>` terminal). New SSH is a read-only pick from the Mac's
+    /// `~/.ssh/config` aliases — the phone never types a host — so it's deferred
+    /// to always reflect the Mac's current config. Shown whenever paired: New
+    /// Terminal is project-less now, so it can seed the first terminal too.
     private func configureNewTerminalButton() {
         newTerminalButton.applyGlassIcon(.add, boxSize: 26)
         newTerminalButton.tintColor = .label
         newTerminalButton.accessibilityLabel = "New Terminal"
-        newTerminalButton.addAction(
-            UIAction { [weak self] _ in self?.store.startDefaultTerminal() },
-            for: .touchUpInside
-        )
+        newTerminalButton.showsMenuAsPrimaryAction = true
+        newTerminalButton.menu = UIMenu(children: [
+            UIAction(
+                title: "New Terminal",
+                image: UIImage(systemName: "terminal")
+            ) { [weak self] _ in self?.store.startNewTerminal() },
+            UIDeferredMenuElement.uncached { [weak self] completion in
+                completion([self?.sshMenu() ?? UIMenu()])
+            },
+        ])
         newTerminalButton.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(newTerminalButton)
         NSLayoutConstraint.activate([
@@ -100,6 +108,27 @@ final class TerminalListViewController: UIViewController {
             newTerminalButton.widthAnchor.constraint(equalToConstant: 64),
             newTerminalButton.heightAnchor.constraint(equalToConstant: 64),
         ])
+    }
+
+    /// The "New SSH" submenu: one entry per `~/.ssh/config` host the Mac knows.
+    /// Read-only by design — the phone chooses a known alias, it never authors a
+    /// host. An empty config shows a disabled hint pointing back to the Mac, so
+    /// the item never dead-ends on a tap.
+    private func sshMenu() -> UIMenu {
+        let icon = UIImage(systemName: "network")
+        let hosts = store.sshHosts
+        guard !hosts.isEmpty else {
+            let hint = UIAction(title: "Add hosts in ~/.ssh/config on your Mac") { _ in }
+            hint.attributes = .disabled
+            return UIMenu(title: "New SSH", image: icon, children: [hint])
+        }
+        let items = hosts.map { host in
+            UIAction(
+                title: host.alias,
+                subtitle: host.user.isEmpty ? host.hostName : "\(host.user)@\(host.hostName)"
+            ) { [weak self] _ in self?.store.startSSH(host: host.alias) }
+        }
+        return UIMenu(title: "New SSH", image: icon, children: items)
     }
 
     // MARK: - Table
@@ -130,7 +159,9 @@ final class TerminalListViewController: UIViewController {
 
     private func refilter() {
         terminals = store.terminalSessions
-        newTerminalButton.isHidden = store.terminalsProject?.rosterID == nil
+        // Shown whenever paired: New Terminal is project-less, so it no longer
+        // needs an existing terminals container to land in (it seeds the first).
+        newTerminalButton.isHidden = store.companionURL == nil
         tableView.reloadData()
         updateEmptyState()
     }
@@ -150,13 +181,13 @@ final class TerminalListViewController: UIViewController {
     }
 
     /// Link-state nuance lives on the Projects tab (the pairing home); this
-    /// zero state only answers "no terminals yet". When the ＋ is visible it is
-    /// the next step; when it's hidden (no container yet) the message points at
-    /// the Mac, since the phone can't seed the first one over the wire.
+    /// zero state only answers "no terminals yet". Whenever paired the ＋ can
+    /// seed the first terminal, so it's the next step; only while unpaired (＋
+    /// hidden) does the message fall back to pointing at the Mac.
     private func updateEmptyState() {
         emptyState.isHidden = !terminals.isEmpty
         guard !emptyState.isHidden else { return }
-        let canStart = store.terminalsProject?.rosterID != nil
+        let canStart = store.companionURL != nil
         emptyState.configure(
             icon: .terminal,
             title: "No terminals yet",


### PR DESCRIPTION
Closes #145 — reworks the iOS bottom **＋** so each tab's primary tap matches what a user expects to *add* there. The theme throughout: **the phone is a read-only control surface** — it picks from Mac-owned state, it never authors it.

## Terminals ＋ → menu {New Terminal, New SSH}

A tap opens a menu instead of just starting a plain shell:

- **New Terminal** → project-less `.startTerminal`: the Mac opens a shell in its loose `.terminals` funnel. It no longer needs a pre-existing container, so the phone can **seed the very first terminal** — the ＋ shows whenever paired.
- **New SSH** → a **read-only pick** from the Mac's `~/.ssh/config` aliases (`.sshConfigHosts` → `.sshConfigList`). The phone **never types a host**, only chooses one the Mac already knows. Empty config → a disabled hint pointing back to the Mac.

## Chats ＋ → direct agent picker

The tap now opens the per-agent menu directly — **choosing the agent is the primary action**, not a default start with the picker hidden behind a long-press. Same Mac-driven `newSessionActions` list, so no wire change. The now-unused `startDefaultChat` is removed.

## Projects ＋ → removed

The old Projects-root ＋ started a session (pick project → agent), which the phone already offers by **tapping a project row** (→ detail) or **long-pressing** it (→ agent menu). Projects are Mac-owned folders you open on the Mac, so there's no "add project" that fits a read-only phone — so the ＋ is **removed** rather than repurposed. (Session-starting is unaffected: row tap and long-press both remain.)

## Design notes

- **No capability negotiation.** Additive-only wire: an old iOS never sends the new messages and ignores new fields; a new-iOS/old-Mac skew isn't a concern (the Mac auto-updates). Matches the existing "nil from an older Mac → fall back" house style.
- **Read-only mobile.** New SSH picks from Mac state rather than authoring; Projects has no authoring at all. The reopen-recent-project idea (and its `.openProject` / `.recentProjects` / `.recentProjectList` plumbing) was considered and dropped as unnecessary — reverted in the last commit so no dead wire ships.

## Verification

- `swift build` (Mac target) — ✅
- `xcodebuild` TermioMobile (iOS Simulator) — ✅ (all three commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)