### PR TITLE
State the macOS 14 requirement where people download

### DIFF
--- a/web/landing/src/components/sections/cta-band.tsx
+++ b/web/landing/src/components/sections/cta-band.tsx
@@ -51,6 +51,9 @@ export function CtaBand() {
                 Download for iOS Beta
               </a>
             </div>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Requires macOS 14 or later
+            </p>
           </div>
         </Reveal>
       </div>

--- a/web/landing/src/components/sections/faq.tsx
+++ b/web/landing/src/components/sections/faq.tsx
@@ -43,7 +43,7 @@ const faqs: { question: string; answer: string }[] = [
   {
     question: "What are the requirements?",
     answer:
-      "macOS, Apple Silicon. Termio is a native app built for Apple Silicon Macs. You bring your own agent CLIs and their API keys.",
+      "macOS 14 or later, Apple Silicon. Termio is a native app built for Apple Silicon Macs. You bring your own agent CLIs and their API keys.",
   },
 ];
 

--- a/web/landing/src/components/sections/hero.tsx
+++ b/web/landing/src/components/sections/hero.tsx
@@ -50,7 +50,7 @@ export function Hero() {
           <AgentMarquee agents={supportedAgents} />
         </Reveal>
         <Reveal delayMs={240}>
-          <div className="mt-10 flex items-center justify-center">
+          <div className="mt-10 flex flex-col items-center justify-center gap-3">
             <a
               href={downloadUrl}
               className={cn(
@@ -62,6 +62,11 @@ export function Hero() {
               <AppleMark />
               Download for Mac
             </a>
+            {/* Below 14 the app will not launch, and macOS reports only a generic
+                Finder error — so the floor is stated where the download happens. */}
+            <p className="text-sm text-muted-foreground">
+              Requires macOS 14 or later
+            </p>
           </div>
         </Reveal>
       </div>


### PR DESCRIPTION
The app will not launch below macOS 14, and macOS reports only a generic Finder error when it fails — so a user on 13 has no way to learn why. The site never named a version anywhere a person actually decides to download: the hero and the closing CTA said nothing, and the FAQ's "What are the requirements?" answered "macOS, Apple Silicon" without a floor.

Adds a quiet line under both download buttons, and puts the version into the FAQ answer. The docs' installation page already stated it; this brings the marketing page in step.

Follow-up to #247, where the spike confirmed macOS 14 stays.

Release Notes:
- The site now states that Termio requires macOS 14 or later, next to each download button and in the FAQ.