### PR TITLE
Point libghostty-swift at termio-sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ software with no backend, no account, and no license server.
 
 macOS 14+ and Swift 6 (Xcode 26). No `zig` toolchain is needed: libghostty
 ships as a prebuilt `GhosttyKit.xcframework` through the
-[jiweiyuan/libghostty-swift](https://github.com/jiweiyuan/libghostty-swift)
+[termio-sh/libghostty-swift](https://github.com/termio-sh/libghostty-swift)
 package. Do not try to build Ghostty from source in this repo.
 
 ## Common commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ open an issue and discuss before writing code.
 - Swift 6 (Xcode 26).
 - No `zig` toolchain needed: libghostty ships as a prebuilt
   `GhosttyKit.xcframework` via the
-  [jiweiyuan/libghostty-swift](https://github.com/jiweiyuan/libghostty-swift)
+  [termio-sh/libghostty-swift](https://github.com/termio-sh/libghostty-swift)
   package. Do not try to build Ghostty from source in this repo.
 
 ## Building and running
@@ -99,7 +99,7 @@ the upstream license in a vendor `README.md`, route resource lookups through
 header.
 
 Changes to libghostty itself go to the
-[jiweiyuan/libghostty-swift](https://github.com/jiweiyuan/libghostty-swift)
+[termio-sh/libghostty-swift](https://github.com/termio-sh/libghostty-swift)
 fork (as rebased patch files there), not this repo; Termio then bumps the
 package version in `Package.swift`.
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -13,7 +13,7 @@
     {
       "identity" : "libghostty-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jiweiyuan/libghostty-swift",
+      "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
         "revision" : "f2d4cbdf7a16bc5d917034f813f47c2a1c5dde97",
         "version" : "1.0.16"

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [.macOS(.v14)],
     dependencies: [
-        // libghostty (Ghostty's terminal core), via our jiweiyuan/libghostty-swift
+        // libghostty (Ghostty's terminal core), via our termio-sh/libghostty-swift
         // fork of Lakr233/libghostty-spm (ships the `GhosttyTerminal` Swift wrapper —
         // incl. the host-managed `.inMemory` backend PTYProcess drives — plus a prebuilt
         // GhosttyKit.xcframework, so no zig toolchain here). Same package the iOS app
@@ -14,7 +14,7 @@ let package = Package(
         // live resize" suspicion that briefly rolled this back to Lakr233 was a
         // misdiagnosis — the real bug was termio's own PTY spawn shape (see
         // docs/bug/terminal-resize-no-reflow-HANDOFF.md §0).
-        .package(url: "https://github.com/jiweiyuan/libghostty-swift", from: "1.0.16"),
+        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.16"),
         // Sparkle powers in-app auto-update (the "Check for Updates…" menu item and
         // background update checks). It reads the appcast published with each GitHub
         // release; the matching EdDSA public key is embedded in packaging/Info.plist.

--- a/ios/TermioMobile.xcodeproj/project.pbxproj
+++ b/ios/TermioMobile.xcodeproj/project.pbxproj
@@ -465,7 +465,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		E76CADD6045BA4FE33901492 /* XCRemoteSwiftPackageReference "libghostty-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/jiweiyuan/libghostty-swift";
+			repositoryURL = "https://github.com/termio-sh/libghostty-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.0.16;

--- a/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,7 +12,7 @@
     {
       "identity" : "libghostty-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jiweiyuan/libghostty-swift",
+      "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
         "revision" : "f2d4cbdf7a16bc5d917034f813f47c2a1c5dde97",
         "version" : "1.0.16"

--- a/skills/check-ghostty-update/SKILL.md
+++ b/skills/check-ghostty-update/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: check-ghostty-update
-description: "Check whether ghostty (the terminal core termio embeds via the jiweiyuan/libghostty-swift fork) has shipped anything worth pulling since the binary termio is currently pinned to. Resolves the pinned ghostty sha, diffs it against ghostty main, filters the gap for changes that actually reach termio's embedded VT/terminal core (dropping app-chrome / packaging / i18n noise), and gives a keep-waiting-or-pull-now verdict. Invoke when the user says 'check ghostty update', 'is ghostty out of date', 'did ghostty ship anything major', 'should I bump ghostty/libghostty', '看看 ghostty 有没有更新', '检查 ghostty 更新', 'ghostty 有什么重大更新', or '要不要更新 libghostty'."
+description: "Check whether ghostty (the terminal core termio embeds via the termio-sh/libghostty-swift fork) has shipped anything worth pulling since the binary termio is currently pinned to. Resolves the pinned ghostty sha, diffs it against ghostty main, filters the gap for changes that actually reach termio's embedded VT/terminal core (dropping app-chrome / packaging / i18n noise), and gives a keep-waiting-or-pull-now verdict. Invoke when the user says 'check ghostty update', 'is ghostty out of date', 'did ghostty ship anything major', 'should I bump ghostty/libghostty', '看看 ghostty 有没有更新', '检查 ghostty 更新', 'ghostty 有什么重大更新', or '要不要更新 libghostty'."
 ---
 
 # Check ghostty update
 
 termio does **not** build ghostty itself — it embeds ghostty's terminal core through
-the **`jiweiyuan/libghostty-swift`** fork, whose weekly CI rebuilds `GhosttyKit.xcframework`
+the **`termio-sh/libghostty-swift`** fork, whose weekly CI rebuilds `GhosttyKit.xcframework`
 against ghostty `main` and publishes it as a `storage.X.Y.Z` release ([[termio-libghostty-swift]]).
 So "is ghostty up to date" really means: **how far is ghostty `main` ahead of the sha baked
 into the binary termio is pinned to, and is anything in that gap relevant to termio?**
@@ -32,7 +32,7 @@ names a `storage.X.Y.Z` binary → that storage release's **title** carries the 
 
 ```bash
 REPO=$(git rev-parse --show-toplevel)
-FORK=jiweiyuan/libghostty-swift
+FORK=termio-sh/libghostty-swift
 GHOSTTY=ghostty-org/ghostty
 
 VER=$(grep -A6 '"identity" : "libghostty-swift"' "$REPO/Package.resolved" \
@@ -106,7 +106,7 @@ Give a short, honest call:
 The binary can't be built locally. To pull ghostty early:
 1. Manually dispatch the fork's CI against a specific ghostty ref — the fork's
    `.github/workflows/build.yml` takes a `ghostty_ref` input (default builds `main` HEAD):
-   `gh workflow run build.yml --repo jiweiyuan/libghostty-swift -f ghostty_ref=main`
+   `gh workflow run build.yml --repo termio-sh/libghostty-swift -f ghostty_ref=main`
    (or pin an exact sha). It publishes a new `storage.X.Y.Z` + `X.Y.Z` tag (~30 min).
 2. Bump termio's pin (`Package.swift` `from:` + re-resolve `Package.resolved`), and the
    iOS `TermioMobile.xcodeproj` pin if the phone should get it too (it pins the fork


### PR DESCRIPTION
The libghostty fork now lives at [termio-sh/libghostty-swift](https://github.com/termio-sh/libghostty-swift), next to the app repo. All 15 releases and their `GhosttyKit.xcframework` assets came across, and GitHub redirects the old URL.

Redirects mean nothing breaks while unpinned, but the URL is recorded in four places that resolve rather than follow links — `Package.swift`, both `Package.resolved` files, and the iOS project's `XCRemoteSwiftPackageReference`. A package whose recorded location disagrees with its declared URL is the kind of thing that resolves fine on a dev machine and stalls in a clean CI checkout, which is the release path.

Also updated: `AGENTS.md`, `CONTRIBUTING.md`, and the `check-ghostty-update` skill (its `FORK=` variable is executable, not prose).

Left alone: `docs/plan/terminal-narrow-grid-frozen-banner-fix.md` and `docs/prompts/terminal-narrow-grid-on-open-investigation.md`. Those are dated records of work done when the fork had the old name.

## Verification

- `swift build` — resolves from the new URL; `Package.resolved` re-resolves to `termio-sh` and stays there
- `swift test` — 252 tests, 0 failures
- `./scripts/build-app.sh` — packaged and signed `termio.app` cleanly, since the release path is the actual risk here

## Release Notes:

No user-facing change.