### PR TITLE
fix(issues): cache issue/PR detail; clip diff wash seam (#176)

### DIFF
--- a/Sources/termio/Git/DiffGutterRulerView.swift
+++ b/Sources/termio/Git/DiffGutterRulerView.swift
@@ -106,8 +106,18 @@ final class DiffGutterRulerView: NSRulerView {
                 band.origin.x = 0
                 band.size.width = ruleThickness
                 if line.isBand { band = band.insetBy(dx: 0, dy: -DiffDocument.bandPadding) }
-                fill.setFill()
-                band.fill()
+                // Clip the wash to the same top margin the numbers respect: a row scrolled
+                // partly under the header must not fill the sliver above the content clip, or
+                // its tint seams into the header (issue #176 — the green top-left sliver).
+                let topClip = bounds.minY + topClipInset
+                if band.minY < topClip {
+                    band.size.height -= topClip - band.minY
+                    band.origin.y = topClip
+                }
+                if band.height > 0 {
+                    fill.setFill()
+                    band.fill()
+                }
             }
 
             guard case .code(let kind) = line.role else { continue }

--- a/Sources/termio/Issues/IssueDetailCache.swift
+++ b/Sources/termio/Issues/IssueDetailCache.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+// MARK: - Issue detail cache
+
+/// App-level cache of fetched issue / pull-request detail, keyed by *remote* identity
+/// (`owner/repo` container + number) rather than the local checkout path. Held on
+/// `TermioStore`, so a fetched conversation and PR files survive everything that tears an
+/// `IssuesPanelModel` down: the inspector switching tab, collapsing, remounting on a session
+/// switch, or a *second worktree of the same repo* opening the same issue. Detail is a
+/// property of the remote item, not the local clone — so two worktrees share one cached copy.
+///
+/// This is the "flat cache" pattern (Khanlou; GitHawk's `FlatCache`): the data lives *above*
+/// the view, keyed by object id, so the view is a pure projection that reads on mount instead
+/// of re-fetching. Detail opens become stale-while-revalidate — see
+/// `IssuesPanelModel.loadDetail`.
+@MainActor
+final class IssueDetailCache {
+    struct Key: Hashable {
+        let container: IssueContainer
+        let number: Int
+    }
+
+    /// One fetched item: the conversation plus (for PRs) the changed files, their inline
+    /// patches, and branch facts — everything `loadDetail` populates in one shot, so a warm
+    /// read restores the whole detail with no further network or git work. `fetchedAt` drives
+    /// the revalidation dedupe window.
+    struct Entry {
+        var detail: IssueDetail
+        var prFiles: [GitChange]
+        var prFilePatches: [String: String]
+        var prInfo: PullRequestGitInfo?
+        /// The conversation is cached the instant it lands — *before* a PR's heavy `/files`
+        /// response — so even opening a PR and immediately switching away warms the cache. This
+        /// marks whether that file list has since folded in: `false` means "files still pending",
+        /// so a warm read fetches them (rather than mistaking it for a PR that changes no files).
+        /// Always `true` for an issue (no files) and for a fully fetched PR.
+        var filesLoaded: Bool
+        var fetchedAt: Date
+
+        /// Whether another entry carries the same remotely fetched content (ignoring
+        /// `fetchedAt`), so a revalidation that finds nothing changed can skip republishing
+        /// and never flickers the open detail.
+        func sameContent(as other: Entry) -> Bool {
+            detail == other.detail
+                && prFiles == other.prFiles
+                && prFilePatches == other.prFilePatches
+                && prInfo == other.prInfo
+        }
+    }
+
+    private var entries: [Key: Entry] = [:]
+
+    func entry(_ container: IssueContainer, _ number: Int) -> Entry? {
+        entries[Key(container: container, number: number)]
+    }
+
+    func store(_ entry: Entry, _ container: IssueContainer, _ number: Int) {
+        entries[Key(container: container, number: number)] = entry
+    }
+
+    /// Drops everything — called when the GitHub token is removed (`IssuesPanelModel.disconnect`),
+    /// since a signed-out or re-authed-as-someone-else session must not read a prior account's
+    /// cached private-repo detail.
+    func clear() {
+        entries.removeAll()
+    }
+}

--- a/Sources/termio/Issues/IssueModels.swift
+++ b/Sources/termio/Issues/IssueModels.swift
@@ -122,7 +122,7 @@ struct IssueSummary: Identifiable, Hashable, Sendable {
 }
 
 /// One comment in the detail thread.
-struct IssueComment: Identifiable, Sendable {
+struct IssueComment: Identifiable, Equatable, Sendable {
     let id: Int
     let author: String
     let avatarURL: URL?
@@ -131,7 +131,7 @@ struct IssueComment: Identifiable, Sendable {
 }
 
 /// The full item: the summary plus its markdown body and comment thread.
-struct IssueDetail: Sendable {
+struct IssueDetail: Equatable, Sendable {
     let summary: IssueSummary
     let bodyMarkdown: String
     let authorAvatarURL: URL?
@@ -142,7 +142,7 @@ struct IssueDetail: Sendable {
 /// The branch facts Checkout needs from a pull request — which head ref to fetch,
 /// and whether it lives in a fork (a fork's branch is only reachable through the
 /// `refs/pull/N/head` ref).
-struct PullRequestGitInfo: Sendable {
+struct PullRequestGitInfo: Equatable, Sendable {
     let headRef: String
     let crossRepository: Bool
 }

--- a/Sources/termio/Issues/IssuesPanelModel.swift
+++ b/Sources/termio/Issues/IssuesPanelModel.swift
@@ -44,6 +44,12 @@ final class IssuesPanelModel: ObservableObject {
     let repoRoot: String
     private var provider: GitHubIssueProvider?
 
+    /// The app-level detail cache (keyed by remote identity), injected by the store on register
+    /// so fetched detail outlives this — inherently transient — model instance. See
+    /// `IssueDetailCache` and `TermioStore.registerIssuesModel`.
+    private var detailCache: IssueDetailCache?
+    func attachDetailCache(_ cache: IssueDetailCache) { detailCache = cache }
+
     init(repoRoot: String) {
         self.repoRoot = repoRoot
     }
@@ -58,17 +64,35 @@ final class IssuesPanelModel: ObservableObject {
     /// Entry point on appear: restore the Keychain token, resolve the binding
     /// from the origin remote, and load.
     func start() async {
-        if provider == nil, let token = GitHubIssueAuth.storedToken() {
-            provider = GitHubIssueProvider(token: token)
-        }
+        await ensureReady()
         guard provider != nil else {
             phase = .disconnected
             return
         }
         guard !didStart else { return }
         didStart = true
-        await resolveContainer()
         await loadList()
+    }
+
+    /// Coalesced one-time getters for the token + binding, so a freshly-created model (a session
+    /// switch remounts `IssuesView` with an empty one) is usable the moment *any* caller needs it
+    /// — `loadDetail` in particular, which must reach the container to form its cache key. The
+    /// `Task` handle dedupes a concurrent `start()` + `loadDetail` into a single git resolve.
+    private var readyTask: Task<Void, Never>?
+    /// Whether the binding has been resolved once. Gates on this rather than `container == nil`, so
+    /// an *unbound* repo (no github.com remote leaves `container` nil) resolves once, not on every
+    /// `loadDetail`. Reset by `disconnect()` so a reconnect re-resolves.
+    private var didResolveContainer = false
+    private func ensureReady() async {
+        if provider == nil, let token = GitHubIssueAuth.storedToken() {
+            provider = GitHubIssueProvider(token: token)
+        }
+        guard provider != nil, !didResolveContainer else { return }
+        if let readyTask { return await readyTask.value }
+        let task = Task { await resolveContainer() }
+        readyTask = task
+        await task.value
+        readyTask = nil
     }
 
     // MARK: Connect / disconnect
@@ -100,7 +124,13 @@ final class IssuesPanelModel: ObservableObject {
         items = []
         openItem = nil
         detail = nil
+        // The token is gone, so a later reconnect (possibly a different account) must not read
+        // this account's cached private-repo detail.
+        detailCache?.clear()
         didStart = false
+        // Re-resolve the binding on the next reconnect (possibly a different account/repo).
+        didResolveContainer = false
+        readyTask = nil
         phase = .disconnected
         errorMessage = nil
         recovery = nil
@@ -133,6 +163,7 @@ final class IssuesPanelModel: ObservableObject {
             container = nil
             phase = .unbound
         }
+        didResolveContainer = true
     }
 
     /// The repo's labels, for the filter menu — loaded once per pane.
@@ -178,38 +209,147 @@ final class IssuesPanelModel: ObservableObject {
         isLoading = false
     }
 
+    /// How long a cached entry counts as fresh enough to skip revalidation — the
+    /// stale-while-revalidate dedupe window (SWR's `dedupingInterval`). Rapid tab / session
+    /// flipping inside it reads the cache with no network at all; past it the cached copy still
+    /// shows instantly, but a silent background refresh confirms it.
+    private static let revalidateAfter: TimeInterval = 30
+
     func loadDetail(for item: IssueSummary) async {
+        // A session switch remounts `IssuesView` with a brand-new, empty model, so make this
+        // self-sufficient rather than assuming `start()` has already run: resolve the token +
+        // binding here if needed. Without the container the cache key can't be formed, so every
+        // open would fall straight through to the network — which is what made the cache look
+        // useless on exactly the switch path it exists for.
+        await ensureReady()
         guard let provider, let container else { return }
-        // Maximizing hoists the detail into the full-window host, which remounts the view and
-        // re-fires its `.task` — but the model outlives that. Skip the wipe-and-refetch when this
-        // exact item is already loaded, so a layout change costs no spinner or network round-trip.
-        if openItem?.number == item.number, detail != nil { return }
+        // Same item already loaded in this instance (e.g. a maximize remount): nothing to do.
+        if openItem?.number == item.number, detail != nil, !prFilesLoading { return }
         // The model's own record of which item is open, independent of what drives the UI.
         openItem = item
+
+        // Warm: a prior fetch of this remote item is cached — possibly by another session, a
+        // different worktree of the same repo, or the model this replaced. Render it instantly:
+        // no `detail = nil` wipe, no spinner.
+        if let cached = detailCache?.entry(container, item.number) {
+            apply(cached)
+            if item.kind == .pullRequest, !cached.filesLoaded {
+                // Only the conversation was cached (opened, then switched away before the file
+                // list landed): fetch just the files now — the conversation already shows.
+                await loadPRFiles(item, provider: provider, container: container,
+                                  conversation: cached.detail)
+            } else if Date().timeIntervalSince(cached.fetchedAt) >= Self.revalidateAfter {
+                // Stale-while-revalidate: confirm in the background, past the dedupe window.
+                do {
+                    let fresh = try await fetchEntry(item, provider: provider, container: container)
+                    guard openItem?.number == item.number else { return }
+                    detailCache?.store(fresh, container, item.number)
+                    // Only republish on a real change, so an unchanged refresh never flickers.
+                    if !fresh.sameContent(as: cached) { apply(fresh) }
+                } catch {
+                    // Revalidation failed (offline, rate limit): the cached copy already shows.
+                }
+            }
+            return
+        }
+
+        // Cold: nothing cached — wipe to the spinner and fetch the conversation.
         detail = nil
         detailError = nil
         prFiles = []
         prFilePatches = [:]
         prInfo = nil
+        prFilesLoading = false
         do {
+            let conversation = try await provider.detail(item.number, in: container)
+            guard openItem?.number == item.number else { return }  // user moved on mid-fetch
+            detail = conversation
+            // Cache the conversation the moment it lands — before a PR's heavy file list — so a
+            // switch-away still warms the cache. `filesLoaded: false` marks the pending files.
+            detailCache?.store(
+                .init(detail: conversation, prFiles: [], prFilePatches: [:], prInfo: nil,
+                      filesLoaded: item.kind != .pullRequest, fetchedAt: Date()),
+                container, item.number)
             if item.kind == .pullRequest {
-                async let loadedDetail = provider.detail(item.number, in: container)
-                async let info = provider.pullRequestGitInfo(item.number, in: container)
-                async let files = provider.pullRequestFiles(item.number, in: container)
-                let loadedFiles = try await files
-                (detail, prInfo) = try await (loadedDetail, info)
-                prFiles = loadedFiles.map(\.change)
-                // The diff arrives inline with the file list — key each file's patch by
-                // path so the Files tab renders with no further network or git work.
-                prFilePatches = Dictionary(
-                    uniqueKeysWithValues: loadedFiles.compactMap { file in
-                        file.patch.map { (file.change.path, $0) }
-                    })
-            } else {
-                detail = try await provider.detail(item.number, in: container)
+                await loadPRFiles(item, provider: provider, container: container,
+                                  conversation: conversation)
             }
         } catch {
             detailError = error.localizedDescription
+        }
+    }
+
+    /// Fetches a PR's branch facts + changed files (`/files` carries every patch inline, the heavy
+    /// part) and folds them into the already-shown conversation, upgrading the cache entry to
+    /// `filesLoaded: true`. Runs behind the conversation so the default tab never waits on it; a
+    /// failure just leaves the Files tab empty rather than erroring the whole detail.
+    private func loadPRFiles(_ item: IssueSummary, provider: GitHubIssueProvider,
+                             container: IssueContainer, conversation: IssueDetail) async {
+        prFilesLoading = true
+        async let info = provider.pullRequestGitInfo(item.number, in: container)
+        async let files = provider.pullRequestFiles(item.number, in: container)
+        do {
+            let (prI, loadedFiles) = try await (info, files)
+            guard openItem?.number == item.number else { prFilesLoading = false; return }
+            let mapped = prFileMapping(loadedFiles)
+            prInfo = prI
+            prFiles = mapped.changes
+            prFilePatches = mapped.patches
+            detailCache?.store(
+                .init(detail: conversation, prFiles: mapped.changes, prFilePatches: mapped.patches,
+                      prInfo: prI, filesLoaded: true, fetchedAt: Date()),
+                container, item.number)
+        } catch {
+            // The conversation stays; the Files tab simply shows no files.
+        }
+        prFilesLoading = false
+    }
+
+    /// Maps GitHub's `/files` payload into the git pane's `GitChange` rows plus each file's inline
+    /// unified-diff patch keyed by path — what the Files tab renders with no further network or git
+    /// work. Absent patch keys are files GitHub gave none for (binary / diff too large to inline).
+    private func prFileMapping(
+        _ files: [PullRequestFile]
+    ) -> (changes: [GitChange], patches: [String: String]) {
+        let patches = Dictionary(
+            uniqueKeysWithValues: files.compactMap { file in
+                file.patch.map { (file.change.path, $0) }
+            })
+        return (files.map(\.change), patches)
+    }
+
+    /// Publishes a fetched entry into the pane's detail state.
+    private func apply(_ entry: IssueDetailCache.Entry) {
+        detail = entry.detail
+        prFiles = entry.prFiles
+        prFilePatches = entry.prFilePatches
+        prInfo = entry.prInfo
+        prFilesLoading = false
+        detailError = nil
+    }
+
+    /// One network round-trip for an item's full detail: the conversation, and for a PR its git
+    /// info and changed files (with each file's inline patch keyed by path). Pure fetch — no
+    /// state writes — so both the cold and revalidation paths share it.
+    private func fetchEntry(
+        _ item: IssueSummary,
+        provider: GitHubIssueProvider,
+        container: IssueContainer
+    ) async throws -> IssueDetailCache.Entry {
+        if item.kind == .pullRequest {
+            async let loadedDetail = provider.detail(item.number, in: container)
+            async let info = provider.pullRequestGitInfo(item.number, in: container)
+            async let files = provider.pullRequestFiles(item.number, in: container)
+            let (detail, prInfo, loadedFiles) = try await (loadedDetail, info, files)
+            let mapped = prFileMapping(loadedFiles)
+            return .init(
+                detail: detail, prFiles: mapped.changes, prFilePatches: mapped.patches,
+                prInfo: prInfo, filesLoaded: true, fetchedAt: Date())
+        } else {
+            let detail = try await provider.detail(item.number, in: container)
+            return .init(
+                detail: detail, prFiles: [], prFilePatches: [:], prInfo: nil,
+                filesLoaded: true, fetchedAt: Date())
         }
     }
 
@@ -221,4 +361,10 @@ final class IssuesPanelModel: ObservableObject {
     /// tab renders. Absent keys are files GitHub gave no patch for (binary / too large).
     @Published private(set) var prFilePatches: [String: String] = [:]
     @Published private(set) var prInfo: PullRequestGitInfo?
+
+    /// The PR's file list is still in flight *after* the conversation has already rendered —
+    /// the two are fetched separately so the (small, fast) conversation isn't gated behind the
+    /// (heavy — every patch inline) `/files` response. Drives the Files tab's own spinner so a
+    /// user who taps Files early sees loading, not a wrong "No Files".
+    @Published private(set) var prFilesLoading = false
 }

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -525,6 +525,13 @@ private struct IssueRowContextMenu: NSViewRepresentable {
 /// `MarkdownHTML` in a themed web view); a pull request adds the Conversation |
 /// Files switch — files diff natively in the `GitDiffView` overlay (which stacks
 /// on top of this one) against the fetched PR refs, JetBrains-style, no checkout needed.
+/// Identity for the detail's load `.task`: the open item *and* the model driving it, so a
+/// model swap (session switch to another repo) re-triggers the load even at the same issue number.
+private struct DetailTaskKey: Hashable {
+    let number: Int
+    let model: ObjectIdentifier
+}
+
 struct IssueDetailView: View {
     let item: IssueSummary
     @ObservedObject var model: IssuesPanelModel
@@ -549,7 +556,12 @@ struct IssueDetailView: View {
         // tab bar included) with the terminal background so the header doesn't fall
         // through to the host's `windowBackgroundColor` and seam against the body.
         .background(Color(nsColor: settings.terminalBackgroundColor))
-        .task(id: item.number) { await model.loadDetail(for: item) }
+        // Key on the model instance too: a session switch can swap in a different repo's model
+        // while `item.number` is unchanged, and without re-firing here that fresh model would sit
+        // on a spinner (its `loadDetail` never called). Re-firing costs nothing on a cache hit.
+        .task(id: DetailTaskKey(number: item.number, model: ObjectIdentifier(model))) {
+            await model.loadDetail(for: item)
+        }
         .onExitCommand(perform: onBack)
     }
 
@@ -648,8 +660,9 @@ struct IssueDetailView: View {
                 files: model.prFiles, patches: model.prFilePatches,
                 repoRoot: model.repoRoot, settings: settings, onClose: onBack
             )
-        } else if model.detail == nil, model.detailError == nil {
-            // The file list arrives with the detail; show a spinner until it lands.
+        } else if model.prFilesLoading || (model.detail == nil && model.detailError == nil) {
+            // The file list streams in behind the conversation (see `loadDetail`); show a
+            // spinner while it's still in flight, so an early tap on Files isn't a wrong "No Files".
             ProgressView()
                 .controlSize(.small)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -211,8 +211,16 @@ final class TermioStore: ObservableObject {
     /// render its saved issue against another repo's model.
     @Published private(set) var issuesModels: [String: IssuesPanelModel] = [:]
 
-    /// Registers (or refreshes) the Issues model for its repo root. Called by `IssuesView`.
+    /// Fetched issue / PR detail, keyed by *remote* identity so it outlives the per-repo
+    /// `IssuesPanelModel` instances above — the fix for the detail re-fetching (spinner) on
+    /// every session switch. See `IssueDetailCache`.
+    let issueDetailCache = IssueDetailCache()
+
+    /// Registers (or refreshes) the Issues model for its repo root, wiring it to the shared
+    /// detail cache so a fresh model (a remount, or a different worktree of the same repo)
+    /// reads previously fetched detail instead of hitting GitHub again. Called by `IssuesView`.
     func registerIssuesModel(_ model: IssuesPanelModel) {
+        model.attachDetailCache(issueDetailCache)
         issuesModels[model.repoRoot] = model
     }
 


### PR DESCRIPTION
## What

Two fixes from a debugging session on the Issues pane and the diff gutter.

### 1. Issue/PR detail re-fetched on every session switch
Opening a GitHub issue/PR detail showed a spinner and re-hit the network each time you switched the left session tab — even for an item just viewed. The fetched detail lived on the per-repo `IssuesPanelModel`, which a session switch tears down and rebuilds, so the data went with it.

- New app-level `IssueDetailCache` on `TermioStore`, keyed by **remote identity** (`container` + number), not local checkout path — so two worktrees of the same repo share one copy and the cache outlives any model.
- `loadDetail` is cache-first (stale-while-revalidate, 30s dedupe window) and **self-resolves the container**, so a freshly-remounted model can form the cache key instead of falling through to the network.
- The detail `.task` is keyed on the model instance too, so a model swap re-fires into the cache.

### 2. Slow first open of a PR
PR detail was gated behind the heavy `/files` response (every patch inline). Now the **conversation renders the moment it lands** and the file list streams in behind it; the conversation is cached immediately so a switch-away still warms the cache (`filesLoaded` marks a PR whose files are still pending).

### 3. #176 — green diff wash bleeds into the file-header
The gutter's added-line wash filled up to the ruler's top edge, seaming into the sticky file-header. Apply the same one-device-pixel top clip the line numbers already use, and drop fully-clipped bands.

## Testing
- `swift build` clean (no warnings from these files).
- Rebuilt the dev app; verified switching sessions renders a cached issue instantly (no spinner), and first PR open shows the conversation immediately.
- Independent review pass; fixed a follow-up bug where an unbound repo re-resolved the binding on every open.

Closes #176