### PR TITLE
Stop the git pane's file watch crashing the app

### DIFF
--- a/Sources/termio/Git/FolderEventStream.swift
+++ b/Sources/termio/Git/FolderEventStream.swift
@@ -20,8 +20,14 @@ final class FolderEventStream {
     /// queue overflowed, FSEvents sets `kFSEventStreamEventFlagMustScanSubDirs` and
     /// the path means "anything under here may have changed" — a consumer applying
     /// events incrementally must widen to a rescan or go silently stale.
+    /// `handler` is `@Sendable` because FSEvents calls it on `queue`, which is rarely the
+    /// main one. Without it a closure written inside a `@MainActor` type silently *inherits*
+    /// that isolation, compiles clean, and traps the moment an event arrives — the Swift 6
+    /// executor check turns the first main-actor touch into `SIGTRAP`, killing the app.
+    /// `@Sendable` forbids the inheritance, so the hop back is the caller's explicit job and
+    /// forgetting it is a compile error rather than a crash in someone's editor.
     init?(paths: [String], latency: TimeInterval, queue: DispatchQueue,
-          handler: @escaping ([String], [FSEventStreamEventFlags]) -> Void) {
+          handler: @escaping @Sendable ([String], [FSEventStreamEventFlags]) -> Void) {
         var context = FSEventStreamContext()
         context.info = Unmanaged.passRetained(Handler(handler)).toOpaque()
         context.release = { info in

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -55,13 +55,15 @@ final class GitPanelModel: ObservableObject {
     /// named like a build product must not go deaf to every event. A repo that
     /// actually tracks one of these still stays honest — any event outside the list,
     /// and app re-activation, reload from git, the source of truth.
-    private static let ignoredEventComponents: Set<String> = [
+    private nonisolated static let ignoredEventComponents: Set<String> = [
         ".build", "node_modules", "DerivedData", ".venv", ".gradle", ".turbo", ".next",
     ]
 
     /// Whether an event path sits under a build-product directory *inside* one of the
     /// watched roots. The roots' own ancestry is deliberately not inspected.
-    private static func isBuildProductEvent(_ path: String, underAny roots: [String]) -> Bool {
+    /// `nonisolated` because the FSEvents handler calls it on the watcher's own queue —
+    /// it is pure string work over its arguments and touches no actor state.
+    private nonisolated static func isBuildProductEvent(_ path: String, underAny roots: [String]) -> Bool {
         for root in roots where path == root || path.hasPrefix(root + "/") {
             return path.dropFirst(root.count).split(separator: "/")
                 .contains { ignoredEventComponents.contains(String($0)) }
@@ -155,13 +157,15 @@ final class GitPanelModel: ObservableObject {
         let (tree, gitDirs) = await GitService.watchPaths(for: repoRoot)
         guard watcher == nil, !gitDirs.isEmpty else { return }
         // The primary checkout's `.git` sits inside the tree and needs no second watch.
-        var paths = [tree]
-        paths += gitDirs.filter { !$0.hasPrefix(tree + "/") }
+        // Immutable, because the handler below runs off the main actor and captures it.
+        let paths = [tree] + gitDirs.filter { !$0.hasPrefix(tree + "/") }
         watcher = FolderEventStream(
             paths: paths, latency: 0.4,
             queue: DispatchQueue(label: "sh.termio.gitpane.fsevents", qos: .utility)
         ) { [weak self] eventPaths, _ in
-            // Build-product churn can't change the pane; don't let it spawn git.
+            // Runs on the FSEvents queue: everything up to the hop below must stay
+            // off the main actor. Build-product churn can't change the pane; don't
+            // let it spawn git.
             let relevant = eventPaths.filter { path in
                 !Self.isBuildProductEvent(path, underAny: paths)
             }


### PR DESCRIPTION
termio dies with `SIGTRAP` when files change under a repo whose git pane is armed. Crash reports show the FSEvents callback going through `swift_task_checkIsolated` → `dispatch_assert_queue_fail` in `GitPanelModel.armWatcher()`.

The handler closure is written inside a `@MainActor` method, so it *inherits* main-actor isolation. `FolderEventStream` runs it on a utility queue, and the first main-actor touch — the `isBuildProductEvent` filter — trips Swift 6's executor check and kills the process. The `Task { @MainActor }` hop at the end of the handler was correct; the work before it was not.

Fixing only the one call would leave the trap armed for the next caller, so the fix is at the API boundary: `FolderEventStream`'s handler is `@Sendable`, which forbids isolation inheritance outright. That turns the same mistake into a compile error — it produced exactly the two errors this PR fixes, at the crash site. `FileTreeWatcher`, the other consumer, already delivers on `.main` and needed no change.

Hit repeatedly today during ordinary rebuilds: an agent's edit-build-look loop writes into the worktree constantly, which is exactly the trigger.

## Verification

`swift build` clean, `swift test` 243/243. The compiler reproducing the defect is the regression guard — the isolation is now checked at build time rather than asserted at runtime. Not exercised on a running app; the runtime check is to open the Changes pane and write a file into the repo.

## Release Notes:

Fixed a crash when files changed on disk while the git pane was open.