### PR TITLE
Record how an agent gets Usage-tab support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,13 @@ Companion:
 - The Mac serves the iOS app over a WebSocket; the wire protocol is in
   `Shared/Sources/TermioShared/WireProtocol.swift`. The mirror is a live
   surface, not a screenshot feed.
+- The Usage tab reads each agent through a `UsageProvider`
+  (`Sources/termio/Companion/Usage/`) — one file per agent, holding its
+  credential read, its plan-limit endpoint, and its session-log scanner.
+  `UsageMonitor` knows only the list, so supporting another agent is a new
+  provider file plus a line in `UsageMonitor.providers`, not an edit threaded
+  through the fetch and scan paths. Only agents whose CLI leaves a usable
+  credential on disk qualify; termio never runs a login flow.
 
 ## Where to work
 
@@ -124,7 +131,8 @@ Companion:
 - `Sources/termio/TermioStore` — session tree, persistence, split groups,
   agent status.
 - `Sources/termio/Agents` — agent manifests, session control, hook contract.
-- `Sources/termio/Companion` — companion server, tunnel, usage monitor.
+- `Sources/termio/Companion` — companion server, tunnel, per-agent usage
+  providers.
 - `Shared/` — anything both platforms must agree on. Changing the wire protocol
   means changing both ends.
 - `web/landing` — marketing copy and site. See `docs/ARCHITECTURE.md`.


### PR DESCRIPTION
`AGENTS.md` still described the Usage tab as it was before #254: two agents, read inline by the monitor. It is four agents now, each behind a `UsageProvider` in its own file, so the note in the Companion architecture section says what adding a fifth actually costs — a provider file and a line in `UsageMonitor.providers` — and that only agents whose CLI leaves a usable credential on disk qualify.

The "Where to work" line for `Sources/termio/Companion` follows.

Release Notes: none