### PR TITLE
feat(splits): flip a pane pair between side-by-side and stacked

### DIFF
--- a/Sources/termio/Terminal/SplitTree.swift
+++ b/Sources/termio/Terminal/SplitTree.swift
@@ -243,6 +243,27 @@ indirect enum SplitNode: Codable, Hashable {
         }
     }
 
+    /// Flips the axis of the branch that has `leaf` as a direct child —
+    /// side-by-side ⇄ stacked — keeping both children and the divider ratio.
+    /// This is the innermost split only: nesting stays put, so flipping an
+    /// A│B pair that sits under C rotates just A and B, never C. Like
+    /// `swapping`, it changes one thing about one pair and leaves the rest of
+    /// the tree byte-for-byte. A miss returns the tree unchanged.
+    func flippingBranch(containing leaf: Session.ID) -> SplitNode {
+        switch self {
+        case .leaf:
+            return self
+        case .split(var branch):
+            if branch.first == .leaf(leaf) || branch.second == .leaf(leaf) {
+                branch.direction = branch.direction == .horizontal ? .vertical : .horizontal
+                return .split(branch)
+            }
+            branch.first = branch.first.flippingBranch(containing: leaf)
+            branch.second = branch.second.flippingBranch(containing: leaf)
+            return .split(branch)
+        }
+    }
+
     /// Writes a divider's ratio (clamped), leaving the rest of the tree intact.
     func updatingRatio(branchID: UUID, to ratio: Double) -> SplitNode {
         switch self {

--- a/Sources/termio/Terminal/TerminalContextMenu.swift
+++ b/Sources/termio/Terminal/TerminalContextMenu.swift
@@ -76,7 +76,14 @@ final class TerminalContextMenu: NSObject {
         clickedLinkURL = TerminalLinkState.hoveredURL
             .flatMap(URL.init(string:))
             .flatMap { ["http", "https"].contains($0.scheme?.lowercased() ?? "") ? $0 : nil }
-        NSMenu.popUpContextMenu(makeMenu(), with: event, for: target)
+        // popUp — not popUpContextMenu(_:with:for:) — presents exactly the menu we
+        // built. Passing the surface as the `for:` view makes AppKit merge in the
+        // system's automatic text-input extras (the "AutoFill" submenu, Services)
+        // because the ghostty surface is an NSTextInputClient; those are meaningless
+        // over a terminal, so we position the menu ourselves and skip the augmentation.
+        makeMenu().popUp(positioning: nil,
+                         at: target.convert(event.locationInWindow, from: nil),
+                         in: target)
         return true
     }
 
@@ -129,6 +136,16 @@ final class TerminalContextMenu: NSObject {
             parent.submenu = submenu
             menu.addItem(parent)
         }
+        // "Flip Layout" turns just the divider that holds the clicked pane and
+        // its neighbour from side-by-side to stacked (or back) — the honest
+        // inverse of the "Split Right"/"Split Down" that made the pair. Nested
+        // splits stay put, matching iTerm2's local, per-pane model (which has no
+        // whole-layout transpose). Only offered when the pane is in a group, so
+        // there is always a branch to flip.
+        if let id = clickedSessionID, let store, store.isInSplitGroup(id) {
+            menu.addItem(storeItem("Flip Layout", action: #selector(flipLayout),
+                                   symbol: "arrow.triangle.2.circlepath"))
+        }
         // "Ungroup" is the layout half: the pane leaves the split group but its
         // session stays alive in the sidebar — the same action the sidebar row
         // names "Ungroup" (the inverse of "Group with"). Its glyph is Split
@@ -175,6 +192,10 @@ final class TerminalContextMenu: NSObject {
     @objc private func splitRight() { store?.splitSelectedPane(.horizontal) }
     @objc private func splitDown() { store?.splitSelectedPane(.vertical) }
     @objc private func ungroup() { store?.ungroupSelectedPane() }
+    @objc private func flipLayout() {
+        guard let id = clickedSessionID else { return }
+        store?.flipPaneLayout(id)
+    }
     @objc private func movePaneLeft() { movePane(.left) }
     @objc private func movePaneRight() { movePane(.right) }
     @objc private func movePaneUp() { movePane(.up) }

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -301,6 +301,19 @@ extension TermioStore {
         isPaneZoomed = false
     }
 
+    /// Flips the layout of the branch immediately enclosing a pane — side-by-side
+    /// ⇄ stacked — via the context menu's "Flip Layout". Only that one divider's
+    /// axis turns; the tree's shape, its ratios, and every other pane stay put,
+    /// the same restraint "Move Pane" keeps. Zoom is dropped so the result is
+    /// visible and the selection sticks with the flipped pane. A no-op when the
+    /// pane isn't grouped (a lone pane has no branch to flip).
+    func flipPaneLayout(_ id: Session.ID) {
+        guard let group = groupIndex(containing: id) else { return }
+        splitGroups[group] = splitGroups[group].flippingBranch(containing: id)
+        selectedSessionID = id
+        isPaneZoomed = false
+    }
+
     /// Moves pane focus directionally (⌥⌘ arrows), scored on the visible
     /// group's normalized geometry. No-op without splits or when nothing lies
     /// that way.

--- a/Tests/termioTests/SplitTreeTests.swift
+++ b/Tests/termioTests/SplitTreeTests.swift
@@ -140,4 +140,37 @@ final class SplitTreeTests: XCTestCase {
                        CGRect(x: 10, y: 45, width: 100, height: 25))
         XCTAssertEqual(PaneDropZone.center.highlightRect(in: frame), frame)
     }
+
+    /// "Flip Layout" turns only the innermost branch: an A│B pair nested under C
+    /// rotates from side-by-side to stacked, while C keeps its own axis, ratio,
+    /// and slot. Both children and the ratio survive the flip.
+    func testFlippingTurnsOnlyTheInnermostBranch() {
+        let inner = SplitBranch(direction: .horizontal, ratio: 0.3,
+                                first: .leaf(run1), second: .leaf(run2))
+        let tree = SplitNode.split(SplitBranch(direction: .vertical, ratio: 0.5,
+                                               first: .leaf(agent), second: .split(inner)))
+        let flipped = tree.flippingBranch(containing: run1)
+
+        guard case let .split(outer) = flipped,
+              case let .split(rotated) = outer.second else {
+            return XCTFail("expected the outer branch and its inner split to survive")
+        }
+        // The outer branch is byte-for-byte the same; only the inner axis turned.
+        XCTAssertEqual(outer.direction, .vertical)
+        XCTAssertEqual(outer.first, .leaf(agent))
+        XCTAssertEqual(rotated.direction, .vertical)   // was .horizontal
+        XCTAssertEqual(rotated.ratio, 0.3)             // ratio preserved
+        XCTAssertEqual(flipped.leafIDs, [agent, run1, run2])
+    }
+
+    /// Flipping a pane that has no enclosing branch, or a leaf that isn't in the
+    /// tree, changes nothing.
+    func testFlippingMissIsANoOp() {
+        let lone = SplitNode.leaf(agent)
+        XCTAssertEqual(lone.flippingBranch(containing: agent), lone)
+
+        let tree = SplitNode.split(SplitBranch(direction: .horizontal, ratio: 0.5,
+                                               first: .leaf(agent), second: .leaf(run1)))
+        XCTAssertEqual(tree.flippingBranch(containing: run3), tree)
+    }
 }


### PR DESCRIPTION
## Summary
- **Flip Layout** joins the pane context menu: it rotates just the divider that holds the clicked pane and its neighbour — side-by-side ⇄ stacked — keeping both children, the divider ratio, and every nested split byte-for-byte in place (`SplitNode.flippingBranch`, the same one-change-one-pair restraint as `swapping`). Matches iTerm2's local, per-pane model; only offered when the pane is actually in a group.
- Presents the terminal context menu with `popUp(positioning:at:in:)` instead of `popUpContextMenu(_:with:for:)` — passing the ghostty surface as the `for:` view made AppKit merge in the automatic text-input extras (AutoFill submenu, Services) because the surface is an `NSTextInputClient`. The terminal-surface twin of the issue-detail menu fix (c5e39e6).

## Testing
- `swift build` clean; `swift test --filter SplitTreeTests` — 11 tests, 0 failures, including the two new ones (innermost-branch-only flip preserving ratio/shape; no-op on lone panes and missing leaves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)