### PR TITLE
Open new terminals in the focused session's directory

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -803,10 +803,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.presentOpenProjectPanel()
     }
 
-    /// The toolbar's `+` button — opens a fresh scratch terminal at the user's home
-    /// directory (like a new iTerm2 window), grouped under a home-rooted section in the
-    /// sidebar. Reached via the responder chain (the toolbar item targets `nil`), like
-    /// the other app actions.
+    /// File ▸ New Terminal (⌘T) — a shell in the focused session's directory, beside
+    /// that session (see `addTerminalHere`). Reached via the responder chain (the menu
+    /// item targets `nil`), like the other app actions.
+    @objc func newTerminalHere(_ sender: Any?) {
+        store.addTerminalHere()
+    }
+
+    /// New Terminal at Home — the same verb in the File menu and the sidebar's `+`,
+    /// always starting at `~` the way a new iTerm2 window does.
     @objc func newScratchTerminal(_ sender: Any?) {
         store.addScratchTerminal()
     }
@@ -1635,9 +1640,15 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     /// as a project. "New Chat" opens the user's agent roster and "New SSH Connection"
     /// the config's hosts as submenus (the same ones the File menu carries — see
     /// `makeNewChatItem` / `makeNewSSHItem`).
+    ///
+    /// Every entry here is context-free: nothing reads the selection, so the terminal
+    /// entry is the `$HOME` one. The `+` lives in the sidebar's toolbar, where "here"
+    /// has no referent — the directory-following New Terminal is ⌘T, pressed with the
+    /// terminal in front of you.
     func makeNewSessionMenu() -> NSMenu {
         let menu = NSMenu()
-        let terminal = NSMenuItem(title: "New Terminal", action: #selector(newTerminal(_:)), keyEquivalent: "")
+        let terminal = NSMenuItem(title: "New Terminal at Home",
+                                  action: #selector(newTerminal(_:)), keyEquivalent: "")
         terminal.target = self
         menu.addItem(terminal)
         menu.addItem(makeNewChatItem())
@@ -1948,8 +1959,15 @@ private func buildMainMenu() -> NSMenu {
     // never Cmd, so it can't shadow a key a terminal app wants.
     fileMenu.addItem(
         withTitle: "New Terminal",
-        action: #selector(AppDelegate.newScratchTerminal(_:)),
+        action: #selector(AppDelegate.newTerminalHere(_:)),
         command: .newTerminal
+    )
+    // The always-`$HOME` terminal, kept as its own verb now that ⌘T follows the
+    // focused session's directory.
+    fileMenu.addItem(
+        withTitle: "New Terminal at Home",
+        action: #selector(AppDelegate.newScratchTerminal(_:)),
+        command: .newTerminalAtHome
     )
     // New Chat ▸ one row per enabled agent (the user's roster, filled on open by the
     // AppDelegate — see `makeNewChatItem`). ⌘N (rebindable in Settings ▸ Keyboard)

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -239,6 +239,13 @@ struct Session: Identifiable, Hashable, Codable {
     /// real (`.folder`) project never set it; their anchor is the project path.
     var lastWorkingDirectory: String?
 
+    /// Where this session was opened, when that isn't its project's own anchor: ⌘T
+    /// records the directory the user was in, so the new shell starts *there* rather
+    /// than at the project root. Persisted, so a relaunch reopens it in the same
+    /// place. `lastWorkingDirectory` outranks it for a loose terminal — a shell that
+    /// reported its own cwd knows better than the seed it was given.
+    var spawnDirectory: String?
+
     /// The last meaningful terminal title (`OSC 0/2`) the session's agent reported,
     /// e.g. Claude Code's conversation topic. Persisted so the sidebar keeps the
     /// adopted label across app restarts — the agent only re-emits a title once it
@@ -261,7 +268,7 @@ struct Session: Identifiable, Hashable, Codable {
 
     private enum CodingKeys: String, CodingKey {
         case id, title, agent, createdAt, worktreePath, resumeID, launched, launchedAt,
-             liveTitle, lastWorkingDirectory, sshHost, pinned
+             liveTitle, lastWorkingDirectory, spawnDirectory, sshHost, pinned
     }
 
     /// Custom decoding so state files written before the resume fields existed still
@@ -281,6 +288,7 @@ struct Session: Identifiable, Hashable, Codable {
         launchedAt = try container.decodeIfPresent(Date.self, forKey: .launchedAt)
         liveTitle = try container.decodeIfPresent(String.self, forKey: .liveTitle)
         lastWorkingDirectory = try container.decodeIfPresent(String.self, forKey: .lastWorkingDirectory)
+        spawnDirectory = try container.decodeIfPresent(String.self, forKey: .spawnDirectory)
         sshHost = try container.decodeIfPresent(String.self, forKey: .sshHost)
     }
 }

--- a/Sources/termio/CommandPalette/CommandPalette.swift
+++ b/Sources/termio/CommandPalette/CommandPalette.swift
@@ -315,7 +315,7 @@ struct CommandPaletteView: View {
         }
         actions.append(.init(id: "new-terminal", title: "New Terminal",
                              icon: .plusSquare, shortcut: keys.display(for: .newTerminal)) {
-            $0.addScratchTerminal()
+            $0.addTerminalHere()
         })
         // The single "New Chat" verb (default agent, always the scratch Chats
         // funnel), carrying its ⌘N shortcut — the palette twin of File ▸ New Chat.

--- a/Sources/termio/Keybindings/KeyCommand.swift
+++ b/Sources/termio/Keybindings/KeyCommand.swift
@@ -6,6 +6,7 @@ import Foundation
 enum KeyCommandID: String, CaseIterable, Identifiable {
     // File
     case newTerminal = "file.new-terminal"
+    case newTerminalAtHome = "file.new-terminal-at-home"
     case newChat = "file.new-chat"
     case openProject = "file.open-project"
     // Navigation
@@ -65,6 +66,11 @@ enum KeyCommandCatalog {
         // File
         .init(id: .newTerminal, category: "File", title: "New Terminal",
               defaultShortcut: .init(modifiers: [.command], key: .char("t"))),
+        // Unbound, the way Split Left and Split Up are: a shell at `~` is the rare
+        // direction, and the key it would take — ⌘⇧T — is "reopen closed tab" muscle
+        // memory everywhere else on the Mac.
+        .init(id: .newTerminalAtHome, category: "File", title: "New Terminal at Home",
+              defaultShortcut: nil),
         .init(id: .newChat, category: "File", title: "New Chat",
               defaultShortcut: .init(modifiers: [.command], key: .char("n"))),
         .init(id: .openProject, category: "File", title: "Open Project…",

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -9,6 +9,7 @@ extension TermioStore {
         to projectID: Project.ID,
         agent: AgentPreset = .terminal,
         worktreePath: String? = nil,
+        spawnDirectory: String? = nil,
         takeFocus: Bool = true
     ) -> Session.ID? {
         guard let index = projects.firstIndex(where: { $0.id == projectID }) else { return nil }
@@ -19,6 +20,7 @@ extension TermioStore {
             : agent.displayName
         var session = Session(title: title, agent: agent)
         session.worktreePath = worktreePath
+        session.spawnDirectory = spawnDirectory
         projects[index].sessions.append(session)
         if takeFocus {
             selectedSessionID = session.id
@@ -282,6 +284,38 @@ extension TermioStore {
     /// it reappears on relaunch (the shells themselves restart fresh).
     func addScratchTerminal() { addScratchSession(agent: .terminal) }
 
+    /// Opens a terminal where the user already is — New Terminal (⌘T). The shell
+    /// starts in the focused session's working directory and the row lands beside it:
+    /// in the same project and worktree bucket for a real project, in the Terminals
+    /// section for a loose shell or a scratch chat (a shell has no business in the
+    /// Chats funnel).
+    ///
+    /// The directory is the cwd the session reported over OSC 7. A shell without
+    /// integration never reports one, and an SSH terminal reports a path that exists
+    /// only on the remote host, so anything that isn't a local directory falls through
+    /// to the session's own anchor — and to `$HOME` with nothing focused, which is
+    /// what New Terminal at Home does on purpose.
+    func addTerminalHere() {
+        guard let id = selectedSessionID,
+              let project = project(for: id),
+              let session = session(id) else {
+            addScratchTerminal()
+            return
+        }
+        let reported = Self.existingDirectory(
+            workingDirectory(for: id) ?? session.lastWorkingDirectory)
+        let directory = reported
+            ?? session.spawnDirectory
+            ?? session.worktreePath
+            ?? project.path
+        guard project.kind == .folder else {
+            addScratchSession(agent: .terminal, spawnDirectory: directory)
+            return
+        }
+        addSession(to: project.id, agent: .terminal,
+                   worktreePath: session.worktreePath, spawnDirectory: directory)
+    }
+
     /// The agent a bare **New Chat** launches, resolved in priority order:
     /// 1. the agent the user pinned in Settings ▸ Agents (`defaultChatAgentID`),
     /// 2. else "Last used" — the last agent a chat was started with,
@@ -323,7 +357,11 @@ extension TermioStore {
     /// `.terminals` funnel for shells, the `.chats` funnel for agents — so a second
     /// click just grows another row there and selects it, rather than piling up
     /// duplicate sections.
-    func addScratchSession(agent: AgentPreset = .terminal) {
+    ///
+    /// `spawnDirectory` overrides where a scratch *terminal* starts, so ⌘T from a
+    /// loose shell opens its sibling at the same cwd. Agents ignore it: being confined
+    /// to the scoped workspace is the point.
+    func addScratchSession(agent: AgentPreset = .terminal, spawnDirectory: String? = nil) {
         // Both funnels are matched by kind, not path: the `.terminals` container's
         // `path` is just the `$HOME` spawn fallback, and the single `.chats` container
         // gathers every agent (Claude, Codex, …) that spawns in the scratch workspace.
@@ -332,12 +370,14 @@ extension TermioStore {
         // action relaunches whatever you actually use (see `defaultChatAgent`).
         if agent != .terminal { settings.lastChatAgentID = agent.rawValue }
         let containerKind: ProjectKind = agent == .terminal ? .terminals : .chats
+        let seededDirectory = agent == .terminal ? spawnDirectory : nil
         if let existing = projects.first(where: { $0.kind == containerKind }) {
-            addSession(to: existing.id, agent: agent)
+            addSession(to: existing.id, agent: agent, spawnDirectory: seededDirectory)
             return
         }
         let title = agent == .terminal ? "Terminal 1" : agent.displayName
-        let session = Session(title: title, agent: agent)
+        var session = Session(title: title, agent: agent)
+        session.spawnDirectory = seededDirectory
         let project = Project(
             name: agent == .terminal ? "Terminals" : "Chats",
             path: path,

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -111,6 +111,15 @@ enum PiSession {
 }
 
 extension TermioStore {
+    /// `path` when it still names a real directory, else `nil`. A recorded cwd outlives
+    /// the folder it points at, and a shell spawned in a deleted directory lands at `/`.
+    static func existingDirectory(_ path: String?) -> String? {
+        guard let path else { return nil }
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+        return exists && isDirectory.boolValue ? path : nil
+    }
+
     /// Returns the cached terminal surface for a session, creating and starting
     /// it on first access. The surface launches `session.command` (or the login
     /// shell) in the project's working directory via the real PTY (`.exec`).
@@ -124,15 +133,17 @@ extension TermioStore {
         // A loose terminal instead respawns at the cwd it last reported over OSC 7
         // (its path is the session's own mutable property, not the container's) —
         // so a relaunch drops the user back where they `cd`'d, not at `$HOME`.
-        // A directory deleted since then falls back to the container's `$HOME`.
-        let restoredCwd: String? = project.kind == .terminals
-            ? session.lastWorkingDirectory.flatMap { path in
-                var isDirectory: ObjCBool = false
-                let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
-                return exists && isDirectory.boolValue ? path : nil
-            }
+        // Ahead of the worktree/project anchor sits the directory the session was
+        // opened in (⌘T): where the user asked *this* shell to start, even when the
+        // session belongs to a project rooted elsewhere. Each rung must still exist —
+        // a stale path falls through rather than dropping the shell at `/`.
+        let restoredCwd = project.kind == .terminals
+            ? Self.existingDirectory(session.lastWorkingDirectory)
             : nil
-        let workspacePath = session.worktreePath ?? restoredCwd ?? project.path
+        let workspacePath = restoredCwd
+            ?? Self.existingDirectory(session.spawnDirectory)
+            ?? session.worktreePath
+            ?? project.path
 
         // Resolve the launch command *with* any resume arguments, so a session that was
         // running when the app last quit picks its conversation back up instead of

--- a/web/landing/content/docs/keyboard.mdx
+++ b/web/landing/content/docs/keyboard.mdx
@@ -11,6 +11,11 @@ is rebindable — see [Customizing](#customizing).
 
 <Keybindings category="File" />
 
+New Terminal opens the shell where you already are — the working directory of the
+focused session — and puts the new session beside it, in the same project. New
+Terminal at Home always starts at `~`; it ships unbound, so bind it under
+[Customizing](#customizing) if that is the one you reach for.
+
 Cycling follows the sidebar's visual order, so `⇧⌘]` moves to the next session as
 you see it listed, not in the order the sessions were created.
 

--- a/web/landing/content/docs/keyboard.zh-CN.mdx
+++ b/web/landing/content/docs/keyboard.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 键盘快捷键
 description: Termio 附带的每一个快捷键，直接读自应用自己的命令目录——以及如何在「设置 ▸ 键盘」里重新绑定它们。
 x-i18n:
   source_path: keyboard.mdx
-  source_hash: 9513fcf2eba36cd483687fd31a54925012d1385a4d6cfffc1327f70dc58a3095
-  generated_at: 2026-08-10
+  source_hash: 9207d93ff044e0241aa8b2d7c8bf5c1225815fea02e1c94781e9607e86a5250d
+  generated_at: 2026-08-12
 ---
 
 Termio 是为键盘操作而造的。下面的表格由应用的命令目录生成，因此列出的正是这个版本实际
@@ -13,6 +13,10 @@ Termio 是为键盘操作而造的。下面的表格由应用的命令目录生�
 ## 会话与项目
 
 <Keybindings category="File" unboundLabel="未绑定" />
+
+「New Terminal」会在你已经在的地方打开 shell——当前会话的工作目录——并把新会话放在它旁边，
+留在同一个项目里。「New Terminal at Home」则始终从 `~` 开始；它出厂不带按键，如果你常用
+它，就去[自定义](#customizing)里绑一个。
 
 循环切换遵循侧栏的视觉顺序，所以 `⇧⌘]` 会移到你看到的下一个会话，而不是按创建顺序。
 

--- a/web/landing/src/data/keybindings.json
+++ b/web/landing/src/data/keybindings.json
@@ -10,6 +10,11 @@
           "shortcut": "⌘T"
         },
         {
+          "id": "newTerminalAtHome",
+          "title": "New Terminal at Home",
+          "shortcut": null
+        },
+        {
           "id": "newChat",
           "title": "New Chat",
           "shortcut": "⌘N"


### PR DESCRIPTION
New Terminal always started a shell at `$HOME`, so the shortcut people reach for to "open another shell right here" threw away where they were.

⌘T now opens the terminal in the focused session's working directory and lands it beside that session — same project, same worktree bucket — instead of creating a project-less scratch session. The directory is the cwd the session last reported over OSC 7 (`workingDirectory(for:)`); when no shell integration ever reported one, or the reported path isn't a local directory (an SSH terminal reports a remote path), it falls back to the session's own spawn anchor, then to the project root, and finally to `$HOME` when nothing is focused at all.

The seeded directory rides on a new `Session.spawnDirectory`, persisted so a relaunched shell reopens where it was opened. A loose terminal's own `lastWorkingDirectory` still wins over it — a shell that reported its cwd knows better than the seed.

A shell never lands in the Chats funnel: ⌘T from a scratch chat opens the terminal in the Terminals section, seeded with the chat's directory.

The old behavior stays available as its own verb, **New Terminal at Home**, in the File menu and in the sidebar's `+` pull-down.

### Which entry points follow the focus

The `+` pull-down is context-free by construction — New Chat always lands in the Chats funnel, New SSH Connection always in Terminals, none of them read the selection — and it sits in the sidebar's toolbar, where "here" has no clear meaning. So its terminal entry is the `$HOME` one, named for where it starts. The directory-following New Terminal is reached where the terminal is actually in front of you: ⌘T, the File menu, and the Command Palette (which lists it with its ⌘T binding, alongside its other selection-dependent verbs). The Terminals section header keeps its own local "New Terminal", which adds to that container as before.

### How this compares to the neighbours

- **cmux** (also ghostty-based) already inherits the focused tab's directory on ⌘T; the live complaint in [cmux#177](https://github.com/manaflow-ai/cmux/issues/177) is that inheritance can't be turned *off*. Their root cause is worth knowing: with nothing to pass, they hand `nil` to `ghostty_surface_new`, which falls back to the process CWD — `/` for a Finder-launched app. This ladder never ends in `nil`, which is the same trap `Project.firstRunProjects()` already documents.
- **Ghostty** defaults `window-inherit-working-directory` to true, needs shell integration for it, and falls back to a configured default otherwise — the same three rungs.
- **Zed** anchors its terminal to the project (`terminal.working_directory`, default `current_project_directory`) and never follows a `cd`. That is the editor answer; termio is terminal-first, and the report behind #243 was a user expecting terminal semantics.

### On the second binding

The issue proposed ⌘⇧T for New Terminal at Home. It ships **unbound** instead, for the reason `splitLeft` / `splitUp` already ship unbound: opening a shell at `~` when your work is in a project is the rare direction, and ⌘⇧T is "reopen closed tab" muscle memory everywhere else on the Mac — worth keeping free for a session-shaped command later. The verb stays in the File menu and in Settings ▸ Keyboard, so it is one binding away for anyone who wants it. Reverting is one line in `KeyCommandCatalog`.

Worth noting that ghostty and cmux both spell this escape hatch as a config key rather than a verb, and cmux#177 is what that costs when the key isn't plumbed through: five confused users and an open bug. A menu item calling `addScratchTerminal()` — a function that already had three call sites — can't fail that way.

### Known limit

For a session in a real project, right after an app relaunch and before the shell's first OSC 7, ⌘T lands at the project root rather than the subdirectory the shell was in. That is deliberate: a project session's anchor is the project (`docs/design/loose-terminal-entity.md`), and only loose terminals persist their own cwd. It can never land at `~`. cmux has the same gap without the floor — after a restore, its ⌘T drops to `~` (last comment on #177).

### Docs

`web/landing/src/data/keybindings.json` is regenerated with `pnpm keybindings:sync`; the shortcut tables are not hand-written. The one prose paragraph added to `keyboard.mdx` is translated in `keyboard.zh-CN.mdx` and re-stamped. `docs:check` passes.

## Verification

- `swift build`, `swift test` (172 tests), and `pnpm docs:check` pass. CI is green.
- **Not verified at runtime.** The dev channel is held by another session, so the File menu items, ⌘T from a project session, and the spawned shell's actual cwd have not been exercised in a running app. Before merging, this is worth one manual pass: `cd` inside a project session then ⌘T (new terminal starts there, row lands beside it), ⌘T from a loose terminal (sibling in Terminals at the same cwd), File ▸ New Terminal at Home (starts at `~`, no shortcut shown), and Settings ▸ Keyboard listing it under File as unbound.

Closes #243

Release Notes:
- New Terminal (⌘T) now opens in the current session's working directory, beside that session. File ▸ New Terminal at Home still starts a shell at your home directory.
