### PR TITLE
Stop the terminal surface from swallowing termio's own shortcuts

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -145,8 +145,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // whole main menu whenever a user rebinds a shortcut in Settings.
         keybindingsObserver = NotificationCenter.default.addObserver(
             forName: .termioKeybindingsChanged, object: nil, queue: .main
-        ) { _ in
-            MainActor.assumeIsolated { NSApp.mainMenu = buildMainMenu() }
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                NSApp.mainMenu = buildMainMenu()
+                // Open surfaces carry the old unbind set, so a shortcut moved onto
+                // a ghostty-bound key would be swallowed until relaunch.
+                self?.store.applyAppearanceToOpenSurfaces()
+            }
         }
         window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1100, height: 720),
@@ -617,6 +622,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         applyChromeAppearance()
         applyWindowTransparency()
         updateInspectorMaxThickness()
+    }
+
+    /// View ▸ Toggle Full Screen (⌃⌘F).
+    ///
+    /// macOS moved its own full-screen shortcut to globe-F in Monterey and pins
+    /// that onto the Enter/Exit Full Screen item AppKit inserts — so ⌃⌘F, what a
+    /// decade of Mac apps taught and what ghostty binds, reaches nothing. This is
+    /// ghostty's own answer, verbatim: an item AppKit will not take over, which
+    /// means neither the reserved titles nor `NSWindow.toggleFullScreen(_:)`
+    /// (ghostty ships "Toggle Full Screen" on `toggleGhosttyFullScreen:`).
+    /// Ghostty's binding on the same key is unbound inside the surface (see
+    /// `applyAppearance`), or the terminal would swallow it first.
+    @objc func toggleFullScreenCommand(_ sender: Any?) {
+        (window ?? Self.mainWindow)?.toggleFullScreen(nil)
     }
 
     func windowDidResize(_ notification: Notification) {
@@ -2062,6 +2081,17 @@ private func buildMainMenu() -> NSMenu {
         action: #selector(AppDelegate.resetFontSize(_:)),
         command: .resetFontSize
     )
+    viewMenu.addItem(.separator())
+    // "Toggle Full Screen", not "Enter/Exit Full Screen": AppKit manages an item
+    // carrying either reserved title (or `NSWindow.toggleFullScreen(_:)`) and
+    // rewrites its key equivalent to the system shortcut. See
+    // `toggleFullScreenCommand`.
+    let fullScreenItem = viewMenu.addItem(
+        withTitle: "Toggle Full Screen",
+        action: #selector(AppDelegate.toggleFullScreenCommand(_:)),
+        keyEquivalent: "f"
+    )
+    fullScreenItem.keyEquivalentModifierMask = [.control, .command]
     viewItem.submenu = viewMenu
 
     // Session menu — Chrome's Tab menu for termio's own navigation unit: the

--- a/Sources/termio/Keybindings/KeybindingStore.swift
+++ b/Sources/termio/Keybindings/KeybindingStore.swift
@@ -101,13 +101,54 @@ final class KeybindingStore: ObservableObject {
 
     /// Fixed shortcuts termio does not expose for rebinding but must still guard
     /// against, so the recorder can warn instead of silently double-binding.
-    private static let reserved: [(label: String, shortcut: Shortcut)] = [
+    private static var reserved: [(label: String, shortcut: Shortcut)] { hostReserved + surfaceReserved }
+
+    /// App-layer keys with no catalog entry: they act on the app, not on the
+    /// terminal's text, so the host owns them and the surface must not keep its
+    /// own binding for them (see `surfaceUnbindTriggers`).
+    static let hostReserved: [(label: String, shortcut: Shortcut)] = [
         ("Settings…", .init(modifiers: [.command], key: .char(","))),
         ("Quit Termio", .init(modifiers: [.command], key: .char("q"))),
+        // macOS reserves ⌃⌘F for full screen; the View menu's Enter Full Screen
+        // item is inserted by AppKit, so termio has no command of its own here —
+        // only the duty to stop the surface from eating the key.
+        ("Enter Full Screen", .init(modifiers: [.command, .control], key: .char("f"))),
+    ]
+
+    /// Keys the *surface* owns: they act on the terminal's own text, ghostty
+    /// already implements them, and unbinding them would break the terminal.
+    /// Listed only so the recorder refuses to rebind them.
+    private static let surfaceReserved: [(label: String, shortcut: Shortcut)] = [
         ("Copy", .init(modifiers: [.command], key: .char("c"))),
         ("Paste", .init(modifiers: [.command], key: .char("v"))),
         ("Select All", .init(modifiers: [.command], key: .char("a"))),
     ]
+
+    // MARK: - Surface handoff
+
+    /// Every trigger the host claims, in ghostty's `keybind` syntax.
+    ///
+    /// A surface-handled keybind is consumed before the menu bar ever sees the
+    /// event, and `TerminalCallbackBridge` drops the actions this embedding
+    /// cannot perform (splits, tabs, windows, full screen), so any ghostty
+    /// default sharing a trigger with a termio command silently kills that
+    /// command while a terminal has focus. Deriving the list from the effective
+    /// table — rather than hand-listing triggers — means a command added to the
+    /// catalog or a shortcut a user rebinds in Settings can never be swallowed.
+    var surfaceUnbindTriggers: [String] {
+        Self.unbindTriggers(claiming: KeyCommandCatalog.all.compactMap { shortcut(for: $0.id) }
+            + Self.hostReserved.map(\.shortcut))
+    }
+
+    /// The pure half, so the mapping can be tested without the singleton's
+    /// on-disk overrides.
+    static func unbindTriggers(claiming shortcuts: [Shortcut]) -> [String] {
+        var triggers = Set(shortcuts.map(\.ghosttyTrigger))
+        // ⌘⇧= arrives as "+", which ghostty binds separately from "=". The
+        // shifted spelling has no `Shortcut` of its own, so pair it by hand.
+        if triggers.contains("super+=") { triggers.insert("super+plus") }
+        return triggers.sorted()
+    }
 
     // MARK: - Persistence
 

--- a/Sources/termio/Keybindings/Shortcut.swift
+++ b/Sources/termio/Keybindings/Shortcut.swift
@@ -74,6 +74,27 @@ extension Shortcut {
     }
 }
 
+// MARK: - Ghostty trigger ("super+alt+arrow_left")
+
+extension Shortcut {
+    /// The same shortcut in Ghostty's `keybind` trigger syntax, so a key the host
+    /// claims can be unbound inside the surface (see `applyAppearance`). Ghostty
+    /// spells ⌘ `super` and ⌥ `alt`, and names the arrow and return keys rather
+    /// than encoding them as characters.
+    var ghosttyTrigger: String {
+        // Ghostty's own `+list-keybinds` output orders modifiers super, ctrl,
+        // alt, shift; its parser accepts any order, but matching the upstream
+        // spelling keeps a config dump readable next to ghostty's.
+        var parts: [String] = []
+        if modifiers.contains(.command) { parts.append("super") }
+        if modifiers.contains(.control) { parts.append("ctrl") }
+        if modifiers.contains(.option) { parts.append("alt") }
+        if modifiers.contains(.shift) { parts.append("shift") }
+        parts.append(key.ghosttyToken)
+        return parts.joined(separator: "+")
+    }
+}
+
 // MARK: - Display (menu glyphs: "⌥⌘←")
 
 extension Shortcut {
@@ -142,6 +163,19 @@ private extension Shortcut.Key {
         case .up: return "up"
         case .down: return "down"
         case .return: return "return"
+        }
+    }
+
+    /// Ghostty's own key names. Single characters (including punctuation like
+    /// `,` `[` `=`) are spelled literally; everything else is a named key.
+    var ghosttyToken: String {
+        switch self {
+        case .char(let c): return c
+        case .left: return "arrow_left"
+        case .right: return "arrow_right"
+        case .up: return "arrow_up"
+        case .down: return "arrow_down"
+        case .return: return "enter"
         }
     }
 

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -794,36 +794,18 @@ extension TermioStore {
         // it just vanishes like a native terminal tab.
         builder.withCustom("wait-after-command", "true")
 
-        // termio's palettes live on ⌘⇧P (Command Palette) and ⌘⇧O (Open
-        // Quickly, see `buildMainMenu`); ghostty binds keys like these to its
-        // own actions, and a surface-handled keybind is consumed before the
-        // menu bar ever sees the event. Unbind them inside the surface so the
-        // shortcuts always reach termio's menu.
-        builder.withCustom("keybind", "super+shift+p=unbind")
-        builder.withCustom("keybind", "super+shift+o=unbind")
-        // ⌘T is termio's "New Terminal" (see `buildMainMenu`). Ghostty binds it to
-        // its own `new_tab`, which is a no-op in termio's tab-less embedding — so a
-        // focused surface swallows the key and the menu action never fires ("nothing
-        // happens"). Unbind it so ⌘T always reaches termio's menu.
-        builder.withCustom("keybind", "super+t=unbind")
-        // Font size and split zoom are termio menu actions too: font size is
-        // driven from the persisted `fontSize` setting (so it survives relaunch
-        // and applies to every surface), and zoom is a host SplitTree operation
-        // (ghostty has no splits in embedded mode). Unbind ghostty's built-in
-        // versions so ⌘=/⌘-/⌘0 and ⌘⇧↩ reach `buildMainMenu` instead of being
-        // swallowed by the surface.
-        builder.withCustom("keybind", "super+equal=unbind")
-        builder.withCustom("keybind", "super+plus=unbind")
-        builder.withCustom("keybind", "super+minus=unbind")
-        builder.withCustom("keybind", "super+zero=unbind")
-        builder.withCustom("keybind", "super+shift+enter=unbind")
-        // Session cycling lives on ⌘⇧[ / ⌘⇧] (Session menu). Ghostty binds both
-        // to previous/next_tab — no-ops in termio's tab-less embedding that would
-        // still swallow the keys before the menu sees them. The bare-character
-        // form matches ghostty's own default triggers (unicode '[' / ']'), which
-        // the named physical keys (bracket_left/right) would not.
-        builder.withCustom("keybind", "super+shift+[=unbind")
-        builder.withCustom("keybind", "super+shift+]=unbind")
+        // The keyboard is split in two: keys that act on the terminal's text
+        // (copy, paste, clear, scrollback, selection, word motion, search) stay
+        // ghostty's, and keys that act on the app (sessions, panes, palettes,
+        // settings, full screen) are the host's. Ghostty ships defaults on both
+        // sides — ⌘D is `new_split`, ⌘T `new_tab`, ⌘, `open_config` — and a
+        // surface-handled keybind is consumed before the menu bar sees the
+        // event, so every host-claimed trigger has to be unbound here or the
+        // menu action never fires. `surfaceUnbindTriggers` derives that set from
+        // the effective binding table, so a rebind in Settings is covered too.
+        for trigger in KeybindingStore.shared.surfaceUnbindTriggers {
+            builder.withCustom("keybind", "\(trigger)=unbind")
+        }
     }
 
     /// The light/dark theme pair libghostty switches between as the system

--- a/Tests/termioTests/KeybindingSurfaceTests.swift
+++ b/Tests/termioTests/KeybindingSurfaceTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import termio
+
+/// The keyboard is split in two layers, and both halves have a failure mode.
+///
+/// Keys the *host* claims must be unbound inside the surface: ghostty consumes a
+/// bound key before the menu bar sees it, and the embedding drops the actions it
+/// cannot perform, so a collision kills the menu command outright (issue #203 —
+/// ⌘D and ⌘⇧D did nothing). Keys the *terminal* owns must never be unbound: they
+/// are ghostty's own text and buffer verbs, and taking them costs line motion
+/// and copy/paste inside the shell.
+///
+/// Both sides are checked against ghostty's shipped defaults, so a new command
+/// landing on a terminal key — or a libghostty bump that binds a key we claim —
+/// fails here instead of in a user's hands.
+@MainActor
+final class KeybindingSurfaceTests: XCTestCase {
+    private func shortcut(_ modifiers: NSEvent.ModifierFlags, _ key: Shortcut.Key) -> Shortcut {
+        Shortcut(modifiers: modifiers, key: key)
+    }
+
+    // MARK: - Trigger spelling
+
+    func testGhosttyTriggerSpelling() {
+        XCTAssertEqual(shortcut([.command], .char("d")).ghosttyTrigger, "super+d")
+        XCTAssertEqual(shortcut([.command, .shift], .char("d")).ghosttyTrigger, "super+shift+d")
+        XCTAssertEqual(shortcut([.command, .option], .left).ghosttyTrigger, "super+alt+arrow_left")
+        XCTAssertEqual(shortcut([.command, .shift], .return).ghosttyTrigger, "super+shift+enter")
+        XCTAssertEqual(shortcut([.command, .control], .char("f")).ghosttyTrigger, "super+ctrl+f")
+        XCTAssertEqual(shortcut([.command], .char(",")).ghosttyTrigger, "super+,")
+        XCTAssertEqual(shortcut([.command, .shift], .char("]")).ghosttyTrigger, "super+shift+]")
+    }
+
+    // MARK: - Host layer
+
+    /// Every shipped command's key, plus the app-layer keys with no catalog entry,
+    /// has to reach the unbind set — that set is what stops the surface from
+    /// eating the shortcut.
+    func testEveryHostShortcutIsUnbound() {
+        let triggers = Set(KeybindingStore.shared.surfaceUnbindTriggers)
+        for info in KeyCommandCatalog.all {
+            guard let shortcut = info.defaultShortcut else { continue }
+            XCTAssertTrue(
+                triggers.contains(shortcut.ghosttyTrigger),
+                "\(info.title) (\(shortcut.display)) can be swallowed by the surface"
+            )
+        }
+        for reserved in KeybindingStore.hostReserved {
+            XCTAssertTrue(
+                triggers.contains(reserved.shortcut.ghosttyTrigger),
+                "\(reserved.label) (\(reserved.shortcut.display)) can be swallowed by the surface"
+            )
+        }
+    }
+
+    /// The collisions that were live when #203 was filed, pinned so they cannot
+    /// come back one at a time.
+    func testKnownGhosttyCollisionsAreUnbound() {
+        let triggers = Set(KeybindingStore.shared.surfaceUnbindTriggers)
+        for trigger in [
+            "super+d",              // new_split:right      → Split Right
+            "super+shift+d",        // new_split:down       → Split Down
+            "super+alt+arrow_left", // goto_split:left      → Focus Pane Left
+            "super+n",              // new_window           → New Chat
+            "super+w",              // close_surface        → Ungroup
+            "super+shift+w",        // close_window         → Close Window
+            "super+t",              // new_tab              → New Terminal
+            "super+,",              // open_config          → Settings…
+            "super+q",              // quit                 → Quit Termio
+            "super+ctrl+f",         // toggle_fullscreen    → Enter Full Screen
+        ] {
+            XCTAssertTrue(triggers.contains(trigger), "\(trigger) is still handled by the surface")
+        }
+    }
+
+    // MARK: - Terminal layer
+
+    /// Ghostty defaults that act on the terminal's own text or buffer. Taken from
+    /// `ghostty +list-keybinds --default` (Ghostty 1.3.1); the app layer must
+    /// never claim one of these, or the shell loses line motion, selection, or
+    /// copy/paste — the mirror-image bug of #203.
+    private static let terminalLayerTriggers: Set<String> = [
+        "super+c", "super+v", "super+shift+v", "super+a",   // copy / paste / select all
+        "super+k",                                          // clear_screen
+        "super+home", "super+end", "super+page_up", "super+page_down", "super+j",
+        "super+arrow_up", "super+arrow_down",               // jump_to_prompt
+        "super+shift+arrow_up", "super+shift+arrow_down",   // jump_to_prompt
+        "super+arrow_left", "super+arrow_right",            // text:\x01 / \x05 (line start/end)
+        "super+backspace",                                  // text:\x15 (kill line)
+        "alt+arrow_left", "alt+arrow_right",                // esc:b / esc:f (word motion)
+        "shift+arrow_left", "shift+arrow_right", "shift+arrow_up", "shift+arrow_down",
+        "shift+page_up", "shift+page_down", "shift+home", "shift+end",
+        "super+f", "super+e", "super+shift+f", "super+g", "super+shift+g",  // search
+    ]
+
+    func testTerminalLayerIsLeftAlone() {
+        let claimed = Set(KeybindingStore.shared.surfaceUnbindTriggers)
+        let stolen = claimed.intersection(Self.terminalLayerTriggers).sorted()
+        XCTAssertTrue(
+            stolen.isEmpty,
+            "the app layer is unbinding terminal keys: \(stolen.joined(separator: ", "))"
+        )
+    }
+}


### PR DESCRIPTION
Fixes #203.

Ghostty binds keys on both sides of the app boundary, and a surface-handled keybind is consumed before the menu bar ever sees the event — `TerminalCallbackBridge` implements 13 actions and drops the rest. Every ghostty default sharing a trigger with a termio command was therefore dead while a terminal had focus: ⌘D, ⌘⇧D (the reported bug), plus ⌥⌘arrows, ⌘N, ⌘W, ⌘⇧W, ⌘, and ⌘Q.

The old unbind list was hand-maintained, nine triggers written out one at a time, and structurally could not cover a shortcut rebound in Settings. It is now derived from the effective binding table: every catalog command plus the two fixed app-layer keys (⌘, ⌘Q), mapped into ghostty's trigger syntax, and re-applied to open surfaces the moment a binding changes.

Full screen follows ghostty's own shape. AppKit manages any View-menu item carrying the reserved titles or `NSWindow.toggleFullScreen(_:)` and pins the current system shortcut (globe-F since Monterey) onto it, so ⌃⌘F reached nothing. Ghostty ships `<menuItem title="Toggle Full Screen" keyEquivalent="f">` on its own selector; this does the same.

The design behind the split — terminal keys stay ghostty's, app keys are the host's — is written up in #204.

## Verification

- `swift build` clean, 122/122 tests pass.
- Every emitted trigger validated against `ghostty +validate-config`, including the awkward `keybind = super+==unbind`.
- Four new tests: trigger spelling, every host shortcut reaching the unbind set, the ten known collisions pinned by name, and `testTerminalLayerIsLeftAlone` — which asserts the app layer never claims one of ghostty's text/buffer keys (copy/paste, line motion, word motion, selection). That last one is the mirror-image bug; cmux currently ships it, having taken ⌘←/⌘→ from the shell.
- Not verified by me: actually pressing the keys. Synthesized input doesn't reach the app from my environment, confirmed with ⌘T as a control. Worth a pass over ⌘D, ⌘⇧D, ⌥⌘arrows, ⌘,, ⌘Q and ⌃⌘F with a pane focused — and ⌘W in particular, which now reaches Ungroup rather than ghostty's `close_surface`.

Release Notes:

- Fixed the split, pane-focus, Settings, Quit and full-screen shortcuts doing nothing while a terminal pane had focus.
- Added ⌃⌘F for full screen, alongside the system's globe-F.
