### PR TITLE
Reveal the pane grab handle on the header and smooth the drag

### DIFF
--- a/Sources/termio/Terminal/PaneDragRearrange.swift
+++ b/Sources/termio/Terminal/PaneDragRearrange.swift
@@ -1,57 +1,77 @@
 import AppKit
 import GhosttyTerminal
 
-/// A pane drag in flight: the lifted pane, plus the pane and drop zone under
-/// the pointer right now. `PaneDragRearrange` writes it, `TerminalPane` draws
-/// it — the store's published copy is what keeps the two in step.
+/// Which pane is showing its grab handle, and whether the pointer is on the
+/// handle itself rather than in the band that reveals it — ghostty dims the
+/// glyph in the band and brightens it under the pointer.
+struct PaneHandleHover: Equatable {
+    var pane: Session.ID
+    var overHandle: Bool
+}
+
+/// A point inside a pane, in that pane's top-left-origin space.
+struct PanePointer: Equatable {
+    var pane: Session.ID
+    var local: CGPoint
+}
+
+/// A pane drag in flight: the lifted pane, plus the pane and drop zone under the
+/// pointer right now. `PaneDragRearrange` writes it, `TerminalPane` draws it —
+/// the store's published copy keeps the two in step.
 struct PaneDragState: Equatable {
-    /// The pane being dragged.
     var source: Session.ID
-    /// The visible pane under the pointer — `nil` over a divider, outside the
-    /// terminal area, or off the window. The source pane itself is a valid
-    /// hover but never a valid drop.
+    /// The visible pane under the pointer — nil over a divider, outside the
+    /// terminal area, or off the window. The source pane is a valid hover but
+    /// never a valid drop.
     var target: Session.ID?
     var zone: PaneDropZone?
+    /// Where the pointer is, in the form the hit test already produces — enough
+    /// for the overlay to place the drag preview without a second coordinate
+    /// bridge.
+    var pointer: PanePointer?
 }
 
 /// Direct-manipulation rearrange (issue #183) through ghostty's grab handle: a
-/// short strip at the top of each pane, revealed when the pointer nears it, that
-/// drags the pane onto a drop zone on another — release to re-split (edge
-/// halves) or swap (center).
+/// strip at the top of each pane, revealed as the pointer reaches it, that drags
+/// the pane onto a drop zone on another — release to re-split (edge halves) or
+/// swap (center).
 ///
 /// The gesture used to be a ⌘⌥⇧ chord over the pane body, which worked and
-/// nobody could find. Ghostty's answer to the same problem — chromeless
-/// surfaces with no title bar to grab — is a visible handle
-/// (`SurfaceGrabHandle`), and a handle explains itself. The strip stays small
-/// and only exists while a split is on screen, so what it costs the terminal is
-/// bounded: clicks land in it only where there is a pane to rearrange.
+/// nobody could find. Ghostty's answer to the same problem — chromeless surfaces
+/// with no title bar to grab — is a visible handle (`SurfaceGrabHandle`), and a
+/// handle explains itself.
 ///
-/// The wrapper instantiates its own view class, so — like `TerminalContextMenu`
-/// — this hooks in one level up: local event monitors held for the app's
-/// lifetime. Hit-testing the handle here rather than mounting a view over the
-/// surface is what keeps the press from ever reaching a mouse-reporting TUI.
-/// The drag itself is plain geometry against the visible panes; the release is
-/// one `dropPane` call into the store, which owns the tree mutation.
+/// Like `TerminalContextMenu`, this hooks in one level above the wrapper's own
+/// view class: local event monitors held for the app's lifetime. Hit-testing the
+/// handle here rather than mounting a view over the surface is what keeps the
+/// press from ever reaching a mouse-reporting TUI. The drag is plain geometry
+/// against the visible panes; the release is one `dropPane` call into the store,
+/// which owns the tree mutation.
 @MainActor
 final class PaneDragRearrange {
     private weak var store: TermioStore?
     // Held for the app's lifetime; never removed.
     private var monitors: [Any] = []
-    /// True from the chorded press to the release. Esc cancels the drag but
-    /// leaves this set, so the tail of the gesture (the remaining dragged/up
-    /// events) is still swallowed instead of leaking into the terminal.
+    private var observers: [NSObjectProtocol] = []
+    /// True from the press to the release. Esc cancels the drag but leaves this
+    /// set, so the tail of the gesture is still swallowed rather than leaking
+    /// into the terminal.
     private var dragging = false
     private var cancelled = false
     private var cursorPushed = false
+    private var hoverCursorPushed = false
 
-    /// The handle itself: ghostty's dimensions (`SurfaceGrabHandle`), centered
-    /// on the pane's top edge. Small on purpose — it is the only place a plain
-    /// click is taken from the terminal.
+    /// Ghostty's handle dimensions (`SurfaceGrabHandle`), centered on the pane's
+    /// top edge. Small on purpose — it is the only place a plain click is taken
+    /// from the terminal.
     static let handleSize = CGSize(width: 80, height: 12)
 
-    /// The handle appears while the pointer is anywhere in the top fifth of the
-    /// pane, so it is reachable without aiming at 12 points of nothing.
-    private static let hoverHeightFactor: CGFloat = 0.2
+    /// The band that reveals the handle. Ghostty uses the pane's top *fifth*,
+    /// which on a tall pane is deep enough to park a pointer in — and since
+    /// mouse-moved events only arrive while the mouse moves, a parked pointer
+    /// leaves the handle up until the next move. A header-sized strip is still a
+    /// wide target for a 12pt handle.
+    private static let hoverBandHeight: CGFloat = 28
 
     /// The handle's rect in a pane of `size`, top-left origin — the space both
     /// this hit test and `TerminalPane`'s overlay work in.
@@ -61,7 +81,7 @@ final class PaneDragRearrange {
     }
 
     private static func isInHoverRegion(_ point: CGPoint, in size: CGSize) -> Bool {
-        point.y >= 0 && point.y <= size.height * hoverHeightFactor
+        point.y >= 0 && point.y <= min(size.height, hoverBandHeight)
     }
 
     init(store: TermioStore) {
@@ -81,65 +101,93 @@ final class PaneDragRearrange {
         monitor(.leftMouseDragged) { [weak self] in self?.moved($0) ?? false }
         monitor(.leftMouseUp) { [weak self] in self?.ended($0) ?? false }
         monitor(.keyDown) { [weak self] in self?.pressedKey($0) ?? false }
-        // Never consumed: the reveal only reads the pointer, so hover tracking
-        // can't interfere with a TUI's own mouse reporting.
+        // Never consumed: the reveal only reads the pointer, so it can't
+        // interfere with a TUI's own mouse reporting.
         monitor(.mouseMoved) { [weak self] in
             self?.hovered($0)
             return false
         }
-    }
-
-    /// Publishes which pane should be showing its handle. Only while a split is
-    /// on screen, matching `began` — a lone pane has nothing to rearrange, so it
-    /// gets no handle and keeps every click.
-    private func hovered(_ event: NSEvent) {
-        guard let store else { return }
-        var revealed: Session.ID?
-        if !dragging, store.splitRoot != nil, !store.isPaneZoomed,
-           let window = event.window,
-           window.frameAutosaveName == AppDelegate.mainWindowFrameAutosaveName,
-           let contentView = window.contentView,
-           let (id, point, size) = paneGeometry(at: event.locationInWindow, in: contentView, window: window),
-           Self.isInHoverRegion(point, in: size) {
-            revealed = id
+        // A pointer that leaves for another app sends no further mouse-moved
+        // events, so the last reveal would hang on screen until it came back.
+        for name in [NSApplication.didResignActiveNotification, NSWindow.didResignKeyNotification] {
+            let token = NotificationCenter.default.addObserver(
+                forName: name, object: nil, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.setHover(nil) }
+            }
+            observers.append(token)
         }
-        // @Published on every mouse-moved event would redraw the pane tree at
-        // pointer rate; only a change is worth a render.
-        if store.paneHandleHover != revealed { store.paneHandleHover = revealed }
     }
 
-    /// Starts a drag from a press on a pane's grab handle. Only meaningful with
-    /// a split on screen: a lone pane has nowhere to go, and a zoomed pane hides
-    /// the layout the drop zones would preview.
+    // MARK: - Hover
+
+    private func hovered(_ event: NSEvent) {
+        guard !dragging, let hit = rearrangeablePane(under: event),
+              Self.isInHoverRegion(hit.point, in: hit.size)
+        else { return setHover(nil) }
+        setHover(PaneHandleHover(pane: hit.id,
+                                 overHandle: Self.handleRect(in: hit.size).contains(hit.point)))
+    }
+
+    /// Republishing on every mouse-moved event would redraw the pane tree at
+    /// pointer rate; only a change is worth a render.
+    private func setHover(_ hover: PaneHandleHover?) {
+        guard let store, store.paneHandleHover != hover else { return }
+        store.paneHandleHover = hover
+        setHoverCursor(hover?.overHandle == true)
+    }
+
+    /// The open hand over the handle, mirroring ghostty's cursor rects. A drawn
+    /// handle has no view to hang a rect on, and a plain `set()` loses the race:
+    /// this monitor runs before the event reaches the surface, which then puts
+    /// the I-beam back on its own cursor update. A pushed cursor outranks that.
+    private func setHoverCursor(_ overHandle: Bool) {
+        guard overHandle != hoverCursorPushed else { return }
+        if overHandle { NSCursor.openHand.push() } else { NSCursor.pop() }
+        hoverCursorPushed = overHandle
+    }
+
+    // MARK: - Drag
+
+    /// Starts a drag from a press on a pane's grab handle.
     private func began(_ event: NSEvent) -> Bool {
         guard let store, !dragging,
-              store.splitRoot != nil, !store.isPaneZoomed,
-              !(store.isDetailPresented && store.inspectorMaximized),
-              let window = event.window,
-              window.frameAutosaveName == AppDelegate.mainWindowFrameAutosaveName,
-              let contentView = window.contentView,
-              let (id, point, size) = paneGeometry(at: event.locationInWindow, in: contentView, window: window),
-              Self.handleRect(in: size).contains(point)
+              let hit = rearrangeablePane(under: event),
+              Self.handleRect(in: hit.size).contains(hit.point),
+              let contentView = event.window?.contentView
         else { return false }
         dragging = true
         cancelled = false
-        store.paneDrag = PaneDragState(source: id)
+        // Snapshot before anything moves, the way ghostty builds its drag image.
+        // A surface that won't cache leaves this nil and the drag runs without a
+        // preview rather than showing a blank card.
+        store.paneDragPreview = terminalView(for: hit.id, in: contentView)?.paneSnapshot
+        store.paneDrag = PaneDragState(source: hit.id,
+                                       pointer: PanePointer(pane: hit.id, local: hit.point))
+        // The overlay washes translucently over live surfaces, which have to
+        // keep producing frames for the length of the gesture.
+        store.beginPaneDragRepaint()
+        // The hand closes on the press; drop the hover cursor so the two can't
+        // stack up.
+        setHoverCursor(false)
         NSCursor.closedHand.push()
         cursorPushed = true
         return true
     }
 
-    /// Tracks the pointer across panes. Once a drag has begun the modifiers no
-    /// longer matter — releasing the chord mid-drag doesn't drop the pane on
-    /// the floor, the mouse button does.
+    /// Tracks the pointer across panes. Once a drag has begun only the mouse
+    /// button ends it.
     private func moved(_ event: NSEvent) -> Bool {
         guard dragging else { return false }
         guard !cancelled, let store, var drag = store.paneDrag,
               let window = event.window, let contentView = window.contentView
         else { return true }
-        let hit = pane(at: event.locationInWindow, in: contentView, window: window)
-        drag.target = hit?.0
-        drag.zone = hit?.1
+        let hit = paneGeometry(at: event.locationInWindow, in: contentView, window: window)
+        drag.target = hit?.id
+        drag.zone = hit.map { PaneDropZone.zone(at: $0.point, in: $0.size) }
+        // Off every pane (a divider, the sidebar) the preview holds its last
+        // position rather than snapping to a corner.
+        if let hit { drag.pointer = PanePointer(pane: hit.id, local: hit.point) }
         store.paneDrag = drag
         return true
     }
@@ -159,7 +207,7 @@ final class PaneDragRearrange {
     private func pressedKey(_ event: NSEvent) -> Bool {
         guard dragging, !cancelled, event.keyCode == 53 else { return false }
         cancelled = true
-        store?.paneDrag = nil
+        clearDrag()
         popCursorIfNeeded()
         return true
     }
@@ -167,8 +215,19 @@ final class PaneDragRearrange {
     private func finish() {
         dragging = false
         cancelled = false
-        store?.paneDrag = nil
+        clearDrag()
+        // The drop rebuilt the layout under the pointer, so whichever pane was
+        // showing a handle may not be there any more; the next move decides.
+        setHover(nil)
         popCursorIfNeeded()
+    }
+
+    /// Drops the overlay and stops the drag pump — whose parting repaint is what
+    /// clears the wash back off the panes.
+    private func clearDrag() {
+        store?.paneDrag = nil
+        store?.paneDragPreview = nil
+        store?.endPaneDragRepaint()
     }
 
     private func popCursorIfNeeded() {
@@ -177,24 +236,31 @@ final class PaneDragRearrange {
         cursorPushed = false
     }
 
-    /// The visible pane under a window point, and the drop zone within it.
-    /// Resolved by geometry rather than `hitTest` for the same reason as
-    /// `TerminalContextMenu`: invisible siblings stay mounted at full pane
-    /// size, so AppKit's topmost hit may be a hidden view. Visible panes tile
-    /// without overlapping, so "contains the point and is visible" is
-    /// unambiguous.
-    private func pane(at point: NSPoint, in contentView: NSView,
-                      window: NSWindow) -> (Session.ID, PaneDropZone)? {
-        guard let (id, local, size) = paneGeometry(at: point, in: contentView, window: window)
+    // MARK: - Geometry
+
+    /// The pane under the pointer, once everything that makes a rearrange
+    /// meaningful holds: a split on screen, not zoomed, no full-window inspector
+    /// over it, and the pointer in the key main window.
+    private func rearrangeablePane(under event: NSEvent) -> PaneHit? {
+        guard let store, store.splitRoot != nil, !store.isPaneZoomed,
+              !(store.isDetailPresented && store.inspectorMaximized),
+              let window = event.window, window.isKeyWindow,
+              window.frameAutosaveName == AppDelegate.mainWindowFrameAutosaveName,
+              let contentView = window.contentView
         else { return nil }
-        return (id, PaneDropZone.zone(at: local, in: size))
+        return paneGeometry(at: event.locationInWindow, in: contentView, window: window)
     }
 
-    /// The visible pane under a window point, with that point in the pane's own
-    /// top-left-origin space and the pane's size — what both the handle hit test
-    /// and the drop-zone lookup are expressed in.
+    /// A visible pane, the pointer in its top-left-origin space, and its size —
+    /// what the handle hit test and the drop-zone lookup are both expressed in.
+    private typealias PaneHit = (id: Session.ID, point: CGPoint, size: CGSize)
+
+    /// Resolved by geometry rather than `hitTest` for the same reason as
+    /// `TerminalContextMenu`: invisible siblings stay mounted at full pane size,
+    /// so AppKit's topmost hit may be a hidden view. Visible panes tile without
+    /// overlapping, so "contains the point and is visible" is unambiguous.
     private func paneGeometry(at point: NSPoint, in contentView: NSView,
-                              window: NSWindow) -> (Session.ID, CGPoint, CGSize)? {
+                              window: NSWindow) -> PaneHit? {
         guard let store else { return nil }
         for view in terminalViews(in: contentView) {
             guard view.window === window,
@@ -208,6 +274,10 @@ final class PaneDragRearrange {
             return (id, normalized, view.bounds.size)
         }
         return nil
+    }
+
+    private func terminalView(for id: Session.ID, in root: NSView) -> TerminalView? {
+        terminalViews(in: root).first { sessionID(for: $0) == id }
     }
 
     // The two resolution helpers below mirror `TerminalContextMenu`'s private
@@ -229,5 +299,19 @@ final class PaneDragRearrange {
     /// cache — the view and its cached `TerminalViewState` share a controller.
     private func sessionID(for view: TerminalView) -> Session.ID? {
         store?.surfaces.first { $0.value.controller === view.controller }?.key
+    }
+}
+
+private extension NSView {
+    /// A still of the view, the way ghostty builds its drag image
+    /// (`SurfaceView.asImage`). Nil for an empty or uncacheable view, so callers
+    /// degrade to no preview.
+    var paneSnapshot: NSImage? {
+        guard bounds.width > 1, bounds.height > 1,
+              let rep = bitmapImageRepForCachingDisplay(in: bounds) else { return nil }
+        cacheDisplay(in: bounds, to: rep)
+        let image = NSImage(size: bounds.size)
+        image.addRepresentation(rep)
+        return image
     }
 }

--- a/Sources/termio/Terminal/SplitTree.swift
+++ b/Sources/termio/Terminal/SplitTree.swift
@@ -243,27 +243,6 @@ indirect enum SplitNode: Codable, Hashable {
         }
     }
 
-    /// Flips the axis of the branch that has `leaf` as a direct child —
-    /// side-by-side ⇄ stacked — keeping both children and the divider ratio.
-    /// This is the innermost split only: nesting stays put, so flipping an
-    /// A│B pair that sits under C rotates just A and B, never C. Like
-    /// `swapping`, it changes one thing about one pair and leaves the rest of
-    /// the tree byte-for-byte. A miss returns the tree unchanged.
-    func flippingBranch(containing leaf: Session.ID) -> SplitNode {
-        switch self {
-        case .leaf:
-            return self
-        case .split(var branch):
-            if branch.first == .leaf(leaf) || branch.second == .leaf(leaf) {
-                branch.direction = branch.direction == .horizontal ? .vertical : .horizontal
-                return .split(branch)
-            }
-            branch.first = branch.first.flippingBranch(containing: leaf)
-            branch.second = branch.second.flippingBranch(containing: leaf)
-            return .split(branch)
-        }
-    }
-
     /// Writes a divider's ratio (clamped), leaving the rest of the tree intact.
     func updatingRatio(branchID: UUID, to ratio: Double) -> SplitNode {
         switch self {

--- a/Sources/termio/Terminal/TerminalContextMenu.swift
+++ b/Sources/termio/Terminal/TerminalContextMenu.swift
@@ -121,16 +121,6 @@ final class TerminalContextMenu: NSObject {
                                symbol: "rectangle.bottomhalf.inset.filled"))
         menu.addItem(storeItem("Split Up", action: #selector(splitUp),
                                symbol: "rectangle.tophalf.inset.filled"))
-        // "Flip Layout" turns just the divider that holds the clicked pane and
-        // its neighbour from side-by-side to stacked (or back) — the honest
-        // inverse of the "Split Right"/"Split Down" that made the pair. Nested
-        // splits stay put, matching iTerm2's local, per-pane model (which has no
-        // whole-layout transpose). Only offered when the pane is in a group, so
-        // there is always a branch to flip.
-        if let id = clickedSessionID, let store, store.isInSplitGroup(id) {
-            menu.addItem(storeItem("Flip Layout", action: #selector(flipLayout),
-                                   symbol: "arrow.triangle.2.circlepath"))
-        }
         // "Ungroup" is the layout half: the pane leaves the split group but its
         // session stays alive in the sidebar — the same action the sidebar row
         // names "Ungroup" (the inverse of "Group with"). Its glyph is Split
@@ -179,10 +169,6 @@ final class TerminalContextMenu: NSObject {
     @objc private func splitDown() { store?.splitSelectedPane(.vertical) }
     @objc private func splitUp() { store?.splitSelectedPane(.vertical, slot: .first) }
     @objc private func ungroup() { store?.ungroupSelectedPane() }
-    @objc private func flipLayout() {
-        guard let id = clickedSessionID else { return }
-        store?.flipPaneLayout(id)
-    }
     @objc private func closeSession() {
         guard let id = clickedSessionID else { return }
         store?.closeSession(id)

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -193,20 +193,21 @@ struct TerminalPane: View {
             // near (see `PaneDragRearrange`). Never hit-testable: the press is
             // taken by the event monitor, so this is purely the affordance.
             if let layout, !zoomed, store.paneDrag == nil,
-               let hovered = store.paneHandleHover, let frame = layout.frames[hovered] {
-                PaneGrabHandle(paneFrame: frame)
+               let hovered = store.paneHandleHover, let frame = layout.frames[hovered.pane] {
+                PaneGrabHandle(paneFrame: frame, isOverHandle: hovered.overHandle)
                     .allowsHitTesting(false)
             }
             // The drag's preview (issue #183): the drop-zone highlight is what
             // resolves the ambiguity a drag-rearrange otherwise has — you see
             // the half (or the swap) the release would commit.
             if let drag = store.paneDrag, let layout, !zoomed {
-                PaneDragOverlay(drag: drag, layout: layout)
+                PaneDragOverlay(drag: drag, layout: layout, preview: store.paneDragPreview)
             }
         }
-        // The handle fades rather than blinking as the pointer crosses into the
-        // reveal band; short enough that it still feels attached to the pointer.
-        .animation(.easeOut(duration: 0.12), value: store.paneHandleHover)
+        // Ghostty's own timing (`SurfaceDragSource`): the handle fades in and
+        // brightens rather than blinking. The drag overlay animates its own
+        // pieces — the highlight slides, the preview must not.
+        .animation(.easeInOut(duration: 0.15), value: store.paneHandleHover)
     }
 
     /// A surface becoming first responder is the source of truth for split selection.
@@ -681,34 +682,52 @@ private final class TerminalFocusDriver {
     }
 }
 
-/// The visual half of the pane drag (issue #183): a wash over the lifted
-/// source pane plus a highlight over the region the release would commit —
-/// the half of the target the pane would occupy, or the whole target for a
-/// swap. Geometry comes straight from the tree's `layout`, so the preview and
-/// the drop can never disagree. The tint family is the file-drop wash's
-/// desaturated blue-grey, not accent blue.
-/// The pane's drag affordance: ghostty's ellipsis strip on the top edge, shown
-/// while the pointer is near it. Drawing only — the press that starts the drag
-/// is hit-tested in `PaneDragRearrange`, so this never stands between the
-/// pointer and the terminal.
+/// The pane's drag affordance: ghostty's ellipsis strip on the top edge, drawn
+/// while the pointer is on it. Drawing only — the press that starts the drag is
+/// hit-tested in `PaneDragRearrange`, so this never stands between the pointer
+/// and the terminal.
 private struct PaneGrabHandle: View {
     let paneFrame: CGRect
+    /// True once the pointer is on the handle itself rather than in the band
+    /// that reveals it: ghostty's two strengths, present then ready.
+    let isOverHandle: Bool
 
     var body: some View {
         let rect = PaneDragRearrange.handleRect(in: paneFrame.size)
         Image(systemName: "ellipsis")
             .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(.primary.opacity(0.55))
+            .foregroundStyle(.primary.opacity(isOverHandle ? 0.8 : 0.3))
             .frame(width: rect.width, height: rect.height)
             .position(x: paneFrame.minX + rect.midX, y: paneFrame.minY + rect.midY)
             .transition(.opacity)
     }
 }
 
+/// The visual half of the pane drag (issue #183): a wash over the lifted source
+/// pane, a highlight over the region the release would commit — the half of the
+/// target the pane would occupy, or the whole target for a swap — and a scaled
+/// still of the pane riding under the pointer. Geometry comes straight from the
+/// tree's `layout`, so the preview and the drop can never disagree. The tint
+/// family is the file-drop wash's desaturated blue-grey, not accent blue.
 private struct PaneDragOverlay: View {
+    /// Ghostty's own drag-image scale (`SurfaceDragSource.previewScale`).
+    private static let previewScale: CGFloat = 0.2
+
     let drag: PaneDragState
     let layout: SplitNode.PaneLayout
+    /// The pane as it looked when picked up, or nil when the surface could not
+    /// be captured — the drag then runs without a preview rather than showing an
+    /// empty card.
+    let preview: NSImage?
     @Environment(\.colorScheme) private var colorScheme
+    @State private var lastHighlight: CGRect = .zero
+
+    /// The pointer in the pane area's coordinate space, rebuilt from the pane it
+    /// is over plus the local point the hit test already resolved.
+    private var pointerCenter: CGPoint? {
+        guard let pointer = drag.pointer, let frame = layout.frames[pointer.pane] else { return nil }
+        return CGPoint(x: frame.minX + pointer.local.x, y: frame.minY + pointer.local.y)
+    }
 
     private var tint: Color {
         colorScheme == .dark
@@ -716,29 +735,75 @@ private struct PaneDragOverlay: View {
             : Color(.sRGB, red: 0.40, green: 0.52, blue: 0.68, opacity: 1)
     }
 
+    /// The half (or whole pane) the release would fill, or `.zero` when the
+    /// pointer is over nothing droppable.
+    private var highlightRect: CGRect {
+        guard let target = drag.target, target != drag.source,
+              let zone = drag.zone, let frame = layout.frames[target]
+        else { return .zero }
+        return zone.highlightRect(in: frame)
+    }
+
     var body: some View {
         ZStack {
-            // The source pane reads as "lifted": a faint wash, no border.
-            if let source = layout.frames[drag.source] {
-                Rectangle()
-                    .fill(tint.opacity(colorScheme == .dark ? 0.08 : 0.07))
-                    .frame(width: source.width, height: source.height)
-                    .position(x: source.midX, y: source.midY)
-            }
-            // Fill only, no border — the same restraint as the file-drop wash
-            // above (and ghostty's own split-drag overlay): the rect's edge
-            // already draws the zone boundary, a stroke would just say it twice.
-            if let target = drag.target, target != drag.source,
-               let zone = drag.zone, let frame = layout.frames[target] {
-                let rect = zone.highlightRect(in: frame)
-                Rectangle()
-                    .fill(tint.opacity(colorScheme == .dark ? 0.20 : 0.17))
-                    .frame(width: rect.width, height: rect.height)
-                    .position(x: rect.midX, y: rect.midY)
-            }
+            liftedSource
+            dropHighlight
+            draggedPreview
         }
         .allowsHitTesting(false)
-        .animation(.easeOut(duration: 0.12), value: drag)
+    }
+
+    /// The pane you picked up, faintly washed so it reads as lifted.
+    @ViewBuilder private var liftedSource: some View {
+        if let source = layout.frames[drag.source] {
+            Rectangle()
+                .fill(tint.opacity(colorScheme == .dark ? 0.08 : 0.07))
+                .frame(width: source.width, height: source.height)
+                .position(x: source.midX, y: source.midY)
+        }
+    }
+
+    /// Where the release would land. Fill only, no border — the same restraint
+    /// as the file-drop wash (and ghostty's split-drag overlay): the rect's edge
+    /// already draws the boundary, a stroke would say it twice.
+    ///
+    /// Always mounted and hidden by opacity, because a view that survives every
+    /// zone change is what lets SwiftUI interpolate the rect — the highlight
+    /// then slides from half to half instead of blinking out and back in
+    /// somewhere else. Leaving every zone keeps the last rect and only fades it;
+    /// animating the frame to nothing reads as the wash shrinking away rather
+    /// than releasing.
+    private var dropHighlight: some View {
+        let rect = highlightRect == .zero ? lastHighlight : highlightRect
+        return Rectangle()
+            .fill(tint.opacity(colorScheme == .dark ? 0.20 : 0.17))
+            .frame(width: rect.width, height: rect.height)
+            .position(x: rect.midX, y: rect.midY)
+            .opacity(highlightRect == .zero ? 0 : 1)
+            .animation(.easeInOut(duration: 0.15), value: rect)
+            .animation(.easeInOut(duration: 0.15), value: highlightRect == .zero)
+            .onChange(of: highlightRect) { _, new in
+                if new != .zero { lastHighlight = new }
+            }
+    }
+
+    /// A still of the dragged pane under the pointer, at ghostty's drag-image
+    /// scale and translucent like the image a real dragging session carries — an
+    /// opaque card reads as a second window dropped on the layout. Never
+    /// animated: an interpolated position is a preview that lags the mouse.
+    @ViewBuilder private var draggedPreview: some View {
+        if let preview, let center = pointerCenter {
+            Image(nsImage: preview)
+                .resizable()
+                .interpolation(.medium)
+                .frame(width: preview.size.width * Self.previewScale,
+                       height: preview.size.height * Self.previewScale)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .shadow(color: .black.opacity(0.35), radius: 14, y: 6)
+                .opacity(0.8)
+                .position(center)
+                .animation(nil, value: drag)
+        }
     }
 }
 

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -286,18 +286,6 @@ extension TermioStore {
         isPaneZoomed = false
     }
 
-    /// Flips the layout of the branch immediately enclosing a pane — side-by-side
-    /// ⇄ stacked — via the context menu's "Flip Layout". Only that one divider's
-    /// axis turns; the tree's shape, its ratios, and every other pane stay put,
-    /// the same restraint "Move Pane" keeps. Zoom is dropped so the result is
-    /// visible and the selection sticks with the flipped pane. A no-op when the
-    /// pane isn't grouped (a lone pane has no branch to flip).
-    func flipPaneLayout(_ id: Session.ID) {
-        guard let group = groupIndex(containing: id) else { return }
-        splitGroups[group] = splitGroups[group].flippingBranch(containing: id)
-        selectedSessionID = id
-        isPaneZoomed = false
-    }
 
     /// Moves pane focus directionally (⌥⌘ arrows), scored on the visible
     /// group's normalized geometry. No-op without splits or when nothing lies

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -843,6 +843,40 @@ extension TermioStore {
         pumpRendering(state, duration: 0.25)
     }
 
+    /// Keeps every visible surface painting for the length of a pane drag.
+    ///
+    /// The drag overlay washes translucently over the *live* surfaces, so the
+    /// layer underneath is re-blended every frame of the gesture. Ghostty.app
+    /// affords that by ticking the core every vsync from a display link; this
+    /// embedding advances only on a PTY-output wakeup (see `warmUpRendering`),
+    /// so a quiet terminal hands the compositor its last frame for the whole
+    /// drag and the wash smears stale pixels. Same failure as the uncovered
+    /// surface above, same fix: pump while it matters, stop when it doesn't.
+    func beginPaneDragRepaint() {
+        paneDragRepaintTimer?.invalidate()
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] timer in
+            MainActor.assumeIsolated {
+                guard let self else { timer.invalidate(); return }
+                for id in self.visiblePaneIDs {
+                    self.surfaces[id]?.controller.tick()
+                }
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        paneDragRepaintTimer = timer
+    }
+
+    /// Ends the drag pump, with one last pass so the panes settle on a fresh
+    /// frame after the tree has been rebuilt under them.
+    func endPaneDragRepaint() {
+        paneDragRepaintTimer?.invalidate()
+        paneDragRepaintTimer = nil
+        for id in visiblePaneIDs {
+            guard let state = surfaces[id] else { continue }
+            pumpRendering(state, duration: 0.25)
+        }
+    }
+
     private func pumpRendering(_ state: TerminalViewState, duration: TimeInterval) {
         let started = Date()
         let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak state] timer in

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -94,10 +94,19 @@ final class TermioStore: ObservableObject {
     /// highlight. Transient gesture state, never persisted.
     @Published var paneDrag: PaneDragState?
 
-    /// The pane whose grab handle is revealed right now — the pointer is near
-    /// its top edge. Also written by `PaneDragRearrange`; nil means no handle is
+    /// The pane whose grab handle is revealed right now — the pointer is on its
+    /// top edge. Also written by `PaneDragRearrange`; nil means no handle is
     /// showing.
-    @Published var paneHandleHover: Session.ID?
+    @Published var paneHandleHover: PaneHandleHover?
+
+    /// A still of the pane picked up by the current drag, drawn scaled under the
+    /// pointer. Nil when no drag is in flight, or when the surface could not be
+    /// captured — the drag then simply has no preview.
+    @Published var paneDragPreview: NSImage?
+
+    /// Drives the visible surfaces while a pane drag is in flight (see
+    /// `beginPaneDragRepaint`). Not published: nothing renders from it.
+    var paneDragRepaintTimer: Timer?
 
     /// Activation *requests* for sessions that are neither selected nor in the
     /// visible group: a background spawn's fresh pane, a `send` target never

--- a/Tests/termioTests/SplitTreeTests.swift
+++ b/Tests/termioTests/SplitTreeTests.swift
@@ -141,36 +141,4 @@ final class SplitTreeTests: XCTestCase {
         XCTAssertEqual(PaneDropZone.center.highlightRect(in: frame), frame)
     }
 
-    /// "Flip Layout" turns only the innermost branch: an A│B pair nested under C
-    /// rotates from side-by-side to stacked, while C keeps its own axis, ratio,
-    /// and slot. Both children and the ratio survive the flip.
-    func testFlippingTurnsOnlyTheInnermostBranch() {
-        let inner = SplitBranch(direction: .horizontal, ratio: 0.3,
-                                first: .leaf(run1), second: .leaf(run2))
-        let tree = SplitNode.split(SplitBranch(direction: .vertical, ratio: 0.5,
-                                               first: .leaf(agent), second: .split(inner)))
-        let flipped = tree.flippingBranch(containing: run1)
-
-        guard case let .split(outer) = flipped,
-              case let .split(rotated) = outer.second else {
-            return XCTFail("expected the outer branch and its inner split to survive")
-        }
-        // The outer branch is byte-for-byte the same; only the inner axis turned.
-        XCTAssertEqual(outer.direction, .vertical)
-        XCTAssertEqual(outer.first, .leaf(agent))
-        XCTAssertEqual(rotated.direction, .vertical)   // was .horizontal
-        XCTAssertEqual(rotated.ratio, 0.3)             // ratio preserved
-        XCTAssertEqual(flipped.leafIDs, [agent, run1, run2])
-    }
-
-    /// Flipping a pane that has no enclosing branch, or a leaf that isn't in the
-    /// tree, changes nothing.
-    func testFlippingMissIsANoOp() {
-        let lone = SplitNode.leaf(agent)
-        XCTAssertEqual(lone.flippingBranch(containing: agent), lone)
-
-        let tree = SplitNode.split(SplitBranch(direction: .horizontal, ratio: 0.5,
-                                               first: .leaf(agent), second: .leaf(run1)))
-        XCTAssertEqual(tree.flippingBranch(containing: run3), tree)
-    }
 }


### PR DESCRIPTION
Follow-up to #212, from using it.

**The handle read as permanently on.** It copied ghostty's reveal band — the pane's top fifth — which on a tall pane is ~180pt, and mouse-moved events only arrive while the mouse *moves*: park the pointer anywhere in that zone, or stop to type, and the handle stayed lit. The band is now a 28pt header strip, and the reveal also clears when the app or window resigns key, after a drop, and under a maximized inspector. It no longer starts a drag from a non-key window either, which the hover rule already refused.

**The glyph and cursor follow ghostty.** Dim in the band, bright under the pointer (their two strengths); open hand hovering, closed hand on the press. A drawn handle has no view to hang a cursor rect on, and a plain `set` loses to the surface's own cursor update — the monitor runs first — so the hover cursor is pushed.

**Dragging carries a preview.** A still of the pane taken on the press, at ghostty's `previewScale = 0.2` and translucent like a real dragging session's image. It is deliberately the one piece that never animates: an interpolated position is a preview that lags the mouse. If the surface can't be captured there is simply no preview, rather than a blank card.

**Leaving a drop zone releases instead of shrinking.** The highlight is always mounted so it can slide between halves; an empty rect made it animate its frame to nothing. It now keeps the last rect and only fades.

**The stale-frame smear is gone.** The overlay washes translucently over *live* surfaces, so the layer underneath is re-blended every frame. Ghostty.app affords that by ticking the core every vsync from a display link; this embedding advances only on a PTY-output wakeup, so a quiet terminal handed the compositor its last frame for the whole drag. Same failure `repaintSelectedSurface` already documents for an uncovered surface, same fix: pump while it matters, stop when it doesn't.

**Flip Layout is gone.** Dragging a pane onto a neighbour's edge half produces what it produced, and shows the landing zone while you aim; flipping could only turn the divider blind. Removes the menu item, `flipPaneLayout`, `SplitNode.flippingBranch`, and the two tests that covered the function.

## Verification

- `swift build` clean, 120/120 tests pass (122 minus the two Flip Layout tests, whose subject no longer exists).
- Every constant here is ghostty's, read from their source: `handleSize`, `previewScale`, the two glyph opacities, the cursor pair, and `easeInOut(0.15)`.
- Not verified by me, as before: nothing on screen. Specifically unknown is whether `cacheDisplay` captures the Metal surface in this embedding — if it comes back empty the drag runs preview-less, which is the pre-PR behavior, but it would need a different capture path to actually work. Worth watching too: whether 28pt is the right reach, and whether the smear is really gone.

Release Notes:

- The pane drag handle now appears only along a pane's top edge, brightens under the pointer, and shows a preview of the pane you are dragging.
- Removed Flip Layout; drag a pane onto a neighbour's edge instead.
