### PR TITLE
docs: name the product plainly in the chinese readme headings

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@ brew install --cask termio-sh/tap/termio
 [TestFlight](https://testflight.apple.com/join/1Arf1UKR) 获取配套应用公测版，
 再扫描 Mac 应用 Settings ▸ Mobile 中的二维码完成配对。
 
-## 为 Agentic Coding & Engineering 而生
+## 终端优先的 AI 编程开发环境
 
 IDE 是围绕一个人敲代码设计的。当大部分代码改由 AI 编码智能体来写，环境的职责也随之改变：它既是智能体干活的地方，也是您指挥、审阅、为它们解困的地方。Termio 正是这样一个环境——之所以终端优先，是因为智能体本来就活在终端里；它为工作的新形态而造：几个智能体同时推进，大多数无需您操心，偶尔有一个卡住等您。（更完整的论述见
 [*From IDE to ADE*](docs/essays/from-ide-to-ade.md)。）

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -41,7 +41,7 @@ brew install --cask termio-sh/tap/termio
 [TestFlight](https://testflight.apple.com/join/1Arf1UKR) 取得配套應用程式
 測試版，再掃描 Mac 應用程式「設定 ▸ 行動裝置」中的 QR code 完成配對。
 
-## 為 Agentic Coding & Engineering 而打造
+## 終端機優先的 AI 程式開發環境
 
 IDE 是圍繞著「人打字寫程式」設計的。當大部分程式碼改由智能體來寫，
 開發環境的職責也隨之改變：它是智能體工作的地方，也是您下指令、審閱成果、


### PR DESCRIPTION
Follow-up to #262, Chinese READMEs only.

"Agentic" has no settled Chinese rendering, so the heading now says what termio is rather than transliterating the adjective: `## 终端优先的 AI 编程开发环境` (zh-TW: `## 終端機優先的 AI 程式開發環境`). 智能体编程 is rejected — it inverts the subject, reading as engineering done *for* agents.

The English heading is unchanged.

Release Notes:
* Reworded the Chinese README section heading; no code changes.