### PR TITLE
Write down the companion wire protocol, and rewrite the mouse essay

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,7 @@ from the real front matter).
 | draft | essay | ["How Claude Code Got the Mouse: Reverse-Engineering the Clickable Terminal"](essays/how-claude-code-got-the-mouse.md) |
 | draft | rfc | ["RFC: Per-project agent sandbox (Apple Seatbelt)"](design/sandbox-seatbelt.md) |
 | draft | rfc | [Automation — scheduled agent runs](rfcs/automation-scheduled-agent-runs.md) |
+| draft | rfc | [Companion Wire Protocol](design/companion-wire-protocol.md) |
 | draft | rfc | [Fork libghostty-spm — own the wrapper, rent the engine?](rfcs/fork-libghostty-spm.md) |
 | draft | rfc | [Loose terminals as first-class entities](design/loose-terminal-entity.md) |
 | draft | rfc | [Onboarding —— 首次启动体验设计](design/onboarding.md) |

--- a/docs/design/companion-wire-protocol.md
+++ b/docs/design/companion-wire-protocol.md
@@ -1,0 +1,401 @@
+---
+title: Companion Wire Protocol
+status: draft
+type: rfc
+created: 2026-08-10
+updated: 2026-08-10
+related:
+  - mobile-agent-ui-protocol.md
+  - termiod-session-protocol.md
+  - remote-access-relay-strategy.md
+---
+
+# RFC: Companion Wire Protocol
+
+> One WebSocket between the Mac app and the iPhone: raw PTY bytes on binary
+> frames, hand-stable JSON on text frames, and a compatibility contract that
+> survives two apps shipping on two release channels that can never be updated
+> together.
+
+## 1. Why this needs writing down
+
+Every other protocol boundary in termio has one deployable behind it. This one
+has two, and they update independently: the Mac ships through Sparkle within
+minutes of a tag, the phone ships through App Store review and whenever the user
+gets around to it. There is no server in the middle to migrate both ends at
+once — the design forbids one (`CLAUDE.md`: never a hosted control plane).
+
+So skew is not an incident to be recovered from. It is the steady state, in both
+directions:
+
+- **Mac newer than phone** — the common case. A Mac updated this morning talks
+  to a phone build from six weeks ago.
+- **Phone newer than Mac** — a user who auto-updates apps but left the Mac open
+  for a week.
+
+The protocol's job is to make both of those boring. This RFC states the shape it
+has today, the compatibility rules that keep it boring, and the one rule that is
+currently missing (§6), which is what PR #234 proposes to add.
+
+## 2. Shape
+
+### 2.1 One socket, two opcodes
+
+`CompanionServer` (`Sources/termio/Companion/CompanionServer.swift`) binds an
+`NWListener` with a WebSocket protocol option on one port per channel — 8787
+release, 8788 dev — and never on the public net. Reaching it from outside the
+LAN is a tunnel's job, not the protocol's.
+
+| Opcode | Direction | Payload | Rule |
+| --- | --- | --- | --- |
+| `binary` | both | raw PTY bytes — output down, keystrokes up | permanently raw. Compression, encryption, or multiplexing needs its own negotiated mechanism and a `Wire` gate, so framing can never be mistaken for keystrokes |
+| `text` | both | one JSON object, `t` = the tag | `CompanionControl`, plus the roster frame (`t: "roster"`) |
+| `ping` | server → client | `"hb"` every ~20s | keeps NAT/proxy mappings warm and surfaces a half-dead link |
+
+`maximumMessageSize` is 16 MB because a phone upload (a photo for an agent
+prompt) arrives as one base64 text frame.
+
+This inherits the same invariant as `termiod` (`termiod-session-protocol.md`
+§A): byte delivery never waits on a parse. The bridge taps `PTYProcess` on a
+private serial queue and writes through; nothing between the PTY and the socket
+looks at the bytes.
+
+### 2.2 A connection has two roles, in order
+
+Every connection starts as a **roster subscriber**: it receives the project /
+session tree on authentication and again whenever it changes. A connection that
+sends `attach` additionally becomes a **PTY bridge** for one session, and stops
+receiving roster pushes — roster frames would only interleave with terminal
+traffic for no benefit; the phone re-subscribes by opening a second socket or
+dropping the bridge.
+
+### 2.3 What is deliberately absent
+
+- No session multiplexing. One socket carries one session's bytes. Panes and
+  layout are client concerns (non-negotiable #5).
+- No per-frame grid encoding. The phone runs a real libghostty surface and the
+  Mac ships it bytes; the mirror is a live surface, not a screenshot feed.
+- No crypto of our own. Possession of the pairing token is the whole auth story,
+  and confidentiality is the tunnel's (non-negotiable #3).
+
+## 3. Message catalogue
+
+`CompanionControl` (`Shared/Sources/TermioShared/WireProtocol.swift`) is one
+enum shared by both apps, with hand-written `encoded()` / `decode()` rather than
+`Codable` synthesis — the JSON is small enough to keep stable by hand, and both
+ends read it with plain `as? String` casts.
+
+| Tag | Direction | Purpose | Reply |
+| --- | --- | --- | --- |
+| `auth` | phone → Mac | pairing token + the phone's `wire` | roster, or refusal |
+| `attach` | phone → Mac | bridge this session's PTY | replay + byte stream |
+| `resize` | phone → Mac | the phone's grid; claims PTY winsize | SIGWINCH repaint |
+| `start` | phone → Mac | new session in a project (`agent` nil = Mac picks) | `started` / `error` |
+| `startTerminal`, `startSSH` | phone → Mac | loose shell / `ssh <host>` | `started` |
+| `stop` | phone → Mac | close a session | next roster push |
+| `exit` | Mac → phone | the child process exited | — |
+| `listFiles` / `fileList` | request / reply | one directory's entries | — |
+| `readFile` / `file` | request / reply | file contents (+ rendered Markdown) | — |
+| `writeFile` / `written` | request / reply | mtime-checked write | `error` prefixed `conflict:` |
+| `upload` / `uploaded` | request / reply | attachment → `<project>/.termio/uploads/` | — |
+| `searchFiles` / `searchResults` | request / reply | filename search, capped | — |
+| `listChanges` / `changes` | request / reply | `git status` with `+`/`−` counts | — |
+| `readDiff` / `diff` | request / reply | one file's unified diff | — |
+| `trace` / `traceHTML` | request / reply | agent transcript as an HTML document | — |
+| `sshConfigHosts` / `sshConfigList` | request / reply | the Mac's `~/.ssh/config` aliases | keys never leave the Mac |
+| `error` | Mac → phone | request refused | terminal for the transport |
+
+The roster is a separate struct, not a `CompanionControl` case, because it is
+pushed rather than requested and it is the only frame carrying `wire` from the
+Mac. Its shape is `CompanionRoster { t, wire, projects[], agents[] }`, where a
+`RosterProject` owns `RosterSession`s. Both apps identify a session by the same
+uuid the desktop deep link uses (`termio://session/<uuid>`).
+
+## 4. Sequences
+
+### 4.1 Connect, authenticate, attach
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant P as iPhone (CompanionTransport)
+    participant M as Mac (CompanionServer)
+    participant T as PTYProcess
+
+    P->>M: WebSocket open
+    Note over M: 10s grace timer armed
+    P->>M: text auth{token, wire}
+    alt token mismatch or wire < minimumClient
+        M-->>P: text error{message}
+        M--xP: close
+    else accepted
+        M->>M: remember the connection's declared wire
+        M-->>P: text roster{wire, projects, agents}
+        Note over P: roster.wire < minimumServer → fail with<br/>"Update Termio on your Mac"
+    end
+
+    P->>M: text attach{session}
+    alt unknown session
+        M-->>P: text error{"unknown session"}
+    else bridged
+        M->>T: addSink(replay ≤ 128 KB, skipped on alt-screen)
+        T-->>M: bytes
+        M-->>P: binary bytes (replay, then live)
+        P->>M: text resize{cols, rows}
+        M->>T: winsize claim (or jiggle when unchanged)
+        T-->>M: full repaint
+        M-->>P: binary bytes
+    end
+
+    loop while attached
+        P->>M: binary keystrokes
+        M->>T: write (non-blocking)
+        T-->>M: output
+        M-->>P: binary bytes
+    end
+
+    T-->>M: child exited
+    M-->>P: text exit{code}
+```
+
+Two details that are contract, not implementation:
+
+- **`auth` precedes everything on the same socket.** `URLSessionWebSocketTask`
+  preserves send order, so the phone can queue `attach` and `resize` right
+  behind it without waiting for the roster.
+- **`resize` after every `attach`, even at an unchanged size.** The attach path
+  wipes the screen; the repaint is driven by the client's size claim, and when
+  the winsize does not actually change the Mac jiggles it to force the SIGWINCH.
+
+### 4.2 Roster push and the request/reply plane
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant P as iPhone
+    participant M as Mac (CompanionServer)
+    participant S as TermioStore
+
+    loop every 1s
+        M->>S: rosterProvider()
+        alt unchanged
+            M->>M: drop (compared by value)
+        else changed
+            M-->>P: text roster{...} to every authed, non-bridged connection
+        end
+    end
+
+    P->>M: text listChanges{project}
+    M-->>P: text changes{files}
+    P->>M: text readDiff{project, path, status}
+    M-->>P: text diff{path, text}
+    P->>M: text writeFile{project, path, data, baseMtime}
+    alt file moved on disk since baseMtime
+        M-->>P: text error{"conflict: …"}
+    else written
+        M-->>P: text written{path, mtime}
+    end
+```
+
+The plane is stateless request/reply with no message ids: replies are matched by
+tag, and the one case where a stale reply is possible (`searchResults` for an
+old keystroke) echoes its `query` so the phone can discard it. Adding ids is a
+`Wire` bump, not a free change.
+
+## 5. State machines
+
+### 5.1 Server-side, per connection
+
+```mermaid
+stateDiagram-v2
+    [*] --> Accepted: newConnectionHandler
+    Accepted --> Authenticated: auth with valid token and wire ≥ minimumClient
+    Accepted --> Refused: bad token / too-old wire / 10s grace expired
+    Authenticated --> Bridged: attach on a live session
+    Bridged --> Authenticated: attach elsewhere (old bridge stopped first)
+    Authenticated --> Refused: any control before auth
+    Bridged --> Closed: socket failed or cancelled
+    Authenticated --> Closed: socket failed or cancelled
+    Refused --> Closed
+    Closed --> [*]
+
+    note right of Authenticated
+        receives roster pushes
+    end note
+    note right of Bridged
+        no roster pushes; bytes only.
+        drop → PTY winsize handed back
+        to the Mac if no bridge remains
+    end note
+```
+
+An unauthenticated connection is served nothing at all — not even a roster —
+because the roster names every project on the Mac and an `attach` is keystroke
+access to a shell. The 10-second grace window exists so a socket that never
+authenticates cannot linger.
+
+### 5.2 Client-side transport
+
+```mermaid
+stateDiagram-v2
+    [*] --> Connecting
+    Connecting --> Connected: didOpen, auth queued
+    Connected --> Reconnecting: socket failure
+    Reconnecting --> Connecting: ReconnectPolicy delay (fast burst, then heartbeat)
+    Connected --> Closed: exit control
+    Connected --> Failed: error control, or roster.wire < minimumServer
+    Reconnecting --> Connecting: foreground / "Try Again"
+    Closed --> [*]
+    Failed --> [*]
+
+    note right of Reconnecting
+        not fatal — the usual cause is
+        the Mac app rebuilding. Re-attach
+        is idempotent: the server replays.
+    end note
+    note right of Failed
+        terminal on purpose: retrying an
+        unauthorized or too-old link just
+        churns with no visible cause
+    end note
+```
+
+`Reconnecting` is deliberately unbounded (see `ReconnectPolicy`): a closed
+laptop should not permanently sever a paired phone. `Failed` is deliberately
+terminal: those two causes are not going to fix themselves on a retry.
+
+## 6. Compatibility
+
+### 6.1 The version ladder
+
+`Wire` carries four integers:
+
+| Constant | Today | Meaning |
+| --- | --- | --- |
+| `current` | 1 | this build's revision |
+| `legacy` | 0 | a peer that predates the `wire` field; absent decodes to this |
+| `minimumClient` | 0 | oldest phone this Mac will serve |
+| `minimumServer` | 0 | oldest Mac this phone will talk to |
+
+The phone declares `wire` on `auth`; the Mac declares it on every roster. Both
+minimums are 0, so nothing is currently refused on version grounds — the ladder
+exists so that the day a refusal is necessary, it is a one-line change with a
+message the user can act on, instead of an unexplained blank screen.
+
+`current` is bumped only for a compatibility decision: a new request the other
+end must know about, a **changed meaning** for an existing field, a new byte
+mode. Purely additive fields do not bump it.
+
+### 6.2 Sender rules
+
+- **R1 — every new field is optional, with a safe default.** An older peer that
+  omits it must decode. `RosterSession.subtitle`, `RosterProject.branch` and
+  `kind`, `WireFile.html`, `started.agent` are all this rule.
+- **R2 — nil omits the key rather than emitting `null`.** Both ends read with
+  `as? String`, and `null` and absent must not mean different things.
+- **R3 — never repurpose a field.** A changed meaning is a `Wire` bump, because
+  no amount of receiver tolerance can detect it.
+- **R4 — degrade to "nothing happens", never to "the wrong thing".** An older
+  Mac that cannot parse an agent-less `start` drops it; it must never launch an
+  arbitrary agent instead.
+
+### 6.3 The rule that is missing: receiver tolerance
+
+R1–R4 govern what a sender may add. They say nothing about what a receiver does
+with an element it cannot parse — and today the answer is the worst possible
+one.
+
+`CompanionRoster.init(from:)` decodes `projects` and `agents` with
+`decodeIfPresent`. That tolerates a **missing** key only. A key that is present
+but whose contents do not match throws, the throw travels up through the array
+to `CompanionRoster.decode`, which returns nil, and the phone drops the frame
+entirely. One session it cannot read costs the whole tree: the app shows nothing
+rather than one row less.
+
+The blast radius is inverted from the mistake. A single field on a single
+session — the smallest thing a future Mac can get wrong — empties the app.
+
+That leads to the rule this RFC adds:
+
+- **R5 — a container's decoder tolerates its elements, but not itself.** Arrays
+  on the wire decode element by element; an element that fails is dropped, not
+  propagated. A peer is only as forward-compatible as its least tolerant array.
+  The tolerance stops at the container: a key that is *absent* decodes to empty,
+  a key that is present but **not an array** must still fail the frame. Silently
+  reading a wrong-shaped container as empty is worse than the bug R5 fixes,
+  because the phone replaces its tree from every roster it accepts
+  (`RosterStore.onRoster`) — a frame that fails to decode leaves the last good
+  tree on screen, while a frame that decodes to nothing wipes it.
+
+And its counterpart for the control plane:
+
+- **R6 — an unknown tag is a value, not a nil.** Ignoring a newer peer's message
+  is correct; ignoring it invisibly is not, and it violates the repo's rule
+  against silently discarding errors. An unknown `t` decodes to
+  `unsupported(type:)` so the receiver can log which message it dropped —
+  "the phone's button did nothing" becomes a line in the log.
+
+Three consequences worth stating explicitly:
+
+1. **Tolerance only counts if it ships first.** The roster is decoded on the
+   *phone*. When a future Mac gets a field wrong, the phone in the field is the
+   old one — it cannot be given tolerance retroactively. This is the entire
+   argument for landing R5 before it is needed rather than when it bites.
+2. **R5 does not weaken R1–R4.** Dropping a bad element is a floor, not a
+   licence to break shapes. A sender that relies on the receiver skipping its
+   elements has already violated R3.
+3. **R5 and R6 disagree about silence.** A dropped control frame is logged; a
+   dropped roster element is not. Either both are logged or the asymmetry needs
+   a reason — a row missing from the phone's list is exactly as invisible as a
+   button that does nothing.
+
+### 6.4 Implementation notes for R5
+
+Decoding an array element by element in `Codable` has one non-obvious hazard: a
+failed `decode` **leaves the unkeyed container's cursor where it was**. The slot
+has to be consumed by decoding something that always succeeds (an empty
+`Decodable` struct), or the loop never reaches `isAtEnd` and spins. The consumer
+must succeed for every JSON shape an element can take — object, array, string,
+number, `true`, `null` — because the first shape it cannot swallow truncates the
+rest of the array silently, which is a second version of the bug being fixed.
+
+Hand-writing an `init(from:)` to get this also means hand-maintaining
+`CodingKeys`. That is a real cost: the compiler catches a property missing from
+the decoder, but a property missing from `CodingKeys` silently stops being
+*encoded*. Any type given a lossy decoder needs a round-trip test.
+
+The other trap is the container itself, per R5. `try? nestedUnkeyedContainer(…)`
+collapses two different situations into one: the key was absent (tolerate → empty)
+and the key held something that is not an array (a shape change → fail the
+frame). They have to be told apart, or the decoder converts an unreadable roster
+into a valid empty one and the phone clears its own tree.
+
+## 7. Open questions
+
+1. **Do dropped roster elements get logged?** §6.3 consequence 3. The phone has
+   no console the user reads, so the honest options are an `os_log` line for a
+   developer attaching a device, or nothing plus an explicit note that this is
+   deliberate.
+2. **Should `unsupported` be encodable at all?** Re-emitting it as its own
+   envelope (`{"t":"unsupported","of":…}`) keeps the enum round-tripping, but
+   nothing ever sends that frame. The alternative is to keep the case
+   decode-only and have `encoded()` return an `error`.
+3. **How much sanitizing does a logged tag deserve?** The tag is remote input,
+   but it arrives from a peer that has already authenticated and can type into a
+   shell. Line-forging in a log the attacker could otherwise simply `echo` into
+   is not obviously worth a helper — and a half-measure is worse than none: a
+   `prefix(40)` on `Character` bounds grapheme clusters, not bytes, so one
+   letter followed by thousands of combining marks passes it unchanged.
+4. **When does `minimumServer` / `minimumClient` first move off 0?** Nothing has
+   needed it yet. The first real answer will probably be the day the binary
+   plane gains a negotiated mode.
+
+## 8. Non-goals
+
+- Message ids and a general request/reply correlator. Tag-matching plus the one
+  echoed `query` covers today's planes; ids are a `Wire` bump when a plane needs
+  them.
+- Multiplexing several sessions over one socket. One socket, one session.
+- A second protocol for the phone. When `termiod` lands, the phone speaks the
+  same framed messages over the same ladder (non-negotiable #4) — this protocol
+  is the near-term shape, not a parallel dialect to maintain forever.

--- a/docs/essays/how-claude-code-got-the-mouse.md
+++ b/docs/essays/how-claude-code-got-the-mouse.md
@@ -3,123 +3,179 @@ title: "How Claude Code Got the Mouse: Reverse-Engineering the Clickable Termina
 status: draft
 type: essay
 created: 2026-08-03
-updated: 2026-08-03
+updated: 2026-08-10
 description: Claude Code's fullscreen mode quietly gave the terminal a working mouse — click-to-position, clickable menus, hover states, drag selection. A dig through the shipped binary reveals a five-layer architecture that any code agent could adopt.
 ---
 
 # How Claude Code Got the Mouse
 
-> A reverse-engineering write-up of Claude Code's fullscreen-mode mouse support, aimed at authors of other agent TUIs — this is a playbook worth copying.
+> A reverse-engineering dig through Claude Code's fullscreen-mode mouse support, written for the people building the other agent TUIs. Everything here was recovered from the publicly shipped binary and a pseudo-terminal probe; inferences are labeled.
 
-Over the spring of 2026 — starting as a hidden env var in v2.1.89 and maturing release by release — Claude Code shipped something that sounds impossible if you grew up on terminals: **you can click**. Click into the middle of a half-typed prompt and the cursor moves there. Click a collapsed tool result and it expands. Click "Yes" on a permission prompt. Hover over things and they respond. Drag to select text *inside the TUI*, and it auto-copies.
+The other day I clicked into the middle of a half-typed prompt in Claude Code — the way you'd click into any text field, without thinking — and the cursor *moved there*.
 
-Terminals have technically supported mouse reporting since xterm in the 1980s, and full-screen apps like vim and htop use it. But for years no mainstream *AI agent* TUI did — Claude Code, Codex, Gemini CLI, and friends were all keyboard-only line-editor UIs where the mouse belonged to the host terminal. Claude Code's fullscreen renderer (`/tui fullscreen`) changed that (Grok's CLI has since shipped similar interactions), and the implementation is more interesting than "they turned on mouse mode."
+That's not supposed to happen. Terminal input runs through a line editor owned by the child process; the mouse belongs to the host terminal, and clicking a TUI's input box normally does nothing. If you grew up on terminals, your hands know this the way they know Ctrl+C. Every mainstream agent CLI — Claude Code, Codex, Gemini CLI — has been a keyboard-only UI for its entire life. And yet: click, cursor moves. Click a collapsed tool result, it expands. Click "Yes" on a permission prompt. Hover over things and they light up. Drag to select text inside the TUI and it lands on your clipboard.
 
-The community has noticed, in fragments. A Japanese demo of the mouse working in Claude Code — enabled via the then-undocumented `CLAUDE_CODE_NO_FLICKER=1` — pulled over 200k views back in April. By late July the discussion had turned into tip-sharing and, more tellingly, **demand aimed at the laggards**: Codex CLI users publicly asking its maintainers for click-to-move-cursor ("Claude Code and Grok already have it — don't force me to leave codex"). What nobody has written up is *how it works* — which is exactly what a competing TUI team would need.
+Here's the part that got me: I went to the changelog to find out when this shipped, and **the sentence "Added mouse support" does not exist in it**. The biggest interaction change a terminal agent has ever shipped was never announced. (The community found it anyway — the most-viewed post about the feature, a 200k-view demo from April, teaches an env var that wasn't documented at the time.)
 
-So I took apart the shipped binary. This post is what I found, and — more importantly — the checklist other agent TUIs can follow to catch up.
+So I had two questions. How does it work? And why is the paper trail so strange? I build a terminal that hosts these agents, so I had a selfish third: is my side of the pipe doing its job?
 
-## Method (and its limits)
+## Probe one: what does it ask the terminal for?
 
-Claude Code no longer ships readable JavaScript. The npm package now contains a single 256 MB Bun-compiled Mach-O binary with the app baked in as JavaScriptCore bytecode. You can't read the logic — but JSC bytecode keeps its **constant tables**: every identifier, property name, string literal, and telemetry event name survives verbatim, grouped by module. Identifier archaeology on those tables, plus a live probe (spawning `claude` under a pseudo-terminal and capturing the escape sequences it emits), is enough to reconstruct the architecture with high confidence.
-
-Two kinds of claims below: things the binary and the pty *prove* (mode sequences, identifier clusters, feature strings), and mechanisms I'm *inferring* from them. I'll mark the inferences.
-
-## What the probe shows
-
-Spawn `claude` under a bare pty and within a second it emits:
+You don't need the source to see what a program negotiates with its terminal — spawn it under a pseudo-terminal and log the bytes. Within a second of startup, `claude` emits:
 
 | Sequence | Meaning |
 |---|---|
-| `CSI ?1049h` | Alternate screen (the fullscreen renderer's canvas) |
-| `CSI ?1000h` | Mouse click reporting |
-| `CSI ?1002h` | Button-drag reporting |
-| `CSI ?1003h` | **Any-motion** reporting — this is what powers hover states |
-| `CSI ?1006h` | SGR extended encoding (coordinates beyond column 223, distinct press/release) |
+| `CSI ?1049h` | Alternate screen — the fullscreen renderer's canvas |
+| `CSI ?1000h` | Report mouse clicks |
+| `CSI ?1002h` | Report drags |
+| `CSI ?1003h` | Report **all motion** — this is what powers hover |
+| `CSI ?1006h` | SGR encoding — coordinates past column 223, distinct press/release |
 | `CSI ?2004h` | Bracketed paste |
 
-That's the full mouse ladder, including motion tracking — the terminal now streams every movement, click, and wheel tick to the app as escape sequences on stdin. From here on, everything is software.
+That's the entire mouse ladder, including the firehose (1003 means the app hears about every pointer movement, not just clicks). From this moment the host terminal streams events as escape sequences on stdin:
 
-## The paper trail: a feature that was never announced
+```
+  ESC [ <   0   ;   34   ;   12   M
+        │       │        │        │
+        │    column     row       └── M = press, m = release
+        │
+        └── button: 0=left  2=right  64=wheel-up  65=wheel-down
+```
 
-Here's the strangest part. Grep the official CHANGELOG for the feature and you find that **"Added mouse support" was never written**. The biggest interaction change a terminal agent has shipped arrived with no headline. Instead, the release notes tell the story sideways, as an archaeology of fix entries:
+This protocol is older than most people reading this — xterm shipped mouse tracking in the 1980s, and vim and htop have used it forever. Which sharpens the real question. The wire was always there. **What did it take to put a UI toolkit on the other end of it?**
 
-- **2.1.89** — the birth, disguised as an env var: *"Added `CLAUDE_CODE_NO_FLICKER=1` environment variable to opt into flicker-free alt-screen rendering with virtualized scrollback."* Mouse isn't mentioned; the renderer is the Trojan horse. (The community found it anyway — the most-viewed post about the feature, a 200k-view April demo, teaches exactly this env var, weeks before the `/tui` command existed.)
-- **2.1.83–2.1.98** — the mouse leaks into the fix log before ever being announced: *"Fixed mouse tracking escape sequences leaking to shell prompt after exit"*, *"Fixed copy-on-select not firing when you release the mouse outside the terminal window"*, *"Fixed click-to-expand hover text being nearly invisible on light terminal themes"*, *"Fixed a crash in fullscreen mode when hovering over MCP tool results."* Copy-on-select, click-to-expand, and hover all demonstrably exist — none was ever introduced.
-- **2.1.110** — the front door appears: *"Added `/tui` command — run `/tui fullscreen` to switch to flicker-free rendering in the same conversation."* Still no mouse in the entry.
-- **2.1.132** — the only sentence that ever admits the feature exists, and it's about a banner: *"Updated the `/tui fullscreen` startup banner to describe additional renderer benefits (lower memory usage, mouse support, auto-copy on select)."* The announcement of mouse support is a note that a banner now mentions mouse support.
-- **2.1.139–2.1.145** — polish ships feature-by-feature: `/scroll-speed` with live preview; *"Slash command and @-mention suggestion list now supports mouse hover and click."*
-- **2.1.187 / 2.1.208** — menus become clickable: *"Added mouse click support to select menus (permission prompts, `/model`, `/config`, etc.)"*, then multi-select menus and "Other" input rows.
-- **2.1.195** — the opt-out tells you the scope: *"Added `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` to disable mouse click/drag/hover in fullscreen mode while keeping wheel scroll."*
-- And click-to-position — the marquee interaction — **appears in no entry at all**. The only written evidence anywhere is the banner string inside the binary: *"Click to move your cursor in the text input."*
+## Probe two: the binary
 
-The changelog also corroborates the quirk matrix from the binary, in official words: the xterm.js wheel-speed bug and JetBrains 2025.2 scroll chaos (*"spurious arrow keys, wrong-direction events, runaway acceleration"*, both 2.1.132), WSL2 wheel regressions (2.1.179), Cmd+click fixed separately for Ghostty (2.1.187), Ghostty-over-ssh/tmux (2.1.191), and Warp (2.1.198), copy-on-select printing base64 into GNU screen (2.1.219), and mouse tracking disabled outright on incapable Windows consoles (2.1.172). Roughly forty entries over thirty-ish releases — a drip of compatibility labor, never a launch.
+Claude Code stopped shipping readable JavaScript. The npm package now contains a single 256 MB Bun-compiled Mach-O with the app baked in as JavaScriptCore bytecode. You can't read the logic. But JSC bytecode keeps its **constant tables** — every identifier, property name, and string literal survives verbatim, *grouped by module*. That last part is the gift: run `strings`-style extraction around a known identifier and its neighbors are its module-mates. Identifier archaeology, plus the pty probe, is enough to reconstruct the architecture. (It also coughs up charming internals: the telemetry namespace is `tengu_*`, and there's a flag named `macCmdClickArrivesWithoutSgrModifierBit`, which is an entire war story in eleven words.)
 
-Why ship it this way? Inference, but the shape is familiar: the renderer was the risky bet (an alt-screen rewrite of the whole UI), so it went out as an env var, graduated to a `/tui` toggle, and grew an upsell banner — with telemetry (`fullscreen-upsell`, `fullscreen-downsell`, an exit survey) deciding the pace. The mouse was never the announcement because the mouse was never the product; it's a *property of the new renderer*. You don't announce that a browser supports clicking.
+What the tables describe is a pipeline:
 
-## The architecture, layer by layer
+```
+ ┌──────────────────────────────────────────────────────────┐
+ │ you: click at pixel (612, 384)                           │
+ └───────────────────────────┬──────────────────────────────┘
+                             ▼
+ ┌─ host terminal ───────────────────────────────────────┐
+ │ pixel → cell    (col 34, row 12)                      │
+ │ encode          ESC [ < 0 ; 34 ; 12 M                 │
+ └───────────────────────────┬───────────────────────────┘
+                             ▼   bytes on stdin — the only wire
+ ┌─ Claude Code ─────────────────────────────────────────┐
+ │ 1 decode      SGR report → (button 0, col 34, row 12) │
+ │ 2 synthesize  click? double? drag? hover?             │
+ │ 3 hit-test    "what did I paint at (34, 12)?"         │
+ │ 4 dispatch    move cursor / expand / select menu row  │
+ └───────────────────────────────────────────────────────┘
+```
 
-### Layer 1 — Capability and quirk negotiation
+Layer by layer, bottom up.
 
-The binary contains a small terminal-mode manager (constants `MOUSE_NORMAL`, `MOUSE_BUTTON`, `MOUSE_ANY`, `MOUSE_SGR`, modes `alternateScreen`, `bracketedPaste`, `focusEvents`, `mouseTracking: off | normal | button | any`) — a declarative ladder rather than scattered writes.
+### Decode, and the quirk matrix
 
-What impressed me more is the **quirk matrix** around it. Terminal mouse support in the wild is a minefield, and the identifier list reads like a war journal:
+There's a tidy terminal-mode manager in there (`mouseTracking: off | normal | button | any`, constants `MOUSE_NORMAL / MOUSE_BUTTON / MOUSE_ANY / MOUSE_SGR`) — but the mode manager is the easy 5%. The other 95% is a compatibility program that the changelog documents as a slow war, one skirmish per release:
 
-- `fullscreen disabled: tmux -CC (iTerm2 integration mode) detected` and `fullscreen disabled: Windows over SSH (ConPTY re-rendering) detected` — whole configurations where they refuse to enable it.
-- `checkedTmuxMouseHint` / `add 'set -g mouse on' to ~/.tmux.conf` — they detect tmux and *coach the user* into passing mouse events through.
-- `emitJediTermScrollBug` / `tengu_jediterm_scroll_bug_detected` — a workaround for JetBrains' JediTerm terminal.
-- `readVSCodeScrollSensitivity` — they read VS Code's own `terminal.integrated.mouseWheelScrollSensitivity` setting so wheel speed matches the host.
-- `Scroll wheel is sending arrow keys` / `scroll-as-arrows` — detecting terminals that translate wheel events into arrow keys and adapting.
-- `macCmdClickArrivesWithoutSgrModifierBit` — the SGR encoding has bits for Shift/Alt/Ctrl but macOS Cmd doesn't reliably arrive as one, and Cmd+click-to-open-URL needs special-casing per terminal.
+- Refuse outright where the ground is bad: *"fullscreen disabled: tmux -CC (iTerm2 integration mode) detected"*, *"fullscreen disabled: Windows over SSH (ConPTY re-rendering) detected"*.
+- Coach where config can fix it: detect tmux and suggest `set -g mouse on`.
+- Patch around named enemies: JetBrains' terminal (*"spurious arrow keys, wrong-direction events, runaway acceleration"* — v2.1.132), an xterm.js wheel-speed bug in VS Code and Cursor, WSL2 regressions, and my favorite — Claude Code *reads VS Code's own `terminal.integrated.mouseWheelScrollSensitivity` setting* so wheel speed matches the host editor.
+- Detect terminals that translate wheel events into arrow keys and fall back gracefully (*"Scroll wheel is sending arrow keys"*).
 
-The lesson: **the hard part isn't enabling mouse mode, it's the compatibility program around it.** They ship escape hatches at every granularity — `CLAUDE_CODE_DISABLE_MOUSE`, `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` (keep wheel, drop clicks), `CLAUDE_CODE_DISABLE_VIRTUAL_SCROLL`, `CLAUDE_CODE_NO_FLICKER`, `CLAUDE_CODE_SCROLL_SPEED` — plus telemetry (`tengu_fullscreen_upsell_dialog_accepted`, `fullscreen-downsell`, and an exit survey: "To help us make fullscreen mode better, what made you switch back?") to find out when the bet fails.
+If you're an agent-TUI author budgeting this feature: the escape sequences are a weekend. The quirk matrix is the roadmap.
 
-### Layer 2 — Input decoding and gesture synthesis
+### Synthesize: the terminal doesn't know what a double-click is
 
-Raw SGR reports (`CSI < button ; x ; y M/m`) are decoded into a gesture stream. The identifier cluster is textbook UI toolkit: `onClickAt`, `onHoverAt`, `onMultiClick`, `onSelectionStart`, `onSelectionDrag`, with `lastClickRow` / `lastClickCol` / `lastClickTime` / `clickCount` / `doubleClickInterval` state behind them.
+The wire delivers "button 0 pressed at (34, 12)". That's all it delivers. Double-click, triple-click, drag, hover — every gesture above a raw press is synthesized in the app, and the constant tables show exactly the state you'd expect from a GUI toolkit: `clickCount`, `lastClickRow`, `lastClickCol`, `lastClickTime`, `doubleClickInterval`, `onMultiClick`, `onHoverAt`. Word-select on double-click exists because someone wrote the timer logic, not because the terminal helped.
 
-That state means they synthesize **double- and triple-click** from raw press events, exactly like a GUI toolkit — the terminal gives you only "button 0 pressed at (34, 12)"; word-select and line-select are app-level constructs. Hover (`onHoverAt`, `lastHoverRow/Col`, `setHoveredKey`) rides on the any-motion firehose from mode 1003.
+### Hit-test: the load-bearing layer
 
-### Layer 3 — The layout registry (hit-testing)
+A click gives you a cell coordinate. The question "what is at row 12, column 34?" has to be answerable, which means the renderer must remember what it painted where. The binary shows a positions registry built during render — `scanElement`, `scanElementSubtree`, `setPositions`, `prefixSum`, and a property literally named `hitTest`:
 
-This is the load-bearing layer. A terminal click gives you a *cell coordinate*; the app has to answer "what UI element is at row 12, column 34?" The binary shows a positions registry built during render: `scanElement`, `scanElementSubtree`, `setPositions`, `positions`, `prefixSum`, `screenOrd$`, and the star witness, a property literally named `hitTest`.
+```
+  col→ 1        10        20        30        40
+ row ┌─────────────────────────────────────────────┐
+  1  │  ● Read(src/main.rs)… +214 lines            │◀─ rect: tool result
+  ⋮  │  …transcript…                               │       (expandable)
+ 10  │  ┌ Select model ──────────────┐             │
+ 11  │  │  1. Opus        ◀━━ click  │             │◀─ rects: menu rows
+ 12  │  │  2. Sonnet                 │             │
+ 13  │  └────────────────────────────┘             │
+ 14  │  ❯ fix the login bug in │auth.ts            │◀─ rect: the input
+     └─────────────────────────────────────────────┘   (cell → char offset)
+```
 
-Inference, but a confident one: the fullscreen renderer (which is a custom frame-diffing engine — `renderFullFrame`, `blit`, `invalidatePrevFrame`, style/char/hyperlink pools — not stock Ink) records each component's screen rectangle as it paints, and click dispatch walks that registry. It's the same design as a browser's layout tree feeding elementFromPoint. Hyperlinks get their own pool (`getHyperlinkAt`, `openHyperlink`), with a scheme allowlist on dispatch (`refusing to dispatch clicked link with non-allowlisted scheme` — someone thought about `file://` and worse being clickable).
+This is a browser's layout tree feeding `elementFromPoint`, rebuilt over terminal cells — and it's worth saying that the renderer underneath is *not* stock Ink. The identifiers describe a custom frame-diffing engine: `renderFullFrame`, `blit`, `invalidatePrevFrame`, pooled styles, chars, and hyperlinks. Links get their own pool (`getHyperlinkAt`, `openHyperlink`) with a scheme allowlist on dispatch — someone thought about what `file://` does when everything is clickable.
 
-Once you have the registry, the features fall out almost for free:
+Once the registry exists, the features people actually notice fall out almost for free. Click-to-position is "hit-test resolved to the editor; map cell to character offset; move cursor." Click-to-expand is "this rect is expandable." Clickable menus are "this rect is option row 3."
 
-- **Click-to-position in the input**: hit-test resolves to the editor component, the cell offset maps to a character offset (wide-char aware), cursor moves. The feature string is right there: "Click to move your cursor in the text input."
-- **Click-to-expand**: `onItemClick`, `isItemClickable`, `isItemExpanded` — collapsed tool results are just clickable components.
-- **Clickable menus**: each option row registers a rect; a click is equivalent to arrowing to it and pressing Enter.
+### One asymmetry you can observe from your chair
 
-### Layer 4 — Rebuilding selection (the tax)
+Here's a detail I hit as a user before I found it in the strings. Type `/` in Claude Code: the command menu pops up, and **hovering it highlights rows — but the scroll wheel won't scroll it**, even while wheel works fine on the transcript behind it. Bug? No — architecture, visible from the outside:
 
-Here's the cost nobody mentions: the moment you enable mouse reporting, **the host terminal's native text selection stops working** — drags go to the app now. So Claude Code had to rebuild selection inside the TUI: `handleSelectionStart`, `handleSelectionDrag`, `handleMultiClick`, `getSelectedText`, `copySelection`, `setSelectionBgColor`, `subscribeToSelectionChange` — plus feature strings for auto-copy-on-select, column (rectangular) selection, and pointers to "terminal native copy" via modifier+drag as the escape hatch.
+```
+        click / hover                        wheel
+             │                                 │
+     positional routing                 focus routing
+     "which rect contains          "which view has claimed
+      the pointer cell?"             the scroll box?"
+             │                                 │
+      hit-test registry             the focused scrollable
+             │                     (transcript, open modal)
+             ▼                                 ▼
+     works anywhere a rect          falls through widgets that
+     is registered                  never claim a scroll box —
+                                    like the slash-command menu
+```
 
-This is the part I'd wave in front of every agent-TUI author considering the feature: mouse capture is not additive. You take ownership of selection, and users have fifteen years of muscle memory about how terminal selection behaves. Budget for it.
+Clicks route by position; wheel routes by focus (the strings: `claimScrollBox`, `modalScrollRef`, *"When a scrollable view is focused"*). The completion menu registers hover rects but never claims a scroll box, so wheel events sail through it. Browsers route wheel positionally, which is why this feels subtly wrong — and why I'd bet a future release either gives that menu a scroll box or flips wheel to positional routing.
 
-The complaints on X corroborate this layer almost line by line: users annoyed that auto-copy-on-select keeps clobbering their clipboard, users startled that clicking the terminal "does something now" when they only wanted keyboard focus, one user spending twenty minutes hunting for the disable flag. None of these are bugs — they're the cost of taking ownership of a gesture users thought belonged to the terminal. The opt-out granularity (`CLAUDE_CODE_DISABLE_MOUSE_CLICKS` keeping wheel but dropping clicks) exists precisely because this tax is real.
+(The wheel path has its own sub-engine, by the way: the alt screen has no native scrollback, so scrolling a long transcript is virtualized — `scrollToIndex`, `scrollAnchor`, prefix-summed line heights — with wheel acceleration, burst detection, and a `wheelFlood` guard on top.)
 
-### Layer 5 — The scroll engine
+### The tax: you now own selection
 
-Fullscreen mode means the app owns scrollback too (the alt screen has none). The binary shows a virtual-scrolling implementation that would look at home in a web app: `virtualScroll`, `scrollToIndex`, `scrollAnchor`, `stickyScroll`, `scrolledOffAbove` / `scrolledOffBelow`, prefix-sum line-height accounting, and a wheel pipeline with acceleration (`wheelMode`, `burst`, `burstCount`, `mult`, `wheel accel`), flood detection (`wheelFlood`), and per-host sensitivity. Rendering only the viewport out of a long transcript is what keeps click latency low — the same reason web apps virtualize lists.
+The moment an app enables mouse reporting, drag events stop reaching the host terminal — which means **native text selection dies**. Fifteen years of muscle memory, gone. So Claude Code rebuilt selection inside the TUI: `handleSelectionStart`, `handleSelectionDrag`, `getSelectedText`, `copySelection`, auto-copy-on-select, column selection, and a modifier+drag passthrough to native selection as the escape hatch.
 
-## The playbook for other agent TUIs
+The complaints on X corroborate this layer almost line by line: users annoyed that copy-on-select keeps clobbering their clipboard, users startled that clicking the terminal "does something now," one user spending twenty minutes hunting for the off switch. None of these are bugs. They're the cost of taking ownership of a gesture users believed belonged to the terminal — and the opt-out granularity (`CLAUDE_CODE_DISABLE_MOUSE_CLICKS`: drop clicks, keep wheel) exists because the cost is real. If you ship mouse capture without rebuilding selection, you haven't shipped a feature; you've shipped a regression with hover states.
 
-This isn't a hypothetical audience. Codex CLI users are asking its maintainers for click-to-position by name; the same requests name-check Claude Code and Grok as the tools that already have it. The demand is public — what's been missing is the implementation map. If you build a code agent TUI and want parity, the shipped evidence suggests this order:
+## The release notes that never said it
 
-1. **Go alt-screen with a frame-diffing renderer first.** Mouse support rides on owning the whole screen; Claude Code gated it behind fullscreen mode rather than retrofitting the scrolling line-based UI.
-2. **Enable the full ladder** — 1000/1002/1006 minimum; add 1003 only when you have hover states to justify the event volume.
-3. **Build the layout registry during render.** Every interactive component registers its screen rect; hit-testing is a lookup, not a heuristic. This is the piece that turns "mouse events" into "UI".
-4. **Synthesize gestures yourself**: click count, double/triple, drag, hover. The terminal gives you presses; everything else is your toolkit.
-5. **Rebuild selection, or don't ship.** Auto-copy-on-select and modifier+drag native passthrough are the minimum to not enrage users.
-6. **Carry a quirk matrix**: tmux, ConPTY, JediTerm, VS Code, scroll-as-arrows terminals. Refuse loudly where it can't work, coach where config fixes it.
-7. **Ship opt-outs at every granularity and instrument the retreat path.** Claude Code measures who leaves fullscreen mode and asks why.
+Back to the strange paper trail. Assembled from the actual changelog:
+
+```
+ 2.1.83   the fix log starts leaking:  "Fixed mouse tracking escape
+          sequences leaking to shell prompt after exit"
+ 2.1.89   CLAUDE_CODE_NO_FLICKER=1          ← the birth, as an env var
+ 2.1.110  /tui fullscreen                   ← the front door opens
+ 2.1.132  banner now mentions              ← the only "announcement"
+          "mouse support, auto-copy on select"
+ 2.1.139  /scroll-speed, with live preview
+ 2.1.145  slash & @-mention menus: hover + click
+ 2.1.187  select menus clickable (permissions, /model, /config)
+ 2.1.195  CLAUDE_CODE_DISABLE_MOUSE_CLICKS
+ 2.1.208  multi-select menus clickable
+   —      click-to-position: never mentioned in any entry, ever
+```
+
+Copy-on-select, hover, and click-to-expand all appear in the changelog *as things being fixed* before ever being introduced. The marquee interaction — click into the input, cursor moves — appears in zero entries; the only written evidence anywhere is a banner string inside the binary: *"Click to move your cursor in the text input."*
+
+Why ship the biggest UX change in the product's history this way? Inference, but the shape is recognizable: the risky bet was the *renderer* — an alt-screen rewrite of the whole UI — so it went out as an env var, graduated to a `/tui` toggle, grew an upsell banner, and was paced by telemetry the whole way (`fullscreen-upsell`, `fullscreen-downsell`, and an exit survey: *"what made you switch back?"*). The mouse was never the product. It's a *property of the new renderer*, and you don't announce that a browser supports clicking.
+
+## The playbook
+
+This section is the reason the post exists. Codex CLI users are already asking its maintainers for click-to-position by name — "Claude Code and Grok already have it" — so the demand is public; what's been missing is the map. From the shipped evidence, the build order is:
+
+1. **Own the whole screen first.** Alt-screen, frame-diffing renderer. Claude Code gated the mouse behind fullscreen mode rather than retrofitting the scrolling line-based UI — that ordering is the design.
+2. **Enable the ladder**: 1000/1002/1006. Add 1003 only when you have hover to justify the event volume.
+3. **Build the layout registry during render.** Every interactive component registers its rect. Hit-testing must be a lookup, not a heuristic — this single structure is what turns "mouse events" into "a UI".
+4. **Synthesize gestures yourself**: click count, double/triple, drag, hover. The terminal gives you presses; the toolkit is your job.
+5. **Rebuild selection or don't ship.** Auto-copy-on-select plus modifier+drag native passthrough is the floor.
+6. **Carry a quirk matrix**: tmux, ConPTY, JediTerm, xterm.js, wheel-as-arrows. Refuse loudly where it can't work; coach where config fixes it.
+7. **Opt-outs at every granularity, instrumented.** Claude Code can tell you exactly who turns the mouse off, and asks them why. That feedback loop is why it's still shipping.
 
 ## Coda
 
-The striking thing isn't any single trick — it's that this is a **GUI toolkit's worth of machinery** (hit-testing, gesture synthesis, hover, selection, virtualized scrolling) built on a byte stream from 1980s escape codes, shipped quietly behind a `/tui` toggle. The terminal's event model was never the limitation; the missing piece was an app willing to treat cells as pixels and build the toolkit above them.
+No single trick here is new. Hit-testing, gesture synthesis, hover, virtualized scrolling — every GUI toolkit since the Xerox Star has these. What's new is the claim implicit in building them *above* a byte stream from the 1980s: that the terminal's event model was never the limitation. The missing piece was always an application willing to treat cells as pixels and put in the unglamorous work — the registry, the quirk matrix, the selection tax — that a real toolkit demands.
 
-If the TUI has the mouse, the line between "terminal app" and "app" gets very thin. That has consequences for everyone building on this substrate — terminals, multiplexers, and every agent that still thinks the keyboard is the only input device.
+Claude Code did the work and didn't even bother to announce it. The other agent TUIs now get to copy it with the map in hand. And if the TUI has the mouse, the line between "terminal app" and "app" is thinner than anyone's roadmap assumed — which should be interesting news for everyone building terminals, multiplexers, or anything else that thought it knew where that line was.
 
-*Method note: all identifiers and quoted strings above were extracted from the publicly shipped `@anthropic-ai/claude-code` 2.1.220 npm binary's constant tables; runtime behavior was verified by spawning it under a pty and logging its escape output. Mechanisms not directly observable in bytecode are labeled as inference.*
+---
+
+*Method: identifiers and quoted strings extracted from the constant tables of the publicly shipped `@anthropic-ai/claude-code` 2.1.220 npm binary; runtime behavior verified by spawning it under a pty and logging its escape output; timeline from the official CHANGELOG. Mechanisms not directly observable in bytecode are labeled as inference.*


### PR DESCRIPTION
## What

Two docs that were sitting uncommitted in the working tree.

- `docs/design/companion-wire-protocol.md` — a draft RFC for the protocol the Mac and the iPhone already speak. Message catalogue, attach/resize sequences, both state machines, the compatibility rules, open questions, non-goals. Nothing about the running code changes; this gives a change on one end something to be checked against.
- `docs/essays/how-claude-code-got-the-mouse.md` — rewritten. The draft led with a feature list and read as a playbook for other TUI authors; it now opens on the click landing and follows the evidence in the order it arrived. The inference labels and the method note survive intact. `created` stays 2026-08-03, only `updated` moves.

The `docs/README.md` row is regenerated from front matter with the `doc` skill's script, not hand-written.

## Release Notes

None — docs only.