### PR TITLE
Stop the Info pane and file tree stalling the main thread

### DIFF
--- a/Sources/termio/FileBrowser/FileIconView.swift
+++ b/Sources/termio/FileBrowser/FileIconView.swift
@@ -76,13 +76,17 @@ struct FileIconView: View {
 @MainActor
 final class LangIconLoader {
     static let shared = LangIconLoader()
-    private var cache: [String: NSImage] = [:]
+    /// `NSImage?`, not `NSImage`: an extension with no Devicon has to be remembered too.
+    /// Caching only the hits left every `.jsonl`, `.lock` and `.plist` in the tree
+    /// repeating a bundle resource lookup — filesystem work — on each row realization,
+    /// and rows realize on every scroll and every layout pass.
+    private var cache: [String: NSImage?] = [:]
 
     func image(named name: String) -> NSImage? {
         if let hit = cache[name] { return hit }
-        guard let url = Bundle.termioResources.url(
+        let image = Bundle.termioResources.url(
             forResource: name, withExtension: "svg", subdirectory: "LangIcons"
-        ), let image = NSImage(contentsOf: url) else { return nil }
+        ).flatMap { NSImage(contentsOf: $0) }
         cache[name] = image
         return image
     }

--- a/Sources/termio/Info/EditorTarget.swift
+++ b/Sources/termio/Info/EditorTarget.swift
@@ -21,9 +21,23 @@ struct EditorTarget: Identifiable, Hashable {
     /// The editor's real app icon (the `.icns` macOS shows in the Dock/Finder), so
     /// each row is unmistakably that app rather than a generic glyph. `nil` only if
     /// the app isn't installed — but callers render only installed targets.
+    ///
+    /// Memoized because the caller is a SwiftUI view builder, and a view builder runs
+    /// far more often than it renders: `ScrollView` sizing re-evaluates its content on
+    /// every layout pass, so an uncached fetch turned one Info pane into thousands of
+    /// `NSWorkspace.icon(forFile:)` calls — each a LaunchServices `getattrlist` — and
+    /// pinned the main thread for seconds when a project opened. One fetch per editor
+    /// per run is plenty: an app's icon does not change under us.
+    @MainActor
     var appIcon: NSImage? {
-        applicationURL.map { NSWorkspace.shared.icon(forFile: $0.path) }
+        if let cached = Self.iconCache[bundleID] { return cached }
+        guard let icon = applicationURL.map({ NSWorkspace.shared.icon(forFile: $0.path) })
+        else { return nil }
+        Self.iconCache[bundleID] = icon
+        return icon
     }
+
+    @MainActor private static var iconCache: [String: NSImage] = [:]
 
     /// Every editor termio knows how to open, in display order. Kept deliberately
     /// short — the popular coding editors that open a folder or file cleanly from
@@ -38,10 +52,12 @@ struct EditorTarget: Identifiable, Hashable {
         EditorTarget(name: "Sublime Text", bundleID: "com.sublimetext.4"),
     ]
 
-    /// The subset of the catalog installed on this machine, in catalog order.
-    static var installed: [EditorTarget] {
-        catalog.filter { $0.applicationURL != nil }
-    }
+    /// The subset of the catalog installed on this machine, in catalog order. Resolved
+    /// once, for the same reason `appIcon` is memoized — this is read from a view
+    /// builder, so a bundle-id lookup per editor per layout pass is filesystem work in
+    /// the middle of drawing. The cost is that an editor installed while termio is
+    /// running appears in the list after the next launch.
+    static let installed: [EditorTarget] = catalog.filter { $0.applicationURL != nil }
 
     /// Opens `url` (a file or a folder) in this editor. A no-op if it isn't
     /// installed — the caller only ever renders installed targets, so this is a


### PR DESCRIPTION
Opening a project froze the app for seconds. Sampling caught it precisely: 837 of 837 samples in `getattrlist`, under `NSWorkspace.icon(forFile:)`, reached from the Info pane's editor rows through `ScrollViewLayoutComputer.sizeThatFits`.

`EditorTarget.installed` and `.appIcon` were computed properties doing a LaunchServices lookup and an icon load on every call — and they are read from a SwiftUI view builder. A view builder runs far more often than it renders: `ScrollView` re-evaluates its content on every layout pass while sizing. One Info pane became thousands of bundle lookups. Individually each call is 0–4ms (measured); multiplied by layout it is seconds of frozen main thread.

`LangIconLoader` had the same shape one level down. It cached the icons it found but not the ones it didn't, so every `.jsonl`, `.lock` and `.plist` in the tree repeated a bundle resource lookup on each row realization.

Both are now resolved once. This is the same family as the earlier beachballs — cheap-looking work inside a view body, multiplied by SwiftUI's evaluation rate.

## Tradeoff

An editor installed while termio is running now appears in the list after the next launch, rather than on the next layout pass. Stated in the code comment.

## Still open

`FileTreeWatcher.watch(_:)` starts its FSEvents stream on the main thread (`FileTreeWatcher.swift:57`) and showed up in a few samples. Left alone here: moving it off-main races the main-actor `stream` assignment, so it deserves its own change.

## Verification

- `swift build` clean, `swift test` 262/262
- Re-sampled the running dev app after the fix: the storm is gone from the stacks

Release Notes: Opening a project and switching to the Info pane no longer freeze the app while macOS resolves editor and file-type icons.