### PR TITLE
Rework the diff's washes, bands, and intraline spans

### DIFF
--- a/Shared/Sources/TermioShared/DiffIntraline.swift
+++ b/Shared/Sources/TermioShared/DiffIntraline.swift
@@ -10,7 +10,7 @@ import Foundation
 /// edits and leaves `(a, ` alone.
 ///
 /// Offsets are `Character` counts, matching `DiffRow.text`.
-enum DiffIntraline {
+public enum DiffIntraline {
     /// Longer lines are left plain rather than diffed — the pathological cases here are
     /// minified bundles and embedded data, where every span would be noise anyway.
     private static let maximumLineLength = 2000
@@ -18,7 +18,7 @@ enum DiffIntraline {
     /// The changed spans of a deletion/addition line pair, or `nil` when the two share so
     /// little that spans would be noise (a rewritten line reads better as a plain
     /// add/delete pair than as one line-long highlight).
-    static func spans(old oldText: String, new newText: String)
+    public static func spans(old oldText: String, new newText: String)
         -> (old: [Range<Int>], new: [Range<Int>])? {
         guard oldText != newText else { return nil }
         let oldCharacters = Array(oldText), newCharacters = Array(newText)

--- a/Shared/Sources/TermioShared/DiffIntraline.swift
+++ b/Shared/Sources/TermioShared/DiffIntraline.swift
@@ -48,14 +48,15 @@ public enum DiffIntraline {
         let oldSpans = spans(of: oldCore, changed: changed.old)
         let newSpans = spans(of: newCore, changed: changed.new)
 
-        // The same "too different to be worth marking" test the prefix/suffix pass used,
-        // now measured on what the word diff actually kept: at least a fifth of the
-        // shorter line must survive unchanged.
+        // "Too different to be worth marking": at least a fifth of the shorter line must
+        // survive unchanged. Survival is measured per side against that side's own length
+        // — charging the longer side's inserted characters against the shorter line reads
+        // a pure insertion (`call()` -> `call(aVeryLongName)`, where the old line survives
+        // whole) as a rewrite and drops the highlight entirely.
         let shorter = min(oldCharacters.count, newCharacters.count)
-        let changedCharacters = max(oldSpans.reduce(0) { $0 + $1.count },
-                                    newSpans.reduce(0) { $0 + $1.count })
-        guard shorter == 0 || (shorter - min(changedCharacters, shorter)) * 5 >= shorter
-        else { return nil }
+        let oldSurvived = oldCharacters.count - oldSpans.reduce(0) { $0 + $1.count }
+        let newSurvived = newCharacters.count - newSpans.reduce(0) { $0 + $1.count }
+        guard shorter == 0 || min(oldSurvived, newSurvived) * 5 >= shorter else { return nil }
 
         return (oldSpans, newSpans)
     }

--- a/Shared/Sources/TermioShared/DiffModel.swift
+++ b/Shared/Sources/TermioShared/DiffModel.swift
@@ -13,15 +13,16 @@ public struct DiffLine: Identifiable, Sendable, Equatable {
     public let text: String
     public let oldLine: Int?
     public let newLine: Int?
-    /// The changed span within a paired deletion/addition line, in `Character`
+    /// The changed spans within a paired deletion/addition line, in `Character`
     /// offsets — rendered with a stronger tint so a one-word edit inside a long line
-    /// reads at a glance. `nil` when the line has no counterpart, or the two sides
-    /// share too little for a span to mean anything.
-    public var emphasis: Range<Int>?
+    /// reads at a glance. A line with two separate edits carries two spans. Empty when
+    /// the line has no counterpart, or the two sides share too little for spans to mean
+    /// anything.
+    public var emphasis: [Range<Int>]
 
     public init(
         id: Int, kind: Kind, text: String, oldLine: Int?, newLine: Int?,
-        emphasis: Range<Int>? = nil
+        emphasis: [Range<Int>] = []
     ) {
         self.id = id
         self.kind = kind
@@ -38,10 +39,66 @@ public enum DiffItem: Sendable, Equatable {
     case line(DiffLine)
     /// A folded run, named by the line range it hides (new-side numbers, so it reads
     /// against the gutter) — "227–348" says where you are; a count would only describe
-    /// the fold. `expandable` bands (full-context diffs) hold their hidden lines and
-    /// splice them back in when tapped; fixed bands (a 3-line-context diff, where the
-    /// hidden lines were never fetched) only mark the gap.
-    case band(id: Int, lines: ClosedRange<Int>, expandable: Bool)
+    /// the fold. `controls` are the directions the run can be revealed from; empty means
+    /// the band is inert (a 3-line-context diff, where the hidden lines were never
+    /// fetched, so there is nothing to splice back in). `heading` is git's section
+    /// heading when the gap came from a hunk boundary — the enclosing scope being skipped.
+    case band(id: Int, lines: ClosedRange<Int>, controls: DiffBandControls, heading: String?)
+}
+
+/// Which end of a folded run a reveal acts on. The direction is the one the reader is
+/// looking: `up` pulls down the lines nearest the code *below* the band, `down` the lines
+/// nearest the code above it. `all` drops the band entirely.
+public enum DiffBandDirection: Sendable {
+    case up, down, all
+}
+
+/// The reveal directions a band offers. A run with nothing rendered above it has no
+/// downward control (there is no code to continue from), and likewise upward. Where the
+/// control is *drawn* is a renderer's business — the desktop puts buttons in the gutter,
+/// the phone makes the whole row one tap target — but which ones exist is model.
+public struct DiffBandControls: OptionSet, Sendable, Equatable {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+    public static let up = DiffBandControls(rawValue: 1 << 0)
+    public static let down = DiffBandControls(rawValue: 1 << 1)
+}
+
+/// How much of each folded run the reader has revealed, keyed by the run's anchor line id.
+/// The anchor is the run's first hidden line, which is stable as the run shrinks: the
+/// always-shown context lines on either side never move, so revealing from one end never
+/// renames the band.
+public struct DiffExpansion: Sendable {
+    /// Lines revealed per step, matching what every other review surface uses. Revealing
+    /// a 400-line gap in one jump loses the reader's place.
+    public static let step = 20
+
+    private struct Reveal {
+        var head = 0
+        var tail = 0
+    }
+
+    private var reveals: [Int: Reveal] = [:]
+
+    public init() {}
+
+    public mutating func reveal(_ anchor: Int, _ direction: DiffBandDirection) {
+        var reveal = reveals[anchor] ?? Reveal()
+        switch direction {
+        case .down: reveal.head += Self.step
+        case .up: reveal.tail += Self.step
+        // Halved rather than `Int.max`, so a later step still adds without trapping.
+        case .all: reveal.head = Int.max / 2
+        }
+        reveals[anchor] = reveal
+    }
+
+    /// How many of a run's `count` hidden lines to splice back in at each end.
+    public func revealed(_ anchor: Int, of count: Int) -> (head: Int, tail: Int) {
+        guard let reveal = reveals[anchor] else { return (0, 0) }
+        let head = min(reveal.head, count)
+        return (head, min(reveal.tail, count - head))
+    }
 }
 
 /// Parsing and folding unified-diff text, kept free of any UI framework so both ends
@@ -89,7 +146,8 @@ public enum DiffParser {
     /// becomes a band), unchanged runs longer than a handful of lines collapse to a
     /// band keeping 3 lines of context on the side(s) facing a change, and ids in
     /// `expanded` splice their hidden lines back in.
-    public static func displayItems(lines rows: [DiffLine], expanded: Set<Int>) -> [DiffItem] {
+    public static func displayItems(lines rows: [DiffLine],
+                                    expansion: DiffExpansion) -> [DiffItem] {
         var items: [DiffItem] = []
         var run: [DiffLine] = []
         var sawChange = false
@@ -109,16 +167,21 @@ public enum DiffParser {
             // A slice, not a copy: a folded run can be thousands of lines, and the
             // collapsed case only reads its two ends.
             let hiddenRows = run[head..<(run.count - tail)]
-            guard let firstHidden = hiddenRows.first, let lastHidden = hiddenRows.last else { return }
-            if expanded.contains(firstHidden.id) {
-                items += hiddenRows.map(DiffItem.line)
-            } else {
+            guard let anchor = hiddenRows.first?.id else { return }
+            let revealed = expansion.revealed(anchor, of: hiddenRows.count)
+            items += hiddenRows.prefix(revealed.head).map(DiffItem.line)
+            let stillHidden = hiddenRows.dropFirst(revealed.head).dropLast(revealed.tail)
+            if let firstHidden = stillHidden.first, let lastHidden = stillHidden.last {
+                // A control only points somewhere there is code to continue from.
+                var controls: DiffBandControls = []
+                if !items.isEmpty { controls.insert(.down) }
+                if !isLast || revealed.tail > 0 { controls.insert(.up) }
                 let first = firstHidden.newLine ?? firstHidden.oldLine ?? 0
                 let last = lastHidden.newLine ?? lastHidden.oldLine ?? first
-                items.append(.band(
-                    id: firstHidden.id, lines: first...max(first, last), expandable: true
-                ))
+                items.append(.band(id: anchor, lines: first...max(first, last),
+                                   controls: controls, heading: nil))
             }
+            items += hiddenRows.suffix(revealed.tail).map(DiffItem.line)
             items += run.suffix(tail).map(DiffItem.line)
         }
 
@@ -128,7 +191,8 @@ public enum DiffParser {
                 flush(isLast: false)
                 if let start = row.newLine, start > lastNewLine + 1 {
                     items.append(.band(
-                        id: row.id, lines: (lastNewLine + 1)...(start - 1), expandable: false
+                        id: row.id, lines: (lastNewLine + 1)...(start - 1),
+                        controls: [], heading: hunkHeading(row.text)
                     ))
                 }
             case .context:
@@ -149,11 +213,9 @@ public enum DiffParser {
         return items
     }
 
-    // MARK: Intraline
-
-    /// Marks the changed span inside modified lines: within each run, a block of
+    /// Marks the changed spans inside modified lines: within each run, a block of
     /// deletions immediately followed by a block of additions is paired index-wise, and
-    /// each pair gets its common prefix/suffix stripped to leave the span that changed.
+    /// each pair is word-diffed by `DiffIntraline`.
     private static func applyIntraline(_ rows: inout [DiffLine]) {
         var i = 0
         while i < rows.count {
@@ -163,47 +225,13 @@ public enum DiffParser {
             let addStart = i
             while i < rows.count, rows[i].kind == .addition { i += 1 }
             for k in 0..<min(addStart - delStart, i - addStart) {
-                guard let (old, new) = emphasisRanges(rows[delStart + k].text, rows[addStart + k].text)
+                guard let spans = DiffIntraline.spans(old: rows[delStart + k].text,
+                                                      new: rows[addStart + k].text)
                 else { continue }
-                rows[delStart + k].emphasis = old
-                rows[addStart + k].emphasis = new
+                rows[delStart + k].emphasis = spans.old
+                rows[addStart + k].emphasis = spans.new
             }
         }
-    }
-
-    /// The changed spans of a deletion/addition pair: the common prefix and suffix are
-    /// peeled off, then the boundaries snap outward to whole words so renaming
-    /// `newValue` → `oldValue` highlights the identifiers, not a `ldValue` tail. `nil`
-    /// when the sides share under a fifth of the shorter line — a rewrite, where
-    /// span-highlighting the whole line would just be noise.
-    private static func emphasisRanges(_ oldText: String, _ newText: String) -> (Range<Int>, Range<Int>)? {
-        guard oldText != newText, oldText.count <= 2000, newText.count <= 2000 else { return nil }
-        let o = Array(oldText), n = Array(newText)
-        var prefix = 0
-        while prefix < o.count, prefix < n.count, o[prefix] == n[prefix] { prefix += 1 }
-        var suffix = 0
-        while suffix < o.count - prefix, suffix < n.count - prefix,
-              o[o.count - 1 - suffix] == n[n.count - 1 - suffix] { suffix += 1 }
-        guard (prefix + suffix) * 5 >= min(o.count, n.count) else { return nil }
-
-        // CJK scripts have no intra-word boundaries, so snapping there would swallow the
-        // whole run — every ideograph/kana counts as its own boundary instead.
-        func isWord(_ c: Character) -> Bool {
-            guard c.isLetter || c.isNumber || c == "_" else { return false }
-            guard let scalar = c.unicodeScalars.first else { return false }
-            return scalar.value < 0x2E80
-        }
-        while prefix > 0, isWord(o[prefix - 1]),
-              (prefix < o.count - suffix && isWord(o[prefix]))
-                || (prefix < n.count - suffix && isWord(n[prefix])) {
-            prefix -= 1
-        }
-        while suffix > 0, isWord(o[o.count - suffix]),
-              (o.count - suffix > prefix && isWord(o[o.count - suffix - 1]))
-                || (n.count - suffix > prefix && isWord(n[n.count - suffix - 1])) {
-            suffix -= 1
-        }
-        return (prefix..<(o.count - suffix), prefix..<(n.count - suffix))
     }
 
     // MARK: Line scanning
@@ -217,6 +245,16 @@ public enum DiffParser {
 
     private static func isFileHeader(_ line: Substring) -> Bool {
         fileHeaderPrefixes.contains(where: line.hasPrefix)
+    }
+
+    /// The section heading git appends to a hunk header (`@@ -a,b +c,d @@ func foo() {`) —
+    /// the enclosing scope of the lines that follow, which a folded band shows to say what
+    /// is being skipped.
+    public static func hunkHeading(_ text: String) -> String? {
+        let parts = text.components(separatedBy: "@@")
+        guard parts.count >= 3 else { return nil }
+        let heading = parts[2...].joined(separator: "@@").trimmingCharacters(in: .whitespaces)
+        return heading.isEmpty ? nil : heading
     }
 
     /// Pulls the starting old and new line numbers out of `@@ -a,b +c,d @@`.

--- a/Sources/termio/Git/DiffDocument.swift
+++ b/Sources/termio/Git/DiffDocument.swift
@@ -1,10 +1,59 @@
 import AppKit
 
+// MARK: - Band expansion
+
+/// Which end of a collapsed run a click reveals. The chevron points the way the reader is
+/// looking: `up` pulls down the lines nearest the code *below* the band, `down` the lines
+/// nearest the code above it. `all` drops the band entirely.
+enum DiffBandDirection {
+    case up, down, all
+}
+
+/// How much of each collapsed run the reader has revealed, keyed by the run's anchor row
+/// id. The anchor is the run's first hidden row, which is stable as the run shrinks: the
+/// always-shown context lines on either side never move, so revealing from one end never
+/// renames the band.
+struct DiffExpansion: Equatable {
+    /// Lines revealed per click, matching the step every other review surface uses.
+    /// Revealing a 400-line gap in one jump loses the reader's place.
+    static let step = 20
+
+    private struct Reveal: Equatable {
+        var head = 0
+        var tail = 0
+        var all = false
+    }
+
+    private var reveals: [Int: Reveal] = [:]
+
+    init() {}
+
+    var isEmpty: Bool { reveals.isEmpty }
+
+    mutating func reveal(_ anchor: Int, _ direction: DiffBandDirection) {
+        var reveal = reveals[anchor] ?? Reveal()
+        switch direction {
+        case .down: reveal.head += Self.step
+        case .up: reveal.tail += Self.step
+        case .all: reveal.all = true
+        }
+        reveals[anchor] = reveal
+    }
+
+    /// How many of a run's `count` hidden lines to splice back in at each end.
+    func revealed(_ anchor: Int, of count: Int) -> (head: Int, tail: Int) {
+        guard let reveal = reveals[anchor] else { return (0, 0) }
+        if reveal.all { return (count, 0) }
+        let head = min(reveal.head, count)
+        return (head, min(reveal.tail, count - head))
+    }
+}
+
 // MARK: - Diff document
 
 /// The whole diff as one immutable text document: an attributed string (one paragraph
 /// per rendered element) plus per-paragraph metadata the layout manager and gutter
-/// read at draw time. Built once per (rows, expanded) pair; the text view swaps it
+/// read at draw time. Built once per (rows, expansion) pair; the text view swaps it
 /// in wholesale — TextKit owns layout, wrapping, selection, and the find bar from
 /// there, which is what buys continuous multi-line selection and ⌘F.
 final class DiffDocument {
@@ -13,17 +62,25 @@ final class DiffDocument {
     struct Line {
         enum Role {
             case code(DiffRow.Kind)
-            /// `expandable` bands (full-context loads) splice their hidden lines back
-            /// in on click; fixed bands (the default-context fallback, where the
-            /// hidden lines were never fetched) just mark the gap.
-            case band(count: Int, expandable: Bool)
+            /// A band's `controls` are the reveal buttons the gutter offers for it. Empty
+            /// means the band is inert: the default-context fallback, where the hidden
+            /// lines were never fetched and so cannot be revealed at all.
+            case band(controls: BandControls)
+        }
+
+        /// The reveal buttons a band offers. A run with nothing rendered above it has no
+        /// downward button (there is no code to continue from), and likewise upward.
+        struct BandControls: OptionSet {
+            let rawValue: Int
+            static let up = BandControls(rawValue: 1 << 0)
+            static let down = BandControls(rawValue: 1 << 1)
         }
 
         let role: Role
         /// The paragraph's range in the document, including its trailing newline.
         let range: NSRange
-        /// `DiffRow.id` for a code line (keys the syntax-color pass); the first hidden
-        /// row's id for a band (keys the expand action).
+        /// `DiffRow.id` for a code line (keys the syntax-color pass); the run's anchor
+        /// row id for a band (keys the reveal state).
         let rowId: Int
         let oldLine: Int?
         let newLine: Int?
@@ -32,10 +89,21 @@ final class DiffDocument {
             if case .band = role { return true }
             return false
         }
+
+        /// The reveal buttons this line offers, empty for anything that is not an
+        /// expandable band.
+        var bandControls: BandControls {
+            if case .band(let controls) = role { return controls }
+            return []
+        }
     }
 
     let attributed: NSAttributedString
     let lines: [Line]
+    /// The tints this document was laid out with. Carried here rather than passed
+    /// alongside so the layout manager, the gutter, and the emphasis spans baked into
+    /// `attributed` can never disagree about the palette.
+    let palette: DiffPalette
     /// Whether any code line carries an old/new number. A pure-addition file has no
     /// old numbers, so that gutter column collapses rather than showing a blank band;
     /// likewise a pure deletion collapses the new column.
@@ -44,17 +112,16 @@ final class DiffDocument {
     /// The largest line number shown, sizing the gutter columns.
     let maxLineNumber: Int
 
-    private init(attributed: NSAttributedString, lines: [Line],
+    private init(attributed: NSAttributedString, lines: [Line], palette: DiffPalette,
                  hasOldGutter: Bool, hasNewGutter: Bool, maxLineNumber: Int) {
         self.attributed = attributed
         self.lines = lines
+        self.palette = palette
         self.hasOldGutter = hasOldGutter
         self.hasNewGutter = hasNewGutter
         self.maxLineNumber = maxLineNumber
     }
 
-    /// Meta text (band labels) speaks in the UI font; code speaks in the terminal font.
-    static let bandFont = NSFont.systemFont(ofSize: 10.5, weight: .medium)
     /// Extra breathing room drawn around a band row (the fill is expanded to match).
     static let bandPadding: CGFloat = 3
 
@@ -63,21 +130,18 @@ final class DiffDocument {
     /// Folds the parsed rows into the display list and lays it down as one attributed
     /// string. Hunk plumbing disappears (its gap becomes a band), unchanged runs longer
     /// than a handful of lines collapse to a band keeping 3 lines of context on the
-    /// side(s) that face a change, and `expanded` bands splice their lines back in.
-    static func build(rows: [DiffRow], expanded: Set<Int>, codeFont: NSFont,
-                      lineSpacing: CGFloat) -> DiffDocument {
-        build(items: displayItems(rows: rows, expanded: expanded), allRows: rows,
-              codeFont: codeFont, lineSpacing: lineSpacing)
+    /// side(s) that face a change, and whatever `expansion` has revealed is spliced back in.
+    static func build(rows: [DiffRow], expansion: DiffExpansion, palette: DiffPalette,
+                      codeFont: NSFont, lineSpacing: CGFloat) -> DiffDocument {
+        build(items: displayItems(rows: rows, expansion: expansion), allRows: rows,
+              palette: palette, codeFont: codeFont, lineSpacing: lineSpacing)
     }
 
-    /// Composes several files into one stacked document (github.com "Files changed"): each file's
-    /// folded rows, prefixed by a full-width header row. Row ids **must** already be globally unique
-    /// across files (offset per file upstream) so band expansion and the syntax pass stay
-    /// unambiguous. One document means one scroll, and selection / ⌘F run continuously across files.
-    /// The shared assembly: lays the display items down as one attributed string with per-paragraph
-    /// metadata. `allRows` sizes the gutter columns (which sides carry numbers, and the widest).
-    private static func build(items: [DisplayItem], allRows: [DiffRow], codeFont: NSFont,
-                              lineSpacing: CGFloat) -> DiffDocument {
+    /// The shared assembly: lays the display items down as one attributed string with
+    /// per-paragraph metadata. `allRows` sizes the gutter columns (which sides carry
+    /// numbers, and the widest).
+    private static func build(items: [DisplayItem], allRows: [DiffRow], palette: DiffPalette,
+                              codeFont: NSFont, lineSpacing: CGFloat) -> DiffDocument {
         var text = String()
         text.reserveCapacity(items.reduce(0) { $0 + $1.textLength + 1 })
         var lines: [Line] = []
@@ -94,12 +158,11 @@ final class DiffDocument {
                 lines.append(Line(role: .code(row.kind), range: NSRange(location: location, length: length),
                                   rowId: row.id, oldLine: row.oldLine, newLine: row.newLine))
                 maxLineNumber = max(maxLineNumber, row.oldLine ?? 0, row.newLine ?? 0)
-            case .band(let id, let count, let expandable):
-                let label = "⋯ \(count) unchanged \(count == 1 ? "line" : "lines")"
+            case .band(let id, let label, let controls):
                 text += label
                 text += "\n"
                 let length = (label as NSString).length + 1
-                lines.append(Line(role: .band(count: count, expandable: expandable),
+                lines.append(Line(role: .band(controls: controls),
                                   range: NSRange(location: location, length: length),
                                   rowId: id, oldLine: nil, newLine: nil))
             }
@@ -115,11 +178,13 @@ final class DiffDocument {
         baseStyle.lineSpacing = lineSpacing
         attributed.addAttribute(.paragraphStyle, value: baseStyle,
                                 range: NSRange(location: 0, length: attributed.length))
-        styleBandsAndEmphasis(attributed, items: items, lines: lines, lineSpacing: lineSpacing)
+        styleBandsAndEmphasis(attributed, items: items, lines: lines, palette: palette,
+                              lineSpacing: lineSpacing)
 
         return DiffDocument(
             attributed: attributed,
             lines: lines,
+            palette: palette,
             hasOldGutter: allRows.contains { $0.kind != .hunk && $0.oldLine != nil },
             hasNewGutter: allRows.contains { $0.kind != .hunk && $0.newLine != nil },
             maxLineNumber: maxLineNumber
@@ -146,39 +211,43 @@ final class DiffDocument {
 
     // MARK: Attributes
 
-    /// Bands restyle to the UI font (centered, tertiary ink, pointing-hand cursor when
-    /// expandable); intraline emphasis lands as a `.backgroundColor` attribute — the
-    /// layout manager's washes paint underneath, and TextKit's own background pass
-    /// composites the deeper tint on top.
+    /// Bands restyle to the UI font — left-aligned at the code column, so the row reads as
+    /// a control rather than as decoration floating in the middle of the diff; the reveal
+    /// chevrons live in the gutter beside it. Intraline emphasis lands as a
+    /// `.backgroundColor` attribute — the layout manager's washes paint underneath, and
+    /// TextKit's own background pass composites the deeper tint on top.
     private static func styleBandsAndEmphasis(_ attributed: NSMutableAttributedString,
                                               items: [DisplayItem], lines: [Line],
-                                              lineSpacing: CGFloat) {
+                                              palette: DiffPalette, lineSpacing: CGFloat) {
         let bandStyle = NSMutableParagraphStyle()
-        bandStyle.alignment = .center
         bandStyle.lineSpacing = lineSpacing
         bandStyle.paragraphSpacingBefore = bandPadding
         bandStyle.paragraphSpacing = bandPadding
 
         for (item, line) in zip(items, lines) {
             switch item {
-            case .band(_, _, let expandable):
+            case .band(_, _, let controls):
+                // The label keeps the code font (inherited from the base attributes):
+                // it is a line range, so it should line up with the numbers it names, the
+                // way github.com renders its `@@` row in the code face.
                 var attrs: [NSAttributedString.Key: Any] = [
-                    .font: bandFont,
-                    .foregroundColor: NSColor.tertiaryLabelColor,
+                    .foregroundColor: NSColor.secondaryLabelColor,
                     .paragraphStyle: bandStyle,
                 ]
-                if expandable { attrs[.cursor] = NSCursor.pointingHand }
+                if !controls.isEmpty { attrs[.cursor] = NSCursor.pointingHand }
                 attributed.addAttributes(attrs, range: line.range)
             case .line(let row):
-                guard let emphasis = row.emphasis, !emphasis.isEmpty,
-                      let range = utf16Range(of: emphasis, in: row.text) else { continue }
+                guard !row.emphasis.isEmpty else { continue }
                 let color = row.kind == .addition
-                    ? NSColor.systemGreen.withAlphaComponent(0.28)
-                    : NSColor.systemRed.withAlphaComponent(0.28)
-                attributed.addAttribute(
-                    .backgroundColor, value: color,
-                    range: NSRange(location: line.range.location + range.location, length: range.length)
-                )
+                    ? palette.additionEmphasis
+                    : palette.deletionEmphasis
+                for span in row.emphasis {
+                    guard !span.isEmpty, let range = utf16Range(of: span, in: row.text) else { continue }
+                    attributed.addAttribute(
+                        .backgroundColor, value: color,
+                        range: NSRange(location: line.range.location + range.location,
+                                       length: range.length))
+                }
             }
         }
     }
@@ -198,17 +267,42 @@ final class DiffDocument {
 
     private enum DisplayItem {
         case line(DiffRow)
-        case band(id: Int, count: Int, expandable: Bool)
+        case band(id: Int, label: String, controls: Line.BandControls)
 
         var textLength: Int {
             switch self {
             case .line(let row): return (row.text as NSString).length
-            case .band: return 24
+            case .band(_, let label, _): return (label as NSString).length
             }
         }
     }
 
-    private static func displayItems(rows: [DiffRow], expanded: Set<Int>) -> [DisplayItem] {
+    /// A band says *where* the skipped lines are, not how many there are. github.com's
+    /// expander row carries the `@@` header and its section heading for the same reason:
+    /// a line range tells the reader what they are jumping over, while "137 unchanged
+    /// lines" only describes the widget they are looking at.
+    private static func bandLabel(first: Int?, last: Int?, heading: String? = nil) -> String {
+        var label = ""
+        if let first, let last {
+            label = first == last ? "\(first)" : "\(first)–\(last)"
+        }
+        if let heading, !heading.isEmpty {
+            label += label.isEmpty ? heading : "   \(heading)"
+        }
+        return label
+    }
+
+    /// The section heading git appends to a hunk header (`@@ -a,b +c,d @@ func foo() {`) —
+    /// the enclosing scope of the lines that follow.
+    static func hunkHeading(_ text: String) -> String? {
+        let parts = text.components(separatedBy: "@@")
+        guard parts.count >= 3 else { return nil }
+        let heading = parts[2...].joined(separator: "@@")
+            .trimmingCharacters(in: .whitespaces)
+        return heading.isEmpty ? nil : heading
+    }
+
+    private static func displayItems(rows: [DiffRow], expansion: DiffExpansion) -> [DisplayItem] {
         var items: [DisplayItem] = []
         var run: [DiffRow] = []
         var sawChange = false
@@ -226,11 +320,20 @@ final class DiffDocument {
             }
             items += run.prefix(head).map(DisplayItem.line)
             let hiddenRows = Array(run.dropFirst(head).dropLast(tail))
-            if expanded.contains(hiddenRows[0].id) {
-                items += hiddenRows.map(DisplayItem.line)
-            } else {
-                items.append(.band(id: hiddenRows[0].id, count: hiddenRows.count, expandable: true))
+            let anchor = hiddenRows[0].id
+            let revealed = expansion.revealed(anchor, of: hiddenRows.count)
+            items += hiddenRows.prefix(revealed.head).map(DisplayItem.line)
+            let stillHidden = hiddenRows.dropFirst(revealed.head).dropLast(revealed.tail)
+            if !stillHidden.isEmpty {
+                // A button only points somewhere there is code to continue from.
+                var controls: Line.BandControls = []
+                if head > 0 || revealed.head > 0 || !items.isEmpty { controls.insert(.down) }
+                if tail > 0 || revealed.tail > 0 || !isLast { controls.insert(.up) }
+                let label = bandLabel(first: stillHidden.first?.newLine ?? stillHidden.first?.oldLine,
+                                      last: stillHidden.last?.newLine ?? stillHidden.last?.oldLine)
+                items.append(.band(id: anchor, label: label, controls: controls))
             }
+            items += hiddenRows.suffix(revealed.tail).map(DisplayItem.line)
             items += run.suffix(tail).map(DisplayItem.line)
         }
 
@@ -239,7 +342,11 @@ final class DiffDocument {
             case .hunk:
                 flush(isLast: false)
                 if let start = row.newLine, start > lastNewLine + 1 {
-                    items.append(.band(id: row.id, count: start - lastNewLine - 1, expandable: false))
+                    // The hidden lines were never fetched, so this band cannot be revealed
+                    // — but git's own section heading still says what is being skipped.
+                    let label = bandLabel(first: lastNewLine + 1, last: start - 1,
+                                          heading: hunkHeading(row.text))
+                    items.append(.band(id: row.id, label: label, controls: []))
                 }
             case .context:
                 run.append(row)

--- a/Sources/termio/Git/DiffDocument.swift
+++ b/Sources/termio/Git/DiffDocument.swift
@@ -1,7 +1,5 @@
 import AppKit
 
-// MARK: - Band expansion
-
 /// Which end of a collapsed run a click reveals. The chevron points the way the reader is
 /// looking: `up` pulls down the lines nearest the code *below* the band, `down` the lines
 /// nearest the code above it. `all` drops the band entirely.
@@ -13,29 +11,27 @@ enum DiffBandDirection {
 /// id. The anchor is the run's first hidden row, which is stable as the run shrinks: the
 /// always-shown context lines on either side never move, so revealing from one end never
 /// renames the band.
-struct DiffExpansion: Equatable {
+struct DiffExpansion {
     /// Lines revealed per click, matching the step every other review surface uses.
     /// Revealing a 400-line gap in one jump loses the reader's place.
     static let step = 20
 
-    private struct Reveal: Equatable {
+    private struct Reveal {
         var head = 0
         var tail = 0
-        var all = false
     }
 
     private var reveals: [Int: Reveal] = [:]
 
     init() {}
 
-    var isEmpty: Bool { reveals.isEmpty }
-
     mutating func reveal(_ anchor: Int, _ direction: DiffBandDirection) {
         var reveal = reveals[anchor] ?? Reveal()
         switch direction {
         case .down: reveal.head += Self.step
         case .up: reveal.tail += Self.step
-        case .all: reveal.all = true
+        // Halved rather than `Int.max`, so a later step-click still adds without trapping.
+        case .all: reveal.head = Int.max / 2
         }
         reveals[anchor] = reveal
     }
@@ -43,7 +39,6 @@ struct DiffExpansion: Equatable {
     /// How many of a run's `count` hidden lines to splice back in at each end.
     func revealed(_ anchor: Int, of count: Int) -> (head: Int, tail: Int) {
         guard let reveal = reveals[anchor] else { return (0, 0) }
-        if reveal.all { return (count, 0) }
         let head = min(reveal.head, count)
         return (head, min(reveal.tail, count - head))
     }
@@ -96,6 +91,9 @@ final class DiffDocument {
             if case .band(let controls) = role { return controls }
             return []
         }
+
+        /// Whether a click anywhere on this row reveals the run it stands for.
+        var isRevealable: Bool { !bandControls.isEmpty }
     }
 
     let attributed: NSAttributedString
@@ -147,9 +145,12 @@ final class DiffDocument {
         var lines: [Line] = []
         lines.reserveCapacity(items.count)
         var maxLineNumber = 0
+        // Tracked rather than re-measured: `(text as NSString).length` is only O(1) while
+        // the accumulated string stays ASCII, so one curly quote anywhere in the file
+        // turned this loop quadratic — and the reveal buttons rebuild on every click.
+        var location = 0
 
         for item in items {
-            let location = (text as NSString).length
             switch item {
             case .line(let row):
                 text += row.text
@@ -157,6 +158,7 @@ final class DiffDocument {
                 let length = (row.text as NSString).length + 1
                 lines.append(Line(role: .code(row.kind), range: NSRange(location: location, length: length),
                                   rowId: row.id, oldLine: row.oldLine, newLine: row.newLine))
+                location += length
                 maxLineNumber = max(maxLineNumber, row.oldLine ?? 0, row.newLine ?? 0)
             case .band(let id, let label, let controls):
                 text += label
@@ -165,6 +167,7 @@ final class DiffDocument {
                 lines.append(Line(role: .band(controls: controls),
                                   range: NSRange(location: location, length: length),
                                   rowId: id, oldLine: nil, newLine: nil))
+                location += length
             }
         }
 
@@ -281,25 +284,10 @@ final class DiffDocument {
     /// expander row carries the `@@` header and its section heading for the same reason:
     /// a line range tells the reader what they are jumping over, while "137 unchanged
     /// lines" only describes the widget they are looking at.
-    private static func bandLabel(first: Int?, last: Int?, heading: String? = nil) -> String {
-        var label = ""
-        if let first, let last {
-            label = first == last ? "\(first)" : "\(first)–\(last)"
-        }
-        if let heading, !heading.isEmpty {
-            label += label.isEmpty ? heading : "   \(heading)"
-        }
-        return label
-    }
-
-    /// The section heading git appends to a hunk header (`@@ -a,b +c,d @@ func foo() {`) —
-    /// the enclosing scope of the lines that follow.
-    static func hunkHeading(_ text: String) -> String? {
-        let parts = text.components(separatedBy: "@@")
-        guard parts.count >= 3 else { return nil }
-        let heading = parts[2...].joined(separator: "@@")
-            .trimmingCharacters(in: .whitespaces)
-        return heading.isEmpty ? nil : heading
+    private static func bandLabel(first: Int, last: Int, heading: String? = nil) -> String {
+        let range = first == last ? "\(first)" : "\(first)–\(last)"
+        guard let heading, !heading.isEmpty else { return range }
+        return "\(range)   \(heading)"
     }
 
     private static func displayItems(rows: [DiffRow], expansion: DiffExpansion) -> [DisplayItem] {
@@ -327,11 +315,13 @@ final class DiffDocument {
             if !stillHidden.isEmpty {
                 // A button only points somewhere there is code to continue from.
                 var controls: Line.BandControls = []
-                if head > 0 || revealed.head > 0 || !items.isEmpty { controls.insert(.down) }
-                if tail > 0 || revealed.tail > 0 || !isLast { controls.insert(.up) }
-                let label = bandLabel(first: stillHidden.first?.newLine ?? stillHidden.first?.oldLine,
-                                      last: stillHidden.last?.newLine ?? stillHidden.last?.oldLine)
-                items.append(.band(id: anchor, label: label, controls: controls))
+                if !items.isEmpty { controls.insert(.down) }
+                if !isLast || revealed.tail > 0 { controls.insert(.up) }
+                // Context rows always carry both numbers, so the range is never partial.
+                let first = stillHidden.first?.newLine ?? stillHidden.first?.oldLine ?? 0
+                let last = stillHidden.last?.newLine ?? stillHidden.last?.oldLine ?? 0
+                items.append(.band(id: anchor, label: bandLabel(first: first, last: last),
+                                   controls: controls))
             }
             items += hiddenRows.suffix(revealed.tail).map(DisplayItem.line)
             items += run.suffix(tail).map(DisplayItem.line)
@@ -345,7 +335,7 @@ final class DiffDocument {
                     // The hidden lines were never fetched, so this band cannot be revealed
                     // — but git's own section heading still says what is being skipped.
                     let label = bandLabel(first: lastNewLine + 1, last: start - 1,
-                                          heading: hunkHeading(row.text))
+                                          heading: GitService.hunkHeading(row.text))
                     items.append(.band(id: row.id, label: label, controls: []))
                 }
             case .context:

--- a/Sources/termio/Git/DiffDocument.swift
+++ b/Sources/termio/Git/DiffDocument.swift
@@ -1,48 +1,5 @@
 import AppKit
-
-/// Which end of a collapsed run a click reveals. The chevron points the way the reader is
-/// looking: `up` pulls down the lines nearest the code *below* the band, `down` the lines
-/// nearest the code above it. `all` drops the band entirely.
-enum DiffBandDirection {
-    case up, down, all
-}
-
-/// How much of each collapsed run the reader has revealed, keyed by the run's anchor row
-/// id. The anchor is the run's first hidden row, which is stable as the run shrinks: the
-/// always-shown context lines on either side never move, so revealing from one end never
-/// renames the band.
-struct DiffExpansion {
-    /// Lines revealed per click, matching the step every other review surface uses.
-    /// Revealing a 400-line gap in one jump loses the reader's place.
-    static let step = 20
-
-    private struct Reveal {
-        var head = 0
-        var tail = 0
-    }
-
-    private var reveals: [Int: Reveal] = [:]
-
-    init() {}
-
-    mutating func reveal(_ anchor: Int, _ direction: DiffBandDirection) {
-        var reveal = reveals[anchor] ?? Reveal()
-        switch direction {
-        case .down: reveal.head += Self.step
-        case .up: reveal.tail += Self.step
-        // Halved rather than `Int.max`, so a later step-click still adds without trapping.
-        case .all: reveal.head = Int.max / 2
-        }
-        reveals[anchor] = reveal
-    }
-
-    /// How many of a run's `count` hidden lines to splice back in at each end.
-    func revealed(_ anchor: Int, of count: Int) -> (head: Int, tail: Int) {
-        guard let reveal = reveals[anchor] else { return (0, 0) }
-        let head = min(reveal.head, count)
-        return (head, min(reveal.tail, count - head))
-    }
-}
+import TermioShared
 
 // MARK: - Diff document
 
@@ -60,15 +17,7 @@ final class DiffDocument {
             /// A band's `controls` are the reveal buttons the gutter offers for it. Empty
             /// means the band is inert: the default-context fallback, where the hidden
             /// lines were never fetched and so cannot be revealed at all.
-            case band(controls: BandControls)
-        }
-
-        /// The reveal buttons a band offers. A run with nothing rendered above it has no
-        /// downward button (there is no code to continue from), and likewise upward.
-        struct BandControls: OptionSet {
-            let rawValue: Int
-            static let up = BandControls(rawValue: 1 << 0)
-            static let down = BandControls(rawValue: 1 << 1)
+            case band(controls: DiffBandControls)
         }
 
         let role: Role
@@ -87,7 +36,7 @@ final class DiffDocument {
 
         /// The reveal buttons this line offers, empty for anything that is not an
         /// expandable band.
-        var bandControls: BandControls {
+        var bandControls: DiffBandControls {
             if case .band(let controls) = role { return controls }
             return []
         }
@@ -270,7 +219,7 @@ final class DiffDocument {
 
     private enum DisplayItem {
         case line(DiffRow)
-        case band(id: Int, label: String, controls: Line.BandControls)
+        case band(id: Int, label: String, controls: DiffBandControls)
 
         var textLength: Int {
             switch self {
@@ -280,79 +229,22 @@ final class DiffDocument {
         }
     }
 
-    /// A band says *where* the skipped lines are, not how many there are. github.com's
-    /// expander row carries the `@@` header and its section heading for the same reason:
-    /// a line range tells the reader what they are jumping over, while "137 unchanged
-    /// lines" only describes the widget they are looking at.
-    private static func bandLabel(first: Int, last: Int, heading: String? = nil) -> String {
-        let range = first == last ? "\(first)" : "\(first)–\(last)"
-        guard let heading, !heading.isEmpty else { return range }
-        return "\(range)   \(heading)"
-    }
-
+    /// The shared fold, rendered into this document's paragraphs. A band says *where* the
+    /// skipped lines are, not how many there are: a line range tells the reader what they
+    /// are jumping over, while "137 unchanged lines" only describes the widget. git's
+    /// section heading rides along when the gap came from a hunk boundary.
     private static func displayItems(rows: [DiffRow], expansion: DiffExpansion) -> [DisplayItem] {
-        var items: [DisplayItem] = []
-        var run: [DiffRow] = []
-        var sawChange = false
-        var lastNewLine = 0
-
-        func flush(isLast: Bool) {
-            defer { run = [] }
-            guard !run.isEmpty else { return }
-            let head = sawChange ? 3 : 0
-            let tail = isLast ? 0 : 3
-            let hidden = run.count - head - tail
-            guard hidden >= 10 else {
-                items += run.map(DisplayItem.line)
-                return
-            }
-            items += run.prefix(head).map(DisplayItem.line)
-            let hiddenRows = Array(run.dropFirst(head).dropLast(tail))
-            let anchor = hiddenRows[0].id
-            let revealed = expansion.revealed(anchor, of: hiddenRows.count)
-            items += hiddenRows.prefix(revealed.head).map(DisplayItem.line)
-            let stillHidden = hiddenRows.dropFirst(revealed.head).dropLast(revealed.tail)
-            if !stillHidden.isEmpty {
-                // A button only points somewhere there is code to continue from.
-                var controls: Line.BandControls = []
-                if !items.isEmpty { controls.insert(.down) }
-                if !isLast || revealed.tail > 0 { controls.insert(.up) }
-                // Context rows always carry both numbers, so the range is never partial.
-                let first = stillHidden.first?.newLine ?? stillHidden.first?.oldLine ?? 0
-                let last = stillHidden.last?.newLine ?? stillHidden.last?.oldLine ?? 0
-                items.append(.band(id: anchor, label: bandLabel(first: first, last: last),
-                                   controls: controls))
-            }
-            items += hiddenRows.suffix(revealed.tail).map(DisplayItem.line)
-            items += run.suffix(tail).map(DisplayItem.line)
-        }
-
-        for row in rows {
-            switch row.kind {
-            case .hunk:
-                flush(isLast: false)
-                if let start = row.newLine, start > lastNewLine + 1 {
-                    // The hidden lines were never fetched, so this band cannot be revealed
-                    // — but git's own section heading still says what is being skipped.
-                    let label = bandLabel(first: lastNewLine + 1, last: start - 1,
-                                          heading: GitService.hunkHeading(row.text))
-                    items.append(.band(id: row.id, label: label, controls: []))
-                }
-            case .context:
-                run.append(row)
-                lastNewLine = row.newLine ?? lastNewLine
-            case .addition:
-                flush(isLast: false)
-                sawChange = true
-                items.append(.line(row))
-                lastNewLine = row.newLine ?? lastNewLine
-            case .deletion:
-                flush(isLast: false)
-                sawChange = true
-                items.append(.line(row))
+        DiffParser.displayItems(lines: rows, expansion: expansion).map { item in
+            switch item {
+            case .line(let row):
+                return .line(row)
+            case .band(let id, let lines, let controls, let heading):
+                let range = lines.lowerBound == lines.upperBound
+                    ? "\(lines.lowerBound)"
+                    : "\(lines.lowerBound)–\(lines.upperBound)"
+                let label = heading.map { "\(range)   \($0)" } ?? range
+                return .band(id: id, label: label, controls: controls)
             }
         }
-        flush(isLast: true)
-        return items
     }
 }

--- a/Sources/termio/Git/DiffGutterRulerView.swift
+++ b/Sources/termio/Git/DiffGutterRulerView.swift
@@ -1,3 +1,4 @@
+import TermioShared
 import AppKit
 
 /// The diff's gutter, following `LineNumberRulerView`'s ruler precedent (including its

--- a/Sources/termio/Git/DiffGutterRulerView.swift
+++ b/Sources/termio/Git/DiffGutterRulerView.swift
@@ -32,6 +32,11 @@ final class DiffGutterRulerView: NSRulerView {
         let direction: DiffBandDirection
     }
     private var buttonHits: [ButtonHit] = []
+    /// The scroll offset the hit rects were built at. Scrolling only *schedules* a redraw,
+    /// so a click landing in between would test the click's position against rects that
+    /// describe where the buttons used to be — and expand whichever band happened to sit
+    /// there. Stamping the offset lets such a click be ignored instead of misfiring.
+    private var hitsOffset: CGFloat = .nan
 
     private static let leadingPad: CGFloat = 8
     private static let columnGap: CGFloat = 8
@@ -102,6 +107,7 @@ final class DiffGutterRulerView: NSRulerView {
         let inset = textView.textContainerInset.height
         // Maps the text view's y-coordinates into the ruler's (carries the scroll offset).
         let yOffset = convert(NSPoint.zero, from: textView).y
+        hitsOffset = yOffset
         // Numbers stranded in the strip above the content clip would ghost over the
         // header; anything at or above the ruler's top edge stays undrawn.
         let topClipInset = window.map { 1 / $0.backingScaleFactor } ?? 0
@@ -260,7 +266,11 @@ final class DiffGutterRulerView: NSRulerView {
 
         override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        guard let hit = buttonHits.first(where: { $0.rect.contains(point) }) else {
+        // Only act on rects built at the current scroll position; a click that beat the
+        // pending redraw does nothing rather than expanding the wrong band.
+        guard let textView = clientView as? NSTextView,
+              convert(NSPoint.zero, from: textView).y == hitsOffset,
+              let hit = buttonHits.first(where: { $0.rect.contains(point) }) else {
             super.mouseDown(with: event)
             return
         }

--- a/Sources/termio/Git/DiffGutterRulerView.swift
+++ b/Sources/termio/Git/DiffGutterRulerView.swift
@@ -21,6 +21,7 @@ final class DiffGutterRulerView: NSRulerView {
     private var numberColor: NSColor = .quaternaryLabelColor
     private var oldColumnWidth: CGFloat = 0
     private var newColumnWidth: CGFloat = 0
+    private var numberAttributes: [NSAttributedString.Key: Any] = [:]
 
     /// Where each visible reveal button landed, refreshed every draw and read by
     /// `mouseDown`. Only visible rows are drawn, so this stays a handful of entries.
@@ -63,6 +64,9 @@ final class DiffGutterRulerView: NSRulerView {
         numberFont = .monospacedDigitSystemFont(ofSize: max(9, codeFont.pointSize - 1.5),
                                                 weight: .regular)
         signFont = codeFont
+        // Digits stay in the shared muted ink on every row — the cell behind them carries
+        // the add/delete signal, and the sign column names it outright.
+        numberAttributes = [.font: numberFont, .foregroundColor: numberColor]
         let digits = max(2, String(max(document?.maxLineNumber ?? 0, 1)).count)
         let digitWidth = ("8" as NSString).size(withAttributes: [.font: numberFont]).width
         let columnWidth = (digitWidth * CGFloat(digits)).rounded(.up)
@@ -91,7 +95,7 @@ final class DiffGutterRulerView: NSRulerView {
               let layoutManager = textView.layoutManager,
               let container = textView.textContainer else { return }
 
-        let previousHits = buttonHits
+        let hadButtons = !buttonHits.isEmpty
         buttonHits = []
 
         let inset = textView.textContainerInset.height
@@ -117,7 +121,7 @@ final class DiffGutterRulerView: NSRulerView {
             // Continue the row's fill across the gutter, over every wrapped fragment of the
             // paragraph — one step stronger than the body's, so the gutter reads as the
             // row's anchor and, on a band, as the block its buttons sit in.
-            if let fill = Self.gutterFill(for: line.role, palette: document.palette) {
+            if let fill = document.palette.gutterFill(for: line.role) {
                 var band = layoutManager.boundingRect(forGlyphRange: glyphs, in: container)
                 band.origin.y += inset + yOffset
                 band.origin.x = 0
@@ -144,38 +148,21 @@ final class DiffGutterRulerView: NSRulerView {
 
             switch line.role {
             case .band:
-                drawRevealButtons(for: line, y: y, height: fragment.height,
-                                  palette: document.palette)
-            case .code(let kind):
-                drawNumbers(for: line, kind: kind, y: y)
+                drawRevealButtons(for: line, y: y, height: fragment.height)
+            case .code:
+                drawNumbers(for: line, y: y)
             }
         }
 
-        // Cursor rects are only rebuilt when the buttons actually moved — invalidating on
-        // every scroll tick would thrash for no visible gain.
-        if !sameHits(previousHits, buttonHits) {
+        // The rects move with the scroll offset, so any draw with a band on screen has
+        // stale ones; only a draw with no band at either end can skip the invalidation.
+        if hadButtons || !buttonHits.isEmpty {
             window?.invalidateCursorRects(for: self)
         }
     }
 
-    /// The gutter's fill for a row. Changed rows take a stronger mix than their body;
-    /// a band takes the button cell's fill, which is what makes it look pressable.
-    private static func gutterFill(for role: DiffDocument.Line.Role,
-                                   palette: DiffPalette) -> NSColor? {
-        switch role {
-        case .code(.addition): return palette.additionGutter
-        case .code(.deletion): return palette.deletionGutter
-        case .band: return palette.bandControlFill
-        case .code: return nil
-        }
-    }
-
-    private func drawNumbers(for line: DiffDocument.Line, kind: DiffRow.Kind, y: CGFloat) {
-        // Digits stay in the shared muted ink on every row — the cell behind them carries
-        // the add/delete signal, and the sign column names it outright.
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font: numberFont, .foregroundColor: numberColor,
-        ]
+    private func drawNumbers(for line: DiffDocument.Line, y: CGFloat) {
+        let attrs = numberAttributes
         var x = Self.leadingPad
         if oldColumnWidth > 0 {
             if let number = line.oldLine {
@@ -189,11 +176,9 @@ final class DiffGutterRulerView: NSRulerView {
             }
             x += newColumnWidth + Self.columnGap
         }
-        if let sign = Self.sign(for: kind) {
-            sign.text.draw(at: NSPoint(x: x, y: y), withAttributes: [
-                .font: signFont, .foregroundColor: sign.color,
-            ])
-        }
+        guard case .code(let kind) = line.role, let sign = Self.sign(for: kind) else { return }
+        sign.text.draw(at: NSPoint(x: x, y: y),
+                       withAttributes: [.font: signFont, .foregroundColor: sign.color])
     }
 
     private static func sign(for kind: DiffRow.Kind) -> (text: NSString, color: NSColor)? {
@@ -208,8 +193,7 @@ final class DiffGutterRulerView: NSRulerView {
     /// stand for the hidden lines and the arrow for the direction they come from — up
     /// pulls down the lines nearest the code *below* the band, down those nearest the code
     /// above. A band that can only be read from one side draws only that button.
-    private func drawRevealButtons(for line: DiffDocument.Line, y: CGFloat, height: CGFloat,
-                                   palette: DiffPalette) {
+    private func drawRevealButtons(for line: DiffDocument.Line, y: CGFloat, height: CGFloat) {
         let controls = line.bandControls
         guard !controls.isEmpty else { return }
 
@@ -225,7 +209,7 @@ final class DiffGutterRulerView: NSRulerView {
         var x = Self.leadingPad
         for direction in directions {
             let hit = NSRect(x: x, y: y - padding, width: cell, height: height + padding * 2)
-            drawRevealIcon(direction, in: hit, ink: palette.bandControlInk)
+            drawRevealIcon(direction, in: hit, ink: numberColor)
             buttonHits.append(ButtonHit(rect: hit, anchor: line.rowId, direction: direction))
             x += cell
         }
@@ -241,21 +225,21 @@ final class DiffGutterRulerView: NSRulerView {
         let pointsUp = direction == .up
         let block = NSRect(x: originX, y: rect.midY - (arrowHeight + gap + dotWidth) / 2,
                            width: width, height: arrowHeight + gap + dotWidth)
-        let arrowBottom = pointsUp ? block.maxY - arrowHeight : block.minY
         let dotsY = pointsUp ? block.minY : block.maxY - dotWidth
+        let tipY = pointsUp ? block.maxY : block.minY
+        let tailY = pointsUp ? block.maxY - arrowHeight : block.minY + arrowHeight
+        let barbY = pointsUp ? tipY - 2.4 : tipY + 2.4
 
         ink.setStroke()
         let arrow = NSBezierPath()
         arrow.lineWidth = 1.2
         arrow.lineCapStyle = .round
         arrow.lineJoinStyle = .round
-        let tipY = pointsUp ? arrowBottom + arrowHeight : arrowBottom
-        let tailY = pointsUp ? arrowBottom : arrowBottom + arrowHeight
         arrow.move(to: NSPoint(x: block.midX, y: tailY))
         arrow.line(to: NSPoint(x: block.midX, y: tipY))
-        arrow.move(to: NSPoint(x: block.minX + 1, y: pointsUp ? tipY - 2.4 : tipY + 2.4))
+        arrow.move(to: NSPoint(x: block.minX + 1, y: barbY))
         arrow.line(to: NSPoint(x: block.midX, y: tipY))
-        arrow.line(to: NSPoint(x: block.maxX - 1, y: pointsUp ? tipY - 2.4 : tipY + 2.4))
+        arrow.line(to: NSPoint(x: block.maxX - 1, y: barbY))
         arrow.stroke()
 
         ink.setFill()
@@ -273,9 +257,7 @@ final class DiffGutterRulerView: NSRulerView {
         string.draw(at: NSPoint(x: rightEdge - width, y: y), withAttributes: attrs)
     }
 
-    // MARK: Button hits
-
-    override func mouseDown(with event: NSEvent) {
+        override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
         guard let hit = buttonHits.first(where: { $0.rect.contains(point) }) else {
             super.mouseDown(with: event)
@@ -289,10 +271,5 @@ final class DiffGutterRulerView: NSRulerView {
         for hit in buttonHits {
             addCursorRect(hit.rect, cursor: .pointingHand)
         }
-    }
-
-    private func sameHits(_ lhs: [ButtonHit], _ rhs: [ButtonHit]) -> Bool {
-        guard lhs.count == rhs.count else { return false }
-        return zip(lhs, rhs).allSatisfy { $0.rect == $1.rect && $0.anchor == $1.anchor }
     }
 }

--- a/Sources/termio/Git/DiffGutterRulerView.swift
+++ b/Sources/termio/Git/DiffGutterRulerView.swift
@@ -1,12 +1,19 @@
 import AppKit
 
 /// The diff's gutter, following `LineNumberRulerView`'s ruler precedent (including its
-/// hard-won full-redraw-on-scroll invalidation, wired up by the pane's coordinator):
-/// old and new line-number columns in the shared muted gutter ink plus the `+`/`−` sign, drawn at
-/// each paragraph's first line fragment. Living in the ruler — outside the text view —
-/// is what keeps the numbers out of selection and the clipboard. The add/delete washes
-/// and band fills continue across it so each row reads as one full-width band.
+/// hard-won full-redraw-on-scroll invalidation, wired up by the pane's coordinator): old
+/// and new line-number columns, the `+`/`−` sign, and — on a collapsed band — the reveal
+/// buttons. Living in the ruler — outside the text view — is what keeps the numbers out of
+/// selection and the clipboard.
+///
+/// The washes continue across it so each row reads edge to edge, but a changed row's
+/// gutter is mixed one step stronger than its body, which is how github.com anchors the
+/// number cell. On a band, the whole gutter becomes one filled cell holding the buttons:
+/// a control needs a block to sit in, or it reads as a glyph stranded in empty space.
 final class DiffGutterRulerView: NSRulerView {
+    /// Reveals part of a collapsed run — the buttons are the ruler's only controls.
+    var onExpand: ((Int, DiffBandDirection) -> Void)?
+
     private var document: DiffDocument?
     private var numberFont: NSFont = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
     private var signFont: NSFont = .monospacedSystemFont(ofSize: 12, weight: .regular)
@@ -14,6 +21,15 @@ final class DiffGutterRulerView: NSRulerView {
     private var numberColor: NSColor = .quaternaryLabelColor
     private var oldColumnWidth: CGFloat = 0
     private var newColumnWidth: CGFloat = 0
+
+    /// Where each visible reveal button landed, refreshed every draw and read by
+    /// `mouseDown`. Only visible rows are drawn, so this stays a handful of entries.
+    private struct ButtonHit {
+        let rect: NSRect
+        let anchor: Int
+        let direction: DiffBandDirection
+    }
+    private var buttonHits: [ButtonHit] = []
 
     private static let leadingPad: CGFloat = 8
     private static let columnGap: CGFloat = 8
@@ -75,12 +91,12 @@ final class DiffGutterRulerView: NSRulerView {
               let layoutManager = textView.layoutManager,
               let container = textView.textContainer else { return }
 
+        let previousHits = buttonHits
+        buttonHits = []
+
         let inset = textView.textContainerInset.height
         // Maps the text view's y-coordinates into the ruler's (carries the scroll offset).
         let yOffset = convert(NSPoint.zero, from: textView).y
-        let numberAttrs: [NSAttributedString.Key: Any] = [
-            .font: numberFont, .foregroundColor: numberColor,
-        ]
         // Numbers stranded in the strip above the content clip would ghost over the
         // header; anything at or above the ruler's top edge stays undrawn.
         let topClipInset = window.map { 1 / $0.backingScaleFactor } ?? 0
@@ -98,9 +114,10 @@ final class DiffGutterRulerView: NSRulerView {
             let glyphs = layoutManager.glyphRange(forCharacterRange: line.range,
                                                   actualCharacterRange: nil)
 
-            // Continue the row's wash/band fill across the gutter, over every wrapped
-            // fragment of the paragraph, so the tint reads edge-to-edge.
-            if let fill = DiffWashLayoutManager.fill(for: line.role) {
+            // Continue the row's fill across the gutter, over every wrapped fragment of the
+            // paragraph — one step stronger than the body's, so the gutter reads as the
+            // row's anchor and, on a band, as the block its buttons sit in.
+            if let fill = Self.gutterFill(for: line.role, palette: document.palette) {
                 var band = layoutManager.boundingRect(forGlyphRange: glyphs, in: container)
                 band.origin.y += inset + yOffset
                 band.origin.x = 0
@@ -120,30 +137,132 @@ final class DiffGutterRulerView: NSRulerView {
                 }
             }
 
-            guard case .code(let kind) = line.role else { continue }
             let fragment = layoutManager.lineFragmentRect(forGlyphAt: glyphs.location,
                                                           effectiveRange: nil)
             let y = fragment.minY + inset + yOffset
             guard y > bounds.minY + topClipInset else { continue }
 
-            var x = Self.leadingPad
-            if oldColumnWidth > 0 {
-                if let number = line.oldLine {
-                    drawNumber(number, rightEdge: x + oldColumnWidth, y: y, attrs: numberAttrs)
-                }
-                x += oldColumnWidth + Self.columnGap
+            switch line.role {
+            case .band:
+                drawRevealButtons(for: line, y: y, height: fragment.height,
+                                  palette: document.palette)
+            case .code(let kind):
+                drawNumbers(for: line, kind: kind, y: y)
             }
-            if newColumnWidth > 0 {
-                if let number = line.newLine {
-                    drawNumber(number, rightEdge: x + newColumnWidth, y: y, attrs: numberAttrs)
-                }
-                x += newColumnWidth + Self.columnGap
+        }
+
+        // Cursor rects are only rebuilt when the buttons actually moved — invalidating on
+        // every scroll tick would thrash for no visible gain.
+        if !sameHits(previousHits, buttonHits) {
+            window?.invalidateCursorRects(for: self)
+        }
+    }
+
+    /// The gutter's fill for a row. Changed rows take a stronger mix than their body;
+    /// a band takes the button cell's fill, which is what makes it look pressable.
+    private static func gutterFill(for role: DiffDocument.Line.Role,
+                                   palette: DiffPalette) -> NSColor? {
+        switch role {
+        case .code(.addition): return palette.additionGutter
+        case .code(.deletion): return palette.deletionGutter
+        case .band: return palette.bandControlFill
+        case .code: return nil
+        }
+    }
+
+    private func drawNumbers(for line: DiffDocument.Line, kind: DiffRow.Kind, y: CGFloat) {
+        // Digits stay in the shared muted ink on every row — the cell behind them carries
+        // the add/delete signal, and the sign column names it outright.
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: numberFont, .foregroundColor: numberColor,
+        ]
+        var x = Self.leadingPad
+        if oldColumnWidth > 0 {
+            if let number = line.oldLine {
+                drawNumber(number, rightEdge: x + oldColumnWidth, y: y, attrs: attrs)
             }
-            if let sign = Self.sign(for: kind) {
-                sign.text.draw(at: NSPoint(x: x, y: y), withAttributes: [
-                    .font: signFont, .foregroundColor: sign.color,
-                ])
+            x += oldColumnWidth + Self.columnGap
+        }
+        if newColumnWidth > 0 {
+            if let number = line.newLine {
+                drawNumber(number, rightEdge: x + newColumnWidth, y: y, attrs: attrs)
             }
+            x += newColumnWidth + Self.columnGap
+        }
+        if let sign = Self.sign(for: kind) {
+            sign.text.draw(at: NSPoint(x: x, y: y), withAttributes: [
+                .font: signFont, .foregroundColor: sign.color,
+            ])
+        }
+    }
+
+    private static func sign(for kind: DiffRow.Kind) -> (text: NSString, color: NSColor)? {
+        switch kind {
+        case .addition: return ("+", .systemGreen)
+        case .deletion: return ("−", .systemRed)
+        case .context, .hunk: return nil
+        }
+    }
+
+    /// A band's reveal buttons: an arrow over a dotted line, github.com's shape. The dots
+    /// stand for the hidden lines and the arrow for the direction they come from — up
+    /// pulls down the lines nearest the code *below* the band, down those nearest the code
+    /// above. A band that can only be read from one side draws only that button.
+    private func drawRevealButtons(for line: DiffDocument.Line, y: CGFloat, height: CGFloat,
+                                   palette: DiffPalette) {
+        let controls = line.bandControls
+        guard !controls.isEmpty else { return }
+
+        var directions: [DiffBandDirection] = []
+        if controls.contains(.down) { directions.append(.down) }
+        if controls.contains(.up) { directions.append(.up) }
+
+        // Side by side rather than github.com's stacked pair: its expander is double
+        // height to fit two 16pt icons, and a diff row here is barely taller than its text.
+        let padding = DiffDocument.bandPadding
+        let cell = (ruleThickness - Self.leadingPad - Self.trailingPad)
+            / CGFloat(directions.count)
+        var x = Self.leadingPad
+        for direction in directions {
+            let hit = NSRect(x: x, y: y - padding, width: cell, height: height + padding * 2)
+            drawRevealIcon(direction, in: hit, ink: palette.bandControlInk)
+            buttonHits.append(ButtonHit(rect: hit, anchor: line.rowId, direction: direction))
+            x += cell
+        }
+    }
+
+    private func drawRevealIcon(_ direction: DiffBandDirection, in rect: NSRect, ink: NSColor) {
+        let width: CGFloat = 7
+        let arrowHeight: CGFloat = 5
+        let gap: CGFloat = 2.5
+        let dotWidth: CGFloat = 1.2
+        let originX = (rect.midX - width / 2).rounded()
+        // The arrow leans toward the code it reveals, the dots sit on the hidden side.
+        let pointsUp = direction == .up
+        let block = NSRect(x: originX, y: rect.midY - (arrowHeight + gap + dotWidth) / 2,
+                           width: width, height: arrowHeight + gap + dotWidth)
+        let arrowBottom = pointsUp ? block.maxY - arrowHeight : block.minY
+        let dotsY = pointsUp ? block.minY : block.maxY - dotWidth
+
+        ink.setStroke()
+        let arrow = NSBezierPath()
+        arrow.lineWidth = 1.2
+        arrow.lineCapStyle = .round
+        arrow.lineJoinStyle = .round
+        let tipY = pointsUp ? arrowBottom + arrowHeight : arrowBottom
+        let tailY = pointsUp ? arrowBottom : arrowBottom + arrowHeight
+        arrow.move(to: NSPoint(x: block.midX, y: tailY))
+        arrow.line(to: NSPoint(x: block.midX, y: tipY))
+        arrow.move(to: NSPoint(x: block.minX + 1, y: pointsUp ? tipY - 2.4 : tipY + 2.4))
+        arrow.line(to: NSPoint(x: block.midX, y: tipY))
+        arrow.line(to: NSPoint(x: block.maxX - 1, y: pointsUp ? tipY - 2.4 : tipY + 2.4))
+        arrow.stroke()
+
+        ink.setFill()
+        var dotX = block.minX
+        while dotX < block.maxX {
+            NSRect(x: dotX, y: dotsY, width: dotWidth, height: dotWidth).fill()
+            dotX += dotWidth * 2
         }
     }
 
@@ -154,11 +273,26 @@ final class DiffGutterRulerView: NSRulerView {
         string.draw(at: NSPoint(x: rightEdge - width, y: y), withAttributes: attrs)
     }
 
-    private static func sign(for kind: DiffRow.Kind) -> (text: NSString, color: NSColor)? {
-        switch kind {
-        case .addition: return ("+", .systemGreen)
-        case .deletion: return ("−", .systemRed)
-        case .context, .hunk: return nil
+    // MARK: Button hits
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        guard let hit = buttonHits.first(where: { $0.rect.contains(point) }) else {
+            super.mouseDown(with: event)
+            return
         }
+        onExpand?(hit.anchor, hit.direction)
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        for hit in buttonHits {
+            addCursorRect(hit.rect, cursor: .pointingHand)
+        }
+    }
+
+    private func sameHits(_ lhs: [ButtonHit], _ rhs: [ButtonHit]) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        return zip(lhs, rhs).allSatisfy { $0.rect == $1.rect && $0.anchor == $1.anchor }
     }
 }

--- a/Sources/termio/Git/DiffIntraline.swift
+++ b/Sources/termio/Git/DiffIntraline.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// MARK: - Intraline emphasis
-
 /// Marks the changed spans inside a modified line pair (Critique's and Xcode's intraline
 /// highlight).
 ///
@@ -16,22 +14,19 @@ enum DiffIntraline {
     /// Longer lines are left plain rather than diffed — the pathological cases here are
     /// minified bundles and embedded data, where every span would be noise anyway.
     private static let maximumLineLength = 2000
-    /// The word diff is quadratic in tokens. Past this many comparisons the pair falls
-    /// back to one span per side covering everything between the first and last change,
-    /// which is what prefix/suffix stripping produced before.
-    private static let maximumComparisons = 4096
 
     /// The changed spans of a deletion/addition line pair, or `nil` when the two share so
     /// little that spans would be noise (a rewritten line reads better as a plain
     /// add/delete pair than as one line-long highlight).
     static func spans(old oldText: String, new newText: String)
         -> (old: [Range<Int>], new: [Range<Int>])? {
-        guard oldText != newText,
-              oldText.count <= maximumLineLength, newText.count <= maximumLineLength
-        else { return nil }
+        guard oldText != newText else { return nil }
+        let oldCharacters = Array(oldText), newCharacters = Array(newText)
+        guard oldCharacters.count <= maximumLineLength,
+              newCharacters.count <= maximumLineLength else { return nil }
 
-        let oldTokens = tokenize(Array(oldText))
-        let newTokens = tokenize(Array(newText))
+        let oldTokens = tokenize(oldCharacters)
+        let newTokens = tokenize(newCharacters)
 
         var prefix = 0
         while prefix < oldTokens.count, prefix < newTokens.count,
@@ -49,21 +44,14 @@ enum DiffIntraline {
         let newCore = Array(newTokens[prefix..<(newTokens.count - suffix)])
         guard !oldCore.isEmpty || !newCore.isEmpty else { return nil }
 
-        let changed: (old: [Bool], new: [Bool])
-        if oldCore.count * newCore.count > maximumComparisons {
-            changed = (Array(repeating: true, count: oldCore.count),
-                       Array(repeating: true, count: newCore.count))
-        } else {
-            changed = changedTokens(oldCore, newCore)
-        }
-
+        let changed = changedTokens(oldCore, newCore)
         let oldSpans = spans(of: oldCore, changed: changed.old)
         let newSpans = spans(of: newCore, changed: changed.new)
 
         // The same "too different to be worth marking" test the prefix/suffix pass used,
         // now measured on what the word diff actually kept: at least a fifth of the
         // shorter line must survive unchanged.
-        let shorter = min(oldText.count, newText.count)
+        let shorter = min(oldCharacters.count, newCharacters.count)
         let changedCharacters = max(oldSpans.reduce(0) { $0 + $1.count },
                                     newSpans.reduce(0) { $0 + $1.count })
         guard shorter == 0 || (shorter - min(changedCharacters, shorter)) * 5 >= shorter
@@ -72,11 +60,8 @@ enum DiffIntraline {
         return (oldSpans, newSpans)
     }
 
-    // MARK: Tokens
-
-    /// One token and the character range it occupies in its line.
     private struct Token {
-        let text: [Character]
+        let text: String
         let range: Range<Int>
         let isBlank: Bool
     }
@@ -98,7 +83,7 @@ enum DiffIntraline {
             } else {
                 index += 1
             }
-            tokens.append(Token(text: Array(characters[start..<index]),
+            tokens.append(Token(text: String(characters[start..<index]),
                                 range: start..<index,
                                 isBlank: character == " " || character == "\t"))
         }
@@ -111,33 +96,17 @@ enum DiffIntraline {
         return scalar.value < 0x2E80
     }
 
-    // MARK: Diff
-
-    /// Which tokens on each side are outside the longest common subsequence.
+    /// Which tokens on each side fall outside the longest common subsequence. The
+    /// stdlib's Myers diff answers exactly this, and answers it in O(ND) — a hand-rolled
+    /// LCS table needed a comparison cap to bound its memory, and that cap degraded long
+    /// lines to a single span.
     private static func changedTokens(_ old: [Token], _ new: [Token]) -> (old: [Bool], new: [Bool]) {
-        var lengths = Array(repeating: Array(repeating: 0, count: new.count + 1),
-                            count: old.count + 1)
-        for i in stride(from: old.count - 1, through: 0, by: -1) {
-            for j in stride(from: new.count - 1, through: 0, by: -1) {
-                lengths[i][j] = old[i].text == new[j].text
-                    ? lengths[i + 1][j + 1] + 1
-                    : max(lengths[i + 1][j], lengths[i][j + 1])
-            }
-        }
-
-        var oldChanged = Array(repeating: true, count: old.count)
-        var newChanged = Array(repeating: true, count: new.count)
-        var i = 0, j = 0
-        while i < old.count, j < new.count {
-            if old[i].text == new[j].text {
-                oldChanged[i] = false
-                newChanged[j] = false
-                i += 1
-                j += 1
-            } else if lengths[i + 1][j] >= lengths[i][j + 1] {
-                i += 1
-            } else {
-                j += 1
+        var oldChanged = Array(repeating: false, count: old.count)
+        var newChanged = Array(repeating: false, count: new.count)
+        for change in new.map(\.text).difference(from: old.map(\.text)) {
+            switch change {
+            case .remove(let offset, _, _): oldChanged[offset] = true
+            case .insert(let offset, _, _): newChanged[offset] = true
             }
         }
         return (oldChanged, newChanged)

--- a/Sources/termio/Git/DiffIntraline.swift
+++ b/Sources/termio/Git/DiffIntraline.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+// MARK: - Intraline emphasis
+
+/// Marks the changed spans inside a modified line pair (Critique's and Xcode's intraline
+/// highlight).
+///
+/// The spans come from a word-level diff, not from stripping the pair's common prefix and
+/// suffix: a line with two separate edits — `foo(a, b)` → `bar(a, c)` — has no common
+/// middle to strip, so prefix/suffix stripping has to emphasize everything between the
+/// first and last change and the reader learns nothing. Diffing the words finds both
+/// edits and leaves `(a, ` alone.
+///
+/// Offsets are `Character` counts, matching `DiffRow.text`.
+enum DiffIntraline {
+    /// Longer lines are left plain rather than diffed — the pathological cases here are
+    /// minified bundles and embedded data, where every span would be noise anyway.
+    private static let maximumLineLength = 2000
+    /// The word diff is quadratic in tokens. Past this many comparisons the pair falls
+    /// back to one span per side covering everything between the first and last change,
+    /// which is what prefix/suffix stripping produced before.
+    private static let maximumComparisons = 4096
+
+    /// The changed spans of a deletion/addition line pair, or `nil` when the two share so
+    /// little that spans would be noise (a rewritten line reads better as a plain
+    /// add/delete pair than as one line-long highlight).
+    static func spans(old oldText: String, new newText: String)
+        -> (old: [Range<Int>], new: [Range<Int>])? {
+        guard oldText != newText,
+              oldText.count <= maximumLineLength, newText.count <= maximumLineLength
+        else { return nil }
+
+        let oldTokens = tokenize(Array(oldText))
+        let newTokens = tokenize(Array(newText))
+
+        var prefix = 0
+        while prefix < oldTokens.count, prefix < newTokens.count,
+              oldTokens[prefix].text == newTokens[prefix].text {
+            prefix += 1
+        }
+        var suffix = 0
+        while suffix < oldTokens.count - prefix, suffix < newTokens.count - prefix,
+              oldTokens[oldTokens.count - 1 - suffix].text
+                == newTokens[newTokens.count - 1 - suffix].text {
+            suffix += 1
+        }
+
+        let oldCore = Array(oldTokens[prefix..<(oldTokens.count - suffix)])
+        let newCore = Array(newTokens[prefix..<(newTokens.count - suffix)])
+        guard !oldCore.isEmpty || !newCore.isEmpty else { return nil }
+
+        let changed: (old: [Bool], new: [Bool])
+        if oldCore.count * newCore.count > maximumComparisons {
+            changed = (Array(repeating: true, count: oldCore.count),
+                       Array(repeating: true, count: newCore.count))
+        } else {
+            changed = changedTokens(oldCore, newCore)
+        }
+
+        let oldSpans = spans(of: oldCore, changed: changed.old)
+        let newSpans = spans(of: newCore, changed: changed.new)
+
+        // The same "too different to be worth marking" test the prefix/suffix pass used,
+        // now measured on what the word diff actually kept: at least a fifth of the
+        // shorter line must survive unchanged.
+        let shorter = min(oldText.count, newText.count)
+        let changedCharacters = max(oldSpans.reduce(0) { $0 + $1.count },
+                                    newSpans.reduce(0) { $0 + $1.count })
+        guard shorter == 0 || (shorter - min(changedCharacters, shorter)) * 5 >= shorter
+        else { return nil }
+
+        return (oldSpans, newSpans)
+    }
+
+    // MARK: Tokens
+
+    /// One token and the character range it occupies in its line.
+    private struct Token {
+        let text: [Character]
+        let range: Range<Int>
+        let isBlank: Bool
+    }
+
+    /// Splits a line into word runs, whitespace runs, and single characters. CJK scripts
+    /// have no intra-word boundaries, so each ideograph or kana is its own token rather
+    /// than being swallowed into a run that would span the whole line.
+    private static func tokenize(_ characters: [Character]) -> [Token] {
+        var tokens: [Token] = []
+        var index = 0
+        while index < characters.count {
+            let start = index
+            let character = characters[index]
+            if isWord(character) {
+                while index < characters.count, isWord(characters[index]) { index += 1 }
+            } else if character == " " || character == "\t" {
+                while index < characters.count,
+                      characters[index] == " " || characters[index] == "\t" { index += 1 }
+            } else {
+                index += 1
+            }
+            tokens.append(Token(text: Array(characters[start..<index]),
+                                range: start..<index,
+                                isBlank: character == " " || character == "\t"))
+        }
+        return tokens
+    }
+
+    private static func isWord(_ character: Character) -> Bool {
+        guard character.isLetter || character.isNumber || character == "_" else { return false }
+        guard let scalar = character.unicodeScalars.first else { return false }
+        return scalar.value < 0x2E80
+    }
+
+    // MARK: Diff
+
+    /// Which tokens on each side are outside the longest common subsequence.
+    private static func changedTokens(_ old: [Token], _ new: [Token]) -> (old: [Bool], new: [Bool]) {
+        var lengths = Array(repeating: Array(repeating: 0, count: new.count + 1),
+                            count: old.count + 1)
+        for i in stride(from: old.count - 1, through: 0, by: -1) {
+            for j in stride(from: new.count - 1, through: 0, by: -1) {
+                lengths[i][j] = old[i].text == new[j].text
+                    ? lengths[i + 1][j + 1] + 1
+                    : max(lengths[i + 1][j], lengths[i][j + 1])
+            }
+        }
+
+        var oldChanged = Array(repeating: true, count: old.count)
+        var newChanged = Array(repeating: true, count: new.count)
+        var i = 0, j = 0
+        while i < old.count, j < new.count {
+            if old[i].text == new[j].text {
+                oldChanged[i] = false
+                newChanged[j] = false
+                i += 1
+                j += 1
+            } else if lengths[i + 1][j] >= lengths[i][j + 1] {
+                i += 1
+            } else {
+                j += 1
+            }
+        }
+        return (oldChanged, newChanged)
+    }
+
+    /// Contiguous runs of changed tokens, as character ranges. Runs separated only by
+    /// unchanged whitespace are joined: `a = 1` → `b = 2` reads better as one span than
+    /// as two boxes with a gap.
+    private static func spans(of tokens: [Token], changed: [Bool]) -> [Range<Int>] {
+        var result: [Range<Int>] = []
+        var index = 0
+        while index < tokens.count {
+            guard changed[index] else { index += 1; continue }
+            var end = index
+            var probe = index
+            while probe < tokens.count {
+                if changed[probe] {
+                    end = probe
+                    probe += 1
+                } else if tokens[probe].isBlank, probe + 1 < tokens.count, changed[probe + 1] {
+                    probe += 1
+                } else {
+                    break
+                }
+            }
+            // A span that opens or closes on whitespace would paint empty background at
+            // its edge; trim it back to real content unless whitespace *is* the change
+            // (an indent edit, where there is nothing else to mark).
+            var first = index, last = end
+            while first < last, tokens[first].isBlank { first += 1 }
+            while last > first, tokens[last].isBlank { last -= 1 }
+            result.append(tokens[first].range.lowerBound..<tokens[last].range.upperBound)
+            index = end + 1
+        }
+        return result
+    }
+}

--- a/Sources/termio/Git/DiffPalette.swift
+++ b/Sources/termio/Git/DiffPalette.swift
@@ -1,21 +1,11 @@
 import AppKit
 
-// MARK: - Diff palette
-
 /// The diff's add/delete tints, mixed into the pane's actual background rather than
-/// composited over it with an alpha.
-///
-/// Alpha compositing in sRGB is the obvious way to tint a row and the wrong one: the
-/// result drifts in hue and lightness with whatever terminal background the user picked,
-/// so the same alpha reads as a firm wash on one theme and as nothing on another, and the
-/// add and delete sides stop being equally legible against each other. Mixing a fixed
-/// fraction of the base color into the real background in a perceptually uniform space
-/// keeps both sides at the same apparent strength on any background.
-///
-/// The space is Oklab. CSS's `color-mix(in lab, …)` is the same idea; Oklab is the better
-/// behaved of the two for exactly this (tinting toward a saturated hue) and, unlike the
-/// web, AppKit has no engine bug pushing us off it.
-struct DiffPalette: Equatable {
+/// composited over it with an alpha. An alpha wash drifts in hue and strength with
+/// whatever terminal background is configured — firm on one theme, invisible on the next,
+/// and rarely equal between the add and delete sides. A fixed fraction mixed in Oklab
+/// holds both sides at the same apparent strength on any background.
+struct DiffPalette {
     /// Full-row washes, painted by the layout manager behind the text.
     let additionWash: NSColor
     let deletionWash: NSColor
@@ -29,12 +19,11 @@ struct DiffPalette: Equatable {
     /// the same flat tint running edge to edge, and the digits stay in neutral ink.
     let additionGutter: NSColor
     let deletionGutter: NSColor
-    /// A collapsed band's row fill, the filled gutter cell that acts as its button, and
-    /// the ink of the arrow drawn in that cell. Neutral rather than github.com's blue —
-    /// an accent-colored block would be the one loud thing in the pane.
+    /// A collapsed band's row fill, and the filled gutter cell that acts as its button.
+    /// Neutral rather than github.com's blue — an accent-colored block would be the one
+    /// loud thing in the pane.
     let bandFill: NSColor
     let bandControlFill: NSColor
-    let bandControlInk: NSColor
 
     /// Bases are picked per appearance rather than lightened from one color: a green that
     /// reads as green on white is muddy on black, and a red that reads on black glares on
@@ -62,7 +51,28 @@ struct DiffPalette: Equatable {
         deletionGutter = Self.mix(background, deletion, washAmount * 1.6)
         bandFill = Self.mix(background, ink, 0.05)
         bandControlFill = Self.mix(background, ink, 0.11)
-        bandControlInk = Self.mix(background, ink, 0.55)
+    }
+
+    /// The fill behind a row's text.
+    func wash(for role: DiffDocument.Line.Role) -> NSColor? {
+        switch role {
+        case .code(.addition): return additionWash
+        case .code(.deletion): return deletionWash
+        case .band: return bandFill
+        case .code: return nil
+        }
+    }
+
+    /// The fill behind a row's gutter — a step stronger than its body, the way github.com
+    /// anchors the number cell. A band's gutter only becomes the button cell when there is
+    /// a button in it: an empty raised box on an inert band reads as a control that broke.
+    func gutterFill(for role: DiffDocument.Line.Role) -> NSColor? {
+        switch role {
+        case .code(.addition): return additionGutter
+        case .code(.deletion): return deletionGutter
+        case .band(let controls): return controls.isEmpty ? bandFill : bandControlFill
+        case .code: return nil
+        }
     }
 
     /// `amount` of `tint` mixed into `base`, interpolated in Oklab. Colors that cannot be
@@ -78,8 +88,6 @@ struct DiffPalette: Equatable {
         ).color
     }
 }
-
-// MARK: - Oklab
 
 /// Björn Ottosson's Oklab, enough of it to interpolate two opaque colors. Kept here
 /// rather than in a general color utility because the diff is its only client.

--- a/Sources/termio/Git/DiffPalette.swift
+++ b/Sources/termio/Git/DiffPalette.swift
@@ -1,0 +1,136 @@
+import AppKit
+
+// MARK: - Diff palette
+
+/// The diff's add/delete tints, mixed into the pane's actual background rather than
+/// composited over it with an alpha.
+///
+/// Alpha compositing in sRGB is the obvious way to tint a row and the wrong one: the
+/// result drifts in hue and lightness with whatever terminal background the user picked,
+/// so the same alpha reads as a firm wash on one theme and as nothing on another, and the
+/// add and delete sides stop being equally legible against each other. Mixing a fixed
+/// fraction of the base color into the real background in a perceptually uniform space
+/// keeps both sides at the same apparent strength on any background.
+///
+/// The space is Oklab. CSS's `color-mix(in lab, …)` is the same idea; Oklab is the better
+/// behaved of the two for exactly this (tinting toward a saturated hue) and, unlike the
+/// web, AppKit has no engine bug pushing us off it.
+struct DiffPalette: Equatable {
+    /// Full-row washes, painted by the layout manager behind the text.
+    let additionWash: NSColor
+    let deletionWash: NSColor
+    /// The deeper tint marking the changed span inside a modified line. Opaque, and
+    /// mixed from the wash rather than layered over it, so the span's strength does not
+    /// depend on how TextKit happens to composite two translucent passes.
+    let additionEmphasis: NSColor
+    let deletionEmphasis: NSColor
+    /// The gutter's share of a changed row, mixed a step stronger than the row's wash.
+    /// github.com does the same: the number cell reads as the row's anchor rather than as
+    /// the same flat tint running edge to edge, and the digits stay in neutral ink.
+    let additionGutter: NSColor
+    let deletionGutter: NSColor
+    /// A collapsed band's row fill, the filled gutter cell that acts as its button, and
+    /// the ink of the arrow drawn in that cell. Neutral rather than github.com's blue —
+    /// an accent-colored block would be the one loud thing in the pane.
+    let bandFill: NSColor
+    let bandControlFill: NSColor
+    let bandControlInk: NSColor
+
+    /// Bases are picked per appearance rather than lightened from one color: a green that
+    /// reads as green on white is muddy on black, and a red that reads on black glares on
+    /// white. `NSColor.systemGreen`/`.systemRed` are tuned for controls on a system
+    /// background, not for a wash on an arbitrary terminal background.
+    private static let additionLight = NSColor(srgbRed: 0.051, green: 0.745, blue: 0.306, alpha: 1)
+    private static let additionDark = NSColor(srgbRed: 0.369, green: 0.800, blue: 0.443, alpha: 1)
+    private static let deletionLight = NSColor(srgbRed: 1.000, green: 0.180, blue: 0.247, alpha: 1)
+    private static let deletionDark = NSColor(srgbRed: 1.000, green: 0.404, blue: 0.384, alpha: 1)
+
+    init(background: NSColor, isDark: Bool) {
+        let addition = isDark ? Self.additionDark : Self.additionLight
+        let deletion = isDark ? Self.deletionDark : Self.deletionLight
+        // A dark background swallows a tint that would be plenty on a light one, so the
+        // wash carries more of the base color there.
+        let washAmount: CGFloat = isDark ? 0.20 : 0.12
+        let emphasisAmount: CGFloat = isDark ? 0.26 : 0.20
+        let ink = isDark ? NSColor.white : NSColor.black
+
+        additionWash = Self.mix(background, addition, washAmount)
+        deletionWash = Self.mix(background, deletion, washAmount)
+        additionEmphasis = Self.mix(additionWash, addition, emphasisAmount)
+        deletionEmphasis = Self.mix(deletionWash, deletion, emphasisAmount)
+        additionGutter = Self.mix(background, addition, washAmount * 1.6)
+        deletionGutter = Self.mix(background, deletion, washAmount * 1.6)
+        bandFill = Self.mix(background, ink, 0.05)
+        bandControlFill = Self.mix(background, ink, 0.11)
+        bandControlInk = Self.mix(background, ink, 0.55)
+    }
+
+    /// `amount` of `tint` mixed into `base`, interpolated in Oklab. Colors that cannot be
+    /// read as sRGB (a pattern or catalog color with no concrete components) fall back to
+    /// the base — a missing tint is better than a crash.
+    static func mix(_ base: NSColor, _ tint: NSColor, _ amount: CGFloat) -> NSColor {
+        guard let from = Oklab(base), let to = Oklab(tint) else { return base }
+        let t = min(max(amount, 0), 1)
+        return Oklab(
+            lightness: from.lightness + (to.lightness - from.lightness) * t,
+            a: from.a + (to.a - from.a) * t,
+            b: from.b + (to.b - from.b) * t
+        ).color
+    }
+}
+
+// MARK: - Oklab
+
+/// Björn Ottosson's Oklab, enough of it to interpolate two opaque colors. Kept here
+/// rather than in a general color utility because the diff is its only client.
+struct Oklab {
+    let lightness: CGFloat
+    let a: CGFloat
+    let b: CGFloat
+
+    init(lightness: CGFloat, a: CGFloat, b: CGFloat) {
+        self.lightness = lightness
+        self.a = a
+        self.b = b
+    }
+
+    init?(_ color: NSColor) {
+        guard let srgb = color.usingColorSpace(.sRGB) else { return nil }
+        let r = Self.linear(srgb.redComponent)
+        let g = Self.linear(srgb.greenComponent)
+        let b = Self.linear(srgb.blueComponent)
+
+        let l = cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b)
+        let m = cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b)
+        let s = cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b)
+
+        lightness = 0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s
+        self.a = 1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s
+        self.b = 0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s
+    }
+
+    var color: NSColor {
+        let l = pow(lightness + 0.3963377774 * a + 0.2158037573 * b, 3)
+        let m = pow(lightness - 0.1055613458 * a - 0.0638541728 * b, 3)
+        let s = pow(lightness - 0.0894841775 * a - 1.2914855480 * b, 3)
+
+        let r = Self.encode(+4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s)
+        let g = Self.encode(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s)
+        let blue = Self.encode(-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s)
+        return NSColor(srgbRed: r, green: g, blue: blue, alpha: 1)
+    }
+
+    private static func linear(_ component: CGFloat) -> CGFloat {
+        component <= 0.04045 ? component / 12.92 : pow((component + 0.055) / 1.055, 2.4)
+    }
+
+    /// Out-of-gamut mixes are clamped rather than gamut-mapped: the inputs here are a
+    /// background and a tint a fifth of the way toward it, which never strays far.
+    private static func encode(_ component: CGFloat) -> CGFloat {
+        let clamped = min(max(component, 0), 1)
+        let encoded = clamped <= 0.0031308
+            ? clamped * 12.92
+            : 1.055 * pow(clamped, 1 / 2.4) - 0.055
+        return min(max(encoded, 0), 1)
+    }
+}

--- a/Sources/termio/Git/DiffTextView.swift
+++ b/Sources/termio/Git/DiffTextView.swift
@@ -1,3 +1,4 @@
+import TermioShared
 import AppKit
 import SwiftUI
 

--- a/Sources/termio/Git/DiffTextView.swift
+++ b/Sources/termio/Git/DiffTextView.swift
@@ -20,8 +20,9 @@ struct DiffTextPane: NSViewRepresentable {
     /// Line-number ink, from the shared `gutterInk(for:)` so the diff's gutter and the
     /// file editor's read as one family.
     let numberColor: NSColor
-    /// Splices a clicked band's hidden lines back in (rebuilds the document upstream).
-    let onExpand: (Int) -> Void
+    /// Splices a band's hidden lines back in, from the end the reader asked for
+    /// (rebuilds the document upstream).
+    let onExpand: (Int, DiffBandDirection) -> Void
     /// ← / → sibling walk; returns false at either end so the press dies quietly.
     let onWalk: (Int) -> Bool
     let onClose: () -> Void
@@ -178,6 +179,7 @@ struct DiffTextPane: NSViewRepresentable {
         }
         // Outside the document-identity check so a theme change re-inks the gutter of an
         // already-open diff, matching the editor's every-update restyle.
+        ruler.onExpand = onExpand
         ruler.configure(document: document, codeFont: font, gutterColor: backgroundColor,
                         numberColor: numberColor)
         // A dictionary identity check, not equality: the highlight pass lands at most
@@ -312,7 +314,7 @@ struct DiffTextPane: NSViewRepresentable {
 /// caret to move), and a click on an expandable band splices its lines back in.
 final class DiffTextView: NSTextView {
     var document: DiffDocument?
-    var onExpand: ((Int) -> Void)?
+    var onExpand: ((Int, DiffBandDirection) -> Void)?
     var onWalk: ((Int) -> Bool)?
     var onClose: (() -> Void)?
     /// "Add to Chat": the argument is the selected diff text (`nil` = no selection,
@@ -383,8 +385,10 @@ final class DiffTextView: NSTextView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        // The row itself is the "show me the whole gap" target; the gutter's chevrons
+        // reveal it a screenful at a time.
         if let anchor = expandableBand(at: event) {
-            onExpand?(anchor)
+            onExpand?(anchor, .all)
             return
         }
         super.mouseDown(with: event)
@@ -401,8 +405,7 @@ final class DiffTextView: NSTextView {
         let padding = DiffDocument.bandPadding
         guard local.y >= fragment.minY - padding, local.y <= fragment.maxY + padding else { return nil }
         let character = layoutManager.characterIndexForGlyph(at: glyph)
-        guard let line = document.line(at: character),
-              case .band(_, expandable: true) = line.role else { return nil }
+        guard let line = document.line(at: character), !line.bandControls.isEmpty else { return nil }
         return line.rowId
     }
 
@@ -466,7 +469,7 @@ final class DiffWashLayoutManager: NSLayoutManager {
                 let line = document.lines[index]
                 index += 1
                 if line.range.location >= NSMaxRange(charRange) { break }
-                guard let fill = Self.fill(for: line.role) else { continue }
+                guard let fill = Self.fill(for: line.role, palette: document.palette) else { continue }
                 let glyphs = glyphRange(forCharacterRange: line.range, actualCharacterRange: nil)
                 var rect = boundingRect(forGlyphRange: glyphs, in: container)
                 rect.origin.x = 0
@@ -480,11 +483,14 @@ final class DiffWashLayoutManager: NSLayoutManager {
         super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
     }
 
-    static func fill(for role: DiffDocument.Line.Role) -> NSColor? {
+    /// The tints are opaque and pre-mixed into the pane's background by `DiffPalette`,
+    /// not alpha-composited here: a wash whose strength depends on the terminal
+    /// background is not the same wash from theme to theme.
+    static func fill(for role: DiffDocument.Line.Role, palette: DiffPalette) -> NSColor? {
         switch role {
-        case .code(.addition): return NSColor.systemGreen.withAlphaComponent(0.13)
-        case .code(.deletion): return NSColor.systemRed.withAlphaComponent(0.13)
-        case .band: return NSColor.labelColor.withAlphaComponent(0.045)
+        case .code(.addition): return palette.additionWash
+        case .code(.deletion): return palette.deletionWash
+        case .band: return palette.bandFill
         case .code: return nil
         }
     }

--- a/Sources/termio/Git/DiffTextView.swift
+++ b/Sources/termio/Git/DiffTextView.swift
@@ -405,7 +405,7 @@ final class DiffTextView: NSTextView {
         let padding = DiffDocument.bandPadding
         guard local.y >= fragment.minY - padding, local.y <= fragment.maxY + padding else { return nil }
         let character = layoutManager.characterIndexForGlyph(at: glyph)
-        guard let line = document.line(at: character), !line.bandControls.isEmpty else { return nil }
+        guard let line = document.line(at: character), line.isRevealable else { return nil }
         return line.rowId
     }
 
@@ -469,7 +469,7 @@ final class DiffWashLayoutManager: NSLayoutManager {
                 let line = document.lines[index]
                 index += 1
                 if line.range.location >= NSMaxRange(charRange) { break }
-                guard let fill = Self.fill(for: line.role, palette: document.palette) else { continue }
+                guard let fill = document.palette.wash(for: line.role) else { continue }
                 let glyphs = glyphRange(forCharacterRange: line.range, actualCharacterRange: nil)
                 var rect = boundingRect(forGlyphRange: glyphs, in: container)
                 rect.origin.x = 0
@@ -481,17 +481,5 @@ final class DiffWashLayoutManager: NSLayoutManager {
             }
         }
         super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
-    }
-
-    /// The tints are opaque and pre-mixed into the pane's background by `DiffPalette`,
-    /// not alpha-composited here: a wash whose strength depends on the terminal
-    /// background is not the same wash from theme to theme.
-    static func fill(for role: DiffDocument.Line.Role, palette: DiffPalette) -> NSColor? {
-        switch role {
-        case .code(.addition): return palette.additionWash
-        case .code(.deletion): return palette.deletionWash
-        case .band: return palette.bandFill
-        case .code: return nil
-        }
     }
 }

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -1,3 +1,4 @@
+import TermioShared
 import AppKit
 import SwiftUI
 

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -25,6 +25,12 @@ struct GitDiffView: View {
 
     @Environment(\.colorScheme) private var colorScheme
 
+    /// Tints mixed into the pane's own background, so the wash reads the same on any
+    /// terminal theme.
+    private var palette: DiffPalette {
+        DiffPalette(background: settings.terminalBackgroundColor, isDark: colorScheme == .dark)
+    }
+
     @State private var rows: [DiffRow] = []
     @State private var document: DiffDocument?
     @State private var isLoading = true
@@ -34,8 +40,8 @@ struct GitDiffView: View {
     /// Syntax-colored line content per row id, filled by a background pass after the
     /// rows land; the document renders plain until then.
     @State private var styledLines: [Int: NSAttributedString] = [:]
-    /// Ids (first hidden row) of the collapsed bands the user has expanded.
-    @State private var expanded: Set<Int> = []
+    /// How much of each collapsed run the reader has revealed.
+    @State private var expansion = DiffExpansion()
 
     // Find bar — the same `FileFindBar` the code editor uses, over the diff's read-only text.
     @State private var findBarVisible = false
@@ -199,12 +205,12 @@ struct GitDiffView: View {
                 font: settings.resolvedTerminalFont(),
                 backgroundColor: settings.terminalBackgroundColor,
                 numberColor: settings.gutterInk(for: colorScheme),
-                onExpand: { id in
-                    expanded.insert(id)
+                onExpand: { anchor, direction in
+                    expansion.reveal(anchor, direction)
                     self.document = DiffDocument.build(
-                        rows: rows, expanded: expanded,
+                        rows: rows, expansion: expansion, palette: palette,
                         codeFont: settings.resolvedTerminalFont(),
-                                 lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
+                        lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
                 },
                 onWalk: { walk($0) },
                 onClose: onClose,
@@ -263,7 +269,7 @@ struct GitDiffView: View {
         rows = parsed
         document = parsed.isEmpty
             ? nil
-            : DiffDocument.build(rows: parsed, expanded: expanded,
+            : DiffDocument.build(rows: parsed, expansion: expansion, palette: palette,
                                  codeFont: settings.resolvedTerminalFont(),
                                  lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
         isLoading = false

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -25,12 +25,6 @@ struct GitDiffView: View {
 
     @Environment(\.colorScheme) private var colorScheme
 
-    /// Tints mixed into the pane's own background, so the wash reads the same on any
-    /// terminal theme.
-    private var palette: DiffPalette {
-        DiffPalette(background: settings.terminalBackgroundColor, isDark: colorScheme == .dark)
-    }
-
     @State private var rows: [DiffRow] = []
     @State private var document: DiffDocument?
     @State private var isLoading = true
@@ -208,7 +202,7 @@ struct GitDiffView: View {
                 onExpand: { anchor, direction in
                     expansion.reveal(anchor, direction)
                     self.document = DiffDocument.build(
-                        rows: rows, expansion: expansion, palette: palette,
+                        rows: rows, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
                         codeFont: settings.resolvedTerminalFont(),
                         lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
                 },
@@ -269,7 +263,7 @@ struct GitDiffView: View {
         rows = parsed
         document = parsed.isEmpty
             ? nil
-            : DiffDocument.build(rows: parsed, expansion: expansion, palette: palette,
+            : DiffDocument.build(rows: parsed, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
                                  codeFont: settings.resolvedTerminalFont(),
                                  lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
         isLoading = false

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -65,6 +65,12 @@ struct GitDiffView: View {
         .onKeyPress(.rightArrow) { walk(+1) ? .handled : .ignored }
         .onExitCommand(perform: onClose)
         .task(id: request) { await load() }
+        // Appearance flips change both the wash palette and the highlighter theme.
+        .task(id: colorScheme) {
+            guard !rows.isEmpty else { return }
+            rebuildDocument()
+            await buildStyledLines(rows)
+        }
         .onReceive(NotificationCenter.default.publisher(for: .termioShowFindBar)) { _ in
             openFindBar()
         }
@@ -202,10 +208,7 @@ struct GitDiffView: View {
                 numberColor: settings.gutterInk(for: colorScheme),
                 onExpand: { anchor, direction in
                     expansion.reveal(anchor, direction)
-                    self.document = DiffDocument.build(
-                        rows: rows, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
-                        codeFont: settings.resolvedTerminalFont(),
-                        lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
+                    rebuildDocument()
                 },
                 onWalk: { walk($0) },
                 onClose: onClose,
@@ -262,13 +265,22 @@ struct GitDiffView: View {
         let parsed = await GitService.diffRows(
             for: request.change, in: request.repoRoot, commit: request.commit, range: request.range)
         rows = parsed
-        document = parsed.isEmpty
-            ? nil
-            : DiffDocument.build(rows: parsed, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
-                                 codeFont: settings.resolvedTerminalFont(),
-                                 lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
+        rebuildDocument()
         isLoading = false
         await buildStyledLines(parsed)
+    }
+
+    /// Lays the rows out again with the palette that applies *now*. The tints are opaque,
+    /// pre-mixed against the terminal background and baked into the document's emphasis
+    /// spans, so unlike the dynamic system colors they replaced they do not re-resolve on
+    /// their own when the appearance flips — the document has to be rebuilt.
+    private func rebuildDocument() {
+        document = rows.isEmpty
+            ? nil
+            : DiffDocument.build(rows: rows, expansion: expansion,
+                                 palette: settings.diffPalette(for: colorScheme),
+                                 codeFont: settings.resolvedTerminalFont(),
+                                 lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
     }
 
     /// Colors the code through `DiffHighlighter` (the editor's Highlightr pipeline

--- a/Sources/termio/Git/GitModels.swift
+++ b/Sources/termio/Git/GitModels.swift
@@ -141,9 +141,10 @@ struct DiffRow: Identifiable, Sendable {
     let text: String
     let oldLine: Int?
     let newLine: Int?
-    /// The changed span within a paired deletion/addition line, in `Character`
+    /// The changed spans within a paired deletion/addition line, in `Character`
     /// offsets — rendered with a stronger background so a one-word edit in a long
-    /// line reads at a glance. `nil` when the line has no counterpart or the two
-    /// sides share too little for a span to mean anything.
-    var emphasis: Range<Int>? = nil
+    /// line reads at a glance. A line with two separate edits carries two spans.
+    /// Empty when the line has no counterpart or the two sides share too little for
+    /// spans to mean anything.
+    var emphasis: [Range<Int>] = []
 }

--- a/Sources/termio/Git/GitModels.swift
+++ b/Sources/termio/Git/GitModels.swift
@@ -1,3 +1,4 @@
+import TermioShared
 import Foundation
 import SwiftUI
 
@@ -131,20 +132,7 @@ struct GitDiffRequest: Hashable, Sendable {
     var name: String { change.name }
 }
 
-/// One rendered line of a unified diff: an added/removed/context line (with its old
-/// and/or new line number), or a hunk header (`@@ … @@`). The file-header lines of
-/// the raw diff are dropped during parsing — the overlay shows the filename itself.
-struct DiffRow: Identifiable, Sendable {
-    enum Kind: Sendable { case addition, deletion, context, hunk }
-    let id: Int
-    let kind: Kind
-    let text: String
-    let oldLine: Int?
-    let newLine: Int?
-    /// The changed spans within a paired deletion/addition line, in `Character`
-    /// offsets — rendered with a stronger background so a one-word edit in a long
-    /// line reads at a glance. A line with two separate edits carries two spans.
-    /// Empty when the line has no counterpart or the two sides share too little for
-    /// spans to mean anything.
-    var emphasis: [Range<Int>] = []
-}
+/// One rendered line of a unified diff. The parse, the fold, and the intraline word diff
+/// all live in `TermioShared` so the Mac and the phone read a diff the same way; this is
+/// the desktop's name for the shared type.
+typealias DiffRow = DiffLine

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -499,6 +499,17 @@ enum GitService {
         return false
     }
 
+    /// The section heading git appends to a hunk header (`@@ -a,b +c,d @@ func foo() {`) —
+    /// the enclosing scope of the lines that follow, which the diff's collapsed bands show
+    /// to say what is being skipped. Lives beside `parseHunkHeader` so the header's grammar
+    /// is read in one file.
+    static func hunkHeading(_ text: String) -> String? {
+        let parts = text.components(separatedBy: "@@")
+        guard parts.count >= 3 else { return nil }
+        let heading = parts[2...].joined(separator: "@@").trimmingCharacters(in: .whitespaces)
+        return heading.isEmpty ? nil : heading
+    }
+
     /// Pulls the starting old and new line numbers out of `@@ -a,b +c,d @@`.
     private static func parseHunkHeader(_ line: String) -> (Int, Int)? {
         let parts = line.split(separator: " ")

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import TermioShared
 
 /// The environment for **every** app-side `git` subprocess. `GIT_OPTIONAL_LOCKS=0`
 /// stops read-only git — notably `git status` — from taking the index lock and
@@ -57,7 +58,7 @@ enum GitService {
             // default 3-line context rather than parse (and render) a whole huge file.
             let text = full.count <= 1_500_000
                 ? full : loadDiffText(change, repoRoot, commit: commit, range: range)
-            return parseDiff(text)
+            return DiffParser.lines(from: text)
         }
     }
 
@@ -71,7 +72,7 @@ enum GitService {
     /// main thread — the same parser the local `git diff` path uses, so a PR file diffed
     /// from the API renders identically without a subprocess or a checkout.
     static func parseDiffText(_ text: String) async -> [DiffRow] {
-        await offMain { parseDiff(text) }
+        await offMain { DiffParser.lines(from: text) }
     }
 
     /// Discards a whole selection in one confirmed action — the multi-select's
@@ -415,7 +416,7 @@ enum GitService {
                        in: repoRoot, ignoreStatus: true) ?? ""
         }
         // History file row: the file's change within one commit. `--format=` strips the
-        // commit header so parseDiff sees only the unified diff.
+        // commit header so the parser sees only the unified diff.
         if let commit {
             return run(["show", "--format=", "-M"] + contextArguments + [commit, "--", change.path],
                        in: repoRoot, ignoreStatus: true) ?? ""
@@ -435,91 +436,6 @@ enum GitService {
         return run(["diff"] + contextArguments + ["--cached", "--", change.path], in: repoRoot) ?? ""
     }
 
-    /// Parses unified-diff text into rows, tracking old/new line numbers from each
-    /// hunk header and dropping the file-header lines (`diff --git`, `+++`, …).
-    private static func parseDiff(_ text: String) -> [DiffRow] {
-        var rows: [DiffRow] = []
-        var id = 0
-        var oldNo = 0
-        var newNo = 0
-        for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {
-            let line = String(raw)
-            if line.hasPrefix("@@") {
-                if let (o, n) = parseHunkHeader(line) { oldNo = o; newNo = n }
-                // Hunk rows carry their start numbers so the overlay can size the gap
-                // to the previous hunk when it renders the boundary as a "⋯ n lines" band.
-                rows.append(DiffRow(id: id, kind: .hunk, text: line, oldLine: oldNo, newLine: newNo)); id += 1
-                continue
-            }
-            if isFileHeader(line) { continue }
-            guard let first = line.first else { continue }
-            let body = String(line.dropFirst())
-            switch first {
-            case "+":
-                rows.append(DiffRow(id: id, kind: .addition, text: body, oldLine: nil, newLine: newNo)); id += 1; newNo += 1
-            case "-":
-                rows.append(DiffRow(id: id, kind: .deletion, text: body, oldLine: oldNo, newLine: nil)); id += 1; oldNo += 1
-            case " ":
-                rows.append(DiffRow(id: id, kind: .context, text: body, oldLine: oldNo, newLine: newNo)); id += 1; oldNo += 1; newNo += 1
-            default:
-                continue
-            }
-        }
-        applyIntraline(&rows)
-        return rows
-    }
-
-    /// Marks the changed spans inside modified lines: within each hunk, a run of
-    /// deletions immediately followed by a run of additions is paired index-wise, and
-    /// each pair is word-diffed by `DiffIntraline`.
-    private static func applyIntraline(_ rows: inout [DiffRow]) {
-        var i = 0
-        while i < rows.count {
-            guard rows[i].kind == .deletion else { i += 1; continue }
-            let delStart = i
-            while i < rows.count, rows[i].kind == .deletion { i += 1 }
-            let addStart = i
-            while i < rows.count, rows[i].kind == .addition { i += 1 }
-            for k in 0..<min(addStart - delStart, i - addStart) {
-                guard let spans = DiffIntraline.spans(old: rows[delStart + k].text,
-                                                      new: rows[addStart + k].text)
-                else { continue }
-                rows[delStart + k].emphasis = spans.old
-                rows[addStart + k].emphasis = spans.new
-            }
-        }
-    }
-
-    private static func isFileHeader(_ line: String) -> Bool {
-        for prefix in ["diff ", "index ", "--- ", "+++ ", "new file", "deleted file",
-                       "old mode", "new mode", "similarity ", "dissimilarity ",
-                       "rename ", "copy ", "\\ "] where line.hasPrefix(prefix) {
-            return true
-        }
-        return false
-    }
-
-    /// The section heading git appends to a hunk header (`@@ -a,b +c,d @@ func foo() {`) —
-    /// the enclosing scope of the lines that follow, which the diff's collapsed bands show
-    /// to say what is being skipped. Lives beside `parseHunkHeader` so the header's grammar
-    /// is read in one file.
-    static func hunkHeading(_ text: String) -> String? {
-        let parts = text.components(separatedBy: "@@")
-        guard parts.count >= 3 else { return nil }
-        let heading = parts[2...].joined(separator: "@@").trimmingCharacters(in: .whitespaces)
-        return heading.isEmpty ? nil : heading
-    }
-
-    /// Pulls the starting old and new line numbers out of `@@ -a,b +c,d @@`.
-    private static func parseHunkHeader(_ line: String) -> (Int, Int)? {
-        let parts = line.split(separator: " ")
-        guard parts.count >= 3 else { return nil }
-        func start(_ s: Substring) -> Int? {
-            Int(s.dropFirst().split(separator: ",").first ?? s.dropFirst())
-        }
-        guard let o = start(parts[1]), let n = start(parts[2]) else { return nil }
-        return (o, n)
-    }
 
     /// A recognized code-hosting forge, detected from the origin remote's hostname.
     /// Each forge shapes its branch-tree URL differently, so a "view remote" link

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -469,10 +469,9 @@ enum GitService {
         return rows
     }
 
-    /// Marks the changed span inside modified lines (Critique/Xcode's intraline
-    /// highlight): within each hunk, a run of deletions immediately followed by a run
-    /// of additions is paired index-wise, and each pair gets its common prefix/suffix
-    /// stripped to leave the span that actually changed.
+    /// Marks the changed spans inside modified lines: within each hunk, a run of
+    /// deletions immediately followed by a run of additions is paired index-wise, and
+    /// each pair is word-diffed by `DiffIntraline`.
     private static func applyIntraline(_ rows: inout [DiffRow]) {
         var i = 0
         while i < rows.count {
@@ -482,47 +481,13 @@ enum GitService {
             let addStart = i
             while i < rows.count, rows[i].kind == .addition { i += 1 }
             for k in 0..<min(addStart - delStart, i - addStart) {
-                guard let (old, new) = emphasisRanges(rows[delStart + k].text, rows[addStart + k].text)
+                guard let spans = DiffIntraline.spans(old: rows[delStart + k].text,
+                                                      new: rows[addStart + k].text)
                 else { continue }
-                rows[delStart + k].emphasis = old
-                rows[addStart + k].emphasis = new
+                rows[delStart + k].emphasis = spans.old
+                rows[addStart + k].emphasis = spans.new
             }
         }
-    }
-
-    /// The changed spans of a deletion/addition line pair: common prefix and suffix
-    /// are peeled off, then the boundaries snap outward to whole words so renaming
-    /// `newValue` → `oldValue` highlights the identifiers, not a `ldValue` tail.
-    /// Returns `nil` when the sides share under a fifth of the shorter line — a
-    /// rewrite, where span-highlighting the whole line would just be noise.
-    private static func emphasisRanges(_ oldText: String, _ newText: String) -> (Range<Int>, Range<Int>)? {
-        guard oldText != newText, oldText.count <= 2000, newText.count <= 2000 else { return nil }
-        let o = Array(oldText), n = Array(newText)
-        var prefix = 0
-        while prefix < o.count, prefix < n.count, o[prefix] == n[prefix] { prefix += 1 }
-        var suffix = 0
-        while suffix < o.count - prefix, suffix < n.count - prefix,
-              o[o.count - 1 - suffix] == n[n.count - 1 - suffix] { suffix += 1 }
-        guard (prefix + suffix) * 5 >= min(o.count, n.count) else { return nil }
-
-        // CJK scripts have no intra-word boundaries, so snapping there would swallow
-        // the whole run — every ideograph/kana counts as its own boundary instead.
-        func isWord(_ c: Character) -> Bool {
-            guard c.isLetter || c.isNumber || c == "_" else { return false }
-            guard let scalar = c.unicodeScalars.first else { return false }
-            return scalar.value < 0x2E80
-        }
-        while prefix > 0, isWord(o[prefix - 1]),
-              (prefix < o.count - suffix && isWord(o[prefix]))
-                || (prefix < n.count - suffix && isWord(n[prefix])) {
-            prefix -= 1
-        }
-        while suffix > 0, isWord(o[o.count - suffix]),
-              (o.count - suffix > prefix && isWord(o[o.count - suffix - 1]))
-                || (n.count - suffix > prefix && isWord(n[n.count - suffix - 1])) {
-            suffix -= 1
-        }
-        return (prefix..<(o.count - suffix), prefix..<(n.count - suffix))
     }
 
     private static func isFileHeader(_ line: String) -> Bool {

--- a/Sources/termio/Git/PRFilesDiffView.swift
+++ b/Sources/termio/Git/PRFilesDiffView.swift
@@ -1,3 +1,4 @@
+import TermioShared
 import AppKit
 import SwiftUI
 

--- a/Sources/termio/Git/PRFilesDiffView.swift
+++ b/Sources/termio/Git/PRFilesDiffView.swift
@@ -175,6 +175,11 @@ private struct PRFileDiffBody: View {
         .onKeyPress(.leftArrow) { onWalk(-1) ? .handled : .ignored }
         .onKeyPress(.rightArrow) { onWalk(+1) ? .handled : .ignored }
         .task(id: change.path) { await load() }
+        .task(id: colorScheme) {
+            guard !rows.isEmpty else { return }
+            rebuildDocument()
+            await buildStyledLines(rows)
+        }
     }
 
     private var header: some View {
@@ -225,10 +230,7 @@ private struct PRFileDiffBody: View {
                 numberColor: settings.gutterInk(for: colorScheme),
                 onExpand: { anchor, direction in
                     expansion.reveal(anchor, direction)
-                    self.document = DiffDocument.build(
-                        rows: rows, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
-                        codeFont: settings.resolvedTerminalFont(),
-                        lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
+                    rebuildDocument()
                 },
                 onWalk: onWalk,
                 onClose: onClose
@@ -254,13 +256,20 @@ private struct PRFileDiffBody: View {
         }
         let parsed = await GitService.parseDiffText(patch)
         rows = parsed
-        document = parsed.isEmpty
-            ? nil
-            : DiffDocument.build(rows: parsed, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
-                                 codeFont: settings.resolvedTerminalFont(),
-                                 lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
+        rebuildDocument()
         isLoading = false
         await buildStyledLines(parsed)
+    }
+
+    /// The palette is baked into the document (opaque tints, mixed against the terminal
+    /// background), so an appearance flip needs a rebuild rather than re-resolving itself.
+    private func rebuildDocument() {
+        document = rows.isEmpty
+            ? nil
+            : DiffDocument.build(rows: rows, expansion: expansion,
+                                 palette: settings.diffPalette(for: colorScheme),
+                                 codeFont: settings.resolvedTerminalFont(),
+                                 lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
     }
 
     private func buildStyledLines(_ rows: [DiffRow]) async {
@@ -360,6 +369,11 @@ private struct FileDiffCard: View {
         .task(id: collapsed) {
             if !collapsed, !loaded { await load() }
         }
+        .task(id: colorScheme) {
+            guard !rows.isEmpty else { return }
+            rebuildDocument()
+            await buildStyled(rows)
+        }
     }
 
     /// The title bar — the whole row toggles the fold; the disclosure chevron mirrors the state.
@@ -436,7 +450,8 @@ private struct FileDiffCard: View {
         rows = parsed
         document = parsed.isEmpty
             ? nil
-            : DiffDocument.build(rows: parsed, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
+            : DiffDocument.build(rows: parsed, expansion: expansion,
+                                 palette: settings.diffPalette(for: colorScheme),
                                  codeFont: settings.resolvedTerminalFont(),
                                  lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
         await buildStyled(parsed)

--- a/Sources/termio/Git/PRFilesDiffView.swift
+++ b/Sources/termio/Git/PRFilesDiffView.swift
@@ -18,6 +18,7 @@ struct PRFilesSplitView: View {
     let onClose: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
+
     @State private var selection: String?
 
     /// The changed-files rail width for a given pane width — a third of the pane, clamped so neither
@@ -154,10 +155,16 @@ private struct PRFileDiffBody: View {
 
     @Environment(\.colorScheme) private var colorScheme
 
+    /// Tints mixed into the pane's own background, so the wash reads the same on any
+    /// terminal theme.
+    private var palette: DiffPalette {
+        DiffPalette(background: settings.terminalBackgroundColor, isDark: colorScheme == .dark)
+    }
+
     @State private var rows: [DiffRow] = []
     @State private var document: DiffDocument?
     @State private var styledLines: [Int: NSAttributedString] = [:]
-    @State private var expanded: Set<Int> = []
+    @State private var expansion = DiffExpansion()
     @State private var isLoading = true
 
     var body: some View {
@@ -221,12 +228,12 @@ private struct PRFileDiffBody: View {
                 font: settings.resolvedTerminalFont(),
                 backgroundColor: settings.terminalBackgroundColor,
                 numberColor: settings.gutterInk(for: colorScheme),
-                onExpand: { id in
-                    expanded.insert(id)
+                onExpand: { anchor, direction in
+                    expansion.reveal(anchor, direction)
                     self.document = DiffDocument.build(
-                        rows: rows, expanded: expanded,
+                        rows: rows, expansion: expansion, palette: palette,
                         codeFont: settings.resolvedTerminalFont(),
-                                 lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
+                        lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
                 },
                 onWalk: onWalk,
                 onClose: onClose
@@ -254,7 +261,7 @@ private struct PRFileDiffBody: View {
         rows = parsed
         document = parsed.isEmpty
             ? nil
-            : DiffDocument.build(rows: parsed, expanded: expanded,
+            : DiffDocument.build(rows: parsed, expansion: expansion, palette: palette,
                                  codeFont: settings.resolvedTerminalFont(),
                                  lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
         isLoading = false
@@ -333,10 +340,16 @@ private struct FileDiffCard: View {
     let onClose: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
+
+    /// Tints mixed into the pane's own background, so the wash reads the same on any
+    /// terminal theme.
+    private var palette: DiffPalette {
+        DiffPalette(background: settings.terminalBackgroundColor, isDark: colorScheme == .dark)
+    }
     @State private var rows: [DiffRow] = []
     @State private var document: DiffDocument?
     @State private var styledLines: [Int: NSAttributedString] = [:]
-    @State private var expanded: Set<Int> = []
+    @State private var expansion = DiffExpansion()
     @State private var contentHeight: CGFloat = 0
     @State private var loaded = false
 
@@ -402,7 +415,10 @@ private struct FileDiffCard: View {
                 font: settings.resolvedTerminalFont(),
                 backgroundColor: settings.terminalBackgroundColor,
                 numberColor: settings.gutterInk(for: colorScheme),
-                onExpand: { id in expanded.insert(id); rebuildDocument() },
+                onExpand: { anchor, direction in
+                    expansion.reveal(anchor, direction)
+                    rebuildDocument()
+                },
                 onWalk: { _ in false },
                 onClose: onClose,
                 embedded: true,
@@ -431,16 +447,16 @@ private struct FileDiffCard: View {
         rows = parsed
         document = parsed.isEmpty
             ? nil
-            : DiffDocument.build(rows: parsed, expanded: expanded,
+            : DiffDocument.build(rows: parsed, expansion: expansion, palette: palette,
                                  codeFont: settings.resolvedTerminalFont(),
                                  lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
         await buildStyled(parsed)
     }
 
     private func rebuildDocument() {
-        document = DiffDocument.build(rows: rows, expanded: expanded,
+        document = DiffDocument.build(rows: rows, expansion: expansion, palette: palette,
                                       codeFont: settings.resolvedTerminalFont(),
-                                 lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
+                                      lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
     }
 
     private func buildStyled(_ parsed: [DiffRow]) async {

--- a/Sources/termio/Git/PRFilesDiffView.swift
+++ b/Sources/termio/Git/PRFilesDiffView.swift
@@ -155,12 +155,6 @@ private struct PRFileDiffBody: View {
 
     @Environment(\.colorScheme) private var colorScheme
 
-    /// Tints mixed into the pane's own background, so the wash reads the same on any
-    /// terminal theme.
-    private var palette: DiffPalette {
-        DiffPalette(background: settings.terminalBackgroundColor, isDark: colorScheme == .dark)
-    }
-
     @State private var rows: [DiffRow] = []
     @State private var document: DiffDocument?
     @State private var styledLines: [Int: NSAttributedString] = [:]
@@ -231,7 +225,7 @@ private struct PRFileDiffBody: View {
                 onExpand: { anchor, direction in
                     expansion.reveal(anchor, direction)
                     self.document = DiffDocument.build(
-                        rows: rows, expansion: expansion, palette: palette,
+                        rows: rows, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
                         codeFont: settings.resolvedTerminalFont(),
                         lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
                 },
@@ -261,7 +255,7 @@ private struct PRFileDiffBody: View {
         rows = parsed
         document = parsed.isEmpty
             ? nil
-            : DiffDocument.build(rows: parsed, expansion: expansion, palette: palette,
+            : DiffDocument.build(rows: parsed, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
                                  codeFont: settings.resolvedTerminalFont(),
                                  lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
         isLoading = false
@@ -340,12 +334,6 @@ private struct FileDiffCard: View {
     let onClose: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
-
-    /// Tints mixed into the pane's own background, so the wash reads the same on any
-    /// terminal theme.
-    private var palette: DiffPalette {
-        DiffPalette(background: settings.terminalBackgroundColor, isDark: colorScheme == .dark)
-    }
     @State private var rows: [DiffRow] = []
     @State private var document: DiffDocument?
     @State private var styledLines: [Int: NSAttributedString] = [:]
@@ -447,14 +435,14 @@ private struct FileDiffCard: View {
         rows = parsed
         document = parsed.isEmpty
             ? nil
-            : DiffDocument.build(rows: parsed, expansion: expansion, palette: palette,
+            : DiffDocument.build(rows: parsed, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
                                  codeFont: settings.resolvedTerminalFont(),
                                  lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
         await buildStyled(parsed)
     }
 
     private func rebuildDocument() {
-        document = DiffDocument.build(rows: rows, expansion: expansion, palette: palette,
+        document = DiffDocument.build(rows: rows, expansion: expansion, palette: settings.diffPalette(for: colorScheme),
                                       codeFont: settings.resolvedTerminalFont(),
                                       lineSpacing: settings.codeLineSpacing(for: settings.resolvedTerminalFont()))
     }

--- a/Sources/termio/Theme/ChromeTheme.swift
+++ b/Sources/termio/Theme/ChromeTheme.swift
@@ -110,6 +110,21 @@ extension AppSettings {
         return ChromeTheme.overlayInk(onDark: dark, alpha: dark ? 0.55 : 0.42)
     }
 
+    /// The diff's add/delete tints, resolved against the same theme `gutterInk` reads so
+    /// the washes and the numbers drawn on them can never disagree about which slot is
+    /// showing. `terminalBackgroundColor` is dynamic and would resolve against whatever
+    /// `NSAppearance.current` happened to be during the Oklab mix — the theme's own
+    /// background is the already-resolved counterpart.
+    func diffPalette(for colorScheme: ColorScheme) -> DiffPalette {
+        let theme = chromeTheme(for: colorScheme)
+        let dark = theme?.isDark ?? (colorScheme == .dark)
+        let background = theme.map { NSColor($0.background) }
+            ?? (dark
+                ? NSColor(srgbRed: 0x21 / 255.0, green: 0x21 / 255.0, blue: 0x21 / 255.0, alpha: 1)
+                : .white)
+        return DiffPalette(background: background, isDark: dark)
+    }
+
     var terminalBackgroundColor: NSColor {
         let lightBackground = chromeTheme(for: .light)?.background
         let darkBackground = chromeTheme(for: .dark)?.background

--- a/Tests/termioTests/DiffDocumentTests.swift
+++ b/Tests/termioTests/DiffDocumentTests.swift
@@ -1,0 +1,117 @@
+import AppKit
+import XCTest
+@testable import termio
+
+/// The fold: which lines a collapsed band hides, what it says about them, and which
+/// reveal buttons it offers. The reveal state is keyed by the run's first hidden row, so
+/// the case that matters most is that revealing one end does not lose the other end's
+/// state — the anchor has to survive its own band shrinking.
+final class DiffDocumentTests: XCTestCase {
+    private let palette = DiffPalette(
+        background: NSColor(srgbRed: 0.11, green: 0.12, blue: 0.15, alpha: 1), isDark: true)
+
+    /// One change, then a long unchanged tail: three lines of context stay, the rest folds.
+    private func rows(context: Int = 40) -> [DiffRow] {
+        var rows = [DiffRow(id: 0, kind: .addition, text: "added", oldLine: nil, newLine: 1)]
+        for offset in 0..<context {
+            rows.append(DiffRow(id: offset + 1, kind: .context, text: "context",
+                                oldLine: offset + 2, newLine: offset + 2))
+        }
+        return rows
+    }
+
+    private func document(_ expansion: DiffExpansion, context: Int = 40) -> DiffDocument {
+        DiffDocument.build(rows: rows(context: context), expansion: expansion, palette: palette,
+                           codeFont: .monospacedSystemFont(ofSize: 12, weight: .regular),
+                           lineSpacing: 0)
+    }
+
+    private func band(_ document: DiffDocument) -> (label: String, line: DiffDocument.Line)? {
+        guard let line = document.lines.first(where: { $0.isBand }) else { return nil }
+        let text = (document.attributed.string as NSString)
+            .substring(with: line.range)
+            .trimmingCharacters(in: .newlines)
+        return (text, line)
+    }
+
+    func testBandNamesTheRangeItHides() {
+        // Rows 2, 3, 4 stay as context; 5 through 41 fold away.
+        XCTAssertEqual(band(document(DiffExpansion()))?.label, "5–41")
+    }
+
+    func testBandAtTheEndOfTheFileOffersOnlyTheDownwardButton() {
+        let controls = band(document(DiffExpansion()))?.line.bandControls
+        XCTAssertEqual(controls, [.down], "nothing follows the run, so up points nowhere")
+    }
+
+    func testRevealingDownwardShrinksTheBandFromTheTop() {
+        var expansion = DiffExpansion()
+        expansion.reveal(4, .down)
+        XCTAssertEqual(band(document(expansion))?.label, "25–41")
+    }
+
+    func testRevealingUpwardShrinksTheBandFromTheBottom() {
+        var expansion = DiffExpansion()
+        expansion.reveal(4, .up)
+        XCTAssertEqual(band(document(expansion))?.label, "5–21")
+    }
+
+    /// The anchor is the run's *first hidden row*, and revealing from the top moves which
+    /// row that is on screen — but not the key. If the key drifted, a second click would
+    /// start a fresh reveal and the first one would snap shut.
+    func testRevealsAccumulateOnTheSameAnchor() {
+        var expansion = DiffExpansion()
+        expansion.reveal(4, .down)
+        expansion.reveal(4, .down)
+        // 80 context rows: 5–81 folds, and two 20-line steps leave 45–81.
+        XCTAssertEqual(band(document(expansion, context: 80))?.label, "45–81")
+    }
+
+    func testRevealingFromBothEndsMeetsInTheMiddle() {
+        var expansion = DiffExpansion()
+        expansion.reveal(4, .down)
+        expansion.reveal(4, .up)
+        XCTAssertEqual(band(document(expansion, context: 80))?.label, "25–61")
+    }
+
+    /// A run shorter than the reveal steps asked for simply runs out — the band closes
+    /// rather than clamping to an empty range.
+    func testRevealsThatOverrunTheRunCloseTheBand() {
+        var expansion = DiffExpansion()
+        expansion.reveal(4, .down)
+        expansion.reveal(4, .up)
+        XCTAssertNil(band(document(expansion)), "37 hidden lines, 40 revealed")
+    }
+
+    func testRevealingEverythingDropsTheBand() {
+        var expansion = DiffExpansion()
+        expansion.reveal(4, .all)
+        XCTAssertNil(band(document(expansion)), "the band is gone once nothing is hidden")
+        XCTAssertEqual(document(expansion).lines.count, 41)
+    }
+
+    func testShortRunsAreNotFoldedAtAll() {
+        let document = DiffDocument.build(
+            rows: rows(context: 8), expansion: DiffExpansion(), palette: palette,
+            codeFont: .monospacedSystemFont(ofSize: 12, weight: .regular), lineSpacing: 0)
+        XCTAssertFalse(document.lines.contains { $0.isBand })
+    }
+
+    // MARK: Hunk headings
+
+    func testHunkHeadingIsTheSectionAfterTheRanges() {
+        XCTAssertEqual(DiffDocument.hunkHeading("@@ -8,7 +8,7 @@ func reload() {"),
+                       "func reload() {")
+    }
+
+    func testHunkHeadingIsNilWhenGitOffersNone() {
+        XCTAssertNil(DiffDocument.hunkHeading("@@ -8,7 +8,7 @@"))
+        XCTAssertNil(DiffDocument.hunkHeading("@@ -8,7 +8,7 @@   "))
+    }
+
+    /// A heading can itself contain `@@` — an operator, a string, a comment.
+    func testHunkHeadingKeepsAtSignsInsideTheHeading() {
+        XCTAssertEqual(DiffDocument.hunkHeading("@@ -1,2 +1,2 @@ let mark = \"@@\""),
+                       "let mark = \"@@\"")
+    }
+}

--- a/Tests/termioTests/DiffDocumentTests.swift
+++ b/Tests/termioTests/DiffDocumentTests.swift
@@ -1,3 +1,4 @@
+import TermioShared
 import AppKit
 import XCTest
 @testable import termio
@@ -95,18 +96,18 @@ final class DiffDocumentTests: XCTestCase {
     }
 
     func testHunkHeadingIsTheSectionAfterTheRanges() {
-        XCTAssertEqual(GitService.hunkHeading("@@ -8,7 +8,7 @@ func reload() {"),
+        XCTAssertEqual(DiffParser.hunkHeading("@@ -8,7 +8,7 @@ func reload() {"),
                        "func reload() {")
     }
 
     func testHunkHeadingIsNilWhenGitOffersNone() {
-        XCTAssertNil(GitService.hunkHeading("@@ -8,7 +8,7 @@"))
-        XCTAssertNil(GitService.hunkHeading("@@ -8,7 +8,7 @@   "))
+        XCTAssertNil(DiffParser.hunkHeading("@@ -8,7 +8,7 @@"))
+        XCTAssertNil(DiffParser.hunkHeading("@@ -8,7 +8,7 @@   "))
     }
 
     /// A heading can itself contain `@@` — an operator, a string, a comment.
     func testHunkHeadingKeepsAtSignsInsideTheHeading() {
-        XCTAssertEqual(GitService.hunkHeading("@@ -1,2 +1,2 @@ let mark = \"@@\""),
+        XCTAssertEqual(DiffParser.hunkHeading("@@ -1,2 +1,2 @@ let mark = \"@@\""),
                        "let mark = \"@@\"")
     }
 }

--- a/Tests/termioTests/DiffDocumentTests.swift
+++ b/Tests/termioTests/DiffDocumentTests.swift
@@ -91,27 +91,22 @@ final class DiffDocumentTests: XCTestCase {
     }
 
     func testShortRunsAreNotFoldedAtAll() {
-        let document = DiffDocument.build(
-            rows: rows(context: 8), expansion: DiffExpansion(), palette: palette,
-            codeFont: .monospacedSystemFont(ofSize: 12, weight: .regular), lineSpacing: 0)
-        XCTAssertFalse(document.lines.contains { $0.isBand })
+        XCTAssertFalse(document(DiffExpansion(), context: 8).lines.contains { $0.isBand })
     }
 
-    // MARK: Hunk headings
-
     func testHunkHeadingIsTheSectionAfterTheRanges() {
-        XCTAssertEqual(DiffDocument.hunkHeading("@@ -8,7 +8,7 @@ func reload() {"),
+        XCTAssertEqual(GitService.hunkHeading("@@ -8,7 +8,7 @@ func reload() {"),
                        "func reload() {")
     }
 
     func testHunkHeadingIsNilWhenGitOffersNone() {
-        XCTAssertNil(DiffDocument.hunkHeading("@@ -8,7 +8,7 @@"))
-        XCTAssertNil(DiffDocument.hunkHeading("@@ -8,7 +8,7 @@   "))
+        XCTAssertNil(GitService.hunkHeading("@@ -8,7 +8,7 @@"))
+        XCTAssertNil(GitService.hunkHeading("@@ -8,7 +8,7 @@   "))
     }
 
     /// A heading can itself contain `@@` — an operator, a string, a comment.
     func testHunkHeadingKeepsAtSignsInsideTheHeading() {
-        XCTAssertEqual(DiffDocument.hunkHeading("@@ -1,2 +1,2 @@ let mark = \"@@\""),
+        XCTAssertEqual(GitService.hunkHeading("@@ -1,2 +1,2 @@ let mark = \"@@\""),
                        "let mark = \"@@\"")
     }
 }

--- a/Tests/termioTests/DiffIntralineTests.swift
+++ b/Tests/termioTests/DiffIntralineTests.swift
@@ -1,3 +1,4 @@
+import TermioShared
 import XCTest
 @testable import termio
 

--- a/Tests/termioTests/DiffIntralineTests.swift
+++ b/Tests/termioTests/DiffIntralineTests.swift
@@ -47,12 +47,6 @@ final class DiffIntralineTests: XCTestCase {
         XCTAssertEqual(result?.new, ["    "])
     }
 
-    func testPureInsertionLeavesTheOldSideUnmarked() {
-        let result = spans("total = base", "total = base + tax")
-        XCTAssertEqual(result?.old, [])
-        XCTAssertEqual(result?.new, ["+ tax"])
-    }
-
     func testRewrittenLineIsNotMarked() {
         XCTAssertNil(spans("let greeting = \"hello\"",
                            "await database.commit(transaction, retries: 3)"))
@@ -76,18 +70,20 @@ final class DiffIntralineTests: XCTestCase {
         XCTAssertEqual(result?.new, [8..<12])
     }
 
-    /// Past the comparison budget the pair still gets a usable span rather than none.
-    func testOversizedPairFallsBackToOneSpanPerSide() {
+    /// A line with hundreds of tokens must still return promptly, and a wholly rewritten
+    /// one stays unmarked however long it is.
+    func testTokenHeavyPairsStayUnmarked() {
         let old = (0..<400).map { "token\($0)" }.joined(separator: " ")
         let new = (0..<400).map { "value\($0)" }.joined(separator: " ")
-        XCTAssertNil(DiffIntraline.spans(old: old, new: new),
-                     "wholly different lines stay unmarked even on the fallback path")
+        XCTAssertNil(DiffIntraline.spans(old: old, new: new))
+    }
 
-        let sharedTail = " end"
-        let mixedOld = (0..<200).map { "token\($0)" }.joined(separator: " ") + sharedTail
-        let mixedNew = (0..<200).map { "other\($0)" }.joined(separator: " ") + sharedTail
-        // Still nothing to salvage — but the call must return, not hang, on a big pair.
-        XCTAssertNil(DiffIntraline.spans(old: mixedOld, new: mixedNew))
+    /// A token-heavy line that still fits under the length cap: one rename in a hundred
+    /// words must come back as one span, not as everything from the change to the end.
+    func testLongLineMarksOnlyTheRenamedWord() {
+        let old = "config = " + (0..<100).map { "field\($0)" }.joined(separator: ", ")
+        let new = old.replacingOccurrences(of: "field7,", with: "renamed,")
+        XCTAssertEqual(spans(old, new)?.new, ["renamed"])
     }
 
     func testOverlongLinesAreSkipped() {

--- a/Tests/termioTests/DiffIntralineTests.swift
+++ b/Tests/termioTests/DiffIntralineTests.swift
@@ -48,6 +48,22 @@ final class DiffIntralineTests: XCTestCase {
         XCTAssertEqual(result?.new, ["    "])
     }
 
+    /// A long insertion into a short line: the old side survives whole, so it is an edit,
+    /// not a rewrite. Charging the inserted characters against the shorter line's budget
+    /// classified this as a rewrite and dropped the span.
+    func testLongInsertionIntoAShortLineIsStillMarked() {
+        let result = spans("call()", "call(aVeryLongInsertedIdentifier)")
+        XCTAssertEqual(result?.old, [])
+        XCTAssertEqual(result?.new, ["aVeryLongInsertedIdentifier"])
+    }
+
+    /// The mirror case: a long deletion leaving a short line behind.
+    func testLongDeletionLeavingAShortLineIsStillMarked() {
+        let result = spans("call(aVeryLongInsertedIdentifier)", "call()")
+        XCTAssertEqual(result?.old, ["aVeryLongInsertedIdentifier"])
+        XCTAssertEqual(result?.new, [])
+    }
+
     func testRewrittenLineIsNotMarked() {
         XCTAssertNil(spans("let greeting = \"hello\"",
                            "await database.commit(transaction, retries: 3)"))

--- a/Tests/termioTests/DiffIntralineTests.swift
+++ b/Tests/termioTests/DiffIntralineTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import termio
+
+/// The word-level intraline pass, pinned on the cases that motivated it: two edits in one
+/// line must produce two spans (prefix/suffix stripping could only produce one, swallowing
+/// everything between them), spans must not open or close on whitespace, CJK must not
+/// collapse into a single line-long run, and a rewritten line must produce nothing at all.
+final class DiffIntralineTests: XCTestCase {
+    private func spans(_ old: String, _ new: String) -> (old: [String], new: [String])? {
+        guard let result = DiffIntraline.spans(old: old, new: new) else { return nil }
+        func texts(_ ranges: [Range<Int>], in text: String) -> [String] {
+            let characters = Array(text)
+            return ranges.map { String(characters[$0]) }
+        }
+        return (texts(result.old, in: old), texts(result.new, in: new))
+    }
+
+    func testSingleWordEditMarksOnlyThatWord() {
+        let result = spans("let value = compute(input)", "let value = derive(input)")
+        XCTAssertEqual(result?.old, ["compute"])
+        XCTAssertEqual(result?.new, ["derive"])
+    }
+
+    func testTwoSeparateEditsProduceTwoSpans() {
+        let result = spans("foo(alpha, beta)", "bar(alpha, gamma)")
+        XCTAssertEqual(result?.old, ["foo", "beta"])
+        XCTAssertEqual(result?.new, ["bar", "gamma"])
+    }
+
+    func testAdjacentEditsMergeAcrossUnchangedWhitespace() {
+        let result = spans("let a = 1", "var b = 1")
+        XCTAssertEqual(result?.old, ["let a"])
+        XCTAssertEqual(result?.new, ["var b"])
+    }
+
+    func testSpanDoesNotOpenOnWhitespace() {
+        let result = spans("call(one)", "call(one, two)")
+        XCTAssertEqual(result?.old, [])
+        // The inserted text is `, two` — the span starts at the comma, not at the space
+        // that happens to precede `two`.
+        XCTAssertEqual(result?.new, [", two"])
+    }
+
+    func testIndentOnlyChangeKeepsItsWhitespaceSpan() {
+        let result = spans("  return x", "    return x")
+        XCTAssertEqual(result?.old, ["  "])
+        XCTAssertEqual(result?.new, ["    "])
+    }
+
+    func testPureInsertionLeavesTheOldSideUnmarked() {
+        let result = spans("total = base", "total = base + tax")
+        XCTAssertEqual(result?.old, [])
+        XCTAssertEqual(result?.new, ["+ tax"])
+    }
+
+    func testRewrittenLineIsNotMarked() {
+        XCTAssertNil(spans("let greeting = \"hello\"",
+                           "await database.commit(transaction, retries: 3)"))
+    }
+
+    func testIdenticalLinesAreNotMarked() {
+        XCTAssertNil(spans("same", "same"))
+    }
+
+    /// CJK has no intra-word boundaries; tokenizing per ideograph is what keeps a
+    /// one-character edit from marking the whole line.
+    func testCJKMarksOnlyTheChangedCharacters() {
+        let result = spans("会话已断开连接", "会话已恢复连接")
+        XCTAssertEqual(result?.old, ["断开"])
+        XCTAssertEqual(result?.new, ["恢复"])
+    }
+
+    /// Character offsets, not UTF-16 or byte offsets — the document maps them back itself.
+    func testOffsetsAreCharacterOffsets() {
+        let result = DiffIntraline.spans(old: "🎉 party time", new: "🎉 party hard")
+        XCTAssertEqual(result?.new, [8..<12])
+    }
+
+    /// Past the comparison budget the pair still gets a usable span rather than none.
+    func testOversizedPairFallsBackToOneSpanPerSide() {
+        let old = (0..<400).map { "token\($0)" }.joined(separator: " ")
+        let new = (0..<400).map { "value\($0)" }.joined(separator: " ")
+        XCTAssertNil(DiffIntraline.spans(old: old, new: new),
+                     "wholly different lines stay unmarked even on the fallback path")
+
+        let sharedTail = " end"
+        let mixedOld = (0..<200).map { "token\($0)" }.joined(separator: " ") + sharedTail
+        let mixedNew = (0..<200).map { "other\($0)" }.joined(separator: " ") + sharedTail
+        // Still nothing to salvage — but the call must return, not hang, on a big pair.
+        XCTAssertNil(DiffIntraline.spans(old: mixedOld, new: mixedNew))
+    }
+
+    func testOverlongLinesAreSkipped() {
+        let long = String(repeating: "a", count: 2100)
+        XCTAssertNil(DiffIntraline.spans(old: long, new: long + "b"))
+    }
+}

--- a/Tests/termioTests/DiffModelTests.swift
+++ b/Tests/termioTests/DiffModelTests.swift
@@ -74,11 +74,12 @@ final class DiffFoldTests: XCTestCase {
         }
         rows.insert(DiffLine(id: 100, kind: .addition, text: "new", oldLine: nil, newLine: 16), at: 15)
 
-        let items = DiffParser.displayItems(lines: rows, expanded: [])
-        guard case .band(let id, let range, let expandable) = items.first else {
+        let items = DiffParser.displayItems(lines: rows, expansion: DiffExpansion())
+        guard case .band(let id, let range, let controls, _) = items.first else {
             return XCTFail("a 15-line leading run should fold to a band, got \(String(describing: items.first))")
         }
-        XCTAssertTrue(expandable)
+        // Nothing is rendered above the leading band, so it reveals upward only.
+        XCTAssertEqual(controls, [.up])
         // 15 lines, 3 kept facing the change → 12 hidden, keyed by the first of them, and
         // named by the lines they hide rather than counted.
         XCTAssertEqual(range, 1...12)
@@ -94,7 +95,9 @@ final class DiffFoldTests: XCTestCase {
         }
         rows.insert(DiffLine(id: 100, kind: .addition, text: "new", oldLine: nil, newLine: 16), at: 15)
 
-        let items = DiffParser.displayItems(lines: rows, expanded: [0])
+        var expansion = DiffExpansion()
+        expansion.reveal(0, .all)
+        let items = DiffParser.displayItems(lines: rows, expansion: expansion)
         // The leading band is gone; its 12 lines are back, so only the trailing one is left.
         XCTAssertEqual(items.filter { if case .band = $0 { return true } else { return false } }.count, 1)
         guard case .line(let first) = items[0] else { return XCTFail("expanded band should start with a line") }
@@ -107,7 +110,7 @@ final class DiffFoldTests: XCTestCase {
             rows.append(DiffLine(id: i, kind: .context, text: "line \(i)", oldLine: i + 1, newLine: i + 1))
         }
         rows.append(DiffLine(id: 100, kind: .addition, text: "new", oldLine: nil, newLine: 9))
-        let items = DiffParser.displayItems(lines: rows, expanded: [])
+        let items = DiffParser.displayItems(lines: rows, expansion: DiffExpansion())
         XCTAssertEqual(items.count, 9)
         XCTAssertFalse(items.contains { if case .band = $0 { return true } else { return false } })
     }
@@ -124,14 +127,15 @@ final class DiffFoldTests: XCTestCase {
         -forty
         +FORTY
         """
-        let items = DiffParser.displayItems(lines: DiffParser.lines(from: diff), expanded: [])
-        let bands = items.compactMap { item -> (ClosedRange<Int>, Bool)? in
-            if case .band(_, let range, let expandable) = item { return (range, expandable) }
+        let items = DiffParser.displayItems(lines: DiffParser.lines(from: diff),
+                                            expansion: DiffExpansion())
+        let bands = items.compactMap { item -> (ClosedRange<Int>, DiffBandControls)? in
+            if case .band(_, let range, let controls, _) = item { return (range, controls) }
             return nil
         }
         XCTAssertEqual(bands.count, 1)
         XCTAssertEqual(bands.first?.0, 2...39) // the gap between the two hunks
-        XCTAssertEqual(bands.first?.1, false)
+        XCTAssertEqual(bands.first?.1, [], "the hidden lines were never sent, so nothing reveals them")
     }
 }
 
@@ -143,23 +147,23 @@ final class DiffIntralineSpanTests: XCTestCase {
         +let value = newName
         """
         let lines = DiffParser.lines(from: diff)
-        guard let old = lines[1].emphasis, let new = lines[2].emphasis else {
+        guard let old = lines[1].emphasis.first, let new = lines[2].emphasis.first else {
             return XCTFail("a one-word edit should carry an intraline span")
         }
         XCTAssertEqual(String(Array(lines[1].text)[old]), "oldName")
         XCTAssertEqual(String(Array(lines[2].text)[new]), "newName")
     }
 
-    /// The boundary snaps outward to whole words: peeling the shared `alph` prefix
-    /// alone would emphasize a bare `a` / `b` and leave the identifier split.
-    func testSpanSnapsToWordBoundaries() {
+    /// Spans are whole words: a character-level peel of the shared `alph` prefix would
+    /// emphasize a bare `a` / `b` and leave the identifier visually split.
+    func testSpanCoversTheWholeWord() {
         let diff = """
         @@ -1,1 +1,1 @@
         -call(alpha)
         +call(alphb)
         """
         let lines = DiffParser.lines(from: diff)
-        guard let old = lines[1].emphasis else {
+        guard let old = lines[1].emphasis.first else {
             return XCTFail("a near-identical pair should carry a span")
         }
         XCTAssertEqual(String(Array(lines[1].text)[old]), "alpha")
@@ -174,7 +178,7 @@ final class DiffIntralineSpanTests: XCTestCase {
         +print(somethingElseEntirely)
         """
         let lines = DiffParser.lines(from: diff)
-        XCTAssertNil(lines[1].emphasis)
-        XCTAssertNil(lines[2].emphasis)
+        XCTAssertTrue(lines[1].emphasis.isEmpty)
+        XCTAssertTrue(lines[2].emphasis.isEmpty)
     }
 }

--- a/Tests/termioTests/DiffPaletteTests.swift
+++ b/Tests/termioTests/DiffPaletteTests.swift
@@ -9,6 +9,14 @@ import XCTest
 /// step away from the background whether the background is black, white, or something in
 /// between.
 final class DiffPaletteTests: XCTestCase {
+    /// Perceptual distance between two colors — how far a wash sits from its background.
+    private func distance(_ from: Oklab, _ to: Oklab) -> CGFloat {
+        let dl = to.lightness - from.lightness
+        let da = to.a - from.a
+        let db = to.b - from.b
+        return (dl * dl + da * da + db * db).squareRoot()
+    }
+
     private func components(_ color: NSColor) -> (CGFloat, CGFloat, CGFloat) {
         guard let srgb = color.usingColorSpace(.sRGB) else { return (-1, -1, -1) }
         return (srgb.redComponent, srgb.greenComponent, srgb.blueComponent)
@@ -69,18 +77,11 @@ final class DiffPaletteTests: XCTestCase {
             guard let base = Oklab(background),
                   let addition = Oklab(palette.additionWash),
                   let deletion = Oklab(palette.deletionWash) else { return XCTFail("no components") }
-
-            func distance(_ other: Oklab) -> CGFloat {
-                let dl = other.lightness - base.lightness
-                let da = other.a - base.a
-                let db = other.b - base.b
-                return (dl * dl + da * da + db * db).squareRoot()
-            }
-            XCTAssertGreaterThan(distance(addition), 0.02, "addition wash vanished")
-            XCTAssertGreaterThan(distance(deletion), 0.02, "deletion wash vanished")
+            XCTAssertGreaterThan(distance(base, addition), 0.02, "addition wash vanished")
+            XCTAssertGreaterThan(distance(base, deletion), 0.02, "deletion wash vanished")
             // Neither side may read as the louder one — that is what makes a diff
             // lopsided, and it is exactly what a fixed alpha stops guaranteeing.
-            XCTAssertEqual(distance(addition), distance(deletion), accuracy: 0.035,
+            XCTAssertEqual(distance(base, addition), distance(base, deletion), accuracy: 0.035,
                            "add and delete washes are not the same strength")
         }
     }

--- a/Tests/termioTests/DiffPaletteTests.swift
+++ b/Tests/termioTests/DiffPaletteTests.swift
@@ -1,0 +1,97 @@
+import AppKit
+import XCTest
+@testable import termio
+
+/// The diff's tints are mixed in Oklab, which is a pile of magic constants: a single
+/// transposed digit would shift every wash in a way that looks plausible on one theme and
+/// wrong on another. These pin the conversion's round trip and the mix's endpoints, then
+/// check the property the whole approach exists for — that a wash stays a visible, similar
+/// step away from the background whether the background is black, white, or something in
+/// between.
+final class DiffPaletteTests: XCTestCase {
+    private func components(_ color: NSColor) -> (CGFloat, CGFloat, CGFloat) {
+        guard let srgb = color.usingColorSpace(.sRGB) else { return (-1, -1, -1) }
+        return (srgb.redComponent, srgb.greenComponent, srgb.blueComponent)
+    }
+
+    private func assertClose(_ lhs: NSColor, _ rhs: NSColor, accuracy: CGFloat = 0.002,
+                             file: StaticString = #filePath, line: UInt = #line) {
+        let a = components(lhs), b = components(rhs)
+        XCTAssertEqual(a.0, b.0, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(a.1, b.1, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(a.2, b.2, accuracy: accuracy, file: file, line: line)
+    }
+
+    func testOklabRoundTripsSRGB() {
+        let samples: [NSColor] = [
+            .init(srgbRed: 0, green: 0, blue: 0, alpha: 1),
+            .init(srgbRed: 1, green: 1, blue: 1, alpha: 1),
+            .init(srgbRed: 0.5, green: 0.5, blue: 0.5, alpha: 1),
+            .init(srgbRed: 0.051, green: 0.745, blue: 0.306, alpha: 1),
+            .init(srgbRed: 1, green: 0.18, blue: 0.247, alpha: 1),
+            .init(srgbRed: 0.11, green: 0.13, blue: 0.18, alpha: 1),
+        ]
+        for sample in samples {
+            guard let oklab = Oklab(sample) else { return XCTFail("no sRGB components") }
+            assertClose(oklab.color, sample)
+        }
+    }
+
+    func testMixEndpointsAreTheInputs() {
+        let background = NSColor(srgbRed: 0.12, green: 0.12, blue: 0.14, alpha: 1)
+        let tint = NSColor(srgbRed: 0.369, green: 0.8, blue: 0.443, alpha: 1)
+        assertClose(DiffPalette.mix(background, tint, 0), background)
+        assertClose(DiffPalette.mix(background, tint, 1), tint)
+    }
+
+    func testMixIsMonotonicInLightness() {
+        let background = NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 1)
+        let tint = NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 1)
+        let steps = stride(from: CGFloat(0), through: 1, by: 0.1).map {
+            Oklab(DiffPalette.mix(background, tint, $0))?.lightness ?? -1
+        }
+        for (lower, higher) in zip(steps, steps.dropFirst()) {
+            XCTAssertLessThan(lower, higher)
+        }
+    }
+
+    /// The failure this replaced: one alpha over any background. On near-black, an sRGB
+    /// alpha wash all but vanishes; the mix has to stay a real step away on both extremes.
+    func testWashIsVisibleOnAnyBackground() {
+        let backgrounds: [(NSColor, Bool)] = [
+            (NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 1), true),
+            (NSColor(srgbRed: 0.11, green: 0.12, blue: 0.15, alpha: 1), true),
+            (NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 1), false),
+            (NSColor(srgbRed: 0.98, green: 0.97, blue: 0.94, alpha: 1), false),
+        ]
+        for (background, isDark) in backgrounds {
+            let palette = DiffPalette(background: background, isDark: isDark)
+            guard let base = Oklab(background),
+                  let addition = Oklab(palette.additionWash),
+                  let deletion = Oklab(palette.deletionWash) else { return XCTFail("no components") }
+
+            func distance(_ other: Oklab) -> CGFloat {
+                let dl = other.lightness - base.lightness
+                let da = other.a - base.a
+                let db = other.b - base.b
+                return (dl * dl + da * da + db * db).squareRoot()
+            }
+            XCTAssertGreaterThan(distance(addition), 0.02, "addition wash vanished")
+            XCTAssertGreaterThan(distance(deletion), 0.02, "deletion wash vanished")
+            // Neither side may read as the louder one — that is what makes a diff
+            // lopsided, and it is exactly what a fixed alpha stops guaranteeing.
+            XCTAssertEqual(distance(addition), distance(deletion), accuracy: 0.035,
+                           "add and delete washes are not the same strength")
+        }
+    }
+
+    func testEmphasisIsStrongerThanTheWashItSitsOn() {
+        let background = NSColor(srgbRed: 0.11, green: 0.12, blue: 0.15, alpha: 1)
+        let palette = DiffPalette(background: background, isDark: true)
+        guard let base = Oklab(background),
+              let wash = Oklab(palette.additionWash),
+              let emphasis = Oklab(palette.additionEmphasis) else { return XCTFail("no components") }
+        XCTAssertGreaterThan(abs(emphasis.lightness - base.lightness),
+                             abs(wash.lightness - base.lightness))
+    }
+}

--- a/ios/Sources/DiffViewController.swift
+++ b/ios/Sources/DiffViewController.swift
@@ -31,7 +31,7 @@ final class DiffViewController: UIViewController {
     var onSendToAgent: ((String) -> Void)?
 
     private var rows: [DiffLine] = []
-    private var expanded: Set<Int> = []
+    private var expansion = DiffExpansion()
     /// The path a `readDiff` is in flight for, so a late reply for the previous file
     /// can't paint over the current one.
     private var pendingPath: String?
@@ -227,7 +227,7 @@ final class DiffViewController: UIViewController {
     private func reloadFile() {
         guard let change else { return }
         rows = []
-        expanded = []
+        expansion = DiffExpansion()
         textView.document = nil
         storage.setAttributedString(NSAttributedString())
         titleLabel.text = change.name
@@ -286,7 +286,7 @@ final class DiffViewController: UIViewController {
     /// first revealed line stays where the band was, so expanding never teleports the
     /// reader. nil rebuilds from the top.
     private func rebuild(anchor: (rowId: Int, y: CGFloat)? = nil) {
-        let items = DiffParser.displayItems(lines: rows, expanded: expanded)
+        let items = DiffParser.displayItems(lines: rows, expansion: expansion)
         let built = DiffDocument.build(items: items, font: MobileSettings.shared.codeFont())
         textView.document = built
         storage.setAttributedString(built.attributed)
@@ -357,7 +357,9 @@ final class DiffViewController: UIViewController {
             return
         }
         let anchorY = textView.rect(forParagraph: line).minY - textView.contentOffset.y
-        expanded.insert(line.rowId)
+        // One tap reveals the whole gap — a phone has no room for a per-direction control,
+        // so the row is the button and `.all` is the only reveal it asks for.
+        expansion.reveal(line.rowId, .all)
         rebuild(anchor: (line.rowId, anchorY))
     }
 
@@ -478,10 +480,14 @@ final class DiffDocument {
                     number: row.kind == .deletion ? row.oldLine : row.newLine
                 ))
                 location += length
-            case .band(let id, let range, let expandable):
+            case .band(let id, let range, let controls, let heading):
                 // The range names the code the fold hides, against the same numbers the
-                // gutter shows. A count would only describe the fold itself.
-                let label = "\(range.lowerBound)–\(range.upperBound)"
+                // gutter shows. A count would only describe the fold itself. git's section
+                // heading rides along when the gap came from a hunk boundary — on a phone
+                // it is the only hint of what scope you are skipping over.
+                let expandable = !controls.isEmpty
+                let rangeLabel = "\(range.lowerBound)–\(range.upperBound)"
+                let label = heading.map { "\(rangeLabel)  \($0)" } ?? rangeLabel
                 text += label
                 text += "\n"
                 let length = (label as NSString).length + 1
@@ -514,7 +520,8 @@ final class DiffDocument {
         attributed.beginEditing()
         for (item, line) in zip(items, lines) {
             switch item {
-            case .band(_, _, let expandable):
+            case .band(_, _, let controls, _):
+                let expandable = !controls.isEmpty
                 attributed.addAttributes([
                     .font: UIFont.roundedCounter(size: 11, weight: .medium),
                     // A fixed band is inert (its lines were never fetched), so it sits a
@@ -532,15 +539,19 @@ final class DiffDocument {
                     return style
                 }()
                 attributed.addAttribute(.paragraphStyle, value: style, range: line.range)
-                guard let emphasis = row.emphasis, !emphasis.isEmpty,
-                      let range = utf16Range(of: emphasis, in: row.text) else { continue }
+                guard !row.emphasis.isEmpty else { continue }
                 let color: UIColor = row.kind == .addition
                     ? UIColor.systemGreen.withAlphaComponent(0.3)
                     : UIColor.systemRed.withAlphaComponent(0.3)
-                attributed.addAttribute(
-                    .backgroundColor, value: color,
-                    range: NSRange(location: line.range.location + range.location, length: range.length)
-                )
+                // A line with two separate edits carries two spans.
+                for span in row.emphasis {
+                    guard !span.isEmpty, let range = utf16Range(of: span, in: row.text) else { continue }
+                    attributed.addAttribute(
+                        .backgroundColor, value: color,
+                        range: NSRange(location: line.range.location + range.location,
+                                       length: range.length)
+                    )
+                }
             }
         }
         attributed.endEditing()


### PR DESCRIPTION
Three changes to how the diff pane reads, taken from github.com's review surface and Pierre's [`@pierre/diffs`](https://diffs.com).

### Washes are mixed, not composited

`NSColor.systemGreen.withAlphaComponent(0.13)` over `settings.terminalBackgroundColor` drifts in hue and strength with whatever background is configured, so the add and delete sides stop being equally legible from theme to theme. `DiffPalette` mixes a fixed fraction of the base color *into* the real background in Oklab instead, with bases picked per appearance and a stronger mix in dark mode. CSS's `color-mix(in lab, …)` is the same idea; Pierre uses `lab` only because Cursor and VS Code ship a Chrome with an `oklch` bug, which does not apply to AppKit.

A changed row's gutter now takes a stronger mix than its body — github.com anchors its number cell the same way — and the digits stay in the shared muted ink.

### Collapsed runs get reveal buttons

The band's gutter becomes a filled cell holding one button per available direction: an arrow over a dotted line, the dots standing for the hidden lines and the arrow for the direction they come from. Each reveals 20 lines from that end; clicking the row itself still expands the whole gap. A run with no code above it offers no downward button, and likewise upward.

The band also names the range it hides — `128–264`, plus git's section heading where the run came from a hunk boundary — instead of counting itself. "137 unchanged lines" describes the widget; a line range describes the code.

Two deliberate departures from github.com: the band stays neutral grey rather than blue, and the buttons sit side by side in a single-height row. github.com's double-height expander exists to fit two 16pt icons; a row here is barely taller than its text.

### Intraline emphasis is a word diff

`emphasisRanges` peeled a common prefix and suffix off a modified line pair, so `foo(alpha, beta)` → `bar(alpha, gamma)` had no common middle to strip and had to emphasize everything between the first and last change. `DiffIntraline` word-diffs the pair and marks both edits, leaving `(alpha, ` alone. Spans merge across unchanged whitespace, never open or close on whitespace unless whitespace *is* the change, and `DiffRow.emphasis` widens from `Range<Int>?` to `[Range<Int>]`.

### Tests

24 new tests across three files, all pure logic: the Oklab round trip and the mix's endpoints, that a wash stays a visible and evenly matched step from black, white, and both a dark and a light theme background; the fold's ranges, reveal accumulation on a shrinking band, and hunk-heading parsing; and the word diff's two-span, whitespace, CJK, and rewrite-bail cases. `swift test` is at 92 passing.

### Not verified on screen

I could not capture the window myself — this machine's `screencapture` returns `could not create image from display`, so Screen Recording permission is missing for the host. `swift build` and `swift test` pass and the dev app is built and running from this worktree, but the visual result has not been reviewed. Worth a look before merge.

Release Notes:
- Diff add/delete tints now mix into the terminal background instead of layering over it, so both sides stay evenly legible on any theme.
- Collapsed regions in a diff can be revealed 20 lines at a time from either end, and name the line range they hide.
- A modified line with two separate edits now highlights both, instead of everything between them.