### PR TITLE
fix(issues): recover from a 403 with reconnect + grant-org-access

### DIFF
--- a/Sources/termio/Issues/GitHubIssueAuth.swift
+++ b/Sources/termio/Issues/GitHubIssueAuth.swift
@@ -17,6 +17,13 @@ enum GitHubIssueAuth {
             ?? "Ov23lipSynmaEBOQR1cM"
     }
 
+    /// The user's connections page for this OAuth app — where org access is
+    /// granted. A 403 on a private repo is usually an org that hasn't authorized
+    /// termio, and reconnecting alone won't fix it; the grant happens here.
+    static var settingsURL: URL {
+        URL(string: "https://github.com/settings/connections/applications/\(clientID)")!
+    }
+
     // MARK: Keychain
 
     private static let service = "sh.termio.app.issues"

--- a/Sources/termio/Issues/GitHubIssueProvider.swift
+++ b/Sources/termio/Issues/GitHubIssueProvider.swift
@@ -16,6 +16,10 @@ struct GitHubIssueProvider: IssueProvider {
 
     enum APIError: LocalizedError {
         case status(Int)
+        /// A 403/429 that is GitHub throttling, not an access denial — kept distinct from
+        /// `.status(403)` so the pane offers "wait and retry" rather than the reconnect/grant-org
+        /// recovery, which can't fix a rate limit.
+        case rateLimited
         case decoding
 
         var errorDescription: String? {
@@ -24,6 +28,7 @@ struct GitHubIssueProvider: IssueProvider {
             case .status(403): return "GitHub denied the request — the token may lack access to this repository."
             case .status(404): return "GitHub can’t find this repository with the connected account."
             case .status(let code): return "GitHub replied with HTTP \(code)."
+            case .rateLimited: return "GitHub’s rate limit is exhausted. Wait a moment and try again."
             case .decoding: return "GitHub returned an unexpected reply."
             }
         }
@@ -163,6 +168,17 @@ struct GitHubIssueProvider: IssueProvider {
         request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
         let (data, response) = try await URLSession.shared.data(for: request)
         if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            // GitHub signals throttling with a 403 or 429 carrying an exhausted primary-limit
+            // header (`x-ratelimit-remaining: 0`) or a secondary-limit `retry-after`. Classify
+            // those as `.rateLimited` so a 403 that is really "no access to this repo" stays the
+            // only case that offers the reconnect/grant-org recovery.
+            if http.statusCode == 403 || http.statusCode == 429 {
+                let remaining = http.value(forHTTPHeaderField: "x-ratelimit-remaining")
+                let retryAfter = http.value(forHTTPHeaderField: "retry-after")
+                if remaining == "0" || retryAfter != nil {
+                    throw APIError.rateLimited
+                }
+            }
             throw APIError.status(http.statusCode)
         }
         let decoder = JSONDecoder()

--- a/Sources/termio/Issues/IssuesPanelModel.swift
+++ b/Sources/termio/Issues/IssuesPanelModel.swift
@@ -25,6 +25,13 @@ final class IssuesPanelModel: ObservableObject {
     @Published private(set) var items: [IssueSummary] = []
     @Published private(set) var isLoading = false
     @Published private(set) var errorMessage: String?
+
+    /// How the user can recover from a failed load, so the error state offers the *right* action.
+    /// `reauthorize` (the reconnect / grant-org path) is reserved for a genuine access 403 — a
+    /// valid token with no rights to this repo. Everything else (rate limits, 404, 5xx, network,
+    /// decode) is `retry`, since reconnecting can't fix it. `nil` when there's no error.
+    enum Recovery { case reauthorize, retry }
+    @Published private(set) var recovery: Recovery?
     /// The pushed-in detail (list → detail, like git pane file → diff).
     @Published var openItem: IssueSummary?
     @Published private(set) var detail: IssueDetail?
@@ -63,6 +70,7 @@ final class IssuesPanelModel: ObservableObject {
     /// polls until approved, then loads the pane.
     func connect() async {
         errorMessage = nil
+        recovery = nil
         do {
             let code = try await GitHubIssueAuth.requestDeviceCode()
             phase = .connecting(userCode: code.userCode)
@@ -85,6 +93,8 @@ final class IssuesPanelModel: ObservableObject {
         openItem = nil
         detail = nil
         phase = .disconnected
+        errorMessage = nil
+        recovery = nil
     }
 
     /// Recover from a non-401 failure (typically a 403: the token is valid but has
@@ -137,14 +147,23 @@ final class IssuesPanelModel: ObservableObject {
         if availableLabels.isEmpty { Task { await loadLabels() } }
         isLoading = true
         errorMessage = nil
+        recovery = nil
         do {
             items = try await provider.issues(in: container, query: query)
         } catch {
             // A revoked token must degrade to the connect zero state, not wedge.
             if case GitHubIssueProvider.APIError.status(401) = error {
                 disconnect()
-            } else {
+            } else if case GitHubIssueProvider.APIError.status(403) = error {
+                // A genuine 403 (rate-limit 403s are classified as `.rateLimited` upstream) means
+                // the token is valid but has no rights to *this* repo — usually an org that hasn't
+                // authorized termio. This is the one case reconnect / grant-org access can fix.
                 errorMessage = error.localizedDescription
+                recovery = .reauthorize
+            } else {
+                // Rate limits, 404, 5xx, decode, network: reconnecting won't help — offer a retry.
+                errorMessage = error.localizedDescription
+                recovery = .retry
             }
         }
         isLoading = false

--- a/Sources/termio/Issues/IssuesPanelModel.swift
+++ b/Sources/termio/Issues/IssuesPanelModel.swift
@@ -87,6 +87,23 @@ final class IssuesPanelModel: ObservableObject {
         phase = .disconnected
     }
 
+    /// Recover from a non-401 failure (typically a 403: the token is valid but has
+    /// no rights to *this* repo). A 401 self-heals via `disconnect()` in `loadList`,
+    /// but a 403 leaves the pane bound-yet-empty with no way out — so drop the token
+    /// and re-run the device flow, letting the user approve under a different account
+    /// (or after granting termio org access, see `openConnectionSettings`).
+    func reconnect() async {
+        disconnect()
+        await connect()
+    }
+
+    /// Opens the OAuth app's connections page, where the user grants termio access
+    /// to the org that owns a private repo — the fix a bare reconnect can't make,
+    /// since GitHub re-issues the same token without re-prompting for org grants.
+    func openConnectionSettings() {
+        NSWorkspace.shared.open(GitHubIssueAuth.settingsURL)
+    }
+
     // MARK: Loading
 
     private func resolveContainer() async {

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -232,20 +232,34 @@ struct IssuesView: View {
                 .controlSize(.small)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if model.errorMessage != nil {
-            // A non-401 failure (typically a 403: valid token, no rights to *this*
-            // repo) leaves the pane bound but unreadable. Offer a way out instead of
-            // wedging — reconnect to switch account, or grant termio org access.
-            // `zeroState` paints `model.errorMessage` in red beneath the actions.
-            zeroState(
-                title: "Couldn’t Load",
-                message: "Reconnect to sign in with a different account, or grant termio access to the organization that owns this repository."
-            ) {
-                Button("Reconnect") { Task { await model.reconnect() } }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.regular)
-                Button("Grant Org Access…") { model.openConnectionSettings() }
-                    .buttonStyle(.link)
-                    .controlSize(.small)
+            // The recovery the model classified drives which actions we offer — reconnecting can
+            // only fix an access 403, not a rate limit / 404 / 5xx / network error. `zeroState`
+            // paints `model.errorMessage` in red beneath the actions.
+            switch model.recovery {
+            case .reauthorize:
+                // A valid token with no rights to *this* repo (403) — usually an org that hasn't
+                // authorized termio. Switch account, or grant org access.
+                zeroState(
+                    title: "Couldn’t Load",
+                    message: "Reconnect to sign in with a different account, or grant termio access to the organization that owns this repository."
+                ) {
+                    Button("Reconnect") { Task { await model.reconnect() } }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.regular)
+                    Button("Grant Org Access…") { model.openConnectionSettings() }
+                        .buttonStyle(.link)
+                        .controlSize(.small)
+                }
+            case .retry, .none:
+                // Rate limit, 404, 5xx, network, decode — reconnecting won't help; just retry.
+                zeroState(
+                    title: "Couldn’t Load",
+                    message: "Something went wrong loading this repository. Try again in a moment."
+                ) {
+                    Button("Try Again") { Task { await model.loadList() } }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.regular)
+                }
             }
         } else if model.items.isEmpty {
             ContentUnavailableView(

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -231,13 +231,22 @@ struct IssuesView: View {
             ProgressView()
                 .controlSize(.small)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let error = model.errorMessage {
-            ContentUnavailableView(
-                "Couldn’t Load",
-                huge: .github,
-                description: Text(error)
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if model.errorMessage != nil {
+            // A non-401 failure (typically a 403: valid token, no rights to *this*
+            // repo) leaves the pane bound but unreadable. Offer a way out instead of
+            // wedging — reconnect to switch account, or grant termio org access.
+            // `zeroState` paints `model.errorMessage` in red beneath the actions.
+            zeroState(
+                title: "Couldn’t Load",
+                message: "Reconnect to sign in with a different account, or grant termio access to the organization that owns this repository."
+            ) {
+                Button("Reconnect") { Task { await model.reconnect() } }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                Button("Grant Org Access…") { model.openConnectionSettings() }
+                    .buttonStyle(.link)
+                    .controlSize(.small)
+            }
         } else if model.items.isEmpty {
             ContentUnavailableView(
                 model.query.kind == .issue ? "No Issues" : "No Pull Requests",


### PR DESCRIPTION
## What

The Issues pane could wedge on a **403**. A 401 self-heals (drop the token → back to disconnected), but a 403 — a valid token with **no rights to this repo**, usually an org that hasn't authorized termio — left the pane bound-yet-empty with **no way out**.

## Changes

The error state now offers two exits instead of a dead-end `ContentUnavailableView`:

- **Reconnect** — drops the token and re-runs the device flow, so you can approve under a different account (`IssuesPanelModel.reconnect()`).
- **Grant Org Access…** — opens the OAuth app's connections page, where the org grant a bare reconnect *can't* make actually happens; GitHub re-issues the same token without re-prompting for org grants (`GitHubIssueAuth.settingsURL`, `openConnectionSettings()`).

## Test plan

- Bind a private repo in an org that hasn't authorized termio → 403 → the pane shows the actionable zero state (message in red) with both buttons.
- Reconnect switches account; Grant Org Access opens the connections page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
