### PR TITLE
fix(inspector): restore close/maximize controls on the file preview header

### DIFF
--- a/Sources/termio/Browser/FilePreview.swift
+++ b/Sources/termio/Browser/FilePreview.swift
@@ -46,12 +46,14 @@ struct FilePreviewView: View {
                 .font(.system(size: 12.5, weight: .medium))
                 .lineLimit(1)
                 .truncationMode(.middle)
-            // Close moved to the toolbar (a bordered, Liquid Glass button on the terminal
-            // column's trailing edge); this trailing spacer keeps the file name left-aligned.
-            Spacer()
+            Spacer(minLength: 8)
+            // The content-area window controls (hide list / maximize / close) ride the header's
+            // trailing edge, matching the editor and every other inspector detail — so a previewed
+            // image/PDF/page has the same visible exit as a diff, not just Escape.
+            InspectorDetailChromeButtons()
         }
         .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .frame(height: GitChangesView.topBarHeight)
         .background(Color(nsColor: settings.terminalBackgroundColor))
     }
 


### PR DESCRIPTION
Opening an image/PDF/HTML file in the inspector left it with **no visible way to exit** — the preview header had only the file name and a bare `Spacer()`, carrying a stale pre-#149 comment ("close moved to the toolbar"). Every other inspector detail (editor, diff, PR, trace) grows an `InspectorDetailChromeButtons` cluster (hide list / maximize / close) at its trailing edge; the preview was the one that got skipped, so you could only dismiss it with Escape.

Add the same cluster and give the header the shared `GitChangesView.topBarHeight`, so a previewed file exits exactly like a diff.

## Test plan
- `swift build` passes.
- Files tab → open an image/PDF/HTML → the header now shows hide-list / maximize / ✕ at the trailing edge; ✕ closes it, ⤢ maximizes, all matching a diff. Escape still works.