### PR TITLE
Drop the redundant comment on the star token

### DIFF
--- a/web/landing/src/app/globals.css
+++ b/web/landing/src/app/globals.css
@@ -15,8 +15,6 @@
   --color-brand-red: #ff5252;
   --color-brand-amber: #ffb764;
   --color-brand-amber-deep: #fd9426;
-  /* Star yellow — the colour people already picture on a GitHub star, kept
-     deep enough to hold its edge on the white GitHub pill. */
   --color-brand-gold: #eab308;
   --color-brand-green: #27c93f;
   --color-brand-green-deep: #16c253;


### PR DESCRIPTION
The `--color-brand-gold` token shipped with a two-line comment explaining what a gold star looks like. No sibling token carries one, and the reasoning already lives in the PR that added it.

Release Notes: None.