### PR TITLE
Install the session-control skill into every skills-capable agent

### DIFF
--- a/Sources/termio/Agents/AgentDefinition.swift
+++ b/Sources/termio/Agents/AgentDefinition.swift
@@ -75,6 +75,10 @@ struct AgentDefinition: Identifiable {
     /// status authority — so `statusRules` is left `nil` and screen-scrape is skipped,
     /// keeping one source of truth per pane. See `AgentHookSpec`.
     let hookSpec: AgentHookSpec?
+    /// The agent's user-level skills directory as declared in the manifest
+    /// (`~/.claude/skills`), or `nil` when the agent has no skills ecosystem.
+    /// `SessionSkillInstaller` installs the termio skill into `<dir>/termio/`.
+    let skillDir: String?
 
     /// All fields after `wireName` are optional so the built-in roster and the
     /// fallback don't each have to spell them out.
@@ -85,7 +89,7 @@ struct AgentDefinition: Identifiable {
         iconRef: TermioShared.IconRef, tint: Color, tintHex: String?, installURL: URL?, wireName: String,
         statusRules: AgentStatusRules? = nil, titleRules: AgentStatusRules? = nil,
         emitsProgressStatus: Bool = false,
-        hookSpec: AgentHookSpec? = nil
+        hookSpec: AgentHookSpec? = nil, skillDir: String? = nil
     ) {
         self.id = id
         self.order = order
@@ -103,6 +107,7 @@ struct AgentDefinition: Identifiable {
         self.titleRules = titleRules
         self.emitsProgressStatus = emitsProgressStatus
         self.hookSpec = hookSpec
+        self.skillDir = skillDir
     }
 
     /// The default `order` for a manifest that declares none — high, so unspecified
@@ -869,6 +874,16 @@ struct AgentManifest: Decodable {
     /// plain shell's `wget`/`npm` progress bar can never move an agent's status dot.
     var progressStatus: Bool?
     var hooks: HookSpec?
+    /// Where the agent loads user-level Agent Skills from, so termio can install
+    /// the session-control skill there. Optional: agents with no skills ecosystem
+    /// (or one termio hasn't confirmed) simply omit it and get no skill install.
+    var skills: SkillsSpec?
+
+    /// The manifest's `skills` — one directory, declared the way hooks declare
+    /// theirs. `~` is expanded at install time.
+    struct SkillsSpec: Decodable {
+        var dir: String?
+    }
 
     struct IconSpec: Decodable {
         var vector: String?
@@ -1040,6 +1055,14 @@ struct AgentManifest: Decodable {
         }
     }
 
+    private func resolvedSkillDir() throws -> String? {
+        guard let skills else { return nil }
+        guard let dir = skills.dir?.trimmingCharacters(in: .whitespaces), !dir.isEmpty else {
+            throw ManifestError.invalid("\(id): skills require 'dir'")
+        }
+        return dir
+    }
+
     private func resolvedHookSpec() throws -> AgentHookSpec? {
         guard let hooks else { return nil }
         let typeName = hooks.type?.lowercased() ?? "json"
@@ -1206,6 +1229,7 @@ struct AgentManifest: Decodable {
             resolvedTintHex = nil
         }
         let hookSpec = try resolvedHookSpec()
+        let skillDir = try resolvedSkillDir()
         let statusRules = hookSpec == nil
             ? AgentStatusRules.from(working: status?.working, attention: status?.attention, label: id)
             : nil
@@ -1223,7 +1247,7 @@ struct AgentManifest: Decodable {
             tint: resolvedTint, tintHex: resolvedTintHex,
             installURL: (install ?? installURL).flatMap(URL.init(string:)), wireName: wire ?? id,
             statusRules: statusRules, titleRules: titleRules,
-            emitsProgressStatus: progressStatus ?? false, hookSpec: hookSpec)
+            emitsProgressStatus: progressStatus ?? false, hookSpec: hookSpec, skillDir: skillDir)
     }
 
     private static func bundledAsset(named name: String, in bundle: Bundle) -> URL? {

--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -507,26 +507,61 @@ private extension SessionWatchEvent {
 }
 
 /// Tells a coding agent that the `termio sessions` CLI exists by installing an
-/// Agent Skill — a `SKILL.md` in each agent's user-level skills directory
-/// (`~/.claude/skills`, `~/.codex/skills`) — instead of editing the agent's
-/// always-loaded instruction file. The agent sees only the skill's one-line
-/// description up front and pulls the full guidance in when a task actually
-/// involves driving sibling sessions, so every unrelated session stays clean.
+/// Agent Skill — a `SKILL.md` in each agent's user-level skills directory, as
+/// declared by that agent's manifest `skills.dir` (`~/.claude/skills`,
+/// `~/.config/opencode/skills`, …) — instead of editing the agent's always-loaded
+/// instruction file. The agent sees only the skill's one-line description up front
+/// and pulls the full guidance in when a task actually involves driving sibling
+/// sessions, so every unrelated session stays clean.
 ///
 /// Earlier versions injected a marker-wrapped block into `~/.claude/CLAUDE.md`
 /// and `~/.codex/AGENTS.md`; every sync still strips that block wherever it
 /// remains, so an upgrade never leaves the guidance installed twice.
+///
+/// The target set is catalog-driven (`AgentCatalog`), so a user-dropped custom
+/// agent that declares `skills.dir` in its manifest gets the skill installed too,
+/// with no code change — the same data path `AgentStatusHooks` uses for hooks.
 enum SessionSkillInstaller {
     private static let beginMarker = "<!-- termio:sessions BEGIN -->"
     private static let endMarker = "<!-- termio:sessions END -->"
 
     private static var home: URL { FileManager.default.homeDirectoryForCurrentUser }
 
-    private static var skillTargets: [URL] {
-        [
-            home.appendingPathComponent(".claude/skills/termio/SKILL.md"),
-            home.appendingPathComponent(".codex/skills/termio/SKILL.md"),
-        ]
+    /// The skill file an agent's declared skills directory will carry, per agent in
+    /// the catalog. Installation follows `AgentCatalog.all` so a user override's
+    /// `skills` declaration wins; duplicate directories (an override of a bundled
+    /// id) install once.
+    static var skillTargets: [(name: String, url: URL)] {
+        let catalog = AgentCatalog.shared
+        var seen = Set<String>()
+        return catalog.all.compactMap { agent in
+            guard let directory = agent.skillDir else { return nil }
+            let url = skillFileURL(directory: directory)
+            guard seen.insert(url.path).inserted else { return nil }
+            return (agent.displayName, url)
+        }
+    }
+
+    /// Every skills directory termio has ever installed into — bundled declarations
+    /// plus the live catalog — so uninstalling also sweeps a shipped dir that a user
+    /// override removed or redirected. Mirrors `AgentStatusHooks.allKnownInstallers`.
+    static var allKnownSkillTargets: [(name: String, url: URL)] {
+        let catalog = AgentCatalog.shared
+        var seen = Set<String>()
+        return (catalog.bundled + catalog.all).compactMap { agent in
+            guard let directory = agent.skillDir else { return nil }
+            let url = skillFileURL(directory: directory)
+            guard seen.insert(url.path).inserted else { return nil }
+            return (agent.displayName, url)
+        }
+    }
+
+    /// Where an agent's declared skills directory carries termio's skill
+    /// (`<dir>/termio/SKILL.md`), with `~` expanded. The pure path logic, so tests
+    /// can pin it without touching the real home directory.
+    static func skillFileURL(directory: String) -> URL {
+        URL(fileURLWithPath: (directory as NSString).expandingTildeInPath)
+            .appendingPathComponent("termio/SKILL.md")
     }
 
     /// The instruction files earlier versions wrote the guidance into.
@@ -563,22 +598,16 @@ enum SessionSkillInstaller {
             guard let skill else {
                 FileHandle.standardError.write(
                     Data("termio: session skill resource missing from the app bundle\n".utf8))
-                for url in skillTargets { outcome.record(displayPath(of: url), installed: false) }
+                for (name, _) in skillTargets { outcome.record(name, installed: false) }
                 return outcome
             }
-            for url in skillTargets {
-                outcome.record(displayPath(of: url), installed: write(skill, to: url))
+            for (name, url) in skillTargets {
+                outcome.record(name, installed: write(skill, to: url))
             }
         } else {
-            for url in skillTargets { removeSkill(at: url) }
+            for (_, url) in allKnownSkillTargets { removeSkill(at: url) }
         }
         return outcome
-    }
-
-    /// The target's path with the home directory abbreviated (`~/.claude/CLAUDE.md`)
-    /// — how the docs and the files themselves refer to it.
-    private static func displayPath(of url: URL) -> String {
-        (url.path as NSString).abbreviatingWithTildeInPath
     }
 
     /// Removes the installed skill folder wholesale — termio owns the folder, so

--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -530,12 +530,21 @@ enum SessionSkillInstaller {
     /// The skill file an agent's declared skills directory will carry, per agent in
     /// the catalog. Installation follows `AgentCatalog.all` so a user override's
     /// `skills` declaration wins; duplicate directories (an override of a bundled
-    /// id) install once.
-    static var skillTargets: [(name: String, url: URL)] {
+    /// id) install once. Only agents whose CLI is actually installed get the skill,
+    /// so a machine without, say, Cursor never grows a `~/.cursor/skills` directory
+    /// it cannot use — `sync` re-checks on every launch, so an agent installed later
+    /// is picked up automatically. The `installed` predicate is injectable for
+    /// tests; the default resolves the agent's command like a session launch would.
+    static func skillTargets(
+        installed: (AgentDefinition) -> Bool = { agent in
+            guard let command = agent.command else { return true }
+            return AgentAvailability.isCommandInstalled(command)
+        }
+    ) -> [(name: String, url: URL)] {
         let catalog = AgentCatalog.shared
         var seen = Set<String>()
         return catalog.all.compactMap { agent in
-            guard let directory = agent.skillDir else { return nil }
+            guard let directory = agent.skillDir, installed(agent) else { return nil }
             let url = skillFileURL(directory: directory)
             guard seen.insert(url.path).inserted else { return nil }
             return (agent.displayName, url)
@@ -598,10 +607,10 @@ enum SessionSkillInstaller {
             guard let skill else {
                 FileHandle.standardError.write(
                     Data("termio: session skill resource missing from the app bundle\n".utf8))
-                for (name, _) in skillTargets { outcome.record(name, installed: false) }
+                for (name, _) in skillTargets() { outcome.record(name, installed: false) }
                 return outcome
             }
-            for (name, url) in skillTargets {
+            for (name, url) in skillTargets() {
                 outcome.record(name, installed: write(skill, to: url))
             }
         } else {

--- a/Sources/termio/Resources/agents/amp.json
+++ b/Sources/termio/Resources/agents/amp.json
@@ -6,6 +6,7 @@
   "command": "amp",
   "icon": { "asset": "amp-favicon" },
   "install": "https://ampcode.com/manual",
+  "skills": { "dir": "~/.config/agents/skills" },
   "hooks": {
     "type": "plugin",
     "dir": "~/.config/amp/plugins",

--- a/Sources/termio/Resources/agents/antigravity.json
+++ b/Sources/termio/Resources/agents/antigravity.json
@@ -5,5 +5,6 @@
   "wire": "antigravity",
   "command": "agy",
   "icon": { "asset": "antigravity-favicon" },
-  "install": "https://antigravity.google/product/antigravity-cli"
+  "install": "https://antigravity.google/product/antigravity-cli",
+  "skills": { "dir": "~/.gemini/antigravity/skills" }
 }

--- a/Sources/termio/Resources/agents/claude.json
+++ b/Sources/termio/Resources/agents/claude.json
@@ -13,6 +13,7 @@
   },
   "icon": { "vector": "claude" },
   "install": "https://claude.com/claude-code",
+  "skills": { "dir": "~/.claude/skills" },
   "titleStatus": {
     "working": ["^[⠀-⣿] "]
   },

--- a/Sources/termio/Resources/agents/codex.json
+++ b/Sources/termio/Resources/agents/codex.json
@@ -16,6 +16,7 @@
   },
   "icon": { "vector": "codex" },
   "install": "https://developers.openai.com/codex/cli",
+  "skills": { "dir": "~/.codex/skills" },
   "titleStatus": {
     "working": ["(?:^| )[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏](?: |$)"],
     "attention": ["Action Required"]

--- a/Sources/termio/Resources/agents/cursor.json
+++ b/Sources/termio/Resources/agents/cursor.json
@@ -6,6 +6,7 @@
   "command": "cursor-agent",
   "icon": { "asset": "cursor-favicon" },
   "install": "https://cursor.com/docs/cli",
+  "skills": { "dir": "~/.cursor/skills" },
   "hooks": {
     "type": "json",
     "file": "~/.cursor/hooks.json",

--- a/Sources/termio/Resources/agents/grok.json
+++ b/Sources/termio/Resources/agents/grok.json
@@ -14,6 +14,7 @@
   },
   "icon": { "vector": "grok" },
   "install": "https://x.ai/cli",
+  "skills": { "dir": "~/.grok/skills" },
   "titleStatus": {
     "attention": ["Action Required"]
   },

--- a/Sources/termio/Resources/agents/hermes.json
+++ b/Sources/termio/Resources/agents/hermes.json
@@ -5,5 +5,6 @@
   "wire": "hermes",
   "command": "hermes",
   "icon": { "asset": "hermes-favicon" },
-  "install": "https://hermes-agent.nousresearch.com/#downloads"
+  "install": "https://hermes-agent.nousresearch.com/#downloads",
+  "skills": { "dir": "~/.hermes/skills" }
 }

--- a/Sources/termio/Resources/agents/kimi.json
+++ b/Sources/termio/Resources/agents/kimi.json
@@ -6,9 +6,10 @@
   "command": "kimi",
   "icon": { "asset": "kimi-favicon" },
   "install": "https://moonshotai.github.io/kimi-code",
+  "skills": { "dir": "~/.kimi-code/skills" },
   "hooks": {
     "type": "toml",
-    "file": "~/.kimi/config.toml",
+    "file": "~/.kimi-code/config.toml",
     "dialect": "kimi",
     "events": [
       { "on": "UserPromptSubmit", "state": "working" },

--- a/Sources/termio/Resources/agents/opencode.json
+++ b/Sources/termio/Resources/agents/opencode.json
@@ -15,6 +15,7 @@
   },
   "icon": { "asset": "opencode-favicon" },
   "install": "https://opencode.ai",
+  "skills": { "dir": "~/.config/opencode/skills" },
   "hooks": {
     "type": "plugin",
     "dir": "~/.config/opencode/plugin",

--- a/Sources/termio/Resources/agents/pi.json
+++ b/Sources/termio/Resources/agents/pi.json
@@ -13,6 +13,7 @@
   },
   "icon": { "asset": "pi-favicon" },
   "install": "https://pi.dev",
+  "skills": { "dir": "~/.pi/agent/skills" },
   "hooks": {
     "type": "plugin",
     "dir": "~/.pi/agent/extensions",

--- a/Sources/termio/Settings/AgentAvailability.swift
+++ b/Sources/termio/Settings/AgentAvailability.swift
@@ -13,7 +13,22 @@ enum AgentAvailability {
     /// for the app run. The probe is bounded so a slow/hung rc can't wedge Settings;
     /// on failure it yields an empty list, which makes every check fall back to
     /// "assume available" rather than raise a false alarm.
-    private static let resolvedPath = Task.detached(priority: .utility) { resolvePathDirectories() }
+    private static let resolvedPath = Task.detached(priority: .utility) { pathDirectories() }
+
+    /// The resolved login-shell PATH, shared between the async probe and the
+    /// synchronous installer check so both agree on one answer. The detached task
+    /// populates it when it finishes; the sync check reads it without blocking.
+    private static let pathLock = NSLock()
+    private static var pathCache: [String]?
+
+    private static func pathDirectories() -> [String] {
+        pathLock.withLock {
+            if let cached = pathCache { return cached }
+            let resolved = resolvePathDirectories()
+            pathCache = resolved
+            return resolved
+        }
+    }
 
     /// Whether the first word of `command` (its binary) is an executable on PATH. An
     /// absolute/`~` path is checked directly; an empty command (the plain login shell)
@@ -28,6 +43,30 @@ enum AgentAvailability {
         let directories = await resolvedPath.value
         // Probe failed (no PATH) → don't cry wolf; only flag when we actually looked.
         guard !directories.isEmpty else { return true }
+        return directories.contains {
+            FileManager.default.isExecutableFile(atPath: $0 + "/" + binary)
+        }
+    }
+
+    /// A non-blocking, synchronous check for call sites that can't await (the skill
+    /// installer's per-launch sync). Absolute/`~` commands are checked directly;
+    /// relative binaries resolve against the login-shell PATH once the async probe
+    /// has populated the cache, and the process PATH before that — so a very early
+    /// call may under-report an installed agent, but never blocks on the shell, and
+    /// the next launch's sync re-checks and picks it up.
+    static func isCommandInstalled(_ command: String) -> Bool {
+        let trimmed = command.trimmingCharacters(in: .whitespaces)
+        guard let binary = trimmed.split(separator: " ").first.map(String.init), !binary.isEmpty
+        else { return true }
+        if binary.hasPrefix("/") || binary.hasPrefix("~") {
+            return FileManager.default.isExecutableFile(atPath: (binary as NSString).expandingTildeInPath)
+        }
+        var directories: [String] = []
+        pathLock.withLock { directories = pathCache ?? [] }
+        if directories.isEmpty {
+            directories = ProcessInfo.processInfo.environment["PATH"]?
+                .split(separator: ":").map(String.init) ?? []
+        }
         return directories.contains {
             FileManager.default.isExecutableFile(atPath: $0 + "/" + binary)
         }

--- a/Sources/termio/Settings/CustomAgentEditor.swift
+++ b/Sources/termio/Settings/CustomAgentEditor.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 /// Reads and writes user agent manifests (`~/.termio[-dev]/config/agents/<id>.json`)
 /// on behalf of the Settings form. The form covers the everyday fields (name,
-/// command, icon symbol, bypass flag); a hand-written manifest's other keys
-/// (status, hooks, resume, …) are preserved verbatim on rewrite.
+/// command, icon symbol, bypass flag, skills directory); a hand-written manifest's
+/// other keys (status, hooks, resume, …) are preserved verbatim on rewrite.
 enum UserAgentStore {
     struct Draft {
         var name = ""
@@ -12,6 +12,9 @@ enum UserAgentStore {
         /// SF Symbol name; empty means the default terminal glyph.
         var symbol = ""
         var permissionBypassFlag = ""
+        /// The agent's user-level skills directory (`~/.config/my-agent/skills`),
+        /// where termio installs the session-control skill; empty declares none.
+        var skillsDir = ""
 
         init() {}
 
@@ -21,6 +24,7 @@ enum UserAgentStore {
             command = definition.command ?? ""
             if case .symbol(let name) = definition.icon { symbol = name }
             permissionBypassFlag = definition.permissionBypassFlag ?? ""
+            skillsDir = definition.skillDir ?? ""
         }
 
         var isValid: Bool {
@@ -57,6 +61,13 @@ enum UserAgentStore {
             // Clearing the field removes a symbol icon (back to the default glyph),
             // but never touches a hand-authored path/vector/asset icon.
             object["icon"] = nil
+        }
+
+        let skillsDir = draft.skillsDir.trimmingCharacters(in: .whitespaces)
+        if skillsDir.isEmpty {
+            object["skills"] = nil
+        } else {
+            object["skills"] = ["dir": skillsDir]
         }
 
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -154,8 +165,15 @@ struct CustomAgentEditorSheet: View {
                             .fontDesign(.monospaced)
                             .labelsHidden()
                     }
+                    LabeledContent("Skills directory") {
+                        TextField("", text: $draft.skillsDir, prompt: Text("~/.config/my-agent/skills"))
+                            .textFieldStyle(.plain)
+                            .multilineTextAlignment(.trailing)
+                            .fontDesign(.monospaced)
+                            .labelsHidden()
+                    }
                 } footer: {
-                    Text("Both optional. The flag powers the agent's “Skip permission prompts” switch; leave it empty if the CLI has none.")
+                    Text("Both optional. The flag powers the agent's “Skip permission prompts” switch; leave it empty if the CLI has none. The directory receives termio's session-control skill (as `<dir>/termio`); leave it empty to skip installing one.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -180,7 +198,7 @@ struct CustomAgentEditorSheet: View {
             }
             .padding(12)
         }
-        .frame(width: 440, height: 380)
+        .frame(width: 440, height: 430)
     }
 
     /// The badge the agent will actually get: the typed symbol when the system

--- a/Sources/termio/Settings/GeneralSettingsTab.swift
+++ b/Sources/termio/Settings/GeneralSettingsTab.swift
@@ -29,7 +29,7 @@ struct GeneralSettingsTab: View {
                 if settings.sessionControlEnabled {
                     InstallButtonRow(title: "Reinstall skill") {
                         .summarizing(SessionSkillInstaller.sync(enabled: true),
-                                     headline: "Skill reinstalled", unit: "files")
+                                     headline: "Skill reinstalled", unit: "agents")
                     }
                 }
             } header: {

--- a/Tests/termioTests/SessionSkillInstallerTests.swift
+++ b/Tests/termioTests/SessionSkillInstallerTests.swift
@@ -38,4 +38,42 @@ final class SessionSkillInstallerTests: XCTestCase {
         XCTAssertTrue(skill.hasPrefix("---\nname: termio\n"))
         XCTAssertTrue(skill.hasSuffix("\n"))
     }
+
+    /// A manifest's `skills.dir` is the declaration the installer trusts — a user
+    /// dropping a custom agent into `~/.termio/config/agents/` gets its skill
+    /// installed through the same field, no code change.
+    func testManifestSkillsDeclaresDirectory() throws {
+        let json = """
+        { "id": "custom", "name": "Custom", "skills": { "dir": "~/.custom/skills" } }
+        """
+        let manifest = try JSONDecoder().decode(AgentManifest.self, from: Data(json.utf8))
+        XCTAssertEqual(manifest.skills?.dir, "~/.custom/skills")
+    }
+
+    /// A declared skills directory resolves to `<dir>/termio/SKILL.md` with `~`
+    /// expanded — the only pure logic between the manifest and the file system.
+    func testSkillFileURLExpandsTilde() throws {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let url = SessionSkillInstaller.skillFileURL(directory: "~/custom/skills")
+        XCTAssertEqual(url.lastPathComponent, "SKILL.md")
+        XCTAssertEqual(url.deletingLastPathComponent().lastPathComponent, "termio")
+        XCTAssertTrue(url.path.hasPrefix(home + "/custom/skills/termio/"))
+    }
+
+    /// The bundled manifests drive the installed surface: every skills-capable agent
+    /// declares its directory, and agents whose ecosystem isn't confirmed stay
+    /// undeclared so no stray directory gets created for them.
+    func testBundledSkillDeclarationsMatchCatalog() throws {
+        let catalog = AgentCatalog.shared
+        let declared = Set(catalog.bundled.compactMap(\.skillDir))
+        for directory in [
+            "~/.claude/skills", "~/.codex/skills", "~/.cursor/skills",
+            "~/.grok/skills", "~/.config/opencode/skills", "~/.pi/agent/skills",
+        ] {
+            XCTAssertTrue(declared.contains(directory), "\(directory) is missing from the bundled manifests")
+        }
+        for id in ["amp", "antigravity", "hermes", "kimi"] {
+            XCTAssertNil(catalog.definition(for: id).skillDir, "\(id) must not declare skills yet")
+        }
+    }
 }

--- a/Tests/termioTests/SessionSkillInstallerTests.swift
+++ b/Tests/termioTests/SessionSkillInstallerTests.swift
@@ -60,20 +60,34 @@ final class SessionSkillInstallerTests: XCTestCase {
         XCTAssertTrue(url.path.hasPrefix(home + "/custom/skills/termio/"))
     }
 
-    /// The bundled manifests drive the installed surface: every skills-capable agent
-    /// declares its directory, and agents whose ecosystem isn't confirmed stay
-    /// undeclared so no stray directory gets created for them.
+    /// The bundled manifests drive the installed surface: every agent declares its
+    /// skills directory, verified against each vendor's documented location so a
+    /// typo in a manifest can't silently install into a directory the agent never
+    /// reads.
     func testBundledSkillDeclarationsMatchCatalog() throws {
         let catalog = AgentCatalog.shared
-        let declared = Set(catalog.bundled.compactMap(\.skillDir))
-        for directory in [
-            "~/.claude/skills", "~/.codex/skills", "~/.cursor/skills",
-            "~/.grok/skills", "~/.config/opencode/skills", "~/.pi/agent/skills",
-        ] {
-            XCTAssertTrue(declared.contains(directory), "\(directory) is missing from the bundled manifests")
+        let expected: [String: String] = [
+            "claudeCode": "~/.claude/skills",
+            "codex": "~/.codex/skills",
+            "cursor": "~/.cursor/skills",
+            "grok": "~/.grok/skills",
+            "opencode": "~/.config/opencode/skills",
+            "pi": "~/.pi/agent/skills",
+            "amp": "~/.config/agents/skills",
+            "antigravity": "~/.gemini/antigravity/skills",
+            "hermes": "~/.hermes/skills",
+            "kimi": "~/.kimi-code/skills",
+        ]
+        for (id, directory) in expected {
+            let definition = catalog.definition(for: id)
+            XCTAssertEqual(
+                definition.skillDir, directory,
+                "\(id) must declare skills at its vendor-documented directory")
         }
-        for id in ["amp", "antigravity", "hermes", "kimi"] {
-            XCTAssertNil(catalog.definition(for: id).skillDir, "\(id) must not declare skills yet")
-        }
+        // Every bundled coding agent declares skills — none should be skipped.
+        let undeclared = catalog.bundled.filter { $0.skillDir == nil && $0.id != "terminal" }
+        XCTAssertTrue(
+            undeclared.isEmpty,
+            "agents without a skills declaration: \(undeclared.map(\.id))")
     }
 }

--- a/Tests/termioTests/SessionSkillInstallerTests.swift
+++ b/Tests/termioTests/SessionSkillInstallerTests.swift
@@ -60,6 +60,30 @@ final class SessionSkillInstallerTests: XCTestCase {
         XCTAssertTrue(url.path.hasPrefix(home + "/custom/skills/termio/"))
     }
 
+    /// Installation skips agents whose CLI isn't installed — a machine without
+    /// Cursor must not grow a `~/.cursor/skills` directory it cannot use. The
+    /// predicate is injectable, so this is testable without touching real PATHs.
+    func testSkillTargetsSkipUninstalledAgents() throws {
+        let bundled = AgentCatalog.shared.bundled.filter { $0.id != "terminal" }
+        let all = SessionSkillInstaller.skillTargets(installed: { _ in true })
+        let targeted = Set(all.map(\.name))
+        for agent in bundled where agent.skillDir != nil {
+            XCTAssertTrue(
+                targeted.contains(agent.displayName),
+                "\(agent.id) should be targeted when its CLI is installed")
+        }
+
+        let onlyClaude = SessionSkillInstaller.skillTargets(installed: { $0.id == "claudeCode" })
+        XCTAssertEqual(onlyClaude.map(\.name), ["Claude Code"])
+
+        XCTAssertTrue(SessionSkillInstaller.skillTargets(installed: { _ in false }).isEmpty)
+
+        // Uninstall sweeps every declared directory regardless of what's installed,
+        // so a skill left behind by an agent removed later still gets cleaned.
+        let sweep = SessionSkillInstaller.allKnownSkillTargets
+        XCTAssertGreaterThanOrEqual(sweep.count, bundled.filter { $0.skillDir != nil }.count)
+    }
+
     /// The bundled manifests drive the installed surface: every agent declares its
     /// skills directory, verified against each vendor's documented location so a
     /// typo in a manifest can't silently install into a directory the agent never


### PR DESCRIPTION
## Problem

Session control installs its `termio` agent skill into exactly two places — `~/.claude/skills` and `~/.codex/skills` — hardcoded in `SessionSkillInstaller`. The agent roster itself is catalog-driven (`AgentCatalog`: ten bundled manifests plus user-dropped ones), and status hooks are installed into every agent whose manifest declares a hook integration. The skill covered only two agents, so the other eight bundled agents never learned the `termio sessions` CLI, and a user-defined agent could not opt in at all.

## Changes

- **`AgentManifest` gains an optional `skills.dir`** (sibling of `hooks`), surfaced as `AgentDefinition.skillDir`; declaring it with an empty dir is a manifest error.
- **`SessionSkillInstaller` walks `AgentCatalog` instead of a hardcoded list**: install from `catalog.all` (user overrides win, URLs deduped), uninstall from bundled + catalog so an override that removed a shipped declaration still gets its old install swept. Mirrors `AgentStatusHooks.allKnownInstallers`.
- **Skill install is gated on the agent actually being installed**: `SessionSkillInstaller` skips any agent whose CLI doesn't resolve (non-blocking sync check reusing the login-shell PATH cache), so a machine without Cursor never grows a `~/.cursor/skills` directory. Uninstall still sweeps every declared directory, and each launch's sync re-checks, so an agent installed later is picked up automatically.
- **All ten bundled manifests declare skills**, each verified against the vendor's documented user-level location:
  - Claude Code `~/.claude/skills`, Codex `~/.codex/skills`, Cursor `~/.cursor/skills`, Grok `~/.grok/skills`, OpenCode `~/.config/opencode/skills`, Pi `~/.pi/agent/skills` (previously added)
  - Amp `~/.config/agents/skills` (ampcode.com/news/agent-skills)
  - Antigravity `~/.gemini/antigravity/skills` (Antigravity does not index symlinked skills, so the real-copy install is the right call for it)
  - Hermes `~/.hermes/skills` (docs: primary directory and source of truth)
  - Kimi `~/.kimi-code/skills` — `~/.kimi` turned out to be a migrated-away legacy dir (`.migrated-to-kimi-code` marker), so Kimi's hook target moved to `~/.kimi-code/config.toml` too, fixing a pre-existing bug where termio's kimi hooks landed in a file the CLI never reads
- **User-agent editor gains a "Skills directory" field**, so a custom agent declares it from the form (hand-written `hooks`/`resume` keys still round-trip untouched).
- Reinstall feedback now names agents instead of paths (`unit: "agents"`, matching the hooks row).

## Testing

- `swift build` clean.
- `SessionSkillInstallerTests` 6/6 — new coverage: manifest `skills.dir` parsing, `~` path expansion, and every bundled agent's declaration pinned to its documented directory (a future manifest typo or omission fails the test), plus the installed-agent gate.
- Full suite: 176 tests, 0 failures.

<img width="1600" height="976" alt="image" src="https://github.com/user-attachments/assets/763c2a76-e645-47d9-9f29-d15a09b051fa" />

<img width="880" height="860" alt="image" src="https://github.com/user-attachments/assets/30ce5c44-a0b4-471a-9828-afe746ac136a" />


pi

<img width="1378" height="194" alt="image" src="https://github.com/user-attachments/assets/67a6b8ea-913e-4420-8bdb-6b2e64175ed9" />


kimi

<img width="2220" height="322" alt="image" src="https://github.com/user-attachments/assets/fa2d7615-2f13-4ac0-9e8d-004fde0a7892" />

grok

<img width="2214" height="492" alt="image" src="https://github.com/user-attachments/assets/5ddff79e-c3ae-4918-bfb4-f4c44af0e247" />


## Release Notes

- Session control now installs its skill into every bundled agent — Claude Code, Codex, Cursor, Grok, OpenCode, Pi, Amp, Antigravity, Hermes and Kimi — instead of only Claude Code and Codex.
- Custom agents can declare a skills directory from the agent editor; the session-control skill follows.

Closes #255

