### PR TITLE
fix(inspector): stop force-growing the inspector when a detail opens

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -925,30 +925,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         NotificationCenter.default.post(name: .termioShowFindBar, object: nil)
     }
 
-    /// Reveals the inspector for a freshly opened detail: un-collapses it if hidden, and grows it
-    /// (never shrinks) toward a comfortable width the first time — enough for the list ‖ detail two
-    /// column layout (see `InspectorRoot`), so a 240pt list still leaves the detail room to read.
-    /// The target stays under the golden-ratio cap (`updateInspectorMaxThickness`).
+    /// Reveals the inspector for a freshly opened detail: un-collapses it if hidden, and otherwise
+    /// leaves its width alone. It comes back at whatever the split last had (the user's own width,
+    /// restored from the autosave), and the responsive `InspectorRoot` — two-column when there's
+    /// room, detail-only when narrow, draggable seam either way — takes it from there.
+    ///
+    /// It used to *grow* the inspector to ~half the window on every open. That shrank the terminal
+    /// unbidden and, because the growth was a mid-layout `minimumThickness` bump, left the terminal a
+    /// blank strip where the surface hadn't reflowed. Respect the user's width; let layout be
+    /// responsive instead of forcing it.
     private func revealInspectorForDetail() {
-        guard let item = filesInspectorItem, let split = splitViewController?.splitView, let window else { return }
+        guard let item = filesInspectorItem else { return }
         // Un-collapse *synchronously* (not via `animator()`) so the split geometry — and the divider
         // the tracking separator binds to — is settled before the toolbar switch is (re)inserted.
         if item.isCollapsed {
             item.isCollapsed = false
             setInspectorSwitchVisible(true)
-        }
-        let contentWidth = window.contentLayoutRect.width
-        let comfortable = min(max(680, contentWidth * 0.5), item.maximumThickness)
-        // Grow to a comfortable width by briefly raising the inspector's *minimum* thickness and
-        // forcing a layout, then restoring it — NOT by `setPosition(ofDividerAt:)`. That divider is
-        // tracked by `.inspectorTrackingSeparator`; moving it directly desyncs the separator, which
-        // then stops splitting the toolbar into terminal/inspector regions and lets the tab switcher
-        // drift to center with no divider line (the glitch that a manual inspector toggle re-binds).
-        if item.viewController.view.frame.width < comfortable - 1 {
-            let savedMinimum = item.minimumThickness
-            item.minimumThickness = comfortable
-            split.layoutSubtreeIfNeeded()
-            item.minimumThickness = savedMinimum
         }
     }
 


### PR DESCRIPTION
## Why
Clicking a GitHub **issue** (or **PR**, file, diff) shrank the terminal and left a large **blank white gap** beside it. (Screenshots in the discussion.)

Root cause: `revealInspectorForDetail()` didn't just reveal — it **grew** the inspector to `min(max(680, contentWidth * 0.5), maxThickness)` on every open, i.e. ~half the window. That:
1. shrank the terminal unbidden, and
2. did the growth via a mid-layout `minimumThickness` bump + `layoutSubtreeIfNeeded()`, which left the terminal surface un-reflowed → the blank strip.

## Fix
Reveal only. Un-collapse the inspector at its **restored, user-set width** (from the split autosave) and let the responsive `InspectorRoot` do the layout — two-column when there's room, detail-only when narrow, draggable seam either way (per #150). No forced width → no terminal squeeze → no blank gap.

## Notes
- Independent of #150/#152; touches `App.swift` like #151 but a different function (`revealInspectorForDetail` vs `setDetailMaximized`) — clean auto-merge.
- Trade-off: opening a detail into a *collapsed* inspector now shows it at the inspector's last width (or its 260pt minimum) rather than auto-widening. That's the point — the user's width is respected, and they drag the seam if they want more. 

## Test plan
- `swift build` passes.
- Widen terminal, collapse inspector → click a GitHub issue/PR → terminal keeps its width, no blank gap; inspector returns at its prior width.
- Drag the inspector wide → it stays wide across opens.