### PR TITLE
feat(ios): long-press text selection and paste in the terminal

### DIFF
--- a/ios/Sources/TerminalSelectionViewController.swift
+++ b/ios/Sources/TerminalSelectionViewController.swift
@@ -1,0 +1,129 @@
+import UIKit
+
+/// The long-press "select text" page: a frozen snapshot of the terminal
+/// viewport in a plain text view, where iOS's own selection machinery —
+/// handles, magnifier, the system edit menu — does the work the Metal
+/// surface can't. The wrapper resolves the word under the finger before
+/// presenting, so the page opens with that word already selected and the
+/// user only adjusts the handles (the Termius/blink select-mode shape).
+///
+/// The page is also where touch users reach Paste: the bar's Paste button
+/// hands the clipboard back to the owner, who types it into the PTY. The
+/// page itself never touches the byte stream.
+final class TerminalSelectionViewController: UIViewController {
+    /// Clipboard text the user asked to type into the terminal.
+    var onPaste: ((String) -> Void)?
+    /// The page left the screen by any route (Copy, Paste, swipe-down) —
+    /// the owner hands keyboard focus back to the terminal.
+    var onClosed: (() -> Void)?
+
+    private let snapshotText: String
+    private let anchorRange: NSRange?
+    private let textView = UITextView()
+    private var backdropObserver: NSObjectProtocol?
+    private var didPreselect = false
+
+    init(text: String, anchorRange: NSRange?) {
+        snapshotText = text
+        self.anchorRange = anchorRange
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    deinit {
+        if let backdropObserver {
+            NotificationCenter.default.removeObserver(backdropObserver)
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Select Text"
+        backdropObserver = installThemeBackdrop()
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: "Paste", style: .plain,
+            target: self, action: #selector(pasteTapped)
+        )
+        // `hasStrings` never triggers the system paste prompt; reading
+        // `.string` is deferred to the tap, where iOS grants it as a
+        // user-initiated paste.
+        navigationItem.leftBarButtonItem?.isEnabled = UIPasteboard.general.hasStrings
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: "Copy", style: .done,
+            target: self, action: #selector(copyTapped)
+        )
+
+        // The terminal's own text, so the page reads as a still frame of the
+        // surface underneath — monospaced, on the theme backdrop.
+        textView.text = snapshotText
+        textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        textView.textColor = .label
+        textView.backgroundColor = .clear
+        textView.isEditable = false
+        textView.alwaysBounceVertical = true
+        textView.textContainerInset = UIEdgeInsets(top: 16, left: 12, bottom: 16, right: 12)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(textView)
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: view.topAnchor),
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // Selection handles need the text view to hold first responder; the
+        // view is non-editable, so no keyboard comes with it. Only once —
+        // reappearing must not clobber a selection the user already adjusted.
+        guard !didPreselect else { return }
+        didPreselect = true
+        textView.becomeFirstResponder()
+        let range = anchorRange
+            ?? NSRange(location: 0, length: (snapshotText as NSString).length)
+        textView.selectedRange = range
+        textView.scrollRangeToVisible(range)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        onClosed?()
+    }
+
+    @objc private func copyTapped() {
+        let text = textView.text ?? ""
+        let selected = textView.selectedRange
+        let raw = selected.length > 0
+            ? (text as NSString).substring(with: selected)
+            : text
+        UIPasteboard.general.string = Self.sanitizedForClipboard(raw)
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        dismiss(animated: true)
+    }
+
+    @objc private func pasteTapped() {
+        guard let text = UIPasteboard.general.string, !text.isEmpty else { return }
+        let onPaste = onPaste
+        dismiss(animated: true) { onPaste?(text) }
+    }
+
+    /// blink's clipboard rule: the terminal grid pads rows with spaces, so
+    /// strip trailing spaces/tabs from every line (and normalize CRLF) or a
+    /// pasted command drags a wall of padding with it.
+    static func sanitizedForClipboard(_ text: String) -> String {
+        text.replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: "\n")
+            .map { line in
+                var trimmed = Substring(line)
+                while let last = trimmed.last, last == " " || last == "\t" {
+                    trimmed.removeLast()
+                }
+                return String(trimmed)
+            }
+            .joined(separator: "\n")
+    }
+}

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -1114,6 +1114,35 @@ extension TerminalViewController: TerminalSurfaceTitleDelegate, TerminalSurfaceC
     }
 }
 
+extension TerminalViewController: TerminalSurfaceTextSelectionRequestDelegate {
+    /// Long-press on the surface: the wrapper already snapshotted the viewport
+    /// and resolved the word under the finger — present the selection page.
+    /// (This conformance is also the switch: the wrapper's long-press
+    /// recognizer only begins when the delegate adopts it.)
+    func terminalDidRequestTextSelection(_ request: TerminalTextSelectionRequest) {
+        guard presentedViewController == nil else { return }
+        let page = TerminalSelectionViewController(
+            text: request.text, anchorRange: request.anchorRange
+        )
+        // Multi-character `insertText` rides the wrapper's sendText, which
+        // wraps in bracketed paste only once the TUI enabled mode 2004 — the
+        // same delivery a Mac paste gets (see DisplayTerminalView.insertText).
+        page.onPaste = { [weak self] text in
+            self?.terminalView.insertText(text)
+        }
+        page.onClosed = { [weak self] in
+            guard let self, !drawerOpen else { return }
+            focusInput()
+        }
+        let nav = UINavigationController(rootViewController: page)
+        if let sheet = nav.sheetPresentationController {
+            sheet.detents = [.large()]
+            sheet.prefersGrabberVisible = true
+        }
+        present(nav, animated: true)
+    }
+}
+
 extension TerminalViewController: TerminalSurfaceRendererHealthDelegate {
     /// libghostty flipped its renderer health. `healthy == false` means it just
     /// tripped the failsafe that paints the "This terminal is non-functional"
@@ -1255,6 +1284,24 @@ private final class DisplayTerminalView: UITerminalView {
             return
         }
         super.insertText(text)
+    }
+
+    /// Hardware Cmd+V (UIKit routes the system Paste key command to the first
+    /// responder's `paste(_:)`). The clipboard goes through `insertText`,
+    /// whose multi-character path rides the wrapper's sendText — bracketed
+    /// paste applied only once the TUI enabled mode 2004, exactly like a Mac
+    /// paste. `hasStrings` gates availability without triggering the system
+    /// paste prompt; the actual read happens inside the user-initiated paste.
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(UIResponderStandardEditActions.paste(_:)) {
+            return UIPasteboard.general.hasStrings
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    override func paste(_ sender: Any?) {
+        guard let text = UIPasteboard.general.string, !text.isEmpty else { return }
+        insertText(text)
     }
 
     // MARK: - Software-keyboard delete auto-repeat (phantom document)


### PR DESCRIPTION
## What

iOS terminal finally supports selecting text and pasting.

- **Long-press to select**: long-pressing the terminal opens a select-text page — a frozen snapshot of the viewport in a plain `UITextView`, where iOS's own selection handles, magnifier, and system edit menu do the work the Metal surface can't. The word under the finger arrives pre-selected, so the page opens with the selection already started.
- **Copy** (bar button or the system edit menu) strips per-line trailing pad spaces and normalizes CRLF before writing to the clipboard — blink's clipboard rule, since the terminal grid pads rows with spaces.
- **Paste** from the page's bar button, or hardware **Cmd+V** anywhere in the terminal (UIKit routes the system Paste key command to the first responder's `paste(_:)`).

## How

The selection machinery already shipped in the libghostty-swift wrapper (long-press recognizer, quicklook word resolution, viewport snapshot via `readViewportText`), but it's gated on the host adopting `TerminalSurfaceTextSelectionRequestDelegate` — and no host ever had. Adopting it in `TerminalViewController` is the switch that arms the gesture; the new `TerminalSelectionViewController` is the page it dispatches to.

Paste deliberately reuses `insertText`: its multi-character path rides the wrapper's `sendText`, which wraps in bracketed paste **only once the TUI enabled mode 2004** — the same delivery a Mac paste gets, so a pasted newline never auto-submits in Claude Code but still executes in a plain shell. `UIPasteboard.hasStrings` gates the affordances without tripping the iOS paste-permission prompt; the actual read happens inside the user-initiated action.

Prior art studied: blink (WKWebView/DOM selection + native menu + clipboard sanitization) and the wrapper's own pointer-selection path. A native-handle drag-selection on the Metal surface itself was rejected — the select-page shape (Termius/blink select mode) gets full native selection UX for a fraction of the surface area.

## Testing

- `xcodebuild -scheme TermioMobile -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (only pre-existing warnings).
- Needs an on-device pass: long-press → page opens with word pre-selected → adjust handles → Copy; Paste button and hardware Cmd+V into Claude Code (bracketed) and a plain shell (raw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)