### PR TITLE
fix(issues): keep the list kind under an open detail and refresh stale state

### DIFF
--- a/Sources/termio/Issues/IssuesPanelModel.swift
+++ b/Sources/termio/Issues/IssuesPanelModel.swift
@@ -251,6 +251,28 @@ final class IssuesPanelModel: ObservableObject {
     /// shows instantly, but a silent background refresh confirms it.
     private static let revalidateAfter: TimeInterval = 30
 
+    /// Confirms the open detail against GitHub once its cached copy has aged past the dedupe
+    /// window — the revalidate half of stale-while-revalidate, shared by the warm `loadDetail`
+    /// path, a same-item reopen, and app refocus. This is what lets a detail notice an
+    /// out-of-band state change: a PR closed by `gh` in a terminal or on github.com keeps
+    /// showing its stale Open badge until some interaction lands here.
+    func revalidateOpenDetail() async {
+        await ensureReady()
+        guard let provider, let container, let item = openItem else { return }
+        guard let cached = cache?.entry(container, item.number),
+              Date().timeIntervalSince(cached.fetchedAt) >= Self.revalidateAfter
+        else { return }
+        do {
+            let fresh = try await fetchEntry(item, provider: provider, container: container)
+            guard openItem?.number == item.number else { return }
+            cache?.store(fresh, container, item.number)
+            // Only republish on a real change, so an unchanged refresh never flickers.
+            if !fresh.sameContent(as: cached) { apply(fresh) }
+        } catch {
+            // Revalidation failed (offline, rate limit): the cached copy already shows.
+        }
+    }
+
     func loadDetail(for item: IssueSummary) async {
         // A session switch remounts `IssuesView` with a brand-new, empty model, so make this
         // self-sufficient rather than assuming `start()` has already run: resolve the token +
@@ -259,8 +281,13 @@ final class IssuesPanelModel: ObservableObject {
         // useless on exactly the switch path it exists for.
         await ensureReady()
         guard let provider, let container else { return }
-        // Same item already loaded in this instance (e.g. a maximize remount): nothing to do.
-        if openItem?.number == item.number, detail != nil, !prFilesLoading { return }
+        // Same item already loaded in this instance (e.g. a maximize remount): the content
+        // already shows — just confirm it, so a reopen picks up a state change that happened
+        // while the detail was up (a PR closed out of band).
+        if openItem?.number == item.number, detail != nil, !prFilesLoading {
+            await revalidateOpenDetail()
+            return
+        }
         // The model's own record of which item is open, independent of what drives the UI.
         openItem = item
 
@@ -274,17 +301,8 @@ final class IssuesPanelModel: ObservableObject {
                 // list landed): fetch just the files now — the conversation already shows.
                 await loadPRFiles(item, provider: provider, container: container,
                                   conversation: cached.detail)
-            } else if Date().timeIntervalSince(cached.fetchedAt) >= Self.revalidateAfter {
-                // Stale-while-revalidate: confirm in the background, past the dedupe window.
-                do {
-                    let fresh = try await fetchEntry(item, provider: provider, container: container)
-                    guard openItem?.number == item.number else { return }
-                    cache?.store(fresh, container, item.number)
-                    // Only republish on a real change, so an unchanged refresh never flickers.
-                    if !fresh.sameContent(as: cached) { apply(fresh) }
-                } catch {
-                    // Revalidation failed (offline, rate limit): the cached copy already shows.
-                }
+            } else {
+                await revalidateOpenDetail()
             }
             return
         }

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -300,7 +300,12 @@ struct IssuesView: View {
                     item: item,
                     font: settings.interfaceFont,
                     chrome: chrome,
+                    // `openItem` outlives the closed overlay, so the last-opened row
+                    // keeps the selected grey — back from a full-screen detail, the
+                    // list still shows which item it was. (`selection` itself is
+                    // released on close so clicking the same row can reopen it.)
                     isSelected: selection == item.number
+                        || model.openItem?.number == item.number
                 )
                 // Drag a row out as its GitHub URL — the terminal pane catches the
                 // drop and inserts the full link at the prompt (see

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -34,18 +34,32 @@ struct IssuesView: View {
         listPane
             .task(id: repoRoot) {
                 store.registerIssuesModel(model)
+                // An already-open detail dictates the list it sits over: exiting a PR
+                // must reveal Pull Requests (a restored detail is the one case the
+                // registry can't cover — no predecessor model after a relaunch), with
+                // its row still selected. Pre-`start()` the kind write is inert: the
+                // query didSet's loadList bails until the phase is ready.
+                if let open = store.openIssueDetail {
+                    if model.query.kind != open.kind { model.query.kind = open.kind }
+                    if selection != open.number { selection = open.number }
+                }
                 await model.start()
             }
             // Selection IS the open gesture; route it to the center overlay. Follow the
-            // overlay back: when it closes, release the selection so the same row reopens.
+            // overlay back: when it closes, release the selection so the same row reopens
+            // — and revalidate the list, so an item whose state changed while its detail
+            // was up (a PR closed out of band) doesn't come back as a stale open row.
             .onChange(of: selection) { _, selected in
                 guard let selected,
                       let item = model.items.first(where: { $0.number == selected })
                 else { return }
                 store.openIssueDetail = item
             }
-            .onChange(of: store.openIssueDetail) { _, item in
-                if item == nil { selection = nil }
+            .onChange(of: store.openIssueDetail) { was, item in
+                if item == nil {
+                    selection = nil
+                    if was != nil { Task { await model.loadList(force: true) } }
+                }
             }
     }
 
@@ -562,8 +576,21 @@ struct IssueDetailView: View {
         .task(id: DetailTaskKey(number: item.number, model: ObjectIdentifier(model))) {
             await model.loadDetail(for: item)
         }
+        // GitHub Desktop's focus-refresh: coming back to the app re-confirms the open
+        // item, so a PR closed on github.com while this detail sat on screen updates
+        // its state badge instead of holding a stale Open.
+        .onReceive(NotificationCenter.default.publisher(
+            for: NSApplication.didBecomeActiveNotification
+        )) { _ in
+            Task { await model.revalidateOpenDetail() }
+        }
         .onExitCommand(perform: onBack)
     }
+
+    /// The freshest identity we hold for the open item: the fetched detail's summary when it
+    /// has landed (it carries state changes — open → closed/merged — that the immutable
+    /// `item` passed in at open time cannot), else that opening summary.
+    private var current: IssueSummary { model.detail?.summary ?? item }
 
     /// The item identity on the left; actions on the right — all buttons are
     /// `TreeHeaderButton`s (the explorer header's quiet hover style), so they
@@ -573,9 +600,9 @@ struct IssueDetailView: View {
     private var header: some View {
         HStack(spacing: 6) {
             OcticonView(
-                icon: item.state.octicon(for: item.kind),
+                icon: current.state.octicon(for: current.kind),
                 size: 14,
-                color: item.state.tint(for: item.kind)
+                color: current.state.tint(for: current.kind)
             )
             .frame(width: 15)
             Text(item.identifier)

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -232,6 +232,9 @@ final class TermioStore: ObservableObject {
         // back to the default Issues kind under whatever detail is open.
         if let outgoing = issuesModels[model.repoRoot], outgoing !== model {
             model.query = outgoing.query
+            // And the last-opened item: its row keeps the selected grey after the
+            // detail closes, a memory that must survive the same remounts.
+            model.openItem = outgoing.openItem
         }
         issuesModels[model.repoRoot] = model
     }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -226,6 +226,13 @@ final class TermioStore: ObservableObject {
     /// previously fetched list + detail instead of hitting GitHub again. Called by `IssuesView`.
     func registerIssuesModel(_ model: IssuesPanelModel) {
         model.attachCache(issueCache)
+        // The list DATA survives a remount through the cache, but the query — the
+        // Issues/Pull Requests kind, the filters — lives on the model instance. Hand it
+        // to the successor, or every remount (session switch, tab switch) snaps the pane
+        // back to the default Issues kind under whatever detail is open.
+        if let outgoing = issuesModels[model.repoRoot], outgoing !== model {
+            model.query = outgoing.query
+        }
         issuesModels[model.repoRoot] = model
     }
 


### PR DESCRIPTION
## Problem (reported with screenshots)

1. Exiting a PR detail landed on the **Issues** list, not Pull Requests.
2. The detail of a PR that had just been closed (out of band, via `gh` in a terminal) still showed an **Open** badge, and nothing highlighted the state change.

## Why

- The Issues/Pull Requests kind lives on `IssuesPanelModel.query`, a `@StateObject` recreated at the default kind (Issues) on every `IssuesView` remount — session switch, inspector tab switch, relaunch. The store's model registry preserves the *data* for the detail overlay, but `registerIssuesModel` replaced the model without carrying the query, and the persisted `InspectorState` saves the tab + open detail, not the kind. Restore could therefore produce a PR detail sitting over an Issues-kind list.
- An open detail never revalidated: a same-item reopen returned early, the warm path only revalidated at open time (30s SWR window), and nothing polls while it's on screen. The header badge also rendered from the immutable `item` summary captured at open time, so even a refetch wouldn't have flipped it.

## Fix

- `registerIssuesModel` hands the outgoing model's query to its successor; an already-open detail aligns the fresh list's kind and row selection with its own (covers relaunch restore, where there is no predecessor).
- `revalidateOpenDetail()` extracted and shared by the warm path, same-item reopens, and app refocus (GitHub Desktop's focus-refresh). The header badge renders from the fetched detail's summary. Closing a detail force-refreshes the list, so the row you return to is current — a closed PR drops out of the default open-only filter, GitHub's own semantics.

Within the pane's fetch-on-interaction design, one gap remains by choice: a detail that stays open while the app never loses focus won't update until the next interaction (reopen, exit, refocus, or the refresh button) — no background polling was added.

## Testing

- `swift build` clean.
- Manual recipe: PR tab → open a PR → close it via `gh pr close` in a terminal → exit the detail: the Pull Requests list shows (refreshed); reopen the detail after 30s: badge shows red Closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)