### PR TITLE
Record the protocol auto-reply hazard on the PTY input stamp

### DIFF
--- a/Sources/termio/Terminal/Ghostty/PTYProcess.swift
+++ b/Sources/termio/Terminal/Ghostty/PTYProcess.swift
@@ -505,6 +505,15 @@ final class PTYProcess: @unchecked Sendable {
     /// keystrokes via the companion bridge, synthetic `sessions send` text — so
     /// this is the one place input can be timestamped for all of them. Guarded
     /// by `writeLock` like the rest of the writer state.
+    ///
+    /// It cuts the other way too: in `.inMemory` mode this is also how libghostty
+    /// answers protocol queries — DSR, DA, XTGETTCAP — and a reply is
+    /// indistinguishable from a keystroke here, so a TUI that queries more often
+    /// than `userInputQuietWindow` starves `noteOutputActivity`'s idle→working
+    /// promotion. Hooks are no escape: a session is on that path *because* it has
+    /// hooks (`statusRules` is nil then), and `antigravity`/`hermes` have neither.
+    /// The fix is to stamp the key/paste entry and the companion input handler
+    /// instead of every stdin byte.
     private var lastInputAtLocked = Date.distantPast
 
     /// Thread-safe read of the last stdin-write instant. The status tap reads it


### PR DESCRIPTION
`PTYProcess.write` timestamps every stdin write so status promotion holds off while the human is the one repainting the screen. The doc on `lastInputAtLocked` sold that single choke point as an unalloyed win, and it isn't: in `.inMemory` mode the surface write callback is the only egress, so the VT's own protocol auto-replies — DSR cursor reports, DA, XTGETTCAP — cross the same stamp and are indistinguishable from a keystroke there. A TUI that queries the terminal more often than `userInputQuietWindow` (3 s) keeps the stamp perpetually fresh and starves idle→working promotion for that session.

Hooks are not the containment they look like. `statusRules` is nil exactly when a manifest carries a hook spec, and promotion is gated on `statusRules == nil`, so having hooks is what puts a session on the promotion path — and promotion is the recovery for the turns hooks miss. `antigravity` and `hermes` ship with neither hooks nor screen rules, so promotion is their only status authority. The comment now says that, and records the fix direction (stamp the key/paste entry and the companion input handler, not every stdin byte) that closing #24 would otherwise have taken with it.

Comment only, no behavior change. `swift build` clean.

Refs #24.

Release Notes: None — internal comment with no user-visible change.
