### PR TITLE
Compare a branch against the one it would merge into

### DIFF
--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -63,6 +63,7 @@ struct GitChangesView: View {
             topBar
             switch mode {
             case .changes: changesBody
+            case .compare: GitCompareView(model: model, repoRoot: repoRoot, chrome: chrome, font: settings.interfaceFont)
             case .history: GitHistoryView(model: model, repoRoot: repoRoot, chrome: chrome, font: settings.interfaceFont)
             }
             // Only Changes has a real total to report ("N files +A −D"). History's
@@ -77,8 +78,12 @@ struct GitChangesView: View {
             // which only fires on change and so misses a diff that was already open.
             if let remembered = store.gitPaneModes[repoRoot] { mode = remembered }
             if let request = store.openDiff, request.repoRoot == repoRoot {
-                mode = request.commit == nil ? .changes : .history
-                if request.commit == nil {
+                if request.range != nil {
+                    mode = .compare
+                } else if request.commit != nil {
+                    mode = .history
+                } else {
+                    mode = .changes
                     selection = [request.change.path]
                     lastOpenedPath = request.change.path
                 }
@@ -120,7 +125,10 @@ struct GitChangesView: View {
         // and release a lone selection so clicking the same row reopens its diff. The
         // `openFileURL` guards keep a diff↔preview hand-off from reading as a close.
         .onChange(of: store.openDiff) { _, request in
-            if let request, request.commit == nil {
+            // Only a working-tree diff belongs to this list; a commit's or a branch
+            // comparison's file rows live in their own tab and must not move the
+            // Changes selection under them.
+            if let request, request.commit == nil, request.range == nil {
                 lastOpenedPath = request.change.path
                 if selection != [request.change.path] { selection = [request.change.path] }
             }
@@ -166,6 +174,7 @@ struct GitChangesView: View {
     private var modeSwitch: some View {
         HStack(spacing: 0) {
             segment(localized("Changes"), .changes)
+            segment(localized("Compare"), .compare)
             segment(localized("History"), .history)
         }
         // The selection pill rides behind the active segment and slides across on switch.

--- a/Sources/termio/Git/GitHistoryView.swift
+++ b/Sources/termio/Git/GitHistoryView.swift
@@ -84,26 +84,37 @@ struct GitCompareView: View {
         // remembered per branch — so the comparison follows the checkout instead of
         // measuring the new branch against the old branch's base.
         .onChange(of: model.compareContext?.branch) { _, _ in
+            dropOpenRangeDiff()
             Task { await restoreBase() }
         }
     }
 
     @ViewBuilder
     private var content: some View {
-        if let context = model.compareContext, !hasComparableBranches(context) {
+        if let context = model.compareContext, context.remoteBranches.isEmpty, context.localBranches.isEmpty {
             PaneEmptyState(
                 localized("Nothing to Compare"),
                 icon: .gitBranch,
                 message: localized("This checkout has no other branch to compare with.")
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if model.compareBaseMissing {
-            PaneEmptyState(
-                localized("Base Branch Missing"),
-                icon: .gitBranch,
-                message: localized("Choose another branch to compare with.")
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let problem = model.compareProblem {
+            switch problem {
+            case .missingBase:
+                PaneEmptyState(
+                    localized("Base Branch Missing"),
+                    icon: .gitBranch,
+                    message: localized("Choose another branch to compare with.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .noCommonHistory:
+                PaneEmptyState(
+                    localized("No Common History"),
+                    icon: .gitBranch,
+                    message: localized("This branch and the base branch share no commits.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         } else if model.compareContext != nil, model.compareBase == nil {
             PaneEmptyState(
                 localized("No Base Branch"),
@@ -113,10 +124,12 @@ struct GitCompareView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let compare = model.compare {
             if compare.files.isEmpty, compare.commits.isEmpty {
+                // True whether the two are even or this branch is simply behind — saying
+                // "even" would contradict the Behind chip in the bar right above.
                 PaneEmptyState(
                     localized("No Changes"),
                     icon: .gitBranch,
-                    message: localized("This branch is even with the branch it would merge into.")
+                    message: localized("This branch has nothing the base branch doesn’t already have.")
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
@@ -142,12 +155,12 @@ struct GitCompareView: View {
         }
     }
 
-    /// Whether there is anything to compare against: a branch (not a detached HEAD) and at
-    /// least one other ref.
-    private func hasComparableBranches(_ context: GitService.CompareContext) -> Bool {
-        guard let branch = context.branch else { return false }
-        return context.remoteBranches.contains { $0 != "origin/\(branch)" }
-            || context.localBranches.contains { $0 != branch }
+    /// Drops a diff opened from an earlier comparison. Its request carries the old
+    /// `base...HEAD` range, so leaving it up would show one base's diff beside another
+    /// base's file list.
+    private func dropOpenRangeDiff() {
+        if store.openDiff?.range != nil { store.openDiff = nil }
+        lastOpenedPath = nil
     }
 
     /// Applies the base remembered for the current branch, falling back to the suggested
@@ -167,6 +180,7 @@ struct GitCompareView: View {
         store.gitCompareBases[
             TermioStore.compareBaseKey(repoRoot: repoRoot, branch: context.branch)] = base ?? ""
         filesExpanded = true
+        dropOpenRangeDiff()
         Task { await model.setCompareBase(base) }
     }
 
@@ -313,12 +327,9 @@ private struct CompareBar: View {
                     Divider()
                 }
                 if let context = model.compareContext {
-                    let remotes = pinned(
-                        context.remoteBranches.filter { $0 != "origin/\(context.branch ?? "")" },
-                        first: context.suggestedBase)
-                    let locals = pinned(
-                        context.localBranches.filter { $0 != context.branch },
-                        first: context.suggestedBase)
+                    // Already filtered of the checkout's own branch and its upstream.
+                    let remotes = pinned(context.remoteBranches, first: context.suggestedBase)
+                    let locals = pinned(context.localBranches, first: context.suggestedBase)
                     if !remotes.isEmpty {
                         Section(localized("Remote")) {
                             ForEach(remotes, id: \.self) { branch in

--- a/Sources/termio/Git/GitHistoryView.swift
+++ b/Sources/termio/Git/GitHistoryView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TermioShared
 
 // MARK: - History tab
 
@@ -8,21 +9,11 @@ import SwiftUI
 /// terminal via the shared `store.openDiff` overlay. Read-only — history is for reading,
 /// not editing.
 struct GitHistoryView: View {
-    @EnvironmentObject var store: TermioStore
     @ObservedObject var model: GitPanelModel
 
     let repoRoot: String
     let chrome: ChromeTheme?
     let font: Font
-
-    /// The single expanded commit (one at a time keeps the narrow column legible).
-    @State private var expanded: String?
-    /// Files per commit, fetched lazily on first expand and kept for the session.
-    @State private var filesByCommit: [String: [GitChange]] = [:]
-    /// The last file diff opened from this list — its row keeps the selected grey after
-    /// the overlay closes (the Issues list's rule), so coming back from a full-screen
-    /// diff still shows which file it was.
-    @State private var lastOpenedFile: (sha: String, path: String)?
 
     var body: some View {
         Group {
@@ -39,24 +30,207 @@ struct GitHistoryView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView(.vertical) {
-                    // No separators: fixed-height rows + the hover/selection wash do the
-                    // separating, like a modern SwiftUI List (hairlines between every row
-                    // read as legacy chrome in a narrow pane).
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(model.commits) { commit in
-                            CommitRow(commit: commit, isExpanded: expanded == commit.sha, chrome: chrome, font: font) {
-                                toggle(commit)
-                            }
-                            if expanded == commit.sha {
-                                commitFiles(commit)
-                            }
-                        }
-                    }
-                    .padding(.vertical, 6)
+                    CommitList(commits: model.commits, repoRoot: repoRoot, chrome: chrome, font: font)
+                        .padding(.vertical, 6)
                 }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}
+
+// MARK: - Compare tab
+
+/// The git pane's **Compare** tab: this branch measured against the branch it would be
+/// merged into — the pull request you are about to open, before you open it. The files come
+/// from a three-dot diff, so the list matches what the forge will show, and each row opens
+/// that file's diff over the terminal. The commits below are the ones the merge would bring.
+///
+/// A tab of its own rather than a mode hidden inside History: preparing a pull request is
+/// what you do at the end of a branch, and it should not be reachable only by knowing that
+/// History has a picker in it.
+struct GitCompareView: View {
+    @EnvironmentObject var store: TermioStore
+    @ObservedObject var model: GitPanelModel
+
+    let repoRoot: String
+    let chrome: ChromeTheme?
+    let font: Font
+
+    /// The last file diff opened from this list — its row keeps the selected grey after the
+    /// overlay closes (the Issues list's rule), so coming back from a full-screen diff still
+    /// shows which file it was.
+    @State private var lastOpenedPath: String?
+    /// Whether the file list is unfolded. Open by default: with a base picked, the files
+    /// *are* what you came to read.
+    @State private var filesExpanded = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            CompareBar(model: model, chrome: chrome, onPick: pick)
+            content
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        // ← / → walk the open overlay across the files; the last-opened memory chases the
+        // shown file so the grey lands on the right row on close.
+        .onChange(of: store.openDiff) { _, request in
+            if let request, request.range != nil { lastOpenedPath = request.change.path }
+        }
+        .task {
+            if model.compareContext == nil { await model.loadCompareContext() }
+            await restoreBase()
+        }
+        // A checkout in the terminal moves the branch under the pane, and the base is
+        // remembered per branch — so the comparison follows the checkout instead of
+        // measuring the new branch against the old branch's base.
+        .onChange(of: model.compareContext?.branch) { _, _ in
+            Task { await restoreBase() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let context = model.compareContext, !hasComparableBranches(context) {
+            PaneEmptyState(
+                localized("Nothing to Compare"),
+                icon: .gitBranch,
+                message: localized("This checkout has no other branch to compare with.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if model.compareBaseMissing {
+            PaneEmptyState(
+                localized("Base Branch Missing"),
+                icon: .gitBranch,
+                message: localized("Choose another branch to compare with.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if model.compareContext != nil, model.compareBase == nil {
+            PaneEmptyState(
+                localized("No Base Branch"),
+                icon: .gitBranch,
+                message: localized("Pick the branch this one would merge into.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let compare = model.compare {
+            if compare.files.isEmpty, compare.commits.isEmpty {
+                PaneEmptyState(
+                    localized("No Changes"),
+                    icon: .gitBranch,
+                    message: localized("This branch is even with the branch it would merge into.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView(.vertical) {
+                    // No separators: fixed-height rows + the hover/selection wash do the
+                    // separating, like a modern SwiftUI List (hairlines between every row
+                    // read as legacy chrome in a narrow pane).
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        compareFiles(compare)
+                        SectionLabel(title: localized("Commits"), count: compare.commits.count)
+                        CommitList(commits: compare.commits, repoRoot: repoRoot, chrome: chrome, font: font)
+                    }
+                    // No top inset: the summary row is the file list's header and butts
+                    // against the compare bar's hairline. Inset it and the gap reads as a
+                    // stray empty band above a highlighted row.
+                    .padding(.bottom, 6)
+                }
+            }
+        } else {
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    /// Whether there is anything to compare against: a branch (not a detached HEAD) and at
+    /// least one other ref.
+    private func hasComparableBranches(_ context: GitService.CompareContext) -> Bool {
+        guard let branch = context.branch else { return false }
+        return context.remoteBranches.contains { $0 != "origin/\(branch)" }
+            || context.localBranches.contains { $0 != branch }
+    }
+
+    /// Applies the base remembered for the current branch, falling back to the suggested
+    /// one the first time a branch is seen — so a feature branch opens already compared
+    /// against the trunk it would merge into.
+    private func restoreBase() async {
+        guard let context = model.compareContext else { return }
+        let remembered = store.gitCompareBases[
+            TermioStore.compareBaseKey(repoRoot: repoRoot, branch: context.branch)]
+        // An empty remembered value is the user having turned the comparison off.
+        let base: String? = remembered.map { $0.isEmpty ? nil : $0 } ?? context.suggestedBase
+        await model.setCompareBase(base)
+    }
+
+    private func pick(_ base: String?) {
+        guard let context = model.compareContext else { return }
+        store.gitCompareBases[
+            TermioStore.compareBaseKey(repoRoot: repoRoot, branch: context.branch)] = base ?? ""
+        filesExpanded = true
+        Task { await model.setCompareBase(base) }
+    }
+
+    /// The comparison's changed files: a foldable summary row over the same file rows the
+    /// commit drill-down uses, each opening the file's three-dot diff across the range —
+    /// the same diff the forge will show on the pull request.
+    @ViewBuilder
+    private func compareFiles(_ compare: GitService.BranchCompare) -> some View {
+        let range = "\(compare.base)...HEAD"
+        CompareSummaryRow(
+            files: compare.files, isExpanded: filesExpanded, chrome: chrome, font: font
+        ) {
+            filesExpanded.toggle()
+        }
+        if filesExpanded {
+            ForEach(compare.files) { file in
+                CommitFileRow(
+                    change: file,
+                    font: font,
+                    chrome: chrome,
+                    isSelected: (store.openDiff?.range == range
+                        && store.openDiff?.change.path == file.path)
+                        || (store.openDiff == nil && lastOpenedPath == file.path)
+                ) {
+                    lastOpenedPath = file.path
+                    store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: file,
+                                                    range: range, siblings: compare.files)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Commit list
+
+/// The commit rows shared by History (the branch's own commits) and Compare (the commits a
+/// merge would bring over): one expandable row per commit, its files underneath.
+private struct CommitList: View {
+    @EnvironmentObject var store: TermioStore
+
+    let commits: [GitCommit]
+    let repoRoot: String
+    let chrome: ChromeTheme?
+    let font: Font
+
+    /// The single expanded commit (one at a time keeps the narrow column legible).
+    @State private var expanded: String?
+    /// Files per commit, fetched lazily on first expand and kept for the session.
+    @State private var filesByCommit: [String: [GitChange]] = [:]
+    /// The last file diff opened from this list, so its row keeps the selected grey after
+    /// the overlay closes.
+    @State private var lastOpenedFile: (sha: String, path: String)?
+
+    var body: some View {
+        LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(commits) { commit in
+                CommitRow(commit: commit, isExpanded: expanded == commit.sha, chrome: chrome, font: font) {
+                    toggle(commit)
+                }
+                if expanded == commit.sha {
+                    commitFiles(commit)
+                }
+            }
+        }
         // ← / → walk the open overlay across the commit's files; the last-opened
         // memory chases the shown file so the grey lands on the right row on close.
         .onChange(of: store.openDiff) { _, request in
@@ -115,6 +289,171 @@ struct GitHistoryView: View {
                 filesByCommit[commit.sha] = files
             }
         }
+    }
+}
+
+// MARK: - Compare bar
+
+/// The base-branch picker above the history, GitHub Desktop's "Compare to branch": which
+/// branch this one would be merged into. Bases are listed remote-first — a stale local
+/// `main` in a long-lived clone would overstate the diff — and the trailing chip says when
+/// the base has moved on since the last fetch, since nothing here fetches on its own.
+private struct CompareBar: View {
+    @ObservedObject var model: GitPanelModel
+    let chrome: ChromeTheme?
+    let onPick: (String?) -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Menu {
+                if model.compareBase != nil {
+                    Button(localized("Don’t Compare")) { onPick(nil) }
+                    Divider()
+                }
+                if let context = model.compareContext {
+                    let remotes = pinned(
+                        context.remoteBranches.filter { $0 != "origin/\(context.branch ?? "")" },
+                        first: context.suggestedBase)
+                    let locals = pinned(
+                        context.localBranches.filter { $0 != context.branch },
+                        first: context.suggestedBase)
+                    if !remotes.isEmpty {
+                        Section(localized("Remote")) {
+                            ForEach(remotes, id: \.self) { branch in
+                                Button(branch) { onPick(branch) }
+                            }
+                        }
+                    }
+                    if !locals.isEmpty {
+                        Section(localized("Local")) {
+                            ForEach(locals, id: \.self) { branch in
+                                Button(branch) { onPick(branch) }
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 5) {
+                    HugeIconView(icon: .gitBranch, size: 10, color: .secondary)
+                    Text(model.compareBase ?? localized("Compare to branch"))
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(model.compareBase == nil ? AnyShapeStyle(.secondary) : AnyShapeStyle(.primary))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.horizontal, 6)
+                .frame(height: 21)
+                .contentShape(Rectangle())
+                .background(
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(Color.primary.opacity(hovering ? 0.07 : 0))
+                )
+            }
+            .menuStyle(.button)
+            .buttonStyle(.plain)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .onHover { hovering = $0 }
+            .help(localized("Compare this branch with the branch it would merge into."))
+
+            Spacer(minLength: 4)
+
+            if let compare = model.compare, compare.behind > 0 {
+                Text(verbatim: "\(localized("Behind")) (\(compare.behind))")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1.5)
+                    .background(Capsule().strokeBorder(Color.primary.opacity(0.18), lineWidth: 1))
+                    .help(localized("The base branch has commits this branch doesn’t have, as of the last fetch."))
+            }
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 30)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 1)
+        }
+    }
+
+    /// Lifts the branch this checkout would actually merge into to the top of its section.
+    /// The rest stay in `for-each-ref`'s alphabetical order, where a repo with a hundred
+    /// remote branches buries `origin/main` under every `origin/agent/…` ever pushed.
+    private func pinned(_ branches: [String], first: String?) -> [String] {
+        guard let first, let index = branches.firstIndex(of: first) else { return branches }
+        var rest = branches
+        rest.remove(at: index)
+        return [first] + rest
+    }
+}
+
+/// The comparison's header row: how many files the merge would touch and the totals, over
+/// the file list it folds open. Shaped like a commit row so the two read as one list, but
+/// it only lifts on hover — a permanent selection wash would compete with the real
+/// selection on the file rows underneath.
+private struct CompareSummaryRow: View {
+    let files: [GitChange]
+    let isExpanded: Bool
+    let chrome: ChromeTheme?
+    let font: Font
+    let onTap: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 6) {
+                Text(localized("Files changed"))
+                    .font(font)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(verbatim: "\(files.count)")
+                    .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 6)
+                // Binary files report no counts, so the totals are of what git measured.
+                let additions = files.reduce(0) { $0 + $1.additions }
+                let deletions = files.reduce(0) { $0 + $1.deletions }
+                if additions > 0 { Text(verbatim: "+\(additions)").foregroundStyle(.green) }
+                if deletions > 0 { Text(verbatim: "−\(deletions)").foregroundStyle(.red) }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+            }
+            .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .background(SidebarRowHighlight(isSelected: false, isHovering: isHovering, chrome: chrome))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+    }
+}
+
+/// A quiet divider label between the comparison's files and its commits.
+private struct SectionLabel: View {
+    let title: String
+    let count: Int
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Text(title)
+            Text(verbatim: "\(count)")
+                .foregroundStyle(.tertiary)
+        }
+        .font(.system(size: 10, weight: .medium))
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 12)
+        .padding(.top, 10)
+        .padding(.bottom, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Sources/termio/Git/GitModels.swift
+++ b/Sources/termio/Git/GitModels.swift
@@ -11,11 +11,13 @@ enum InspectorTab: String, Hashable, Sendable, Codable {
     case files, search, changes, issues, info
 }
 
-/// The git pane's own inner switch: the working-tree changes, or the commit
-/// history — GitHub Desktop's Changes / History split. Committing lives in the
-/// terminal; the GUI is for staging, reviewing diffs, and reading history.
+/// The git pane's own inner switch, in scope order: what isn't committed yet, what
+/// this branch would merge into another (the pull request about to be opened), and
+/// the commit history — GitHub Desktop's Changes / History split with its branch
+/// comparison promoted beside them. Committing lives in the terminal; the GUI is for
+/// staging, reviewing diffs, and reading history.
 enum GitPaneMode: Hashable, Sendable {
-    case changes, history
+    case changes, compare, history
 }
 
 /// One changed file in the working tree, as reported by `git status`. `path` is

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -33,9 +33,9 @@ final class GitPanelModel: ObservableObject {
     /// `nil` while a comparison is loading — the Compare tab shows a spinner then, so no
     /// separate loading flag is needed.
     @Published private(set) var compare: GitService.BranchCompare?
-    /// The picked base no longer resolves (its branch was deleted). Held as its own state
-    /// so the pane can say so — an empty file list would read as "nothing to review".
-    @Published private(set) var compareBaseMissing = false
+    /// Why the comparison couldn't be made, when it couldn't. Held as its own state so the
+    /// pane can say so — an empty file list would read as "nothing to review".
+    @Published private(set) var compareProblem: GitService.CompareProblem?
 
     private var watcher: FolderEventStream?
     private var appActiveObserver: AnyCancellable?
@@ -164,7 +164,7 @@ final class GitPanelModel: ObservableObject {
         guard base != compareBase else { return }
         compareBase = base
         compare = nil
-        compareBaseMissing = false
+        compareProblem = nil
         await loadCompare()
     }
 
@@ -174,13 +174,19 @@ final class GitPanelModel: ObservableObject {
     func loadCompare() async {
         guard let base = compareBase else {
             compare = nil
-            compareBaseMissing = false
+            compareProblem = nil
             return
         }
-        let loaded = await GitService.branchCompare(base: base, in: repoRoot)
+        let outcome = await GitService.branchCompare(base: base, in: repoRoot)
         guard compareBase == base else { return }
-        compare = loaded
-        compareBaseMissing = loaded == nil
+        switch outcome {
+        case .ready(let loaded):
+            compare = loaded
+            compareProblem = nil
+        case .problem(let problem):
+            compare = nil
+            compareProblem = problem
+        }
     }
 
     /// Replays a refresh that was deferred while the pane was hidden. Called by the

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -24,6 +24,19 @@ final class GitPanelModel: ObservableObject {
     @Published var isLoadingHistory = false
     private var didLoadHistory = false
 
+    /// The branch and the refs it can be compared against, for the Compare tab's base
+    /// picker. Nil until that tab is first opened; re-read whenever the git dir changes,
+    /// so a checkout in the terminal moves the picker with it.
+    @Published var compareContext: GitService.CompareContext?
+    /// The base the Compare tab is measuring the branch against.
+    @Published private(set) var compareBase: String?
+    /// `nil` while a comparison is loading — the Compare tab shows a spinner then, so no
+    /// separate loading flag is needed.
+    @Published private(set) var compare: GitService.BranchCompare?
+    /// The picked base no longer resolves (its branch was deleted). Held as its own state
+    /// so the pane can say so — an empty file list would read as "nothing to review".
+    @Published private(set) var compareBaseMissing = false
+
     private var watcher: FolderEventStream?
     private var appActiveObserver: AnyCancellable?
     private var refreshDebounce: Task<Void, Never>?
@@ -137,6 +150,39 @@ final class GitPanelModel: ObservableObject {
         isLoadingHistory = false
     }
 
+    // MARK: Branch compare
+
+    /// Re-reads the branch and the bases it can be compared against. Cheap enough to run
+    /// on every history refresh: three `git` reads of refs, no diff.
+    func loadCompareContext() async {
+        compareContext = await GitService.compareContext(in: repoRoot)
+    }
+
+    /// Points the Compare tab at a base branch (or `nil` for none) and loads the
+    /// comparison. The base itself is remembered by the view, per branch.
+    func setCompareBase(_ base: String?) async {
+        guard base != compareBase else { return }
+        compareBase = base
+        compare = nil
+        compareBaseMissing = false
+        await loadCompare()
+    }
+
+    /// Loads the diff and commits between the branch and its base. A base picked while a
+    /// load is in flight wins: the stale result is dropped rather than published under the
+    /// new base's label.
+    func loadCompare() async {
+        guard let base = compareBase else {
+            compare = nil
+            compareBaseMissing = false
+            return
+        }
+        let loaded = await GitService.branchCompare(base: base, in: repoRoot)
+        guard compareBase == base else { return }
+        compare = loaded
+        compareBaseMissing = loaded == nil
+    }
+
     /// Replays a refresh that was deferred while the pane was hidden. Called by the
     /// view when the pane (re)appears, so the shown list is never stale.
     func flushDeferredRefresh() {
@@ -195,6 +241,15 @@ final class GitPanelModel: ObservableObject {
             guard let self, !Task.isCancelled else { return }
             await self.load()
             if includeHistory, self.didLoadHistory { await self.loadHistory(force: true) }
+            // A commit, a checkout, or a fetch all land as git-dir events, and each one
+            // moves the comparison: new commits ahead, a different branch, a base that
+            // just gained commits. Gated on the Compare tab having been opened at least
+            // once (which is what fills `compareContext`), like the log above — a
+            // Changes-only session must not pay four `git` spawns an event.
+            if includeHistory, self.compareContext != nil {
+                await self.loadCompareContext()
+                await self.loadCompare()
+            }
         }
     }
 }

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -118,7 +118,10 @@ enum GitService {
     /// by RS (`\u{1e}`), so subjects with spaces/tabs survive intact. `%D` carries the
     /// commit's decorations, from which only tags are kept (branch refs would restate
     /// what the pane's scope and the sidebar already say).
-    private static func loadLog(_ repoRoot: String, _ limit: Int) -> [GitCommit] {
+    ///
+    /// `range` narrows the log to a revision range (`base..HEAD` for the branch compare);
+    /// without one it walks back from `HEAD`.
+    private static func loadLog(_ repoRoot: String, _ limit: Int, range: String? = nil) -> [GitCommit] {
         // Commits the upstream doesn't have yet. `run` returns nil on a non-zero exit,
         // so a branch with no upstream yields an empty set — no rows marked.
         let unpushed = Set(
@@ -127,7 +130,8 @@ enum GitService {
         )
         let format = ["%H", "%h", "%s", "%an", "%ae", "%ad", "%D"].joined(separator: "\u{1f}") + "\u{1e}"
         guard let out = run(
-            ["log", "-n", String(limit), "--date=relative", "--pretty=format:\(format)"],
+            ["log", "-n", String(limit), "--date=relative", "--pretty=format:\(format)"]
+                + (range.map { [$0] } ?? []),
             in: repoRoot
         ) else { return [] }
         return out.components(separatedBy: "\u{1e}").compactMap { record in
@@ -174,6 +178,200 @@ enum GitService {
             return GitChange(path: path, status: status[path] ?? .modified, isUntracked: false,
                              additions: c.0, deletions: c.1)
         }
+    }
+
+    // MARK: Branch compare
+
+    /// What the Compare tab's base picker needs about a checkout: the branch it is on, the
+    /// refs it can be compared against, and the base to start on. Gathered in one hop —
+    /// a menu that spawned a `git` per field would fork four processes every time it opened.
+    struct CompareContext: Sendable {
+        /// `nil` on a detached HEAD, where "the branch this pull request comes from" has
+        /// no answer, so the pane offers no comparison.
+        let branch: String?
+        /// Remote-tracking refs (`origin/main`), the honest bases: a stale local `main`
+        /// would silently overstate the diff.
+        let remoteBranches: [String]
+        let localBranches: [String]
+        /// The base to preselect: the remote's recorded default branch, else the first
+        /// conventional trunk name that exists. `nil` when the checkout *is* the trunk —
+        /// there is nothing to open a pull request against.
+        let suggestedBase: String?
+    }
+
+    /// A branch measured against the base it would be merged into.
+    struct BranchCompare: Sendable {
+        let base: String
+        /// The files the merge would touch, three-dot (from the merge base) — the change
+        /// the pull request itself introduces, matching what the forge will show. Committed
+        /// work only: uncommitted edits stay the Changes tab's business.
+        let files: [GitChange]
+        /// The commits the merge would bring over, newest first.
+        let commits: [GitCommit]
+        /// Commits on the base this branch doesn't have. Not an error — the base moved on —
+        /// but it dates the comparison, and it is measured against the last *fetched* state
+        /// of a remote base, never a fresh network fetch.
+        let behind: Int
+    }
+
+    static func compareContext(in repoRoot: String) async -> CompareContext {
+        await offMain { loadCompareContext(repoRoot) }
+    }
+
+    /// The branch's diff and commits against `base`. `nil` when the base no longer resolves
+    /// (a branch deleted since it was picked) — the caller shows "pick another base" rather
+    /// than an empty list, which would read as "nothing to review".
+    static func branchCompare(base: String, in repoRoot: String, limit: Int = 200) async -> BranchCompare? {
+        await offMain { loadBranchCompare(base, repoRoot, limit) }
+    }
+
+    private static func loadCompareContext(_ repoRoot: String) -> CompareContext {
+        let head = run(["rev-parse", "--abbrev-ref", "HEAD"], in: repoRoot)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let branch = (head == "HEAD" || head?.isEmpty == true) ? nil : head
+        var locals: [String] = []
+        var remotes: [String] = []
+        // Full refnames, not `%(refname:short)`: a local `feat/x` and a remote `origin/main`
+        // are indistinguishable once shortened, and the two lists mean different things.
+        for ref in (run(["for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes"], in: repoRoot) ?? "")
+            .split(separator: "\n").map(String.init) {
+            if ref.hasPrefix("refs/heads/") {
+                locals.append(String(ref.dropFirst("refs/heads/".count)))
+            } else if ref.hasPrefix("refs/remotes/") {
+                let short = String(ref.dropFirst("refs/remotes/".count))
+                // `origin/HEAD` is a symbolic pointer at the default branch, not a branch.
+                if !short.hasSuffix("/HEAD") { remotes.append(short) }
+            }
+        }
+        let originHead = run(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], in: repoRoot)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return CompareContext(
+            branch: branch, remoteBranches: remotes, localBranches: locals,
+            suggestedBase: suggestedCompareBase(
+                branch: branch, originHead: originHead,
+                remoteBranches: remotes, localBranches: locals))
+    }
+
+    /// Branch names a repository conventionally merges into, in the order they are tried.
+    private static let trunkBranchNames = ["main", "master", "dev", "develop", "trunk"]
+
+    /// Picks the base to compare a branch against: the remote's recorded default first
+    /// (`origin/HEAD`, what the forge will default the pull request's base to), then the
+    /// conventional trunk names — preferring `origin/main` over a local `main`, which in a
+    /// long-lived clone is usually months stale and would invent changes the branch never made.
+    /// The branch is never compared against itself, so a checkout of the trunk gets `nil` —
+    /// as does a detached HEAD, which has no branch to open a pull request from.
+    static func suggestedCompareBase(
+        branch: String?, originHead: String?,
+        remoteBranches: [String], localBranches: [String]
+    ) -> String? {
+        guard let branch else { return nil }
+        if let originHead, remoteBranches.contains(originHead),
+           remoteBranchName(originHead) != branch { return originHead }
+        for name in trunkBranchNames where name != branch {
+            if let remote = remoteBranches.first(where: { remoteBranchName($0) == name }) { return remote }
+            if localBranches.contains(name) { return name }
+        }
+        return nil
+    }
+
+    /// `origin/feat/x` → `feat/x`. Only ever applied to a remote-tracking ref, where the
+    /// first component is the remote's name.
+    private static func remoteBranchName(_ ref: String) -> String {
+        ref.split(separator: "/").dropFirst().joined(separator: "/")
+    }
+
+    private static func loadBranchCompare(_ base: String, _ repoRoot: String, _ limit: Int) -> BranchCompare? {
+        guard run(["rev-parse", "--verify", "--quiet", "\(base)^{commit}"], in: repoRoot) != nil
+        else { return nil }
+        // Three dots: diff from the merge base, so commits that landed on the base since
+        // this branch started don't show up inverted as changes the branch never made.
+        let range = "\(base)...HEAD"
+        let files = rangeChanges(
+            numstat: run(["diff", "--numstat", "-z", "-M", range], in: repoRoot) ?? "",
+            nameStatus: run(["diff", "--name-status", "-z", "-M", range], in: repoRoot) ?? "")
+        // Two dots for the counts — "how far apart are the tips", not "what would merge".
+        let behind = Int((run(["rev-list", "--count", "HEAD..\(base)"], in: repoRoot) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+        return BranchCompare(
+            base: base, files: files,
+            commits: loadLog(repoRoot, limit, range: "\(base)..HEAD"), behind: behind)
+    }
+
+    /// Merges `git diff --numstat -z` (counts) with `--name-status -z` (the status letter)
+    /// into the pane's change rows, keyed by the new path.
+    ///
+    /// `-z` rather than the default: without it git quotes any path holding a space or a
+    /// non-ASCII byte (`"src/\303\251.swift"`), and the quoted form doesn't match the path
+    /// the rest of the pane — the diff overlay, the file tree — addresses the file by.
+    static func rangeChanges(numstat: String, nameStatus: String) -> [GitChange] {
+        let statuses = parseNameStatus(nameStatus)
+        return parseNumstat(numstat)
+            .map { entry in
+                GitChange(
+                    path: entry.path,
+                    status: statuses[entry.path] ?? (entry.originalPath == nil ? .modified : .renamed),
+                    isUntracked: false,
+                    additions: entry.additions ?? 0, deletions: entry.deletions ?? 0,
+                    originalPath: entry.originalPath,
+                    isBinary: entry.additions == nil || entry.deletions == nil)
+            }
+            .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
+    }
+
+    private struct NumstatEntry {
+        let path: String
+        let originalPath: String?
+        /// `nil` when git reported `-`, which it does for a binary file — `+`/`−` counts
+        /// would be a lie there, so the row shows none.
+        let additions: Int?
+        let deletions: Int?
+    }
+
+    /// One `--numstat -z` record is `"<adds>\t<dels>\t<path>"`. A rename or copy leaves the
+    /// path field empty and follows with the old and new paths as their own two records.
+    private static func parseNumstat(_ raw: String) -> [NumstatEntry] {
+        let fields = raw.split(separator: "\0", omittingEmptySubsequences: false).map(String.init)
+        var entries: [NumstatEntry] = []
+        var index = 0
+        while index < fields.count {
+            let record = fields[index]
+            index += 1
+            guard !record.isEmpty else { continue }
+            let parts = record.split(separator: "\t", maxSplits: 2, omittingEmptySubsequences: false)
+            guard parts.count == 3 else { continue }
+            let additions = Int(parts[0])
+            let deletions = Int(parts[1])
+            var path = String(parts[2])
+            var originalPath: String?
+            if path.isEmpty {
+                guard index + 1 < fields.count else { break }
+                originalPath = fields[index]
+                path = fields[index + 1]
+                index += 2
+            }
+            entries.append(NumstatEntry(path: path, originalPath: originalPath,
+                                        additions: additions, deletions: deletions))
+        }
+        return entries
+    }
+
+    /// `--name-status -z` alternates a status record with its path — two paths for a rename
+    /// or copy, whose letter carries a similarity score (`R100`).
+    private static func parseNameStatus(_ raw: String) -> [String: GitFileStatus] {
+        let fields = raw.split(separator: "\0", omittingEmptySubsequences: false).map(String.init)
+        var statuses: [String: GitFileStatus] = [:]
+        var index = 0
+        while index < fields.count {
+            let code = fields[index]
+            index += 1
+            guard let letter = code.first else { continue }
+            let isPair = letter == "R" || letter == "C"
+            guard index + (isPair ? 1 : 0) < fields.count else { break }
+            statuses[fields[index + (isPair ? 1 : 0)]] = GitFileStatus(code: letter)
+            index += isPair ? 2 : 1
+        }
+        return statuses
     }
 
     // MARK: Loading

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -190,8 +190,10 @@ enum GitService {
         /// no answer, so the pane offers no comparison.
         let branch: String?
         /// Remote-tracking refs (`origin/main`), the honest bases: a stale local `main`
-        /// would silently overstate the diff.
+        /// would silently overstate the diff. The branch's own upstream is filtered out —
+        /// comparing a branch with the ref it tracks is not a pull request.
         let remoteBranches: [String]
+        /// Local branches other than the checkout's own.
         let localBranches: [String]
         /// The base to preselect: the remote's recorded default branch, else the first
         /// conventional trunk name that exists. `nil` when the checkout *is* the trunk —
@@ -214,14 +216,28 @@ enum GitService {
         let behind: Int
     }
 
+    /// Why a comparison couldn't be made — stated, never folded into an empty file list,
+    /// which would read as "this branch changes nothing".
+    enum CompareProblem: Sendable {
+        /// The picked base no longer resolves: its branch was deleted since it was chosen.
+        case missingBase
+        /// Nothing connects the two — unrelated histories, or a shallow clone whose graft
+        /// point sits above where the branches diverged. There is no merge base to diff
+        /// from, so any file list here would be the whole tree rather than a change.
+        case noCommonHistory
+    }
+
+    enum CompareOutcome: Sendable {
+        case ready(BranchCompare)
+        case problem(CompareProblem)
+    }
+
     static func compareContext(in repoRoot: String) async -> CompareContext {
         await offMain { loadCompareContext(repoRoot) }
     }
 
-    /// The branch's diff and commits against `base`. `nil` when the base no longer resolves
-    /// (a branch deleted since it was picked) — the caller shows "pick another base" rather
-    /// than an empty list, which would read as "nothing to review".
-    static func branchCompare(base: String, in repoRoot: String, limit: Int = 200) async -> BranchCompare? {
+    /// The branch's diff and commits against `base`.
+    static func branchCompare(base: String, in repoRoot: String, limit: Int = 200) async -> CompareOutcome {
         await offMain { loadBranchCompare(base, repoRoot, limit) }
     }
 
@@ -229,6 +245,12 @@ enum GitService {
         let head = run(["rev-parse", "--abbrev-ref", "HEAD"], in: repoRoot)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let branch = (head == "HEAD" || head?.isEmpty == true) ? nil : head
+        // The ref this branch tracks, whatever the remote is called. Filtering the literal
+        // `origin/<branch>` instead would leave a fork's `upstream/<branch>` in the list —
+        // offered as a base even though comparing a branch with its own upstream is the
+        // Changes-and-History question ("what haven't I pushed"), not a pull request.
+        let upstream = run(["rev-parse", "--abbrev-ref", "@{upstream}"], in: repoRoot)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         var locals: [String] = []
         var remotes: [String] = []
         // Full refnames, not `%(refname:short)`: a local `feat/x` and a remote `origin/main`
@@ -236,11 +258,12 @@ enum GitService {
         for ref in (run(["for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes"], in: repoRoot) ?? "")
             .split(separator: "\n").map(String.init) {
             if ref.hasPrefix("refs/heads/") {
-                locals.append(String(ref.dropFirst("refs/heads/".count)))
+                let short = String(ref.dropFirst("refs/heads/".count))
+                if short != branch { locals.append(short) }
             } else if ref.hasPrefix("refs/remotes/") {
                 let short = String(ref.dropFirst("refs/remotes/".count))
                 // `origin/HEAD` is a symbolic pointer at the default branch, not a branch.
-                if !short.hasSuffix("/HEAD") { remotes.append(short) }
+                if !short.hasSuffix("/HEAD"), short != upstream { remotes.append(short) }
             }
         }
         let originHead = run(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], in: repoRoot)?
@@ -281,9 +304,14 @@ enum GitService {
         ref.split(separator: "/").dropFirst().joined(separator: "/")
     }
 
-    private static func loadBranchCompare(_ base: String, _ repoRoot: String, _ limit: Int) -> BranchCompare? {
+    private static func loadBranchCompare(_ base: String, _ repoRoot: String, _ limit: Int) -> CompareOutcome {
         guard run(["rev-parse", "--verify", "--quiet", "\(base)^{commit}"], in: repoRoot) != nil
-        else { return nil }
+        else { return .problem(.missingBase) }
+        // Without a merge base the three-dot diff below exits non-zero and would degrade to
+        // an empty file list — while `base..HEAD` still lists commits, so the tab would show
+        // "no files, 40 commits". Ask git first and say what is actually wrong.
+        guard run(["merge-base", base, "HEAD"], in: repoRoot) != nil
+        else { return .problem(.noCommonHistory) }
         // Three dots: diff from the merge base, so commits that landed on the base since
         // this branch started don't show up inverted as changes the branch never made.
         let range = "\(base)...HEAD"
@@ -293,9 +321,9 @@ enum GitService {
         // Two dots for the counts — "how far apart are the tips", not "what would merge".
         let behind = Int((run(["rev-list", "--count", "HEAD..\(base)"], in: repoRoot) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
-        return BranchCompare(
+        return .ready(BranchCompare(
             base: base, files: files,
-            commits: loadLog(repoRoot, limit, range: "\(base)..HEAD"), behind: behind)
+            commits: loadLog(repoRoot, limit, range: "\(base)..HEAD"), behind: behind))
     }
 
     /// Merges `git diff --numstat -z` (counts) with `--name-status -z` (the status letter)
@@ -611,8 +639,13 @@ enum GitService {
         let contextArguments = context.map { ["-U\($0)"] } ?? []
         // PR file row: the file's change across a `base...head` range (three-dot, so
         // git diffs from the merge base — the change the PR itself introduces).
+        //
+        // A rename is limited to *both* paths: git applies the path limit before rename
+        // detection, so asking only for the destination turns a pure rename into the whole
+        // file arriving as additions — contradicting the row's own `R` and its zero counts.
         if let range {
-            return run(["diff", "-M"] + contextArguments + [range, "--", change.path],
+            let paths = [change.path] + (change.originalPath.map { [$0] } ?? [])
+            return run(["diff", "-M"] + contextArguments + [range, "--"] + paths,
                        in: repoRoot, ignoreStatus: true) ?? ""
         }
         // History file row: the file's change within one commit. `--format=` strips the

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5445,16 +5445,6 @@
         }
       }
     },
-    "This branch is even with the branch it would merge into.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "当前分支与它将要合入的分支没有差异。"
-          }
-        }
-      }
-    },
     "Compare": {
       "localizations": {
         "zh-Hans": {
@@ -5501,6 +5491,36 @@
           "stringUnit": {
             "state": "translated",
             "value": "这个检出没有其他分支可以对比。"
+          }
+        }
+      }
+    },
+    "No Common History": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有共同历史"
+          }
+        }
+      }
+    },
+    "This branch and the base branch share no commits.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个分支和基础分支没有共同的提交。"
+          }
+        }
+      }
+    },
+    "This branch has nothing the base branch doesn’t already have.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个分支没有基础分支尚未包含的内容。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5334,6 +5334,176 @@
           }
         }
       }
+    },
+    "Base Branch Missing": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到基础分支"
+          }
+        }
+      }
+    },
+    "Behind": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "落后"
+          }
+        }
+      }
+    },
+    "Choose another branch to compare with.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请另选一个用于对比的分支。"
+          }
+        }
+      }
+    },
+    "Commits": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提交"
+          }
+        }
+      }
+    },
+    "Compare this branch with the branch it would merge into.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把当前分支与它将要合入的分支做对比。"
+          }
+        }
+      }
+    },
+    "Compare to branch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对比分支"
+          }
+        }
+      }
+    },
+    "Don’t Compare": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不对比"
+          }
+        }
+      }
+    },
+    "Files changed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "变更文件"
+          }
+        }
+      }
+    },
+    "Local": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地"
+          }
+        }
+      }
+    },
+    "Remote": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "远程"
+          }
+        }
+      }
+    },
+    "The base branch has commits this branch doesn’t have, as of the last fetch.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截至上次 fetch，基础分支上有当前分支还没有的提交。"
+          }
+        }
+      }
+    },
+    "This branch is even with the branch it would merge into.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前分支与它将要合入的分支没有差异。"
+          }
+        }
+      }
+    },
+    "Compare": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对比"
+          }
+        }
+      }
+    },
+    "No Base Branch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择基础分支"
+          }
+        }
+      }
+    },
+    "Nothing to Compare": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可对比的分支"
+          }
+        }
+      }
+    },
+    "Pick the branch this one would merge into.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择这个分支将要合入的分支。"
+          }
+        }
+      }
+    },
+    "This checkout has no other branch to compare with.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个检出没有其他分支可以对比。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -572,6 +572,8 @@
 	<string>No Base Branch</string>
 	<key>No Changes</key>
 	<string>No Changes</string>
+	<key>No Common History</key>
+	<string>No Common History</string>
 	<key>No Diff</key>
 	<string>No Diff</string>
 	<key>No File Selected</key>
@@ -966,10 +968,12 @@
 	<string>Themes</string>
 	<key>Thicken glyphs</key>
 	<string>Thicken glyphs</string>
+	<key>This branch and the base branch share no commits.</key>
+	<string>This branch and the base branch share no commits.</string>
 	<key>This branch has no commits yet.</key>
 	<string>This branch has no commits yet.</string>
-	<key>This branch is even with the branch it would merge into.</key>
-	<string>This branch is even with the branch it would merge into.</string>
+	<key>This branch has nothing the base branch doesn’t already have.</key>
+	<string>This branch has nothing the base branch doesn’t already have.</string>
 	<key>This checkout has no other branch to compare with.</key>
 	<string>This checkout has no other branch to compare with.</string>
 	<key>This diff is too large to show here — open the file on GitHub.</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -134,6 +134,10 @@
 	<string>Available when Termio runs from the built app bundle.</string>
 	<key>Bar</key>
 	<string>Bar</string>
+	<key>Base Branch Missing</key>
+	<string>Base Branch Missing</string>
+	<key>Behind</key>
+	<string>Behind</string>
 	<key>Binary File</key>
 	<string>Binary File</string>
 	<key>Binary file — open it on GitHub to view.</key>
@@ -172,6 +176,8 @@
 	<string>Choose a different name.</string>
 	<key>Choose a project folder to open in Termio.</key>
 	<string>Choose a project folder to open in Termio.</string>
+	<key>Choose another branch to compare with.</key>
+	<string>Choose another branch to compare with.</string>
 	<key>Choose how projects are ordered</key>
 	<string>Choose how projects are ordered</string>
 	<key>Choose…</key>
@@ -208,8 +214,16 @@
 	<string>Command-line tool</string>
 	<key>Commit or discard the changes in “%@” before removing it.</key>
 	<string>Commit or discard the changes in “%@” before removing it.</string>
+	<key>Commits</key>
+	<string>Commits</string>
 	<key>Community</key>
 	<string>Community</string>
+	<key>Compare</key>
+	<string>Compare</string>
+	<key>Compare this branch with the branch it would merge into.</key>
+	<string>Compare this branch with the branch it would merge into.</string>
+	<key>Compare to branch</key>
+	<string>Compare to branch</string>
 	<key>Config file</key>
 	<string>Config file</string>
 	<key>Connect</key>
@@ -326,6 +340,8 @@
 	<string>Discord, GitHub, and the WeChat group</string>
 	<key>Done</key>
 	<string>Done</string>
+	<key>Don’t Compare</key>
+	<string>Don’t Compare</string>
 	<key>Draft</key>
 	<string>Draft</string>
 	<key>Drag the list to change the order agents appear in.</key>
@@ -358,6 +374,8 @@
 	<string>File</string>
 	<key>Files</key>
 	<string>Files</string>
+	<key>Files changed</key>
+	<string>Files changed</string>
 	<key>Filter</key>
 	<string>Filter</string>
 	<key>Find</key>
@@ -480,6 +498,8 @@
 	<string>Live agent status</string>
 	<key>Live agent status is off</key>
 	<string>Live agent status is off</string>
+	<key>Local</key>
+	<string>Local</string>
 	<key>Login shell</key>
 	<string>Login shell</string>
 	<key>Match Case</key>
@@ -548,6 +568,8 @@
 	<string>Next Session</string>
 	<key>No Agents Enabled</key>
 	<string>No Agents Enabled</string>
+	<key>No Base Branch</key>
+	<string>No Base Branch</string>
 	<key>No Changes</key>
 	<string>No Changes</string>
 	<key>No Diff</key>
@@ -608,6 +630,8 @@
 	<string>Not connected</string>
 	<key>Not pushed to upstream</key>
 	<string>Not pushed to upstream</string>
+	<key>Nothing to Compare</key>
+	<string>Nothing to Compare</string>
 	<key>Nothing to install.</key>
 	<string>Nothing to install.</string>
 	<key>Notifications</key>
@@ -660,6 +684,8 @@
 	<string>Permissions</string>
 	<key>Pick a file on the left to see its changes.</key>
 	<string>Pick a file on the left to see its changes.</string>
+	<key>Pick the branch this one would merge into.</key>
+	<string>Pick the branch this one would merge into.</string>
 	<key>Pin</key>
 	<string>Pin</string>
 	<key>Pin Termio to a light or dark look, or follow the system. The light and dark terminal themes below apply to the matching appearance.</key>
@@ -730,6 +756,8 @@
 	<string>Relaunch Termio to switch language?</string>
 	<key>Reload</key>
 	<string>Reload</string>
+	<key>Remote</key>
+	<string>Remote</string>
 	<key>Remote session</key>
 	<string>Remote session</string>
 	<key>Remove</key>
@@ -914,6 +942,8 @@
 	<string>The SSH connection is closed. Reconnect in the terminal, then refresh.</string>
 	<key>The agent New Chat (⌘N) starts. “Last used” follows whichever agent you most recently chatted with.</key>
 	<string>The agent New Chat (⌘N) starts. “Last used” follows whichever agent you most recently chatted with.</string>
+	<key>The base branch has commits this branch doesn’t have, as of the last fetch.</key>
+	<string>The base branch has commits this branch doesn’t have, as of the last fetch.</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>The coding agents offered when you start a session</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
@@ -938,6 +968,10 @@
 	<string>Thicken glyphs</string>
 	<key>This branch has no commits yet.</key>
 	<string>This branch has no commits yet.</string>
+	<key>This branch is even with the branch it would merge into.</key>
+	<string>This branch is even with the branch it would merge into.</string>
+	<key>This checkout has no other branch to compare with.</key>
+	<string>This checkout has no other branch to compare with.</string>
 	<key>This diff is too large to show here — open the file on GitHub.</key>
 	<string>This diff is too large to show here — open the file on GitHub.</string>
 	<key>This file is binary — open it on GitHub to view.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -134,6 +134,10 @@
 	<string>仅当 Termio 从构建的应用包运行时可用。</string>
 	<key>Bar</key>
 	<string>竖线</string>
+	<key>Base Branch Missing</key>
+	<string>找不到基础分支</string>
+	<key>Behind</key>
+	<string>落后</string>
 	<key>Binary File</key>
 	<string>二进制文件</string>
 	<key>Binary file — open it on GitHub to view.</key>
@@ -172,6 +176,8 @@
 	<string>请选取其他名称。</string>
 	<key>Choose a project folder to open in Termio.</key>
 	<string>选取要在 Termio 中打开的项目文件夹。</string>
+	<key>Choose another branch to compare with.</key>
+	<string>请另选一个用于对比的分支。</string>
 	<key>Choose how projects are ordered</key>
 	<string>选取项目的排序方式</string>
 	<key>Choose…</key>
@@ -208,8 +214,16 @@
 	<string>命令行工具</string>
 	<key>Commit or discard the changes in “%@” before removing it.</key>
 	<string>移除前请先提交或放弃“%@”中的更改。</string>
+	<key>Commits</key>
+	<string>提交</string>
 	<key>Community</key>
 	<string>社区</string>
+	<key>Compare</key>
+	<string>对比</string>
+	<key>Compare this branch with the branch it would merge into.</key>
+	<string>把当前分支与它将要合入的分支做对比。</string>
+	<key>Compare to branch</key>
+	<string>对比分支</string>
 	<key>Config file</key>
 	<string>配置文件</string>
 	<key>Connect</key>
@@ -326,6 +340,8 @@
 	<string>Discord、GitHub 与微信群</string>
 	<key>Done</key>
 	<string>完成</string>
+	<key>Don’t Compare</key>
+	<string>不对比</string>
 	<key>Draft</key>
 	<string>草稿</string>
 	<key>Drag the list to change the order agents appear in.</key>
@@ -358,6 +374,8 @@
 	<string>文件</string>
 	<key>Files</key>
 	<string>文件</string>
+	<key>Files changed</key>
+	<string>变更文件</string>
 	<key>Filter</key>
 	<string>过滤</string>
 	<key>Find</key>
@@ -480,6 +498,8 @@
 	<string>Agent 实时状态</string>
 	<key>Live agent status is off</key>
 	<string>Agent 实时状态已关闭</string>
+	<key>Local</key>
+	<string>本地</string>
 	<key>Login shell</key>
 	<string>登录 shell</string>
 	<key>Match Case</key>
@@ -548,6 +568,8 @@
 	<string>下一个会话</string>
 	<key>No Agents Enabled</key>
 	<string>未启用任何 Agent</string>
+	<key>No Base Branch</key>
+	<string>未选择基础分支</string>
 	<key>No Changes</key>
 	<string>没有更改</string>
 	<key>No Diff</key>
@@ -608,6 +630,8 @@
 	<string>未连接</string>
 	<key>Not pushed to upstream</key>
 	<string>尚未推送到上游</string>
+	<key>Nothing to Compare</key>
+	<string>没有可对比的分支</string>
 	<key>Nothing to install.</key>
 	<string>没有可安装的内容。</string>
 	<key>Notifications</key>
@@ -660,6 +684,8 @@
 	<string>权限</string>
 	<key>Pick a file on the left to see its changes.</key>
 	<string>在左侧选择一个文件以查看其更改。</string>
+	<key>Pick the branch this one would merge into.</key>
+	<string>选择这个分支将要合入的分支。</string>
 	<key>Pin</key>
 	<string>固定</string>
 	<key>Pin Termio to a light or dark look, or follow the system. The light and dark terminal themes below apply to the matching appearance.</key>
@@ -730,6 +756,8 @@
 	<string>重新启动 Termio 以切换语言？</string>
 	<key>Reload</key>
 	<string>重新载入</string>
+	<key>Remote</key>
+	<string>远程</string>
 	<key>Remote session</key>
 	<string>远程会话</string>
 	<key>Remove</key>
@@ -914,6 +942,8 @@
 	<string>SSH 连接已关闭。请在终端中重新连接，然后刷新。</string>
 	<key>The agent New Chat (⌘N) starts. “Last used” follows whichever agent you most recently chatted with.</key>
 	<string>新建聊天（⌘N）启动的 Agent。“上次使用”跟随你最近一次聊天所用的 Agent。</string>
+	<key>The base branch has commits this branch doesn’t have, as of the last fetch.</key>
+	<string>截至上次 fetch，基础分支上有当前分支还没有的提交。</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>新建会话时可以选用的编程 Agent</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
@@ -938,6 +968,10 @@
 	<string>加粗字形</string>
 	<key>This branch has no commits yet.</key>
 	<string>此分支还没有提交。</string>
+	<key>This branch is even with the branch it would merge into.</key>
+	<string>当前分支与它将要合入的分支没有差异。</string>
+	<key>This checkout has no other branch to compare with.</key>
+	<string>这个检出没有其他分支可以对比。</string>
 	<key>This diff is too large to show here — open the file on GitHub.</key>
 	<string>此差异太大，无法在此显示，请在 GitHub 上打开该文件。</string>
 	<key>This file is binary — open it on GitHub to view.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -572,6 +572,8 @@
 	<string>未选择基础分支</string>
 	<key>No Changes</key>
 	<string>没有更改</string>
+	<key>No Common History</key>
+	<string>没有共同历史</string>
 	<key>No Diff</key>
 	<string>没有差异</string>
 	<key>No File Selected</key>
@@ -966,10 +968,12 @@
 	<string>主题</string>
 	<key>Thicken glyphs</key>
 	<string>加粗字形</string>
+	<key>This branch and the base branch share no commits.</key>
+	<string>这个分支和基础分支没有共同的提交。</string>
 	<key>This branch has no commits yet.</key>
 	<string>此分支还没有提交。</string>
-	<key>This branch is even with the branch it would merge into.</key>
-	<string>当前分支与它将要合入的分支没有差异。</string>
+	<key>This branch has nothing the base branch doesn’t already have.</key>
+	<string>这个分支没有基础分支尚未包含的内容。</string>
 	<key>This checkout has no other branch to compare with.</key>
 	<string>这个检出没有其他分支可以对比。</string>
 	<key>This diff is too large to show here — open the file on GitHub.</key>

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -321,6 +321,18 @@ final class TermioStore: ObservableObject {
     /// so the pane resumes from here instead. In-memory only, like the registry.
     var gitPaneModes: [String: GitPaneMode] = [:]
 
+    /// The base branch the git pane's History tab compares against, per repo *and branch*
+    /// (`compareBaseKey`). Per branch, not per repo: the base is a property of the branch —
+    /// a feature branch cut from `main` and a stacked one cut from that feature branch
+    /// merge into different places, and one shared slot would mislabel every second
+    /// checkout. An empty value means the user turned the comparison off for that branch,
+    /// which must outlast a remount too. In-memory only, like `gitPaneModes`.
+    var gitCompareBases: [String: String] = [:]
+
+    static func compareBaseKey(repoRoot: String, branch: String?) -> String {
+        "\(repoRoot)\u{1f}\(branch ?? "")"
+    }
+
     /// Whether the selected session is running a coding agent (not a plain shell) —
     /// gates the file tree's "Add to Chat" row action.
     var selectedSessionRunsAgent: Bool {

--- a/Tests/termioTests/GitBranchCompareTests.swift
+++ b/Tests/termioTests/GitBranchCompareTests.swift
@@ -40,7 +40,7 @@ final class GitBranchCompareTests: XCTestCase {
         try git(["commit", "-qam", "moved on"])
         try git(["checkout", "-q", "feature"])
 
-        let loaded = await GitService.branchCompare(base: "main", in: repo.path)
+        let loaded = await readyCompare(base: "main")
         let compare = try XCTUnwrap(loaded)
         XCTAssertEqual(compare.files.map(\.path), ["feature.txt"])
         XCTAssertEqual(compare.files.first?.additions, 2)
@@ -52,12 +52,54 @@ final class GitBranchCompareTests: XCTestCase {
 
     /// A base that was deleted since it was picked reads as "missing", never as an empty
     /// comparison — an empty file list would say "nothing to review" about work that exists.
-    func testMissingBaseIsNilRatherThanEmpty() async throws {
+    func testMissingBaseIsStatedRatherThanShownAsAnEmptyDiff() async throws {
         try write("a.txt", "a\n")
         try git(["add", "."])
         try git(["commit", "-qm", "one"])
-        let compare = await GitService.branchCompare(base: "origin/gone", in: repo.path)
-        XCTAssertNil(compare)
+        let outcome = await GitService.branchCompare(base: "origin/gone", in: repo.path)
+        guard case .problem(.missingBase) = outcome else {
+            return XCTFail("expected a missing base, got \(outcome)")
+        }
+    }
+
+    /// Unrelated histories have no merge base, so the three-dot diff fails while
+    /// `base..HEAD` would still list every commit. Reporting that as "0 files, N commits"
+    /// is a lie about the branch; the tab has to say what is actually wrong.
+    func testUnrelatedHistoriesAreReportedRatherThanDiffedToNothing() async throws {
+        try write("a.txt", "a\n")
+        try git(["add", "."])
+        try git(["commit", "-qm", "one"])
+        try git(["checkout", "-q", "--orphan", "detached-history"])
+        try write("b.txt", "b\n")
+        try git(["add", "."])
+        try git(["commit", "-qm", "unrelated"])
+
+        let outcome = await GitService.branchCompare(base: "main", in: repo.path)
+        guard case .problem(.noCommonHistory) = outcome else {
+            return XCTFail("expected no common history, got \(outcome)")
+        }
+    }
+
+    /// Git applies a path limit *before* rename detection, so asking for the destination
+    /// alone turns a pure rename into the whole file arriving as additions — contradicting
+    /// the row's own `R` badge and its zero counts.
+    func testRenameOpensAsARenameNotAWholeFileAdd() async throws {
+        try write("old.swift", (1...40).map { "line \($0)\n" }.joined())
+        try git(["add", "."])
+        try git(["commit", "-qm", "base"])
+        try git(["checkout", "-qb", "feature"])
+        try git(["mv", "old.swift", "new.swift"])
+        try git(["commit", "-qm", "rename"])
+
+        let loaded = await readyCompare(base: "main")
+        let compare = try XCTUnwrap(loaded)
+        let renamed = try XCTUnwrap(compare.files.first)
+        XCTAssertEqual(renamed.status, .renamed)
+        XCTAssertEqual(renamed.originalPath, "old.swift")
+
+        let rows = await GitService.diffRows(for: renamed, in: repo.path, range: "main...HEAD")
+        XCTAssertTrue(rows.allSatisfy { $0.kind == .context || $0.kind == .hunk },
+                      "a pure rename has no added or deleted lines")
     }
 
     func testSuggestedBaseIsTheBranchTheCheckoutWouldMergeInto() async throws {
@@ -69,7 +111,31 @@ final class GitBranchCompareTests: XCTestCase {
         let context = await GitService.compareContext(in: repo.path)
         XCTAssertEqual(context.branch, "feat/x")
         XCTAssertEqual(context.suggestedBase, "main")
-        XCTAssertEqual(context.localBranches.sorted(), ["feat/x", "main"])
+        XCTAssertEqual(context.localBranches, ["main"], "the checkout's own branch is not a base")
+    }
+
+    /// A branch's own upstream is not a base to compare with, whatever the remote is
+    /// called — comparing a branch with the ref it tracks answers "what haven't I pushed",
+    /// which is the Changes and History tabs' question.
+    func testTheBranchsOwnUpstreamIsNotOfferedAsABase() async throws {
+        let remote = repo.appendingPathExtension("remote.git")
+        try FileManager.default.createDirectory(at: remote, withIntermediateDirectories: true)
+        try git(["init", "-q", "--bare", remote.path])
+        try write("a.txt", "a\n")
+        try git(["add", "."])
+        try git(["commit", "-qm", "one"])
+        // Deliberately not named `origin`: the filter must follow the configured upstream,
+        // not a hard-coded remote name (a fork's `upstream/…` is the real-world case).
+        try git(["remote", "add", "fork", remote.path])
+        try git(["checkout", "-qb", "feat/x"])
+        try git(["push", "-q", "-u", "fork", "main", "feat/x"])
+        defer { try? FileManager.default.removeItem(at: remote) }
+
+        let context = await GitService.compareContext(in: repo.path)
+        XCTAssertEqual(context.branch, "feat/x")
+        XCTAssertFalse(context.remoteBranches.contains("fork/feat/x"), "own upstream offered as a base")
+        XCTAssertTrue(context.remoteBranches.contains("fork/main"))
+        XCTAssertFalse(context.localBranches.contains("feat/x"), "own branch offered as a base")
     }
 
     // MARK: Base resolution
@@ -156,6 +222,14 @@ final class GitBranchCompareTests: XCTestCase {
     }
 
     // MARK: Helpers
+
+    /// The comparison when it could be made, `nil` when the service reported a problem.
+    private func readyCompare(base: String) async -> GitService.BranchCompare? {
+        if case .ready(let compare) = await GitService.branchCompare(base: base, in: repo.path) {
+            return compare
+        }
+        return nil
+    }
 
     private func git(_ args: [String]) throws {
         let process = Process()

--- a/Tests/termioTests/GitBranchCompareTests.swift
+++ b/Tests/termioTests/GitBranchCompareTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import termio
+
+/// The branch comparison behind the History tab's compare bar: the diff a pull request
+/// from this branch would carry. Two things here are easy to get wrong and invisible
+/// once wrong — the three-dot range, and `-z` record parsing — so both are pinned.
+final class GitBranchCompareTests: XCTestCase {
+    private var repo: URL!
+
+    override func setUpWithError() throws {
+        repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("termio-git-compare-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try git(["init", "-q", "-b", "main"])
+        try git(["config", "user.email", "test@termio.sh"])
+        try git(["config", "user.name", "Test"])
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: repo)
+    }
+
+    // MARK: Range semantics
+
+    /// The comparison must diff from the *merge base*, not from the base branch's tip.
+    /// With a two-dot range, a file that only ever changed on `main` after the branch was
+    /// cut shows up in the branch's list — inverted, as a change the branch never made.
+    func testCompareIgnoresCommitsThatLandedOnTheBaseAfterBranching() async throws {
+        try write("shared.txt", "one\n")
+        try git(["add", "."])
+        try git(["commit", "-qm", "base"])
+
+        try git(["checkout", "-qb", "feature"])
+        try write("feature.txt", "hello\nthere\n")
+        try git(["add", "."])
+        try git(["commit", "-qm", "feature work"])
+
+        try git(["checkout", "-q", "main"])
+        try write("shared.txt", "one\ntwo\n")
+        try git(["commit", "-qam", "moved on"])
+        try git(["checkout", "-q", "feature"])
+
+        let loaded = await GitService.branchCompare(base: "main", in: repo.path)
+        let compare = try XCTUnwrap(loaded)
+        XCTAssertEqual(compare.files.map(\.path), ["feature.txt"])
+        XCTAssertEqual(compare.files.first?.additions, 2)
+        XCTAssertEqual(compare.files.first?.status, .added)
+        XCTAssertEqual(compare.commits.map(\.subject), ["feature work"])
+        // The base moved on by exactly the one commit — surfaced, not silently folded in.
+        XCTAssertEqual(compare.behind, 1)
+    }
+
+    /// A base that was deleted since it was picked reads as "missing", never as an empty
+    /// comparison — an empty file list would say "nothing to review" about work that exists.
+    func testMissingBaseIsNilRatherThanEmpty() async throws {
+        try write("a.txt", "a\n")
+        try git(["add", "."])
+        try git(["commit", "-qm", "one"])
+        let compare = await GitService.branchCompare(base: "origin/gone", in: repo.path)
+        XCTAssertNil(compare)
+    }
+
+    func testSuggestedBaseIsTheBranchTheCheckoutWouldMergeInto() async throws {
+        try write("a.txt", "a\n")
+        try git(["add", "."])
+        try git(["commit", "-qm", "one"])
+        try git(["checkout", "-qb", "feat/x"])
+
+        let context = await GitService.compareContext(in: repo.path)
+        XCTAssertEqual(context.branch, "feat/x")
+        XCTAssertEqual(context.suggestedBase, "main")
+        XCTAssertEqual(context.localBranches.sorted(), ["feat/x", "main"])
+    }
+
+    // MARK: Base resolution
+
+    func testBaseResolutionPrefersTheRemoteDefaultThenRemoteTrunks() {
+        // The remote's recorded default wins outright — it is what the forge will default
+        // the pull request's base to.
+        XCTAssertEqual(
+            GitService.suggestedCompareBase(
+                branch: "feat/x", originHead: "origin/dev",
+                remoteBranches: ["origin/dev", "origin/main"], localBranches: ["main"]),
+            "origin/dev")
+        // Without one, a remote trunk beats the same-named local branch, which in a
+        // long-lived clone is usually stale.
+        XCTAssertEqual(
+            GitService.suggestedCompareBase(
+                branch: "feat/x", originHead: nil,
+                remoteBranches: ["origin/main"], localBranches: ["main", "feat/x"]),
+            "origin/main")
+        // A local trunk is the fallback when nothing is on a remote.
+        XCTAssertEqual(
+            GitService.suggestedCompareBase(
+                branch: "feat/x", originHead: nil,
+                remoteBranches: [], localBranches: ["master", "feat/x"]),
+            "master")
+    }
+
+    func testNoBaseIsSuggestedForTheTrunkItself() {
+        // On `main`, comparing against `origin/main` would answer "what have I not pushed",
+        // which is the History tab's own job — so the pane opens uncompared.
+        XCTAssertNil(
+            GitService.suggestedCompareBase(
+                branch: "main", originHead: "origin/main",
+                remoteBranches: ["origin/main"], localBranches: ["main"]))
+        XCTAssertNil(
+            GitService.suggestedCompareBase(
+                branch: nil, originHead: nil, remoteBranches: [], localBranches: ["main"]))
+    }
+
+    // MARK: `-z` record parsing
+
+    /// `--numstat -z` writes a rename as an empty path field followed by the old and new
+    /// paths as their own records, and binary files as `-` counts. Both must survive, and
+    /// paths must arrive unquoted so they match the ones the diff overlay addresses.
+    func testRangeChangesParsesRenamesBinariesAndAwkwardPaths() {
+        let numstat = [
+            "3\t1\tSources/a.swift",
+            "0\t0\t", "old name.swift", "new name.swift",
+            "-\t-\tassets/icon.png",
+            "0\t9\tgone.txt",
+        ].joined(separator: "\0") + "\0"
+        let nameStatus = [
+            "M", "Sources/a.swift",
+            "R096", "old name.swift", "new name.swift",
+            "M", "assets/icon.png",
+            "D", "gone.txt",
+        ].joined(separator: "\0") + "\0"
+
+        let changes = GitService.rangeChanges(numstat: numstat, nameStatus: nameStatus)
+        XCTAssertEqual(changes.map(\.path),
+                       ["assets/icon.png", "gone.txt", "new name.swift", "Sources/a.swift"])
+
+        let renamed = changes.first { $0.path == "new name.swift" }
+        XCTAssertEqual(renamed?.status, .renamed)
+        XCTAssertEqual(renamed?.originalPath, "old name.swift")
+
+        let binary = changes.first { $0.path == "assets/icon.png" }
+        XCTAssertEqual(binary?.isBinary, true)
+        XCTAssertEqual(binary?.additions, 0)
+
+        let deleted = changes.first { $0.path == "gone.txt" }
+        XCTAssertEqual(deleted?.status, .deleted)
+        XCTAssertEqual(deleted?.deletions, 9)
+
+        let modified = changes.first { $0.path == "Sources/a.swift" }
+        XCTAssertEqual(modified?.status, .modified)
+        XCTAssertEqual(modified?.additions, 3)
+        XCTAssertEqual(modified?.deletions, 1)
+        XCTAssertEqual(modified?.isBinary, false)
+    }
+
+    func testRangeChangesIsEmptyForAnEmptyDiff() {
+        XCTAssertTrue(GitService.rangeChanges(numstat: "", nameStatus: "").isEmpty)
+    }
+
+    // MARK: Helpers
+
+    private func git(_ args: [String]) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = repo
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, "git \(args.joined(separator: " ")) failed")
+    }
+
+    private func write(_ relative: String, _ contents: String) throws {
+        let url = repo.appendingPathComponent(relative)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(contents.utf8).write(to: url)
+    }
+}

--- a/web/landing/content/docs/inspector.mdx
+++ b/web/landing/content/docs/inspector.mdx
@@ -30,9 +30,12 @@ in a Quick Look preview instead.
 
 ## Changes
 
-The git pane has two read-only tabs:
+The git pane has three read-only tabs:
 
 - **Changes** — the current diff, rendered as a clean unified view.
+- **Compare** — this branch against the branch it would merge into: the files and
+  commits a pull request from it would carry, diffed from the merge base so the
+  list matches what the forge will show.
 - **History** — recent commits with author avatars, expandable file lists, and
   per-commit diffs.
 

--- a/web/landing/content/docs/inspector.zh-CN.mdx
+++ b/web/landing/content/docs/inspector.zh-CN.mdx
@@ -3,7 +3,7 @@ title: 检查器
 description: 浏览文件、带语法高亮地编辑、读 git 差异、搜索项目——一整块侧面板，永不把你从终端里拽出来。
 x-i18n:
   source_path: inspector.mdx
-  source_hash: affcce1214632250f4d7a06f5f39e4136484a8cb3f92313aea7cfb880a25cd2f
+  source_hash: b819a8f91967d9a35cbb611110137c5c886ccbd42c4fb62e67ecc4c0689fd1ad
   generated_at: 2026-08-16
 ---
 
@@ -31,9 +31,11 @@ x-i18n:
 
 ## 更改
 
-git 面板有两个只读标签：
+git 面板有三个只读标签：
 
 - **更改** —— 当前的差异，以清晰的统一视图渲染。
+- **对比** —— 当前分支相对它将要合入的分支：一个 PR 会带过去的文件和提交，从合并基点
+  算差异，所以列表和平台上看到的一致。
 - **历史** —— 最近的提交，带作者头像、可展开的文件列表和逐个提交的差异。
 
 <DocsImage

--- a/web/landing/content/docs/worktrees.mdx
+++ b/web/landing/content/docs/worktrees.mdx
@@ -37,10 +37,11 @@ An empty worktree still appears in the tree. Open its context menu and choose
 
 ## Reviewing the work
 
-The inspector's git pane is read-only by design: two tabs, **Changes** and
-**History**, let you read the diff and browse commits per worktree. Committing,
-pushing, and opening pull requests happen in the terminal, where you (or the
-agent) already are — see the [inspector guide](/docs/inspector).
+The inspector's git pane is read-only by design: three tabs — **Changes**,
+**Compare**, and **History** — let you read the diff, see what the branch would
+merge, and browse commits per worktree. Committing, pushing, and opening pull
+requests happen in the terminal, where you (or the agent) already are — see the
+[inspector guide](/docs/inspector).
 
 <DocsImage
   src="/screenshots/docs/13-review-worktree.png"

--- a/web/landing/content/docs/worktrees.zh-CN.mdx
+++ b/web/landing/content/docs/worktrees.zh-CN.mdx
@@ -3,7 +3,7 @@ title: Git worktree
 description: Termio 直接从 git 读取仓库的 worktree，并把它们显示为项目下嵌套的一层，让并行的 Agent 工作彼此隔离。
 x-i18n:
   source_path: worktrees.mdx
-  source_hash: 978a044024ee116ecde01590163a89a312446354cc99041d271b6acedbc2e983
+  source_hash: 4dca84ce78e77f875b51272c4f7ce825896228d74ea66514cb6a8bfb763b5ddc
   generated_at: 2026-08-16
 ---
 
@@ -37,9 +37,9 @@ Agent 对着你的 `main` 检出，另一个对着 `feat/…` worktree，它们�
 
 ## 审阅成果
 
-检查器的 git 面板按设计是只读的：两个标签 **更改** 和 **历史**，让你逐个 worktree 读差异、
-浏览提交。提交、推送和开 PR 都发生在终端里，因为你（或 Agent）本来就在那里——参见
-[检查器指南](/zh-CN/docs/inspector)。
+检查器的 git 面板按设计是只读的：三个标签 **更改**、**对比** 和 **历史**，让你逐个 worktree
+读差异、看这个分支会合入什么、浏览提交。提交、推送和开 PR 都发生在终端里，因为你（或
+Agent）本来就在那里——参见[检查器指南](/zh-CN/docs/inspector)。
 
 <DocsImage
   src="/screenshots/docs/13-review-worktree.png"


### PR DESCRIPTION
The git pane showed uncommitted changes and past commits, but not the thing you read right before opening a pull request: everything the branch would carry over. A third tab — **Changes | Compare | History** — answers it.

**Compare** shows the branch measured against the branch it would merge into: a base picker, the changed files with `+`/`−` totals, and the commits the merge would bring. Clicking a file opens its diff over the terminal through the overlay that already existed for the Issues pane's pull-request rows (`GitDiffRequest.range`).

Details that decide whether this is correct:

- **Three-dot range.** `base...HEAD` diffs from the merge base, so the list matches the forge's own "Files changed" instead of inverting whatever landed on the base since the branch was cut. Pinned by a test.
- **The base is remembered per branch, not per repo.** A feature branch cut from `main` and one stacked on that feature branch merge into different places; a single per-repo slot would mislabel every second checkout.
- **Remote bases beat local ones.** The default is `origin/HEAD`'s target, then conventional trunk names, preferring `origin/main` over a local `main` that in a long-lived clone is months stale. The picker lifts that branch to the top of its section.
- **`Behind (N)`** reports the base's last *fetched* state. Nothing here fetches on its own.
- **`-z` record parsing** for `--numstat` / `--name-status`, so paths with spaces or non-ASCII bytes arrive unquoted and match the ones the diff overlay addresses.

The pane stays read-only: opening the pull request still happens in the terminal.

Release Notes:
- The git pane has a new **Compare** tab that shows what the current branch would merge into another — the files and commits a pull request from it would carry, diffed from the merge base so the list matches what GitHub shows.