### PR TITLE
Rebuild the issues list when the kind or filter changes

### DIFF
--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -331,6 +331,11 @@ struct IssuesView: View {
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .environment(\.defaultMinListRowHeight, 1)
+            // A kind or filter change swaps the whole data set under one table, and the
+            // reused table keeps the previous list's scroll offset and row metrics — a
+            // pane that draws nothing until a remount. Fresh identity rebuilds it.
+            // Revalidating the same query keeps its identity, so no flicker.
+            .id(model.query)
         }
     }
 


### PR DESCRIPTION
Switching Issues ↔ Pull Requests swaps the whole data set under one reused `List`, which keeps the previous list's scroll offset and row metrics. The pane draws nothing, refresh can't heal it (the query is unchanged, so the table is reused again), and only an inspector tab flip — which unmounts the pane — brings the rows back.

The git pane never hits this: Changes and History are two separate view branches, so AppKit tears its table down between them.

Fresh identity per query rebuilds the table with the switch. A background revalidation of the same query keeps its identity, so the list still never flickers or loses scroll position.

Release Notes:
- Fixed the Issues pane going blank when switching between Issues and Pull Requests.