### PR TITLE
Replace the pane rearrange chord with a hover grab handle

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -120,7 +120,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // The ghostty-style right-click menu over the terminal surfaces (Copy/Paste + splits);
     // owns the rightMouseDown monitor for the app's lifetime.
     private var terminalContextMenu: TerminalContextMenu?
-    // The ⌘⌥⇧ drag-to-rearrange gesture over the panes (issue #183); owns its
+    // The pane drag-to-rearrange gesture (issue #183); owns its
     // mouse monitors for the app's lifetime.
     private var paneDragRearrange: PaneDragRearrange?
 
@@ -160,6 +160,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             defer: false
         )
         window.title = "Termio"
+        // Mouse-moved events are off by default; the pane grab handle reveals on
+        // hover, so it needs them (see `PaneDragRearrange`).
+        window.acceptsMouseMovedEvents = true
         // Floor the window size so it can't be dragged down to an unusable sliver: the
         // sidebar alone wants ~220pt, leaving room for a workable terminal beside it.
         window.contentMinSize = NSSize(width: 640, height: 420)

--- a/Sources/termio/Terminal/PaneDragRearrange.swift
+++ b/Sources/termio/Terminal/PaneDragRearrange.swift
@@ -1,9 +1,9 @@
 import AppKit
 import GhosttyTerminal
 
-/// A ⌘⌥⇧ pane drag in flight: the lifted pane, plus the pane and drop zone
-/// under the pointer right now. `PaneDragRearrange` writes it, `TerminalPane`
-/// draws it — the store's published copy is what keeps the two in step.
+/// A pane drag in flight: the lifted pane, plus the pane and drop zone under
+/// the pointer right now. `PaneDragRearrange` writes it, `TerminalPane` draws
+/// it — the store's published copy is what keeps the two in step.
 struct PaneDragState: Equatable {
     /// The pane being dragged.
     var source: Session.ID
@@ -14,18 +14,24 @@ struct PaneDragState: Equatable {
     var zone: PaneDropZone?
 }
 
-/// iTerm2-style direct-manipulation rearrange (issue #183): while ⌘⌥⇧ is held,
-/// the whole pane body is its drag handle — press anywhere on a pane, drag to
-/// a drop zone on another pane, release to re-split (edge halves) or swap
-/// (center). The chord *is* the handle because termio's panes are chromeless
-/// libghostty surfaces with no title bar to grab; it also disambiguates
-/// "rearrange" from terminal input, letting the app consume the events before
-/// the surface (or a mouse-reporting TUI) ever sees them.
+/// Direct-manipulation rearrange (issue #183) through ghostty's grab handle: a
+/// short strip at the top of each pane, revealed when the pointer nears it, that
+/// drags the pane onto a drop zone on another — release to re-split (edge
+/// halves) or swap (center).
+///
+/// The gesture used to be a ⌘⌥⇧ chord over the pane body, which worked and
+/// nobody could find. Ghostty's answer to the same problem — chromeless
+/// surfaces with no title bar to grab — is a visible handle
+/// (`SurfaceGrabHandle`), and a handle explains itself. The strip stays small
+/// and only exists while a split is on screen, so what it costs the terminal is
+/// bounded: clicks land in it only where there is a pane to rearrange.
 ///
 /// The wrapper instantiates its own view class, so — like `TerminalContextMenu`
 /// — this hooks in one level up: local event monitors held for the app's
-/// lifetime. The drag itself is plain geometry against the visible panes; the
-/// release is one `dropPane` call into the store, which owns the tree mutation.
+/// lifetime. Hit-testing the handle here rather than mounting a view over the
+/// surface is what keeps the press from ever reaching a mouse-reporting TUI.
+/// The drag itself is plain geometry against the visible panes; the release is
+/// one `dropPane` call into the store, which owns the tree mutation.
 @MainActor
 final class PaneDragRearrange {
     private weak var store: TermioStore?
@@ -38,13 +44,24 @@ final class PaneDragRearrange {
     private var cancelled = false
     private var cursorPushed = false
 
-    /// The full rearrange chord. Only the modifiers that mean something here
-    /// are compared: ⌘⌥⇧ must all be down and ⌃ must not be, while Caps Lock
-    /// (routinely latched by CJK users to switch input sources) and fn are
-    /// ignored — an exact-mask match would let them silently defeat the
-    /// gesture.
-    static func isRearrangeChord(_ flags: NSEvent.ModifierFlags) -> Bool {
-        flags.intersection([.command, .option, .shift, .control]) == [.command, .option, .shift]
+    /// The handle itself: ghostty's dimensions (`SurfaceGrabHandle`), centered
+    /// on the pane's top edge. Small on purpose — it is the only place a plain
+    /// click is taken from the terminal.
+    static let handleSize = CGSize(width: 80, height: 12)
+
+    /// The handle appears while the pointer is anywhere in the top fifth of the
+    /// pane, so it is reachable without aiming at 12 points of nothing.
+    private static let hoverHeightFactor: CGFloat = 0.2
+
+    /// The handle's rect in a pane of `size`, top-left origin — the space both
+    /// this hit test and `TerminalPane`'s overlay work in.
+    static func handleRect(in size: CGSize) -> CGRect {
+        CGRect(x: (size.width - handleSize.width) / 2, y: 0,
+               width: handleSize.width, height: handleSize.height)
+    }
+
+    private static func isInHoverRegion(_ point: CGPoint, in size: CGSize) -> Bool {
+        point.y >= 0 && point.y <= size.height * hoverHeightFactor
     }
 
     init(store: TermioStore) {
@@ -64,20 +81,45 @@ final class PaneDragRearrange {
         monitor(.leftMouseDragged) { [weak self] in self?.moved($0) ?? false }
         monitor(.leftMouseUp) { [weak self] in self?.ended($0) ?? false }
         monitor(.keyDown) { [weak self] in self?.pressedKey($0) ?? false }
+        // Never consumed: the reveal only reads the pointer, so hover tracking
+        // can't interfere with a TUI's own mouse reporting.
+        monitor(.mouseMoved) { [weak self] in
+            self?.hovered($0)
+            return false
+        }
     }
 
-    /// Starts a drag on a chorded press over a visible pane. Only meaningful
-    /// with a split on screen: a lone pane has nowhere to go, and a zoomed
-    /// pane hides the layout the drop zones would preview.
+    /// Publishes which pane should be showing its handle. Only while a split is
+    /// on screen, matching `began` — a lone pane has nothing to rearrange, so it
+    /// gets no handle and keeps every click.
+    private func hovered(_ event: NSEvent) {
+        guard let store else { return }
+        var revealed: Session.ID?
+        if !dragging, store.splitRoot != nil, !store.isPaneZoomed,
+           let window = event.window,
+           window.frameAutosaveName == AppDelegate.mainWindowFrameAutosaveName,
+           let contentView = window.contentView,
+           let (id, point, size) = paneGeometry(at: event.locationInWindow, in: contentView, window: window),
+           Self.isInHoverRegion(point, in: size) {
+            revealed = id
+        }
+        // @Published on every mouse-moved event would redraw the pane tree at
+        // pointer rate; only a change is worth a render.
+        if store.paneHandleHover != revealed { store.paneHandleHover = revealed }
+    }
+
+    /// Starts a drag from a press on a pane's grab handle. Only meaningful with
+    /// a split on screen: a lone pane has nowhere to go, and a zoomed pane hides
+    /// the layout the drop zones would preview.
     private func began(_ event: NSEvent) -> Bool {
         guard let store, !dragging,
-              Self.isRearrangeChord(event.modifierFlags),
               store.splitRoot != nil, !store.isPaneZoomed,
               !(store.isDetailPresented && store.inspectorMaximized),
               let window = event.window,
               window.frameAutosaveName == AppDelegate.mainWindowFrameAutosaveName,
               let contentView = window.contentView,
-              let (id, _) = pane(at: event.locationInWindow, in: contentView, window: window)
+              let (id, point, size) = paneGeometry(at: event.locationInWindow, in: contentView, window: window),
+              Self.handleRect(in: size).contains(point)
         else { return false }
         dragging = true
         cancelled = false
@@ -143,6 +185,16 @@ final class PaneDragRearrange {
     /// unambiguous.
     private func pane(at point: NSPoint, in contentView: NSView,
                       window: NSWindow) -> (Session.ID, PaneDropZone)? {
+        guard let (id, local, size) = paneGeometry(at: point, in: contentView, window: window)
+        else { return nil }
+        return (id, PaneDropZone.zone(at: local, in: size))
+    }
+
+    /// The visible pane under a window point, with that point in the pane's own
+    /// top-left-origin space and the pane's size — what both the handle hit test
+    /// and the drop-zone lookup are expressed in.
+    private func paneGeometry(at point: NSPoint, in contentView: NSView,
+                              window: NSWindow) -> (Session.ID, CGPoint, CGSize)? {
         guard let store else { return nil }
         for view in terminalViews(in: contentView) {
             guard view.window === window,
@@ -153,7 +205,7 @@ final class PaneDragRearrange {
             // Zone space is top-left-origin; flip out of AppKit's default.
             let normalized = CGPoint(x: local.x,
                                      y: view.isFlipped ? local.y : view.bounds.height - local.y)
-            return (id, PaneDropZone.zone(at: normalized, in: view.bounds.size))
+            return (id, normalized, view.bounds.size)
         }
         return nil
     }

--- a/Sources/termio/Terminal/TerminalContextMenu.swift
+++ b/Sources/termio/Terminal/TerminalContextMenu.swift
@@ -121,30 +121,6 @@ final class TerminalContextMenu: NSObject {
                                symbol: "rectangle.bottomhalf.inset.filled"))
         menu.addItem(storeItem("Split Up", action: #selector(splitUp),
                                symbol: "rectangle.tophalf.inset.filled"))
-        // Rearranging without drag-and-drop: each direction trades the clicked
-        // pane with its neighbour that way (tmux's swap-pane), scored by the
-        // same geometry ⌥⌘-arrow focus uses. Directions with no neighbour are
-        // greyed out rather than hidden, so the submenu's shape is stable.
-        if let id = clickedSessionID, let store, store.isInSplitGroup(id) {
-            let submenu = NSMenu()
-            submenu.autoenablesItems = false
-            let directions: [(String, String, Selector, PaneFocusDirection)] = [
-                ("Left", "arrow.left", #selector(movePaneLeft), .left),
-                ("Right", "arrow.right", #selector(movePaneRight), .right),
-                ("Up", "arrow.up", #selector(movePaneUp), .up),
-                ("Down", "arrow.down", #selector(movePaneDown), .down),
-            ]
-            for (title, symbol, action, direction) in directions {
-                let item = storeItem(title, action: action, symbol: symbol)
-                item.isEnabled = store.movePaneTarget(of: id, direction) != nil
-                submenu.addItem(item)
-            }
-            let parent = NSMenuItem(title: "Move Pane", action: nil, keyEquivalent: "")
-            parent.image = NSImage(systemSymbolName: "arrow.up.and.down.and.arrow.left.and.right",
-                                   accessibilityDescription: nil)
-            parent.submenu = submenu
-            menu.addItem(parent)
-        }
         // "Flip Layout" turns just the divider that holds the clicked pane and
         // its neighbour from side-by-side to stacked (or back) — the honest
         // inverse of the "Split Right"/"Split Down" that made the pair. Nested
@@ -206,14 +182,6 @@ final class TerminalContextMenu: NSObject {
     @objc private func flipLayout() {
         guard let id = clickedSessionID else { return }
         store?.flipPaneLayout(id)
-    }
-    @objc private func movePaneLeft() { movePane(.left) }
-    @objc private func movePaneRight() { movePane(.right) }
-    @objc private func movePaneUp() { movePane(.up) }
-    @objc private func movePaneDown() { movePane(.down) }
-    private func movePane(_ direction: PaneFocusDirection) {
-        guard let id = clickedSessionID else { return }
-        store?.movePane(id, direction)
     }
     @objc private func closeSession() {
         guard let id = clickedSessionID else { return }

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -189,13 +189,24 @@ struct TerminalPane: View {
                     }
                 }
             }
-            // The ⌘⌥⇧ drag's preview (issue #183): the drop-zone highlight is
-            // what resolves the ambiguity a drag-rearrange otherwise has — you
-            // see the half (or the swap) the release would commit.
+            // The handle that starts a rearrange, on the pane the pointer is
+            // near (see `PaneDragRearrange`). Never hit-testable: the press is
+            // taken by the event monitor, so this is purely the affordance.
+            if let layout, !zoomed, store.paneDrag == nil,
+               let hovered = store.paneHandleHover, let frame = layout.frames[hovered] {
+                PaneGrabHandle(paneFrame: frame)
+                    .allowsHitTesting(false)
+            }
+            // The drag's preview (issue #183): the drop-zone highlight is what
+            // resolves the ambiguity a drag-rearrange otherwise has — you see
+            // the half (or the swap) the release would commit.
             if let drag = store.paneDrag, let layout, !zoomed {
                 PaneDragOverlay(drag: drag, layout: layout)
             }
         }
+        // The handle fades rather than blinking as the pointer crosses into the
+        // reveal band; short enough that it still feels attached to the pointer.
+        .animation(.easeOut(duration: 0.12), value: store.paneHandleHover)
     }
 
     /// A surface becoming first responder is the source of truth for split selection.
@@ -670,12 +681,30 @@ private final class TerminalFocusDriver {
     }
 }
 
-/// The visual half of the ⌘⌥⇧ pane drag (issue #183): a wash over the lifted
+/// The visual half of the pane drag (issue #183): a wash over the lifted
 /// source pane plus a highlight over the region the release would commit —
 /// the half of the target the pane would occupy, or the whole target for a
 /// swap. Geometry comes straight from the tree's `layout`, so the preview and
 /// the drop can never disagree. The tint family is the file-drop wash's
 /// desaturated blue-grey, not accent blue.
+/// The pane's drag affordance: ghostty's ellipsis strip on the top edge, shown
+/// while the pointer is near it. Drawing only — the press that starts the drag
+/// is hit-tested in `PaneDragRearrange`, so this never stands between the
+/// pointer and the terminal.
+private struct PaneGrabHandle: View {
+    let paneFrame: CGRect
+
+    var body: some View {
+        let rect = PaneDragRearrange.handleRect(in: paneFrame.size)
+        Image(systemName: "ellipsis")
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.primary.opacity(0.55))
+            .frame(width: rect.width, height: rect.height)
+            .position(x: paneFrame.minX + rect.midX, y: paneFrame.minY + rect.midY)
+            .transition(.opacity)
+    }
+}
+
 private struct PaneDragOverlay: View {
     let drag: PaneDragState
     let layout: SplitNode.PaneLayout

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -263,28 +263,7 @@ extension TermioStore {
         isPaneZoomed.toggle()
     }
 
-    /// The pane `id` would trade places with when moved `direction`, or `nil`
-    /// when nothing lies that way — what greys out the "Move Pane" menu items.
-    /// Uses the same directional scoring as focus movement, so "Move Left" and
-    /// ⌥⌘← always agree on which pane is the neighbour.
-    func movePaneTarget(of id: Session.ID, _ direction: PaneFocusDirection) -> Session.ID? {
-        groupIndex(containing: id).flatMap { splitGroups[$0].pane(direction, of: id) }
-    }
-
-    /// Moves a pane by trading places with its directional neighbour (tmux's
-    /// swap-pane) — the context menu's "Move Pane". The tree's shape and every
-    /// divider ratio stay put; only the two leaves change slots. Zoom is
-    /// dropped so the result is visible, and the selection sticks with the
-    /// moved pane.
-    func movePane(_ id: Session.ID, _ direction: PaneFocusDirection) {
-        guard let group = groupIndex(containing: id),
-              let target = movePaneTarget(of: id, direction) else { return }
-        splitGroups[group] = splitGroups[group].swapping(id, and: target)
-        selectedSessionID = id
-        isPaneZoomed = false
-    }
-
-    /// Lands a modifier-dragged pane on `target` (issue #183). An edge zone
+    /// Lands a dragged pane on `target` (issue #183). An edge zone
     /// re-splits the target with the dragged pane on that side — the pane
     /// leaves its old slot first, its vacated space collapsing into the
     /// sibling exactly as if it had closed, so one gesture subsumes move +

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -89,10 +89,15 @@ final class TermioStore: ObservableObject {
     /// pane. `TerminalPane` honours it only while a split is on screen.
     @Published var isPaneZoomed = false
 
-    /// The in-flight ⌘⌥⇧ pane drag (issue #183): written by `PaneDragRearrange`
+    /// The in-flight pane drag (issue #183): written by `PaneDragRearrange`
     /// as the pointer moves, read by `TerminalPane` to draw the drop-zone
     /// highlight. Transient gesture state, never persisted.
     @Published var paneDrag: PaneDragState?
+
+    /// The pane whose grab handle is revealed right now — the pointer is near
+    /// its top edge. Also written by `PaneDragRearrange`; nil means no handle is
+    /// showing.
+    @Published var paneHandleHover: Session.ID?
 
     /// Activation *requests* for sessions that are neither selected nor in the
     /// visible group: a background spawn's fresh pane, a `send` target never
@@ -817,9 +822,6 @@ final class TermioStore: ObservableObject {
         linkClickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak self] event in
             guard let self,
                   event.modifierFlags.contains(.command),
-                  // ⌘⌥⇧+press is the pane-rearrange chord (see `PaneDragRearrange`);
-                  // that gesture owns the click even when a link is hovered.
-                  !PaneDragRearrange.isRearrangeChord(event.modifierFlags),
                   let url = TerminalLinkState.hoveredURL else { return event }
             self.openTerminalLink(url, surfaceWorkingDirectory: nil)
             return nil


### PR DESCRIPTION
Rearranging panes needed a ⌘⌥⇧ chord nobody could find, and "Move Pane ▸ Left/Right/Up/Down" existed because of it — a four-item submenu doing the swap half of a gesture that already did more. Both are gone, along with the store API that served only that menu.

They were two workarounds for one missing affordance, which the chord's own header comment admitted: *"The chord is the handle because termio's panes are chromeless libghostty surfaces with no title bar to grab."*

In their place is ghostty's answer to the same problem (`SurfaceGrabHandle`): an 80×12 strip on each pane's top edge, revealed while the pointer is in the top fifth of that pane, drawn as `ellipsis` with a short fade. The drag it starts is unchanged — same drop zones, same preview, same single `dropPane` into the store.

One deliberate divergence from ghostty: the handle is drawn, not mounted. They need a live view because their drag is an `NSDraggingSession` crossing windows; termio has one window and already intercepts one level up, so the press is hit-tested in the existing event monitor and the glyph takes no hits. Nothing stands between the pointer and a mouse-reporting TUI. The handle exists only while a split is on screen, so a lone pane keeps every click it has today.

Net −86/+116 lines.

## Verification

- `swift build` clean, 118/118 tests pass.
- Not verified by me: this is a hover affordance and I can't capture the screen from my environment. Three things worth checking — the ellipsis appears approaching a pane's top edge and never with a single pane; a drag from it still previews drop zones and lands correctly; and a click in that strip inside Claude Code does nothing surprising.

Release Notes:

- Panes now show a drag handle at their top edge; drag it to move a pane beside or onto another. Replaces the ⌘⌥⇧ drag and the "Move Pane" menu.
