### PR TITLE
Carry a pasted image across to the device the agent runs on

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -119,6 +119,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // The ghostty-style right-click menu over the terminal surfaces (Copy/Paste + splits);
     // owns the rightMouseDown monitor for the app's lifetime.
     private var terminalContextMenu: TerminalContextMenu?
+    private var termiodImagePaste: TermiodImagePaste?
     // The pane drag-to-rearrange gesture (issue #183); owns its
     // mouse monitors for the app's lifetime.
     private var paneDragRearrange: PaneDragRearrange?
@@ -327,7 +328,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 }
             }
 
-        terminalContextMenu = TerminalContextMenu(store: store)
+        // Installed before the context menu so the menu can hand its Paste to
+        // the same interceptor rather than growing a second copy of the rule.
+        termiodImagePaste = TermiodImagePaste(store: store)
+        terminalContextMenu = TerminalContextMenu(store: store, imagePaste: termiodImagePaste)
         paneDragRearrange = PaneDragRearrange(store: store)
 
         menuBar = MenuBarController(store: store) { [weak self] id in

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -327,6 +327,27 @@ struct Session: Identifiable, Hashable, Codable {
     /// is nil.
     var termiodRemoteCwd: String?
 
+    /// Adopt another session's machine — both halves of it.
+    ///
+    /// A device has two identities during its life (device architecture §9.5):
+    /// the SSH alias it was *authored* against, known before anything connects,
+    /// and the `deviceID` the first `hello_ok` reveals. A session derived from
+    /// another — a split, and every future "open beside this" verb — has to
+    /// carry both, or it lands on this Mac while sitting in a pane that reads
+    /// as the same machine.
+    ///
+    /// This helper exists so the copying happens in one place rather than at
+    /// each call site: **when sessions stop naming a host and take their device
+    /// from the container that owns them, this method is the only thing to
+    /// delete.** Spreading `termiodRemoteHost = …` across call sites is what
+    /// makes that migration expensive, and it is the fork the RFC removes.
+    mutating func inheritDevice(from origin: Session?) {
+        guard let origin else { return }
+        deviceID = origin.deviceID
+        termiodRemoteHost = origin.termiodRemoteHost
+        termiodRemoteCwd = origin.termiodRemoteCwd
+    }
+
     /// The last working directory the shell reported over OSC 7, persisted for
     /// sessions in the loose-terminals container only: a loose terminal's identity
     /// is the session, its path is this mutable property — so a relaunched shell

--- a/Sources/termio/Terminal/TerminalContextMenu.swift
+++ b/Sources/termio/Terminal/TerminalContextMenu.swift
@@ -15,6 +15,9 @@ import GhosttyTerminal
 @MainActor
 final class TerminalContextMenu: NSObject {
     private weak var store: TermioStore?
+    /// The ⌘V interceptor, so the menu's Paste answers the image-at-a-remote-
+    /// session case the same way the key does instead of restating the rule.
+    private weak var imagePaste: TermiodImagePaste?
     // Held for the app's lifetime; never removed.
     private var monitor: Any?
     /// The surface the open menu acts on, resolved at click time.
@@ -24,8 +27,9 @@ final class TerminalContextMenu: NSObject {
     /// when the menu opens so the actions don't chase a moved mouse.
     private var clickedLinkURL: URL?
 
-    init(store: TermioStore) {
+    init(store: TermioStore, imagePaste: TermiodImagePaste?) {
         self.store = store
+        self.imagePaste = imagePaste
         super.init()
         monitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { event in
             // Local event monitors are always called on the main thread; the
@@ -97,11 +101,12 @@ final class TerminalContextMenu: NSObject {
             menu.addItem(storeItem(localized("Open Link"), action: #selector(openLink), symbol: "safari"))
             menu.addItem(.separator())
         }
-        // Copy/Paste target the surface's own responder actions: copy is a
-        // no-op without a selection, and paste routes through ghostty's
-        // `paste_from_clipboard` binding so bracketed paste is preserved.
+        // Copy targets the surface's own responder action, and is a no-op
+        // without a selection. Paste goes through `paste(_:)` below, which ends
+        // up at the same responder action for everything except the one case
+        // that cannot work there.
         menu.addItem(surfaceItem(localized("Copy"), action: "copy:", symbol: "doc.on.doc"))
-        menu.addItem(surfaceItem(localized("Paste"), action: "paste:", symbol: "doc.on.clipboard"))
+        menu.addItem(storeItem(localized("Paste"), action: #selector(paste), symbol: "doc.on.clipboard"))
         // The session's deep link (`termio://session/<uuid>`) — the canonical
         // address every `termio sessions` command takes and the form that stays
         // self-describing when pasted into an agent prompt, so wiring one agent
@@ -172,6 +177,15 @@ final class TerminalContextMenu: NSObject {
     @objc private func closeSession() {
         guard let id = clickedSessionID else { return }
         store?.requestCloseSession(id)
+    }
+
+    /// An image aimed at a session on another device crosses the boundary and
+    /// pastes the path it landed at; everything else is the surface's own
+    /// paste, which routes through ghostty's `paste_from_clipboard` binding so
+    /// bracketed paste is preserved.
+    @objc private func paste() {
+        if imagePaste?.pasteImageFromMenu(sessionID: clickedSessionID) == true { return }
+        clickedView?.perform(NSSelectorFromString("paste:"), with: nil)
     }
 
     @objc private func openLink() {

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -404,6 +404,8 @@ enum Termiod {
         case snapshot = 0x53 // 'S'
         case history = 0x48 // 'H'
         case grid = 0x47 // 'G'
+        case file = 0x46 // 'F'
+        case upload = 0x55 // 'U'
     }
 
     static let maximumFrameSize = 16 * 1024 * 1024
@@ -519,6 +521,32 @@ enum Termiod {
         let op = "detach"
     }
 
+    /// Opens a transfer into a session's scratch directory on the device
+    /// (§C.12 `temp:` dest). `session` is the termiod session name — the app's
+    /// session UUID — and the daemon reaps whatever lands there when that
+    /// session dies, so a pasted screenshot never outlives the conversation it
+    /// belonged to.
+    struct UploadOpenOperation: Encodable {
+        let op = "upload_open"
+        let dest: String
+        let session: String
+        let size: UInt64
+        let sha256: String
+        let seq: UInt64
+    }
+
+    struct UploadCommitOperation: Encodable {
+        let op = "upload_commit"
+        let uploadId: String
+        let seq: UInt64
+    }
+
+    struct UploadAbortOperation: Encodable {
+        let op = "upload_abort"
+        let uploadId: String
+        let seq: UInt64
+    }
+
     /// Only the `op` tag — the second decode pass picks the payload shape.
     private struct ControlTag: Decodable {
         let op: String
@@ -579,6 +607,39 @@ enum Termiod {
         let alive: Bool
     }
 
+    /// Reply to `upload_open`. `offset` is where the next chunk starts: 0 for a
+    /// fresh transfer, and the bytes the daemon already holds when this open
+    /// resumed one a dropped connection left behind. Absent on a daemon that
+    /// predates resume, which reads as "start over" — the same thing it does.
+    struct UploadOpenedPayload: Decodable {
+        let uploadId: String
+        let offset: UInt64
+
+        private enum CodingKeys: String, CodingKey {
+            case uploadId, offset
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            uploadId = try container.decode(String.self, forKey: .uploadId)
+            offset = try container.decodeIfPresent(UInt64.self, forKey: .offset) ?? 0
+        }
+    }
+
+    /// The credit-of-one grant: `offset` is the total the daemon has received,
+    /// which is where the next chunk goes. Holding the next chunk until this
+    /// arrives is what bounds a keystroke's wait on a shared pipe to one chunk.
+    struct UploadAckPayload: Decodable {
+        let uploadId: String
+        let offset: UInt64
+    }
+
+    /// Where the verified bytes landed on the device — an absolute path on
+    /// *that* machine, which is the whole point of the transfer.
+    struct UploadCommittedPayload: Decodable {
+        let path: String
+    }
+
     /// Decoded control frames the client reacts to. Anything else — unknown
     /// ops, responses this slice doesn't consume — becomes `.unknown` and is
     /// ignored, matching the protocol's additive-evolution rule.
@@ -588,6 +649,9 @@ enum Termiod {
         case attached(AttachedPayload)
         case exited(ExitedPayload)
         case sessions(SessionsPayload)
+        case uploadOpened(UploadOpenedPayload)
+        case uploadAck(UploadAckPayload)
+        case uploadCommitted(UploadCommittedPayload)
         case error(ErrorPayload)
         case unknown(String)
     }
@@ -613,6 +677,12 @@ enum Termiod {
             return .exited(try decoder.decode(ExitedPayload.self, from: payload))
         case "sessions":
             return .sessions(try decoder.decode(SessionsPayload.self, from: payload))
+        case "upload_opened":
+            return .uploadOpened(try decoder.decode(UploadOpenedPayload.self, from: payload))
+        case "upload_ack":
+            return .uploadAck(try decoder.decode(UploadAckPayload.self, from: payload))
+        case "upload_committed":
+            return .uploadCommitted(try decoder.decode(UploadCommittedPayload.self, from: payload))
         case "error":
             return .error(try decoder.decode(ErrorPayload.self, from: payload))
         default:
@@ -1025,10 +1095,12 @@ final class TermiodSessionLink: @unchecked Sendable {
                     }
                 case .control:
                     if self.handleControl(frame.payload) { return }
-                case .event, .resize, .history, .grid:
+                case .event, .resize, .history, .grid, .file, .upload:
                     // `ready` (an `E` event) marks snapshot-complete but needs no
                     // action — serial ordering already sequences S then D. The
-                    // rest is unnegotiated in this slice and safe to skip.
+                    // rest is unnegotiated in this slice and safe to skip;
+                    // `F`/`U` never ride an attach channel at all (transfers use
+                    // their own control channel, so the hot path stays raw).
                     break
                 }
             }

--- a/Sources/termio/Terminal/Termiod/TermiodTransfer.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodTransfer.swift
@@ -1,0 +1,315 @@
+import AppKit
+import CryptoKit
+import Foundation
+import GhosttyTerminal
+
+/// The transfer plane: bytes crossing the viewer↔device boundary.
+///
+/// The clipboard belongs to the viewer and the agent belongs to the device
+/// (device architecture §4.1), so pasting a screenshot at an agent running on
+/// another machine is not an upload to a server — it is a crossing, and this is
+/// where it happens. Locally the crossing does not exist, because the agent
+/// reads the Mac's pasteboard itself.
+///
+/// Transfers ride their **own control channel**, never a session's attach
+/// channel: the anti-100× invariant says byte delivery must not queue behind
+/// anything, and the daemon enforces the same split by refusing `U` frames on
+/// an attachment. Chunks are credit-of-one — the next one is held until the
+/// previous is acked — which bounds what a keystroke could ever wait behind to
+/// a single 64 KiB frame even when the two channels share one SSH connection.
+extension Termiod {
+    /// One `U` frame's worth of payload, sized so the whole frame (header, id,
+    /// offset, bytes) stays inside the daemon's 64 KiB cap for this kind.
+    static let uploadChunkSize = 64 * 1024 - 512
+
+    /// Lands `data` in `session`'s scratch directory on the device `route`
+    /// leads to and returns the absolute path **on that machine** — the string
+    /// an agent over there can open.
+    ///
+    /// Blocking; call it off the main thread. A transfer that loses its pipe
+    /// part-way is retried once by re-opening, which resumes at the bytes the
+    /// daemon already holds rather than re-sending them.
+    static func uploadToSessionScratch(
+        route: TermiodRoute,
+        session: String,
+        name: String,
+        data: Data
+    ) throws -> String {
+        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        do {
+            return try performUpload(
+                route: route, session: session, name: name, data: data, sha256: digest)
+        } catch TermiodClientError.connectionClosed {
+            Log.termiod.info("""
+            transfer to \(session, privacy: .public) lost its pipe; resuming
+            """)
+            return try performUpload(
+                route: route, session: session, name: name, data: data, sha256: digest)
+        }
+    }
+
+    private static func performUpload(
+        route: TermiodRoute,
+        session: String,
+        name: String,
+        data: Data,
+        sha256: String
+    ) throws -> String {
+        let transport = try Transport.open(route)
+        defer { transport.close() }
+        try performHello(transport, role: "control", caps: ["upload"])
+
+        let opened = try request(transport, UploadOpenOperation(
+            dest: "temp:\(name)",
+            session: session,
+            size: UInt64(data.count),
+            sha256: sha256,
+            seq: 1
+        )) { control in
+            if case .uploadOpened(let payload) = control { return payload }
+            return nil
+        }
+
+        var offset = Int(clamping: opened.offset)
+        // A daemon that reports more bytes than we hold is describing a
+        // different transfer under the same name; start over rather than
+        // commit something we cannot account for.
+        if offset > data.count { offset = 0 }
+        while offset < data.count {
+            let end = min(offset + uploadChunkSize, data.count)
+            try writeFrame(transport.writeDescriptor, kind: .upload,
+                           payload: uploadChunkPayload(
+                               uploadID: opened.uploadId,
+                               offset: UInt64(offset),
+                               data: data.subdata(in: offset ..< end)))
+            let ack = try readReply(transport) { control in
+                if case .uploadAck(let payload) = control { return payload }
+                return nil
+            }
+            let acked = Int(clamping: ack.offset)
+            // The ack is the daemon's own running total, so it — not our
+            // arithmetic — decides where the next chunk starts. Refusing to go
+            // backwards keeps a confused daemon from looping us forever.
+            guard acked > offset else {
+                throw TermiodClientError.requestFailed(
+                    "transfer stalled at \(offset) of \(data.count) bytes")
+            }
+            offset = acked
+        }
+
+        let committed = try request(
+            transport, UploadCommitOperation(uploadId: opened.uploadId, seq: 2)
+        ) { control in
+            if case .uploadCommitted(let payload) = control { return payload }
+            return nil
+        }
+        return committed.path
+    }
+
+    /// `U` payload: id_len u8, upload id, offset u64 big-endian, then bytes —
+    /// termiod/src/protocol.rs `decode_upload_chunk`. Internal so a test can
+    /// hold it to that layout: the daemon rejects the whole frame on a byte of
+    /// drift, and there is no partial credit on a wire format.
+    static func uploadChunkPayload(
+        uploadID: String, offset: UInt64, data: Data
+    ) -> Data {
+        let id = Data(uploadID.utf8)
+        var payload = Data(capacity: 1 + id.count + 8 + data.count)
+        payload.append(UInt8(clamping: id.count))
+        payload.append(id)
+        var bigEndianOffset = offset.bigEndian
+        withUnsafeBytes(of: &bigEndianOffset) { payload.append(contentsOf: $0) }
+        payload.append(data)
+        return payload
+    }
+
+    /// Send one request and read frames until `match` claims one. A typed
+    /// `error` reply fails the call with the daemon's own message, so a refused
+    /// transfer says why rather than timing out.
+    private static func request<Operation: Encodable, Reply>(
+        _ transport: Transport,
+        _ operation: Operation,
+        _ match: (IncomingControl) -> Reply?
+    ) throws -> Reply {
+        try writeFrame(transport.writeDescriptor, kind: .control,
+                       payload: encodeControl(operation))
+        return try readReply(transport, match)
+    }
+
+    private static func readReply<Reply>(
+        _ transport: Transport,
+        _ match: (IncomingControl) -> Reply?
+    ) throws -> Reply {
+        while true {
+            let frame = try readFrame(transport.readDescriptor)
+            guard frame.kind == .control else { continue }
+            let control = try decodeControl(frame.payload)
+            if let reply = match(control) { return reply }
+            if case .error(let failure) = control {
+                throw TermiodClientError.requestFailed(failure.message)
+            }
+        }
+    }
+}
+
+/// ⌘V of an image at a session running on another device.
+///
+/// Locally this needs no code at all: the agent reads the Mac's pasteboard
+/// itself when the terminal delivers Ctrl+V, which is what libghostty's wrapper
+/// already does. That mechanism cannot survive the machine boundary — a
+/// Ctrl+V delivered to a VPS makes the agent read *the VPS's* clipboard — so a
+/// remote session gets the crossing instead: the bytes move to the device, and
+/// the path they landed at is pasted as text. The agent then opens a local
+/// file, which is a thing it can do anywhere.
+///
+/// Intercepted with a local key monitor for the same reason `TerminalContextMenu`
+/// uses one: the wrapper instantiates its own view class, so there is no
+/// subclass to override, and a monitor runs before the surface sees the key.
+/// Everything that is not exactly this case — a local session, a text
+/// clipboard, a non-terminal responder — falls straight through untouched.
+@MainActor
+final class TermiodImagePaste: NSObject {
+    private weak var store: TermioStore?
+    // Held for the app's lifetime; never removed.
+    private var monitor: Any?
+    /// Sessions with a transfer in flight. A second ⌘V is swallowed rather than
+    /// starting a duplicate — and swallowed rather than passed on, because
+    /// letting it reach ghostty would deliver the wrong paste entirely.
+    private var inFlight: Set<Session.ID> = []
+
+    init(store: TermioStore) {
+        self.store = store
+        super.init()
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // Local event monitors are always called on the main thread; the
+            // annotation just can't say so (and `NSEvent` isn't `Sendable`, so
+            // only the Bool verdict crosses the `assumeIsolated` boundary).
+            nonisolated(unsafe) let event = event
+            let consumed = MainActor.assumeIsolated { self.intercept(event) }
+            return consumed ? nil : event
+        }
+    }
+
+    /// Bare ⌘V only. Any other modifier is somebody else's binding, and the
+    /// same key with a text clipboard is ghostty's `paste_from_clipboard`.
+    private func intercept(_ event: NSEvent) -> Bool {
+        guard event.charactersIgnoringModifiers?.lowercased() == "v",
+              event.modifierFlags.contains(.command),
+              event.modifierFlags.isDisjoint(with: [.shift, .option, .control])
+        else { return false }
+        return pasteImage(into: focusedTerminalSessionID())
+    }
+
+    /// The right-click menu's Paste, which reaches the surface by selector
+    /// rather than by key event. Returns whether the transfer took it over; the
+    /// menu falls back to the surface's own `paste:` when it did not.
+    func pasteImageFromMenu(sessionID: Session.ID?) -> Bool {
+        pasteImage(into: sessionID)
+    }
+
+    /// Returns whether this paste was taken over. `false` means "not our case"
+    /// and the ordinary paste must still happen.
+    private func pasteImage(into sessionID: Session.ID?) -> Bool {
+        guard Termiod.isEnabled, let store, let sessionID,
+              let session = store.session(sessionID),
+              // The device boundary is the whole condition: a session on this
+              // Mac keeps the local mechanism, unchanged.
+              let host = session.termiodRemoteHost,
+              let image = ClipboardImage.current()
+        else { return false }
+
+        guard !inFlight.contains(sessionID) else { return true }
+        inFlight.insert(sessionID)
+
+        let route = TermiodRoute(sshAlias: host)
+        let name = image.scratchFileName
+        let target = session.id.uuidString
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let result = Result {
+                try Termiod.uploadToSessionScratch(
+                    route: route, session: target, name: name, data: image.data)
+            }
+            DispatchQueue.main.async {
+                self?.finish(result, for: sessionID, host: host, bytes: image.data.count)
+            }
+        }
+        return true
+    }
+
+    private func finish(_ result: Result<String, Error>, for sessionID: Session.ID,
+                        host: String, bytes: Int) {
+        inFlight.remove(sessionID)
+        switch result {
+        case .success(let path):
+            Log.termiod.info("""
+            pasted \(bytes, privacy: .public) bytes to \
+            \(host, privacy: .public):\(path, privacy: .public)
+            """)
+            // The path is what the agent reads, so it goes in as a paste — the
+            // raw PTY seam, wrapped in bracketed paste, exactly as
+            // `addSnippetToSelectedSessionPrompt` explains: hand-written
+            // `\e[200~` re-encoded through ghostty's key encoder would arrive
+            // as a literal `[200~`.
+            guard let state = store?.surfaces[sessionID],
+                  case let .inMemory(backend) = state.configuration.backend
+            else { return }
+            backend.sendInput(Data(("\u{1B}[200~" + path + " \u{1B}[201~").utf8))
+        case .failure(let error):
+            Log.termiod.error("""
+            pasting an image to \(host, privacy: .public) failed: \
+            \(error.localizedDescription, privacy: .public)
+            """)
+            let alert = NSAlert()
+            alert.messageText = "Couldn't paste the image to \(host)"
+            alert.informativeText = error.localizedDescription
+            alert.alertStyle = .warning
+            alert.runModal()
+        }
+    }
+
+    /// The session whose surface has the keyboard, resolved through the store's
+    /// surface cache — the view and its cached state share a controller.
+    private func focusedTerminalSessionID() -> Session.ID? {
+        guard let window = NSApp.keyWindow,
+              window.frameAutosaveName == AppDelegate.mainWindowFrameAutosaveName,
+              let surface = window.firstResponder as? TerminalView
+        else { return nil }
+        return store?.surfaces.first { $0.value.controller === surface.controller }?.key
+    }
+}
+
+/// An image on the pasteboard with no text form — a fresh screenshot, a copied
+/// image — reduced to bytes plus the name they should land under.
+///
+/// The image-only rule is the wrapper's, kept verbatim so the two layers agree
+/// on what a paste is: a clipboard carrying text is a text paste, whatever else
+/// rides along with it.
+struct ClipboardImage {
+    let data: Data
+    let fileExtension: String
+
+    /// Unique per paste so two screenshots in one session never collide, and
+    /// timestamped so the name says when it arrived. The daemon reaps the whole
+    /// scratch directory with the session, so nothing accumulates.
+    var scratchFileName: String {
+        "paste-\(UInt64(Date().timeIntervalSince1970 * 1000)).\(fileExtension)"
+    }
+
+    static func current(_ pasteboard: NSPasteboard = .general) -> ClipboardImage? {
+        guard pasteboard.string(forType: .string) == nil else { return nil }
+        if let png = pasteboard.data(forType: .png) {
+            return ClipboardImage(data: png, fileExtension: "png")
+        }
+        if let jpeg = pasteboard.data(forType: NSPasteboard.PasteboardType("public.jpeg")) {
+            return ClipboardImage(data: jpeg, fileExtension: "jpg")
+        }
+        // Anything else an NSImage can read (TIFF, PDF page, a dragged icon)
+        // is re-encoded, because the far side wants a file an agent will open,
+        // not whichever pasteboard flavor happened to be first.
+        guard let tiff = pasteboard.data(forType: .tiff),
+              let representation = NSBitmapImageRep(data: tiff),
+              let png = representation.representation(using: .png, properties: [:])
+        else { return nil }
+        return ClipboardImage(data: png, fileExtension: "png")
+    }
+}

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -41,6 +41,11 @@ extension TermioStore {
         // A worktree session runs somewhere other than the project root; the
         // companion shell should land where the focused session actually works.
         newSession.worktreePath = session(focusedID)?.worktreePath
+        // …and "where it works" includes *which machine*. Splitting a session
+        // that runs on another device must not silently hand back a shell on
+        // this Mac: the pane sits beside its origin and reads as the same
+        // place, so it has to be the same place.
+        newSession.inheritDevice(from: session(focusedID))
         // Beside the session it splits, not at the end of the project — the
         // sidebar then reads the split group as adjacent rows, which is what lets
         // it draw the VS Code-style ┌/└ group bracket (see `splitLinkMarks`). The
@@ -112,6 +117,9 @@ extension TermioStore {
         // Share the anchor's working directory so a worktree agent's sibling lands
         // in the same checkout — the same courtesy `splitSelectedPane` extends.
         newSession.worktreePath = session(anchorID)?.worktreePath
+        // And the anchor's device, for the same reason: a split of a session on
+        // another machine stays on that machine.
+        newSession.inheritDevice(from: session(anchorID))
         // Adjacent to the anchor, so the sidebar reads the group as neighbouring
         // rows and draws its ┌/└ bracket (see `splitLinkMarks`).
         projects[projectIndex].sessions.insert(newSession, at: anchorIndex + 1)

--- a/Tests/termioTests/ClipboardTransferTests.swift
+++ b/Tests/termioTests/ClipboardTransferTests.swift
@@ -1,0 +1,115 @@
+import AppKit
+import XCTest
+@testable import termio
+
+/// The two decisions on the clipboard side of the viewer↔device boundary.
+///
+/// Both have a real failure mode. Misreading the clipboard sends a text paste
+/// down the transfer plane (or swallows a normal ⌘V), and a byte of drift in
+/// the `U` chunk layout makes the daemon reject the frame outright — there is
+/// no partial credit on a wire format, and the failure surfaces as a paste that
+/// silently does nothing, which is the bug this whole path exists to end.
+final class ClipboardTransferTests: XCTestCase {
+    private var pasteboard: NSPasteboard!
+
+    override func setUp() {
+        super.setUp()
+        pasteboard = NSPasteboard(name: NSPasteboard.Name("sh.termio.tests.clipboard"))
+        pasteboard.clearContents()
+    }
+
+    override func tearDown() {
+        pasteboard.releaseGlobally()
+        super.tearDown()
+    }
+
+    /// A 1×1 image encoded the way the pasteboard would carry it.
+    private func imageData(_ type: NSBitmapImageRep.FileType) -> Data {
+        let representation = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: 1, pixelsHigh: 1,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 4, bitsPerPixel: 32)
+        guard let representation,
+              let data = representation.representation(using: type, properties: [:])
+        else {
+            XCTFail("could not build a \(type) fixture")
+            return Data()
+        }
+        return data
+    }
+
+    func testPNGOnTheClipboardIsTakenVerbatim() {
+        let png = imageData(.png)
+        pasteboard.setData(png, forType: .png)
+
+        let image = ClipboardImage.current(pasteboard)
+        XCTAssertEqual(image?.data, png, "PNG travels as-is, not re-encoded")
+        XCTAssertEqual(image?.fileExtension, "png")
+    }
+
+    /// A screenshot lands as PNG *and* TIFF. The far side wants a file an agent
+    /// will open, so the flavor the client picks must not be whichever one the
+    /// pasteboard happened to list first.
+    func testAScreenshotsPNGIsPreferredOverItsTIFFTwin() {
+        let png = imageData(.png)
+        pasteboard.setData(imageData(.tiff), forType: .tiff)
+        pasteboard.setData(png, forType: .png)
+
+        XCTAssertEqual(ClipboardImage.current(pasteboard)?.data, png)
+    }
+
+    /// Only TIFF: re-encoded rather than shipped, because a `.png` name has to
+    /// mean PNG bytes on the other machine.
+    func testATIFFOnlyClipboardIsReencodedAsPNG() {
+        pasteboard.setData(imageData(.tiff), forType: .tiff)
+
+        let image = ClipboardImage.current(pasteboard)
+        XCTAssertEqual(image?.fileExtension, "png")
+        XCTAssertEqual(image?.data.prefix(8), Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+                       "the re-encode must actually produce a PNG")
+    }
+
+    /// The rule libghostty's wrapper already applies locally, kept identical so
+    /// the two layers cannot disagree about what a paste is: a clipboard that
+    /// carries text is a text paste, whatever else rides along with it.
+    func testAClipboardCarryingTextIsNeverATransfer() {
+        pasteboard.setData(imageData(.png), forType: .png)
+        pasteboard.setString("git status", forType: .string)
+
+        XCTAssertNil(ClipboardImage.current(pasteboard))
+    }
+
+    func testAnEmptyClipboardIsNotATransfer() {
+        XCTAssertNil(ClipboardImage.current(pasteboard))
+    }
+
+    /// Each paste gets its own name, so two screenshots in one session cannot
+    /// collide on a dest the daemon would then refuse as conflicting content.
+    func testEachPasteNamesItsOwnFile() {
+        let image = ClipboardImage(data: Data([1]), fileExtension: "png")
+        XCTAssertTrue(image.scratchFileName.hasPrefix("paste-"))
+        XCTAssertTrue(image.scratchFileName.hasSuffix(".png"))
+        XCTAssertFalse(image.scratchFileName.contains("/"), "a temp: name is one plain component")
+    }
+
+    /// `decode_upload_chunk` in termiod/src/protocol.rs, byte for byte.
+    func testUploadChunkMatchesTheDaemonsLayout() {
+        let payload = Termiod.uploadChunkPayload(
+            uploadID: "u_2a", offset: 131_072, data: Data("pasted".utf8))
+
+        XCTAssertEqual(payload, Data([4]) + Data("u_2a".utf8)
+            + Data([0, 0, 0, 0, 0, 2, 0, 0])
+            + Data("pasted".utf8))
+    }
+
+    /// The frame the chunk rides in is capped at 64 KiB by the daemon, and a
+    /// client that overruns it gets the frame refused rather than truncated.
+    func testAFullChunkStaysInsideTheFrameCap() {
+        let payload = Termiod.uploadChunkPayload(
+            uploadID: String(repeating: "u", count: 64),
+            offset: 0,
+            data: Data(count: Termiod.uploadChunkSize))
+
+        XCTAssertLessThanOrEqual(payload.count, 64 * 1024)
+    }
+}

--- a/Tests/termioTests/TermiodTransferIntegrationTests.swift
+++ b/Tests/termioTests/TermiodTransferIntegrationTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import termio
+
+/// The transfer client against a real daemon, end to end.
+///
+/// Opt-in: point `TERMIO_TERMIOD_TEST_BIN` at a built `termiod` and it runs;
+/// without one it skips, so `swift test` never grows a cargo dependency. It is
+/// here rather than in a scratch script because the thing worth pinning is
+/// *this client's* half of the contract — the ack loop, the resume offset, the
+/// `U` frame on a control channel — and none of that is provable without a
+/// daemon on the other end.
+final class TermiodTransferIntegrationTests: XCTestCase {
+    private var binary = ""
+    private var daemon: Process?
+    private var socketDirectory: URL?
+    private let session = "transfer-test-\(ProcessInfo.processInfo.processIdentifier)"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let configured = ProcessInfo.processInfo.environment["TERMIO_TERMIOD_TEST_BIN"] ?? ""
+        try XCTSkipIf(configured.isEmpty, "set TERMIO_TERMIOD_TEST_BIN to run this")
+        binary = configured
+
+        // Its own daemon on its own socket, started and stopped here, so the
+        // test never adopts (or disturbs) the one the developer is using.
+        // Short name on purpose: a Unix socket path is capped at 104 bytes and
+        // the per-user temp directory already spends half of it, so a full UUID
+        // here makes `bind` fail with nothing to read but a dead socket.
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tdx-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        socketDirectory = directory
+        let socket = directory.appendingPathComponent("termiod.sock").path
+        XCTAssertLessThan(socket.utf8.count, 104, "socket path must fit sun_path")
+        setenv("TERMIOD_SOCK", socket, 1)
+
+        let serve = Process()
+        serve.executableURL = URL(fileURLWithPath: binary)
+        serve.arguments = ["serve"]
+        serve.environment = ProcessInfo.processInfo.environment.merging(
+            ["TERMIOD_SOCK": socket]) { _, new in new }
+        serve.standardOutput = FileHandle.nullDevice
+        serve.standardError = FileHandle.nullDevice
+        try serve.run()
+        daemon = serve
+
+        let deadline = Date().addingTimeInterval(10)
+        while !FileManager.default.fileExists(atPath: socket), Date() < deadline {
+            usleep(50_000)
+        }
+        XCTAssertEqual(run([binary, "create", "--name", session, "--", "cat"]).code, 0,
+                       "the daemon must come up and hold a session to paste into")
+    }
+
+    override func tearDownWithError() throws {
+        if !binary.isEmpty { _ = run([binary, "kill", session]) }
+        daemon?.terminate()
+        daemon?.waitUntilExit()
+        if let socketDirectory {
+            try? FileManager.default.removeItem(at: socketDirectory)
+        }
+        unsetenv("TERMIOD_SOCK")
+        try super.tearDownWithError()
+    }
+
+    /// Several chunks, so the credit-of-one loop is genuinely exercised rather
+    /// than short-circuited by a payload that fits in one frame.
+    func testAnImageCrossesToTheSessionsScratchDirectory() throws {
+        var bytes = Data("\u{89}PNG\r\n\u{1A}\n".utf8)
+        bytes.append(Data((0 ..< 200_000).map { UInt8($0 % 251) }))
+
+        let path = try Termiod.uploadToSessionScratch(
+            route: .local, session: session, name: "paste-1.png", data: bytes)
+
+        XCTAssertTrue(path.hasPrefix("/"), "the path is the device's, and absolute")
+        XCTAssertTrue(path.contains("session-"), "a temp: transfer lands in the session's scratch")
+        XCTAssertEqual(try Data(contentsOf: URL(fileURLWithPath: path)), bytes)
+
+        // What the session owns dies with it — a pasted screenshot must not
+        // outlive the conversation it belonged to.
+        _ = run([binary, "kill", session])
+        let deadline = Date().addingTimeInterval(5)
+        while FileManager.default.fileExists(atPath: path), Date() < deadline {
+            usleep(100_000)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path),
+                       "killing the session reaps what was pasted into it")
+    }
+
+    /// The daemon refuses a `temp:` transfer it cannot attribute, and the
+    /// client surfaces that message instead of hanging on a reply that will
+    /// never come.
+    func testATransferAtAnUnknownSessionFailsWithTheDaemonsReason() {
+        XCTAssertThrowsError(try Termiod.uploadToSessionScratch(
+            route: .local, session: "no-such-session", name: "paste-1.png",
+            data: Data("x".utf8))) { error in
+            XCTAssertTrue("\(error)".contains("no such session"), "got: \(error)")
+        }
+    }
+
+    @discardableResult
+    private func run(_ arguments: [String]) -> (code: Int32, output: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: arguments[0])
+        process.arguments = Array(arguments.dropFirst())
+        process.environment = ProcessInfo.processInfo.environment
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do { try process.run() } catch { return (-1, "") }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus,
+                String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
+    }
+}

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -3,7 +3,7 @@ title: termiod Session Protocol
 status: draft
 type: design
 created: 2026-07-30
-updated: 2026-08-13
+updated: 2026-08-16
 related:
   - 20260730-termiod-session-mux.md
   - 20260708-session-daemon-architecture.md
@@ -678,7 +678,7 @@ listing, and three mechanisms buy back the replica's perceived speed:
 tree folder, drag into the terminal, paste an image at a remote agent):
 
 ```
-→ upload.open   {dest, size, sha256, mode?}    ← {upload_id}
+→ upload.open   {dest, size, sha256, mode?}    ← {upload_id, offset}
 → U <upload_id, offset> + ≤64 KiB payload      ← {ack, offset}   (×N, credit-of-one)
 → upload.commit {upload_id}                    ← {path}
    (or upload.abort {upload_id})
@@ -691,9 +691,14 @@ tree folder, drag into the terminal, paste an image at a remote agent):
   tree uploads to the real path and injects nothing — the `fs_changed` push
   makes the file appear in every attached client's tree.
 - Host writes to a dotfile, verifies size + sha256 on commit, `rename()`s
-  into place. Re-`open` with the same hash is idempotent. No resume in v1
-  (abort/retry; memory stays O(chunk)); `{resume: upload_id}` is a
-  compatible later extension.
+  into place. Memory stays O(chunk) throughout.
+- **Re-`open` is idempotent and resumes.** Same dest, size, and hash returns
+  the same `upload_id` plus the `offset` already on disk, so a client that
+  lost its pipe sends only the tail. Resuming is safe *because* size and
+  sha256 are declared at open: two transfers agreeing on both have the same
+  bytes, so any prefix of one is a prefix of the other and the running hash
+  stays valid. A client that ignores `offset` and sends from 0 is read as a
+  restart and served by rewinding, which is what makes the field additive.
 - **Head-of-line discipline** (the anti-100× clause for a shared pipe):
   credit-of-one — the client sends the next chunk only after the previous
   ack — and the daemon's writer drains PTY frames before upload chunks.

--- a/docs/design/20260805-termiod-device-architecture.md
+++ b/docs/design/20260805-termiod-device-architecture.md
@@ -3,7 +3,7 @@ title: Device Architecture — one server per device, every UI a client
 status: draft
 type: design
 created: 2026-08-05
-updated: 2026-08-06
+updated: 2026-08-16
 related:
   - 20260730-termiod-session-protocol.md
   - 20260730-termiod-session-mux.md
@@ -349,7 +349,7 @@ to a Mirror (client-classes doc §D.4).
 | **Terminal** | raw bytes (default) · `S` VT snapshot (bootstrap) · `G` diffs (opt-in only — §3) | snapshot + seq | shipped |
 | **Resource** | subscriptions with `seq` + bounded ring + linger (`fs:` first) | re-subscribe at cursor | `fs:` shipped |
 | **Request** | `exec`, `list`, `read`, `write` | idempotent, request id | **not built** |
-| **Transfer** | bytes across the viewer↔device boundary (§4.1): clipboard, images, files | resume at offset | **not built** |
+| **Transfer** | bytes across the viewer↔device boundary (§4.1): clipboard, images, files | resume at offset | `temp:` + project uploads shipped |
 
 All four ride one connection per device, multiplexed by channel id, over one
 SSH ControlMaster. Reconnect is not a feature: open a pipe, re-subscribe every
@@ -538,7 +538,16 @@ Each step is independently shippable and mostly removes code.
    machine is pick-from-list rather than hand-written alias plus cross-compile.
 9. **Request plane**, then file tree and git move to the current device.
 10. **Transfer plane**, then clipboard and image paste cross the viewer↔device
-    boundary (§4.1).
+    boundary (§4.1). **Image paste done** — `upload.open` / `U` / `upload.commit`
+    on a control channel of their own (never an attachment, so the tee is
+    untouched), credit-of-one chunks, and re-open resuming at the offset the
+    device already holds. ⌘V at a session on another machine moves the bytes to
+    that session's scratch dir and pastes the path they landed at; a session on
+    this Mac is untouched, because there the agent reads the pasteboard itself.
+    **Not done:** the other three directions — text clipboard sync (§9.4's
+    push-on-copy vs pull-on-paste is still undecided), drag-a-file-onto-the-tree
+    (the same verbs, a project `dest` instead of `temp:`), and download-direction
+    drag-out.
 11. **Workspaces on the device (§2.2).** `termiod` gains a workspace registry —
     enumerate, open, and create worktrees on the device that owns them. This is
     what makes "open a remote project" a normal action rather than a mode, and

--- a/termiod/smoke_test.py
+++ b/termiod/smoke_test.py
@@ -187,9 +187,9 @@ def send_upload_chunk(client, upload_id, offset, data):
     client.send_frame("U", bytes([len(uid)]) + uid + struct.pack(">Q", offset) + data)
 
 
-def upload_credit_of_one(client, upload_id, body, chunk=64 * 1024 - 64):
+def upload_credit_of_one(client, upload_id, body, chunk=64 * 1024 - 64, start=0):
     """Send the body chunk by chunk, holding each until the previous ack."""
-    sent = 0
+    sent = start
     while True:
         piece = body[sent : sent + chunk]
         send_upload_chunk(client, upload_id, sent, piece)
@@ -1478,6 +1478,53 @@ def main():
         lambda kind, msg: kind == "C" and msg.get("op") == "error"
     )
     check("upload: a chunk for an unknown id is a typed error", ghost is not None)
+
+    # Resume: the upload outlives the connection that opened it, so a client
+    # that lost its link re-opens and is told where the bytes stopped.
+    resume_body = os.urandom(200_000)
+    resume_open = {
+        "op": "upload_open",
+        "root": updir,
+        "dest": f"assets/resume-{os.getpid()}.bin",
+        "size": len(resume_body),
+        "sha256": hashlib.sha256(resume_body).hexdigest(),
+        "seq": 110,
+    }
+    dying = WireClient(caps=["upload"])
+    dying.send_control(resume_open)
+    half, _ = dying.recv_matching(
+        lambda kind, msg: kind == "C" and msg.get("op") == "upload_opened" and msg.get("re") == 110
+    )
+    resume_id = half[1]["upload_id"]
+    fresh_offset = half[1].get("offset")
+    partial, _ = upload_credit_of_one(dying, resume_id, resume_body[:120_000])
+    dying.close()
+
+    up.send_control(dict(resume_open, seq=111))
+    reopened, _ = up.recv_matching(
+        lambda kind, msg: kind == "C" and msg.get("op") == "upload_opened" and msg.get("re") == 111
+    )
+    resumed_at = reopened[1].get("offset") if reopened else None
+    check(
+        "upload: re-opening resumes at the bytes already landed",
+        fresh_offset == 0
+        and reopened is not None
+        and reopened[1]["upload_id"] == resume_id
+        and resumed_at == partial
+        and partial > 0,
+    )
+    upload_credit_of_one(up, resume_id, resume_body, start=resumed_at)
+    up.send_control({"op": "upload_commit", "upload_id": resume_id, "seq": 112})
+    resume_done, _ = up.recv_matching(
+        lambda kind, msg: kind == "C"
+        and msg.get("op") == "upload_committed"
+        and msg.get("re") == 112
+    )
+    check(
+        "upload: only the tail is re-sent and the whole file still verifies",
+        resume_done is not None
+        and open(resume_done[1]["path"], "rb").read() == resume_body,
+    )
 
     up.send_control(
         {

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -1173,7 +1173,11 @@ async fn process_control(
                             .uploads
                             .open(resolved, size, &sha256, mode, session_id)
                         {
-                            Ok(upload_id) => Control::UploadOpened { upload_id, re: seq },
+                            Ok((upload_id, offset)) => Control::UploadOpened {
+                                upload_id,
+                                offset,
+                                re: seq,
+                            },
                             Err(e) => error(seq, ErrorCode::Denied, format!("{e:#}"), false),
                         }
                     }

--- a/termiod/src/files.rs
+++ b/termiod/src/files.rs
@@ -562,8 +562,14 @@ struct UploadState {
 
 /// In-flight uploads (§C.12). Memory stays O(chunk): bytes stream through an
 /// incremental hasher into a dotfile beside the dest, and commit verifies
-/// size + sha256 before the atomic rename. No resume in v1 — a re-open with
-/// the same dest/size/hash is idempotent and restarts from zero.
+/// size + sha256 before the atomic rename.
+///
+/// A re-open with the same dest/size/hash is idempotent and **resumes**: it
+/// returns the same id and the byte count already on disk, so a client that
+/// lost its connection mid-transfer sends only the tail. Resuming is safe
+/// precisely because size and sha256 are declared up front — two transfers
+/// that agree on both have the same bytes, so any prefix of one is a prefix
+/// of the other, and the running hash over that prefix stays valid.
 #[derive(Clone, Default)]
 pub struct Uploads {
     inner: std::sync::Arc<std::sync::Mutex<UploadsInner>>,
@@ -581,7 +587,9 @@ impl Uploads {
     }
 
     /// Open (or idempotently re-open) an upload. `session` ties a scratch
-    /// upload to the session whose death reaps it.
+    /// upload to the session whose death reaps it. Returns the upload id and
+    /// the offset the next chunk must carry — 0 for a fresh open, the bytes
+    /// already landed when resuming.
     pub fn open(
         &self,
         dest: UploadDest,
@@ -589,7 +597,7 @@ impl Uploads {
         sha256: &str,
         mode: Option<u32>,
         session: Option<String>,
-    ) -> Result<String> {
+    ) -> Result<(String, u64)> {
         if sha256.len() != 64 || !sha256.bytes().all(|byte| byte.is_ascii_hexdigit()) {
             bail!("sha256 must be 64 hex characters");
         }
@@ -608,18 +616,11 @@ impl Uploads {
                     dest.final_path.display()
                 );
             }
-            // Idempotent re-open: same id, restarted from zero. This is the
-            // reconnect story — the client lost the acks, not the daemon.
-            let state = inner.by_id.get_mut(&id).expect("looked up above");
-            state.file.set_len(0).context("truncating upload dotfile")?;
-            use std::io::Seek;
-            state
-                .file
-                .seek(std::io::SeekFrom::Start(0))
-                .context("rewinding upload dotfile")?;
-            state.received = 0;
-            state.hasher = <sha2::Sha256 as sha2::Digest>::new();
-            return Ok(id);
+            // Idempotent re-open: same id, resumed where the bytes stopped.
+            // This is the reconnect story — the client lost the acks, not the
+            // daemon, so the daemon is the one that knows how far it got.
+            let state = inner.by_id.get(&id).expect("looked up above");
+            return Ok((id, state.received));
         }
 
         inner.counter += 1;
@@ -655,19 +656,34 @@ impl Uploads {
                 file,
             },
         );
-        Ok(id)
+        Ok((id, 0))
     }
 
     /// Apply one chunk. Credit-of-one makes chunks strictly sequential, so
     /// any offset other than the running total is a protocol violation, not
     /// something to reorder around. Returns the new total (the next expected
     /// offset, echoed in the ack).
+    ///
+    /// The one exception is offset 0 on an upload that already has bytes: that
+    /// is a client restarting rather than resuming — the shape every client
+    /// had before `upload_opened` carried an offset — and it rewinds instead
+    /// of failing.
     pub fn chunk(&self, upload_id: &str, offset: u64, data: &[u8]) -> Result<u64> {
         let mut inner = self.inner.lock().unwrap();
         let state = inner
             .by_id
             .get_mut(upload_id)
             .ok_or_else(|| anyhow!("no such upload: {upload_id}"))?;
+        if offset == 0 && state.received > 0 {
+            state.file.set_len(0).context("truncating upload dotfile")?;
+            use std::io::Seek;
+            state
+                .file
+                .seek(std::io::SeekFrom::Start(0))
+                .context("rewinding upload dotfile")?;
+            state.received = 0;
+            state.hasher = <sha2::Sha256 as sha2::Digest>::new();
+        }
         if offset != state.received {
             bail!(
                 "upload {upload_id} expected offset {}, got {offset}",
@@ -996,9 +1012,10 @@ mod tests {
         let uploads = Uploads::new();
         let body = vec![7u8; 100_000];
         let dest = resolve_project_dest(root.to_str().unwrap(), "out.bin").unwrap();
-        let id = uploads
+        let (id, offset) = uploads
             .open(dest, body.len() as u64, &hex_sha256(&body), None, None)
             .unwrap();
+        assert_eq!(offset, 0, "a fresh open starts at zero");
 
         let mut sent = 0;
         for piece in body.chunks(64 * 1024 - 64) {
@@ -1036,7 +1053,7 @@ mod tests {
         let root = scratch("upload-hash");
         let uploads = Uploads::new();
         let dest = resolve_project_dest(root.to_str().unwrap(), "bad.bin").unwrap();
-        let id = uploads
+        let (id, _) = uploads
             .open(dest, 4, &hex_sha256(b"good"), None, None)
             .unwrap();
         uploads.chunk(&id, 0, b"evil").unwrap();
@@ -1049,7 +1066,7 @@ mod tests {
         );
 
         let dest = resolve_project_dest(root.to_str().unwrap(), "short.bin").unwrap();
-        let id = uploads
+        let (id, _) = uploads
             .open(dest, 10, &hex_sha256(b"0123456789"), None, None)
             .unwrap();
         uploads.chunk(&id, 0, b"0123").unwrap();
@@ -1065,7 +1082,7 @@ mod tests {
     }
 
     #[test]
-    fn upload_reopen_with_the_same_hash_is_idempotent() {
+    fn upload_reopen_resumes_at_the_bytes_already_landed() {
         let root = scratch("upload-reopen");
         let uploads = Uploads::new();
         let body = b"reconnect survivor".to_vec();
@@ -1073,25 +1090,39 @@ mod tests {
         let root_str = root.to_str().unwrap();
 
         let dest = resolve_project_dest(root_str, "again.txt").unwrap();
-        let first = uploads
+        let (first, _) = uploads
             .open(dest, body.len() as u64, &sha, None, None)
             .unwrap();
         uploads.chunk(&first, 0, &body[..5]).unwrap();
 
-        // The connection dies; the client re-opens and starts over.
+        // The connection dies; the client re-opens and is told where to pick up.
         let dest = resolve_project_dest(root_str, "again.txt").unwrap();
-        let second = uploads
+        let (second, offset) = uploads
             .open(dest, body.len() as u64, &sha, None, None)
             .unwrap();
         assert_eq!(first, second, "same dest + hash + size = same upload");
-        uploads.chunk(&second, 0, &body).unwrap();
+        assert_eq!(offset, 5, "re-open resumes rather than restarting");
+        uploads.chunk(&second, offset, &body[5..]).unwrap();
         let landed = uploads.commit(&second).unwrap();
         assert_eq!(std::fs::read(&landed).unwrap(), body);
+
+        // A client that ignores the offset restarts from zero, which still
+        // works — the hash is what proves the bytes, not the route to them.
+        let dest = resolve_project_dest(root_str, "restart.txt").unwrap();
+        let (third, _) = uploads
+            .open(dest, body.len() as u64, &sha, None, None)
+            .unwrap();
+        uploads.chunk(&third, 0, &body[..5]).unwrap();
+        uploads.chunk(&third, 0, &body).unwrap();
+        assert_eq!(
+            std::fs::read(uploads.commit(&third).unwrap()).unwrap(),
+            body
+        );
 
         // A different payload aimed at the same dest is a conflict, not a
         // silent replacement.
         let dest = resolve_project_dest(root_str, "again.txt").unwrap();
-        let one = uploads.open(dest, 1, &hex_sha256(b"a"), None, None).unwrap();
+        let (one, _) = uploads.open(dest, 1, &hex_sha256(b"a"), None, None).unwrap();
         let dest = resolve_project_dest(root_str, "again.txt").unwrap();
         assert!(uploads.open(dest, 1, &hex_sha256(b"b"), None, None).is_err());
         uploads.abort(&one);
@@ -1138,7 +1169,7 @@ mod tests {
         let uploads = Uploads::new();
         let body = b"paste".to_vec();
         let dest = resolve_scratch_dest(&root, "paste-1.png").unwrap();
-        let id = uploads
+        let (id, _) = uploads
             .open(
                 dest,
                 body.len() as u64,
@@ -1156,7 +1187,7 @@ mod tests {
         // A second upload still in flight when the session dies leaves no
         // dotfile behind.
         let dest = resolve_scratch_dest(&root, "paste-2.png").unwrap();
-        let id = uploads
+        let (id, _) = uploads
             .open(dest, 4, &hex_sha256(b"gone"), None, Some("s_1".to_string()))
             .unwrap();
         uploads.chunk(&id, 0, b"go").unwrap();

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -629,8 +629,15 @@ pub enum Control {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         re: Option<u64>,
     },
+    /// Reply to `upload_open`. `offset` is where the next chunk should start:
+    /// 0 for a fresh upload, and the bytes already landed when this open
+    /// resumed one the daemon still holds. Purely additive — a client that
+    /// ignores the field starts at 0, which the daemon reads as "restart" and
+    /// serves by rewinding, exactly as it did before resume existed.
     UploadOpened {
         upload_id: String,
+        #[serde(default)]
+        offset: u64,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         re: Option<u64>,
     },


### PR DESCRIPTION
Two commits: the transfer plane, and a split-inheritance fix that surfaced while testing it.

## Why image paste never worked remotely

termio has **never implemented image paste**. Locally it works because the *agent* reads the Mac's pasteboard itself — termio only forwards a real ctrl+v keystroke. An agent running on a VPS gets that keystroke and reads its own machine's clipboard, which is empty.

Per the device architecture (§4.1), the clipboard belongs to the **viewer** and the agent belongs to the **device**. So this is not "uploading to a server" — it is a crossing of that boundary, and the crossing did not exist.

## What this adds

**Transfer plane** — an `F` frame carrying chunked bytes with offset-based resume. Request/response on the control channel, never near the byte tee, so §A's invariant that delivery cannot block on anything is untouched.

**⌘V interceptor** — text pastes exactly as before through ghostty's own binding; an image is written into the device's scratch directory and its **remote absolute path** is pasted as text, which is what an agent can actually act on. Local sessions are unchanged.

## Verified

End to end against a real aarch64 VPS — an image pasted on the Mac lands at `/run/user/1001/termiod/scratch/session-*/paste-*.png` and the agent reads it:

```
⏺ [Image #1]
  ls -la /run/user/1001/termiod/scratch/session-cd7f951f/paste-1786889090047.png
```

42 unit + 4 integration tests, 48 local smoke checks, 8 remote smoke checks, `build-app.sh` clean.

## Second commit: splits changed machine silently

Splitting a session that runs on another device handed back a shell on **this Mac**. The pane sits directly beside its origin and reads as the same place, so the switch is invisible until a command runs against the wrong filesystem.

Both split entry points copied the anchor's working directory but not its machine, and only `addRemoteTerminal` ever set one — so every session *derived* from a remote one fell back to local.

Copying now lives in one method (`Session.inheritDevice`) carrying both identities a device has mid-transition: the SSH alias it was authored against, and the `deviceID` the first handshake reveals. That single point is deliberate — when sessions stop naming a host and take their device from the container that owns them, it is the only thing to delete.

**This is the fourth instance of one root cause**: with no authoritative device context, each entry point decides for itself which machine to use, so every new one misses it again. The device RFC removes the cause; this fixes the instance.

## Known gap, stated rather than carried silently

The two new Swift test files **compile but never execute**. `swift test` cannot run in this repository at all — Swift 6 concurrency diagnostics in `CompanionServer.swift`, present on `main` and unrelated to this change (verified by running the same command on `main`: 285 identical errors). That is why the project builds through `scripts/build-app.sh`. The Rust assertions did run.

Release Notes: Pasting an image into a session running on another machine now works — the image is transferred to that machine and its path handed to the agent.