### PR TITLE
Decode the companion roster element by element

### DIFF
--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -255,10 +255,12 @@ public enum CompanionControl: Codable, Sendable, Equatable {
                 .replacingOccurrences(of: "\"", with: "\\\"")
             return #"{"t":"error","message":"\#(escaped)"}"#
         case .unsupported(let type):
-            // Re-encoding keeps only what was understood: the tag. Nothing
-            // originates this case, so this exists to satisfy the switch and to
-            // round-trip in tests.
-            return Self.json(["t": type])
+            // The tag is carried under its own envelope rather than re-emitted
+            // as itself. Echoing the raw tag would turn a message this build
+            // could not read into one a peer *can*: forwarding an unsupported
+            // `startTerminal` would spawn a terminal. What was not understood on
+            // the way in must not become a command on the way out.
+            return Self.json(["t": "unsupported", "of": type])
         }
     }
 
@@ -416,6 +418,11 @@ public enum CompanionControl: Codable, Sendable, Equatable {
         case "error":
             guard let message = obj["message"] as? String else { return nil }
             return .error(message: message)
+        case "unsupported":
+            // Only reachable from this build's own `encoded()`; a peer never
+            // originates it. Named so the envelope round-trips instead of
+            // decaying into a second layer of "unsupported".
+            return .unsupported(type: obj["of"] as? String ?? "")
         default:
             return .unsupported(type: type)
         }

--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -143,6 +143,13 @@ public enum CompanionControl: Codable, Sendable, Equatable {
 
     case error(message: String)
 
+    /// A message this build has no case for — a newer peer's vocabulary. The
+    /// receiver ignores it, but it arrives as a value rather than as `nil` so
+    /// the drop can be logged: "the phone asked for something this Mac is too
+    /// old to do" is the failure mode `wire` exists to explain, and it is
+    /// invisible if an unknown tag decodes to nothing.
+    case unsupported(type: String)
+
     public func encoded() -> String {
         // Small, hand-stable JSON so both ends agree without a schema tool.
         switch self {
@@ -247,6 +254,11 @@ public enum CompanionControl: Codable, Sendable, Equatable {
                 .replacingOccurrences(of: "\\", with: "\\\\")
                 .replacingOccurrences(of: "\"", with: "\\\"")
             return #"{"t":"error","message":"\#(escaped)"}"#
+        case .unsupported(let type):
+            // Re-encoding keeps only what was understood: the tag. Nothing
+            // originates this case, so this exists to satisfy the switch and to
+            // round-trip in tests.
+            return Self.json(["t": type])
         }
     }
 
@@ -405,7 +417,7 @@ public enum CompanionControl: Codable, Sendable, Equatable {
             guard let message = obj["message"] as? String else { return nil }
             return .error(message: message)
         default:
-            return nil
+            return .unsupported(type: type)
         }
     }
 
@@ -578,6 +590,38 @@ public struct RosterSession: Codable, Sendable, Equatable {
 }
 
 /// One project and its sessions.
+/// Decodes an array element by element, dropping the ones that fail.
+///
+/// `decodeIfPresent` only tolerates a *missing* key: a key that is present but
+/// whose contents don't match throws, and the throw travels all the way up. On
+/// the roster that turns one unreadable session into an empty tree — the phone
+/// shows nothing at all rather than one row less. A peer is only as forward-
+/// compatible as its least tolerant array.
+///
+/// A failed `decode` leaves the container's cursor where it was, so the slot has
+/// to be consumed by decoding something that always succeeds; without that the
+/// loop never reaches `isAtEnd`.
+private struct SkippedWireElement: Decodable {}
+
+private func decodeLossyArray<Element: Decodable, Key: CodingKey>(
+    _ container: KeyedDecodingContainer<Key>,
+    _ key: Key
+) -> [Element] {
+    typealias Skipped = SkippedWireElement
+    guard var unkeyed = try? container.nestedUnkeyedContainer(forKey: key) else { return [] }
+    var elements: [Element] = []
+    while !unkeyed.isAtEnd {
+        if let element = try? unkeyed.decode(Element.self) {
+            elements.append(element)
+        } else if (try? unkeyed.decode(Skipped.self)) == nil {
+            // Nothing consumed the slot, so the cursor can't advance — stop
+            // rather than spin.
+            break
+        }
+    }
+    return elements
+}
+
 public struct RosterProject: Codable, Sendable, Equatable {
     public let id: String
     public let name: String
@@ -601,6 +645,18 @@ public struct RosterProject: Codable, Sendable, Equatable {
         self.branch = branch
         self.kind = kind
         self.sessions = sessions
+    }
+
+    private enum CodingKeys: String, CodingKey { case id, name, path, branch, kind, sessions }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        path = try c.decode(String.self, forKey: .path)
+        branch = try c.decodeIfPresent(String.self, forKey: .branch)
+        kind = try c.decodeIfPresent(String.self, forKey: .kind)
+        sessions = decodeLossyArray(c, CodingKeys.sessions)
     }
 }
 
@@ -651,8 +707,8 @@ public struct CompanionRoster: Codable, Sendable, Equatable {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         t = try c.decode(String.self, forKey: .t)
         wire = try c.decodeIfPresent(Int.self, forKey: .wire) ?? Wire.legacy
-        projects = try c.decodeIfPresent([RosterProject].self, forKey: .projects) ?? []
-        agents = try c.decodeIfPresent([RosterAgent].self, forKey: .agents) ?? []
+        projects = decodeLossyArray(c, CodingKeys.projects)
+        agents = decodeLossyArray(c, CodingKeys.agents)
     }
 
     public func encodedJSON() -> String {

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -385,16 +385,32 @@ final class CompanionServer {
         case .sshConfigHosts:
             sendControl(.sshConfigList(hosts: Self.parseSSHConfigHosts()), to: connection)
         case .unsupported(let type):
-            // The phone speaks a newer vocabulary than this Mac. Nothing to do
-            // but say so: the request is silently dropped either way, and this
-            // line is the only trace of why the phone's button did nothing.
+            // Usually the phone speaks a newer vocabulary than this Mac, and
+            // this line is the only trace of why its button did nothing. But
+            // the tag is remote input — a paired phone chooses it — so it is
+            // sanitized before it reaches a `.public` log field, and the line
+            // states what happened rather than guessing which end is older.
             Log.companion.notice(
-                "ignoring unsupported control \(type, privacy: .public) — this Mac is older than the phone"
+                "ignoring unsupported control \(Self.loggableTag(type), privacy: .public)"
             )
         case .auth, .exit, .error, .started, .fileList, .file, .written, .uploaded,
              .searchResults, .traceHTML, .sshConfigList, .changes, .diff:
             break
         }
+    }
+
+    /// A wire tag reduced to something safe to write into a `.public` log field.
+    ///
+    /// The tag arrives from the phone, so it can carry newlines that forge extra
+    /// log lines, or a payload long enough to bury the surrounding entries. Only
+    /// the shape a real tag has survives — letters, digits, and the separators
+    /// the vocabulary already uses — and only the first 40 characters of it.
+    nonisolated static func loggableTag(_ tag: String) -> String {
+        let kept = tag.prefix(40).map { character -> Character in
+            character.isLetter || character.isNumber || character == "." || character == "-"
+                || character == "_" ? character : "?"
+        }
+        return kept.isEmpty ? "(empty)" : String(kept)
     }
 
     /// The Mac user's connectable `~/.ssh/config` hosts (see `SSHConfigFile`),

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -384,6 +384,13 @@ final class CompanionServer {
             handleTrace(sessionID: sessionID, dark: dark, on: connection)
         case .sshConfigHosts:
             sendControl(.sshConfigList(hosts: Self.parseSSHConfigHosts()), to: connection)
+        case .unsupported(let type):
+            // The phone speaks a newer vocabulary than this Mac. Nothing to do
+            // but say so: the request is silently dropped either way, and this
+            // line is the only trace of why the phone's button did nothing.
+            Log.companion.notice(
+                "ignoring unsupported control \(type, privacy: .public) — this Mac is older than the phone"
+            )
         case .auth, .exit, .error, .started, .fileList, .file, .written, .uploaded,
              .searchResults, .traceHTML, .sshConfigList, .changes, .diff:
             break

--- a/Tests/termioTests/WireProtocolTests.swift
+++ b/Tests/termioTests/WireProtocolTests.swift
@@ -86,4 +86,71 @@ final class WireProtocolTests: XCTestCase {
     func testMalformedControlFrameStillDecodesToNil() {
         XCTAssertNil(CompanionControl.decode("not json at all"))
     }
+
+    /// A bad element is not always an object. The slot-consuming decode has to
+    /// swallow scalars, null, and arrays too, or the array truncates at the
+    /// first one of those and everything after it is lost.
+    func testRosterSkipsNonObjectSessionEntries() throws {
+        for bad in ["null", "42", #""a string""#, "[1,2]", "[]", "true"] {
+            let json = """
+            {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio","sessions":[\
+            {"id":"s1","title":"Good","agent":"claude","status":"idle"},\
+            \(bad),\
+            {"id":"s3","title":"Also good","agent":"codex","status":"working"}]}]}
+            """
+
+            let decoded = try XCTUnwrap(CompanionRoster.decode(json), "failed for \(bad)")
+
+            XCTAssertEqual(
+                decoded.projects.first?.sessions.map(\.id), ["s1", "s3"],
+                "the element after \(bad) was lost"
+            )
+        }
+    }
+
+    func testRosterDropsOnlyTheUnreadableAgent() throws {
+        let json = """
+        {"t":"roster","projects":[],"agents":[\
+        {"id":"claude","name":"Claude Code"},\
+        {"id":"missing name"},\
+        {"id":"codex","name":"Codex"}]}
+        """
+
+        let decoded = try XCTUnwrap(CompanionRoster.decode(json))
+
+        XCTAssertEqual(decoded.agents.map(\.id), ["claude", "codex"])
+    }
+
+    /// `RosterProject` decodes through a hand-written `init(from:)` while its
+    /// encoder stays synthesized, so the two can drift apart. Every optional
+    /// field has to be populated or the round trip proves nothing.
+    func testPopulatedRosterRoundTrips() throws {
+        let roster = CompanionRoster(
+            projects: [
+                RosterProject(
+                    id: "p1", name: "termio", path: "/tmp/termio",
+                    branch: "fix/wire-tolerance", kind: "folder",
+                    sessions: [
+                        RosterSession(
+                            id: "s1", title: "Session", agent: "claude", status: "working",
+                            subtitle: "Working — Bash", branch: "fix/wire-tolerance"
+                        )
+                    ]
+                )
+            ],
+            agents: [RosterAgent(id: "claude", name: "Claude Code", tintHex: "#D97757")]
+        )
+
+        XCTAssertEqual(CompanionRoster.decode(roster.encodedJSON()), roster)
+    }
+
+    /// Re-encoding an unsupported message must not hand a peer the command this
+    /// build refused to read: `.unsupported("startTerminal")` may never come
+    /// back out as a real `.startTerminal`.
+    func testUnsupportedDoesNotReEncodeAsARealCommand() {
+        let unsupported = CompanionControl.unsupported(type: "startTerminal")
+
+        XCTAssertNotEqual(CompanionControl.decode(unsupported.encoded()), .startTerminal)
+        XCTAssertEqual(CompanionControl.decode(unsupported.encoded()), unsupported)
+    }
 }

--- a/Tests/termioTests/WireProtocolTests.swift
+++ b/Tests/termioTests/WireProtocolTests.swift
@@ -30,4 +30,60 @@ final class WireProtocolTests: XCTestCase {
 
         XCTAssertEqual(decoded.wire, Wire.legacy)
     }
+
+    /// The whole point: one session the phone can't read costs that row, not the
+    /// tree. Before lossy decoding this returned nil and the phone showed an
+    /// empty app.
+    func testRosterDropsOnlyTheUnreadableSession() throws {
+        let json = """
+        {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio","sessions":[\
+        {"id":"s1","title":"Good","agent":"claude","status":"idle"},\
+        {"id":"s2","title":"Missing agent and status"},\
+        {"id":"s3","title":"Also good","agent":"codex","status":"working"}]}]}
+        """
+
+        let decoded = try XCTUnwrap(CompanionRoster.decode(json))
+
+        XCTAssertEqual(decoded.projects.count, 1)
+        XCTAssertEqual(decoded.projects.first?.sessions.map(\.id), ["s1", "s3"])
+    }
+
+    func testRosterDropsOnlyTheUnreadableProject() throws {
+        let json = """
+        {"t":"roster","projects":[\
+        {"id":"p1","name":"termio","path":"/tmp/termio","sessions":[]},\
+        {"name":"no id","path":"/tmp/broken","sessions":[]},\
+        {"id":"p3","name":"other","path":"/tmp/other","sessions":[]}]}
+        """
+
+        let decoded = try XCTUnwrap(CompanionRoster.decode(json))
+
+        XCTAssertEqual(decoded.projects.map(\.id), ["p1", "p3"])
+    }
+
+    /// A session from a newer Mac carrying fields this build never heard of
+    /// still decodes — unknown keys are ignored, not fatal.
+    func testRosterKeepsSessionWithUnknownFields() throws {
+        let json = """
+        {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio","sessions":[\
+        {"id":"s1","title":"Good","agent":"claude","status":"idle","somethingNewer":{"a":1}}]}]}
+        """
+
+        let decoded = try XCTUnwrap(CompanionRoster.decode(json))
+
+        XCTAssertEqual(decoded.projects.first?.sessions.map(\.id), ["s1"])
+    }
+
+    /// An unknown tag has to arrive as a value, not as nil: the drop is only
+    /// loggable if the receiver is handed something.
+    func testUnknownControlTypeDecodesAsUnsupported() {
+        XCTAssertEqual(
+            CompanionControl.decode(#"{"t":"somethingFromANewerPhone","x":1}"#),
+            .unsupported(type: "somethingFromANewerPhone")
+        )
+    }
+
+    func testMalformedControlFrameStillDecodesToNil() {
+        XCTAssertNil(CompanionControl.decode("not json at all"))
+    }
 }

--- a/Tests/termioTests/WireProtocolTests.swift
+++ b/Tests/termioTests/WireProtocolTests.swift
@@ -1,3 +1,4 @@
+@testable import termio
 import TermioShared
 import XCTest
 
@@ -152,5 +153,26 @@ final class WireProtocolTests: XCTestCase {
 
         XCTAssertNotEqual(CompanionControl.decode(unsupported.encoded()), .startTerminal)
         XCTAssertEqual(CompanionControl.decode(unsupported.encoded()), unsupported)
+    }
+
+    /// The tag reaches a `.public` log field and a paired phone picks it, so a
+    /// newline in it would forge a log line and a long one would bury its
+    /// neighbours.
+    func testLoggableTagCannotForgeALogLine() {
+        let forged = CompanionServer.loggableTag("secret-value\nmisleading log text")
+
+        XCTAssertFalse(forged.contains("\n"))
+        XCTAssertFalse(forged.contains(" "))
+        XCTAssertEqual(forged, "secret-value?misleading?log?text")
+    }
+
+    func testLoggableTagIsBounded() {
+        XCTAssertEqual(CompanionServer.loggableTag(String(repeating: "a", count: 500)).count, 40)
+    }
+
+    func testLoggableTagKeepsRealTagsReadable() {
+        XCTAssertEqual(CompanionServer.loggableTag("startTerminal"), "startTerminal")
+        XCTAssertEqual(CompanionServer.loggableTag("read-file_v2.1"), "read-file_v2.1")
+        XCTAssertEqual(CompanionServer.loggableTag(""), "(empty)")
     }
 }


### PR DESCRIPTION
PR #213 gave the wire a version, but the roster still decodes all-or-nothing. `decodeIfPresent` only tolerates a *missing* key — a key that is present but whose contents don't match throws, and the throw travels up through the array to `CompanionRoster.decode`, which returns nil. One session the phone can't read empties the whole tree: the app shows nothing rather than one row less.

That is the failure mode `wire` was added to explain, and it is the one shape of skew the every-new-field-is-Optional discipline cannot cover. The discipline governs what the *sender* adds; it says nothing about what the *receiver* does with an element it can't parse. A peer is only as forward-compatible as its least tolerant array.

Projects, agents, and sessions now decode element by element, dropping the ones that fail. A failed `decode` leaves the container's cursor in place, so each bad slot is consumed by a throwaway type — without that the loop never reaches `isAtEnd`.

An unknown control tag now decodes to `.unsupported(type:)` instead of nil. Ignoring a newer peer's message is right; ignoring it invisibly is not, and it violates the repo's rule against silently discarding errors. The Mac logs which message it dropped, so "the phone's button did nothing" becomes a line in the log rather than a mystery.

No wire format change: nothing new is sent, and every existing frame decodes as before. This is receiver-side only, so it takes effect against Macs already in the field without a matching update on the other end.

Tests cover a malformed session costing one row, a malformed project costing one row, a session carrying unknown fields still decoding, and an unknown tag arriving as `.unsupported`. `swift test`: 140 passed.

Release Notes: Fixed the iPhone app showing an empty session list when one session on the Mac sent data it could not read.