### PR TITLE
Keep a split group's sidebar rows in one adjacent run

### DIFF
--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -63,6 +63,10 @@ extension TermioStore {
             ?? projects[p].sessions.count - 1
         let insertAt = movedIndex < targetIndex ? newTarget + 1 : newTarget
         projects[p].sessions.insert(row, at: insertAt)
+        // A drop that lands between a group's rows would split its bracket in two;
+        // rows only join or leave a group through "Group with" / "Ungroup", so the
+        // run closes back up around the dropped row (see `gatherSplitRuns`).
+        gatherSplitRuns()
     }
 
     /// The sidebar bucket a session sits in: `nil` for the primary checkout (a `nil`

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -173,6 +173,7 @@ extension TermioStore {
     func detachFromSplit(_ id: Session.ID) {
         guard let group = groupIndex(containing: id) else { return }
         setGroup(at: group, to: splitGroups[group].removing(leaf: id))
+        gatherSplitRuns()
         selectedSessionID = id
         isPaneZoomed = false
     }
@@ -251,6 +252,7 @@ extension TermioStore {
               let group = groupIndex(containing: focusedID) else { return }
         let neighbor = neighborPane(of: focusedID, in: splitGroups[group])
         setGroup(at: group, to: splitGroups[group].removing(leaf: focusedID))
+        gatherSplitRuns()
         if let neighbor { selectedSessionID = neighbor }
         isPaneZoomed = false
     }
@@ -338,6 +340,25 @@ extension TermioStore {
         return preferred
     }
 
+    /// Restores the invariant every split group's sidebar bracket is drawn from:
+    /// a group's rows are one adjacent run (see `splitLinkMarks`). Insertion keeps
+    /// the run intact by construction, but a row can still be lifted out from
+    /// under it — "Ungroup" leaves the detached row wedged between its former
+    /// mates, and a drag can drop a stranger into the middle. The bracket then
+    /// spans only the longest surviving run, so a three-pane group reads as a
+    /// two-row bracket while three panes are on screen.
+    func gatherSplitRuns() {
+        let groups = splitGroups.map(\.leafIDs)
+        for index in projects.indices {
+            let rows = projects[index].sessions.map(\.id)
+            let gathered = gatheringSplitRuns(rows, groups: groups)
+            guard gathered != rows else { continue }
+            let byID = Dictionary(projects[index].sessions.map { ($0.id, $0) },
+                                  uniquingKeysWith: { first, _ in first })
+            projects[index].sessions = gathered.compactMap { byID[$0] }
+        }
+    }
+
     /// Installs a mutated group, dissolving it when fewer than two panes remain
     /// (absence of a group *is* the single-pane state).
     private func setGroup(at index: Int, to tree: SplitNode?) {
@@ -356,4 +377,36 @@ extension TermioStore {
         if index + 1 < leaves.count { return leaves[index + 1] }
         return index > 0 ? leaves[index - 1] : nil
     }
+}
+
+/// Reorders one project's session rows so each split group's members sit
+/// together. A run lands where its own first member already sat and its members
+/// keep their relative order, so the gesture that broke the run is what moves:
+/// a detached pane, or a stranger dragged into the middle, slides just below the
+/// group it interrupted. Pure and idempotent — rows already in runs come back
+/// untouched, which is what lets the store call it after every such mutation.
+func gatheringSplitRuns(_ rows: [Session.ID], groups: [[Session.ID]]) -> [Session.ID] {
+    var groupOf: [Session.ID: Int] = [:]
+    for (index, members) in groups.enumerated() {
+        for id in members { groupOf[id] = index }
+    }
+    guard rows.contains(where: { groupOf[$0] != nil }) else { return rows }
+
+    // Row order, not tree order: the sidebar's own order is what the user
+    // arranged, and gathering must not silently re-sort a run to match the layout.
+    var membersInRowOrder: [Int: [Session.ID]] = [:]
+    for id in rows {
+        guard let group = groupOf[id] else { continue }
+        membersInRowOrder[group, default: []].append(id)
+    }
+
+    var emitted: Set<Int> = []
+    var gathered: [Session.ID] = []
+    for id in rows {
+        guard let group = groupOf[id] else { gathered.append(id); continue }
+        if emitted.insert(group).inserted {
+            gathered.append(contentsOf: membersInRowOrder[group] ?? [id])
+        }
+    }
+    return gathered
 }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1019,6 +1019,10 @@ final class TermioStore: ObservableObject {
         store.splitGroups = savedGroups.filter { group in
             group.leafIDs.count >= 2 && group.leafIDs.allSatisfy { store.session($0) != nil }
         }
+        // State files written before the runs were kept adjacent can hold a group
+        // whose rows a since-ungrouped session still sits between; heal it on load
+        // rather than waiting for the next group edit.
+        store.gatherSplitRuns()
         return store
     }
 

--- a/Tests/termioTests/SplitTreeTests.swift
+++ b/Tests/termioTests/SplitTreeTests.swift
@@ -141,4 +141,35 @@ final class SplitTreeTests: XCTestCase {
         XCTAssertEqual(PaneDropZone.center.highlightRect(in: frame), frame)
     }
 
+    /// Ungrouping the middle pane of a three-pane group used to leave its row
+    /// wedged between its former mates, so the sidebar bracketed two rows while
+    /// three panes were on screen. The run closes back up and the detached row
+    /// lands just below it.
+    func testGatheringClosesTheRunAroundADetachedRow() {
+        let above = Session.ID(), below = Session.ID()
+        let rows = [above, agent, run1, run2, below]
+        XCTAssertEqual(gatheringSplitRuns(rows, groups: [[agent, run2]]),
+                       [above, agent, run2, run1, below])
+    }
+
+    /// Two groups whose rows touch stay two runs, and a run already adjacent is
+    /// returned untouched — gathering runs after every group edit, so it must be
+    /// idempotent and must never fuse neighbouring groups.
+    func testGatheringLeavesAdjacentRunsAlone() {
+        let other1 = Session.ID(), other2 = Session.ID()
+        let rows = [agent, run1, other1, other2, run3]
+        let groups = [[agent, run1], [other1, other2]]
+        XCTAssertEqual(gatheringSplitRuns(rows, groups: groups), rows)
+        XCTAssertEqual(gatheringSplitRuns(gatheringSplitRuns(rows, groups: groups),
+                                          groups: groups), rows)
+    }
+
+    /// A member dragged clear of its group is pulled back into the run: rows
+    /// join and leave a group through "Group with" / "Ungroup", never by drag.
+    func testGatheringPullsBackAStrayMember() {
+        let stranger = Session.ID()
+        let rows = [agent, stranger, run1]
+        XCTAssertEqual(gatheringSplitRuns(rows, groups: [[agent, run1]]),
+                       [agent, run1, stranger])
+    }
 }


### PR DESCRIPTION
A group's sidebar bracket is drawn over a run of adjacent same-group rows, and nothing kept the run adjacent — ungrouping a middle pane or reordering rows left a three-pane group reading as a two-row bracket, so the rows are gathered back into a run after those mutations and once on load.

Release Notes:
- Fixed a split group's sidebar bracket covering fewer rows than the panes on screen.