### PR TITLE
refactor(inspector): unify pane-header icon buttons on one hover chip

### DIFF
--- a/Sources/termio/FileBrowser/FileTreeControls.swift
+++ b/Sources/termio/FileBrowser/FileTreeControls.swift
@@ -1,10 +1,30 @@
 import Foundation
 import SwiftUI
 
+/// The one quiet-chip chrome worn by every inspector pane-header icon control — the
+/// explorer/Changes buttons, the Issues refresh & filter, the ↗ Open-on-GitHub, and the
+/// detail's hide-list / maximize / close. A 22×22 hit target with a faint rounded fill that
+/// fades in on hover; the glyph itself is coloured secondary→primary by its host. Factored out
+/// so a `Button` and a `Menu` label render pixel-identical chrome despite being different types.
+struct TreeHeaderChip: ViewModifier {
+    @Binding var hovering: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .frame(width: 22, height: 22)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.primary.opacity(hovering ? 0.08 : 0))
+            )
+            .contentShape(Rectangle())
+            .onHover { hovering = $0 }
+    }
+}
+
 /// A quiet icon button for the explorer / Changes pane headers. The explorer's file
 /// actions draw VS Code's own codicon glyphs (see `Codicon`) so the toolbar matches
 /// VS Code; the Changes pane uses SF Symbols. Both render quiet `.secondary` at rest,
-/// brightening to primary on hover over a faint rounded fill.
+/// brightening to primary on hover over the shared `TreeHeaderChip` fill.
 struct TreeHeaderButton: View {
     /// An SF Symbol, a VS Code codicon, or a Hugeicons stroke glyph — the icon
     /// sources the pane header toolbars draw from.
@@ -39,16 +59,9 @@ struct TreeHeaderButton: View {
 
     var body: some View {
         Button(action: action) {
-            icon
-                .frame(width: 22, height: 22)
-                .background(
-                    RoundedRectangle(cornerRadius: 5, style: .continuous)
-                        .fill(Color.primary.opacity(isHovering ? 0.08 : 0))
-                )
-                .contentShape(Rectangle())
+            icon.modifier(TreeHeaderChip(hovering: $isHovering))
         }
         .buttonStyle(.plain)
-        .onHover { isHovering = $0 }
         .help(help)
     }
 
@@ -63,10 +76,11 @@ struct TreeHeaderButton: View {
         case .codicon(let codicon):
             CodiconView(icon: codicon, size: 15, color: isHovering ? .primary : .secondary)
         case .huge(let icon):
-            // 1.5pt override matches the inspector switch's optical weight — the
-            // size-derived default reads hairline next to SF Symbols.
+            // 1.0pt: the one weight every inspector header Hugeicon shares (↗, the detail's
+            // window controls, the filter funnel), tuned to sit at the optical weight of the
+            // codicon refresh beside it rather than reading heavier than it.
             HugeIconView(icon: icon, size: 15, color: isHovering ? .primary : .secondary,
-                         lineWidthOverride: 1.5)
+                         lineWidthOverride: 1.0)
         }
     }
 }

--- a/Sources/termio/FileBrowser/InspectorDetailHost.swift
+++ b/Sources/termio/FileBrowser/InspectorDetailHost.swift
@@ -81,9 +81,10 @@ struct InspectorDetailChromeButtons: View {
     }
 }
 
-/// One content-area control: a fully-round Hugeicons button whose hover state is a Liquid Glass
-/// disc (real `glassEffect` on macOS 26, a translucent material disc below it). Quiet `.secondary`
-/// ink at rest, brightening to primary under the cursor — the inspector's detail window controls.
+/// One content-area control, wearing the shared `TreeHeaderChip` so the detail's window controls
+/// read as one family with the refresh / filter / ↗ buttons in the same header — a 22×22 Hugeicons
+/// glyph, quiet `.secondary` at rest and brightening to primary over a faint rounded fill on hover.
+/// `size` varies per glyph so each sits at the same optical weight (the diagonal-heavy ✕ shrinks).
 private struct DetailChromeButton: View {
     let icon: HugeIcon
     var size: CGFloat = 14
@@ -95,32 +96,11 @@ private struct DetailChromeButton: View {
         Button(action: action) {
             HugeIconView(icon: icon, size: size,
                          color: hovering ? .primary : .secondary,
-                         lineWidthOverride: 1.5)
-                .frame(width: 24, height: 24)
-                .modifier(GlassDisc(active: hovering))
-                .contentShape(Circle())
+                         lineWidthOverride: 1.0)
+                .modifier(TreeHeaderChip(hovering: $hovering))
         }
         .buttonStyle(.plain)
-        .onHover { hovering = $0 }
         .help(help)
-    }
-}
-
-/// A circular Liquid Glass background, shown only while `active`. Falls back to a translucent
-/// material disc below macOS 26, which lacks the real `glassEffect`.
-private struct GlassDisc: ViewModifier {
-    let active: Bool
-
-    func body(content: Content) -> some View {
-        if active {
-            if #available(macOS 26.0, *) {
-                content.glassEffect(.regular.interactive(), in: Circle())
-            } else {
-                content.background(Circle().fill(.ultraThinMaterial))
-            }
-        } else {
-            content
-        }
     }
 }
 

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -522,6 +522,10 @@ struct IssueDetailView: View {
             case .files: filesBody
             }
         }
+        // Match the diff/editor detail overlays: paint the whole view (header and
+        // tab bar included) with the terminal background so the header doesn't fall
+        // through to the host's `windowBackgroundColor` and seam against the body.
+        .background(Color(nsColor: settings.terminalBackgroundColor))
         .task(id: item.number) { await model.loadDetail(for: item) }
         .onExitCommand(perform: onBack)
     }

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -19,6 +19,7 @@ struct IssuesView: View {
 
     @StateObject private var model: IssuesPanelModel
     @State private var selection: Int?
+    @State private var filterHovering = false
 
     init(repoRoot: String) {
         self.repoRoot = repoRoot
@@ -79,8 +80,8 @@ struct IssuesView: View {
     /// The list is otherwise fetch-on-interaction, so this is the "prove it's
     /// current" escape hatch when something changed on GitHub out of band.
     private var refreshButton: some View {
-        // VS Code codicon refresh, matching the File Explorer header's four codicon actions so the
-        // two pane toolbars read as one family.
+        // VS Code codicon refresh — the two-arrow ring reads more refined than the Hugeicons
+        // single-arrow one, and matches the File Explorer header's four codicon actions.
         TreeHeaderButton(codicon: .refresh, help: "Refresh") {
             Task { await model.loadList() }
         }
@@ -133,8 +134,8 @@ struct IssuesView: View {
             }
         } label: {
             // macOS flattens a Menu label to Text/Image and drops shape-drawn
-            // views — so the label is only a clear hit-area, and the funnel is
-            // painted behind it (see .background below).
+            // views — so the label is only a clear hit-area, and the chip + funnel
+            // are painted behind it (see .background below).
             Color.clear
                 .frame(width: 22, height: 22)
                 .contentShape(Rectangle())
@@ -143,18 +144,27 @@ struct IssuesView: View {
         .menuIndicator(.hidden)
         .fixedSize()
         .background {
-            // The funnel takes the accent color while any filter narrows the list
-            // (non-default state, an assignee, or a label), so a filtered view
-            // can't be mistaken for the full one.
-            // A thinner stroke than the switches use (1.5 read heavier than the filled codicons
-            // beside it) so the funnel sits at the codicons' optical weight.
-            HugeIconView(
-                icon: .filter, size: 13,
-                color: isFiltered ? .accentColor : .secondary,
-                lineWidthOverride: 1
-            )
+            // The shared `TreeHeaderChip` fill (drawn here, not in the label, because the
+            // Menu drops shape-drawn label views) so the funnel hovers exactly like the
+            // refresh codicon beside it. On top of the chip:
+            // the funnel takes the accent color while any filter narrows the list (non-default
+            // state, an assignee, or a label), so a filtered view can't be mistaken for the full
+            // one — and only otherwise follows the secondary→primary hover of every header glyph.
+            // 1.0pt: the shared inspector-header Hugeicon weight, so the funnel matches the
+            // detail's window controls and the ↗ exactly and sits at the codicon refresh's weight.
+            ZStack {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.primary.opacity(filterHovering ? 0.08 : 0))
+                    .frame(width: 22, height: 22)
+                HugeIconView(
+                    icon: .filter, size: 13,
+                    color: isFiltered ? .accentColor : (filterHovering ? .primary : .secondary),
+                    lineWidthOverride: 1.0
+                )
+            }
             .allowsHitTesting(false)
         }
+        .onHover { filterHovering = $0 }
         .help("Filter")
     }
 


### PR DESCRIPTION
## What

The inspector's header icon controls carried three unrelated hover treatments — rounded-square fill (explorer/refresh codicons, ↗), circular Liquid Glass disc (detail window controls), and *nothing at all* (the Issues filter menu). Side by side in one bar they read as different button families.

- **One shared chip.** Extract the 22×22 rounded-square hover fill into a `TreeHeaderChip` modifier. `TreeHeaderButton` and the detail's hide-list / maximize / close controls both wear it; the filter `Menu` paints it in `.background` behind its funnel (a `Menu` drops shape-drawn label views, so the chip rides there with `.onHover` on the menu).
- **Drop the glass disc** from the detail window controls.
- **Unify stroke weight.** Lower the Hugeicons stroke to `1.0pt` so the ↗, the window controls and the filter funnel sit at the codicon refresh's optical weight instead of reading heavier than the glyphs beside them.
- **Detail background seam.** Back the whole issue/PR detail (header + tab bar, not just the body) with the terminal background, matching the diff and editor overlays.

The File Explorer's four VS-Code-codicon actions (new file / new folder / refresh / collapse-all) are deliberately left as codicons; the Issues refresh stays a codicon too (its two-arrow ring reads more refined than the Hugeicons single-arrow one).

## Test

`swift build` clean; verified in the dev app — refresh + filter + ↗ + window controls now share one chip and one weight across the Issues detail and file/diff details.