### PR TITLE
Fix the crash when editing ~/.ssh/config from Settings

### DIFF
--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -22,19 +22,19 @@ struct FileEditorView: View {
     /// Dismisses the overlay (clears `store.openFileURL`) and hands focus back to the terminal.
     let onClose: () -> Void
 
-    /// For the right-click "Add to Chat" on both faces (editor and Markdown reader):
-    /// the gate and the prompt insertion live on the store.
-    @EnvironmentObject private var store: TermioStore
+    /// The right-click "Add to Chat" on both faces (editor and Markdown reader), supplied by the
+    /// host rather than read out of the environment — the editor also opens from the Settings
+    /// window, whose SwiftUI root is a separate `NSHostingView` with no store in scope. The
+    /// argument is the selected text, `nil` for the whole document (Cursor's split: selection →
+    /// snippet, file → reference). Left nil where there is no session to send to; the menu item
+    /// then never appears.
+    let addToChat: ((String?) -> Void)?
+    let canAddToChat: (() -> Bool)?
 
-    /// Cursor's split, shared by both faces: a selection goes over as the pasted
-    /// snippet itself; no selection means the document, which lands as its path.
-    private func addToChat(selection: String?) {
-        if let selection {
-            _ = store.addSnippetToSelectedSessionPrompt(selection)
-        } else {
-            _ = store.addPathToSelectedSessionPrompt(url)
-        }
-    }
+    /// Whether the header carries the inspector's window controls (hide list / maximize / close).
+    /// A sheet has no list column to collapse and no inspector to fill, so it hosts the editor
+    /// without them and supplies its own way out.
+    let showsInspectorChrome: Bool
 
     @Environment(\.colorScheme) private var colorScheme
 
@@ -86,11 +86,15 @@ struct FileEditorView: View {
     @State private var relativePath: String?
 
     init(url: URL, settings: AppSettings, readOnly: Bool = false, jumpLine: Int? = nil,
-         onClose: @escaping () -> Void) {
+         addToChat: ((String?) -> Void)? = nil, canAddToChat: (() -> Bool)? = nil,
+         showsInspectorChrome: Bool = true, onClose: @escaping () -> Void) {
         self.url = url
         self.settings = settings
         self.readOnly = readOnly
         self.jumpLine = jumpLine
+        self.addToChat = addToChat
+        self.canAddToChat = canAddToChat
+        self.showsInspectorChrome = showsInspectorChrome
         self.onClose = onClose
         // No I/O here: SwiftUI re-runs this init on every parent render (the store's
         // session churn), and only the first init per `.id(url)` identity keeps its
@@ -195,8 +199,8 @@ struct FileEditorView: View {
                 fileURL: url,
                 settings: settings,
                 colorScheme: colorScheme,
-                addToChat: { addToChat(selection: $0) },
-                canAddToChat: { store.selectedSessionRunsAgent }
+                addToChat: addToChat,
+                canAddToChat: canAddToChat
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
@@ -220,8 +224,8 @@ struct FileEditorView: View {
                     if count > 0, findFocusedIndex >= count { findFocusedIndex = 0 }
                 },
                 showsCloseMenuItem: true,
-                addToChat: { addToChat(selection: $0) },
-                canAddToChat: { store.selectedSessionRunsAgent },
+                addToChat: addToChat,
+                canAddToChat: canAddToChat,
                 onSave: saveNow
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -286,7 +290,9 @@ struct FileEditorView: View {
             }
             // The content-area window controls (hide list / maximize / close) ride the header's
             // trailing edge, after the file's own controls.
-            InspectorDetailChromeButtons()
+            if showsInspectorChrome {
+                InspectorDetailChromeButtons()
+            }
         }
         // Leading edge matches the Markdown reader's body padding (20) so the file name lines up
         // with the document text beneath it.
@@ -465,6 +471,13 @@ struct FileEditorView: View {
         case "gemfile", "podfile", "rakefile", "gemfile.lock": return "ruby"
         case "cargo.lock", "poetry.lock", "pipfile": return "ini" // TOML-ish (no toml grammar)
         case "yarn.lock": return "yaml"
+        // highlight.js ships no ssh_config grammar; `properties` is the closest fit — an
+        // ssh_config line *is* `Directive value`, which it colors as key + rest-of-line value
+        // (`ini` needs `=` or `[section]` and would leave the whole file grey). The bare name
+        // `config` only qualifies inside `.ssh`, since it's also git's ini-style config.
+        case "ssh_config", "sshd_config": return "properties"
+        case "config" where url.deletingLastPathComponent().lastPathComponent == ".ssh":
+            return "properties"
         case ".gitignore", ".dockerignore", ".npmignore": return "bash"
         case ".env", ".editorconfig", ".npmrc": return "ini"
         case "nginx.conf": return "nginx"

--- a/Sources/termio/FileBrowser/InspectorDetailHost.swift
+++ b/Sources/termio/FileBrowser/InspectorDetailHost.swift
@@ -204,7 +204,16 @@ struct InspectorDetailContent: View {
             } else {
                 FileEditorView(url: url, settings: settings,
                                readOnly: store.openFileReadOnly,
-                               jumpLine: store.openFileLine, onClose: close)
+                               jumpLine: store.openFileLine,
+                               addToChat: { selection in
+                                   if let selection {
+                                       _ = store.addSnippetToSelectedSessionPrompt(selection)
+                                   } else {
+                                       _ = store.addPathToSelectedSessionPrompt(url)
+                                   }
+                               },
+                               canAddToChat: { store.selectedSessionRunsAgent },
+                               onClose: close)
                     .id(url)
             }
         } else if let request = store.openTrace {

--- a/Sources/termio/Settings/SSHSettingsTab.swift
+++ b/Sources/termio/Settings/SSHSettingsTab.swift
@@ -42,12 +42,13 @@ struct SSHSettingsTab: View {
                 url: target.url,
                 settings: settings,
                 jumpLine: target.line,
+                showsInspectorChrome: false,
                 onClose: { configEditor = nil }
             )
             .frame(minWidth: 640, minHeight: 460)
-            // FileEditorView delegates its close to an external toolbar that only
-            // exists over the terminal pane — in a sheet there's none, so supply
-            // one. Escape closes too; the visible button is the guaranteed way out.
+            // The editor's own header controls belong to the inspector, which a sheet
+            // doesn't have — so supply the one control that still applies. Escape closes
+            // too; the visible button is the guaranteed way out.
             .overlay(alignment: .topTrailing) {
                 Button { configEditor = nil } label: {
                     Image(systemName: "xmark")


### PR DESCRIPTION
Settings ▸ SSH ▸ **Edit** (and a host row's "Edit in Config") quit the app on the spot — `EXC_BREAKPOINT` from SwiftUI's missing-environment-object trap, reproducible every time, in every release since v0.23.0.

The Settings window is its own `NSHostingView` root and, alone among the app's hosts, never injected `TermioStore`. A sheet inherits the presenter's environment, so the editor opened with no store in scope, and the `InspectorDetailChromeButtons` in its header reads one straight from its body. The same wire ran under the editor's right-click "Add to Chat", which would have trapped too.

Rather than inject the store into the Settings root — which would silence the trap but leave those buttons collapsing and maximizing an inspector the sheet doesn't have — the editor now takes what it needs from whoever hosts it: the chat hooks as closures (nil in Settings, where there is no session to send to) and a flag for the inspector's window controls, which the sheet turns off in favour of the close button it already draws.

While the file was open: `~/.ssh/config`, `ssh_config` and `sshd_config` now highlight. highlight.js ships no ssh_config grammar; of the ones bundled, `properties` is the only one that reads `Directive value` lines (`ini` wants `=` or `[section]` and leaves the file grey). `Include`d fragments under other names still open as plain text.

Verified against a dev build: Edit opens the editor, the file loads, the app survives, and no new crash report is written.

Release Notes:
- Fixed a crash when opening `~/.ssh/config` from Settings ▸ SSH.
- SSH config files now open with syntax highlighting.