### PR TITLE
Match the terminal's glyph weight in diffs

### DIFF
--- a/Sources/termio/Git/DiffTextView.swift
+++ b/Sources/termio/Git/DiffTextView.swift
@@ -17,6 +17,9 @@ struct DiffTextPane: NSViewRepresentable {
     /// once they land; the document renders plain until then.
     let styled: [Int: NSAttributedString]
     let font: NSFont
+    /// The terminal's `Thicken glyphs`, so a diff and the terminal beside it are smoothed
+    /// the same way (see `DiffWashLayoutManager.thickenGlyphs`).
+    let thickenGlyphs: Bool
     let backgroundColor: NSColor
     /// Line-number ink, from the shared `gutterInk(for:)` so the diff's gutter and the
     /// file editor's read as one family.
@@ -171,6 +174,7 @@ struct DiffTextPane: NSViewRepresentable {
     private func apply(to textView: DiffTextView, layoutManager: DiffWashLayoutManager,
                        ruler: DiffGutterRulerView, coordinator: Coordinator) {
         textView.backgroundColor = backgroundColor
+        layoutManager.thickenGlyphs = thickenGlyphs
         if coordinator.appliedDocument !== document {
             coordinator.appliedDocument = document
             coordinator.appliedStyled = nil
@@ -458,6 +462,18 @@ final class DiffTextView: NSTextView {
 /// composites on top.
 final class DiffWashLayoutManager: NSLayoutManager {
     var document: DiffDocument?
+    /// Follows the terminal's `Thicken glyphs`. Ghostty rasterizes its own glyphs and only
+    /// dilates them when that switch is on, while AppKit smooths every glyph it draws — so
+    /// the same face at the same size reads heavier in a diff than in the terminal one pane
+    /// over. Turning smoothing off with the switch keeps one setting over both surfaces.
+    var thickenGlyphs = false
+
+    override func drawGlyphs(forGlyphRange glyphsToShow: NSRange, at origin: NSPoint) {
+        if !thickenGlyphs {
+            NSGraphicsContext.current?.cgContext.setShouldSmoothFonts(false)
+        }
+        super.drawGlyphs(forGlyphRange: glyphsToShow, at: origin)
+    }
 
     override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: NSPoint) {
         if let document, let container = textContainers.first {

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -208,6 +208,7 @@ struct GitDiffView: View {
                 document: document,
                 styled: styledLines,
                 font: settings.resolvedTerminalFont(),
+                thickenGlyphs: settings.fontThicken,
                 backgroundColor: settings.terminalBackgroundColor,
                 numberColor: settings.gutterInk(for: colorScheme),
                 onExpand: { anchor, direction in

--- a/Sources/termio/Git/PRFilesDiffView.swift
+++ b/Sources/termio/Git/PRFilesDiffView.swift
@@ -226,6 +226,7 @@ private struct PRFileDiffBody: View {
                 document: document,
                 styled: styledLines,
                 font: settings.resolvedTerminalFont(),
+                thickenGlyphs: settings.fontThicken,
                 backgroundColor: settings.terminalBackgroundColor,
                 numberColor: settings.gutterInk(for: colorScheme),
                 onExpand: { anchor, direction in
@@ -416,6 +417,7 @@ private struct FileDiffCard: View {
                 document: document,
                 styled: styledLines,
                 font: settings.resolvedTerminalFont(),
+                thickenGlyphs: settings.fontThicken,
                 backgroundColor: settings.terminalBackgroundColor,
                 numberColor: settings.gutterInk(for: colorScheme),
                 onExpand: { anchor, direction in

--- a/Sources/termio/Theme/ChromeTheme.swift
+++ b/Sources/termio/Theme/ChromeTheme.swift
@@ -84,12 +84,13 @@ extension AppSettings {
     /// fallback: name lookup fails for system faces like the default "SF Mono"
     /// (Apple doesn't expose it by name to third-party apps), and SwiftUI's
     /// `Font.custom` would paper over that by silently substituting Helvetica.
-    func resolvedTerminalFont(minSize: Double = 11) -> NSFont {
-        let size = max(minSize, fontSize)
-        if !fontFamily.isEmpty, let font = NSFont(name: fontFamily, size: size) {
+    /// The size is the terminal's own — no floor of its own, or a code surface would
+    /// stop shrinking with the terminal it is supposed to match.
+    func resolvedTerminalFont() -> NSFont {
+        if !fontFamily.isEmpty, let font = NSFont(name: fontFamily, size: fontSize) {
             return font
         }
-        return .monospacedSystemFont(ofSize: size, weight: .regular)
+        return .monospacedSystemFont(ofSize: fontSize, weight: .regular)
     }
 
     /// Extra leading (points) lifting `font`'s natural line height to the configured


### PR DESCRIPTION
The same font at the same size read heavier in a diff than in the terminal one pane over — measured at 13.6% more ink with Berkeley Mono 16. AppKit smooths every glyph it draws; Ghostty rasterizes the terminal's own and dilates them only when `font-thicken` is on. Two different answers to the same question, on two surfaces sitting side by side.

`DiffWashLayoutManager` now follows that same switch: with `Thicken glyphs` off it turns font smoothing off before drawing, so one setting governs both surfaces. `resolvedTerminalFont` also drops its 11pt floor, so a code surface keeps shrinking with the terminal it is meant to match.

Touches the working-tree diff, the PR files diff, and the shared chrome theme.

## Release Notes:

Diffs now render text at the same weight as the terminal, and follow the Thicken Glyphs setting.