### PR TITLE
Paint the GitHub star count yellow

### DIFF
--- a/web/landing/src/app/globals.css
+++ b/web/landing/src/app/globals.css
@@ -15,6 +15,9 @@
   --color-brand-red: #ff5252;
   --color-brand-amber: #ffb764;
   --color-brand-amber-deep: #fd9426;
+  /* Star yellow — the colour people already picture on a GitHub star, kept
+     deep enough to hold its edge on the white GitHub pill. */
+  --color-brand-gold: #eab308;
   --color-brand-green: #27c93f;
   --color-brand-green-deep: #16c253;
   --color-brand-blue: #0088ff;

--- a/web/landing/src/components/github-star-count.tsx
+++ b/web/landing/src/components/github-star-count.tsx
@@ -45,7 +45,7 @@ export function GitHubStarCount({
   if (stars === null) return null;
   return (
     <span className="ml-1 inline-flex items-center gap-1 border-l border-primary-foreground/20 pl-3 text-primary-foreground/70">
-      <StarMark className="h-3.5 w-3.5" />
+      <StarMark className="h-3.5 w-3.5 text-brand-gold" />
       {formatStarCount(stars)}
     </span>
   );


### PR DESCRIPTION
The GitHub band's whole ask is "A star helps other builders find it," but the star next to the count rendered at the same muted grey as the number, so the one glyph carrying that ask was the quietest thing in the pill.

It now uses a new `--color-brand-gold: #eab308` token — the yellow people already picture on a GitHub star, deep enough to hold its edge on the white pill. The traffic-light `brand-amber-deep` was tried first and read as an orange warning tint; GitHub's own `#e3b341` washed out against white. The count stays grey so only the star carries colour.

Release Notes: The landing page's GitHub star count now shows a yellow star.