### PR TITLE
Never let Cmd-W quit the app

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1286,28 +1286,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// where the last pane's ⌘W closes its container. That close is just a
     /// close: the app and every session keep running (issue #242).
     @objc func ungroupPane(_ sender: Any?) {
-        // Menu actions hang off the app delegate, not a window, so this has to
-        // resolve its own target: without the key-window check, ⌘W pressed in
-        // Settings reaches past it and ungroups a pane in the terminal behind.
-        // No key window at all (the main window is closed) means there is
-        // nothing on screen to close, so ⌘W does nothing rather than mutating
-        // an invisible layout.
-        guard let keyWindow = NSApp.keyWindow else { return }
-        guard keyWindow === window else {
-            keyWindow.performClose(sender)
-            return
-        }
-        if store.splitRoot != nil {
-            store.ungroupSelectedPane()
-        } else {
-            window?.performClose(sender)
-        }
+        performClose(sender, ungroupingSplit: store.splitRoot != nil)
     }
 
     /// File ▸ Close Window (⌘⇧W) — closes the frontmost window regardless of
     /// splits, so it dismisses Settings when Settings is what's in front.
     @objc func closeMainWindow(_ sender: Any?) {
-        (NSApp.keyWindow ?? window)?.performClose(sender)
+        performClose(sender, ungroupingSplit: false)
+    }
+
+    /// Shared body of the two close keys. Menu actions hang off the app delegate
+    /// rather than a window, so the target is resolved here (see `CloseCommand`):
+    /// without it, ⌘W pressed in Settings reaches past it and ungroups a pane in
+    /// the terminal behind.
+    private func performClose(_ sender: Any?, ungroupingSplit: Bool) {
+        let frontmost = CloseCommand.frontmost(mainWindow: window, palettePanel: palettePanel)
+        switch CloseCommand.action(for: frontmost, ungroupingSplit: ungroupingSplit) {
+        case .nothing:
+            break
+        case .dismissPalette:
+            // The store flag owns the palette's presentation; the observer tears
+            // the panel down (see `presentCommandPalette`).
+            store.paletteMode = nil
+        case .closeKeyWindow:
+            NSApp.keyWindow?.performClose(sender)
+        case .ungroupPane:
+            store.ungroupSelectedPane()
+        case .closeMainWindow:
+            window?.performClose(sender)
+        }
     }
 
     /// View ▸ Zoom Split (⌘⇧↩) — maximise the focused pane, or restore the split.

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1286,6 +1286,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// where the last pane's ⌘W closes its container. That close is just a
     /// close: the app and every session keep running (issue #242).
     @objc func ungroupPane(_ sender: Any?) {
+        // Menu actions hang off the app delegate, not a window, so this has to
+        // resolve its own target: without the key-window check, ⌘W pressed in
+        // Settings reaches past it and ungroups a pane in the terminal behind.
+        // No key window at all (the main window is closed) means there is
+        // nothing on screen to close, so ⌘W does nothing rather than mutating
+        // an invisible layout.
+        guard let keyWindow = NSApp.keyWindow else { return }
+        guard keyWindow === window else {
+            keyWindow.performClose(sender)
+            return
+        }
         if store.splitRoot != nil {
             store.ungroupSelectedPane()
         } else {
@@ -1293,9 +1304,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
-    /// File ▸ Close Window (⌘⇧W) — closes the whole window regardless of splits.
+    /// File ▸ Close Window (⌘⇧W) — closes the frontmost window regardless of
+    /// splits, so it dismisses Settings when Settings is what's in front.
     @objc func closeMainWindow(_ sender: Any?) {
-        window?.performClose(sender)
+        (NSApp.keyWindow ?? window)?.performClose(sender)
     }
 
     /// View ▸ Zoom Split (⌘⇧↩) — maximise the focused pane, or restore the split.
@@ -2186,6 +2198,32 @@ private func buildMainMenu() -> NSMenu {
     let sessionMenu = NSMenu(title: "Session")
     sessionMenu.delegate = NSApp.delegate as? AppDelegate
     sessionItem.submenu = sessionMenu
+
+    // Window menu — the standard one every Mac app has and termio didn't, which is
+    // why ⌘M did nothing. These actions travel the responder chain to whichever
+    // window is key (Settings included), so they need no delegate plumbing.
+    // Handing the menu to `NSApp.windowsMenu` lets AppKit keep its window list in it.
+    let windowItem = NSMenuItem()
+    mainMenu.addItem(windowItem)
+    let windowMenu = NSMenu(title: "Window")
+    windowMenu.addItem(
+        withTitle: "Minimize",
+        action: #selector(NSWindow.performMiniaturize(_:)),
+        keyEquivalent: "m"
+    )
+    windowMenu.addItem(
+        withTitle: "Zoom",
+        action: #selector(NSWindow.performZoom(_:)),
+        keyEquivalent: ""
+    )
+    windowMenu.addItem(.separator())
+    windowMenu.addItem(
+        withTitle: "Bring All to Front",
+        action: #selector(NSApplication.arrangeInFront(_:)),
+        keyEquivalent: ""
+    )
+    windowItem.submenu = windowMenu
+    NSApp.windowsMenu = windowMenu
 
     return mainMenu
 }

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -160,6 +160,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             defer: false
         )
         window.title = "Termio"
+        // Closing the window no longer quits (see `applicationShouldTerminate-
+        // AfterLastWindowClosed`), so the window object has to survive its own close:
+        // the terminal surfaces live in its view tree, and a Dock reopen re-shows this
+        // very window rather than rebuilding one. The default `true` would also
+        // over-release it out from under the strong reference held here.
+        window.isReleasedWhenClosed = false
         // Mouse-moved events are off by default; the pane grab handle reveals on
         // hover, so it needs them (see `PaneDragRearrange`).
         window.acceptsMouseMovedEvents = true
@@ -403,13 +409,65 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
+    /// termio is single-window, so terminating with the last window would make ⌘W a
+    /// quit — and quitting kills every session's agent (see `applicationWillTerminate`).
+    /// The app stays running with its sessions alive; the Dock icon brings the window
+    /// back (see `applicationShouldHandleReopen`). Only ⌘Q ends sessions.
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        true
+        false
+    }
+
+    /// Dock click (or `open -b sh.termio.app`) with the window closed. The window
+    /// survived its close, so it is re-shown rather than rebuilt — the sessions kept
+    /// running in its view tree the whole time.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        if !hasVisibleWindows { showMainWindow() }
+        return true
+    }
+
+    /// Brings the main window back and repaints the terminal it reveals: a surface that
+    /// spent time off-screen stops ticking and comes back unpainted until the next
+    /// keystroke (the same rescue `windowDidDeminiaturize` applies).
+    private func showMainWindow() {
+        guard let window else { return }
+        if window.isMiniaturized { window.deminiaturize(nil) }
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        window.contentView?.layoutSubtreeIfNeeded()
+        store.repaintSelectedSurface()
+    }
+
+    /// Quitting is now the only path that kills sessions, so a quit that would cut
+    /// short an agent mid-turn — or one already waiting on an answer — asks first.
+    /// An all-idle app quits without a word.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        let busy = store.busySessionTitles
+        guard !busy.isEmpty else { return .terminateNow }
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = busy.count == 1
+            ? "“\(busy[0])” is still running."
+            : "\(busy.count) sessions are still running."
+        alert.informativeText =
+            "Quitting stops every session's agent and shell. "
+            + "Closing the window leaves them running."
+        // Cancel goes first so it takes both the default (Return) and, being titled
+        // Cancel, the Escape key: no stray keypress on this sheet can end a running
+        // agent. Quitting is deliberate — a click, or ⌘Q a second time.
+        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: "Quit")
+        if let quitButton = alert.buttons.last {
+            quitButton.hasDestructiveAction = true
+            quitButton.keyEquivalent = "q"
+            quitButton.keyEquivalentModifierMask = .command
+        }
+        return alert.runModal() == .alertSecondButtonReturn ? .terminateNow : .terminateCancel
     }
 
     /// Closing the app closes its sessions' processes. Without this there is
     /// no teardown path at all on quit — the PTYs die with the process and
     /// agent children that ignore the resulting SIGHUP live on as orphans.
+    /// Only a real quit reaches here; closing the window does not.
     func applicationWillTerminate(_ notification: Notification) {
         // Delivered banners would outlive the sessions they point at.
         TaskNotificationCenter.shared.withdrawAll()
@@ -1225,7 +1283,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// The session itself stays alive in the sidebar (killing it remains the
     /// explicit "Close Session"). With no split on screen there is no pane to
     /// peel off, so ⌘W falls through to closing the window, matching iTerm2
-    /// where the last pane's ⌘W closes its container.
+    /// where the last pane's ⌘W closes its container. That close is just a
+    /// close: the app and every session keep running (issue #242).
     @objc func ungroupPane(_ sender: Any?) {
         if store.splitRoot != nil {
             store.ungroupSelectedPane()

--- a/Sources/termio/Keybindings/CloseCommand.swift
+++ b/Sources/termio/Keybindings/CloseCommand.swift
@@ -1,0 +1,62 @@
+import AppKit
+
+/// Where ⌘W and ⌘⇧W land, resolved as a pure decision.
+///
+/// Menu actions hang off the app delegate rather than a window, so the close keys
+/// have to work out their own target — the app's one hand-rolled substitute for the
+/// context tree Zed and VS Code resolve bindings against
+/// (`docs/design/keyboard-command-design.md`). Two branches don't justify a context
+/// engine, but they do justify keeping the decision in one readable, testable place:
+/// this routing regresses silently, which is why cmux guards the same key with a CI
+/// lint. `CloseCommandTests` is termio's version of that guard.
+enum CloseCommand {
+    /// What holds the key window when a close key arrives.
+    enum Frontmost: Equatable {
+        /// Nothing on screen — the main window is closed and the app runs on.
+        case nothing
+        case mainWindow
+        /// The ⌘⇧P / ⌘⇧O panel. Borderless, so `performClose` would only beep;
+        /// it dismisses through the store flag that owns its presentation.
+        case palette
+        /// Settings, or any other window the app puts up.
+        case auxiliaryWindow(closable: Bool)
+    }
+
+    enum Action: Equatable {
+        case nothing
+        case dismissPalette
+        case closeKeyWindow
+        case ungroupPane
+        case closeMainWindow
+    }
+
+    /// - Parameter ungroupingSplit: whether this key peels a pane off a split before
+    ///   it will consider the window — true for ⌘W with a split on screen, false for
+    ///   ⌘⇧W, which closes the window whatever the layout.
+    static func action(for frontmost: Frontmost, ungroupingSplit: Bool) -> Action {
+        switch frontmost {
+        case .nothing:
+            // Nothing is on screen, so there is nothing to close. Acting on the
+            // main window here would mutate a layout the user cannot see.
+            return .nothing
+        case .palette:
+            return .dismissPalette
+        case .auxiliaryWindow(let closable):
+            // A window with no close button can't be closed by AppKit; beeping at
+            // the user is worse than leaving the key inert.
+            return closable ? .closeKeyWindow : .nothing
+        case .mainWindow:
+            return ungroupingSplit ? .ungroupPane : .closeMainWindow
+        }
+    }
+
+    /// Classifies the live key window. Split from `action(for:ungroupingSplit:)` so
+    /// the decision itself stays free of AppKit state and can be tested.
+    @MainActor
+    static func frontmost(mainWindow: NSWindow?, palettePanel: NSWindow?) -> Frontmost {
+        guard let keyWindow = NSApp.keyWindow else { return .nothing }
+        if let palettePanel, keyWindow === palettePanel { return .palette }
+        if let mainWindow, keyWindow === mainWindow { return .mainWindow }
+        return .auxiliaryWindow(closable: keyWindow.styleMask.contains(.closable))
+    }
+}

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -956,7 +956,7 @@ private struct SessionRow: View {
             .separator,
             .action(session.pinned ? "Unpin" : "Pin") { store.toggleSessionPinned(session.id) },
             .separator,
-            .action("Close Session") { store.closeSession(session.id) },
+            .action("Close Session") { store.requestCloseSession(session.id) },
         ])
         return items
     }
@@ -1035,7 +1035,7 @@ private struct SessionRow: View {
                     help: "Close session",
                     chrome: chrome
                 ) {
-                    store.closeSession(session.id)
+                    store.requestCloseSession(session.id)
                 }
                 .opacity(isHovering ? 1 : 0)
                 .allowsHitTesting(isHovering)

--- a/Sources/termio/Terminal/Ghostty/PTYProcess.swift
+++ b/Sources/termio/Terminal/Ghostty/PTYProcess.swift
@@ -897,6 +897,26 @@ final class PTYProcess: @unchecked Sendable {
         return arguments.isEmpty ? nil : arguments
     }
 
+    /// Whether the child is still running — the session has a live process to
+    /// lose. False once the pid is reaped.
+    var isAlive: Bool {
+        lock.lock()
+        let exited = childExited
+        lock.unlock()
+        return !exited && pid > 0
+    }
+
+    /// Whether something other than the child shell itself holds the tty's
+    /// foreground group, i.e. a command is actually running in the pane rather
+    /// than a shell idling at its prompt. This is the signal iTerm2 keys its
+    /// prompt-on-close off; a bare prompt is its own foreground group and reads
+    /// as free to close.
+    var hasForegroundJob: Bool {
+        guard isAlive else { return false }
+        let foreground = tcgetpgrp(masterFD)
+        return foreground > 0 && foreground != pid
+    }
+
     /// SIGKILLs the child's process group if it hasn't been reaped yet.
     /// Idempotent; safe after the pid is reaped (the `childExited` check keeps
     /// the kill off a recycled pid). The app-quit path calls this directly

--- a/Sources/termio/Terminal/TerminalContextMenu.swift
+++ b/Sources/termio/Terminal/TerminalContextMenu.swift
@@ -171,7 +171,7 @@ final class TerminalContextMenu: NSObject {
     @objc private func ungroup() { store?.ungroupSelectedPane() }
     @objc private func closeSession() {
         guard let id = clickedSessionID else { return }
-        store?.closeSession(id)
+        store?.requestCloseSession(id)
     }
 
     @objc private func openLink() {

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -585,6 +585,46 @@ extension TermioStore {
         projects[projectIndex].sessions[sessionIndex].title = name
     }
 
+    /// The user-facing "Close Session": the same teardown as `closeSession`, but it
+    /// asks first when there is live work to lose. Only the interactive entry points
+    /// (the sidebar row, the terminal's context menu) route through here — a session
+    /// whose process already exited, the `termio sessions close` CLI, and the phone's
+    /// stop button all closed deliberately and call `closeSession` directly.
+    func requestCloseSession(_ id: Session.ID) {
+        guard let session = session(id) else { return }
+        guard let reason = closeConfirmationReason(for: session) else {
+            closeSession(id)
+            return
+        }
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Close “\(displayTitle(for: session))”?"
+        alert.informativeText = reason
+        // Cancel first so it owns both Return and Escape; the destructive button
+        // takes a deliberate click (see the quit confirmation in `App.swift`).
+        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: "Close Session")
+        alert.buttons.last?.hasDestructiveAction = true
+        guard alert.runModal() == .alertSecondButtonReturn else { return }
+        closeSession(id)
+    }
+
+    /// Why closing this session needs confirming, or `nil` when it doesn't. Keyed on
+    /// what the session would actually *lose*, not on its attention status: a `done`
+    /// or `idle` agent still holds a whole conversation, and looking at a session is
+    /// enough to settle it back to `idle`, so status is the wrong safety signal. A
+    /// plain shell is the one free case — closing one parked at its prompt costs
+    /// nothing, which is the carve-out iTerm2 makes too.
+    private func closeConfirmationReason(for session: Session) -> String? {
+        guard let pty = ptyProcesses[session.id], pty.isAlive else { return nil }
+        guard session.agent.isShell else {
+            return "\(session.agent.displayName) is running in this session. "
+                + "Closing it ends the conversation and stops the process."
+        }
+        guard pty.hasForegroundJob else { return nil }
+        return "A command is still running in this session. Closing it stops the command."
+    }
+
     /// Closes a session: drops its cached surface (which tears down the PTY) and
     /// moves the selection to a neighbouring session if the closed one was active.
     /// Any git worktree created for the session is deliberately left on disk — it

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1256,6 +1256,15 @@ final class TermioStore: ObservableObject {
         return .idle
     }
 
+    /// The sessions a quit would cut short: an agent mid-turn, or one already
+    /// blocked on the user. A finished (`.done`) session has nothing left to lose,
+    /// so it doesn't count — the quit confirmation names these and only these.
+    var busySessionTitles: [String] {
+        projects.flatMap(\.sessions)
+            .filter { [.working, .needsAttention].contains(status(for: $0.id)) }
+            .map { displayTitle(for: $0) }
+    }
+
     func session(_ id: Session.ID) -> Session? {
         for project in projects {
             if let session = project.sessions.first(where: { $0.id == id }) {

--- a/Tests/termioTests/CloseCommandTests.swift
+++ b/Tests/termioTests/CloseCommandTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import termio
+
+/// ⌘W must never reach past what's in front of it, and must never end a process.
+/// Both properties live in one decision (`CloseCommand.action`), and both regress
+/// silently — the window still closes, just the wrong one — so they are pinned
+/// here. See `docs/design/keyboard-command-design.md`.
+final class CloseCommandTests: XCTestCase {
+    // ⌘W passes the live split state; ⌘⇧W always passes false.
+    private func commandW(_ frontmost: CloseCommand.Frontmost, split: Bool) -> CloseCommand.Action {
+        CloseCommand.action(for: frontmost, ungroupingSplit: split)
+    }
+
+    private func commandShiftW(_ frontmost: CloseCommand.Frontmost) -> CloseCommand.Action {
+        CloseCommand.action(for: frontmost, ungroupingSplit: false)
+    }
+
+    func testCommandWPeelsAPaneOffASplitBeforeTouchingTheWindow() {
+        XCTAssertEqual(commandW(.mainWindow, split: true), .ungroupPane)
+    }
+
+    func testCommandWClosesTheWindowOnlyWhenNoSplitIsLeft() {
+        XCTAssertEqual(commandW(.mainWindow, split: false), .closeMainWindow)
+    }
+
+    /// The #242 regression guard: with Settings in front, ⌘W must close Settings
+    /// rather than reach through to the terminal's layout or window.
+    func testCommandWClosesAnAuxiliaryWindowInsteadOfTheTerminalBehindIt() {
+        XCTAssertEqual(commandW(.auxiliaryWindow(closable: true), split: true), .closeKeyWindow)
+        XCTAssertEqual(commandW(.auxiliaryWindow(closable: true), split: false), .closeKeyWindow)
+    }
+
+    /// The palette panel is borderless, so `performClose` would only beep at the
+    /// user; it dismisses through the store flag that owns its presentation.
+    func testCommandWDismissesThePaletteRatherThanBeepingAtIt() {
+        XCTAssertEqual(commandW(.palette, split: true), .dismissPalette)
+        XCTAssertEqual(commandShiftW(.palette), .dismissPalette)
+    }
+
+    func testAnUnclosableWindowSwallowsTheKeyInsteadOfBeeping() {
+        XCTAssertEqual(commandW(.auxiliaryWindow(closable: false), split: false), .nothing)
+    }
+
+    /// The app outlives its window (#242). With nothing on screen there is nothing
+    /// to close, and ungrouping would mutate a layout the user cannot see.
+    func testCloseKeysDoNothingWhenNoWindowIsOnScreen() {
+        XCTAssertEqual(commandW(.nothing, split: true), .nothing)
+        XCTAssertEqual(commandW(.nothing, split: false), .nothing)
+        XCTAssertEqual(commandShiftW(.nothing), .nothing)
+    }
+
+    /// ⌘⇧W is "close the window" whatever the layout — it never peels off a pane.
+    func testCommandShiftWIgnoresSplitsEntirely() {
+        XCTAssertEqual(commandShiftW(.mainWindow), .closeMainWindow)
+    }
+
+    /// The whole decision as a table, so any change to it has to be made on
+    /// purpose. Only `.mainWindow` may read the split state; every other row is
+    /// the same under both keys.
+    func testEveryCombinationResolvesAsDocumented() {
+        let expected: [(CloseCommand.Frontmost, Bool, CloseCommand.Action)] = [
+            (.nothing, true, .nothing),
+            (.nothing, false, .nothing),
+            (.palette, true, .dismissPalette),
+            (.palette, false, .dismissPalette),
+            (.auxiliaryWindow(closable: true), true, .closeKeyWindow),
+            (.auxiliaryWindow(closable: true), false, .closeKeyWindow),
+            (.auxiliaryWindow(closable: false), true, .nothing),
+            (.auxiliaryWindow(closable: false), false, .nothing),
+            (.mainWindow, true, .ungroupPane),
+            (.mainWindow, false, .closeMainWindow),
+        ]
+        for (frontmost, split, action) in expected {
+            XCTAssertEqual(
+                CloseCommand.action(for: frontmost, ungroupingSplit: split), action,
+                "\(frontmost) ungroupingSplit=\(split)")
+        }
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ from the real front matter).
 | active | design | [iOS libghostty "non-functional" panel + teardown UAF — root-cause findings](design/ios-ghostty-renderer-panic-investigation-findings.md) |
 | active | design | [iOS terminal input & attachments](design/ios-terminal-input.md) |
 | active | design | [iOS TestFlight runbook — build, upload, and drive ASC from the API](runbook/ios-testflight-runbook.md) |
+| active | design | [Keyboard and command design](design/keyboard-command-design.md) |
 | active | design | [macOS release runbook — cut, notarize, publish termio.dmg](runbook/macos-release-runbook.md) |
 | active | design | [Research brief — termiod Session Protocol (for design agent)](design/_research-session-protocol-brief.md) |
 | active | design | [Sessions CLI v2 — reliability & command design](design/sessions-cli-v2.md) |

--- a/docs/design/keyboard-command-design.md
+++ b/docs/design/keyboard-command-design.md
@@ -149,6 +149,33 @@ That last point is the sharpest contrast in this doc. termio confirms on ⌘Q fo
 exactly the reason Zed doesn't: quitting termio kills live processes that no
 autosave can bring back.
 
+### Ghostty — the same confirmation policy, a different probe
+
+Ghostty's `confirm-close-surface` defaults to `true`, documented as: confirm before
+closing a surface, *"even if shell integration says a process isn't running"* only
+when set to `always`. So its default is already "ask only when something is
+running" — the same policy as termio's Close Session, reached independently.
+
+The difference is the liveness probe. Ghostty asks the **shell** (OSC 133 command
+marks, via shell integration); termio asks the **kernel** (`tcgetpgrp` on the PTY
+master) plus the session's declared agent. Ghostty's signal is the more general
+one, but it depends on shell integration being installed and emitting marks;
+termio's works regardless of the user's shell config, at the cost of needing the
+agent carve-out described above.
+
+Its close dialog also defaults focus to **Cancel**, so Return cancels. termio's
+does the same, after a first cut where Escape landed on the destructive button.
+Two independent implementations converging on that is the strongest signal in this
+doc that it's the right default.
+
+Worth watching: Ghostty users are actively pushing back on the dialog —
+[#9669](https://github.com/ghostty-org/ghostty/discussions/9669) asks for a
+`force_close_surface` action to bypass it,
+[#7357](https://github.com/ghostty-org/ghostty/discussions/7357) asks how to
+remove it entirely. That is the failure mode this design avoids by keeping the
+prompt off ⌘W: a confirmation that fires constantly becomes something users
+engineer their way around.
+
 ### Raycast — the command layer, not the window layer
 
 Raycast isn't a window app in this sense, and it's closed-source, so it belongs
@@ -164,6 +191,35 @@ a rebind can't be swallowed by the terminal. The lesson taken from Raycast is
 restraint — a command earns a default key by being pressed constantly, not by
 existing. Split Left and Split Up ship unbound for this reason, as does Close
 Session.
+
+## Resolution: one action that branches, not a context tree
+
+Every tool above resolves a key **declaratively by context**. Zed's rule is
+explicit:
+
+> Bindings that match on lower nodes in the context tree win. […] If there are
+> multiple bindings that match at the same level in the tree, then the binding
+> defined later takes precedence.
+
+VS Code says the same thing with `when` clauses. termio does not: `KeyCommandCatalog`
+is a flat table, and ⌘W resolves itself *imperatively*, inside one action — is the
+key window an auxiliary one, is there a split, otherwise close the window.
+
+At two branches that is the simpler design, and it stays honest because there is
+exactly one place to read. It is deliberate, not an oversight. But it has a known
+cost, and one visible symptom today: with a diff or editor detail open in the
+inspector, ⌘W ungroups a pane instead of closing the detail. Zed would close it —
+its `Workspace` context binds ⌘W to `CloseActiveDock`.
+
+That symptom is **not** fixed by adding another branch. Zed's dock binding matches
+only when focus is *in* the dock; termio has no focus notion for the inspector, so
+"close the detail whenever one is open" would break the common case — a diff open
+beside a terminal you are typing in. Doing it correctly needs a focus/context
+notion, which is the refactor, not a patch.
+
+**The trigger to build contexts:** when a third state needs its own answer for the
+same key, or when a binding's correctness depends on which region has focus. Until
+then, branch and keep it in one function.
 
 ## Rejected
 
@@ -191,3 +247,5 @@ Tracked in [#204](https://github.com/termio-sh/termio/issues/204):
 - ⌃⌘ arrows to resize the divider and ⌃⌘= to equalize. Blocked on defining which
   divider moves when the focused pane touches several ancestors; the binding is
   easy, the rule isn't.
+- A focus/context notion for key resolution, and with it ⌘W closing a focused
+  inspector detail. See *Resolution* above for the trigger.

--- a/docs/design/keyboard-command-design.md
+++ b/docs/design/keyboard-command-design.md
@@ -1,0 +1,193 @@
+---
+title: Keyboard and command design
+status: active
+type: design
+created: 2026-08-12
+updated: 2026-08-12
+---
+
+# Keyboard and command design
+
+> One rule decides every binding: a key either changes what you're looking at or
+> it ends a process, and only the second kind is allowed to ask — or to destroy.
+
+## The rule
+
+**Presentation or process.** Every command in termio acts on one or the other,
+and that decides its key, its confirmation, and whether it may cascade.
+
+- Keys that change presentation — panes, windows, focus, the inspector — never
+  end a process. They need no confirmation, because nothing is lost.
+- Keys that end a process are few, named, and confirm when there is live work.
+
+⌘W is always the first kind. ⌘Q is the second. That is the whole design; the rest
+of this doc is why the obvious alternative is wrong and how the neighbours answer
+the same question.
+
+This replaces the earlier "termio is sidebar-shaped, not tab-shaped" framing,
+which described the same conclusion but couldn't be applied to a key you hadn't
+already decided. Presentation-or-process can.
+
+## Why the literal translation is wrong
+
+Every tabbed terminal binds ⌘W to "close the surface", and in those apps the
+surface *is* the process — closing it kills the program. termio's objects don't
+line up that way:
+
+| termio | tabbed terminal (iTerm2, Ghostty) |
+| --- | --- |
+| **Pane** — a view slot in a split group | surface — the process itself |
+| **Session** — durable: owns the PTY, a resume id, sometimes a worktree; lives in the sidebar; survives relaunch | (no equivalent) |
+| **Split group** — the layout, persisted | tab |
+| **Window** — one, always | one of many |
+
+So `close_surface` has two possible readings in termio: *remove this pane from
+the layout* (Ungroup), or *end this session*. Structurally the first is the
+faithful one — it's the same "close the thing in front" — while the second
+smuggles in a process kill that the original binding only implies because tabs
+and processes are the same object there.
+
+Choosing the second reading is what produced [#242](https://github.com/termio-sh/termio/issues/242):
+⌘W fell through to closing the single window, the app terminated with it, and
+every agent died with no confirmation. Two users reported it the same day.
+
+## The map
+
+| Key | Action | Kind |
+| --- | --- | --- |
+| ⌘W | Ungroup the focused pane; with no split, close the window; in an auxiliary window, close that window | presentation |
+| ⌘⇧W | Close the frontmost window | presentation |
+| ⌘M | Minimize the frontmost window | presentation |
+| ⌘D / ⌘⇧D | Split right / down | presentation |
+| ⌥⌘ arrows | Focus pane by direction | presentation |
+| ⌘⇧↩ | Zoom split | presentation |
+| ⌘⇧[ / ⌘⇧] | Previous / next session | presentation |
+| ⌃⌘F | Toggle full screen | presentation |
+| ⌘T / ⌘N | New Terminal / New Chat | creation |
+| ⌘Q | Quit — **confirms** when any session is working or needs you | process |
+| *(unbound)* | Close Session — **confirms** while its PTY is alive | process |
+
+Closing the window keeps the app running with every session alive; the Dock icon
+brings the window back. Only ⌘Q reaches the teardown that kills PTYs.
+
+Window-scoped commands resolve the **key window**, so ⌘W and ⌘⇧W close Settings
+when Settings is in front rather than reaching past it to the terminal behind.
+With no window on screen, ⌘W does nothing rather than mutating an invisible
+layout.
+
+## Confirmation policy
+
+A confirmation is a tax on every correct use of a key, levied to prevent the
+rare wrong one. It is worth paying only where the action destroys something
+unrecoverable, which is why the policy is keyed on **what would be lost**, not on
+how alarming the command sounds:
+
+- **⌘Q** confirms when a session is `working` or `needs-you`. An all-idle app
+  quits without a word.
+- **Close Session** confirms whenever the session's PTY is alive — with one
+  carve-out: a plain shell parked at its prompt costs nothing to close, so it
+  doesn't ask. This is the same carve-out iTerm2 makes.
+- **⌘W** never confirms, because after #242 it destroys nothing.
+
+Two traps this policy avoids, both found while building it:
+
+1. **Attention status is not process safety.** Keying Close Session off
+   `working` / `needs-you` looks right and is wrong: a `done` or `idle` agent
+   still holds an entire conversation, and merely *looking* at a session settles
+   it back to `idle`. What matters is whether a process is alive, not whether it
+   currently wants you.
+2. **A live agent looks idle to the kernel.** `tcgetpgrp` on the PTY master
+   reports the foreground process group, which is how iTerm2 decides whether a
+   pane is busy. A running `claude` shares the shell's process group, so that
+   check reports *no foreground job* for a live agent — verified. The rule is
+   therefore: a non-shell session with a live PTY always confirms; a plain shell
+   confirms only when something is actually running in front of it.
+
+## How the neighbours answer this
+
+### cmux — the same category
+
+cmux is a Ghostty-based macOS terminal for coding agents, and the closest
+comparison. Its published shortcut table and changelog (2026-02-09):
+
+| Key | cmux |
+| --- | --- |
+| ⌘W | **Close Tab** — closes the focused tab; if it's the last tab, closes the workspace/window |
+| ⌘⇧W | Close Workspace (with a confirmation dialog) |
+| ⌃⌘W | Close Window |
+| ⌘D | confirms the close dialog (the macOS "Don't Save" mnemonic) |
+
+cmux lets ⌘W cascade all the way up to closing the window, and gates the cascade
+with a confirmation — plus a separate "running process" dialog. It also enforces
+the routing with a CI lint and a review-bot rule whose stated purpose is that ⌘W
+must close the active window "instead of falling through to workspace panel
+closing." They care enough about this one key to gate it in CI.
+
+**Where termio differs:** cmux needs the confirmation because its close still
+tears things down. termio's doesn't, so there's no dialog to dismiss at all. The
+divergence isn't taste — it follows from the window close being non-destructive.
+
+### Zed — the same object problem, solved by context
+
+Zed's `default-macos.json` resolves ⌘W per context:
+
+| Context | Binding |
+| --- | --- |
+| `Pane` | `pane::CloseActiveItem` |
+| `Workspace` | `workspace::CloseActiveDock` |
+| `SettingsWindow` | `workspace::CloseWindow` |
+| global | ⌘⇧W `CloseWindow`, ⌘M `Minimize`, ⌘Q `Quit` |
+
+Zed is the closest structural match: a durable object list on the side, panes as
+views, and ⌘W closing the *item* while the file stays on disk. Two things
+transfer directly. First, ⌘W in an auxiliary window means Close Window — the
+key-window routing termio now implements. Second, `confirm_quit` defaults to
+**false**: Zed doesn't need a quit confirmation because quitting an editor
+destroys nothing recoverable.
+
+That last point is the sharpest contrast in this doc. termio confirms on ⌘Q for
+exactly the reason Zed doesn't: quitting termio kills live processes that no
+autosave can bring back.
+
+### Raycast — the command layer, not the window layer
+
+Raycast isn't a window app in this sense, and it's closed-source, so it belongs
+here for a different reason: its **command layer**. Every command is an object in
+one searchable root, with an optional per-command hotkey and alias, and a
+contextual action panel on ⌘K. Almost nothing is bound by default; discovery
+carries the long tail and the user promotes what they use.
+
+termio's equivalent is already in place: `KeyCommandCatalog` is the single source
+of truth for every rebindable command, the ⌘⇧P palette searches it, Settings ▸
+Keyboard rebinds it, and the surface's ghostty unbind set is *derived* from it so
+a rebind can't be swallowed by the terminal. The lesson taken from Raycast is
+restraint — a command earns a default key by being pressed constantly, not by
+existing. Split Left and Split Up ship unbound for this reason, as does Close
+Session.
+
+## Rejected
+
+- **⌘W = Close Session.** The literal iTerm2/Ghostty reading, and the original
+  recommendation in [#204](https://github.com/termio-sh/termio/issues/204).
+  Adopting it means adopting its running-job prompt too — and with agents,
+  `working` is the *normal* state, so the prompt would fire on nearly every press.
+  A dialog that always fires is one people learn to dismiss reflexively, which
+  arrives back at #242 by a slower road.
+- **⌘1…⌘9 to select the Nth session.** Ghostty's `goto_tab` and the
+  Safari/Chrome convention, but there is no stable Nth: with `recentActivity`
+  sorting, selecting a session reorders the tree, so pressing ⌘4 changes what ⌘1
+  means. Positional keys need explicit user-assigned slots, not a live tree.
+- **⌥⌘W = Ungroup All.** Mirrors Ghostty's `close_tab:this` positionally, but
+  that binding is destructive and dissolving a split group is not, so it would
+  mislead both audiences. Ungroup All stays a menu verb.
+
+## Deferred
+
+Tracked in [#204](https://github.com/termio-sh/termio/issues/204):
+
+- The ghostty-defaults fixture test, so a libghostty bump that adds a default
+  binding breaks the build instead of silently shadowing an app key.
+- ⌘[ / ⌘] for previous/next pane — redundant with ⌥⌘ arrows; wait for demand.
+- ⌃⌘ arrows to resize the divider and ⌃⌘= to equalize. Blocked on defining which
+  divider moves when the focused pane touches several ancestors; the binding is
+  easy, the rule isn't.

--- a/docs/design/keyboard-command-design.md
+++ b/docs/design/keyboard-command-design.md
@@ -55,7 +55,7 @@ every agent died with no confirmation. Two users reported it the same day.
 
 | Key | Action | Kind |
 | --- | --- | --- |
-| ⌘W | Ungroup the focused pane; with no split, close the window; in an auxiliary window, close that window | presentation |
+| ⌘W | Ungroup the focused pane; with no split, close the window; in an auxiliary window, close that window; with the palette up, dismiss it | presentation |
 | ⌘⇧W | Close the frontmost window | presentation |
 | ⌘M | Minimize the frontmost window | presentation |
 | ⌘D / ⌘⇧D | Split right / down | presentation |
@@ -205,9 +205,20 @@ VS Code says the same thing with `when` clauses. termio does not: `KeyCommandCat
 is a flat table, and ⌘W resolves itself *imperatively*, inside one action — is the
 key window an auxiliary one, is there a split, otherwise close the window.
 
-At two branches that is the simpler design, and it stays honest because there is
-exactly one place to read. It is deliberate, not an oversight. But it has a known
-cost, and one visible symptom today: with a diff or editor detail open in the
+At this size that is the simpler design, and it stays honest because there is
+exactly one place to read. It is deliberate, not an oversight — but it only earns
+that defence if the decision is *isolated and tested*, because this is the binding
+that regresses silently: the window still closes, just the wrong one. cmux guards
+the same key with a CI lint. termio's equivalent is `CloseCommand.action`, a pure
+function over "what is in front" × "is there a split", with `CloseCommandTests`
+pinning every combination.
+
+Keeping the decision pure also made a case visible that the imperative version had
+wrong: the ⌘⇧P palette is a **borderless** panel, and `performClose` on a window
+with no close button only beeps. Routing it to the store flag that owns the
+palette's presentation turns a dead key into a dismiss.
+
+The known cost shows up one layer in: with a diff or editor detail open in the
 inspector, ⌘W ungroups a pane instead of closing the detail. Zed would close it —
 its `Workspace` context binds ⌘W to `CloseActiveDock`.
 


### PR DESCRIPTION
⌘W with no split on screen fell through to closing the window, and because
`applicationShouldTerminateAfterLastWindowClosed` returned `true`, that closed the
whole app — killing every session's shell and agent with no confirmation. Two users
hit it independently.

Closing the window is now just closing the window. The window object survives its
close, so a Dock click re-shows the same window with its terminals still running,
and `applicationWillTerminate` (which tears down every PTY) is reached only by a
real quit. That quit asks first when a session is working or waiting on you; an
all-idle app still quits without a word.

Reviewing the rest of the close/quit keys turned up three more gaps in the same
area, fixed here rather than left for later:

- **⌘W and ⌘⇧W ignored the frontmost window.** Both acted on the stored main
  window, so pressing them while Settings was in front reached past it and
  ungrouped a pane — or closed the window — behind the sheet. Both now resolve the
  key window, and ⌘W does nothing when no window is on screen instead of mutating
  an invisible layout.
- **Close Session killed a running agent with no confirmation.** It now asks, keyed
  on what the session would actually lose rather than on its attention status: an
  idle or done agent still holds a whole conversation, and merely looking at a
  session settles it back to idle. A plain shell parked at its prompt stays free to
  close — the carve-out iTerm2 makes with its own prompt-on-close. Verified that a
  live `claude` session reports no foreground job (the agent shares the shell's
  process group), which is exactly why the process-group check alone would have been
  the wrong signal.
- **There was no Window menu**, so ⌘M did nothing. Added with Minimize, Zoom, and
  Bring All to Front, all travelling the responder chain to the key window.

⌘W with a split still ungroups the focused pane, and the keybinding catalog is
untouched.

Verified on a packaged build, driving the real menu actions and lifecycle paths:
⌘W ungroups pane-by-pane while a split is on screen and only closes the window once
the last split is gone; with the window closed the app stays alive, a running
`claude` session and a ticking shell job keep going, and the control socket still
answers; a Dock reopen brings the same window back in the same process; ⌘Q with
working sessions blocks on the confirmation, Escape and Return cancel it with every
session untouched, and confirming quits and tears the sessions down; ⌘Q with
everything idle quits immediately. ⌘W with Settings frontmost closes Settings and
leaves the terminal layout alone. Close Session on an idle shell closes silently, on
a shell running `sleep 600` asks first, and on a live agent asks first; cancelling
leaves the session and its process running. `swift build` and `swift test` (172
tests) pass.

`docs/design/keyboard-command-design.md` records the rule these changes follow — a
key changes presentation or ends a process, and only the second kind may confirm or
destroy — plus how cmux, Zed, and Raycast answer the same question.

Closes #242

Release Notes:
- ⌘W no longer quits Termio. Closing the window leaves the app running with every
  session and agent alive; clicking the Dock icon brings the window back.
- Quitting Termio while a session is working or waiting on you now asks for
  confirmation first.
- Closing a session that is still running something now asks for confirmation.
- ⌘W and ⌘⇧W now act on the frontmost window, so they close Settings when Settings
  is in front.
- Added the Window menu, so ⌘M minimizes.