### PR TITLE
Make the inspector file tree fast on huge project roots

### DIFF
--- a/Shared/Sources/TermioShared/BrandIcons.swift
+++ b/Shared/Sources/TermioShared/BrandIcons.swift
@@ -172,6 +172,7 @@ public enum HugeIcon: Hashable, Sendable {
     case folder
     case camera
     case folderOpen
+    case folderSymlink
     case chevronRight
     case chevronLeft
     case gitPullRequest
@@ -238,6 +239,15 @@ public enum HugeIcon: Hashable, Sendable {
             return "M7.5 7.5L8.72654 8.55719C9.24218 9.00163 9.5 9.22386 9.5 9.5C9.5 9.77614 9.24218 9.99836 8.72654 10.4428L7.5 11.5 M11.5 12.5H15.5 M12 21C15.7497 21 17.6246 21 18.9389 20.0451C19.3634 19.7367 19.7367 19.3634 20.0451 18.9389C21 17.6246 21 15.7497 21 12C21 8.25027 21 6.3754 20.0451 5.06107C19.7367 4.6366 19.3634 4.26331 18.9389 3.95491C17.6246 3 15.7497 3 12 3C8.25027 3 6.3754 3 5.06107 3.95491C4.6366 4.26331 4.26331 4.6366 3.95491 5.06107C3 6.3754 3 8.25027 3 12C3 15.7497 3 17.6246 3.95491 18.9389C4.26331 19.3634 4.6366 19.7367 5.06107 20.0451C6.3754 21 8.25027 21 12 21Z"
         case .folder:
             return "M8 7H16.75C18.8567 7 19.91 7 20.6667 7.50559C20.9943 7.72447 21.2755 8.00572 21.4944 8.33329C22 9.08996 22 10.1433 22 12.25C22 15.7612 22 17.5167 21.1573 18.7779C20.7926 19.3238 20.3238 19.7926 19.7779 20.1573C18.5167 21 16.7612 21 13.25 21H12C7.28595 21 4.92893 21 3.46447 19.5355C2 18.0711 2 15.714 2 11V7.94427C2 6.1278 2 5.21956 2.38032 4.53806C2.65142 4.05227 3.05227 3.65142 3.53806 3.38032C4.21956 3 5.1278 3 6.94427 3C8.10802 3 8.6899 3 9.19926 3.19101C10.3622 3.62712 10.8418 4.68358 11.3666 5.73313L12 7"
+        case .folderSymlink:
+            // Hugeicons "folder-symlink": the same folder body as `.folder` with an
+            // arrow pushing out through its left wall. A purpose-drawn glyph rather than
+            // the Finder's badge-on-top: rendered at 128pt the Finder's alias arrow is
+            // unmistakable, but at the 15pt this tree draws it collapses to a five-pixel
+            // grey smudge. A line set solves that by integrating the mark into the glyph
+            // — which is also why VS Code ships `file-symlink-directory` as its own
+            // codicon instead of compositing one.
+            return "M8 7H12M12 7H16.75C18.8567 7 19.91 7 20.6667 7.50559C20.9943 7.72447 21.2755 8.00572 21.4944 8.33329C22 9.08996 22 10.1433 22 12.25C22 15.7612 22 17.5167 21.1573 18.7779C20.7926 19.3238 20.3238 19.7926 19.7779 20.1573C18.5167 21 16.7612 21 13.25 21H12C7.28595 21 4.92893 21 3.46447 19.5355C2.93416 19.0052 2.64986 18.2157 2.50661 17.3979C2.27647 16.0841 2.16139 15.4271 2.76083 14.7136C3.36026 14 4.21042 14 5.91073 14L11 14M12 7L11.3666 5.73313C10.8418 4.68358 10.3622 3.62712 9.19926 3.19101C8.6899 3 8.10802 3 6.94427 3C5.1278 3 4.21956 3 3.53806 3.38032C3.05227 3.65142 2.65142 4.05227 2.38032 4.53806C2 5.21956 2 6.1278 2 7.94427L2.02008 10M9.00002 17C9.00002 17 12 14.7905 12 14C12 13.2094 9 11 9 11"
         case .camera:
             // Hugeicons "camera-01": a camera body with a round lens and a flash
             // dot (three subpaths). Relative + arc commands, which the SVG parser

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -25,6 +25,10 @@ struct FileBrowserView: View {
     /// list runs an update pass and the mutation reaches the rows (the `root`
     /// reference itself never changes on an incremental reload).
     @State private var treeRevision = 0
+    /// Bumped per `refresh()` call; an off-main root read that finishes after a newer
+    /// refresh (or after the project moved) compares stale and discards its result,
+    /// so roots can never land out of order.
+    @State private var refreshGeneration = 0
     /// Reload targets accumulated while a reload is already in flight, keyed by URL
     /// so repeat events for one directory coalesce. Unioned rather than replaced —
     /// a newer batch must never orphan an older disjoint one, or those directories
@@ -47,52 +51,23 @@ struct FileBrowserView: View {
     private var projectPath: String? { store.inspectorProjectPath }
 
     var body: some View {
-        VStack(spacing: 0) {
-            switch store.inspectorTab {
-            case .files:
+        ZStack {
+            // The Files pane is ALWAYS mounted; a tab switch merely covers it. A
+            // fresh `List(children:)` re-realizes every row of the outline, which
+            // on a huge root (a home directory) costs whole seconds per switch —
+            // and loses the tree's disclosure state besides (#207). Same
+            // always-mounted-under-an-opaque-overlay shape as `InspectorRoot`.
+            VStack(spacing: 0) {
                 if let root { header(root: root) }
                 content
-            case .search:
-                if let root {
-                    FileSearchView(
-                        rootURL: root.url,
-                        font: settings.interfaceFont,
-                        onDismiss: { store.inspectorTab = .files },
-                        onOpen: { url, line in store.openFileInEditor(url, at: line) }
-                    )
-                    // Fresh identity per project, so a stale query/result set
-                    // doesn't carry over when the root moves.
-                    .id(root.url)
-                } else {
-                    noProject
-                }
-            case .changes:
-                if let repoRoot = projectPath {
-                    // Fresh identity per repo, so the panel model (selection, draft message,
-                    // PR status) resets cleanly when the selected project moves.
-                    // The visibility closure reads the store live (weakly — the model may
-                    // outlive a closing window), so a collapsed inspector parks the pane's
-                    // auto-refresh even while this view stays in the hierarchy.
-                    GitChangesView(
-                        repoRoot: repoRoot,
-                        changeCount: $store.gitChangeCount,
-                        isPaneVisible: { [weak store] in store?.inspectorVisible ?? true }
-                    )
-                    .id(repoRoot)
-                } else {
-                    content
-                }
-            case .issues:
-                if let repoRoot = projectPath {
-                    // Fresh identity per repo, like Changes: the panel model (connection
-                    // phase, binding, list, pushed-in detail) resets when the project moves.
-                    IssuesView(repoRoot: repoRoot)
-                        .id(repoRoot)
-                } else {
-                    noProject
-                }
-            case .info:
-                SessionInfoView()
+            }
+            .allowsHitTesting(store.inspectorTab == .files)
+            .accessibilityHidden(store.inspectorTab != .files)
+            if store.inspectorTab != .files {
+                activePane
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    // Opaque terminal background so the live tree never shows through.
+                    .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
             }
         }
         // The file column lives on the terminal side, so it takes the terminal's own background
@@ -156,6 +131,14 @@ struct FileBrowserView: View {
             refresh()
             if store.inspectorTab != .changes { seedChangeCount() }
         }
+        // Covering or uncovering the always-mounted tree resets its scroll view's
+        // wheel increment (SwiftUI re-configures the scroll view on the overlay
+        // flip, and no row update follows to heal it — see `OutlineViewFixups`);
+        // reassert once the switch's update pass has settled.
+        .onChange(of: store.inspectorTab) {
+            let outline = browserState.outlineView
+            DispatchQueue.main.async { OutlineViewFixups.assertWheelIncrement(on: outline) }
+        }
         .onChange(of: browserState.selection) {
             // The table fires native selection on a clean click — reliably, unlike a
             // click recognizer, which `NSOutlineView`'s own primary-button tracking
@@ -208,6 +191,56 @@ struct FileBrowserView: View {
         return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
     }
 
+    /// The non-Files pane covering the always-mounted tree (see `body`).
+    @ViewBuilder
+    private var activePane: some View {
+        switch store.inspectorTab {
+        case .files:
+            EmptyView()
+        case .search:
+            if let root {
+                FileSearchView(
+                    rootURL: root.url,
+                    font: settings.interfaceFont,
+                    onDismiss: { store.inspectorTab = .files },
+                    onOpen: { url, line in store.openFileInEditor(url, at: line) }
+                )
+                // Fresh identity per project, so a stale query/result set
+                // doesn't carry over when the root moves.
+                .id(root.url)
+            } else {
+                noProject
+            }
+        case .changes:
+            if let repoRoot = projectPath {
+                // Fresh identity per repo, so the panel model (selection, draft message,
+                // PR status) resets cleanly when the selected project moves.
+                // The visibility closure reads the store live (weakly — the model may
+                // outlive a closing window), so a collapsed inspector parks the pane's
+                // auto-refresh even while this view stays in the hierarchy.
+                GitChangesView(
+                    repoRoot: repoRoot,
+                    changeCount: $store.gitChangeCount,
+                    isPaneVisible: { [weak store] in store?.inspectorVisible ?? true }
+                )
+                .id(repoRoot)
+            } else {
+                noProject
+            }
+        case .issues:
+            if let repoRoot = projectPath {
+                // Fresh identity per repo, like Changes: the panel model (connection
+                // phase, binding, list, pushed-in detail) resets when the project moves.
+                IssuesView(repoRoot: repoRoot)
+                    .id(repoRoot)
+            } else {
+                noProject
+            }
+        case .info:
+            SessionInfoView()
+        }
+    }
+
     @ViewBuilder
     private var content: some View {
         if let root {
@@ -228,6 +261,10 @@ struct FileBrowserView: View {
             }
             // Collapse All rebuilds the list by changing its identity (see `treeGeneration`).
             .id(treeGeneration)
+        } else if projectPath != nil {
+            // The off-main root read is still in flight; hold the pane blank rather
+            // than flashing the no-project copy for the moment a huge root takes.
+            Color.clear
         } else {
             noProject
         }
@@ -297,14 +334,35 @@ struct FileBrowserView: View {
     /// Rebuilds the tree from the current project path. Called on appear, whenever
     /// the selected session moves to a different project, and after a drop. Watcher
     /// batches accumulated so far are superseded by the full rebuild, so drop them.
+    ///
+    /// The disk reads run off the main thread and the assembled root lands back on
+    /// main pre-realized, so the swap's first render reads nothing. Realizing a huge
+    /// root (a home directory) synchronously was ~100 ms of main-thread I/O, re-paid
+    /// on every full rescan — which a high-churn root produces constantly — and it
+    /// landed as the inspector's tab-switch stutter (#207). The outgoing tree keeps
+    /// showing until the new root is ready; on an ordinary project the gap is a few
+    /// milliseconds.
     private func refresh() {
         _ = watcher.drainTreeBatch()
         pendingReloads.removeAll()
+        refreshGeneration &+= 1
         guard let projectPath else {
             root = nil
             return
         }
-        root = FileNode(url: URL(fileURLWithPath: projectPath), isDirectory: true)
+        let generation = refreshGeneration
+        let rootURL = URL(fileURLWithPath: projectPath)
+        // What the outgoing tree had realized — re-listed off main so the swap
+        // keeps the outline's expanded subtree without a main-thread read.
+        let realized = root?.url == rootURL ? (root?.realizedDirectoryURLs() ?? []) : []
+        Task {
+            let listings = await Task.detached(priority: .userInitiated) {
+                FileNode.listingsForRefresh(of: rootURL, realized: realized)
+            }.value
+            // The project moved, or a newer refresh superseded this one, while we read.
+            guard generation == refreshGeneration else { return }
+            root = FileNode.preloaded(url: rootURL, isDirectory: true, listings: listings)
+        }
     }
 
     /// Reloads just the realized directories a settled watcher batch touched — the
@@ -352,8 +410,14 @@ struct FileBrowserView: View {
                 // `refresh` already cleared the queue; the fresh root re-reads
                 // its directories as the outline realizes them.
                 guard root === rootNow else { break }
-                for (url, listing) in zip(urls, listings) { laps[url]?.applyReloaded(listing) }
-                treeRevision &+= 1
+                var changedAny = false
+                for (url, listing) in zip(urls, listings) where laps[url]?.applyReloaded(listing) == true {
+                    changedAny = true
+                }
+                // Only a changed row set is worth an outline update pass — churn
+                // inside files (the common case on a busy root) adopts every node
+                // and would re-walk the whole realized tree for nothing.
+                if changedAny { treeRevision &+= 1 }
             }
             reloadInFlight = false
         }

--- a/Sources/termio/FileBrowser/FileNode.swift
+++ b/Sources/termio/FileBrowser/FileNode.swift
@@ -8,25 +8,56 @@ import Foundation
 /// rebuilt.
 final class FileNode: Identifiable {
     let url: URL
+    /// Whether this browses as a folder — resolved *through* a symlink, so a link to a
+    /// directory expands like the directory it points at (what the Finder and the VS Code
+    /// explorer both do).
     let isDirectory: Bool
+    /// Whether the entry itself is a symlink, so the row can mark it. Independent of
+    /// `isDirectory`: a link can point at either kind.
+    let isSymbolicLink: Bool
     var id: URL { url }
     var name: String { url.lastPathComponent }
 
     private var loadedChildren: [FileNode]?
 
-    init(url: URL, isDirectory: Bool) {
+    init(url: URL, isDirectory: Bool, isSymbolicLink: Bool = false) {
         self.url = url
         self.isDirectory = isDirectory
+        self.isSymbolicLink = isSymbolicLink
+    }
+
+    /// Where a symlink points, for the row's tooltip — the one fact about a link an icon
+    /// can't carry. Relative to the link's own parent when the target sits inside the
+    /// project (`.claude/skills` → `../skills`), absolute when it escapes.
+    var symbolicLinkTarget: String? {
+        guard isSymbolicLink else { return nil }
+        return try? FileManager.default.destinationOfSymbolicLink(atPath: url.path)
+    }
+
+    /// Where a symlink actually lands, absolute — for the row menu's Show Original. Nil
+    /// when this isn't a link, or when the link dangles: a target that doesn't exist
+    /// can't be revealed, and offering a menu item that silently does nothing is worse
+    /// than not offering it.
+    var resolvedSymbolicLinkTarget: URL? {
+        guard isSymbolicLink else { return nil }
+        let resolved = url.resolvingSymlinksInPath()
+        guard resolved != url, FileManager.default.fileExists(atPath: resolved.path) else { return nil }
+        return resolved
     }
 
     /// `nil` for a file (so the outline draws no disclosure triangle); a folder's
     /// contents — read lazily and cached — for a directory. SwiftUI only asks for
     /// the children of an *expanded* node, so this stays cheap on a large tree.
+    ///
+    /// A symlink that points at one of its own ancestors therefore nests forever, one
+    /// level per click. That's the Finder's and the VS Code explorer's behavior too:
+    /// laziness bounds the recursion by what the user actually opens, so no cycle
+    /// detection is worth the bookkeeping.
     var children: [FileNode]? {
         guard isDirectory else { return nil }
         if let loadedChildren { return loadedChildren }
         let contents = FileNode.listContents(of: url)
-            .map { FileNode(url: $0.url, isDirectory: $0.isDirectory) }
+            .map { FileNode(url: $0.url, isDirectory: $0.isDirectory, isSymbolicLink: $0.isSymbolicLink) }
         loadedChildren = contents
         return contents
     }
@@ -53,17 +84,20 @@ final class FileNode: Identifiable {
     /// Replaces this directory's realized contents with `entries` (a fresh disk
     /// listing), adopting the existing child node — realized subtree, and with it
     /// the outline's expansion state — wherever the entry survived.
-    func applyReloaded(_ entries: [(url: URL, isDirectory: Bool)]) {
+    func applyReloaded(_ entries: [(url: URL, isDirectory: Bool, isSymbolicLink: Bool)]) {
         guard isDirectory, let current = loadedChildren else { return }
         var existing = [URL: FileNode]()
         for child in current { existing[child.url] = child }
         loadedChildren = entries.map { entry in
-            // Same URL but a different kind (a file replaced by a folder, or the
-            // reverse) is a new entry — `isDirectory` is immutable on the node.
-            if let node = existing[entry.url], node.isDirectory == entry.isDirectory {
+            // Same URL but a different kind (a file replaced by a folder, a real folder
+            // replaced by a link to one) is a new entry — both flags are immutable on
+            // the node.
+            if let node = existing[entry.url],
+               node.isDirectory == entry.isDirectory,
+               node.isSymbolicLink == entry.isSymbolicLink {
                 return node
             }
-            return FileNode(url: entry.url, isDirectory: entry.isDirectory)
+            return FileNode(url: entry.url, isDirectory: entry.isDirectory, isSymbolicLink: entry.isSymbolicLink)
         }
     }
 
@@ -73,19 +107,32 @@ final class FileNode: Identifiable {
     /// `files.exclude`, which likewise leaves `node_modules`/build folders visible.
     /// Plain values (not nodes) so callers can list on a background thread and build
     /// or merge nodes back on main (`FileNode` itself is main-thread state).
-    static func listContents(of url: URL) -> [(url: URL, isDirectory: Bool)] {
+    static func listContents(of url: URL) -> [(url: URL, isDirectory: Bool, isSymbolicLink: Bool)] {
         let manager = FileManager.default
         guard let entries = try? manager.contentsOfDirectory(
             at: url,
-            includingPropertiesForKeys: [.isDirectoryKey],
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
             options: []
         ) else { return [] }
 
         return entries
             .filter { !ignoredNames.contains($0.lastPathComponent) }
             .map { entry in
-                let isDirectory = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-                return (url: entry, isDirectory: isDirectory)
+                let values = try? entry.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+                let isSymbolicLink = values?.isSymbolicLink ?? false
+                // `.isDirectoryKey` describes the link itself, not its target, so a
+                // symlink to a folder reports false and would render as a file with no
+                // disclosure triangle. `fileExists` follows the link, which is the
+                // answer the tree wants — and the same probe `FileBrowserView` already
+                // uses to decide whether a double-click opens an editor.
+                let isDirectory: Bool
+                if isSymbolicLink {
+                    var target: ObjCBool = false
+                    isDirectory = manager.fileExists(atPath: entry.path, isDirectory: &target) && target.boolValue
+                } else {
+                    isDirectory = values?.isDirectory ?? false
+                }
+                return (url: entry, isDirectory: isDirectory, isSymbolicLink: isSymbolicLink)
             }
             .sorted { left, right in
                 if left.isDirectory != right.isDirectory { return left.isDirectory }

--- a/Sources/termio/FileBrowser/FileNode.swift
+++ b/Sources/termio/FileBrowser/FileNode.swift
@@ -46,8 +46,14 @@ final class FileNode: Identifiable {
     }
 
     /// `nil` for a file (so the outline draws no disclosure triangle); a folder's
-    /// contents — read lazily and cached — for a directory. SwiftUI only asks for
-    /// the children of an *expanded* node, so this stays cheap on a large tree.
+    /// contents — read lazily and cached — for a directory. The outline realizes the
+    /// children of every *rendered* directory row, expanded or not — it needs them to
+    /// decide which rows get a disclosure triangle — so rendering a level costs one
+    /// listing per folder row on it: one level ahead of what the user opened, never
+    /// the whole tree. On a huge root that one level is still ~100 ms of disk I/O
+    /// (#207), so the initial and refresh listings are read off main and seeded via
+    /// `preloaded`; this getter is the lazy path for levels an expansion click
+    /// uncovers first.
     ///
     /// A symlink that points at one of its own ancestors therefore nests forever, one
     /// level per click. That's the Finder's and the VS Code explorer's behavior too:
@@ -67,6 +73,62 @@ final class FileNode: Identifiable {
     /// the watcher path skips it — the next expansion reads the disk fresh anyway.
     var isLoaded: Bool { loadedChildren != nil }
 
+    /// Every realized directory in this subtree, itself included — what is (or was)
+    /// on screen, so a refresh can re-list exactly that set off the main thread
+    /// before swapping roots (see `listingsForRefresh`).
+    func realizedDirectoryURLs() -> [URL] {
+        guard isDirectory, let loadedChildren else { return [] }
+        var urls = [url]
+        for child in loadedChildren {
+            urls.append(contentsOf: child.realizedDirectoryURLs())
+        }
+        return urls
+    }
+
+    /// A node for `url` whose subtree is pre-realized wherever `listings` holds that
+    /// directory's contents — built on main from listings read off it, so the swap's
+    /// first render touches no disk. Directories absent from `listings` stay lazy,
+    /// exactly as if never expanded.
+    static func preloaded(
+        url: URL, isDirectory: Bool, isSymbolicLink: Bool = false,
+        listings: [URL: [(url: URL, isDirectory: Bool, isSymbolicLink: Bool)]]
+    ) -> FileNode {
+        let node = FileNode(url: url, isDirectory: isDirectory, isSymbolicLink: isSymbolicLink)
+        if isDirectory, let listing = listings[url] {
+            node.loadedChildren = listing.map {
+                preloaded(url: $0.url, isDirectory: $0.isDirectory, isSymbolicLink: $0.isSymbolicLink, listings: listings)
+            }
+        }
+        return node
+    }
+
+    /// Every listing the outline needs to render a fresh root for `rootURL` without
+    /// a main-thread read: the root itself, every directory in `realized` (what the
+    /// outgoing tree had realized — which, because the outline realizes the children
+    /// of every *rendered* directory row (see `children`), already covers every
+    /// listing rendering will ask for), plus the root listing's own directories so
+    /// the very first render (nothing realized yet) is read-free too. Never lists
+    /// deeper: sweeping the children of every realized directory instead would make
+    /// each refresh realize one level more than the last — unbounded creep on a
+    /// high-churn root that full-rescans often, which is thousands of extra live
+    /// nodes for every later update pass to re-walk (#207). Plain values, safe to
+    /// run off main; a directory that vanished since `realized` was captured just
+    /// lists empty.
+    static func listingsForRefresh(
+        of rootURL: URL, realized: [URL]
+    ) -> [URL: [(url: URL, isDirectory: Bool, isSymbolicLink: Bool)]] {
+        var listings = [rootURL: listContents(of: rootURL)]
+        for url in realized where listings[url] == nil {
+            listings[url] = listContents(of: url)
+        }
+        if let rootListing = listings[rootURL] {
+            for entry in rootListing where entry.isDirectory && listings[entry.url] == nil {
+                listings[entry.url] = listContents(of: entry.url)
+            }
+        }
+        return listings
+    }
+
     /// The realized node at `path` (itself or a descendant), walking only realized
     /// children — never triggering a directory read. Nil when `path` isn't part of
     /// the realized tree, which is what lets a high-churn root (a home directory)
@@ -83,12 +145,16 @@ final class FileNode: Identifiable {
 
     /// Replaces this directory's realized contents with `entries` (a fresh disk
     /// listing), adopting the existing child node — realized subtree, and with it
-    /// the outline's expansion state — wherever the entry survived.
-    func applyReloaded(_ entries: [(url: URL, isDirectory: Bool, isSymbolicLink: Bool)]) {
-        guard isDirectory, let current = loadedChildren else { return }
+    /// the outline's expansion state — wherever the entry survived. Returns whether
+    /// the row set actually changed: churn *inside* files leaves the listing's
+    /// shape identical, every node is adopted, and nothing on screen moved — the
+    /// caller then skips the outline update pass, which on a huge realized tree is
+    /// a real main-thread cost per watcher batch (#207).
+    func applyReloaded(_ entries: [(url: URL, isDirectory: Bool, isSymbolicLink: Bool)]) -> Bool {
+        guard isDirectory, let current = loadedChildren else { return false }
         var existing = [URL: FileNode]()
         for child in current { existing[child.url] = child }
-        loadedChildren = entries.map { entry in
+        let reloaded = entries.map { entry in
             // Same URL but a different kind (a file replaced by a folder, a real folder
             // replaced by a link to one) is a new entry — both flags are immutable on
             // the node.
@@ -99,6 +165,10 @@ final class FileNode: Identifiable {
             }
             return FileNode(url: entry.url, isDirectory: entry.isDirectory, isSymbolicLink: entry.isSymbolicLink)
         }
+        let changed = reloaded.count != current.count
+            || !zip(reloaded, current).allSatisfy { $0 === $1 }
+        loadedChildren = reloaded
+        return changed
     }
 
     /// Directory entries, folders first then files, each alphabetized the way the

--- a/Sources/termio/FileBrowser/FileTreeList.swift
+++ b/Sources/termio/FileBrowser/FileTreeList.swift
@@ -592,6 +592,14 @@ struct OutlineViewFixups: NSViewRepresentable {
         DispatchQueue.main.async { Self.apply(from: nsView) }
     }
 
+    /// Reasserts the wheel increment on an outline captured earlier (see
+    /// `OutlineViewCapture`) — for callers that know a specific update just reset
+    /// it, like the inspector's tab switch covering the always-mounted file tree.
+    static func assertWheelIncrement(on outline: NSOutlineView?) {
+        guard let scroll = outline?.enclosingScrollView, scroll.verticalLineScroll != 24 else { return }
+        scroll.verticalLineScroll = 24
+    }
+
     private static func apply(from view: NSView) {
         var ancestor = view.superview
         while let current = ancestor {
@@ -600,12 +608,41 @@ struct OutlineViewFixups: NSViewRepresentable {
                 if table.selectionHighlightStyle != .none {
                     table.selectionHighlightStyle = .none
                 }
-                if let scroll = table.enclosingScrollView, scroll.verticalLineScroll != 24 {
-                    scroll.verticalLineScroll = 24
+                if let scroll = table.enclosingScrollView {
+                    if scroll.verticalLineScroll != 24 {
+                        scroll.verticalLineScroll = 24
+                    }
+                    enforce(scroll)
                 }
                 return
             }
             ancestor = current.superview
         }
     }
+
+    /// SwiftUI re-configures the List's scroll view on some structural updates
+    /// (covering the pane with another tab's overlay is one), resetting
+    /// `verticalLineScroll` back to the 1pt it mirrors from `rowHeight` — and a
+    /// property-less representable gets no `updateNSView` afterward to re-run
+    /// `apply`, so a one-shot write stays clobbered on an always-mounted list.
+    /// This observer watches the clip view's bounds (they change on every scroll)
+    /// and re-asserts the increment the moment a reset scroll view first moves, so
+    /// a wheel is never slow for more than its first notch. One observer per
+    /// scroll view; the token dies with the scroll view it's associated to.
+    private static func enforce(_ scroll: NSScrollView) {
+        guard objc_getAssociatedObject(scroll, &enforcementKey) == nil else { return }
+        scroll.contentView.postsBoundsChangedNotifications = true
+        let token = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scroll.contentView,
+            queue: nil
+        ) { [weak scroll] _ in
+            guard let scroll, scroll.verticalLineScroll != 24 else { return }
+            scroll.verticalLineScroll = 24
+        }
+        objc_setAssociatedObject(scroll, &enforcementKey, token, .OBJC_ASSOCIATION_RETAIN)
+    }
 }
+
+/// Unique address keying the enforcement token onto its scroll view.
+private var enforcementKey: UInt8 = 0

--- a/Sources/termio/FileBrowser/FileTreeList.swift
+++ b/Sources/termio/FileBrowser/FileTreeList.swift
@@ -129,8 +129,16 @@ private struct FileRow: View {
                 // Static — the disclosure chevron already carries open/closed state
                 // (Finder/Xcode's pattern), so the glyph doesn't need to swap and the
                 // row needs no expansion tracking of its own.
-                HugeIconView(icon: .folder, size: 15, color: chrome?.foreground ?? .primary)
-                    .frame(width: 16, alignment: .leading)
+                // A symlinked folder gets its own glyph rather than the folder plus a
+                // badge — the folder mark carries nothing but "folder", so swapping it
+                // for "symlinked folder" costs no information, and one line glyph stays
+                // legible at 15pt where a composited badge does not.
+                HugeIconView(
+                    icon: node.isSymbolicLink ? .folderSymlink : .folder,
+                    size: 15,
+                    color: chrome?.foreground ?? .primary
+                )
+                .frame(width: 16, alignment: .leading)
             } else {
                 // The file's real language/tool logo (a Devicon mark) when bundled,
                 // else a tinted SF Symbol — see `FileIconView`. Boxed below the folder's
@@ -138,6 +146,11 @@ private struct FileRow: View {
                 // ink only ~75% of theirs (the left sidebar's shared-column rule), so an
                 // equal nominal size made every file icon read a step LARGER than the
                 // folder and sidebar family — 12 brings their ink widths level.
+                // A symlinked *file* keeps its plain language logo — that mark says more
+                // than its link-ness, and the Finder's badge doesn't survive the trade:
+                // an arrow small enough to sit in the corner of a 12pt glyph collides
+                // with its outline and reads as damage, not as a mark. The tooltip and
+                // the row menu's Show Original carry it instead.
                 FileIconView(url: node.url, size: 12, symbolSize: 11, ink: chrome?.foreground ?? .primary)
                     .frame(width: 16, alignment: .leading)
             }
@@ -158,6 +171,10 @@ private struct FileRow: View {
         // full width, not just the label's footprint.
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
+        // Where a symlink points — the one fact about a link no badge can carry, and the
+        // reason the Finder puts it in Get Info rather than on the icon. Applied only to
+        // links: an empty `help` string still arms an (empty) AppKit tooltip.
+        .modifier(SymbolicLinkTooltip(target: node.symbolicLinkTarget))
         .onHover { isHovering = $0 }
         // Strip the source list's blue selection fill and restore the mouse-wheel
         // scroll increment at the AppKit layer (see `OutlineViewFixups`). Lives in a
@@ -199,6 +216,7 @@ private struct FileRow: View {
         // `EmptyAreaContextMenu`).
         .background(RowContextMenu(
             isDirectory: node.isDirectory,
+            symbolicLinkTarget: node.resolvedSymbolicLinkTarget,
             target: node.url,
             rootURL: rootURL,
             actions: actions
@@ -216,6 +234,22 @@ private struct FileRow: View {
             row
         }
     }
+
+}
+
+/// Hover text naming a symlink's target, applied only when there is one — `.help("")`
+/// still arms an AppKit tooltip, which would flash an empty bubble over every ordinary
+/// row in the tree.
+private struct SymbolicLinkTooltip: ViewModifier {
+    let target: String?
+
+    func body(content: Content) -> some View {
+        if let target {
+            content.help("Alias → \(target)")
+        } else {
+            content
+        }
+    }
 }
 
 /// The per-row right-click menu, via AppKit `NSMenu` rather than SwiftUI's
@@ -226,6 +260,9 @@ private struct FileRow: View {
 /// Path, Rename, and Delete.
 private struct RowContextMenu: NSViewRepresentable {
     let isDirectory: Bool
+    /// Where this row's symlink lands, or nil when the row isn't a link — gates Show
+    /// Original.
+    let symbolicLinkTarget: URL?
     let target: URL
     let rootURL: URL
     let actions: FileTreeActions
@@ -235,13 +272,25 @@ private struct RowContextMenu: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
         context.coordinator.owner = view
-        context.coordinator.configure(isDirectory: isDirectory, target: target, rootURL: rootURL, actions: actions)
+        context.coordinator.configure(
+            isDirectory: isDirectory,
+            symbolicLinkTarget: symbolicLinkTarget,
+            target: target,
+            rootURL: rootURL,
+            actions: actions
+        )
         context.coordinator.attach()
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        context.coordinator.configure(isDirectory: isDirectory, target: target, rootURL: rootURL, actions: actions)
+        context.coordinator.configure(
+            isDirectory: isDirectory,
+            symbolicLinkTarget: symbolicLinkTarget,
+            target: target,
+            rootURL: rootURL,
+            actions: actions
+        )
         context.coordinator.attach()
     }
 
@@ -253,14 +302,22 @@ private struct RowContextMenu: NSViewRepresentable {
     final class Coordinator: NSObject {
         weak var owner: NSView?
         private var isDirectory = false
+        private var symbolicLinkTarget: URL?
         private var target = URL(fileURLWithPath: "/")
         private var rootURL = URL(fileURLWithPath: "/")
         private var actions: FileTreeActions?
         private weak var hostView: NSView?
         private var recognizer: NSClickGestureRecognizer?
 
-        func configure(isDirectory: Bool, target: URL, rootURL: URL, actions: FileTreeActions) {
+        func configure(
+            isDirectory: Bool,
+            symbolicLinkTarget: URL?,
+            target: URL,
+            rootURL: URL,
+            actions: FileTreeActions
+        ) {
             self.isDirectory = isDirectory
+            self.symbolicLinkTarget = symbolicLinkTarget
             self.target = target
             self.rootURL = rootURL
             self.actions = actions
@@ -302,6 +359,12 @@ private struct RowContextMenu: NSViewRepresentable {
                 menu.addItem(menuItem("New Folder", #selector(newFolder)))
                 menu.addItem(.separator())
             }
+            // The Finder's own verb for an alias, and directly above Reveal in Finder so
+            // the pair reads as "the original" versus "this link". Absent on a row that
+            // isn't a link, and on one whose target is gone.
+            if symbolicLinkTarget != nil {
+                menu.addItem(menuItem("Show Original", #selector(showOriginal)))
+            }
             menu.addItem(menuItem("Reveal in Finder", #selector(revealInFinder)))
             menu.addItem(.separator())
             menu.addItem(menuItem("Copy Path", #selector(copyPath)))
@@ -326,6 +389,14 @@ private struct RowContextMenu: NSViewRepresentable {
         @objc private func deleteItem() { actions?.delete(target) }
         @objc private func revealInFinder() {
             NSWorkspace.shared.activateFileViewerSelecting([target])
+        }
+
+        /// Reveals what the link points at, not the link — the Finder selects the target
+        /// in its own folder, which is where "where does this actually live" gets
+        /// answered.
+        @objc private func showOriginal() {
+            guard let symbolicLinkTarget else { return }
+            NSWorkspace.shared.activateFileViewerSelecting([symbolicLinkTarget])
         }
 
         @objc private func copyPath() {

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -129,8 +129,13 @@ struct InspectorTabsToolbar: View {
         .padding(Self.trackPadding)
         .background { trackBackground }
         // Scope the slide animation to just this control's subtree, so switching panes doesn't
-        // drag the inspector content along with it.
-        .animation(.snappy(duration: 0.28), value: store.inspectorTab)
+        // drag the inspector content along with it. Fast and bounce-free: the pane itself
+        // switches instantly, and the pill is the motion cue the eye tracks — at 0.28s it
+        // arrived visibly after the content and made every switch read slow. A tab switch
+        // is a dozens-of-times-a-day micro-interaction, and the eye finishes tracking a
+        // hop this small in under ~80ms, so 0.1s is the floor that still shows *which way*
+        // the selection moved without ever being waited on.
+        .animation(.snappy(duration: 0.1, extraBounce: 0), value: store.inspectorTab)
     }
 
     // MARK: Materials — macOS 26 (Tahoe) Finder segmented control

--- a/Tests/termioTests/FileNodePreloadTests.swift
+++ b/Tests/termioTests/FileNodePreloadTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import termio
+
+/// The refresh preload path (#207): `listingsForRefresh` must read, in one off-main
+/// pass, every listing the outline touches on first render — the root, everything
+/// previously realized, and every directory that appears as a row of one of those —
+/// and `preloaded` must seed exactly that set so rendering performs no disk read.
+///
+/// Listings are navigated by their own keys, never by reconstructed URLs: the
+/// dictionary is keyed by the URLs `contentsOfDirectory` returns (canonicalized,
+/// trailing-slashed), which is also the only way production looks entries up —
+/// `realized` comes from `FileNode` urls, themselves born from those entries.
+final class FileNodePreloadTests: XCTestCase {
+    private var root: URL = FileManager.default.temporaryDirectory
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileNodePreloadTests-\(UUID().uuidString)")
+        // root/{alpha/{nested/{deep.txt}, a.txt}, beta/{b.txt}, top.txt}
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("alpha/nested"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("beta"), withIntermediateDirectories: true)
+        for path in ["alpha/nested/deep.txt", "alpha/a.txt", "beta/b.txt", "top.txt"] {
+            try Data().write(to: root.appendingPathComponent(path))
+        }
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: root)
+    }
+
+    private func key(
+        _ listings: [URL: [(url: URL, isDirectory: Bool, isSymbolicLink: Bool)]], named name: String
+    ) -> URL? {
+        listings.keys.first { $0.lastPathComponent == name }
+    }
+
+    func testFreshRootListsRootAndEveryTopLevelDirectory() {
+        let listings = FileNode.listingsForRefresh(of: root, realized: [])
+        XCTAssertEqual(
+            Set(listings.keys.map(\.lastPathComponent)),
+            [root.lastPathComponent, "alpha", "beta"])
+        // One level ahead of the rendered rows, not the whole tree.
+        XCTAssertNil(key(listings, named: "nested"))
+    }
+
+    func testRealizedDirectoriesAreRelisted() throws {
+        let fresh = FileNode.listingsForRefresh(of: root, realized: [])
+        let alpha = try XCTUnwrap(key(fresh, named: "alpha"))
+        let nested = try XCTUnwrap(fresh[alpha]?.first { $0.isDirectory }?.url)
+
+        // `alpha` was expanded, which realized its child `nested` (the outline
+        // asks every rendered row's directory for its children): both are in the
+        // realized set and both get re-listed so the swap keeps them fresh.
+        let listings = FileNode.listingsForRefresh(of: root, realized: [root, alpha, nested])
+        XCTAssertEqual(
+            Set(listings.keys.map(\.lastPathComponent)),
+            [root.lastPathComponent, "alpha", "beta", "nested"])
+    }
+
+    func testApplyReloadedReportsWhetherTheRowSetChanged() throws {
+        let node = FileNode(url: root, isDirectory: true)
+        let listing = try XCTUnwrap(node.children.map { _ in FileNode.listContents(of: root) })
+
+        // Same listing again: every node adopted, nothing on screen moved.
+        XCTAssertFalse(node.applyReloaded(listing))
+
+        // A new entry changes the row set.
+        try Data().write(to: root.appendingPathComponent("fresh.txt"))
+        XCTAssertTrue(node.applyReloaded(FileNode.listContents(of: root)))
+    }
+
+    func testRefreshRealizationDoesNotCreepDeeper() {
+        // A refresh sweep fed by what the previous sweep realized must reproduce
+        // the same set — if it swept the children of realized directories, every
+        // full rescan would realize one level more than the last, ballooning a
+        // high-churn root without the user expanding anything.
+        let first = FileNode.listingsForRefresh(of: root, realized: [])
+        let node = FileNode.preloaded(url: root, isDirectory: true, listings: first)
+        let second = FileNode.listingsForRefresh(of: root, realized: node.realizedDirectoryURLs())
+        XCTAssertEqual(Set(second.keys), Set(first.keys))
+    }
+
+    func testVanishedRealizedDirectoryListsEmpty() {
+        let gone = root.appendingPathComponent("gone")
+        let listings = FileNode.listingsForRefresh(of: root, realized: [gone])
+        XCTAssertEqual(listings[gone]?.isEmpty, true)
+    }
+
+    func testPreloadedSeedsListedDirectoriesAndLeavesTheRestLazy() throws {
+        let fresh = FileNode.listingsForRefresh(of: root, realized: [])
+        let alphaURL = try XCTUnwrap(key(fresh, named: "alpha"))
+        let listings = FileNode.listingsForRefresh(of: root, realized: [root, alphaURL])
+        let node = FileNode.preloaded(url: root, isDirectory: true, listings: listings)
+
+        XCTAssertTrue(node.isLoaded)
+        XCTAssertEqual(node.children?.map(\.name), ["alpha", "beta", "top.txt"])
+
+        let alpha = try XCTUnwrap(node.children?.first { $0.name == "alpha" })
+        XCTAssertTrue(alpha.isLoaded)
+        let beta = try XCTUnwrap(node.children?.first { $0.name == "beta" })
+        XCTAssertTrue(beta.isLoaded)
+
+        // `nested` was never realized before this refresh, so it is not seeded —
+        // it stays lazy exactly as if never expanded (no deeper creep).
+        let nested = try XCTUnwrap(alpha.children?.first { $0.name == "nested" })
+        XCTAssertFalse(nested.isLoaded)
+    }
+}


### PR DESCRIPTION
Fixes #207.

Switching inspector tabs stuttered (whole seconds) when a session's project was rooted at a huge directory like `~`, mouse-wheel scrolling in the tree crawled at 1pt per notch, and a busy root paid a recurring main-thread hitch per filesystem-watcher batch. Four compounding causes, each measured before fixing:

- **Main-thread disk I/O on render.** `List(children:)` realizes the children of every *rendered* directory row to decide leafness — at `~` that is the root plus all 171 top-level folders, ~92ms of synchronous I/O, re-paid after every full-rescan refresh. `refresh()` now reads those listings off the main thread and swaps in a pre-seeded root; a generation counter keeps stale reads from landing out of order, and the sweep never lists deeper than what rendering itself realized (so realization cannot creep one level per rescan — pinned by a test).
- **Outline teardown per tab switch.** Each switch rebuilt the whole outline (200–350ms with bare rows; seconds with real ones). The Files pane is now always mounted and the other panes cover it as an opaque overlay (the `InspectorRoot` shape), so a switch is an overlay flip and the tree keeps its disclosure state.
- **Wheel increment reset.** SwiftUI re-configures the List's scroll view on the overlay flip, resetting `verticalLineScroll` to the 1pt it mirrors from `rowHeight`, with no row update following to heal the one-shot fixup. The tab switch reasserts it, and a per-scroll-view bounds-change observer self-heals any other reset on its first scroll tick.
- **No-op watcher merges.** Reloads whose listing came back identical (churn inside files — the common case on a busy root) still bumped `treeRevision`, forcing a 70–90ms outline re-walk per settled batch. Merges now report whether the row set changed and skip the pass otherwise.

Also included: the tree marks symlinked entries (dedicated folder-symlink glyph, target tooltip, Show Original in the row menu), and the pane-switch pill now slides in 0.1s instead of 0.28s so the switch reads as instant.

New `FileNodePreloadTests` cover the refresh sweep's contract: coverage, no-creep stability, vanished directories, lazy seeding, and change detection.

Release Notes:
- Fixed inspector tab switches stuttering when the project is rooted at a very large directory; the Files tree now loads off the main thread, survives tab switches without rebuilding, and keeps its expansion state.
- Fixed mouse-wheel scrolling in the file tree crawling after switching inspector tabs.
- The file tree now marks symlinked files and folders, with the link target shown on hover and a Show Original action in the row menu.