### PR TITLE
fix(menus): strip preview right-click menus to their real actions

### DIFF
--- a/Sources/termio/Browser/FilePreview.swift
+++ b/Sources/termio/Browser/FilePreview.swift
@@ -74,6 +74,18 @@ struct FilePreviewView: View {
                     .scaledToFit()
                     .padding(24)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
+                    .contextMenu {
+                        Button("Copy Image") {
+                            // The NSImage goes on the pasteboard as bitmap data, so it pastes
+                            // into chat and design apps as the picture, not a file path.
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.writeObjects([image])
+                        }
+                        Button("Reveal in Finder") {
+                            NSWorkspace.shared.activateFileViewerSelecting([url])
+                        }
+                    }
             } else {
                 WebPreview(url: url)
             }

--- a/Sources/termio/Editor/MarkdownReaderView.swift
+++ b/Sources/termio/Editor/MarkdownReaderView.swift
@@ -23,6 +23,7 @@ struct MarkdownReaderView: View {
         MarkdownReaderWebView(
             html: MarkdownReaderRenderer.document(source, theme: theme, fontFamily: settings.fontFamily),
             baseURL: fileURL.deletingLastPathComponent(),
+            fileURL: fileURL,
             background: settings.terminalBackgroundColor
         )
     }
@@ -35,6 +36,7 @@ struct MarkdownReaderView: View {
 private struct MarkdownReaderWebView: NSViewRepresentable {
     let html: String
     let baseURL: URL
+    let fileURL: URL
     let background: NSColor
 
     /// `loadHTMLString` pages get no filesystem access in the WebContent process, so a
@@ -55,6 +57,7 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
         let config = WKWebViewConfiguration()
         config.setURLSchemeHandler(LocalFileSchemeHandler(), forURLScheme: Self.fileScheme)
         let view = ContextMenuWebView(frame: .zero, configuration: config)
+        view.fileURL = fileURL
         view.setValue(false, forKey: "drawsBackground")
         view.navigationDelegate = context.coordinator
         view.loadHTMLString(html, baseURL: schemeBaseURL)
@@ -119,15 +122,31 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
 /// A `WKWebView` that appends a "Close" to its right-click menu, so the Markdown preview closes
 /// terminal-style like the source editor — the overlay has no chrome button.
 private final class ContextMenuWebView: WKWebView {
+    /// The document on disk, so the menu can reveal it in Finder (like the file tree's row menu).
+    var fileURL: URL?
+
     override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
         super.willOpenMenu(menu, with: event)
         // Strip the reader's menu down to Copy — a read-only document doesn't need Reload / Look Up
-        // / Translate / Share / Services — then add a prominent Close so it's not buried.
+        // / Translate / Share, and the OS-injected AutoFill / Services grab-bag is meaningless over
+        // a rendered doc. Whitelisting Copy by identifier drops all of it. Then add the actions that
+        // *do* fit a file preview: Reveal in Finder (an explicit item, not a flaky Services shortcut)
+        // and a prominent Close so it isn't buried.
         menu.items = menu.items.filter { $0.identifier?.rawValue == "WKMenuItemIdentifierCopy" }
-        if !menu.items.isEmpty { menu.addItem(.separator()) }
+        menu.addItem(.separator())
+        if fileURL != nil {
+            let reveal = NSMenuItem(title: "Reveal in Finder", action: #selector(revealInFinder), keyEquivalent: "")
+            reveal.target = self
+            menu.addItem(reveal)
+        }
         let close = NSMenuItem(title: "Close", action: #selector(closeEditorOverlay), keyEquivalent: "")
         close.target = self
         menu.addItem(close)
+    }
+
+    @objc private func revealInFinder() {
+        guard let fileURL else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([fileURL])
     }
 
     @objc private func closeEditorOverlay() {

--- a/Sources/termio/Git/DiffTextView.swift
+++ b/Sources/termio/Git/DiffTextView.swift
@@ -324,6 +324,24 @@ final class DiffTextView: NSTextView {
         onClose?()
     }
 
+    /// A minimal right-click menu: Copy, plus Close. NSTextView's default would inject
+    /// the read-only text grab-bag (Look Up / Translate / Speech / Share / Services) a
+    /// diff has no use for; returning our own menu — without calling `super` — drops all
+    /// of it, matching the editor's and reader's stripped menus.
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = NSMenu()
+        menu.addItem(withTitle: "Copy", action: #selector(copy(_:)), keyEquivalent: "")
+        if onClose != nil {
+            menu.addItem(.separator())
+            let close = NSMenuItem(title: "Close", action: #selector(closeFromMenu), keyEquivalent: "")
+            close.target = self
+            menu.addItem(close)
+        }
+        return menu
+    }
+
+    @objc private func closeFromMenu() { onClose?() }
+
     override func mouseDown(with event: NSEvent) {
         if let anchor = expandableBand(at: event) {
             onExpand?(anchor)


### PR DESCRIPTION
## Summary
Continues the context-menu cleanup (c5e39e6, #187) across the read-only preview surfaces — each now offers exactly the actions that fit it, instead of the OS-injected grab-bag:

- **Image preview** (`FilePreviewView`): adds a context menu with **Copy Image** — the `NSImage` goes on the pasteboard as bitmap data, so it pastes into chat/design apps as a picture, not a file path — and **Reveal in Finder**.
- **Markdown reader**: keeps the menu stripped to Copy, and adds **Reveal in Finder** beside the existing Close (the reader now knows its on-disk `fileURL`).
- **Diff overlay** (`DiffTextView`): overrides `menu(for:)` to return a minimal **Copy + Close**, dropping NSTextView's read-only defaults (Look Up / Translate / Speech / Share / Services), matching the editor's and reader's stripped menus.

## Testing
- `swift build` clean with all three changes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)