### PR TITLE
fix(menus): drop macOS AutoFill/Services from terminal, diff, and file preview

### DIFF
--- a/Sources/termio/Editor/MarkdownReaderView.swift
+++ b/Sources/termio/Editor/MarkdownReaderView.swift
@@ -23,6 +23,7 @@ struct MarkdownReaderView: View {
         MarkdownReaderWebView(
             html: MarkdownReaderRenderer.document(source, theme: theme, fontFamily: settings.fontFamily),
             baseURL: fileURL.deletingLastPathComponent(),
+            fileURL: fileURL,
             background: settings.terminalBackgroundColor
         )
     }
@@ -35,6 +36,7 @@ struct MarkdownReaderView: View {
 private struct MarkdownReaderWebView: NSViewRepresentable {
     let html: String
     let baseURL: URL
+    let fileURL: URL
     let background: NSColor
 
     /// `loadHTMLString` pages get no filesystem access in the WebContent process, so a
@@ -55,6 +57,7 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
         let config = WKWebViewConfiguration()
         config.setURLSchemeHandler(LocalFileSchemeHandler(), forURLScheme: Self.fileScheme)
         let view = ContextMenuWebView(frame: .zero, configuration: config)
+        view.fileURL = fileURL
         view.setValue(false, forKey: "drawsBackground")
         view.navigationDelegate = context.coordinator
         view.loadHTMLString(html, baseURL: schemeBaseURL)
@@ -119,15 +122,31 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
 /// A `WKWebView` that appends a "Close" to its right-click menu, so the Markdown preview closes
 /// terminal-style like the source editor — the overlay has no chrome button.
 private final class ContextMenuWebView: WKWebView {
+    /// The document on disk, so the menu can reveal it in Finder (like the file tree's row menu).
+    var fileURL: URL?
+
     override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
         super.willOpenMenu(menu, with: event)
         // Strip the reader's menu down to Copy — a read-only document doesn't need Reload / Look Up
-        // / Translate / Share / Services — then add a prominent Close so it's not buried.
+        // / Translate / Share, and the OS-injected AutoFill / Services grab-bag is meaningless over
+        // a rendered doc. Whitelisting Copy by identifier drops all of it. Then add the actions that
+        // *do* fit a file preview: Reveal in Finder (an explicit item, not a flaky Services shortcut)
+        // and a prominent Close so it isn't buried.
         menu.items = menu.items.filter { $0.identifier?.rawValue == "WKMenuItemIdentifierCopy" }
-        if !menu.items.isEmpty { menu.addItem(.separator()) }
+        menu.addItem(.separator())
+        if fileURL != nil {
+            let reveal = NSMenuItem(title: "Reveal in Finder", action: #selector(revealInFinder), keyEquivalent: "")
+            reveal.target = self
+            menu.addItem(reveal)
+        }
         let close = NSMenuItem(title: "Close", action: #selector(closeEditorOverlay), keyEquivalent: "")
         close.target = self
         menu.addItem(close)
+    }
+
+    @objc private func revealInFinder() {
+        guard let fileURL else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([fileURL])
     }
 
     @objc private func closeEditorOverlay() {

--- a/Sources/termio/Git/DiffTextView.swift
+++ b/Sources/termio/Git/DiffTextView.swift
@@ -324,6 +324,24 @@ final class DiffTextView: NSTextView {
         onClose?()
     }
 
+    /// A minimal right-click menu: Copy, plus Close. NSTextView's default would inject
+    /// the read-only text grab-bag (Look Up / Translate / Speech / Share / Services) a
+    /// diff has no use for; returning our own menu — without calling `super` — drops all
+    /// of it, matching the editor's and reader's stripped menus.
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = NSMenu()
+        menu.addItem(withTitle: "Copy", action: #selector(copy(_:)), keyEquivalent: "")
+        if onClose != nil {
+            menu.addItem(.separator())
+            let close = NSMenuItem(title: "Close", action: #selector(closeFromMenu), keyEquivalent: "")
+            close.target = self
+            menu.addItem(close)
+        }
+        return menu
+    }
+
+    @objc private func closeFromMenu() { onClose?() }
+
     override func mouseDown(with event: NSEvent) {
         if let anchor = expandableBand(at: event) {
             onExpand?(anchor)

--- a/Sources/termio/Terminal/TerminalContextMenu.swift
+++ b/Sources/termio/Terminal/TerminalContextMenu.swift
@@ -76,7 +76,14 @@ final class TerminalContextMenu: NSObject {
         clickedLinkURL = TerminalLinkState.hoveredURL
             .flatMap(URL.init(string:))
             .flatMap { ["http", "https"].contains($0.scheme?.lowercased() ?? "") ? $0 : nil }
-        NSMenu.popUpContextMenu(makeMenu(), with: event, for: target)
+        // popUp — not popUpContextMenu(_:with:for:) — presents exactly the menu we
+        // built. Passing the surface as the `for:` view makes AppKit merge in the
+        // system's automatic text-input extras (the "AutoFill" submenu, Services)
+        // because the ghostty surface is an NSTextInputClient; those are meaningless
+        // over a terminal, so we position the menu ourselves and skip the augmentation.
+        makeMenu().popUp(positioning: nil,
+                         at: target.convert(event.locationInWindow, from: nil),
+                         in: target)
         return true
     }
 


### PR DESCRIPTION
## What
Right-click menus over termio's text/web views were carrying macOS's **auto-injected extras** — the **AutoFill** submenu, **Services**, Look Up, Translate, Share — none of which mean anything in termio. Three sites now show only what termio builds.

| Site | Before | After |
|---|---|---|
| **Terminal pane** | `popUpContextMenu(_:for: surface)` → AppKit merged in the surface's `NSTextInputClient` **AutoFill** | `menu.popUp(...)` — presents exactly our menu |
| **Diff viewer** (`DiffTextView`) | no `menu(for:)` → full default read-only text menu (Look Up/Translate/Speech/Share/**Services**) | `menu(for:)` returns Copy + Close, no `super` |
| **File preview** (`MarkdownReaderView`) | whitelisted Copy, but **Services** leaked; no Finder access | Copy + explicit **Reveal in Finder** (like the file tree) + Close |

## Why
The explicit menus (file tree, sidebar, issues) already present their own `NSMenu` via `popUp` with **no** injected items. These three text/web-view menus were the exception because AppKit augments `NSTextInputClient`/`WKWebView`/`NSTextView` context menus automatically. This brings them in line.

The "Reveal in Finder" in the file preview is a deliberate, first-class item mirroring `FileTreeList`'s row menu — a real Finder action instead of the flaky text-Services shortcut it replaces.

## Test
- ✅ `swift build` clean on latest `origin/main` (built in an isolated worktree).
- Scoped to exactly 3 files; no behavior change beyond the menus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)