### PR TITLE
Restore the Font keybinding category key

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -1341,6 +1341,16 @@
         }
       }
     },
+    "Font": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体"
+          }
+        }
+      }
+    },
     "Focus Pane Left": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 	<string>Focus Pane Right</string>
 	<key>Focus Pane Up</key>
 	<string>Focus Pane Up</string>
+	<key>Font</key>
+	<string>Font</string>
 	<key>Font name</key>
 	<string>Font name</string>
 	<key>General</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 	<string>聚焦右侧窗格</string>
 	<key>Focus Pane Up</key>
 	<string>聚焦上方窗格</string>
+	<key>Font</key>
+	<string>字体</string>
 	<key>Font name</key>
 	<string>字体名称</string>
 	<key>General</key>


### PR DESCRIPTION
Keyboard's three font commands ask for a `Font` category, but the catalog has no such key: renaming the Appearance section header from "Font" to "Terminal font" took it along. It was the only one of the eight keybinding categories missing, and its three commands are all translated — so a Chinese user got an English `Font` heading over 增大字体, 减小字体, 重设字体大小.

Adds the key with 字体, matching `Terminal font` → 终端字体, and regenerates the compiled `.lproj` output.

Release Notes: The Keyboard settings tab now shows its Font category heading in Chinese.