### PR TITLE
Drop a file into the pane under the pointer

### DIFF
--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -42,20 +42,12 @@ struct TerminalPane: View {
     static let splitCoordinateSpace = "termio.splitPane"
     @EnvironmentObject var store: TermioStore
     @EnvironmentObject var settings: AppSettings
-    @Environment(\.colorScheme) private var colorScheme
     @State private var focusDriver = TerminalFocusDriver()
     @State private var activated: [Session.ID] = []
-    @State private var isDropTargeted = false
-
-    /// The wash painted over the terminal while a file is dragged onto it. The old fill was a flat
-    /// `accentColor.opacity(0.18)`, which read as a heavy, saturated blue. This is a much softer,
-    /// desaturated blue-grey: barely-there in light mode, a touch stronger in dark so it still
-    /// registers over a dark terminal without looking like a solid panel.
-    private var dropTint: Color {
-        colorScheme == .dark
-            ? Color(.sRGB, red: 0.62, green: 0.70, blue: 0.82, opacity: 0.10)
-            : Color(.sRGB, red: 0.40, green: 0.52, blue: 0.68, opacity: 0.09)
-    }
+    /// The pane the pointer is currently over during a drag. With splits, the drop
+    /// resolves to one pane, not the whole terminal group: the wash and the insert
+    /// both follow the pane under the pointer.
+    @State private var dropTargetPane: Session.ID?
 
     var body: some View {
         GeometryReader { geo in
@@ -72,17 +64,6 @@ struct TerminalPane: View {
         // Paint the terminal's own background behind the pane, extending up under the toolbar so
         // the system toolbar material picks up a terminal tint instead of a flat grey band.
         .background(paneBackground.ignoresSafeArea(.container, edges: .top))
-        // A VSCode-style drop overlay: just a translucent accent wash over the whole
-        // terminal while a file is dragged over it (their `terminal-dropBackground`) —
-        // no border, only the background tint, fading in and out.
-        .overlay {
-            if isDropTargeted {
-                dropTint
-                    .allowsHitTesting(false)
-                    .transition(.opacity)
-            }
-        }
-        .animation(.easeOut(duration: 0.15), value: isDropTargeted)
         // The ⌘⇧O/⌘⇧P palette lives in its own floating NSPanel (owned by
         // the app delegate — a SwiftUI overlay would render *under* the NSView
         // terminal surfaces); this only hands focus back to the terminal when
@@ -90,14 +71,6 @@ struct TerminalPane: View {
         .onChange(of: store.paletteMode) { _, mode in
             if mode == nil { requestSelectedTerminalFocus(reason: .paletteClosed) }
         }
-        // Dropping a file (dragged from the file-tree inspector or the Finder) inserts
-        // its shell-quoted path at the prompt — the prebuilt libghostty surface does not
-        // register for file drops itself, so the pane catches them and feeds the path to
-        // the selected session's surface. No trailing return, so the path is inserted for
-        // the user (or the agent) to act on rather than run.
-        .dropDestination(for: URL.self) { urls, _ in
-            sendPaths(urls)
-        } isTargeted: { isDropTargeted = $0 }
         // Every visible pane must be mounted — with splits that is all the
         // tree's leaves, not just the selection.
         .onChange(of: store.visiblePaneIDs, initial: true) { _, ids in
@@ -190,6 +163,28 @@ struct TerminalPane: View {
                     }
                 )
                 .frame(width: rect.width, height: rect.height)
+                // Dropping a file (dragged from the file-tree inspector, the Issues list or
+                // the Finder) inserts its shell-quoted path at the prompt — the prebuilt
+                // libghostty surface does not register for file drops itself, so each pane
+                // catches them and feeds the path to *its own* session. No trailing return,
+                // so the path is inserted for the user (or the agent) to act on rather than run.
+                //
+                // This must sit above `.position`, which grows the modified view to fill the
+                // whole terminal group: a drop destination applied after it would accept the
+                // drag anywhere, and the topmost pane in the stack would swallow every drop.
+                .dropDestination(for: URL.self) { urls, _ in
+                    guard isVisible else { return false }
+                    return sendPaths(urls, to: id)
+                } isTargeted: { targeted in
+                    guard isVisible else { return }
+                    // Moving between panes can report the new pane's `true` before the old
+                    // pane's `false`; only the pane that still owns the highlight clears it.
+                    if targeted {
+                        dropTargetPane = id
+                    } else if dropTargetPane == id {
+                        dropTargetPane = nil
+                    }
+                }
                 .position(x: rect.midX, y: rect.midY)
                 .opacity(isVisible ? 1 : 0)
                 .allowsHitTesting(isVisible)
@@ -215,6 +210,12 @@ struct TerminalPane: View {
             if let drag = store.paneDrag, let layout, !zoomed {
                 PaneDragOverlay(drag: drag, layout: layout, preview: store.paneDragPreview)
             }
+            // Dragging a file or an issue in reads the same as dragging a pane around:
+            // the identical wash over the one pane the release would land in, sliding
+            // from pane to pane rather than blinking.
+            PaneDropWash(rect: dropTargetPane.map { id in
+                zoomed && store.selectedSessionID == id ? bounds : (paneFrames[id] ?? bounds)
+            } ?? .zero)
         }
         // Ghostty's own timing (`SurfaceDragSource`): the handle fades in and
         // brightens rather than blinking. The drag overlay animates its own
@@ -281,23 +282,25 @@ struct TerminalPane: View {
         )
     }
 
-    /// Inserts the dropped files' paths into the selected session's terminal,
+    /// Inserts the dropped files' paths into the dropped-on pane's terminal,
     /// space-separated and each shell-quoted so spaces and other special characters
     /// survive. Focuses the session first (VSCode's focus-on-drop), and if its shell
     /// isn't attached yet, activates the session so its surface mounts and retries
     /// once it has come up. Returns whether a drop was accepted at all.
-    private func sendPaths(_ urls: [URL]) -> Bool {
+    private func sendPaths(_ urls: [URL], to id: Session.ID) -> Bool {
         guard !urls.isEmpty,
-              let id = store.selectedSessionID,
               let session = store.session(id),
               let project = store.project(for: id) else { return false }
+        // The drop is also a selection: the path lands where the pointer released, so
+        // that pane takes the write token before focus moves (`requestTerminalFocus`
+        // only focuses the selected session).
+        store.selectedSessionID = id
         requestTerminalFocus(for: id, reason: .fileDrop)
         let text = urls.map { TermioStore.promptToken(for: $0) }.joined(separator: " ") + " "
         if store.surface(for: session, in: project).send(text) { return true }
 
         // The shell may not be attached yet (a freshly opened session whose surface
-        // hasn't mounted). Activating it mounts the surface; retry a moment later, once.
-        store.selectedSessionID = id
+        // hasn't mounted). Selecting it above mounts the surface; retry a moment later, once.
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(300))
             if !store.surface(for: session, in: project).send(text) {
@@ -721,6 +724,44 @@ private struct PaneGrabHandle: View {
 /// still of the pane riding under the pointer. Geometry comes straight from the
 /// tree's `layout`, so the preview and the drop can never disagree. The tint
 /// family is the file-drop wash's desaturated blue-grey, not accent blue.
+/// Where a release would land: a fill in the split tint over one pane (or one half of
+/// it), no border — the rect's own edge already draws the boundary, a stroke would say
+/// it twice. Shared by the pane-rearrange drag and by dragging a file or an issue in,
+/// so both drags speak with the same highlight.
+///
+/// Always mounted and hidden by opacity, because a view that survives every target
+/// change is what lets SwiftUI interpolate the rect — the wash then slides from pane to
+/// pane instead of blinking out and back in somewhere else. Leaving every target keeps
+/// the last rect and only fades it; animating the frame to nothing reads as the wash
+/// shrinking away rather than releasing.
+private struct PaneDropWash: View {
+    /// `.zero` when the pointer is over nothing droppable.
+    let rect: CGRect
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var lastRect: CGRect = .zero
+
+    static func tint(for scheme: ColorScheme) -> Color {
+        scheme == .dark
+            ? Color(.sRGB, red: 0.62, green: 0.70, blue: 0.82, opacity: 1)
+            : Color(.sRGB, red: 0.40, green: 0.52, blue: 0.68, opacity: 1)
+    }
+
+    var body: some View {
+        let drawn = rect == .zero ? lastRect : rect
+        return Rectangle()
+            .fill(Self.tint(for: colorScheme).opacity(colorScheme == .dark ? 0.20 : 0.17))
+            .frame(width: drawn.width, height: drawn.height)
+            .position(x: drawn.midX, y: drawn.midY)
+            .opacity(rect == .zero ? 0 : 1)
+            .allowsHitTesting(false)
+            .animation(.easeInOut(duration: 0.15), value: drawn)
+            .animation(.easeInOut(duration: 0.15), value: rect == .zero)
+            .onChange(of: rect) { _, new in
+                if new != .zero { lastRect = new }
+            }
+    }
+}
+
 private struct PaneDragOverlay: View {
     /// Ghostty's own drag-image scale (`SurfaceDragSource.previewScale`).
     private static let previewScale: CGFloat = 0.2
@@ -732,7 +773,6 @@ private struct PaneDragOverlay: View {
     /// empty card.
     let preview: NSImage?
     @Environment(\.colorScheme) private var colorScheme
-    @State private var lastHighlight: CGRect = .zero
 
     /// The pointer in the pane area's coordinate space, rebuilt from the pane it
     /// is over plus the local point the hit test already resolved.
@@ -741,11 +781,7 @@ private struct PaneDragOverlay: View {
         return CGPoint(x: frame.minX + pointer.local.x, y: frame.minY + pointer.local.y)
     }
 
-    private var tint: Color {
-        colorScheme == .dark
-            ? Color(.sRGB, red: 0.62, green: 0.70, blue: 0.82, opacity: 1)
-            : Color(.sRGB, red: 0.40, green: 0.52, blue: 0.68, opacity: 1)
-    }
+    private var tint: Color { PaneDropWash.tint(for: colorScheme) }
 
     /// The half (or whole pane) the release would fill, or `.zero` when the
     /// pointer is over nothing droppable.
@@ -759,7 +795,7 @@ private struct PaneDragOverlay: View {
     var body: some View {
         ZStack {
             liftedSource
-            dropHighlight
+            PaneDropWash(rect: highlightRect)
             draggedPreview
         }
         .allowsHitTesting(false)
@@ -773,30 +809,6 @@ private struct PaneDragOverlay: View {
                 .frame(width: source.width, height: source.height)
                 .position(x: source.midX, y: source.midY)
         }
-    }
-
-    /// Where the release would land. Fill only, no border — the same restraint
-    /// as the file-drop wash (and ghostty's split-drag overlay): the rect's edge
-    /// already draws the boundary, a stroke would say it twice.
-    ///
-    /// Always mounted and hidden by opacity, because a view that survives every
-    /// zone change is what lets SwiftUI interpolate the rect — the highlight
-    /// then slides from half to half instead of blinking out and back in
-    /// somewhere else. Leaving every zone keeps the last rect and only fades it;
-    /// animating the frame to nothing reads as the wash shrinking away rather
-    /// than releasing.
-    private var dropHighlight: some View {
-        let rect = highlightRect == .zero ? lastHighlight : highlightRect
-        return Rectangle()
-            .fill(tint.opacity(colorScheme == .dark ? 0.20 : 0.17))
-            .frame(width: rect.width, height: rect.height)
-            .position(x: rect.midX, y: rect.midY)
-            .opacity(highlightRect == .zero ? 0 : 1)
-            .animation(.easeInOut(duration: 0.15), value: rect)
-            .animation(.easeInOut(duration: 0.15), value: highlightRect == .zero)
-            .onChange(of: highlightRect) { _, new in
-                if new != .zero { lastHighlight = new }
-            }
     }
 
     /// A still of the dragged pane under the pointer, at ghostty's drag-image


### PR DESCRIPTION
With a split, the terminal had a single drop target: the wash covered the whole group and the dropped path always went to the selected session, wherever you released it.

Each mounted pane now owns its own drop destination, and the drop selects and focuses that pane before inserting the path. The destination has to sit above `.position` — that modifier grows the view to fill the whole group, so a destination applied after it accepted the drag anywhere and the topmost pane in the stack swallowed every drop.

The hover wash is now the same highlight the pane-rearrange drag draws, factored into a shared `PaneDropWash`: always mounted, so the rect interpolates and the highlight slides from pane to pane instead of blinking.

Release Notes:
- Dragging a file or an issue onto a split now drops it into the pane under the pointer, which highlights on its own.