### PR TITLE
fix(hooks): survive another tool overwriting the shared agent-hook config

### DIFF
--- a/Sources/termio/Agents/HookListener.swift
+++ b/Sources/termio/Agents/HookListener.swift
@@ -205,6 +205,16 @@ enum AgentStatusHooks {
     /// or the legacy `marker`, so upgrades cleanly replace old hooks with new ones.
     static let cliMarker = "agent report"
 
+    /// Fingerprints of third-party status hooks that full-replace the shared `hooks`
+    /// block (Claude's `settings.json`, Codex's `hooks.json`) instead of merging, wiping
+    /// termio's entries. We strip these on install so a destructive writer can't out-merge
+    /// us. Each substring is specific to one tool's command, so a user's own hook is never
+    /// matched — extend only with equally specific fingerprints.
+    static let conflictingHookMarkers = [
+        "SUPERSET_HOME_DIR",
+        "SUPERSET_AGENT_ID",
+    ]
+
     /// Re-applies every agent's integration (or removes them all) to match `enabled`.
     static func sync(enabled: Bool) {
         // Every hook references the channel-stable CLI copy, so make sure it carries
@@ -287,7 +297,29 @@ enum AgentStatusHooks {
         } else {
             command += " 2>/dev/null || true"
         }
+        // Stamp the build version as a trailing shell comment (ignored at runtime): the
+        // command string changes each release, so the idempotent `write()` re-installs the
+        // hook on the first launch after an upgrade, and `installedVersion` can read it back.
+        command += " \(hookVersionComment)"
         return command
+    }
+
+    /// Marker + version stamped into every installed hook (`# termio-hooks v0.21.0`);
+    /// the marker is the anchor `installedVersion` scans for.
+    static let hookVersionMarker = "# termio-hooks v"
+    static var appVersion: String {
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "0"
+    }
+    static var hookVersionComment: String { "\(hookVersionMarker)\(appVersion)" }
+
+    /// The termio-hooks version stamped in a host hooks file, or `nil` if none is present —
+    /// so a caller can tell current from stale from not-installed.
+    static func installedVersion(inFileAt url: URL) -> String? {
+        guard let text = try? String(contentsOf: url, encoding: .utf8),
+              let range = text.range(of: hookVersionMarker) else { return nil }
+        let tail = text[range.upperBound...]
+        let version = tail.prefix { !$0.isWhitespace && $0 != "\"" && $0 != "\\" }
+        return version.isEmpty ? nil : String(version)
     }
 
     /// Absolute path to this channel's stable `termio`/`termio-dev` CLI copy under
@@ -412,6 +444,9 @@ private struct JSONHookFile: AgentStatusInstaller {
         // ones we're about to re-add — so an event we no longer manage (e.g. a
         // mapping we dropped between versions) doesn't leave an orphan behind.
         stripTermioEntries(from: &hooks)
+        // Then drop known conflicting third-party hooks that full-replace the block, so
+        // the next destructive writer can't win again — this makes our install authoritative.
+        stripConflictingEntries(from: &hooks)
         for event in events {
             var groups = hooks[event.name] as? [[String: Any]] ?? []
             let command = AgentStatusHooks.reportCommand(
@@ -481,6 +516,27 @@ private struct JSONHookFile: AgentStatusInstaller {
                 hooks[key] = groups
             }
         }
+    }
+
+    private func stripConflictingEntries(from hooks: inout [String: Any]) {
+        for key in Array(hooks.keys) {
+            guard var groups = hooks[key] as? [[String: Any]] else { continue }
+            groups.removeAll { isConflictingGroup($0) }
+            if groups.isEmpty {
+                hooks.removeValue(forKey: key)
+            } else {
+                hooks[key] = groups
+            }
+        }
+    }
+
+    private func isConflictingGroup(_ group: [String: Any]) -> Bool {
+        func isTheirs(_ command: String) -> Bool {
+            AgentStatusHooks.conflictingHookMarkers.contains { command.contains($0) }
+        }
+        if let command = group["command"] as? String { return isTheirs(command) }
+        guard let hooks = group["hooks"] as? [[String: Any]] else { return false }
+        return hooks.contains { ($0["command"] as? String).map(isTheirs) == true }
     }
 
     private func isTermioGroup(_ group: [String: Any]) -> Bool {

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -159,6 +159,13 @@ struct SidebarView: View {
         let hasTerminals = terminals.contains { !$0.sessions.isEmpty }
         let hasChats = chats.contains { !$0.sessions.isEmpty }
         return List {
+            // Nudge when agents are running but the status hooks are off — without them
+            // the sidebar spinner stays dark. One tap enables (and reinstalls) them.
+            if !settings.agentHooksEnabled && store.isRunningAnyAgent {
+                AgentHooksOffBanner { settings.agentHooksEnabled = true }
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+            }
             // The top "Pinned" working set, under its own section header: pinned projects
             // as full blocks, then pinned worktrees as mini-blocks (header + their
             // sessions), then pinned sessions as shortcut rows — each nested entry tagged
@@ -1228,4 +1235,35 @@ extension Color {
     static let sidebarWorkingInk = Color(nsColor: NSColor(name: nil) { appearance in
         appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? .white : .black
     })
+}
+
+/// Sidebar nudge shown when agents run with the status hooks disabled. Low-alarm by
+/// design — a neutral card, not an accent banner. "Enable" turns the hooks back on.
+private struct AgentHooksOffBanner: View {
+    let enable: () -> Void
+
+    var body: some View {
+        HStack(spacing: 9) {
+            Image(systemName: "dot.radiowaves.left.and.right")
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Live agent status is off")
+                    .font(.callout.weight(.medium))
+                Text("Agents won't show as working.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 4)
+            Button("Enable", action: enable)
+                .buttonStyle(.borderless)
+                .font(.callout.weight(.medium))
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(0.06))
+        )
+        .padding(.vertical, 4)
+    }
 }

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -33,6 +33,14 @@ extension TermioStore {
         }
     }
 
+    /// Whether any session is an agent (declared or detected via `effectiveAgent`). Gates
+    /// the "status is off" reminder — a shell-only workspace has nothing to report.
+    var isRunningAnyAgent: Bool {
+        projects.contains { project in
+            project.sessions.contains { effectiveAgent(for: $0) != .terminal }
+        }
+    }
+
     /// Re-aligns the installed hooks when, and only when, the hooks setting itself
     /// changed. Called from the shared settings observer, which fires for every
     /// preference, so the guard keeps unrelated changes from rewriting the file.

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -602,7 +602,15 @@ final class TermioStore: ObservableObject {
             self?.scheduleWorktreeReconcile(for: folder)
         }
         appActiveObserver = NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
-            .sink { [weak self] _ in self?.scheduleWorktreeReconcile() }
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.scheduleWorktreeReconcile()
+                // Re-assert agent hooks on refocus: a third-party tool can overwrite the
+                // shared hooks file while termio is backgrounded, wiping ours. Re-installing
+                // restores them (and drops the conflicting entries); skipped when the file
+                // is already byte-identical.
+                if self.settings.agentHooksEnabled { AgentStatusHooks.sync(enabled: true) }
+            }
         reconcileWorktrees()
 
         startHookMonitoring()


### PR DESCRIPTION
## Problem

A user's Claude Code sidebar title stopped updating after `/new`. Root cause: **Superset had overwritten termio's hooks in `~/.claude/settings.json`**.

Superset (and tools like it) install into the same shared host hook files by **full-replacing** the `hooks` block, silently deleting termio's `agent report` entries. termio's installer is "conservative by construction" — it merges and preserves others' hooks — so it always loses the file to a destructive writer. With no hooks installed, termio receives **zero** status/rotation reports:

- the sidebar working/idle state goes stale, and
- the `SessionStart`→`idle` signal that termio uses to detect an in-process `/new` never arrives, so `adoptConversationID` never clears the discarded conversation's topic title.

(Titles still update in general because those ride the OSC title stream, not hooks — only the `/new` *clear* was dead.) Verified by tracing: `REPORT: 0`, `ROTATE: 0`, titles flowing normally; and `~/.claude/settings.json` held 0 termio / 8 Superset entries while the release app had hooks enabled.

## Fix

- **Evict conflicting hooks on install** — `HookListener.install()` now strips known conflicting third-party status hooks (`conflictingHookMarkers`, e.g. `SUPERSET_HOME_DIR`) alongside our own stale entries, so termio's (re)install is authoritative. Fingerprints are specific to each tool's own command so a hand-written user hook is never matched.
- **Re-assert on refocus** — `TermioStore` re-runs the hook sync when the app returns to the foreground, so the fix survives the other tool's relaunch instead of only holding until termio's next start.
- **Version stamp + self-heal** — each hook command carries `# termio-hooks v<version>`; the command changes every release so the idempotent write re-installs on the first launch after an upgrade, and `installedVersion(inFileAt:)` can read it back to distinguish a current install from a stale one.
- **"Live agent status is off" reminder** — a neutral (non-accent) sidebar card with a one-tap **Enable**, shown only when agents are actually running with the hooks disabled.

## Verification

`~/.claude/settings.json` went `0 termio / 8 Superset` → `6 termio / 0 Superset`, with `# termio-hooks v<version>` stamped on every entry, on both launch and refocus.

## Not included / follow-up

- The Codex **stuck-spinner** half of the same clobber issue (promotion-set `working` has no non-hook exit) is still open — separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)