### PR TITLE
Fill the selected home tab icon on iPhone

### DIFF
--- a/Shared/Sources/TermioShared/BrandIcons.swift
+++ b/Shared/Sources/TermioShared/BrandIcons.swift
@@ -454,6 +454,30 @@ public enum HugeIcon: Hashable, Sendable {
             return "M20.5 3.5L14.5 9.5 M14.5 9.5L18.5 9.5 M14.5 9.5L14.5 5.5 M3.5 20.5L9.5 14.5 M9.5 14.5L5.5 14.5 M9.5 14.5L9.5 18.5"
         }
     }
+
+    /// Which of the glyph's `M`-delimited subpaths form its solid silhouette,
+    /// for marks that have a filled twin. The listed subpaths are filled; every
+    /// other one — the bubble's dots, the terminal's prompt, the gear's bore —
+    /// is punched back out of that fill, which is how Hugeicons draws its own
+    /// solid style. `nil` where a mark has no solid reading: the free Hugeicons
+    /// set ships stroke glyphs only, so a filled variant exists only where the
+    /// stroke outline already closes into a body.
+    ///
+    /// Used for the selected state of the iOS home tabs, matching the platform
+    /// convention that a selected tab's symbol fills in.
+    public var solidSubpaths: [Int]? {
+        switch self {
+        // One open outline that closes into the folder silhouette.
+        case .folder: return [0]
+        // Bubble, then the three dots.
+        case .bubbleChat: return [0]
+        // Prompt chevron, prompt line, then the screen body.
+        case .terminal: return [2]
+        // Bore, then the gear body.
+        case .settings: return [1]
+        default: return nil
+        }
+    }
 }
 
 /// A vendor brand mark, stored as its official SVG path so it renders crisp

--- a/ios/Sources/GlassControls.swift
+++ b/ios/Sources/GlassControls.swift
@@ -70,4 +70,88 @@ extension HugeIcon {
             cg.strokePath()
         }.withRenderingMode(.alwaysTemplate)
     }
+
+    /// The glyph's filled twin, for a selected tab — nil for marks that have no
+    /// solid reading (see `solidSubpaths`). Drawn from the same path at the same
+    /// placement as `strokeImage`, minus the half-stroke inset, so the fill's
+    /// outer edge lands exactly where the outline's did and the mark neither
+    /// shifts nor changes size when the tab is selected. The remaining subpaths
+    /// are punched back out in `.clear`, which is what keeps the bubble's dots,
+    /// the terminal's prompt, and the gear's bore legible against the fill: a
+    /// closed one becomes a hole, an open one a cleared stroke of the same
+    /// round-capped line the outline drew.
+    func solidImage(boxSize: CGFloat) -> UIImage? {
+        guard let solidSubpaths else { return nil }
+        let bounds = CGRect(x: 0, y: 0, width: boxSize, height: boxSize)
+        let subpaths = HugeIconShape(icon: self).path(in: bounds).cgPath.subpaths
+        // A shade heavier than the outline's own line: a cleared mark on a solid
+        // body reads thinner than the same line drawn on its own.
+        let detailWidth = max(1.4, boxSize * 2.0 / viewBox)
+        let renderer = UIGraphicsImageRenderer(bounds: bounds)
+        return renderer.image { context in
+            let cg = context.cgContext
+            cg.setFillColor(UIColor.white.cgColor)
+            for (index, subpath) in subpaths.enumerated() where solidSubpaths.contains(index) {
+                cg.addPath(subpath.path)
+            }
+            cg.fillPath(using: .evenOdd)
+
+            let detail = subpaths.enumerated()
+                .filter { !solidSubpaths.contains($0.offset) }
+                .map(\.element)
+            cg.setBlendMode(.clear)
+            for hole in detail where hole.isClosed {
+                cg.addPath(hole.path)
+            }
+            cg.fillPath(using: .evenOdd)
+
+            cg.setLineWidth(detailWidth)
+            cg.setLineCap(.round)
+            cg.setLineJoin(.round)
+            for mark in detail where !mark.isClosed {
+                cg.addPath(mark.path)
+            }
+            cg.strokePath()
+        }.withRenderingMode(.alwaysTemplate)
+    }
+}
+
+/// One `M`-delimited run of a glyph, and whether it closed — a closed run
+/// bounds an area (the gear's bore), an open one is a line (the terminal's
+/// prompt), and the solid renderer punches each out accordingly.
+private struct Subpath {
+    let path: CGPath
+    let isClosed: Bool
+}
+
+private extension CGPath {
+    /// The path split at each `moveTo`, so a glyph's body can be filled while
+    /// its interior detail is drawn separately. Walking the built path rather
+    /// than splitting the source string keeps relative `m` subpaths correct.
+    var subpaths: [Subpath] {
+        var paths: [CGMutablePath] = []
+        var closed: [Bool] = []
+        applyWithBlock { element in
+            let points = element.pointee.points
+            switch element.pointee.type {
+            case .moveToPoint:
+                let subpath = CGMutablePath()
+                subpath.move(to: points[0])
+                paths.append(subpath)
+                closed.append(false)
+            case .addLineToPoint:
+                paths.last?.addLine(to: points[0])
+            case .addQuadCurveToPoint:
+                paths.last?.addQuadCurve(to: points[1], control: points[0])
+            case .addCurveToPoint:
+                paths.last?.addCurve(to: points[2], control1: points[0], control2: points[1])
+            case .closeSubpath:
+                paths.last?.closeSubpath()
+                if !closed.isEmpty { closed[closed.count - 1] = true }
+            @unknown default:
+                break
+            }
+        }
+        return zip(paths, closed).map { Subpath(path: $0, isClosed: $1) }
+    }
 }

--- a/ios/Sources/RootContainerViewController.swift
+++ b/ios/Sources/RootContainerViewController.swift
@@ -72,6 +72,9 @@ final class RootContainerViewController: UIViewController {
                 image: destination.icon.strokeImage(boxSize: 24, strokeWeight: 1.7),
                 tag: index
             )
+            // A selected tab fills its symbol in, the way every system tab bar
+            // does; the outline stays for the unselected ones.
+            item.selectedImage = destination.icon.solidImage(boxSize: 24)
             item.accessibilityIdentifier = "home.tab.\(destination.key)"
             destination.nav.tabBarItem = item
         }


### PR DESCRIPTION
The four home tabs drew the same stroke glyph whether selected or not, so the selection read only as the tab bar's own lens.

`HugeIcon.solidSubpaths` names which of a glyph's subpaths form its silhouette, and `solidImage(boxSize:)` renders the solid twin: fill the body, then punch the interior detail back out — a closed leftover becomes a hole (the gear's bore), an open one a cleared round-capped stroke (the bubble's dots, the terminal's prompt). Same path placement as the outline minus the half-stroke inset, so the mark neither shifts nor resizes on selection.

The free Hugeicons set ships stroke glyphs only, so there is no vendor solid variant to import; marks without a closed body return nil and keep their outline.

Verified on an iPhone 17 Pro simulator: the selected tab fills, the other three stay outlined.

Release Notes:
- The selected tab on iPhone now fills its icon in.