### PR TITLE
Version the companion wire protocol and surface connection refusals

### DIFF
--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -1,5 +1,24 @@
 import Foundation
 
+/// The companion wire contract's revision. One monotonically increasing
+/// integer, bumped when either end needs to make a compatibility decision — a
+/// new request, a changed meaning for an existing field, a new byte mode — not
+/// for additive fields that already have a safe default.
+///
+/// History:
+///   0: pre-versioning. No `wire` field on the wire; any peer that omits it.
+///   1: 2026-08-07: `wire` declared on `.auth` and `CompanionRoster`.
+public enum Wire {
+    /// A peer that predates the field entirely. Absent decodes to this.
+    public static let legacy = 0
+    /// This build's revision.
+    public static let current = 1
+    /// Oldest Mac this phone will talk to.
+    public static let minimumServer = 0
+    /// Oldest phone this Mac will serve.
+    public static let minimumClient = 0
+}
+
 /// The companion wire protocol, shared by the Mac companion server and the iOS
 /// client so the two never drift. v1 is deliberately tiny:
 ///
@@ -16,7 +35,7 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     /// pairing token from the Mac's QR code. Until it lands, the server sends
     /// nothing and refuses every other message — the port may sit behind a
     /// public tunnel URL, where "connected" must not mean "trusted".
-    case auth(token: String)
+    case auth(token: String, wire: Int)
     /// The client asks to bridge a specific session's PTY (roster session id).
     /// Sent once, immediately after the socket opens; the server replays its
     /// recent output and starts streaming.
@@ -127,8 +146,8 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     public func encoded() -> String {
         // Small, hand-stable JSON so both ends agree without a schema tool.
         switch self {
-        case .auth(let token):
-            return Self.json(["t": "auth", "token": token])
+        case .auth(let token, let wire):
+            return Self.json(["t": "auth", "token": token, "wire": wire])
         case .attach(let sessionID):
             return #"{"t":"attach","session":"\#(sessionID)"}"#
         case .start(let projectID, let agent):
@@ -239,7 +258,7 @@ public enum CompanionControl: Codable, Sendable, Equatable {
         switch type {
         case "auth":
             guard let token = obj["token"] as? String else { return nil }
-            return .auth(token: token)
+            return .auth(token: token, wire: obj["wire"] as? Int ?? Wire.legacy)
         case "attach":
             guard let sessionID = obj["session"] as? String else { return nil }
             return .attach(sessionID: sessionID)
@@ -609,6 +628,7 @@ public struct RosterAgent: Codable, Sendable, Equatable {
 /// `"roster"` so it coexists with the small `CompanionControl` messages.
 public struct CompanionRoster: Codable, Sendable, Equatable {
     public let t: String
+    public let wire: Int
     public let projects: [RosterProject]
     /// The agents the Mac has enabled in Settings ▸ Agents, in preset order —
     /// the phone's new-session menu mirrors this instead of a fixed list. Empty
@@ -616,17 +636,21 @@ public struct CompanionRoster: Codable, Sendable, Equatable {
     /// falls back to its built-in defaults).
     public let agents: [RosterAgent]
 
-    public init(projects: [RosterProject], agents: [RosterAgent] = []) {
+    public init(
+        projects: [RosterProject], agents: [RosterAgent] = [], wire: Int = Wire.current
+    ) {
         t = "roster"
+        self.wire = wire
         self.projects = projects
         self.agents = agents
     }
 
-    private enum CodingKeys: String, CodingKey { case t, projects, agents }
+    private enum CodingKeys: String, CodingKey { case t, wire, projects, agents }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         t = try c.decode(String.self, forKey: .t)
+        wire = try c.decodeIfPresent(Int.self, forKey: .wire) ?? Wire.legacy
         projects = try c.decodeIfPresent([RosterProject].self, forKey: .projects) ?? []
         agents = try c.decodeIfPresent([RosterAgent].self, forKey: .agents) ?? []
     }

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -99,7 +99,7 @@ final class CompanionServer {
     /// Connections that have presented the pairing token. Everyone else gets
     /// silence and a short clock: the roster names every project on this Mac
     /// and an attach is keystroke access to a shell.
-    private var authed: Set<ObjectIdentifier> = []
+    private var authenticatedWireByConnection: [ObjectIdentifier: Int] = [:]
     private var bridges: [ObjectIdentifier: PTYBridge] = [:]
     private var lastRoster: CompanionRoster?
     private var pollTimer: Timer?
@@ -199,6 +199,7 @@ final class CompanionServer {
         for connection in connectionByID.values { connection.cancel() }
         connectionByID.removeAll()
         connections.removeAll()
+        authenticatedWireByConnection.removeAll()
     }
 
     private func accept(_ connection: NWConnection) {
@@ -220,7 +221,8 @@ final class CompanionServer {
         // to linger either.
         DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
             Task { @MainActor in
-                guard let self, self.connections.contains(id), !self.authed.contains(id) else { return }
+                guard let self, self.connections.contains(id),
+                      self.authenticatedWireByConnection[id] == nil else { return }
                 self.refuse(connection, message: "unauthorized — scan the QR code in Settings ▸ Mobile")
             }
         }
@@ -240,7 +242,7 @@ final class CompanionServer {
         connectionByID[id]?.cancel()
         connectionByID[id] = nil
         connections.remove(id)
-        authed.remove(id)
+        authenticatedWireByConnection[id] = nil
     }
 
     private func receive(on connection: NWConnection) {
@@ -254,6 +256,9 @@ final class CompanionServer {
             if let meta, let content, !content.isEmpty {
                 switch meta.opcode {
                 case .binary:
+                    // Binary frames are raw PTY bytes permanently. Compression,
+                    // encryption, or multiplexing needs a separately negotiated
+                    // mechanism and Wire gate so framing can never become keystrokes.
                     // Keystrokes from the phone into the session's PTY.
                     // Typing from the phone is active use — the size follows it.
                     Task { @MainActor in
@@ -276,16 +281,21 @@ final class CompanionServer {
 
     private func handle(_ control: CompanionControl, on connection: NWConnection) {
         let id = ObjectIdentifier(connection)
-        if case .auth(let token) = control {
+        if case .auth(let token, let wire) = control {
             guard token == PairingToken.current else {
                 refuse(connection, message: "unauthorized — re-scan the QR code on your Mac")
                 return
             }
-            authed.insert(id)
+            Log.companion.notice("phone declared wire version \(wire, privacy: .public)")
+            guard wire >= Wire.minimumClient else {
+                refuse(connection, message: "Update termio on your phone to connect to this Mac.")
+                return
+            }
+            authenticatedWireByConnection[id] = wire
             send(rosterProvider(), to: connection)
             return
         }
-        guard authed.contains(id) else {
+        guard authenticatedWireByConnection[id] != nil else {
             refuse(connection, message: "unauthorized — scan the QR code in Settings ▸ Mobile")
             return
         }
@@ -847,7 +857,7 @@ final class CompanionServer {
         // interleave with PTY traffic for no benefit. Unauthenticated ones
         // get nothing at all.
         for (id, connection) in connectionByID
-        where bridges[id] == nil && authed.contains(id) {
+        where bridges[id] == nil && authenticatedWireByConnection[id] != nil {
             send(roster, to: connection)
         }
     }

--- a/Tests/termioTests/WireProtocolTests.swift
+++ b/Tests/termioTests/WireProtocolTests.swift
@@ -1,0 +1,33 @@
+import TermioShared
+import XCTest
+
+final class WireProtocolTests: XCTestCase {
+    func testAuthRoundTripCarriesCurrentWireVersion() {
+        let auth = CompanionControl.auth(token: "pairing-token", wire: Wire.current)
+
+        XCTAssertEqual(CompanionControl.decode(auth.encoded()), auth)
+    }
+
+    func testAuthWithoutWireDecodesAsLegacy() {
+        XCTAssertEqual(
+            CompanionControl.decode(#"{"t":"auth","token":"pairing-token"}"#),
+            .auth(token: "pairing-token", wire: Wire.legacy)
+        )
+    }
+
+    func testRosterRoundTripCarriesCurrentWireVersion() throws {
+        let roster = CompanionRoster(projects: [])
+
+        let decoded = try XCTUnwrap(CompanionRoster.decode(roster.encodedJSON()))
+        XCTAssertEqual(decoded, roster)
+        XCTAssertEqual(decoded.wire, Wire.current)
+    }
+
+    func testRosterWithoutWireDecodesAsLegacy() throws {
+        let decoded = try XCTUnwrap(
+            CompanionRoster.decode(#"{"t":"roster","projects":[]}"#)
+        )
+
+        XCTAssertEqual(decoded.wire, Wire.legacy)
+    }
+}

--- a/ios/Sources/CompanionClient.swift
+++ b/ios/Sources/CompanionClient.swift
@@ -23,6 +23,11 @@ final class CompanionClient: NSObject {
     private var pathMonitor: NWPathMonitor?
     private var lastPathStatus: NWPath.Status?
     private var pingTimer: Timer?
+    /// `refuse()` sends one final `.error` and immediately cancels the socket,
+    /// while request errors leave it open. Keep the last reason briefly so the
+    /// close path can distinguish those two cases without expanding the wire.
+    private var lastServerError: (message: String, uptime: TimeInterval)?
+    private static let refusalCloseWindow: TimeInterval = 1
 
     /// Latest roster, delivered on the main queue.
     var onRoster: ((CompanionRoster) -> Void)?
@@ -49,6 +54,8 @@ final class CompanionClient: NSObject {
     var onDiff: ((WireDiff) -> Void)?
     /// The server rejected a request (e.g. a failed `start`).
     var onError: ((String) -> Void)?
+    /// The server sent an error and immediately dropped the connection.
+    var onConnectionFailure: ((String) -> Void)?
     /// The Mac's parsed `~/.ssh/config` host blocks, answering a
     /// `.sshConfigHosts` request — the read-only menu the Terminals ＋ → New SSH
     /// picks from (the phone never authors a host, only chooses a known alias).
@@ -107,6 +114,7 @@ final class CompanionClient: NSObject {
         pathMonitor?.cancel()
         pathMonitor = nil
         lastPathStatus = nil
+        lastServerError = nil
         pingTimer?.invalidate()
         pingTimer = nil
         if let observer = foregroundObserver {
@@ -117,6 +125,7 @@ final class CompanionClient: NSObject {
 
     private func connect() {
         guard !stopped else { return }
+        lastServerError = nil
         task?.cancel(with: .goingAway, reason: nil)
         let task = session.webSocketTask(with: url)
         // A `file` reply for a 1 MB source is ~1.4 MB of base64 JSON — past
@@ -144,6 +153,14 @@ final class CompanionClient: NSObject {
             guard let self, !stopped, !isConnected else { return }
             connect()
         }
+    }
+
+    private func takeErrorForImmediateDrop() -> String? {
+        defer { lastServerError = nil }
+        guard let lastServerError,
+              ProcessInfo.processInfo.systemUptime - lastServerError.uptime
+                <= Self.refusalCloseWindow else { return nil }
+        return lastServerError.message
     }
 
     /// Reconnect the instant the network path comes back (Wi-Fi rejoin, VPN
@@ -191,13 +208,15 @@ final class CompanionClient: NSObject {
             case .success(let message):
                 if case .string(let text) = message {
                     if let roster = CompanionRoster.decode(text) {
+                        lastServerError = nil
                         if roster.wire < Wire.minimumServer {
-                            onError?("Update termio on your Mac to connect this phone.")
+                            onConnectionFailure?("Update termio on your Mac to connect this phone.")
                             stop()
                         } else {
                             onRoster?(roster)
                         }
                     } else {
+                        lastServerError = nil
                         switch CompanionControl.decode(text) {
                         case .started(let sessionID, let agent): onStarted?(sessionID, agent)
                         case .fileList(let path, let entries): onFileList?(path, entries)
@@ -208,7 +227,12 @@ final class CompanionClient: NSObject {
                             onSearchResults?(query, paths, truncated)
                         case .changes(let files): onChanges?(files)
                         case .diff(let diff): onDiff?(diff)
-                        case .error(let reason): onError?(reason)
+                        case .error(let reason):
+                            lastServerError = (
+                                message: reason,
+                                uptime: ProcessInfo.processInfo.systemUptime
+                            )
+                            onError?(reason)
                         case .sshConfigList(let hosts): onSSHConfig?(hosts)
                         default: break
                         }
@@ -219,8 +243,10 @@ final class CompanionClient: NSObject {
                 // A superseded task's death is not a drop of the current link.
                 guard task === self.task else { return }
                 Log.companion.notice("roster link dropped: \(error.localizedDescription, privacy: .public)")
+                let connectionFailure = takeErrorForImmediateDrop()
                 isConnected = false
                 onConnected?(false)
+                if let connectionFailure { onConnectionFailure?(connectionFailure) }
                 scheduleReconnect()
             }
         }
@@ -256,7 +282,9 @@ extension CompanionClient: URLSessionWebSocketDelegate {
     func urlSession(_: URLSession, webSocketTask task: URLSessionWebSocketTask,
                     didCloseWith _: URLSessionWebSocketTask.CloseCode, reason _: Data?) {
         guard task === self.task else { return }
+        let connectionFailure = takeErrorForImmediateDrop()
         isConnected = false
         onConnected?(false)
+        if let connectionFailure { onConnectionFailure?(connectionFailure) }
     }
 }

--- a/ios/Sources/CompanionClient.swift
+++ b/ios/Sources/CompanionClient.swift
@@ -191,7 +191,12 @@ final class CompanionClient: NSObject {
             case .success(let message):
                 if case .string(let text) = message {
                     if let roster = CompanionRoster.decode(text) {
-                        onRoster?(roster)
+                        if roster.wire < Wire.minimumServer {
+                            onError?("Update termio on your Mac to connect this phone.")
+                            stop()
+                        } else {
+                            onRoster?(roster)
+                        }
                     } else {
                         switch CompanionControl.decode(text) {
                         case .started(let sessionID, let agent): onStarted?(sessionID, agent)
@@ -228,7 +233,9 @@ extension CompanionClient: URLSessionWebSocketDelegate {
         Log.companion.notice("roster link connected to \(self.url.host ?? "?", privacy: .public)")
         // Auth rides first on every connect; the roster is the server's reply.
         if let token = CompanionLink.token(of: url) {
-            task.send(.string(CompanionControl.auth(token: token).encoded())) { _ in }
+            task.send(
+                .string(CompanionControl.auth(token: token, wire: Wire.current).encoded())
+            ) { _ in }
         } else {
             // No `?t=` on the paired URL: the socket opens, but the Mac refuses
             // it after its ~10s auth grace window, so the link loops

--- a/ios/Sources/CompanionTransport.swift
+++ b/ios/Sources/CompanionTransport.swift
@@ -59,6 +59,10 @@ final class CompanionTransport: NSObject {
     /// terminal didn't). So grid and keystroke frames stay suppressed until
     /// `didOpen` has queued the auth preamble and set this true. Guarded by `gridLock`.
     private var authSent = false
+    /// Raw PTY input stays closed until the Mac acknowledges auth with its
+    /// roster. Control messages remain optimistic because their version-0
+    /// meanings are stable. Guarded by `gridLock`.
+    private var authAccepted = false
 
     /// Remote PTY bytes for the terminal. Fired on a URLSession queue.
     var onOutput: ((Data) -> Void)?
@@ -106,9 +110,12 @@ final class CompanionTransport: NSObject {
 
     func send(_ data: Data) {
         gridLock.lock()
-        let ready = authSent
+        let ready = authAccepted
         gridLock.unlock()
         guard ready else { return }
+        // Binary frames are raw PTY bytes permanently. Compression, encryption,
+        // or multiplexing needs a separately negotiated mechanism and Wire gate
+        // so a stale Mac can never interpret framing as keystrokes.
         task?.send(.data(data)) { _ in }
     }
 
@@ -173,6 +180,7 @@ final class CompanionTransport: NSObject {
         // keystroke frames until `didOpen` does, so nothing precedes `auth`.
         gridLock.lock()
         authSent = false
+        authAccepted = false
         gridLock.unlock()
         task.resume()
         receive(on: task)
@@ -217,15 +225,26 @@ final class CompanionTransport: NSObject {
                 case .data(let data):
                     onOutput?(data)
                 case .string(let text):
-                    switch CompanionControl.decode(text) {
-                    case .exit:
-                        finish(.closed)
-                    case .error(let message):
-                        finish(.failed(message))
-                    case .traceHTML(_, let html):
-                        DispatchQueue.main.async { [onTrace] in onTrace?(html) }
-                    default:
-                        break // roster frames and echoes are not for this link
+                    if let roster = CompanionRoster.decode(text) {
+                        if roster.wire < Wire.minimumServer {
+                            task.cancel(with: .policyViolation, reason: nil)
+                            finish(.failed("Update termio on your Mac to connect this phone."))
+                        } else {
+                            gridLock.lock()
+                            authAccepted = true
+                            gridLock.unlock()
+                        }
+                    } else {
+                        switch CompanionControl.decode(text) {
+                        case .exit:
+                            finish(.closed)
+                        case .error(let message):
+                            finish(.failed(message))
+                        case .traceHTML(_, let html):
+                            DispatchQueue.main.async { [onTrace] in onTrace?(html) }
+                        default:
+                            break
+                        }
                     }
                 @unknown default:
                     break
@@ -256,7 +275,9 @@ extension CompanionTransport: URLSessionWebSocketDelegate {
         // Auth precedes the attach on the same socket — the server refuses
         // the bridge (and everything else) until the token lands.
         if let token = CompanionLink.token(of: url) {
-            task.send(.string(CompanionControl.auth(token: token).encoded())) { _ in }
+            task.send(
+                .string(CompanionControl.auth(token: token, wire: Wire.current).encoded())
+            ) { _ in }
         } else {
             // No `?t=` on the URL: the Mac drops this socket after its ~10s
             // auth grace window, so the session just churns "Reconnecting…"

--- a/ios/Sources/Models.swift
+++ b/ios/Sources/Models.swift
@@ -344,12 +344,15 @@ extension Notification.Name {
 /// socket and keeps `state` current; other screens (the Connectivity settings
 /// page, the sidebar's presence dot) observe `stateDidChange` and read it.
 enum CompanionLink {
-    enum State {
+    enum State: Equatable {
         /// No Mac address saved.
         case unpaired
         /// Paired, but the socket is down — connecting or in backoff retry.
         case connecting
         case connected
+        /// The Mac answered but refused this pairing. The reason is rendered by
+        /// the existing link-status surfaces so reconnecting cannot hide it.
+        case failed(String)
     }
 
     static var state: State = .unpaired {

--- a/ios/Sources/ProjectListViewController.swift
+++ b/ios/Sources/ProjectListViewController.swift
@@ -272,6 +272,16 @@ final class ProjectListViewController: UIViewController {
                 actionTitle: nil,
                 busy: false
             )
+        case .failed(let reason):
+            stopConnectingGraceTimer()
+            reconnectStalled = false
+            emptyState.configure(
+                icon: .wifiError,
+                title: "Connection failed",
+                message: reason,
+                actionTitle: "Open Settings",
+                busy: false
+            )
         }
     }
 
@@ -299,6 +309,10 @@ final class ProjectListViewController: UIViewController {
     /// immediate reconnect and drop back to the "Connecting…" copy.
     private func emptyStateAction() {
         if case .unpaired = CompanionLink.state {
+            presentSettings(deepLinkToConnectivity: true)
+            return
+        }
+        if case .failed = CompanionLink.state {
             presentSettings(deepLinkToConnectivity: true)
             return
         }

--- a/ios/Sources/RosterStore.swift
+++ b/ios/Sources/RosterStore.swift
@@ -234,12 +234,12 @@ final class RosterStore {
             self?.openStartedSession(sessionID, agentID: agentID)
         }
         client.onError = { [weak self] reason in
+            guard let self, pendingStart != nil else { return }
+            pendingStart = nil
+            onStartError?(reason)
+        }
+        client.onConnectionFailure = { [weak self] reason in
             guard let self else { return }
-            if pendingStart != nil {
-                pendingStart = nil
-                onStartError?(reason)
-                return
-            }
             // A refusal closes the socket immediately; stop the reconnect loop
             // so its next optimistic open cannot erase the reason from the UI.
             self.client?.stop()

--- a/ios/Sources/RosterStore.swift
+++ b/ios/Sources/RosterStore.swift
@@ -234,9 +234,20 @@ final class RosterStore {
             self?.openStartedSession(sessionID, agentID: agentID)
         }
         client.onError = { [weak self] reason in
-            guard let self, pendingStart != nil else { return }
-            pendingStart = nil
-            onStartError?(reason)
+            guard let self else { return }
+            if pendingStart != nil {
+                pendingStart = nil
+                onStartError?(reason)
+                return
+            }
+            // A refusal closes the socket immediately; stop the reconnect loop
+            // so its next optimistic open cannot erase the reason from the UI.
+            self.client?.stop()
+            projects = []
+            enabledAgents = []
+            sshHosts = []
+            CompanionLink.state = .failed(reason)
+            NotificationCenter.default.post(name: Self.didChange, object: nil)
         }
         client.start()
         self.client = client

--- a/ios/Sources/SettingsViewController.swift
+++ b/ios/Sources/SettingsViewController.swift
@@ -127,6 +127,7 @@ final class SettingsViewController: UITableViewController {
         case .unpaired: (.tertiaryLabel, "Not Paired")
         case .connecting: (.systemOrange, "Reconnecting…")
         case .connected: (.systemGreen, "Connected")
+        case .failed: (.systemRed, "Connection Failed")
         }
         // The dot is a drawn image in an NSTextAttachment, not a glyph:
         // mixed-size text runs never sit still (a ● run smaller than the text


### PR DESCRIPTION
The Mac auto-updates silently through Sparkle; the phone ships through App Store review. Nothing in the handshake said which build was on the other end, so compatibility rested entirely on the discipline that every new wire field is Optional. That discipline covers added fields and nothing else — it cannot express a field whose *meaning* changed, and the file already records one skew bug it missed: older Macs drop an agent-less `.start` because their decoder required the field.

The skew here runs the opposite way from most client/server projects. The stale end is the phone, and the end that can ship a fix tomorrow is the Mac. So the phone declares one integer and the Mac adapts, rather than the client branching on the server. `Wire.legacy` (0, any peer that omits the field) and `Wire.current` (1) are distinct on purpose: a Mac that predates the field has to be distinguishable from one that implements the contract, or the version cannot answer the question that motivated it.

`wire` rides on `.auth` and on the roster — both already sent on every connect, so no new message type and no new round-trip. The Mac stores it per connection rather than globally, because one Mac can serve an old iPhone and a current iPad at once.

Both floors (`minimumServer`, `minimumClient`) are 0, so **nothing is refused today**. This arms a lever; it does not pull it.

The one behavior change is on the byte plane. `authSent` meant "auth was enqueued", not "auth was accepted", so keystroke frames could reach a Mac that had validated nothing — and the Mac writes binary frames straight into the PTY. Raw input now waits for the Mac's roster acknowledgement. `attach` and `resize` stay optimistic: their version-0 meanings are stable, and gating them would add a round-trip to terminal attach on every cellular reconnect. The invariant that makes this safe is now written down at both ends — binary frames are raw PTY bytes permanently, and any future compression, encryption, or multiplexing gets its own negotiated mechanism rather than reusing the opcode.

Two iOS fixes came out of building it. A Mac refusal reached `onError` and was discarded unless a session start happened to be pending, so the roster link looped connect → refuse → reconnect with nothing on screen while the terminal socket showed the reason — the "list works, terminal unauthorized" symptom. Refusals now surface in the Projects empty state and in Settings ▸ Connectivity.

The first version of that fix treated every non-start error as fatal, which would have torn the link down on `"unknown project or path"` from the file plane. `refuse()` cancels the socket after sending and `sendControl()` does not, so the client correlates the two instead of expanding the wire: an error is promoted to a link failure only if the socket drops within a second. This rebase proved the point — `main`'s diff work added two more benign `.error` senders on the same link, and the correlation handles them without knowing they exist.

## Verification

- `swift build` clean, 126/126 tests pass, including four new round-trip tests covering legacy and current on both `.auth` and the roster.
- iOS Simulator build succeeds.
- Not verified by me: the refusal empty state and the Settings row are UI I can't capture here. Worth checking that an expired pairing token now shows "Connection failed" with the Mac's reason rather than a silent retry loop, and that browsing to a stale path in the file browser still fails harmlessly without dropping the link.
- Known limitation: the one-second correlation window is a heuristic. A benign request error followed within a second by an unrelated network drop would show that error as a connection failure and route the user to Settings ▸ Connectivity. Now that a version exists, the clean fix is an optional `fatal` flag on `.error` — additive, safe default, no bump required.

Release Notes:

- The iPhone app now explains why a Mac refused the connection — an expired pairing code shows "Connection failed" with the reason instead of retrying silently.
