### PR TITLE
Keep the diff header on one line in a narrow pane

### DIFF
--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -135,31 +135,35 @@ struct GitDiffView: View {
                 .font(.system(size: 12, weight: .bold, design: .monospaced))
                 .foregroundStyle(request.change.status.tint)
                 .frame(width: 16)
-            Text(request.name)
-                .font(.system(size: 12.5, weight: .medium))
-                .lineLimit(1)
-                .truncationMode(.middle)
+            // Name and directory as one text run with a single truncation point: as two
+            // flexible texts a narrow pane split the width between them and truncated
+            // both into noise. Tail truncation keeps the name (the head) readable longest.
             let directory = (request.change.path as NSString).deletingLastPathComponent
-            if !directory.isEmpty {
-                Text(directory)
+            let name = Text(request.name).font(.system(size: 12.5, weight: .medium))
+            (directory.isEmpty
+                ? name
+                : name + Text("  \(directory)")
                     .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.head)
-            }
+                    .foregroundStyle(.secondary))
+                .lineLimit(1)
+                .truncationMode(.tail)
             Spacer(minLength: 8)
             // "n of m" (Mail's message-walk wording) whenever there is a set to walk.
             if request.siblings.count > 1, let index = walkIndex {
                 Text("\(index + 1) of \(request.siblings.count)")
                     .font(.system(size: 10.5, weight: .medium).monospacedDigit())
                     .foregroundStyle(.secondary)
+                    .fixedSize()
                     .padding(.trailing, 2)
             }
             // For a history diff, tag the header with the commit it belongs to.
+            // `fixedSize` (as on the ± counts) keeps the tag on one line in a narrow
+            // pane — the flexible path is the only element that gives up width.
             if let commit = request.commit {
                 Text("@ \(commit.prefix(7))")
                     .font(.system(size: 10.5, design: .monospaced))
                     .foregroundStyle(.secondary)
+                    .fixedSize()
                     .padding(.trailing, 2)
             }
             HStack(spacing: 5) {

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -145,12 +145,14 @@ enum GitService {
 
     /// The changed files of a single commit. `--name-status` gives the status letter and
     /// path; `--numstat` gives the counts — merged by path. `--format=` drops the commit
-    /// header so only the file lines remain. The first-parent diff (`<sha>^!`) is used so
-    /// a merge shows a sensible file set; the root commit falls back to the empty tree.
+    /// header so only the file lines remain. `--first-parent` makes a merge diff against
+    /// its first parent (the branch that was merged into) — without it `git show` emits a
+    /// combined diff, which is empty for a clean merge, so every PR merge in the history
+    /// read as "No file changes". The root commit diffs against the empty tree as before.
     private static func loadCommitChanges(_ sha: String, _ repoRoot: String) -> [GitChange] {
         var order: [String] = []
         var status: [String: GitFileStatus] = [:]
-        if let out = run(["show", "--name-status", "--format=", "-M", sha], in: repoRoot) {
+        if let out = run(["show", "--name-status", "--format=", "-M", "--first-parent", sha], in: repoRoot) {
             for line in out.split(separator: "\n") {
                 let parts = line.split(separator: "\t")
                 guard let code = parts.first?.first, parts.count >= 2 else { continue }
@@ -160,7 +162,7 @@ enum GitService {
             }
         }
         var counts: [String: (Int, Int)] = [:]
-        if let out = run(["show", "--numstat", "--format=", sha], in: repoRoot) {
+        if let out = run(["show", "--numstat", "--format=", "--first-parent", sha], in: repoRoot) {
             for line in out.split(separator: "\n") {
                 let parts = line.split(separator: "\t", maxSplits: 2)
                 guard parts.count == 3 else { continue }
@@ -416,9 +418,10 @@ enum GitService {
                        in: repoRoot, ignoreStatus: true) ?? ""
         }
         // History file row: the file's change within one commit. `--format=` strips the
-        // commit header so the parser sees only the unified diff.
+        // commit header so the parser sees only the unified diff; `--first-parent` keeps
+        // a merge commit's file diff non-empty, matching the file list above.
         if let commit {
-            return run(["show", "--format=", "-M"] + contextArguments + [commit, "--", change.path],
+            return run(["show", "--format=", "-M", "--first-parent"] + contextArguments + [commit, "--", change.path],
                        in: repoRoot, ignoreStatus: true) ?? ""
         }
         if change.isUntracked {


### PR DESCRIPTION
Stacked on #219 (merge that first; this PR then shows only the header commit).

In a narrow pane the diff overlay's header collapsed into noise: the file name (middle-truncated) and directory (head-truncated) were two independently flexible texts, so SwiftUI split the width between them and neither survived ("Pa...wift  ...erminal"). The history commit tag ("@ abc1234") had no `fixedSize` and wrapped onto two lines, breaking the bar's single-line rhythm.

Now the name and directory are one text run with a single tail truncation — the name, at the head of the run, stays readable longest — and the commit tag and "n of m" counter pin to one line like the ± counts already did. The path is the only element that gives up width, so the bar degrades to one readable line at any pane width.

Verified: `swift build` clean. Visual check at narrow pane widths pending on the dev build.

Release Notes:

- Fixed: the diff header no longer garbles the file name or wraps the commit tag in a narrow pane.