### PR TITLE
Install session control as an agent skill

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,10 @@ let package = Package(
                 .process("Resources/Fonts"),
                 .copy("Resources/agents"),
                 .copy("Resources/terminal.json"),
+                // Agent skills installed into ~/.claude/skills and ~/.codex/skills
+                // by SessionSkillInstaller, kept as real markdown files. Folder copy
+                // so the skill-folder layout survives into the bundle.
+                .copy("Resources/skills"),
                 // Devicon language/tool logos (one SVG per file type), loaded by name
                 // for the file tree; see LangIconCatalog / LangIconView. Kept as a
                 // folder copy (not `.process`) so the lookup subdirectory survives.

--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -506,130 +506,71 @@ private extension SessionWatchEvent {
     }
 }
 
-/// Tells a coding agent that the `termio sessions` CLI exists and is scoped to its
-/// own project, by writing a small marker-wrapped block into the user-level
-/// instruction files agents read on startup (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`).
+/// Tells a coding agent that the `termio sessions` CLI exists by installing an
+/// Agent Skill — a `SKILL.md` in each agent's user-level skills directory
+/// (`~/.claude/skills`, `~/.codex/skills`) — instead of editing the agent's
+/// always-loaded instruction file. The agent sees only the skill's one-line
+/// description up front and pulls the full guidance in when a task actually
+/// involves driving sibling sessions, so every unrelated session stays clean.
 ///
-/// Deliberately writes to the *user-level* files, not a project's own `CLAUDE.md`
-/// / `AGENTS.md`: those belong to the user's repository and editing them would
-/// dirty their git tree. Conservative like `AgentStatusHooks` — it only ever
-/// touches text between its own markers, leaving everything else untouched, and
-/// removes exactly that block on uninstall.
+/// Earlier versions injected a marker-wrapped block into `~/.claude/CLAUDE.md`
+/// and `~/.codex/AGENTS.md`; every sync still strips that block wherever it
+/// remains, so an upgrade never leaves the guidance installed twice.
 enum SessionSkillInstaller {
     private static let beginMarker = "<!-- termio:sessions BEGIN -->"
     private static let endMarker = "<!-- termio:sessions END -->"
 
-    private static var targets: [URL] {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return [
+    private static var home: URL { FileManager.default.homeDirectoryForCurrentUser }
+
+    private static var skillTargets: [URL] {
+        [
+            home.appendingPathComponent(".claude/skills/termio/SKILL.md"),
+            home.appendingPathComponent(".codex/skills/termio/SKILL.md"),
+        ]
+    }
+
+    /// The instruction files earlier versions wrote the guidance into.
+    private static var legacyTargets: [URL] {
+        [
             home.appendingPathComponent(".claude/CLAUDE.md"),
             home.appendingPathComponent(".codex/AGENTS.md"),
         ]
     }
 
-    /// The injected guidance — a compact "skill" teaching the agent the `termio
-    /// sessions` CLI: the commands, and the key idea that a sibling's *response* is
-    /// read from its own transcript (the address `send` returns), not by scraping the
-    /// terminal. Scoped to the current project automatically.
-    private static var block: String {
-        """
-        \(beginMarker)
-        ## Driving sibling sessions (termio)
-
-        You are running inside termio alongside other agent sessions in this same
-        project. Coordinate with them through the `termio sessions` CLI. Every command
-        is scoped to this project automatically; add `--json` for machine-readable
-        output. Sessions are addressed by the link `list` prints:
-        `termio://session/<uuid>` (a bare id or unique id-prefix works too).
-
-        - `termio sessions list` — siblings in this project, with status (working /
-          idle / needs-you / done)
-        - `termio sessions watch` — block and stream one line per sibling status
-          change (`done` / `needs-you` by default) until you interrupt it — the push
-          alternative to polling `list`. `--state working,idle,done,needs-you` widens
-          it, and `--state stalled` adds the runaway signal: a sibling still
-          `working` that has made no repo or transcript progress for 20+ minutes
-          (long builds streaming output don't trip it). A stalled event says why in
-          `evidence`, fires once, and re-arms when progress resumes. It opens with
-          one snapshot line per sibling's current status
-          (`"snapshot":true` in `--json`; `--no-snapshot` skips), and in `--json`
-          writes `{"heartbeat":true}` after 30s of silence so a dead stream is
-          detectable. Exits 0 on your Ctrl-C, 2 if termio itself went away.
-        - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
-          prompt (`--agent codex` picks the agent; default: your own kind). Replies
-          immediately with the new session's link — use it for every follow-up;
-          the prompt itself is typed in once the agent finishes booting.
-        - `termio sessions run "<command>"` — start a NEW plain terminal session
-          typing that shell command (a dev server, a test run) into a visible pane —
-          no LLM. Use it instead of your own background shell when the user should
-          be able to see and take over the process.
-        - `termio sessions send <link> "<text>"` — type text into that existing
-          sibling and submit it with a real Return keypress. Send a prompt to drive
-          it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
-        - `termio sessions read <link> [--lines N]` — the session's current
-          screen. The result channel for `run` sessions (a plain command has no
-          transcript; its screen is the result) — for agent replies keep using the
-          transcript, not the screen.
-        - `--wait [--timeout <ms>]` on `send`, `spawn`, or `run` — block until that turn
-          settles and reply with the final `status`, the `transcript` path, and the
-          `cursor`..`cursor_end` line range holding the response — one call instead
-          of send-then-poll. A sibling that stops to ask you something short-circuits
-          the wait: the reply is `status:"needs-you"` with the on-screen question in
-          `prompt` — answer it with another `send`. Exit codes: 0 settled, 1 error
-          (`prompt_stalled` = the input showed no effect within 5s; `session_closed`
-          / `agent_gone` = the target vanished mid-wait), 3 timed out (session still
-          running — re-arm or read its transcript).
-        - `termio sessions close <link> …` — close session tabs;
-          `termio sessions focus <link>` — bring one to the front in the app
-
-        ### Targeting discipline
-
-        - Copy links verbatim from `list` or a `send` reply; never guess or
-          construct one.
-        - One request, one target. Never send the same prompt to several siblings,
-          and never run multiple `send` commands in parallel — delegate to ONE
-          session.
-        - Unsure which sibling the user means? Ask them, or start a fresh session
-          with `spawn` — don't broadcast.
-
-        ### Reading a sibling's response
-
-        Don't scrape the terminal. `spawn`/`send` returns the sibling's **transcript**
-        — the agent's own structured Q&A log (Claude Code: a JSONL file) — plus a
-        **cursor** (its line count at send time). To read the reply:
-
-        1. `spawn`/`send` and note `transcript` + `cursor` from the output. (A just-
-           started session has no transcript yet; it appears in `list --json` once the
-           agent reports it — read that file from the start.)
-        2. Poll `termio sessions list` until that session's status is `done` (or
-           `needs-you` if it's blocked waiting on input — then `send` its answer).
-        3. Read the transcript file from line `cursor` onward; the `assistant` entries
-           after it are the reply. (Each line is a JSON object with a `type`/`role`.)
-
-        Workflow: send → wait for `done` via `list` → read the transcript tail. Prefer
-        this over assuming a sibling is finished — or collapse steps 1–2 into one call
-        with `send --wait`, whose reply carries the final status and the exact
-        `cursor`..`cursor_end` range to read. Supervising several at once? Block on
-        `termio sessions watch` instead of polling — it prints the link the moment any
-        sibling turns `done` or `needs-you`, so you act on the transition, not a spin
-        loop; its `--json` `needs-you` events carry the question in `prompt`, and `done`
-        events carry `transcript` + `cursor_end`, so you can act straight from the event.
-        \(endMarker)
-        """
+    /// The skill content, shipped as a real markdown file in the app's resource
+    /// bundle (`Resources/skills/termio/SKILL.md`) rather than a string in
+    /// code, and installed verbatim. `nil` only when the resource bundle is missing
+    /// or unreadable — sync reports that as a per-target failure instead of
+    /// installing an empty skill. Mirrored at the repo-root `skills/termio/`
+    /// (installable from GitHub via `npx skills add` / `gh skill`) and at
+    /// https://termio.sh/skill.md (`web/landing/public/skill.md`); a test keeps
+    /// all copies identical.
+    static var skill: String? {
+        Bundle.termioResources
+            .url(forResource: "SKILL", withExtension: "md", subdirectory: "skills/termio")
+            .flatMap { try? String(contentsOf: $0, encoding: .utf8) }
     }
 
-    /// Returns which instruction files ended up carrying the note, so the Settings
-    /// row can confirm the install; the uninstall path reports nothing, since no UI
-    /// asks about it.
+    /// Returns which skills directories ended up carrying the skill, so the
+    /// Settings row can confirm the install; the uninstall path reports nothing,
+    /// since no UI asks about it. Every sync also strips the legacy instruction-
+    /// file block, so re-enabling after an upgrade migrates in place.
     @discardableResult
     static func sync(enabled: Bool) -> InstallOutcome {
         var outcome = InstallOutcome()
-        for url in targets {
-            if enabled {
-                outcome.record(displayPath(of: url), installed: install(into: url))
-            } else {
-                uninstall(from: url)
+        for url in legacyTargets { removeLegacyBlock(from: url) }
+        if enabled {
+            guard let skill else {
+                FileHandle.standardError.write(
+                    Data("termio: session skill resource missing from the app bundle\n".utf8))
+                for url in skillTargets { outcome.record(displayPath(of: url), installed: false) }
+                return outcome
             }
+            for url in skillTargets {
+                outcome.record(displayPath(of: url), installed: write(skill, to: url))
+            }
+        } else {
+            for url in skillTargets { removeSkill(at: url) }
         }
         return outcome
     }
@@ -640,18 +581,27 @@ enum SessionSkillInstaller {
         (url.path as NSString).abbreviatingWithTildeInPath
     }
 
-    private static func install(into url: URL) -> Bool {
-        let stripped = strippedExisting(at: url)
-        let separator = stripped.isEmpty ? "" : "\n\n"
-        return write(stripped + separator + block + "\n", to: url)
+    /// Removes the installed skill folder wholesale — termio owns the folder, so
+    /// there is no user content inside it to preserve.
+    private static func removeSkill(at url: URL) {
+        let folder = url.deletingLastPathComponent()
+        guard FileManager.default.fileExists(atPath: folder.path) else { return }
+        try? FileManager.default.removeItem(at: folder)
     }
 
-    private static func uninstall(from url: URL) {
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
-        let stripped = strippedExisting(at: url)
-        // If removing our block leaves nothing, the file held only our note (we
-        // created it), so delete it rather than leaving an empty file behind. A
-        // file with the user's own content is rewritten preserving it.
+    /// Strips the marker-wrapped block earlier versions injected into the
+    /// user-level instruction file, leaving the user's own text untouched. A file
+    /// left empty by the strip held only our note (we created it), so it is
+    /// deleted rather than kept as an empty file. Files without the markers are
+    /// never rewritten.
+    private static func removeLegacyBlock(from url: URL) {
+        guard let contents = try? String(contentsOf: url, encoding: .utf8),
+              let begin = contents.range(of: beginMarker),
+              let end = contents.range(of: endMarker, range: begin.upperBound..<contents.endIndex)
+        else { return }
+        var result = contents
+        result.removeSubrange(begin.lowerBound..<end.upperBound)
+        let stripped = result.trimmingCharacters(in: .newlines)
         if stripped.isEmpty {
             try? FileManager.default.removeItem(at: url)
         } else {
@@ -659,26 +609,13 @@ enum SessionSkillInstaller {
         }
     }
 
-    /// The file's current contents with any existing termio block (and the
-    /// whitespace around it) removed, so install/uninstall never touch the user's
-    /// own text. Returns "" when the file is absent or unreadable.
-    private static func strippedExisting(at url: URL) -> String {
-        guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return "" }
-        guard let begin = contents.range(of: beginMarker),
-              let end = contents.range(of: endMarker, range: begin.upperBound..<contents.endIndex)
-        else { return contents.trimmingCharacters(in: .newlines) }
-        var result = contents
-        result.removeSubrange(begin.lowerBound..<end.upperBound)
-        return result.trimmingCharacters(in: .newlines)
-    }
-
     /// Returns whether the file now holds `contents` — true both for a fresh write
     /// and for the skipped identical one, false only when the write threw.
     @discardableResult
     private static func write(_ contents: String, to url: URL) -> Bool {
         let data = Data(contents.utf8)
-        // Don't rewrite an unchanged note on every launch: avoids churning a
-        // user-owned instruction file and the race of clobbering a concurrent edit.
+        // Don't rewrite an unchanged file on every launch: avoids churning it
+        // and the race of clobbering a concurrent edit.
         if (try? Data(contentsOf: url)) == data { return true }
         do {
             try FileManager.default.createDirectory(
@@ -796,8 +733,39 @@ enum CommandLineTool {
         if case .conflict = audit() { return .conflict }
         let target = installURL.path
         if linkWithoutPrivileges(from: supportCopyURL.path, to: target) { return audit() }
-        linkWithAdminPrompt(from: supportCopyURL.path, to: target)
+        let directory = (target as NSString).deletingLastPathComponent
+        runWithAdminPrompt(
+            "mkdir -p \(shellQuote(directory)) && ln -sf \(shellQuote(supportCopyURL.path)) \(shellQuote(target))",
+            label: "install")
         return audit()
+    }
+
+    /// Removes our PATH symlink and returns the fresh audit. Only ever deletes a
+    /// link the audit attributes to termio (installed or stale); a conflicting
+    /// file someone else created is left alone.
+    @discardableResult
+    static func uninstall() -> Status {
+        let current = audit()
+        switch current {
+        case .installed, .stale:
+            let target = installURL.path
+            if removeWithoutPrivileges(at: target) { return audit() }
+            runWithAdminPrompt("rm \(shellQuote(target))", label: "uninstall")
+            return audit()
+        case .notInstalled, .conflict, .unavailable:
+            return current
+        }
+    }
+
+    private static func removeWithoutPrivileges(at target: String) -> Bool {
+        let directory = (target as NSString).deletingLastPathComponent
+        guard FileManager.default.isWritableFile(atPath: directory) else { return false }
+        do {
+            try FileManager.default.removeItem(atPath: target)
+            return true
+        } catch {
+            return false
+        }
     }
 
     private static func linkWithoutPrivileges(from source: String, to target: String) -> Bool {
@@ -815,18 +783,16 @@ enum CommandLineTool {
         }
     }
 
-    /// One authorization prompt does `mkdir -p` + `ln -sf` as admin, for the case
-    /// where `/usr/local/bin` is root-owned. The user can cancel, in which case the
-    /// follow-up audit simply reports it still isn't installed.
-    private static func linkWithAdminPrompt(from source: String, to target: String) {
-        let directory = (target as NSString).deletingLastPathComponent
-        let command = "mkdir -p \(shellQuote(directory)) && ln -sf \(shellQuote(source)) \(shellQuote(target))"
+    /// One authorization prompt runs the command as admin, for the case where
+    /// `/usr/local/bin` is root-owned. The user can cancel, in which case the
+    /// follow-up audit simply reports the state unchanged.
+    private static func runWithAdminPrompt(_ command: String, label: String) {
         let script = "do shell script \"\(command)\" with administrator privileges"
         var error: NSDictionary?
         NSAppleScript(source: script)?.executeAndReturnError(&error)
         if let error {
             FileHandle.standardError.write(
-                Data("termio: command-line tool install declined or failed: \(error)\n".utf8))
+                Data("termio: command-line tool \(label) declined or failed: \(error)\n".utf8))
         }
     }
 

--- a/Sources/termio/App/ResourceBundle.swift
+++ b/Sources/termio/App/ResourceBundle.swift
@@ -14,11 +14,19 @@ extension Bundle {
     /// user's machine. Resolve from the standard app resource directory instead, and
     /// degrade to the empty main bundle (a missing icon, never a crash) if absent.
     static let termioResources: Bundle = {
-        let candidates = [Bundle.main.resourceURL, Bundle.main.bundleURL]
-            .compactMap { $0?.appendingPathComponent("termio_termio.bundle") }
+        let candidates = [
+            Bundle.main.resourceURL,
+            Bundle.main.bundleURL,
+            // Unit tests: `Bundle.main` is the xctest runner, but the bundle
+            // holding this class is the `.xctest` in the SwiftPM build directory,
+            // which sits next to the resource bundle.
+            Bundle(for: TermioResourcesAnchor.self).bundleURL.deletingLastPathComponent(),
+        ].compactMap { $0?.appendingPathComponent("termio_termio.bundle") }
         for url in candidates where FileManager.default.fileExists(atPath: url.path) {
             if let bundle = Bundle(url: url) { return bundle }
         }
         return .main
     }()
 }
+
+private final class TermioResourcesAnchor {}

--- a/Sources/termio/Resources/skills/termio/SKILL.md
+++ b/Sources/termio/Resources/skills/termio/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: termio
+description: See and drive the sibling agent sessions running alongside you in this termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside termio (TERMIO_SESSION set).
+---
+
+# Driving sibling sessions (termio)
+
+If `TERMIO_SESSION` is not set in your environment, you are not running inside
+a termio-managed session — say so and stop instead of trying to drive sessions
+you cannot see.
+
+You are running inside termio alongside other agent sessions in this same
+project. Coordinate with them through the `termio sessions` CLI. Every command
+is scoped to this project automatically; add `--json` for machine-readable
+output. The installed CLI is the authority on syntax: where this text and
+`termio sessions --help` disagree, trust the CLI. Sessions are addressed by
+the link `list` prints: `termio://session/<uuid>` (a bare id or unique
+id-prefix works too).
+
+- `termio sessions list` — siblings in this project, with status (working /
+  idle / needs-you / done)
+- `termio sessions watch` — block and stream one line per sibling status
+  change (`done` / `needs-you` by default) until you interrupt it — the push
+  alternative to polling `list`. `--state working,idle,done,needs-you` widens
+  it, and `--state stalled` adds the runaway signal: a sibling still
+  `working` that has made no repo or transcript progress for 20+ minutes
+  (long builds streaming output don't trip it). A stalled event says why in
+  `evidence`, fires once, and re-arms when progress resumes. It opens with
+  one snapshot line per sibling's current status
+  (`"snapshot":true` in `--json`; `--no-snapshot` skips), and in `--json`
+  writes `{"heartbeat":true}` after 30s of silence so a dead stream is
+  detectable. Exits 0 on your Ctrl-C, 2 if termio itself went away.
+- `termio sessions spawn "<prompt>"` — start a NEW agent session on the
+  prompt (`--agent codex` picks the agent; default: your own kind). Replies
+  immediately with the new session's link — use it for every follow-up;
+  the prompt itself is typed in once the agent finishes booting.
+- `termio sessions run "<command>"` — start a NEW plain terminal session
+  typing that shell command (a dev server, a test run) into a visible pane —
+  no LLM. Use it instead of your own background shell when the user should
+  be able to see and take over the process.
+- `termio sessions send <link> "<text>"` — type text into that existing
+  sibling and submit it with a real Return keypress. Send a prompt to drive
+  it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
+- `termio sessions read <link> [--lines N]` — the session's current
+  screen. The result channel for `run` sessions (a plain command has no
+  transcript; its screen is the result) — for agent replies keep using the
+  transcript, not the screen.
+- `--wait [--timeout <ms>]` on `send`, `spawn`, or `run` — block until that turn
+  settles and reply with the final `status`, the `transcript` path, and the
+  `cursor`..`cursor_end` line range holding the response — one call instead
+  of send-then-poll. A sibling that stops to ask you something short-circuits
+  the wait: the reply is `status:"needs-you"` with the on-screen question in
+  `prompt` — answer it with another `send`. Exit codes: 0 settled, 1 error
+  (`prompt_stalled` = the input showed no effect within 5s; `session_closed`
+  / `agent_gone` = the target vanished mid-wait), 3 timed out (session still
+  running — re-arm or read its transcript).
+- `termio sessions close <link> …` — close session tabs;
+  `termio sessions focus <link>` — bring one to the front in the app
+
+### Targeting discipline
+
+- Copy links verbatim from `list` or a `send` reply; never guess or
+  construct one.
+- One request, one target. Never send the same prompt to several siblings,
+  and never run multiple `send` commands in parallel — delegate to ONE
+  session.
+- Unsure which sibling the user means? Ask them, or start a fresh session
+  with `spawn` — don't broadcast.
+
+### Reading a sibling's response
+
+Don't scrape the terminal. `spawn`/`send` returns the sibling's **transcript**
+— the agent's own structured Q&A log (Claude Code: a JSONL file) — plus a
+**cursor** (its line count at send time). To read the reply:
+
+1. `spawn`/`send` and note `transcript` + `cursor` from the output. (A just-
+   started session has no transcript yet; it appears in `list --json` once the
+   agent reports it — read that file from the start.)
+2. Poll `termio sessions list` until that session's status is `done` (or
+   `needs-you` if it's blocked waiting on input — then `send` its answer).
+3. Read the transcript file from line `cursor` onward; the `assistant` entries
+   after it are the reply. (Each line is a JSON object with a `type`/`role`.)
+
+Workflow: send → wait for `done` via `list` → read the transcript tail. Prefer
+this over assuming a sibling is finished — or collapse steps 1–2 into one call
+with `send --wait`, whose reply carries the final status and the exact
+`cursor`..`cursor_end` range to read. Supervising several at once? Block on
+`termio sessions watch` instead of polling — it prints the link the moment any
+sibling turns `done` or `needs-you`, so you act on the transition, not a spin
+loop; its `--json` `needs-you` events carry the question in `prompt`, and `done`
+events carry `transcript` + `cursor_end`, so you can act straight from the event.

--- a/Sources/termio/Settings/GeneralSettingsTab.swift
+++ b/Sources/termio/Settings/GeneralSettingsTab.swift
@@ -57,14 +57,14 @@ struct GeneralSettingsTab: View {
                     SettingsLabel(
                         .huge(.gitBranch),
                         title: "Session control",
-                        subtext: "Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command."
+                        subtext: "Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command. Installs the termio skill into each agent's skills folder."
                     )
                 }
                 .toggleStyle(.switch)
                 if settings.sessionControlEnabled {
-                    InstallButtonRow(title: "Reinstall note") {
+                    InstallButtonRow(title: "Reinstall skill") {
                         .summarizing(SessionSkillInstaller.sync(enabled: true),
-                                     headline: "Note reinstalled", unit: "files")
+                                     headline: "Skill reinstalled", unit: "files")
                     }
                 }
             } header: {
@@ -140,22 +140,22 @@ private struct NotificationPermissionRow: View {
     }
 }
 
-/// Installs and reports the `termio` command-line tool. It audits on appear so the
-/// row always reflects reality (a moved app shows "Update"), and re-audits after
-/// the install action so the button and caption update in place.
+/// Installs and reports the `termio` command-line tool, as a switch like the other
+/// feature rows: on means the PATH symlink exists, off removes it. The switch is
+/// bound to the audit, not a stored preference, so it always reflects reality (a
+/// declined admin prompt snaps it back). It audits on appear (a moved app shows
+/// "Update") and re-audits after every action so the caption updates in place.
 private struct CommandLineToolRow: View {
     @State private var status: CommandLineTool.Status = .notInstalled
     @State private var state = InstallFeedbackState()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 10) {
+            Toggle(isOn: Binding(get: { isOn }, set: { setEnabled($0) })) {
                 SettingsLabel(.huge(.terminal), title: "Command-line tool", subtext: description)
-                Spacer()
-                if let title = buttonTitle {
-                    Button(title) { install() }
-                }
             }
+            .toggleStyle(.switch)
+            .disabled(!isSwitchable)
             if let feedback = state.feedback {
                 // Aligned under the caption, past the row's icon badge.
                 InstallFeedbackLabel(feedback: feedback)
@@ -164,31 +164,62 @@ private struct CommandLineToolRow: View {
         }
         .onAppear { status = CommandLineTool.audit() }
         .autoDismissing($state)
+        if isOn {
+            // For re-linking after something else has touched /usr/local/bin;
+            // install is idempotent. Reports through its own feedback line.
+            InstallButtonRow(title: buttonTitle) { withAnimation { runInstall() } }
+        }
+    }
+
+    private var isOn: Bool {
+        switch status {
+        case .installed, .stale: return true
+        case .notInstalled, .conflict, .unavailable: return false
+        }
+    }
+
+    /// A conflicting file isn't ours to remove and a bare binary has nothing to
+    /// link, so in both states the switch is disabled and the caption explains.
+    private var isSwitchable: Bool {
+        switch status {
+        case .installed, .stale, .notInstalled: return true
+        case .conflict, .unavailable: return false
+        }
+    }
+
+    private func setEnabled(_ enabled: Bool) {
+        withAnimation {
+            if enabled {
+                state.show(runInstall())
+            } else {
+                status = CommandLineTool.uninstall()
+                state.show(isOn
+                    ? .failure("Couldn’t remove \(CommandLineTool.installURL.path).")
+                    : .success("Removed from PATH."))
+            }
+        }
     }
 
     /// Installs, then reports the fresh audit. The caption alone can't carry this:
     /// a declined admin prompt leaves the row reading exactly as it did before the
     /// click, so success and cancellation would be indistinguishable. The
     /// confirmation stays short — the caption above it already names the path — and
-    /// echoes the verb of the button that was pressed.
-    private func install() {
-        // Echo the verb the button offered: an "Update" that lands says "Updated."
+    /// echoes the verb that was offered: an "Update" that lands says "Updated."
+    private func runInstall() -> InstallFeedback {
         let wasStale: Bool
         if case .stale = status { wasStale = true } else { wasStale = false }
         let result = CommandLineTool.install()
-        withAnimation {
-            status = result
-            switch result {
-            case .installed:
-                state.show(.success(wasStale ? "Updated." : "Installed."))
-            case .conflict:
-                state.show(.failure("Something else already owns \(CommandLineTool.installURL.path)."))
-            case .unavailable:
-                state.show(.failure("No bundled tool to install from."))
-            case .notInstalled, .stale:
-                let directory = CommandLineTool.installURL.deletingLastPathComponent().path
-                state.show(.failure("Couldn’t link `\(CommandLineTool.toolName)` into \(directory)."))
-            }
+        status = result
+        switch result {
+        case .installed:
+            return .success(wasStale ? "Updated." : "Installed.")
+        case .conflict:
+            return .failure("Something else already owns \(CommandLineTool.installURL.path).")
+        case .unavailable:
+            return .failure("No bundled tool to install from.")
+        case .notInstalled, .stale:
+            let directory = CommandLineTool.installURL.deletingLastPathComponent().path
+            return .failure("Couldn’t link `\(CommandLineTool.toolName)` into \(directory).")
         }
     }
 
@@ -200,7 +231,7 @@ private struct CommandLineToolRow: View {
         case .stale(let path):
             return "An older install points at \(path). Update it to this version of Termio."
         case .notInstalled:
-            return "Install `\(tool)` so you (and agents) can run `\(tool) sessions …` from any shell. Links to /usr/local/bin."
+            return "Links `\(tool)` into /usr/local/bin so you (and agents) can run `\(tool) sessions …` from any shell."
         case .conflict:
             return "A different `\(tool)` already exists at \(CommandLineTool.installURL.path). Remove it first — Termio won't overwrite a file it didn't create."
         case .unavailable:
@@ -208,12 +239,8 @@ private struct CommandLineToolRow: View {
         }
     }
 
-    private var buttonTitle: String? {
-        switch status {
-        case .installed: return "Reinstall"
-        case .stale: return "Update"
-        case .notInstalled: return "Install"
-        case .conflict, .unavailable: return nil
-        }
+    private var buttonTitle: String {
+        if case .stale = status { return "Update" }
+        return "Reinstall"
     }
 }

--- a/Tests/termioTests/SessionSkillInstallerTests.swift
+++ b/Tests/termioTests/SessionSkillInstallerTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import termio
+
+/// The termio skill exists in three places: the app's bundled resource
+/// (`Sources/termio/Resources/skills/termio/SKILL.md`, what
+/// `SessionSkillInstaller` writes into each agent's skills directory), the
+/// repo-root `skills/termio/SKILL.md` (the layout `npx skills add` and
+/// `gh skill` discover for installs straight from GitHub), and the published
+/// copy at `web/landing/public/skill.md` (https://termio.sh/skill.md). Nothing
+/// at runtime ties them together, so this is the only thing that stops an edit
+/// to one from silently drifting the others.
+final class SessionSkillInstallerTests: XCTestCase {
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // termioTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+    }
+
+    func testPublishedSkillMatchesInstalledSkill() throws {
+        let source = repoRoot.appendingPathComponent(
+            "Sources/termio/Resources/skills/termio/SKILL.md")
+        let canonical = try String(contentsOf: source, encoding: .utf8)
+        for mirror in ["skills/termio/SKILL.md", "web/landing/public/skill.md"] {
+            XCTAssertEqual(
+                try String(contentsOf: repoRoot.appendingPathComponent(mirror), encoding: .utf8),
+                canonical,
+                "\(mirror) must stay identical to the skill the app installs — update all copies together"
+            )
+        }
+    }
+
+    /// Exercises the resource-bundle lookup the installer relies on: a wrong
+    /// `.copy` path or a renamed file would otherwise only surface as a silent
+    /// per-target install failure at launch.
+    func testBundledSkillResolves() throws {
+        let skill = try XCTUnwrap(SessionSkillInstaller.skill)
+        XCTAssertTrue(skill.hasPrefix("---\nname: termio\n"))
+        XCTAssertTrue(skill.hasSuffix("\n"))
+    }
+}

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: termio
+description: See and drive the sibling agent sessions running alongside you in this termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside termio (TERMIO_SESSION set).
+---
+
+# Driving sibling sessions (termio)
+
+If `TERMIO_SESSION` is not set in your environment, you are not running inside
+a termio-managed session — say so and stop instead of trying to drive sessions
+you cannot see.
+
+You are running inside termio alongside other agent sessions in this same
+project. Coordinate with them through the `termio sessions` CLI. Every command
+is scoped to this project automatically; add `--json` for machine-readable
+output. The installed CLI is the authority on syntax: where this text and
+`termio sessions --help` disagree, trust the CLI. Sessions are addressed by
+the link `list` prints: `termio://session/<uuid>` (a bare id or unique
+id-prefix works too).
+
+- `termio sessions list` — siblings in this project, with status (working /
+  idle / needs-you / done)
+- `termio sessions watch` — block and stream one line per sibling status
+  change (`done` / `needs-you` by default) until you interrupt it — the push
+  alternative to polling `list`. `--state working,idle,done,needs-you` widens
+  it, and `--state stalled` adds the runaway signal: a sibling still
+  `working` that has made no repo or transcript progress for 20+ minutes
+  (long builds streaming output don't trip it). A stalled event says why in
+  `evidence`, fires once, and re-arms when progress resumes. It opens with
+  one snapshot line per sibling's current status
+  (`"snapshot":true` in `--json`; `--no-snapshot` skips), and in `--json`
+  writes `{"heartbeat":true}` after 30s of silence so a dead stream is
+  detectable. Exits 0 on your Ctrl-C, 2 if termio itself went away.
+- `termio sessions spawn "<prompt>"` — start a NEW agent session on the
+  prompt (`--agent codex` picks the agent; default: your own kind). Replies
+  immediately with the new session's link — use it for every follow-up;
+  the prompt itself is typed in once the agent finishes booting.
+- `termio sessions run "<command>"` — start a NEW plain terminal session
+  typing that shell command (a dev server, a test run) into a visible pane —
+  no LLM. Use it instead of your own background shell when the user should
+  be able to see and take over the process.
+- `termio sessions send <link> "<text>"` — type text into that existing
+  sibling and submit it with a real Return keypress. Send a prompt to drive
+  it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
+- `termio sessions read <link> [--lines N]` — the session's current
+  screen. The result channel for `run` sessions (a plain command has no
+  transcript; its screen is the result) — for agent replies keep using the
+  transcript, not the screen.
+- `--wait [--timeout <ms>]` on `send`, `spawn`, or `run` — block until that turn
+  settles and reply with the final `status`, the `transcript` path, and the
+  `cursor`..`cursor_end` line range holding the response — one call instead
+  of send-then-poll. A sibling that stops to ask you something short-circuits
+  the wait: the reply is `status:"needs-you"` with the on-screen question in
+  `prompt` — answer it with another `send`. Exit codes: 0 settled, 1 error
+  (`prompt_stalled` = the input showed no effect within 5s; `session_closed`
+  / `agent_gone` = the target vanished mid-wait), 3 timed out (session still
+  running — re-arm or read its transcript).
+- `termio sessions close <link> …` — close session tabs;
+  `termio sessions focus <link>` — bring one to the front in the app
+
+### Targeting discipline
+
+- Copy links verbatim from `list` or a `send` reply; never guess or
+  construct one.
+- One request, one target. Never send the same prompt to several siblings,
+  and never run multiple `send` commands in parallel — delegate to ONE
+  session.
+- Unsure which sibling the user means? Ask them, or start a fresh session
+  with `spawn` — don't broadcast.
+
+### Reading a sibling's response
+
+Don't scrape the terminal. `spawn`/`send` returns the sibling's **transcript**
+— the agent's own structured Q&A log (Claude Code: a JSONL file) — plus a
+**cursor** (its line count at send time). To read the reply:
+
+1. `spawn`/`send` and note `transcript` + `cursor` from the output. (A just-
+   started session has no transcript yet; it appears in `list --json` once the
+   agent reports it — read that file from the start.)
+2. Poll `termio sessions list` until that session's status is `done` (or
+   `needs-you` if it's blocked waiting on input — then `send` its answer).
+3. Read the transcript file from line `cursor` onward; the `assistant` entries
+   after it are the reply. (Each line is a JSON object with a `type`/`role`.)
+
+Workflow: send → wait for `done` via `list` → read the transcript tail. Prefer
+this over assuming a sibling is finished — or collapse steps 1–2 into one call
+with `send --wait`, whose reply carries the final status and the exact
+`cursor`..`cursor_end` range to read. Supervising several at once? Block on
+`termio sessions watch` instead of polling — it prints the link the moment any
+sibling turns `done` or `needs-you`, so you act on the transition, not a spin
+loop; its `--json` `needs-you` events carry the question in `prompt`, and `done`
+events carry `transcript` + `cursor_end`, so you can act straight from the event.

--- a/web/landing/public/skill.md
+++ b/web/landing/public/skill.md
@@ -1,0 +1,91 @@
+---
+name: termio
+description: See and drive the sibling agent sessions running alongside you in this termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside termio (TERMIO_SESSION set).
+---
+
+# Driving sibling sessions (termio)
+
+If `TERMIO_SESSION` is not set in your environment, you are not running inside
+a termio-managed session — say so and stop instead of trying to drive sessions
+you cannot see.
+
+You are running inside termio alongside other agent sessions in this same
+project. Coordinate with them through the `termio sessions` CLI. Every command
+is scoped to this project automatically; add `--json` for machine-readable
+output. The installed CLI is the authority on syntax: where this text and
+`termio sessions --help` disagree, trust the CLI. Sessions are addressed by
+the link `list` prints: `termio://session/<uuid>` (a bare id or unique
+id-prefix works too).
+
+- `termio sessions list` — siblings in this project, with status (working /
+  idle / needs-you / done)
+- `termio sessions watch` — block and stream one line per sibling status
+  change (`done` / `needs-you` by default) until you interrupt it — the push
+  alternative to polling `list`. `--state working,idle,done,needs-you` widens
+  it, and `--state stalled` adds the runaway signal: a sibling still
+  `working` that has made no repo or transcript progress for 20+ minutes
+  (long builds streaming output don't trip it). A stalled event says why in
+  `evidence`, fires once, and re-arms when progress resumes. It opens with
+  one snapshot line per sibling's current status
+  (`"snapshot":true` in `--json`; `--no-snapshot` skips), and in `--json`
+  writes `{"heartbeat":true}` after 30s of silence so a dead stream is
+  detectable. Exits 0 on your Ctrl-C, 2 if termio itself went away.
+- `termio sessions spawn "<prompt>"` — start a NEW agent session on the
+  prompt (`--agent codex` picks the agent; default: your own kind). Replies
+  immediately with the new session's link — use it for every follow-up;
+  the prompt itself is typed in once the agent finishes booting.
+- `termio sessions run "<command>"` — start a NEW plain terminal session
+  typing that shell command (a dev server, a test run) into a visible pane —
+  no LLM. Use it instead of your own background shell when the user should
+  be able to see and take over the process.
+- `termio sessions send <link> "<text>"` — type text into that existing
+  sibling and submit it with a real Return keypress. Send a prompt to drive
+  it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
+- `termio sessions read <link> [--lines N]` — the session's current
+  screen. The result channel for `run` sessions (a plain command has no
+  transcript; its screen is the result) — for agent replies keep using the
+  transcript, not the screen.
+- `--wait [--timeout <ms>]` on `send`, `spawn`, or `run` — block until that turn
+  settles and reply with the final `status`, the `transcript` path, and the
+  `cursor`..`cursor_end` line range holding the response — one call instead
+  of send-then-poll. A sibling that stops to ask you something short-circuits
+  the wait: the reply is `status:"needs-you"` with the on-screen question in
+  `prompt` — answer it with another `send`. Exit codes: 0 settled, 1 error
+  (`prompt_stalled` = the input showed no effect within 5s; `session_closed`
+  / `agent_gone` = the target vanished mid-wait), 3 timed out (session still
+  running — re-arm or read its transcript).
+- `termio sessions close <link> …` — close session tabs;
+  `termio sessions focus <link>` — bring one to the front in the app
+
+### Targeting discipline
+
+- Copy links verbatim from `list` or a `send` reply; never guess or
+  construct one.
+- One request, one target. Never send the same prompt to several siblings,
+  and never run multiple `send` commands in parallel — delegate to ONE
+  session.
+- Unsure which sibling the user means? Ask them, or start a fresh session
+  with `spawn` — don't broadcast.
+
+### Reading a sibling's response
+
+Don't scrape the terminal. `spawn`/`send` returns the sibling's **transcript**
+— the agent's own structured Q&A log (Claude Code: a JSONL file) — plus a
+**cursor** (its line count at send time). To read the reply:
+
+1. `spawn`/`send` and note `transcript` + `cursor` from the output. (A just-
+   started session has no transcript yet; it appears in `list --json` once the
+   agent reports it — read that file from the start.)
+2. Poll `termio sessions list` until that session's status is `done` (or
+   `needs-you` if it's blocked waiting on input — then `send` its answer).
+3. Read the transcript file from line `cursor` onward; the `assistant` entries
+   after it are the reply. (Each line is a JSON object with a `type`/`role`.)
+
+Workflow: send → wait for `done` via `list` → read the transcript tail. Prefer
+this over assuming a sibling is finished — or collapse steps 1–2 into one call
+with `send --wait`, whose reply carries the final status and the exact
+`cursor`..`cursor_end` range to read. Supervising several at once? Block on
+`termio sessions watch` instead of polling — it prints the link the moment any
+sibling turns `done` or `needs-you`, so you act on the transition, not a spin
+loop; its `--json` `needs-you` events carry the question in `prompt`, and `done`
+events carry `transcript` + `cursor_end`, so you can act straight from the event.

--- a/web/landing/src/app/llms.txt/route.ts
+++ b/web/landing/src/app/llms.txt/route.ts
@@ -29,6 +29,7 @@ export function GET() {
     `- [Changelog](${siteUrl}/changelog): release history`,
     `- [iPhone companion beta](${testflightUrl}): TestFlight — mirrors Mac sessions live on the phone`,
     `- [Full docs in one file](${siteUrl}/llms-full.txt): every page above, concatenated`,
+    `- [Agent skill](${siteUrl}/skill.md): the termio skill the Mac app installs into ~/.claude/skills and ~/.codex/skills — save it there yourself to drive sibling sessions from an agent Termio doesn't auto-configure`,
     `- Programmatic docs search: \`GET ${siteUrl}/api/search?query=<terms>\` returns JSON results with page URLs`,
   ].join("\n");
 


### PR DESCRIPTION
Replaces the marker block termio injected into `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md` with a real Agent Skill installed into each agent's skills directory (`~/.claude/skills/termio`, `~/.codex/skills/termio`). Agents now carry only the skill's one-line description and load the full `termio sessions` guidance on demand. Launch sync still strips the legacy instruction-file block, so existing installs migrate in place, and re-asserts the skill on every launch (byte-compared, so app updates propagate automatically).

The skill body is a real markdown file shipped in the app's resource bundle, with two mirrors kept byte-identical by a unit test:

- `skills/termio/SKILL.md` — the repo layout `npx skills add termio-sh/termio --skill termio` and `gh skill install` discover (both verified against this branch)
- `web/landing/public/skill.md` — served at https://termio.sh/skill.md and linked from `llms.txt` for manual installs

Following herdr's skill design: the body opens with a `TERMIO_SESSION` guardrail, names the installed CLI as the authority on syntax, and the description carries a negative trigger so it doesn't fire on generic parallelism.

The Command-line tool settings row becomes a switch like the other feature rows — on means the PATH symlink actually exists (bound to the audit, not a stored preference), off removes it, with the same admin-prompt fallback as install and never touching a conflicting file termio didn't create.

Release Notes:
- Session control now installs a `termio` agent skill instead of editing `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md`; existing installs migrate automatically
- The skill is also installable straight from GitHub (`npx skills add termio-sh/termio`) or from https://termio.sh/skill.md
- The command-line tool can now be turned off in Settings, removing the PATH link