### PR TITLE
Localize the iPhone companion into Simplified Chinese

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5206,6 +5206,76 @@
           }
         }
       }
+    },
+    "On iPhone, tap the Mac pill ▸ Scan QR Code. Traffic crosses the relay you run yourself — no third party in the path.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。流量经由你自己运行的中继，路径中没有第三方。"
+          }
+        }
+      }
+    },
+    "On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network, and terminates on the provider's servers. Pick Custom to run your own relay instead.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。隧道地址可在任意网络使用，并终结于服务商的服务器。若要改用自己的中继，请选择“自定义”。"
+          }
+        }
+      }
+    },
+    "URL Pattern": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL 模式"
+          }
+        }
+      }
+    },
+    "Not a valid regular expression": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不是有效的正则表达式"
+          }
+        }
+      }
+    },
+    "Apply": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        }
+      }
+    },
+    "Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择“自定义”后，该命令会以你的权限在这台 Mac 上运行——不经过 shell，参数按空格拆分。用 {port} 表示配套端口；URL 模式是用于匹配中继输出的公开 https URL 的正则表达式。"
+          }
+        }
+      }
+    },
+    "Font": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -122,6 +122,8 @@
 	<string>Appearance</string>
 	<key>Appends a Host block to ~/.ssh/config, so the alias works in plain `ssh %@` too.</key>
 	<string>Appends a Host block to ~/.ssh/config, so the alias works in plain `ssh %@` too.</string>
+	<key>Apply</key>
+	<string>Apply</string>
 	<key>Assigned to Me</key>
 	<string>Assigned to Me</string>
 	<key>Assignee</key>
@@ -366,6 +368,8 @@
 	<string>Focus Pane Right</string>
 	<key>Focus Pane Up</key>
 	<string>Focus Pane Up</string>
+	<key>Font</key>
+	<string>Font</string>
 	<key>Font name</key>
 	<string>Font name</string>
 	<key>General</key>
@@ -594,6 +598,8 @@
 	<string>No themes match “%@”</string>
 	<key>Not Now</key>
 	<string>Not Now</string>
+	<key>Not a valid regular expression</key>
+	<string>Not a valid regular expression</string>
 	<key>Not pushed to upstream</key>
 	<string>Not pushed to upstream</string>
 	<key>Nothing to install.</key>
@@ -608,8 +614,12 @@
 	<string>Off — LAN only</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Both devices must share a LAN.</key>
 	<string>On iPhone, tap the Mac pill ▸ Scan QR Code. Both devices must share a LAN.</string>
+	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network, and terminates on the provider's servers. Pick Custom to run your own relay instead.</key>
+	<string>On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network, and terminates on the provider's servers. Pick Custom to run your own relay instead.</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network.</key>
 	<string>On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network.</string>
+	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Traffic crosses the relay you run yourself — no third party in the path.</key>
+	<string>On iPhone, tap the Mac pill ▸ Scan QR Code. Traffic crosses the relay you run yourself — no third party in the path.</string>
 	<key>Opacity</key>
 	<string>Opacity</string>
 	<key>Opacity below 100% lets the desktop show through; blur softens it. The window stays solid at full opacity.</key>
@@ -758,6 +768,8 @@
 	<string>Run a command…</string>
 	<key>Running terminal sessions will end. You can relaunch later instead.</key>
 	<string>Running terminal sessions will end. You can relaunch later instead.</string>
+	<key>Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.</key>
+	<string>Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.</string>
 	<key>Runs with `%@`. The agent won't ask before editing files or running commands.</key>
 	<string>Runs with `%@`. The agent won't ask before editing files or running commands.</string>
 	<key>SF Symbol name</key>
@@ -956,6 +968,8 @@
 	<string>Turn off to disconnect your iPhone; pairing is kept.</string>
 	<key>Type this code at github.com/login/device to approve Termio. Waiting for approval…</key>
 	<string>Type this code at github.com/login/device to approve Termio. Waiting for approval…</string>
+	<key>URL Pattern</key>
+	<string>URL Pattern</string>
 	<key>Underline</key>
 	<string>Underline</string>
 	<key>Ungroup</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -122,6 +122,8 @@
 	<string>外观</string>
 	<key>Appends a Host block to ~/.ssh/config, so the alias works in plain `ssh %@` too.</key>
 	<string>将 Host 块追加到 ~/.ssh/config，该别名也可直接用于 `ssh %@`。</string>
+	<key>Apply</key>
+	<string>应用</string>
 	<key>Assigned to Me</key>
 	<string>指派给我</string>
 	<key>Assignee</key>
@@ -366,6 +368,8 @@
 	<string>聚焦右侧窗格</string>
 	<key>Focus Pane Up</key>
 	<string>聚焦上方窗格</string>
+	<key>Font</key>
+	<string>字体</string>
 	<key>Font name</key>
 	<string>字体名称</string>
 	<key>General</key>
@@ -594,6 +598,8 @@
 	<string>没有与“%@”匹配的主题</string>
 	<key>Not Now</key>
 	<string>以后再说</string>
+	<key>Not a valid regular expression</key>
+	<string>不是有效的正则表达式</string>
 	<key>Not pushed to upstream</key>
 	<string>尚未推送到上游</string>
 	<key>Nothing to install.</key>
@@ -608,8 +614,12 @@
 	<string>关闭 — 仅局域网</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Both devices must share a LAN.</key>
 	<string>在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。两台设备须处于同一局域网。</string>
+	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network, and terminates on the provider's servers. Pick Custom to run your own relay instead.</key>
+	<string>在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。隧道地址可在任意网络使用，并终结于服务商的服务器。若要改用自己的中继，请选择“自定义”。</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network.</key>
 	<string>在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。隧道地址可在任意网络使用。</string>
+	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Traffic crosses the relay you run yourself — no third party in the path.</key>
+	<string>在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。流量经由你自己运行的中继，路径中没有第三方。</string>
 	<key>Opacity</key>
 	<string>不透明度</string>
 	<key>Opacity below 100% lets the desktop show through; blur softens it. The window stays solid at full opacity.</key>
@@ -758,6 +768,8 @@
 	<string>运行命令…</string>
 	<key>Running terminal sessions will end. You can relaunch later instead.</key>
 	<string>正在运行的终端会话将会结束。你也可以稍后再重新启动。</string>
+	<key>Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.</key>
+	<string>选择“自定义”后，该命令会以你的权限在这台 Mac 上运行——不经过 shell，参数按空格拆分。用 {port} 表示配套端口；URL 模式是用于匹配中继输出的公开 https URL 的正则表达式。</string>
 	<key>Runs with `%@`. The agent won't ask before editing files or running commands.</key>
 	<string>以 `%@` 运行。Agent 在编辑文件或运行命令前将不再询问。</string>
 	<key>SF Symbol name</key>
@@ -956,6 +968,8 @@
 	<string>关闭后 iPhone 将断开连接；配对会保留。</string>
 	<key>Type this code at github.com/login/device to approve Termio. Waiting for approval…</key>
 	<string>在 github.com/login/device 输入此代码以授权 Termio。正在等待批准…</string>
+	<key>URL Pattern</key>
+	<string>URL 模式</string>
 	<key>Underline</key>
 	<string>下划线</string>
 	<key>Ungroup</key>

--- a/ios/Sources/AppleSpeechFallback.swift
+++ b/ios/Sources/AppleSpeechFallback.swift
@@ -12,9 +12,9 @@ enum AppleSpeechFallback {
 
         var errorDescription: String? {
             switch self {
-            case .unavailable: "On-device transcription isn't available"
-            case .unsupportedLocale: "The current language isn't supported on device"
-            case .empty: "On-device transcription returned no text"
+            case .unavailable: localized("On-device transcription isn't available")
+            case .unsupportedLocale: localized("The current language isn't supported on device")
+            case .empty: localized("On-device transcription returned no text")
             }
         }
     }

--- a/ios/Sources/ChatListViewController.swift
+++ b/ios/Sources/ChatListViewController.swift
@@ -59,7 +59,7 @@ final class ChatListViewController: UIViewController {
 
     private func configureTopBar() -> UIView {
         let pageTitle = UILabel()
-        pageTitle.text = "Chats"
+        pageTitle.text = localized("Chats")
         pageTitle.font = .systemFont(ofSize: 34, weight: .bold)
         pageTitle.textColor = .label
 
@@ -102,7 +102,7 @@ final class ChatListViewController: UIViewController {
     private func configureNewChatButton() {
         newChatButton.applyGlassIcon(.add, boxSize: 24)
         newChatButton.tintColor = .label
-        newChatButton.accessibilityLabel = "New Chat"
+        newChatButton.accessibilityLabel = localized("New Chat")
         newChatButton.showsMenuAsPrimaryAction = true
         newChatButton.menu = UIMenu(children: [
             UIDeferredMenuElement.uncached { [weak self] completion in
@@ -168,8 +168,8 @@ final class ChatListViewController: UIViewController {
         guard !emptyState.isHidden else { return }
         emptyState.configure(
             icon: .bubbleChat,
-            title: "No chats yet",
-            message: "Chats are agent sessions that aren't tied to a project. Start one with ＋, or on your Mac.",
+            title: localized("No chats yet"),
+            message: localized("Chats are agent sessions that aren't tied to a project. Start one with ＋, or on your Mac."),
             actionTitle: nil,
             busy: false
         )
@@ -214,7 +214,7 @@ extension ChatListViewController: UITableViewDataSource, UITableViewDelegate {
         guard store.companionURL != nil,
               let sessionID = chats[indexPath.row].rosterID
         else { return nil }
-        let close = UIContextualAction(style: .destructive, title: "Close") { [weak self] _, _, done in
+        let close = UIContextualAction(style: .destructive, title: localized("Close")) { [weak self] _, _, done in
             self?.store.stopSession(sessionID)
             done(true)
         }

--- a/ios/Sources/CompanionClient.swift
+++ b/ios/Sources/CompanionClient.swift
@@ -210,7 +210,7 @@ final class CompanionClient: NSObject {
                     if let roster = CompanionRoster.decode(text) {
                         lastServerError = nil
                         if roster.wire < Wire.minimumServer {
-                            onConnectionFailure?("Update Termio on your Mac to connect this phone.")
+                            onConnectionFailure?(localized("Update Termio on your Mac to connect this phone."))
                             stop()
                         } else {
                             onRoster?(roster)

--- a/ios/Sources/CompanionTransport.swift
+++ b/ios/Sources/CompanionTransport.swift
@@ -228,7 +228,7 @@ final class CompanionTransport: NSObject {
                     if let roster = CompanionRoster.decode(text) {
                         if roster.wire < Wire.minimumServer {
                             task.cancel(with: .policyViolation, reason: nil)
-                            finish(.failed("Update Termio on your Mac to connect this phone."))
+                            finish(.failed(localized("Update Termio on your Mac to connect this phone.")))
                         } else {
                             gridLock.lock()
                             authAccepted = true

--- a/ios/Sources/DiffViewController.swift
+++ b/ios/Sources/DiffViewController.swift
@@ -232,13 +232,13 @@ final class DiffViewController: UIViewController {
         storage.setAttributedString(NSAttributedString())
         titleLabel.text = change.name
         subtitleLabel.text = change.caption
-        walkerLabel.text = "\(index + 1) of \(files.count)"
+        walkerLabel.text = localized("\(index + 1) of \(files.count)")
         previousButton.isEnabled = index > 0
         nextButton.isEnabled = index < files.count - 1
         hunkButton.isHidden = true
         statusLabel.isHidden = true
         guard !change.isBinary else {
-            show(status: "Binary file — no text diff to show.")
+            show(status: localized("Binary file — no text diff to show."))
             return
         }
         pendingPath = change.path
@@ -252,12 +252,12 @@ final class DiffViewController: UIViewController {
         pendingPath = nil
         spinner.stopAnimating()
         guard !diff.binary else {
-            show(status: "Binary file — no text diff to show.")
+            show(status: localized("Binary file — no text diff to show."))
             return
         }
         rows = DiffParser.lines(from: diff.text)
         guard !rows.isEmpty else {
-            show(status: "No textual changes in this file.")
+            show(status: localized("No textual changes in this file."))
             return
         }
         statusLabel.isHidden = true
@@ -348,11 +348,11 @@ final class DiffViewController: UIViewController {
         guard expandable else {
             // A fixed band's lines were never fetched — say so instead of no-oping.
             let alert = UIAlertController(
-                title: "Not available",
-                message: "This diff was fetched without full context because the file is large, so the skipped lines aren't on the phone.",
+                title: localized("Not available"),
+                message: localized("This diff was fetched without full context because the file is large, so the skipped lines aren't on the phone."),
                 preferredStyle: .alert
             )
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            alert.addAction(UIAlertAction(title: localized("OK"), style: .default))
             present(alert, animated: true)
             return
         }
@@ -401,7 +401,7 @@ extension DiffViewController: UITextViewDelegate {
         suggestedActions: [UIMenuElement]
     ) -> UIMenu? {
         guard onSendToAgent != nil, range.length > 0 else { return nil }
-        let send = UIAction(title: "Send to Agent", image: UIImage(systemName: "arrow.up.message")) {
+        let send = UIAction(title: localized("Send to Agent"), image: UIImage(systemName: "arrow.up.message")) {
             [weak self] _ in
             guard let self, let code = selectedCode() else { return }
             onSendToAgent?(code)

--- a/ios/Sources/FileListViewController.swift
+++ b/ios/Sources/FileListViewController.swift
@@ -59,7 +59,7 @@ final class FileListViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        loaded && entries.isEmpty ? "This folder is empty." : nil
+        loaded && entries.isEmpty ? localized("This folder is empty.") : nil
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -149,11 +149,11 @@ enum FileRow {
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak browser] _ in
             var actions: [UIMenuElement] = []
             if !entry.isDir {
-                actions.append(UIAction(title: "Open File", image: UIImage(systemName: "doc.text")) { _ in
+                actions.append(UIAction(title: localized("Open File"), image: UIImage(systemName: "doc.text")) { _ in
                     browser?.openFile(at: relative)
                 })
             }
-            actions.append(UIAction(title: "Copy Path", image: UIImage(systemName: "doc.on.doc")) { _ in
+            actions.append(UIAction(title: localized("Copy Path"), image: UIImage(systemName: "doc.on.doc")) { _ in
                 UIPasteboard.general.string = absolute
             })
             return UIMenu(title: relative, children: actions)

--- a/ios/Sources/FileViewerController.swift
+++ b/ios/Sources/FileViewerController.swift
@@ -238,7 +238,7 @@ final class FileViewerController: UIViewController {
 
     private func render() {
         guard let data = file.data, let text = String(data: data, encoding: .utf8) else {
-            textView.text = "Couldn't decode this file as text."
+            textView.text = localized("Couldn't decode this file as text.")
             footerLabel.text = Self.format(bytes: file.size)
             editButton.isHidden = true
             return
@@ -255,10 +255,10 @@ final class FileViewerController: UIViewController {
 
     private func updateFooter(state: String? = nil) {
         var parts = [
-            CodeHighlighter.language(forFileNamed: fileName) ?? "plain text",
+            CodeHighlighter.language(forFileNamed: fileName) ?? localized("plain text"),
             Self.format(bytes: file.size),
         ]
-        if file.truncated { parts.append("truncated preview") }
+        if file.truncated { parts.append(localized("truncated preview")) }
         if let state { parts.append(state) }
         footerLabel.text = parts.joined(separator: " · ")
     }
@@ -303,7 +303,7 @@ final class FileViewerController: UIViewController {
         let text = textView.text ?? ""
         guard force || (text != savedText && pendingSaveText == nil) else { return }
         pendingSaveText = text
-        updateFooter(state: "saving…")
+        updateFooter(state: localized("saving…"))
         onSave(Data(text.utf8), force ? 0 : baseMtime)
     }
 
@@ -312,7 +312,7 @@ final class FileViewerController: UIViewController {
         baseMtime = mtime
         if let pending = pendingSaveText { savedText = pending }
         pendingSaveText = nil
-        updateFooter(state: "saved")
+        updateFooter(state: localized("saved"))
         // Keystrokes landed while the write was in flight — save them too.
         if textView.text != savedText { scheduleSave() }
     }
@@ -322,27 +322,27 @@ final class FileViewerController: UIViewController {
     func saveFailed(_ message: String) {
         pendingSaveText = nil
         guard message.hasPrefix("conflict") else {
-            updateFooter(state: "save failed")
-            let alert = UIAlertController(title: "Couldn't save", message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            updateFooter(state: localized("save failed"))
+            let alert = UIAlertController(title: localized("Couldn't save"), message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: localized("OK"), style: .default))
             present(alert, animated: true)
             return
         }
-        updateFooter(state: "conflict")
+        updateFooter(state: localized("conflict"))
         let alert = UIAlertController(
-            title: "File changed on the Mac",
-            message: "\(fileName) was modified since you opened it — likely by the agent.",
+            title: localized("File changed on the Mac"),
+            message: localized("\(fileName) was modified since you opened it — likely by the agent."),
             preferredStyle: .alert
         )
-        alert.addAction(UIAlertAction(title: "Reload", style: .default) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: localized("Reload"), style: .default) { [weak self] _ in
             guard let self else { return }
             let onReload = onReload
             dismiss(animated: true) { onReload?() }
         })
-        alert.addAction(UIAlertAction(title: "Overwrite", style: .destructive) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: localized("Overwrite"), style: .destructive) { [weak self] _ in
             self?.flushSave(force: true)
         })
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: localized("Cancel"), style: .cancel))
         present(alert, animated: true)
     }
 

--- a/ios/Sources/InspectorViewController.swift
+++ b/ios/Sources/InspectorViewController.swift
@@ -16,7 +16,7 @@ final class InspectorViewController: UIViewController {
     private let session: MockSession
     private let companionURL: URL?
     private let tableView = UITableView(frame: .zero, style: .plain)
-    private let segment = UISegmentedControl(items: ["Changes", "Files"])
+    private let segment = UISegmentedControl(items: [localized("Changes"), localized("Files")])
     private let spinner = UIActivityIndicatorView(style: .medium)
     private let searchBar = UISearchBar()
     private let refreshControl = UIRefreshControl()
@@ -85,7 +85,7 @@ final class InspectorViewController: UIViewController {
         navigationItem.titleView = segment
 
         searchBar.delegate = self
-        searchBar.placeholder = "Search files"
+        searchBar.placeholder = localized("Search files")
         searchBar.showsCancelButton = true
         searchBar.sizeToFit()
 
@@ -292,8 +292,8 @@ final class InspectorViewController: UIViewController {
             return
         }
         pendingRead = nil
-        let alert = UIAlertController(title: "Couldn't open file", message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        let alert = UIAlertController(title: localized("Couldn't open file"), message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: localized("OK"), style: .default))
         present(alert, animated: true)
     }
 
@@ -411,18 +411,18 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
             $0.added += $1.additions
             $0.deleted += $1.deletions
         }
-        let files = changes.count == 1 ? "1 changed file" : "\(changes.count) changed files"
-        return "\(files)  +\(totals.added) −\(totals.deleted)"
+        let files = changes.count == 1 ? localized("1 changed file") : localized("\(changes.count) changed files")
+        return localized("\(files)  +\(totals.added) −\(totals.deleted)")
     }
 
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if isSearching, pane == .files, searchTruncated {
-            return "Too many matches — showing the first batch. Refine to narrow."
+            return localized("Too many matches — showing the first batch. Refine to narrow.")
         }
         if pane == .changes, changes.isEmpty {
             return changesLoaded
-                ? "No changes in this project's working tree."
-                : "Loading changes…"
+                ? localized("No changes in this project's working tree.")
+                : localized("Loading changes…")
         }
         return nil
     }

--- a/ios/Sources/Localizable.xcstrings
+++ b/ios/Sources/Localizable.xcstrings
@@ -1,0 +1,1646 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    " Your key stays in this device's Keychain and is used only for transcription.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "密钥保存在本机的钥匙串中，仅用于转写。"
+          }
+        }
+      }
+    },
+    "1 changed file": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 个文件有更改"
+          }
+        }
+      }
+    },
+    "API Key": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥"
+          }
+        }
+      }
+    },
+    "About": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于"
+          }
+        }
+      }
+    },
+    "Add an API key in Settings ▸ Voice": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请在“设置 ▸ 语音”中添加 API 密钥"
+          }
+        }
+      }
+    },
+    "Add hosts in ~/.ssh/config on your Mac": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Mac 的 ~/.ssh/config 中添加主机"
+          }
+        }
+      }
+    },
+    "Address": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地址"
+          }
+        }
+      }
+    },
+    "All Themes": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有主题"
+          }
+        }
+      }
+    },
+    "Allow microphone access in Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请在“设置”中允许访问麦克风"
+          }
+        }
+      }
+    },
+    "Appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外观"
+          }
+        }
+      }
+    },
+    "Attach": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "附加"
+          }
+        }
+      }
+    },
+    "Autocomplete, accept a suggestion": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动补全，接受建议"
+          }
+        }
+      }
+    },
+    "Back": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "返回"
+          }
+        }
+      }
+    },
+    "Binary file — no text diff to show.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "二进制文件，无文本差异可显示。"
+          }
+        }
+      }
+    },
+    "Camera": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相机"
+          }
+        }
+      }
+    },
+    "Camera unavailable.\nType the address instead.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相机不可用。\n请改为手动输入地址。"
+          }
+        }
+      }
+    },
+    "Can't reach your Mac": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法连接到你的 Mac"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "Cancel recording": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消录音"
+          }
+        }
+      }
+    },
+    "Changes": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改"
+          }
+        }
+      }
+    },
+    "Chats": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聊天"
+          }
+        }
+      }
+    },
+    "Chats are agent sessions that aren't tied to a project. Start one with ＋, or on your Mac.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聊天是不隶属于任何项目的 Agent 会话。点按 ＋ 新建，或在 Mac 上开始。"
+          }
+        }
+      }
+    },
+    "Close": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
+        }
+      }
+    },
+    "Close Session": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭会话"
+          }
+        }
+      }
+    },
+    "Companion connection failed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接 Mac 失败"
+          }
+        }
+      }
+    },
+    "Connect": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接"
+          }
+        }
+      }
+    },
+    "Connect a Mac": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接 Mac"
+          }
+        }
+      }
+    },
+    "Connect to Mac": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接到 Mac"
+          }
+        }
+      }
+    },
+    "Connected": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已连接"
+          }
+        }
+      }
+    },
+    "Connecting…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在连接…"
+          }
+        }
+      }
+    },
+    "Connection Failed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接失败"
+          }
+        }
+      }
+    },
+    "Connection failed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接失败"
+          }
+        }
+      }
+    },
+    "Connectivity": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接"
+          }
+        }
+      }
+    },
+    "Control Keys": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制键"
+          }
+        }
+      }
+    },
+    "Copy Path": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝路径"
+          }
+        }
+      }
+    },
+    "Couldn't decode this file as text.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法将此文件解码为文本。"
+          }
+        }
+      }
+    },
+    "Couldn't encode an OpenAI Realtime event": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法编码 OpenAI Realtime 事件"
+          }
+        }
+      }
+    },
+    "Couldn't open file": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法打开文件"
+          }
+        }
+      }
+    },
+    "Couldn't read: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取：%@"
+          }
+        }
+      }
+    },
+    "Couldn't save": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法存储"
+          }
+        }
+      }
+    },
+    "Couldn't start recording": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法开始录音"
+          }
+        }
+      }
+    },
+    "Couldn't start session": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法启动会话"
+          }
+        }
+      }
+    },
+    "Cycle permission modes — default, accept edits, plan": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换权限模式：默认、接受编辑、计划"
+          }
+        }
+      }
+    },
+    "Dark": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色"
+          }
+        }
+      }
+    },
+    "Dark Theme": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色主题"
+          }
+        }
+      }
+    },
+    "Didn't catch that — try again": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没听清，请再试一次"
+          }
+        }
+      }
+    },
+    "Disconnected": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已断开连接"
+          }
+        }
+      }
+    },
+    "End of file — exits a shell or REPL": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件结束，退出 shell 或 REPL"
+          }
+        }
+      }
+    },
+    "Enter Address Manually": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手动输入地址"
+          }
+        }
+      }
+    },
+    "File changed on the Mac": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件已在 Mac 上更改"
+          }
+        }
+      }
+    },
+    "Files": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件"
+          }
+        }
+      }
+    },
+    "Font Size": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体大小"
+          }
+        }
+      }
+    },
+    "Forget This Mac": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忽略此 Mac"
+          }
+        }
+      }
+    },
+    "Hold the mic key on the terminal keyboard to dictate a prompt — release to send it, slide up to cancel.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按住终端键盘上的麦克风键即可口述提示词，松开发送，上滑取消。"
+          }
+        }
+      }
+    },
+    "Interrupt — pressed twice while idle it exits the agent": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中断；空闲时连按两次可退出 Agent"
+          }
+        }
+      }
+    },
+    "It may be asleep or off your network. Termio keeps trying — reopen the lid, or tap to retry now.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "它可能已睡眠或不在同一网络。Termio 会持续尝试，你可以打开 Mac，或点按立即重试。"
+          }
+        }
+      }
+    },
+    "Keys on the control bar above the system keyboard. Esc and the arrows are always there; hold esc for esc-esc (Claude Code's rewind menu).": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统键盘上方控制栏中的按键。Esc 和方向键始终显示；长按 esc 可发送 esc-esc（Claude Code 的回退菜单）。"
+          }
+        }
+      }
+    },
+    "Light": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浅色"
+          }
+        }
+      }
+    },
+    "Light Theme": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浅色主题"
+          }
+        }
+      }
+    },
+    "Loading changes…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在载入更改…"
+          }
+        }
+      }
+    },
+    "Mac": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac"
+          }
+        }
+      }
+    },
+    "Move the running task to the background": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将正在运行的任务移至后台"
+          }
+        }
+      }
+    },
+    "Name": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称"
+          }
+        }
+      }
+    },
+    "Needs You": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要你"
+          }
+        }
+      }
+    },
+    "Network error — check your connection": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络错误，请检查你的连接"
+          }
+        }
+      }
+    },
+    "New Chat": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建聊天"
+          }
+        }
+      }
+    },
+    "New SSH": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 SSH"
+          }
+        }
+      }
+    },
+    "New Terminal": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建终端"
+          }
+        }
+      }
+    },
+    "New session in %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 %@ 中新建会话"
+          }
+        }
+      }
+    },
+    "No Mac connected": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未连接 Mac"
+          }
+        }
+      }
+    },
+    "No changes in this project's working tree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此项目的工作区没有更改。"
+          }
+        }
+      }
+    },
+    "No chats yet": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还没有聊天"
+          }
+        }
+      }
+    },
+    "No projects open": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有打开的项目"
+          }
+        }
+      }
+    },
+    "No response": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有响应"
+          }
+        }
+      }
+    },
+    "No sessions": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有会话"
+          }
+        }
+      }
+    },
+    "No terminals yet": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还没有终端"
+          }
+        }
+      }
+    },
+    "No textual changes in this file.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此文件没有文本更改。"
+          }
+        }
+      }
+    },
+    "Not Paired": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未配对"
+          }
+        }
+      }
+    },
+    "Not Set": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未设置"
+          }
+        }
+      }
+    },
+    "Not available": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不可用"
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
+        }
+      }
+    },
+    "On-device transcription isn't available": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备端转写不可用"
+          }
+        }
+      }
+    },
+    "On-device transcription returned no text": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备端转写未返回文本"
+          }
+        }
+      }
+    },
+    "Open File": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开文件"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
+          }
+        }
+      }
+    },
+    "Open Termio on your Mac, then pair this phone to see and drive your projects from here.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Mac 上打开 Termio，然后配对这台 iPhone，即可在此查看并驱动你的项目。"
+          }
+        }
+      }
+    },
+    "Open a project in Termio on your Mac and it'll show up here.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Mac 的 Termio 中打开一个项目，它就会显示在这里。"
+          }
+        }
+      }
+    },
+    "OpenAI Realtime connection closed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenAI Realtime 连接已关闭"
+          }
+        }
+      }
+    },
+    "OpenAI Realtime failed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenAI Realtime 失败"
+          }
+        }
+      }
+    },
+    "OpenAI Realtime transcription timed out": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenAI Realtime 转写超时"
+          }
+        }
+      }
+    },
+    "OpenAI Realtime, with file and on-device fallback.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 OpenAI Realtime，并在需要时回退到文件转写和设备端转写。"
+          }
+        }
+      }
+    },
+    "OpenAI returned an empty transcript": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenAI 返回了空的转写结果"
+          }
+        }
+      }
+    },
+    "Over the 8 MB cap: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超过 8 MB 上限：%@"
+          }
+        }
+      }
+    },
+    "Overwrite": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖"
+          }
+        }
+      }
+    },
+    "Pair once with the address Termio on your Mac is serving — every project and session rides this one link.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 Mac 上 Termio 提供的地址配对一次即可，所有项目和会话都走这一条连接。"
+          }
+        }
+      }
+    },
+    "Paste": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴"
+          }
+        }
+      }
+    },
+    "Paste your key. It's stored in this device's Keychain.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴你的密钥。它将保存在本机的钥匙串中。"
+          }
+        }
+      }
+    },
+    "Photos": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "照片"
+          }
+        }
+      }
+    },
+    "Popular": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "热门"
+          }
+        }
+      }
+    },
+    "Privacy Policy": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐私政策"
+          }
+        }
+      }
+    },
+    "Projects": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "项目"
+          }
+        }
+      }
+    },
+    "Provider": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "服务提供方"
+          }
+        }
+      }
+    },
+    "Reaching your Mac over the companion link.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在通过配套连接接入你的 Mac。"
+          }
+        }
+      }
+    },
+    "Recent Activity": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近活动"
+          }
+        }
+      }
+    },
+    "Reconnecting…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在重新连接…"
+          }
+        }
+      }
+    },
+    "Redraw a glitched screen": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重绘花屏"
+          }
+        }
+      }
+    },
+    "Reload": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新载入"
+          }
+        }
+      }
+    },
+    "Remove Key": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除密钥"
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储"
+          }
+        }
+      }
+    },
+    "Scan QR Code": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "扫描二维码"
+          }
+        }
+      }
+    },
+    "Scroll to bottom": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "滚动到底部"
+          }
+        }
+      }
+    },
+    "Scroll to top": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "滚动到顶部"
+          }
+        }
+      }
+    },
+    "Search files": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索文件"
+          }
+        }
+      }
+    },
+    "Search prompt history": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索提示词历史"
+          }
+        }
+      }
+    },
+    "Send to Agent": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发送给 Agent"
+          }
+        }
+      }
+    },
+    "Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
+          }
+        }
+      }
+    },
+    "Some files were skipped": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分文件已跳过"
+          }
+        }
+      }
+    },
+    "Sort": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排序"
+          }
+        }
+      }
+    },
+    "Start a session on your Mac and it'll show up here.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Mac 上开始一个会话，它就会显示在这里。"
+          }
+        }
+      }
+    },
+    "Status": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状态"
+          }
+        }
+      }
+    },
+    "Stop and transcribe": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止并转写"
+          }
+        }
+      }
+    },
+    "Suspend the foreground process": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "挂起前台进程"
+          }
+        }
+      }
+    },
+    "System": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统"
+          }
+        }
+      }
+    },
+    "Tap ＋ to start an agent in this project.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点按 ＋ 即可在此项目中启动 Agent。"
+          }
+        }
+      }
+    },
+    "Terminal": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端"
+          }
+        }
+      }
+    },
+    "Terminal Keyboard": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端键盘"
+          }
+        }
+      }
+    },
+    "Terminals": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端"
+          }
+        }
+      }
+    },
+    "Terminals are plain shells that aren't tied to a project. Start one on your Mac and it appears here.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端是不隶属于任何项目的普通 shell。在 Mac 上开始一个，它就会显示在这里。"
+          }
+        }
+      }
+    },
+    "Terminals are plain shells that aren't tied to a project. Start one with ＋, or on your Mac.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端是不隶属于任何项目的普通 shell。点按 ＋ 新建，或在 Mac 上开始。"
+          }
+        }
+      }
+    },
+    "The address Termio on your Mac is serving.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac 上 Termio 正在提供的地址。"
+          }
+        }
+      }
+    },
+    "The current language isn't supported on device": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前语言不支持设备端转写"
+          }
+        }
+      }
+    },
+    "This diff was fetched without full context because the file is large, so the skipped lines aren't on the phone.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由于文件较大，此差异未获取完整上下文，省略的行不在这台 iPhone 上。"
+          }
+        }
+      }
+    },
+    "This folder is empty.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此文件夹为空。"
+          }
+        }
+      }
+    },
+    "Toggle the task checklist": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示或隐藏任务清单"
+          }
+        }
+      }
+    },
+    "Toggle the transcript viewer (what the agent did)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示或隐藏转录视图（Agent 做了什么）"
+          }
+        }
+      }
+    },
+    "Too many matches — showing the first batch. Refine to narrow.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匹配过多，仅显示第一批。请细化搜索条件。"
+          }
+        }
+      }
+    },
+    "Trace": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轨迹"
+          }
+        }
+      }
+    },
+    "Transcribed with ElevenLabs Scribe.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 ElevenLabs Scribe 转写。"
+          }
+        }
+      }
+    },
+    "Transcribing…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在转写…"
+          }
+        }
+      }
+    },
+    "Transcription": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转写"
+          }
+        }
+      }
+    },
+    "Transcription failed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转写失败"
+          }
+        }
+      }
+    },
+    "Try Again": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试"
+          }
+        }
+      }
+    },
+    "Update Termio on your Mac to connect this phone.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请更新 Mac 上的 Termio 以连接这台 iPhone。"
+          }
+        }
+      }
+    },
+    "Upload failed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上传失败"
+          }
+        }
+      }
+    },
+    "Version": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本"
+          }
+        }
+      }
+    },
+    "View Trace": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看轨迹"
+          }
+        }
+      }
+    },
+    "Voice": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音"
+          }
+        }
+      }
+    },
+    "Voice Input": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音输入"
+          }
+        }
+      }
+    },
+    "Website": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网站"
+          }
+        }
+      }
+    },
+    "Which service transcribes your voice. Each keeps its own key.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由哪个服务转写你的语音。每个服务各自保存自己的密钥。"
+          }
+        }
+      }
+    },
+    "Your ElevenLabs API key": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的 ElevenLabs API 密钥"
+          }
+        }
+      }
+    },
+    "conflict": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有冲突"
+          }
+        }
+      }
+    },
+    "plain text": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "纯文本"
+          }
+        }
+      }
+    },
+    "save failed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储失败"
+          }
+        }
+      }
+    },
+    "saved": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已存储"
+          }
+        }
+      }
+    },
+    "saving…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在存储…"
+          }
+        }
+      }
+    },
+    "truncated preview": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预览已截断"
+          }
+        }
+      }
+    },
+    "%lld pt": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 磅"
+          }
+        }
+      }
+    },
+    "%lld changed files": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 个文件有更改"
+          }
+        }
+      }
+    },
+    "%@ was modified since you opened it — likely by the agent.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自你打开以来，%@ 已被修改，很可能是 Agent 改的。"
+          }
+        }
+      }
+    },
+    "%@  +%lld −%lld": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@  +%lld −%lld"
+          }
+        }
+      }
+    },
+    "%lld of %lld": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %lld 个，共 %lld 个"
+          }
+        }
+      }
+    },
+    "%@ API Key": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ API 密钥"
+          }
+        }
+      }
+    },
+    "•••• Set": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•••• 已设置"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/ios/Sources/Localized.swift
+++ b/ios/Sources/Localized.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Resolves a user-facing string from `Localizable.xcstrings`. Xcode compiles
+/// the catalog into the app bundle itself, so `Bundle.main` is already the
+/// right table — unlike the Mac app, whose strings live in a SwiftPM resource
+/// bundle and need an explicit one. The call shape is deliberately the same as
+/// the Mac's `localized(_:)` so one sweep finds every UI string on both sides.
+func localized(_ key: String.LocalizationValue) -> String {
+    String(localized: key)
+}

--- a/ios/Sources/MobileSettings.swift
+++ b/ios/Sources/MobileSettings.swift
@@ -26,9 +26,9 @@ final class MobileSettings {
 
         var label: String {
             switch self {
-            case .system: "System"
-            case .light: "Light"
-            case .dark: "Dark"
+            case .system: localized("System")
+            case .light: localized("Light")
+            case .dark: localized("Dark")
             }
         }
     }

--- a/ios/Sources/OpenAIRealtimeTranscriber.swift
+++ b/ios/Sources/OpenAIRealtimeTranscriber.swift
@@ -16,8 +16,8 @@ final class OpenAIRealtimeTranscriber: NSObject {
         var errorDescription: String? {
             switch self {
             case .connection(let message), .api(let message): message
-            case .empty: "OpenAI returned an empty transcript"
-            case .timedOut: "OpenAI Realtime transcription timed out"
+            case .empty: localized("OpenAI returned an empty transcript")
+            case .timedOut: localized("OpenAI Realtime transcription timed out")
             }
         }
     }
@@ -159,7 +159,7 @@ final class OpenAIRealtimeTranscriber: NSObject {
         guard let data = try? JSONSerialization.data(withJSONObject: event),
               let text = String(data: data, encoding: .utf8)
         else {
-            record(.connection("Couldn't encode an OpenAI Realtime event"))
+            record(.connection(localized("Couldn't encode an OpenAI Realtime event")))
             return
         }
         task.send(.string(text)) { [weak self] error in
@@ -204,7 +204,7 @@ final class OpenAIRealtimeTranscriber: NSObject {
             finish(transcript.isEmpty ? .failure(.empty) : .success(transcript))
         case "error":
             let error = json["error"] as? [String: Any]
-            let message = error?["message"] as? String ?? "OpenAI Realtime failed"
+            let message = error?["message"] as? String ?? localized("OpenAI Realtime failed")
             record(.api(message))
         default:
             break
@@ -265,7 +265,7 @@ extension OpenAIRealtimeTranscriber: URLSessionWebSocketDelegate {
         stateQueue.async { [weak self] in
             guard let self, !finished, task === self.task else { return }
             let detail = reason.flatMap { String(data: $0, encoding: .utf8) }
-                ?? "OpenAI Realtime connection closed"
+                ?? localized("OpenAI Realtime connection closed")
             record(.connection(detail))
         }
     }

--- a/ios/Sources/ProjectDetailViewController.swift
+++ b/ios/Sources/ProjectDetailViewController.swift
@@ -82,7 +82,7 @@ final class ProjectDetailViewController: UIViewController {
         let back = UIButton(type: .system)
         back.applyGlassSymbol("chevron.backward")
         back.tintColor = .label
-        back.accessibilityLabel = "Back"
+        back.accessibilityLabel = localized("Back")
         back.accessibilityIdentifier = "project.back"
         back.addAction(UIAction { [weak self] _ in
             self?.navigationController?.popViewController(animated: true)
@@ -165,7 +165,7 @@ final class ProjectDetailViewController: UIViewController {
     private func configureAddButton() {
         addButton.applyGlassIcon(.add, boxSize: 24)
         addButton.tintColor = .label
-        addButton.accessibilityLabel = "New session in \(project.name)"
+        addButton.accessibilityLabel = localized("New session in \(project.name)")
         addButton.showsMenuAsPrimaryAction = true
         addButton.menu = UIMenu(children: [
             UIDeferredMenuElement.uncached { [weak self] completion in
@@ -227,10 +227,10 @@ final class ProjectDetailViewController: UIViewController {
         guard !emptyState.isHidden else { return }
         emptyState.configure(
             icon: .inbox,
-            title: "No sessions",
+            title: localized("No sessions"),
             message: addButton.isHidden
-                ? "Start a session on your Mac and it'll show up here."
-                : "Tap ＋ to start an agent in this project.",
+                ? localized("Start a session on your Mac and it'll show up here.")
+                : localized("Tap ＋ to start an agent in this project."),
             actionTitle: nil,
             busy: false
         )
@@ -273,7 +273,7 @@ extension ProjectDetailViewController: UITableViewDataSource, UITableViewDelegat
         guard store.companionURL != nil,
               let sessionID = project.sessions[indexPath.row].rosterID
         else { return nil }
-        let close = UIContextualAction(style: .destructive, title: "Close") { [weak self] _, _, done in
+        let close = UIContextualAction(style: .destructive, title: localized("Close")) { [weak self] _, _, done in
             self?.store.stopSession(sessionID)
             done(true)
         }
@@ -293,7 +293,7 @@ extension ProjectDetailViewController: UITableViewDataSource, UITableViewDelegat
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             UIMenu(title: title, children: [
                 UIAction(
-                    title: "Close Session",
+                    title: localized("Close Session"),
                     image: UIImage(systemName: "xmark.circle"),
                     attributes: .destructive
                 ) { _ in

--- a/ios/Sources/ProjectListViewController.swift
+++ b/ios/Sources/ProjectListViewController.swift
@@ -90,7 +90,7 @@ final class ProjectListViewController: UIViewController {
 
     private func configureTopBar() -> UIView {
         let pageTitle = UILabel()
-        pageTitle.text = "Projects"
+        pageTitle.text = localized("Projects")
         pageTitle.font = .systemFont(ofSize: 34, weight: .bold)
         pageTitle.textColor = .label
 
@@ -98,7 +98,7 @@ final class ProjectListViewController: UIViewController {
         // a glass circle riding the large title, menu as primary action.
         filterButton.applyGlassSymbol("line.3.horizontal.decrease")
         filterButton.tintColor = .label
-        filterButton.accessibilityLabel = "Sort"
+        filterButton.accessibilityLabel = localized("Sort")
         filterButton.showsMenuAsPrimaryAction = true
         filterButton.menu = UIMenu(children: [
             UIDeferredMenuElement.uncached { [weak self] completion in
@@ -127,10 +127,10 @@ final class ProjectListViewController: UIViewController {
     /// The same two orders as the Mac's sort menu, checkmarked like it too.
     private func sortMenuItems() -> [UIMenuElement] {
         [
-            UIAction(title: "Recent Activity", state: sortByName ? .off : .on) { [weak self] _ in
+            UIAction(title: localized("Recent Activity"), state: sortByName ? .off : .on) { [weak self] _ in
                 self?.setSortByName(false)
             },
-            UIAction(title: "Name", state: sortByName ? .on : .off) { [weak self] _ in
+            UIAction(title: localized("Name"), state: sortByName ? .on : .off) { [weak self] _ in
                 self?.setSortByName(true)
             },
         ]
@@ -237,9 +237,9 @@ final class ProjectListViewController: UIViewController {
             reconnectStalled = false
             emptyState.configure(
                 icon: .devicePair,
-                title: "No Mac connected",
-                message: "Open Termio on your Mac, then pair this phone to see and drive your projects from here.",
-                actionTitle: "Connect a Mac",
+                title: localized("No Mac connected"),
+                message: localized("Open Termio on your Mac, then pair this phone to see and drive your projects from here."),
+                actionTitle: localized("Connect a Mac"),
                 busy: false
             )
         case .connecting where reconnectStalled:
@@ -248,17 +248,17 @@ final class ProjectListViewController: UIViewController {
             // the link keeps trying on its slow heartbeat regardless.
             emptyState.configure(
                 icon: .wifiError,
-                title: "Can't reach your Mac",
-                message: "It may be asleep or off your network. Termio keeps trying — reopen the lid, or tap to retry now.",
-                actionTitle: "Try Again",
+                title: localized("Can't reach your Mac"),
+                message: localized("It may be asleep or off your network. Termio keeps trying — reopen the lid, or tap to retry now."),
+                actionTitle: localized("Try Again"),
                 busy: false
             )
         case .connecting:
             startConnectingGraceTimer()
             emptyState.configure(
                 icon: nil,
-                title: "Connecting…",
-                message: "Reaching your Mac over the companion link.",
+                title: localized("Connecting…"),
+                message: localized("Reaching your Mac over the companion link."),
                 actionTitle: nil,
                 busy: true
             )
@@ -267,8 +267,8 @@ final class ProjectListViewController: UIViewController {
             reconnectStalled = false
             emptyState.configure(
                 icon: .folder,
-                title: "No projects open",
-                message: "Open a project in Termio on your Mac and it'll show up here.",
+                title: localized("No projects open"),
+                message: localized("Open a project in Termio on your Mac and it'll show up here."),
                 actionTitle: nil,
                 busy: false
             )
@@ -277,9 +277,9 @@ final class ProjectListViewController: UIViewController {
             reconnectStalled = false
             emptyState.configure(
                 icon: .wifiError,
-                title: "Connection failed",
+                title: localized("Connection failed"),
                 message: reason,
-                actionTitle: "Open Settings",
+                actionTitle: localized("Open Settings"),
                 busy: false
             )
         }
@@ -343,7 +343,7 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
         guard let header = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: SectionCapView.reuseID
         ) as? SectionCapView else { return nil }
-        header.configure(title: sections[section] == .needsYou ? "Needs You" : "Projects")
+        header.configure(title: sections[section] == .needsYou ? localized("Needs You") : localized("Projects"))
         return header
     }
 
@@ -415,7 +415,7 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
               store.companionURL != nil,
               let sessionID = attention[indexPath.row].rosterID
         else { return nil }
-        let close = UIContextualAction(style: .destructive, title: "Close") { [weak self] _, _, done in
+        let close = UIContextualAction(style: .destructive, title: localized("Close")) { [weak self] _, _, done in
             self?.store.stopSession(sessionID)
             done(true)
         }

--- a/ios/Sources/QRScannerViewController.swift
+++ b/ios/Sources/QRScannerViewController.swift
@@ -16,7 +16,7 @@ final class QRScannerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Scan QR Code"
+        title = localized("Scan QR Code")
         view.backgroundColor = .black
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .cancel, target: self, action: #selector(cancelTapped)
@@ -66,7 +66,7 @@ final class QRScannerViewController: UIViewController {
 
     private func showUnavailableHint() {
         let label = UILabel()
-        label.text = "Camera unavailable.\nType the address instead."
+        label.text = localized("Camera unavailable.\nType the address instead.")
         label.numberOfLines = 0
         label.textAlignment = .center
         label.textColor = .secondaryLabel

--- a/ios/Sources/RootContainerViewController.swift
+++ b/ios/Sources/RootContainerViewController.swift
@@ -58,23 +58,24 @@ final class RootContainerViewController: UIViewController {
     /// libghostty surfaces stay installed in the window exactly as before.
     private lazy var homeTabs: UITabBarController = {
         let controller = UITabBarController()
-        let destinations: [(UIViewController, String, HugeIcon)] = [
-            (projectsNav, "Projects", .folder),
-            (chatsNav, "Chats", .bubbleChat),
-            (terminalsNav, "Terminals", .terminal),
-            (settingsNav, "Settings", .settings),
+        // The identifier carries its own English key rather than the title, so
+        // the UI tests keep addressing `home.tab.projects` in every language.
+        let destinations: [(nav: UIViewController, key: String, title: String, icon: HugeIcon)] = [
+            (projectsNav, "projects", localized("Projects"), .folder),
+            (chatsNav, "chats", localized("Chats"), .bubbleChat),
+            (terminalsNav, "terminals", localized("Terminals"), .terminal),
+            (settingsNav, "settings", localized("Settings"), .settings),
         ]
         for (index, destination) in destinations.enumerated() {
-            let (viewController, title, icon) = destination
             let item = UITabBarItem(
-                title: title,
-                image: icon.strokeImage(boxSize: 24, strokeWeight: 1.7),
+                title: destination.title,
+                image: destination.icon.strokeImage(boxSize: 24, strokeWeight: 1.7),
                 tag: index
             )
-            item.accessibilityIdentifier = "home.tab.\(title.lowercased())"
-            viewController.tabBarItem = item
+            item.accessibilityIdentifier = "home.tab.\(destination.key)"
+            destination.nav.tabBarItem = item
         }
-        controller.setViewControllers(destinations.map(\.0), animated: false)
+        controller.setViewControllers(destinations.map(\.nav), animated: false)
         controller.tabBar.tintColor = .label
         controller.tabBar.unselectedItemTintColor = .secondaryLabel
         return controller
@@ -133,9 +134,9 @@ final class RootContainerViewController: UIViewController {
         }
         store.onStartError = { [weak self] reason in
             let alert = UIAlertController(
-                title: "Couldn't start session", message: reason, preferredStyle: .alert
+                title: localized("Couldn't start session"), message: reason, preferredStyle: .alert
             )
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            alert.addAction(UIAlertAction(title: localized("OK"), style: .default))
             self?.present(alert, animated: true)
         }
         store.start()

--- a/ios/Sources/SettingsViewController.swift
+++ b/ios/Sources/SettingsViewController.swift
@@ -18,10 +18,10 @@ final class SettingsViewController: UITableViewController {
 
         var title: String {
             switch self {
-            case .connectivity: "Connectivity"
-            case .appearance: "Appearance"
-            case .terminalKeyboard: "Terminal Keyboard"
-            case .voice: "Voice"
+            case .connectivity: localized("Connectivity")
+            case .appearance: localized("Appearance")
+            case .terminalKeyboard: localized("Terminal Keyboard")
+            case .voice: localized("Voice")
             }
         }
 
@@ -79,7 +79,7 @@ final class SettingsViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Settings"
+        title = localized("Settings")
         // Tint the backdrop behind the inset cards to the terminal theme, so
         // Settings matches every other page when the theme changes (the cards
         // stay standard grouped-cells for legibility).
@@ -90,7 +90,7 @@ final class SettingsViewController: UITableViewController {
             // Telegram's sheet close: a 44pt glass circle with a ~17pt cross.
             let close = UIButton(type: .system)
             close.applyGlassSymbol("xmark", pointSize: 17)
-            close.accessibilityLabel = "Close"
+            close.accessibilityLabel = localized("Close")
             close.addAction(UIAction { [weak self] _ in
                 self?.dismiss(animated: true)
             }, for: .touchUpInside)
@@ -124,10 +124,10 @@ final class SettingsViewController: UITableViewController {
     /// the Connectivity page's Status row so the two always read the same.
     static func linkStatus() -> NSAttributedString {
         let (color, text): (UIColor, String) = switch CompanionLink.state {
-        case .unpaired: (.tertiaryLabel, "Not Paired")
-        case .connecting: (.systemOrange, "Reconnecting…")
-        case .connected: (.systemGreen, "Connected")
-        case .failed: (.systemRed, "Connection Failed")
+        case .unpaired: (.tertiaryLabel, localized("Not Paired"))
+        case .connecting: (.systemOrange, localized("Reconnecting…"))
+        case .connected: (.systemGreen, localized("Connected"))
+        case .failed: (.systemRed, localized("Connection Failed"))
         }
         // The dot is a drawn image in an NSTextAttachment, not a glyph:
         // mixed-size text runs never sit still (a ● run smaller than the text
@@ -162,7 +162,7 @@ final class SettingsViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        section == Section.about.rawValue ? "About" : nil
+        section == Section.about.rawValue ? localized("About") : nil
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -180,15 +180,15 @@ final class SettingsViewController: UITableViewController {
         default:
             switch AboutRow(rawValue: indexPath.row) {
             case .version:
-                cell.textLabel?.text = "Version"
+                cell.textLabel?.text = localized("Version")
                 cell.selectionStyle = .none
                 cell.detailTextLabel?.text =
                     Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
             case .website:
-                cell.textLabel?.text = "Website"
+                cell.textLabel?.text = localized("Website")
                 cell.detailTextLabel?.text = "termio.sh"
             case .privacy, nil:
-                cell.textLabel?.text = "Privacy Policy"
+                cell.textLabel?.text = localized("Privacy Policy")
             }
         }
         return cell
@@ -239,7 +239,7 @@ final class AppearanceSettingsViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Appearance"
+        title = localized("Appearance")
         themeObserver = installThemeBackdrop()
     }
 
@@ -258,7 +258,7 @@ final class AppearanceSettingsViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        "Terminal"
+        localized("Terminal")
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -266,7 +266,7 @@ final class AppearanceSettingsViewController: UITableViewController {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         switch Row(rawValue: indexPath.row) {
         case .appearance:
-            cell.textLabel?.text = "Appearance"
+            cell.textLabel?.text = localized("Appearance")
             cell.selectionStyle = .none
             let modes = MobileSettings.AppearanceMode.allCases
             let control = UISegmentedControl(items: modes.map(\.label))
@@ -278,15 +278,15 @@ final class AppearanceSettingsViewController: UITableViewController {
             control.sizeToFit()
             cell.accessoryView = control
         case .lightTheme:
-            cell.textLabel?.text = "Light Theme"
+            cell.textLabel?.text = localized("Light Theme")
             cell.detailTextLabel?.text = settings.lightThemeName
             cell.accessoryType = .disclosureIndicator
         case .darkTheme:
-            cell.textLabel?.text = "Dark Theme"
+            cell.textLabel?.text = localized("Dark Theme")
             cell.detailTextLabel?.text = settings.darkThemeName
             cell.accessoryType = .disclosureIndicator
         case .fontSize, nil:
-            cell.textLabel?.text = "Font Size"
+            cell.textLabel?.text = localized("Font Size")
             cell.detailTextLabel?.text = Self.pointsLabel(settings.fontSize)
             cell.selectionStyle = .none
             let stepper = UIStepper()
@@ -317,7 +317,7 @@ final class AppearanceSettingsViewController: UITableViewController {
     }
 
     private static func pointsLabel(_ size: Double) -> String {
-        "\(Int(size)) pt"
+        localized("\(Int(size)) pt")
     }
 }
 
@@ -347,7 +347,7 @@ final class TerminalKeyboardSettingsViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Terminal Keyboard"
+        title = localized("Terminal Keyboard")
         themeObserver = installThemeBackdrop()
     }
 
@@ -360,13 +360,11 @@ final class TerminalKeyboardSettingsViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        "Control Keys"
+        localized("Control Keys")
     }
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        "Keys on the control bar above the system keyboard. "
-            + "Esc and the arrows are always there; "
-            + "hold esc for esc-esc (Claude Code's rewind menu)."
+        localized("Keys on the control bar above the system keyboard. Esc and the arrows are always there; hold esc for esc-esc (Claude Code's rewind menu).")
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -429,7 +427,7 @@ final class VoiceSettingsViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Voice"
+        title = localized("Voice")
         themeObserver = installThemeBackdrop()
     }
 
@@ -447,7 +445,7 @@ final class VoiceSettingsViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch Section(rawValue: section) {
-        case .provider: "Transcription"
+        case .provider: localized("Transcription")
         // The key belongs to the chosen provider — name it so the two read together.
         case .key: provider.displayName
         default: nil
@@ -457,13 +455,12 @@ final class VoiceSettingsViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         switch Section(rawValue: section) {
         case .voice, nil:
-            "Hold the mic key on the terminal keyboard to dictate a prompt — "
-                + "release to send it, slide up to cancel."
+            localized("Hold the mic key on the terminal keyboard to dictate a prompt — release to send it, slide up to cancel.")
         case .provider:
-            "Which service transcribes your voice. Each keeps its own key."
+            localized("Which service transcribes your voice. Each keeps its own key.")
         case .key:
             provider.keyFooter
-                + " Your key stays in this device's Keychain and is used only for transcription."
+                + localized(" Your key stays in this device's Keychain and is used only for transcription.")
         }
     }
 
@@ -471,7 +468,7 @@ final class VoiceSettingsViewController: UITableViewController {
         switch Section(rawValue: indexPath.section) {
         case .voice, nil:
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-            cell.textLabel?.text = "Voice Input"
+            cell.textLabel?.text = localized("Voice Input")
             cell.selectionStyle = .none
             let toggle = UISwitch()
             toggle.isOn = settings.pushToTalkEnabled
@@ -483,7 +480,7 @@ final class VoiceSettingsViewController: UITableViewController {
             return cell
         case .provider:
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-            cell.textLabel?.text = "Provider"
+            cell.textLabel?.text = localized("Provider")
             cell.selectionStyle = .none
             let providers = TranscriptionProvider.allCases
             let control = UISegmentedControl(items: providers.map(\.displayName))
@@ -502,12 +499,12 @@ final class VoiceSettingsViewController: UITableViewController {
             let isSet = VoiceDictation.hasAPIKey(for: provider)
             switch KeyRow(rawValue: indexPath.row) {
             case .apiKey, nil:
-                cell.textLabel?.text = "API Key"
-                cell.detailTextLabel?.text = isSet ? "•••• Set" : "Not Set"
+                cell.textLabel?.text = localized("API Key")
+                cell.detailTextLabel?.text = isSet ? localized("•••• Set") : localized("Not Set")
                 cell.detailTextLabel?.textColor = isSet ? .systemGreen : .secondaryLabel
                 cell.accessoryType = .disclosureIndicator
             case .remove:
-                cell.textLabel?.text = "Remove Key"
+                cell.textLabel?.text = localized("Remove Key")
                 cell.textLabel?.textColor = .systemRed
             }
             return cell
@@ -529,8 +526,8 @@ final class VoiceSettingsViewController: UITableViewController {
     private func presentKeyEditor() {
         let provider = self.provider
         let alert = UIAlertController(
-            title: "\(provider.displayName) API Key",
-            message: "Paste your key. It's stored in this device's Keychain.",
+            title: localized("\(provider.displayName) API Key"),
+            message: localized("Paste your key. It's stored in this device's Keychain."),
             preferredStyle: .alert
         )
         alert.addTextField { field in
@@ -540,11 +537,11 @@ final class VoiceSettingsViewController: UITableViewController {
             field.autocorrectionType = .no
             field.text = VoiceDictation.apiKey(for: provider)
         }
-        alert.addAction(UIAlertAction(title: "Save", style: .default) { [weak self, weak alert] _ in
+        alert.addAction(UIAlertAction(title: localized("Save"), style: .default) { [weak self, weak alert] _ in
             VoiceDictation.setAPIKey(alert?.textFields?.first?.text, for: provider)
             self?.tableView.reloadData()
         })
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: localized("Cancel"), style: .cancel))
         present(alert, animated: true)
     }
 }
@@ -585,7 +582,7 @@ final class ConnectivitySettingsViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Connectivity"
+        title = localized("Connectivity")
         themeObserver = installThemeBackdrop()
         stateObserver = NotificationCenter.default.addObserver(
             forName: CompanionLink.stateDidChange, object: nil, queue: .main
@@ -608,12 +605,12 @@ final class ConnectivitySettingsViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        section == Section.mac.rawValue ? "Mac" : nil
+        section == Section.mac.rawValue ? localized("Mac") : nil
     }
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard section == Section.mac.rawValue else { return nil }
-        return "Pair once with the address Termio on your Mac is serving — every project and session rides this one link."
+        return localized("Pair once with the address Termio on your Mac is serving — every project and session rides this one link.")
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -622,7 +619,7 @@ final class ConnectivitySettingsViewController: UITableViewController {
         cell.imageView?.tintColor = .label
         switch (Section(rawValue: indexPath.section), MacRow(rawValue: indexPath.row)) {
         case (.mac, .status):
-            cell.textLabel?.text = "Status"
+            cell.textLabel?.text = localized("Status")
             cell.imageView?.image = HugeIcon.link.strokeImage(boxSize: 22)
             cell.selectionStyle = .none
             // The dot rides right before the state word ("● Connected"), not
@@ -631,7 +628,7 @@ final class ConnectivitySettingsViewController: UITableViewController {
         case (.mac, .address):
             cell.accessoryType = .disclosureIndicator
             if let url = CompanionLink.savedURL {
-                cell.textLabel?.text = "Address"
+                cell.textLabel?.text = localized("Address")
                 cell.imageView?.image = HugeIcon.network.strokeImage(boxSize: 22)
                 // Host + port only: the scheme is noise and the pairing token
                 // riding the query is a secret — and the full URL overflows the
@@ -641,14 +638,14 @@ final class ConnectivitySettingsViewController: UITableViewController {
             } else {
                 // Empty state: a plain "Not Set" is a dead end. Make the row
                 // the invitation to type the address itself.
-                cell.textLabel?.text = "Enter Address Manually"
+                cell.textLabel?.text = localized("Enter Address Manually")
                 cell.imageView?.image = HugeIcon.keyboard.strokeImage(boxSize: 22)
             }
         case (.mac, .scan):
-            cell.textLabel?.text = "Scan QR Code"
+            cell.textLabel?.text = localized("Scan QR Code")
             cell.imageView?.image = HugeIcon.qrCode.strokeImage(boxSize: 22)
         default:
-            cell.textLabel?.text = "Forget This Mac"
+            cell.textLabel?.text = localized("Forget This Mac")
             cell.textLabel?.textColor = .systemRed
         }
         return cell
@@ -679,8 +676,8 @@ final class ConnectivitySettingsViewController: UITableViewController {
 
     private func presentEditAddress() {
         let alert = UIAlertController(
-            title: "Connect to Mac",
-            message: "The address Termio on your Mac is serving.",
+            title: localized("Connect to Mac"),
+            message: localized("The address Termio on your Mac is serving."),
             preferredStyle: .alert
         )
         alert.addTextField { field in
@@ -690,14 +687,14 @@ final class ConnectivitySettingsViewController: UITableViewController {
             field.autocorrectionType = .no
             field.keyboardType = .URL
         }
-        alert.addAction(UIAlertAction(title: "Connect", style: .default) { [weak self, weak alert] _ in
+        alert.addAction(UIAlertAction(title: localized("Connect"), style: .default) { [weak self, weak alert] _ in
             guard let raw = alert?.textFields?.first?.text,
                   let url = CompanionLink.normalize(raw) else { return }
             UserDefaults.standard.set(url.absoluteString, forKey: CompanionLink.defaultsKey)
             NotificationCenter.default.post(name: CompanionLink.pairingDidChange, object: nil)
             self?.tableView.reloadData()
         })
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: localized("Cancel"), style: .cancel))
         present(alert, animated: true)
     }
 
@@ -797,7 +794,7 @@ final class ThemePickerViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = slot == .light ? "Light Theme" : "Dark Theme"
+        title = slot == .light ? localized("Light Theme") : localized("Dark Theme")
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "theme")
 
         let search = UISearchController(searchResultsController: nil)
@@ -827,7 +824,7 @@ final class ThemePickerViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         if isSearching { return nil }
-        return section == 0 ? "Popular" : "All Themes"
+        return section == 0 ? localized("Popular") : localized("All Themes")
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/ios/Sources/TerminalAccessoryBar.swift
+++ b/ios/Sources/TerminalAccessoryBar.swift
@@ -18,52 +18,52 @@ enum TerminalKeyCatalog {
     static let all: [TerminalControlKey] = [
         TerminalControlKey(
             id: "tab", title: "tab",
-            detail: "Autocomplete, accept a suggestion",
+            detail: localized("Autocomplete, accept a suggestion"),
             payload: Data([0x09])
         ),
         TerminalControlKey(
             id: "shiftTab", title: "⇧⇥",
-            detail: "Cycle permission modes — default, accept edits, plan",
+            detail: localized("Cycle permission modes — default, accept edits, plan"),
             payload: Data("\u{1B}[Z".utf8)
         ),
         TerminalControlKey(
             id: "ctrlO", title: "^O",
-            detail: "Toggle the transcript viewer (what the agent did)",
+            detail: localized("Toggle the transcript viewer (what the agent did)"),
             payload: Data([0x0F])
         ),
         TerminalControlKey(
             id: "ctrlC", title: "^C",
-            detail: "Interrupt — pressed twice while idle it exits the agent",
+            detail: localized("Interrupt — pressed twice while idle it exits the agent"),
             payload: Data([0x03])
         ),
         TerminalControlKey(
             id: "ctrlL", title: "^L",
-            detail: "Redraw a glitched screen",
+            detail: localized("Redraw a glitched screen"),
             payload: Data([0x0C])
         ),
         TerminalControlKey(
             id: "ctrlB", title: "^B",
-            detail: "Move the running task to the background",
+            detail: localized("Move the running task to the background"),
             payload: Data([0x02])
         ),
         TerminalControlKey(
             id: "ctrlT", title: "^T",
-            detail: "Toggle the task checklist",
+            detail: localized("Toggle the task checklist"),
             payload: Data([0x14])
         ),
         TerminalControlKey(
             id: "ctrlR", title: "^R",
-            detail: "Search prompt history",
+            detail: localized("Search prompt history"),
             payload: Data([0x12])
         ),
         TerminalControlKey(
             id: "ctrlZ", title: "^Z",
-            detail: "Suspend the foreground process",
+            detail: localized("Suspend the foreground process"),
             payload: Data([0x1A])
         ),
         TerminalControlKey(
             id: "ctrlD", title: "^D",
-            detail: "End of file — exits a shell or REPL",
+            detail: localized("End of file — exits a shell or REPL"),
             payload: Data([0x04])
         ),
     ]
@@ -329,7 +329,7 @@ final class TerminalAccessoryBar: UIInputView {
         )
         config.cornerStyle = .medium
         attachButton.configuration = config
-        attachButton.accessibilityLabel = "Attach"
+        attachButton.accessibilityLabel = localized("Attach")
         attachButton.tintColor = .label
         // Invisible until the owner reports an upload backend, but never
         // removed — the grid must not reflow around it.
@@ -404,10 +404,10 @@ final class TerminalAccessoryBar: UIInputView {
         // so each source is one neutral chip with a thin outline glyph — the
         // Hugeicons look, done natively in SF Symbols (see makeMenuRow).
         let rows = UIStackView(arrangedSubviews: [
-            makeMenuRow(title: "Camera", icon: .camera) { [weak self] in self?.onAttach?(.camera) },
-            makeMenuRow(title: "Photos", icon: .image) { [weak self] in self?.onAttach?(.photos) },
-            makeMenuRow(title: "Voice", icon: .voice) { [weak self] in self?.startVoiceRecording() },
-            makeMenuRow(title: "Files", icon: .folder) { [weak self] in self?.onAttach?(.files) },
+            makeMenuRow(title: localized("Camera"), icon: .camera) { [weak self] in self?.onAttach?(.camera) },
+            makeMenuRow(title: localized("Photos"), icon: .image) { [weak self] in self?.onAttach?(.photos) },
+            makeMenuRow(title: localized("Voice"), icon: .voice) { [weak self] in self?.startVoiceRecording() },
+            makeMenuRow(title: localized("Files"), icon: .folder) { [weak self] in self?.onAttach?(.files) },
         ])
         rows.axis = .vertical
         rows.translatesAutoresizingMaskIntoConstraints = false
@@ -665,7 +665,7 @@ final class TerminalAccessoryBar: UIInputView {
             self?.haptic.impactOccurred()
             self?.onScrollEdge?(edge)
         }
-        button.accessibilityLabel = edge == .top ? "Scroll to top" : "Scroll to bottom"
+        button.accessibilityLabel = edge == .top ? localized("Scroll to top") : localized("Scroll to bottom")
         button.heightAnchor.constraint(equalToConstant: Self.keyHeight).isActive = true
         return button
     }

--- a/ios/Sources/TerminalListViewController.swift
+++ b/ios/Sources/TerminalListViewController.swift
@@ -61,7 +61,7 @@ final class TerminalListViewController: UIViewController {
 
     private func configureTopBar() -> UIView {
         let pageTitle = UILabel()
-        pageTitle.text = "Terminals"
+        pageTitle.text = localized("Terminals")
         pageTitle.font = .systemFont(ofSize: 34, weight: .bold)
         pageTitle.textColor = .label
 
@@ -104,11 +104,11 @@ final class TerminalListViewController: UIViewController {
     private func configureNewTerminalButton() {
         newTerminalButton.applyGlassIcon(.add, boxSize: 24)
         newTerminalButton.tintColor = .label
-        newTerminalButton.accessibilityLabel = "New Terminal"
+        newTerminalButton.accessibilityLabel = localized("New Terminal")
         newTerminalButton.showsMenuAsPrimaryAction = true
         newTerminalButton.menu = UIMenu(children: [
             UIAction(
-                title: "New Terminal",
+                title: localized("New Terminal"),
                 image: HugeIcon.terminal.strokeImage(boxSize: 22)
             ) { [weak self] _ in self?.store.startNewTerminal() },
             UIDeferredMenuElement.uncached { [weak self] completion in
@@ -125,9 +125,9 @@ final class TerminalListViewController: UIViewController {
         let icon = HugeIcon.network.strokeImage(boxSize: 22)
         let hosts = store.sshHosts
         guard !hosts.isEmpty else {
-            let hint = UIAction(title: "Add hosts in ~/.ssh/config on your Mac") { _ in }
+            let hint = UIAction(title: localized("Add hosts in ~/.ssh/config on your Mac")) { _ in }
             hint.attributes = .disabled
-            return UIMenu(title: "New SSH", image: icon, children: [hint])
+            return UIMenu(title: localized("New SSH"), image: icon, children: [hint])
         }
         let items = hosts.map { host in
             UIAction(
@@ -135,7 +135,7 @@ final class TerminalListViewController: UIViewController {
                 subtitle: host.user.isEmpty ? host.hostName : "\(host.user)@\(host.hostName)"
             ) { [weak self] _ in self?.store.startSSH(host: host.alias) }
         }
-        return UIMenu(title: "New SSH", image: icon, children: items)
+        return UIMenu(title: localized("New SSH"), image: icon, children: items)
     }
 
     // MARK: - Table
@@ -195,10 +195,10 @@ final class TerminalListViewController: UIViewController {
         let canStart = store.companionURL != nil
         emptyState.configure(
             icon: .terminal,
-            title: "No terminals yet",
+            title: localized("No terminals yet"),
             message: canStart
-                ? "Terminals are plain shells that aren't tied to a project. Start one with ＋, or on your Mac."
-                : "Terminals are plain shells that aren't tied to a project. Start one on your Mac and it appears here.",
+                ? localized("Terminals are plain shells that aren't tied to a project. Start one with ＋, or on your Mac.")
+                : localized("Terminals are plain shells that aren't tied to a project. Start one on your Mac and it appears here."),
             actionTitle: nil,
             busy: false
         )
@@ -243,7 +243,7 @@ extension TerminalListViewController: UITableViewDataSource, UITableViewDelegate
         guard store.companionURL != nil,
               let sessionID = terminals[indexPath.row].rosterID
         else { return nil }
-        let close = UIContextualAction(style: .destructive, title: "Close") { [weak self] _, _, done in
+        let close = UIContextualAction(style: .destructive, title: localized("Close")) { [weak self] _, _, done in
             self?.store.stopSession(sessionID)
             done(true)
         }

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -250,7 +250,7 @@ final class TerminalViewController: UIViewController {
         statusLabel.textColor = .secondaryLabel
         statusLabel.text = switch backend {
         case .demoShell: "\(session.agent.name) · \(session.time)"
-        case .companion: "Connecting…"
+        case .companion: localized("Connecting…")
         }
         contextLabel.isHidden = contextLabel.text?.isEmpty ?? true
         switch backend {
@@ -325,12 +325,12 @@ final class TerminalViewController: UIViewController {
         var items: [UIMenuElement] = []
         if case .companion = backend {
             items.append(UIAction(
-                title: "View Trace", image: UIImage(systemName: "list.bullet.rectangle")
+                title: localized("View Trace"), image: UIImage(systemName: "list.bullet.rectangle")
             ) { [weak self] _ in self?.showTrace() })
         }
         if let path = session.projectPath, !path.isEmpty {
             items.append(UIAction(
-                title: "Copy Path", image: UIImage(systemName: "doc.on.doc")
+                title: localized("Copy Path"), image: UIImage(systemName: "doc.on.doc")
             ) { _ in UIPasteboard.general.string = path })
         }
         return UIMenu(children: items)
@@ -635,7 +635,7 @@ final class TerminalViewController: UIViewController {
                 self.uploadTotal = 0
                 self.uploadDone = 0
                 self.terminalView.keyBar.setAttachBusy(false)
-                self.presentAlert("Upload failed", message)
+                self.presentAlert(localized("Upload failed"), message)
             }
             client.start()
             uploadClient = client
@@ -669,18 +669,18 @@ final class TerminalViewController: UIViewController {
     private func reportSkipped(oversized: [String], unreadable: [String] = []) {
         var lines: [String] = []
         if !oversized.isEmpty {
-            lines.append("Over the 8 MB cap: \(oversized.joined(separator: ", "))")
+            lines.append(localized("Over the 8 MB cap: \(oversized.joined(separator: ", "))"))
         }
         if !unreadable.isEmpty {
-            lines.append("Couldn't read: \(unreadable.joined(separator: ", "))")
+            lines.append(localized("Couldn't read: \(unreadable.joined(separator: ", "))"))
         }
         guard !lines.isEmpty else { return }
-        presentAlert("Some files were skipped", lines.joined(separator: "\n"))
+        presentAlert(localized("Some files were skipped"), lines.joined(separator: "\n"))
     }
 
     private func presentAlert(_ title: String, _ message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        alert.addAction(UIAlertAction(title: localized("OK"), style: .default))
         present(alert, animated: true)
     }
 
@@ -751,9 +751,9 @@ final class TerminalViewController: UIViewController {
         contextLabel.isHidden = true
         switch state {
         case .connecting:
-            statusLabel.text = "Connecting…"
+            statusLabel.text = localized("Connecting…")
         case .reconnecting:
-            statusLabel.text = "Reconnecting…"
+            statusLabel.text = localized("Reconnecting…")
         case .connected:
             statusLabel.isHidden = true
             contextLabel.isHidden = contextLabel.text?.isEmpty ?? true
@@ -773,14 +773,14 @@ final class TerminalViewController: UIViewController {
                 companion?.reassertGrid()
             }
         case .failed(let reason):
-            statusLabel.text = "Connection failed"
-            let alert = UIAlertController(title: "Companion connection failed", message: reason, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default) { [weak self] _ in
+            statusLabel.text = localized("Connection failed")
+            let alert = UIAlertController(title: localized("Companion connection failed"), message: reason, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: localized("OK"), style: .default) { [weak self] _ in
                 self?.close()
             })
             present(alert, animated: true)
         case .closed:
-            statusLabel.text = "Disconnected"
+            statusLabel.text = localized("Disconnected")
             companionSession?.finish(exitCode: 0, runtimeMilliseconds: 0)
         }
     }
@@ -1184,7 +1184,7 @@ extension TerminalViewController: UIEditMenuInteractionDelegate {
     ) -> UIMenu? {
         guard UIPasteboard.general.hasStrings else { return nil }
         return UIMenu(options: .displayInline, children: [
-            UIAction(title: "Paste") { [weak self] _ in
+            UIAction(title: localized("Paste")) { [weak self] _ in
                 self?.terminalView.paste(nil)
             },
         ])

--- a/ios/Sources/TraceViewController.swift
+++ b/ios/Sources/TraceViewController.swift
@@ -12,7 +12,7 @@ final class TraceViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Trace"
+        title = localized("Trace")
         view.backgroundColor = .systemBackground
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .done, target: self, action: #selector(dismissSelf)

--- a/ios/Sources/VoiceDictation.swift
+++ b/ios/Sources/VoiceDictation.swift
@@ -20,15 +20,15 @@ enum TranscriptionProvider: String, CaseIterable {
     var keyPlaceholder: String {
         switch self {
         case .openAI: "sk-..."
-        case .elevenLabs: "Your ElevenLabs API key"
+        case .elevenLabs: localized("Your ElevenLabs API key")
         }
     }
 
     /// The Key section's footer — which model does the transcribing.
     var keyFooter: String {
         switch self {
-        case .openAI: "OpenAI Realtime, with file and on-device fallback."
-        case .elevenLabs: "Transcribed with ElevenLabs Scribe."
+        case .openAI: localized("OpenAI Realtime, with file and on-device fallback.")
+        case .elevenLabs: localized("Transcribed with ElevenLabs Scribe.")
         }
     }
 
@@ -74,12 +74,12 @@ final class VoiceDictation: NSObject {
         /// A short line fit for the recording pill's error state.
         var hudMessage: String {
             switch self {
-            case .missingKey: "Add an API key in Settings ▸ Voice"
-            case .microphonePermissionDenied: "Allow microphone access in Settings"
-            case .recordingFailed: "Couldn't start recording"
-            case .empty: "Didn't catch that — try again"
-            case .localUnavailable: "On-device transcription isn't available"
-            case .network: "Network error — check your connection"
+            case .missingKey: localized("Add an API key in Settings ▸ Voice")
+            case .microphonePermissionDenied: localized("Allow microphone access in Settings")
+            case .recordingFailed: localized("Couldn't start recording")
+            case .empty: localized("Didn't catch that — try again")
+            case .localUnavailable: localized("On-device transcription isn't available")
+            case .network: localized("Network error — check your connection")
             case .api(_, let message): message
             }
         }
@@ -403,13 +403,13 @@ final class VoiceDictation: NSObject {
                 return
             }
             guard let http = response as? HTTPURLResponse, let data else {
-                result = .failure(.network("No response"))
+                result = .failure(.network(localized("No response")))
                 return
             }
             guard (200..<300).contains(http.statusCode) else {
                 result = .failure(.api(
                     status: http.statusCode,
-                    message: provider.errorMessage(from: data) ?? "Transcription failed"
+                    message: provider.errorMessage(from: data) ?? localized("Transcription failed")
                 ))
                 return
             }
@@ -618,12 +618,12 @@ final class VoiceRecordingBar: UIView {
         cancelConfig.background.backgroundColor = .tertiarySystemFill
         cancelButton.configuration = cancelConfig
         cancelButton.clipsToBounds = true
-        cancelButton.accessibilityLabel = "Cancel recording"
+        cancelButton.accessibilityLabel = localized("Cancel recording")
         cancelButton.addAction(UIAction { [weak self] _ in self?.onCancel?() }, for: .touchUpInside)
 
         stopButton.backgroundColor = .tertiarySystemFill
         stopButton.clipsToBounds = true
-        stopButton.accessibilityLabel = "Stop and transcribe"
+        stopButton.accessibilityLabel = localized("Stop and transcribe")
         stopButton.addAction(UIAction { [weak self] _ in self?.onStop?() }, for: .touchUpInside)
         stopGlyph.backgroundColor = .label
         stopGlyph.layer.cornerRadius = 3.5
@@ -753,7 +753,7 @@ final class VoiceRecordingBar: UIView {
     func showTranscribing() {
         stopTimer()
         recordingControls.forEach { $0.isHidden = true }
-        statusLabel.text = "Transcribing…"
+        statusLabel.text = localized("Transcribing…")
         statusLabel.textColor = .secondaryLabel
         statusStack.isHidden = false
         spinner.startAnimating()

--- a/ios/TermioMobile.xcodeproj/project.pbxproj
+++ b/ios/TermioMobile.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 			knownRegions = (
 				Base,
 				en,
+				"zh-Hans",
 			);
 			mainGroup = 600AAD319D9C4100B4D7E969;
 			minimizedProjectReferenceProxies = 1;


### PR DESCRIPTION
## What

The iPhone companion was the one surface #224 left in English. It now speaks Simplified Chinese too.

- **A String Catalog in the iOS target.** `ios/Sources/Localizable.xcstrings`, 171 strings, and `zh-Hans` added to the project's known regions. Xcode compiles `.xcstrings` natively, so the phone needs none of the Mac's `compile-strings.sh` pipeline — the catalog is the only source, and `zh-Hans.lproj` falls out of the build.
- **Every user-facing string goes through `localized(_:)`**, the same call shape as the Mac so one sweep finds both sides: the tab bar, the Projects / Chats / Terminals lists and their empty states, the Devices pairing page, Appearance, Terminal Keyboard, Voice, the terminal screen and its key bar, the inspector (changes, file tree, diff, editor), the QR scanner, and the voice-dictation errors.
- **The tab bar's accessibility identifiers keep their English keys** (`home.tab.projects`), so the UI tests address the same handles in every language.
- Untouched on purpose: theme names and provider names (proper nouns), demo/mock data, wire-protocol strings composed on the Mac, and the persisted paired-Mac name.

Also, one commit for the Mac: the custom-tunnel relay rows from #253 and the keybindings list's Font category were resolving to their English keys. Translated, catalog recompiled.

## Verification

- Simulator build clean; `swiftlint` clean; `swift build` and 206/206 Mac unit tests pass.
- Built `TermioMobile.app` carries `zh-Hans.lproj/Localizable.strings` with all 171 entries, and every `localized(…)` call site in `ios/Sources` maps to a catalog key (no key falls back to English by accident).
- Seen on the simulator under `-AppleLanguages (zh-Hans)`: the Projects home and its zero state, the tab bar, Settings ▸ 设备 (the multi-Mac page from #229), and the inspector drawer's 更改/文件 segment with its interpolated `4 个文件有更改  +240 −56` summary.
- iOS UI suite: same two failures as `main` before this branch — `testInspectorFileTreeShowsLanguageIcons` and `testScanEntryPresentsScanner`, both stale since the drawer gained its Changes default and #229 renamed Connectivity to Devices. Verified against a pristine `main` checkout; not caused by this PR and not fixed here.

Release Notes:
- The iPhone app can now speak Simplified Chinese: it follows your iPhone's language, or set it per app in Settings.
