### PR TITLE
feat(inspector): responsive PR files column + native-fullscreen maximize

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -103,6 +103,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // The full-window host that shows the active inspector detail blown up to cover everything
     // while `store.inspectorMaximized`; nil when the detail is docked in the inspector.
     private var maximizedDetailHost: NSHostingView<AnyView>?
+    // Whether *we* drove the window into native fullscreen when the detail was maximized, so restore
+    // exits only the fullscreen we entered — never one the user opened with the green button first.
+    private var maximizeDidEnterFullScreen = false
     // Coalesces the per-frame `windowDidResize` stream into a single settle so the inspector's
     // max thickness (and the tracking-separator re-bind it forces) is recomputed once the drag
     // stops, not on every intermediate frame.
@@ -974,9 +977,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 host.bottomAnchor.constraint(equalTo: container.bottomAnchor),
             ])
             maximizedDetailHost = host
+            // Take the maximize all the way into native macOS fullscreen (own Space, hidden menu bar)
+            // for a truly immersive read — but only if the window isn't already fullscreen, so a
+            // green-button fullscreen the user set up themselves is left for them to exit.
+            if let window, !window.styleMask.contains(.fullScreen) {
+                window.toggleFullScreen(nil)
+                maximizeDidEnterFullScreen = true
+            }
         } else {
             maximizedDetailHost?.removeFromSuperview()
             maximizedDetailHost = nil
+            // Leave fullscreen only when this maximize is what entered it.
+            if maximizeDidEnterFullScreen {
+                if let window, window.styleMask.contains(.fullScreen) {
+                    window.toggleFullScreen(nil)
+                }
+                maximizeDidEnterFullScreen = false
+            }
         }
     }
 

--- a/Sources/termio/Git/PRFilesDiffView.swift
+++ b/Sources/termio/Git/PRFilesDiffView.swift
@@ -19,14 +19,41 @@ struct PRFilesSplitView: View {
 
     @Environment(\.colorScheme) private var colorScheme
     @State private var selection: String?
+    /// Narrow mode only: whether we've drilled from the file list into a file's diff.
+    @State private var narrowShowingDiff = false
 
     /// The list rail's width — the changed-files column, a touch wider than the sidebar
     /// since PR paths run deep.
     private static let listWidth: CGFloat = 260
+    /// Below this the file list and the diff can't both breathe, so the view collapses to a single
+    /// navigable column (list → tap → diff → back) — the same single-column, master→detail idiom the
+    /// issue/PR detail (and the whole inspector) already uses. Above it, side-by-side has room.
+    private static let sideBySideMinWidth: CGFloat = 620
 
     var body: some View {
+        GeometryReader { geo in
+            Group {
+                if geo.size.width >= Self.sideBySideMinWidth {
+                    sideBySide
+                } else {
+                    narrow
+                }
+            }
+            .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
+        }
+        .onExitCommand(perform: onClose)
+        // Select the first file on open (and if the set changes under us). Assigned directly — not
+        // through the list's selection binding — so this initial pick isn't treated as a drill-in and
+        // narrow mode still opens on the list.
+        .onAppear { if selection == nil { selection = files.first?.path } }
+    }
+
+    // MARK: Layouts
+
+    /// Wide: GitHub Desktop's side-by-side — the file list rail beside the selected file's diff.
+    private var sideBySide: some View {
         HStack(spacing: 0) {
-            fileList
+            fileList(onSelect: { _ in })
                 .frame(width: Self.listWidth)
                 .background(Color(nsColor: settings.terminalBackgroundColor).opacity(0.4))
             Rectangle()
@@ -35,16 +62,61 @@ struct PRFilesSplitView: View {
             detail
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
-        .onExitCommand(perform: onClose)
-        // Select the first file on open (and if the set changes under us).
-        .onAppear { if selection == nil { selection = files.first?.path } }
+    }
+
+    /// Narrow: one column at a time — the file list, or (after a tap) the selected file's diff behind
+    /// a "‹ Files" back bar. The arrow-key walk inside the diff still steps files without popping out.
+    @ViewBuilder
+    private var narrow: some View {
+        if narrowShowingDiff, selection != nil {
+            VStack(spacing: 0) {
+                narrowBackBar
+                detail.frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        } else {
+            fileList(onSelect: { _ in narrowShowingDiff = true })
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    /// The narrow-mode back control, sized like the pane's other header bars.
+    private var narrowBackBar: some View {
+        HStack(spacing: 4) {
+            Button { narrowShowingDiff = false } label: {
+                HStack(spacing: 2) {
+                    Image(systemName: "chevron.left").font(.system(size: 11, weight: .semibold))
+                    Text("Files").font(.system(size: 12, weight: .medium))
+                }
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+            Text("\(files.count) file\(files.count == 1 ? "" : "s")")
+                .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: GitChangesView.topBarHeight)
+        .background(Color(nsColor: settings.terminalBackgroundColor))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 1)
+        }
     }
 
     // MARK: List rail
 
-    private var fileList: some View {
-        List(files, selection: $selection) { change in
+    private func fileList(onSelect: @escaping (String) -> Void) -> some View {
+        // A custom binding so a user's row tap (which flows through `set`) can drive narrow-mode
+        // navigation, while the programmatic initial pick and the arrow `walk` assign `selection`
+        // directly and don't — and without a row tap gesture, which would break List selection.
+        let selectionBinding = Binding<String?>(
+            get: { selection },
+            set: { newValue in
+                selection = newValue
+                if let newValue { onSelect(newValue) }
+            }
+        )
+        return List(files, selection: selectionBinding) { change in
             PRFileRow(
                 change: change,
                 font: settings.interfaceFont,


### PR DESCRIPTION
Follow-ups to the two-column inspector, from reviewing PR #150 inside termio itself.

## 1. Responsive PR "Files" view
The PR Files tab hard-coded a **260pt file-list rail + diff** (`PRFilesSplitView`) with no min-width guard. In a narrow inspector the diff got `panelWidth − 261`, so at ~350pt it collapsed to just the gutter — file names truncated, code overflowing. (Screenshot in the discussion.)

Now it's **responsive, mirroring the issue/PR detail's single-column idiom**:
- **< 620pt** → one navigable column: the file list; tap a file → its diff full-width behind a **"‹ Files"** back bar. Same master→detail move the rest of the inspector uses.
- **≥ 620pt** → GitHub-Desktop side-by-side, as before.
- Row taps drive the drill-in via a **custom selection `Binding`**, so the initial auto-pick and the diff's arrow-key **walk** still change files *without* a tap gesture on the rows (a row tap gesture breaks `List` selection — a known gotcha in this codebase).

## 2. ⤢ maximize now goes to real fullscreen
The detail's ⤢ button maximized into a window-filling host but **not** native macOS fullscreen. It now also calls `window.toggleFullScreen(nil)` — own Space, hidden menu bar — for a truly immersive read. Restore exits **only** the fullscreen it entered, so a green-button fullscreen the user set up first is left alone (tracked by `maximizeDidEnterFullScreen`).

## Notes
- Independent of #150 (different files: `PRFilesDiffView.swift`, `App.swift`) — no conflicts; can land in either order.
- The ⤢ button's tooltip still says "Maximize detail to fill the window"; left unchanged here to avoid touching `InspectorDetailHost.swift`, which #150 also edits. Easy to update once one of the two lands.

## Test plan
- `swift build` passes.
- Open a PR in the inspector → Files: narrow the inspector, confirm it collapses to the file list, tapping opens the diff full-width, "‹ Files" returns, arrow keys walk files inside the diff. Widen past 620pt → side-by-side returns.
- Click ⤢ on any detail → window enters native fullscreen; click ⤢/Esc → restores and exits fullscreen. Enter fullscreen via the green button first, then ⤢ and restore → fullscreen is left on.