### PR TITLE
Add the browser-control and agent-plugins design docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ from the real front matter).
 | draft | design | [分享 Agent 会话（带密码的实时分享链接）](design/session-share.md) |
 | draft | design | [调研：下一批 AgentAdapter 的落盘格式（OpenCode / Pi / Amp / Cursor / Kimi）](design/agent-transcript-survey.md) |
 | draft | design | ["Markdown preview — Apple-grade reading typography"](design/markdown-preview-reading-typography.md) |
+| draft | design | [Agent Plugins](design/agent-plugins.md) |
 | draft | design | [Browser Control over CDP](design/browser-cdp.md) |
 | draft | design | [Device Architecture — one server per device, every UI a client](design/termiod-device-architecture.md) |
 | draft | design | [Hot path, attach join point, and client classes](design/termiod-hot-path-and-client-classes.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ from the real front matter).
 | draft | design | [分享 Agent 会话（带密码的实时分享链接）](design/session-share.md) |
 | draft | design | [调研：下一批 AgentAdapter 的落盘格式（OpenCode / Pi / Amp / Cursor / Kimi）](design/agent-transcript-survey.md) |
 | draft | design | ["Markdown preview — Apple-grade reading typography"](design/markdown-preview-reading-typography.md) |
+| draft | design | [Browser Control over CDP](design/browser-cdp.md) |
 | draft | design | [Device Architecture — one server per device, every UI a client](design/termiod-device-architecture.md) |
 | draft | design | [Hot path, attach join point, and client classes](design/termiod-hot-path-and-client-classes.md) |
 | draft | design | [Issue Triage → 本地 agent（GitHub / Linear 事件驱动 Termio session）](design/issue-triage-local-agent.md) |

--- a/docs/design/agent-plugins.md
+++ b/docs/design/agent-plugins.md
@@ -1,0 +1,228 @@
+---
+title: Agent Plugins
+status: draft
+type: design
+created: 2026-08-12
+updated: 2026-08-12
+related:
+  - agent-extensibility.md
+  - browser-cdp.md
+---
+
+# Agent Plugins
+
+> Adopt the Agent Plugins spec so a user can install one folder and have every
+> agent termio manages pick up its skills — starting with skills only, because
+> the MCP half is where config-clobbering lives.
+
+## 1. Why a standard instead of our own scheme
+
+termio already fans out per-agent configuration: hooks are written into
+`~/.claude/settings.json`, `~/.codex/hooks.json`, Cursor's flat dialect, and
+plugin drop-in directories for OpenCode and Pi — all modelled by
+`AgentHookSpec` + `HookDialect` in `AgentDefinition.swift`. Skills are the same
+shape of problem one level up, and today every tool solves it privately: the
+browser CLI ships its own `skill install` that writes into `~/.claude/skills`
+and `~/.agents/skills`.
+
+[Agent Plugins v1](https://agent-plugins.org) is a vendor-neutral format for
+exactly that, with 900+ stars and an active spec repo. Adopting it means a
+plugin authored for any conforming host works here, and a plugin we ship works
+elsewhere.
+
+This is not the "plugin system" argument rejected in
+[browser-cdp.md §10](./browser-cdp.md). That objection was against **inventing** a
+bespoke extension API for a single internal consumer. Adopting a published
+standard with an existing ecosystem is a different act, and the objection does
+not transfer.
+
+## 2. What v1 actually is
+
+Two component types, and the spec is explicit that the list is closed:
+
+> "Agent Plugins v1 defines exactly two component types: **skills** and **MCP
+> servers**. Other component types are outside the v1 format and do not affect
+> conformance."
+
+and
+
+> "Other component types — such as commands, hooks, agents, rules, and LSP
+> servers — remain too client-specific for a stable portable contract and are
+> outside the v1 format until their formats converge."
+
+Layout:
+
+```
+my-plugin/
+├── plugin.json
+├── skills/
+│   └── <skill-name>/SKILL.md
+├── mcp.json
+└── LICENSE
+```
+
+`plugin.json` permits only `$schema`, `name`, `version`, `description`,
+`author`, `homepage`, `repository`, `license`, `keywords`, `extensions`.
+`$schema` and `name` are required. **There is no registry** — v1 is a format,
+not a distribution network — so there is nothing to "browse", and install is
+always from a path or a git URL.
+
+Consequences worth stating plainly:
+
+- termio's **hooks stay outside the spec**. `AgentHookSpec` continues to be
+  termio's own concern; a plugin cannot ship hooks in v1.
+- A plugin cannot ship a **CLI command**. So `termio browser` is not, and will
+  not become, a plugin artifact.
+
+## 3. Where plugins live
+
+```
+~/.termio/plugins/<name>/          # the plugin directory, spec layout verbatim
+~/.termio/plugins/.state.json      # enabled flags, source, installed hashes
+```
+
+The plugin directory is stored **unmodified** — a byte-identical copy of what
+was fetched. Anything termio needs to remember about it goes in `.state.json`,
+never inside the plugin, so a `git pull` on a plugin installed from source is
+never in conflict with our bookkeeping.
+
+## 4. Lifecycle
+
+**Add** — from a local path or a git URL. Validate `plugin.json` against the
+1.0.0 schema before anything is copied; a manifest that fails validation is
+rejected with the schema error, not partially installed.
+
+**Enable** — fan out its components (§5, §6). Disabled is the default on add,
+so adding is never the same act as granting.
+
+**Disable** — remove what we installed, leave the plugin directory.
+
+**Remove** — disable, then delete the directory.
+
+Fan-out is idempotent and re-runs on launch, so upgrading a plugin (or termio)
+converges without user action — the same property `BundledSkillInstaller`-style
+symlinking has in prior art.
+
+## 5. Skills fan-out — cut 1
+
+For each `skills/<name>/` in an enabled plugin, symlink into both:
+
+```
+~/.claude/skills/<name>   →  ~/.termio/plugins/<plugin>/skills/<name>
+~/.agents/skills/<name>   →  (same)
+```
+
+Symlink rather than copy, so updating the plugin updates the skill with no
+second sync path.
+
+Two directories because the ecosystem has two conventions and agents read one or
+the other; writing both is what the browser CLI already does and what makes a
+skill work regardless of which agent picks it up.
+
+**Name collision across plugins** is possible — two plugins can both ship
+`skills/browser/`. Reject the second at enable time with a clear message naming
+the holder, rather than silently letting one win.
+
+## 6. MCP fan-out — cut 2, deliberately
+
+This is where the risk is. `mcp.json` is portable, but the file it must be
+merged into is not: every agent keeps MCP servers in its own location and shape,
+exactly as hooks do.
+
+Reuse the existing model — a per-agent descriptor beside `AgentHookSpec` saying
+where that agent's MCP config lives and which dialect it speaks — rather than
+inventing a second fan-out mechanism.
+
+Merging into a config file the user also edits is the operation that has already
+bitten this project once: Superset wiped termio's hooks, and the fix was
+strip-conflicts + re-assert on refocus + a version stamp. Any MCP writer must
+carry that lesson from the start.
+
+**Cut 1 ships skills only.** A plugin declaring `mcp.json` installs, and the
+Settings tab shows its MCP servers as *recognised but not installed*, with the
+reason. That is honest and inert; silently ignoring them is not.
+
+## 7. Never clobber
+
+The rule from the browser CLI's installer, corrected by review: **an ownership
+marker proves origin, not absence of edits.** A file we wrote and the user then
+edited must not be overwritten by a later enable, nor deleted by disable.
+
+So `.state.json` records a content hash per installed artifact:
+
+- hash matches → ours, untouched → safe to replace or remove
+- hash differs → the user edited it → leave it, report it
+- path exists but we have no record → not ours → leave it, report it
+
+## 8. What a plugin may not do
+
+`AgentHookSpec` already encodes the right instinct: *"The dialect chooses the
+fixed filename and source shape; the manifest cannot inject code."* Extend it.
+
+A `plugin.json` is **data**. It may not name an executable, a script path, a
+postinstall step, or an arbitrary destination. Everything a plugin ships lands
+in locations termio chooses, derived from the component type — never from a
+string in the manifest.
+
+The counter-example is in our own history: the browser repo's site-command
+system downloads unpinned JavaScript from GitHub and executes modules through
+`jiti` **merely to list them**. Enumerating available extensions should never
+run third-party code. Listing a plugin reads `plugin.json` and nothing else.
+
+MCP servers are the exception that proves it — an MCP server *is* a command the
+agent will run, which is precisely why that half is cut 2 and why enabling it
+must be an explicit, per-plugin act with the command shown before it is written.
+
+## 9. The Settings tab
+
+`PluginsSettingsTab`, beside `AgentSettingsTab`. Per row: name, version,
+description, source, an enable toggle, and what it contributed — "2 skills" or
+"1 skill, 1 MCP server (not installed)".
+
+Follows the Agents tab's established grammar: **added ≠ enabled**, availability
+gated on something external, and neutral rather than accent-coloured controls.
+
+Actions: *Add Plugin…* (path or git URL), *Reveal in Finder*, *Remove*. No
+browse or search, because v1 has no registry and pretending otherwise would be
+inventing one.
+
+## 10. `extensions` is the escape hatch
+
+The spec reserves a reverse-domain namespace for client-specific data:
+
+```json
+"extensions": { "sh.termio": { } }
+```
+
+Anything termio-specific goes there and conformance is preserved. Use it
+sparingly — every key added is a thing that only works here, which is the
+opposite of why the standard was adopted.
+
+## 11. Relationship to the browser work
+
+The browser skill is the obvious first plugin: it exists, it is maintained in
+another repo, and it currently ships through a bespoke `skill install` in the
+browser CLI. Repackaging it as a conforming plugin dogfoods the loader against
+a real case instead of a toy.
+
+Note what does *not* move: `termio browser cdp`, the Settings gate, and the
+Chrome extension stay native, because v1 has no component type for any of them.
+The plugin carries the skill; termio carries the capability.
+
+## 12. Open questions
+
+1. **Does enabling a plugin need per-agent scoping** — this plugin for Claude
+   Code but not Codex — or is global fan-out enough? Global is simpler and
+   matches how hooks are installed today. Start there.
+2. **Updating a git-sourced plugin**: a *Check for updates* action, or refresh
+   on launch? Refreshing silently changes agent behaviour without the user
+   asking, which argues for explicit.
+3. **Project-local plugins** — a `.termio/plugins/` in a repo, so a project can
+   carry its own. Defer; nothing asks for it yet.
+4. **MCP dialect coverage** — cut 2 needs the real per-agent config shapes
+   surveyed the way the hook dialects were.
+
+## Sources
+
+- Spec and schemas: <https://github.com/agentplugins/agent-plugins-spec>
+- <https://agent-plugins.org/schemas/1.0.0/plugin.schema.json>

--- a/docs/design/browser-cdp.md
+++ b/docs/design/browser-cdp.md
@@ -71,17 +71,15 @@ and every name in it has to be taught in a skill file.
 This is not speculative. `termio-sh/browser` (formerly `runbrowser`) shipped the
 verb design and then removed it: 38 CLI commands to 11, 28 HTTP routes to 6, and
 a `@ref` element-handle system deleted outright. Each verb existed in five
-places at once — a CLI
-registration, a client method, an HTTP route, a server-side implementation, and
-a doc line — and they had drifted far enough that three tab routes were being
-called with no route registered to serve them. See
-`rfcs/minimal-cdp-surface.md` in that repo for the full accounting.
+places at once — a CLI registration, a client method, an HTTP route, a
+server-side implementation and a doc line — and they had drifted far enough
+that three tab routes were being called with no route registered to serve them.
+`rfcs/minimal-cdp-surface.md` in that repo has the full accounting.
 
-The industry poles are `chrome-devtools-mcp` (51 tools, `uid` handles, no raw
-CDP passthrough) and `browser-use/browser-harness` (one code-execution entry
-point, raw `cdp()`, coordinate clicks from accessibility-tree boxes). termio
-belongs at the second pole for a reason specific to it: **the agent already has
-a shell.** A verb CLI re-implements, badly, what the agent can do by piping.
+The reason to sit at the raw end rather than the `chrome-devtools-mcp` end
+(51 tools, `uid` handles, no CDP passthrough) is specific to termio: **the agent
+already has a shell.** A verb CLI re-implements, badly, what the agent can do by
+piping. Everything below is why that is necessary but not sufficient.
 
 ### Prior art, and the limit of this argument
 
@@ -113,6 +111,27 @@ We are not adopting it, for reasons of dependency rather than design:
 So: same wire as playwriter, none of playwriter's dependencies, and — stated
 plainly rather than hidden — **a thinner layer than playwriter's by choice.**
 Where that thinness costs real capability, the answer is §7, not a Node runtime.
+
+`browser-use/browser-harness` (16.6k stars) is the third design, and reading it
+carefully is what produced §7. Its interface is one code-execution entry point
+with ~25 thin helpers, and it clicks with `click_at_xy` computed from an
+accessibility-tree box — **no visibility, stability, enabled or obstruction
+check**, exactly the weakness of raw CDP. It compensates with two bets nobody
+else makes: the agent **edits its own helpers mid-task** when something is
+missing, and site-specific knowledge accumulates as **per-domain markdown**
+loaded on demand. The repo's mass is in the latter — roughly 20KB per site.
+
+Two theories of reliability, then. Playwright makes the primitive strong so the
+agent need not think; browser-harness accepts a weak primitive and invests in
+the loop that repairs it. They are complementary, not opposed, and §7 takes
+from both.
+
+One asymmetry disqualifies browser-harness as a model for the transport,
+though: it connects over `--remote-debugging-port` and launches Chrome itself.
+Per §1 that **cannot reach the user's default profile** on Chrome 136+. It
+automates *a* browser; termio automates *your* browser. Its design choices —
+coordinate clicks, launch-your-own — are reasonable in a world where the
+profile does not matter, and are not reasonable here.
 
 **`status` earns its place** because it is the one fact that is not about the
 page. Whether a browser is attached, and which target this session is bound to,
@@ -253,6 +272,43 @@ The host-side surface for events, when it lands, should be one verb —
 them, not guessed at now. What is decided is *where they live* — in the
 extension, not in a skill file and not behind a Node dependency.
 
+### The two capabilities that cost nothing
+
+browser-harness's distinctive bets are the cheapest things on this list for
+termio, and they are currently missing from the design.
+
+**Self-repair.** browser-harness lets the agent edit `agent_helpers.py`
+mid-task: hit a missing capability, write it, re-run. That requires a code
+execution environment with an editable helpers file — which **termio's agent
+already has**, because it is sitting in a shell with a filesystem. The cost is
+not code; it is one instruction in the skill: *when you work out a CDP sequence
+that works, write it to a script and reuse it, rather than re-deriving it next
+turn.* Without that sentence the agent re-derives the same click sequence every
+time and we get browser-harness's weak primitive with none of its recovery.
+
+**Domain knowledge.** The long tail — this site needs a scroll before the button
+is real, that one rejects synthetic events — is not eliminable by any interface.
+browser-harness stores it as per-domain markdown. termio's equivalent already
+exists: **skills**, with a distribution format defined in
+[agent-plugins.md](./agent-plugins.md). Also free.
+
+That yields the full picture:
+
+| need | answer | cost |
+| --- | --- | --- |
+| grounding | AX tree + stable handles minted in-extension | small |
+| actionability | extension content script | ~100 lines |
+| waiting / events | `browser events subscribe\|read` | the one real gap |
+| self-repair | agent writes scripts to disk — say so in the skill | free |
+| domain knowledge | skills, distributed as plugins | free |
+| escape hatch | `cdp` | done |
+
+Which is stronger than the alternatives on their own terms: better primitives
+than browser-harness, fewer dependencies than playwriter, and the only one of
+the three that reaches a logged-in profile at all. **Events remain the honest
+weak spot** — the one item where both are ahead and no amount of skill-writing
+substitutes.
+
 ## 8. Remote sessions: the part that is ours
 
 `termio browser` from a termiod session on a VPS routes back over the same
@@ -322,3 +378,6 @@ in their browser from their pocket.
 - `remorses/playwriter` — the upstream this forked from; Playwright in a
   stateful sandbox over the same extension relay:
   <https://github.com/remorses/playwriter>
+- `browser-use/browser-harness` — thin CDP helpers, agent-editable at runtime,
+  with per-domain knowledge as markdown:
+  <https://github.com/browser-use/browser-harness>

--- a/docs/design/browser-cdp.md
+++ b/docs/design/browser-cdp.md
@@ -3,7 +3,7 @@ title: Browser Control over CDP
 status: draft
 type: design
 created: 2026-08-07
-updated: 2026-08-07
+updated: 2026-08-12
 related:
   - companion-wire-protocol.md
   - termiod-session-protocol.md
@@ -68,9 +68,10 @@ in the way. Chrome's protocol is documented, versioned by Chrome, and heavily
 represented in model training data. A hand-rolled vocabulary is none of those,
 and every name in it has to be taught in a skill file.
 
-This is not speculative. `runbrowser` shipped the verb design and then removed
-it: 38 CLI commands to 11, 28 HTTP routes to 6, and a `@ref` element-handle
-system deleted outright. Each verb had existed in five places at once — a CLI
+This is not speculative. `termio-sh/browser` (formerly `runbrowser`) shipped the
+verb design and then removed it: 38 CLI commands to 11, 28 HTTP routes to 6, and
+a `@ref` element-handle system deleted outright. Each verb existed in five
+places at once — a CLI
 registration, a client method, an HTTP route, a server-side implementation, and
 a doc line — and they had drifted far enough that three tab routes were being
 called with no route registered to serve them. See
@@ -81,6 +82,37 @@ CDP passthrough) and `browser-use/browser-harness` (one code-execution entry
 point, raw `cdp()`, coordinate clicks from accessibility-tree boxes). termio
 belongs at the second pole for a reason specific to it: **the agent already has
 a shell.** A verb CLI re-implements, badly, what the agent can do by piping.
+
+### Prior art, and the limit of this argument
+
+`remorses/playwriter` (3.7k stars) is the same architecture — Chrome extension,
+`chrome.debugger`, WebSocket relay on port 19988 — and `runbrowser` began as a
+fork of it. Its interface is not verbs and not raw CDP: it runs **real
+Playwright** in a stateful sandbox, so the agent writes
+`await page.locator('aria-ref=e5').click()`.
+
+The "don't invent a vocabulary" argument does **not** dispose of that. Playwright
+is not a vocabulary we invented — it is a de facto standard with more
+training-data presence than raw CDP calls, and `page.click()` is not a naive
+wrapper around `Input.dispatchMouseEvent`. It is auto-waiting plus actionability
+checks (visible, stable, enabled, receives events) refined over years. On the
+two axes that matter most it is simply better than what is specified here:
+grounding (`aria-ref` handles) and event-driven waiting (`waitForResponse`,
+`Promise.all`).
+
+We are not adopting it, for reasons of dependency rather than design:
+
+- It requires **Node plus Playwright** on the machine. termio ships no JS
+  runtime and must not acquire one — the same objection that rules out bundling
+  `bun`.
+- playwriter depends on `@xmorse/playwright-core`, a **fork** of playwright-core.
+  Driving a browser through an extension relay needed patches upstream does not
+  carry. Adopting Playwright would mean depending on someone's fork of a large,
+  fast-moving Google library, or maintaining our own.
+
+So: same wire as playwriter, none of playwriter's dependencies, and — stated
+plainly rather than hidden — **a thinner layer than playwriter's by choice.**
+Where that thinness costs real capability, the answer is §7, not a Node runtime.
 
 **`status` earns its place** because it is the one fact that is not about the
 page. Whether a browser is attached, and which target this session is bound to,
@@ -178,24 +210,48 @@ Every response echoes the target it acted on. Agents lose their thread between
 turns, and self-describing output survives context compaction where implicit
 server-side state does not.
 
-## 7. The known gap: events
+## 7. The two known gaps, and where they get closed
 
-`cdp` sends commands and returns results. CDP is commands **and** events, and
-this design currently delivers none of them. That forecloses:
+Raw CDP is missing two things Playwright gives away for free. Both are real, and
+the answer to both is **the extension**, not a runtime on the Mac.
 
-- waiting on navigation, popups, dialogs, download completion
-- capturing network or console activity caused by an action
-- screencast frames, which arrive as `Page.screencastFrame`
-- out-of-process iframe and worker target attachment
+**Events.** `cdp` sends commands and returns results. CDP is commands *and*
+events, and this design currently delivers none of them. That forecloses waiting
+on navigation, popups, dialogs and download completion; capturing the network or
+console activity an action caused; screencast frames, which arrive as
+`Page.screencastFrame`; and out-of-process iframe or worker attachment. Polling
+for an observable side effect covers loads and most SPA waiting, but genuinely
+does not cover downloads or dialogs, and the skill must say so rather than let
+an agent discover it by retrying.
 
-The workaround is polling for an observable side effect, which covers loads and
-most SPA waiting but genuinely does not cover downloads or dialogs. The skill
-must say so plainly rather than letting an agent discover it by retrying.
+**Actionability.** `Input.dispatchMouseEvent` at a computed coordinate has no
+notion of whether the element is visible, stable, enabled, scrolled into view,
+or covered by an overlay. Writing those steps into a skill file as prose is a
+hand-rolled, unverified reimplementation of the thing Playwright spent years
+getting right — precisely the mistake §2 claims to avoid, just relocated from
+code into documentation.
 
-If this needs solving, the shape that preserves the minimalism is a third verb —
+**The extension is already JavaScript running in the page.** That is the part
+worth noticing: actionability does not need Node on the host. A content script
+can wait for visible + stable + enabled, scroll into view, and then dispatch —
+on the order of a hundred lines, no runtime anywhere, and it recovers most of
+what Playwright's `click()` actually buys. The same applies to grounding: stable
+element handles minted in-page survive better than backend node ids resolved
+host-side.
+
+So the split is:
+
+- **`cdp`** stays the escape hatch and the whole protocol.
+- **The extension** owns the few behaviours that are genuinely hard and
+  genuinely reusable: actionability, stable handles, and an event subscription
+  the host can read.
+
+The host-side surface for events, when it lands, should be one verb —
 `termio browser events subscribe|read` — not a per-case `wait` vocabulary.
-**Deliberately deferred:** it should be designed once, with a real task that
-needs it, rather than guessed at now.
+
+**Deliberately deferred:** both are designed against a real task that needs
+them, not guessed at now. What is decided is *where they live* — in the
+extension, not in a skill file and not behind a Node dependency.
 
 ## 8. Remote sessions: the part that is ours
 
@@ -238,9 +294,12 @@ in their browser from their pocket.
 
 ## 11. Open questions
 
-1. **Where the extension source lives** — `chrome-extension/` in this repo,
-   beside the Mac app, iOS app and `Shared/`, or a separate `termio-sh/browser`.
-   Leaning in-repo: it must stay in lockstep with the protocol it speaks.
+1. ~~Where the extension source lives.~~ **Decided:** `termio-sh/browser`, its
+   own repo, transferred from `runbrowser/runbrowser` with history intact. The
+   accepted cost is cross-repo protocol sync — the extension and the companion
+   server define two ends of one contract and now ship from two repos, which is
+   the skew problem `companion-wire-protocol.md` exists to describe. Version the
+   handshake accordingly.
 2. **Web Store listing** — unavoidable cost, and the long pole. v0 can ship the
    extension unpacked in the bundle with the Settings button revealing it and
    opening `chrome://extensions`; that unblocks everything else.
@@ -259,4 +318,7 @@ in their browser from their pocket.
 - `chrome-devtools-mcp` tool reference:
   <https://github.com/ChromeDevTools/chrome-devtools-mcp>
 - The verb-removal accounting: `rfcs/minimal-cdp-surface.md` in
-  <https://github.com/runbrowser/runbrowser>
+  <https://github.com/termio-sh/browser>
+- `remorses/playwriter` — the upstream this forked from; Playwright in a
+  stateful sandbox over the same extension relay:
+  <https://github.com/remorses/playwriter>

--- a/docs/design/browser-cdp.md
+++ b/docs/design/browser-cdp.md
@@ -1,0 +1,262 @@
+---
+title: Browser Control over CDP
+status: draft
+type: design
+created: 2026-08-07
+updated: 2026-08-07
+related:
+  - companion-wire-protocol.md
+  - termiod-session-protocol.md
+  - agent-extensibility.md
+---
+
+# Browser Control over CDP
+
+> Give an agent the user's real logged-in Chrome through two CLI verbs and one
+> Chrome extension, with nothing listening until the user turns it on — and
+> route it back from a remote session, which is the part nobody else can do.
+
+## 1. The constraint everything else follows from
+
+**Chrome 136 killed the port.** `--remote-debugging-port` and
+`--remote-debugging-pipe` are no longer respected against the default user data
+directory; they must be accompanied by `--user-data-dir` pointing somewhere
+else, and a separate data directory uses different encryption, so the profile
+cannot be copied across either. Chrome for Testing keeps the old behaviour.
+Current Chrome is 151.
+
+That single fact decides the architecture:
+
+| path | reaches the user's real profile? |
+| --- | --- |
+| Chrome extension (`chrome.debugger`) | **yes** — cookies, logins, extensions, live sessions |
+| `--remote-debugging-port` + `--user-data-dir` | no — a fresh profile, logged into nothing |
+| Chrome for Testing | yes, old behaviour — but not the user's browser |
+
+An agent driving a browser that is logged into nothing is worth very little:
+the tasks people actually want — read this dashboard, file this form, check
+this account — are all behind a session. So the extension is not the convenient
+option among several. **It is the only door**, and whoever ships it holds the
+capability.
+
+Two consequences that are easy to get wrong:
+
+- The Settings pane must not offer "or just open the debug port" as an
+  alternative. It would silently hand the agent a logged-out browser, and every
+  authenticated page would fail for a reason the user cannot see.
+- A CDP-port path is still legitimate for CI against Chrome for Testing, where
+  a fresh profile is what you want. Worth keeping the code path; not worth
+  offering to users.
+
+## 2. The interface is two verbs
+
+```
+termio browser cdp <Method> [params-json]   # the page API
+termio browser status                       # is a browser attached, what is bound
+```
+
+That is the whole agent-facing surface. `tabs` is `Target.getTargets`. Reading
+the page is `Accessibility.getFullAXTree`. Clicking is `DOM.getBoxModel` plus a
+pair of `Input.dispatchMouseEvent` calls. Screenshots are
+`Page.captureScreenshot`. None of them needs a verb.
+
+**Why not a verb vocabulary.** Every wrapper encodes one answer to "how do you
+click" — resolve a ref, get a box, dispatch a mouse event — and when a page
+needs a different answer (a trusted event sequence, a framework-safe value
+assignment, a shadow-DOM traversal) the wrapper is not merely unhelpful, it is
+in the way. Chrome's protocol is documented, versioned by Chrome, and heavily
+represented in model training data. A hand-rolled vocabulary is none of those,
+and every name in it has to be taught in a skill file.
+
+This is not speculative. `runbrowser` shipped the verb design and then removed
+it: 38 CLI commands to 11, 28 HTTP routes to 6, and a `@ref` element-handle
+system deleted outright. Each verb had existed in five places at once — a CLI
+registration, a client method, an HTTP route, a server-side implementation, and
+a doc line — and they had drifted far enough that three tab routes were being
+called with no route registered to serve them. See
+`rfcs/minimal-cdp-surface.md` in that repo for the full accounting.
+
+The industry poles are `chrome-devtools-mcp` (51 tools, `uid` handles, no raw
+CDP passthrough) and `browser-use/browser-harness` (one code-execution entry
+point, raw `cdp()`, coordinate clicks from accessibility-tree boxes). termio
+belongs at the second pole for a reason specific to it: **the agent already has
+a shell.** A verb CLI re-implements, badly, what the agent can do by piping.
+
+**`status` earns its place** because it is the one fact that is not about the
+page. Whether a browser is attached, and which target this session is bound to,
+are things the app knows and the caller cannot derive from a CDP result.
+
+**No `launch` verb.** The value is the user's authenticated Chrome; spawning a
+fresh one abandons it. A verb that has to be documented as "never use this" is
+a design error, not a documentation problem.
+
+## 3. Discovery costs zero turns
+
+Browser availability is a fact termio holds — the app *is* the endpoint the
+extension connects to. So it belongs in the environment, stamped at PTY spawn
+alongside `TERMIO_SESSION`:
+
+```
+TERMIO_BROWSER=ready | no-extension | off
+```
+
+The skill's first instruction is to read it. `ready` means go straight to the
+verb: no probe, no subprocess, no round trip. Anything else means one
+`termio browser status` (the env is fixed at spawn; the extension may have
+connected since) and then stop.
+
+This matters more because the feature is opt-in: `off` is the common case, and
+it is answerable for free.
+
+## 4. Off by default, enabled in Settings
+
+`BrowserSettingsTab`, alongside `AgentSettingsTab` and `MobileSettingsTab`. The
+pattern already exists — added ≠ enabled, with availability gated on something
+external being present (`AgentAvailability.swift`).
+
+"Install" means four different things and only three are installable:
+
+| piece | preinstalled? |
+| --- | --- |
+| `termio browser` verbs (Swift) | yes — compiled in; cannot not be |
+| companion server accepting extension clients | **no** — refuses until enabled |
+| Chrome extension | **no** — only the user can install into Chrome |
+| the skill in the agent's skill dirs | **no** — written on enable |
+
+Enabling does three things: flips the gate so the server will accept an
+extension, opens the Chrome install path, installs the skill.
+
+**Why off by default is not merely taste.** A `chrome.debugger` extension with
+`<all_urls>` over the user's logged-in Chrome is the most invasive thing termio
+would ship — more invasive than the agent's shell access, because it carries
+live authenticated sessions. And concretely: if the companion server accepted
+extension connections unconditionally, any local process could impersonate an
+extension and drive the browser. Gating means nothing is listening until asked.
+That is the flaw in both `browseruse`'s port 9876 and `runbrowser`'s port 19988,
+closed here by construction rather than by adding auth to an always-open door.
+
+**The verb still exists when disabled.** `command not found` teaches an agent
+nothing; a structured failure lets it report accurately and move on:
+
+```
+error: browser support is off — the user can enable it in Settings ▸ Browser
+```
+
+Onboarding is the app's job. An agent mid-task must never be walking the user
+through a Chrome Web Store install — it cannot complete it, cannot verify it,
+and derails whatever it was doing.
+
+## 5. Transport: no second server
+
+The extension dials **out** to termio's existing companion WebSocket
+(`CompanionServer`, port 8787 / 8788 dev) and presents the pairing token, using
+the same `.auth` control frame the phone uses. Health check first, reconnect
+loop after.
+
+No new port, no second daemon, no Node runtime. termio ships no JS runtime and
+must not acquire one for this — the same objection that rules out bundling
+`bun` for `browseruse` or depending on a global `npm install` of `runbrowser`.
+
+`termio browser` reaches the app over the existing AF_UNIX control socket,
+beside `termio sessions` and `termio agent report`. Passing a method name and a
+JSON blob down a socket is framing, not logic, so the CLI stays thin shell.
+
+**The Swift side never parses a page.** It moves a method and a params blob in
+one direction and a result blob back. This is the same discipline as the VT
+sidecar never sitting in the byte path: no per-call interpretation, no grid
+encoder, nothing that has to understand the payload to forward it.
+
+## 6. Tabs are connection state
+
+Bind by **target ID, never by list index**. `Target.getTargets` makes no
+ordering guarantee, so an index captured in one call can name a different tab
+in the next — a bug shipped in the runbrowser rewrite and caught in review.
+`status` reports the bound target; a session binds explicitly at creation
+rather than lazily attaching to whatever non-blank target appears first.
+
+Every response echoes the target it acted on. Agents lose their thread between
+turns, and self-describing output survives context compaction where implicit
+server-side state does not.
+
+## 7. The known gap: events
+
+`cdp` sends commands and returns results. CDP is commands **and** events, and
+this design currently delivers none of them. That forecloses:
+
+- waiting on navigation, popups, dialogs, download completion
+- capturing network or console activity caused by an action
+- screencast frames, which arrive as `Page.screencastFrame`
+- out-of-process iframe and worker target attachment
+
+The workaround is polling for an observable side effect, which covers loads and
+most SPA waiting but genuinely does not cover downloads or dialogs. The skill
+must say so plainly rather than letting an agent discover it by retrying.
+
+If this needs solving, the shape that preserves the minimalism is a third verb —
+`termio browser events subscribe|read` — not a per-case `wait` vocabulary.
+**Deliberately deferred:** it should be designed once, with a real task that
+needs it, rather than guessed at now.
+
+## 8. Remote sessions: the part that is ours
+
+`termio browser` from a termiod session on a VPS routes back over the same
+framed connection to the Mac's Chrome. From the agent's side nothing changes —
+same verbs, same PATH, same env var.
+
+This falls out of the transport-agnostic protocol for free, and it is the case
+standalone browser tooling structurally cannot serve, because it assumes agent
+and browser share a machine. A browser on a VPS is worthless: no cookies, no
+SSO, no 2FA. The correct primitive is **the browser lives where the human is,
+the agent may live elsewhere.**
+
+## 9. Visibility is the feature
+
+An agent acting in the user's authenticated Chrome is a trust event. Three
+surfaces, all of which already exist:
+
+- ghost cursor and element highlight in-page, from the extension's content script
+- Chrome's own "termio is debugging this browser" infobar — **never suppress it**
+- the session trace: browser calls and screenshots land there, and the trace
+  already renders as themed HTML and already shows on the phone
+
+That last one has no equivalent elsewhere: the user can audit what an agent did
+in their browser from their pocket.
+
+## 10. What this is not
+
+- **Not a plugin system.** termio has no extension mechanism and should not
+  grow one for a single consumer. A settings gate and a skill install is the
+  whole mechanism.
+- **Not an in-app browser.** A WKWebView pane is logged into nothing, which is
+  exactly what makes automated browsing useless for real tasks, and it puts an
+  app inside the terminal.
+- **Not a second binary.** The capability cannot function without termio.app
+  running, so a standalone `browser` command would be a client of termio
+  wearing a costume. Its Unix analogues are `systemctl` and `ip` — subcommand
+  dispatchers over a daemon — not `ls`.
+- **Not an npm dependency.** See §5.
+
+## 11. Open questions
+
+1. **Where the extension source lives** — `chrome-extension/` in this repo,
+   beside the Mac app, iOS app and `Shared/`, or a separate `termio-sh/browser`.
+   Leaning in-repo: it must stay in lockstep with the protocol it speaks.
+2. **Web Store listing** — unavoidable cost, and the long pole. v0 can ship the
+   extension unpacked in the bundle with the Settings button revealing it and
+   opening `chrome://extensions`; that unblocks everything else.
+3. **Skill install scope** — global (`~/.claude/skills`), matching how termio
+   installs hooks, rather than project-local.
+4. **Events** — §7.
+5. **Whether a portable host ever ships** for non-termio agents. The contract
+   makes it possible; nothing suggests demand yet. Wait for the signal.
+
+## Sources
+
+- Chrome 136 remote-debugging change:
+  <https://developer.chrome.com/blog/remote-debugging-port>
+- "The Bitter Lesson of Agent Harnesses":
+  <https://browser-use.com/posts/bitter-lesson-agent-harnesses>
+- `chrome-devtools-mcp` tool reference:
+  <https://github.com/ChromeDevTools/chrome-devtools-mcp>
+- The verb-removal accounting: `rfcs/minimal-cdp-surface.md` in
+  <https://github.com/runbrowser/runbrowser>


### PR DESCRIPTION
Two design docs, both draft, no code.

## Browser Control over CDP

`docs/design/browser-cdp.md` — how an agent drives a real browser from a termio
session. The shape it settles on:

- The interface is two verbs, not a browser API surface.
- Discovery costs zero turns — an agent learns the capability without spending a
  round trip to find it.
- Off by default, enabled in Settings.
- No second server: it rides the transport that already exists.
- Tabs are connection state, not addressable objects.
- Section 7 names the two known gaps and where each one closes, after weighing
  the design against playwriter and browser-harness.
- Section 8 covers the remote-session case, which is the part no existing tool
  does for us.

## Agent Plugins

`docs/design/agent-plugins.md` — adopting an existing plugin standard instead of
inventing a termio scheme. Covers where plugins live, lifecycle, the skills
fan-out as cut 1 and the MCP fan-out as cut 2, the never-clobber rule, what a
plugin may not do, and `extensions` as the escape hatch.

Both carry front matter, so `docs/README.md` picks them up through the generated
index rather than a hand-edited row.

## Release Notes

None — documentation only.
