### PR TITLE
Bump libghostty-swift to 1.0.16

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "779e3545e5185f08b3e0fa1352f2d4fcd6322b06f92dc197e3337490f267e961",
+  "originHash" : "2e07b945a0d55b2a219d579e837f2e3b82f0e14a665851a385f3e1bc3e2f4708",
   "pins" : [
     {
       "identity" : "highlightr",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jiweiyuan/libghostty-swift",
       "state" : {
-        "revision" : "ffc7c068e89b12b2b1a1375dd0d7e6ef82403f62",
-        "version" : "1.0.15"
+        "revision" : "f2d4cbdf7a16bc5d917034f813f47c2a1c5dde97",
+        "version" : "1.0.16"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lakr233/MSDisplayLink.git",
       "state" : {
-        "revision" : "1ba3e769b734e456317fa7e45321fa7f53eefb67",
-        "version" : "2.1.0"
+        "revision" : "87eb0af130744c8cbe2e31b6e1a5bcd659f1c220",
+        "version" : "2.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         // live resize" suspicion that briefly rolled this back to Lakr233 was a
         // misdiagnosis — the real bug was termio's own PTY spawn shape (see
         // docs/bug/terminal-resize-no-reflow-HANDOFF.md §0).
-        .package(url: "https://github.com/jiweiyuan/libghostty-swift", from: "1.0.15"),
+        .package(url: "https://github.com/jiweiyuan/libghostty-swift", from: "1.0.16"),
         // Sparkle powers in-app auto-update (the "Check for Updates…" menu item and
         // background update checks). It reads the appcast published with each GitHub
         // release; the matching EdDSA public key is embedded in packaging/Info.plist.

--- a/ios/TermioMobile.xcodeproj/project.pbxproj
+++ b/ios/TermioMobile.xcodeproj/project.pbxproj
@@ -467,7 +467,7 @@
 			repositoryURL = "https://github.com/jiweiyuan/libghostty-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.15;
+				minimumVersion = 1.0.16;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jiweiyuan/libghostty-swift",
       "state" : {
-        "revision" : "ffc7c068e89b12b2b1a1375dd0d7e6ef82403f62",
-        "version" : "1.0.15"
+        "revision" : "f2d4cbdf7a16bc5d917034f813f47c2a1c5dde97",
+        "version" : "1.0.16"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lakr233/MSDisplayLink.git",
       "state" : {
-        "revision" : "1ba3e769b734e456317fa7e45321fa7f53eefb67",
-        "version" : "2.1.0"
+        "revision" : "87eb0af130744c8cbe2e31b6e1a5bcd659f1c220",
+        "version" : "2.2.0"
       }
     }
   ],


### PR DESCRIPTION
Moves the terminal core from ghostty `2511abe` (2026-07-20) to `9d8fbd15b3b4` — 425 commits of upstream.

The fork had been frozen at `storage.1.0.13` because its weekly build cron was red for three weeks. It died during patch application, before zig compiled anything: ghostty's zig 0.16 migration renamed call sites that `0002-host-managed-io` depended on. Fixed on the fork side — patches rebased, patch scripts hardened to fail closed instead of silently emitting invalid Zig, and Mac Catalyst dropped because zig 0.16 removed the `macabi` ABI (termio never built for Catalyst).

Both pins move together: SwiftPM for the Mac app, the Xcode project for iOS. Both resolve to `1.0.16` / `f2d4cbdf`.

Verified against the published `storage.1.0.16` xcframework rather than a local build:

- `swift build` clean, 177 tests pass
- iOS `** BUILD SUCCEEDED **`
- both apps installed and exercised by hand on a Mac and an iPhone 16

Release Notes:
Updated the embedded terminal core to the latest Ghostty.