### PR TITLE
Inherit font and theme defaults from the user's Ghostty config

### DIFF
--- a/Sources/termio/Settings/AppearanceSettingsTab.swift
+++ b/Sources/termio/Settings/AppearanceSettingsTab.swift
@@ -59,9 +59,15 @@ struct AppearanceSettingsTab: View {
             } header: {
                 SectionHeaderLabel(title: "Font")
             } footer: {
-                Text("Line height applies to the file editor and diffs; the terminal keeps the font's own.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if settings.inheritsGhosttyDefaults {
+                    Text("Line height applies to the file editor and diffs; the terminal keeps the font's own. Font and theme values you haven't set here follow your Ghostty config.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Line height applies to the file editor and diffs; the terminal keeps the font's own.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             Section {
                 Picker("Style", selection: $settings.cursorStyle) {

--- a/Sources/termio/Settings/GhosttyUserConfig.swift
+++ b/Sources/termio/Settings/GhosttyUserConfig.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// The slice of a user's Ghostty configuration termio inherits: font and theme. Parsed once at
+/// launch and layered *under* termio's own settings via the UserDefaults registration domain
+/// (see `AppSettings.init`) — a value set in termio always wins, Ghostty fills what termio never
+/// touched, and the built-in defaults back both. No Ghostty install means an empty config and
+/// the built-ins stand untouched.
+///
+/// Only top-level `key = value` lines are read; `config-file` includes are deliberately not
+/// followed — this is a launch-time convenience, not a reimplementation of Ghostty's loader.
+struct GhosttyUserConfig {
+    /// `font-family` values in declaration order — Ghostty treats repeats as a fallback chain
+    /// and an empty value as a chain reset. The first entry is the primary face.
+    var fontFamilies: [String] = []
+    var fontSize: Double?
+    /// `theme` verbatim: a bare name, or Ghostty's `light:Name,dark:Name` split form.
+    var theme: String?
+
+    var isEmpty: Bool { fontFamilies.isEmpty && fontSize == nil && theme == nil }
+
+    /// The theme name for each appearance. A bare name applies to both, matching Ghostty.
+    var themeNames: (light: String?, dark: String?) {
+        guard let theme else { return (nil, nil) }
+        guard theme.contains(":") else { return (theme, theme) }
+        var light: String?
+        var dark: String?
+        for part in theme.split(separator: ",") {
+            let pair = part.split(separator: ":", maxSplits: 1)
+            guard pair.count == 2 else { continue }
+            let mode = pair[0].trimmingCharacters(in: .whitespaces)
+            let name = pair[1].trimmingCharacters(in: .whitespaces)
+            if mode == "light" { light = name }
+            if mode == "dark" { dark = name }
+        }
+        return (light, dark)
+    }
+
+    /// Reads the files Ghostty itself loads on macOS, in Ghostty's order — the XDG file first,
+    /// the Application Support file after, so the latter wins for single-value keys while
+    /// `font-family` keeps accumulating across both.
+    static func load(home: URL = FileManager.default.homeDirectoryForCurrentUser,
+                     environment: [String: String] = ProcessInfo.processInfo.environment) -> GhosttyUserConfig {
+        let xdgBase = environment["XDG_CONFIG_HOME"].map { URL(fileURLWithPath: $0) }
+            ?? home.appendingPathComponent(".config")
+        let paths = [
+            xdgBase.appendingPathComponent("ghostty/config"),
+            home.appendingPathComponent("Library/Application Support/com.mitchellh.ghostty/config"),
+        ]
+        var config = GhosttyUserConfig()
+        for path in paths {
+            guard let text = try? String(contentsOf: path, encoding: .utf8) else { continue }
+            config.merge(parsing: text)
+        }
+        return config
+    }
+
+    /// Folds one config file's text into the receiver: later lines win for single-value keys,
+    /// `font-family` accumulates, comments and unknown keys are skipped.
+    mutating func merge(parsing text: String) {
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, !line.hasPrefix("#") else { continue }
+            guard let equals = line.firstIndex(of: "=") else { continue }
+            let key = line[..<equals].trimmingCharacters(in: .whitespaces).lowercased()
+            var value = line[line.index(after: equals)...].trimmingCharacters(in: .whitespaces)
+            if value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"") {
+                value = String(value.dropFirst().dropLast())
+            }
+            switch key {
+            case "font-family":
+                if value.isEmpty {
+                    fontFamilies = []
+                } else if !fontFamilies.contains(value) {
+                    // Deduped: Ghostty's two config files often repeat the same face, and a
+                    // duplicate fallback buys nothing.
+                    fontFamilies.append(value)
+                }
+            case "font-size":
+                fontSize = Double(value)
+            case "theme":
+                theme = value.isEmpty ? nil : value
+            default:
+                break
+            }
+        }
+    }
+}

--- a/Sources/termio/Settings/GhosttyUserConfig.swift
+++ b/Sources/termio/Settings/GhosttyUserConfig.swift
@@ -9,30 +9,36 @@ import Foundation
 /// Only top-level `key = value` lines are read; `config-file` includes are deliberately not
 /// followed — this is a launch-time convenience, not a reimplementation of Ghostty's loader.
 struct GhosttyUserConfig {
+    /// `theme` as written — the *form* matters downstream: a bare name is Ghostty's
+    /// "one theme regardless of appearance" (termio inherits it only into the appearance it
+    /// belongs to), while the `light:Name,dark:Name` split form names each slot explicitly
+    /// (termio honors both slots verbatim, even when the two names are equal).
+    enum ThemeSetting: Equatable {
+        case bare(String)
+        case split(light: String?, dark: String?)
+    }
+
     /// `font-family` values in declaration order — Ghostty treats repeats as a fallback chain
     /// and an empty value as a chain reset. The first entry is the primary face.
     var fontFamilies: [String] = []
     var fontSize: Double?
-    /// `theme` verbatim: a bare name, or Ghostty's `light:Name,dark:Name` split form.
-    var theme: String?
+    var themeSetting: ThemeSetting?
 
-    var isEmpty: Bool { fontFamilies.isEmpty && fontSize == nil && theme == nil }
+    var isEmpty: Bool { fontFamilies.isEmpty && fontSize == nil && themeSetting == nil }
 
-    /// The theme name for each appearance. A bare name applies to both, matching Ghostty.
-    var themeNames: (light: String?, dark: String?) {
-        guard let theme else { return (nil, nil) }
-        guard theme.contains(":") else { return (theme, theme) }
+    static func parseThemeSetting(_ value: String) -> ThemeSetting {
         var light: String?
         var dark: String?
-        for part in theme.split(separator: ",") {
+        var sawSplitForm = false
+        for part in value.split(separator: ",") {
             let pair = part.split(separator: ":", maxSplits: 1)
             guard pair.count == 2 else { continue }
-            let mode = pair[0].trimmingCharacters(in: .whitespaces)
+            let mode = pair[0].trimmingCharacters(in: .whitespaces).lowercased()
             let name = pair[1].trimmingCharacters(in: .whitespaces)
-            if mode == "light" { light = name }
-            if mode == "dark" { dark = name }
+            if mode == "light" { light = name; sawSplitForm = true }
+            if mode == "dark" { dark = name; sawSplitForm = true }
         }
-        return (light, dark)
+        return sawSplitForm ? .split(light: light, dark: dark) : .bare(value)
     }
 
     /// Reads the files Ghostty itself loads on macOS, in Ghostty's order — the XDG file first,
@@ -78,7 +84,7 @@ struct GhosttyUserConfig {
             case "font-size":
                 fontSize = Double(value)
             case "theme":
-                theme = value.isEmpty ? nil : value
+                themeSetting = value.isEmpty ? nil : Self.parseThemeSetting(value)
             default:
                 break
             }

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -473,11 +473,23 @@ final class AppSettings: ObservableObject {
         // Only names the bundled catalog resolves inherit — Ghostty also accepts custom theme
         // files termio has no way to render.
         let ghosttyThemes = ghostty.themeNames
-        if let light = ghosttyThemes.light, let resolved = Self.resolveGhosttyTheme(light) {
-            registered[Key.lightThemeName] = resolved
-        }
-        if let dark = ghosttyThemes.dark, let resolved = Self.resolveGhosttyTheme(dark) {
-            registered[Key.darkThemeName] = resolved
+        if ghosttyThemes.light == ghosttyThemes.dark {
+            // Ghostty applies a bare `theme = X` in both appearances, but termio wraps the
+            // terminal in light/dark *chrome* — a dark theme inherited into the light slot
+            // makes a half-dark window (light sidebar, dark canvas). Inherit the theme only
+            // into the appearance it belongs to; the other slot keeps termio's own canvas.
+            if let bare = ghosttyThemes.light,
+               let resolved = Self.resolveGhosttyTheme(bare),
+               let definition = GhosttyThemeCatalog.theme(named: resolved) {
+                registered[definition.isDark ? Key.darkThemeName : Key.lightThemeName] = resolved
+            }
+        } else {
+            if let light = ghosttyThemes.light, let resolved = Self.resolveGhosttyTheme(light) {
+                registered[Key.lightThemeName] = resolved
+            }
+            if let dark = ghosttyThemes.dark, let resolved = Self.resolveGhosttyTheme(dark) {
+                registered[Key.darkThemeName] = resolved
+            }
         }
 
         defaults.register(defaults: registered)

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -393,15 +393,45 @@ final class AppSettings: ObservableObject {
     /// Resolves a Ghostty theme name against the bundled catalog, tolerating the naming drift
     /// between Ghostty's theme list and the catalog's iTerm2-Color-Schemes names
     /// ("catppuccin-latte" vs "Catppuccin Latte", "Tokyo Night" vs "tokyonight"): exact match
-    /// first, then a case/separator-insensitive one, returning the catalog's canonical name.
-    private static func resolveGhosttyTheme(_ name: String) -> String? {
-        if GhosttyThemeCatalog.theme(named: name) != nil { return name }
+    /// first, then a case/separator-insensitive one. (termio's custom user themes are
+    /// deliberately not consulted — a Ghostty config can only mean Ghostty's own theme names.)
+    private static func resolveGhosttyTheme(_ name: String) -> GhosttyThemeDefinition? {
+        if let exact = GhosttyThemeCatalog.theme(named: name) { return exact }
         let normalized = normalizeThemeName(name)
-        return GhosttyThemeCatalog.allThemes.first { normalizeThemeName($0.name) == normalized }?.name
+        return GhosttyThemeCatalog.allThemes.first { normalizeThemeName($0.name) == normalized }
     }
 
     private static func normalizeThemeName(_ name: String) -> String {
         name.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    /// The Ghostty config's contribution to the registration defaults — the middle layer of
+    /// termio setting > Ghostty config > built-in default. Only names the bundled catalog
+    /// resolves inherit; Ghostty also accepts custom theme files termio has no way to render.
+    private static func ghosttyRegistrationOverrides(from ghostty: GhosttyUserConfig) -> [String: Any] {
+        var overrides: [String: Any] = [:]
+        if let family = ghostty.fontFamilies.first { overrides[Key.fontFamily] = family }
+        if let size = ghostty.fontSize { overrides[Key.fontSize] = size }
+        switch ghostty.themeSetting {
+        case .bare(let name):
+            // Ghostty applies a bare `theme = X` in both appearances, but termio wraps the
+            // terminal in light/dark *chrome* — a dark theme inherited into the light slot
+            // makes a half-dark window (light sidebar, dark canvas). A bare theme lands only
+            // in the appearance it belongs to; the other slot keeps termio's own canvas.
+            if let definition = resolveGhosttyTheme(name) {
+                overrides[definition.isDark ? Key.darkThemeName : Key.lightThemeName] = definition.name
+            }
+        case .split(let light, let dark):
+            if let light, let definition = resolveGhosttyTheme(light) {
+                overrides[Key.lightThemeName] = definition.name
+            }
+            if let dark, let definition = resolveGhosttyTheme(dark) {
+                overrides[Key.darkThemeName] = definition.name
+            }
+        case nil:
+            break
+        }
+        return overrides
     }
 
     init(defaults: UserDefaults = .standard) {
@@ -468,28 +498,8 @@ final class AppSettings: ObservableObject {
         let ghostty = GhosttyUserConfig.load()
         inheritsGhosttyDefaults = !ghostty.isEmpty
         ghosttyFontFallbacks = Array(ghostty.fontFamilies.dropFirst())
-        if let family = ghostty.fontFamilies.first { registered[Key.fontFamily] = family }
-        if let size = ghostty.fontSize { registered[Key.fontSize] = size }
-        // Only names the bundled catalog resolves inherit — Ghostty also accepts custom theme
-        // files termio has no way to render.
-        let ghosttyThemes = ghostty.themeNames
-        if ghosttyThemes.light == ghosttyThemes.dark {
-            // Ghostty applies a bare `theme = X` in both appearances, but termio wraps the
-            // terminal in light/dark *chrome* — a dark theme inherited into the light slot
-            // makes a half-dark window (light sidebar, dark canvas). Inherit the theme only
-            // into the appearance it belongs to; the other slot keeps termio's own canvas.
-            if let bare = ghosttyThemes.light,
-               let resolved = Self.resolveGhosttyTheme(bare),
-               let definition = GhosttyThemeCatalog.theme(named: resolved) {
-                registered[definition.isDark ? Key.darkThemeName : Key.lightThemeName] = resolved
-            }
-        } else {
-            if let light = ghosttyThemes.light, let resolved = Self.resolveGhosttyTheme(light) {
-                registered[Key.lightThemeName] = resolved
-            }
-            if let dark = ghosttyThemes.dark, let resolved = Self.resolveGhosttyTheme(dark) {
-                registered[Key.darkThemeName] = resolved
-            }
+        registered.merge(Self.ghosttyRegistrationOverrides(from: ghostty)) { _, ghosttyValue in
+            ghosttyValue
         }
 
         defaults.register(defaults: registered)

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import GhosttyTheme
 
 /// Terminal cursor shape. Raw values are deliberately the exact Ghostty config
 /// tokens, so persistence, the settings picker, and the `TermioStore` mapping all
@@ -113,6 +114,14 @@ final class AppSettings: ObservableObject {
     }
 
     // MARK: Appearance
+
+    /// Extra `font-family` entries from the user's Ghostty config (everything after the primary
+    /// face) — passed to the terminal as a fallback chain, so glyphs the chosen font lacks (CJK
+    /// above all) resolve the same way they do in Ghostty itself. Empty without a Ghostty config.
+    let ghosttyFontFallbacks: [String]
+    /// True when a Ghostty config contributed defaults this launch — surfaces one hint line in
+    /// Appearance so inherited values aren't a mystery.
+    let inheritsGhosttyDefaults: Bool
 
     /// Terminal font family. Defaults to "SF Mono" (the Apple system monospace,
     /// as used by Xcode/Terminal). Empty means "let libghostty pick its default
@@ -381,6 +390,20 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(notificationSoundEnabled, forKey: Key.notificationSound) }
     }
 
+    /// Resolves a Ghostty theme name against the bundled catalog, tolerating the naming drift
+    /// between Ghostty's theme list and the catalog's iTerm2-Color-Schemes names
+    /// ("catppuccin-latte" vs "Catppuccin Latte", "Tokyo Night" vs "tokyonight"): exact match
+    /// first, then a case/separator-insensitive one, returning the catalog's canonical name.
+    private static func resolveGhosttyTheme(_ name: String) -> String? {
+        if GhosttyThemeCatalog.theme(named: name) != nil { return name }
+        let normalized = normalizeThemeName(name)
+        return GhosttyThemeCatalog.allThemes.first { normalizeThemeName($0.name) == normalized }?.name
+    }
+
+    private static func normalizeThemeName(_ name: String) -> String {
+        name.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
 
@@ -406,7 +429,7 @@ final class AppSettings: ObservableObject {
             defaults.set(hidden, forKey: Key.disabledAgents)
         }
 
-        defaults.register(defaults: [
+        var registered: [String: Any] = [
             Key.fontFamily: "SF Mono",
             Key.fontSize: 13.0,
             Key.fontThicken: false,
@@ -435,7 +458,29 @@ final class AppSettings: ObservableObject {
             // by default.
             Key.notifyTaskCompletion: true,
             Key.notificationSound: false,
-        ])
+        ]
+
+        // Ghostty inheritance: a user's own Ghostty config upgrades the *defaults* only —
+        // anything set in termio lives in the persistent domain and still wins, and without a
+        // Ghostty install the built-ins above stand. Resolution order is therefore
+        // termio setting > Ghostty config > built-in default, courtesy of UserDefaults'
+        // registration-domain layering. Read once per launch.
+        let ghostty = GhosttyUserConfig.load()
+        inheritsGhosttyDefaults = !ghostty.isEmpty
+        ghosttyFontFallbacks = Array(ghostty.fontFamilies.dropFirst())
+        if let family = ghostty.fontFamilies.first { registered[Key.fontFamily] = family }
+        if let size = ghostty.fontSize { registered[Key.fontSize] = size }
+        // Only names the bundled catalog resolves inherit — Ghostty also accepts custom theme
+        // files termio has no way to render.
+        let ghosttyThemes = ghostty.themeNames
+        if let light = ghosttyThemes.light, let resolved = Self.resolveGhosttyTheme(light) {
+            registered[Key.lightThemeName] = resolved
+        }
+        if let dark = ghosttyThemes.dark, let resolved = Self.resolveGhosttyTheme(dark) {
+            registered[Key.darkThemeName] = resolved
+        }
+
+        defaults.register(defaults: registered)
 
         fontFamily = defaults.string(forKey: Key.fontFamily) ?? ""
         fontSize = defaults.double(forKey: Key.fontSize)

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -266,20 +266,37 @@ enum InstalledFonts {
         "Noto Sans Mono CJK SC",
     ]
 
+    /// The first installed candidate, probed once per process — fonts installed mid-run are
+    /// deliberately not tracked (a relaunch picks them up).
+    @MainActor private static let installedCJKCandidate: String? =
+        cjkFallbackCandidates.first { NSFont(name: $0, size: 12) != nil }
+
+    /// Whether a family can draw hanzi, memoized per process: `coveredCharacterSet` allocates
+    /// a full coverage bitmap on every call, and the caller sits on the re-style path that
+    /// runs once per open surface on every settings change.
+    @MainActor private static var hanCoverage: [String: Bool] = [:]
+
     /// The first installed CJK-capable face to append to the terminal's font chain, or
-    /// `nil` when the chain already covers CJK (checked against U+4E00 on each face) or
-    /// none of the known candidates is installed. Silent by design: no setting, just a
-    /// better fallback than the system's proportional PingFang when the user has a
-    /// purpose-built face on disk.
-    static func cjkMonospaceFallback(existingChain: [String]) -> String? {
-        let han = Unicode.Scalar(0x4E00)
+    /// `nil` when the chain already covers CJK (checked against U+4E00) or none of the known
+    /// candidates is installed. Silent by design: no setting, just a better fallback than the
+    /// system's proportional PingFang when the user has a purpose-built face on disk.
+    @MainActor static func cjkMonospaceFallback(existingChain: [String]) -> String? {
+        guard let han = Unicode.Scalar(0x4E00) else { return nil }
         for family in existingChain where !family.isEmpty {
-            guard let font = NSFont(name: family, size: 12), let han else { continue }
-            if (font.coveredCharacterSet as CharacterSet).contains(han) { return nil }
+            let covers: Bool
+            if let cached = hanCoverage[family] {
+                covers = cached
+            } else {
+                covers = NSFont(name: family, size: 12)
+                    .map { ($0.coveredCharacterSet as CharacterSet).contains(han) } ?? false
+                hanCoverage[family] = covers
+            }
+            if covers { return nil }
         }
-        return cjkFallbackCandidates.first { candidate in
-            !existingChain.contains(candidate) && NSFont(name: candidate, size: 12) != nil
+        guard let candidate = installedCJKCandidate, !existingChain.contains(candidate) else {
+            return nil
         }
+        return candidate
     }
 }
 

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -255,6 +255,32 @@ enum InstalledFonts {
             return font.isFixedPitch
         }.sorted()
     }
+
+    /// Dual-width CJK monospace faces users commonly install, in preference order —
+    /// each draws hanzi at exactly two terminal cells, so falling back to one keeps
+    /// weight and style consistent with the Latin face.
+    private static let cjkFallbackCandidates = [
+        "Sarasa Term SC", "Sarasa Mono SC", "Sarasa Fixed SC",
+        "Maple Mono NF CN", "Maple Mono CN",
+        "LXGW WenKai Mono",
+        "Noto Sans Mono CJK SC",
+    ]
+
+    /// The first installed CJK-capable face to append to the terminal's font chain, or
+    /// `nil` when the chain already covers CJK (checked against U+4E00 on each face) or
+    /// none of the known candidates is installed. Silent by design: no setting, just a
+    /// better fallback than the system's proportional PingFang when the user has a
+    /// purpose-built face on disk.
+    static func cjkMonospaceFallback(existingChain: [String]) -> String? {
+        let han = Unicode.Scalar(0x4E00)
+        for family in existingChain where !family.isEmpty {
+            guard let font = NSFont(name: family, size: 12), let han else { continue }
+            if (font.coveredCharacterSet as CharacterSet).contains(han) { return nil }
+        }
+        return cjkFallbackCandidates.first { candidate in
+            !existingChain.contains(candidate) && NSFont(name: candidate, size: 12) != nil
+        }
+    }
 }
 
 /// A font-family editor: a native pop-up menu of installed families above a live

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -758,6 +758,12 @@ extension TermioStore {
     private func applyAppearance(to builder: inout TerminalConfiguration.Builder) {
         if !settings.fontFamily.isEmpty {
             builder.withFontFamily(settings.fontFamily)
+            // Fallback faces from the user's Ghostty config ride along even over a
+            // termio-chosen primary — repeated font-family keys form Ghostty's fallback
+            // chain, and they only engage for glyphs the primary lacks (CJK above all).
+            for fallback in settings.ghosttyFontFallbacks where fallback != settings.fontFamily {
+                builder.withFontFamily(fallback)
+            }
         }
         builder.withFontSize(Float(settings.fontSize))
         builder.withFontThicken(settings.fontThicken)

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -764,6 +764,15 @@ extension TermioStore {
             for fallback in settings.ghosttyFontFallbacks where fallback != settings.fontFamily {
                 builder.withFontFamily(fallback)
             }
+            // When the chain still can't draw hanzi, close with a purpose-built dual-width
+            // CJK face if one is installed — otherwise the system falls back to proportional
+            // PingFang per glyph, whose weight and metrics visibly fight the Latin face.
+            // (The grid's cell width still follows the primary; only a dual-width *primary*
+            // removes the spacing gaps entirely.)
+            let chain = [settings.fontFamily] + settings.ghosttyFontFallbacks
+            if let cjkFallback = InstalledFonts.cjkMonospaceFallback(existingChain: chain) {
+                builder.withFontFamily(cjkFallback)
+            }
         }
         builder.withFontSize(Float(settings.fontSize))
         builder.withFontThicken(settings.fontThicken)

--- a/Tests/termioTests/GhosttyUserConfigTests.swift
+++ b/Tests/termioTests/GhosttyUserConfigTests.swift
@@ -49,19 +49,27 @@ final class GhosttyUserConfigTests: XCTestCase {
         theme = Nord
         """)
         XCTAssertEqual(config.fontSize, 16)
-        XCTAssertEqual(config.theme, "Nord")
+        XCTAssertEqual(config.themeSetting, .bare("Nord"))
     }
 
-    func testBareThemeAppliesToBothAppearances() {
-        let names = parsed("theme = Dracula").themeNames
-        XCTAssertEqual(names.light, "Dracula")
-        XCTAssertEqual(names.dark, "Dracula")
+    func testBareThemeParsesAsBareForm() {
+        XCTAssertEqual(parsed("theme = Dracula").themeSetting, .bare("Dracula"))
     }
 
     func testSplitThemeFormParsesPerAppearance() {
-        let names = parsed("theme = light:Solarized Light, dark:Nord").themeNames
-        XCTAssertEqual(names.light, "Solarized Light")
-        XCTAssertEqual(names.dark, "Nord")
+        XCTAssertEqual(
+            parsed("theme = light:Solarized Light, dark:Nord").themeSetting,
+            .split(light: "Solarized Light", dark: "Nord")
+        )
+    }
+
+    func testExplicitSplitWithEqualNamesStaysSplit() {
+        // `light:Nord,dark:Nord` is an explicit per-appearance choice, not the bare form —
+        // it must inherit into both slots.
+        XCTAssertEqual(
+            parsed("theme = light:Nord,dark:Nord").themeSetting,
+            .split(light: "Nord", dark: "Nord")
+        )
     }
 
     func testDuplicateFontFamiliesCollapse() {

--- a/Tests/termioTests/GhosttyUserConfigTests.swift
+++ b/Tests/termioTests/GhosttyUserConfigTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import termio
+
+final class GhosttyUserConfigTests: XCTestCase {
+    private func parsed(_ text: String) -> GhosttyUserConfig {
+        var config = GhosttyUserConfig()
+        config.merge(parsing: text)
+        return config
+    }
+
+    func testParsesFontFamilyChainInOrder() {
+        let config = parsed("""
+        font-family = Berkeley Mono
+        font-family = Sarasa Mono SC
+        """)
+        XCTAssertEqual(config.fontFamilies, ["Berkeley Mono", "Sarasa Mono SC"])
+    }
+
+    func testEmptyFontFamilyResetsChain() {
+        let config = parsed("""
+        font-family = Menlo
+        font-family =
+        font-family = JetBrains Mono
+        """)
+        XCTAssertEqual(config.fontFamilies, ["JetBrains Mono"])
+    }
+
+    func testStripsQuotesAndWhitespace() {
+        let config = parsed("  font-family   =  \"JetBrains Mono\"  ")
+        XCTAssertEqual(config.fontFamilies, ["JetBrains Mono"])
+    }
+
+    func testSkipsCommentsAndUnknownKeys() {
+        let config = parsed("""
+        # font-family = Commented Out
+        window-decoration = false
+        not a config line
+        font-size = 15
+        """)
+        XCTAssertEqual(config.fontFamilies, [])
+        XCTAssertEqual(config.fontSize, 15)
+    }
+
+    func testLastValueWinsForSingleValueKeys() {
+        let config = parsed("""
+        font-size = 12
+        font-size = 16
+        theme = Dracula
+        theme = Nord
+        """)
+        XCTAssertEqual(config.fontSize, 16)
+        XCTAssertEqual(config.theme, "Nord")
+    }
+
+    func testBareThemeAppliesToBothAppearances() {
+        let names = parsed("theme = Dracula").themeNames
+        XCTAssertEqual(names.light, "Dracula")
+        XCTAssertEqual(names.dark, "Dracula")
+    }
+
+    func testSplitThemeFormParsesPerAppearance() {
+        let names = parsed("theme = light:Solarized Light, dark:Nord").themeNames
+        XCTAssertEqual(names.light, "Solarized Light")
+        XCTAssertEqual(names.dark, "Nord")
+    }
+
+    func testDuplicateFontFamiliesCollapse() {
+        var config = parsed("font-family = Berkeley Mono")
+        config.merge(parsing: "font-family = Berkeley Mono")
+        XCTAssertEqual(config.fontFamilies, ["Berkeley Mono"])
+    }
+
+    func testMergeAcrossFilesAccumulatesFamiliesAndOverridesScalars() {
+        var config = parsed("""
+        font-family = Menlo
+        font-size = 12
+        """)
+        config.merge(parsing: """
+        font-family = Sarasa Mono SC
+        font-size = 14
+        """)
+        XCTAssertEqual(config.fontFamilies, ["Menlo", "Sarasa Mono SC"])
+        XCTAssertEqual(config.fontSize, 14)
+    }
+
+    func testMissingFilesYieldEmptyConfig() {
+        let config = GhosttyUserConfig.load(
+            home: URL(fileURLWithPath: "/nonexistent-home-for-test"),
+            environment: [:]
+        )
+        XCTAssertTrue(config.isEmpty)
+    }
+}


### PR DESCRIPTION
Settings resolution becomes **termio setting > Ghostty config > built-in default**, implemented on UserDefaults' own domain layering: parsed Ghostty values upgrade the registration domain only, so values the user ever set in termio still win, and with no Ghostty install the built-ins stand untouched. (The practice is borrowed from cmux, which reads the Ghostty config wholesale; termio inherits only font and theme, as defaults.)

- `GhosttyUserConfig` parses the two files Ghostty loads on macOS (`$XDG_CONFIG_HOME/ghostty/config`, then `~/Library/Application Support/com.mitchellh.ghostty/config` — later wins for scalars, `font-family` accumulates into the fallback chain, deduped). `config-file` includes are deliberately not followed.
- Inherited: primary font family, font size, theme. The theme's written *form* matters: a bare `theme = X` inherits only into the appearance the theme itself belongs to (a dark theme in the light slot made a half-dark window — light sidebar, dark canvas), while the `light:Name,dark:Name` split form honors both slots verbatim. Names resolve against the bundled catalog with a separator/case-insensitive match (`catppuccin-latte` → "Catppuccin Latte").
- The chain's remaining faces pass through to the terminal as repeated `font-family` keys, so glyphs the primary font lacks fall back exactly as they do in Ghostty.
- CJK: when the chain still can't draw hanzi, a purpose-built dual-width CJK monospace face (Sarasa / Maple Mono CN / LXGW WenKai Mono / Noto CJK) closes the chain automatically if installed — no setting; this repairs the weight/metric clash of per-glyph PingFang fallback in Chinese TUI output. Cell-width gaps fully disappear only with a dual-width primary face, which the font picker already offers.
- One Appearance footer line notes that unset values follow the Ghostty config.

`swift build` passes; `swift test` runs 135 tests (11 new parser tests) with 0 failures. Verified against real Ghostty configs on a machine with LXGW WenKai Mono installed.

Release Notes:
- Termio now picks up font and theme defaults from your Ghostty config when you haven't chosen your own in Settings.
- Chinese/Japanese/Korean text in the terminal now falls back to an installed dual-width monospace font (Sarasa, Maple Mono CN, LXGW WenKai, Noto CJK) instead of mismatched system glyphs.