### PR TITLE
feat(status): read Grok's OSC 9;4 progress as an in-band busy/idle signal

### DIFF
--- a/Sources/termio/Agents/AgentDefinition.swift
+++ b/Sources/termio/Agents/AgentDefinition.swift
@@ -61,6 +61,14 @@ struct AgentDefinition: Identifiable {
     /// script, no socket), so it corrects a missed or late hook the instant the
     /// title flips. See `TermioStore.applyTitleActivity` for the arbitration.
     let titleRules: AgentStatusRules?
+    /// Whether this agent reports its busy/idle state as ConEmu-style `OSC 9;4`
+    /// progress in the PTY byte stream (Grok natively; Claude Code once
+    /// `terminalProgressBarEnabled` is set). When true, termio scans the raw stream
+    /// for it and drives status the same way the title does — a correction channel
+    /// that coexists with hooks, never a competing authority. See `OSCProgressScanner`
+    /// and `TermioStore.applyProgressActivity`. Off for agents (and the plain shell)
+    /// that don't, so an unrelated tool's progress bar can't move an agent's dot.
+    let emitsProgressStatus: Bool
     /// A manifest's declarative hook integration: the destination owned by the agent,
     /// a closed installer/dialect, and its event→state mapping.
     /// When present it is installed by `AgentStatusHooks` and becomes the session's
@@ -76,6 +84,7 @@ struct AgentDefinition: Identifiable {
         resumeSpec: ResumeSpec, icon: AgentIcon,
         iconRef: TermioShared.IconRef, tint: Color, tintHex: String?, installURL: URL?, wireName: String,
         statusRules: AgentStatusRules? = nil, titleRules: AgentStatusRules? = nil,
+        emitsProgressStatus: Bool = false,
         hookSpec: AgentHookSpec? = nil
     ) {
         self.id = id
@@ -92,6 +101,7 @@ struct AgentDefinition: Identifiable {
         self.wireName = wireName
         self.statusRules = statusRules
         self.titleRules = titleRules
+        self.emitsProgressStatus = emitsProgressStatus
         self.hookSpec = hookSpec
     }
 
@@ -854,6 +864,10 @@ struct AgentManifest: Decodable {
     /// correction channel, not a competing authority), so it is not gated the way
     /// `status` is.
     var titleStatus: StatusSpec?
+    /// Opt-in to reading this agent's ConEmu-style `OSC 9;4` progress out of the PTY
+    /// byte stream as a busy/idle signal (`OSCProgressScanner`). Off by default so a
+    /// plain shell's `wget`/`npm` progress bar can never move an agent's status dot.
+    var progressStatus: Bool?
     var hooks: HookSpec?
 
     struct IconSpec: Decodable {
@@ -1208,7 +1222,8 @@ struct AgentManifest: Decodable {
             resumeSpec: resumeSpec, icon: resolvedIcon, iconRef: resolvedIconRef,
             tint: resolvedTint, tintHex: resolvedTintHex,
             installURL: (install ?? installURL).flatMap(URL.init(string:)), wireName: wire ?? id,
-            statusRules: statusRules, titleRules: titleRules, hookSpec: hookSpec)
+            statusRules: statusRules, titleRules: titleRules,
+            emitsProgressStatus: progressStatus ?? false, hookSpec: hookSpec)
     }
 
     private static func bundledAsset(named name: String, in bundle: Bundle) -> URL? {

--- a/Sources/termio/Agents/OSCProgressScanner.swift
+++ b/Sources/termio/Agents/OSCProgressScanner.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Parses ConEmu-style `OSC 9;4` progress reports out of a terminal byte stream
+/// and maps them to an agent activity — an in-band busy/idle signal on the same
+/// unbreakable channel as the OSC title, but more precise: an agent that reports
+/// progress says "I am working" without termio having to recognise a spinner glyph.
+///
+/// The sequence is the ConEmu / Windows Terminal progress protocol that libghostty
+/// forwards but does not surface: `ESC ] 9 ; 4 ; <state> ; <pct> (BEL | ST)`, where
+/// - state `0` = clear → **idle**,
+/// - state `1` (normal) and `3` (indeterminate) → **working**,
+/// - state `2` (error) and `4` (paused) → ignored (neither a clean busy nor idle
+///   transition; leaving the last signal in place beats guessing).
+///
+/// Grok emits `9;4;1;-1` natively while a turn runs and `9;4;0;` when it finishes;
+/// Claude Code emits the same shape once `terminalProgressBarEnabled` is set. This is
+/// fed every raw read chunk from the PTY (sequences split across reads are tolerated)
+/// and returns a value only when the busy/idle state actually flips — a stream of
+/// identical `9;4;1` keepalives collapses to a single `.working`.
+///
+/// It reads only OSC 9 *progress* (`9;4;…`); the neighbouring OSC 9 notification
+/// (`9;<text>`), OSC 9;9 cwd, and OSC 4 palette forms all fall through to `nil`.
+struct OSCProgressScanner {
+    private enum State { case ground, esc, osc, oscEsc }
+    private var state: State = .ground
+    private var payload: [UInt8] = []
+    private var lastActivity: AgentStatusRules.Activity?
+    /// Progress payloads are a handful of bytes (`9;4;1;-1`); anything longer is
+    /// some other OSC and can't be a progress report, so it is capped rather than
+    /// buffered unboundedly across a pathological unterminated sequence.
+    private static let maxPayload = 32
+
+    /// Scans a raw chunk, returning the new activity iff the busy/idle state changed.
+    mutating func scan(_ data: Data) -> AgentStatusRules.Activity? {
+        var transition: AgentStatusRules.Activity?
+        for byte in data {
+            switch state {
+            case .ground:
+                if byte == 0x1B { state = .esc }
+            case .esc:
+                if byte == UInt8(ascii: "]") {
+                    state = .osc
+                    payload.removeAll(keepingCapacity: true)
+                } else if byte == 0x1B {
+                    state = .esc
+                } else {
+                    state = .ground
+                }
+            case .osc:
+                switch byte {
+                case 0x07: // BEL terminator
+                    if let t = finish() { transition = t }
+                    state = .ground
+                case 0x1B: // possible ST (ESC \) terminator
+                    state = .oscEsc
+                default:
+                    if payload.count < Self.maxPayload { payload.append(byte) }
+                }
+            case .oscEsc:
+                if byte == UInt8(ascii: "\\") { // ST terminator
+                    if let t = finish() { transition = t }
+                    state = .ground
+                } else if byte == 0x1B {
+                    state = .oscEsc
+                } else {
+                    // A bare ESC mid-payload aborts this OSC.
+                    state = .ground
+                }
+            }
+        }
+        return transition
+    }
+
+    /// Classifies the buffered payload and reports it only on a state change.
+    private mutating func finish() -> AgentStatusRules.Activity? {
+        defer { payload.removeAll(keepingCapacity: true) }
+        guard let activity = Self.classify(payload), activity != lastActivity else { return nil }
+        lastActivity = activity
+        return activity
+    }
+
+    /// Maps an OSC 9 payload to an activity. Fast-rejects everything that isn't a
+    /// `9;4;<state>` progress report before allocating, so the common OSC 0/2 title
+    /// spinner (one OSC per frame) never pays for a `String`.
+    static func classify(_ payload: [UInt8]) -> AgentStatusRules.Activity? {
+        guard payload.count >= 3,
+              payload[0] == UInt8(ascii: "9"),
+              payload[1] == UInt8(ascii: ";"),
+              payload[2] == UInt8(ascii: "4") else { return nil }
+        let parts = String(decoding: payload, as: UTF8.self)
+            .split(separator: ";", omittingEmptySubsequences: false)
+        guard parts.count >= 3, parts[1] == "4", let stateDigit = Int(parts[2]) else { return nil }
+        switch stateDigit {
+        case 0: return .idle
+        case 1, 3: return .working
+        default: return nil // 2 = error, 4 = paused — not a clean transition
+        }
+    }
+}

--- a/Sources/termio/Agents/OSCProgressScanner.swift
+++ b/Sources/termio/Agents/OSCProgressScanner.swift
@@ -16,16 +16,25 @@ import Foundation
 /// Grok emits `9;4;1;-1` natively while a turn runs and `9;4;0;` when it finishes;
 /// Claude Code emits the same shape once `terminalProgressBarEnabled` is set. This is
 /// fed every raw read chunk from the PTY (sequences split across reads are tolerated)
-/// and returns each busy/idle flip in order — a stream of identical `9;4;1`
-/// keepalives collapses to nothing, but a chunk that carries a whole `busy … idle`
-/// turn yields both transitions rather than only the last (which the arbitration,
-/// keyed on the previous *delivered* state, would otherwise silently drop).
+/// and returns each completed report in byte order — including *both* edges when a
+/// single read carries a whole `busy … idle` turn, which the arbitration (keyed on
+/// the previous *delivered* state) would otherwise silently drop.
+///
+/// The scanner keeps **no** cross-chunk state of its own: consecutive identical
+/// reports within one chunk collapse, but it never remembers the last activity across
+/// reads. Dedup is the store's job (`lastProgressActivity`, applied under the
+/// live-agent gate) — exactly like the title channel, whose every spinner frame
+/// re-fires and is collapsed in `applyTitleActivity`. Keeping the memory there and
+/// not here is what lets a session promoted to Grok mid-stream pick the signal up: a
+/// scanner that had privately deduped a pre-promotion `working` (rejected by the
+/// gate) would then swallow the keepalives the promoted row needs.
 ///
 /// It reads only OSC 9 *progress* (`9;4;<state>;<progress>`); the neighbouring OSC 9
 /// notification (`9;<text>`), OSC 9;9 cwd, and OSC 4 palette forms all fall through —
-/// the grammar is validated end to end (state numeric, at most one numeric-or-empty
-/// progress field) and an overrun payload is rejected, so a notification whose body
-/// merely starts `4;…` can't be mistaken for progress.
+/// the grammar is validated end to end (numeric state, a progress field in the
+/// documented `0…100` range plus Grok's `-1`, no trailing fields) and an overrun
+/// payload is rejected, so a notification whose body merely starts `4;…` can't be
+/// mistaken for progress.
 struct OSCProgressScanner {
     private enum State { case ground, esc, osc, oscEsc }
     private var state: State = .ground
@@ -33,13 +42,12 @@ struct OSCProgressScanner {
     /// Set when a payload exceeds `maxPayload`: it is then too long to be a progress
     /// report, so it is rejected outright rather than classified from its prefix.
     private var overflowed = false
-    private var lastActivity: AgentStatusRules.Activity?
     /// Progress payloads are a handful of bytes (`9;4;1;-1`); anything longer is some
     /// other, longer OSC (a title, a notification) and cannot be a progress report.
     private static let maxPayload = 24
 
-    /// Scans a raw chunk, returning every busy/idle flip it completes, in order.
-    /// Empty in the common case (no progress, or only repeats of the current state).
+    /// Scans a raw chunk, returning every completed report in it, in byte order,
+    /// with consecutive duplicates collapsed. Empty in the common case (no progress).
     mutating func scan(_ data: Data) -> [AgentStatusRules.Activity] {
         var transitions: [AgentStatusRules.Activity] = []
         for byte in data {
@@ -57,7 +65,7 @@ struct OSCProgressScanner {
             case .osc:
                 switch byte {
                 case 0x07: // BEL terminator
-                    if let t = finish() { transitions.append(t) }
+                    emit(into: &transitions)
                     state = .ground
                 case 0x1B: // possible ST (ESC \) terminator
                     state = .oscEsc
@@ -66,7 +74,7 @@ struct OSCProgressScanner {
                 }
             case .oscEsc:
                 if byte == UInt8(ascii: "\\") { // ST terminator
-                    if let t = finish() { transitions.append(t) }
+                    emit(into: &transitions)
                     state = .ground
                 } else if byte == 0x1B {
                     state = .oscEsc
@@ -85,19 +93,20 @@ struct OSCProgressScanner {
         overflowed = false
     }
 
-    /// Classifies the buffered payload and reports it only on a state change.
-    private mutating func finish() -> AgentStatusRules.Activity? {
+    /// Classifies the buffered payload and appends it unless it repeats the previous
+    /// report in this same chunk. No state survives the call.
+    private mutating func emit(into transitions: inout [AgentStatusRules.Activity]) {
         defer { payload.removeAll(keepingCapacity: true); overflowed = false }
-        guard !overflowed, let activity = Self.classify(payload), activity != lastActivity else { return nil }
-        lastActivity = activity
-        return activity
+        guard !overflowed, let activity = Self.classify(payload) else { return }
+        if transitions.last != activity { transitions.append(activity) }
     }
 
     /// Maps an OSC 9 payload to an activity. Fast-rejects everything that isn't a
     /// `9;4;<state>` progress report before allocating, so the common OSC 0/2 title
     /// spinner (one OSC per frame) never pays for a `String`, then validates the whole
-    /// grammar so a longer OSC 9 notification that happens to begin `4;…` is not
-    /// misread as progress.
+    /// grammar — a numeric state and, for the busy states, a progress field in the
+    /// documented `0…100` range (plus Grok's indeterminate `-1`, and an empty value) —
+    /// so a longer OSC 9 notification that happens to begin `4;…` is not misread.
     static func classify(_ payload: [UInt8]) -> AgentStatusRules.Activity? {
         guard payload.count >= 3,
               payload[0] == UInt8(ascii: "9"),
@@ -109,17 +118,20 @@ struct OSCProgressScanner {
         guard parts.count == 3 || parts.count == 4,
               parts[0] == "9", parts[1] == "4",
               let stateDigit = Int(parts[2]) else { return nil }
-        if parts.count == 4 {
-            // The progress field is a percentage; Grok reports `-1` for its
-            // indeterminate bar and an empty value on clear. Anything else (a
-            // notification body, stray text) means this wasn't a progress report.
-            let progress = parts[3]
-            guard progress.isEmpty || Int(progress) != nil else { return nil }
-        }
         switch stateDigit {
-        case 0: return .idle
-        case 1, 3: return .working
-        default: return nil // 2 = error, 4 = paused — not a clean transition
+        case 0:
+            return .idle // clear; any progress value is ignored
+        case 1, 3:
+            // Busy states carry a progress field. It is a percentage (`0…100`),
+            // Grok's indeterminate `-1`, or empty. A missing field, a stray value, or
+            // an out-of-range number means this wasn't a progress report.
+            guard parts.count == 4 else { return nil }
+            let progress = parts[3]
+            if progress.isEmpty { return .working }
+            guard let value = Int(progress), value == -1 || (0 ... 100).contains(value) else { return nil }
+            return .working
+        default:
+            return nil // 2 = error, 4 = paused — not a clean transition
         }
     }
 }

--- a/Sources/termio/Agents/OSCProgressScanner.swift
+++ b/Sources/termio/Agents/OSCProgressScanner.swift
@@ -6,7 +6,8 @@ import Foundation
 /// progress says "I am working" without termio having to recognise a spinner glyph.
 ///
 /// The sequence is the ConEmu / Windows Terminal progress protocol that libghostty
-/// forwards but does not surface: `ESC ] 9 ; 4 ; <state> ; <pct> (BEL | ST)`, where
+/// forwards but does not surface: `ESC ] 9 ; 4 ; <state> ; <progress> (BEL | ST)`,
+/// where
 /// - state `0` = clear → **idle**,
 /// - state `1` (normal) and `3` (indeterminate) → **working**,
 /// - state `2` (error) and `4` (paused) → ignored (neither a clean busy nor idle
@@ -15,32 +16,39 @@ import Foundation
 /// Grok emits `9;4;1;-1` natively while a turn runs and `9;4;0;` when it finishes;
 /// Claude Code emits the same shape once `terminalProgressBarEnabled` is set. This is
 /// fed every raw read chunk from the PTY (sequences split across reads are tolerated)
-/// and returns a value only when the busy/idle state actually flips — a stream of
-/// identical `9;4;1` keepalives collapses to a single `.working`.
+/// and returns each busy/idle flip in order — a stream of identical `9;4;1`
+/// keepalives collapses to nothing, but a chunk that carries a whole `busy … idle`
+/// turn yields both transitions rather than only the last (which the arbitration,
+/// keyed on the previous *delivered* state, would otherwise silently drop).
 ///
-/// It reads only OSC 9 *progress* (`9;4;…`); the neighbouring OSC 9 notification
-/// (`9;<text>`), OSC 9;9 cwd, and OSC 4 palette forms all fall through to `nil`.
+/// It reads only OSC 9 *progress* (`9;4;<state>;<progress>`); the neighbouring OSC 9
+/// notification (`9;<text>`), OSC 9;9 cwd, and OSC 4 palette forms all fall through —
+/// the grammar is validated end to end (state numeric, at most one numeric-or-empty
+/// progress field) and an overrun payload is rejected, so a notification whose body
+/// merely starts `4;…` can't be mistaken for progress.
 struct OSCProgressScanner {
     private enum State { case ground, esc, osc, oscEsc }
     private var state: State = .ground
     private var payload: [UInt8] = []
+    /// Set when a payload exceeds `maxPayload`: it is then too long to be a progress
+    /// report, so it is rejected outright rather than classified from its prefix.
+    private var overflowed = false
     private var lastActivity: AgentStatusRules.Activity?
-    /// Progress payloads are a handful of bytes (`9;4;1;-1`); anything longer is
-    /// some other OSC and can't be a progress report, so it is capped rather than
-    /// buffered unboundedly across a pathological unterminated sequence.
-    private static let maxPayload = 32
+    /// Progress payloads are a handful of bytes (`9;4;1;-1`); anything longer is some
+    /// other, longer OSC (a title, a notification) and cannot be a progress report.
+    private static let maxPayload = 24
 
-    /// Scans a raw chunk, returning the new activity iff the busy/idle state changed.
-    mutating func scan(_ data: Data) -> AgentStatusRules.Activity? {
-        var transition: AgentStatusRules.Activity?
+    /// Scans a raw chunk, returning every busy/idle flip it completes, in order.
+    /// Empty in the common case (no progress, or only repeats of the current state).
+    mutating func scan(_ data: Data) -> [AgentStatusRules.Activity] {
+        var transitions: [AgentStatusRules.Activity] = []
         for byte in data {
             switch state {
             case .ground:
                 if byte == 0x1B { state = .esc }
             case .esc:
                 if byte == UInt8(ascii: "]") {
-                    state = .osc
-                    payload.removeAll(keepingCapacity: true)
+                    beginPayload()
                 } else if byte == 0x1B {
                     state = .esc
                 } else {
@@ -49,16 +57,16 @@ struct OSCProgressScanner {
             case .osc:
                 switch byte {
                 case 0x07: // BEL terminator
-                    if let t = finish() { transition = t }
+                    if let t = finish() { transitions.append(t) }
                     state = .ground
                 case 0x1B: // possible ST (ESC \) terminator
                     state = .oscEsc
                 default:
-                    if payload.count < Self.maxPayload { payload.append(byte) }
+                    if payload.count < Self.maxPayload { payload.append(byte) } else { overflowed = true }
                 }
             case .oscEsc:
                 if byte == UInt8(ascii: "\\") { // ST terminator
-                    if let t = finish() { transition = t }
+                    if let t = finish() { transitions.append(t) }
                     state = .ground
                 } else if byte == 0x1B {
                     state = .oscEsc
@@ -68,20 +76,28 @@ struct OSCProgressScanner {
                 }
             }
         }
-        return transition
+        return transitions
+    }
+
+    private mutating func beginPayload() {
+        state = .osc
+        payload.removeAll(keepingCapacity: true)
+        overflowed = false
     }
 
     /// Classifies the buffered payload and reports it only on a state change.
     private mutating func finish() -> AgentStatusRules.Activity? {
-        defer { payload.removeAll(keepingCapacity: true) }
-        guard let activity = Self.classify(payload), activity != lastActivity else { return nil }
+        defer { payload.removeAll(keepingCapacity: true); overflowed = false }
+        guard !overflowed, let activity = Self.classify(payload), activity != lastActivity else { return nil }
         lastActivity = activity
         return activity
     }
 
     /// Maps an OSC 9 payload to an activity. Fast-rejects everything that isn't a
     /// `9;4;<state>` progress report before allocating, so the common OSC 0/2 title
-    /// spinner (one OSC per frame) never pays for a `String`.
+    /// spinner (one OSC per frame) never pays for a `String`, then validates the whole
+    /// grammar so a longer OSC 9 notification that happens to begin `4;…` is not
+    /// misread as progress.
     static func classify(_ payload: [UInt8]) -> AgentStatusRules.Activity? {
         guard payload.count >= 3,
               payload[0] == UInt8(ascii: "9"),
@@ -89,7 +105,17 @@ struct OSCProgressScanner {
               payload[2] == UInt8(ascii: "4") else { return nil }
         let parts = String(decoding: payload, as: UTF8.self)
             .split(separator: ";", omittingEmptySubsequences: false)
-        guard parts.count >= 3, parts[1] == "4", let stateDigit = Int(parts[2]) else { return nil }
+        // `9 ; 4 ; <state>` with an optional trailing `<progress>` — nothing more.
+        guard parts.count == 3 || parts.count == 4,
+              parts[0] == "9", parts[1] == "4",
+              let stateDigit = Int(parts[2]) else { return nil }
+        if parts.count == 4 {
+            // The progress field is a percentage; Grok reports `-1` for its
+            // indeterminate bar and an empty value on clear. Anything else (a
+            // notification body, stray text) means this wasn't a progress report.
+            let progress = parts[3]
+            guard progress.isEmpty || Int(progress) != nil else { return nil }
+        }
         switch stateDigit {
         case 0: return .idle
         case 1, 3: return .working

--- a/Sources/termio/Agents/OSCProgressScanner.swift
+++ b/Sources/termio/Agents/OSCProgressScanner.swift
@@ -1,40 +1,26 @@
 import Foundation
 
-/// Parses ConEmu-style `OSC 9;4` progress reports out of a terminal byte stream
-/// and maps them to an agent activity — an in-band busy/idle signal on the same
-/// unbreakable channel as the OSC title, but more precise: an agent that reports
-/// progress says "I am working" without termio having to recognise a spinner glyph.
+/// Parses ConEmu-style `OSC 9;4` progress out of a terminal byte stream as an agent
+/// busy/idle signal — the same unbreakable channel as the OSC title, but more precise
+/// (the agent says "I'm working" without termio having to recognise a spinner glyph).
+/// libghostty forwards the sequence but surfaces only titles (OSC 0/2) and cwd (OSC 7).
 ///
-/// The sequence is the ConEmu / Windows Terminal progress protocol that libghostty
-/// forwards but does not surface: `ESC ] 9 ; 4 ; <state> ; <progress> (BEL | ST)`,
-/// where
-/// - state `0` = clear → **idle**,
-/// - state `1` (normal) and `3` (indeterminate) → **working**,
-/// - state `2` (error) and `4` (paused) → ignored (neither a clean busy nor idle
-///   transition; leaving the last signal in place beats guessing).
+/// The protocol is `ESC ] 9 ; 4 ; <state> ; <progress> (BEL | ST)`: state `0` = clear
+/// → idle, `1`/`3` (normal/indeterminate) → working, `2`/`4` (error/paused) ignored.
+/// Grok emits `9;4;1;-1` while a turn runs and `9;4;0;` when it ends.
 ///
-/// Grok emits `9;4;1;-1` natively while a turn runs and `9;4;0;` when it finishes;
-/// Claude Code emits the same shape once `terminalProgressBarEnabled` is set. This is
-/// fed every raw read chunk from the PTY (sequences split across reads are tolerated)
-/// and returns each completed report in byte order — including *both* edges when a
-/// single read carries a whole `busy … idle` turn, which the arbitration (keyed on
-/// the previous *delivered* state) would otherwise silently drop.
+/// Fed every raw read chunk (sequences split across reads are tolerated), it returns
+/// each completed report in byte order — both edges when one read carries a whole
+/// `busy … idle` turn. It keeps NO cross-chunk state: duplicates collapse within a
+/// chunk, but dedup across reads is the store's job (`lastProgressActivity`, under the
+/// live-agent gate), exactly like the title channel. That is deliberate — a scanner
+/// that privately deduped a pre-promotion `working` (which the gate rejects) would then
+/// swallow the keepalives a row just promoted to Grok needs.
 ///
-/// The scanner keeps **no** cross-chunk state of its own: consecutive identical
-/// reports within one chunk collapse, but it never remembers the last activity across
-/// reads. Dedup is the store's job (`lastProgressActivity`, applied under the
-/// live-agent gate) — exactly like the title channel, whose every spinner frame
-/// re-fires and is collapsed in `applyTitleActivity`. Keeping the memory there and
-/// not here is what lets a session promoted to Grok mid-stream pick the signal up: a
-/// scanner that had privately deduped a pre-promotion `working` (rejected by the
-/// gate) would then swallow the keepalives the promoted row needs.
-///
-/// It reads only OSC 9 *progress* (`9;4;<state>;<progress>`); the neighbouring OSC 9
-/// notification (`9;<text>`), OSC 9;9 cwd, and OSC 4 palette forms all fall through —
-/// the grammar is validated end to end (numeric state, a progress field in the
-/// documented `0…100` range plus Grok's `-1`, no trailing fields) and an overrun
-/// payload is rejected, so a notification whose body merely starts `4;…` can't be
-/// mistaken for progress.
+/// Only `9;4` progress is read; OSC 9 notifications (`9;<text>`), OSC 9;9 cwd and OSC 4
+/// palette fall through — the grammar is validated whole (numeric state; busy carries a
+/// `0…100` percentage, Grok's `-1`, or empty) and overruns rejected, so a notification
+/// body starting `4;…` can't be misread as progress.
 struct OSCProgressScanner {
     private enum State { case ground, esc, osc, oscEsc }
     private var state: State = .ground
@@ -114,9 +100,11 @@ struct OSCProgressScanner {
               payload[2] == UInt8(ascii: "4") else { return nil }
         let parts = String(decoding: payload, as: UTF8.self)
             .split(separator: ";", omittingEmptySubsequences: false)
-        // `9 ; 4 ; <state>` with an optional trailing `<progress>` — nothing more.
+        // `9 ; 4 ; <state>` with an optional trailing `<progress>` — nothing more. The
+        // byte prefix already pinned `parts[0] == "9"`, but `4` may have been a longer
+        // run (`9;41;…`), so the second field is re-checked exactly.
         guard parts.count == 3 || parts.count == 4,
-              parts[0] == "9", parts[1] == "4",
+              parts[1] == "4",
               let stateDigit = Int(parts[2]) else { return nil }
         switch stateDigit {
         case 0:

--- a/Sources/termio/Resources/agents/grok.json
+++ b/Sources/termio/Resources/agents/grok.json
@@ -17,6 +17,7 @@
   "titleStatus": {
     "attention": ["Action Required"]
   },
+  "progressStatus": true,
   "hooks": {
     "type": "json",
     "file": "~/.grok/hooks/termio.json",

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -381,14 +381,24 @@ extension TermioStore {
     /// The `OSCProgressScanner` only reaches busy/idle, never attention, so the
     /// attention arm is unreachable here but kept exhaustive for the shared enum.
     func applyProgressActivity(_ activity: AgentStatusRules.Activity, for id: Session.ID) {
+        // Gate on the session's *live* agent, not a value captured when the sink was
+        // built: a plain terminal promoted to a hand-started Grok now opts in, while a
+        // shell that stays a shell (its `wget` bar) stays out. Re-reading the session
+        // here also drops any event that outlived the pane it came from — a session
+        // torn down or relaunched before this main-actor block ran no longer resolves,
+        // or resolves to an agent that doesn't emit progress, so it can't repopulate a
+        // cleared entry or move a replacement process's dot.
+        guard let session = session(id), effectiveAgent(for: session).emitsProgressStatus else { return }
         guard lastProgressActivity[id] != activity else { return }
         let previous = lastProgressActivity[id]
         lastProgressActivity[id] = activity
         switch activity {
         case .working:
+            // `needsAttention` stays senior — a blocked agent can keep its busy bar
+            // lit (herdr's "a blocker outranks a stale busy progress" rule). The live
+            // agent is already known to emit progress (top gate), so it is never the
+            // plain shell.
             guard status(for: id) != .needsAttention else { return }
-            guard let session = session(id), effectiveAgent(for: session) != .terminal
-            else { return }
             setStatus(.working, for: id)
             lastWorkingAt[id] = Date()
         case .attention:

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -208,6 +208,7 @@ extension TermioStore {
         lastUserInputAt[id] = nil
         promotionStreak[id] = nil
         lastTitleActivity[id] = nil
+        lastProgressActivity[id] = nil
         lastScreenActivity[id] = nil
         stallProbes[id] = nil
         blockingAttention.remove(id)
@@ -368,6 +369,38 @@ extension TermioStore {
         }
     }
 
+    /// Drives status from the agent's ConEmu-style `OSC 9;4` progress reports —
+    /// the in-band busy/idle signal Grok ships natively (`9;4;1;-1` while a turn
+    /// runs, `9;4;0;` when it ends). Like the title, this is a *correction* channel
+    /// layered over hooks on the one channel that cannot break (the PTY byte stream),
+    /// so its arbitration is deliberately identical to `applyTitleActivity` and just
+    /// as subordinate: a progress-working never overrides `needsAttention` (a blocked
+    /// agent can keep its busy bar lit — the herdr "blocker outranks a stale busy
+    /// progress" rule), and a progress-idle only ends a turn that is genuinely
+    /// working, so a lone or stale `9;4;0` can't clear a hook- or title-set state.
+    /// The `OSCProgressScanner` only reaches busy/idle, never attention, so the
+    /// attention arm is unreachable here but kept exhaustive for the shared enum.
+    func applyProgressActivity(_ activity: AgentStatusRules.Activity, for id: Session.ID) {
+        guard lastProgressActivity[id] != activity else { return }
+        let previous = lastProgressActivity[id]
+        lastProgressActivity[id] = activity
+        switch activity {
+        case .working:
+            guard status(for: id) != .needsAttention else { return }
+            guard let session = session(id), effectiveAgent(for: session) != .terminal
+            else { return }
+            setStatus(.working, for: id)
+            lastWorkingAt[id] = Date()
+        case .attention:
+            clearWorking(id)
+            flagBlockingAttention(for: id)
+        case .idle:
+            guard previous == .working, status(for: id) == .working else { return }
+            clearWorking(id)
+            setStatus(isViewing(id) ? .idle : .done, for: id)
+        }
+    }
+
     /// Reclassifies a shell-backed session to whatever agent runs in its foreground —
     /// for real, not as a runtime overlay: a hand-started `claude` makes the session
     /// *become* a Claude Code session (persisted, so a reopened app relaunches it as
@@ -423,6 +456,7 @@ extension TermioStore {
         projects[location.project].sessions[location.session] = session
         setLiveTitle(nil, for: id)
         lastTitleActivity[id] = nil
+        lastProgressActivity[id] = nil
         clearWorking(id)
         let current = status(for: id)
         if current == .working || current == .done { setStatus(.idle, for: id) }

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -394,10 +394,6 @@ extension TermioStore {
         lastProgressActivity[id] = activity
         switch activity {
         case .working:
-            // `needsAttention` stays senior — a blocked agent can keep its busy bar
-            // lit (herdr's "a blocker outranks a stale busy progress" rule). The live
-            // agent is already known to emit progress (top gate), so it is never the
-            // plain shell.
             guard status(for: id) != .needsAttention else { return }
             setStatus(.working, for: id)
             lastWorkingAt[id] = Date()

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -275,7 +275,16 @@ extension TermioStore {
                             agent: "\(agentID).progress", session: session.id,
                             activity: progress, matched: "OSC 9;4")
                     }
-                    DispatchQueue.main.async { self?.applyProgressActivity(progress, for: session.id) }
+                    // Tie the event to the PTY that produced it. Unlike the title
+                    // channel — whose Combine subscription is torn down with the view
+                    // state on relaunch — this sink is only session-id-keyed, so a
+                    // same-agent relaunch could otherwise let a dead PTY's queued
+                    // `working` mark the replacement process. Applying only while this
+                    // PTY is still the session's live one drops that stale event.
+                    DispatchQueue.main.async { [weak pty] in
+                        guard let self, let pty, self.ptyProcesses[session.id] === pty else { return }
+                        self.applyProgressActivity(progress, for: session.id)
+                    }
                 }
                 let now = Date()
                 guard now.timeIntervalSince(lastPoke) >= 1 else { return }

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -252,12 +252,14 @@ extension TermioStore {
             let agentID = session.agent.id
             let isAgentSession = session.agent != .terminal && !session.isSSH
             let statusTrace = ProcessInfo.processInfo.environment["TERMIO_STATUS_TRACE"] != nil
-            // Whether to read this agent's ConEmu `OSC 9;4` progress out of the raw
-            // stream as a busy/idle signal (Grok emits it natively). Scanned on every
-            // chunk *before* the 1 s status throttle below — an agent's turn boundary
-            // is an edge, not something to sample once a second — but only for agents
-            // that opt in, so a plain shell's download progress bar can't move a dot.
-            let emitsProgress = session.agent.emitsProgressStatus
+            // Reads this session's ConEmu `OSC 9;4` progress out of the raw stream as
+            // a busy/idle signal (Grok emits it natively). Scanned on every chunk
+            // *before* the 1 s status throttle below — an agent's turn boundary is an
+            // edge, not something to sample once a second. The scan runs for every
+            // session (a plain terminal can be promoted to a hand-started Grok, whose
+            // sink was built while the row was still a shell); whether a transition is
+            // *acted on* is gated in `applyProgressActivity` by the session's live
+            // agent, so an unrelated shell's `wget`/`npm` progress bar can't move a dot.
             var progressScanner = OSCProgressScanner()
             var lastPoke = Date.distantPast
             var lastScreenSignature: Int?
@@ -267,7 +269,7 @@ extension TermioStore {
             var pendingBytes = 0
             pty.addSink { [weak self, weak inMemory, weak pty] data in
                 pendingBytes += data.count
-                if emitsProgress, let progress = progressScanner.scan(data) {
+                for progress in progressScanner.scan(data) {
                     if statusTrace {
                         AgentStatusRules.trace(
                             agent: "\(agentID).progress", session: session.id,

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -252,6 +252,13 @@ extension TermioStore {
             let agentID = session.agent.id
             let isAgentSession = session.agent != .terminal && !session.isSSH
             let statusTrace = ProcessInfo.processInfo.environment["TERMIO_STATUS_TRACE"] != nil
+            // Whether to read this agent's ConEmu `OSC 9;4` progress out of the raw
+            // stream as a busy/idle signal (Grok emits it natively). Scanned on every
+            // chunk *before* the 1 s status throttle below — an agent's turn boundary
+            // is an edge, not something to sample once a second — but only for agents
+            // that opt in, so a plain shell's download progress bar can't move a dot.
+            let emitsProgress = session.agent.emitsProgressStatus
+            var progressScanner = OSCProgressScanner()
             var lastPoke = Date.distantPast
             var lastScreenSignature: Int?
             // Bytes seen since the last poke, so the throttled tick can report the
@@ -260,6 +267,14 @@ extension TermioStore {
             var pendingBytes = 0
             pty.addSink { [weak self, weak inMemory, weak pty] data in
                 pendingBytes += data.count
+                if emitsProgress, let progress = progressScanner.scan(data) {
+                    if statusTrace {
+                        AgentStatusRules.trace(
+                            agent: "\(agentID).progress", session: session.id,
+                            activity: progress, matched: "OSC 9;4")
+                    }
+                    DispatchQueue.main.async { self?.applyProgressActivity(progress, for: session.id) }
+                }
                 let now = Date()
                 guard now.timeIntervalSince(lastPoke) >= 1 else { return }
                 lastPoke = now

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -510,6 +510,11 @@ final class TermioStore: ObservableObject {
     /// transitions — a spinner frame change re-classifies as the same `working`
     /// and is dropped here.
     var lastTitleActivity: [Session.ID: AgentStatusRules.Activity] = [:]
+    /// The last busy/idle state an agent's `OSC 9;4` progress reports resolved to
+    /// (see `applyProgressActivity` / `OSCProgressScanner`). The scanner already
+    /// collapses keepalives, but a session torn down and rebuilt gets a fresh scanner,
+    /// so the store dedupes here too — and the transition guard mirrors the title path.
+    var lastProgressActivity: [Session.ID: AgentStatusRules.Activity] = [:]
     /// Sessions whose `.needsAttention` dot came from a genuine, *observable*
     /// blocking condition — a hook / screen / title "attention" signal, all of which
     /// have a matching "resolved" transition (the agent proceeds → working/idle/done).

--- a/Tests/termioTests/OSCProgressScannerTests.swift
+++ b/Tests/termioTests/OSCProgressScannerTests.swift
@@ -36,10 +36,22 @@ final class OSCProgressScannerTests: XCTestCase {
         XCTAssertEqual(scan(["\u{1B}]9;4;3;\u{1B}\\"]), [.working])
     }
 
-    func testRepeatedBusyKeepalivesCollapseToOneTransition() {
+    func testKeepalivesInOneChunkCollapse() {
+        // Consecutive duplicates within a single read collapse to one report.
+        XCTAssertEqual(
+            scan(["\u{1B}]9;4;1;-1\u{07}\u{1B}]9;4;1;-1\u{07}\u{1B}]9;4;1;-1\u{07}"]),
+            [.working])
+    }
+
+    /// The scanner keeps no memory across reads: each chunk's keepalive is reported,
+    /// and the *store* dedupes under the live-agent gate (`lastProgressActivity`).
+    /// This is what lets a session promoted to Grok mid-stream pick the signal up
+    /// after its first `working` was gate-rejected — a scanner that privately deduped
+    /// would swallow the keepalives the promoted row needs.
+    func testKeepalivesAcrossChunksAreEachReported() {
         XCTAssertEqual(
             scan(["\u{1B}]9;4;1;-1\u{07}", "\u{1B}]9;4;1;-1\u{07}", "\u{1B}]9;4;1;-1\u{07}"]),
-            [.working])
+            [.working, .working, .working])
     }
 
     /// A single PTY read can carry a whole fast turn — both edges must survive, in
@@ -72,6 +84,17 @@ final class OSCProgressScannerTests: XCTestCase {
         XCTAssertEqual(scan(["\u{1B}]9;4;1;-1;extra;fields\u{07}"]), [])
     }
 
+    /// The busy states carry a progress field in the documented `0…100` range (plus
+    /// Grok's `-1`). An out-of-range value, or no field at all, is not a progress
+    /// report — which also narrows the OSC 9 notification collision.
+    func testBusyStateValidatesProgressRange() {
+        XCTAssertEqual(scan(["\u{1B}]9;4;1;100\u{07}"]), [.working]) // upper bound ok
+        XCTAssertEqual(scan(["\u{1B}]9;4;1;0\u{07}"]), [.working])   // lower bound ok
+        XCTAssertEqual(scan(["\u{1B}]9;4;1;101\u{07}"]), [])         // out of range
+        XCTAssertEqual(scan(["\u{1B}]9;4;1;-2\u{07}"]), [])          // only -1 allowed
+        XCTAssertEqual(scan(["\u{1B}]9;4;1\u{07}"]), [])             // busy needs a field
+    }
+
     /// An overlong payload can't be a progress report, so it is rejected outright
     /// rather than classified from its truncated prefix.
     func testOverlongPayloadIsRejected() {
@@ -88,8 +111,10 @@ final class OSCProgressScannerTests: XCTestCase {
 
     func testClassifyDirect() {
         XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;0;".utf8)), .idle)
+        XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;0".utf8)), .idle) // clear needs no field
         XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;1;-1".utf8)), .working)
-        XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;3".utf8)), .working)
+        XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;3;".utf8)), .working) // indeterminate, empty
+        XCTAssertNil(OSCProgressScanner.classify(Array("9;4;3".utf8))) // busy needs a progress field
         XCTAssertNil(OSCProgressScanner.classify(Array("9;4".utf8)))
         XCTAssertNil(OSCProgressScanner.classify(Array("9;4;1;text".utf8)))
         XCTAssertNil(OSCProgressScanner.classify(Array("9;9;cwd".utf8)))

--- a/Tests/termioTests/OSCProgressScannerTests.swift
+++ b/Tests/termioTests/OSCProgressScannerTests.swift
@@ -2,14 +2,16 @@ import XCTest
 @testable import termio
 
 /// Pins the `OSC 9;4` progress parser (issue #23): the ConEmu busy/idle states map
-/// correctly, the busy/idle transition fires only on a real flip, the two OSC
-/// terminators (BEL and ST) both close a sequence, sequences split across read
-/// chunks reassemble, and neighbouring OSC forms (title, notification, palette) are
-/// ignored so nothing but a genuine progress report can move an agent's dot.
+/// correctly, the busy/idle transition fires only on a real flip, *every* flip in a
+/// chunk is reported in order, the two OSC terminators (BEL and ST) both close a
+/// sequence, sequences split across read chunks reassemble, and neighbouring OSC
+/// forms (title, notification, palette) plus malformed/overlong payloads are all
+/// rejected so nothing but a genuine progress report can move an agent's dot.
 final class OSCProgressScannerTests: XCTestCase {
+    /// Feeds each chunk and flattens every transition, in order.
     private func scan(_ chunks: [String]) -> [AgentStatusRules.Activity] {
         var scanner = OSCProgressScanner()
-        return chunks.compactMap { scanner.scan(Data($0.utf8)) }
+        return chunks.flatMap { scanner.scan(Data($0.utf8)) }
     }
 
     func testBusyThenIdle() {
@@ -40,6 +42,14 @@ final class OSCProgressScannerTests: XCTestCase {
             [.working])
     }
 
+    /// A single PTY read can carry a whole fast turn — both edges must survive, in
+    /// order, or the arbitration (keyed on the previous *delivered* state) drops both.
+    func testBothTransitionsInOneChunkAreReported() {
+        XCTAssertEqual(
+            scan(["\u{1B}]9;4;1;-1\u{07}some output\u{1B}]9;4;0;\u{07}"]),
+            [.working, .idle])
+    }
+
     func testSequenceSplitAcrossChunks() {
         // The terminator lands in a later read than the introducer.
         XCTAssertEqual(scan(["\u{1B}]9;4", ";1;", "-1\u{07}"]), [.working])
@@ -54,6 +64,21 @@ final class OSCProgressScannerTests: XCTestCase {
         XCTAssertEqual(scan(["\u{1B}]4;0;rgb:11/22/33\u{07}"]), [])
     }
 
+    /// A notification whose body merely *starts* `4;<state>;` must not be mistaken for
+    /// progress: the trailing field isn't numeric, and extra `;`-fields overrun the
+    /// `9;4;state;progress` grammar.
+    func testProgressLikeNotificationBodyIsRejected() {
+        XCTAssertEqual(scan(["\u{1B}]9;4;1;this is a notification\u{07}"]), [])
+        XCTAssertEqual(scan(["\u{1B}]9;4;1;-1;extra;fields\u{07}"]), [])
+    }
+
+    /// An overlong payload can't be a progress report, so it is rejected outright
+    /// rather than classified from its truncated prefix.
+    func testOverlongPayloadIsRejected() {
+        let long = "9;4;1;" + String(repeating: "9", count: 64)
+        XCTAssertEqual(scan(["\u{1B}]" + long + "\u{07}"]), [])
+    }
+
     func testProgressAmidstOtherOutput() {
         // A busy report embedded in a burst of ordinary bytes still lands.
         XCTAssertEqual(
@@ -64,7 +89,9 @@ final class OSCProgressScannerTests: XCTestCase {
     func testClassifyDirect() {
         XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;0;".utf8)), .idle)
         XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;1;-1".utf8)), .working)
+        XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;3".utf8)), .working)
         XCTAssertNil(OSCProgressScanner.classify(Array("9;4".utf8)))
+        XCTAssertNil(OSCProgressScanner.classify(Array("9;4;1;text".utf8)))
         XCTAssertNil(OSCProgressScanner.classify(Array("9;9;cwd".utf8)))
     }
 }

--- a/Tests/termioTests/OSCProgressScannerTests.swift
+++ b/Tests/termioTests/OSCProgressScannerTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import termio
+
+/// Pins the `OSC 9;4` progress parser (issue #23): the ConEmu busy/idle states map
+/// correctly, the busy/idle transition fires only on a real flip, the two OSC
+/// terminators (BEL and ST) both close a sequence, sequences split across read
+/// chunks reassemble, and neighbouring OSC forms (title, notification, palette) are
+/// ignored so nothing but a genuine progress report can move an agent's dot.
+final class OSCProgressScannerTests: XCTestCase {
+    private func scan(_ chunks: [String]) -> [AgentStatusRules.Activity] {
+        var scanner = OSCProgressScanner()
+        return chunks.compactMap { scanner.scan(Data($0.utf8)) }
+    }
+
+    func testBusyThenIdle() {
+        // Grok's native shape: `9;4;1;-1` busy while a turn runs, `9;4;0;` when done.
+        XCTAssertEqual(
+            scan(["\u{1B}]9;4;1;-1\u{07}", "\u{1B}]9;4;0;\u{07}"]),
+            [.working, .idle])
+    }
+
+    func testIndeterminateStateIsWorking() {
+        XCTAssertEqual(scan(["\u{1B}]9;4;3;\u{07}"]), [.working])
+    }
+
+    func testErrorAndPausedStatesAreIgnored() {
+        // State 2 (error) and 4 (paused) are neither a clean busy nor idle edge.
+        XCTAssertEqual(scan(["\u{1B}]9;4;2;50\u{07}"]), [])
+        XCTAssertEqual(scan(["\u{1B}]9;4;4;\u{07}"]), [])
+    }
+
+    func testStringTerminatorClosesSequence() {
+        // `9;4;3` opened with an ST (ESC \) instead of BEL.
+        XCTAssertEqual(scan(["\u{1B}]9;4;3;\u{1B}\\"]), [.working])
+    }
+
+    func testRepeatedBusyKeepalivesCollapseToOneTransition() {
+        XCTAssertEqual(
+            scan(["\u{1B}]9;4;1;-1\u{07}", "\u{1B}]9;4;1;-1\u{07}", "\u{1B}]9;4;1;-1\u{07}"]),
+            [.working])
+    }
+
+    func testSequenceSplitAcrossChunks() {
+        // The terminator lands in a later read than the introducer.
+        XCTAssertEqual(scan(["\u{1B}]9;4", ";1;", "-1\u{07}"]), [.working])
+    }
+
+    func testTitleAndNotificationAndPaletteAreIgnored() {
+        // OSC 0/2 title (with a Claude braille spinner), OSC 9 notification,
+        // OSC 9;9 cwd, OSC 4 palette query — none is a 9;4 progress report.
+        XCTAssertEqual(scan(["\u{1B}]2;\u{2801} building\u{07}"]), [])
+        XCTAssertEqual(scan(["\u{1B}]9;done\u{07}"]), [])
+        XCTAssertEqual(scan(["\u{1B}]9;9;/Users/me/repo\u{07}"]), [])
+        XCTAssertEqual(scan(["\u{1B}]4;0;rgb:11/22/33\u{07}"]), [])
+    }
+
+    func testProgressAmidstOtherOutput() {
+        // A busy report embedded in a burst of ordinary bytes still lands.
+        XCTAssertEqual(
+            scan(["hello\r\n\u{1B}]2;title\u{07}world \u{1B}]9;4;1;-1\u{07} more"]),
+            [.working])
+    }
+
+    func testClassifyDirect() {
+        XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;0;".utf8)), .idle)
+        XCTAssertEqual(OSCProgressScanner.classify(Array("9;4;1;-1".utf8)), .working)
+        XCTAssertNil(OSCProgressScanner.classify(Array("9;4".utf8)))
+        XCTAssertNil(OSCProgressScanner.classify(Array("9;9;cwd".utf8)))
+    }
+}


### PR DESCRIPTION
Closes #23.

## What

Grok natively emits ConEmu-style **`OSC 9;4` progress** on the PTY byte stream — `9;4;1;-1` while a turn runs, `9;4;0;` when it ends. That's a busy/idle signal on the one channel that cannot break (no hook file, no external script, no socket). libghostty forwards the sequence but only surfaces titles (OSC 0/2) and cwd (OSC 7), so termio never saw it — this wires it in.

## How

- **`OSCProgressScanner`** — a small, allocation-light value-type byte parser fed every raw read chunk from the *existing* status tap, **before** the 1 s throttle (a turn boundary is an edge, not something to sample once a second). Tolerates both OSC terminators (BEL / ST) and sequences split across reads, maps the ConEmu states (`0` idle, `1`/`3` busy, `2`/`4` ignored), and reports only on a real busy↔idle flip so keepalives collapse.
- **`applyProgressActivity`** — arbitration *identical to and as subordinate as* the existing title path: a progress-working never overrides `needsAttention`, and a progress-idle only ends a turn that is genuinely working, so a lone or stale `9;4;0` can't clear a hook- or title-set state. This is herdr's "a blocker outranks a stale busy progress" discipline.
- **Opt-in per agent** via manifest `progressStatus` (Grok only for now), so a plain shell's `wget`/`npm` progress bar can never move an agent's status dot.

## Why Grok-only

Grok emits this with **zero config**. Claude Code can emit the same shape, but only once `terminalProgressBarEnabled` is set — a managed write to the clobber-prone `~/.claude/settings.json`, for a *redundant idle confirm* that hooks already cover. Not worth the surface; left as a documented follow-up. Design rationale from comparing herdr (ships this, ranks it above the title) and cmux (skips it for a hooks + OSC 99 model — what termio already has).

## Tests

`OSCProgressScannerTests` (9 cases): state mapping, transition dedup, BEL vs ST terminators, split-read reassembly, and that OSC 0/2 title / OSC 9 notification / OSC 9;9 cwd / OSC 4 palette are all ignored. Full suite green (41/41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)