### PR TITLE
Scale pane empty states to the pane

### DIFF
--- a/Sources/termio/App/BrandIcons.swift
+++ b/Sources/termio/App/BrandIcons.swift
@@ -193,21 +193,43 @@ struct BrandLogoShape: Shape {
     }
 }
 
-extension ContentUnavailableView
-where Label == SwiftUI.Label<Text, HugeIconView>, Description == Text?, Actions == EmptyView {
-    /// The `ContentUnavailableView(_:systemImage:description:)` shorthand for a
-    /// Hugeicons glyph, so empty states share the app's icon language. The glyph is
-    /// drawn at the same optical size the system styles an SF Symbol to there.
-    init(_ title: String, huge icon: HugeIcon, description: Text? = nil) {
-        self.init {
-            SwiftUI.Label {
-                Text(title)
-            } icon: {
-                HugeIconView(icon: icon, size: 38, color: .secondary)
+/// The empty state every pane shows when it has nothing to list.
+///
+/// `ContentUnavailableView` is proportioned for a full window: a `.title2` headline
+/// over a stroke glyph, with the stack spacing to match. In a 240pt inspector that
+/// headline is wider than most of the pane's own rows, so the pane reads as an error
+/// page rather than as a quiet state. This is the same composition — glyph, title,
+/// one sentence — sized to the pane it sits in, and grouped tightly enough that the
+/// three parts read as one object.
+struct PaneEmptyState: View {
+    let title: String
+    let icon: HugeIcon
+    let message: String?
+
+    init(_ title: String, icon: HugeIcon, message: String? = nil) {
+        self.title = title
+        self.icon = icon
+        self.message = message
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HugeIconView(icon: icon, size: 26, color: .secondary)
+                .opacity(0.5)
+                .padding(.bottom, 9)
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+            if let message {
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 2)
             }
-        } description: {
-            description
         }
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 240)
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 

--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -144,10 +144,10 @@ struct FileEditorView: View {
         // the safe-area top; padding it again just opened a dead band above the header.)
         Group {
             if loadFailed {
-                ContentUnavailableView(
+                PaneEmptyState(
                     localized("Can’t open as text"),
-                    huge: .fileQuestion,
-                    description: Text(localized("\(url.lastPathComponent) isn’t a UTF-8 text file."))
+                    icon: .fileQuestion,
+                    message: localized("\(url.lastPathComponent) isn’t a UTF-8 text file.")
                 )
             } else if !loaded {
                 // The bare background while the async read runs — small files land

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -271,10 +271,10 @@ struct FileBrowserView: View {
 
     /// The empty state the Files and Search panes share when no session is selected.
     private var noProject: some View {
-        ContentUnavailableView(
+        PaneEmptyState(
             localized("No Project"),
-            huge: .folder,
-            description: Text(localized("Select a session to browse its files."))
+            icon: .folder,
+            message: localized("Select a session to browse its files.")
         )
     }
 

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -235,10 +235,10 @@ struct GitChangesView: View {
             // Fill the pane (like the loading state) rather than sizing to the compact empty
             // view — otherwise the enclosing `VStack` shrinks to content height and the host
             // centers the whole pane instead of pinning the header to the top.
-            ContentUnavailableView(
+            PaneEmptyState(
                 localized("No Changes"),
-                huge: .checkCircle,
-                description: Text(localized("The working tree is clean."))
+                icon: .checkCircle,
+                message: localized("The working tree is clean.")
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -254,10 +254,10 @@ struct GitDiffView: View {
                 }
             }
         } else {
-            ContentUnavailableView(
+            PaneEmptyState(
                 localized("No Diff"),
-                huge: .fileDoc,
-                description: Text(localized("No textual changes to show."))
+                icon: .fileDoc,
+                message: localized("No textual changes to show.")
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }

--- a/Sources/termio/Git/GitHistoryView.swift
+++ b/Sources/termio/Git/GitHistoryView.swift
@@ -31,10 +31,10 @@ struct GitHistoryView: View {
                     .controlSize(.small)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if model.commits.isEmpty {
-                ContentUnavailableView(
+                PaneEmptyState(
                     localized("No History"),
-                    huge: .clock,
-                    description: Text(localized("This branch has no commits yet."))
+                    icon: .clock,
+                    message: localized("This branch has no commits yet.")
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {

--- a/Sources/termio/Git/PRFilesDiffView.swift
+++ b/Sources/termio/Git/PRFilesDiffView.swift
@@ -120,10 +120,10 @@ struct PRFilesSplitView: View {
             // Rebuild for each file so the diff, syntax colors, and scroll reset cleanly.
             .id(change.path)
         } else {
-            ContentUnavailableView(
+            PaneEmptyState(
                 localized("No File Selected"),
-                huge: .fileDoc,
-                description: Text(localized("Pick a file on the left to see its changes."))
+                icon: .fileDoc,
+                message: localized("Pick a file on the left to see its changes.")
             )
         }
     }
@@ -236,12 +236,12 @@ private struct PRFileDiffBody: View {
                 onClose: onClose
             )
         } else {
-            ContentUnavailableView(
+            PaneEmptyState(
                 change.isBinary ? localized("Binary File") : localized("No Diff"),
-                huge: .fileDoc,
-                description: Text(change.isBinary
+                icon: .fileDoc,
+                message: change.isBinary
                     ? localized("This file is binary — open it on GitHub to view.")
-                    : localized("This diff is too large to show here — open the file on GitHub."))
+                    : localized("This diff is too large to show here — open the file on GitHub.")
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }

--- a/Sources/termio/Info/SessionInfoView.swift
+++ b/Sources/termio/Info/SessionInfoView.swift
@@ -80,15 +80,11 @@ struct SessionInfoView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         } else {
-            ContentUnavailableView {
-                Label {
-                    Text(localized("No Session"))
-                } icon: {
-                    HugeIconView(icon: .infoCircle, size: 38, color: .secondary)
-                }
-            } description: {
-                Text(localized("Select a session to see its info."))
-            }
+            PaneEmptyState(
+                localized("No Session"),
+                icon: .infoCircle,
+                message: localized("Select a session to see its info.")
+            )
         }
     }
 

--- a/Sources/termio/Info/TraceView.swift
+++ b/Sources/termio/Info/TraceView.swift
@@ -135,7 +135,7 @@ struct TraceView: View {
             if let html {
                 TraceWebView(html: html)
             } else if let loadError {
-                ContentUnavailableView("Couldn’t build the trace", huge: .bot, description: Text(loadError))
+                PaneEmptyState("Couldn’t build the trace", icon: .bot, message: loadError)
             } else {
                 ProgressView()
             }

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -286,10 +286,10 @@ struct IssuesView: View {
                 }
             }
         } else if model.items.isEmpty {
-            ContentUnavailableView(
+            PaneEmptyState(
                 model.query.kind == .issue ? localized("No Issues") : localized("No Pull Requests"),
-                huge: .checkCircle,
-                description: Text(emptyMessage)
+                icon: .checkCircle,
+                message: emptyMessage
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
@@ -738,7 +738,7 @@ struct IssueDetailView: View {
                 diagrams = await MermaidRenderer.shared.diagrams(for: sources, theme: mermaidTheme)
             }
         } else if let error = model.detailError {
-            ContentUnavailableView(localized("Couldn’t load"), huge: .github, description: Text(error))
+            PaneEmptyState(localized("Couldn’t load"), icon: .github, message: error)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             ProgressView()
@@ -763,9 +763,9 @@ struct IssueDetailView: View {
                 .controlSize(.small)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            ContentUnavailableView(
-                localized("No Files"), huge: .fileDoc,
-                description: Text(localized("This pull request changes no files."))
+            PaneEmptyState(
+                localized("No Files"), icon: .fileDoc,
+                message: localized("This pull request changes no files.")
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }


### PR DESCRIPTION
`ContentUnavailableView` is proportioned for a full window — a `.title2` headline over the glyph, with stack spacing to match. In a 240pt inspector that headline ran wider than any row in the pane, and the spacing left the glyph stranded above it, so a clean working tree read like an error page rather than a quiet state.

`PaneEmptyState` is the same composition — glyph, title, one sentence — at the pane's own scale: a 26pt glyph at half opacity, a 13pt semibold title, an 11pt secondary sentence, grouped tightly enough to read as one object. All twelve empty states share it, and the hand-rolled one in the Info pane folds in.

Release Notes:

- Empty states in the sidebar panes are sized for the pane instead of a full window.