### PR TITLE
Document the termio agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,17 @@ a task, and read back the reply:
 ```sh
 termio sessions list                       # who's working, idle, or waiting on you
 termio sessions spawn "fix the flaky test" # start a new agent session on a prompt
-termio sessions send claude@ab12cd34 "1"   # answer a sibling's permission prompt
+termio sessions send ab12cd34 "1"          # answer a sibling's permission prompt
 termio sessions watch                      # stream status changes as they happen
+```
+
+Agents learn this themselves: Session control installs a `termio`
+[agent skill](https://termio.sh/skill.md) into each agent's skills folder
+(`~/.claude/skills`, `~/.codex/skills`) and keeps it current on every launch.
+Any other agent can install the same skill straight from this repo:
+
+```sh
+npx skills add termio-sh/termio --skill termio
 ```
 
 ## On your iPhone

--- a/web/landing/content/docs/installation.mdx
+++ b/web/landing/content/docs/installation.mdx
@@ -52,8 +52,8 @@ session.
 
 ## The `termio` command (optional)
 
-Termio ships a small command-line tool. Open **Settings ▸ General** and click
-**Install Command-Line Tool** to symlink `termio` onto your `PATH`. From then on
+Termio ships a small command-line tool. Open **Settings ▸ General** and turn on
+**Command-line tool** to symlink `termio` onto your `PATH`. From then on
 `termio` in any directory opens it as a project, and `termio sessions …` lets your
 agents coordinate with each other. It's entirely optional — see
 [Session control & the CLI](/docs/session-control).

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -9,7 +9,7 @@ command-line tool** that lets you — or another agent — drive sessions from t
 shell. Neither is required to use Termio; both make a fleet of agents easier to
 run.
 
-## Session control
+## Live agent status
 
 Termio can install small **status hooks** into your agents' own config files
 (Claude Code, Codex, Cursor, and the plugin-based agents). When an agent starts
@@ -17,21 +17,39 @@ working, finishes, or stops to ask a question, the hook reports that to Termio, 
 the sidebar's [status dots](/docs/sidebar#status) reflect exactly what's happening
 instead of being guessed from output.
 
-Turn it on from **Settings ▸ Agents** (Termio also offers it once on first
-launch). Toggling it off removes the hooks again, leaving any hooks you added
-yourself untouched.
+Turn it on from **Settings ▸ General ▸ Live agent status** (Termio also offers it
+once on first launch). Toggling it off removes the hooks again, leaving any hooks
+you added yourself untouched.
+
+## Session control
+
+**Settings ▸ General ▸ Session control** turns on the `termio sessions`
+orchestration API below, and teaches your agents it exists by installing a
+`termio` **agent skill** into each agent's skills folder (`~/.claude/skills`,
+`~/.codex/skills`). The skill loads on demand — an agent carries only its
+one-line description until a task actually involves driving sibling sessions —
+and Termio re-asserts it on every launch, so app updates propagate and
+hand-edits heal automatically. Toggling it off removes the skill again.
+
+Running an agent Termio doesn't auto-configure? The same skill is published at
+[termio.sh/skill.md](https://termio.sh/skill.md) and installable straight from
+the repo:
+
+```bash
+npx skills add termio-sh/termio --skill termio
+```
 
 <Callout type="note">
-  Session control only writes the status hooks into agent configs on your Mac.
-  Nothing leaves your machine — the reports travel over a local socket to the
-  Termio app, and nowhere else.
+  Both toggles only write files on your Mac — hook entries in agent configs and
+  the skill file. Nothing leaves your machine: status reports and session
+  commands travel over a local socket to the Termio app, and nowhere else.
 </Callout>
 
 ## The `termio` command-line tool
 
-Install the CLI from **Settings ▸ General ▸ Install Command-Line Tool**. It
-symlinks a `termio` command onto your `PATH` (at `/usr/local/bin/termio`; macOS
-asks for permission once).
+Turn on **Settings ▸ General ▸ Command-line tool**. It symlinks a `termio`
+command onto your `PATH` (at `/usr/local/bin/termio`; macOS asks for permission
+once), and turning it off removes the link again.
 
 ### Open a project
 


### PR DESCRIPTION
Documents the agent skill shipped in v0.33.0 and aligns docs with the Settings ▸ General switches.

- Splits the session-control docs page into **Live agent status** (the hooks) and **Session control** (the `termio sessions` API plus the `termio` skill Termio installs into `~/.claude/skills` / `~/.codex/skills`), with the manual install paths: [termio.sh/skill.md](https://termio.sh/skill.md) and `npx skills add termio-sh/termio --skill termio`
- README: notes that agents learn the CLI via the auto-installed skill, and fixes the dead `agent@id` addressing in the example
- Installation page: "Install Command-Line Tool" button → the **Command-line tool** switch

Release Notes:
- N/A (docs only)