### PR TITLE
Show the Mac's real changes and diff on the phone

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,6 +80,9 @@ let package = Package(
             name: "termioTests",
             dependencies: [
                 "termio",
+                // The shared diff model the iOS reader parses with — pure logic,
+                // so it is tested here rather than in an Xcode-only test bundle.
+                .product(name: "TermioShared", package: "Shared"),
             ],
             path: "Tests/termioTests",
             swiftSettings: [

--- a/Shared/Sources/TermioShared/DiffModel.swift
+++ b/Shared/Sources/TermioShared/DiffModel.swift
@@ -55,13 +55,12 @@ public enum DiffParser {
         var id = 0
         var oldNo = 0
         var newNo = 0
-        for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {
-            let line = String(raw)
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
             if line.hasPrefix("@@") {
                 if let (o, n) = parseHunkHeader(line) { oldNo = o; newNo = n }
                 // Hunk rows carry their start numbers so a renderer can size the gap to
                 // the previous hunk when it draws the boundary as a band.
-                rows.append(DiffLine(id: id, kind: .hunk, text: line, oldLine: oldNo, newLine: newNo))
+                rows.append(DiffLine(id: id, kind: .hunk, text: String(line), oldLine: oldNo, newLine: newNo))
                 id += 1
                 continue
             }
@@ -107,15 +106,17 @@ public enum DiffParser {
                 return
             }
             items += run.prefix(head).map(DiffItem.line)
-            let hiddenRows = Array(run.dropFirst(head).dropLast(tail))
-            if expanded.contains(hiddenRows[0].id) {
+            // A slice, not a copy: a folded run can be thousands of lines, and the
+            // collapsed case only reads its two ends.
+            let hiddenRows = run[head..<(run.count - tail)]
+            guard let firstHidden = hiddenRows.first, let lastHidden = hiddenRows.last else { return }
+            if expanded.contains(firstHidden.id) {
                 items += hiddenRows.map(DiffItem.line)
             } else {
-                let first = hiddenRows[0].newLine ?? hiddenRows[0].oldLine ?? 0
-                let last = hiddenRows[hiddenRows.count - 1].newLine
-                    ?? hiddenRows[hiddenRows.count - 1].oldLine ?? first
+                let first = firstHidden.newLine ?? firstHidden.oldLine ?? 0
+                let last = lastHidden.newLine ?? lastHidden.oldLine ?? first
                 items.append(.band(
-                    id: hiddenRows[0].id, lines: first...max(first, last), expandable: true
+                    id: firstHidden.id, lines: first...max(first, last), expandable: true
                 ))
             }
             items += run.suffix(tail).map(DiffItem.line)
@@ -207,17 +208,19 @@ public enum DiffParser {
 
     // MARK: Line scanning
 
-    private static func isFileHeader(_ line: String) -> Bool {
-        for prefix in ["diff ", "index ", "--- ", "+++ ", "new file", "deleted file",
-                       "old mode", "new mode", "similarity ", "dissimilarity ",
-                       "rename ", "copy ", "\\ "] where line.hasPrefix(prefix) {
-            return true
-        }
-        return false
+    /// git's plumbing lines, which carry no code and no line numbers.
+    private static let fileHeaderPrefixes = [
+        "diff ", "index ", "--- ", "+++ ", "new file", "deleted file",
+        "old mode", "new mode", "similarity ", "dissimilarity ",
+        "rename ", "copy ", "\\ ",
+    ]
+
+    private static func isFileHeader(_ line: Substring) -> Bool {
+        fileHeaderPrefixes.contains(where: line.hasPrefix)
     }
 
     /// Pulls the starting old and new line numbers out of `@@ -a,b +c,d @@`.
-    private static func parseHunkHeader(_ line: String) -> (Int, Int)? {
+    private static func parseHunkHeader(_ line: Substring) -> (Int, Int)? {
         let parts = line.split(separator: " ")
         guard parts.count >= 3 else { return nil }
         func start(_ s: Substring) -> Int? {

--- a/Shared/Sources/TermioShared/DiffModel.swift
+++ b/Shared/Sources/TermioShared/DiffModel.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+// MARK: - Unified diff model
+
+/// One line of a parsed unified diff. `text` is the line *without* its `+`/`-`/space
+/// marker, so a renderer can style the marker itself (or draw it outside the text, the
+/// way both the desktop gutter and the phone's edge bar do) instead of baking it in.
+public struct DiffLine: Identifiable, Sendable, Equatable {
+    public enum Kind: Sendable, Equatable { case addition, deletion, context, hunk }
+
+    public let id: Int
+    public let kind: Kind
+    public let text: String
+    public let oldLine: Int?
+    public let newLine: Int?
+    /// The changed span within a paired deletion/addition line, in `Character`
+    /// offsets — rendered with a stronger tint so a one-word edit inside a long line
+    /// reads at a glance. `nil` when the line has no counterpart, or the two sides
+    /// share too little for a span to mean anything.
+    public var emphasis: Range<Int>?
+
+    public init(
+        id: Int, kind: Kind, text: String, oldLine: Int?, newLine: Int?,
+        emphasis: Range<Int>? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.text = text
+        self.oldLine = oldLine
+        self.newLine = newLine
+        self.emphasis = emphasis
+    }
+}
+
+/// What a renderer actually lays out: a code line, or a band standing in for a run of
+/// unchanged lines that is folded away.
+public enum DiffItem: Sendable, Equatable {
+    case line(DiffLine)
+    /// `expandable` bands (full-context diffs) hold their hidden lines and splice them
+    /// back in when tapped; fixed bands (a 3-line-context diff, where the hidden lines
+    /// were never fetched) only mark the gap.
+    case band(id: Int, count: Int, expandable: Bool)
+}
+
+/// Parsing and folding unified-diff text, kept free of any UI framework so both ends
+/// share one reading of a diff. The desktop renders through its own AppKit document
+/// today; this is the model the iOS diff view is built on.
+public enum DiffParser {
+    /// Parses unified-diff text into lines, tracking old/new line numbers from each
+    /// hunk header and dropping the file-header plumbing (`diff --git`, `+++`, …).
+    public static func lines(from text: String) -> [DiffLine] {
+        var rows: [DiffLine] = []
+        var id = 0
+        var oldNo = 0
+        var newNo = 0
+        for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(raw)
+            if line.hasPrefix("@@") {
+                if let (o, n) = parseHunkHeader(line) { oldNo = o; newNo = n }
+                // Hunk rows carry their start numbers so a renderer can size the gap to
+                // the previous hunk when it draws the boundary as a band.
+                rows.append(DiffLine(id: id, kind: .hunk, text: line, oldLine: oldNo, newLine: newNo))
+                id += 1
+                continue
+            }
+            if isFileHeader(line) { continue }
+            guard let first = line.first else { continue }
+            let body = String(line.dropFirst())
+            switch first {
+            case "+":
+                rows.append(DiffLine(id: id, kind: .addition, text: body, oldLine: nil, newLine: newNo))
+                id += 1; newNo += 1
+            case "-":
+                rows.append(DiffLine(id: id, kind: .deletion, text: body, oldLine: oldNo, newLine: nil))
+                id += 1; oldNo += 1
+            case " ":
+                rows.append(DiffLine(id: id, kind: .context, text: body, oldLine: oldNo, newLine: newNo))
+                id += 1; oldNo += 1; newNo += 1
+            default:
+                continue
+            }
+        }
+        applyIntraline(&rows)
+        return rows
+    }
+
+    /// Folds parsed lines into the display list: hunk plumbing disappears (its gap
+    /// becomes a band), unchanged runs longer than a handful of lines collapse to a
+    /// band keeping 3 lines of context on the side(s) facing a change, and ids in
+    /// `expanded` splice their hidden lines back in.
+    public static func displayItems(lines rows: [DiffLine], expanded: Set<Int>) -> [DiffItem] {
+        var items: [DiffItem] = []
+        var run: [DiffLine] = []
+        var sawChange = false
+        var lastNewLine = 0
+
+        func flush(isLast: Bool) {
+            defer { run = [] }
+            guard !run.isEmpty else { return }
+            let head = sawChange ? 3 : 0
+            let tail = isLast ? 0 : 3
+            let hidden = run.count - head - tail
+            guard hidden >= 10 else {
+                items += run.map(DiffItem.line)
+                return
+            }
+            items += run.prefix(head).map(DiffItem.line)
+            let hiddenRows = Array(run.dropFirst(head).dropLast(tail))
+            if expanded.contains(hiddenRows[0].id) {
+                items += hiddenRows.map(DiffItem.line)
+            } else {
+                items.append(.band(id: hiddenRows[0].id, count: hiddenRows.count, expandable: true))
+            }
+            items += run.suffix(tail).map(DiffItem.line)
+        }
+
+        for row in rows {
+            switch row.kind {
+            case .hunk:
+                flush(isLast: false)
+                if let start = row.newLine, start > lastNewLine + 1 {
+                    items.append(.band(id: row.id, count: start - lastNewLine - 1, expandable: false))
+                }
+            case .context:
+                run.append(row)
+                lastNewLine = row.newLine ?? lastNewLine
+            case .addition:
+                flush(isLast: false)
+                sawChange = true
+                items.append(.line(row))
+                lastNewLine = row.newLine ?? lastNewLine
+            case .deletion:
+                flush(isLast: false)
+                sawChange = true
+                items.append(.line(row))
+            }
+        }
+        flush(isLast: true)
+        return items
+    }
+
+    // MARK: Intraline
+
+    /// Marks the changed span inside modified lines: within each run, a block of
+    /// deletions immediately followed by a block of additions is paired index-wise, and
+    /// each pair gets its common prefix/suffix stripped to leave the span that changed.
+    private static func applyIntraline(_ rows: inout [DiffLine]) {
+        var i = 0
+        while i < rows.count {
+            guard rows[i].kind == .deletion else { i += 1; continue }
+            let delStart = i
+            while i < rows.count, rows[i].kind == .deletion { i += 1 }
+            let addStart = i
+            while i < rows.count, rows[i].kind == .addition { i += 1 }
+            for k in 0..<min(addStart - delStart, i - addStart) {
+                guard let (old, new) = emphasisRanges(rows[delStart + k].text, rows[addStart + k].text)
+                else { continue }
+                rows[delStart + k].emphasis = old
+                rows[addStart + k].emphasis = new
+            }
+        }
+    }
+
+    /// The changed spans of a deletion/addition pair: the common prefix and suffix are
+    /// peeled off, then the boundaries snap outward to whole words so renaming
+    /// `newValue` → `oldValue` highlights the identifiers, not a `ldValue` tail. `nil`
+    /// when the sides share under a fifth of the shorter line — a rewrite, where
+    /// span-highlighting the whole line would just be noise.
+    private static func emphasisRanges(_ oldText: String, _ newText: String) -> (Range<Int>, Range<Int>)? {
+        guard oldText != newText, oldText.count <= 2000, newText.count <= 2000 else { return nil }
+        let o = Array(oldText), n = Array(newText)
+        var prefix = 0
+        while prefix < o.count, prefix < n.count, o[prefix] == n[prefix] { prefix += 1 }
+        var suffix = 0
+        while suffix < o.count - prefix, suffix < n.count - prefix,
+              o[o.count - 1 - suffix] == n[n.count - 1 - suffix] { suffix += 1 }
+        guard (prefix + suffix) * 5 >= min(o.count, n.count) else { return nil }
+
+        // CJK scripts have no intra-word boundaries, so snapping there would swallow the
+        // whole run — every ideograph/kana counts as its own boundary instead.
+        func isWord(_ c: Character) -> Bool {
+            guard c.isLetter || c.isNumber || c == "_" else { return false }
+            guard let scalar = c.unicodeScalars.first else { return false }
+            return scalar.value < 0x2E80
+        }
+        while prefix > 0, isWord(o[prefix - 1]),
+              (prefix < o.count - suffix && isWord(o[prefix]))
+                || (prefix < n.count - suffix && isWord(n[prefix])) {
+            prefix -= 1
+        }
+        while suffix > 0, isWord(o[o.count - suffix]),
+              (o.count - suffix > prefix && isWord(o[o.count - suffix - 1]))
+                || (n.count - suffix > prefix && isWord(n[n.count - suffix - 1])) {
+            suffix -= 1
+        }
+        return (prefix..<(o.count - suffix), prefix..<(n.count - suffix))
+    }
+
+    // MARK: Line scanning
+
+    private static func isFileHeader(_ line: String) -> Bool {
+        for prefix in ["diff ", "index ", "--- ", "+++ ", "new file", "deleted file",
+                       "old mode", "new mode", "similarity ", "dissimilarity ",
+                       "rename ", "copy ", "\\ "] where line.hasPrefix(prefix) {
+            return true
+        }
+        return false
+    }
+
+    /// Pulls the starting old and new line numbers out of `@@ -a,b +c,d @@`.
+    private static func parseHunkHeader(_ line: String) -> (Int, Int)? {
+        let parts = line.split(separator: " ")
+        guard parts.count >= 3 else { return nil }
+        func start(_ s: Substring) -> Int? {
+            Int(s.dropFirst().split(separator: ",").first ?? s.dropFirst())
+        }
+        guard let o = start(parts[1]), let n = start(parts[2]) else { return nil }
+        return (o, n)
+    }
+}

--- a/Shared/Sources/TermioShared/DiffModel.swift
+++ b/Shared/Sources/TermioShared/DiffModel.swift
@@ -36,10 +36,12 @@ public struct DiffLine: Identifiable, Sendable, Equatable {
 /// unchanged lines that is folded away.
 public enum DiffItem: Sendable, Equatable {
     case line(DiffLine)
-    /// `expandable` bands (full-context diffs) hold their hidden lines and splice them
-    /// back in when tapped; fixed bands (a 3-line-context diff, where the hidden lines
-    /// were never fetched) only mark the gap.
-    case band(id: Int, count: Int, expandable: Bool)
+    /// A folded run, named by the line range it hides (new-side numbers, so it reads
+    /// against the gutter) — "227–348" says where you are; a count would only describe
+    /// the fold. `expandable` bands (full-context diffs) hold their hidden lines and
+    /// splice them back in when tapped; fixed bands (a 3-line-context diff, where the
+    /// hidden lines were never fetched) only mark the gap.
+    case band(id: Int, lines: ClosedRange<Int>, expandable: Bool)
 }
 
 /// Parsing and folding unified-diff text, kept free of any UI framework so both ends
@@ -109,7 +111,12 @@ public enum DiffParser {
             if expanded.contains(hiddenRows[0].id) {
                 items += hiddenRows.map(DiffItem.line)
             } else {
-                items.append(.band(id: hiddenRows[0].id, count: hiddenRows.count, expandable: true))
+                let first = hiddenRows[0].newLine ?? hiddenRows[0].oldLine ?? 0
+                let last = hiddenRows[hiddenRows.count - 1].newLine
+                    ?? hiddenRows[hiddenRows.count - 1].oldLine ?? first
+                items.append(.band(
+                    id: hiddenRows[0].id, lines: first...max(first, last), expandable: true
+                ))
             }
             items += run.suffix(tail).map(DiffItem.line)
         }
@@ -119,7 +126,9 @@ public enum DiffParser {
             case .hunk:
                 flush(isLast: false)
                 if let start = row.newLine, start > lastNewLine + 1 {
-                    items.append(.band(id: row.id, count: start - lastNewLine - 1, expandable: false))
+                    items.append(.band(
+                        id: row.id, lines: (lastNewLine + 1)...(start - 1), expandable: false
+                    ))
                 }
             case .context:
                 run.append(row)

--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -90,6 +90,18 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     /// `truncated` marks that more matched than the returned batch. `query`
     /// echoes the request so a stale reply for an old keystroke is discardable.
     case searchResults(query: String, paths: [String], truncated: Bool)
+    /// The client asks for the project's working-tree changes — the phone's
+    /// Changes pane, the same `git status` the desktop git pane lists. Answered
+    /// with `.changes` (empty when the project isn't a git work tree).
+    case listChanges(projectID: String)
+    /// The working-tree changes (server → client), repo-relative and already
+    /// carrying their `+`/`−` counts so the list needs no second round trip.
+    case changes(files: [WireChange])
+    /// The client asks for one changed file's unified diff. Answered with
+    /// `.diff` or `.error`.
+    case readDiff(projectID: String, path: String)
+    /// One file's unified diff (server → client).
+    case diff(WireDiff)
     /// The server rejected a request (unknown session, no live PTY).
     /// Phone → Mac: render this session's agent transcript as an HTML trace
     /// (the same dashboard-over-conversation the desktop Info pane shows). The
@@ -174,6 +186,26 @@ public enum CompanionControl: Codable, Sendable, Equatable {
         case .searchResults(let query, let paths, let truncated):
             return Self.json([
                 "t": "searchResults", "query": query, "paths": paths, "truncated": truncated,
+            ])
+        case .listChanges(let projectID):
+            return Self.json(["t": "listChanges", "project": projectID])
+        case .changes(let files):
+            return Self.json([
+                "t": "changes",
+                "files": files.map {
+                    [
+                        "path": $0.path, "status": $0.status,
+                        "add": $0.additions, "del": $0.deletions,
+                        "binary": $0.isBinary, "staged": $0.isStaged,
+                    ]
+                },
+            ])
+        case .readDiff(let projectID, let path):
+            return Self.json(["t": "readDiff", "project": projectID, "path": path])
+        case .diff(let diff):
+            return Self.json([
+                "t": "diff", "path": diff.path, "text": diff.text,
+                "full": diff.fullContext, "binary": diff.binary,
             ])
         case .trace(let sessionID, let dark):
             return Self.json(["t": "trace", "session": sessionID, "dark": dark])
@@ -296,6 +328,34 @@ public enum CompanionControl: Codable, Sendable, Equatable {
                 query: query, paths: paths,
                 truncated: obj["truncated"] as? Bool ?? false
             )
+        case "listChanges":
+            guard let projectID = obj["project"] as? String else { return nil }
+            return .listChanges(projectID: projectID)
+        case "changes":
+            let raw = obj["files"] as? [[String: Any]] ?? []
+            return .changes(files: raw.compactMap { entry in
+                guard let path = entry["path"] as? String else { return nil }
+                return WireChange(
+                    path: path,
+                    status: entry["status"] as? String ?? "M",
+                    additions: entry["add"] as? Int ?? 0,
+                    deletions: entry["del"] as? Int ?? 0,
+                    isBinary: entry["binary"] as? Bool ?? false,
+                    isStaged: entry["staged"] as? Bool ?? false
+                )
+            })
+        case "readDiff":
+            guard let projectID = obj["project"] as? String,
+                  let path = obj["path"] as? String else { return nil }
+            return .readDiff(projectID: projectID, path: path)
+        case "diff":
+            guard let path = obj["path"] as? String,
+                  let text = obj["text"] as? String else { return nil }
+            return .diff(WireDiff(
+                path: path, text: text,
+                fullContext: obj["full"] as? Bool ?? false,
+                binary: obj["binary"] as? Bool ?? false
+            ))
         case "trace":
             guard let sessionID = obj["session"] as? String else { return nil }
             return .trace(sessionID: sessionID, dark: obj["dark"] as? Bool ?? false)
@@ -344,6 +404,57 @@ public struct WireFileEntry: Codable, Sendable, Equatable {
         self.name = name
         self.isDir = isDir
         self.changed = changed
+    }
+}
+
+// MARK: - Changes (git working tree)
+
+/// One changed file in the Mac's working tree, as the phone's Changes pane shows it:
+/// the repo-relative path, git's status letter, and the line counts. Deliberately
+/// flatter than the desktop's `GitChange` — the phone lists and diffs, it never stages.
+public struct WireChange: Codable, Sendable, Equatable {
+    public let path: String
+    /// git's status letter, the desktop's own vocabulary: `M`odified, `A`dded,
+    /// `D`eleted, `R`enamed, `C`opied, `U`ntracked, `!` conflicted.
+    public let status: String
+    public let additions: Int
+    public let deletions: Int
+    /// `--numstat` reported `-` for the counts, so `+`/`−` would be a lie.
+    public let isBinary: Bool
+    /// The change sits entirely in the index — what `git commit` would take now.
+    public let isStaged: Bool
+
+    public init(
+        path: String, status: String, additions: Int, deletions: Int,
+        isBinary: Bool = false, isStaged: Bool = false
+    ) {
+        self.path = path
+        self.status = status
+        self.additions = additions
+        self.deletions = deletions
+        self.isBinary = isBinary
+        self.isStaged = isStaged
+    }
+}
+
+/// A `readDiff` reply: one file's unified diff as text, parsed on the phone with
+/// `DiffParser`. `fullContext` marks a diff fetched with the whole file as context —
+/// the phone can then fold unchanged runs into bands the reader *expands*. Without it
+/// (a huge file, refetched at git's default 3-line context) the gaps between hunks are
+/// fixed markers, since the hidden lines were never sent.
+public struct WireDiff: Codable, Sendable, Equatable {
+    public let path: String
+    public let text: String
+    public let fullContext: Bool
+    /// Binary content: `text` is empty and the reader says so rather than
+    /// rendering git's "Binary files differ" line as if it were code.
+    public let binary: Bool
+
+    public init(path: String, text: String, fullContext: Bool, binary: Bool = false) {
+        self.path = path
+        self.text = text
+        self.fullContext = fullContext
+        self.binary = binary
     }
 }
 

--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -97,9 +97,11 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     /// The working-tree changes (server → client), repo-relative and already
     /// carrying their `+`/`−` counts so the list needs no second round trip.
     case changes(files: [WireChange])
-    /// The client asks for one changed file's unified diff. Answered with
-    /// `.diff` or `.error`.
-    case readDiff(projectID: String, path: String)
+    /// The client asks for one changed file's unified diff, echoing the status letter
+    /// it already holds from `.changes` — an untracked file diffs against nothing, and
+    /// re-deriving that on the Mac would mean a second `git status` walk of the repo per
+    /// tap. Answered with `.diff` or `.error`.
+    case readDiff(projectID: String, path: String, status: String)
     /// One file's unified diff (server → client).
     case diff(WireDiff)
     /// The server rejected a request (unknown session, no live PTY).
@@ -200,12 +202,13 @@ public enum CompanionControl: Codable, Sendable, Equatable {
                     ]
                 },
             ])
-        case .readDiff(let projectID, let path):
-            return Self.json(["t": "readDiff", "project": projectID, "path": path])
+        case .readDiff(let projectID, let path, let status):
+            return Self.json([
+                "t": "readDiff", "project": projectID, "path": path, "status": status,
+            ])
         case .diff(let diff):
             return Self.json([
-                "t": "diff", "path": diff.path, "text": diff.text,
-                "full": diff.fullContext, "binary": diff.binary,
+                "t": "diff", "path": diff.path, "text": diff.text, "binary": diff.binary,
             ])
         case .trace(let sessionID, let dark):
             return Self.json(["t": "trace", "session": sessionID, "dark": dark])
@@ -347,13 +350,15 @@ public enum CompanionControl: Codable, Sendable, Equatable {
         case "readDiff":
             guard let projectID = obj["project"] as? String,
                   let path = obj["path"] as? String else { return nil }
-            return .readDiff(projectID: projectID, path: path)
+            return .readDiff(
+                projectID: projectID, path: path,
+                status: obj["status"] as? String ?? "M"
+            )
         case "diff":
             guard let path = obj["path"] as? String,
                   let text = obj["text"] as? String else { return nil }
             return .diff(WireDiff(
                 path: path, text: text,
-                fullContext: obj["full"] as? Bool ?? false,
                 binary: obj["binary"] as? Bool ?? false
             ))
         case "trace":
@@ -437,23 +442,34 @@ public struct WireChange: Codable, Sendable, Equatable {
     }
 }
 
+extension WireChange {
+    /// The one-line caption both the Changes row and the diff reader's header show:
+    /// where the file lives and what it gained and lost.
+    public var caption: String {
+        let directory = (path as NSString).deletingLastPathComponent
+        var parts: [String] = directory.isEmpty ? [] : [directory]
+        parts.append(isBinary ? "binary" : "+\(additions) −\(deletions)")
+        if isStaged { parts.append("staged") }
+        return parts.joined(separator: " · ")
+    }
+
+    public var name: String { (path as NSString).lastPathComponent }
+}
+
 /// A `readDiff` reply: one file's unified diff as text, parsed on the phone with
-/// `DiffParser`. `fullContext` marks a diff fetched with the whole file as context —
-/// the phone can then fold unchanged runs into bands the reader *expands*. Without it
-/// (a huge file, refetched at git's default 3-line context) the gaps between hunks are
-/// fixed markers, since the hidden lines were never sent.
+/// `DiffParser`. Whether a fold can be *expanded* is read off the text itself — a diff
+/// fetched with whole-file context has every line in it, one fetched at git's default
+/// context does not — so nothing here has to describe it separately.
 public struct WireDiff: Codable, Sendable, Equatable {
     public let path: String
     public let text: String
-    public let fullContext: Bool
     /// Binary content: `text` is empty and the reader says so rather than
     /// rendering git's "Binary files differ" line as if it were code.
     public let binary: Bool
 
-    public init(path: String, text: String, fullContext: Bool, binary: Bool = false) {
+    public init(path: String, text: String, binary: Bool = false) {
         self.path = path
         self.text = text
-        self.fullContext = fullContext
         self.binary = binary
     }
 }

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -366,12 +366,16 @@ final class CompanionServer {
             handleUpload(projectID: projectID, name: name, base64: base64, on: connection)
         case .searchFiles(let projectID, let query):
             handleSearchFiles(projectID: projectID, query: query, on: connection)
+        case .listChanges(let projectID):
+            handleListChanges(projectID: projectID, on: connection)
+        case .readDiff(let projectID, let path):
+            handleReadDiff(projectID: projectID, path: path, on: connection)
         case .trace(let sessionID, let dark):
             handleTrace(sessionID: sessionID, dark: dark, on: connection)
         case .sshConfigHosts:
             sendControl(.sshConfigList(hosts: Self.parseSSHConfigHosts()), to: connection)
         case .auth, .exit, .error, .started, .fileList, .file, .written, .uploaded,
-             .searchResults, .traceHTML, .sshConfigList:
+             .searchResults, .traceHTML, .sshConfigList, .changes, .diff:
             break
         }
     }
@@ -680,6 +684,77 @@ final class CompanionServer {
         return Set(raw.split(separator: "\0").compactMap { record in
             record.count > 3 ? String(record.dropFirst(3)) : nil
         })
+    }
+
+    // MARK: - Changes plane (git working tree)
+
+    /// The project's working-tree changes, straight from the same `GitService` the
+    /// desktop git pane reads — the phone never shells out to git itself, so the two
+    /// lists can't disagree about what "changed" means.
+    private func handleListChanges(projectID: String, on connection: NWConnection) {
+        guard let root = projectRoot(for: projectID) else {
+            sendControl(.error(message: "unknown project"), to: connection)
+            return
+        }
+        Task { [weak self] in
+            let files = await GitService.changes(in: root).map {
+                WireChange(
+                    path: $0.path, status: $0.status.letter,
+                    additions: $0.additions, deletions: $0.deletions,
+                    isBinary: $0.isBinary, isStaged: $0.isStaged
+                )
+            }
+            self?.sendControl(.changes(files: files), to: connection)
+        }
+    }
+
+    /// One changed file's diff. Rows come back with *full* file context so the phone
+    /// can fold unchanged runs into bands the reader expands; past the byte cap the
+    /// reassembled text would be a multi-megabyte frame, so that case degrades to
+    /// git's default 3-line context and says so (`fullContext: false`).
+    private func handleReadDiff(projectID: String, path: String, on connection: NWConnection) {
+        guard let root = projectRoot(for: projectID) else {
+            sendControl(.error(message: "unknown project"), to: connection)
+            return
+        }
+        Task { [weak self] in
+            guard let change = await GitService.changes(in: root).first(where: { $0.path == path }) else {
+                self?.sendControl(.error(message: "\(path) has no working-tree changes"), to: connection)
+                return
+            }
+            guard !change.isBinary else {
+                self?.sendControl(
+                    .diff(WireDiff(path: path, text: "", fullContext: false, binary: true)),
+                    to: connection
+                )
+                return
+            }
+            let full = Self.unifiedText(await GitService.diffRows(for: change, in: root))
+            let fits = full.utf8.count <= Self.maxDiffBytes
+            let text = fits ? full : await GitService.diffText(for: change, in: root)
+            self?.sendControl(
+                .diff(WireDiff(path: path, text: text, fullContext: fits)),
+                to: connection
+            )
+        }
+    }
+
+    /// 2 MB of diff text — ~50k lines of source, well inside the socket's 8 MB frame
+    /// cap and past anything a phone reader can usefully scroll.
+    nonisolated private static let maxDiffBytes = 2 << 20
+
+    /// Reassembles parsed rows into unified-diff text for the wire. The phone re-parses
+    /// with the same rules (`DiffParser`), so the round trip is lossless for everything
+    /// it renders; only the file-header plumbing the parser already drops is gone.
+    nonisolated static func unifiedText(_ rows: [DiffRow]) -> String {
+        rows.map { row in
+            switch row.kind {
+            case .hunk: return row.text
+            case .addition: return "+" + row.text
+            case .deletion: return "-" + row.text
+            case .context: return " " + row.text
+            }
+        }.joined(separator: "\n")
     }
 
     nonisolated private static let maxFileBytes = 1 << 20 // 1 MB — plenty for "peek at a source file"

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -368,8 +368,8 @@ final class CompanionServer {
             handleSearchFiles(projectID: projectID, query: query, on: connection)
         case .listChanges(let projectID):
             handleListChanges(projectID: projectID, on: connection)
-        case .readDiff(let projectID, let path):
-            handleReadDiff(projectID: projectID, path: path, on: connection)
+        case .readDiff(let projectID, let path, let status):
+            handleReadDiff(projectID: projectID, path: path, status: status, on: connection)
         case .trace(let sessionID, let dark):
             handleTrace(sessionID: sessionID, dark: dark, on: connection)
         case .sshConfigHosts:
@@ -696,7 +696,9 @@ final class CompanionServer {
             sendControl(.error(message: "unknown project"), to: connection)
             return
         }
-        Task { [weak self] in
+        // Detached like every other handler here: `CompanionServer` is main-actor, and a
+        // repo-wide status walk has no business on the UI thread.
+        Task.detached(priority: .userInitiated) { [weak self] in
             let files = await GitService.changes(in: root).map {
                 WireChange(
                     path: $0.path, status: $0.status.letter,
@@ -704,38 +706,40 @@ final class CompanionServer {
                     isBinary: $0.isBinary, isStaged: $0.isStaged
                 )
             }
-            self?.sendControl(.changes(files: files), to: connection)
+            await MainActor.run { self?.sendControl(.changes(files: files), to: connection) }
         }
     }
 
-    /// One changed file's diff. Rows come back with *full* file context so the phone
-    /// can fold unchanged runs into bands the reader expands; past the byte cap the
-    /// reassembled text would be a multi-megabyte frame, so that case degrades to
-    /// git's default 3-line context and says so (`fullContext: false`).
-    private func handleReadDiff(projectID: String, path: String, on connection: NWConnection) {
+    /// One changed file's diff. The request carries the status the phone read off the
+    /// listing, so this costs one git invocation rather than a second whole-repo scan
+    /// per tap — and per step of the reader's file walker.
+    ///
+    /// Rows come back with *full* file context so the phone can fold unchanged runs into
+    /// bands the reader expands; past the byte cap the reassembled text would be a
+    /// multi-megabyte frame, so that case degrades to git's default 3-line context.
+    private func handleReadDiff(
+        projectID: String, path: String, status: String, on connection: NWConnection
+    ) {
         guard let root = projectRoot(for: projectID) else {
             sendControl(.error(message: "unknown project"), to: connection)
             return
         }
-        Task { [weak self] in
-            guard let change = await GitService.changes(in: root).first(where: { $0.path == path }) else {
-                self?.sendControl(.error(message: "\(path) has no working-tree changes"), to: connection)
-                return
-            }
-            guard !change.isBinary else {
-                self?.sendControl(
-                    .diff(WireDiff(path: path, text: "", fullContext: false, binary: true)),
-                    to: connection
-                )
-                return
-            }
+        let change = GitChange(
+            path: path,
+            status: GitFileStatus(code: status.first ?? "M"),
+            isUntracked: status == "U"
+        )
+        Task.detached(priority: .userInitiated) { [weak self] in
             let full = Self.unifiedText(await GitService.diffRows(for: change, in: root))
-            let fits = full.utf8.count <= Self.maxDiffBytes
-            let text = fits ? full : await GitService.diffText(for: change, in: root)
-            self?.sendControl(
-                .diff(WireDiff(path: path, text: text, fullContext: fits)),
-                to: connection
+            let text = full.utf8.count <= Self.maxDiffBytes
+                ? full : await GitService.diffText(for: change, in: root)
+            // git answers a binary file with its own one-line note rather than a diff;
+            // the reader says so instead of rendering that note as code.
+            let binary = text.contains("Binary files ")
+            let reply = CompanionControl.diff(
+                WireDiff(path: path, text: binary ? "" : text, binary: binary)
             )
+            await MainActor.run { self?.sendControl(reply, to: connection) }
         }
     }
 
@@ -746,6 +750,8 @@ final class CompanionServer {
     /// Reassembles parsed rows into unified-diff text for the wire. The phone re-parses
     /// with the same rules (`DiffParser`), so the round trip is lossless for everything
     /// it renders; only the file-header plumbing the parser already drops is gone.
+    /// (Once `GitService` exposes its full-context text directly — it is private today,
+    /// and that file belongs to another change in flight — this detour goes away.)
     nonisolated static func unifiedText(_ rows: [DiffRow]) -> String {
         rows.map { row in
             switch row.kind {

--- a/Tests/termioTests/CompanionChangesWireTests.swift
+++ b/Tests/termioTests/CompanionChangesWireTests.swift
@@ -1,0 +1,99 @@
+import TermioShared
+import XCTest
+@testable import termio
+
+/// The changes/diff messages the phone's Changes pane rides on. The wire encoder is
+/// hand-written JSON on both ends, so a round trip is the only thing standing between a
+/// typo'd key and a pane that silently shows nothing.
+final class CompanionChangesWireTests: XCTestCase {
+    func testListChangesRoundTrips() {
+        let message = CompanionControl.listChanges(projectID: "abc123")
+        XCTAssertEqual(CompanionControl.decode(message.encoded()), message)
+    }
+
+    func testChangesRoundTripsEveryField() {
+        let message = CompanionControl.changes(files: [
+            WireChange(path: "Sources/termio/App.swift", status: "M", additions: 40, deletions: 12),
+            WireChange(
+                path: "assets/icon.png", status: "A", additions: 0, deletions: 0,
+                isBinary: true, isStaged: true
+            ),
+        ])
+        XCTAssertEqual(CompanionControl.decode(message.encoded()), message)
+    }
+
+    /// Paths carry quotes, backslashes and non-ASCII in the wild; the file messages go
+    /// through JSONSerialization precisely so escaping is free.
+    func testAwkwardPathsSurvive() {
+        let path = #"src/a "quoted"/b\c/文件.swift"#
+        let message = CompanionControl.changes(files: [
+            WireChange(path: path, status: "R", additions: 1, deletions: 1),
+        ])
+        guard case .changes(let files) = CompanionControl.decode(message.encoded()) else {
+            return XCTFail("changes should decode")
+        }
+        XCTAssertEqual(files.first?.path, path)
+    }
+
+    func testReadDiffRoundTrips() {
+        let message = CompanionControl.readDiff(projectID: "abc123", path: "Sources/termio/App.swift")
+        XCTAssertEqual(CompanionControl.decode(message.encoded()), message)
+    }
+
+    func testDiffRoundTripsItsText() {
+        let message = CompanionControl.diff(WireDiff(
+            path: "App.swift",
+            text: "@@ -1,2 +1,2 @@\n-let a = 1\n+let a = 2\n",
+            fullContext: true
+        ))
+        XCTAssertEqual(CompanionControl.decode(message.encoded()), message)
+    }
+
+    /// An older peer sends neither flag; both must read as "not full context, not
+    /// binary" rather than failing the decode and blanking the reader.
+    func testDiffToleratesMissingFlags() {
+        let json = #"{"t":"diff","path":"App.swift","text":"@@ -1 +1 @@"}"#
+        guard case .diff(let diff) = CompanionControl.decode(json) else {
+            return XCTFail("a diff without flags should still decode")
+        }
+        XCTAssertFalse(diff.fullContext)
+        XCTAssertFalse(diff.binary)
+    }
+}
+
+/// The Mac reassembles parsed rows into unified-diff text for the wire, and the phone
+/// re-parses it. The markers have to go back on exactly, or every line lands in the
+/// wrong column on the phone.
+final class DiffUnifiedTextTests: XCTestCase {
+    func testMarkersAreRestored() {
+        let rows = [
+            DiffRow(id: 0, kind: .hunk, text: "@@ -1,3 +1,3 @@ func thing()", oldLine: 1, newLine: 1),
+            DiffRow(id: 1, kind: .context, text: "let a = 1", oldLine: 1, newLine: 1),
+            DiffRow(id: 2, kind: .deletion, text: "let b = 2", oldLine: 2, newLine: nil),
+            DiffRow(id: 3, kind: .addition, text: "let b = 3", oldLine: nil, newLine: 2),
+        ]
+        XCTAssertEqual(
+            CompanionServer.unifiedText(rows),
+            "@@ -1,3 +1,3 @@ func thing()\n let a = 1\n-let b = 2\n+let b = 3"
+        )
+    }
+
+    /// The round trip the two ends actually perform: git text → rows → wire text →
+    /// `DiffParser`. Kinds, line numbers and content must all come out the far side
+    /// unchanged.
+    func testRoundTripThroughTheSharedParser() {
+        let rows = [
+            DiffRow(id: 0, kind: .hunk, text: "@@ -10,4 +10,5 @@", oldLine: 10, newLine: 10),
+            DiffRow(id: 1, kind: .context, text: "", oldLine: 10, newLine: 10),
+            DiffRow(id: 2, kind: .deletion, text: "    old()", oldLine: 11, newLine: nil),
+            DiffRow(id: 3, kind: .addition, text: "    new()", oldLine: nil, newLine: 11),
+            DiffRow(id: 4, kind: .addition, text: "    extra()", oldLine: nil, newLine: 12),
+            DiffRow(id: 5, kind: .context, text: "}", oldLine: 12, newLine: 13),
+        ]
+        let parsed = DiffParser.lines(from: CompanionServer.unifiedText(rows))
+        XCTAssertEqual(parsed.map(\.text), rows.map(\.text))
+        XCTAssertEqual(parsed.map(\.oldLine), rows.map(\.oldLine))
+        XCTAssertEqual(parsed.map(\.newLine), rows.map(\.newLine))
+        XCTAssertEqual(parsed.map(\.kind), [.hunk, .context, .deletion, .addition, .addition, .context])
+    }
+}

--- a/Tests/termioTests/CompanionChangesWireTests.swift
+++ b/Tests/termioTests/CompanionChangesWireTests.swift
@@ -35,29 +35,34 @@ final class CompanionChangesWireTests: XCTestCase {
         XCTAssertEqual(files.first?.path, path)
     }
 
-    func testReadDiffRoundTrips() {
-        let message = CompanionControl.readDiff(projectID: "abc123", path: "Sources/termio/App.swift")
+    func testReadDiffRoundTripsItsStatus() {
+        let message = CompanionControl.readDiff(
+            projectID: "abc123", path: "Sources/termio/App.swift", status: "U"
+        )
         XCTAssertEqual(CompanionControl.decode(message.encoded()), message)
     }
 
     func testDiffRoundTripsItsText() {
         let message = CompanionControl.diff(WireDiff(
             path: "App.swift",
-            text: "@@ -1,2 +1,2 @@\n-let a = 1\n+let a = 2\n",
-            fullContext: true
+            text: "@@ -1,2 +1,2 @@\n-let a = 1\n+let a = 2\n"
         ))
         XCTAssertEqual(CompanionControl.decode(message.encoded()), message)
     }
 
-    /// An older peer sends neither flag; both must read as "not full context, not
-    /// binary" rather than failing the decode and blanking the reader.
-    func testDiffToleratesMissingFlags() {
+    /// An older peer sends no binary flag; it must read as "not binary" rather than
+    /// failing the decode and blanking the reader. Likewise a `readDiff` with no status.
+    func testToleratesMissingOptionalFields() {
         let json = #"{"t":"diff","path":"App.swift","text":"@@ -1 +1 @@"}"#
         guard case .diff(let diff) = CompanionControl.decode(json) else {
             return XCTFail("a diff without flags should still decode")
         }
-        XCTAssertFalse(diff.fullContext)
         XCTAssertFalse(diff.binary)
+        guard case .readDiff(_, _, let status) =
+            CompanionControl.decode(#"{"t":"readDiff","project":"a","path":"b"}"#) else {
+            return XCTFail("a readDiff without a status should still decode")
+        }
+        XCTAssertEqual(status, "M")
     }
 }
 

--- a/Tests/termioTests/DiffModelTests.swift
+++ b/Tests/termioTests/DiffModelTests.swift
@@ -75,12 +75,13 @@ final class DiffFoldTests: XCTestCase {
         rows.insert(DiffLine(id: 100, kind: .addition, text: "new", oldLine: nil, newLine: 16), at: 15)
 
         let items = DiffParser.displayItems(lines: rows, expanded: [])
-        guard case .band(let id, let count, let expandable) = items.first else {
+        guard case .band(let id, let range, let expandable) = items.first else {
             return XCTFail("a 15-line leading run should fold to a band, got \(String(describing: items.first))")
         }
         XCTAssertTrue(expandable)
-        // 15 lines, 3 kept facing the change → 12 hidden, keyed by the first of them.
-        XCTAssertEqual(count, 12)
+        // 15 lines, 3 kept facing the change → 12 hidden, keyed by the first of them, and
+        // named by the lines they hide rather than counted.
+        XCTAssertEqual(range, 1...12)
         XCTAssertEqual(id, 0)
         XCTAssertEqual(items.count, 1 + 3 + 1 + 3 + 1) // band, context, add, context, band
         XCTAssertEqual(items.filter { if case .band = $0 { return true } else { return false } }.count, 2)
@@ -124,12 +125,12 @@ final class DiffFoldTests: XCTestCase {
         +FORTY
         """
         let items = DiffParser.displayItems(lines: DiffParser.lines(from: diff), expanded: [])
-        let bands = items.compactMap { item -> (Int, Bool)? in
-            if case .band(_, let count, let expandable) = item { return (count, expandable) }
+        let bands = items.compactMap { item -> (ClosedRange<Int>, Bool)? in
+            if case .band(_, let range, let expandable) = item { return (range, expandable) }
             return nil
         }
         XCTAssertEqual(bands.count, 1)
-        XCTAssertEqual(bands.first?.0, 38) // lines 2…39 of the new side
+        XCTAssertEqual(bands.first?.0, 2...39) // the gap between the two hunks
         XCTAssertEqual(bands.first?.1, false)
     }
 }

--- a/Tests/termioTests/DiffModelTests.swift
+++ b/Tests/termioTests/DiffModelTests.swift
@@ -1,0 +1,179 @@
+import TermioShared
+import XCTest
+
+/// The shared diff model the iOS reader renders from: parsing unified-diff text into
+/// numbered lines, folding unchanged runs into bands, and marking the changed span of a
+/// modified line. Pure logic, and the place an off-by-one turns into "the phone showed
+/// the wrong line number next to the wrong code".
+final class DiffParserTests: XCTestCase {
+    func testLineNumbersFollowTheHunkHeader() {
+        let diff = """
+        @@ -10,4 +10,5 @@ func makeThing() {
+             let a = 1
+        -    let b = 2
+        +    let b = 3
+        +    let c = 4
+             return a
+        """
+        let lines = DiffParser.lines(from: diff)
+        XCTAssertEqual(lines.map(\.kind), [.hunk, .context, .deletion, .addition, .addition, .context])
+        // Context at the hunk's start sits on line 10 of both sides.
+        XCTAssertEqual(lines[1].oldLine, 10)
+        XCTAssertEqual(lines[1].newLine, 10)
+        // A deletion advances only the old side, an addition only the new side.
+        XCTAssertEqual(lines[2].oldLine, 11)
+        XCTAssertNil(lines[2].newLine)
+        XCTAssertEqual(lines[3].newLine, 11)
+        XCTAssertNil(lines[3].oldLine)
+        XCTAssertEqual(lines[4].newLine, 12)
+        // The trailing context resumes past both edits.
+        XCTAssertEqual(lines[5].oldLine, 12)
+        XCTAssertEqual(lines[5].newLine, 13)
+    }
+
+    func testMarkersAreStrippedAndPlumbingDropped() {
+        let diff = """
+        diff --git a/App.swift b/App.swift
+        index 1234567..89abcde 100644
+        --- a/App.swift
+        +++ b/App.swift
+        @@ -1,2 +1,2 @@
+        -let old = 1
+        +let new = 1
+        \\ No newline at end of file
+        """
+        let lines = DiffParser.lines(from: diff)
+        XCTAssertEqual(lines.map(\.kind), [.hunk, .deletion, .addition])
+        XCTAssertEqual(lines[1].text, "let old = 1")
+        XCTAssertEqual(lines[2].text, "let new = 1")
+    }
+
+    /// A `+` in column 1 of the *content* (a diff of a diff, or a leading-plus line)
+    /// must still read as an addition — the marker is positional, not semantic.
+    func testEmptyContextLineSurvives() {
+        let diff = """
+        @@ -1,3 +1,3 @@
+         first
+        \u{20}
+         third
+        """
+        let lines = DiffParser.lines(from: diff)
+        XCTAssertEqual(lines.count, 4)
+        XCTAssertEqual(lines[2].kind, .context)
+        XCTAssertEqual(lines[2].text, "")
+    }
+}
+
+final class DiffFoldTests: XCTestCase {
+    /// One addition buried in a long file: the run before it keeps 3 lines of context
+    /// and folds the rest into an expandable band; the run after it does the same.
+    func testLongUnchangedRunsCollapseAroundAChange() {
+        var rows: [DiffLine] = []
+        for i in 0..<30 {
+            rows.append(DiffLine(id: i, kind: .context, text: "line \(i)", oldLine: i + 1, newLine: i + 1))
+        }
+        rows.insert(DiffLine(id: 100, kind: .addition, text: "new", oldLine: nil, newLine: 16), at: 15)
+
+        let items = DiffParser.displayItems(lines: rows, expanded: [])
+        guard case .band(let id, let count, let expandable) = items.first else {
+            return XCTFail("a 15-line leading run should fold to a band, got \(String(describing: items.first))")
+        }
+        XCTAssertTrue(expandable)
+        // 15 lines, 3 kept facing the change → 12 hidden, keyed by the first of them.
+        XCTAssertEqual(count, 12)
+        XCTAssertEqual(id, 0)
+        XCTAssertEqual(items.count, 1 + 3 + 1 + 3 + 1) // band, context, add, context, band
+        XCTAssertEqual(items.filter { if case .band = $0 { return true } else { return false } }.count, 2)
+    }
+
+    func testExpandingABandSplicesItsLinesBack() {
+        var rows: [DiffLine] = []
+        for i in 0..<30 {
+            rows.append(DiffLine(id: i, kind: .context, text: "line \(i)", oldLine: i + 1, newLine: i + 1))
+        }
+        rows.insert(DiffLine(id: 100, kind: .addition, text: "new", oldLine: nil, newLine: 16), at: 15)
+
+        let items = DiffParser.displayItems(lines: rows, expanded: [0])
+        // The leading band is gone; its 12 lines are back, so only the trailing one is left.
+        XCTAssertEqual(items.filter { if case .band = $0 { return true } else { return false } }.count, 1)
+        guard case .line(let first) = items[0] else { return XCTFail("expanded band should start with a line") }
+        XCTAssertEqual(first.id, 0)
+    }
+
+    func testShortRunsAreNeverFolded() {
+        var rows: [DiffLine] = []
+        for i in 0..<8 {
+            rows.append(DiffLine(id: i, kind: .context, text: "line \(i)", oldLine: i + 1, newLine: i + 1))
+        }
+        rows.append(DiffLine(id: 100, kind: .addition, text: "new", oldLine: nil, newLine: 9))
+        let items = DiffParser.displayItems(lines: rows, expanded: [])
+        XCTAssertEqual(items.count, 9)
+        XCTAssertFalse(items.contains { if case .band = $0 { return true } else { return false } })
+    }
+
+    /// A diff fetched at git's default context has real gaps between hunks. Those become
+    /// bands too — but fixed ones: the hidden lines were never sent, so tapping can't
+    /// reveal them.
+    func testHunkGapBecomesAFixedBand() {
+        let diff = """
+        @@ -1,2 +1,2 @@
+        -one
+        +ONE
+        @@ -40,2 +40,2 @@
+        -forty
+        +FORTY
+        """
+        let items = DiffParser.displayItems(lines: DiffParser.lines(from: diff), expanded: [])
+        let bands = items.compactMap { item -> (Int, Bool)? in
+            if case .band(_, let count, let expandable) = item { return (count, expandable) }
+            return nil
+        }
+        XCTAssertEqual(bands.count, 1)
+        XCTAssertEqual(bands.first?.0, 38) // lines 2…39 of the new side
+        XCTAssertEqual(bands.first?.1, false)
+    }
+}
+
+final class DiffIntralineSpanTests: XCTestCase {
+    func testSpanCoversTheChangedWordOnly() {
+        let diff = """
+        @@ -1,1 +1,1 @@
+        -let value = oldName
+        +let value = newName
+        """
+        let lines = DiffParser.lines(from: diff)
+        guard let old = lines[1].emphasis, let new = lines[2].emphasis else {
+            return XCTFail("a one-word edit should carry an intraline span")
+        }
+        XCTAssertEqual(String(Array(lines[1].text)[old]), "oldName")
+        XCTAssertEqual(String(Array(lines[2].text)[new]), "newName")
+    }
+
+    /// The boundary snaps outward to whole words: peeling the shared `alph` prefix
+    /// alone would emphasize a bare `a` / `b` and leave the identifier split.
+    func testSpanSnapsToWordBoundaries() {
+        let diff = """
+        @@ -1,1 +1,1 @@
+        -call(alpha)
+        +call(alphb)
+        """
+        let lines = DiffParser.lines(from: diff)
+        guard let old = lines[1].emphasis else {
+            return XCTFail("a near-identical pair should carry a span")
+        }
+        XCTAssertEqual(String(Array(lines[1].text)[old]), "alpha")
+    }
+
+    /// Two lines with almost nothing in common are a rewrite, not an edit — spanning
+    /// them would highlight the whole line, which says nothing.
+    func testUnrelatedLinesGetNoSpan() {
+        let diff = """
+        @@ -1,1 +1,1 @@
+        -let a = 1
+        +print(somethingElseEntirely)
+        """
+        let lines = DiffParser.lines(from: diff)
+        XCTAssertNil(lines[1].emphasis)
+        XCTAssertNil(lines[2].emphasis)
+    }
+}

--- a/ios/Sources/CompanionClient.swift
+++ b/ios/Sources/CompanionClient.swift
@@ -43,6 +43,10 @@ final class CompanionClient: NSObject {
     /// Filename-search matches (reply to `.searchFiles`): the echoed query,
     /// repo-relative paths, and whether the batch was capped.
     var onSearchResults: ((String, [String], Bool) -> Void)?
+    /// The project's working-tree changes (reply to `.listChanges`).
+    var onChanges: (([WireChange]) -> Void)?
+    /// One file's unified diff (reply to `.readDiff`).
+    var onDiff: ((WireDiff) -> Void)?
     /// The server rejected a request (e.g. a failed `start`).
     var onError: ((String) -> Void)?
     /// The Mac's parsed `~/.ssh/config` host blocks, answering a
@@ -197,6 +201,8 @@ final class CompanionClient: NSObject {
                         case .uploaded(let path): onUploaded?(path)
                         case .searchResults(let query, let paths, let truncated):
                             onSearchResults?(query, paths, truncated)
+                        case .changes(let files): onChanges?(files)
+                        case .diff(let diff): onDiff?(diff)
                         case .error(let reason): onError?(reason)
                         case .sshConfigList(let hosts): onSSHConfig?(hosts)
                         default: break

--- a/ios/Sources/DiffViewController.swift
+++ b/ios/Sources/DiffViewController.swift
@@ -12,8 +12,8 @@ import UIKit
 ///   leading edge and the line itself takes a very light wash.
 /// - **One line-number column.** Two would cost a tenth of the width; a deletion shows
 ///   its old number, everything else the new one, which is what a reviewer quotes.
-/// - **Fold bands are rows, not gutter buttons.** The whole band is the tap target, so
-///   it clears 44pt.
+/// - **Folds are a pill on a hairline**, named by the line range they hide. The whole
+///   row is the tap target, so it clears 44pt without a slab of grey in the code.
 /// - **The file walker is in the view.** ‹ 3 of 12 › moves between changed files without
 ///   a trip back to the list, and the floating button jumps to the next hunk.
 /// - **Selection feeds the agent.** Long-press → "Send to Agent" bracketed-pastes the
@@ -429,6 +429,7 @@ final class DiffDocument {
 
     struct Line {
         let role: Role
+
         /// The paragraph's range, including its trailing newline.
         let range: NSRange
         /// `DiffLine.id` for code (keys the syntax pass), the first hidden line's id for
@@ -436,6 +437,11 @@ final class DiffDocument {
         let rowId: Int
         /// The number drawn in the gutter: a deletion's old line, else the new one.
         let number: Int?
+
+        var isBand: Bool {
+            if case .band = role { return true }
+            return false
+        }
     }
 
     let attributed: NSAttributedString
@@ -474,8 +480,10 @@ final class DiffDocument {
                     rowId: row.id,
                     number: row.kind == .deletion ? row.oldLine : row.newLine
                 ))
-            case .band(let id, let count, let expandable):
-                let label = "⋯ \(count) unchanged \(count == 1 ? "line" : "lines")"
+            case .band(let id, let range, let expandable):
+                // The range names the code the fold hides, against the same numbers the
+                // gutter shows. A count would only describe the fold itself.
+                let label = "\(range.lowerBound)–\(range.upperBound)"
                 text += label
                 text += "\n"
                 previousWasChange = false
@@ -518,10 +526,12 @@ final class DiffDocument {
         band.paragraphSpacing = bandPadding
         for (item, line) in zip(items, lines) {
             switch item {
-            case .band:
+            case .band(_, _, let expandable):
                 attributed.addAttributes([
-                    .font: UIFont.systemFont(ofSize: 11, weight: .medium),
-                    .foregroundColor: UIColor.tertiaryLabel,
+                    .font: UIFont.roundedCounter(size: 11, weight: .medium),
+                    // A fixed band is inert (its lines were never fetched), so it sits a
+                    // step back in the ink hierarchy.
+                    .foregroundColor: expandable ? UIColor.secondaryLabel : UIColor.tertiaryLabel,
                     .paragraphStyle: band,
                 ], range: line.range)
             case .line(let row):
@@ -603,10 +613,15 @@ final class DiffTextView: UITextView {
         )
         // `characterIndex` snaps to the nearest character, so a tap in the empty space
         // past the end would "hit" the last line. Take the hit only if the point is
-        // actually inside that paragraph.
-        guard let line = document.line(at: index),
-              rect(forParagraph: line).insetBy(dx: 0, dy: -DiffDocument.bandPadding).contains(point)
-        else { return nil }
+        // actually inside that paragraph — with a band's row grown to a full 44pt, since
+        // its pill is a smaller target than the row it stands for.
+        guard let line = document.line(at: index) else { return nil }
+        var hit = rect(forParagraph: line)
+        if line.isBand {
+            let grow = max(0, 44 - hit.height) / 2
+            hit = hit.insetBy(dx: 0, dy: -grow)
+        }
+        guard hit.contains(point) else { return nil }
         return line
     }
 
@@ -654,13 +669,19 @@ final class DiffWashLayoutManager: NSLayoutManager {
                 let glyphs = glyphRange(forCharacterRange: line.range, actualCharacterRange: nil)
                 var rect = boundingRect(forGlyphRange: glyphs, in: container)
                 rect.origin.y += origin.y
-                if let (wash, bar) = Self.fills(for: line.role) {
+                if case .band(let expandable) = line.role {
+                    // The fold reads as a seam in the file with a control sitting on it —
+                    // Mail's trimmed-quote pill — not as a grey slab competing with the
+                    // code around it. The used rect is the centered label's real extent,
+                    // so the capsule wraps the text wherever it lands.
+                    var used = lineFragmentUsedRect(forGlyphAt: glyphs.location, effectiveRange: nil)
+                    used.origin.x += origin.x
+                    used.origin.y += origin.y
+                    drawBand(around: used, across: width, expandable: expandable)
+                } else if let (wash, bar) = Self.fills(for: line.role) {
                     var fill = rect
                     fill.origin.x = 0
                     fill.size.width = width
-                    if case .band = line.role {
-                        fill = fill.insetBy(dx: 0, dy: -DiffDocument.bandPadding)
-                    }
                     wash.setFill()
                     UIRectFill(fill)
                     if let bar {
@@ -683,6 +704,24 @@ final class DiffWashLayoutManager: NSLayoutManager {
         super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
     }
 
+    /// A hairline across the row with an opaque capsule behind the label. Drawn under
+    /// the glyphs, so the range text lands inside the capsule.
+    private func drawBand(around label: CGRect, across width: CGFloat, expandable: Bool) {
+        let capsule = label.insetBy(dx: -10, dy: -4)
+        let rule = CGRect(x: 0, y: capsule.midY - 0.25, width: width, height: 0.5)
+        UIColor.separator.withAlphaComponent(expandable ? 0.6 : 0.35).setFill()
+        UIRectFill(rule)
+        let path = UIBezierPath(roundedRect: capsule, cornerRadius: capsule.height / 2)
+        // Opaque, so the rule stops cleanly at the capsule instead of striking through it.
+        UIColor.secondarySystemBackground.setFill()
+        path.fill()
+        if expandable {
+            UIColor.separator.setStroke()
+            path.lineWidth = 0.5
+            path.stroke()
+        }
+    }
+
     private static func numberAttributes() -> [NSAttributedString.Key: Any] {
         let size = max(9, MobileSettings.shared.codeFont().pointSize - 2)
         return [
@@ -691,16 +730,15 @@ final class DiffWashLayoutManager: NSLayoutManager {
         ]
     }
 
-    /// (row wash, leading bar). The wash is deliberately faint; the bar is full strength.
+    /// (row wash, leading bar) for a code line. The wash is deliberately faint; the bar
+    /// is full strength. Bands paint themselves — see `drawBand`.
     static func fills(for role: DiffDocument.Role) -> (UIColor, UIColor?)? {
         switch role {
         case .code(.addition):
             return (UIColor.systemGreen.withAlphaComponent(0.09), UIColor.systemGreen)
         case .code(.deletion):
             return (UIColor.systemRed.withAlphaComponent(0.09), UIColor.systemRed)
-        case .band:
-            return (UIColor.label.withAlphaComponent(0.05), nil)
-        case .code:
+        case .band, .code:
             return nil
         }
     }

--- a/ios/Sources/DiffViewController.swift
+++ b/ios/Sources/DiffViewController.swift
@@ -568,8 +568,9 @@ final class DiffDocument {
 
 // MARK: - Text view
 
-/// The diff's text view: TextKit 1 so the wash layout manager can paint underneath the
-/// glyphs, plus the line-number column drawn into the container's left inset.
+/// The diff's text view: TextKit 1, so `DiffWashLayoutManager` can paint the row
+/// semantics — washes, edge bars, and the line-number column — underneath the glyphs.
+/// The view itself draws nothing of its own; see the layout manager for why.
 final class DiffTextView: UITextView {
     static let gutterWidth: CGFloat = 34
 
@@ -614,45 +615,6 @@ final class DiffTextView: UITextView {
         (layoutManager as? DiffWashLayoutManager)?.contentWidth = bounds.width
     }
 
-    override func draw(_ rect: CGRect) {
-        super.draw(rect)
-        drawLineNumbers(in: rect)
-    }
-
-    /// Numbers ride in the container's left inset, outside the selectable text — so a
-    /// selection copies pure code, never "214 let x = 1". Only the visible paragraphs
-    /// are measured.
-    private func drawLineNumbers(in rect: CGRect) {
-        guard let document, let context = UIGraphicsGetCurrentContext() else { return }
-        let size = max(9, MobileSettings.shared.codeFont().pointSize - 2)
-        let font = UIFont.monospacedDigitSystemFont(ofSize: size, weight: .regular)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: UIColor.tertiaryLabel,
-        ]
-        // Start at the first paragraph the dirty rect touches — a 5000-line diff must
-        // not measure every line on every scroll tick.
-        let visible = rect.offsetBy(dx: -textContainerInset.left, dy: -textContainerInset.top)
-        let glyphs = layoutManager.glyphRange(forBoundingRect: visible, in: textContainer)
-        let characters = layoutManager.characterRange(forGlyphRange: glyphs, actualGlyphRange: nil)
-        context.saveGState()
-        var index = document.lineIndex(at: characters.location)
-        while index < document.lines.count {
-            let line = document.lines[index]
-            index += 1
-            if line.range.location >= NSMaxRange(characters) { break }
-            guard let number = line.number else { continue }
-            let paragraph = self.rect(forParagraph: line)
-            let text = NSAttributedString(string: "\(number)", attributes: attributes)
-            // Right-aligned against the code's leading edge, drawn on the paragraph's
-            // first line so a wrapped line is numbered once.
-            text.draw(at: CGPoint(
-                x: Self.gutterWidth - text.size().width - 8,
-                y: paragraph.minY + font.lineHeight * 0.1
-            ))
-        }
-        context.restoreGState()
-    }
 }
 
 /// Paints each line's meaning behind its glyphs: a saturated 3pt bar at the leading
@@ -667,33 +629,66 @@ final class DiffWashLayoutManager: NSLayoutManager {
 
     static let barWidth: CGFloat = 3
 
+    /// Everything the row means is drawn here, in one pass over the visible lines:
+    /// washes, edge bars, and the line numbers.
+    ///
+    /// The numbers belong on *this* surface specifically. TextKit renders a layout
+    /// manager's drawing into the text view's scrolling container, so it travels with
+    /// `contentOffset` for free; a `UITextView.draw(_:)` override paints into the view's
+    /// own layer instead, which does not move — the numbers then hang in the viewport
+    /// while the code scrolls under them, and the only way back is repainting the whole
+    /// viewport every frame. The desktop learned the same lesson from the other side
+    /// (see `Sources/termio/Git/DiffTextView.swift`, where AppKit's copy-on-scroll
+    /// forces a full ruler invalidation). They still stay out of any selection, because
+    /// they are painted, not part of the string.
     override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
         if let document, let container = textContainers.first {
             let charRange = characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
             let width = max(usedRect(for: container).width + origin.x, contentWidth)
+            let numberAttributes = Self.numberAttributes()
             var index = document.lineIndex(at: charRange.location)
             while index < document.lines.count {
                 let line = document.lines[index]
                 index += 1
                 if line.range.location >= NSMaxRange(charRange) { break }
-                guard let (wash, bar) = Self.fills(for: line.role) else { continue }
                 let glyphs = glyphRange(forCharacterRange: line.range, actualCharacterRange: nil)
                 var rect = boundingRect(forGlyphRange: glyphs, in: container)
-                rect.origin.x = 0
-                rect.size.width = width
                 rect.origin.y += origin.y
-                if case .band = line.role {
-                    rect = rect.insetBy(dx: 0, dy: -DiffDocument.bandPadding)
+                if let (wash, bar) = Self.fills(for: line.role) {
+                    var fill = rect
+                    fill.origin.x = 0
+                    fill.size.width = width
+                    if case .band = line.role {
+                        fill = fill.insetBy(dx: 0, dy: -DiffDocument.bandPadding)
+                    }
+                    wash.setFill()
+                    UIRectFill(fill)
+                    if let bar {
+                        bar.setFill()
+                        UIRectFill(CGRect(x: 0, y: fill.minY, width: Self.barWidth, height: fill.height))
+                    }
                 }
-                wash.setFill()
-                UIRectFill(rect)
-                if let bar {
-                    bar.setFill()
-                    UIRectFill(CGRect(x: 0, y: rect.minY, width: Self.barWidth, height: rect.height))
+                // `origin.x` is the container's left inset — exactly the column the
+                // numbers live in, and it holds no glyphs to collide with. Drawn on the
+                // paragraph's first line, so a wrapped line is numbered once.
+                if let number = line.number {
+                    let text = NSAttributedString(string: "\(number)", attributes: numberAttributes)
+                    text.draw(at: CGPoint(
+                        x: origin.x - text.size().width - 8,
+                        y: rect.minY
+                    ))
                 }
             }
         }
         super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
+    }
+
+    private static func numberAttributes() -> [NSAttributedString.Key: Any] {
+        let size = max(9, MobileSettings.shared.codeFont().pointSize - 2)
+        return [
+            .font: UIFont.monospacedDigitSystemFont(ofSize: size, weight: .regular),
+            .foregroundColor: UIColor.tertiaryLabel,
+        ]
     }
 
     /// (row wash, leading bar). The wash is deliberately faint; the bar is full strength.

--- a/ios/Sources/DiffViewController.swift
+++ b/ios/Sources/DiffViewController.swift
@@ -1,14 +1,65 @@
+import Highlightr
+import TermioShared
 import UIKit
 
-/// Unified diff, mobile rules: soft-wrap, no horizontal scroll, colored edge
-/// bars instead of full-line backgrounds.
+/// Full-screen unified diff, phone rules. The desktop pane renders the same model in
+/// AppKit; what changes here is what a 390pt screen can carry:
+///
+/// - **Never scroll horizontally.** Lines soft-wrap, and a hanging indent keeps a
+///   wrapped continuation visually inside its line.
+/// - **A saturated edge bar, not a full-line fill.** A heavy green behind a whole line
+///   drowns the syntax colors at this size, so the strong ink is a 3pt bar at the
+///   leading edge and the line itself takes a very light wash.
+/// - **One line-number column.** Two would cost a tenth of the width; a deletion shows
+///   its old number, everything else the new one, which is what a reviewer quotes.
+/// - **Fold bands are rows, not gutter buttons.** The whole band is the tap target, so
+///   it clears 44pt.
+/// - **The file walker is in the view.** ‹ 3 of 12 › moves between changed files without
+///   a trip back to the list, and the floating button jumps to the next hunk.
+/// - **Selection feeds the agent.** Long-press → "Send to Agent" bracketed-pastes the
+///   selected code into the session's PTY: the thing a phone diff is *for*.
 final class DiffViewController: UIViewController {
-    private let change: MockChange
+    private var files: [WireChange]
+    private var index: Int
 
-    init(change: MockChange) {
-        self.change = change
+    /// Ask the owner (which holds the companion socket) for one file's diff; the reply
+    /// arrives back through `receive(_:)`.
+    var onRequestDiff: ((String) -> Void)?
+    /// Bracketed-paste selected code into the session's terminal. nil hides the action —
+    /// a plain shell has no prompt to feed.
+    var onSendToAgent: ((String) -> Void)?
+
+    private var rows: [DiffLine] = []
+    private var expanded: Set<Int> = []
+    private var document: DiffDocument?
+    /// The path a `readDiff` is in flight for, so a late reply for the previous file
+    /// can't paint over the current one.
+    private var pendingPath: String?
+
+    private let storage = NSTextStorage()
+    private var textView: DiffTextView!
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    private let statusLabel = UILabel()
+    private let spinner = UIActivityIndicatorView(style: .medium)
+    private let walkerLabel = UILabel()
+    private let previousButton = UIButton(type: .system)
+    private let nextButton = UIButton(type: .system)
+    private let hunkButton = UIButton(type: .system)
+    private var walkerBar: UIStackView!
+
+    /// A `readDiff` is outstanding, so a failure belongs to this screen.
+    var isAwaitingDiff: Bool { pendingPath != nil }
+
+    private var change: WireChange? {
+        files.indices.contains(index) ? files[index] : nil
+    }
+
+    init(files: [WireChange], index: Int) {
+        self.files = files
+        self.index = min(max(index, 0), max(files.count - 1, 0))
         super.init(nibName: nil, bundle: nil)
-        title = (change.path as NSString).lastPathComponent
+        modalPresentationStyle = .fullScreen
     }
 
     @available(*, unavailable)
@@ -17,46 +68,714 @@ final class DiffViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-
-        let summary = UILabel()
-        summary.font = MobileSettings.shared.codeFont()
-        summary.textColor = .secondaryLabel
-        summary.text = "+\(change.additions) −\(change.deletions)"
-        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: summary)
-
-        let textView = UITextView()
-        textView.isEditable = false
-        textView.alwaysBounceVertical = true
-        textView.attributedText = Self.render(diff: MockChange.sampleDiff)
-        textView.textContainerInset = UIEdgeInsets(top: 12, left: 8, bottom: 12, right: 8)
-        textView.frame = view.bounds
-        textView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        view.addSubview(textView)
+        let header = configureHeader()
+        let walker = configureWalker()
+        configureText(below: header, above: walker)
+        configureHunkButton(above: walker)
+        configureStatus()
+        reloadFile()
     }
 
-    private static func render(diff: String) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        let font = MobileSettings.shared.codeFont()
-        let paragraph = NSMutableParagraphStyle()
-        paragraph.headIndent = 14 // hanging indent keeps wrapped lines aligned
-        for line in diff.components(separatedBy: "\n") {
-            var attrs: [NSAttributedString.Key: Any] = [
-                .font: font,
-                .paragraphStyle: paragraph,
-                .foregroundColor: UIColor.label,
-            ]
-            if line.hasPrefix("@@") {
-                attrs[.foregroundColor] = UIColor.systemPurple
-                attrs[.font] = MobileSettings.shared.codeFont(weight: .semibold)
-            } else if line.hasPrefix("+") {
-                attrs[.foregroundColor] = UIColor.systemGreen
-            } else if line.hasPrefix("-") {
-                attrs[.foregroundColor] = UIColor.systemRed
-            } else {
-                attrs[.foregroundColor] = UIColor.secondaryLabel
-            }
-            result.append(NSAttributedString(string: line + "\n", attributes: attrs))
+    // MARK: - Chrome
+
+    private func configureHeader() -> UIView {
+        let close = UIButton(type: .system)
+        close.applyGlassSymbol("xmark")
+        close.tintColor = .label
+        close.addAction(UIAction { [weak self] _ in
+            self?.dismiss(animated: true)
+        }, for: .touchUpInside)
+
+        titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        titleLabel.textColor = .label
+        titleLabel.lineBreakMode = .byTruncatingMiddle
+
+        subtitleLabel.font = .preferredFont(forTextStyle: .caption2)
+        subtitleLabel.textColor = .secondaryLabel
+        subtitleLabel.lineBreakMode = .byTruncatingHead
+
+        let titles = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        titles.axis = .vertical
+        titles.alignment = .center
+
+        spinner.hidesWhenStopped = true
+
+        let bar = UIStackView(arrangedSubviews: [close, titles, spinner])
+        bar.axis = .horizontal
+        bar.alignment = .center
+        bar.spacing = 4
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bar)
+        NSLayoutConstraint.activate([
+            bar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            bar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8),
+            bar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8),
+            close.widthAnchor.constraint(equalToConstant: 40),
+            close.heightAnchor.constraint(equalToConstant: 40),
+            spinner.widthAnchor.constraint(equalToConstant: 40),
+        ])
+        return bar
+    }
+
+    /// ‹ 3 of 12 › — walking the changed files without going back to the list. Absent
+    /// for a single file, where it would only take height away from the code.
+    private func configureWalker() -> UIView {
+        previousButton.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        previousButton.addAction(UIAction { [weak self] _ in self?.walk(-1) }, for: .touchUpInside)
+        nextButton.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+        nextButton.addAction(UIAction { [weak self] _ in self?.walk(1) }, for: .touchUpInside)
+
+        walkerLabel.font = .roundedCounter(size: 13, weight: .medium)
+        walkerLabel.textColor = .secondaryLabel
+        walkerLabel.textAlignment = .center
+
+        let bar = UIStackView(arrangedSubviews: [previousButton, walkerLabel, nextButton])
+        bar.axis = .horizontal
+        bar.alignment = .center
+        bar.distribution = .fill
+        bar.isLayoutMarginsRelativeArrangement = true
+        bar.directionalLayoutMargins = .init(top: 6, leading: 12, bottom: 6, trailing: 12)
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        bar.isHidden = files.count < 2
+        view.addSubview(bar)
+        NSLayoutConstraint.activate([
+            bar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            previousButton.widthAnchor.constraint(equalToConstant: 44),
+            previousButton.heightAnchor.constraint(equalToConstant: 44),
+            nextButton.widthAnchor.constraint(equalToConstant: 44),
+            nextButton.heightAnchor.constraint(equalToConstant: 44),
+        ])
+        walkerBar = bar
+        return bar
+    }
+
+    private func configureText(below header: UIView, above walker: UIView) {
+        let layoutManager = DiffWashLayoutManager()
+        storage.addLayoutManager(layoutManager)
+        let container = NSTextContainer(size: CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
+        container.widthTracksTextView = true
+        // Breathing room between the edge bar and the first glyph lives in the
+        // container's padding, so the wash the layout manager paints still reaches the
+        // full width instead of stopping at an inset.
+        container.lineFragmentPadding = 8
+        layoutManager.addTextContainer(container)
+
+        textView = DiffTextView(frame: .zero, textContainer: container)
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.alwaysBounceVertical = true
+        textView.backgroundColor = .clear
+        textView.delegate = self
+        // The left inset is the line-number column the text view paints into.
+        textView.textContainerInset = UIEdgeInsets(top: 10, left: DiffTextView.gutterWidth, bottom: 24, right: 8)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(textView)
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: header.bottomAnchor, constant: 4),
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            textView.bottomAnchor.constraint(equalTo: walker.topAnchor),
+        ])
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+        textView.addGestureRecognizer(tap)
+    }
+
+    /// Jump to the next change in a long diff — the one navigation a scrolling reader
+    /// actually needs. Floats over the code, out of the text's way.
+    private func configureHunkButton(above walker: UIView) {
+        hunkButton.applyGlassSymbol("chevron.down")
+        hunkButton.tintColor = .label
+        hunkButton.isHidden = true
+        hunkButton.addAction(UIAction { [weak self] _ in self?.scrollToNextChange() }, for: .touchUpInside)
+        hunkButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hunkButton)
+        NSLayoutConstraint.activate([
+            hunkButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -14),
+            hunkButton.bottomAnchor.constraint(equalTo: walker.topAnchor, constant: -14),
+            hunkButton.widthAnchor.constraint(equalToConstant: 44),
+            hunkButton.heightAnchor.constraint(equalToConstant: 44),
+        ])
+    }
+
+    private func configureStatus() {
+        statusLabel.font = .preferredFont(forTextStyle: .subheadline)
+        statusLabel.textColor = .secondaryLabel
+        statusLabel.textAlignment = .center
+        statusLabel.numberOfLines = 0
+        statusLabel.isHidden = true
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(statusLabel)
+        NSLayoutConstraint.activate([
+            statusLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            statusLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32),
+            statusLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -32),
+        ])
+    }
+
+    // MARK: - Files
+
+    private func walk(_ delta: Int) {
+        let target = index + delta
+        guard files.indices.contains(target) else { return }
+        index = target
+        reloadFile()
+    }
+
+    private func reloadFile() {
+        guard let change else { return }
+        rows = []
+        expanded = []
+        document = nil
+        storage.setAttributedString(NSAttributedString())
+        titleLabel.text = (change.path as NSString).lastPathComponent
+        subtitleLabel.text = summary(for: change)
+        walkerLabel.text = "\(index + 1) of \(files.count)"
+        previousButton.isEnabled = index > 0
+        nextButton.isEnabled = index < files.count - 1
+        hunkButton.isHidden = true
+        statusLabel.isHidden = true
+        pendingPath = change.path
+        spinner.startAnimating()
+        onRequestDiff?(change.path)
+    }
+
+    private func summary(for change: WireChange) -> String {
+        let directory = (change.path as NSString).deletingLastPathComponent
+        var parts: [String] = []
+        if !directory.isEmpty { parts.append(directory) }
+        if change.isBinary {
+            parts.append("binary")
+        } else {
+            parts.append("+\(change.additions) −\(change.deletions)")
         }
-        return result
+        if change.isStaged { parts.append("staged") }
+        return parts.joined(separator: " · ")
+    }
+
+    /// A `readDiff` reply arrived (routed in by the owner).
+    func receive(_ diff: WireDiff) {
+        guard diff.path == pendingPath else { return }
+        pendingPath = nil
+        spinner.stopAnimating()
+        guard !diff.binary else {
+            show(status: "Binary file — no text diff to show.")
+            return
+        }
+        rows = DiffParser.lines(from: diff.text)
+        guard !rows.isEmpty else {
+            show(status: "No textual changes in this file.")
+            return
+        }
+        statusLabel.isHidden = true
+        rebuild(preservingScroll: false)
+        highlightSyntax()
+    }
+
+    /// The Mac refused the request (routed in by the owner).
+    func failed(_ message: String) {
+        pendingPath = nil
+        spinner.stopAnimating()
+        show(status: message)
+    }
+
+    private func show(status: String) {
+        storage.setAttributedString(NSAttributedString())
+        document = nil
+        textView.document = nil
+        hunkButton.isHidden = true
+        statusLabel.text = status
+        statusLabel.isHidden = false
+    }
+
+    // MARK: - Rendering
+
+    private func rebuild(preservingScroll: Bool, anchorRowId: Int? = nil, anchorY: CGFloat = 0) {
+        let items = DiffParser.displayItems(lines: rows, expanded: expanded)
+        let built = DiffDocument.build(items: items, font: MobileSettings.shared.codeFont())
+        document = built
+        textView.document = built
+        storage.setAttributedString(built.attributed)
+        hunkButton.isHidden = built.changeAnchors.count < 2
+        guard preservingScroll, let anchorRowId,
+              let line = built.lines.first(where: { $0.rowId == anchorRowId }) else { return }
+        // Keep the tapped band's first revealed line where the band was, so expanding
+        // never teleports the reader.
+        let rect = textView.rect(forParagraph: line)
+        let offset = max(rect.minY - anchorY, -textView.adjustedContentInset.top)
+        textView.setContentOffset(CGPoint(x: 0, y: offset), animated: false)
+    }
+
+    /// Colors the diff the way the desktop does: each side is highlighted as one text so
+    /// multi-line constructs (block comments, raw strings) keep their real state, then
+    /// the per-line results are dropped onto the built document. Context lines take the
+    /// new side's colors; the old side contributes only its deletions.
+    private func highlightSyntax() {
+        guard let change,
+              let language = CodeHighlighter.language(forFileNamed: (change.path as NSString).lastPathComponent)
+        else { return }
+        let dark = traitCollection.userInterfaceStyle == .dark
+        let font = MobileSettings.shared.codeFont()
+        let newSide = rows.filter { $0.kind == .context || $0.kind == .addition }
+        let oldSide = rows.filter { $0.kind == .deletion }
+        let path = change.path
+        DiffSyntaxHighlighter.shared.styledLines(
+            newSide: newSide, oldSide: oldSide, language: language,
+            theme: dark ? "xcode-dark" : "xcode", font: font
+        ) { [weak self] styled in
+            guard let self, !styled.isEmpty, self.change?.path == path else { return }
+            apply(styled: styled)
+        }
+    }
+
+    private func apply(styled: [Int: NSAttributedString]) {
+        guard let document else { return }
+        storage.beginEditing()
+        for line in document.lines {
+            guard case .code = line.role, let colored = styled[line.rowId],
+                  colored.length == line.range.length - 1 else { continue }
+            colored.enumerateAttribute(.foregroundColor, in: NSRange(location: 0, length: colored.length)) {
+                value, range, _ in
+                guard let color = value as? UIColor else { return }
+                storage.addAttribute(
+                    .foregroundColor, value: color,
+                    range: NSRange(location: line.range.location + range.location, length: range.length)
+                )
+            }
+        }
+        storage.endEditing()
+    }
+
+    // MARK: - Interaction
+
+    /// A tap on a fold band reveals its lines. Everything else is the text view's own
+    /// business (a tap in code just dismisses any selection).
+    @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
+        let point = gesture.location(in: textView)
+        guard let line = textView.line(at: point), case .band(let expandable) = line.role else { return }
+        guard expandable else {
+            // A fixed band's lines were never fetched — say so instead of no-oping.
+            let alert = UIAlertController(
+                title: "Not available",
+                message: "This diff was fetched without full context because the file is large, so the skipped lines aren't on the phone.",
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            present(alert, animated: true)
+            return
+        }
+        let anchorY = textView.rect(forParagraph: line).minY - textView.contentOffset.y
+        expanded.insert(line.rowId)
+        rebuild(preservingScroll: true, anchorRowId: line.rowId, anchorY: anchorY)
+    }
+
+    private func scrollToNextChange() {
+        guard let document, !document.changeAnchors.isEmpty else { return }
+        let current = textView.contentOffset.y + textView.adjustedContentInset.top
+        let next = document.changeAnchors.first {
+            textView.rect(forParagraph: document.lines[$0]).minY > current + 8
+        } ?? document.changeAnchors[0]
+        let target = textView.rect(forParagraph: document.lines[next]).minY - 12
+        textView.setContentOffset(CGPoint(x: 0, y: max(target, -textView.adjustedContentInset.top)), animated: true)
+    }
+
+    /// The selected text as pure code: band labels are chrome, so a selection that
+    /// spans one hands the agent the code around it, not "⋯ 24 unchanged lines".
+    private func selectedCode() -> String? {
+        guard let document, let range = textView.selectedTextRange, !range.isEmpty else { return nil }
+        let selection = textView.selectedRange
+        var parts: [String] = []
+        for line in document.lines {
+            guard NSIntersectionRange(line.range, selection).length > 0 else { continue }
+            if case .band = line.role { continue }
+            let clipped = NSIntersectionRange(line.range, selection)
+            parts.append((storage.string as NSString).substring(with: clipped))
+        }
+        let text = parts.joined()
+        return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : text
+    }
+}
+
+extension DiffViewController: UITextViewDelegate {
+    func textView(
+        _ textView: UITextView,
+        editMenuForTextIn range: NSRange,
+        suggestedActions: [UIMenuElement]
+    ) -> UIMenu? {
+        guard onSendToAgent != nil, range.length > 0 else { return nil }
+        let send = UIAction(title: "Send to Agent", image: UIImage(systemName: "arrow.up.message")) {
+            [weak self] _ in
+            guard let self, let code = selectedCode() else { return }
+            onSendToAgent?(code)
+            self.textView.selectedTextRange = nil
+            dismiss(animated: true)
+        }
+        return UIMenu(children: [send] + suggestedActions)
+    }
+}
+
+// MARK: - Document
+
+/// The folded diff laid down as one attributed string plus per-paragraph metadata the
+/// text view reads at draw time. One document means one scroll and one continuous
+/// selection, which is what lets a selection cross lines and reach the agent intact.
+final class DiffDocument {
+    enum Role {
+        case code(DiffLine.Kind)
+        case band(expandable: Bool)
+    }
+
+    struct Line {
+        let role: Role
+        /// The paragraph's range, including its trailing newline.
+        let range: NSRange
+        /// `DiffLine.id` for code (keys the syntax pass), the first hidden line's id for
+        /// a band (keys the expand).
+        let rowId: Int
+        /// The number drawn in the gutter: a deletion's old line, else the new one.
+        let number: Int?
+    }
+
+    let attributed: NSAttributedString
+    let lines: [Line]
+    /// Indices into `lines` where a run of additions/deletions starts — the stops the
+    /// next-hunk button walks.
+    let changeAnchors: [Int]
+
+    private init(attributed: NSAttributedString, lines: [Line], changeAnchors: [Int]) {
+        self.attributed = attributed
+        self.lines = lines
+        self.changeAnchors = changeAnchors
+    }
+
+    /// Extra height around a band's text, so the whole row clears a 44pt tap target.
+    static let bandPadding: CGFloat = 13
+
+    static func build(items: [DiffItem], font: UIFont) -> DiffDocument {
+        var text = String()
+        var lines: [Line] = []
+        var changeAnchors: [Int] = []
+        var previousWasChange = false
+
+        for item in items {
+            let location = (text as NSString).length
+            switch item {
+            case .line(let row):
+                text += row.text
+                text += "\n"
+                let isChange = row.kind == .addition || row.kind == .deletion
+                if isChange, !previousWasChange { changeAnchors.append(lines.count) }
+                previousWasChange = isChange
+                lines.append(Line(
+                    role: .code(row.kind),
+                    range: NSRange(location: location, length: (row.text as NSString).length + 1),
+                    rowId: row.id,
+                    number: row.kind == .deletion ? row.oldLine : row.newLine
+                ))
+            case .band(let id, let count, let expandable):
+                let label = "⋯ \(count) unchanged \(count == 1 ? "line" : "lines")"
+                text += label
+                text += "\n"
+                previousWasChange = false
+                lines.append(Line(
+                    role: .band(expandable: expandable),
+                    range: NSRange(location: location, length: (label as NSString).length + 1),
+                    rowId: id,
+                    number: nil
+                ))
+            }
+        }
+
+        let attributed = NSMutableAttributedString(string: text, attributes: [
+            .font: font,
+            .foregroundColor: UIColor.label,
+        ])
+        // A wrapped continuation hangs off the line's *own* indentation, not off the
+        // margin: on a 390pt screen most lines wrap, and a continuation that jumps back
+        // to column 0 reads as a new statement. One style per distinct indent, cached —
+        // a 5000-line diff has a handful.
+        var styles: [String: NSParagraphStyle] = [:]
+        for (item, line) in zip(items, lines) {
+            guard case .line(let row) = item else { continue }
+            let indent = String(row.text.prefix { $0 == " " || $0 == "\t" })
+            let style = styles[indent] ?? {
+                let style = NSMutableParagraphStyle()
+                style.lineSpacing = 2
+                let width = (indent as NSString).size(withAttributes: [.font: font]).width
+                style.headIndent = width + 16
+                styles[indent] = style
+                return style
+            }()
+            attributed.addAttribute(.paragraphStyle, value: style, range: line.range)
+        }
+
+        let band = NSMutableParagraphStyle()
+        band.alignment = .center
+        band.lineSpacing = 2
+        band.paragraphSpacingBefore = bandPadding
+        band.paragraphSpacing = bandPadding
+        for (item, line) in zip(items, lines) {
+            switch item {
+            case .band:
+                attributed.addAttributes([
+                    .font: UIFont.systemFont(ofSize: 11, weight: .medium),
+                    .foregroundColor: UIColor.tertiaryLabel,
+                    .paragraphStyle: band,
+                ], range: line.range)
+            case .line(let row):
+                guard let emphasis = row.emphasis, !emphasis.isEmpty,
+                      let range = utf16Range(of: emphasis, in: row.text) else { continue }
+                let color: UIColor = row.kind == .addition
+                    ? UIColor.systemGreen.withAlphaComponent(0.3)
+                    : UIColor.systemRed.withAlphaComponent(0.3)
+                attributed.addAttribute(
+                    .backgroundColor, value: color,
+                    range: NSRange(location: line.range.location + range.location, length: range.length)
+                )
+            }
+        }
+
+        return DiffDocument(attributed: attributed, lines: lines, changeAnchors: changeAnchors)
+    }
+
+    /// The index of the first line whose paragraph ends past `location`.
+    func lineIndex(at location: Int) -> Int {
+        var low = 0, high = lines.count
+        while low < high {
+            let mid = (low + high) / 2
+            if NSMaxRange(lines[mid].range) <= location { low = mid + 1 } else { high = mid }
+        }
+        return low
+    }
+
+    func line(at location: Int) -> Line? {
+        let index = lineIndex(at: location)
+        guard index < lines.count, NSLocationInRange(location, lines[index].range) else { return nil }
+        return lines[index]
+    }
+
+    /// `DiffLine.emphasis` counts `Character`s (the intraline pass is CJK-aware);
+    /// attributed ranges are UTF-16. Bail rather than misplace the span.
+    private static func utf16Range(of emphasis: Range<Int>, in text: String) -> NSRange? {
+        guard let lower = text.index(text.startIndex, offsetBy: emphasis.lowerBound, limitedBy: text.endIndex),
+              let upper = text.index(text.startIndex, offsetBy: emphasis.upperBound, limitedBy: text.endIndex),
+              lower < upper else { return nil }
+        return NSRange(lower..<upper, in: text)
+    }
+}
+
+// MARK: - Text view
+
+/// The diff's text view: TextKit 1 so the wash layout manager can paint underneath the
+/// glyphs, plus the line-number column drawn into the container's left inset.
+final class DiffTextView: UITextView {
+    static let gutterWidth: CGFloat = 34
+
+    var document: DiffDocument? {
+        didSet {
+            (layoutManager as? DiffWashLayoutManager)?.document = document
+            setNeedsDisplay()
+        }
+    }
+
+    /// The paragraph's rect in content coordinates.
+    func rect(forParagraph line: DiffDocument.Line) -> CGRect {
+        let glyphs = layoutManager.glyphRange(forCharacterRange: line.range, actualCharacterRange: nil)
+        var rect = layoutManager.boundingRect(forGlyphRange: glyphs, in: textContainer)
+        rect.origin.x += textContainerInset.left
+        rect.origin.y += textContainerInset.top
+        return rect
+    }
+
+    /// The line under a point in view coordinates, if any.
+    func line(at point: CGPoint) -> DiffDocument.Line? {
+        guard let document else { return nil }
+        let inContainer = CGPoint(
+            x: point.x - textContainerInset.left,
+            y: point.y - textContainerInset.top
+        )
+        let index = layoutManager.characterIndex(
+            for: inContainer, in: textContainer,
+            fractionOfDistanceBetweenInsertionPoints: nil
+        )
+        // `characterIndex` snaps to the nearest character, so a tap in the empty space
+        // past the end would "hit" the last line. Take the hit only if the point is
+        // actually inside that paragraph.
+        guard let line = document.line(at: index),
+              rect(forParagraph: line).insetBy(dx: 0, dy: -DiffDocument.bandPadding).contains(point)
+        else { return nil }
+        return line
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        (layoutManager as? DiffWashLayoutManager)?.contentWidth = bounds.width
+    }
+
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        drawLineNumbers(in: rect)
+    }
+
+    /// Numbers ride in the container's left inset, outside the selectable text — so a
+    /// selection copies pure code, never "214 let x = 1". Only the visible paragraphs
+    /// are measured.
+    private func drawLineNumbers(in rect: CGRect) {
+        guard let document, let context = UIGraphicsGetCurrentContext() else { return }
+        let size = max(9, MobileSettings.shared.codeFont().pointSize - 2)
+        let font = UIFont.monospacedDigitSystemFont(ofSize: size, weight: .regular)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: UIColor.tertiaryLabel,
+        ]
+        // Start at the first paragraph the dirty rect touches — a 5000-line diff must
+        // not measure every line on every scroll tick.
+        let visible = rect.offsetBy(dx: -textContainerInset.left, dy: -textContainerInset.top)
+        let glyphs = layoutManager.glyphRange(forBoundingRect: visible, in: textContainer)
+        let characters = layoutManager.characterRange(forGlyphRange: glyphs, actualGlyphRange: nil)
+        context.saveGState()
+        var index = document.lineIndex(at: characters.location)
+        while index < document.lines.count {
+            let line = document.lines[index]
+            index += 1
+            if line.range.location >= NSMaxRange(characters) { break }
+            guard let number = line.number else { continue }
+            let paragraph = self.rect(forParagraph: line)
+            let text = NSAttributedString(string: "\(number)", attributes: attributes)
+            // Right-aligned against the code's leading edge, drawn on the paragraph's
+            // first line so a wrapped line is numbered once.
+            text.draw(at: CGPoint(
+                x: Self.gutterWidth - text.size().width - 8,
+                y: paragraph.minY + font.lineHeight * 0.1
+            ))
+        }
+        context.restoreGState()
+    }
+}
+
+/// Paints each line's meaning behind its glyphs: a saturated 3pt bar at the leading
+/// edge and a light wash across the row for additions and deletions, a flat fill for
+/// fold bands. The bar is what carries at phone size — the wash stays light enough that
+/// syntax colors on top stay readable, which a full-strength green does not.
+final class DiffWashLayoutManager: NSLayoutManager {
+    var document: DiffDocument?
+    /// The hosting view's width — washes span the whole row, including the line-number
+    /// column, not just the laid-out text.
+    var contentWidth: CGFloat = 0
+
+    static let barWidth: CGFloat = 3
+
+    override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
+        if let document, let container = textContainers.first {
+            let charRange = characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
+            let width = max(usedRect(for: container).width + origin.x, contentWidth)
+            var index = document.lineIndex(at: charRange.location)
+            while index < document.lines.count {
+                let line = document.lines[index]
+                index += 1
+                if line.range.location >= NSMaxRange(charRange) { break }
+                guard let (wash, bar) = Self.fills(for: line.role) else { continue }
+                let glyphs = glyphRange(forCharacterRange: line.range, actualCharacterRange: nil)
+                var rect = boundingRect(forGlyphRange: glyphs, in: container)
+                rect.origin.x = 0
+                rect.size.width = width
+                rect.origin.y += origin.y
+                if case .band = line.role {
+                    rect = rect.insetBy(dx: 0, dy: -DiffDocument.bandPadding)
+                }
+                wash.setFill()
+                UIRectFill(rect)
+                if let bar {
+                    bar.setFill()
+                    UIRectFill(CGRect(x: 0, y: rect.minY, width: Self.barWidth, height: rect.height))
+                }
+            }
+        }
+        super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
+    }
+
+    /// (row wash, leading bar). The wash is deliberately faint; the bar is full strength.
+    static func fills(for role: DiffDocument.Role) -> (UIColor, UIColor?)? {
+        switch role {
+        case .code(.addition):
+            return (UIColor.systemGreen.withAlphaComponent(0.09), UIColor.systemGreen)
+        case .code(.deletion):
+            return (UIColor.systemRed.withAlphaComponent(0.09), UIColor.systemRed)
+        case .band:
+            return (UIColor.label.withAlphaComponent(0.05), nil)
+        case .code:
+            return nil
+        }
+    }
+}
+
+// MARK: - Syntax
+
+/// One reusable Highlightr on a serial queue. Building its JavaScriptCore context costs
+/// on the order of 100 ms — too much to pay per file — and the context is not safe to
+/// share across threads, so every request is funnelled through the same queue. The
+/// desktop keeps the same arrangement behind an actor.
+final class DiffSyntaxHighlighter {
+    static let shared = DiffSyntaxHighlighter()
+
+    /// Past this, highlighting a whole file's diff costs more than it returns on a
+    /// phone; the reader stays readable in plain ink.
+    private static let maxCharacters = 200_000
+
+    private let queue = DispatchQueue(label: "sh.termio.diff-syntax", qos: .userInitiated)
+    private var highlightr: Highlightr?
+    private var appliedTheme: String?
+    private var appliedFont: UIFont?
+
+    func styledLines(
+        newSide: [DiffLine], oldSide: [DiffLine], language: String,
+        theme: String, font: UIFont,
+        completion: @escaping ([Int: NSAttributedString]) -> Void
+    ) {
+        let total = newSide.reduce(0) { $0 + $1.text.count } + oldSide.reduce(0) { $0 + $1.text.count }
+        guard total <= Self.maxCharacters else { return }
+        queue.async { [weak self] in
+            guard let self, let highlightr = prepared(theme: theme, font: font) else { return }
+            var result: [Int: NSAttributedString] = [:]
+            Self.apply(newSide, keeping: [.context, .addition], highlightr, language, into: &result)
+            Self.apply(oldSide, keeping: [.deletion], highlightr, language, into: &result)
+            DispatchQueue.main.async { completion(result) }
+        }
+    }
+
+    private func prepared(theme: String, font: UIFont) -> Highlightr? {
+        if highlightr == nil { highlightr = Highlightr() }
+        guard let highlightr else { return nil }
+        if appliedTheme != theme {
+            guard highlightr.setTheme(to: theme) else { return nil }
+            appliedTheme = theme
+            appliedFont = nil
+        }
+        if appliedFont != font {
+            highlightr.theme.setCodeFont(font)
+            appliedFont = font
+        }
+        return highlightr
+    }
+
+    private static func apply(
+        _ side: [DiffLine], keeping kinds: Set<DiffLine.Kind>,
+        _ highlightr: Highlightr, _ language: String,
+        into result: inout [Int: NSAttributedString]
+    ) {
+        let joined = side.map(\.text).joined(separator: "\n")
+        // The colored text must round-trip exactly, or the per-line offsets below would
+        // attribute the wrong spans — bail to plain rendering instead.
+        guard let colored = highlightr.highlight(joined, as: language, fastRender: true),
+              colored.string == joined else { return }
+        var location = 0
+        for row in side {
+            let length = (row.text as NSString).length
+            defer { location += length + 1 }
+            guard kinds.contains(row.kind), length > 0 else { continue }
+            result[row.id] = colored.attributedSubstring(from: NSRange(location: location, length: length))
+        }
     }
 }

--- a/ios/Sources/DiffViewController.swift
+++ b/ios/Sources/DiffViewController.swift
@@ -22,16 +22,16 @@ final class DiffViewController: UIViewController {
     private var files: [WireChange]
     private var index: Int
 
-    /// Ask the owner (which holds the companion socket) for one file's diff; the reply
-    /// arrives back through `receive(_:)`.
-    var onRequestDiff: ((String) -> Void)?
+    /// Ask the owner (which holds the companion socket) for one file's diff, passing the
+    /// status from the listing so the Mac needn't re-derive it; the reply arrives back
+    /// through `receive(_:)`.
+    var onRequestDiff: ((String, String) -> Void)?
     /// Bracketed-paste selected code into the session's terminal. nil hides the action —
     /// a plain shell has no prompt to feed.
     var onSendToAgent: ((String) -> Void)?
 
     private var rows: [DiffLine] = []
     private var expanded: Set<Int> = []
-    private var document: DiffDocument?
     /// The path a `readDiff` is in flight for, so a late reply for the previous file
     /// can't paint over the current one.
     private var pendingPath: String?
@@ -46,7 +46,6 @@ final class DiffViewController: UIViewController {
     private let previousButton = UIButton(type: .system)
     private let nextButton = UIButton(type: .system)
     private let hunkButton = UIButton(type: .system)
-    private var walkerBar: UIStackView!
 
     /// A `readDiff` is outstanding, so a failure belongs to this screen.
     var isAwaitingDiff: Bool { pendingPath != nil }
@@ -54,6 +53,8 @@ final class DiffViewController: UIViewController {
     private var change: WireChange? {
         files.indices.contains(index) ? files[index] : nil
     }
+
+    private var document: DiffDocument? { textView.document }
 
     init(files: [WireChange], index: Int) {
         self.files = files
@@ -147,7 +148,6 @@ final class DiffViewController: UIViewController {
             nextButton.widthAnchor.constraint(equalToConstant: 44),
             nextButton.heightAnchor.constraint(equalToConstant: 44),
         ])
-        walkerBar = bar
         return bar
     }
 
@@ -228,31 +228,22 @@ final class DiffViewController: UIViewController {
         guard let change else { return }
         rows = []
         expanded = []
-        document = nil
+        textView.document = nil
         storage.setAttributedString(NSAttributedString())
-        titleLabel.text = (change.path as NSString).lastPathComponent
-        subtitleLabel.text = summary(for: change)
+        titleLabel.text = change.name
+        subtitleLabel.text = change.caption
         walkerLabel.text = "\(index + 1) of \(files.count)"
         previousButton.isEnabled = index > 0
         nextButton.isEnabled = index < files.count - 1
         hunkButton.isHidden = true
         statusLabel.isHidden = true
+        guard !change.isBinary else {
+            show(status: "Binary file — no text diff to show.")
+            return
+        }
         pendingPath = change.path
         spinner.startAnimating()
-        onRequestDiff?(change.path)
-    }
-
-    private func summary(for change: WireChange) -> String {
-        let directory = (change.path as NSString).deletingLastPathComponent
-        var parts: [String] = []
-        if !directory.isEmpty { parts.append(directory) }
-        if change.isBinary {
-            parts.append("binary")
-        } else {
-            parts.append("+\(change.additions) −\(change.deletions)")
-        }
-        if change.isStaged { parts.append("staged") }
-        return parts.joined(separator: " · ")
+        onRequestDiff?(change.path, change.status)
     }
 
     /// A `readDiff` reply arrived (routed in by the owner).
@@ -270,7 +261,7 @@ final class DiffViewController: UIViewController {
             return
         }
         statusLabel.isHidden = true
-        rebuild(preservingScroll: false)
+        rebuild()
         highlightSyntax()
     }
 
@@ -283,7 +274,6 @@ final class DiffViewController: UIViewController {
 
     private func show(status: String) {
         storage.setAttributedString(NSAttributedString())
-        document = nil
         textView.document = nil
         hunkButton.isHidden = true
         statusLabel.text = status
@@ -292,19 +282,19 @@ final class DiffViewController: UIViewController {
 
     // MARK: - Rendering
 
-    private func rebuild(preservingScroll: Bool, anchorRowId: Int? = nil, anchorY: CGFloat = 0) {
+    /// `anchor` pins a row to a screen position across the rebuild — the tapped band's
+    /// first revealed line stays where the band was, so expanding never teleports the
+    /// reader. nil rebuilds from the top.
+    private func rebuild(anchor: (rowId: Int, y: CGFloat)? = nil) {
         let items = DiffParser.displayItems(lines: rows, expanded: expanded)
         let built = DiffDocument.build(items: items, font: MobileSettings.shared.codeFont())
-        document = built
         textView.document = built
         storage.setAttributedString(built.attributed)
         hunkButton.isHidden = built.changeAnchors.count < 2
-        guard preservingScroll, let anchorRowId,
-              let line = built.lines.first(where: { $0.rowId == anchorRowId }) else { return }
-        // Keep the tapped band's first revealed line where the band was, so expanding
-        // never teleports the reader.
+        guard let anchor, let line = built.lines.first(where: { $0.rowId == anchor.rowId })
+        else { return }
         let rect = textView.rect(forParagraph: line)
-        let offset = max(rect.minY - anchorY, -textView.adjustedContentInset.top)
+        let offset = max(rect.minY - anchor.y, -textView.adjustedContentInset.top)
         textView.setContentOffset(CGPoint(x: 0, y: offset), animated: false)
     }
 
@@ -368,7 +358,7 @@ final class DiffViewController: UIViewController {
         }
         let anchorY = textView.rect(forParagraph: line).minY - textView.contentOffset.y
         expanded.insert(line.rowId)
-        rebuild(preservingScroll: true, anchorRowId: line.rowId, anchorY: anchorY)
+        rebuild(anchor: (line.rowId, anchorY))
     }
 
     private func scrollToNextChange() {
@@ -387,10 +377,14 @@ final class DiffViewController: UIViewController {
         guard let document, let range = textView.selectedTextRange, !range.isEmpty else { return nil }
         let selection = textView.selectedRange
         var parts: [String] = []
-        for line in document.lines {
-            guard NSIntersectionRange(line.range, selection).length > 0 else { continue }
+        var index = document.lineIndex(at: selection.location)
+        while index < document.lines.count {
+            let line = document.lines[index]
+            index += 1
+            if line.range.location >= NSMaxRange(selection) { break }
             if case .band = line.role { continue }
             let clipped = NSIntersectionRange(line.range, selection)
+            guard clipped.length > 0 else { continue }
             parts.append((storage.string as NSString).substring(with: clipped))
         }
         let text = parts.joined()
@@ -457,42 +451,48 @@ final class DiffDocument {
     }
 
     /// Extra height around a band's text, so the whole row clears a 44pt tap target.
-    static let bandPadding: CGFloat = 13
+    fileprivate static let bandPadding: CGFloat = 13
 
     static func build(items: [DiffItem], font: UIFont) -> DiffDocument {
         var text = String()
         var lines: [Line] = []
         var changeAnchors: [Int] = []
         var previousWasChange = false
+        // A running offset: `(text as NSString).length` on the growing string is O(n) for
+        // non-ASCII content, which would make laying the document down quadratic.
+        var location = 0
 
         for item in items {
-            let location = (text as NSString).length
             switch item {
             case .line(let row):
                 text += row.text
                 text += "\n"
+                let length = (row.text as NSString).length + 1
                 let isChange = row.kind == .addition || row.kind == .deletion
                 if isChange, !previousWasChange { changeAnchors.append(lines.count) }
                 previousWasChange = isChange
                 lines.append(Line(
                     role: .code(row.kind),
-                    range: NSRange(location: location, length: (row.text as NSString).length + 1),
+                    range: NSRange(location: location, length: length),
                     rowId: row.id,
                     number: row.kind == .deletion ? row.oldLine : row.newLine
                 ))
+                location += length
             case .band(let id, let range, let expandable):
                 // The range names the code the fold hides, against the same numbers the
                 // gutter shows. A count would only describe the fold itself.
                 let label = "\(range.lowerBound)–\(range.upperBound)"
                 text += label
                 text += "\n"
+                let length = (label as NSString).length + 1
                 previousWasChange = false
                 lines.append(Line(
                     role: .band(expandable: expandable),
-                    range: NSRange(location: location, length: (label as NSString).length + 1),
+                    range: NSRange(location: location, length: length),
                     rowId: id,
                     number: nil
                 ))
+                location += length
             }
         }
 
@@ -500,30 +500,18 @@ final class DiffDocument {
             .font: font,
             .foregroundColor: UIColor.label,
         ])
-        // A wrapped continuation hangs off the line's *own* indentation, not off the
-        // margin: on a 390pt screen most lines wrap, and a continuation that jumps back
-        // to column 0 reads as a new statement. One style per distinct indent, cached —
-        // a 5000-line diff has a handful.
-        var styles: [String: NSParagraphStyle] = [:]
-        for (item, line) in zip(items, lines) {
-            guard case .line(let row) = item else { continue }
-            let indent = String(row.text.prefix { $0 == " " || $0 == "\t" })
-            let style = styles[indent] ?? {
-                let style = NSMutableParagraphStyle()
-                style.lineSpacing = 2
-                let width = (indent as NSString).size(withAttributes: [.font: font]).width
-                style.headIndent = width + 16
-                styles[indent] = style
-                return style
-            }()
-            attributed.addAttribute(.paragraphStyle, value: style, range: line.range)
-        }
-
         let band = NSMutableParagraphStyle()
         band.alignment = .center
         band.lineSpacing = 2
         band.paragraphSpacingBefore = bandPadding
         band.paragraphSpacing = bandPadding
+        // A wrapped continuation hangs off the line's *own* indentation, not off the
+        // margin: on a 390pt screen most lines wrap, and a continuation that jumps back
+        // to column 0 reads as a new statement. One style per distinct indent, cached —
+        // a 5000-line diff has a handful.
+        var styles: [String: NSParagraphStyle] = [:]
+
+        attributed.beginEditing()
         for (item, line) in zip(items, lines) {
             switch item {
             case .band(_, _, let expandable):
@@ -535,6 +523,15 @@ final class DiffDocument {
                     .paragraphStyle: band,
                 ], range: line.range)
             case .line(let row):
+                let indent = String(row.text.prefix { $0 == " " || $0 == "\t" })
+                let style = styles[indent] ?? {
+                    let style = NSMutableParagraphStyle()
+                    style.lineSpacing = 2
+                    style.headIndent = (indent as NSString).size(withAttributes: [.font: font]).width + 16
+                    styles[indent] = style
+                    return style
+                }()
+                attributed.addAttribute(.paragraphStyle, value: style, range: line.range)
                 guard let emphasis = row.emphasis, !emphasis.isEmpty,
                       let range = utf16Range(of: emphasis, in: row.text) else { continue }
                 let color: UIColor = row.kind == .addition
@@ -546,6 +543,7 @@ final class DiffDocument {
                 )
             }
         }
+        attributed.endEditing()
 
         return DiffDocument(attributed: attributed, lines: lines, changeAnchors: changeAnchors)
     }
@@ -644,6 +642,15 @@ final class DiffWashLayoutManager: NSLayoutManager {
 
     static let barWidth: CGFloat = 3
 
+    /// Everything below is constant per document; a draw pass fires on every scroll
+    /// tick, so none of it is rebuilt there.
+    private static let additionWash = UIColor.systemGreen.withAlphaComponent(0.09)
+    private static let deletionWash = UIColor.systemRed.withAlphaComponent(0.09)
+    private lazy var numberAttributes = Self.numberAttributes()
+    /// One digit's advance in the (monospaced-digit) number font, so a number can be
+    /// right-aligned by arithmetic instead of a measuring layout pass per line.
+    private lazy var digitWidth: CGFloat = ("0" as NSString).size(withAttributes: numberAttributes).width
+
     /// Everything the row means is drawn here, in one pass over the visible lines:
     /// washes, edge bars, and the line numbers.
     ///
@@ -659,8 +666,10 @@ final class DiffWashLayoutManager: NSLayoutManager {
     override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
         if let document, let container = textContainers.first {
             let charRange = characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
-            let width = max(usedRect(for: container).width + origin.x, contentWidth)
-            let numberAttributes = Self.numberAttributes()
+            // The view's width, not the used rect: the text soft-wraps, so it never
+            // exceeds the view — and `usedRect` would lay out the whole container on
+            // every pass to tell us so.
+            let width = contentWidth
             var index = document.lineIndex(at: charRange.location)
             while index < document.lines.count {
                 let line = document.lines[index]
@@ -684,18 +693,16 @@ final class DiffWashLayoutManager: NSLayoutManager {
                     fill.size.width = width
                     wash.setFill()
                     UIRectFill(fill)
-                    if let bar {
-                        bar.setFill()
-                        UIRectFill(CGRect(x: 0, y: fill.minY, width: Self.barWidth, height: fill.height))
-                    }
+                    bar.setFill()
+                    UIRectFill(CGRect(x: 0, y: fill.minY, width: Self.barWidth, height: fill.height))
                 }
                 // `origin.x` is the container's left inset — exactly the column the
                 // numbers live in, and it holds no glyphs to collide with. Drawn on the
                 // paragraph's first line, so a wrapped line is numbered once.
                 if let number = line.number {
-                    let text = NSAttributedString(string: "\(number)", attributes: numberAttributes)
-                    text.draw(at: CGPoint(
-                        x: origin.x - text.size().width - 8,
+                    let digits = "\(number)"
+                    NSAttributedString(string: digits, attributes: numberAttributes).draw(at: CGPoint(
+                        x: origin.x - CGFloat(digits.count) * digitWidth - 8,
                         y: rect.minY
                     ))
                 }
@@ -732,14 +739,11 @@ final class DiffWashLayoutManager: NSLayoutManager {
 
     /// (row wash, leading bar) for a code line. The wash is deliberately faint; the bar
     /// is full strength. Bands paint themselves — see `drawBand`.
-    static func fills(for role: DiffDocument.Role) -> (UIColor, UIColor?)? {
+    private static func fills(for role: DiffDocument.Role) -> (UIColor, UIColor)? {
         switch role {
-        case .code(.addition):
-            return (UIColor.systemGreen.withAlphaComponent(0.09), UIColor.systemGreen)
-        case .code(.deletion):
-            return (UIColor.systemRed.withAlphaComponent(0.09), UIColor.systemRed)
-        case .band, .code:
-            return nil
+        case .code(.addition): return (additionWash, .systemGreen)
+        case .code(.deletion): return (deletionWash, .systemRed)
+        case .band, .code: return nil
         }
     }
 }
@@ -767,13 +771,14 @@ final class DiffSyntaxHighlighter {
         theme: String, font: UIFont,
         completion: @escaping ([Int: NSAttributedString]) -> Void
     ) {
-        let total = newSide.reduce(0) { $0 + $1.text.count } + oldSide.reduce(0) { $0 + $1.text.count }
+        let total = newSide.reduce(0) { $0 + $1.text.utf8.count }
+            + oldSide.reduce(0) { $0 + $1.text.utf8.count }
         guard total <= Self.maxCharacters else { return }
         queue.async { [weak self] in
             guard let self, let highlightr = prepared(theme: theme, font: font) else { return }
             var result: [Int: NSAttributedString] = [:]
-            Self.apply(newSide, keeping: [.context, .addition], highlightr, language, into: &result)
-            Self.apply(oldSide, keeping: [.deletion], highlightr, language, into: &result)
+            Self.apply(newSide, highlightr, language, into: &result)
+            Self.apply(oldSide, highlightr, language, into: &result)
             DispatchQueue.main.async { completion(result) }
         }
     }
@@ -794,8 +799,7 @@ final class DiffSyntaxHighlighter {
     }
 
     private static func apply(
-        _ side: [DiffLine], keeping kinds: Set<DiffLine.Kind>,
-        _ highlightr: Highlightr, _ language: String,
+        _ side: [DiffLine], _ highlightr: Highlightr, _ language: String,
         into result: inout [Int: NSAttributedString]
     ) {
         let joined = side.map(\.text).joined(separator: "\n")
@@ -807,7 +811,7 @@ final class DiffSyntaxHighlighter {
         for row in side {
             let length = (row.text as NSString).length
             defer { location += length + 1 }
-            guard kinds.contains(row.kind), length > 0 else { continue }
+            guard length > 0 else { continue }
             result[row.id] = colored.attributedSubstring(from: NSRange(location: location, length: length))
         }
     }

--- a/ios/Sources/FileIcons.swift
+++ b/ios/Sources/FileIcons.swift
@@ -13,6 +13,12 @@ enum FileIcons {
     /// (nil tint); monochrome marks and the Hugeicons resource glyphs are
     /// template images tinted with label ink so they stay visible in either
     /// appearance, matching the Mac's `monochromeInk` treatment.
+    /// The folder mark, in the same line family as every other glyph in the row —
+    /// an SF `folder` beside Hugeicons strokes reads as two different alphabets.
+    static func folder() -> (image: UIImage?, tint: UIColor?) {
+        (HugeIcon.folder.strokeImage(boxSize: 16), .secondaryLabel)
+    }
+
     static func icon(forFileName name: String) -> (image: UIImage?, tint: UIColor?) {
         if let resource = LangIconCatalog.resource(forFileName: name),
            let image = UIImage(named: resource.name) {

--- a/ios/Sources/FileListViewController.swift
+++ b/ios/Sources/FileListViewController.swift
@@ -98,18 +98,18 @@ final class FileListViewController: UITableViewController {
 /// The one recipe for a file/folder row, so the root listing in the drawer and every
 /// pushed directory read identically.
 enum FileRow {
-    static func configure(_ cell: UITableViewCell, entry: WireFileEntry) {
+    /// `subtitle` is for the flat search results, where a name alone doesn't say which
+    /// file it is; a directory listing needs none.
+    static func configure(_ cell: UITableViewCell, entry: WireFileEntry, subtitle: String? = nil) {
         var config = cell.defaultContentConfiguration()
         config.text = entry.name
         config.textProperties.font = .preferredFont(forTextStyle: .subheadline)
-        if entry.isDir {
-            config.image = UIImage(systemName: "folder")
-            config.imageProperties.tintColor = .secondaryLabel
-        } else {
-            let icon = FileIcons.icon(forFileName: entry.name)
-            config.image = icon.image
-            config.imageProperties.tintColor = icon.tint
-        }
+        config.secondaryText = subtitle
+        config.secondaryTextProperties.font = .preferredFont(forTextStyle: .caption1)
+        config.secondaryTextProperties.color = .secondaryLabel
+        let icon = entry.isDir ? FileIcons.folder() : FileIcons.icon(forFileName: entry.name)
+        config.image = icon.image
+        config.imageProperties.tintColor = icon.tint
         // Icons vary in width (folder vs logo vs symbol); a fixed layout box keeps
         // every name at the same leading edge.
         config.imageProperties.maximumSize = CGSize(width: 16, height: 16)
@@ -131,26 +131,14 @@ enum FileRow {
         stack.axis = .horizontal
         stack.alignment = .center
         stack.spacing = 8
+        // A stack lays its children out by intrinsic size and ignores their frames, so
+        // both pieces carry constraints — a bare `UIView` dot would otherwise collapse to
+        // zero width and vanish. The cell then sizes the accessory from this frame.
         stack.frame = CGRect(
-            x: 0, y: 0,
-            width: pieces.reduce(0) { $0 + $1.frame.width } + CGFloat(pieces.count - 1) * 8,
-            height: 16
+            origin: .zero,
+            size: stack.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
         )
         return stack
-    }
-
-    /// The system disclosure indicator's twin, drawn by hand so it can sit beside the
-    /// changed dot.
-    private static func chevron() -> UIView {
-        let image = UIImage(
-            systemName: "chevron.right",
-            withConfiguration: UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
-        )
-        let view = UIImageView(image: image)
-        view.tintColor = .tertiaryLabel
-        view.frame = CGRect(x: 0, y: 0, width: 10, height: 16)
-        view.contentMode = .scaleAspectFit
-        return view
     }
 
     static func menu(
@@ -161,23 +149,41 @@ enum FileRow {
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak browser] _ in
             var actions: [UIMenuElement] = []
             if !entry.isDir {
-                actions.append(UIAction(title: "Open", image: UIImage(systemName: "doc.text")) { _ in
+                actions.append(UIAction(title: "Open File", image: UIImage(systemName: "doc.text")) { _ in
                     browser?.openFile(at: relative)
                 })
             }
             actions.append(UIAction(title: "Copy Path", image: UIImage(systemName: "doc.on.doc")) { _ in
                 UIPasteboard.general.string = absolute
             })
-            return UIMenu(title: entry.name, children: actions)
+            return UIMenu(title: relative, children: actions)
         }
+    }
+
+    /// The system disclosure indicator's twin, drawn by hand so it can sit beside the
+    /// changed dot (a cell's accessory type and accessory view are mutually exclusive).
+    private static func chevron() -> UIView {
+        let image = UIImage(
+            systemName: "chevron.right",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
+        )
+        let view = UIImageView(image: image)
+        view.tintColor = .tertiaryLabel
+        view.contentMode = .scaleAspectFit
+        return view
     }
 
     /// The dot marking a file the working diff touches (and the folders above it) —
     /// the same signal the desktop tree shows.
-    static func changedDot() -> UIView {
-        let dot = UIView(frame: CGRect(x: 0, y: 0, width: 8, height: 8))
+    private static func changedDot() -> UIView {
+        let dot = UIView()
         dot.backgroundColor = .systemBlue
         dot.layer.cornerRadius = 4
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            dot.widthAnchor.constraint(equalToConstant: 8),
+            dot.heightAnchor.constraint(equalToConstant: 8),
+        ])
         return dot
     }
 }

--- a/ios/Sources/FileListViewController.swift
+++ b/ios/Sources/FileListViewController.swift
@@ -1,0 +1,183 @@
+import TermioShared
+import UIKit
+
+/// What a file list needs from whoever owns the companion socket. The inspector
+/// implements it; every pushed directory screen borrows the same link.
+protocol RemoteFileBrowsing: AnyObject {
+    /// One directory's entries ("" is the project root). The reply may be slow (it
+    /// crosses the wire) or immediate (the offline sample tree).
+    func listEntries(at path: String, then: @escaping ([WireFileEntry]) -> Void)
+    /// Open a file in the read-only viewer.
+    func openFile(at path: String)
+    /// The file's absolute path on the Mac — what "Copy Path" yields, ready to paste
+    /// into an agent prompt.
+    func absolutePath(for path: String) -> String
+}
+
+/// One directory, one screen — the Apple Files shape. An indented tree loses 18pt of a
+/// 390pt screen per level, so by the fourth folder half the width is gutter and every
+/// name is truncated; drilling in spends nothing, and the navigation bar's title and
+/// back button say where you are and walk you out.
+final class FileListViewController: UITableViewController {
+    private let path: String
+    private weak var browser: RemoteFileBrowsing?
+    private var entries: [WireFileEntry] = []
+    private var loaded = false
+    private let spinner = UIActivityIndicatorView(style: .medium)
+
+    init(path: String, browser: RemoteFileBrowsing) {
+        self.path = path
+        self.browser = browser
+        super.init(style: .plain)
+        title = (path as NSString).lastPathComponent
+        // The breadcrumb: where this folder sits, above its own name.
+        let parent = (path as NSString).deletingLastPathComponent
+        navigationItem.prompt = parent.isEmpty ? nil : parent
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 44
+        spinner.startAnimating()
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: spinner)
+        browser?.listEntries(at: path) { [weak self] entries in
+            guard let self else { return }
+            self.entries = entries
+            loaded = true
+            spinner.stopAnimating()
+            navigationItem.rightBarButtonItem = nil
+            tableView.reloadData()
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        entries.count
+    }
+
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        loaded && entries.isEmpty ? "This folder is empty." : nil
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell")
+            ?? UITableViewCell(style: .default, reuseIdentifier: "cell")
+        FileRow.configure(cell, entry: entries[indexPath.row])
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let browser else { return }
+        let entry = entries[indexPath.row]
+        let child = path.isEmpty ? entry.name : "\(path)/\(entry.name)"
+        if entry.isDir {
+            navigationController?.pushViewController(
+                FileListViewController(path: child, browser: browser), animated: true
+            )
+        } else {
+            browser.openFile(at: child)
+        }
+    }
+
+    override func tableView(
+        _ tableView: UITableView,
+        contextMenuConfigurationForRowAt indexPath: IndexPath,
+        point: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard let browser else { return nil }
+        return FileRow.menu(for: entries[indexPath.row], in: path, browser: browser)
+    }
+}
+
+// MARK: - Shared row
+
+/// The one recipe for a file/folder row, so the root listing in the drawer and every
+/// pushed directory read identically.
+enum FileRow {
+    static func configure(_ cell: UITableViewCell, entry: WireFileEntry) {
+        var config = cell.defaultContentConfiguration()
+        config.text = entry.name
+        config.textProperties.font = .preferredFont(forTextStyle: .subheadline)
+        if entry.isDir {
+            config.image = UIImage(systemName: "folder")
+            config.imageProperties.tintColor = .secondaryLabel
+        } else {
+            let icon = FileIcons.icon(forFileName: entry.name)
+            config.image = icon.image
+            config.imageProperties.tintColor = icon.tint
+        }
+        // Icons vary in width (folder vs logo vs symbol); a fixed layout box keeps
+        // every name at the same leading edge.
+        config.imageProperties.maximumSize = CGSize(width: 16, height: 16)
+        config.imageProperties.reservedLayoutSize = CGSize(width: 16, height: 16)
+        cell.contentConfiguration = config
+        // A directory keeps its chevron even when it carries a changed dot: the system
+        // accessory type and a custom accessory view are mutually exclusive, so a row
+        // that needs both draws both itself.
+        cell.accessoryType = .none
+        cell.accessoryView = accessory(changed: entry.changed, isDir: entry.isDir)
+    }
+
+    private static func accessory(changed: Bool, isDir: Bool) -> UIView? {
+        var pieces: [UIView] = []
+        if changed { pieces.append(changedDot()) }
+        if isDir { pieces.append(chevron()) }
+        guard !pieces.isEmpty else { return nil }
+        let stack = UIStackView(arrangedSubviews: pieces)
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 8
+        stack.frame = CGRect(
+            x: 0, y: 0,
+            width: pieces.reduce(0) { $0 + $1.frame.width } + CGFloat(pieces.count - 1) * 8,
+            height: 16
+        )
+        return stack
+    }
+
+    /// The system disclosure indicator's twin, drawn by hand so it can sit beside the
+    /// changed dot.
+    private static func chevron() -> UIView {
+        let image = UIImage(
+            systemName: "chevron.right",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
+        )
+        let view = UIImageView(image: image)
+        view.tintColor = .tertiaryLabel
+        view.frame = CGRect(x: 0, y: 0, width: 10, height: 16)
+        view.contentMode = .scaleAspectFit
+        return view
+    }
+
+    static func menu(
+        for entry: WireFileEntry, in parent: String, browser: RemoteFileBrowsing
+    ) -> UIContextMenuConfiguration {
+        let relative = parent.isEmpty ? entry.name : "\(parent)/\(entry.name)"
+        let absolute = browser.absolutePath(for: relative)
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak browser] _ in
+            var actions: [UIMenuElement] = []
+            if !entry.isDir {
+                actions.append(UIAction(title: "Open", image: UIImage(systemName: "doc.text")) { _ in
+                    browser?.openFile(at: relative)
+                })
+            }
+            actions.append(UIAction(title: "Copy Path", image: UIImage(systemName: "doc.on.doc")) { _ in
+                UIPasteboard.general.string = absolute
+            })
+            return UIMenu(title: entry.name, children: actions)
+        }
+    }
+
+    /// The dot marking a file the working diff touches (and the folders above it) —
+    /// the same signal the desktop tree shows.
+    static func changedDot() -> UIView {
+        let dot = UIView(frame: CGRect(x: 0, y: 0, width: 8, height: 8))
+        dot.backgroundColor = .systemBlue
+        dot.layer.cornerRadius = 4
+        return dot
+    }
+}

--- a/ios/Sources/InspectorViewController.swift
+++ b/ios/Sources/InspectorViewController.swift
@@ -33,8 +33,10 @@ final class InspectorViewController: UIViewController {
 
     private var client: CompanionClient?
     /// Directory listings in flight, keyed by path — a pushed screen's reply must reach
-    /// that screen, not whichever list asked last.
-    private var listingHandlers: [String: ([WireFileEntry]) -> Void] = [:]
+    /// that screen, not whichever list asked last. A path can have more than one waiter
+    /// (pull-to-refresh while the first load is still out), and dropping the earlier one
+    /// would leave its screen spinning forever.
+    private var listingHandlers: [String: [([WireFileEntry]) -> Void]] = [:]
     /// The file path awaiting a `.file` reply, so late/errored replies don't open stale
     /// viewers.
     private var pendingRead: String?
@@ -140,13 +142,8 @@ final class InspectorViewController: UIViewController {
     /// Show/hide the nav-bar spinner, attaching its bar button only while busy so no
     /// empty glass capsule lingers in the header when idle.
     private func setLoading(_ loading: Bool) {
-        if loading {
-            spinner.startAnimating()
-            navigationItem.rightBarButtonItem = UIBarButtonItem(customView: spinner)
-        } else {
-            spinner.stopAnimating()
-            updateRightBarButton()
-        }
+        if loading { spinner.startAnimating() } else { spinner.stopAnimating() }
+        updateRightBarButton()
     }
 
     /// The right slot shows the search affordance when idle in the Files pane; the
@@ -272,6 +269,10 @@ final class InspectorViewController: UIViewController {
     private func receiveError(_ message: String) {
         setLoading(false)
         refreshControl.endRefreshing()
+        // Whatever the failure was, a Changes pane that never loaded has to stop saying
+        // it is loading — the wire's `.error` carries no request id to tell us it was
+        // ours, and "Loading changes…" forever is the worst of the readings.
+        changesLoaded = true
         // A diff on screen owns any failure while it is waiting for one.
         if let activeDiff, activeDiff.isAwaitingDiff {
             activeDiff.failed(message)
@@ -281,7 +282,7 @@ final class InspectorViewController: UIViewController {
             // A directory that never lands would leave its screen spinning forever —
             // answer the waiters with nothing so they settle on their empty state.
             if !listingHandlers.isEmpty {
-                let waiting = listingHandlers.values
+                let waiting = listingHandlers.values.flatMap { $0 }
                 listingHandlers = [:]
                 for handler in waiting { handler([]) }
                 return
@@ -307,8 +308,8 @@ final class InspectorViewController: UIViewController {
     private func receiveListing(path: String, entries: [WireFileEntry]) {
         setLoading(false)
         refreshControl.endRefreshing()
-        guard let handler = listingHandlers.removeValue(forKey: path) else { return }
-        handler(entries)
+        guard let waiting = listingHandlers.removeValue(forKey: path) else { return }
+        for handler in waiting { handler(entries) }
     }
 
     private func receiveFile(_ file: WireFile) {
@@ -340,13 +341,16 @@ final class InspectorViewController: UIViewController {
     /// reader.
     private func openDiff(at index: Int) {
         let viewer = DiffViewController(files: changes, index: index)
-        viewer.onRequestDiff = { [weak self] path in
+        // `viewer` weakly: this closure is stored *on* the viewer, so capturing it
+        // strongly would keep every diff ever opened — text storage and all — alive for
+        // the app's lifetime.
+        viewer.onRequestDiff = { [weak self, weak viewer] path, status in
             guard let self else { return }
             guard isLive, let projectID = session.projectRosterID else {
-                viewer.receive(WireDiff(path: path, text: MockChanges.sampleDiff, fullContext: true))
+                viewer?.receive(WireDiff(path: path, text: MockChanges.sampleDiff))
                 return
             }
-            client?.send(.readDiff(projectID: projectID, path: path))
+            client?.send(.readDiff(projectID: projectID, path: path, status: status))
         }
         // A plain shell has no prompt to paste into; only an agent session gets the action.
         if session.agent.id != RosterAgent.terminal.id, let onSendToAgent {
@@ -365,7 +369,7 @@ extension InspectorViewController: RemoteFileBrowsing {
             then(FileNode.sampleEntries(at: path))
             return
         }
-        listingHandlers[path] = then
+        listingHandlers[path, default: []].append(then)
         setLoading(true)
         client?.send(.listFiles(projectID: projectID, path: path))
     }
@@ -403,10 +407,12 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard pane == .changes, !changes.isEmpty else { return nil }
-        let additions = changes.reduce(0) { $0 + $1.additions }
-        let deletions = changes.reduce(0) { $0 + $1.deletions }
+        let totals = changes.reduce(into: (added: 0, deleted: 0)) {
+            $0.added += $1.additions
+            $0.deleted += $1.deletions
+        }
         let files = changes.count == 1 ? "1 changed file" : "\(changes.count) changed files"
-        return "\(files)  +\(additions) −\(deletions)"
+        return "\(files)  +\(totals.added) −\(totals.deleted)"
     }
 
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
@@ -428,21 +434,12 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
         case .files where isSearching:
             guard indexPath.row < searchResults.count else { break }
             let path = searchResults[indexPath.row]
-            var config = cell.defaultContentConfiguration()
-            config.text = (path as NSString).lastPathComponent
-            config.textProperties.font = .preferredFont(forTextStyle: .subheadline)
             let parent = (path as NSString).deletingLastPathComponent
-            config.secondaryText = parent.isEmpty ? nil : parent
-            config.secondaryTextProperties.font = .preferredFont(forTextStyle: .caption1)
-            config.secondaryTextProperties.color = .secondaryLabel
-            let icon = FileIcons.icon(forFileName: config.text ?? "")
-            config.image = icon.image
-            config.imageProperties.tintColor = icon.tint
-            config.imageProperties.maximumSize = CGSize(width: 16, height: 16)
-            config.imageProperties.reservedLayoutSize = CGSize(width: 16, height: 16)
-            cell.contentConfiguration = config
-            cell.accessoryView = nil
-            cell.accessoryType = .none
+            FileRow.configure(
+                cell,
+                entry: WireFileEntry(name: (path as NSString).lastPathComponent, isDir: false),
+                subtitle: parent.isEmpty ? nil : parent
+            )
         case .files:
             guard indexPath.row < rootEntries.count else { break }
             FileRow.configure(cell, entry: rootEntries[indexPath.row])
@@ -450,9 +447,9 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
             guard indexPath.row < changes.count else { break }
             let change = changes[indexPath.row]
             var config = cell.defaultContentConfiguration()
-            config.text = (change.path as NSString).lastPathComponent
+            config.text = change.name
             config.textProperties.font = .preferredFont(forTextStyle: .subheadline)
-            config.secondaryText = Self.subtitle(for: change)
+            config.secondaryText = change.caption
             config.secondaryTextProperties.font = .preferredFont(forTextStyle: .caption1)
             config.secondaryTextProperties.color = .secondaryLabel
             config.secondaryTextProperties.lineBreakMode = .byTruncatingHead
@@ -513,24 +510,11 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
         case .changes:
             guard indexPath.row < changes.count else { return nil }
             let change = changes[indexPath.row]
-            let absolute = absolutePath(for: change.path)
-            return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
-                UIMenu(title: change.path, children: [
-                    UIAction(title: "Open File", image: UIImage(systemName: "doc.text")) { _ in
-                        self?.openFile(at: change.path)
-                    },
-                    UIAction(title: "Copy Path", image: UIImage(systemName: "doc.on.doc")) { _ in
-                        UIPasteboard.general.string = absolute
-                    },
-                ])
-            }
+            return FileRow.menu(
+                for: WireFileEntry(name: change.name, isDir: false),
+                in: (change.path as NSString).deletingLastPathComponent, browser: self
+            )
         }
-    }
-
-    private static func subtitle(for change: WireChange) -> String {
-        let directory = (change.path as NSString).deletingLastPathComponent
-        let counts = change.isBinary ? "binary" : "+\(change.additions) −\(change.deletions)"
-        return directory.isEmpty ? counts : "\(directory) · \(counts)"
     }
 
     /// git's status letter as its own glyph — the desktop's single-letter badge, in the

--- a/ios/Sources/InspectorViewController.swift
+++ b/ios/Sources/InspectorViewController.swift
@@ -1,45 +1,58 @@
 import TermioShared
 import UIKit
 
-/// The right-side drawer: Files (expandable tree) / Changes (diff list),
-/// mirroring the desktop inspector's segmented layout. On a live companion
-/// session the tree is the Mac project's real filesystem — directories load
-/// lazily over the wire, tapping a file opens the full-screen read-only
-/// viewer. Offline (mock sessions) it falls back to the bundled sample tree.
+/// The right-side drawer: Changes / Files, mirroring the desktop inspector's segmented
+/// layout — with the phone's priority reversed. On a phone the question is "what did the
+/// agent just touch", not "show me the tree", so **Changes leads**: the working diff,
+/// straight from the Mac's git, and a tap opens the full-screen reader. Files is one tap
+/// away and drills in one directory per screen (see `FileListViewController`).
+///
+/// On a live companion session both panes are the Mac's real project. Offline (mock
+/// sessions) they fall back to the bundled sample tree and sample diff, which run
+/// through exactly the same UI.
 final class InspectorViewController: UIViewController {
-    private enum Pane: Int { case files = 0, changes = 1 }
+    private enum Pane: Int { case changes = 0, files = 1 }
 
     private let session: MockSession
     private let companionURL: URL?
     private let tableView = UITableView(frame: .zero, style: .plain)
-    private let segment = UISegmentedControl(items: ["Files", "Changes"])
+    private let segment = UISegmentedControl(items: ["Changes", "Files"])
     private let spinner = UIActivityIndicatorView(style: .medium)
     private let searchBar = UISearchBar()
+    private let refreshControl = UIRefreshControl()
 
-    /// Offline sample tree (mock sessions, PoC streams).
-    private var fileRows: [(node: FileNode, depth: Int)] = []
-    /// Live tree mirrored from the Mac, built lazily one directory at a time.
-    private var remoteRoots: [RemoteNode] = []
-    private var remoteRows: [(node: RemoteNode, depth: Int)] = []
+    /// Bracketed-paste text into this session's terminal — the diff reader's "Send to
+    /// Agent". Set by the terminal that owns this drawer; nil for a plain shell.
+    var onSendToAgent: ((String) -> Void)?
+
+    /// The project root's entries. Deeper directories live on pushed screens.
+    private var rootEntries: [WireFileEntry] = []
+    /// The working-tree changes, newest listing wins.
+    private var changes: [WireChange] = []
+    private var changesLoaded = false
+
     private var client: CompanionClient?
-    /// The file path awaiting a `.file` reply, so late/errored replies don't
-    /// open stale viewers.
+    /// Directory listings in flight, keyed by path — a pushed screen's reply must reach
+    /// that screen, not whichever list asked last.
+    private var listingHandlers: [String: ([WireFileEntry]) -> Void] = [:]
+    /// The file path awaiting a `.file` reply, so late/errored replies don't open stale
+    /// viewers.
     private var pendingRead: String?
-    /// The presented viewer, kept weak so save acks/conflicts route to it.
+    /// The presented viewers, kept weak so replies route to whichever is up.
     private weak var activeViewer: FileViewerController?
-    private var pane: Pane = .files
+    private weak var activeDiff: DiffViewController?
+    private var pane: Pane = .changes
 
     /// Filename search. Live sessions search the *whole* repo on the Mac
-    /// (`searchFiles`), since the on-device tree is only lazily loaded; results
-    /// come back as repo-relative paths. Offline mocks filter the sample tree.
+    /// (`searchFiles`), since the on-device listing is one directory deep; results come
+    /// back as repo-relative paths. Offline mocks filter the sample tree.
     private var isSearching = false
     private var searchQuery = ""
-    private var remoteResults: [String] = []
+    private var searchResults: [String] = []
     private var searchTruncated = false
     private var searchDebounce: DispatchWorkItem?
-    private var fileResults: [FileNode] = []
 
-    /// The file plane needs a companion link and a project to scope it to.
+    /// The file and changes planes need a companion link and a project to scope to.
     private var isLive: Bool { companionURL != nil && session.projectRosterID != nil }
 
     init(session: MockSession, companionURL: URL? = nil) {
@@ -58,10 +71,10 @@ final class InspectorViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-        segment.selectedSegmentIndex = 0
+        segment.selectedSegmentIndex = Pane.changes.rawValue
         segment.addAction(UIAction { [weak self] _ in
             guard let self else { return }
-            pane = Pane(rawValue: segment.selectedSegmentIndex) ?? .files
+            pane = Pane(rawValue: segment.selectedSegmentIndex) ?? .changes
             // Search only applies to Files; leaving the pane drops out of it.
             if isSearching { endSearch() }
             updateRightBarButton()
@@ -78,35 +91,54 @@ final class InspectorViewController: UIViewController {
         tableView.delegate = self
         // Self-sizing rows: a fixed 44pt height left only ~2pt of slack over the
         // subheadline line height plus the content margins, so glyph descenders
-        // (p, g, j) clipped at the bottom. Let each cell's content configuration
-        // drive the height instead — it always reserves room for descenders, and
-        // the two-line Changes rows breathe too.
+        // (p, g, j) clipped at the bottom. Let each cell's content configuration drive
+        // the height instead — it always reserves room for descenders, and the two-line
+        // Changes rows breathe too.
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 44
         tableView.frame = view.bounds
         tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        refreshControl.addAction(UIAction { [weak self] _ in self?.refresh() }, for: .valueChanged)
+        tableView.refreshControl = refreshControl
         view.addSubview(tableView)
 
-        // The spinner rides the nav bar only while a request is in flight. On
-        // iOS 26 a bar button item is wrapped in a glass capsule, so leaving an
-        // idle (zero-size) spinner attached leaves an empty glass circle
-        // crowding the segment — attach it lazily instead.
+        // The spinner rides the nav bar only while a request is in flight. On iOS 26 a
+        // bar button item is wrapped in a glass capsule, so leaving an idle (zero-size)
+        // spinner attached leaves an empty glass circle crowding the segment — attach it
+        // lazily instead.
         spinner.hidesWhenStopped = true
 
         if isLive {
             connectFilePlane()
         } else {
-            reloadFileRows()
+            rootEntries = FileNode.sampleEntries(at: "")
+            changes = MockChanges.samples
+            changesLoaded = true
             updateRightBarButton()
         }
     }
 
-    private func reloadFileRows() {
-        fileRows = FileNode.visibleRows(from: FileNode.sampleRoot)
+    /// Pull to refresh: re-ask for whatever the visible pane shows. Both lists are
+    /// snapshots of a repo an agent is actively writing to, so a manual re-read is the
+    /// honest affordance.
+    private func refresh() {
+        guard isLive, let projectID = session.projectRosterID else {
+            refreshControl.endRefreshing()
+            return
+        }
+        switch pane {
+        case .changes:
+            client?.send(.listChanges(projectID: projectID))
+        case .files:
+            listEntries(at: "") { [weak self] entries in
+                self?.rootEntries = entries
+                self?.tableView.reloadData()
+            }
+        }
     }
 
-    /// Show/hide the nav-bar spinner, attaching its bar button only while busy
-    /// so no empty glass capsule lingers in the header when idle.
+    /// Show/hide the nav-bar spinner, attaching its bar button only while busy so no
+    /// empty glass capsule lingers in the header when idle.
     private func setLoading(_ loading: Bool) {
         if loading {
             spinner.startAnimating()
@@ -117,8 +149,8 @@ final class InspectorViewController: UIViewController {
         }
     }
 
-    /// The right slot shows the search affordance when idle in the Files pane;
-    /// the loading spinner and active search both claim it while they're up.
+    /// The right slot shows the search affordance when idle in the Files pane; the
+    /// loading spinner and active search both claim it while they're up.
     private func updateRightBarButton() {
         guard pane == .files, !isSearching, !spinner.isAnimating else {
             navigationItem.rightBarButtonItem = spinner.isAnimating
@@ -131,12 +163,13 @@ final class InspectorViewController: UIViewController {
         )
     }
 
+    // MARK: - Search
+
     private func beginSearch() {
         isSearching = true
         searchQuery = ""
         searchBar.text = ""
-        remoteResults = []
-        fileResults = []
+        searchResults = []
         searchTruncated = false
         tableView.tableHeaderView = searchBar
         updateRightBarButton()
@@ -151,20 +184,19 @@ final class InspectorViewController: UIViewController {
         searchBar.text = ""
         searchBar.resignFirstResponder()
         tableView.tableHeaderView = nil
-        remoteResults = []
-        fileResults = []
+        searchResults = []
         searchTruncated = false
         updateRightBarButton()
         tableView.reloadData()
     }
 
-    /// Live search runs on the Mac; debounce so each keystroke doesn't fire a
-    /// whole-repo walk. The reply echoes its query so a stale batch is dropped.
+    /// Live search runs on the Mac; debounce so each keystroke doesn't fire a whole-repo
+    /// walk. The reply echoes its query so a stale batch is dropped.
     private func scheduleRemoteSearch() {
         searchDebounce?.cancel()
         let query = searchQuery.trimmingCharacters(in: .whitespaces)
         guard !query.isEmpty else {
-            remoteResults = []
+            searchResults = []
             searchTruncated = false
             tableView.reloadData()
             return
@@ -181,35 +213,43 @@ final class InspectorViewController: UIViewController {
     private func receiveSearchResults(query: String, paths: [String], truncated: Bool) {
         guard isSearching, query == searchQuery.trimmingCharacters(in: .whitespaces) else { return }
         setLoading(false)
-        remoteResults = paths
+        searchResults = paths
         searchTruncated = truncated
         tableView.reloadData()
     }
 
     private func rebuildOfflineResults() {
         let query = searchQuery.trimmingCharacters(in: .whitespaces).lowercased()
-        fileResults = query.isEmpty ? [] : Self.flatten(FileNode.sampleRoot)
-            .filter { !$0.isDirectory && $0.name.lowercased().contains(query) }
+        searchResults = query.isEmpty ? [] : FileNode.flattened()
+            .filter { ($0 as NSString).lastPathComponent.lowercased().contains(query) }
     }
 
-    private static func flatten(_ nodes: [FileNode]) -> [FileNode] {
-        nodes.flatMap { [$0] + flatten($0.children ?? []) }
-    }
+    // MARK: - Live planes (companion file + changes)
 
-    // MARK: - Live tree (companion file plane)
-
-    /// A dedicated control connection for file browsing — the terminal's own
-    /// socket is a raw PTY byte stream once attached, so it can't carry these.
+    /// A dedicated control connection for browsing — the terminal's own socket is a raw
+    /// PTY byte stream once attached, so it can't carry these.
     private func connectFilePlane() {
         guard let companionURL, let projectID = session.projectRosterID else { return }
         setLoading(true)
         let client = CompanionClient(url: companionURL)
         client.onConnected = { [weak self] connected in
-            guard let self, connected, remoteRoots.isEmpty else { return }
-            client.send(.listFiles(projectID: projectID, path: ""))
+            guard let self, connected else { return }
+            client.send(.listChanges(projectID: projectID))
+            if rootEntries.isEmpty {
+                listEntries(at: "") { [weak self] entries in
+                    self?.rootEntries = entries
+                    if self?.pane == .files { self?.tableView.reloadData() }
+                }
+            }
         }
         client.onFileList = { [weak self] path, entries in
             self?.receiveListing(path: path, entries: entries)
+        }
+        client.onChanges = { [weak self] files in
+            self?.receiveChanges(files)
+        }
+        client.onDiff = { [weak self] diff in
+            self?.activeDiff?.receive(diff)
         }
         client.onFile = { [weak self] file in
             self?.receiveFile(file)
@@ -221,33 +261,54 @@ final class InspectorViewController: UIViewController {
             self?.activeViewer?.didSave(mtime: mtime)
         }
         client.onError = { [weak self] message in
-            guard let self else { return }
-            // With no read in flight, the failed request was the viewer's write.
-            if pendingRead == nil {
-                activeViewer?.saveFailed(message)
-                return
-            }
-            pendingRead = nil
-            setLoading(false)
-            let alert = UIAlertController(title: "Couldn't open file", message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
+            self?.receiveError(message)
         }
         client.start()
         self.client = client
     }
 
+    /// The wire's `.error` carries no request id, so the failure is attributed to
+    /// whatever this drawer has outstanding, newest concern first.
+    private func receiveError(_ message: String) {
+        setLoading(false)
+        refreshControl.endRefreshing()
+        // A diff on screen owns any failure while it is waiting for one.
+        if let activeDiff, activeDiff.isAwaitingDiff {
+            activeDiff.failed(message)
+            return
+        }
+        if pendingRead == nil {
+            // A directory that never lands would leave its screen spinning forever —
+            // answer the waiters with nothing so they settle on their empty state.
+            if !listingHandlers.isEmpty {
+                let waiting = listingHandlers.values
+                listingHandlers = [:]
+                for handler in waiting { handler([]) }
+                return
+            }
+            // Nothing else was in flight, so the failed request was the viewer's write.
+            activeViewer?.saveFailed(message)
+            return
+        }
+        pendingRead = nil
+        let alert = UIAlertController(title: "Couldn't open file", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+
+    private func receiveChanges(_ files: [WireChange]) {
+        setLoading(false)
+        refreshControl.endRefreshing()
+        changes = files
+        changesLoaded = true
+        if pane == .changes { tableView.reloadData() }
+    }
+
     private func receiveListing(path: String, entries: [WireFileEntry]) {
         setLoading(false)
-        let nodes = entries.map { RemoteNode(entry: $0, parentPath: path) }
-        if path.isEmpty {
-            remoteRoots = nodes
-        } else if let dir = findRemoteNode(path, in: remoteRoots) {
-            dir.children = nodes
-            dir.isExpanded = true
-        }
-        rebuildRemoteRows()
-        if pane == .files { tableView.reloadData() }
+        refreshControl.endRefreshing()
+        guard let handler = listingHandlers.removeValue(forKey: path) else { return }
+        handler(entries)
     }
 
     private func receiveFile(_ file: WireFile) {
@@ -268,98 +329,96 @@ final class InspectorViewController: UIViewController {
             ))
         }
         viewer.onReload = { [weak self] in
-            self?.requestFile(file.path)
+            self?.openFile(at: file.path)
         }
         activeViewer = viewer
         present(viewer, animated: true)
     }
 
-    private func requestFile(_ path: String) {
-        guard let projectID = session.projectRosterID else { return }
+    /// The full-screen diff reader for the change at `index`, wired to this drawer's
+    /// socket for its file walk. Offline it renders the sample diff through the same
+    /// reader.
+    private func openDiff(at index: Int) {
+        let viewer = DiffViewController(files: changes, index: index)
+        viewer.onRequestDiff = { [weak self] path in
+            guard let self else { return }
+            guard isLive, let projectID = session.projectRosterID else {
+                viewer.receive(WireDiff(path: path, text: MockChanges.sampleDiff, fullContext: true))
+                return
+            }
+            client?.send(.readDiff(projectID: projectID, path: path))
+        }
+        // A plain shell has no prompt to paste into; only an agent session gets the action.
+        if session.agent.id != RosterAgent.terminal.id, let onSendToAgent {
+            viewer.onSendToAgent = onSendToAgent
+        }
+        activeDiff = viewer
+        present(viewer, animated: true)
+    }
+}
+
+// MARK: - File browsing
+
+extension InspectorViewController: RemoteFileBrowsing {
+    func listEntries(at path: String, then: @escaping ([WireFileEntry]) -> Void) {
+        guard isLive, let projectID = session.projectRosterID else {
+            then(FileNode.sampleEntries(at: path))
+            return
+        }
+        listingHandlers[path] = then
+        setLoading(true)
+        client?.send(.listFiles(projectID: projectID, path: path))
+    }
+
+    func openFile(at path: String) {
+        guard isLive, let projectID = session.projectRosterID else { return }
         pendingRead = path
         setLoading(true)
         client?.send(.readFile(
             projectID: projectID, path: path,
-            // For the Mac-rendered Markdown preview — same trait contract as
-            // `.trace`, so the page matches this screen's appearance.
+            // For the Mac-rendered Markdown preview — same trait contract as `.trace`,
+            // so the page matches this screen's appearance.
             dark: traitCollection.userInterfaceStyle == .dark
         ))
     }
 
-    private func findRemoteNode(_ path: String, in nodes: [RemoteNode]) -> RemoteNode? {
-        for node in nodes {
-            if node.relPath == path { return node }
-            // Only walk ancestors of the target path.
-            if node.isDir, path.hasPrefix(node.relPath + "/"),
-               let children = node.children,
-               let found = findRemoteNode(path, in: children) {
-                return found
-            }
-        }
-        return nil
-    }
-
-    private func rebuildRemoteRows(from nodes: [RemoteNode]? = nil, depth: Int = 0) {
-        if depth == 0 { remoteRows = [] }
-        for node in nodes ?? remoteRoots {
-            remoteRows.append((node, depth))
-            if node.isDir, node.isExpanded, let children = node.children {
-                rebuildRemoteRows(from: children, depth: depth + 1)
-            }
-        }
-    }
-
-    /// The row's node as (name, project-relative path, isDir), resolving which
-    /// backing list feeds this index (live vs mock, search vs tree). nil for
-    /// non-file panes or a stale index.
-    private func fileNode(at indexPath: IndexPath) -> (name: String, relPath: String, isDir: Bool)? {
-        guard pane == .files else { return nil }
-        if isSearching {
-            if isLive {
-                guard indexPath.row < remoteResults.count else { return nil }
-                let path = remoteResults[indexPath.row]
-                return ((path as NSString).lastPathComponent, path, false)
-            }
-            guard indexPath.row < fileResults.count else { return nil }
-            return (fileResults[indexPath.row].name, "", fileResults[indexPath.row].isDirectory)
-        }
-        if isLive {
-            guard indexPath.row < remoteRows.count else { return nil }
-            let node = remoteRows[indexPath.row].node
-            return (node.name, node.relPath, node.isDir)
-        }
-        guard indexPath.row < fileRows.count else { return nil }
-        let node = fileRows[indexPath.row].node
-        return (node.name, "", node.isDirectory)
-    }
-
-    /// Join a project-relative path onto the Mac's absolute project root, so
-    /// "Copy Path" yields a full path ready to paste into an agent prompt.
-    private func absolutePath(for relPath: String) -> String {
+    /// Join a project-relative path onto the Mac's absolute project root, so "Copy Path"
+    /// yields a full path ready to paste into an agent prompt.
+    func absolutePath(for relPath: String) -> String {
         guard let root = session.projectPath, !root.isEmpty else { return relPath }
         return relPath.isEmpty ? root : "\(root)/\(relPath)"
     }
-
-    private static func changedDot() -> UIView {
-        let dot = UIView(frame: CGRect(x: 0, y: 0, width: 8, height: 8))
-        dot.backgroundColor = .systemBlue
-        dot.layer.cornerRadius = 4
-        return dot
-    }
 }
+
+// MARK: - Table
 
 extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch pane {
-        case .files where isSearching: isLive ? remoteResults.count : fileResults.count
-        case .files: isLive ? remoteRows.count : fileRows.count
-        case .changes: MockChange.samples.count
+        case .files where isSearching: searchResults.count
+        case .files: rootEntries.count
+        case .changes: changes.count
         }
     }
 
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard pane == .changes, !changes.isEmpty else { return nil }
+        let additions = changes.reduce(0) { $0 + $1.additions }
+        let deletions = changes.reduce(0) { $0 + $1.deletions }
+        let files = changes.count == 1 ? "1 changed file" : "\(changes.count) changed files"
+        return "\(files)  +\(additions) −\(deletions)"
+    }
+
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard isSearching, pane == .files, searchTruncated else { return nil }
-        return "Too many matches — showing the first batch. Refine to narrow."
+        if isSearching, pane == .files, searchTruncated {
+            return "Too many matches — showing the first batch. Refine to narrow."
+        }
+        if pane == .changes, changes.isEmpty {
+            return changesLoaded
+                ? "No changes in this project's working tree."
+                : "Loading changes…"
+        }
+        return nil
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -367,15 +426,16 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
             ?? UITableViewCell(style: .value1, reuseIdentifier: "cell")
         switch pane {
         case .files where isSearching:
-            guard let info = fileNode(at: indexPath) else { break }
+            guard indexPath.row < searchResults.count else { break }
+            let path = searchResults[indexPath.row]
             var config = cell.defaultContentConfiguration()
-            config.text = info.name
+            config.text = (path as NSString).lastPathComponent
             config.textProperties.font = .preferredFont(forTextStyle: .subheadline)
-            let parent = (info.relPath as NSString).deletingLastPathComponent
+            let parent = (path as NSString).deletingLastPathComponent
             config.secondaryText = parent.isEmpty ? nil : parent
             config.secondaryTextProperties.font = .preferredFont(forTextStyle: .caption1)
             config.secondaryTextProperties.color = .secondaryLabel
-            let icon = FileIcons.icon(forFileName: info.name)
+            let icon = FileIcons.icon(forFileName: config.text ?? "")
             config.image = icon.image
             config.imageProperties.tintColor = icon.tint
             config.imageProperties.maximumSize = CGSize(width: 16, height: 16)
@@ -384,44 +444,22 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
             cell.accessoryView = nil
             cell.accessoryType = .none
         case .files:
-            let name: String, isDir: Bool, expanded: Bool, changed: Bool, depth: Int
-            if isLive {
-                let (node, d) = remoteRows[indexPath.row]
-                (name, isDir, expanded, changed, depth) =
-                    (node.name, node.isDir, node.isExpanded, node.changed, d)
-            } else {
-                let (node, d) = fileRows[indexPath.row]
-                (name, isDir, expanded, changed, depth) =
-                    (node.name, node.isDirectory, node.isExpanded, node.changed, d)
-            }
-            var config = cell.defaultContentConfiguration()
-            config.text = name
-            config.textProperties.font = .preferredFont(forTextStyle: .subheadline)
-            if isDir {
-                config.image = UIImage(systemName: expanded ? "chevron.down" : "chevron.right")
-                config.imageProperties.tintColor = .secondaryLabel
-                config.imageProperties.maximumSize = CGSize(width: 14, height: 14)
-            } else {
-                let icon = FileIcons.icon(forFileName: name)
-                config.image = icon.image
-                config.imageProperties.tintColor = icon.tint
-                config.imageProperties.maximumSize = CGSize(width: 16, height: 16)
-            }
-            // Icons vary in width (chevron vs logo vs symbol); a fixed layout
-            // box keeps every label at the same leading edge per depth.
-            config.imageProperties.reservedLayoutSize = CGSize(width: 16, height: 16)
-            config.directionalLayoutMargins.leading = CGFloat(depth) * 18 + 12
-            cell.contentConfiguration = config
-            cell.accessoryView = changed ? Self.changedDot() : nil
-            cell.accessoryType = .none
+            guard indexPath.row < rootEntries.count else { break }
+            FileRow.configure(cell, entry: rootEntries[indexPath.row])
         case .changes:
-            let change = MockChange.samples[indexPath.row]
+            guard indexPath.row < changes.count else { break }
+            let change = changes[indexPath.row]
             var config = cell.defaultContentConfiguration()
             config.text = (change.path as NSString).lastPathComponent
-            config.secondaryText = "\(change.kind)  +\(change.additions) −\(change.deletions)"
             config.textProperties.font = .preferredFont(forTextStyle: .subheadline)
-            config.secondaryTextProperties.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
-            config.secondaryTextProperties.color = change.kind == "A" ? .systemGreen : .systemOrange
+            config.secondaryText = Self.subtitle(for: change)
+            config.secondaryTextProperties.font = .preferredFont(forTextStyle: .caption1)
+            config.secondaryTextProperties.color = .secondaryLabel
+            config.secondaryTextProperties.lineBreakMode = .byTruncatingHead
+            config.image = Self.statusBadge(for: change.status)
+            config.imageProperties.tintColor = Self.statusTint(for: change.status)
+            config.imageProperties.maximumSize = CGSize(width: 17, height: 17)
+            config.imageProperties.reservedLayoutSize = CGSize(width: 17, height: 17)
             cell.contentConfiguration = config
             cell.accessoryView = nil
             cell.accessoryType = .disclosureIndicator
@@ -432,60 +470,86 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         if isSearching, pane == .files {
-            // Results are files only; offline mocks have no path to open.
-            if isLive, let info = fileNode(at: indexPath) { requestFile(info.relPath) }
+            // Results are files only; offline mocks have no content to open.
+            guard indexPath.row < searchResults.count else { return }
+            openFile(at: searchResults[indexPath.row])
             return
         }
         switch pane {
-        case .files where isLive:
-            let (node, _) = remoteRows[indexPath.row]
-            if node.isDir {
-                if node.children != nil {
-                    node.isExpanded.toggle()
-                    rebuildRemoteRows()
-                    tableView.reloadData()
-                } else if let projectID = session.projectRosterID {
-                    // First expand: fetch, then `receiveListing` opens it.
-                    setLoading(true)
-                    client?.send(.listFiles(projectID: projectID, path: node.relPath))
-                }
-            } else {
-                requestFile(node.relPath)
-            }
         case .files:
-            let (node, _) = fileRows[indexPath.row]
-            if node.isDirectory {
-                node.isExpanded.toggle()
-                reloadFileRows()
-                tableView.reloadData()
+            guard indexPath.row < rootEntries.count else { return }
+            let entry = rootEntries[indexPath.row]
+            if entry.isDir {
+                navigationController?.pushViewController(
+                    FileListViewController(path: entry.name, browser: self), animated: true
+                )
+            } else {
+                openFile(at: entry.name)
             }
         case .changes:
-            let change = MockChange.samples[indexPath.row]
-            navigationController?.pushViewController(DiffViewController(change: change), animated: true)
+            guard indexPath.row < changes.count else { return }
+            openDiff(at: indexPath.row)
         }
     }
 
-    /// Long-press a file/folder row for its per-item actions — the iOS-native
-    /// tree menu (Apple Files, and the session rows use the same). Only live
-    /// rows carry a real Mac path, so the mock tree gets no menu.
+    /// Long-press a file/folder row for its per-item actions — the iOS-native tree menu
+    /// (Apple Files, and the session rows use the same). Only live rows carry a real Mac
+    /// path, so the mock tree gets no menu.
     func tableView(
         _ tableView: UITableView,
         contextMenuConfigurationForRowAt indexPath: IndexPath,
         point: CGPoint
     ) -> UIContextMenuConfiguration? {
-        guard isLive, let node = fileNode(at: indexPath) else { return nil }
-        let absolute = absolutePath(for: node.relPath)
-        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
-            var actions: [UIMenuElement] = []
-            if !node.isDir {
-                actions.append(UIAction(
-                    title: "Open", image: UIImage(systemName: "doc.text")
-                ) { [weak self] _ in self?.requestFile(node.relPath) })
+        guard isLive else { return nil }
+        switch pane {
+        case .files where isSearching:
+            guard indexPath.row < searchResults.count else { return nil }
+            let path = searchResults[indexPath.row]
+            let entry = WireFileEntry(name: (path as NSString).lastPathComponent, isDir: false)
+            return FileRow.menu(for: entry, in: (path as NSString).deletingLastPathComponent, browser: self)
+        case .files:
+            guard indexPath.row < rootEntries.count else { return nil }
+            return FileRow.menu(for: rootEntries[indexPath.row], in: "", browser: self)
+        case .changes:
+            guard indexPath.row < changes.count else { return nil }
+            let change = changes[indexPath.row]
+            let absolute = absolutePath(for: change.path)
+            return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+                UIMenu(title: change.path, children: [
+                    UIAction(title: "Open File", image: UIImage(systemName: "doc.text")) { _ in
+                        self?.openFile(at: change.path)
+                    },
+                    UIAction(title: "Copy Path", image: UIImage(systemName: "doc.on.doc")) { _ in
+                        UIPasteboard.general.string = absolute
+                    },
+                ])
             }
-            actions.append(UIAction(
-                title: "Copy Path", image: UIImage(systemName: "doc.on.doc")
-            ) { _ in UIPasteboard.general.string = absolute })
-            return UIMenu(title: node.name, children: actions)
+        }
+    }
+
+    private static func subtitle(for change: WireChange) -> String {
+        let directory = (change.path as NSString).deletingLastPathComponent
+        let counts = change.isBinary ? "binary" : "+\(change.additions) −\(change.deletions)"
+        return directory.isEmpty ? counts : "\(directory) · \(counts)"
+    }
+
+    /// git's status letter as its own glyph — the desktop's single-letter badge, in the
+    /// shape iOS already draws for lettered markers.
+    private static func statusBadge(for status: String) -> UIImage? {
+        let name = status.lowercased()
+        guard let first = name.first, first.isLetter else {
+            return UIImage(systemName: "exclamationmark.square")
+        }
+        return UIImage(systemName: "\(first).square")
+    }
+
+    private static func statusTint(for status: String) -> UIColor {
+        switch status {
+        case "A", "U": return .systemGreen
+        case "D": return .systemRed
+        case "R", "C": return .systemOrange
+        case "!": return .systemYellow
+        default: return .systemBlue
         }
     }
 }
@@ -507,25 +571,5 @@ extension InspectorViewController: UISearchBarDelegate {
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         endSearch()
-    }
-}
-
-// MARK: - Remote tree node
-
-/// One node of the live tree. `children == nil` means "not fetched yet" —
-/// the first expand requests the listing and the reply fills it in.
-private final class RemoteNode {
-    let name: String
-    let relPath: String
-    let isDir: Bool
-    let changed: Bool
-    var children: [RemoteNode]?
-    var isExpanded = false
-
-    init(entry: WireFileEntry, parentPath: String) {
-        name = entry.name
-        relPath = parentPath.isEmpty ? entry.name : "\(parentPath)/\(entry.name)"
-        isDir = entry.isDir
-        changed = entry.changed
     }
 }

--- a/ios/Sources/Models.swift
+++ b/ios/Sources/Models.swift
@@ -188,24 +188,25 @@ extension MockProject {
 
 // MARK: - Mock file tree
 
+/// The bundled sample tree, shown when there is no Mac behind the drawer (the demo
+/// sessions and App Store screenshots). Browsed the same way a live project is —
+/// one directory per screen — so the offline path exercises the real UI.
 final class FileNode {
     let name: String
     let children: [FileNode]?
     let changed: Bool
-    var isExpanded: Bool
 
     var isDirectory: Bool { children != nil }
 
-    init(_ name: String, changed: Bool = false, expanded: Bool = false, children: [FileNode]? = nil) {
+    init(_ name: String, changed: Bool = false, children: [FileNode]? = nil) {
         self.name = name
         self.changed = changed
         self.children = children
-        isExpanded = expanded
     }
 
     static let sampleRoot: [FileNode] = [
-        FileNode("Sources", expanded: true, children: [
-            FileNode("termio", expanded: true, children: [
+        FileNode("Sources", children: [
+            FileNode("termio", children: [
                 FileNode("App.swift", changed: true),
                 FileNode("Models.swift"),
                 FileNode("SessionInfoView.swift", changed: true),
@@ -227,48 +228,100 @@ final class FileNode {
         FileNode("README.md"),
     ]
 
-    /// Flattens the tree into visible rows (respecting collapsed dirs).
-    static func visibleRows(from roots: [FileNode], depth: Int = 0) -> [(node: FileNode, depth: Int)] {
-        var rows: [(FileNode, Int)] = []
-        for node in roots {
-            rows.append((node, depth))
-            if node.isDirectory, node.isExpanded, let children = node.children {
-                rows.append(contentsOf: visibleRows(from: children, depth: depth + 1))
+    /// One directory's entries in the same shape the wire delivers, so the browser has a
+    /// single code path. "" is the root.
+    static func sampleEntries(at path: String) -> [WireFileEntry] {
+        var level = sampleRoot
+        if !path.isEmpty {
+            for component in path.split(separator: "/") {
+                guard let node = level.first(where: { $0.name == component }),
+                      let children = node.children else { return [] }
+                level = children
             }
         }
-        return rows
+        return level.map {
+            WireFileEntry(name: $0.name, isDir: $0.isDirectory, changed: $0.changed || containsChange($0))
+        }
+    }
+
+    /// Every file in the tree as a repo-relative path, for the offline filename search.
+    static func flattened(_ nodes: [FileNode] = sampleRoot, prefix: String = "") -> [String] {
+        nodes.flatMap { node -> [String] in
+            let path = prefix.isEmpty ? node.name : "\(prefix)/\(node.name)"
+            guard let children = node.children else { return [path] }
+            return flattened(children, prefix: path)
+        }
+    }
+
+    private static func containsChange(_ node: FileNode) -> Bool {
+        guard let children = node.children else { return node.changed }
+        return children.contains { $0.changed || containsChange($0) }
     }
 }
 
 // MARK: - Mock changes
 
-struct MockChange {
-    let kind: String // "M" / "A" / "D"
-    let path: String
-    let additions: Int
-    let deletions: Int
-
-    static let samples: [MockChange] = [
-        .init(kind: "M", path: "Sources/termio/App.swift", additions: 40, deletions: 12),
-        .init(kind: "M", path: "Sources/termio/SessionInfoView.swift", additions: 18, deletions: 3),
-        .init(kind: "M", path: "Sources/termio/TermioStore/TermioStore+TerminalSurface.swift", additions: 62, deletions: 41),
-        .init(kind: "A", path: "Sources/termio/SessionHost.swift", additions: 120, deletions: 0),
+/// The offline Changes pane and its diff — the same `WireChange` and unified-diff text a
+/// live Mac sends, so the demo renders through the real reader rather than a stand-in.
+enum MockChanges {
+    static let samples: [WireChange] = [
+        WireChange(path: "Sources/termio/App.swift", status: "M", additions: 40, deletions: 12),
+        WireChange(path: "Sources/termio/SessionInfoView.swift", status: "M", additions: 18, deletions: 3),
+        WireChange(
+            path: "Sources/termio/TermioStore/TermioStore+TerminalSurface.swift",
+            status: "M", additions: 62, deletions: 41
+        ),
+        WireChange(path: "Sources/termio/SessionHost.swift", status: "A", additions: 120, deletions: 0),
     ]
 
+    /// Full-context sample: one long unchanged run, so the fold band and its reveal are
+    /// visible offline exactly as they behave on a real full-context diff.
     static let sampleDiff = """
-    @@ -41,7 +41,9 @@ func makeContentSplitViewController() {
-         let sidebar = NSSplitViewItem(sidebarWithViewController: sidebarVC)
+    @@ -1,44 +1,48 @@
+     import AppKit
+     import SwiftUI
+    \u{20}
+     /// The window's content: a sidebar of sessions beside the terminal surface.
+     /// Layout is AppKit's, so the sidebar can run the full height of the window.
+     struct ContentSplit {
+         let store: TermioStore
+    \u{20}
+         var sidebarWidth: CGFloat = 220
+         var minimumSidebarWidth: CGFloat = 180
+         var maximumSidebarWidth: CGFloat = 420
+    \u{20}
+         func makeSplitViewController() -> NSSplitViewController {
+             let controller = NSSplitViewController()
+             controller.splitView.dividerStyle = .thin
+             return controller
+         }
+    \u{20}
+         func makeSidebarItem(_ viewController: NSViewController) -> NSSplitViewItem {
+             let item = NSSplitViewItem(sidebarWithViewController: viewController)
+             item.minimumThickness = minimumSidebarWidth
+             item.maximumThickness = maximumSidebarWidth
+             return item
+         }
+     }
+    \u{20}
+     func makeContentSplitViewController(store: TermioStore) -> NSSplitViewController {
+         let split = ContentSplit(store: store)
+         let splitViewController = split.makeSplitViewController()
+         let sidebar = split.makeSidebarItem(SidebarViewController(store: store))
          sidebar.minimumThickness = 220
     -    window.styleMask.insert(.fullSizeContentView)
     +    sidebar.titlebarSeparatorStyle = .automatic
     +    window.titlebarAppearsTransparent = true
     +    window.styleMask.insert(.fullSizeContentView)
          splitViewController.addSplitViewItem(sidebar)
-
-    @@ -88,6 +90,12 @@ func applyTheme(_ theme: TerminalTheme) {
+         splitViewController.addSplitViewItem(NSSplitViewItem(viewController: terminalVC))
+         return splitViewController
+     }
+    \u{20}
+     func applyTheme(_ theme: TerminalTheme, to window: NSWindow) {
          controller.setTheme(theme)
-    +    // Resolve the dynamic color statically: fullscreen windows on
-    +    // macOS 26 do not re-evaluate NSColor appearance providers.
+    +    // Resolve the dynamic color statically: fullscreen windows on macOS 26
+    +    // do not re-evaluate an NSColor's appearance provider.
     +    let resolved = theme.background.resolvedColor(for: window)
     +    window.backgroundColor = resolved
          inspector.refresh()

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -93,14 +93,19 @@ final class TerminalViewController: UIViewController {
     )
 
     // Drawer
-    private lazy var inspectorNav = UINavigationController(
-        rootViewController: InspectorViewController(
+    private lazy var inspector: InspectorViewController = {
+        let inspector = InspectorViewController(
             session: session,
             companionURL: {
                 if case .companion(let url) = backend { url } else { nil }
             }()
         )
-    )
+        inspector.onSendToAgent = { [weak self] text in
+            self?.sendSnippetToPrompt(text)
+        }
+        return inspector
+    }()
+    private lazy var inspectorNav = UINavigationController(rootViewController: inspector)
     private let dimView = UIControl()
     private var drawerOpen = false
     /// Direction the surface pan locked at its start: rightward = back to
@@ -631,6 +636,15 @@ final class TerminalViewController: UIViewController {
         uploadClient?.send(
             .upload(projectID: projectID, name: item.name, base64: item.data.base64EncodedString())
         )
+    }
+
+    /// Pastes a diff selection into the TUI's input line — the drawer's "Send to Agent",
+    /// and the phone twin of the desktop's "Add to Chat". Bracketed paste keeps the
+    /// whole block one literal insert instead of a line-by-line submit, and the drawer
+    /// steps aside so the prompt it landed in is visible.
+    private func sendSnippetToPrompt(_ text: String) {
+        terminalView.send(Data(("\u{1B}[200~" + text + "\u{1B}[201~").utf8))
+        setDrawer(open: false, animated: true)
     }
 
     /// Types the uploaded file's Mac path into the TUI's input line, where it

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -643,16 +643,20 @@ final class TerminalViewController: UIViewController {
     /// whole block one literal insert instead of a line-by-line submit, and the drawer
     /// steps aside so the prompt it landed in is visible.
     private func sendSnippetToPrompt(_ text: String) {
-        terminalView.send(Data(("\u{1B}[200~" + text + "\u{1B}[201~").utf8))
+        pasteIntoPrompt(text)
         setDrawer(open: false, animated: true)
     }
 
+    /// Bracketed paste: the whole block lands as one literal insert instead of a
+    /// line-by-line submit, and the TUI's own Return still sends it.
+    private func pasteIntoPrompt(_ text: String) {
+        terminalView.send(Data(("\u{1B}[200~" + text + "\u{1B}[201~").utf8))
+    }
+
     /// Types the uploaded file's Mac path into the TUI's input line, where it
-    /// stays editable and submits with the TUI's own Return. Bracketed paste
-    /// keeps a name with spaces one literal insert; the trailing space
-    /// separates it from whatever gets typed next.
+    /// stays editable. The trailing space separates it from whatever gets typed next.
     private func typeUploadedPath(_ path: String) {
-        terminalView.send(Data(("\u{1B}[200~" + path + " \u{1B}[201~").utf8))
+        pasteIntoPrompt(path + " ")
     }
 
     private func reportSkipped(oversized: [String], unreadable: [String] = []) {


### PR DESCRIPTION
The iOS drawer's Changes pane was fake — `numberOfRowsInSection` returned `MockChange.samples.count` unconditionally, and tapping pushed a 62-line hardcoded string rendered as whole-line green/red text in a plain `UITextView`. That was true even on a live companion session. This replaces both ends with real data and a reader built for a phone.

### Wire

Two message pairs: `listChanges`/`changes` and `readDiff`/`diff`, plus `WireChange` and `WireDiff`. The Mac answers from the same `GitService` the desktop git pane reads, so the two lists can't disagree about what "changed" means. Diffs come back with **full file context** so the phone can fold unchanged runs into bands the reader *expands*; past a 2 MB cap the reply degrades to git's default 3-line context and marks itself `fullContext: false`, which turns the bands into fixed markers rather than lying about what was sent.

Nothing under `Sources/termio/Git/` is touched — #205 owns those files. The server calls into them and reassembles the parsed rows into unified-diff text for the wire.

### Shared diff model

`DiffParser` in `TermioShared` parses unified-diff text into numbered lines, marks intraline spans, and folds long unchanged runs — the desktop's `GitService`/`DiffDocument` logic as pure Foundation. The phone renders from it today; the desktop can adopt it once #205 lands, instead of the two ends drifting.

### The reader

Phone constraints, not a shrunk desktop pane:

- **No horizontal scroll.** Lines soft-wrap, and the hanging indent is computed from the line's *own* leading whitespace, so a wrapped comment stays visually inside its line instead of jumping back to column 0.
- **A saturated 3pt leading bar with a very light wash**, not a full-line fill. The file's own doc comment already argued for this and it was never implemented; at phone size a full-strength green makes syntax colors unreadable.
- **Syntax highlighting** through the same Highlightr pipeline as `FileViewerController`, each diff side highlighted as one text so block comments and raw strings keep their real state.
- **One line-number column** (34pt): a deletion shows its old number, everything else the new one. Two columns would cost a tenth of the width.
- **Fold bands are full-width 44pt rows.** The Mac's gutter-cell buttons don't transfer to a thumb.
- **A "3 of 12" walker** between changed files and a floating jump-to-next-hunk button, so reading a review doesn't mean bouncing back to the list.
- **Long-press → Send to Agent** bracketed-pastes the selected code into the session's prompt and steps the drawer aside. Band labels are stripped from the selection, so the agent gets code, not "⋯ 24 unchanged lines". This is the thing a phone diff can do that a Mac diff doesn't need.

### Files

The tree drilled 18pt deeper per level on a 390pt screen. It now pushes one directory per screen — Apple Files' shape — with the folder name as the title, the parent path as the navigation prompt, and the back button walking out. Repo-wide filename search is unchanged.

Changes is also now the **default** pane: on a phone the question is what the agent just touched.

### Verification

- `swift build`, and `swift test` at 81 passing (28 new: fold ranges and reveal, hunk-gap bands, line numbering, intraline spans, wire round-trips including awkward paths and an older peer's missing flags, and the row→text→`DiffParser` round trip).
- **Mac handlers, live** against a dev build over the companion socket: 39 changed files with correct status letters, ±counts and binary flags; a full-context diff (506 lines carrying an 8-line change); a binary file answering `binary: true` with no text; an untracked file diffing as `@@ -0,0 +1,128 @@`.
- **Phone, live on the simulator** against real git data: the Changes list, a diff rendering with syntax colors and intraline emphasis, tapping a band revealing its 79 hidden lines, the walker moving 1 of 12 → 2 of 12, the changes-row context menu, Files drilling into `.github`, and "Send to Agent" putting `\x1b[200~…\x1b[201~` on the wire.

Release Notes:
- The iPhone app's Changes tab now lists the Mac's real working-tree changes, and tapping one opens a full diff with syntax highlighting instead of a sample.
- A diff on the phone soft-wraps instead of scrolling sideways, marks added and removed lines with a colored edge bar, folds long unchanged runs into a tappable band, and walks between changed files without going back to the list.
- Selecting code in a diff offers "Send to Agent", which pastes it straight into that session's prompt.
- The Files tab opens one folder per screen instead of indenting deeper with every level.