### PR TITLE
feat(notify): agent-triggered `termio notify` CLI + reliable notifications

### DIFF
--- a/.claude/skills/macos-rebuild-dev/SKILL.md
+++ b/.claude/skills/macos-rebuild-dev/SKILL.md
@@ -29,8 +29,14 @@ All of this falls out of the `.dev` bundle-id suffix via `Sources/termio/Compani
 
 termio is a plain SwiftPM executable (`Package.swift` → `executableTarget` named
 `termio`); `swift build` alone produces a bare binary with **no Dock icon**. So this
-skill builds the real bundle via `scripts/build-app.sh` (ad-hoc signed; the app runs
-unsandboxed with `.exec` PTYs — see `CLAUDE.md`). The icon is `packaging/icon-static.svg`,
+skill builds the real bundle via `scripts/build-app.sh`. For a dev build the script
+auto-picks a real codesigning identity from **your own** keychain (any "Apple
+Development" / "Developer ID Application" cert — a free Apple ID gives you one) so the
+dev app can post macOS notifications; `usernoted` rejects an ad-hoc signature outright,
+so an unsigned dev build can **never** banner. A contributor with **no** signing cert
+falls back to ad-hoc automatically — the build still succeeds, they just don't get
+notifications. Set `SIGN_IDENTITY=…` to force a specific one. The app runs
+unsandboxed with `.exec` PTYs — see `CLAUDE.md`. The icon is `packaging/icon-static.svg`,
 rasterized to `packaging/AppIcon.png` by `scripts/render-icon.sh` (needs headless
 Chrome). Note: dev and release currently share the same icon art and differ only by
 name ("termio dev") — a tinted dev icon is a possible follow-up.

--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -35,9 +35,12 @@ struct ControlRequest: Decodable {
     let wait: Bool?
     /// The `--wait` cap in milliseconds; clamped server-side. Nil uses the default.
     let timeoutMs: Int?
+    /// Optional banner title for the `notify` op; defaults to the calling agent's
+    /// name when absent.
+    let title: String?
 
     private enum CodingKeys: String, CodingKey {
-        case op, format, target, text, lines, agent, snapshot, wait
+        case op, format, target, text, lines, agent, snapshot, wait, title
         case callerSession = "caller_session"
         case callerCwd = "caller_cwd"
         case timeoutMs = "timeout_ms"

--- a/Sources/termio/App/TaskNotifications.swift
+++ b/Sources/termio/App/TaskNotifications.swift
@@ -62,6 +62,26 @@ final class TaskNotificationCenter: NSObject {
         self.store = store
         guard AppChannel.isBundledApp else { return }
         UNUserNotificationCenter.current().delegate = self
+        // Ask for authorization eagerly, at launch, when the feature is on.
+        // The lazy per-settle request (below) only ever fires while termio is
+        // *backgrounded* — so a user who watches their agents finish never
+        // trips it, the prompt never appears, and no grant is ever recorded
+        // (the failure is completely silent). Requesting here guarantees the
+        // prompt is offered once. `requestAuthorization` is idempotent: after
+        // the first decision it returns the recorded answer without
+        // re-prompting, so this is free on every later launch.
+        guard store.settings.notifyOnTaskCompletion else { return }
+        UNUserNotificationCenter.current()
+            .requestAuthorization(options: [.alert, .sound]) { granted, error in
+                if let error {
+                    // An ad-hoc-signed dev build is rejected outright here
+                    // (UNErrorDomain 1) — dev builds can NEVER banner; test on
+                    // the release build. A user denial just reads granted=false.
+                    Log.app.error("notification authorization failed at launch: \(error.localizedDescription, privacy: .public)")
+                } else {
+                    Log.app.info("notification authorization at launch: granted=\(granted, privacy: .public)")
+                }
+            }
     }
 
     /// A session's turn began. Called from the status choke point on the
@@ -93,16 +113,23 @@ final class TaskNotificationCenter: NSObject {
         // policy Cursor and Codex both ship (`unfocused`-only). While termio is
         // frontmost, the sidebar dot and menu-bar pulse are the completion
         // channel; a banner would duplicate them in a louder one.
-        guard !NSApp.isActive else { return }
+        guard !NSApp.isActive else {
+            Log.app.debug("notification suppressed for \(id, privacy: .public): termio is frontmost")
+            return
+        }
         if status == .done {
             // A quick reply isn't worth an interruption; a blocked agent always is.
             if let since = turn?.workingSince,
                Date().timeIntervalSince(since) < Self.minimumTurnDuration {
+                Log.app.debug("notification suppressed for \(id, privacy: .public): turn shorter than \(Self.minimumTurnDuration, privacy: .public)s")
                 return
             }
             // Task vs chat: a turn that ran no tools produced an answer, not work.
             // Applied only to sessions with proven tool telemetry.
-            if let turn, turn.toolCapable, !turn.sawTool { return }
+            if let turn, turn.toolCapable, !turn.sawTool {
+                Log.app.debug("notification suppressed for \(id, privacy: .public): tool-capable turn ran no tool")
+                return
+            }
         }
 
         let content = UNMutableNotificationContent()
@@ -156,6 +183,50 @@ final class TaskNotificationCenter: NSObject {
                 center.add(request) { error in
                     if let error {
                         Log.app.error("notification post failed: \(error.localizedDescription, privacy: .public)")
+                    }
+                }
+            }
+        }
+    }
+
+    /// Posts a notification on an agent's explicit request (`termio notify`),
+    /// bypassing the automatic path's policy gates — the agent asked for it, so it
+    /// fires whether or not termio is frontmost. When a calling session is known,
+    /// the banner is keyed to it (so a click focuses it and a later automatic
+    /// banner replaces rather than stacks) and carries the agent's icon; a
+    /// plain-shell caller posts a standalone, unlinked banner. Deliberately not
+    /// gated on `notifyOnTaskCompletion`: that switch governs the *automatic*
+    /// banners, whereas this is a direct, opt-in call.
+    func postManual(title: String, body: String, project: Project?, session: Session?) {
+        guard AppChannel.isBundledApp else { return }
+        let content = UNMutableNotificationContent()
+        content.title = title
+        if let project { content.subtitle = project.name }
+        content.body = body
+        if store?.settings.notificationSoundEnabled == true { content.sound = .default }
+        let agent = session.flatMap { store?.effectiveAgent(for: $0) }
+        let identifier: String
+        if let session {
+            content.userInfo = [Self.sessionKey: session.id.uuidString]
+            identifier = Self.identifier(for: session.id)
+        } else {
+            identifier = "task-manual.\(UUID().uuidString)"
+        }
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                Log.app.error("manual notification authorization failed: \(error.localizedDescription, privacy: .public)")
+            }
+            guard granted else { return }
+            DispatchQueue.main.async {
+                if let agent, let attachment = Self.agentIconAttachment(for: agent) {
+                    content.attachments = [attachment]
+                }
+                let request = UNNotificationRequest(
+                    identifier: identifier, content: content, trigger: nil)
+                center.add(request) { error in
+                    if let error {
+                        Log.app.error("manual notification post failed: \(error.localizedDescription, privacy: .public)")
                     }
                 }
             }

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -46,9 +46,37 @@ extension TermioStore {
         case "close": return closeTab(request, in: project)
         case "focus": return focusSession(request, in: project)
         case "read": return readScreen(request, in: project)
+        case "notify": return notify(request, in: project)
         default:
             return controlError(request, "bad_op", "Unknown op '\(request.op)'.")
         }
+    }
+
+    /// `termio notify` — post a macOS notification on the agent's explicit request
+    /// ("I'm done", "I need input"). Unlike the automatic task-completion banner,
+    /// this carries no policy gate: the agent asked for it, so it fires whether or
+    /// not termio is frontmost and regardless of turn length. The calling session
+    /// rides in the banner so a click focuses it, and the project supplies the
+    /// subtitle. The body is the only required argument.
+    private func notify(_ request: ControlRequest, in project: Project) -> Data {
+        let body = (request.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else {
+            return controlError(request, "empty_body",
+                "notify needs a message, e.g. `termio notify \"tests passed\"`.")
+        }
+        // The calling session, when there is one, makes the banner clickable back to
+        // the agent that posted it. A plain-shell caller simply posts an unlinked one.
+        let caller = request.callerSession
+            .flatMap { UUID(uuidString: $0) }
+            .flatMap { session($0) }
+        let title = request.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedTitle = (title?.isEmpty == false)
+            ? title!
+            : caller.map { effectiveAgent(for: $0).displayName } ?? "termio"
+        TaskNotificationCenter.shared.postManual(
+            title: resolvedTitle, body: body, project: project, session: caller)
+        return control(request, ok: true, text: "notified",
+                       json: ["notified": true, "title": resolvedTitle])
     }
 
     /// Validates a `watch` subscription and returns the caller's project id to scope

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -49,7 +49,29 @@ contents_dir="$app_dir/Contents"
 macos_dir="$contents_dir/MacOS"
 resources_dir="$contents_dir/Resources"
 frameworks_dir="$contents_dir/Frameworks"
-sign_identity="${SIGN_IDENTITY:--}"
+# Signing identity resolution:
+#   - Explicit SIGN_IDENTITY always wins (the release runbook sets it).
+#   - Otherwise a dev build tries to auto-pick a real identity from the keychain,
+#     because local notifications (UNUserNotificationCenter) are rejected outright
+#     for an ad-hoc-signed app — dev builds can only banner when properly signed.
+#   - If no identity is present (e.g. a contributor without a signing cert), fall
+#     back to ad-hoc so the build STILL succeeds — you just don't get notifications.
+if [[ -n "${SIGN_IDENTITY:-}" ]]; then
+    sign_identity="$SIGN_IDENTITY"
+elif [[ "$channel" == "dev" ]]; then
+    # Prefer a Developer ID cert: it is self-sufficient for notification
+    # authorization. An "Apple Development" cert needs a matching provisioning
+    # profile or usernoted answers "Notifications are not allowed", so it is only
+    # a last resort.
+    ids="$(security find-identity -v -p codesigning 2>/dev/null)"
+    sign_identity="$(printf '%s\n' "$ids" | grep -oE '"Developer ID Application:[^"]*"' | head -1 | tr -d '"')"
+    [[ -z "$sign_identity" ]] && sign_identity="$(printf '%s\n' "$ids" | grep -oE '"Apple Development:[^"]*"' | head -1 | tr -d '"')"
+    sign_identity="${sign_identity:--}"
+    [[ "$sign_identity" == "-" ]] \
+        && echo "==> No signing identity found — ad-hoc (notifications will not work in this dev build)"
+else
+    sign_identity="-"
+fi
 
 echo "==> Building $app_name ($configuration)"
 swift build -c "$configuration"
@@ -163,7 +185,10 @@ fi
 # the framework before the outer app, or codesign rejects the bundle.
 sign_args=(--force --sign "$sign_identity")
 if [[ "$sign_identity" != "-" ]]; then
-    sign_args+=(--options runtime --timestamp)
+    sign_args+=(--options runtime)
+    # A secure timestamp needs the network and only matters for notarized
+    # distribution; skip it for local dev builds so a rebuild works offline/fast.
+    [[ "$channel" == "dev" ]] || sign_args+=(--timestamp)
 fi
 
 echo "==> Signing with identity: $sign_identity"

--- a/scripts/termio
+++ b/scripts/termio
@@ -33,6 +33,8 @@ usage:
   termio sessions close <agent>@<id> [...]   close session tabs
   termio sessions focus <agent>@<id>         select the session in the app
 
+  termio notify [--title T] "<message>"      post a macOS notification (e.g. "I'm done")
+
   termio agent report <state>                report this agent's activity (hook contract)
 
 options:
@@ -568,6 +570,50 @@ agent() {
     if [ "$reply" -eq 1 ]; then printf '{}'; fi
 }
 
+# `termio notify [--title T] "<message>"` — post a macOS notification on demand.
+# An agent calls this to ping the user ("tests passed", "I need input") without
+# waiting for the automatic task-completion banner, which only fires while termio
+# is backgrounded. The message is required; --title overrides the default (the
+# calling agent's name). Routed through the running app over the control socket so
+# the banner wears termio's identity and a click focuses the calling session.
+notify() {
+    format=text
+    title=""
+    body=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --json) format=json ;;
+            --title)
+                [ $# -ge 2 ] || { echo "termio: --title needs a value" >&2; exit 1; }
+                title="$2"; shift ;;
+            -h|--help)
+                cat <<'EOF'
+usage: termio notify [--title T] "<message>" [--json]
+
+Post a macOS notification from the running app. The agent uses this to ping you
+directly — "build finished", "need a decision" — regardless of whether termio is
+frontmost (unlike the automatic completion banner). --title overrides the default
+(the calling agent's name); the banner's subtitle is the project, and clicking it
+focuses the session that posted it.
+EOF
+                exit 0 ;;
+            *) body="${body:+$body }$1" ;;
+        esac
+        shift
+    done
+    if [ -z "$body" ]; then
+        echo "termio: notify needs a message (e.g. \`termio notify \"tests passed\"\`)" >&2
+        exit 1
+    fi
+    if [ ! -S "$SOCKET" ]; then
+        echo "termio: app is not running (no control socket at $SOCKET)" >&2
+        exit 1
+    fi
+    extra=""
+    [ -n "$title" ] && extra="\"title\":\"$(json_escape "$title")\""
+    request_once notify "$format" "" "" "$body" "$extra"
+}
+
 open_project() {
     dir="${1:-.}"
     if [ ! -d "$dir" ]; then
@@ -599,6 +645,11 @@ case "${1:-}" in
     agent)
         shift
         agent "$@"
+        exit 0
+        ;;
+    notify)
+        shift
+        notify "$@"
         exit 0
         ;;
     open)


### PR DESCRIPTION
## What

Adds an **agent-triggered** notification path and fixes why task-completion banners never appeared for some users.

### `termio notify [--title T] "<msg>"`
An agent posts a macOS banner on demand ("done", "need input"), routed through the app's control socket so the banner carries termio's identity and a click focuses the calling session. No policy gate (unlike the automatic completion banner) — the agent explicitly asked for it.

- CLI verb in `scripts/termio` → `ControlRequest{op:"notify", text, title}` → `TermioStore.notify()` → `TaskNotificationCenter.postManual()`.
- Added a `title` field to `ControlRequest`.

### Notification reliability fix
- **Request authorization at launch** instead of lazily on first settle. The lazy request sat behind the `!NSApp.isActive` gate, so a user who watches agents finish was never prompted and no grant was ever recorded — a silent, permanent failure. (Root-caused live: macOS had *zero* notification records for termio.)
- **Log which gate suppressed each settle** (frontmost / <10s / no-tool) so it can't fail invisibly again.

### Dev testability
- `build-app.sh` dev builds now auto-sign with a real keychain identity (prefer Developer ID → Apple Development → ad-hoc fallback so a contributor with no cert still builds), and skip `--timestamp` for dev (offline/fast). Lets a dev build reach the auth path.

## Test status
- ✅ **Plumbing verified end-to-end**: CLI → socket → `postManual` → `UNUserNotificationCenter` returns `notified` (exit 0).
- ✅ Release app confirmed delivering banners live (`usernoted: Presenting … as banner`).
- ⚠️ **Not yet visually verified for `termio notify` specifically** — a visible banner needs a signed release build (locally-built dev can't banner: unnotarized + poisoned bundle id). **Do not tag/release until the banner is seen on a release build.**

## Not included
Unrelated pre-existing working-tree changes (git pane, trace view, screenshots, iOS icon) were deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)