### PR TITLE
Skip the download digest when it is not configured

### DIFF
--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -40,7 +40,28 @@ jobs:
           ref: stats
           path: _stats
 
+      - name: Check that the digest is configured
+        id: config
+        env:
+          CF_ANALYTICS_TOKEN: ${{ secrets.CF_ANALYTICS_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+        # The secrets below are set per-repo and a fork or a fresh clone has
+        # none of them. Without this the nightly cron fails every single night,
+        # and a check that is always red is one nobody reads — which is exactly
+        # what happened here: this workflow had never once succeeded.
+        run: |
+          missing=""
+          [ -n "$CF_ANALYTICS_TOKEN" ] || missing="$missing CF_ANALYTICS_TOKEN"
+          [ -n "$CF_ZONE_ID" ]         || missing="$missing CF_ZONE_ID"
+          if [ -n "$missing" ]; then
+            echo "::notice::Download digest is not configured — missing secrets:$missing. Skipping."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Collect + post
+        if: steps.config.outputs.configured == 'true'
         env:
           CF_ANALYTICS_TOKEN: ${{ secrets.CF_ANALYTICS_TOKEN }}
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
@@ -52,6 +73,7 @@ jobs:
             ${{ github.event.inputs.date && format('--date {0}', github.event.inputs.date) || '' }}
 
       - name: Commit ledger
+        if: steps.config.outputs.configured == 'true'
         run: |
           cd _stats
           git config user.name  "termio-stats-bot"


### PR DESCRIPTION
`Download stats` has failed **every night since it was added** and has never once succeeded — I checked the last 30 runs. Eight consecutive reds sat on the trunk unnoticed, which is the whole problem: a check that is always red is one nobody reads.

The cause is not the code. Three of its four secrets do not exist:

```
CF_ANALYTICS_TOKEN:      (empty)
CF_ZONE_ID: ***          (set)
TELEGRAM_BOT_TOKEN:      (empty)
TELEGRAM_CHAT_ID:        (empty)

→ CF_ANALYTICS_TOKEN and CF_ZONE_ID are required
```

So the script exits before doing anything, every night, forever.

This PR does not turn the digest on — it stops it lying. The job now checks its configuration first, and when secrets are missing it emits a `::notice::` naming them and skips the two steps that need them. A run that cannot do its work says so instead of failing, and a red here goes back to meaning something actually broke.

**To actually enable it**, add `CF_ANALYTICS_TOKEN`, `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` to repo secrets.

Two things worth a look while you are in there, which I did not change because both alter which credential is used:

- `CLOUDFLARE_API_TOKEN` already exists. If it carries `Zone > Analytics > Read`, the digest may only need renaming rather than a new token — but it may equally lack that scope, so I did not silently repoint it.
- `CF_ZONE_ID` and `CLOUDFLARE_ZONE_ID` are both set, and the workflow's own comment says they are the same value. That duplication is worth collapsing.

## Release Notes:

No user-facing change.