### PR TITLE
Add Split Left and Split Up

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1184,9 +1184,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.splitSelectedPane(.horizontal)
     }
 
+    /// View ▸ Split Left — side-by-side, with the new terminal on the leading side.
+    @objc func splitPaneLeft(_ sender: Any?) {
+        store.splitSelectedPane(.horizontal, slot: .first)
+    }
+
     /// View ▸ Split Down (⌘⇧D) — splits the focused pane stacked.
     @objc func splitPaneDown(_ sender: Any?) {
         store.splitSelectedPane(.vertical)
+    }
+
+    /// View ▸ Split Up — stacked, with the new terminal above.
+    @objc func splitPaneUp(_ sender: Any?) {
+        store.splitSelectedPane(.vertical, slot: .first)
     }
 
     /// View ▸ Ungroup (⌘W) — collapses the focused pane out of the layout.
@@ -2004,9 +2014,19 @@ private func buildMainMenu() -> NSMenu {
         command: .splitRight
     )
     viewMenu.addItem(
+        withTitle: "Split Left",
+        action: #selector(AppDelegate.splitPaneLeft(_:)),
+        command: .splitLeft
+    )
+    viewMenu.addItem(
         withTitle: "Split Down",
         action: #selector(AppDelegate.splitPaneDown(_:)),
         command: .splitDown
+    )
+    viewMenu.addItem(
+        withTitle: "Split Up",
+        action: #selector(AppDelegate.splitPaneUp(_:)),
+        command: .splitUp
     )
     // ⌘⇧↩ maximises the focused pane (tmux/iTerm2 zoom), toggling back to the split.
     viewMenu.addItem(

--- a/Sources/termio/CommandPalette/CommandPalette.swift
+++ b/Sources/termio/CommandPalette/CommandPalette.swift
@@ -249,9 +249,17 @@ struct CommandPaletteView: View {
                                  icon: .layoutColumns, shortcut: keys.display(for: .splitRight)) {
                 $0.splitSelectedPane(.horizontal)
             })
+            actions.append(.init(id: "split-left", title: "Split Left",
+                                 icon: .layoutColumns, shortcut: keys.display(for: .splitLeft)) {
+                $0.splitSelectedPane(.horizontal, slot: .first)
+            })
             actions.append(.init(id: "split-down", title: "Split Down",
                                  icon: .layoutRows, shortcut: keys.display(for: .splitDown)) {
                 $0.splitSelectedPane(.vertical)
+            })
+            actions.append(.init(id: "split-up", title: "Split Up",
+                                 icon: .layoutRows, shortcut: keys.display(for: .splitUp)) {
+                $0.splitSelectedPane(.vertical, slot: .first)
             })
         }
         if store.splitRoot != nil {

--- a/Sources/termio/Keybindings/KeyCommand.swift
+++ b/Sources/termio/Keybindings/KeyCommand.swift
@@ -19,7 +19,9 @@ enum KeyCommandID: String, CaseIterable, Identifiable {
     case newPullRequest = "branch.new-pull-request"
     // Panes
     case splitRight = "pane.split-right"
+    case splitLeft = "pane.split-left"
     case splitDown = "pane.split-down"
+    case splitUp = "pane.split-up"
     case splitZoom = "pane.zoom"
     // Raw value predates the Ungroup rename — kept so saved keybindings resolve.
     case ungroup = "pane.close"
@@ -90,8 +92,13 @@ enum KeyCommandCatalog {
         // Panes
         .init(id: .splitRight, category: "Panes", title: "Split Right",
               defaultShortcut: .init(modifiers: [.command], key: .char("d"))),
+        // Left and Up ship unbound, the way ghostty ships them: the two directions
+        // people reach for constantly earn the keys, the mirrored pair stays a
+        // menu verb until a user decides otherwise in Settings ▸ Keyboard.
+        .init(id: .splitLeft, category: "Panes", title: "Split Left", defaultShortcut: nil),
         .init(id: .splitDown, category: "Panes", title: "Split Down",
               defaultShortcut: .init(modifiers: [.command, .shift], key: .char("d"))),
+        .init(id: .splitUp, category: "Panes", title: "Split Up", defaultShortcut: nil),
         .init(id: .splitZoom, category: "Panes", title: "Zoom Split",
               defaultShortcut: .init(modifiers: [.command, .shift], key: .return)),
         .init(id: .ungroup, category: "Panes", title: "Ungroup",

--- a/Sources/termio/Terminal/TerminalContextMenu.swift
+++ b/Sources/termio/Terminal/TerminalContextMenu.swift
@@ -110,8 +110,17 @@ final class TerminalContextMenu: NSObject {
             menu.addItem(storeItem("Copy Session Link", action: #selector(copyLink), symbol: "link"))
         }
         menu.addItem(.separator())
-        menu.addItem(storeItem("Split Right", action: #selector(splitRight), symbol: "rectangle.split.2x1"))
-        menu.addItem(storeItem("Split Down", action: #selector(splitDown), symbol: "rectangle.split.1x2"))
+        // Ghostty's own split glyphs and order (Right, Left, Down, Up): the filled
+        // half of the rectangle is where the new pane lands, which reads at a
+        // glance in a way "rectangle.split.2x1" never did once there were four.
+        menu.addItem(storeItem("Split Right", action: #selector(splitRight),
+                               symbol: "rectangle.righthalf.inset.filled"))
+        menu.addItem(storeItem("Split Left", action: #selector(splitLeft),
+                               symbol: "rectangle.leadinghalf.inset.filled"))
+        menu.addItem(storeItem("Split Down", action: #selector(splitDown),
+                               symbol: "rectangle.bottomhalf.inset.filled"))
+        menu.addItem(storeItem("Split Up", action: #selector(splitUp),
+                               symbol: "rectangle.tophalf.inset.filled"))
         // Rearranging without drag-and-drop: each direction trades the clicked
         // pane with its neighbour that way (tmux's swap-pane), scored by the
         // same geometry ⌥⌘-arrow focus uses. Directions with no neighbour are
@@ -190,7 +199,9 @@ final class TerminalContextMenu: NSObject {
     }
 
     @objc private func splitRight() { store?.splitSelectedPane(.horizontal) }
+    @objc private func splitLeft() { store?.splitSelectedPane(.horizontal, slot: .first) }
     @objc private func splitDown() { store?.splitSelectedPane(.vertical) }
+    @objc private func splitUp() { store?.splitSelectedPane(.vertical, slot: .first) }
     @objc private func ungroup() { store?.ungroupSelectedPane() }
     @objc private func flipLayout() {
         guard let id = clickedSessionID else { return }

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -25,7 +25,11 @@ extension TermioStore {
     /// beside a working agent, and silently auto-launching another agent
     /// instance is a side effect ⌘D shouldn't have; an agent can still be put
     /// there by splitting from it or grouping it later.
-    func splitSelectedPane(_ direction: SplitDirection) {
+    ///
+    /// `slot` is which half the new pane takes: `.second` is Split Right / Split
+    /// Down, `.first` is Split Left / Split Up. Either way the new pane takes
+    /// focus — the direction says where the pane lands, not where attention goes.
+    func splitSelectedPane(_ direction: SplitDirection, slot: SplitSlot = .second) {
         guard let focusedID = selectedSessionID,
               let projectIndex = projects.firstIndex(where: { $0.sessions.contains { $0.id == focusedID } }),
               let sessionIndex = projects[projectIndex].sessions.firstIndex(where: { $0.id == focusedID })
@@ -37,18 +41,20 @@ extension TermioStore {
         // A worktree session runs somewhere other than the project root; the
         // companion shell should land where the focused session actually works.
         newSession.worktreePath = session(focusedID)?.worktreePath
-        // Right below the session it splits, not at the end of the project — the
+        // Beside the session it splits, not at the end of the project — the
         // sidebar then reads the split group as adjacent rows, which is what lets
-        // it draw the VS Code-style ┌/└ group bracket (see `splitLinkMarks`).
-        projects[projectIndex].sessions.insert(newSession, at: sessionIndex + 1)
+        // it draw the VS Code-style ┌/└ group bracket (see `splitLinkMarks`). The
+        // row order follows the layout, so a leading split lists above its origin.
+        projects[projectIndex].sessions.insert(newSession, at: slot == .first ? sessionIndex : sessionIndex + 1)
 
         if let group = groupIndex(containing: focusedID) {
             splitGroups[group] = splitGroups[group]
-                .splitting(leaf: focusedID, direction: direction, adding: newSession.id)
+                .splitting(leaf: focusedID, direction: direction, adding: newSession.id, slot: slot)
         } else {
-            splitGroups.append(.split(SplitBranch(direction: direction, ratio: 0.5,
-                                                  first: .leaf(focusedID),
-                                                  second: .leaf(newSession.id))))
+            splitGroups.append(.split(SplitBranch(
+                direction: direction, ratio: 0.5,
+                first: .leaf(slot == .first ? newSession.id : focusedID),
+                second: .leaf(slot == .first ? focusedID : newSession.id))))
         }
         // The new pane takes focus; it is a member of the (possibly new) group,
         // so the derived `splitRoot` keeps showing this layout.


### PR DESCRIPTION
Splitting could only ever put the new pane on the right or below. Getting one on the left meant Split Right followed by Move Pane Left — two steps for a one-step intent, the second being a verb most people never find.

`SplitTree` already modelled the leading slot for drag-rearrange, so this is that slot threaded through `splitSelectedPane` rather than new machinery. A leading split also inserts its sidebar row above its origin, so the group bracket still reads in layout order.

Both directions ship **unbound**, exactly as ghostty ships its own Split Left and Split Up: ⌘D and ⌘⇧D keep the keys, the mirrored pair stays a menu verb until someone binds it in Settings ▸ Keyboard. Wired into the View menu, the right-click menu, and the palette.

The four directions now carry ghostty's split glyphs, where the filled half of the rectangle shows where the new pane lands:

| | |
|---|---|
| Split Right | `rectangle.righthalf.inset.filled` |
| Split Left | `rectangle.leadinghalf.inset.filled` |
| Split Down | `rectangle.bottomhalf.inset.filled` |
| Split Up | `rectangle.tophalf.inset.filled` |

`rectangle.split.2x1` and its stacked twin stopped carrying meaning once there were four directions.

## Verification

- `swift build` clean, 118/118 tests pass; the `.first` slot's tree behavior was already covered by `SplitTreeTests`.
- All four symbols verified to resolve on this macOS by constructing the `NSImage`s — a typo'd symbol name fails silently as a missing icon.
- Not verified by me: the menus on screen. Worth one look at the View menu and a right-click, plus a Split Left from a session in the middle of a project to confirm the sidebar row lands above its origin.

Release Notes:

- Added Split Left and Split Up, available from the View menu, the right-click menu, and the command palette. Both are unbound by default and can be given a shortcut in Settings ▸ Keyboard.
