### PR TITLE
Reap a phone whose companion link died without a FIN

### DIFF
--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -92,6 +92,69 @@ final class MobileAccess: ObservableObject {
     }
 }
 
+/// Which companion links are still answering, by the only signal that crosses
+/// the whole path: the pong to the server's own ping.
+///
+/// A phone that leaves coverage or sleeps mid-session never sends a FIN, so its
+/// socket stays on the books for minutes — and that is not a harmless ghost,
+/// because the bridge on it still owns the PTY's winsize, leaving the Mac's own
+/// window sized to a phone that is gone. Nothing underneath reports this in
+/// time: TCP keepalive only proves the *next hop* answers, which over a tunnel
+/// is a daemon on this very machine.
+///
+/// A pure value with an injected clock, because this arithmetic is the whole
+/// decision to tear down a live session's bridge and deserves to be tested
+/// without a socket.
+struct LinkLiveness {
+    /// Two and a half missed pings. Under this a phone on a slow cellular hop
+    /// gets reaped mid-session; far over it, a dead phone keeps the winsize.
+    static let silenceLimit: TimeInterval = 50
+    /// A sweep this far behind the previous one means nobody was *reading*
+    /// pongs for the gap: the receive handlers hop through the main queue, so a
+    /// block there leaves proof of life sitting in a backlog rather than
+    /// missing. The silence is ours, not the phones'.
+    ///
+    /// Measured sweep-to-sweep, which makes `silentLinks` a per-tick call by
+    /// contract — sweep it on a cadence slower than this and every round looks
+    /// like a stall, so nothing is ever reaped.
+    static let stallGrace: TimeInterval = 5
+
+    private var lastHeard: [ObjectIdentifier: TimeInterval] = [:]
+    private var sweptAt: TimeInterval?
+
+    /// Any frame is proof of life, and a pong counts: an attached phone that is
+    /// only reading sends nothing else for minutes at a stretch.
+    mutating func heard(_ id: ObjectIdentifier, at now: TimeInterval) {
+        lastHeard[id] = now
+    }
+
+    mutating func forget(_ id: ObjectIdentifier) {
+        lastHeard[id] = nil
+    }
+
+    mutating func forgetAll() {
+        lastHeard.removeAll()
+        sweptAt = nil
+    }
+
+    /// The links that have answered nothing for `silenceLimit`, and how long
+    /// each has been silent. Uses a monotonic clock (`systemUptime`), so a
+    /// clock change can never reap a healthy phone.
+    mutating func silentLinks(at now: TimeInterval) -> [(id: ObjectIdentifier, silence: TimeInterval)] {
+        defer { sweptAt = now }
+        // A late sweep — the main runloop was blocked — means the pongs went
+        // unheard rather than unanswered. Forgive the gap and restart every
+        // clock, or one beachball reaps every phone at once.
+        if let sweptAt, now - sweptAt > Self.stallGrace {
+            for id in lastHeard.keys { lastHeard[id] = now }
+            return []
+        }
+        return lastHeard.compactMap { id, heard in
+            now - heard > Self.silenceLimit ? (id, now - heard) : nil
+        }
+    }
+}
+
 /// Serves the iOS companion app over WebSockets on one port: every connection
 /// starts as a roster subscriber (the same project/session tree the sidebar
 /// shows, pushed on connect and on change); a connection that sends an
@@ -133,6 +196,7 @@ final class CompanionServer {
     private var lastRoster: CompanionRoster?
     private var pollTimer: Timer?
     private var ticks = 0
+    private var liveness = LinkLiveness()
 
     /// The one port everything agrees on: the app serves here, dev-run.sh
     /// points the phone here, and the Settings ▸ Mobile QR encodes it. A dev-channel
@@ -207,13 +271,18 @@ final class CompanionServer {
         broadcastIfChanged()
         ticks += 1
         // Active pings (autoReplyPing only answers the peer's): keeps NAT /
-        // proxy mappings warm and surfaces half-dead links within ~20s.
+        // proxy mappings warm, and the pong that answers is the proof of life
+        // the sweep below reads.
         if ticks % 20 == 0 {
             let meta = NWProtocolWebSocket.Metadata(opcode: .ping)
             let context = NWConnection.ContentContext(identifier: "ping", metadata: [meta])
             for connection in connectionByID.values {
                 connection.send(content: Data("hb".utf8), contentContext: context, completion: .idempotent)
             }
+        }
+        for (id, silence) in liveness.silentLinks(at: ProcessInfo.processInfo.systemUptime) {
+            Log.companion.notice("reaping silent phone link after \(Int(silence), privacy: .public)s")
+            drop(id)
         }
     }
 
@@ -229,12 +298,14 @@ final class CompanionServer {
         connectionByID.removeAll()
         connections.removeAll()
         authenticatedWireByConnection.removeAll()
+        liveness.forgetAll()
     }
 
     private func accept(_ connection: NWConnection) {
         let id = ObjectIdentifier(connection)
         connections.insert(id)
         connectionByID[id] = connection
+        liveness.heard(id, at: ProcessInfo.processInfo.systemUptime)
         connection.stateUpdateHandler = { [weak self] state in
             switch state {
             case .cancelled, .failed:
@@ -272,6 +343,7 @@ final class CompanionServer {
         connectionByID[id] = nil
         connections.remove(id)
         authenticatedWireByConnection[id] = nil
+        liveness.forget(id)
     }
 
     private func receive(on connection: NWConnection) {
@@ -279,6 +351,10 @@ final class CompanionServer {
             if error != nil {
                 Task { @MainActor in self?.drop(ObjectIdentifier(connection)) }
                 return
+            }
+            let heardAt = ProcessInfo.processInfo.systemUptime
+            Task { @MainActor in
+                self?.liveness.heard(ObjectIdentifier(connection), at: heardAt)
             }
             let meta = context?.protocolMetadata(definition: NWProtocolWebSocket.definition)
                 as? NWProtocolWebSocket.Metadata

--- a/Tests/termioTests/LinkLivenessTests.swift
+++ b/Tests/termioTests/LinkLivenessTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import termio
+
+/// The rule that decides when a phone's companion link is dead. Both directions
+/// cost something real: reaping a live link tears down a session the user is
+/// typing into, and sparing a dead one leaves the Mac's own window sized to a
+/// phone that left the building.
+final class LinkLivenessTests: XCTestCase {
+    // Held for the test's lifetime — an `ObjectIdentifier` of a temporary is
+    // just a freed address, and the next allocation can reuse it.
+    private let firstSocket = NSObject()
+    private let secondSocket = NSObject()
+    private var phone: ObjectIdentifier { ObjectIdentifier(firstSocket) }
+    private var other: ObjectIdentifier { ObjectIdentifier(secondSocket) }
+
+    func testLinkAnsweringInsideTheLimitSurvives() {
+        var liveness = LinkLiveness()
+        liveness.heard(phone, at: 0)
+        // The server pings every 20s, so a healthy link refreshes well inside
+        // the limit however long the session runs.
+        for beat in stride(from: 20.0, through: 200.0, by: 20.0) {
+            XCTAssertTrue(liveness.silentLinks(at: beat).isEmpty)
+            liveness.heard(phone, at: beat)
+        }
+    }
+
+    func testSilentLinkIsReapedOnceTheLimitPasses() {
+        var liveness = LinkLiveness()
+        liveness.heard(phone, at: 0)
+        liveness.heard(other, at: 0)
+        liveness.heard(other, at: 45)
+
+        XCTAssertTrue(liveness.silentLinks(at: 50).isEmpty, "the limit is exclusive")
+        let reaped = liveness.silentLinks(at: 51)
+        XCTAssertEqual(reaped.map(\.id), [phone], "only the link that stopped answering")
+        XCTAssertEqual(reaped.first?.silence, 51)
+    }
+
+    /// The failure this guards against is a mass reap: one blocked runloop would
+    /// otherwise look like every phone going silent at the same instant, and
+    /// every session on the Mac would lose its bridge together.
+    func testAStalledRunloopForgivesTheGapInsteadOfReapingEveryone() {
+        var liveness = LinkLiveness()
+        liveness.heard(phone, at: 0)
+        liveness.heard(other, at: 0)
+        XCTAssertTrue(liveness.silentLinks(at: 1).isEmpty)
+
+        // Nothing swept for two minutes: nobody was reading pongs during the
+        // gap, so the silence is the Mac's, not the phones'.
+        XCTAssertTrue(liveness.silentLinks(at: 121).isEmpty)
+
+        // Back on the tick. One phone answers, the other never does — the
+        // stall bought it a fresh limit, not immunity.
+        var reaped: [(second: TimeInterval, id: ObjectIdentifier)] = []
+        for second in stride(from: 122.0, through: 200.0, by: 1.0) {
+            if second == 150 { liveness.heard(other, at: second) }
+            reaped += liveness.silentLinks(at: second).map { (second, $0.id) }
+        }
+        XCTAssertEqual(Set(reaped.map(\.id)), [phone], "the link that stayed silent past the stall is gone")
+        XCTAssertEqual(reaped.first?.second, 172, "the stall bought it a fresh limit, not immunity")
+    }
+
+    /// `stallGrace` is measured sweep-to-sweep, so sweeping slower than it
+    /// makes every round look like a stalled runloop and nothing is ever
+    /// reaped. This is the trap in moving the sweep under the 20s ping cadence.
+    func testSweepingSlowerThanTheGraceNeverReaps() {
+        var liveness = LinkLiveness()
+        liveness.heard(phone, at: 0)
+        for sweep in stride(from: 20.0, through: 300.0, by: 20.0) {
+            XCTAssertTrue(liveness.silentLinks(at: sweep).isEmpty)
+        }
+    }
+
+    func testForgivenessNeedsAPriorSweepToMeasureAgainst() {
+        var liveness = LinkLiveness()
+        liveness.heard(phone, at: 0)
+        // First sweep of the process's life, long after this socket was
+        // accepted: there is no gap to blame, so the silence stands.
+        XCTAssertEqual(liveness.silentLinks(at: 100).map(\.id), [phone])
+    }
+
+    func testDroppedLinkStopsBeingSwept() {
+        var liveness = LinkLiveness()
+        liveness.heard(phone, at: 0)
+        liveness.forget(phone)
+        XCTAssertTrue(liveness.silentLinks(at: 40).isEmpty)
+
+        liveness.heard(phone, at: 41)
+        liveness.forgetAll()
+        XCTAssertTrue(liveness.silentLinks(at: 42).isEmpty)
+    }
+}

--- a/ios/Sources/CompanionTransport.swift
+++ b/ios/Sources/CompanionTransport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 import TermioShared
 import UIKit
 
@@ -39,6 +40,9 @@ final class CompanionTransport: NSObject {
     private var isConnected = false
     private var policy = ReconnectPolicy()
     private var foregroundObserver: NSObjectProtocol?
+    private var pathMonitor: NWPathMonitor?
+    private var lastPathStatus: NWPath.Status?
+    private var pingTimer: Timer?
     /// Only touched on the delegate queue (see `didOpen`).
     private var everConnected = false
     /// Last grid the terminal reported, re-sent on every (re)connect and on
@@ -88,6 +92,8 @@ final class CompanionTransport: NSObject {
         policy.reset()
         notify(.connecting)
         connect()
+        startPathMonitor()
+        startPingTimer()
         if foregroundObserver == nil {
             foregroundObserver = NotificationCenter.default.addObserver(
                 forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main
@@ -161,10 +167,61 @@ final class CompanionTransport: NSObject {
         isConnected = false
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
+        pathMonitor?.cancel()
+        pathMonitor = nil
+        lastPathStatus = nil
+        pingTimer?.invalidate()
+        pingTimer = nil
         if let observer = foregroundObserver {
             NotificationCenter.default.removeObserver(observer)
             foregroundObserver = nil
         }
+    }
+
+    /// Reconnect the instant the network path comes back (Wi-Fi rejoin, cellular
+    /// handoff, VPN toggle) instead of sitting out a scheduled backoff. Without
+    /// this the terminal stays dead for up to the 30s heartbeat after a network
+    /// switch that the phone itself already knows about.
+    private func startPathMonitor() {
+        guard pathMonitor == nil else { return }
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self, !stopped else { return }
+            let cameUp = path.status == .satisfied
+                && lastPathStatus != nil && lastPathStatus != .satisfied
+            lastPathStatus = path.status
+            guard cameUp, !isConnected else { return }
+            policy.reset()
+            connect()
+        }
+        monitor.start(queue: .main)
+        pathMonitor = monitor
+    }
+
+    /// A half-open socket (the Mac slept, the network switched under us, the
+    /// tunnel dropped the hop) never fails `receive` — the read just waits
+    /// forever on a connection nothing will ever answer, and the session looks
+    /// frozen rather than disconnected. A periodic ping is what notices, and
+    /// its failure forces the reconnect loop.
+    private func startPingTimer() {
+        pingTimer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
+            guard let self, !stopped, isConnected, let task else { return }
+            task.sendPing { [weak self] error in
+                guard error != nil else { return }
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, !stopped, task === self.task, isConnected else { return }
+                    isConnected = false
+                    notify(.reconnecting)
+                    policy.reset()
+                    connect()
+                }
+            }
+        }
+        // Common mode, or scrolling the scrollback holds the probe off for as
+        // long as the finger is down.
+        RunLoop.main.add(timer, forMode: .common)
+        pingTimer = timer
     }
 
     private func connect() {


### PR DESCRIPTION
A phone that leaves coverage or sleeps never sends a FIN, so its half-open socket stays on the books for minutes — and the bridge on it still owns the PTY's winsize, leaving the Mac's window sized to a phone that is gone. `drop()` is the only path that hands ownership back, and nothing was calling it.

The server now reads the pong to its own 20s ping as proof of life and drops a link that has answered nothing for 50s. That signal is the one that crosses the whole path: TCP keepalive would only prove the next hop answers, which over a tunnel is a daemon on this very machine.

A sweep that arrives late means the main queue was blocked and the pongs are sitting in a backlog rather than missing, so it forgives the gap instead of reaping every phone at once. The rule is `LinkLiveness` — a pure value with an injected clock, because deciding to tear down a live session's bridge deserves a test that doesn't need a socket. Its grace is measured sweep to sweep, so `silentLinks` is a per-tick call by contract; sweeping slower than the grace would make every round look like a stall and reap nothing, which `testSweepingSlowerThanTheGraceNeverReaps` pins.

`CompanionTransport` gains the 15s ping that `CompanionClient` already had, so the phone notices its own half-open socket instead of showing a frozen screen. Without it the reap above just moves the freeze to the other end.

## Compatibility with shipped phones

The 50s reap counts any received frame as proof of life, so it must not kill a TestFlight 1.1 phone that predates the client-side ping. Verified against a Network.framework listener built to mirror `CompanionServer.start()` (`autoReplyPing = true`, same receive pump, same 20s ping), with a client that never initiates a ping and never sends data:

```
PING sent
RECEIVED opcode=pong bytes=2
PING sent
RECEIVED opcode=pong bytes=2
```

`NWConnection` surfaces the pong to the receive handler, so `lastHeard` refreshes every 20s on a link that sends nothing at all — two refreshes inside the 50s limit. A pong also falls through to `default: break` rather than being decoded as a control frame, and the pump re-arms outside the opcode switch, so it cannot end the receive loop.

## Release Notes

- The Mac now releases a session's window size when a phone drops off the network instead of holding it until the socket times out.
- A phone whose terminal link goes half-open reconnects instead of sitting on a frozen screen.