### PR TITLE
feat(splits): modifier-drag pane rearrange with drop-zone overlay

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -119,6 +119,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // The ghostty-style right-click menu over the terminal surfaces (Copy/Paste + splits);
     // owns the rightMouseDown monitor for the app's lifetime.
     private var terminalContextMenu: TerminalContextMenu?
+    // The ⌘⌥⇧ drag-to-rearrange gesture over the panes (issue #183); owns its
+    // mouse monitors for the app's lifetime.
+    private var paneDragRearrange: PaneDragRearrange?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Sweep up session processes a previous instance stranded (crash,
@@ -285,6 +288,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
 
         terminalContextMenu = TerminalContextMenu(store: store)
+        paneDragRearrange = PaneDragRearrange(store: store)
 
         menuBar = MenuBarController(store: store) { [weak self] id in
             // The tray's "come look at this" — same verb as a notification click

--- a/Sources/termio/Terminal/PaneDragRearrange.swift
+++ b/Sources/termio/Terminal/PaneDragRearrange.swift
@@ -1,0 +1,181 @@
+import AppKit
+import GhosttyTerminal
+
+/// A ⌘⌥⇧ pane drag in flight: the lifted pane, plus the pane and drop zone
+/// under the pointer right now. `PaneDragRearrange` writes it, `TerminalPane`
+/// draws it — the store's published copy is what keeps the two in step.
+struct PaneDragState: Equatable {
+    /// The pane being dragged.
+    var source: Session.ID
+    /// The visible pane under the pointer — `nil` over a divider, outside the
+    /// terminal area, or off the window. The source pane itself is a valid
+    /// hover but never a valid drop.
+    var target: Session.ID?
+    var zone: PaneDropZone?
+}
+
+/// iTerm2-style direct-manipulation rearrange (issue #183): while ⌘⌥⇧ is held,
+/// the whole pane body is its drag handle — press anywhere on a pane, drag to
+/// a drop zone on another pane, release to re-split (edge halves) or swap
+/// (center). The chord *is* the handle because termio's panes are chromeless
+/// libghostty surfaces with no title bar to grab; it also disambiguates
+/// "rearrange" from terminal input, letting the app consume the events before
+/// the surface (or a mouse-reporting TUI) ever sees them.
+///
+/// The wrapper instantiates its own view class, so — like `TerminalContextMenu`
+/// — this hooks in one level up: local event monitors held for the app's
+/// lifetime. The drag itself is plain geometry against the visible panes; the
+/// release is one `dropPane` call into the store, which owns the tree mutation.
+@MainActor
+final class PaneDragRearrange {
+    private weak var store: TermioStore?
+    // Held for the app's lifetime; never removed.
+    private var monitors: [Any] = []
+    /// True from the chorded press to the release. Esc cancels the drag but
+    /// leaves this set, so the tail of the gesture (the remaining dragged/up
+    /// events) is still swallowed instead of leaking into the terminal.
+    private var dragging = false
+    private var cancelled = false
+    private var cursorPushed = false
+
+    /// The full rearrange chord. Only the modifiers that mean something here
+    /// are compared: ⌘⌥⇧ must all be down and ⌃ must not be, while Caps Lock
+    /// (routinely latched by CJK users to switch input sources) and fn are
+    /// ignored — an exact-mask match would let them silently defeat the
+    /// gesture.
+    static func isRearrangeChord(_ flags: NSEvent.ModifierFlags) -> Bool {
+        flags.intersection([.command, .option, .shift, .control]) == [.command, .option, .shift]
+    }
+
+    init(store: TermioStore) {
+        self.store = store
+        // Local event monitors are always called on the main thread; the
+        // annotation just can't say so (see `TerminalContextMenu`).
+        func monitor(_ mask: NSEvent.EventTypeMask,
+                     _ handler: @escaping @MainActor (NSEvent) -> Bool) {
+            let installed = NSEvent.addLocalMonitorForEvents(matching: mask) { event in
+                nonisolated(unsafe) let event = event
+                let consumed = MainActor.assumeIsolated { handler(event) }
+                return consumed ? nil : event
+            }
+            if let installed { monitors.append(installed) }
+        }
+        monitor(.leftMouseDown) { [weak self] in self?.began($0) ?? false }
+        monitor(.leftMouseDragged) { [weak self] in self?.moved($0) ?? false }
+        monitor(.leftMouseUp) { [weak self] in self?.ended($0) ?? false }
+        monitor(.keyDown) { [weak self] in self?.pressedKey($0) ?? false }
+    }
+
+    /// Starts a drag on a chorded press over a visible pane. Only meaningful
+    /// with a split on screen: a lone pane has nowhere to go, and a zoomed
+    /// pane hides the layout the drop zones would preview.
+    private func began(_ event: NSEvent) -> Bool {
+        guard let store, !dragging,
+              Self.isRearrangeChord(event.modifierFlags),
+              store.splitRoot != nil, !store.isPaneZoomed,
+              !(store.isDetailPresented && store.inspectorMaximized),
+              let window = event.window,
+              window.frameAutosaveName == AppDelegate.mainWindowFrameAutosaveName,
+              let contentView = window.contentView,
+              let (id, _) = pane(at: event.locationInWindow, in: contentView, window: window)
+        else { return false }
+        dragging = true
+        cancelled = false
+        store.paneDrag = PaneDragState(source: id)
+        NSCursor.closedHand.push()
+        cursorPushed = true
+        return true
+    }
+
+    /// Tracks the pointer across panes. Once a drag has begun the modifiers no
+    /// longer matter — releasing the chord mid-drag doesn't drop the pane on
+    /// the floor, the mouse button does.
+    private func moved(_ event: NSEvent) -> Bool {
+        guard dragging else { return false }
+        guard !cancelled, let store, var drag = store.paneDrag,
+              let window = event.window, let contentView = window.contentView
+        else { return true }
+        let hit = pane(at: event.locationInWindow, in: contentView, window: window)
+        drag.target = hit?.0
+        drag.zone = hit?.1
+        store.paneDrag = drag
+        return true
+    }
+
+    private func ended(_ event: NSEvent) -> Bool {
+        guard dragging else { return false }
+        defer { finish() }
+        guard !cancelled, let store, let drag = store.paneDrag,
+              let target = drag.target, let zone = drag.zone,
+              target != drag.source else { return true }
+        store.dropPane(drag.source, onto: target, zone: zone)
+        return true
+    }
+
+    /// Esc abandons the drag. The mouse is still down, so `dragging` stays set
+    /// and the gesture's tail is swallowed until the release.
+    private func pressedKey(_ event: NSEvent) -> Bool {
+        guard dragging, !cancelled, event.keyCode == 53 else { return false }
+        cancelled = true
+        store?.paneDrag = nil
+        popCursorIfNeeded()
+        return true
+    }
+
+    private func finish() {
+        dragging = false
+        cancelled = false
+        store?.paneDrag = nil
+        popCursorIfNeeded()
+    }
+
+    private func popCursorIfNeeded() {
+        guard cursorPushed else { return }
+        NSCursor.pop()
+        cursorPushed = false
+    }
+
+    /// The visible pane under a window point, and the drop zone within it.
+    /// Resolved by geometry rather than `hitTest` for the same reason as
+    /// `TerminalContextMenu`: invisible siblings stay mounted at full pane
+    /// size, so AppKit's topmost hit may be a hidden view. Visible panes tile
+    /// without overlapping, so "contains the point and is visible" is
+    /// unambiguous.
+    private func pane(at point: NSPoint, in contentView: NSView,
+                      window: NSWindow) -> (Session.ID, PaneDropZone)? {
+        guard let store else { return nil }
+        for view in terminalViews(in: contentView) {
+            guard view.window === window,
+                  view.convert(view.bounds, to: nil).contains(point),
+                  let id = sessionID(for: view),
+                  store.visiblePaneIDs.contains(id) else { continue }
+            let local = view.convert(point, from: nil)
+            // Zone space is top-left-origin; flip out of AppKit's default.
+            let normalized = CGPoint(x: local.x,
+                                     y: view.isFlipped ? local.y : view.bounds.height - local.y)
+            return (id, PaneDropZone.zone(at: normalized, in: view.bounds.size))
+        }
+        return nil
+    }
+
+    // The two resolution helpers below mirror `TerminalContextMenu`'s private
+    // copies — small enough that sharing them isn't worth coupling the two
+    // interceptors.
+
+    /// All terminal surface views under `root`, in tree order.
+    private func terminalViews(in root: NSView) -> [TerminalView] {
+        var found: [TerminalView] = []
+        var stack: [NSView] = [root]
+        while let view = stack.popLast() {
+            if let terminal = view as? TerminalView { found.append(terminal) }
+            stack.append(contentsOf: view.subviews)
+        }
+        return found
+    }
+
+    /// Maps a surface view back to its session through the store's surface
+    /// cache — the view and its cached `TerminalViewState` share a controller.
+    private func sessionID(for view: TerminalView) -> Session.ID? {
+        store?.surfaces.first { $0.value.controller === view.controller }?.key
+    }
+}

--- a/Sources/termio/Terminal/SplitTree.swift
+++ b/Sources/termio/Terminal/SplitTree.swift
@@ -15,6 +15,81 @@ enum PaneFocusDirection {
     case left, right, up, down
 }
 
+/// Which side of a new divider an added pane takes. `.second` is the trailing
+/// slot — what "Split Right"/"Split Down" mean — and `.first` the leading one,
+/// which is how a drag-drop onto a pane's left/top half lands the dropped pane
+/// *before* its target.
+enum SplitSlot {
+    case first, second
+}
+
+/// Where a modifier-dragged pane is about to land on the pane under the
+/// pointer (issue #183): an edge half → the target splits and the dragged pane
+/// takes that side; the center → the two panes trade places (the existing
+/// `swapping` behaviour). Pure math on pane-local geometry, so the hit regions
+/// are testable without a view in sight. Points are in top-left-origin space.
+enum PaneDropZone: Equatable {
+    case left, right, top, bottom
+    case center
+
+    /// The middle box (as a fraction of each axis) that reads as "swap" rather
+    /// than an edge: 0.4 keeps the swap target hittable without aiming while
+    /// leaving each edge a generous 30% band.
+    private static let centerFraction: CGFloat = 0.4
+
+    /// The zone for a pointer at `point` in a pane of `size`. Outside the
+    /// center box the nearest edge wins — the corner-to-corner diagonals
+    /// ghostty's split drag uses, which give each edge a natural triangular
+    /// region.
+    static func zone(at point: CGPoint, in size: CGSize) -> PaneDropZone {
+        guard size.width > 0, size.height > 0 else { return .center }
+        let relX = point.x / size.width
+        let relY = point.y / size.height
+        let half = centerFraction / 2
+        if abs(relX - 0.5) <= half, abs(relY - 0.5) <= half { return .center }
+        let edges: [(PaneDropZone, CGFloat)] = [
+            (.left, relX), (.right, 1 - relX), (.top, relY), (.bottom, 1 - relY),
+        ]
+        return edges.min { $0.1 < $1.1 }!.0
+    }
+
+    /// The part of the target pane to highlight while this zone is hovered:
+    /// the half the dropped pane would occupy, or the whole pane for a swap —
+    /// the preview that makes the drop unambiguous before the mouse releases.
+    func highlightRect(in frame: CGRect) -> CGRect {
+        switch self {
+        case .left:
+            CGRect(x: frame.minX, y: frame.minY, width: frame.width / 2, height: frame.height)
+        case .right:
+            CGRect(x: frame.midX, y: frame.minY, width: frame.width / 2, height: frame.height)
+        case .top:
+            CGRect(x: frame.minX, y: frame.minY, width: frame.width, height: frame.height / 2)
+        case .bottom:
+            CGRect(x: frame.minX, y: frame.midY, width: frame.width, height: frame.height / 2)
+        case .center:
+            frame
+        }
+    }
+
+    /// The split axis a drop here produces, or `nil` for the center swap.
+    var splitDirection: SplitDirection? {
+        switch self {
+        case .left, .right: .horizontal
+        case .top, .bottom: .vertical
+        case .center: nil
+        }
+    }
+
+    /// The slot the dragged pane takes in the new branch: leading for the
+    /// left/top halves, trailing for right/bottom.
+    var slot: SplitSlot {
+        switch self {
+        case .left, .top: .first
+        case .right, .bottom, .center: .second
+        }
+    }
+}
+
 /// A branch of the split tree: two subtrees separated by a draggable divider.
 /// `ratio` is the fraction of the branch's span given to `first`; it is clamped
 /// so neither side can be dragged into an unusable sliver.
@@ -76,20 +151,24 @@ indirect enum SplitNode: Codable, Hashable {
         }
     }
 
-    /// Replaces the `target` leaf with a split of it and `newLeaf` (the new pane
-    /// takes the second/trailing slot, matching "Split Right"/"Split Down").
+    /// Replaces the `target` leaf with a split of it and `newLeaf`. The default
+    /// slot puts the new pane second/trailing, matching "Split Right"/"Split
+    /// Down"; a drag-drop passes `.first` to land it on the leading side.
     /// A miss returns the tree unchanged.
     func splitting(leaf target: Session.ID, direction: SplitDirection,
-                   adding newLeaf: Session.ID) -> SplitNode {
+                   adding newLeaf: Session.ID, slot: SplitSlot = .second) -> SplitNode {
         switch self {
         case .leaf(let id) where id == target:
             return .split(SplitBranch(direction: direction, ratio: 0.5,
-                                      first: .leaf(id), second: .leaf(newLeaf)))
+                                      first: slot == .first ? .leaf(newLeaf) : .leaf(id),
+                                      second: slot == .first ? .leaf(id) : .leaf(newLeaf)))
         case .leaf:
             return self
         case .split(var branch):
-            branch.first = branch.first.splitting(leaf: target, direction: direction, adding: newLeaf)
-            branch.second = branch.second.splitting(leaf: target, direction: direction, adding: newLeaf)
+            branch.first = branch.first.splitting(leaf: target, direction: direction,
+                                                  adding: newLeaf, slot: slot)
+            branch.second = branch.second.splitting(leaf: target, direction: direction,
+                                                    adding: newLeaf, slot: slot)
             return .split(branch)
         }
     }

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -181,6 +181,12 @@ struct TerminalPane: View {
                     }
                 }
             }
+            // The ⌘⌥⇧ drag's preview (issue #183): the drop-zone highlight is
+            // what resolves the ambiguity a drag-rearrange otherwise has — you
+            // see the half (or the swap) the release would commit.
+            if let drag = store.paneDrag, let layout, !zoomed {
+                PaneDragOverlay(drag: drag, layout: layout)
+            }
         }
     }
 
@@ -632,6 +638,49 @@ private final class TerminalFocusDriver {
             // is occasionally skipped during SwiftUI/AppKit reconciliation.
             _ = previous.resignFirstResponder()
         }
+    }
+}
+
+/// The visual half of the ⌘⌥⇧ pane drag (issue #183): a wash over the lifted
+/// source pane plus a highlight over the region the release would commit —
+/// the half of the target the pane would occupy, or the whole target for a
+/// swap. Geometry comes straight from the tree's `layout`, so the preview and
+/// the drop can never disagree. The tint family is the file-drop wash's
+/// desaturated blue-grey, not accent blue.
+private struct PaneDragOverlay: View {
+    let drag: PaneDragState
+    let layout: SplitNode.PaneLayout
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var tint: Color {
+        colorScheme == .dark
+            ? Color(.sRGB, red: 0.62, green: 0.70, blue: 0.82, opacity: 1)
+            : Color(.sRGB, red: 0.40, green: 0.52, blue: 0.68, opacity: 1)
+    }
+
+    var body: some View {
+        ZStack {
+            // The source pane reads as "lifted": a faint wash, no border.
+            if let source = layout.frames[drag.source] {
+                Rectangle()
+                    .fill(tint.opacity(colorScheme == .dark ? 0.08 : 0.07))
+                    .frame(width: source.width, height: source.height)
+                    .position(x: source.midX, y: source.midY)
+            }
+            // Fill only, no border — the same restraint as the file-drop wash
+            // above (and ghostty's own split-drag overlay): the rect's edge
+            // already draws the zone boundary, a stroke would just say it twice.
+            if let target = drag.target, target != drag.source,
+               let zone = drag.zone, let frame = layout.frames[target] {
+                let rect = zone.highlightRect(in: frame)
+                Rectangle()
+                    .fill(tint.opacity(colorScheme == .dark ? 0.20 : 0.17))
+                    .frame(width: rect.width, height: rect.height)
+                    .position(x: rect.midX, y: rect.midY)
+            }
+        }
+        .allowsHitTesting(false)
+        .animation(.easeOut(duration: 0.12), value: drag)
     }
 }
 

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -278,6 +278,29 @@ extension TermioStore {
         isPaneZoomed = false
     }
 
+    /// Lands a modifier-dragged pane on `target` (issue #183). An edge zone
+    /// re-splits the target with the dragged pane on that side — the pane
+    /// leaves its old slot first, its vacated space collapsing into the
+    /// sibling exactly as if it had closed, so one gesture subsumes move +
+    /// re-split + orientation. The center zone trades places, same as "Move
+    /// Pane". Dropping a pane on itself, or across groups, is a no-op — the
+    /// self-drop guard matters, because removing the pane and then missing
+    /// the (gone) target would otherwise drop it from the tree entirely.
+    func dropPane(_ source: Session.ID, onto target: Session.ID, zone: PaneDropZone) {
+        guard source != target,
+              let group = groupIndex(containing: source),
+              group == groupIndex(containing: target) else { return }
+        if let direction = zone.splitDirection {
+            guard let vacated = splitGroups[group].removing(leaf: source) else { return }
+            splitGroups[group] = vacated.splitting(leaf: target, direction: direction,
+                                                   adding: source, slot: zone.slot)
+        } else {
+            splitGroups[group] = splitGroups[group].swapping(source, and: target)
+        }
+        selectedSessionID = source
+        isPaneZoomed = false
+    }
+
     /// Moves pane focus directionally (⌥⌘ arrows), scored on the visible
     /// group's normalized geometry. No-op without splits or when nothing lies
     /// that way.

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -89,6 +89,11 @@ final class TermioStore: ObservableObject {
     /// pane. `TerminalPane` honours it only while a split is on screen.
     @Published var isPaneZoomed = false
 
+    /// The in-flight ⌘⌥⇧ pane drag (issue #183): written by `PaneDragRearrange`
+    /// as the pointer moves, read by `TerminalPane` to draw the drop-zone
+    /// highlight. Transient gesture state, never persisted.
+    @Published var paneDrag: PaneDragState?
+
     /// Activation *requests* for sessions that are neither selected nor in the
     /// visible group: a background spawn's fresh pane, a `send` target never
     /// shown. `TerminalPane` folds these into its own `activated` list — the
@@ -748,6 +753,9 @@ final class TermioStore: ObservableObject {
         linkClickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak self] event in
             guard let self,
                   event.modifierFlags.contains(.command),
+                  // ⌘⌥⇧+press is the pane-rearrange chord (see `PaneDragRearrange`);
+                  // that gesture owns the click even when a link is hovered.
+                  !PaneDragRearrange.isRearrangeChord(event.modifierFlags),
                   let url = TerminalLinkState.hoveredURL else { return event }
             self.openTerminalLink(url, surfaceWorkingDirectory: nil)
             return nil

--- a/Tests/termioTests/SplitTreeTests.swift
+++ b/Tests/termioTests/SplitTreeTests.swift
@@ -79,4 +79,65 @@ final class SplitTreeTests: XCTestCase {
                                                first: .leaf(agent), second: .leaf(run1)))
         XCTAssertEqual(tree.splitting(oppositeLeaf: run3, adding: run2), tree)
     }
+
+    /// The drag-drop slot: `.first` lands the added pane on the leading side of
+    /// the new divider (a drop on the left/top half), where the default keeps
+    /// "Split Right"/"Split Down"'s trailing placement.
+    func testSplittingLeadingSlotPutsNewcomerFirst() {
+        let split = SplitNode.leaf(agent)
+            .splitting(leaf: agent, direction: .horizontal, adding: run1, slot: .first)
+        guard case let .split(branch) = split else {
+            return XCTFail("expected a branch")
+        }
+        XCTAssertEqual(branch.direction, .horizontal)
+        XCTAssertEqual(branch.first, .leaf(run1))
+        XCTAssertEqual(branch.second, .leaf(agent))
+    }
+
+    /// An edge drop is remove-then-resplit: the dragged pane's old slot
+    /// collapses into its sibling, and the target divides on the drop zone's
+    /// axis with the dragged pane on the dropped side. From `[agent | run1]`,
+    /// dropping `agent` onto `run1`'s bottom half yields `[run1 / agent]`.
+    func testEdgeDropRecomposesAroundTheTarget() {
+        let tree = SplitNode.split(SplitBranch(direction: .horizontal, ratio: 0.7,
+                                               first: .leaf(agent), second: .leaf(run1)))
+        let zone = PaneDropZone.bottom
+        let vacated = tree.removing(leaf: agent)!
+        let dropped = vacated.splitting(leaf: run1, direction: zone.splitDirection!,
+                                        adding: agent, slot: zone.slot)
+
+        let frames = dropped.layout(in: CGRect(x: 0, y: 0, width: 1, height: 1),
+                                    dividerThickness: 0).frames
+        XCTAssertEqual(dropped.leafIDs, [run1, agent])
+        // Stacked now: run1 owns the full-width top half, agent the bottom.
+        XCTAssertEqual(frames[run1]!.width, 1, accuracy: 0.001)
+        XCTAssertGreaterThanOrEqual(frames[agent]!.minY, frames[run1]!.maxY - 0.001)
+    }
+
+    /// The drop-zone hit regions (top-left-origin space): a middle box swaps,
+    /// and outside it the nearest edge wins, so the regions are the four
+    /// corner-to-corner triangles.
+    func testDropZoneRegions() {
+        let size = CGSize(width: 100, height: 100)
+        XCTAssertEqual(PaneDropZone.zone(at: CGPoint(x: 50, y: 50), in: size), .center)
+        XCTAssertEqual(PaneDropZone.zone(at: CGPoint(x: 65, y: 65), in: size), .center)
+        XCTAssertEqual(PaneDropZone.zone(at: CGPoint(x: 5, y: 50), in: size), .left)
+        XCTAssertEqual(PaneDropZone.zone(at: CGPoint(x: 95, y: 50), in: size), .right)
+        XCTAssertEqual(PaneDropZone.zone(at: CGPoint(x: 50, y: 5), in: size), .top)
+        XCTAssertEqual(PaneDropZone.zone(at: CGPoint(x: 50, y: 95), in: size), .bottom)
+        // Diagonal tie-breaking: near a corner the closer edge wins.
+        XCTAssertEqual(PaneDropZone.zone(at: CGPoint(x: 10, y: 20), in: size), .left)
+        XCTAssertEqual(PaneDropZone.zone(at: CGPoint(x: 20, y: 10), in: size), .top)
+    }
+
+    /// The highlight previews exactly what the drop commits: the occupied half
+    /// for an edge, the whole pane for a swap.
+    func testDropZoneHighlightMatchesOutcome() {
+        let frame = CGRect(x: 10, y: 20, width: 100, height: 50)
+        XCTAssertEqual(PaneDropZone.left.highlightRect(in: frame),
+                       CGRect(x: 10, y: 20, width: 50, height: 50))
+        XCTAssertEqual(PaneDropZone.bottom.highlightRect(in: frame),
+                       CGRect(x: 10, y: 45, width: 100, height: 25))
+        XCTAssertEqual(PaneDropZone.center.highlightRect(in: frame), frame)
+    }
 }

--- a/web/landing/content/docs/first-session.mdx
+++ b/web/landing/content/docs/first-session.mdx
@@ -36,6 +36,10 @@ Most real work wants more than one pane. Split the current pane to the right wit
 agent in one, your dev server in another, a shell in a third. Panes tile as a
 tree, so you can nest splits into any layout.
 
+To rearrange a layout, hold `⌘⌥⇧` and drag any pane. A highlight previews where
+it will land: drop on another pane's left, right, top, or bottom half to place it
+on that side, or on the center to swap the two panes.
+
 Move focus between panes with `⌘⌥` + an arrow key, temporarily zoom the focused
 pane to fill the window with `⌘⇧↩`, and close it with `⌘W`. Every shortcut is
 rebindable — see [Keyboard shortcuts](/docs/keyboard).

--- a/web/landing/content/docs/keyboard.mdx
+++ b/web/landing/content/docs/keyboard.mdx
@@ -26,6 +26,10 @@ they do. Every one is rebindable — see [Customizing](#customizing) below.
 | Close pane | `⌘W` |
 | Focus left / right / up / down | `⌘⌥←` · `⌘⌥→` · `⌘⌥↑` · `⌘⌥↓` |
 
+Panes can also be rearranged with the mouse: hold `⌘⌥⇧` and drag a pane onto a
+neighbour — a highlight previews the drop. An edge half places the pane on that
+side; the center swaps the two.
+
 ## View
 
 | Action | Shortcut |


### PR DESCRIPTION
Closes #183

## What

Hold **⌘⌥⇧** and drag any pane body onto another pane — iTerm2's single-gesture rearrange, adapted for termio's chromeless panes where the modifier chord is the drag handle (no per-pane title bar, no permanent chrome). Prior art: ghostty's just-merged split drag ([ghostty#10090](https://github.com/ghostty-org/ghostty/pull/10090)), whose nearest-edge zone geometry this borrows.

- **Left / right / top / bottom half** → the target re-splits on that axis with the dragged pane on that side; the vacated slot collapses into its sibling. One gesture subsumes move + re-split + orientation.
- **Center** → the two panes trade places (the existing `swapping` behaviour).
- A borderless drop-zone wash (the file-drop tint family, deliberately not accent blue) previews the outcome before release — the preview is what resolves the drop ambiguity `SplitTree`'s `swapping` comment once avoided. The lifted source pane gets a fainter wash; **Esc** cancels; releasing the chord mid-drag doesn't — only the mouse button commits.

## How

- `PaneDragRearrange` (new): local `NSEvent` monitors one level above the libghostty surfaces — the same interception path as the right-click menu — so the gesture fires even under a mouse-reporting TUI. Pane resolution is by geometry, not `hitTest`, for the same hidden-sibling reason as `TerminalContextMenu`. The chord check tolerates Caps Lock/fn (an input-source-switching Caps Lock silently defeated an exact mask match) and rejects a held ⌃.
- `SplitTree`: `PaneDropZone` with pure, tested hit-region + highlight geometry; `splitting(leaf:)` learns a leading/trailing slot. The drop is composition: `removing` + `splitting`, or `swapping` for center.
- `TermioStore`: one `dropPane(_:onto:zone:)` mutation plus a transient published `paneDrag` the overlay reads; the cmd-click link monitor yields to the chord.
- Docs: the gesture is covered in *Your first session* and *Keyboard shortcuts*.

Move Pane and Flip Layout stay as the always-works menu fallback (they fire under TUIs that swallow drags).

## Testing

- 4 new `SplitTreeTests` (leading-slot split, edge-drop recomposition, zone hit regions, highlight-matches-outcome); full suite 55/55 green.
- Verified live in the dev build: all five zones, Esc cancel, chord-with-Caps-Lock, and the no-op self-drop (guarded — remove-then-miss would otherwise delete the pane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)