### PR TITLE
Cut editor per-keystroke redraw churn and fix find and jump edge cases

### DIFF
--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -75,12 +75,15 @@ struct FileEditorView: View {
     /// whole-document relayout — seconds of beachball on a generated 600 KB YAML.
     private static let highlightByteLimit = 256 * 1024
 
-    /// The highlight.js language id, sniffed once from the file extension (`nil` lets highlight.js
-    /// auto-detect). Stable for the lifetime of the open file.
+    /// The highlight.js language id, sniffed once from the file extension. `nil` renders the file
+    /// as plain text — the storage skips highlighting entirely without a language (there is no
+    /// auto-detect pass). Stable for the lifetime of the open file.
     private let language: String?
     /// The file's path relative to its git root — shown next to the name like the diff header
-    /// (`GitDiffView`), so the two overlays read the same. `nil` outside a repo.
-    private let relativePath: String?
+    /// (`GitDiffView`), so the two overlays read the same. `nil` outside a repo. Resolved in
+    /// `load()` alongside the file read: the walk-up-for-`.git` is filesystem work, and this
+    /// init re-runs on every parent render.
+    @State private var relativePath: String?
 
     init(url: URL, settings: AppSettings, readOnly: Bool = false, jumpLine: Int? = nil,
          onClose: @escaping () -> Void) {
@@ -91,13 +94,12 @@ struct FileEditorView: View {
         self.onClose = onClose
         // No I/O here: SwiftUI re-runs this init on every parent render (the store's
         // session churn), and only the first init per `.id(url)` identity keeps its
-        // state — a sync read would hit the disk over and over just to be discarded.
-        // The actual load happens once, in `.task`.
+        // state — filesystem work would hit the disk over and over just to be discarded.
+        // The actual load (and the git-root walk) happens once, in `.task`.
         // A jump-to-line open (content-search hit, cmd-click) targets the *source*, so it
         // must land in Edit — Preview has no lines to jump to and would swallow the scroll.
         _mode = State(initialValue: Self.isMarkdown(url) && jumpLine == nil ? .preview : .edit)
         self.language = Self.highlightLanguage(for: url)
-        self.relativePath = Self.repoRelativePath(for: url)
     }
 
     /// Markdown files get the Edit/Preview toggle; sniffed from the extension only (matching
@@ -106,14 +108,6 @@ struct FileEditorView: View {
         ["md", "markdown", "mdx"].contains(url.pathExtension.lowercased())
     }
     private var isMarkdown: Bool { Self.isMarkdown(url) }
-
-    /// The file's path relative to its git root (the form the diff header shows, e.g.
-    /// `core 2/lib/fs.ts`). `nil` when the file isn't inside a git work tree.
-    private static func repoRelativePath(for url: URL) -> String? {
-        let file = url.standardizedFileURL
-        guard let root = GitRoot.find(for: file) else { return nil }
-        return String(file.path.dropFirst(root.path.count + 1))
-    }
 
     private var isDirty: Bool { text != savedText }
 
@@ -176,6 +170,12 @@ struct FileEditorView: View {
         // peek never writes, so neither the debounce nor the exit flush is armed.
         .onChange(of: text) {
             if !readOnly { scheduleSave() }
+        }
+        // A fresh jump target while a Markdown file sits in Preview (clicking another
+        // content-search hit): the jump needs the source editor's lines, so flip to Edit
+        // first — Preview has no text view to scroll and would swallow it.
+        .onChange(of: jumpLine) {
+            if jumpLine != nil, mode == .preview { mode = .edit }
         }
         .onExitCommand { close() }
         // A safety flush if the overlay goes away without the close button (file switch, app quit).
@@ -415,10 +415,18 @@ struct FileEditorView: View {
     /// also flip `highlightDisabled` so the editor renders them as plain text.
     private func load() async {
         let url = url
-        let result: (text: String?, bytes: Int) = await Task.detached(priority: .userInitiated) {
-            guard let data = try? Data(contentsOf: url) else { return (nil, 0) }
-            return (String(data: data, encoding: .utf8), data.count)
-        }.value
+        let result: (text: String?, bytes: Int, relativePath: String?) =
+            await Task.detached(priority: .userInitiated) {
+                // The repo-relative header path rides the same background hop as the read:
+                // GitRoot walks ancestors with filesystem checks, which stalls on network mounts.
+                let file = url.standardizedFileURL
+                let relative = GitRoot.find(for: file).map {
+                    String(file.path.dropFirst($0.path.count + 1))
+                }
+                guard let data = try? Data(contentsOf: url) else { return (nil, 0, relative) }
+                return (String(data: data, encoding: .utf8), data.count, relative)
+            }.value
+        relativePath = result.relativePath
         guard let contents = result.text else {
             loadFailed = true
             return
@@ -445,7 +453,8 @@ struct FileEditorView: View {
     /// Maps a file to a highlight.js language id, matched against grammars the bundled highlight.js
     /// actually ships (e.g. it has no `toml`/`jsonc` — those fold into `ini`/`json`). The whole file
     /// name is checked first (so `Dockerfile`, `Cargo.lock`, `yarn.lock`, … resolve by name, not
-    /// extension), then the extension. Unknown files return `nil` to let highlight.js auto-detect.
+    /// extension), then the extension. Unknown files return `nil` and render as plain text — the
+    /// storage treats a missing language as "don't highlight", not as an auto-detect request.
     /// Shared with `GitDiffView`, which colors diff lines through the same grammar set.
     static func highlightLanguage(for url: URL) -> String? {
         // Extension-less or specially-named files, keyed by the whole (lowercased) name.

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -197,6 +197,9 @@ struct HighlightedTextView: NSViewRepresentable {
             textView.setSelectedRange(
                 NSRange(location: location, length: min(selection.length, length - location))
             )
+            // A programmatic replace bypasses textDidChange, so the gutter's line anchor
+            // must be reset here.
+            coordinator.ruler?.invalidateLineAnchor()
         }
         apply(to: textView)
         scrollView.backgroundColor = backgroundColor
@@ -334,6 +337,7 @@ struct HighlightedTextView: NSViewRepresentable {
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
             text.wrappedValue = textView.string
+            ruler?.invalidateLineAnchor()
             ruler?.needsDisplay = true
             if !appliedFindQuery.isEmpty {
                 find.recompute(query: appliedFindQuery, options: appliedFindOptions, in: textView)
@@ -341,6 +345,7 @@ struct HighlightedTextView: NSViewRepresentable {
                 // typing in the document, not navigating, so don't steal the scroll or re-pulse
                 // the find indicator.
                 find.paint(focused: min(appliedFocusedIndex, find.matches.count - 1), reveal: false, in: textView)
+                (textView as? SavingTextView)?.reassertBracketMatch()
                 notifyMatchCount()
             }
         }
@@ -366,6 +371,7 @@ struct HighlightedTextView: NSViewRepresentable {
             // moved, so we don't churn the temporary attributes or re-fire the find pulse.
             guard queryChanged || focusedIndex != appliedFocusedIndex else { return }
             find.paint(focused: focusedIndex, reveal: true, in: textView)
+            (textView as? SavingTextView)?.reassertBracketMatch()
             appliedFocusedIndex = focusedIndex
         }
 
@@ -393,7 +399,12 @@ private final class SavingTextView: NSTextView {
     var addToChat: ((String?) -> Void)?
     var canAddToChat: (() -> Bool)?
     /// Full-width wash under the caret's line; `.clear` (or a read-only buffer) draws nothing.
-    var currentLineColor: NSColor = .clear { didSet { needsDisplay = true } }
+    /// Reassigned from every representable update, so only a genuine change may invalidate —
+    /// an unconditional `didSet` forced a full-view repaint per keystroke, defeating the
+    /// caret-line optimization in `caretDidMove`.
+    var currentLineColor: NSColor = .clear {
+        didSet { if currentLineColor != oldValue { needsDisplay = true } }
+    }
     /// Background wash on a bracket pair when the caret sits against one of them.
     var bracketHighlightColor: NSColor = .clear
 
@@ -550,6 +561,13 @@ private final class SavingTextView: NSTextView {
         guard lineRect.intersects(rect) else { return }
         currentLineColor.setFill()
         lineRect.fill()
+    }
+
+    /// The find bar's repaint clears the temporary background color over the whole document,
+    /// taking the bracket wash with it while `bracketRanges` still claims it's applied — re-derive
+    /// the wash after any find repaint so the pair doesn't silently vanish until the caret moves.
+    func reassertBracketMatch() {
+        updateBracketMatch()
     }
 
     /// Selection moved: the line band follows the caret, and the bracket wash re-derives.

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -544,6 +544,14 @@ private final class SavingTextView: NSTextView {
 
     // MARK: Insertion indicator
 
+    /// The caret's bar width, matching the system indicator's own preference.
+    private static let caretWidth: CGFloat = 2
+
+    /// Whether this view currently holds first-responder status. Tracked here because inside
+    /// `resignFirstResponder` the window still reports the *old* responder — asking the window
+    /// would keep the caret alive through the handoff.
+    private var isCaretFocused = false
+
     /// The legacy caret stays undrawn — `insertionIndicator` is the caret.
     override func drawInsertionPoint(in rect: NSRect, color: NSColor, turnedOn flag: Bool) {}
 
@@ -553,13 +561,19 @@ private final class SavingTextView: NSTextView {
 
     override func becomeFirstResponder() -> Bool {
         let accepted = super.becomeFirstResponder()
-        if accepted { updateInsertionIndicator(animated: false) }
+        if accepted {
+            isCaretFocused = true
+            updateInsertionIndicator(animated: false)
+        }
         return accepted
     }
 
     override func resignFirstResponder() -> Bool {
         let accepted = super.resignFirstResponder()
-        if accepted { insertionIndicator.displayMode = .hidden }
+        if accepted {
+            isCaretFocused = false
+            updateInsertionIndicator(animated: false)
+        }
         return accepted
     }
 
@@ -569,12 +583,39 @@ private final class SavingTextView: NSTextView {
         updateInsertionIndicator(animated: false)
     }
 
+    /// The caret follows the platform convention of showing only in the key window: re-evaluate
+    /// on every key-status change of whichever window the view lands in.
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        for observer in windowKeyObservers { NotificationCenter.default.removeObserver(observer) }
+        windowKeyObservers = []
+        guard let window else { return }
+        for name in [NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification] {
+            windowKeyObservers.append(NotificationCenter.default.addObserver(
+                forName: name, object: window, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.updateInsertionIndicator(animated: false) }
+            })
+        }
+    }
+
+    private var windowKeyObservers: [NSObjectProtocol] = []
+
+    deinit {
+        for observer in windowKeyObservers { NotificationCenter.default.removeObserver(observer) }
+    }
+
+    /// The one decision point for the caret: every input that can change its visibility or rect
+    /// (selection, focus, editability, resize, window key status) funnels through here.
     private func updateInsertionIndicator(animated: Bool) {
-        guard isEditable, selectedRange().length == 0, let window,
-              window.firstResponder === self else {
+        guard isEditable, isCaretFocused, selectedRange().length == 0,
+              let window, window.isKeyWindow else {
             insertionIndicator.displayMode = .hidden
             return
         }
+        // `firstRect` (the input-method geometry query) over hand-rolled layout math: it already
+        // answers for wrapped lines, marked text, and the trailing newline — the round-trip
+        // through screen coordinates is the price of not duplicating those cases here.
         let caret = NSRange(location: selectedRange().location, length: 0)
         var rect = convert(
             window.convertFromScreen(firstRect(forCharacterRange: caret, actualRange: nil)),
@@ -582,14 +623,17 @@ private final class SavingTextView: NSTextView {
         )
         if rect.height <= 0 {
             // An empty document has no glyphs for `firstRect` to measure; stand the caret at the
-            // text origin at the fixed line height.
-            let height = defaultParagraphStyle?.minimumLineHeight
-                ?? layoutManager?.defaultLineHeight(for: font ?? .systemFont(ofSize: 12)) ?? 14
-            let padding = textContainer?.lineFragmentPadding ?? 5
+            // text origin at the line height every real line will use.
+            let height = fixedLineHeight
+            guard height > 0 else {
+                insertionIndicator.displayMode = .hidden
+                return
+            }
+            let padding = textContainer?.lineFragmentPadding ?? 0
             rect = NSRect(x: textContainerOrigin.x + padding, y: textContainerOrigin.y,
                           width: 0, height: height)
         }
-        rect.size.width = 2
+        rect.size.width = Self.caretWidth
         // Glide only between two on-screen positions; appearing (or a passive relayout) snaps,
         // so the caret never animates in from a stale corner.
         if animated, insertionIndicator.displayMode != .hidden {
@@ -603,6 +647,15 @@ private final class SavingTextView: NSTextView {
             insertionIndicator.frame = rect
         }
         insertionIndicator.displayMode = .automatic
+    }
+
+    /// The fixed line height the paragraph style enforces, falling back to the font's natural
+    /// height — shared by the empty-document caret and the empty-document current-line band so
+    /// the two can never disagree.
+    private var fixedLineHeight: CGFloat {
+        if let height = defaultParagraphStyle?.minimumLineHeight, height > 0 { return height }
+        guard let layoutManager else { return 0 }
+        return layoutManager.defaultLineHeight(for: font ?? .systemFont(ofSize: 12))
     }
 
     // MARK: Current line
@@ -624,14 +677,7 @@ private final class SavingTextView: NSTextView {
             // fragment separately.
             lineRect = layoutManager.extraLineFragmentRect
             if lineRect.isEmpty {
-                // Match the fixed line height the paragraph style enforces, not the font's
-                // natural height — otherwise the empty-document band draws shorter than every
-                // real line's.
-                let fixedHeight = defaultParagraphStyle?.minimumLineHeight ?? 0
-                let height = fixedHeight > 0
-                    ? fixedHeight
-                    : layoutManager.defaultLineHeight(for: font ?? .systemFont(ofSize: 12))
-                lineRect = NSRect(x: 0, y: 0, width: 0, height: height)
+                lineRect = NSRect(x: 0, y: 0, width: 0, height: fixedLineHeight)
             }
         } else {
             let caret = min(selection.location, text.length - 1)

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -264,6 +264,7 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.typingAttributes[.baselineOffset] = Self.baselineOffset(lineSpacing: lineSpacing)
         if let saving = textView as? SavingTextView {
             saving.currentLineColor = currentLineColor
+            saving.caretIndicatorColor = caretColor
             // The matched pair glows in the caret's own accent, dimmed to a wash.
             saving.bracketHighlightColor = caretColor.withAlphaComponent(0.28)
         }
@@ -408,6 +409,26 @@ private final class SavingTextView: NSTextView {
     /// Background wash on a bracket pair when the caret sits against one of them.
     var bracketHighlightColor: NSColor = .clear
 
+    /// The system insertion indicator (macOS 14's `NSTextInsertionIndicator`) in place of the
+    /// legacy hard-blink caret — the same soft fade-and-glide caret Xcode shows. TextKit 2 text
+    /// views adopt it automatically; this TextKit 1 view hosts it as a subview instead: the
+    /// legacy caret draw is suppressed in `drawInsertionPoint`, and the indicator is repositioned
+    /// (with a short glide) on every caret move.
+    private let insertionIndicator = NSTextInsertionIndicator()
+    /// Tint for the indicator; the view's own `insertionPointColor` no longer draws anything.
+    var caretIndicatorColor: NSColor = .textColor {
+        didSet { insertionIndicator.color = caretIndicatorColor }
+    }
+
+    override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
+        super.init(frame: frameRect, textContainer: container)
+        insertionIndicator.displayMode = .hidden
+        addSubview(insertionIndicator)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
+
     /// The bracket pair currently washed, so the previous pair can be cleanly un-washed.
     private var bracketRanges: [NSRange] = []
     /// Start offset of the line last painted with the current-line band (-1 = none), so caret
@@ -521,6 +542,69 @@ private final class SavingTextView: NSTextView {
         NotificationCenter.default.post(name: .termioCloseContentOverlay, object: nil)
     }
 
+    // MARK: Insertion indicator
+
+    /// The legacy caret stays undrawn — `insertionIndicator` is the caret.
+    override func drawInsertionPoint(in rect: NSRect, color: NSColor, turnedOn flag: Bool) {}
+
+    override var isEditable: Bool {
+        didSet { updateInsertionIndicator(animated: false) }
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let accepted = super.becomeFirstResponder()
+        if accepted { updateInsertionIndicator(animated: false) }
+        return accepted
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let accepted = super.resignFirstResponder()
+        if accepted { insertionIndicator.displayMode = .hidden }
+        return accepted
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        // A resize re-wraps the text, moving the caret's rect without any selection change.
+        updateInsertionIndicator(animated: false)
+    }
+
+    private func updateInsertionIndicator(animated: Bool) {
+        guard isEditable, selectedRange().length == 0, let window,
+              window.firstResponder === self else {
+            insertionIndicator.displayMode = .hidden
+            return
+        }
+        let caret = NSRange(location: selectedRange().location, length: 0)
+        var rect = convert(
+            window.convertFromScreen(firstRect(forCharacterRange: caret, actualRange: nil)),
+            from: nil
+        )
+        if rect.height <= 0 {
+            // An empty document has no glyphs for `firstRect` to measure; stand the caret at the
+            // text origin at the fixed line height.
+            let height = defaultParagraphStyle?.minimumLineHeight
+                ?? layoutManager?.defaultLineHeight(for: font ?? .systemFont(ofSize: 12)) ?? 14
+            let padding = textContainer?.lineFragmentPadding ?? 5
+            rect = NSRect(x: textContainerOrigin.x + padding, y: textContainerOrigin.y,
+                          width: 0, height: height)
+        }
+        rect.size.width = 2
+        // Glide only between two on-screen positions; appearing (or a passive relayout) snaps,
+        // so the caret never animates in from a stale corner.
+        if animated, insertionIndicator.displayMode != .hidden {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.07
+                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                context.allowsImplicitAnimation = true
+                insertionIndicator.frame = rect
+            }
+        } else {
+            insertionIndicator.frame = rect
+        }
+        insertionIndicator.displayMode = .automatic
+    }
+
     // MARK: Current line
 
     /// Xcode-style band under the logical line holding the caret (all of its wrapped rows),
@@ -591,6 +675,7 @@ private final class SavingTextView: NSTextView {
             needsDisplay = true
         }
         updateBracketMatch()
+        updateInsertionIndicator(animated: true)
     }
 
     // MARK: Bracket matching

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -556,14 +556,14 @@ private final class SavingTextView: NSTextView {
     override func drawInsertionPoint(in rect: NSRect, color: NSColor, turnedOn flag: Bool) {}
 
     override var isEditable: Bool {
-        didSet { updateInsertionIndicator(animated: false) }
+        didSet { updateInsertionIndicator() }
     }
 
     override func becomeFirstResponder() -> Bool {
         let accepted = super.becomeFirstResponder()
         if accepted {
             isCaretFocused = true
-            updateInsertionIndicator(animated: false)
+            updateInsertionIndicator()
         }
         return accepted
     }
@@ -572,7 +572,7 @@ private final class SavingTextView: NSTextView {
         let accepted = super.resignFirstResponder()
         if accepted {
             isCaretFocused = false
-            updateInsertionIndicator(animated: false)
+            updateInsertionIndicator()
         }
         return accepted
     }
@@ -580,7 +580,7 @@ private final class SavingTextView: NSTextView {
     override func setFrameSize(_ newSize: NSSize) {
         super.setFrameSize(newSize)
         // A resize re-wraps the text, moving the caret's rect without any selection change.
-        updateInsertionIndicator(animated: false)
+        updateInsertionIndicator()
     }
 
     /// The caret follows the platform convention of showing only in the key window: re-evaluate
@@ -594,7 +594,7 @@ private final class SavingTextView: NSTextView {
             windowKeyObservers.append(NotificationCenter.default.addObserver(
                 forName: name, object: window, queue: .main
             ) { [weak self] _ in
-                MainActor.assumeIsolated { self?.updateInsertionIndicator(animated: false) }
+                MainActor.assumeIsolated { self?.updateInsertionIndicator() }
             })
         }
     }
@@ -607,7 +607,7 @@ private final class SavingTextView: NSTextView {
 
     /// The one decision point for the caret: every input that can change its visibility or rect
     /// (selection, focus, editability, resize, window key status) funnels through here.
-    private func updateInsertionIndicator(animated: Bool) {
+    private func updateInsertionIndicator() {
         guard isEditable, isCaretFocused, selectedRange().length == 0,
               let window, window.isKeyWindow else {
             insertionIndicator.displayMode = .hidden
@@ -634,18 +634,9 @@ private final class SavingTextView: NSTextView {
                           width: 0, height: height)
         }
         rect.size.width = Self.caretWidth
-        // Glide only between two on-screen positions; appearing (or a passive relayout) snaps,
-        // so the caret never animates in from a stale corner.
-        if animated, insertionIndicator.displayMode != .hidden {
-            NSAnimationContext.runAnimationGroup { context in
-                context.duration = 0.07
-                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-                context.allowsImplicitAnimation = true
-                insertionIndicator.frame = rect
-            }
-        } else {
-            insertionIndicator.frame = rect
-        }
+        // Always snap to the new position — a glide between caret positions read as lag on every
+        // click (user report). The smoothness this indicator buys is the soft blink, not movement.
+        insertionIndicator.frame = rect
         insertionIndicator.displayMode = .automatic
     }
 
@@ -721,7 +712,7 @@ private final class SavingTextView: NSTextView {
             needsDisplay = true
         }
         updateBracketMatch()
-        updateInsertionIndicator(animated: true)
+        updateInsertionIndicator()
     }
 
     // MARK: Bracket matching

--- a/Sources/termio/Editor/Highlightr/CodeAttributedString.swift
+++ b/Sources/termio/Editor/Highlightr/CodeAttributedString.swift
@@ -208,11 +208,11 @@ open class CodeAttributedString : NSTextStorage
     
     func setupListeners()
     {
-        highlightr.themeChanged =
-            { [weak self] _ in
-                    guard let self = self else { return }
-                    self.highlight(NSMakeRange(0, self.stringStorage.length))
-        }
+        // termio deviation: upstream re-highlighted the whole document from `themeChanged` here.
+        // The editor re-themes, re-fonts, and re-metrics as one package and then triggers a single
+        // explicit re-highlight (`HighlightedTextView.updateNSView`) — the automatic pass ran the
+        // same whole-document work a second time and could apply results computed with stale font
+        // metrics, since it fired before the new metrics were assigned.
     }
     
     

--- a/Sources/termio/Editor/LineNumberRulerView.swift
+++ b/Sources/termio/Editor/LineNumberRulerView.swift
@@ -30,7 +30,12 @@ final class LineNumberRulerView: NSRulerView {
 
     func restyle(editorFont: NSFont, numberColor: NSColor, gutterColor: NSColor,
                  baselineShift: CGFloat) {
-        numberFont = Self.gutterFont(for: editorFont)
+        // Called from every representable update — bail when nothing changed, so the routine
+        // per-render pass doesn't force a full gutter repaint alongside every keystroke.
+        let font = Self.gutterFont(for: editorFont)
+        if font == numberFont, numberColor == self.numberColor,
+           gutterColor == self.gutterColor, baselineShift == self.baselineShift { return }
+        numberFont = font
         self.numberColor = numberColor
         self.gutterColor = gutterColor
         self.baselineShift = baselineShift
@@ -80,13 +85,9 @@ final class LineNumberRulerView: NSRulerView {
         let visibleGlyphRange = layoutManager.glyphRange(forBoundingRect: textView.visibleRect, in: container)
         let visibleCharRange = layoutManager.characterRange(forGlyphRange: visibleGlyphRange, actualGlyphRange: nil)
 
-        // Line number of the first visible character: 1 + the newlines before it.
-        var lineNumber = 1
-        var index = 0
-        while index < visibleCharRange.location {
-            if content.character(at: index) == 10 { lineNumber += 1 }
-            index += 1
-        }
+        // Line number of the first visible character, counted from the scroll anchor — O(delta)
+        // per draw. Counting from character zero made every scroll tick O(document prefix).
+        var lineNumber = line(forCharacter: visibleCharRange.location, in: content)
 
         // One number per logical line (paragraph), at its first line fragment.
         content.enumerateSubstrings(
@@ -108,5 +109,37 @@ final class LineNumberRulerView: NSRulerView {
            layoutManager.extraLineFragmentTextContainer != nil {
             drawNumber(lineNumber, layoutManager.extraLineFragmentRect.minY)
         }
+    }
+
+    // MARK: Line numbering anchor
+
+    /// The line number at a known character offset, advanced as the view scrolls so each draw
+    /// counts newlines only over the scroll delta. Reset whenever the text changes — an edit
+    /// above the anchor shifts every line number below it.
+    private var lineAnchor: (character: Int, line: Int) = (0, 1)
+
+    /// The text changed: restart the anchor from the top. The next draw pays one prefix scan;
+    /// scrolling stays O(delta).
+    func invalidateLineAnchor() {
+        lineAnchor = (0, 1)
+    }
+
+    /// 1-based line number of the character at `index`, counted from the nearest anchor, which
+    /// then moves to `index` for the next draw.
+    private func line(forCharacter index: Int, in content: NSString) -> Int {
+        var (anchorCharacter, anchorLine) = lineAnchor
+        if anchorCharacter > content.length { (anchorCharacter, anchorLine) = (0, 1) }
+        var line = anchorLine
+        if index >= anchorCharacter {
+            for position in anchorCharacter..<index where content.character(at: position) == 10 {
+                line += 1
+            }
+        } else {
+            for position in index..<anchorCharacter where content.character(at: position) == 10 {
+                line -= 1
+            }
+        }
+        lineAnchor = (index, line)
+        return line
     }
 }


### PR DESCRIPTION
The smoothness batch from an independent review of the editor stack (six of its fifteen findings; the highlight-pipeline rework items are deferred to a separate branch), plus the Xcode-style caret.

Per-keystroke and per-scroll cost:

- `currentLineColor`'s unconditional `didSet` and the gutter's unconditional `restyle` both ran on every representable update, forcing a full text-view and gutter repaint per keystroke. Both are now no-ops when nothing changed.
- Gutter line numbering counted newlines from character zero on every scroll tick — O(document prefix) per frame, which is most of the file when scrolled deep. It now counts from a scroll anchor (O(scroll delta)); any edit resets the anchor.
- A theme switch ran the whole-document re-highlight twice (the vendored `themeChanged` callback plus the editor's explicit pass), and the automatic pass could apply results computed with stale font metrics. The vendored callback is removed; the editor's single explicit pass remains.

Correctness:

- Find's repaint clears the temporary background color over the whole document, silently erasing the bracket-pair wash until the caret moved. The wash is now re-derived after every find repaint.
- Clicking a new content-search hit while a Markdown file sat in Preview swallowed the jump — Preview has no text view to scroll. A new jump target now flips the file to Edit first.
- `FileEditorView.init` walked the filesystem for the git root on every parent render despite its "No I/O here" comment; the repo-relative header path now resolves on the same background hop as the file read.

Caret:

- The TextKit 1 editor drew AppKit's legacy caret — hard on/off blink, teleporting moves. It now hosts macOS 14's `NSTextInsertionIndicator` (the same soft fade-and-glide caret Xcode shows, which TextKit 2 views adopt automatically) as a subview, repositioned with a short glide on every caret move.

`swift build` and `swift test` (124 tests) pass.

Release Notes:
- The editor caret now fades and glides like Xcode's instead of hard-blinking.
- Reduced editor typing and scrolling overhead, especially in large files.
- Fixed the bracket-pair highlight disappearing while the find bar is open.
- Fixed jump-to-line landing nowhere when a Markdown file was open in Preview.