### PR TITLE
fix(git): keep the pane mode under an open diff and the last-opened row grey

### DIFF
--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -43,6 +43,12 @@ struct GitChangesView: View {
     /// several become the targets of the batch context-menu actions.
     @State private var selection = Set<String>()
 
+    /// The last working-tree diff opened from this list. Closing the overlay releases
+    /// `selection` (so clicking the same row reopens it), but this row keeps the
+    /// selected grey — back from a full-screen diff, the list still shows which file
+    /// it was (the Issues list's rule).
+    @State private var lastOpenedPath: String?
+
     init(repoRoot: String, changeCount: Binding<Int>, isPaneVisible: (() -> Bool)? = nil) {
         self.repoRoot = repoRoot
         self._changeCount = changeCount
@@ -63,8 +69,24 @@ struct GitChangesView: View {
             // count would just echo the fetch limit — meaningless, so no bar.
             if mode == .changes { bottomBar }
         }
-        .task(id: repoRoot) { await model.load() }
+        .task(id: repoRoot) {
+            // Resume the remembered inner mode, then let an open overlay override it:
+            // the detail dictates the list it sits over (the Issues pane's rule), so a
+            // restored History diff never sits on a Changes list. Re-selecting the
+            // working-tree row is the mount-time half of the `openDiff` follow below,
+            // which only fires on change and so misses a diff that was already open.
+            if let remembered = store.gitPaneModes[repoRoot] { mode = remembered }
+            if let request = store.openDiff, request.repoRoot == repoRoot {
+                mode = request.commit == nil ? .changes : .history
+                if request.commit == nil {
+                    selection = [request.change.path]
+                    lastOpenedPath = request.change.path
+                }
+            }
+            await model.load()
+        }
         .task(id: mode) { if mode == .history { await model.loadHistory() } }
+        .onChange(of: mode) { _, mode in store.gitPaneModes[repoRoot] = mode }
         // Replay any refresh that arrived while the inspector was collapsed, the
         // moment the pane is actually shown again (either signal can fire first
         // depending on how the view was re-attached).
@@ -86,8 +108,9 @@ struct GitChangesView: View {
         // and release a lone selection so clicking the same row reopens its diff. The
         // `openFileURL` guards keep a diff↔preview hand-off from reading as a close.
         .onChange(of: store.openDiff) { _, request in
-            if let request, request.commit == nil, selection != [request.change.path] {
-                selection = [request.change.path]
+            if let request, request.commit == nil {
+                lastOpenedPath = request.change.path
+                if selection != [request.change.path] { selection = [request.change.path] }
             }
             if request == nil, store.openFileURL == nil {
                 Task { await model.load() }
@@ -233,7 +256,10 @@ struct GitChangesView: View {
                 fileURL: fileURL(for: change),
                 font: settings.interfaceFont,
                 chrome: chrome,
-                isSelected: selection.contains(change.path),
+                // The lone last-opened row stays grey after its overlay closes; a live
+                // multi-selection takes over the moment one exists.
+                isSelected: selection.contains(change.path)
+                    || (selection.isEmpty && lastOpenedPath == change.path),
                 onDiscard: { pendingDiscard = [change] }
             )
             .contextMenu { contextMenu(for: change) }

--- a/Sources/termio/Git/GitHistoryView.swift
+++ b/Sources/termio/Git/GitHistoryView.swift
@@ -19,6 +19,10 @@ struct GitHistoryView: View {
     @State private var expanded: String?
     /// Files per commit, fetched lazily on first expand and kept for the session.
     @State private var filesByCommit: [String: [GitChange]] = [:]
+    /// The last file diff opened from this list — its row keeps the selected grey after
+    /// the overlay closes (the Issues list's rule), so coming back from a full-screen
+    /// diff still shows which file it was.
+    @State private var lastOpenedFile: (sha: String, path: String)?
 
     var body: some View {
         Group {
@@ -53,6 +57,13 @@ struct GitHistoryView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        // ← / → walk the open overlay across the commit's files; the last-opened
+        // memory chases the shown file so the grey lands on the right row on close.
+        .onChange(of: store.openDiff) { _, request in
+            if let request, let sha = request.commit {
+                lastOpenedFile = (sha, request.change.path)
+            }
+        }
     }
 
     /// The changed-file rows shown under an expanded commit — a loading placeholder until
@@ -72,8 +83,13 @@ struct GitHistoryView: View {
                         change: file,
                         font: font,
                         chrome: chrome,
-                        isSelected: store.openDiff?.commit == commit.sha && store.openDiff?.change.path == file.path
+                        isSelected: (store.openDiff?.commit == commit.sha
+                            && store.openDiff?.change.path == file.path)
+                            || (store.openDiff == nil
+                                && lastOpenedFile?.sha == commit.sha
+                                && lastOpenedFile?.path == file.path)
                     ) {
+                        lastOpenedFile = (commit.sha, file.path)
                         store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: file,
                                                         commit: commit.sha, siblings: files)
                     }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -247,6 +247,12 @@ final class TermioStore: ObservableObject {
         inspectorProjectPath.flatMap { issuesModels[$0] }
     }
 
+    /// The git pane's inner mode (Changes / History) per repo root — the same continuity
+    /// the Issues pane's kind gets through its model registry: an inspector tab flip or
+    /// session switch remounts `GitChangesView` with its `@State` mode back at Changes,
+    /// so the pane resumes from here instead. In-memory only, like the registry.
+    var gitPaneModes: [String: GitPaneMode] = [:]
+
     /// Which pane the trailing inspector shows — the file tree or git changes. Set by the toolbar's
     /// segmented switch and read by `FileBrowserView`. (The inspector's open/closed state is owned by
     /// the app delegate's `NSSplitViewItem`, not mirrored here, so the two cannot desync.)


### PR DESCRIPTION
The git pane's copies of the Issues pane's continuity bugs (#193), reported together:

- **Mode reset**: Changes/History is `@State`, so an inspector tab flip or session switch remounted the pane at Changes — and a restored History diff sat over a Changes list, landing there on close. The store now remembers the mode per repo root, and an open overlay overrides it at mount (the detail dictates the list it sits over), re-selecting the working-tree row — the mount-time half of the `openDiff` follow, which only fires on change.
- **Highlight lost on close**: closing a diff released the selection (needed so the same row can reopen) and with it the grey — no trace of which file the full-screen diff was. Both the Changes list and History's file rows now keep a last-opened memory that survives the close and chases ←/→ walks inside the overlay; a live multi-selection takes over the moment one exists.

Staleness needed nothing: the pane already re-reads `git status` on overlay close and follows FS events.

## Testing
- `swift build` clean.
- Manual: History → open a file diff → close → the row stays grey and the pane stays on History; flip to Files tab and back → still History; same for a Changes-row diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)