### PR TITLE
Keep the trunk pickable and preselected in the Compare tab

### DIFF
--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -190,14 +190,16 @@ enum GitService {
         /// no answer, so the pane offers no comparison.
         let branch: String?
         /// Remote-tracking refs (`origin/main`), the honest bases: a stale local `main`
-        /// would silently overstate the diff. The branch's own upstream is filtered out —
-        /// comparing a branch with the ref it tracks is not a pull request.
+        /// would silently overstate the diff. The branch's own upstream stays in the list —
+        /// `origin/main` from a checkout of `main` answers "what haven't I pushed", which is
+        /// a comparison worth making, and dropping it left a trunk checkout with no base to
+        /// pick at all.
         let remoteBranches: [String]
         /// Local branches other than the checkout's own.
         let localBranches: [String]
-        /// The base to preselect: the remote's recorded default branch, else the first
-        /// conventional trunk name that exists. `nil` when the checkout *is* the trunk —
-        /// there is nothing to open a pull request against.
+        /// The base to preselect, and the ref the picker lifts to the top of its section:
+        /// the remote's recorded default branch, else the first conventional trunk name
+        /// that exists. `nil` only when neither is there to pick.
         let suggestedBase: String?
     }
 
@@ -245,12 +247,6 @@ enum GitService {
         let head = run(["rev-parse", "--abbrev-ref", "HEAD"], in: repoRoot)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let branch = (head == "HEAD" || head?.isEmpty == true) ? nil : head
-        // The ref this branch tracks, whatever the remote is called. Filtering the literal
-        // `origin/<branch>` instead would leave a fork's `upstream/<branch>` in the list —
-        // offered as a base even though comparing a branch with its own upstream is the
-        // Changes-and-History question ("what haven't I pushed"), not a pull request.
-        let upstream = run(["rev-parse", "--abbrev-ref", "@{upstream}"], in: repoRoot)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
         var locals: [String] = []
         var remotes: [String] = []
         // Full refnames, not `%(refname:short)`: a local `feat/x` and a remote `origin/main`
@@ -258,12 +254,14 @@ enum GitService {
         for ref in (run(["for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes"], in: repoRoot) ?? "")
             .split(separator: "\n").map(String.init) {
             if ref.hasPrefix("refs/heads/") {
+                // The checkout's own branch is the only ref that can't be a base: a branch
+                // compared with itself is always empty.
                 let short = String(ref.dropFirst("refs/heads/".count))
                 if short != branch { locals.append(short) }
             } else if ref.hasPrefix("refs/remotes/") {
                 let short = String(ref.dropFirst("refs/remotes/".count))
                 // `origin/HEAD` is a symbolic pointer at the default branch, not a branch.
-                if !short.hasSuffix("/HEAD"), short != upstream { remotes.append(short) }
+                if !short.hasSuffix("/HEAD") { remotes.append(short) }
             }
         }
         let originHead = run(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], in: repoRoot)?
@@ -282,18 +280,21 @@ enum GitService {
     /// (`origin/HEAD`, what the forge will default the pull request's base to), then the
     /// conventional trunk names — preferring `origin/main` over a local `main`, which in a
     /// long-lived clone is usually months stale and would invent changes the branch never made.
-    /// The branch is never compared against itself, so a checkout of the trunk gets `nil` —
-    /// as does a detached HEAD, which has no branch to open a pull request from.
+    ///
+    /// A checkout of the trunk gets `origin/main` rather than nothing: the comparison then
+    /// reads "what haven't I pushed", which is worth showing, and the tab used to open on a
+    /// dead end — telling the user to pick a base while the trunk was filtered out of the
+    /// menu. Only a local branch is skipped when it *is* the checkout (a branch compared
+    /// with itself is always empty), and a detached HEAD has no branch to compare at all.
     static func suggestedCompareBase(
         branch: String?, originHead: String?,
         remoteBranches: [String], localBranches: [String]
     ) -> String? {
         guard let branch else { return nil }
-        if let originHead, remoteBranches.contains(originHead),
-           remoteBranchName(originHead) != branch { return originHead }
-        for name in trunkBranchNames where name != branch {
+        if let originHead, remoteBranches.contains(originHead) { return originHead }
+        for name in trunkBranchNames {
             if let remote = remoteBranches.first(where: { remoteBranchName($0) == name }) { return remote }
-            if localBranches.contains(name) { return name }
+            if name != branch, localBranches.contains(name) { return name }
         }
         return nil
     }

--- a/Tests/termioTests/GitBranchCompareTests.swift
+++ b/Tests/termioTests/GitBranchCompareTests.swift
@@ -114,18 +114,17 @@ final class GitBranchCompareTests: XCTestCase {
         XCTAssertEqual(context.localBranches, ["main"], "the checkout's own branch is not a base")
     }
 
-    /// A branch's own upstream is not a base to compare with, whatever the remote is
-    /// called — comparing a branch with the ref it tracks answers "what haven't I pushed",
-    /// which is the Changes and History tabs' question.
-    func testTheBranchsOwnUpstreamIsNotOfferedAsABase() async throws {
+    /// Only the checkout's own branch is excluded from the picker. Its upstream stays:
+    /// `origin/main` from a checkout of `main` answers "what haven't I pushed", and
+    /// dropping it left a trunk checkout with nothing at all to pick.
+    func testOnlyTheCheckoutsOwnBranchIsExcludedFromTheBases() async throws {
         let remote = repo.appendingPathExtension("remote.git")
         try FileManager.default.createDirectory(at: remote, withIntermediateDirectories: true)
         try git(["init", "-q", "--bare", remote.path])
         try write("a.txt", "a\n")
         try git(["add", "."])
         try git(["commit", "-qm", "one"])
-        // Deliberately not named `origin`: the filter must follow the configured upstream,
-        // not a hard-coded remote name (a fork's `upstream/…` is the real-world case).
+        // Deliberately not named `origin`, so a hard-coded remote name would show up here.
         try git(["remote", "add", "fork", remote.path])
         try git(["checkout", "-qb", "feat/x"])
         try git(["push", "-q", "-u", "fork", "main", "feat/x"])
@@ -133,9 +132,30 @@ final class GitBranchCompareTests: XCTestCase {
 
         let context = await GitService.compareContext(in: repo.path)
         XCTAssertEqual(context.branch, "feat/x")
-        XCTAssertFalse(context.remoteBranches.contains("fork/feat/x"), "own upstream offered as a base")
-        XCTAssertTrue(context.remoteBranches.contains("fork/main"))
         XCTAssertFalse(context.localBranches.contains("feat/x"), "own branch offered as a base")
+        XCTAssertTrue(context.remoteBranches.contains("fork/main"))
+        XCTAssertTrue(context.remoteBranches.contains("fork/feat/x"),
+                      "the upstream is a legitimate base — it answers what hasn't been pushed")
+    }
+
+    /// A checkout of the trunk opens compared against its own remote. Before the fix both
+    /// the local `main` and its upstream were filtered out, leaving the tab telling the
+    /// user to pick a branch from a menu that contained none.
+    func testTrunkCheckoutComparesAgainstItsRemote() async throws {
+        let remote = repo.appendingPathExtension("remote.git")
+        try FileManager.default.createDirectory(at: remote, withIntermediateDirectories: true)
+        try git(["init", "-q", "--bare", remote.path])
+        try write("a.txt", "a\n")
+        try git(["add", "."])
+        try git(["commit", "-qm", "one"])
+        try git(["remote", "add", "origin", remote.path])
+        try git(["push", "-q", "-u", "origin", "main"])
+        defer { try? FileManager.default.removeItem(at: remote) }
+
+        let context = await GitService.compareContext(in: repo.path)
+        XCTAssertEqual(context.branch, "main")
+        XCTAssertEqual(context.remoteBranches, ["origin/main"])
+        XCTAssertEqual(context.suggestedBase, "origin/main")
     }
 
     // MARK: Base resolution
@@ -163,13 +183,19 @@ final class GitBranchCompareTests: XCTestCase {
             "master")
     }
 
-    func testNoBaseIsSuggestedForTheTrunkItself() {
-        // On `main`, comparing against `origin/main` would answer "what have I not pushed",
-        // which is the History tab's own job — so the pane opens uncompared.
-        XCTAssertNil(
+    func testTheTrunkComparesAgainstItsOwnRemote() {
+        // On `main`, the useful comparison is against `origin/main` — what hasn't been
+        // pushed. Suggesting nothing left the tab on an empty state with no way forward.
+        XCTAssertEqual(
             GitService.suggestedCompareBase(
                 branch: "main", originHead: "origin/main",
-                remoteBranches: ["origin/main"], localBranches: ["main"]))
+                remoteBranches: ["origin/main"], localBranches: []),
+            "origin/main")
+        // A local branch that *is* the checkout stays excluded — that comparison is
+        // always empty — and a detached HEAD has no branch to compare at all.
+        XCTAssertNil(
+            GitService.suggestedCompareBase(
+                branch: "main", originHead: nil, remoteBranches: [], localBranches: []))
         XCTAssertNil(
             GitService.suggestedCompareBase(
                 branch: nil, originHead: nil, remoteBranches: [], localBranches: ["main"]))


### PR DESCRIPTION
Two reports against the Compare tab shipped in #312, both from the same mistake: the base picker filtered out the checkout's own upstream.

On a checkout of `main` that removed the local `main` (its own branch) *and* `origin/main` (its upstream), so the tab asked the user to pick a base from a menu that contained neither — a dead end. Comparing `main` with `origin/main` is a real question, "what haven't I pushed", answered correctly by the same three-dot diff. Only a branch compared with *itself* is always empty, so that is now the only exclusion.

The suggestion follows from the same rule: a trunk checkout preselects `origin/HEAD`'s target rather than nothing. That also fixes the ordering complaint — the picker lifts the suggested base to the top of its section, so in a repo with a hundred remote branches `origin/main` is first instead of buried under every `origin/agent/…`.

Three tests cover it: the trunk checkout's suggestion, the upstream staying in the list (against a remote deliberately not named `origin`), and the ladder's remaining exclusions.

Release Notes:
- Fixed the git pane's Compare tab offering no base branch at all on a checkout of `main`, and burying the default branch in the picker.