### PR TITLE
Remove unreachable code

### DIFF
--- a/Sources/termio/Agents/HookListener.swift
+++ b/Sources/termio/Agents/HookListener.swift
@@ -311,28 +311,17 @@ enum AgentStatusHooks {
         }
         // Stamp the build version as a trailing shell comment (ignored at runtime): the
         // command string changes each release, so the idempotent `write()` re-installs the
-        // hook on the first launch after an upgrade, and `installedVersion` can read it back.
+        // hook on the first launch after an upgrade.
         command += " \(hookVersionComment)"
         return command
     }
 
-    /// Marker + version stamped into every installed hook (`# termio-hooks v0.21.0`);
-    /// the marker is the anchor `installedVersion` scans for.
+    /// Marker + version stamped into every installed hook (`# termio-hooks v0.21.0`).
     static let hookVersionMarker = "# termio-hooks v"
     static var appVersion: String {
         (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "0"
     }
     static var hookVersionComment: String { "\(hookVersionMarker)\(appVersion)" }
-
-    /// The termio-hooks version stamped in a host hooks file, or `nil` if none is present —
-    /// so a caller can tell current from stale from not-installed.
-    static func installedVersion(inFileAt url: URL) -> String? {
-        guard let text = try? String(contentsOf: url, encoding: .utf8),
-              let range = text.range(of: hookVersionMarker) else { return nil }
-        let tail = text[range.upperBound...]
-        let version = tail.prefix { !$0.isWhitespace && $0 != "\"" && $0 != "\\" }
-        return version.isEmpty ? nil : String(version)
-    }
 
     /// Absolute path to this channel's stable `termio`/`termio-dev` CLI copy under
     /// Application Support (see `CommandLineTool.supportCopyURL`), stamped into each
@@ -391,7 +380,6 @@ private struct JSONHookFile: AgentStatusInstaller {
     /// tool events (the shape it expects) and `nil` everywhere else — Codex treats
     /// a missing matcher as "match every occurrence".
     let events: [AgentHookEvent]
-    let label: String
     /// Whether this agent's hooks pass a JSON payload on stdin we can mine for the
     /// session's `transcript_path`. Only enabled for agents verified to always
     /// supply stdin (Claude Code, Codex), so the capturing `cat` can't block.
@@ -426,7 +414,6 @@ private struct JSONHookFile: AgentStatusInstaller {
         return JSONHookFile(
             url: url,
             events: spec.events,
-            label: id,
             capturesTranscript: spec.capturesTranscript,
             conversationField: spec.conversation,
             toolField: spec.tool,

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -120,7 +120,6 @@ enum AgentIcon: Hashable {
 /// with iOS); these aliases keep the app's unqualified references compiling.
 typealias HugeIcon = TermioShared.HugeIcon
 typealias HugeIconView = TermioShared.HugeIconView
-typealias HugeIconShape = TermioShared.HugeIconShape
 
 /// GitHub's Octicons for issue/PR state, shared with iOS from `TermioShared`.
 typealias StateOcticon = TermioShared.StateOcticon

--- a/Sources/termio/Editor/MarkdownReaderView.swift
+++ b/Sources/termio/Editor/MarkdownReaderView.swift
@@ -43,7 +43,6 @@ struct MarkdownReaderView: View {
             html: MermaidRenderer.applying(drawn, to: document),
             baseURL: fileURL.deletingLastPathComponent(),
             fileURL: fileURL,
-            background: settings.terminalBackgroundColor,
             addToChat: addToChat,
             canAddToChat: canAddToChat
         )
@@ -69,7 +68,6 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
     let html: String
     let baseURL: URL
     let fileURL: URL
-    let background: NSColor
     var addToChat: ((String?) -> Void)?
     var canAddToChat: (() -> Bool)?
 

--- a/Sources/termio/Editor/TextFindEngine.swift
+++ b/Sources/termio/Editor/TextFindEngine.swift
@@ -66,12 +66,6 @@ final class TextFindEngine {
         }
     }
 
-    /// Drop every match and wipe the highlights — the query cleared or the bar closed.
-    func clear(in textView: NSTextView) {
-        matches.removeAll()
-        clearHighlights(in: textView)
-    }
-
     private func clearHighlights(in textView: NSTextView) {
         guard let layoutManager = textView.layoutManager else { return }
         let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)

--- a/Sources/termio/Editor/TextPositions.swift
+++ b/Sources/termio/Editor/TextPositions.swift
@@ -1,34 +1,10 @@
 import Foundation
 
 /// The editor's one line/offset vocabulary. `NSString` offsets *are* UTF-16 code units — the
-/// unit `NSTextView` selections use — so every conversion here is pure newline bookkeeping, no
-/// transcoding. Linear scans are fine: callers are user-initiated (a caret move, a search-hit
-/// reveal) on editor-sized buffers, and the scan allocates nothing (unlike the
-/// `substring`/`components` split it replaced in the footer path).
+/// unit `NSTextView` selections use — so the conversion here is pure newline bookkeeping, no
+/// transcoding. A linear scan is fine: the caller is user-initiated (a search-hit reveal) on an
+/// editor-sized buffer, and the scan allocates nothing.
 enum TextPositions {
-    /// Text-view character offset → 0-based (line, UTF-16 character). In a `\r\n` pair only the
-    /// `\n` advances the line.
-    static func position(utf16Offset: Int, in text: NSString) -> (line: Int, character: Int) {
-        let offset = min(max(utf16Offset, 0), text.length)
-        var line = 0
-        var lineStart = 0
-        var index = 0
-        while index < offset {
-            if text.character(at: index) == 0x0A {
-                line += 1
-                lineStart = index + 1
-            }
-            index += 1
-        }
-        return (line, offset - lineStart)
-    }
-
-    /// The same scan in the footer's 1-based dialect (`Ln 12, Col 4`).
-    static func lineColumn(utf16Offset: Int, in text: NSString) -> (line: Int, column: Int) {
-        let position = position(utf16Offset: utf16Offset, in: text)
-        return (position.line + 1, position.character + 1)
-    }
-
     /// 1-based line number → the offset of that line's first character, clamped to the last
     /// line when the number runs past the end (the reveal-a-search-hit contract).
     static func offset(ofLine line: Int, in text: NSString) -> Int {

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -201,7 +201,6 @@ struct FileBrowserView: View {
             if let root {
                 FileSearchView(
                     rootURL: root.url,
-                    font: settings.interfaceFont,
                     onDismiss: { store.inspectorTab = .files },
                     onOpen: { url, line in store.openFileInEditor(url, at: line) }
                 )

--- a/Sources/termio/FileBrowser/FileSearchView.swift
+++ b/Sources/termio/FileBrowser/FileSearchView.swift
@@ -13,7 +13,6 @@ struct FileSearchView: View {
 
     /// The project (or worktree) root the search runs under.
     let rootURL: URL
-    let font: Font
     /// Leaves the pane (back to the Files tab) — Esc in an empty field.
     let onDismiss: () -> Void
     /// Opens a hit in the editor at its 1-based line.

--- a/Sources/termio/FileBrowser/FileTreeControls.swift
+++ b/Sources/termio/FileBrowser/FileTreeControls.swift
@@ -45,12 +45,6 @@ struct TreeHeaderButton: View {
         self.action = action
     }
 
-    init(symbol: String, help: String, action: @escaping () -> Void) {
-        self.source = .symbol(symbol)
-        self.help = help
-        self.action = action
-    }
-
     init(huge: HugeIcon, help: String, action: @escaping () -> Void) {
         self.source = .huge(huge)
         self.help = help

--- a/Sources/termio/Info/MermaidRenderer.swift
+++ b/Sources/termio/Info/MermaidRenderer.swift
@@ -33,7 +33,6 @@ final class MermaidRenderer: NSObject {
         let panel: String
         let foreground: String
         let muted: String
-        let accent: String
         let line: String
 
         init(_ theme: TraceTheme) {
@@ -41,7 +40,6 @@ final class MermaidRenderer: NSObject {
             panel = theme.panel
             foreground = theme.foreground
             muted = theme.secondary
-            accent = theme.accent
             line = theme.isDark ? "rgba(255,255,255,0.22)" : "rgba(0,0,0,0.22)"
         }
     }

--- a/Sources/termio/Info/TraceView.swift
+++ b/Sources/termio/Info/TraceView.swift
@@ -133,7 +133,7 @@ struct TraceView: View {
     @ViewBuilder private var content: some View {
         Group {
             if let html {
-                TraceWebView(html: html, background: settings.terminalBackgroundColor)
+                TraceWebView(html: html)
             } else if let loadError {
                 ContentUnavailableView("Couldn’t build the trace", huge: .bot, description: Text(loadError))
             } else {
@@ -171,7 +171,6 @@ struct TraceView: View {
 /// during load, avoiding a white flash before the themed page paints.
 private struct TraceWebView: NSViewRepresentable {
     let html: String
-    let background: NSColor
 
     func makeNSView(context: Context) -> WKWebView {
         // PreviewWebView: right-click stripped to Copy — the rendered trace is

--- a/Sources/termio/Issues/GitHubIssueProvider.swift
+++ b/Sources/termio/Issues/GitHubIssueProvider.swift
@@ -52,7 +52,7 @@ struct GitHubIssueProvider: IssueProvider {
         let raw: [RawIssue] = try await get(components.url!)
         return raw
             .filter { ($0.pullRequest != nil) == (query.kind == .pullRequest) }
-            .map { $0.summary(in: container) }
+            .map { $0.summary() }
     }
 
     func detail(_ number: Int, in container: IssueContainer) async throws -> IssueDetail {
@@ -61,7 +61,7 @@ struct GitHubIssueProvider: IssueProvider {
         async let rawComments: [RawComment] = get(URL(string: "\(base)/comments?per_page=100")!)
         let (issue, comments) = try await (rawIssue, rawComments)
         return IssueDetail(
-            summary: issue.summary(in: container),
+            summary: issue.summary(),
             bodyMarkdown: issue.body ?? "",
             authorAvatarURL: issue.user?.avatarUrl,
             createdAt: issue.createdAt,
@@ -91,27 +91,6 @@ struct GitHubIssueProvider: IssueProvider {
     }
 
     // MARK: Pull-request extras (GitHub-specific, outside the tracker protocol)
-
-    /// The PR's branch facts, from `/pulls/{n}` — the fields the `/issues` view of
-    /// a PR doesn't carry.
-    func pullRequestGitInfo(_ number: Int, in container: IssueContainer) async throws -> PullRequestGitInfo {
-        struct RawPR: Decodable {
-            struct Side: Decodable {
-                struct Repo: Decodable { let fullName: String }
-                let ref: String
-                let repo: Repo?
-            }
-            let head: Side
-            let base: Side
-        }
-        let raw: RawPR = try await get(
-            URL(string: "https://api.github.com/repos/\(container.id)/pulls/\(number)")!)
-        return PullRequestGitInfo(
-            headRef: raw.head.ref,
-            // A deleted fork leaves `head.repo` null — only the pull ref remains.
-            crossRepository: raw.head.repo?.fullName != raw.base.repo?.fullName
-        )
-    }
 
     /// The PR's changed files as `GitChange` rows (the git pane's own model) *with the
     /// diff inline*: the `/pulls/{n}/files` response already carries each file's unified
@@ -215,14 +194,13 @@ private struct RawIssue: Decodable {
     let body: String?
     let labels: [RawLabel]
     let user: RawUser?
-    let comments: Int?
     let createdAt: Date
     let updatedAt: Date
     let htmlUrl: URL?
     let draft: Bool?
     let pullRequest: RawPullRequest?
 
-    func summary(in container: IssueContainer) -> IssueSummary {
+    func summary() -> IssueSummary {
         let kind: IssueKind = pullRequest == nil ? .issue : .pullRequest
         let itemState: IssueItemState
         if state == "open" {
@@ -238,7 +216,6 @@ private struct RawIssue: Decodable {
             state: itemState,
             labels: labels.map { IssueLabel(name: $0.name, colorHex: $0.color ?? "") },
             author: user?.login ?? "ghost",
-            commentCount: comments ?? 0,
             updatedAt: updatedAt,
             url: htmlUrl
         )

--- a/Sources/termio/Issues/IssueCache.swift
+++ b/Sources/termio/Issues/IssueCache.swift
@@ -22,15 +22,14 @@ final class IssueCache {
         let number: Int
     }
 
-    /// One fetched item: the conversation plus (for PRs) the changed files, their inline patches,
-    /// and branch facts — everything `loadDetail` populates in one shot, so a warm read restores the
+    /// One fetched item: the conversation plus (for PRs) the changed files and their inline
+    /// patches — everything `loadDetail` populates in one shot, so a warm read restores the
     /// whole detail with no further network or git work. `fetchedAt` drives the revalidation dedupe
     /// window.
     struct Entry {
         var detail: IssueDetail
         var prFiles: [GitChange]
         var prFilePatches: [String: String]
-        var prInfo: PullRequestGitInfo?
         /// The conversation is cached the instant it lands — *before* a PR's heavy `/files`
         /// response — so even opening a PR and immediately switching away warms the cache. This
         /// marks whether that file list has since folded in: `false` means "files still pending",
@@ -46,7 +45,6 @@ final class IssueCache {
             detail == other.detail
                 && prFiles == other.prFiles
                 && prFilePatches == other.prFilePatches
-                && prInfo == other.prInfo
         }
     }
 

--- a/Sources/termio/Issues/IssueModels.swift
+++ b/Sources/termio/Issues/IssueModels.swift
@@ -93,8 +93,6 @@ struct IssueLabel: Hashable, Sendable {
 struct IssueContainer: Hashable, Sendable {
     let provider: IssueProviderID
     let id: String
-
-    var displayName: String { id }
 }
 
 /// The list request: which kind, and the light filters the top bar offers.
@@ -116,7 +114,6 @@ struct IssueSummary: Identifiable, Hashable, Sendable {
     let state: IssueItemState
     let labels: [IssueLabel]
     let author: String
-    let commentCount: Int
     let updatedAt: Date
     let url: URL?
 
@@ -139,14 +136,6 @@ struct IssueDetail: Equatable, Sendable {
     let authorAvatarURL: URL?
     let createdAt: Date
     let comments: [IssueComment]
-}
-
-/// The branch facts Checkout needs from a pull request — which head ref to fetch,
-/// and whether it lives in a fork (a fork's branch is only reachable through the
-/// `refs/pull/N/head` ref).
-struct PullRequestGitInfo: Equatable, Sendable {
-    let headRef: String
-    let crossRepository: Bool
 }
 
 /// One PR file with its unified-diff `patch` straight from the GitHub API — the Files

--- a/Sources/termio/Issues/IssuesPanelModel.swift
+++ b/Sources/termio/Issues/IssuesPanelModel.swift
@@ -312,7 +312,6 @@ final class IssuesPanelModel: ObservableObject {
         detailError = nil
         prFiles = []
         prFilePatches = [:]
-        prInfo = nil
         prFilesLoading = false
         do {
             let conversation = try await provider.detail(item.number, in: container)
@@ -321,7 +320,7 @@ final class IssuesPanelModel: ObservableObject {
             // Cache the conversation the moment it lands — before a PR's heavy file list — so a
             // switch-away still warms the cache. `filesLoaded: false` marks the pending files.
             cache?.store(
-                .init(detail: conversation, prFiles: [], prFilePatches: [:], prInfo: nil,
+                .init(detail: conversation, prFiles: [], prFilePatches: [:],
                       filesLoaded: item.kind != .pullRequest, fetchedAt: Date()),
                 container, item.number)
             if item.kind == .pullRequest {
@@ -333,25 +332,22 @@ final class IssuesPanelModel: ObservableObject {
         }
     }
 
-    /// Fetches a PR's branch facts + changed files (`/files` carries every patch inline, the heavy
-    /// part) and folds them into the already-shown conversation, upgrading the cache entry to
+    /// Fetches a PR's changed files (`/files` carries every patch inline, the heavy part) and folds
+    /// them into the already-shown conversation, upgrading the cache entry to
     /// `filesLoaded: true`. Runs behind the conversation so the default tab never waits on it; a
     /// failure just leaves the Files tab empty rather than erroring the whole detail.
     private func loadPRFiles(_ item: IssueSummary, provider: GitHubIssueProvider,
                              container: IssueContainer, conversation: IssueDetail) async {
         prFilesLoading = true
-        async let info = provider.pullRequestGitInfo(item.number, in: container)
-        async let files = provider.pullRequestFiles(item.number, in: container)
         do {
-            let (prI, loadedFiles) = try await (info, files)
+            let loadedFiles = try await provider.pullRequestFiles(item.number, in: container)
             guard openItem?.number == item.number else { prFilesLoading = false; return }
             let mapped = prFileMapping(loadedFiles)
-            prInfo = prI
             prFiles = mapped.changes
             prFilePatches = mapped.patches
             cache?.store(
                 .init(detail: conversation, prFiles: mapped.changes, prFilePatches: mapped.patches,
-                      prInfo: prI, filesLoaded: true, fetchedAt: Date()),
+                      filesLoaded: true, fetchedAt: Date()),
                 container, item.number)
         } catch {
             // The conversation stays; the Files tab simply shows no files.
@@ -377,14 +373,13 @@ final class IssuesPanelModel: ObservableObject {
         detail = entry.detail
         prFiles = entry.prFiles
         prFilePatches = entry.prFilePatches
-        prInfo = entry.prInfo
         prFilesLoading = false
         detailError = nil
     }
 
-    /// One network round-trip for an item's full detail: the conversation, and for a PR its git
-    /// info and changed files (with each file's inline patch keyed by path). Pure fetch — no
-    /// state writes — so both the cold and revalidation paths share it.
+    /// One network round-trip for an item's full detail: the conversation, and for a PR its
+    /// changed files (with each file's inline patch keyed by path). Pure fetch — no state
+    /// writes — so both the cold and revalidation paths share it.
     private func fetchEntry(
         _ item: IssueSummary,
         provider: GitHubIssueProvider,
@@ -392,29 +387,27 @@ final class IssuesPanelModel: ObservableObject {
     ) async throws -> IssueCache.Entry {
         if item.kind == .pullRequest {
             async let loadedDetail = provider.detail(item.number, in: container)
-            async let info = provider.pullRequestGitInfo(item.number, in: container)
             async let files = provider.pullRequestFiles(item.number, in: container)
-            let (detail, prInfo, loadedFiles) = try await (loadedDetail, info, files)
+            let (detail, loadedFiles) = try await (loadedDetail, files)
             let mapped = prFileMapping(loadedFiles)
             return .init(
                 detail: detail, prFiles: mapped.changes, prFilePatches: mapped.patches,
-                prInfo: prInfo, filesLoaded: true, fetchedAt: Date())
+                filesLoaded: true, fetchedAt: Date())
         } else {
             let detail = try await provider.detail(item.number, in: container)
             return .init(
-                detail: detail, prFiles: [], prFilePatches: [:], prInfo: nil,
+                detail: detail, prFiles: [], prFilePatches: [:],
                 filesLoaded: true, fetchedAt: Date())
         }
     }
 
     // MARK: Pull-request extras
 
-    /// The PR's changed files (empty for issues) and branch facts.
+    /// The PR's changed files (empty for issues).
     @Published private(set) var prFiles: [GitChange] = []
     /// Each file's inline unified-diff patch from the API, keyed by path — what the Files
     /// tab renders. Absent keys are files GitHub gave no patch for (binary / too large).
     @Published private(set) var prFilePatches: [String: String] = [:]
-    @Published private(set) var prInfo: PullRequestGitInfo?
 
     /// The PR's file list is still in flight *after* the conversation has already rendered —
     /// the two are fetched separately so the (small, fast) conversation isn't gated behind the

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -716,7 +716,6 @@ struct IssueDetailView: View {
                 MermaidRenderer.shared.cachedDiagrams(for: sources, theme: mermaidTheme)) { _, new in new }
             IssueWebView(
                 html: MermaidRenderer.applying(drawn, to: document),
-                background: settings.terminalBackgroundColor,
                 // Selected conversation text goes over as the pasted snippet; a
                 // selection-less click hands the agent the item's GitHub URL — the
                 // same token dragging the list row inserts.
@@ -942,7 +941,6 @@ private enum IssueDetailHTML {
 /// page: transparent while loading, links open in the browser.
 private struct IssueWebView: NSViewRepresentable {
     let html: String
-    let background: NSColor
     /// "Add to Chat" in the conversation's right-click menu — selection as pasted
     /// snippet, `nil` (no selection) as the item's GitHub URL. Injected by
     /// `IssueDetailView`, which holds both the item and the store.

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -69,11 +69,6 @@ struct SettingsLabel: View {
         self.titleFont = titleFont
     }
 
-    /// Convenience for the common SF Symbol case, mirroring `IconBadge(symbol:)`.
-    init(symbol: String, title: String, subtext: String? = nil, titleFont: Font = .headline) {
-        self.init(.symbol(symbol), title: title, subtext: subtext, titleFont: titleFont)
-    }
-
     /// Icon-less row, for a nested sub-option that hangs under an icon-led row.
     init(title: String, subtext: String? = nil, titleFont: Font = .body) {
         self.icon = nil

--- a/Sources/termio/Terminal/PaneDragRearrange.swift
+++ b/Sources/termio/Terminal/PaneDragRearrange.swift
@@ -99,7 +99,7 @@ final class PaneDragRearrange {
         }
         monitor(.leftMouseDown) { [weak self] in self?.began($0) ?? false }
         monitor(.leftMouseDragged) { [weak self] in self?.moved($0) ?? false }
-        monitor(.leftMouseUp) { [weak self] in self?.ended($0) ?? false }
+        monitor(.leftMouseUp) { [weak self] _ in self?.ended() ?? false }
         monitor(.keyDown) { [weak self] in self?.pressedKey($0) ?? false }
         // Never consumed: the reveal only reads the pointer, so it can't
         // interfere with a TUI's own mouse reporting.
@@ -192,7 +192,7 @@ final class PaneDragRearrange {
         return true
     }
 
-    private func ended(_ event: NSEvent) -> Bool {
+    private func ended() -> Bool {
         guard dragging else { return false }
         defer { finish() }
         guard !cancelled, let store, let drag = store.paneDrag,

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -180,7 +180,6 @@ struct TerminalPane: View {
                 // ungrouped session has no split geometry and fills the pane.
                 let rect = zoomed && isSelected ? bounds : (paneFrames[id] ?? bounds)
                 ManagedTerminalSurface(
-                    id: id,
                     context: store.surface(for: item.session, in: item.project),
                     isSelected: isSelected,
                     isVisible: isVisible,
@@ -386,7 +385,6 @@ private enum TerminalFocusReason {
 /// focus is handled from AppKit by TerminalFocusDriver, never by waiting for this value
 /// to transition through nil.
 private struct ManagedTerminalSurface: View {
-    let id: Session.ID
     let context: TerminalViewState
     let isSelected: Bool
     let isVisible: Bool

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -236,7 +236,7 @@ extension TermioStore {
         switch resolveTarget(token, in: project) {
         case .found(let session):
             let state = surface(for: session, in: project)
-            return await deliver(payload, to: session, state: state, request: request, in: project)
+            return await deliver(payload, to: session, state: state, request: request)
         case .notFound:
             return controlError(request, "not_found", targetNotFoundMessage(request.target))
         case .ambiguous:
@@ -355,7 +355,7 @@ extension TermioStore {
     /// turn settles and reports the outcome plus the transcript range it landed in.
     private func deliver(
         _ payload: String, to session: Session, state: TerminalViewState,
-        request: ControlRequest, in project: Project
+        request: ControlRequest
     ) async -> Data {
         guard await performDelivery(payload, to: session, state: state) else {
             return controlError(request, "not_live",

--- a/Tests/termioTests/EditorTextTests.swift
+++ b/Tests/termioTests/EditorTextTests.swift
@@ -4,48 +4,6 @@ import XCTest
 /// The editor's pure text logic: line/offset mapping and bracket pairing. These are the pieces
 /// where a silent off-by-one becomes "revealed the wrong line" — cheap to pin down.
 final class TextPositionsTests: XCTestCase {
-    func testAsciiOffsets() {
-        let text = "let a = 1\nlet b = 2\n" as NSString
-        XCTAssertEqual(TextPositions.position(utf16Offset: 0, in: text).line, 0)
-        XCTAssertEqual(TextPositions.position(utf16Offset: 0, in: text).character, 0)
-        // "l" of the second line: offset 10 → line 1, character 0.
-        XCTAssertEqual(TextPositions.position(utf16Offset: 10, in: text).line, 1)
-        XCTAssertEqual(TextPositions.position(utf16Offset: 10, in: text).character, 0)
-        // Mid-second-line.
-        XCTAssertEqual(TextPositions.position(utf16Offset: 14, in: text).character, 4)
-    }
-
-    func testUTF16UnitsCountSurrogatePairsAsTwo() {
-        // "🙂" is two UTF-16 units, so the symbol after it starts at character 3.
-        let text = "🙂 var x = 1" as NSString
-        let position = TextPositions.position(utf16Offset: 3, in: text)
-        XCTAssertEqual(position.line, 0)
-        XCTAssertEqual(position.character, 3)
-        // CJK stays one unit each.
-        let cjk = "中文注释 foo" as NSString
-        XCTAssertEqual(TextPositions.position(utf16Offset: 5, in: cjk).character, 5)
-    }
-
-    func testCRLFAdvancesOncePerPair() {
-        let text = "a\r\nb\r\nc" as NSString
-        // "b" sits at offset 3: one \r\n behind it → line 1, character 0.
-        XCTAssertEqual(TextPositions.position(utf16Offset: 3, in: text).line, 1)
-        XCTAssertEqual(TextPositions.position(utf16Offset: 3, in: text).character, 0)
-    }
-
-    func testOffsetClampsOutOfRange() {
-        let text = "ab" as NSString
-        XCTAssertEqual(TextPositions.position(utf16Offset: -5, in: text).character, 0)
-        XCTAssertEqual(TextPositions.position(utf16Offset: 99, in: text).character, 2)
-    }
-
-    func testLineColumnIsOneBased() {
-        let text = "ab\ncd" as NSString
-        let footer = TextPositions.lineColumn(utf16Offset: 4, in: text)
-        XCTAssertEqual(footer.line, 2)
-        XCTAssertEqual(footer.column, 2)
-    }
-
     func testOffsetOfLineWalksAndClamps() {
         let text = "one\ntwo\nthree\n" as NSString
         XCTAssertEqual(TextPositions.offset(ofLine: 1, in: text), 0)
@@ -55,13 +13,13 @@ final class TextPositionsTests: XCTestCase {
         XCTAssertLessThan(TextPositions.offset(ofLine: 99, in: text), text.length)
     }
 
-    /// The two directions agree: offset(ofLine:) followed by position() lands on the same line.
-    func testRoundTrip() {
+    /// Multi-byte content doesn't shift the mapping: `offset(ofLine:)` counts UTF-16 units, the
+    /// same unit `NSTextView` selections use.
+    func testOffsetOfLineCountsUTF16Units() {
         let text = "alpha\nβeta 🙂\ngamma" as NSString
-        for line in 1...3 {
-            let offset = TextPositions.offset(ofLine: line, in: text)
-            XCTAssertEqual(TextPositions.position(utf16Offset: offset, in: text).line, line - 1)
-        }
+        XCTAssertEqual(TextPositions.offset(ofLine: 2, in: text), 6)
+        // "🙂" is a surrogate pair, so line 3 starts 8 units after line 2, not 7.
+        XCTAssertEqual(TextPositions.offset(ofLine: 3, in: text), 14)
     }
 }
 


### PR DESCRIPTION
Periphery flagged 93 declarations across the app target. Most were false positives — retain-holder properties, fields read only through synthesized `Equatable`/`Hashable`, `@objc` selector parameters, and the vendored Highlightr API. This removes the ones that were genuinely unreachable, verified by hand.

The one behavior change is in the Issues pane. Opening a pull request fetched `/pulls/{n}` for its branch facts, cached them, and published `prInfo` — which no view ever read. That round-trip per PR open is gone.

`TextPositions.position` and `lineColumn` mapped an offset to a `Ln, Col` editor footer that no longer exists in the codebase; only their tests kept them alive. `offset(ofLine:)` stays and keeps its coverage, plus a new case pinning the UTF-16 arithmetic the deleted round-trip test used to cover.

The rest are unread stored properties and their call-site arguments, two unused initializers, and three vestigial function parameters.

Left in place deliberately: the `IssueProvider` protocol (unused as a type, but a documented extension point for Linear — see `docs/design/issue-tracker-integration.md` and #100) and `Session.createdAt` (unread, but persisted in the state file, so removing it is a schema change rather than a cleanup).

`swift build` clean, 201 tests pass.

Release Notes: None — internal cleanup with no user-visible change.