### PR TITLE
feat(inspector): resizable list column + flat tab pill

### DIFF
--- a/Sources/termio/FileBrowser/InspectorDetailHost.swift
+++ b/Sources/termio/FileBrowser/InspectorDetailHost.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 /// The right inspector's content: its list (file tree / search / changes / issues) beside any open
 /// detail — a file editor or preview, a git diff, a PR/issue, or an agent trace. Every one of these
@@ -15,10 +16,20 @@ struct InspectorRoot: View {
 
     /// The leading list column's width once the detail sits beside it — a comfortable browse strip
     /// (Mail's message-list / VS Code's explorer proportions), not so wide it starves the detail.
-    private static let listColumnWidth: CGFloat = 240
+    /// Persisted, so the drag-to-resize width survives relaunch, and shared across inspector panes.
+    @AppStorage("inspectorListColumnWidth") private var listColumnWidth: Double = 240
+
+    /// The default browse width a double-click on the divider snaps back to.
+    private static let defaultListWidth: CGFloat = 240
+    /// Drag bounds for the list column: wide enough to read a path, never so wide the detail starves.
+    private static let minListWidth: CGFloat = 180
+    private static let maxListWidth: CGFloat = 460
     /// Below this the list ‖ detail split leaves the detail too narrow, so the detail takes the whole
     /// panel and the list hides until the inspector is widened (or a tab switch brings it back).
     private static let twoColumnMinWidth: CGFloat = 600
+    /// The named space the resize drag reads its pointer x in — the list column's leading edge is its
+    /// origin, so the pointer's x *is* the target column width.
+    private static let dragSpace = "inspectorList"
 
     var body: some View {
         GeometryReader { geo in
@@ -28,11 +39,18 @@ struct InspectorRoot: View {
             // List hides only in the narrow, detail-only fallback; otherwise it's the full panel
             // (no detail) or the leading column (two-column).
             let showList = !showDetail || twoColumn
+            // Never let the column eat the detail on a narrow inspector: cap it to leave the detail at
+            // least a readable strip, then clamp the persisted width into the drag bounds.
+            let maxAllowed = max(Self.minListWidth, min(Self.maxListWidth, geo.size.width - 260))
+            let width = max(Self.minListWidth, min(CGFloat(listColumnWidth), maxAllowed))
             HStack(spacing: 0) {
                 if showList {
-                    list
-                        .frame(maxWidth: twoColumn ? Self.listColumnWidth : .infinity)
-                    if twoColumn { Divider() }
+                    if twoColumn {
+                        list.frame(width: width)
+                        columnDivider(maxAllowed: maxAllowed)
+                    } else {
+                        list.frame(maxWidth: .infinity)
+                    }
                 }
                 if showDetail {
                     InspectorDetailContent()
@@ -41,9 +59,32 @@ struct InspectorRoot: View {
                 }
             }
             .frame(width: geo.size.width, height: geo.size.height)
+            .coordinateSpace(.named(Self.dragSpace))
             .animation(.easeOut(duration: 0.12), value: showDetail)
             .animation(.easeOut(duration: 0.12), value: twoColumn)
         }
+    }
+
+    /// The draggable seam between the list and the detail. A hairline `Divider` under a wider,
+    /// invisible grab strip: the pointer flips to the resize cursor on hover, the drag retunes the
+    /// column width (clamped so neither side starves), and a double-click snaps back to the default.
+    private func columnDivider(maxAllowed: CGFloat) -> some View {
+        Divider()
+            .overlay {
+                Color.clear
+                    .frame(width: 10)
+                    .contentShape(Rectangle())
+                    .onHover { inside in
+                        if inside { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
+                    }
+                    .gesture(
+                        DragGesture(coordinateSpace: .named(Self.dragSpace))
+                            .onChanged { value in
+                                listColumnWidth = Double(max(Self.minListWidth, min(value.location.x, maxAllowed)))
+                            }
+                    )
+                    .onTapGesture(count: 2) { listColumnWidth = Double(Self.defaultListWidth) }
+            }
     }
 }
 

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -129,34 +129,19 @@ struct InspectorTabsToolbar: View {
         .animation(.snappy(duration: 0.28), value: store.inspectorTab)
     }
 
-    // MARK: Materials — Liquid Glass on macOS 26, flat fills below
+    // MARK: Materials — flat capsule fills, no Liquid Glass
 
-    @ViewBuilder
+    // A flat fill, no `.glassEffect` and no drop shadow: the glass pill cast an ambient shadow that
+    // read as stray chrome floating in the toolbar. The brighter fill alone (over the fainter track)
+    // marks the active pane. Built the same way as the file editor's mode toggle, so the two match.
     private var selectionPill: some View {
-        if #available(macOS 26.0, *) {
-            Capsule()
-                .fill(.clear)
-                .glassEffect(.regular.interactive(), in: .capsule)
-                // Non-source: takes the frame + position of the currently selected segment.
-                .matchedGeometryEffect(id: store.inspectorTab, in: pillNamespace, isSource: false)
-        } else {
-            Capsule(style: .continuous)
-                .fill(Color(nsColor: .controlColor))
-                .shadow(color: .black.opacity(0.18), radius: 0.5, y: 0.5)
-                .matchedGeometryEffect(id: store.inspectorTab, in: pillNamespace, isSource: false)
-        }
+        Capsule(style: .continuous)
+            .fill(Color.primary.opacity(0.14))
+            // Non-source: takes the frame + position of the currently selected segment.
+            .matchedGeometryEffect(id: store.inspectorTab, in: pillNamespace, isSource: false)
     }
 
-    @ViewBuilder
     private var trackBackground: some View {
-        if #available(macOS 26.0, *) {
-            // A faint, slightly-whitened glass so the track stays lighter than the system collapse
-            // button and lets the brighter selected pill read as raised above it.
-            Capsule()
-                .fill(.clear)
-                .glassEffect(.regular.tint(Color.white.opacity(0.12)), in: .capsule)
-        } else {
-            Capsule(style: .continuous).fill(Color.primary.opacity(0.06))
-        }
+        Capsule(style: .continuous).fill(Color.primary.opacity(0.06))
     }
 }


### PR DESCRIPTION
## What

Two bits of two-column inspector polish:

### Drag-to-resize the list column
The seam between the inspector's list and its detail is now draggable. A hairline `Divider()` sits under a 10pt invisible grab strip that shows the **resize cursor** on hover; dragging retunes the list width live.

- Reads the pointer's x in a named coordinate space anchored at the list's leading edge, so x maps straight to column width (no translation drift).
- **Clamped** to 180–460pt, and additionally capped to always leave the detail ≥260pt on a narrow inspector, so neither column starves.
- **Persisted** in `@AppStorage("inspectorListColumnWidth")` — survives relaunch, shared across all inspector panes (files/search/changes/issues/PRs).
- **Double-click** the divider snaps back to the default 240pt.

The list column was pinned at a fixed 240pt before.

### Drop the Liquid Glass ambient shadow
macOS 26's `.glassEffect` casts an elevation shadow with no opt-out (`Glass` exposes only `.regular/.clear/.identity` + `.tint()/.interactive()`), and it read as stray chrome floating in the toolbar. Replaced with flat fills on:

- the inspector **tab pill** (`InspectorTabsToolbar`) — flat capsule track + selection pill;
- the detail header's **collapse/close buttons** (`HoverDisc`, was `GlassDisc`) — flat hover disc.

Both now match the file-editor mode toggle and the git-changes switch, which had already made the same call for the same reason.

## Test plan
- `swift build` passes.
- Open a file/diff in the inspector → drag the list↔detail seam, confirm the cursor flips, the width tracks, clamps at both ends, persists across relaunch, and double-click resets.
- Confirm the tab pill and header buttons no longer cast a drop shadow.