### PR TITLE
Use the Termio brand casing in landing prose

### DIFF
--- a/Sources/termio/Resources/skills/termio/SKILL.md
+++ b/Sources/termio/Resources/skills/termio/SKILL.md
@@ -3,7 +3,7 @@ name: termio
 description: See and drive the sibling agent sessions running alongside you in this Termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside Termio (TERMIO_SESSION set).
 ---
 
-# Driving sibling sessions (termio)
+# Driving sibling sessions (Termio)
 
 If `TERMIO_SESSION` is not set in your environment, you are not running inside
 a Termio-managed session — say so and stop instead of trying to drive sessions

--- a/Sources/termio/Resources/skills/termio/SKILL.md
+++ b/Sources/termio/Resources/skills/termio/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: termio
-description: See and drive the sibling agent sessions running alongside you in this termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside termio (TERMIO_SESSION set).
+description: See and drive the sibling agent sessions running alongside you in this Termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside Termio (TERMIO_SESSION set).
 ---
 
 # Driving sibling sessions (termio)
 
 If `TERMIO_SESSION` is not set in your environment, you are not running inside
-a termio-managed session — say so and stop instead of trying to drive sessions
+a Termio-managed session — say so and stop instead of trying to drive sessions
 you cannot see.
 
-You are running inside termio alongside other agent sessions in this same
+You are running inside Termio alongside other agent sessions in this same
 project. Coordinate with them through the `termio sessions` CLI. Every command
 is scoped to this project automatically; add `--json` for machine-readable
 output. The installed CLI is the authority on syntax: where this text and
@@ -29,7 +29,7 @@ id-prefix works too).
   one snapshot line per sibling's current status
   (`"snapshot":true` in `--json`; `--no-snapshot` skips), and in `--json`
   writes `{"heartbeat":true}` after 30s of silence so a dead stream is
-  detectable. Exits 0 on your Ctrl-C, 2 if termio itself went away.
+  detectable. Exits 0 on your Ctrl-C, 2 if Termio itself went away.
 - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
   prompt (`--agent codex` picks the agent; default: your own kind). Replies
   immediately with the new session's link — use it for every follow-up;

--- a/VOICE.md
+++ b/VOICE.md
@@ -142,8 +142,9 @@ literal someone types or the system reads: the `termio` CLI and its subcommands,
 `sh.termio.app`, `~/.termio`, `TERMIO_SESSION`, termio.sh, and the skill's own
 `name: termio`. Never `TermIO`.
 
-The landing site and the `termio` skill follow this. The README, `docs/`, and the
-UI strings are still mostly lowercase in prose — backlog, not a second standard.
+The landing site, the README, the UI strings, and the `termio` skill follow this.
+The design docs under `docs/` still use lowercase in prose — backlog, not a
+second standard.
 
 ### Never describe termio as paid
 

--- a/VOICE.md
+++ b/VOICE.md
@@ -136,13 +136,14 @@ Decided. A synonym is a bug, not a style choice.
 | agent | assistant, bot, AI |
 | needs you | blocked, waiting for input (as a status label) |
 
-`termio` is lowercase, including at the start of a sentence — what the README,
-the docs, and the UI strings do. Never `TermIO`.
+**Termio** in prose, `termio` on the command line. The brand is capitalized
+wherever it names the product in a sentence. It stays lowercase wherever it is a
+literal someone types or the system reads: the `termio` CLI and its subcommands,
+`sh.termio.app`, `~/.termio`, `TERMIO_SESSION`, termio.sh, and the skill's own
+`name: termio`. Never `TermIO`.
 
-**Open:** the landing site is split, roughly 79 `Termio` to 49 `termio`. Either
-it converges on lowercase like the rest of the repo, or the marketing surface
-gets a stated exception. Until that is decided, don't "fix" landing strings
-either way as a drive-by.
+The landing site and the `termio` skill follow this. The README, `docs/`, and the
+UI strings are still mostly lowercase in prose — backlog, not a second standard.
 
 ### Never describe termio as paid
 
@@ -328,7 +329,7 @@ sentence, a label, or a commit message is always wrong.
 - [ ] **Next action** — do empty states and errors tell the user what to do?
 - [ ] **Rhythm** — do the sentences vary in length, or all run the same?
 - [ ] **Vocabulary** — Group with / Ungroup / Close Session / session / project
-      / agent, lowercase `termio`?
+      / agent, `Termio` in prose and `termio` in commands?
 - [ ] **Case** — sentence case for sentences, Title Case for feature names?
 - [ ] **Apostrophes** — curly, and `Couldn't` over `Could not`?
 - [ ] **Never paid** — no upgrade, unlock, pro, trial, or tier?

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -3,7 +3,7 @@ name: termio
 description: See and drive the sibling agent sessions running alongside you in this Termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside Termio (TERMIO_SESSION set).
 ---
 
-# Driving sibling sessions (termio)
+# Driving sibling sessions (Termio)
 
 If `TERMIO_SESSION` is not set in your environment, you are not running inside
 a Termio-managed session — say so and stop instead of trying to drive sessions

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: termio
-description: See and drive the sibling agent sessions running alongside you in this termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside termio (TERMIO_SESSION set).
+description: See and drive the sibling agent sessions running alongside you in this Termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside Termio (TERMIO_SESSION set).
 ---
 
 # Driving sibling sessions (termio)
 
 If `TERMIO_SESSION` is not set in your environment, you are not running inside
-a termio-managed session — say so and stop instead of trying to drive sessions
+a Termio-managed session — say so and stop instead of trying to drive sessions
 you cannot see.
 
-You are running inside termio alongside other agent sessions in this same
+You are running inside Termio alongside other agent sessions in this same
 project. Coordinate with them through the `termio sessions` CLI. Every command
 is scoped to this project automatically; add `--json` for machine-readable
 output. The installed CLI is the authority on syntax: where this text and
@@ -29,7 +29,7 @@ id-prefix works too).
   one snapshot line per sibling's current status
   (`"snapshot":true` in `--json`; `--no-snapshot` skips), and in `--json`
   writes `{"heartbeat":true}` after 30s of silence so a dead stream is
-  detectable. Exits 0 on your Ctrl-C, 2 if termio itself went away.
+  detectable. Exits 0 on your Ctrl-C, 2 if Termio itself went away.
 - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
   prompt (`--agent codex` picks the agent; default: your own kind). Replies
   immediately with the new session's link — use it for every follow-up;

--- a/web/landing/README.md
+++ b/web/landing/README.md
@@ -1,13 +1,13 @@
-# termio — landing page
+# Termio — landing page
 
-The marketing site for **termio**, a native macOS terminal that gives every AI
+The marketing site for **Termio**, a native macOS terminal that gives every AI
 coding agent (Claude Code, Codex, Gemini, Amp, and more) a first-class home.
-termio is **free to use** — the site's only call to action is the Mac download.
+Termio is **free to use** — the site's only call to action is the Mac download.
 
 Built with **Next.js (App Router) + TypeScript + Tailwind CSS v4 + shadcn/ui**.
 The visual design is modeled on [superwhisper.com](https://superwhisper.com) — a
 dark, cinematic, gradient-forward Mac-app aesthetic — while all copy and product
-facts are about termio.
+facts are about Termio.
 
 ## Run it
 

--- a/web/landing/public/screenshots/README.md
+++ b/web/landing/public/screenshots/README.md
@@ -6,7 +6,7 @@ hand-built CSS mockups so the page shows the actual product.
 ## Hero (the one that matters most)
 
 - **File:** `public/screenshots/hero.png` (or `.webp` — webp is smaller, prefer it)
-- **What to show:** the termio window, **dark**, showing the sidebar (project →
+- **What to show:** the Termio window, **dark**, showing the sidebar (project →
   agent sessions) next to a **working** terminal pane — ideally a real Claude Code
   or Codex session mid-task. A dark screenshot is correct: it floats as a dark
   product shot on the light page (Apple "dark device on white" treatment).

--- a/web/landing/public/skill.md
+++ b/web/landing/public/skill.md
@@ -3,7 +3,7 @@ name: termio
 description: See and drive the sibling agent sessions running alongside you in this Termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside Termio (TERMIO_SESSION set).
 ---
 
-# Driving sibling sessions (termio)
+# Driving sibling sessions (Termio)
 
 If `TERMIO_SESSION` is not set in your environment, you are not running inside
 a Termio-managed session — say so and stop instead of trying to drive sessions

--- a/web/landing/public/skill.md
+++ b/web/landing/public/skill.md
@@ -1,15 +1,15 @@
 ---
 name: termio
-description: See and drive the sibling agent sessions running alongside you in this termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside termio (TERMIO_SESSION set).
+description: See and drive the sibling agent sessions running alongside you in this Termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside Termio (TERMIO_SESSION set).
 ---
 
 # Driving sibling sessions (termio)
 
 If `TERMIO_SESSION` is not set in your environment, you are not running inside
-a termio-managed session — say so and stop instead of trying to drive sessions
+a Termio-managed session — say so and stop instead of trying to drive sessions
 you cannot see.
 
-You are running inside termio alongside other agent sessions in this same
+You are running inside Termio alongside other agent sessions in this same
 project. Coordinate with them through the `termio sessions` CLI. Every command
 is scoped to this project automatically; add `--json` for machine-readable
 output. The installed CLI is the authority on syntax: where this text and
@@ -29,7 +29,7 @@ id-prefix works too).
   one snapshot line per sibling's current status
   (`"snapshot":true` in `--json`; `--no-snapshot` skips), and in `--json`
   writes `{"heartbeat":true}` after 30s of silence so a dead stream is
-  detectable. Exits 0 on your Ctrl-C, 2 if termio itself went away.
+  detectable. Exits 0 on your Ctrl-C, 2 if Termio itself went away.
 - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
   prompt (`--agent codex` picks the agent; default: your own kind). Replies
   immediately with the new session's link — use it for every follow-up;


### PR DESCRIPTION
#215 left the landing site's `Termio`/`termio` split open as a call to make deliberately. Making it: prose takes the capital, and the lowercase stays wherever the word is literally lowercase.

Auditing the site by context rather than by raw count, almost every lowercase `termio` was already correct — the CLI command (64 code spans, 10 shell invocations, 30 fenced examples), URLs and paths (`termio.sh`, `termio-sh/termio`, `~/.termio`, `sh.termio.app`, `termio://session/…`), and source paths in comments. The prose split was down to two READMEs and the agent skill.

Left lowercase on purpose:

- `name: termio` and the heading that echoes it — the skill's id
- "a termio skill" in the changelog — the skill is named `termio`
- every `termio sessions …` command and every URL, path, and bundle id

The skill is edited at its source (`Sources/termio/Resources/skills/termio/SKILL.md`) and at both mirrors together, so the three stay byte-identical; `SessionSkillInstallerTests` passes. Agents get the reworded skill the next time the app installs it.

Release Notes: none — documentation and the agent skill's own prose.