### PR TITLE
Write the 0.36.0 changelog and correct the Intel claims

### DIFF
--- a/web/landing/content/docs/installation.mdx
+++ b/web/landing/content/docs/installation.mdx
@@ -3,12 +3,12 @@ title: Installation
 description: Download Termio for macOS, drag it to Applications, and let Sparkle keep it up to date — no account or license key required.
 ---
 
-Termio runs on Apple Silicon Macs. Installation is a normal drag-to-Applications
+Termio runs on Apple silicon and Intel Macs from the same download. Installation is a normal drag-to-Applications
 — there's no account to create and no license key to enter.
 
 <Callout type="note" title="Before you begin">
-  Termio is an Apple Silicon (M-series) Mac app running macOS 14 or later. It
-  hosts the agent CLIs you already have installed — it doesn't bundle them.
+  Termio needs macOS 14 or later, on Apple silicon or Intel. It hosts the agent
+  CLIs you already have installed — it doesn't bundle them.
 </Callout>
 
 ## Download and install

--- a/web/landing/content/docs/installation.zh-CN.mdx
+++ b/web/landing/content/docs/installation.zh-CN.mdx
@@ -3,16 +3,16 @@ title: 安装
 description: 下载 macOS 版 Termio，拖进「应用程序」，之后交给 Sparkle 自动更新——无需账号，也没有许可证密钥。
 x-i18n:
   source_path: installation.mdx
-  source_hash: 8280233370d4be5654e28261a78968e466567384b8b92fe1996b1a6628d9de8f
-  generated_at: 2026-08-10
+  source_hash: 57c4d0917e54ec974157f1beb5062a2149fd5f0d908fa40cc0b399e2409222f9
+  generated_at: 2026-08-12
 ---
 
-Termio 运行在 Apple 芯片的 Mac 上。安装就是普通的拖进「应用程序」——不用注册账号，
+Termio 用同一个下载包同时运行在 Apple 芯片和 Intel 的 Mac 上。安装就是普通的拖进「应用程序」——不用注册账号，
 也没有许可证密钥要填。
 
 <Callout type="note" title="开始之前">
-  Termio 是一款面向 Apple 芯片（M 系列）Mac 的应用，需要 macOS 14 或更高版本。它
-  托管你已经装好的 Agent 命令行工具，本身不打包它们。
+  Termio 需要 macOS 14 或更高版本，Apple 芯片和 Intel 的 Mac 都可以。它托管你已经
+  装好的 Agent 命令行工具，本身不打包它们。
 </Callout>
 
 ## 下载并安装

--- a/web/landing/src/app/layout.tsx
+++ b/web/landing/src/app/layout.tsx
@@ -22,6 +22,7 @@ export const metadata: Metadata = {
     "Codex",
     "git worktree",
     "Apple Silicon",
+    "Intel Mac",
   ],
   applicationName: "Termio",
   alternates: {

--- a/web/landing/src/components/sections/companion.tsx
+++ b/web/landing/src/components/sections/companion.tsx
@@ -21,7 +21,8 @@ const points = [
   },
   {
     title: "Paired, not hosted",
-    blurb: "Pair with a QR code. Token-gated, no Termio cloud in the middle.",
+    blurb:
+      "Pair every Mac you work on with a QR code and switch between them. Token-gated, no Termio cloud in the middle.",
   },
 ] as const;
 

--- a/web/landing/src/components/sections/faq.tsx
+++ b/web/landing/src/components/sections/faq.tsx
@@ -41,9 +41,14 @@ const faqs: { question: string; answer: string }[] = [
       "Yes. Termio is local-only: no telemetry, no cloud sync, and no account is needed to start. Your repositories, agent output and sessions never leave your machine.",
   },
   {
+    question: "Is Termio available in my language?",
+    answer:
+      "Termio and the iPhone companion ship in English and Simplified Chinese. The app follows your macOS language; Settings → General pins one if you'd rather choose.",
+  },
+  {
     question: "What are the requirements?",
     answer:
-      "macOS 14 or later, Apple Silicon. Termio is a native app built for Apple Silicon Macs. You bring your own agent CLIs and their API keys.",
+      "macOS 14 or later, on Apple silicon or Intel — Termio ships as a universal binary, so the same download runs natively on both. You bring your own agent CLIs and their API keys.",
   },
 ];
 

--- a/web/landing/src/data/changelog.ts
+++ b/web/landing/src/data/changelog.ts
@@ -17,6 +17,29 @@ export type ChangelogEntry = {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: "0.36.0",
+    date: "2026-08-12",
+    title: "Speaks Simplified Chinese",
+    changes: {
+      new: [
+        "Simplified Chinese: the Mac app and the iPhone companion are fully translated. Termio follows your macOS language, and Settings ▸ General pins one if you'd rather choose.",
+        "More than one Mac: pair every Mac you work on from the phone and switch between them — the laptop at home, the devbox at the office — from a rail on the Projects screen or the Devices settings page.",
+        "Custom relay: point remote access at a relay you host yourself instead of the built-in tunnel.",
+        "Session control reaches every agent that supports skills, Amp, Antigravity, Hermes and Kimi included. Agents whose CLI isn't installed are skipped rather than half-configured.",
+      ],
+      improved: [
+        "Agents: adding an agent and building a custom one are one flow now, instead of two controls that did nearly the same thing.",
+      ],
+      fixed: [
+        "A file dropped on a split lands in the pane under the pointer, not the focused one.",
+        "A pane's empty state scales to the pane instead of overflowing a small one.",
+        "A hidden split group keeps its own pane sizes instead of adopting the visible group's.",
+        "Closing an agent session only asks when that session is still running something.",
+        "The iPhone holds a session's title steady while an agent rewrites it.",
+      ],
+    },
+  },
+  {
     version: "0.35.0",
     date: "2026-08-12",
     title: "Runs on Intel Macs",


### PR DESCRIPTION
## What

Two things, both driven by what has actually landed since `v0.35.0`.

**The site was still turning Intel users away.** Termio has shipped as a universal binary since 0.35.0 — that release's own headline — but the requirements FAQ read "macOS 14 or later, Apple Silicon. Termio is a native app built for Apple Silicon Macs", the install page opened with "Termio runs on Apple Silicon Macs", and the page metadata listed only Apple Silicon. Someone on an Intel Mac reading any of those would conclude the app isn't for them. Corrected in both locales.

**The 0.36.0 entry.** Written from the 78 commits on `main` since the tag, filtered to what a user would notice:

- Simplified Chinese across the Mac app and the iPhone companion, with a language picker
- Pairing more than one Mac from the phone, and switching between them
- A self-hosted relay for remote access
- Session control reaching every skills-capable agent, skipping the ones whose CLI is absent
- The reworked Agents tab, plus five fixes

## Notes

The entry is written ahead of the tag. `docs:check` allows that — it only fails when the newest entry is *older* than the newest tag — so this is the release notes waiting for `v0.36.0` to be cut. **Nothing here claims a build that exists yet**, so it should land close to the tag rather than sit.

The settings file work in #286 is deliberately not in this entry; it is not on `main` yet. It wants one more line under `new` once that merges.

Two smaller copy changes: the companion section framed pairing as a single Mac, and there is now an FAQ answer for which languages the app speaks.

## How it was verified

`pnpm docs:check` green — keybindings table matches the catalog, `i18n: 15 pages × 1 locale(s) in step`, and it now reports `newest entry 0.36.0 covers v0.35.0`. The Next build is left to the Vercel preview, which is what gates landing changes here.

## Release Notes

None — this *is* the release notes.