### PR TITLE
Point diff reveal arrows at the code they reveal

### DIFF
--- a/Sources/termio/Git/DiffGutterRulerView.swift
+++ b/Sources/termio/Git/DiffGutterRulerView.swift
@@ -229,7 +229,10 @@ final class DiffGutterRulerView: NSRulerView {
         let dotWidth: CGFloat = 1.2
         let originX = (rect.midX - width / 2).rounded()
         // The arrow leans toward the code it reveals, the dots sit on the hidden side.
-        let pointsUp = direction == .up
+        // `.up` reveals the lines nearest the code *below* the band, so its arrow points
+        // down at that code; `.down`'s arrow points up. The enum names the direction the
+        // reveal reads from, not the arrow's pointing — do not "simplify" the mapping.
+        let pointsUp = direction == .down
         let block = NSRect(x: originX, y: rect.midY - (arrowHeight + gap + dotWidth) / 2,
                            width: width, height: arrowHeight + gap + dotWidth)
         let dotsY = pointsUp ? block.minY : block.maxY - dotWidth


### PR DESCRIPTION
## What

The gutter's reveal buttons on a collapsed diff band drew their arrows swapped: `.up` (expands the lines nearest the code *below* the band) pointed up, `.down` pointed down. The arrow should lean toward the code it reveals.

## How

`DiffGutterRulerView.drawRevealIcon` set `pointsUp = direction == .up`, but the ruler is not flipped, so the tip/barb/dots geometry ran the wrong way. The mapping is now `direction == .down`: `.up`'s arrow points down at the code below, `.down`'s points up at the code above, dots on the hidden side. Button placement and click behavior are unchanged.

## Verification

- `swift build` passes.
- Pure drawing change; needs a visual pass in the dev app (arrow direction on a band with both controls).

<img width="1190" height="798" alt="image" src="https://github.com/user-attachments/assets/2bfc2b85-d852-4854-9afd-685d4da3e604" />



Release Notes: Fixed the collapsed-diff reveal buttons pointing away from the code they expand.
