### PR TITLE
Keep preferences in an editable settings.json

### DIFF
--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -71,7 +71,31 @@ enum ProjectSortOrder: String, CaseIterable, Identifiable {
 /// to already-open terminals.
 @MainActor
 final class AppSettings: ObservableObject {
+    /// State and consent live here: the recent-project list, the last agent a
+    /// chat used, whether the session-control prompt has been answered, and the
+    /// Usage tab's per-agent authorizations. None of it is a preference a user
+    /// would hand-edit or carry to another machine.
     private let defaults: UserDefaults
+    /// Preferences live here, in `settings.json`. See `SettingsStore` for why the
+    /// file holds only what the user actually chose.
+    private let store: SettingsStore
+
+    /// The keys `settings.json` owns — everything in `Key` except the state and
+    /// consent above, plus `themeName`, which exists only to migrate pre-split
+    /// installs into the light/dark pair.
+    private static let fileManagedKeys: Set<String> = [
+        Key.fontFamily, Key.fontSize, Key.fontThicken, Key.codeLineHeight,
+        Key.appearanceMode, Key.lightThemeName, Key.darkThemeName,
+        Key.cursorStyle, Key.cursorBlink, Key.windowPadding,
+        Key.backgroundOpacity, Key.backgroundBlur,
+        Key.scrollbackMegabytes, Key.copyOnSelect,
+        Key.interfaceFontFamily, Key.interfaceFontSize, Key.interfaceRowPadding,
+        Key.agentCommands, Key.bypassPermissionAgents, Key.disabledAgents,
+        Key.addedAgents, Key.agentOrder, Key.agentHooksEnabled,
+        Key.sessionControlEnabled, Key.githubIntegrationEnabled,
+        Key.notifyTaskCompletion, Key.notificationSound,
+        Key.projectSortOrder, Key.defaultChatAgent,
+    ]
 
     private enum Key {
         static let fontFamily = "appearance.fontFamily"
@@ -127,36 +151,36 @@ final class AppSettings: ObservableObject {
     /// as used by Xcode/Terminal). Empty means "let libghostty pick its default
     /// monospace", so we never force a face the user doesn't have installed.
     @Published var fontFamily: String {
-        didSet { defaults.set(fontFamily, forKey: Key.fontFamily) }
+        didSet { store.set(fontFamily, forKey: Key.fontFamily) }
     }
 
     @Published var fontSize: Double {
-        didSet { defaults.set(fontSize, forKey: Key.fontSize) }
+        didSet { store.set(fontSize, forKey: Key.fontSize) }
     }
 
     /// Synthesizes a heavier weight by drawing glyphs slightly thicker — a small
     /// readability win on long agent transcripts.
     @Published var fontThicken: Bool {
-        didSet { defaults.set(fontThicken, forKey: Key.fontThicken) }
+        didSet { store.set(fontThicken, forKey: Key.fontThicken) }
     }
 
     /// Line height for the file editor and diffs, as a multiple of the font size
     /// (VS Code's model). The terminal grid is ghostty's own and is unaffected.
     @Published var codeLineHeight: Double {
-        didSet { defaults.set(codeLineHeight, forKey: Key.codeLineHeight) }
+        didSet { store.set(codeLineHeight, forKey: Key.codeLineHeight) }
     }
 
     /// Whether termio follows the system appearance or pins itself to light or
     /// dark. `App` applies this as an `NSAppearance`; the terminal's light/dark
     /// theme pair then follows the resulting effective appearance.
     @Published var appearanceMode: AppearanceMode {
-        didSet { defaults.set(appearanceMode.rawValue, forKey: Key.appearanceMode) }
+        didSet { store.set(appearanceMode.rawValue, forKey: Key.appearanceMode) }
     }
 
     /// How the sidebar orders projects (pinned always first; see `ProjectSortOrder`).
     /// Driven by the sort menu in the sidebar's toolbar.
     @Published var projectSortOrder: ProjectSortOrder {
-        didSet { defaults.set(projectSortOrder.rawValue, forKey: Key.projectSortOrder) }
+        didSet { store.set(projectSortOrder.rawValue, forKey: Key.projectSortOrder) }
     }
 
     /// Folders the user has opened, most-recent first, so the welcome page's
@@ -184,7 +208,7 @@ final class AppSettings: ObservableObject {
     /// it so ⌘N always starts that one. Resolved by `TermioStore.defaultChatAgent`,
     /// which also falls back gracefully when the pinned agent is later disabled.
     @Published var defaultChatAgentID: String? {
-        didSet { defaults.set(defaultChatAgentID, forKey: Key.defaultChatAgent) }
+        didSet { store.set(defaultChatAgentID, forKey: Key.defaultChatAgent) }
     }
 
     /// The most a project can be opened is capped so the Recent column stays a
@@ -208,42 +232,42 @@ final class AppSettings: ObservableObject {
     /// and `darkThemeName` automatically as the system appearance changes. Resolved
     /// against `GhosttyThemeCatalog` in `TermioStore`.
     @Published var lightThemeName: String {
-        didSet { defaults.set(lightThemeName, forKey: Key.lightThemeName) }
+        didSet { store.set(lightThemeName, forKey: Key.lightThemeName) }
     }
 
     /// Name of the Ghostty bundled theme used while macOS is in dark mode, or empty
     /// for termio's default dark canvas. Counterpart to `lightThemeName`.
     @Published var darkThemeName: String {
-        didSet { defaults.set(darkThemeName, forKey: Key.darkThemeName) }
+        didSet { store.set(darkThemeName, forKey: Key.darkThemeName) }
     }
 
     /// Cursor shape. The app-side `CursorStyle` keeps this type free of
     /// terminal-core types while staying type-safe end to end; it persists as its
     /// raw token and `TermioStore` maps it to libghostty.
     @Published var cursorStyle: CursorStyle {
-        didSet { defaults.set(cursorStyle.rawValue, forKey: Key.cursorStyle) }
+        didSet { store.set(cursorStyle.rawValue, forKey: Key.cursorStyle) }
     }
 
     @Published var cursorBlink: Bool {
-        didSet { defaults.set(cursorBlink, forKey: Key.cursorBlink) }
+        didSet { store.set(cursorBlink, forKey: Key.cursorBlink) }
     }
 
     /// Inset (points) between the terminal grid and the window edge, applied on
     /// both axes. Comfort spacing so agent output doesn't run into the chrome.
     @Published var windowPadding: Int {
-        didSet { defaults.set(windowPadding, forKey: Key.windowPadding) }
+        didSet { store.set(windowPadding, forKey: Key.windowPadding) }
     }
 
     /// Terminal background alpha (0.2–1.0). Below 1.0 the window goes non-opaque
     /// so the desktop shows through; 1.0 keeps the normal solid look.
     @Published var backgroundOpacity: Double {
-        didSet { defaults.set(backgroundOpacity, forKey: Key.backgroundOpacity) }
+        didSet { store.set(backgroundOpacity, forKey: Key.backgroundOpacity) }
     }
 
     /// Blur radius applied behind a translucent background (0 = off). Only visible
     /// when `backgroundOpacity` is below 1.0.
     @Published var backgroundBlur: Int {
-        didSet { defaults.set(backgroundBlur, forKey: Key.backgroundBlur) }
+        didSet { store.set(backgroundBlur, forKey: Key.backgroundBlur) }
     }
 
     // MARK: Terminal
@@ -251,12 +275,12 @@ final class AppSettings: ObservableObject {
     /// Scrollback buffer size in megabytes. Agents emit a lot of output, so the
     /// default history is generous; capped to keep memory bounded.
     @Published var scrollbackMegabytes: Int {
-        didSet { defaults.set(scrollbackMegabytes, forKey: Key.scrollbackMegabytes) }
+        didSet { store.set(scrollbackMegabytes, forKey: Key.scrollbackMegabytes) }
     }
 
     /// When on, selecting text copies it straight to the system clipboard.
     @Published var copyOnSelect: Bool {
-        didSet { defaults.set(copyOnSelect, forKey: Key.copyOnSelect) }
+        didSet { store.set(copyOnSelect, forKey: Key.copyOnSelect) }
     }
 
     // MARK: Interface
@@ -265,17 +289,17 @@ final class AppSettings: ObservableObject {
     /// means the system UI font. Unlike the terminal font this need not be
     /// monospaced.
     @Published var interfaceFontFamily: String {
-        didSet { defaults.set(interfaceFontFamily, forKey: Key.interfaceFontFamily) }
+        didSet { store.set(interfaceFontFamily, forKey: Key.interfaceFontFamily) }
     }
 
     @Published var interfaceFontSize: Double {
-        didSet { defaults.set(interfaceFontSize, forKey: Key.interfaceFontSize) }
+        didSet { store.set(interfaceFontSize, forKey: Key.interfaceFontSize) }
     }
 
     /// Vertical padding (points) on each sidebar row — the VSCode-style density
     /// control, from compact to roomy.
     @Published var interfaceRowPadding: Double {
-        didSet { defaults.set(interfaceRowPadding, forKey: Key.interfaceRowPadding) }
+        didSet { store.set(interfaceRowPadding, forKey: Key.interfaceRowPadding) }
     }
 
     // MARK: Agents
@@ -284,7 +308,7 @@ final class AppSettings: ObservableObject {
     /// the user run, say, `claude --dangerously-skip-permissions` instead of the
     /// built-in default. An empty/whitespace value is treated as "no override".
     @Published var agentCommandOverrides: [String: String] {
-        didSet { defaults.set(agentCommandOverrides, forKey: Key.agentCommands) }
+        didSet { store.set(agentCommandOverrides, forKey: Key.agentCommands) }
     }
 
     /// Agents whose permission/approval prompts should be bypassed, by `rawValue`.
@@ -292,13 +316,13 @@ final class AppSettings: ObservableObject {
     /// resolved command (see `command(for:)`). Opt-in and stored as the on-set so
     /// the default (nothing stored) means every agent keeps its prompts.
     @Published var bypassPermissionAgents: Set<String> {
-        didSet { defaults.set(Array(bypassPermissionAgents), forKey: Key.bypassPermissionAgents) }
+        didSet { store.set(Array(bypassPermissionAgents), forKey: Key.bypassPermissionAgents) }
     }
 
     /// Agent presets hidden from the sidebar quick-add row, by `rawValue`. Stored
     /// as the disabled set so the default (nothing stored) means "all enabled".
     @Published var disabledAgents: Set<String> {
-        didSet { defaults.set(Array(disabledAgents), forKey: Key.disabledAgents) }
+        didSet { store.set(Array(disabledAgents), forKey: Key.disabledAgents) }
     }
 
     /// Agents pinned to the Agents settings list even while switched off, by
@@ -307,7 +331,7 @@ final class AppSettings: ObservableObject {
     /// flips in here, so switching one off leaves its row in place — only
     /// `removeAgent` drops a row back into the menu.
     @Published var addedAgents: Set<String> {
-        didSet { defaults.set(Array(addedAgents), forKey: Key.addedAgents) }
+        didSet { store.set(Array(addedAgents), forKey: Key.addedAgents) }
     }
 
     /// The user's own agent arrangement, as an ordered list of `rawValue`s — the
@@ -318,7 +342,7 @@ final class AppSettings: ObservableObject {
     /// after ranked ones; Terminal is always pinned first regardless (see
     /// `orderedAgents`).
     @Published var agentOrder: [String] {
-        didSet { defaults.set(agentOrder, forKey: Key.agentOrder) }
+        didSet { store.set(agentOrder, forKey: Key.agentOrder) }
     }
 
     /// When on, termio installs Claude Code hooks (into `~/.claude/settings.json`)
@@ -328,7 +352,7 @@ final class AppSettings: ObservableObject {
     /// off removes termio's entries again. The `TermioStore` watches this and
     /// installs/uninstalls to match.
     @Published var agentHooksEnabled: Bool {
-        didSet { defaults.set(agentHooksEnabled, forKey: Key.agentHooksEnabled) }
+        didSet { store.set(agentHooksEnabled, forKey: Key.agentHooksEnabled) }
     }
 
     /// When on, termio runs a local control socket the `termio sessions` CLI talks
@@ -338,7 +362,7 @@ final class AppSettings: ObservableObject {
     /// user-level agent instruction files; turning it off removes that note. The
     /// `TermioStore` watches this and installs/uninstalls to match.
     @Published var sessionControlEnabled: Bool {
-        didSet { defaults.set(sessionControlEnabled, forKey: Key.sessionControlEnabled) }
+        didSet { store.set(sessionControlEnabled, forKey: Key.sessionControlEnabled) }
     }
 
     /// Whether the one-time "let your agents coordinate?" prompt has been shown, so
@@ -353,7 +377,7 @@ final class AppSettings: ObservableObject {
     /// pane additionally only appears for projects whose origin remote points at
     /// github.com, so this switch is for opting out of GitHub entirely.
     @Published var githubIntegrationEnabled: Bool {
-        didSet { defaults.set(githubIntegrationEnabled, forKey: Key.githubIntegrationEnabled) }
+        didSet { store.set(githubIntegrationEnabled, forKey: Key.githubIntegrationEnabled) }
     }
 
     /// Agents whose usage data the user has allowed termio to read, by `rawValue`.
@@ -382,12 +406,12 @@ final class AppSettings: ObservableObject {
     /// what triggers the standard macOS permission prompt (see
     /// `TaskNotificationCenter`).
     @Published var notifyOnTaskCompletion: Bool {
-        didSet { defaults.set(notifyOnTaskCompletion, forKey: Key.notifyTaskCompletion) }
+        didSet { store.set(notifyOnTaskCompletion, forKey: Key.notifyTaskCompletion) }
     }
 
     /// Whether those notifications also play the system alert sound.
     @Published var notificationSoundEnabled: Bool {
-        didSet { defaults.set(notificationSoundEnabled, forKey: Key.notificationSound) }
+        didSet { store.set(notificationSoundEnabled, forKey: Key.notificationSound) }
     }
 
     /// Resolves a Ghostty theme name against the bundled catalog, tolerating the naming drift
@@ -434,8 +458,9 @@ final class AppSettings: ObservableObject {
         return overrides
     }
 
-    init(defaults: UserDefaults = .standard) {
+    init(defaults: UserDefaults = .standard, settingsStore: SettingsStore? = nil) {
         self.defaults = defaults
+        self.store = settingsStore ?? SettingsStore(defaults: defaults)
 
         // One-time migration: older installs persisted a single `themeName` that
         // applied to both appearances. Seed the new split keys from it before the
@@ -447,6 +472,12 @@ final class AppSettings: ObservableObject {
             defaults.set(legacyTheme, forKey: Key.lightThemeName)
             defaults.set(legacyTheme, forKey: Key.darkThemeName)
         }
+
+        // Carry an existing install's own choices into `settings.json` before
+        // anything below writes a shipped default into the same domain. The
+        // persistent domain is exactly what the user picked, so a fresh install
+        // has nothing to carry and gets no file until it changes something.
+        self.store.migrateIfNeeded(managing: Self.fileManagedKeys)
 
         // First-run default: ship focused. Only Claude Code and Codex (plus the plain
         // Terminal) are enabled out of the box; the long tail of agents is hidden from
@@ -504,40 +535,40 @@ final class AppSettings: ObservableObject {
 
         defaults.register(defaults: registered)
 
-        fontFamily = defaults.string(forKey: Key.fontFamily) ?? ""
-        fontSize = defaults.double(forKey: Key.fontSize)
-        fontThicken = defaults.bool(forKey: Key.fontThicken)
-        codeLineHeight = defaults.double(forKey: Key.codeLineHeight)
-        appearanceMode = defaults.string(forKey: Key.appearanceMode).flatMap(AppearanceMode.init) ?? .system
-        lightThemeName = defaults.string(forKey: Key.lightThemeName) ?? ""
-        darkThemeName = defaults.string(forKey: Key.darkThemeName) ?? ""
-        cursorStyle = defaults.string(forKey: Key.cursorStyle).flatMap(CursorStyle.init) ?? .block
-        cursorBlink = defaults.bool(forKey: Key.cursorBlink)
-        windowPadding = defaults.integer(forKey: Key.windowPadding)
-        backgroundOpacity = defaults.double(forKey: Key.backgroundOpacity)
-        backgroundBlur = defaults.integer(forKey: Key.backgroundBlur)
-        scrollbackMegabytes = defaults.integer(forKey: Key.scrollbackMegabytes)
-        copyOnSelect = defaults.bool(forKey: Key.copyOnSelect)
-        interfaceFontFamily = defaults.string(forKey: Key.interfaceFontFamily) ?? ""
-        interfaceFontSize = defaults.double(forKey: Key.interfaceFontSize)
-        interfaceRowPadding = defaults.double(forKey: Key.interfaceRowPadding)
-        agentCommandOverrides = defaults.dictionary(forKey: Key.agentCommands) as? [String: String] ?? [:]
-        bypassPermissionAgents = Set(defaults.stringArray(forKey: Key.bypassPermissionAgents) ?? [])
-        disabledAgents = Set(defaults.stringArray(forKey: Key.disabledAgents) ?? [])
-        addedAgents = Set(defaults.stringArray(forKey: Key.addedAgents) ?? [])
-        agentOrder = defaults.stringArray(forKey: Key.agentOrder) ?? []
-        agentHooksEnabled = defaults.bool(forKey: Key.agentHooksEnabled)
-        sessionControlEnabled = defaults.bool(forKey: Key.sessionControlEnabled)
-        githubIntegrationEnabled = defaults.bool(forKey: Key.githubIntegrationEnabled)
+        fontFamily = store.string(Key.fontFamily) ?? ""
+        fontSize = store.double(Key.fontSize)
+        fontThicken = store.bool(Key.fontThicken)
+        codeLineHeight = store.double(Key.codeLineHeight)
+        appearanceMode = store.string(Key.appearanceMode).flatMap(AppearanceMode.init) ?? .system
+        lightThemeName = store.string(Key.lightThemeName) ?? ""
+        darkThemeName = store.string(Key.darkThemeName) ?? ""
+        cursorStyle = store.string(Key.cursorStyle).flatMap(CursorStyle.init) ?? .block
+        cursorBlink = store.bool(Key.cursorBlink)
+        windowPadding = store.integer(Key.windowPadding)
+        backgroundOpacity = store.double(Key.backgroundOpacity)
+        backgroundBlur = store.integer(Key.backgroundBlur)
+        scrollbackMegabytes = store.integer(Key.scrollbackMegabytes)
+        copyOnSelect = store.bool(Key.copyOnSelect)
+        interfaceFontFamily = store.string(Key.interfaceFontFamily) ?? ""
+        interfaceFontSize = store.double(Key.interfaceFontSize)
+        interfaceRowPadding = store.double(Key.interfaceRowPadding)
+        agentCommandOverrides = store.stringDictionary(Key.agentCommands) ?? [:]
+        bypassPermissionAgents = Set(store.stringArray(Key.bypassPermissionAgents) ?? [])
+        disabledAgents = Set(store.stringArray(Key.disabledAgents) ?? [])
+        addedAgents = Set(store.stringArray(Key.addedAgents) ?? [])
+        agentOrder = store.stringArray(Key.agentOrder) ?? []
+        agentHooksEnabled = store.bool(Key.agentHooksEnabled)
+        sessionControlEnabled = store.bool(Key.sessionControlEnabled)
+        githubIntegrationEnabled = store.bool(Key.githubIntegrationEnabled)
         usageAuthorizedAgents = Set(defaults.stringArray(forKey: Key.usageAuthorizedAgents) ?? [])
         claudeKeychainDeclined = defaults.bool(forKey: Key.claudeKeychainDeclined)
-        notifyOnTaskCompletion = defaults.bool(forKey: Key.notifyTaskCompletion)
-        notificationSoundEnabled = defaults.bool(forKey: Key.notificationSound)
-        projectSortOrder = defaults.string(forKey: Key.projectSortOrder).flatMap(ProjectSortOrder.init) ?? .name
+        notifyOnTaskCompletion = store.bool(Key.notifyTaskCompletion)
+        notificationSoundEnabled = store.bool(Key.notificationSound)
+        projectSortOrder = store.string(Key.projectSortOrder).flatMap(ProjectSortOrder.init) ?? .name
         recentProjects = defaults.data(forKey: Key.recentProjects)
             .flatMap { try? JSONDecoder().decode([RecentProject].self, from: $0) } ?? []
         lastChatAgentID = defaults.string(forKey: Key.lastChatAgent)
-        defaultChatAgentID = defaults.string(forKey: Key.defaultChatAgent)
+        defaultChatAgentID = store.string(Key.defaultChatAgent)
     }
 
     /// Effective command for an agent: the user's override if it's non-empty,

--- a/Sources/termio/Settings/SettingsFile.swift
+++ b/Sources/termio/Settings/SettingsFile.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// Where a preference the user actually chose is kept: `~/.termio[-dev]/settings.json`,
+/// beside `keybindings.json`, in the same hand-editable JSON the rest of termio's
+/// config already uses.
+///
+/// Only keys the user has *set* are written. That is the rule `KeybindingStore`
+/// follows for its own file, and it buys the same two things: a shipped default
+/// that changes later still reaches everyone who never touched that setting, and
+/// the file stays short enough to read at a glance and keep in a dotfiles repo.
+/// A file that seeded every key with its current value would freeze both.
+///
+/// This layer replaces `UserDefaults`' *persistent* domain and nothing else.
+/// Resolution stays what it has always been — user setting > Ghostty config >
+/// built-in default — because the lower two layers are still the registration
+/// domain `AppSettings.init` seeds. `SettingsStore` is what enforces that order,
+/// so no call site has to remember it.
+///
+/// Writes are synchronous, like `KeybindingStore`'s: the file is a few hundred
+/// bytes, `set` ignores a value that didn't change, and saving inline means a
+/// preference chosen a moment before quitting is already on disk.
+@MainActor
+final class SettingsStore {
+    /// The user's own values, keyed exactly as `AppSettings.Key` spells them.
+    /// Absent key = the user never chose one; fall through to the lower layers.
+    private var chosen: [String: Any]
+    private let defaults: UserDefaults
+    private let fileURL: URL
+    /// The `UserDefaults` domain migration reads. Named rather than assumed so a
+    /// test can hand in its own suite — `persistentDomain` only answers for the
+    /// domain it is asked about.
+    private let domainName: String?
+
+    static var defaultURL: URL {
+        AppChannel.homeConfigDirectory
+            .appendingPathComponent("settings.json", isDirectory: false)
+    }
+
+    init(defaults: UserDefaults = .standard,
+         fileURL: URL = SettingsStore.defaultURL,
+         domainName: String? = Bundle.main.bundleIdentifier) {
+        self.defaults = defaults
+        self.fileURL = fileURL
+        self.domainName = domainName
+        chosen = Self.read(fileURL)
+    }
+
+    // MARK: - Reading
+
+    // Each getter is "the user's choice, else whatever the registration domain
+    // resolves to" — Ghostty's value when the user has a Ghostty config, the
+    // built-in otherwise.
+
+    func string(_ key: String) -> String? {
+        chosen[key] as? String ?? defaults.string(forKey: key)
+    }
+
+    func double(_ key: String) -> Double {
+        if let value = chosen[key] as? Double { return value }
+        if let value = chosen[key] as? Int { return Double(value) }
+        return defaults.double(forKey: key)
+    }
+
+    func integer(_ key: String) -> Int {
+        if let value = chosen[key] as? Int { return value }
+        if let value = chosen[key] as? Double { return Int(value) }
+        return defaults.integer(forKey: key)
+    }
+
+    func bool(_ key: String) -> Bool {
+        chosen[key] as? Bool ?? defaults.bool(forKey: key)
+    }
+
+    func stringArray(_ key: String) -> [String]? {
+        chosen[key] as? [String] ?? defaults.stringArray(forKey: key)
+    }
+
+    func stringDictionary(_ key: String) -> [String: String]? {
+        chosen[key] as? [String: String]
+            ?? defaults.dictionary(forKey: key) as? [String: String]
+    }
+
+    /// Whether the user chose this key themselves, as opposed to inheriting it.
+    /// Lets a Reset control clear the value instead of writing today's default
+    /// back in as if it were a choice.
+    func isChosen(_ key: String) -> Bool { chosen[key] != nil }
+
+    // MARK: - Writing
+
+    /// Records the user's choice. `nil` clears it, handing the key back to the
+    /// Ghostty and built-in layers rather than pinning today's default.
+    func set(_ value: Any?, forKey key: String) {
+        if let value {
+            if let existing = chosen[key], Self.equal(existing, value) { return }
+            chosen[key] = value
+        } else {
+            guard chosen[key] != nil else { return }
+            chosen.removeValue(forKey: key)
+        }
+        save()
+    }
+
+    // MARK: - Migration
+
+    /// Seeds the file, once, from what an existing install already wrote to
+    /// `UserDefaults`. The persistent domain holds exactly the keys the user
+    /// chose — defaults live in the registration domain — so it maps onto this
+    /// file's rule without having to guess which values were deliberate.
+    ///
+    /// Only when the file is absent, so a user who has since edited or deleted
+    /// keys is never re-seeded from a stale domain.
+    func migrateIfNeeded(managing keys: Set<String>) {
+        guard !FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        guard let domainName, let domain = defaults.persistentDomain(forName: domainName)
+        else { return }
+        let carried = domain.filter { keys.contains($0.key) }
+        guard !carried.isEmpty else { return }
+        chosen.merge(carried) { _, migrated in migrated }
+        save()
+    }
+
+    // MARK: - File
+
+    private static func read(_ url: URL) -> [String: Any] {
+        guard let data = try? Data(contentsOf: url),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [:] }
+        return parsed
+    }
+
+    /// Sorted and pretty-printed because a human edits this file; the stable key
+    /// order also keeps it diffable in a dotfiles repo.
+    private func save() {
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(
+                withJSONObject: chosen, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            Log.app.error(
+                "could not write settings.json: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Value comparison across the JSON types these settings use. Bridged to
+    /// `NSObject` they all answer `isEqual`; anything exotic reports "changed"
+    /// and is written, which is the safe direction.
+    private static func equal(_ lhs: Any, _ rhs: Any) -> Bool {
+        guard let lhs = lhs as? NSObject, let rhs = rhs as? NSObject else { return false }
+        return lhs.isEqual(rhs)
+    }
+}

--- a/Tests/termioTests/SettingsStoreTests.swift
+++ b/Tests/termioTests/SettingsStoreTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+
+@testable import termio
+
+/// `settings.json` is the file a user hand-edits and commits to a dotfiles repo,
+/// so what it *omits* matters as much as what it stores. These cover the rule
+/// that makes the omission safe: only a chosen value is written, and everything
+/// else keeps resolving through the layers below.
+@MainActor
+final class SettingsStoreTests: XCTestCase {
+    private var directory: URL!
+    private var fileURL: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("settings-store-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        fileURL = directory.appendingPathComponent("settings.json")
+        suiteName = "settings-store-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        defaults.removePersistentDomain(forName: suiteName)
+        try await super.tearDown()
+    }
+
+    private func makeStore() -> SettingsStore {
+        SettingsStore(defaults: defaults, fileURL: fileURL, domainName: suiteName)
+    }
+
+    // MARK: - The rule
+
+    func testUntouchedSettingWritesNoFile() {
+        let store = makeStore()
+        defaults.register(defaults: ["appearance.fontSize": 13.0])
+
+        XCTAssertEqual(store.double("appearance.fontSize"), 13.0)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: fileURL.path),
+            "reading a default must not create settings.json — an untouched key stays inherited")
+    }
+
+    /// The reason the file stores choices rather than a full snapshot: a user who
+    /// never picked a font size follows termio's default when that default moves.
+    func testChangedDefaultReachesAnUntouchedSetting() {
+        defaults.register(defaults: ["appearance.fontSize": 13.0])
+        XCTAssertEqual(makeStore().double("appearance.fontSize"), 13.0)
+
+        // Ship a new default in a later version.
+        defaults.register(defaults: ["appearance.fontSize": 14.0])
+        XCTAssertEqual(makeStore().double("appearance.fontSize"), 14.0)
+    }
+
+    /// ...while a value the user did pick survives that same default change, even
+    /// when their pick happens to equal the old default.
+    func testChosenValueSurvivesADefaultChange() {
+        defaults.register(defaults: ["appearance.fontSize": 13.0])
+        let store = makeStore()
+        store.set(13.0, forKey: "appearance.fontSize")
+
+        defaults.register(defaults: ["appearance.fontSize": 14.0])
+        XCTAssertEqual(makeStore().double("appearance.fontSize"), 13.0)
+    }
+
+    func testClearingAChoiceRestoresTheInheritedValue() {
+        defaults.register(defaults: ["appearance.fontSize": 13.0])
+        let store = makeStore()
+        store.set(20.0, forKey: "appearance.fontSize")
+        XCTAssertTrue(store.isChosen("appearance.fontSize"))
+
+        store.set(nil, forKey: "appearance.fontSize")
+        XCTAssertFalse(store.isChosen("appearance.fontSize"))
+        XCTAssertEqual(makeStore().double("appearance.fontSize"), 13.0)
+    }
+
+    // MARK: - Round trip
+
+    func testValuesRoundTripAcrossTypes() {
+        let store = makeStore()
+        store.set("Menlo", forKey: "appearance.fontFamily")
+        store.set(15.5, forKey: "appearance.fontSize")
+        store.set(12, forKey: "appearance.windowPadding")
+        store.set(true, forKey: "terminal.copyOnSelect")
+        store.set(["gemini", "amp"], forKey: "agents.disabled")
+        store.set(["claudeCode": "claude --resume"], forKey: "agents.commandOverrides")
+
+        let reloaded = makeStore()
+        XCTAssertEqual(reloaded.string("appearance.fontFamily"), "Menlo")
+        XCTAssertEqual(reloaded.double("appearance.fontSize"), 15.5)
+        XCTAssertEqual(reloaded.integer("appearance.windowPadding"), 12)
+        XCTAssertTrue(reloaded.bool("terminal.copyOnSelect"))
+        XCTAssertEqual(reloaded.stringArray("agents.disabled"), ["gemini", "amp"])
+        XCTAssertEqual(
+            reloaded.stringDictionary("agents.commandOverrides"), ["claudeCode": "claude --resume"])
+    }
+
+    /// The file is hand-editable, so a key termio doesn't manage — a typo, a
+    /// comment-ish marker, a key from a newer version — must survive a write.
+    func testUnmanagedKeySurvivesAWrite() throws {
+        try Data(#"{"appearance.fontSize": 15, "some.future.key": "keep me"}"#.utf8)
+            .write(to: fileURL)
+
+        let store = makeStore()
+        store.set(16.0, forKey: "appearance.fontSize")
+
+        let raw = try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL))
+        let parsed = try XCTUnwrap(raw as? [String: Any])
+        XCTAssertEqual(parsed["some.future.key"] as? String, "keep me")
+        XCTAssertEqual(parsed["appearance.fontSize"] as? Double, 16.0)
+    }
+
+    func testMalformedFileFallsBackToInheritedValues() throws {
+        try Data("{ not json".utf8).write(to: fileURL)
+        defaults.register(defaults: ["appearance.fontSize": 13.0])
+
+        // A corrupt file must not take the app's settings down with it.
+        XCTAssertEqual(makeStore().double("appearance.fontSize"), 13.0)
+    }
+
+    func testRewritingTheSameValueIsANoOp() throws {
+        let store = makeStore()
+        store.set(15.0, forKey: "appearance.fontSize")
+        let firstWrite = try FileManager.default
+            .attributesOfItem(atPath: fileURL.path)[.modificationDate] as? Date
+
+        store.set(15.0, forKey: "appearance.fontSize")
+        let secondWrite = try FileManager.default
+            .attributesOfItem(atPath: fileURL.path)[.modificationDate] as? Date
+        XCTAssertEqual(firstWrite, secondWrite, "an unchanged value should not rewrite the file")
+    }
+
+    // MARK: - Migration
+
+    func testMigrationCarriesOnlyManagedKeys() {
+        defaults.set(17.0, forKey: "appearance.fontSize")
+        defaults.set(["a-project"], forKey: "welcome.recentProjects")
+
+        let store = makeStore()
+        store.migrateIfNeeded(managing: ["appearance.fontSize"])
+
+        XCTAssertTrue(store.isChosen("appearance.fontSize"))
+        XCTAssertFalse(
+            store.isChosen("welcome.recentProjects"),
+            "app state must stay in UserDefaults rather than leak into the config file")
+    }
+
+    func testMigrationDoesNotRunTwice() {
+        defaults.set(17.0, forKey: "appearance.fontSize")
+        let store = makeStore()
+        store.migrateIfNeeded(managing: ["appearance.fontSize"])
+
+        // The user clears the value by hand; a second launch must respect that.
+        store.set(nil, forKey: "appearance.fontSize")
+        let relaunched = makeStore()
+        relaunched.migrateIfNeeded(managing: ["appearance.fontSize"])
+        XCTAssertFalse(relaunched.isChosen("appearance.fontSize"))
+    }
+}
+
+/// The rewiring itself: `AppSettings`' setters must land in `settings.json`, and
+/// its reads must come back from there on the next launch. Covers the seam the
+/// unit tests above cannot — that every `didSet` was pointed at the file rather
+/// than left writing to `UserDefaults`.
+@MainActor
+final class AppSettingsFileBackingTests: XCTestCase {
+    private var directory: URL!
+    private var fileURL: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("app-settings-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        fileURL = directory.appendingPathComponent("settings.json")
+        suiteName = "app-settings-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        defaults.removePersistentDomain(forName: suiteName)
+        try await super.tearDown()
+    }
+
+    private func makeSettings() -> AppSettings {
+        AppSettings(
+            defaults: defaults,
+            settingsStore: SettingsStore(
+                defaults: defaults, fileURL: fileURL, domainName: suiteName))
+    }
+
+    private func fileContents() throws -> [String: Any] {
+        let data = try Data(contentsOf: fileURL)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    func testChangingASettingWritesItToTheFile() throws {
+        let settings = makeSettings()
+        settings.fontSize = 17
+        settings.copyOnSelect = true
+        settings.cursorStyle = .bar
+
+        let parsed = try fileContents()
+        XCTAssertEqual(parsed["appearance.fontSize"] as? Double, 17)
+        XCTAssertEqual(parsed["terminal.copyOnSelect"] as? Bool, true)
+        XCTAssertEqual(parsed["appearance.cursorStyle"] as? String, "bar")
+    }
+
+    func testSettingsReloadFromTheFile() {
+        let settings = makeSettings()
+        settings.fontSize = 19
+        settings.lightThemeName = "xcode-light"
+
+        let relaunched = makeSettings()
+        XCTAssertEqual(relaunched.fontSize, 19)
+        XCTAssertEqual(relaunched.lightThemeName, "xcode-light")
+    }
+
+    /// App state must not follow preferences into the file.
+    func testStateStaysOutOfTheFile() throws {
+        let settings = makeSettings()
+        settings.fontSize = 15
+        settings.noteRecentProject(name: "termio", path: "/tmp/termio")
+
+        XCTAssertNil(try fileContents()["welcome.recentProjects"])
+    }
+}


### PR DESCRIPTION
## What

The 29 preferences behind the Settings window were the last thing in termio reachable only through the GUI. Keybindings (`~/.termio/keybindings.json`) and agent manifests (`~/.termio/config/agents/*.json`) have been hand-editable files for a while; app preferences could not be version-controlled, edited in an editor, or carried to another Mac.

They now live in `~/.termio[-dev]/settings.json`, beside `keybindings.json` and in the same JSON.

## Only what the user chose

`SettingsStore` follows the rule `KeybindingStore` already set: a key is written when the user picks a value, and cleared when they reset it. Nothing else is in the file.

That is the whole design, and it is worth being explicit about why, because the obvious alternative — seed the file with every key and its current value — fails twice. It pins today's defaults forever, so a later default change never reaches anyone who has launched the app once. And it buries the two or three settings someone actually changed under twenty-odd inherited ones, which is exactly the file they were hoping to keep in a dotfiles repo.

The file replaces `UserDefaults`' *persistent* domain and nothing else. Resolution stays what it has always been — **user setting > Ghostty config > built-in default** — because the lower two layers are still the registration domain `AppSettings.init` seeds. `SettingsStore` enforces that order so no call site has to remember it.

## Scope

Preferences move; state and consent stay in `UserDefaults` — recent projects, the last agent a chat used, Usage-tab authorizations, and whether the session-control prompt has been answered. None of those are things to hand-edit or carry between machines.

Existing installs migrate once, from the persistent domain, which is precisely the set of keys the user chose. A fresh install writes no file at all until something changes.

## How it was verified

- `swift build` clean, **214 tests** green (13 new).
- The tests cover the properties the design rests on, not just round-tripping: an untouched setting writes no file; a changed shipped default reaches a user who never touched that key; a value the user *did* choose survives that same default change even when it equals the old default; clearing a choice restores the inherited value; an unmanaged key in the file survives a write; a corrupt file falls back to inherited values instead of taking settings down.
- Three of them drive `AppSettings` itself, so the rewiring of every `didSet` is covered rather than just the store underneath it.
- Migration checked end-to-end against a packaged dev build: launching it carried this machine's real dev-channel choices (bypass-permission agent, disabled agents, hooks, session control, appearance) into `settings.json`, and left the ~20 untouched preferences out of it.

## Finding it, and reading it

**Settings ▸ General ▸ Settings file ▸ Reveal in Finder** points at the file from the window that writes it. Before anything has been changed there is no file, so the button opens the folder instead.

The docs gain a [Settings reference](/docs/settings): every setting in the app, what it does, its default, and its `settings.json` key, tab by tab. It states the resolution order in one place, names the two settings that are not in the Settings window (sidebar sort) or not in the file (language, the CLI), and says which things are state rather than settings. Written in both locales, `docs:check` green, and the Appearance page now links to it rather than growing a second summary of the same tabs.

## Release Notes

Settings are now stored in `~/.termio/settings.json`, so you can edit them in an editor or keep them in a dotfiles repo. Existing settings carry over automatically.
