### PR TITLE
Diff merge commits against their first parent in the History tab

### DIFF
--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -145,12 +145,14 @@ enum GitService {
 
     /// The changed files of a single commit. `--name-status` gives the status letter and
     /// path; `--numstat` gives the counts — merged by path. `--format=` drops the commit
-    /// header so only the file lines remain. The first-parent diff (`<sha>^!`) is used so
-    /// a merge shows a sensible file set; the root commit falls back to the empty tree.
+    /// header so only the file lines remain. `--first-parent` makes a merge diff against
+    /// its first parent (the branch that was merged into) — without it `git show` emits a
+    /// combined diff, which is empty for a clean merge, so every PR merge in the history
+    /// read as "No file changes". The root commit diffs against the empty tree as before.
     private static func loadCommitChanges(_ sha: String, _ repoRoot: String) -> [GitChange] {
         var order: [String] = []
         var status: [String: GitFileStatus] = [:]
-        if let out = run(["show", "--name-status", "--format=", "-M", sha], in: repoRoot) {
+        if let out = run(["show", "--name-status", "--format=", "-M", "--first-parent", sha], in: repoRoot) {
             for line in out.split(separator: "\n") {
                 let parts = line.split(separator: "\t")
                 guard let code = parts.first?.first, parts.count >= 2 else { continue }
@@ -160,7 +162,7 @@ enum GitService {
             }
         }
         var counts: [String: (Int, Int)] = [:]
-        if let out = run(["show", "--numstat", "--format=", sha], in: repoRoot) {
+        if let out = run(["show", "--numstat", "--format=", "--first-parent", sha], in: repoRoot) {
             for line in out.split(separator: "\n") {
                 let parts = line.split(separator: "\t", maxSplits: 2)
                 guard parts.count == 3 else { continue }
@@ -416,9 +418,10 @@ enum GitService {
                        in: repoRoot, ignoreStatus: true) ?? ""
         }
         // History file row: the file's change within one commit. `--format=` strips the
-        // commit header so the parser sees only the unified diff.
+        // commit header so the parser sees only the unified diff; `--first-parent` keeps
+        // a merge commit's file diff non-empty, matching the file list above.
         if let commit {
-            return run(["show", "--format=", "-M"] + contextArguments + [commit, "--", change.path],
+            return run(["show", "--format=", "-M", "--first-parent"] + contextArguments + [commit, "--", change.path],
                        in: repoRoot, ignoreStatus: true) ?? ""
         }
         if change.isUntracked {


### PR DESCRIPTION
Fixes #217.

Expanding a merge commit in the History tab showed "No file changes", and its per-file diffs were empty: plain `git show` emits a combined diff for merges, which is empty for a clean merge. In a trunk-based repo most of main's history is PR merges, so nearly every commit offered nothing to open — the previously opened diff stayed on the overlay, which users read as "every commit shows the same diff" (the report in #217).

The fix adds `--first-parent` at the three `git show` call sites (`--name-status` file list, `--numstat` counts, per-file diff), so a merge diffs against the branch it was merged into — GitHub Desktop's shape. Non-merge and root commits behave exactly as before (verified by running each command against a normal commit and the root commit).

Verified: `swift build` clean, `swift test` 124 tests / 0 failures; the three commands run against merge commit `92395b0` now produce the merged PR's file list, counts, and per-file diffs.

Release Notes:

- Fixed: merge commits in the git History tab now show their file list and diffs (previously "No file changes").
