### PR TITLE
Localize the tunnel picker and gate string-catalog drift

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,6 +18,8 @@ on:
       - "Package.swift"
       - "Package.resolved"
       - ".swiftlint.yml"
+      - "scripts/check-strings.sh"
+      - "scripts/compile-strings.sh"
       - ".github/workflows/macos.yml"
   pull_request:
     paths:
@@ -27,6 +29,8 @@ on:
       - "Package.swift"
       - "Package.resolved"
       - ".swiftlint.yml"
+      - "scripts/check-strings.sh"
+      - "scripts/compile-strings.sh"
       - ".github/workflows/macos.yml"
 
 concurrency:
@@ -55,6 +59,12 @@ jobs:
         run: |
           which swiftlint || brew install swiftlint
           swiftlint lint --reporter github-actions-logging
+
+      # A `localized("…")` key the catalog doesn't carry compiles and runs — it
+      # just resolves to English — so only a check catches it. Runs before the
+      # build: it's seconds, and it fails for a reason no compiler error names.
+      - name: Check strings
+        run: ./scripts/check-strings.sh
 
       - name: Build
         run: swift build

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -1252,6 +1252,7 @@
       }
     },
     "Custom": {
+      "comment": "Picker entry for a user-supplied item rather than a built-in one. Shown in both the theme picker and the Mobile tunnel picker, so keep it context-neutral.",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
@@ -5198,6 +5199,7 @@
       }
     },
     "On iPhone, tap the Mac pill ▸ Scan QR Code. Traffic crosses the relay you run yourself — no third party in the path.": {
+      "comment": "Footer under Settings ▸ Mobile ▸ Connect iPhone when the user runs their own relay. “Mac pill” is a control in the iPhone app and ▸ separates steps in a menu path.",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
@@ -5208,6 +5210,7 @@
       }
     },
     "On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network, and terminates on the provider's servers. Pick Custom to run your own relay instead.": {
+      "comment": "Footer under Settings ▸ Mobile ▸ Connect iPhone when a bundled third-party tunnel is selected. “Custom” names another entry in the same picker — translate it identically.",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
@@ -5218,6 +5221,7 @@
       }
     },
     "URL Pattern": {
+      "comment": "Label for the Settings ▸ Mobile field holding a regular expression that matches the public URL a self-hosted tunnel prints on start-up.",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
@@ -5228,6 +5232,7 @@
       }
     },
     "Not a valid regular expression": {
+      "comment": "Inline warning shown beneath the URL Pattern field when what the user typed does not compile as a regular expression.",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
@@ -5238,6 +5243,7 @@
       }
     },
     "Apply": {
+      "comment": "Button that saves the custom tunnel command and restarts the tunnel.",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
@@ -5248,6 +5254,7 @@
       }
     },
     "Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.": {
+      "comment": "Help text beneath the custom tunnel fields. “{port}” is a literal token the app substitutes at runtime — keep it exactly as written. “Custom” names an entry in the tunnel picker above.",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
@@ -5258,6 +5265,7 @@
       }
     },
     "Font": {
+      "comment": "Category grouping the font-size shortcuts in Settings ▸ Keyboard.",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {

--- a/Sources/termio/Settings/MobileSettingsTab.swift
+++ b/Sources/termio/Settings/MobileSettingsTab.swift
@@ -75,7 +75,7 @@ struct MobileSettingsTab: View {
                         set: { tunnel.setProvider($0) }
                     )) {
                         ForEach(TunnelManager.Provider.allCases) { provider in
-                            Text(provider == .off ? localized("Off — LAN only") : provider.label).tag(provider)
+                            Text(Self.pickerLabel(provider)).tag(provider)
                         }
                     }
                     // The custom-relay editor: shown only when Custom is picked,
@@ -126,6 +126,19 @@ struct MobileSettingsTab: View {
             let custom = CustomTunnel.current
             customCommand = custom.command
             customURLPattern = custom.urlPattern
+        }
+    }
+
+    /// A provider's name as the picker shows it. `Spec.label` is the tool's own
+    /// name, so it reaches the screen untranslated — right for the three brands
+    /// (Tunelo, Cloudflare, ngrok are proper nouns everywhere), wrong for the
+    /// two entries that are ordinary words. Those go through the catalog, which
+    /// already carries "Custom" for the theme picker.
+    private static func pickerLabel(_ provider: TunnelManager.Provider) -> String {
+        switch provider {
+        case .off: return localized("Off — LAN only")
+        case .custom: return localized("Custom")
+        case .tunelo, .cloudflared, .ngrok: return provider.label
         }
     }
 

--- a/scripts/check-strings.sh
+++ b/scripts/check-strings.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Fail when the String Catalog and the source have drifted apart.
+#
+# Every UI literal reaches the catalog through `localized("…")` (see
+# Sources/termio/App/Localized.swift), and nothing verifies that the key it
+# passes actually exists. A missing key doesn't crash or fail the build — it
+# silently resolves to the English source string, so a localized pane ships
+# half-translated and looks fine to anyone testing in English. That is how six
+# keys walked in unnoticed with the custom tunnel relay.
+#
+# Two checks, both cheap enough for every PR:
+#   1. every static `localized("…")` key exists in the catalog
+#   2. the checked-in .lproj output matches what the catalog compiles to
+#
+# Interpolated calls — `localized("\(count) files")` — are skipped: their key
+# carries a format specifier whose type this script cannot infer from the text.
+# Multi-line (`"""`) literals are skipped too: their key depends on Swift's
+# indentation stripping and line continuations, which this scan doesn't model.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 - "$repo_root" <<'PYTHON'
+import json, pathlib, re, sys
+
+repo_root = pathlib.Path(sys.argv[1])
+catalog_path = repo_root / "Sources/termio/Resources/Localizable.xcstrings"
+catalog = json.loads(catalog_path.read_text())
+known = set(catalog["strings"])
+
+# `localized(` + a single-line Swift string literal. The negative lookahead
+# leaves `localized("""` to the multi-line case, which this scan skips.
+call = re.compile(r'\blocalized\(\s*"(?!"")((?:[^"\\\n]|\\.)*)"')
+escapes = {'\\"': '"', "\\\\": "\\", "\\n": "\n", "\\t": "\t"}
+
+missing, used = {}, set()
+for swift in sorted((repo_root / "Sources").rglob("*.swift")):
+    for match in call.finditer(swift.read_text()):
+        literal = match.group(1)
+        if "\\(" in literal:
+            continue
+        key = literal
+        for escaped, plain in escapes.items():
+            key = key.replace(escaped, plain)
+        used.add(key)
+        if key not in known:
+            line = swift.read_text()[: match.start()].count("\n") + 1
+            missing.setdefault(key, f"{swift.relative_to(repo_root)}:{line}")
+
+# Format keys (from interpolated calls) and multi-line keys come from the call
+# shapes the scan skips, so they can't be proven unused here.
+orphans = sorted(k for k in known - used if "%" not in k and "\n" not in k)
+untranslated = sorted(
+    k for k in known if "zh-Hans" not in catalog["strings"][k].get("localizations", {})
+)
+
+for key, where in sorted(missing.items()):
+    print(f"missing from the catalog: {key!r}\n  used at {where}")
+if orphans:
+    print(f"note: {len(orphans)} catalog keys are no longer used in Sources:")
+    for key in orphans[:10]:
+        print(f"  {key!r}")
+if untranslated:
+    print(f"note: {len(untranslated)} keys have no zh-Hans translation yet")
+
+sys.exit(1 if missing else 0)
+PYTHON
+
+# The compiled .lproj resources are checked in because SwiftPM can't compile a
+# String Catalog itself; a catalog edit without a recompile ships stale strings.
+output_dir="$repo_root/Sources/termio/Resources/Localization"
+scratch="$(mktemp -d)"
+# compile-strings.sh writes to the checked-in path, so stash a copy and put it
+# back however this exits: a check must never leave the tree modified.
+cp -R "$output_dir" "$scratch/checked-in"
+restore() {
+    rm -rf "$output_dir"
+    cp -R "$scratch/checked-in" "$output_dir"
+    rm -rf "$scratch"
+}
+trap restore EXIT
+"$repo_root/scripts/compile-strings.sh" >/dev/null
+if ! diff -r "$scratch/checked-in" "$output_dir" >/dev/null; then
+    echo "the compiled .lproj output is stale — run scripts/compile-strings.sh and commit the result"
+    exit 1
+fi


### PR DESCRIPTION
The custom tunnel relay (#253) landed with one string that bypassed the catalog entirely and six that were never added to it. Nothing failed, because a missing key resolves to the English source — a half-translated pane looks correct to anyone testing in English.

## The visible bug

`TunnelManager.Spec.label` is a plain `String`, so `Text(provider.label)` rendered the Custom entry verbatim. A Chinese user saw `自定义` in the theme picker and `Custom` in the tunnel picker, from the same catalog key. The three bundled providers are proper nouns and stay untranslated; the two entries that are ordinary words now go through the catalog.

## Translator context

#278 translated the six new strings while this branch was open, so the catalog change here is what's still missing: comments on the eight keys where a translator has no way to guess the context. One marks `{port}` as a literal token to leave exactly as written; two warn that "Custom" names a picker entry that has to match. The compiled `.lproj` output is unchanged — comments are metadata.

## The gate

`scripts/check-strings.sh` fails on the two kinds of drift nothing else can see:

1. a `localized("…")` key the catalog doesn't carry
2. a catalog edit committed without recompiling the `.lproj` output SwiftPM actually ships

Six keys reached main unnoticed with the custom relay, and `Font` had been resolving to English since the catalog landed — the check found that one too. It runs in `macos.yml` before the build, takes seconds, and restores the tree on failure. Interpolated and multi-line `localized()` calls are skipped, since their keys can't be derived from the text; that limitation is written into the script.

## Release Notes:

- The Custom tunnel option in Settings ▸ Mobile is now translated rather than showing English in localized builds.