### PR TITLE
Keep the inspector closed when a session restores its detail

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -92,12 +92,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // Keeps the native window title (path) and subtitle (git branch) in step with the
     // selected session — NetNewsWire's approach, no custom title-bar views.
     private var titleObserver: AnyCancellable?
-    // Reveals the inspector and manages the maximize host as a detail opens/closes (see the
-    // `store.objectWillChange` sink in `applicationDidFinishLaunching`).
+    // Manages the maximize host as a detail opens/closes (see the `store.objectWillChange`
+    // sink in `applicationDidFinishLaunching`).
     private var overlayObserver: AnyCancellable?
-    // Previous detail-presented state, so the observer fires reveal only on the open transition
-    // rather than on every store change.
-    private var detailWasPresented = false
+    // Un-collapses the inspector when the user opens a detail (see `store.detailDidOpen`).
+    private var detailOpenObserver: AnyCancellable?
     // Previous maximize state, so the observer re-binds the tracking separator on the restore
     // transition (tearing down the full-window host relayouts the inspector) and not every tick.
     private var detailWasMaximized = false
@@ -252,10 +251,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 MainActor.assumeIsolated { self?.updateWindowTitle() }
             }
 
+        // The user opening a detail (a file, a diff, a trace, a PR row) is the only thing that
+        // un-collapses the inspector — the store raises it as an event rather than the delegate
+        // inferring it from `isDetailPresented`, which also goes true when a session switch or a
+        // launch restore puts a saved detail back and must not move the panel (issue #272).
+        // Delivered on the next runloop so the split geometry the separator binds to is settled.
+        detailOpenObserver = store.detailDidOpen
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in
+                MainActor.assumeIsolated {
+                    self?.revealInspectorForDetail()
+                    // Revealing relayouts around divider 1, which can leave the tracking separator
+                    // inert (the centered-tabs / missing-divider glitch). Re-bind once it settles.
+                    DispatchQueue.main.async { [weak self] in self?.reassertInspectorSeparator() }
+                }
+            }
+
         // A detail (file editor, diff, trace, PR/issue) opens in the right inspector, beside the
         // terminal. Its own window controls (hide list / maximize / close) live *in* the detail's
         // header now (see `InspectorDetailChromeButtons`), not the toolbar — so this observer only
-        // reveals the inspector on open and mounts/tears down the full-window maximize host.
+        // mounts and tears down the full-window maximize host.
         // `objectWillChange` fires before the value lands, so read the settled state next runloop.
         overlayObserver = store.objectWillChange
             .receive(on: RunLoop.main)
@@ -263,15 +278,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 MainActor.assumeIsolated {
                     guard let self else { return }
                     let presented = self.store.isDetailPresented
-                    let opened = presented && !self.detailWasPresented
-                    self.detailWasPresented = presented
                     let maximized = self.store.inspectorMaximized && presented
                     let restored = self.detailWasMaximized && !maximized
                     self.detailWasMaximized = maximized
-                    // Opening a detail reveals the inspector and gives it a comfortable reading width
-                    // the first time — only on the open transition, so a later store change can't yank
-                    // an inspector the user has since resized.
-                    if opened { self.revealInspectorForDetail() }
                     // Blow the detail up into a full-window host when maximized; tear it down otherwise.
                     self.setDetailMaximized(maximized)
                     // The pane switch (Files/Search/Changes/Issues/Info) re-aims the inspector's list
@@ -279,10 +288,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                     // would act on something off-screen. Pull them from the toolbar for the duration
                     // and restore them on the way back down (the inspector is still open behind the host).
                     self.syncInspectorTabsVisibility()
-                    // Revealing the inspector (open) or tearing down the maximize host (restore) both
-                    // relayout around divider 1, which can leave the tracking separator inert (the
-                    // centered-tabs / missing-divider glitch). Re-bind once layout settles.
-                    if opened || restored {
+                    // Tearing down the maximize host relayouts around divider 1, which can leave the
+                    // tracking separator inert (the centered-tabs / missing-divider glitch). Re-bind
+                    // once layout settles.
+                    if restored {
                         DispatchQueue.main.async { [weak self] in self?.reassertInspectorSeparator() }
                     }
                 }

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -97,6 +97,18 @@ struct GitChangesView: View {
         .onChange(of: model.changes.count) { _, count in changeCount = count }
         .onChange(of: selection) { _, selected in
             if selected.count == 1, let change = model.changes.first(where: { $0.path == selected.first }) {
+                // A selection that merely mirrors the working-tree diff already on screen is the
+                // echo of the `store.openDiff` mirror below — a session switch restoring a saved
+                // diff lands here — not a click. Re-opening it would count as a fresh open and
+                // un-collapse an inspector the user closed (issue #272). Closing the overlay
+                // releases the selection, so clicking the same row still reopens it. The saved
+                // request carries the sibling list it was captured with, so hand the pane's
+                // current one over — that keeps the ← / → walk honest without re-opening.
+                let showing = store.openDiff
+                guard showing?.commit != nil || showing?.change.path != change.path else {
+                    store.refreshOpenDiffSiblings(model.changes)
+                    return
+                }
                 open(change)
             } else if selected.count > 1, store.openDiff != nil {
                 // A multi-selection has no single diff to show — drop the overlay.

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -145,7 +145,7 @@ final class TermioStore: ObservableObject {
     /// Opening a file dismisses any open diff — the two overlays are mutually exclusive.
     @Published var openFileURL: URL? {
         didSet {
-            if openFileURL != nil { openDiff = nil; openTrace = nil; openIssueDetail = nil }
+            if openFileURL != nil { openDiff = nil; openTrace = nil; openIssueDetail = nil; noteDetailOpened() }
             // Closing always returns to the editable default; a read-only open re-asserts the flag
             // immediately before setting the URL (see `openTerminalLink`). The jump line clears too,
             // so a later plain open of the same file doesn't scroll to a stale hit.
@@ -171,7 +171,7 @@ final class TermioStore: ObservableObject {
     /// pane covers itself with `GitDiffView` while it is non-nil. Opening a diff dismisses any open
     /// file editor.
     @Published var openDiff: GitDiffRequest? {
-        didSet { if openDiff != nil { openFileURL = nil; openTrace = nil }; refreshDetailPresentation() }
+        didSet { if openDiff != nil { openFileURL = nil; openTrace = nil; noteDetailOpened() }; refreshDetailPresentation() }
     }
 
     /// The agent trace currently shown over the terminal, or `nil` when none is. The
@@ -179,7 +179,7 @@ final class TermioStore: ObservableObject {
     /// "View Trace" sets it, and `TerminalPane` covers itself with `TraceView` while
     /// it is non-nil. Mutually exclusive with the other two.
     @Published var openTrace: TraceRequest? {
-        didSet { if openTrace != nil { openFileURL = nil; openDiff = nil; openIssueDetail = nil }; refreshDetailPresentation() }
+        didSet { if openTrace != nil { openFileURL = nil; openDiff = nil; openIssueDetail = nil; noteDetailOpened() }; refreshDetailPresentation() }
     }
 
     /// The GitHub issue / pull request whose detail is shown, or `nil` when none is. The
@@ -188,14 +188,46 @@ final class TermioStore: ObservableObject {
     /// Unlike the others it deliberately COEXISTS with `openDiff`: a PR's file diff stacks on
     /// top of the detail, so closing the diff returns to the PR rather than the list.
     @Published var openIssueDetail: IssueSummary? {
-        didSet { if openIssueDetail != nil { openFileURL = nil; openDiff = nil; openTrace = nil }; refreshDetailPresentation() }
+        didSet { if openIssueDetail != nil { openFileURL = nil; openDiff = nil; openTrace = nil; noteDetailOpened() }; refreshDetailPresentation() }
     }
 
-    /// True while any inspector detail (file, diff, trace, PR/issue) is open. Drives the app
-    /// delegate: it un-collapses the inspector and gives it a comfortable reading width on the
-    /// first detail, and tears down the full-window maximize host when the last one closes.
+    /// True while any inspector detail (file, diff, trace, PR/issue) is open. A render
+    /// predicate — "is there content to show" — read by the inspector, the terminal context
+    /// menu and the pane drag, and by the app delegate to mount or tear down the full-window
+    /// maximize host. It is deliberately *not* what reveals the inspector; see `detailDidOpen`.
     /// `private(set)` — only the detail setters above flip it, via `refreshDetailPresentation`.
     @Published private(set) var isDetailPresented = false
+
+    /// Fires when a detail opens because the *user* opened one — a file or diff clicked in the
+    /// inspector, a trace, a PR row, a cmd-clicked path in the terminal. The app delegate
+    /// un-collapses the inspector on it, and nothing else does. Deliberately silent while a
+    /// detail is merely re-stated (see `isRestatingDetail`): what the inspector shows is
+    /// per-session, but whether the panel is open is global, so a session switch (or a launch
+    /// restore) must never flip it back open (issue #272). An event rather than an edge
+    /// detected on `isDetailPresented`, which cannot tell a user's open from a restore.
+    let detailDidOpen = PassthroughSubject<Void, Never>()
+
+    /// Raised by each detail setter when it is handed a detail to show, so *every* user open
+    /// reveals a collapsed inspector — not just the first. Keying this off `isDetailPresented`
+    /// going false → true would miss opening a second file (or a diff over a file) while the
+    /// inspector is collapsed, which is precisely the state a collapse-with-a-detail-open
+    /// leaves behind: the aggregate never dips, so the new detail would open unseen.
+    private func noteDetailOpened() {
+        guard !isRestatingDetail else { return }
+        detailDidOpen.send()
+    }
+
+    /// Re-points the open working-tree diff at a freshened sibling list — the set ← / → walks
+    /// and the header's "n of m" — without counting as a user open. The Changes pane calls this
+    /// when its change list reloads under a diff that is already on screen; re-stating the same
+    /// target must leave a collapsed inspector collapsed (issue #272).
+    func refreshOpenDiffSiblings(_ siblings: [GitChange]) {
+        guard var request = openDiff, request.commit == nil, request.siblings != siblings else { return }
+        request.siblings = siblings
+        isRestatingDetail = true
+        defer { isRestatingDetail = false }
+        openDiff = request
+    }
 
     /// Whether the active inspector detail is blown up to fill the whole window. The inspector
     /// hosts the detail beside the terminal by default; the detail's maximize button flips this
@@ -358,13 +390,18 @@ final class TermioStore: ObservableObject {
     /// spawning `git status` for a pane nobody could see.
     @Published var inspectorVisible = false
 
-    /// A per-session snapshot of the inspector's *content* — which tab is showing and
-    /// which detail (file / diff / trace / PR-issue) is open, plus the detail's
-    /// maximize / list-collapse chrome. Switching terminal tabs restores each session's
+    /// A per-session snapshot of the inspector's *content* — which tab is showing, which
+    /// detail (file / diff / trace / PR-issue) is open, and how that detail splits the
+    /// panel between its list and itself. Switching terminal tabs restores each session's
     /// own right-side context instead of clearing it (issue #160): one session left on a
-    /// file, another on a PR, another on the changes list. The inspector's *width* and
-    /// *open/closed* state stay global — those belong to the AppKit split item; it's the
-    /// content that is session-specific.
+    /// file, another on a PR, another on the changes list.
+    ///
+    /// Chrome that covers something the arriving session did not ask to hide is deliberately
+    /// absent. The inspector's *width* and *open/closed* state belong to the AppKit split
+    /// item, and the full-window maximize is not carried either: re-mounting that host on a
+    /// session switch buries the terminal without the user asking (the same defect as #272,
+    /// which is why the reveal is an event now). A returning session shows its detail docked;
+    /// the user re-maximizes if they want it back.
     struct InspectorState {
         var tab: InspectorTab = .files
         var openFileURL: URL?
@@ -373,7 +410,6 @@ final class TermioStore: ObservableObject {
         var openDiff: GitDiffRequest?
         var openTrace: TraceRequest?
         var openIssueDetail: IssueSummary?
-        var maximized = false
         var listCollapsed = false
     }
 
@@ -390,6 +426,13 @@ final class TermioStore: ObservableObject {
     /// one — it suppresses the capture/restore in `selectedSessionID`'s didSet so a
     /// programmatic selection during launch can't overwrite a just-seeded layout.
     private var isRestoringInspector = false
+
+    /// True while a detail is being *re-stated* rather than opened: `applyInspectorState`
+    /// re-hydrating a session's saved layout (the session switch and the launch restore both
+    /// route through it), or `refreshOpenDiffSiblings` freshening the walk order under a diff
+    /// already on screen. The detail setters run normally — only `detailDidOpen` is withheld,
+    /// so putting content back can never re-expand an inspector the user collapsed.
+    private var isRestatingDetail = false
 
     /// Debounced whole-state save for durable inspector edits (opening a file, switching
     /// the tab). Unlike a session switch, these don't move `selectedSessionID`, so nothing
@@ -413,7 +456,6 @@ final class TermioStore: ObservableObject {
             openDiff: openDiff,
             openTrace: openTrace,
             openIssueDetail: openIssueDetail,
-            maximized: inspectorMaximized,
             listCollapsed: inspectorListCollapsed
         )
     }
@@ -424,6 +466,8 @@ final class TermioStore: ObservableObject {
     /// stacks on top of an open issue (see `openIssueDetail`); and the read-only flag /
     /// jump line precede the file URL (see `openFileURL`).
     private func applyInspectorState(_ state: InspectorState) {
+        isRestatingDetail = true
+        defer { isRestatingDetail = false }
         inspectorTab = state.tab
         openFileURL = nil; openDiff = nil; openTrace = nil; openIssueDetail = nil
         openTrace = state.openTrace
@@ -432,7 +476,10 @@ final class TermioStore: ObservableObject {
         openFileLine = state.openFileLine
         openFileURL = state.openFileURL
         openDiff = state.openDiff
-        inspectorMaximized = state.maximized
+        // Always docked, never carried: see `InspectorState`. A session left maximized
+        // must not blow its detail back up over the arriving terminal, and the departing
+        // session's maximize must not follow the selection either.
+        inspectorMaximized = false
         inspectorListCollapsed = state.listCollapsed
     }
 


### PR DESCRIPTION
Collapsing the right-side inspector, switching sessions, and switching back re-opened it. So did quitting with a file open and the inspector closed. The reveal was inferred from an edge on `isDetailPresented`, which a session restore drives just as a click does — so the panel's global open/closed state followed per-session content.

`TermioStore` now raises `detailDidOpen` from the detail setters and withholds it while a detail is only being re-stated. The delegate's `detailWasPresented` latch is deleted. Because the event is on the assignment rather than the aggregate, opening a *second* file while the inspector is collapsed reveals it too — the old edge never fired there.

Two related paths that moved chrome without the user asking:

- The Changes pane mirrored a restored diff into its selection and re-opened it, revealing the inspector after the restore guard had ended. It now freshens the diff's sibling list in place via `refreshOpenDiffSiblings` instead.
- `InspectorState` no longer carries `maximized`, so returning to a session cannot re-mount the full-window host over the terminal.

Reviewed with Codex across four passes; the first two found the second-file and Changes-pane holes, both fixed here.

## Verification

`swift build` clean, `swift test` 214/214. On-screen behavior is not machine-verifiable here — the collapse state lives in the AppKit split item — so it needs a manual pass:

- open a file, collapse the inspector, switch sessions and back → stays collapsed, file still there
- while collapsed, cmd-click a path in the terminal → inspector opens
- open a file, collapse, quit, relaunch → stays collapsed
- maximize a detail, switch sessions and back → detail comes back docked

## Release Notes:

Fixed the right-side inspector reopening itself when you returned to a session, or after a relaunch, once you had closed it.