### PR TITLE
Review the device RFC and correct what shipped code refutes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,9 @@ from the real front matter).
 | draft | design | [termiod Session Protocol](design/20260730-termiod-session-protocol.md) |
 | draft | design | [远程访问与中转策略（tunelo / BYO-tunnel）](design/20260705-remote-access-relay-strategy.md) |
 | draft | essay | ["How Claude Code Got the Mouse: Reverse-Engineering the Clickable Terminal"](essays/how-claude-code-got-the-mouse.md) |
+| draft | rfc | ["Adversarial review: Retire remote — every machine is a device"](rfcs/remote-to-device.review-codex.md) |
 | draft | rfc | ["RFC: Per-project agent sandbox (Apple Seatbelt)"](design/20260630-sandbox-seatbelt.md) |
+| draft | rfc | [Adversarial review — Retire "remote", every machine is a device](rfcs/remote-to-device.review-claude.md) |
 | draft | rfc | [Automation — scheduled agent runs](rfcs/automation-scheduled-agent-runs.md) |
 | draft | rfc | [Companion Wire Protocol](design/companion-wire-protocol.md) |
 | draft | rfc | [Fork libghostty-spm — own the wrapper, rent the engine?](rfcs/fork-libghostty-spm.md) |

--- a/docs/rfcs/remote-to-device.md
+++ b/docs/rfcs/remote-to-device.md
@@ -3,7 +3,7 @@ title: Retire "remote" — every machine is a device
 status: draft
 type: rfc
 created: 2026-08-14
-updated: 2026-08-14
+updated: 2026-08-15
 related:
   - 20260805-termiod-device-architecture.md
   - 20260730-termiod-session-protocol.md
@@ -64,11 +64,30 @@ file, stale in ours.
 
 | State | Produced by | Home |
 | --- | --- | --- |
-| The list of reachable machines | the user's `~/.ssh/config` | read-only; no Settings entry |
+| The list of reachable machines | the user's `~/.ssh/config` | **already has a Settings entry — see below** |
 | Device colour, display name, "forget" | termio | Settings ▸ Devices |
 | `termiod` version, install/upgrade status | termio's probe | Settings ▸ Devices |
 | Merged device identities (§9.5) | termio | Settings ▸ Devices |
 | A free-form `user@host` target the user typed | termio (it cannot be written to `~/.ssh/config`) | Settings ▸ Devices, entered through the verb |
+
+**Correction — `Settings ▸ SSH` already ships, and it writes.** The first row as
+originally drafted said "read-only; no Settings entry". Both halves are false.
+`Sources/termio/Settings/SSHSettingsTab.swift` is a shipped tab that lists every
+alias, probes reachability per host, opens the raw config in the editor, and
+appends `Host` blocks through **Add Host** — "a block indistinguishable from a
+hand-written one". So this RFC as drafted proposes `Settings ▸ Devices` beside an
+existing `Settings ▸ SSH`: two lists of machines, built from overlapping sources,
+with no stated boundary. That is the two-copies problem instantiated inside the
+Settings window by the document that exists to delete it.
+
+The ownership test cannot resolve it either, because reachability is produced by
+termio's own probe and therefore qualifies as "termio produced this state
+itself". **This is a blocking open decision, not a detail** — see Open question 5.
+
+The appending also sits close to the `~/.ssh/config` non-negotiable. Adding a new
+`Host` block arguably does not *override* anything, so this reads as a gap in the
+rule's wording rather than a violation, but the rule should say which it means
+before a second surface starts writing.
 
 This is why the analogy to `Settings ▸ Agents` misleads: an agent manifest **is**
 a termio-owned list, so `Add Agent` belongs there. A device list is not.
@@ -162,18 +181,40 @@ any shipped build still loads.
 
 ## Staging
 
-**This lands after PR #177.** That branch is 73 commits ahead of `main` at
-+20,084/−660 and still a draft; `main` has no `termiod/` directory and no
-`Sources/termio/Terminal/Termiod/` at all. Renaming now enlarges the diff that is
-already hard to merge, and no worktree cut from `main` can build against a device
-model that does not exist there.
+**PR #177 has merged** (`66b1722`), so `main` now carries `termiod/`,
+`Sources/termio/Terminal/Termiod/`, and the termiod CI workflow. The blocker
+this section originally described is gone.
 
-1. **Vocabulary and switcher.** Menu titles, the indicator, `Connect to…`,
-   single-device collapse. Client-only, no persistence change, independently
-   revertable.
-2. **Settings ▸ Devices.** Colour, name, forget, install status.
-3. **Data model.** Retire `sshHost`, demote `termiodRemoteHost`, migrate.
-4. **Merge** (§9.5), which only becomes safe once identities are primary.
+**Corrected order.** The draft staged the switcher first and never staged the
+flag at all. That reverses the settled architecture, which orders the work: own
+the connection (§4) → **delete the fork, including `TERMIO_TERMIOD`** (§5) →
+device switcher (§6), and marks §6 *"Only meaningful after step 5 — before it,
+local is still a special case"*
+(`20260805-termiod-device-architecture.md:513-531`). Since that document is
+listed above under "do not reopen", the RFC cannot contradict its ordering.
+
+The reversal is not academic. `Termiod.isEnabled` reads the flag
+(`TermiodClient.swift:17-20`) and surface creation still chooses between termiod
+and an in-process `PTYProcess` (`TermioStore+TerminalSurface.swift:214-231`), so
+with the flag off, opening on a non-local device stops at an alert reading *"Set
+TERMIO_TERMIOD=1 and relaunch termio"* (`TermioStore+Termiod.swift:468-476`). A
+device switcher above that fork shows a device the product cannot open a session
+on.
+
+1. **Own the connection.** `TermiodConnection` per device — transport, health,
+   reconnect — so readiness is a real state and a transport failure stops being
+   reported as `exited`. Architecture §4.
+2. **Delete the fork.** Remove `TERMIO_TERMIOD`, the in-process `PTYProcess`
+   path, per-session remote host, and every "Remote" verb. This is the stage
+   with real risk: it makes the daemon a release-critical dependency and changes
+   the execution path of *every* session, local included. It is not a rename and
+   must not be staged as one.
+3. **Vocabulary and switcher.** Menu titles, the indicator, `Connect to…`,
+   single-device collapse, reading readiness from stage 1.
+4. **Settings ▸ Devices**, once Open question 5 decides its boundary with
+   `Settings ▸ SSH`.
+5. **Data model.** Retire `sshHost`, demote `termiodRemoteHost`, migrate.
+6. **Merge** (§9.5), which only becomes safe once identities are primary.
 
 ## Open questions
 
@@ -184,7 +225,46 @@ model that does not exist there.
    terminal's colours belong to the user's theme — the presentation boundary says
    the viewer decides. The tint probably has to stop at chrome (sidebar, title
    bar, indicator) and never touch the grid.
-3. **Guardrail strength** for destructive actions on a non-local device: extra
-   confirmation, hold-to-confirm, or typed device name.
+3. ~~**Guardrail strength** for destructive actions on a non-local device: extra
+   confirmation, hold-to-confirm, or typed device name.~~ **Closed — the question
+   was wrong.** All three options are the local/remote fork wearing a warning
+   triangle. The shipped doctrine is narrower and better: `closeConfirmationReason`
+   (`TermioStore+ProjectActions.swift:684-692`) confirms on exactly one condition —
+   a *shell* with a live foreground job, because that command "exists nowhere
+   else" — and deliberately never for agent sessions. Confirm when closing
+   destroys the only copy of something; never because of where it runs.
+
+   The live defect is the opposite of the one asked about. That check reads
+   `ptyProcesses[session.id]`, and `hasForegroundJob` exists only on `PTYProcess`
+   (`PTYProcess.swift:923`) with no counterpart anywhere in `termiod/src`. **So a
+   remote session with a build running closes silently today, while a local one
+   asks** — non-local sessions have *less* protection, not more. The work item is
+   to carry the existing rule across the wire (a `tcgetpgrp` on the PTY master,
+   one field on `list`), not to add a dialog. Whether that rides in this RFC or
+   becomes its own protocol change is Open question 6.
+
+   Forget device and uninstall termiod keep an explicit confirmation: those are
+   device-scoped irreversible actions rather than command execution.
 4. **Does `Connect to…` belong in the `+` menu too?** Every item in that menu is
    global by rule; `Connect to…` qualifies, but it may not deserve the weight.
+   Proposal on the table: add no item — convert the existing dead end
+   `New Remote Terminal ▸ (No SSH hosts in ~/.ssh/config)` *into* `Connect to…`,
+   so the slot and weight are unchanged and the motivation's own complaint is
+   answered. Both reviews accept the slot and contest what the item does.
+
+5. **Does `Settings ▸ Devices` subsume `Settings ▸ SSH`, or coexist with it?**
+   Blocking. They are two lists of machines from overlapping sources, and the
+   ownership test cannot separate them because reachability is termio's own
+   probe. Subsuming is cleaner and deletes a surface; coexisting needs a stated,
+   defensible split written into this document before either is built.
+
+6. **Does porting `hasForegroundJob` across the wire belong here or in its own
+   protocol change?** It is additive on `list`, but it is a protocol change to a
+   daemon that now ships on `main`, and it fixes a live asymmetry rather than
+   supporting the rename.
+
+7. **What does an unreachable device look like?** Device identity is about to
+   appear in the sidebar, the menus, and the switcher, and nothing in this draft
+   says what any of them render when the device cannot be reached. Both reviews
+   raise it independently; there is prior pain here, where a stale tunnel URL
+   produced "list works but terminal unauthorized".

--- a/docs/rfcs/remote-to-device.review-claude.md
+++ b/docs/rfcs/remote-to-device.review-claude.md
@@ -1,0 +1,454 @@
+---
+title: Adversarial review — Retire "remote", every machine is a device
+status: draft
+type: rfc
+created: 2026-08-15
+updated: 2026-08-15
+related:
+  - remote-to-device.md
+  - 20260805-termiod-device-architecture.md
+---
+
+# Adversarial review — "Retire remote"
+
+Review only. Nothing here reopens the "Already decided" table; where I touch one of
+those rows it is because the RFC's *citation* of it is inaccurate, not because the
+decision is wrong.
+
+**Verdict up front.** The thesis is right and the RFC does not deliver it. It
+retires the *word* "remote" while leaving the *fork* — which lives in
+`sshHost` vs `termiodRemoteHost`, not in menu titles — intact and, after the
+rename, harder to name. Four shipped surfaces that this work must absorb are
+missing from the document entirely: `New SSH Connection`, `New SSH Shell`,
+**Settings ▸ SSH**, and the command palette's `New SSH Connection…`. Two of the
+RFC's factual premises are false against `main` as of today.
+
+Of your four positions: **2 and 3 survive** (3 with a stronger mechanism than you
+gave it), **1 fails on its own safety argument**, **4 is right about the slot and
+wrong about which item to convert**. All three gaps you named are real; there is a
+fourth that is worse than any of them.
+
+---
+
+## 1. Where it recreates the two-copies problem
+
+This is the central claim, so it gets the most space.
+
+### 1.1 The fork is in the data model, and the RFC removes the wrong half
+
+There are two ways to reach a machine today, and they are not "a verb and its
+remote twin" — they are genuinely different products:
+
+| | `Session.sshHost` (`Models.swift:298`) | `Session.termiodRemoteHost` (`Models.swift:311`) |
+| --- | --- | --- |
+| What runs | `ssh <host>` in a **local** PTY | a session inside the **remote** `termiod` |
+| Survives detach | no | yes |
+| Needs `termiod` on the box | **no** | yes |
+| Verb | `New SSH Connection` / `New SSH Shell` | `New Remote Terminal` |
+
+The shipped code states the distinction as load-bearing, not vestigial —
+`TermioStore+ProjectActions.swift:434-437`:
+
+> the distinction matters inside a host block: an "SSH Shell" dies with the
+> connection, while the numbered rows beside it are durable termiod sessions that
+> survive a detach.
+
+The RFC's data-model table disposes of this in six words: `Session.sshHost` →
+"**removed**; such a session is a device session." That is not a rename. It
+deletes the only path that reaches a box where `termiod` cannot be installed —
+no write access, an unsupported arch, a jump host, a router, a container, a
+colleague's machine, a box you are touching once. After it, "device" means "a
+machine running our daemon", and every machine that isn't one becomes
+unreachable from termio. The word "remote" disappears; the *capability* fork
+becomes a hard wall.
+
+Either outcome is a two-copies regression:
+
+- **Keep both** — then after the rename a host header offers `New Terminal` and
+  `New SSH Shell` (`SidebarView.swift:610-618`) and nothing in either name says
+  which one survives a detach. Today "Remote" vs "SSH" at least carries that
+  signal, badly. The rename makes the fork *less* legible.
+- **Drop `sshHost`** — then you have deleted a working feature with four entry
+  points (File menu `App.swift:2133`, `+` menu `App.swift:1804`, Settings ▸ SSH's
+  Connect button `SSHSettingsTab.swift:11`, command palette `CommandPalette.swift:342`)
+  and the RFC nowhere says so.
+
+**The RFC must pick one and defend it.** My recommendation: keep both, and rename
+on the axis that actually differs — `New Terminal on <device>` (durable) vs
+`SSH Shell to <host>` (transient, no daemon). "Remote" is the wrong word because
+it names the road; "SSH Shell" is the *right* word for the same reason — that
+session really is nothing but an ssh road in a local PTY.
+
+### 1.2 Settings ▸ SSH already exists, and it is Settings ▸ Devices
+
+The ownership table's second row — "The list of reachable machines | the user's
+`~/.ssh/config` | **read-only; no Settings entry**" — is false today.
+`Sources/termio/Settings/SSHSettingsTab.swift` is a shipped settings tab
+(`SettingsTab.swift:10`, subtitle "Your ~/.ssh/config hosts, one click away")
+that lists every alias, tests reachability per host, opens the raw config in the
+editor, and **appends `Host` blocks via Add Host** (`SSHSettingsTab.swift:279-282`).
+
+So the RFC proposes `Settings ▸ Devices` next to an existing `Settings ▸ SSH`,
+where both are lists of machines built from overlapping sources, and never
+mentions the collision. That is the two-copies problem instantiated *inside the
+Settings window* by the document that exists to delete it. Whatever lands must
+either subsume the SSH tab into Devices or say precisely which machine facts live
+in which tab — and the ownership rule as written cannot decide it, because
+"reachability" is produced by termio's own probe (`SSHSettingsTab.swift:241-247`)
+and therefore qualifies as "termio produced this state itself".
+
+### 1.3 The argument against `Add Device…` is a strawman that shipped code refutes
+
+> it implies a termio-owned roster, which would immediately fork from the
+> `~/.ssh/config` it was copied from
+
+`AddSSHHostSheet` already solves this and has for releases: it appends a real
+`Host` block to the real file, "indistinguishable from a hand-written one"
+(`SSHSettingsTab.swift:278-281`), then connects. No second roster, no fork,
+because the write goes to the authoritative file rather than beside it. The RFC
+rejects a verb on grounds the codebase has already disproved.
+
+This matters for the `Already decided` row that reads "`~/.ssh/config` is
+authoritative — read it, **never write it**", cited to `CLAUDE.md` #3. CLAUDE.md
+#3 says "read it, **never override it**." Those are different rules, and the
+substitution retroactively makes a shipped, deliberate feature a violation. I am
+not reopening the decision; I am flagging that the RFC's version of it is not the
+one in the file it cites.
+
+### 1.4 The device would live in three places at once
+
+`Project.kind == .host` containers already exist and already group both session
+kinds under one machine (`hostContainer(for:)`,
+`TermioStore+ProjectActions.swift:398-420`; header menu at `SidebarView.swift:608`).
+The RFC adds (a) an always-visible indicator with a switcher, and (b) a device
+column on the cross-device session list — without retiring (c) the host container
+that is the sidebar's current answer to "which machine is this".
+
+Three representations of device identity, each authoritative for a different
+question. If the indicator says `vps` and the sidebar simultaneously shows host
+blocks for `vps` and `laptop`, "the current device" is a *fourth* thing that
+scopes only new work. That needs to be designed, not assumed; right now the RFC
+adds a layer and deletes none.
+
+### 1.5 `Connect to…` is not new
+
+The vocabulary table lists `Connect to…` as "— (new)". It is `New SSH Connection`,
+shipped, in the File menu, the `+` pull-down and the command palette, complete
+with the free-form `user@host` entry the RFC asks for
+(`presentSSHConnectPanel`, `TermioStore+ProjectActions.swift:447-469`) and the
+"not in the config yet" escape (`addSSHHost`, `App.swift:926-935`). Presenting it
+as new is how the third connect verb gets added without anyone noticing.
+
+---
+
+## 2. Repo invariants and shipped conventions
+
+**Colour is already spent, twice, in the exact surfaces the RFC wants to tint.**
+
+| Surface | What colour already means | Cite |
+| --- | --- | --- |
+| Sidebar session ring | **orange = needs you**, **green = done** | `SidebarView.swift:1393-1395` |
+| Sidebar session icon | the **agent's** brand tint | `AgentDefinition.swift:129`, `BrandIcons.swift:96` |
+| Settings ▸ SSH row badge | green / orange / red = reachable / auth-failed / unreachable | `SSHSettingsTab.swift:263-268` |
+
+Workstream status being first-class is the stated differentiator (`CLAUDE.md`,
+"agent-native at the protocol level"). Colour in the sidebar is its channel. A
+third colour system — device identity, hash-assigned from a fixed palette —
+puts an arbitrary orange next to a meaningful orange in the same row. That is not
+a preference; it degrades the one signal the product claims as its own.
+
+**Accent-coloured control backgrounds are forbidden.** Any tint that lands on a
+control must be a swatch, not a fill. Your position 2 already says this; the RFC's
+"colour … **bleeds into the surface**" heading and its Dia precedent
+(`didBackfillSpaceThemesFromProfileColor`) say the opposite.
+
+**Evidence policy.** The companion doc labels every external claim
+**Announced / Inferred / Unknown** and states the policy up front. This RFC's
+entire Interface section rests on private symbol names from a closed-source
+competitor's binary with no label and no way for a reader to check any of it.
+Same repo, same subject, weaker standard.
+
+**Localization.** `New Remote Terminal` appears zero times in
+`Sources/termio/Resources/Localizable.xcstrings` while `New Terminal` and
+`New SSH Connection` are both there, and the sidebar/menu sites pass bare strings
+(`SidebarView.swift:797`, `App.swift:1457`, `SidebarView.swift:610-618`). So
+stage 1 is not "client-only, no persistence change" — it is also the zh-Hans work
+(#224) these strings never got, plus whatever the iOS catalogue needs. Small, but
+the staging note currently understates it.
+
+---
+
+## 3. Your four positions
+
+### Q1 — Deterministic colour from `host_id`: **fails**
+
+Determinism and distinguishability are in direct conflict, and the RFC's own
+safety argument ("picking the wrong machine runs `rm -rf` on the wrong disk")
+depends entirely on distinguishability.
+
+A palette that survives §2 above — chrome-legible, not colliding with
+orange/green/red status, readable in both appearances — is realistically 8 to 10
+colours. Hashing `host_id` into it is uniform random assignment, so by the
+birthday bound two devices share a colour with ~50% probability at **four**
+devices, and near-certainty by eight. The failure mode is not cosmetic: two
+same-coloured devices is strictly worse than no colour, because the user has been
+taught to read colour as identity and now reads it wrong.
+
+Least-recently-used assignment guarantees zero collisions until the palette is
+exhausted — the whole range where the feature is supposed to work.
+
+The benefit you are buying with determinism is "the same machine gets the same
+colour on every Mac the user pairs". Weigh it honestly: the user looks at one Mac
+at a time. They never see two Macs' sidebars side by side, so there is no moment
+where the inconsistency is visible. You are trading a real, common failure
+(collision at 4 devices) for a benefit that is only observable across a context
+switch measured in minutes.
+
+If cross-Mac stability matters to you, it is a *sync* problem, and you already
+have the place for it — `devices.json` is termio-produced state
+(`TermiodDevice.swift:94-110`), so the colour belongs there and travels the same
+way any other device fact would. Hashing is not the cheap way to get sync; it is
+a way to get collisions and call them consistency.
+
+**Recommendation:** assign least-used-first on first handshake, persist per Mac,
+user-overridable. Keep the "user-overridable in Settings" half of your position —
+that part is right, and it is also the escape hatch when two machines land close.
+
+### Q2 — Chrome only, never the grid: **survives**
+
+Correct, and it is a boundary consequence rather than taste: the grid's colours
+are the viewer's theme, and the presentation boundary (device-architecture §4)
+says the viewer decides. A host-derived tint in the grid is the same class of
+error as the resolved-RGB bug that section was written about. Add the swatch-not-
+fill constraint from §2 and this is settled. Nothing to argue.
+
+One addition the RFC needs and you did not mention: the **title bar** you list is
+the one chrome surface that is also the macOS window's own; tinting it needs to
+survive fullscreen and inactive-window states, where a low-saturation tint on
+an inactive title bar is close to invisible — i.e. the indicator has to carry the
+signal on its own anyway, and the title bar tint is decoration. Cheapest correct
+answer: indicator + sidebar header only.
+
+### Q3 — No device-scoped guardrail: **survives, and the RFC asked the wrong question**
+
+Your argument is right and the shipped rule is stronger than the one you made.
+`closeConfirmationReason` (`TermioStore+ProjectActions.swift:684-692`) confirms on
+exactly one condition — a shell with a live foreground job, because that command
+"exists nowhere else" — and explicitly refuses to confirm for agent sessions
+because taxing every close to protect a resumable conversation was not worth it.
+
+That is the repo's actual doctrine: **confirm when closing destroys the only copy
+of something, never because of where it runs.** A device-scoped confirmation
+fails that test on both halves.
+
+But the interesting part is that the RFC has the polarity backwards. The
+confirmation reads `ptyProcesses[session.id]` — the **in-process** PTY handle. A
+termiod-backed session has no entry there (it lives in `termiodLinks`), and
+`hasForegroundJob` exists only on `PTYProcess` (`PTYProcess.swift:923`), with no
+counterpart anywhere in `termiod/src`. So **today a remote session with a build
+running closes silently, and a local one asks.** Non-local sessions have *less*
+protection, not more.
+
+So the real work item is not "how heavy should the extra dialog be" — it is
+*port the existing rule across the wire*: `termiod` needs to report whether a
+session has a foreground job (a `tcgetpgrp` on the PTY master, one field on the
+`list`/`kill` path), so the one confirmation the product already believes in
+works on every device. That is the same rule everywhere, which is the RFC's whole
+thesis; the RFC's three options are all the local/remote fork wearing a warning
+triangle.
+
+Keep your carve-out for Forget device / uninstall termiod. Those are
+device-scoped irreversible actions, not command execution, and Apple confirms
+those too.
+
+### Q4 — Right slot, wrong item: **half survives**
+
+The slot is right: `New Remote Terminal ▸ (No SSH hosts in ~/.ssh/config)`
+(`SidebarView.swift:795-797`) is a dead end and should not exist. Adding a fifth
+verb to fix it would be absurd. Agreed, and the `+` menu's global rule is
+satisfied — `makeNewSessionMenu` is explicitly context-free
+(`App.swift:1790-1794`).
+
+Two problems with converting *that* item:
+
+1. **The dead end is already solved one row below.** `New SSH Connection ▸` ends
+   with `Add Host…` (`App.swift:926-935`), which is the exact escape the empty
+   submenu lacks. The narrow bug is that `remoteTerminalMenuItem` doesn't share
+   it. That is a three-line fix, not an RFC item, and the RFC's opening
+   motivation overstates it as a design flaw.
+2. **Converting `New Remote Terminal` into `Connect to…` puts two connect verbs
+   one row apart** — `Connect to…` and `New SSH Connection`, both enumerating the
+   same aliases from the same file, differing only in durability, with the more
+   descriptive name now on the *less* capable one. Your position deletes the
+   ambiguity from one item by concentrating it in the pair.
+
+`Connect to…` is also a weaker string than what it replaces. Finder's precedent
+is `Connect to Server` — the noun is what makes it legible. And `Connect` is
+already spent in this product on the transient act: the Settings ▸ SSH row button
+(`SSHSettingsTab.swift:10-12`) and the connect panel's default button
+(`TermioStore+ProjectActions.swift:450`) both mean "open a plain ssh shell now",
+whereas the RFC's `Connect to…` means "install a daemon and open a durable
+session." Same word, opposite weight.
+
+**Recommendation:** your slot, but the conversion has to cover both items or
+neither. One machine-reaching verb in the `+` menu, named for the object
+(`Connect to Device…`), whose submenu lists known devices, then unused
+`~/.ssh/config` aliases, then `Add Host…`, then free-form entry — and
+`New SSH Connection` retires into it as the transient variant (a modifier row, or
+the `SSH Shell` verb kept only on a host header where the machine is already
+named). That fixes the dead end, removes a verb instead of renaming one, and
+costs a single-device user nothing.
+
+---
+
+## 4. Your three gaps
+
+**Unreachable presentation — real, and partly already built.** Confirmed: the RFC
+puts device identity in permanent chrome and never says what it renders when the
+device is gone. But you are being slightly unfair to the codebase — the vocabulary
+exists, in the tab the RFC doesn't cite: `reachable / authFailed / unreachable`
+with per-state copy and tint (`SSHSettingsTab.swift:251-275`), and
+`ensureRemoteReady` already produces a specific human-readable cause, including
+ssh's own last stderr line (`TermioStore+Termiod.swift:386-394`). The gap is that
+none of it reaches the indicator, and that the architecture doc's §8.6 promises a
+**third** state — *degraded* — that has no representation anywhere. Three states
+in the settings tab, four in the architecture, zero in the RFC. Name them once,
+in the RFC, and reuse the shipped ones.
+
+**`TERMIO_TERMIOD` retirement missing from Staging — real, and it is the most
+dangerous omission in the document.** Confirmed absent; the architecture doc
+claims it (§0, §8.5) and the RFC's four stages never mention it. And it is worse
+than "its own risk profile":
+
+Retiring the flag deletes the in-process `PTYProcess` path. `ptyProcesses` becomes
+permanently empty. `closeConfirmationReason` gates on
+`ptyProcesses[session.id]` (`TermioStore+ProjectActions.swift:690`). Therefore
+**retiring the flag silently deletes the "a command is still running" confirmation
+for every session on every device, including purely local ones**, with no code
+change at the call site and nothing in any staging list that would catch it. It is
+a one-line consequence of a step nobody scheduled, landing on the user who never
+leaves their laptop.
+
+That single finding ties your gap 2 to your position 3, and it is the strongest
+argument in the document for why the foreground-job probe has to be part of the
+protocol before the flag goes away — not a guardrail *added* for remote devices,
+but an existing guardrail *rescued* before the fork deletion takes it out.
+
+**Stale PR #177 paragraph — confirmed, worse than stale.** PR #177
+("termiod: durable PTY session host (Rust POC)") merged to `main` at
+2026-08-15T13:07:15Z, commit `66b1722`. Every factual claim in that paragraph is
+now false: it is not a draft, it is not 73 commits ahead, and `main` has both
+`termiod/` and `Sources/termio/Terminal/Termiod/`. Stage 1 is unblocked. Delete
+the paragraph rather than updating it — the reasoning it contains ("renaming now
+enlarges a hard merge") has no successor.
+
+### A fourth gap: `Connect to…` promises an install that most users cannot run
+
+The RFC's switcher entry says "First use installs `termiod`
+(`ensureRemoteReady` already does this)." What `ensureRemoteReady` actually does
+when the binary is absent is shell out to `termiod remote deploy <host>`, which
+**cross-compiles a musl binary with `cargo` on the user's Mac**
+(`termiod/src/remote.rs:211-280`), and whose failure message tells the user to
+`brew install FiloSottile/musl-cross/musl-cross`
+(`termiod/src/remote.rs:271-275`).
+
+For a shipped `.app`, that is not an install path — it is a toolchain
+prerequisite that approximately no user of a native Mac terminal has. The
+architecture doc knows this (§2: "adding a box means … a deploy that
+cross-compiles a musl binary on the Mac and `scp`s it") and schedules prebuilt
+per-arch binaries at §8.8, which is not done.
+
+So `Connect to…` as specified is a verb that fails for most users at the moment
+of first use — the exact "dead end at the moment a new user arrives" the RFC
+opens by condemning, moved one click later. **Prebuilt binaries (§8.8) are a
+hard prerequisite for stage 1**, not a later nicety, and the RFC must say so.
+
+---
+
+## 5. One device
+
+The RFC's promise is "no indicator, no submenu, no Settings tab". That part it
+can keep — the collapse is cheap and the Dia precedent for it is the least
+contentious thing in the document.
+
+What the single-device user actually pays is everything in §4 gap 2, none of
+which is in the RFC:
+
+- Their local terminal moves from an in-process PTY to a daemon over a Unix
+  socket — a new process, a launchd agent (which the architecture doc §8.3 says
+  is deliberately *never* installed automatically, so someone must decide when it
+  is), and a new single point of failure where the app previously shared fate
+  with its PTYs (§6).
+- They lose the running-command confirmation, as above.
+- Crash recovery becomes "tombstone says what died" instead of "the PTY died with
+  the app", which is better in principle and is more UI they now have to meet.
+
+None of that is an argument against the direction. It is an argument that "someone
+who never leaves their laptop must never pay for this feature" is a claim the RFC
+has not earned, because the largest cost to that user is in the step the RFC
+forgot to list.
+
+## 6. Twenty devices
+
+- **Colour breaks first**, at four, for the reasons in Q1. By twenty it is
+  decoration, and the RFC's safety argument for it is gone. At that scale the
+  identity signal has to be text — the device name in the indicator, colour as a
+  secondary cue — which inverts the RFC's "colour is readable in peripheral
+  vision; a text label is not."
+- **The menus become unusable before the switcher does.**
+  `remoteTerminalMenuItem` and `cloneOnRemoteMenuItem` both map *every*
+  `SSHConfigFile.hosts()` alias into a flat submenu (`SidebarView.swift:799-813`,
+  `SidebarView.swift:833-841`), built synchronously on every right-click. Twenty
+  aliases is a twenty-row submenu on a project row; a config with `Include`d
+  work hosts is routinely more than that. The RFC's `Clone to <device>…` inherits
+  this shape unchanged and needs a scale answer (recents first, then a search
+  field) that it does not have.
+- **`Connect to…` gets worse with scale, not better.** It is specified as
+  "aliases not yet used" — a list that is *largest* for the user with the most
+  hosts, and that shrinks only as they connect. The heavy user gets the longest
+  list of the least interesting items.
+- **Aliases outnumber devices.** The whole point of `host_id` is that
+  `vps-lan` / `vps-wan` / a tailnet name are one machine (architecture §2). So at
+  twenty devices the alias list is 30–50 rows while the switcher shows twenty.
+  Two lists of different lengths describing the same machines, and the RFC never
+  says how the `Connect to…` list hides aliases that resolve to a device already
+  in the switcher — it can't, because that mapping is only known after connecting.
+  This is fine, but it should be stated: the unused-alias list is necessarily
+  imprecise, and some rows will resolve to a device the user already has.
+
+---
+
+## 7. Vocabulary table
+
+| Row | Assessment |
+| --- | --- |
+| `New Remote Terminal` → **New Terminal** | **Worse.** Collides with two shipped items: `New Terminal` (⌘T, follows the focused session's directory, `App.swift:2111-2115`) and `New Terminal at Home` (context-free, the `+` menu's own, `App.swift:1797`). Under the RFC the `+` menu would carry `New Terminal at Home` and a device-submenu `New Terminal` — and ⌘T becomes ambiguous the moment the focused session is on another device, because "here" no longer has a referent. The collapse silently makes ⌘T device-dependent and the RFC does not say what it does. |
+| `Clone on Remote…` → **Clone to \<device\>…** | **Actively misleading.** The operation runs `git clone` from `origin` **on** that machine (`cloneOnRemote`, `SidebarView.swift:830-855`); nothing is copied from the Mac, and uncommitted or unpushed work does not travel — which is exactly the mistake the click-time `cloneInfo` check exists to catch. "to" names a copy destination and invites precisely that expectation. Keep the preposition: **Clone on \<device\>…**. |
+| "remote session/host" → "a session on \<device\>" | Fine. No objection. |
+| **Connect to…** (new) | **Not new** (§1.5), **and the word is spent** (§3 Q4). Name the object: `Connect to Device…`. |
+| — | **Missing rows:** `New SSH Connection`, `New SSH Shell`, `Add Host…`, and the palette's `New SSH Connection…`. A vocabulary table that retires "remote" while leaving four SSH-named verbs in the same menus has not retired the road-name — it has retired one synonym for it. |
+| **"Device"** | **Collides in the shipped Settings sidebar.** `Settings ▸ Mobile` is the iPhone pairing tab (`SettingsTab.swift:13`), and in everyday Apple usage a paired iPhone *is* "a device". `Settings ▸ Devices` sitting beside `Settings ▸ Mobile` will read as "my paired phones", not "machines that run my agents". This deserves an explicit answer in the RFC — either Mobile folds into Devices, or the tab is named for what it holds (`Machines`). Note the architecture doc has the same exposure but never has to render the word in a settings sidebar; the RFC does. |
+
+---
+
+## 8. What I would change before this is implementable
+
+1. **Decide `sshHost`'s fate explicitly** and say which machines termio can still
+   reach without `termiod` (§1.1). This is the RFC's real subject.
+2. **Fold Settings ▸ SSH into the Devices design** or state the split (§1.2).
+3. **Schedule the `TERMIO_TERMIOD` retirement**, with the foreground-job probe as
+   its precondition (§4 gap 2). Without it, deleting the fork deletes a shipped
+   confirmation on every device.
+4. **Make prebuilt per-arch binaries (architecture §8.8) a stage-1 prerequisite**,
+   or `Connect to…` ships as a dead end (§4 gap 4).
+5. **Name the reachability states once** — reachable / auth-failed / unreachable /
+   degraded — and reuse the shipped copy and tints (§4 gap 1).
+6. **Delete the stale PR #177 paragraph** (§4 gap 3).
+7. **Drop hash-derived colour for least-used assignment**, and state the palette
+   constraint that it must not collide with the status ring's orange/green (§3 Q1).
+8. **Add the four missing verbs to the vocabulary table** and re-derive the menu
+   shape from the full set, not from two of six (§7).
+
+Nothing here argues against the thesis. Every machine should be a device, and the
+word "remote" should go. The document just has not yet found the fork — it is in
+`Models.swift:298` and `Models.swift:311`, not in the menu titles.

--- a/docs/rfcs/remote-to-device.review-codex.md
+++ b/docs/rfcs/remote-to-device.review-codex.md
@@ -1,0 +1,409 @@
+---
+title: "Adversarial review: Retire remote — every machine is a device"
+status: draft
+type: rfc
+created: 2026-08-15
+updated: 2026-08-15
+---
+
+# Adversarial review: Retire remote — every machine is a device
+
+> Request changes. This review accepts every decision in the RFC’s “Already
+> decided” table and tests whether the proposed product model actually follows
+> from them.
+
+## Verdict
+
+Do not approve the RFC as written. Removing the local/remote product fork is the
+right direction, but the replacement currently introduces competing sources of
+truth for routes, competing notions of focus, competing device selectors, and an
+unresolved choice between plain SSH and device sessions. Those are the same
+two-copies failure at different layers.
+
+The most serious defect is staging. The settled architecture requires a durable
+connection object, deletion of the `TERMIO_TERMIOD` fork, and only then a device
+switcher (`docs/design/20260805-termiod-device-architecture.md:513-531`). This RFC
+starts with the switcher, calls that stage client-only, and omits deletion of the
+flag (`docs/rfcs/remote-to-device.md:163-176`). That ordering cannot produce a
+truthful current-device UI.
+
+## Where the design recreates two copies
+
+| First copy | Second copy | Failure |
+| --- | --- | --- |
+| Live SSH routes from `~/.ssh/config` | Typed `user@host` targets persisted under Settings ▸ Devices | A port, jump host, username, or removal can change in the authoritative file while termio keeps using its own target. |
+| The selected/focused session | An independent “current device” | The terminal can be on device B while the panels, title bar, and creation commands still claim device A. |
+| The sidebar switcher | A device submenu under New Terminal | There are two places to choose the target, and no rule says which choice updates the other. |
+| `New SSH Connection` and saved `Session.sshHost` state | `Connect to…` and a durable termiod device session | The same machine still has two terminal products unless the RFC explicitly removes, converts, or scopes plain SSH. |
+| A learned device row | An unresolved SSH alias row | A second alias for an already-known device appears as another machine until its first handshake. That temporary ambiguity is inherent in the settled bootstrap identity, but the UI currently pretends the two lists are disjoint. |
+
+The alias plus `deviceID` model is not the problem; that coexistence is settled.
+The problem is promoting both sides into independent user-facing authorities.
+
+## Blocking findings
+
+### 1. The ownership test is false, and it selects the wrong authority
+
+“Did termio produce this state itself?” (`docs/rfcs/remote-to-device.md:53-63`)
+does not classify the RFC’s own table:
+
+- The user produces a display name and colour choice.
+- `termiod` produces its version.
+- The user produces a typed `user@host` target.
+- A probe observes readiness; it does not produce it.
+
+Provenance is not authority. The useful split is narrower: SSH route
+configuration belongs to `~/.ssh/config`; handshake observations belong to the
+device registry; viewer presentation preferences belong to the viewer; device
+state belongs to `termiod`.
+
+The typed-target row is therefore an architectural violation, not an exception.
+A `user@host` value is an SSH route. Persisting it in Settings creates the host
+database that `CLAUDE.md:42-44` forbids. “It cannot be written to
+`~/.ssh/config`” does not make termio its owner (`docs/rfcs/remote-to-device.md:71`);
+it means the target must remain ephemeral or the design needs an explicit,
+user-authored route mechanism consistent with the settled read-only rule.
+
+There is already a second-copy hazard in the learned map. A `TermiodDevice`
+persists routes while deliberately refusing to persist reachability
+(`Sources/termio/Terminal/Termiod/TermiodDevice.swift:71-79`), and the registry
+loads those routes back as candidates
+(`Sources/termio/Terminal/Termiod/TermiodDevice.swift:167-203`). That observation
+cache is valid. Treating a cached alias as an actionable route after it has been
+removed or changed in `~/.ssh/config` is not. The RFC must say that every SSH
+route is revalidated against the live config before selection or connection.
+
+At 20 devices this becomes visible rot: removed aliases remain attached to old
+devices, new aliases appear separately until contacted, and one physical machine
+can occupy both the known-device section and the untried-route section.
+
+### 2. “Current device” and focused session can disagree
+
+The RFC says new work and panels follow the current device while running
+sessions remain cross-device (`docs/rfcs/remote-to-device.md:125-140`). It never
+defines what happens when the user clicks a session on another device.
+
+Today there is one focus authority. Changing `selectedSessionID` saves and
+restores that session’s inspector state
+(`Sources/termio/TermioStore/TermioStore.swift:22-49`), and the file, search, and
+git root derives from the selected session
+(`Sources/termio/TermioStore/TermioStore.swift:391-410`). The proposed model has
+two incompatible outcomes:
+
+- If selecting a session on device B leaves current device A unchanged, the
+  terminal and inspector describe different machines. New Terminal, Clone,
+  file deletion, and title-bar colour can target or label A while the keyboard
+  focus is visibly on B.
+- If selecting that session changes the current device to B, “current device” is
+  not an independent switcher choice. Merely inspecting an old session changes
+  where the next terminal and project will be created.
+
+The wording also drifts from “current device” to “focused device” at
+`docs/rfcs/remote-to-device.md:144-146`. Those cannot remain informal synonyms.
+The RFC needs a transition table for launch, switcher selection, session
+selection, pane focus, Connect, route loss, closing the last session on a device,
+and app restore. It must name which state controls terminal input, panels,
+creation commands, the indicator, and the title bar after every transition.
+
+The session-list description is internally inconsistent too: it first promises a
+cross-device list with a device column, then says the attention badge avoids
+“flattening every device into one list”
+(`docs/rfcs/remote-to-device.md:133-142`). Pick one information architecture.
+
+### 3. The staging order directly violates the settled architecture
+
+The companion design deliberately orders the work as:
+
+1. own connection health and reconnect per device;
+2. delete the backend fork, including `TERMIO_TERMIOD`;
+3. add the switcher, reading readiness from that connection object.
+
+That order is explicit at
+`docs/design/20260805-termiod-device-architecture.md:513-531`. The RFC reverses
+it. Stage 1 adds the switcher and single-device collapse as a client-only change;
+the flag is absent from every stage (`docs/rfcs/remote-to-device.md:163-176`).
+
+The current source still has two execution paths. `Termiod.isEnabled` reads
+`TERMIO_TERMIOD` (`Sources/termio/Terminal/Termiod/TermiodClient.swift:17-20`),
+and surface creation chooses termiod or an in-process `PTYProcess`
+(`Sources/termio/TermioStore/TermioStore+TerminalSurface.swift:214-231`). With
+the flag off, `New Terminal` cannot open on a non-local current device at all;
+the durable-device action currently stops with an alert
+(`Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift:205-241`). A switcher
+above that fork is cosmetic fiction.
+
+Retiring the flag is not a rename. It changes the execution path of every
+session and makes the daemon a release-critical dependency. The current fallback
+daemon path points into the working tree unless an environment variable overrides
+it (`Sources/termio/Terminal/Termiod/TermiodClient.swift:55-63`), while the
+architecture records that the launchd service is never installed automatically
+and that Linux lifecycle work is incomplete
+(`docs/design/20260805-termiod-device-architecture.md:502-512`). Packaging,
+installation, startup failure, upgrade rollback, old-session adoption, and the
+removal of the in-process fallback need their own stage and release criteria
+before the UI claims there is one path.
+
+### 4. The RFC does not decide the fate of plain SSH
+
+The data-model table says `Session.sshHost` is removed and “such a session is a
+device session” (`docs/rfcs/remote-to-device.md:153-161`). The vocabulary and
+staging sections never say what happens to the shipped `New SSH Connection`
+command. Today that command is separate from the durable termiod action
+(`Sources/termio/App/App.swift:2127-2133`), and `Session.sshHost` specifically
+means a local PTY running plain `ssh`
+(`Sources/termio/App/Models.swift:290-311`).
+
+Every outcome has a product consequence that needs a decision:
+
+- Keep it: the local/device fork survives as plain SSH versus termiod.
+- Convert it: clicking a familiar SSH verb can now install software and create a
+  durable server-side session.
+- Remove it: termio loses the escape hatch for a machine where `termiod` cannot
+  be installed or negotiated.
+
+Tolerant decoding only keeps old JSON readable. It does not define what a saved
+plain-SSH session becomes after the field disappears. This is a semantic
+migration and belongs in staging.
+
+### 5. Unreachable is a first-class state, not an empty-state detail
+
+The RFC defines identity everywhere and failure nowhere. A learned device can
+have no valid route, an SSH alias can fail before handshake, an existing
+connection can be reconnecting, and a daemon can be incompatible or absent.
+Those states have different safe actions.
+
+The architecture already requires a `TermiodConnection` that owns a coherent
+“reachable / degraded / gone” state
+(`docs/design/20260805-termiod-device-architecture.md:395-411`) and says the
+switcher must consume it. The current registry cannot substitute: `lastSeen` is
+intentionally cleared on launch so persisted data never claims current
+reachability (`Sources/termio/Terminal/Termiod/TermiodDevice.swift:71-79`). The
+current startup check also probes only this Mac, specifically to avoid an SSH
+round trip to every known route
+(`Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift:155-164`).
+
+The RFC must define at least what the user sees and can do when the current
+device becomes unreachable, what happens to already-visible sessions and panels,
+whether another route is tried, and how the user returns to a reachable device.
+Without that, colour can keep confidently naming a device that the UI is no
+longer showing.
+
+The cited historical pain is real, but its attribution needs correction. The
+“list works but terminal unauthorized” bug was caused by terminal `resize`
+frames overtaking authentication
+(`docs/bug/companion-terminal-unauthorized-over-tunnel.md:9-37`). The stale tunnel
+URL was adjacent and contributory, but the bug reproduced with a fresh pairing
+and one clean tunnel (`docs/bug/companion-terminal-unauthorized-over-tunnel.md:98-103`).
+The lesson still applies: independent roster and terminal connections can report
+incompatible truths, which is exactly why connection ownership must precede the
+switcher.
+
+### 6. Literal single-device collapse hides the only recovery surface
+
+“No indicator, no submenu, no Settings tab”
+(`docs/rfcs/remote-to-device.md:108-112`) is too strong once termiod is the only
+PTY owner. A one-device user is the user most likely to have no alternative when
+the local daemon fails. Hiding Devices also hides the RFC’s only home for install
+status, version, and device-scoped maintenance
+(`docs/rfcs/remote-to-device.md:65-70,119-123`).
+
+The correct promise is no steady-state tax. Failure and maintenance still need a
+reachable surface. The RFC also needs to define “one”: one learned identity, one
+device with sessions, one currently reachable device, or this Mac plus no other
+configured routes. A user who tried one VPS once and later removed its SSH alias
+must not pay the multi-device UI forever merely because `devices.json` remembers
+the handshake.
+
+## Attack on the four proposed positions
+
+### 1. Colour assignment: reject as stated
+
+Deriving the default from `host_id` is deterministic, but it does not deliver the
+stated guarantee that the same machine keeps the same colour. The settled
+architecture says the identifier belongs to one daemon installation/socket:
+the dev and release channels on one Mac are two devices, and a changed `TMPDIR`
+can mint a new identity
+(`docs/design/20260805-termiod-device-architecture.md:561-576`). A reinstallation
+can therefore change the colour of the same hardware; a cloned identifier gives
+two machines the same colour at exactly the moment they most need distinction.
+That follows from the settled identity decision and does not reopen it.
+
+A fixed palette also stops being identity at 20 devices. If it has fewer than 20
+accessible swatches, repeats are guaranteed; even a larger palette cannot make
+20 peripheral-vision colours reliably distinguishable. A user override stored
+only on one viewer also defeats the cross-Mac consistency this proposal is meant
+to buy.
+
+There is a smaller specification contradiction: “assign on first handshake”
+implies persistence, while “derived deterministically” does not need assignment.
+If the result is persisted to survive palette changes, define algorithm/version
+and override precedence. If it is recomputed, changing the palette or hash
+mapping changes existing identities.
+
+Use a deterministic colour only as a default decoration. It cannot be the
+identity or the safety mechanism; a text label and non-colour state cue must
+remain authoritative.
+
+### 2. Colour bleed: the grid conclusion survives; the rationale does not
+
+The presentation boundary says the host cannot resolve viewer presentation. It
+does not say which parts of a viewer may use colour
+(`docs/design/20260805-termiod-device-architecture.md:272-309`). “Chrome only” is
+a client design choice, not an architectural consequence.
+
+Keeping device colour out of the terminal grid is still correct. The terminal
+palette belongs to the selected theme, and the existing title bar is deliberately
+the terminal background so it joins the grid without a seam
+(`Sources/termio/App/App.swift:629-657`). The title bar is therefore not a free
+piece of chrome to tint. A device-coloured title bar would either break that
+shipped convention or mislabel a focused session when current device and focus
+diverge. A global sidebar tint is also wrong because the sidebar remains
+cross-device.
+
+The claimed repo-wide ban on accent-coloured control backgrounds is not an
+invariant. The app strips AppKit’s saturated blue selection, but its themed
+sidebar intentionally uses an accent-tinted selected-row fill
+(`Sources/termio/Sidebar/SidebarView.swift:1318-1371`). The “neutral rather than
+accent-coloured controls” sentence in `docs/design/agent-plugins.md:176-187` is
+the grammar of that Settings tab, not a global rule.
+
+A swatch beside a device label survives this attack because it occupies a
+device-owned atom and does not compete with selection, agent status, terminal
+theme, or window focus. The RFC should name exact atoms, not “sidebar, indicator,
+title bar” as one undifferentiated chrome region.
+
+### 3. Guardrails: reject locality as the predicate, not confirmation itself
+
+The strongest case against the proposed rejection is that a risk-dependent
+policy is not a second execution path. One command implementation can decide
+whether to confirm from the action’s reversibility and scope. Network location
+can correlate with risk: a local delete goes to Trash, while a device request may
+have no recoverable trash operation.
+
+The `rm -rf` comparison misses the RFC’s examples. termio cannot interpret every
+shell command, but it does own Close Session and file deletion. The shipped local
+file action already confirms and moves the item to Trash
+(`Sources/termio/FileBrowser/FileBrowserView.swift:578-593`). Close Session also
+confirms when a plain shell has a foreground job
+(`Sources/termio/TermioStore/TermioStore+ProjectActions.swift:658-691`). The
+existing convention is “confirm known loss,” not “never confirm local actions.”
+
+Your rejection does survive in two narrower forms:
+
+- Never interpose on ordinary terminal commands. Colour, labels, and focus are
+  the only viable cues there.
+- Do not key app-owned confirmation on “not this machine.” That predicate is
+  Mac-centric and fails the settled peer-client model: on iOS every session host
+  is another machine. Key it on irreversibility, inability to recover, or a
+  device-wide blast radius, identically on every viewer.
+
+Typed device names are especially weak because names are mutable and need not be
+unique; hold-to-confirm is undiscoverable and input-device-dependent. A normal
+confirmation that names the device and the irreversible consequence remains
+defensible for Forget Device, uninstalling termiod with live sessions, permanent
+file deletion, and other device-scoped destruction. Colour is a cue, not a
+guardrail: palette collisions, colour-vision differences, and ambiguous chrome
+make it incapable of carrying that burden alone.
+
+### 4. `Connect to…` in the `+` menu: survives, with two required decisions
+
+Replacing the existing dead `New Remote Terminal` row is the best use of the
+slot. The `+` menu already puts that row directly below New Terminal at Home
+(`Sources/termio/App/App.swift:1784-1808`), so this adds no new weight for a
+one-device user and fixes the empty-config dead end instead of adding another
+item.
+
+Two ambiguities remain:
+
+1. Does Connect only learn/switch the device, or does it also create a terminal?
+   The former does not replace the old creation action; the latter hides a
+   session-creation side effect behind a connection verb.
+2. What happens to the adjacent `New SSH Connection` command, which already has
+   its own Add Host path (`Sources/termio/App/App.swift:1621-1644`)? Shipping both
+   during stage 1 presents two ways to reach the same machine before the data
+   model resolves their semantics.
+
+Keep the same slot, but do not stage the rename before those behaviors are
+decided.
+
+## The three suspected gaps
+
+| Suspected gap | Verdict |
+| --- | --- |
+| Unreachable-device presentation | Correct and blocking. The prior bug supports the need for one connection truth, but stale tunnel URL was not its confirmed root cause. |
+| `TERMIO_TERMIOD` absent from staging | Correct and the largest omitted risk. The settled architecture places deletion of the flag before the switcher. |
+| PR #177 paragraph is stale | Correct. [PR #177](https://github.com/termio-sh/termio/pull/177) merged into `main` on 2026-08-15 at 13:07 UTC as `66b1722`; it is no longer a draft or a blocker. |
+
+## Scale tests
+
+### One device
+
+- Healthy steady state can collapse completely. That part of the promise holds.
+- Failure cannot collapse. With termiod as the only PTY owner, daemon failure
+  needs an error and recovery action even when no device indicator or Settings
+  tab is normally shown.
+- “One” must ignore stale learned devices that have no sessions, no live route,
+  and no route left in `~/.ssh/config`, or trying the feature once permanently
+  changes the UI.
+- The fate of old plain-SSH sessions must be explicit. Silent conversion would
+  install software and change session durability; retaining them preserves the
+  fork.
+- Replacing the existing `+`-menu row with Connect costs nothing. Adding a second
+  Connect item would break the promise.
+
+### 20 devices
+
+- A fixed colour palette repeats and cannot serve as identity.
+- A flat switcher needs search, recent ordering, or another bounded selection
+  rule. The current registry’s stable order is opaque `host_id` order
+  (`Sources/termio/Terminal/Termiod/TermiodDevice.swift:167-172`), which is unusable
+  as presentation order.
+- Eager reachability probing is not acceptable, but no probing leaves 20 devices
+  in an unknown state after launch. The RFC needs a lazy status model tied to
+  actual `TermiodConnection` objects, plus explicit “not checked” presentation.
+- A single badge saying another device needs attention loses which device and how
+  many. With several devices in `needs-you`, it becomes a generic alarm rather
+  than navigation.
+- A “device column” does not fit the shipped hierarchical source-list model
+  without a layout decision. The sidebar is constrained to 240–400 points
+  (`Sources/termio/App/App.swift:505-509`); 20 repeated device names on session
+  rows will either dominate the agent/session labels or truncate into uselessness.
+- Multiple aliases per device make the switcher’s known-device and untried-alias
+  sections duplicate entries until handshake. The design needs an explicit
+  unresolved-route row and a merge transition, not the fiction that the sections
+  are clean rosters.
+
+## Vocabulary problems
+
+| Term | Problem |
+| --- | --- |
+| **Device** | In the architecture it means a machine running termiod. In the product it already naturally includes the iPhone viewer. Settings ▸ Devices will sound as if paired phones belong there even though the peer-client model says they do not. The UI needs a qualifier or copy that makes “session host” clear. |
+| **Connect to…** | It does not say whether the user is selecting a known device, entering an SSH route, installing termiod, switching context, or opening a terminal. Beside `New SSH Connection`, the ambiguity is worse. Finder’s full verb is “Connect to Server…”, which names the object. |
+| **Clone to <device>…** | “To” implies copying the current checkout, including local work. The shipped operation actually runs `git clone <origin>` on the target and excludes unpushed commits (`Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift:489-520`). “Clone on <device>…” is more accurate without restoring the word remote. |
+| **New Terminal** | A direct command with one device and a submenu with two changes both interaction shape and keyboard meaning at an arbitrary roster count. If a current device exists, New Terminal should have one target: that device. |
+| **Reachable machines** | `~/.ssh/config` contains candidate aliases and patterns, not proof of current reachability. Call them SSH routes or targets until a connection succeeds. |
+| **New Project** | This is not shipped vocabulary. The app uses `Open Project…` (`Sources/termio/App/App.swift:2134-2139`), and `VOICE.md:130-138` fixes “project” as the UI noun. The scoping table should use the real command. |
+| **Retire remote** | Scope the retirement to execution-topology nouns and verbs. “Git remote”, Apple’s “Remote Management”, and remote access for the iPhone remain accurate domain terms; a lexical purge would make those strings worse. |
+
+## Required changes before approval
+
+1. Replace the provenance-based ownership rule with explicit authorities for
+   routes, observations, viewer preferences, and device state. Do not persist a
+   typed SSH target as a termio-owned route.
+2. Define one focus model with a transition table. It must be impossible for the
+   indicator, focused terminal, panels, title bar, and creation commands to name
+   different devices without an explicit split-state presentation.
+3. Rewrite staging to follow the settled dependency order: own connection health,
+   make termiod the default and remove the in-process fork, prove packaging and
+   lifecycle, then expose the switcher.
+4. Specify unreachable, reconnecting, unverified, incompatible, and route-removed
+   presentation, including recovery for the one-device case.
+5. Decide and migrate `New SSH Connection` / `Session.sshHost`; tolerant decoding
+   is not a migration policy.
+6. Treat deterministic colour as a secondary default cue, define its stability
+   and accessibility contract, and name the exact UI atoms it may colour.
+7. Base confirmations on irreversible consequences and blast radius, never on
+   local versus non-local. Do not intercept terminal commands.
+8. Define the 20-device interaction: ordering, search or recency, lazy status,
+   attention routing, stale-device cleanup, and how device identity fits the
+   existing sidebar without becoming a repeated text column.


### PR DESCRIPTION
Two independent adversarial reviews of `docs/rfcs/remote-to-device.md` — one from Codex, one from Claude, working from the same brief without seeing each other — plus the corrections they forced on the RFC itself.

Both reach the same verdict: **the direction is right, the draft is not approvable as written.** Retiring "remote" as a product concept is correct; the replacement as drafted introduces competing sources of truth for routes, focus, and device selection, which is the same two-copies failure at a different layer.

Draft, because three of the questions it raises are yours to settle, not mine.

## Corrections shipped code decides

**`Settings ▸ SSH` already exists, and it writes.** The ownership table claimed the machine list was "read-only; no Settings entry". Both halves are false — `SSHSettingsTab.swift` lists aliases, probes reachability per host, opens the raw config, and appends `Host` blocks via **Add Host**. The RFC therefore proposed `Settings ▸ Devices` next to a shipped tab covering the same ground, with no boundary drawn. The ownership test can't resolve it either, since reachability is termio's own probe.

**The staging order was reversed.** The settled architecture orders the work *own the connection → delete the `TERMIO_TERMIOD` fork → device switcher*, and marks the switcher "only meaningful after step 5". The RFC staged the switcher first and never staged the flag. With the flag off, opening on a non-local device stops at an alert telling you to set it — so a switcher above that fork advertises devices no session can open on. Flag deletion is now its own stage with its risk written down: it changes the execution path of *every* session and makes the daemon release-critical.

**The guardrail question was the wrong question.** All three proposed options were the local/remote fork wearing a warning triangle. The shipped doctrine is narrower and better — `closeConfirmationReason` confirms only when a shell has a live foreground job, because that command "exists nowhere else", and never for agent sessions. And the live defect runs the *other* way: that check reads `ptyProcesses[session.id]`, and `hasForegroundJob` has no counterpart in `termiod/src`, so **a remote session with a build running closes silently while a local one asks.** Carrying the existing rule across the wire is the work item.

## Both blocking questions are now decided

**Settings splits at the handshake — the tabs coexist.** `Settings ▸ SSH` owns *routes*: anything meaningful before `hello_ok`, keyed by an alias, or affecting how OpenSSH resolves and authenticates. `Settings ▸ Devices` owns *identities*: anything learned after `hello_ok`, keyed by `host_id`. A value is never persisted in both.

Subsuming was rejected because an alias exists before any device is known, and one `host_id` can be reached through several aliases — one list would have to invent device rows for unresolved routes, or hide a route model inside each device. That is the two-copies problem again, under one tab. The split is written as a key test so a new field can be placed without reopening it.

**Foreground-job parity belongs here, and gates the fork deletion.** Not because the rename needs it, but because this RFC *causes* the regression: removing the in-process PTY path deletes a shipped safety behaviour from every **local** session, since `closeConfirmationReason` reads `ptyProcesses[session.id]`. It rides as an optional additive field and needs no `proto` bump — the protocol already treats unknown ops and events as ignorable and its caps as additive. Skew rule: an older daemon omitting the field preserves today's no-confirm behaviour, and must never read absence as "unknown, so confirm".

## A misquote of our own invariant

The "already decided — do not reopen" table rendered non-negotiable #3 as *"read it, never write it"*. `CLAUDE.md:43-44` says *"never **override** it"*.

That difference is load-bearing. The stricter paraphrase made the shipped **Add Host** look like a violation of a rule it does not break — appending a user-authorised `Host` block overrides nothing. A hardened quote of our own invariant, in the one table headed "do not reopen", was about to condemn working code. Corrected with the line reference.

## Still open

- What does an **unreachable** device render, in the sidebar, the menus, and the switcher? Both reviews raised it independently, and nothing in the draft answers it.

## Release Notes:

No user-facing change — design documents only.
