### PR TITLE
Make the context menus plain text again

### DIFF
--- a/Sources/termio/Browser/PreviewWebView.swift
+++ b/Sources/termio/Browser/PreviewWebView.swift
@@ -1,15 +1,119 @@
 import WebKit
 
-/// The `WKWebView` for read-only preview surfaces — the session trace and HTML/SVG
-/// file previews. Its right-click menu is stripped to Copy: WebKit's default menu
-/// carries Reload, Look Up, Translate, Services, and search items rendered-and-done
-/// content has no use for. Same whitelist-by-identifier treatment as the Markdown
-/// reader and the issue detail (non-editable web content never gets AutoFill, and
-/// WebKit's proposed menu exists by `willOpenMenu` time, so the filter holds here —
-/// unlike an editable NSTextView, where AppKit appends extras later).
+/// Right-click for termio's web surfaces — the Markdown reader, the session trace, HTML/SVG file
+/// previews, the issue conversation — *without* WebKit's own menu.
+///
+/// WebKit's proposed menu cannot be trimmed down to plain text. Filtering it in `willOpenMenu`
+/// leaves Services behind, because AppKit appends that submenu afterwards and
+/// `allowsContextMenuPlugIns = false` does not stop it; and macOS 26 synthesizes a symbol image for
+/// any item carrying the standard `copy:` selector, which reads back even right after assigning
+/// `image = nil`. So the page cancels its own context menu and posts the click over instead, and
+/// the host pops a menu it built itself — the same "pop it ourselves" shape the file tree uses.
+final class WebContextMenuBridge: NSObject, WKScriptMessageHandler {
+    /// What the page reports about a right-click.
+    struct Click {
+        /// The page's selected text, empty when nothing is selected.
+        let selection: String
+        /// The `href` of the link under the pointer, if any.
+        let link: URL?
+    }
+
+    private var makeMenu: ((Click) -> NSMenu)?
+    private weak var webView: WKWebView?
+
+    private static let handlerName = "termioContextMenu"
+
+    private static let script = """
+    document.addEventListener('contextmenu', function (event) {
+        event.preventDefault();
+        var target = event.target;
+        var link = target && target.closest ? target.closest('a') : null;
+        window.webkit.messageHandlers.\(handlerName).postMessage({
+            x: event.clientX,
+            y: event.clientY,
+            selection: String(window.getSelection()),
+            link: link ? link.href : ''
+        });
+    }, true);
+    """
+
+    /// Adds the page script and the message handler. This has to happen *before* the web view is
+    /// created — `WKWebView.configuration` hands back a copy, so a script added afterwards would
+    /// never reach the page. `attach(to:makeMenu:)` finishes the wiring once the view exists.
+    func install(on configuration: WKWebViewConfiguration) {
+        let controller = configuration.userContentController
+        controller.addUserScript(WKUserScript(source: Self.script,
+                                              injectionTime: .atDocumentStart,
+                                              forMainFrameOnly: false))
+        controller.add(self, name: Self.handlerName)
+    }
+
+    /// The controller owns the bridge and the bridge holds the view weakly, so `makeMenu` must
+    /// capture its owner weakly too.
+    func attach(to webView: WKWebView, makeMenu: @escaping (Click) -> NSMenu) {
+        self.webView = webView
+        self.makeMenu = makeMenu
+    }
+
+    func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let body = message.body as? [String: Any], let webView, let makeMenu else { return }
+        let link = (body["link"] as? String).flatMap { $0.isEmpty ? nil : URL(string: $0) }
+        let menu = makeMenu(Click(selection: body["selection"] as? String ?? "", link: link))
+        guard !menu.items.isEmpty else { return }
+        // The page reports viewport coordinates, top-left origin; an unflipped view counts from the
+        // bottom.
+        let x = (body["x"] as? NSNumber)?.doubleValue ?? 0
+        let y = (body["y"] as? NSNumber)?.doubleValue ?? 0
+        let point = NSPoint(x: x, y: webView.isFlipped ? y : webView.bounds.height - y)
+        menu.popUp(positioning: nil, at: point, in: webView)
+    }
+}
+
+extension NSMenu {
+    /// A plain-text item: no image, and never a standard editing selector for macOS 26 to decorate.
+    @discardableResult
+    func addPlainItem(_ title: String, target: AnyObject, action: Selector,
+                      representedObject: Any? = nil) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = target
+        item.representedObject = representedObject
+        addItem(item)
+        return item
+    }
+}
+
+/// The `WKWebView` for read-only preview surfaces — the session trace and HTML/SVG file previews.
+/// Its right-click menu is just Copy: WebKit's default carries Reload, Look Up, Translate,
+/// Services, and search items rendered-and-done content has no use for.
 final class PreviewWebView: WKWebView {
-    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
-        super.willOpenMenu(menu, with: event)
-        menu.items = menu.items.filter { $0.identifier?.rawValue == "WKMenuItemIdentifierCopy" }
+    private var bridge: WebContextMenuBridge?
+
+    init() {
+        let configuration = WKWebViewConfiguration()
+        let bridge = WebContextMenuBridge()
+        bridge.install(on: configuration)
+        self.bridge = bridge
+        super.init(frame: .zero, configuration: configuration)
+        bridge.attach(to: self) { [weak self] click in
+            self?.contextMenu(for: click) ?? NSMenu()
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    private func contextMenu(for click: WebContextMenuBridge.Click) -> NSMenu {
+        let menu = NSMenu()
+        guard !click.selection.isEmpty else { return menu }
+        menu.addPlainItem("Copy", target: self, action: #selector(copySelection(_:)),
+                          representedObject: click.selection)
+        return menu
+    }
+
+    @objc private func copySelection(_ sender: NSMenuItem) {
+        guard let text = sender.representedObject as? String else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
     }
 }

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -376,17 +376,22 @@ private final class SavingTextView: NSTextView {
     /// A deliberately minimal right-click menu — just the edit basics and a prominent Close —
     /// instead of AppKit's full text menu (Look Up, Translate, Font, Substitutions, Speech,
     /// Layout Orientation, Services…), which buried Close under a wall of items an editor covering
-    /// the terminal has no use for. `cut`/`copy`/`paste` route through the responder chain, so they
-    /// auto-enable off the selection and clipboard exactly like the native items did.
+    /// the terminal has no use for.
+    ///
+    /// The edit items go through private wrappers rather than `cut:` / `copy:` / `paste:` because
+    /// macOS 26 decorates the standard editing selectors with a system symbol that cannot be
+    /// cleared — `item.image = nil` reads back as the symbol again. The wrappers forward to the
+    /// real actions and `validateUserInterfaceItem` restores the selection / clipboard gating the
+    /// responder chain used to do.
     override func menu(for event: NSEvent) -> NSMenu? {
         guard showsCloseMenuItem else { return super.menu(for: event) }
         let menu = NSMenu()
         if isEditable {
-            menu.addItem(withTitle: "Cut", action: #selector(cut(_:)), keyEquivalent: "")
+            menu.addItem(withTitle: "Cut", action: #selector(cutSelection), keyEquivalent: "")
         }
-        menu.addItem(withTitle: "Copy", action: #selector(copy(_:)), keyEquivalent: "")
+        menu.addItem(withTitle: "Copy", action: #selector(copySelection), keyEquivalent: "")
         if isEditable {
-            menu.addItem(withTitle: "Paste", action: #selector(paste(_:)), keyEquivalent: "")
+            menu.addItem(withTitle: "Paste", action: #selector(pasteClipboard), keyEquivalent: "")
         }
         menu.addItem(.separator())
         if canAddToChat?() == true {
@@ -395,7 +400,6 @@ private final class SavingTextView: NSTextView {
             // says which, the label stays put.
             let add = NSMenuItem(title: "Add to Chat", action: #selector(addToChatAction), keyEquivalent: "")
             add.target = self
-            add.image = NSImage(systemSymbolName: "plus.bubble", accessibilityDescription: nil)
             menu.addItem(add)
         }
         let close = NSMenuItem(title: "Close", action: #selector(closeEditorOverlay), keyEquivalent: "")
@@ -408,6 +412,23 @@ private final class SavingTextView: NSTextView {
         let range = selectedRange()
         let selection = range.length > 0 ? (string as NSString).substring(with: range) : nil
         addToChat?(selection)
+    }
+
+    @objc private func cutSelection(_ sender: Any?) { cut(sender) }
+    @objc private func copySelection(_ sender: Any?) { copy(sender) }
+    @objc private func pasteClipboard(_ sender: Any?) { paste(sender) }
+
+    override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
+        switch item.action {
+        case #selector(cutSelection):
+            return isEditable && selectedRange().length > 0
+        case #selector(copySelection):
+            return selectedRange().length > 0
+        case #selector(pasteClipboard):
+            return isEditable && NSPasteboard.general.canReadObject(forClasses: [NSString.self], options: nil)
+        default:
+            return super.validateUserInterfaceItem(item)
+        }
     }
 
     /// AppKit appends AutoFill + Services to an EDITABLE text view's context menu after

--- a/Sources/termio/Editor/MarkdownReaderView.swift
+++ b/Sources/termio/Editor/MarkdownReaderView.swift
@@ -65,7 +65,12 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         config.setURLSchemeHandler(LocalFileSchemeHandler(), forURLScheme: Self.fileScheme)
+        let bridge = WebContextMenuBridge()
+        bridge.install(on: config)
         let view = ContextMenuWebView(frame: .zero, configuration: config)
+        bridge.attach(to: view) { [weak view] click in
+            view?.contextMenu(for: click) ?? NSMenu()
+        }
         view.fileURL = fileURL
         view.addToChat = addToChat
         view.canAddToChat = canAddToChat
@@ -130,7 +135,8 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
     }
 }
 
-/// A `WKWebView` that appends a "Close" to its right-click menu, so the Markdown preview closes
+/// A `WKWebView` whose right-click menu is termio's, not WebKit's: `WebContextMenuBridge`
+/// suppresses the page's native menu and hands the click here, so the Markdown preview closes
 /// terminal-style like the source editor — the overlay has no chrome button.
 private final class ContextMenuWebView: WKWebView {
     /// The document on disk, so the menu can reveal it in Finder (like the file tree's row menu).
@@ -141,38 +147,38 @@ private final class ContextMenuWebView: WKWebView {
     var addToChat: ((String?) -> Void)?
     var canAddToChat: (() -> Bool)?
 
-    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
-        super.willOpenMenu(menu, with: event)
-        // Strip the reader's menu down to Copy — a read-only document doesn't need Reload / Look Up
-        // / Translate / Share, and the OS-injected AutoFill / Services grab-bag is meaningless over
-        // a rendered doc. Whitelisting Copy by identifier drops all of it. Then add the actions that
-        // *do* fit a file preview: Reveal in Finder (an explicit item, not a flaky Services shortcut)
-        // and a prominent Close so it isn't buried.
-        menu.items = menu.items.filter { $0.identifier?.rawValue == "WKMenuItemIdentifierCopy" }
-        menu.addItem(.separator())
+    /// The reader's menu, built from the page's own right-click: Copy for a selection, then the
+    /// actions that fit a file preview — Reveal in Finder (an explicit item, not a flaky Services
+    /// shortcut) and a prominent Close, since the overlay has no chrome button.
+    func contextMenu(for click: WebContextMenuBridge.Click) -> NSMenu {
+        let menu = NSMenu()
+        if !click.selection.isEmpty {
+            menu.addPlainItem("Copy", target: self, action: #selector(copySelection(_:)),
+                              representedObject: click.selection)
+            menu.addItem(.separator())
+        }
         if canAddToChat?() == true {
-            let add = NSMenuItem(title: "Add to Chat", action: #selector(addToChatAction), keyEquivalent: "")
-            add.target = self
-            add.image = NSImage(systemSymbolName: "plus.bubble", accessibilityDescription: nil)
-            menu.addItem(add)
+            menu.addPlainItem("Add to Chat", target: self, action: #selector(addToChatAction(_:)),
+                              representedObject: click.selection)
         }
         if fileURL != nil {
-            let reveal = NSMenuItem(title: "Reveal in Finder", action: #selector(revealInFinder), keyEquivalent: "")
-            reveal.target = self
-            menu.addItem(reveal)
+            menu.addPlainItem("Reveal in Finder", target: self, action: #selector(revealInFinder))
         }
-        let close = NSMenuItem(title: "Close", action: #selector(closeEditorOverlay), keyEquivalent: "")
-        close.target = self
-        menu.addItem(close)
+        menu.addPlainItem("Close", target: self, action: #selector(closeEditorOverlay))
+        return menu
     }
 
-    /// The web view's selection lives in the WebContent process, so it's read via JS at
-    /// click time: a non-empty selection goes over as the snippet, else `nil` for the path.
-    @objc private func addToChatAction() {
-        evaluateJavaScript("window.getSelection().toString()") { [weak self] result, _ in
-            let text = (result as? String).flatMap { $0.isEmpty ? nil : $0 }
-            self?.addToChat?(text)
-        }
+    @objc private func copySelection(_ sender: NSMenuItem) {
+        guard let text = sender.representedObject as? String else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    /// A non-empty selection goes over as the snippet, an empty one as `nil` — the owner inserts
+    /// the document's path instead.
+    @objc private func addToChatAction(_ sender: NSMenuItem) {
+        let selection = (sender.representedObject as? String).flatMap { $0.isEmpty ? nil : $0 }
+        addToChat?(selection)
     }
 
     @objc private func revealInFinder() {

--- a/Sources/termio/FileBrowser/FileTreeList.swift
+++ b/Sources/termio/FileBrowser/FileTreeList.swift
@@ -294,7 +294,6 @@ private struct RowContextMenu: NSViewRepresentable {
             // inserts. Gated live at open time; a plain shell has no chat to add to.
             if actions?.canAddToChat() == true {
                 let add = menuItem("Add to Chat", #selector(addToChat))
-                add.image = NSImage(systemSymbolName: "plus.bubble", accessibilityDescription: nil)
                 menu.addItem(add)
                 menu.addItem(.separator())
             }

--- a/Sources/termio/Git/DiffTextView.swift
+++ b/Sources/termio/Git/DiffTextView.swift
@@ -346,14 +346,16 @@ final class DiffTextView: NSTextView {
     /// of it, matching the editor's and reader's stripped menus.
     override func menu(for event: NSEvent) -> NSMenu? {
         let menu = NSMenu()
-        menu.addItem(withTitle: "Copy", action: #selector(copy(_:)), keyEquivalent: "")
+        menu.allowsContextMenuPlugIns = false
+        // Not `copy:`: macOS 26 decorates the standard editing selectors with a system symbol
+        // that `image = nil` cannot clear, and the rest of this menu is plain text.
+        menu.addItem(withTitle: "Copy", action: #selector(copySelection), keyEquivalent: "")
         if canAddToChat?() == true {
             menu.addItem(.separator())
             // One name everywhere (Cursor's): a selection goes over as the pasted
             // snippet, none means the diffed file's path — context says which.
             let add = NSMenuItem(title: "Add to Chat", action: #selector(addToChatAction), keyEquivalent: "")
             add.target = self
-            add.image = NSImage(systemSymbolName: "plus.bubble", accessibilityDescription: nil)
             menu.addItem(add)
         }
         if onClose != nil {
@@ -372,6 +374,13 @@ final class DiffTextView: NSTextView {
     }
 
     @objc private func closeFromMenu() { onClose?() }
+
+    @objc private func copySelection(_ sender: Any?) { copy(sender) }
+
+    override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
+        if item.action == #selector(copySelection) { return selectedRange().length > 0 }
+        return super.validateUserInterfaceItem(item)
+    }
 
     override func mouseDown(with event: NSEvent) {
         if let anchor = expandableBand(at: event) {

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -522,7 +522,6 @@ private struct IssueRowContextMenu: NSViewRepresentable {
             // The agent verb leads, like the file tree's rows.
             if canAddToChat?() == true {
                 let add = menuItem("Add to Chat", #selector(addToChatAction))
-                add.image = NSImage(systemSymbolName: "plus.bubble", accessibilityDescription: nil)
                 menu.addItem(add)
                 menu.addItem(.separator())
             }
@@ -922,7 +921,12 @@ private struct IssueWebView: NSViewRepresentable {
         // through the handler so it can attach the bearer WebKit can't add itself.
         config.setURLSchemeHandler(context.coordinator.assetHandler,
                                    forURLScheme: GitHubAssetSchemeHandler.scheme)
+        let bridge = WebContextMenuBridge()
+        bridge.install(on: config)
         let view = IssueDetailWKWebView(frame: .zero, configuration: config)
+        bridge.attach(to: view) { [weak view] click in
+            view?.contextMenu(for: click) ?? NSMenu()
+        }
         view.addToChat = addToChat
         view.canAddToChat = canAddToChat
         view.setValue(false, forKey: "drawsBackground")
@@ -962,12 +966,11 @@ private struct IssueWebView: NSViewRepresentable {
     }
 }
 
-/// A `WKWebView` for the issue/PR detail that strips its right-click menu down to the
-/// items that mean something over a rendered conversation, matching the file preview's
-/// `ContextMenuWebView`. AppKit otherwise injects a grab-bag onto a `WKWebView` menu
-/// (Look Up / Translate / Search / Copy Link with Highlight / Share / Speech / Services)
-/// — none of it fits a read-only issue thread. Whitelisting by identifier keeps Copy
-/// (text selection) plus Copy Link (a link's URL under the cursor) and drops the rest.
+/// A `WKWebView` for the issue/PR detail that replaces its right-click menu with the items that
+/// mean something over a rendered conversation, matching the file preview's `ContextMenuWebView`.
+/// WebKit's own menu is a grab-bag (Look Up / Translate / Search / Copy Link with Highlight /
+/// Share / Speech / Services) that cannot be trimmed to plain text, so `WebContextMenuBridge`
+/// suppresses it and the page's click builds this one instead.
 ///
 /// "Open Link" is deliberately *not* kept: the nav delegate only diverts `.linkActivated`
 /// navigations to the browser, but the context-menu item fires a different navigation type
@@ -979,32 +982,37 @@ private final class IssueDetailWKWebView: WKWebView {
     var addToChat: ((String?) -> Void)?
     var canAddToChat: (() -> Bool)?
 
-    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
-        super.willOpenMenu(menu, with: event)
-        let keep: Set<String> = [
-            "WKMenuItemIdentifierCopy",
-            "WKMenuItemIdentifierCopyLink",
-        ]
-        menu.items = menu.items.filter { item in
-            guard let id = item.identifier?.rawValue else { return false }
-            return keep.contains(id)
+    /// Built from the page's own right-click: Copy for a text selection, Copy Link for a link
+    /// under the pointer, then Add to Chat.
+    func contextMenu(for click: WebContextMenuBridge.Click) -> NSMenu {
+        let menu = NSMenu()
+        if !click.selection.isEmpty {
+            menu.addPlainItem("Copy", target: self, action: #selector(copyText(_:)),
+                              representedObject: click.selection)
+        }
+        if let link = click.link {
+            menu.addPlainItem("Copy Link", target: self, action: #selector(copyText(_:)),
+                              representedObject: link.absoluteString)
         }
         if canAddToChat?() == true {
             if !menu.items.isEmpty { menu.addItem(.separator()) }
-            let add = NSMenuItem(title: "Add to Chat", action: #selector(addToChatAction), keyEquivalent: "")
-            add.target = self
-            add.image = NSImage(systemSymbolName: "plus.bubble", accessibilityDescription: nil)
-            menu.addItem(add)
+            menu.addPlainItem("Add to Chat", target: self, action: #selector(addToChatAction(_:)),
+                              representedObject: click.selection)
         }
+        return menu
     }
 
-    /// The web view's selection lives in the WebContent process, so it's read via JS
-    /// at click time: non-empty selection → snippet, else `nil` for the item's URL.
-    @objc private func addToChatAction() {
-        evaluateJavaScript("window.getSelection().toString()") { [weak self] result, _ in
-            let text = (result as? String).flatMap { $0.isEmpty ? nil : $0 }
-            self?.addToChat?(text)
-        }
+    @objc private func copyText(_ sender: NSMenuItem) {
+        guard let text = sender.representedObject as? String else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    /// A non-empty selection goes over as the snippet, an empty one as `nil` — the owner inserts
+    /// the item's GitHub URL instead.
+    @objc private func addToChatAction(_ sender: NSMenuItem) {
+        let selection = (sender.representedObject as? String).flatMap { $0.isEmpty ? nil : $0 }
+        addToChat?(selection)
     }
 }
 


### PR DESCRIPTION
Right-click menus had picked up two kinds of noise on macOS 26: system-drawn icons on Cut / Copy / Paste, and a Services submenu on every web surface.

Neither could be removed the obvious way. The OS synthesizes a symbol for any item carrying a standard editing selector, and `item.image = nil` reads back as the symbol again — verified with a standalone AppKit probe. And filtering WebKit's proposed menu in `willOpenMenu` never removes Services, because AppKit attaches it after that call returns; `allowsContextMenuPlugIns = false` does not cover it.

So the editing items go through the view's own selectors, with `validateUserInterfaceItem` restoring the selection / clipboard gating, and the web surfaces stop using WebKit's menu at all: the page cancels its own `contextmenu` and posts the click over — position, selected text, link under the pointer — and `WebContextMenuBridge` pops a menu termio built. That is the same self-popped shape the file tree already uses.

Surfaces covered: file editor, Markdown reader, diff view, session trace, HTML/SVG file preview, issue conversation, and the `plus.bubble` glyph on all six Add to Chat items.

Copy on a web surface now writes plain text rather than WebKit's rich-text flavor.

Release Notes:

- Fixed right-click menus showing stray icons and a Services submenu in the editor, Markdown preview, diffs, file previews, and issue conversations.