### PR TITLE
feat(settings): confirm what an install button actually did

### DIFF
--- a/Sources/termio/Agents/HookListener.swift
+++ b/Sources/termio/Agents/HookListener.swift
@@ -216,23 +216,35 @@ enum AgentStatusHooks {
     ]
 
     /// Re-applies every agent's integration (or removes them all) to match `enabled`.
-    static func sync(enabled: Bool) {
+    /// Returns which agents' configs took the hooks, so a Settings row can confirm
+    /// the install rather than leaving the click silent; the uninstall path reports
+    /// nothing, since no UI asks about it.
+    @discardableResult
+    static func sync(enabled: Bool) -> InstallOutcome {
         // Every hook references the channel-stable CLI copy, so make sure it carries
         // this build's content before (re)stamping its path anywhere.
         CommandLineTool.refreshSupportCopy()
+        var outcome = InstallOutcome()
         if enabled {
             // A full user override may intentionally remove/redirect a shipped hook.
             // Remove that old managed wiring before installing the merged catalog.
             for installer in staleBundledInstallers { installer.uninstall() }
-            for installer in installers { installer.install() }
+            for (name, installer) in installers {
+                outcome.record(name, installed: installer.install())
+            }
         } else {
             for installer in allKnownInstallers { installer.uninstall() }
         }
+        return outcome
     }
 
-    private static var installers: [AgentStatusInstaller] {
+    /// Each hook-carrying agent's display name paired with its installer, so an
+    /// install result can be reported per agent rather than as one opaque total.
+    private static var installers: [(name: String, installer: AgentStatusInstaller)] {
         AgentCatalog.shared.all.compactMap { agent in
-            agent.hookSpec.flatMap { installer(id: agent.id, spec: $0) }
+            agent.hookSpec
+                .flatMap { installer(id: agent.id, spec: $0) }
+                .map { (agent.displayName, $0) }
         }
     }
 
@@ -342,7 +354,11 @@ enum AgentStatusHooks {
 }
 
 private protocol AgentStatusInstaller {
-    func install()
+    /// Whether the agent's config carries termio's current hooks afterwards —
+    /// including the common no-op case where it already did. `false` means the
+    /// config was left alone on purpose (unparseable, or not ours to overwrite) or
+    /// the write failed; the reason is logged.
+    func install() -> Bool
     func uninstall()
 }
 
@@ -425,14 +441,14 @@ private struct JSONHookFile: AgentStatusInstaller {
         case ok([String: Any])
     }
 
-    func install() {
+    func install() -> Bool {
         let root: [String: Any]
         switch readState(at: url) {
         case .ok(let dictionary): root = dictionary
         case .missing: root = [:]
         case .unreadable:
             AgentStatusHooks.log("refusing to modify unparseable \(url.path)")
-            return
+            return false
         }
 
         var settings = root
@@ -464,14 +480,15 @@ private struct JSONHookFile: AgentStatusInstaller {
             hooks[event.name] = groups
         }
         settings["hooks"] = hooks
-        write(settings, to: url)
+        guard write(settings, to: url) else { return false }
 
         // Publish the replacement before removing its predecessor. If the new file
         // could not be written, retain the working legacy integration for next launch.
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        guard FileManager.default.fileExists(atPath: url.path) else { return false }
         for legacyURL in legacyURLs {
             uninstall(at: legacyURL, removeFileWhenEmpty: true)
         }
+        return true
     }
 
     func uninstall() {
@@ -561,7 +578,10 @@ private struct JSONHookFile: AgentStatusInstaller {
         return .ok(dictionary)
     }
 
-    private func write(_ settings: [String: Any], to destinationURL: URL) {
+    /// Returns whether the file now holds `settings` — true both for a fresh write
+    /// and for the skipped identical one, false only when the write threw.
+    @discardableResult
+    private func write(_ settings: [String: Any], to destinationURL: URL) -> Bool {
         do {
             try FileManager.default.createDirectory(
                 at: destinationURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -572,10 +592,12 @@ private struct JSONHookFile: AgentStatusInstaller {
             // there (the common case on every launch): avoids needless churn on a
             // user-owned file and shrinks the window where this atomic write could
             // clobber a concurrent hand-edit. `.sortedKeys` makes the bytes stable.
-            if (try? Data(contentsOf: destinationURL)) == data { return }
+            if (try? Data(contentsOf: destinationURL)) == data { return true }
             try data.write(to: destinationURL, options: .atomic)
+            return true
         } catch {
             AgentStatusHooks.log("could not write \(destinationURL.path): \(error)")
+            return false
         }
     }
 }
@@ -624,7 +646,7 @@ private struct PluginFile: AgentStatusInstaller {
             legacyURLs: [directoryURL.appendingPathComponent(legacyFilename)])
     }
 
-    func install() {
+    func install() -> Bool {
         let data = Data(contents.utf8)
         if FileManager.default.fileExists(atPath: url.path) {
             // `termio.js` is a deliberately simple name, so never claim a user's
@@ -633,7 +655,7 @@ private struct PluginFile: AgentStatusInstaller {
                   existing == contents || isOwned(existing)
             else {
                 AgentStatusHooks.log("refusing to overwrite non-termio plugin \(url.path)")
-                return
+                return false
             }
         }
         if (try? Data(contentsOf: url)) != data {
@@ -643,12 +665,13 @@ private struct PluginFile: AgentStatusInstaller {
                 try data.write(to: url, options: .atomic)
             } catch {
                 AgentStatusHooks.log("could not write \(url.path): \(error)")
-                return
+                return false
             }
         }
         for legacyURL in legacyURLs {
             removeOwnedFile(at: legacyURL)
         }
+        return true
     }
 
     func uninstall() {
@@ -842,12 +865,12 @@ private struct TOMLHookBlock: AgentStatusInstaller {
             events: spec.events)
     }
 
-    func install() {
+    func install() -> Bool {
         let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
         let base = Self.stripBlock(from: existing).trimmingCharacters(in: .newlines)
         let block = Self.render(events: events)
         let updated = base.isEmpty ? block + "\n" : base + "\n\n" + block + "\n"
-        Self.write(updated, to: url)
+        return Self.write(updated, to: url)
     }
 
     func uninstall() {
@@ -888,16 +911,19 @@ private struct TOMLHookBlock: AgentStatusInstaller {
         return result
     }
 
-    private static func write(_ contents: String, to url: URL) {
+    @discardableResult
+    private static func write(_ contents: String, to url: URL) -> Bool {
         do {
             try FileManager.default.createDirectory(
                 at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
             let data = Data(contents.utf8)
             // No-op when the result is byte-identical (the common case each launch).
-            if (try? Data(contentsOf: url)) == data { return }
+            if (try? Data(contentsOf: url)) == data { return true }
             try data.write(to: url, options: .atomic)
+            return true
         } catch {
             AgentStatusHooks.log("could not write \(url.path): \(error)")
+            return false
         }
     }
 }

--- a/Sources/termio/Agents/InstallOutcome.swift
+++ b/Sources/termio/Agents/InstallOutcome.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// What a settings-initiated (re)install actually did, per target.
+///
+/// The installers write *outside* the app — a PATH symlink, each agent's config
+/// file, the user-level instruction files — and report problems only to stderr,
+/// which nobody clicking a button in Settings ever sees. Returning the outcome
+/// lets the row say what landed, and name what didn't, instead of leaving a click
+/// that succeeded and a click that silently failed looking identical.
+struct InstallOutcome {
+    /// Names of the targets that now carry termio's wiring.
+    private(set) var succeeded: [String] = []
+    /// Names of the targets that refused it (unparseable config, failed write, or
+    /// a file termio doesn't own sitting at its path).
+    private(set) var failed: [String] = []
+
+    var isEmpty: Bool { succeeded.isEmpty && failed.isEmpty }
+
+    mutating func record(_ name: String, installed: Bool) {
+        if installed { succeeded.append(name) } else { failed.append(name) }
+    }
+
+    /// A human list of target names: spelled out up to three ("Claude Code, Codex
+    /// and Cursor"), counted beyond that ("6 agents") so a confirmation line stays
+    /// one line no matter how many agents are in the catalog.
+    static func list(_ names: [String], unit: String) -> String {
+        switch names.count {
+        case 0: return "nothing"
+        case 1: return names[0]
+        case 2: return "\(names[0]) and \(names[1])"
+        case 3: return "\(names[0]), \(names[1]) and \(names[2])"
+        default: return "\(names.count) \(unit)"
+        }
+    }
+}

--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -530,16 +530,32 @@ enum SessionSkillInstaller {
         """
     }
 
-    static func sync(enabled: Bool) {
+    /// Returns which instruction files ended up carrying the note, so the Settings
+    /// row can confirm the install; the uninstall path reports nothing, since no UI
+    /// asks about it.
+    @discardableResult
+    static func sync(enabled: Bool) -> InstallOutcome {
+        var outcome = InstallOutcome()
         for url in targets {
-            if enabled { install(into: url) } else { uninstall(from: url) }
+            if enabled {
+                outcome.record(displayPath(of: url), installed: install(into: url))
+            } else {
+                uninstall(from: url)
+            }
         }
+        return outcome
     }
 
-    private static func install(into url: URL) {
+    /// The target's path with the home directory abbreviated (`~/.claude/CLAUDE.md`)
+    /// — how the docs and the files themselves refer to it.
+    private static func displayPath(of url: URL) -> String {
+        (url.path as NSString).abbreviatingWithTildeInPath
+    }
+
+    private static func install(into url: URL) -> Bool {
         let stripped = strippedExisting(at: url)
         let separator = stripped.isEmpty ? "" : "\n\n"
-        write(stripped + separator + block + "\n", to: url)
+        return write(stripped + separator + block + "\n", to: url)
     }
 
     private static func uninstall(from url: URL) {
@@ -568,18 +584,23 @@ enum SessionSkillInstaller {
         return result.trimmingCharacters(in: .newlines)
     }
 
-    private static func write(_ contents: String, to url: URL) {
+    /// Returns whether the file now holds `contents` — true both for a fresh write
+    /// and for the skipped identical one, false only when the write threw.
+    @discardableResult
+    private static func write(_ contents: String, to url: URL) -> Bool {
         let data = Data(contents.utf8)
         // Don't rewrite an unchanged note on every launch: avoids churning a
         // user-owned instruction file and the race of clobbering a concurrent edit.
-        if (try? Data(contentsOf: url)) == data { return }
+        if (try? Data(contentsOf: url)) == data { return true }
         do {
             try FileManager.default.createDirectory(
                 at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
             try data.write(to: url, options: .atomic)
+            return true
         } catch {
             FileHandle.standardError.write(
                 Data("termio: session skill could not write \(url.path): \(error)\n".utf8))
+            return false
         }
     }
 }

--- a/Sources/termio/Settings/GeneralSettingsTab.swift
+++ b/Sources/termio/Settings/GeneralSettingsTab.swift
@@ -44,7 +44,10 @@ struct GeneralSettingsTab: View {
                 if settings.agentHooksEnabled {
                     // For re-applying after the user (or another tool) has edited
                     // ~/.claude/settings.json; install is idempotent.
-                    Button("Reinstall hooks") { AgentStatusHooks.sync(enabled: true) }
+                    InstallButtonRow(title: "Reinstall hooks") {
+                        .summarizing(AgentStatusHooks.sync(enabled: true),
+                                     headline: "Hooks reinstalled", unit: "agents")
+                    }
                 }
             } header: {
                 SectionHeaderLabel(title: "Status")
@@ -59,7 +62,10 @@ struct GeneralSettingsTab: View {
                 }
                 .toggleStyle(.switch)
                 if settings.sessionControlEnabled {
-                    Button("Reinstall note") { SessionSkillInstaller.sync(enabled: true) }
+                    InstallButtonRow(title: "Reinstall note") {
+                        .summarizing(SessionSkillInstaller.sync(enabled: true),
+                                     headline: "Note reinstalled", unit: "files")
+                    }
                 }
             } header: {
                 SectionHeaderLabel(title: "Orchestration")
@@ -139,16 +145,51 @@ private struct NotificationPermissionRow: View {
 /// the install action so the button and caption update in place.
 private struct CommandLineToolRow: View {
     @State private var status: CommandLineTool.Status = .notInstalled
+    @State private var state = InstallFeedbackState()
 
     var body: some View {
-        HStack(spacing: 10) {
-            SettingsLabel(.huge(.terminal), title: "Command-line tool", subtext: description)
-            Spacer()
-            if let title = buttonTitle {
-                Button(title) { status = CommandLineTool.install() }
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                SettingsLabel(.huge(.terminal), title: "Command-line tool", subtext: description)
+                Spacer()
+                if let title = buttonTitle {
+                    Button(title) { install() }
+                }
+            }
+            if let feedback = state.feedback {
+                // Aligned under the caption, past the row's icon badge.
+                InstallFeedbackLabel(feedback: feedback)
+                    .padding(.leading, 32)
             }
         }
         .onAppear { status = CommandLineTool.audit() }
+        .autoDismissing($state)
+    }
+
+    /// Installs, then reports the fresh audit. The caption alone can't carry this:
+    /// a declined admin prompt leaves the row reading exactly as it did before the
+    /// click, so success and cancellation would be indistinguishable. The
+    /// confirmation stays short — the caption above it already names the path — and
+    /// echoes the verb of the button that was pressed.
+    private func install() {
+        // Echo the verb the button offered: an "Update" that lands says "Updated."
+        let wasStale: Bool
+        if case .stale = status { wasStale = true } else { wasStale = false }
+        let result = CommandLineTool.install()
+        withAnimation {
+            status = result
+            switch result {
+            case .installed:
+                state.show(.success(wasStale ? "Updated." : "Installed."))
+            case .conflict:
+                state.show(.failure("Something else already owns \(CommandLineTool.installURL.path)."))
+            case .unavailable:
+                state.show(.failure("No bundled tool to install from."))
+            case .notInstalled, .stale:
+                let directory = CommandLineTool.installURL.deletingLastPathComponent().path
+                state.show(.failure("Couldn’t link `\(CommandLineTool.toolName)` into \(directory)."))
+            }
+        }
     }
 
     private var description: String {

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -101,6 +101,118 @@ struct SettingsLabel: View {
     }
 }
 
+/// The result of an install button, shown beside it as one caption line.
+///
+/// Installing writes outside the app — a PATH symlink, an agent's config file, a
+/// user-level instruction file — and none of that shows up in the window, so a
+/// click that worked and one that quietly failed look identical. A success fades
+/// on its own once it has been read; a failure stays put, because it names
+/// something the user has to deal with.
+struct InstallFeedback: Equatable {
+    enum Kind { case success, failure }
+    let kind: Kind
+    let message: String
+
+    static func success(_ message: String) -> InstallFeedback {
+        InstallFeedback(kind: .success, message: message)
+    }
+
+    static func failure(_ message: String) -> InstallFeedback {
+        InstallFeedback(kind: .failure, message: message)
+    }
+
+    /// Turns an installer's per-target result into that one line. The targets are
+    /// the point: "Reinstall hooks" writes into several agents' config files the
+    /// settings pane never otherwise names, so naming them is what makes the
+    /// confirmation worth reading. A partial install reports as a failure even
+    /// though something landed — the part that didn't is the part to act on.
+    static func summarizing(
+        _ outcome: InstallOutcome, headline: String, unit: String
+    ) -> InstallFeedback {
+        let installed = InstallOutcome.list(outcome.succeeded, unit: unit)
+        let missed = InstallOutcome.list(outcome.failed, unit: unit)
+        if outcome.isEmpty { return .failure("Nothing to install.") }
+        if outcome.failed.isEmpty { return .success("\(headline) — \(installed).") }
+        if outcome.succeeded.isEmpty { return .failure("Couldn’t update \(missed).") }
+        return .failure("\(headline) — \(installed). Couldn’t update \(missed).")
+    }
+}
+
+/// The current message plus the click that produced it. The counter is what makes
+/// a *repeat* click honest: keyed on the message alone, pressing the button again
+/// inside the dismissal window would inherit the first click's timer and could
+/// clear the line a moment later — the button reading as if it did nothing, which
+/// is the exact problem this feedback exists to fix.
+struct InstallFeedbackState: Equatable {
+    private(set) var attempt = 0
+    private(set) var feedback: InstallFeedback?
+
+    mutating func show(_ feedback: InstallFeedback) {
+        attempt += 1
+        self.feedback = feedback
+    }
+
+    mutating func clear() {
+        feedback = nil
+    }
+}
+
+/// The message itself: a status glyph and one caption line, sized to sit under or
+/// beside a settings control without competing with it.
+struct InstallFeedbackLabel: View {
+    let feedback: InstallFeedback
+
+    var body: some View {
+        HStack(spacing: 5) {
+            HugeIconView(
+                icon: feedback.kind == .success ? .checkCircle : .infoCircle,
+                size: 12,
+                color: feedback.kind == .success ? .green : .orange)
+            Text(feedback.message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        // A cross-fade rather than a slide: the reduced-motion-safe form, so this
+        // needs no separate accessibility path.
+        .transition(.opacity)
+    }
+}
+
+extension View {
+    /// Clears a success message a few seconds after it appears — long enough to
+    /// read, short enough that a stale "Installed" never sits next to a button the
+    /// user is about to press again. Failures stay.
+    func autoDismissing(_ state: Binding<InstallFeedbackState>) -> some View {
+        task(id: state.wrappedValue) {
+            guard state.wrappedValue.feedback?.kind == .success else { return }
+            try? await Task.sleep(for: .seconds(4))
+            guard !Task.isCancelled else { return }
+            withAnimation { state.wrappedValue.clear() }
+        }
+    }
+}
+
+/// A settings action that writes outside the app, with its result shown next to
+/// the button: the action performs the install and hands back the line to display.
+struct InstallButtonRow: View {
+    let title: String
+    let action: () -> InstallFeedback
+
+    @State private var state = InstallFeedbackState()
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button(title) { withAnimation { state.show(action()) } }
+            if let feedback = state.feedback {
+                InstallFeedbackLabel(feedback: feedback)
+            }
+            Spacer(minLength: 0)
+        }
+        .autoDismissing($state)
+    }
+}
+
 /// Centers a `LabeledContent` row's trailing control vertically against its label,
 /// matching macOS 26 / System Settings rows. The default style anchors the control
 /// to the label's first-text baseline, which sits visibly high once a label wraps to

--- a/Tests/termioTests/InstallFeedbackTests.swift
+++ b/Tests/termioTests/InstallFeedbackTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import termio
+
+/// The line a Settings install button shows after it runs. The rule that matters:
+/// anything that didn't land has to be visible and has to stay visible, so a
+/// half-installed set of hooks can never read as a clean success.
+final class InstallFeedbackTests: XCTestCase {
+    private func outcome(succeeded: [String] = [], failed: [String] = []) -> InstallOutcome {
+        var outcome = InstallOutcome()
+        for name in succeeded { outcome.record(name, installed: true) }
+        for name in failed { outcome.record(name, installed: false) }
+        return outcome
+    }
+
+    func testNamesEveryTargetItReached() {
+        let feedback = InstallFeedback.summarizing(
+            outcome(succeeded: ["Claude Code", "Codex", "Cursor"]),
+            headline: "Hooks reinstalled", unit: "agents")
+        XCTAssertEqual(feedback.kind, .success)
+        XCTAssertEqual(feedback.message, "Hooks reinstalled — Claude Code, Codex and Cursor.")
+    }
+
+    /// Past three the names would wrap the row, so the line counts instead.
+    func testCountsBeyondThreeTargets() {
+        let feedback = InstallFeedback.summarizing(
+            outcome(succeeded: ["A", "B", "C", "D"]),
+            headline: "Hooks reinstalled", unit: "agents")
+        XCTAssertEqual(feedback.message, "Hooks reinstalled — 4 agents.")
+    }
+
+    /// A partial install is a failure: it stays on screen, because the half that
+    /// didn't land is the half the user has to deal with.
+    func testPartialInstallReportsAsFailure() {
+        let feedback = InstallFeedback.summarizing(
+            outcome(succeeded: ["Claude Code"], failed: ["Codex"]),
+            headline: "Hooks reinstalled", unit: "agents")
+        XCTAssertEqual(feedback.kind, .failure)
+        XCTAssertEqual(
+            feedback.message, "Hooks reinstalled — Claude Code. Couldn’t update Codex.")
+    }
+
+    func testTotalFailureNamesOnlyWhatFailed() {
+        let feedback = InstallFeedback.summarizing(
+            outcome(failed: ["~/.claude/CLAUDE.md"]),
+            headline: "Note reinstalled", unit: "files")
+        XCTAssertEqual(feedback.kind, .failure)
+        XCTAssertEqual(feedback.message, "Couldn’t update ~/.claude/CLAUDE.md.")
+    }
+
+    /// Nothing attempted is not a success — silence is what this feedback exists
+    /// to eliminate.
+    func testEmptyOutcomeIsNotASuccess() {
+        let feedback = InstallFeedback.summarizing(
+            outcome(), headline: "Hooks reinstalled", unit: "agents")
+        XCTAssertEqual(feedback.kind, .failure)
+        XCTAssertEqual(feedback.message, "Nothing to install.")
+    }
+
+    /// Re-running the same action must restart the dismissal timer, which is keyed
+    /// on the state's identity — so two identical messages must not compare equal.
+    func testRepeatedShowChangesIdentity() {
+        var state = InstallFeedbackState()
+        state.show(.success("Installed."))
+        let first = state
+        state.show(.success("Installed."))
+        XCTAssertNotEqual(first, state)
+    }
+}


### PR DESCRIPTION
Install / Reinstall hooks / Reinstall note all wrote outside the app — the PATH symlink, each agent's config file, the user-level instruction files — and reported problems only to stderr. A click that worked and one that silently failed looked identical. The CLI row was the worst case: declining the admin prompt left the row reading exactly as it did before the click.

## What changed

- The installers report per-target results (`InstallOutcome`): `AgentStatusHooks.sync`, `SessionSkillInstaller.sync`, and the three hook installers (`JSONHookFile` / `PluginFile` / `TOMLHookBlock`) now return whether the config carries termio's wiring afterwards — an already-correct file counts as success, a refused or failed write does not. Both `sync` entry points are `@discardableResult`, so the launch-time callers are unchanged.
- Each row shows one caption line: a green check that fades after 4s, or an orange line that stays because it names something to act on. Hooks and note name their targets (`Hooks reinstalled — Claude Code, Codex and Cursor.`, counted past three); the CLI row stays short (`Installed.` / `Updated.`) since its caption already gives the path.
- A partial install reports as a failure — the half that didn't land is the half worth seeing.
- `InstallFeedbackState` carries an attempt counter so a repeat click restarts the dismissal timer instead of inheriting the previous one (otherwise a second click just inside the window could clear the line a moment later — the exact "did nothing" reading this is meant to fix).

Motion is an opacity cross-fade, which is already the reduced-motion-safe form.

## Testing

`swift test` — 63 tests pass, including 6 new ones over the summary logic. Verified in the dev app: Settings ▸ General, all three buttons.

## Known gaps

- Flipping the toggles on runs the same installers via the store and is still silent; a failure there shows a happy switch and a broken status light.
- The failure glyph is `.infoCircle` tinted orange — the Hugeicons set has no warning/alert glyph.