### PR TITLE
fix(menus): drop Open Link from issue detail context menu

### DIFF
--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -882,14 +882,17 @@ private struct IssueWebView: NSViewRepresentable {
 /// `ContextMenuWebView`. AppKit otherwise injects a grab-bag onto a `WKWebView` menu
 /// (Look Up / Translate / Search / Copy Link with Highlight / Share / Speech / Services)
 /// — none of it fits a read-only issue thread. Whitelisting by identifier keeps Copy
-/// (text selection) plus Open/Copy Link (an actual link under the cursor) and drops all
-/// the rest.
+/// (text selection) plus Copy Link (a link's URL under the cursor) and drops the rest.
+///
+/// "Open Link" is deliberately *not* kept: the nav delegate only diverts `.linkActivated`
+/// navigations to the browser, but the context-menu item fires a different navigation type
+/// that would load the target *inside* this webview (unauthenticated), replacing the
+/// conversation. A left-click already opens links in the browser, so the item is redundant.
 private final class IssueDetailWKWebView: WKWebView {
     override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
         super.willOpenMenu(menu, with: event)
         let keep: Set<String> = [
             "WKMenuItemIdentifierCopy",
-            "WKMenuItemIdentifierOpenLink",
             "WKMenuItemIdentifierCopyLink",
         ]
         menu.items = menu.items.filter { item in


### PR DESCRIPTION
## What
Follow-up cleanup to `ab663db` (the issue/PR detail context-menu declutter, sibling to #184). Narrows the `IssueDetailWKWebView.willOpenMenu` whitelist from `{Copy, Open Link, Copy Link}` to `{Copy, Copy Link}`.

## Why
The detail view's navigation delegate only diverts `.linkActivated` navigations to the browser (`NSWorkspace.open` + `.cancel`); everything else is `.allow`ed. WebKit's context-menu **Open Link** fires a *different* navigation type, so it fell through to `.allow` and loaded the target **inside** the issue-detail webview — unauthenticated (the webview only carries a bearer for the asset scheme handler, not github.com navigations), replacing the rendered conversation.

A normal left-click already opens links in the browser via the delegate, so **Open Link** was both redundant and misbehaving. **Copy Link** (copy a URL) is harmless and kept.

Found in a post-merge review of `ab663db`.

## Test
- Change is a one-element removal from a `Set<String>` literal plus a comment; no signature or control-flow change. `origin/main` already builds with this file. (No full clean-worktree rebuild run for a trivial whitelist edit.)