### PR TITLE
Budget the VT sidecar and resync a slow client before dropping it

### DIFF
--- a/docs/design/20260805-termiod-hot-path-and-client-classes.md
+++ b/docs/design/20260805-termiod-hot-path-and-client-classes.md
@@ -3,7 +3,7 @@ title: Hot path, attach join point, and client classes
 status: draft
 type: design
 created: 2026-08-05
-updated: 2026-08-13
+updated: 2026-08-16
 related:
   - 20260730-termiod-session-protocol.md
   - 20260805-termiod-device-architecture.md
@@ -58,7 +58,9 @@ details nobody wrote down:
    `session.rs:1064`). Refusing to block byte delivery on the VT parse means a
    slow parse now accumulates *the whole PTY output* in a queue instead. It is
    the same bug as risk #10, one hop upstream, and it is not written anywhere
-   (D4).
+   (D4). **Closed 2026-08-16** by `SidecarQueue`: the channel stays unbounded and
+   fire-and-forget, and a byte budget beside it decides when to stop feeding the
+   VT. The degrade is `vt_stale`, never a dropped byte — in either direction.
 
 Everything else in this doc is naming, policy wording, and PR sequencing.
 
@@ -346,7 +348,7 @@ break.
 | **D1** | §C.5 | Add invariant **JOIN** (§D.2) with its three corollaries, replacing the prose "resync: … one `S` snapshot". Explicitly: the PTY is never paused; the sidecar FIFO is the ordering authority; no wire `seq` | **Landed 2026-08-12** |
 | **D2** | §C.6 | The `S` payload **includes its own prologue** and must be state-independent on apply. Clients MUST NOT prepend their own reset. Frame order after `attached` is fixed: `S` → `ready` → `H`* interleavable with `D` | **Landed 2026-08-13** (prologue in `format_vt`; the reference client and the Mac client apply raw) |
 | **D3** | §C.6 | Replace the stage table's "who parses VT" column with the **client-class profiles** of §D.3. Stages describe the host's capability; classes describe what a client negotiates | Doc restructure |
-| **D4** | §F #10 | Mark risk #10 **closed** (4 MiB `CLIENT_BACKLOG_CAP`, shipped) and open its two residuals: (a) the degrade should be **forced resync** (`S` + `ready` + `E{ev:"resynced", reason:"backlog"}`), dropping only on a second strike; (b) the **sidecar command queue is unbounded** — give it its own budget whose only legal degrade is `vt_stale` (refuse snapshots, fall back to ring replay, emit an event), never dropping bytes to the VT | New risk + wire event |
+| **D4** | §F #10 | Mark risk #10 **closed** (4 MiB `CLIENT_BACKLOG_CAP`, shipped) and both residuals closed too: (a) the degrade is **forced resync** — `S` + `ready` + `E{ev:"resynced", reason}`, dropping only on a second strike; (b) the sidecar command queue carries a 16 MiB budget whose only legal degrade is `E{ev:"vt_stale", reason}` (refuse snapshots, fall back to ring replay), never dropping bytes to the VT and never dropping a byte owed to a client | **Landed 2026-08-16** |
 | **D5** | §C.4, §C.5 | `attach` gains `claim:"newest"|"polite"` (default `newest`, i.e. today's behaviour). `polite` returns `error{code:"busy"}` when a live writer exists. Supersedes the sticky-writer idea | Additive control field |
 | **D6** | §C.6 | Normative: `grid_diff` MUST NOT be selected by transport class; legal selection signals enumerated (§D.4). Lead with the capability argument, cite the 8.6× second | Wording, normative |
 | **D7** | §C.10 + §C.6 | State the shared mechanism once — *durable object + monotonic cursor + bounded ring + explicit gap signal* — and keep the two words distinct: **`gap`** = your baseline is unusable, resync; **tombstone** = this session is dead and here is why (`tombstone.rs`). The terminal plane adopts `gap`, not the word "tombstone" | Vocabulary |
@@ -372,11 +374,13 @@ transport table, §D.1's QUIC binding, §H's rejection list.
    One consequence worth stating: the prologue leaves the alternate screen
    unconditionally, so the payload owes the re-entry, which the formatter already
    emits and the test now pins in both directions.
-2. **What should a wedged client cost a healthy one?** Today a slow client is
-   dropped at 4 MiB. Forced resync is friendlier and unbounded in the pathological
-   case (a client that cannot keep up will fail resync repeatedly). Drop, resync,
-   or freeze-and-notify is a UX call: a phone in a tunnel should not be able to
-   degrade the Mac the user is typing on, and it also should not silently vanish.
+2. ~~**What should a wedged client cost a healthy one?**~~ **Answered 2026-08-16
+   by PR 5: resync once, then drop.** The pathological case is bounded by never
+   forgiving a strike — the resync zeroes what the client owes, so a second
+   overflow proves it cannot keep up even from a clean start. What the resync
+   discards is the point of it: retiring the queued megabytes is what lets a
+   phone coming out of a tunnel rejoin at a screen instead of replaying a flood.
+   The residual is D10, unchanged: the resynced client's scrollback is a hole.
 3. **Do we speak Superlogical's protocol if it ships as open?** Described as
    *"predominantly part of libghostty"* and an *open protocol* (**Announced**).
    If both ends are libghostty anyway, a shared wire is plausible — and would
@@ -391,7 +395,16 @@ transport table, §D.1's QUIC binding, §H's rejection list.
    it means the host renders — a deliberate, scoped exception to the presentation
    boundary. Not building it means the CLI is a debugging tool, not a product
    surface.
-6. **Should `polite` be the default for the Mac app?** Newest-claim-wins means
+6. **Can a stale VT ever recover?** Today it cannot: once the sidecar budget
+   bites, that session answers snapshots from the ring for the rest of its life,
+   which for an agent session is days. The tempting fix — reset the VT and
+   re-seed it from the 128 KiB ring once the queue drains — is refused here
+   because it would make `S` silently approximate: the payload would claim a
+   boundary it does not describe, which is exactly the failure invariant JOIN
+   exists to prevent. An honest recovery needs a *marked* baseline (`gap:true`
+   on the snapshot, §D7's vocabulary), not a quiet reseed.
+
+7. **Should `polite` be the default for the Mac app?** Newest-claim-wins means
    glancing at a session on the phone silently demotes the Mac. That is correct
    for a single user with two devices *if* the demotion is visible; it is wrong
    the moment sharing exists (§F #3 of the protocol doc).
@@ -410,8 +423,8 @@ current correctness *provable*.
 | 2 | **Test: attach during a flood** — **landed 2026-08-12** (`termiod/tests/join_invariant.rs`) | A second client attaches mid-flood of a monotonic counter; the `S` payload is replayed through a VT and the sequence must run unbroken from the last complete line on that screen into the first line of the buffered stream, with the early client's delivery untouched. Proven to bite by dropping one buffered chunk in `finish_snapshot`: "the snapshot ends at 55861 but the stream resumes at 55868". **The flood must be unbroken** — a paced one lets the attach land in a gap, where an empty buffer hides a broken barrier and the test passes vacuously | 1 |
 | 3 | **Test: snapshot applied to a dirty screen** — **landed 2026-08-13** (`termiod/tests/snapshot_prologue.rs`) | One case per state a client can be carrying when `S` arrives; each applies the payload after that state and diffs against a fresh terminal. It failed on five of nine before PR 4 — stale content showing through, alt-screen kept, origin mode re-basing the cursor addressing, a shifted charset turning the text into line-drawing glyphs, a pending SGR colouring the first row. Insert mode, autowrap-off and a scrolling region passed only because the fixture's content was short enough not to expose them; reverse video is a render-time flip the cell snapshot cannot see at all | 1 |
 | 4 | **Host-owned snapshot prologue** — **landed 2026-08-13** | D2. `SNAPSHOT_PROLOGUE` prepended in `VtTerminal::format_vt`; `render_snapshot` and `TermiodSnapshot.render` stop synthesising a prelude and apply raw. Old clients that still prepend a reset stay correct (idempotent). The Mac's prelude was asymmetric in the same way the formatter is — it entered the alternate screen but never left it, so a primary-screen snapshot repainted onto the alt buffer | 3 |
-| 5 | **Backlog degrade: resync before drop** | D4(a). Reuse `begin_snapshot_barrier` for one client; add `E{ev:"resynced", reason}`; drop on second strike. Decide D10 here or defer explicitly | 2 |
-| 6 | **Sidecar queue budget** | D4(b). Bound the `SidecarCommand` channel by bytes; on exhaustion mark the VT stale, refuse snapshots (existing `fallback_snapshot` path), emit an event. Never drop bytes to the VT | 2 |
+| 5 | **Backlog degrade: resync before drop** — **landed 2026-08-16** | D4(a). `force_resync` retires the client's queued payloads by bumping a backlog *epoch* — the socket writer drops anything reserved under an older one — then takes a fresh snapshot barrier for that client alone and follows `S`/`ready` with `E{ev:"resynced"}`. Second strike drops. D10 is **deferred**: `H` is still attach-only, so a resynced client's scrollback is a hole it cannot see | 2 |
+| 6 | **Sidecar queue budget** — **landed 2026-08-16** | D4(b). `SidecarQueue` charges every `Write` and credits it back when the VT has parsed it. At 16 MiB the session stops feeding the VT, marks it stale, emits `E{ev:"vt_stale"}`, disconnects Mirrors, and fails every pending and future snapshot into `fallback_snapshot`. `fan_out` is untouched, so no client loses a byte. **Stale is sticky** — see §F #7 | 2 |
 | 7 | **Client conformance suite** | D3, D8. Replica and Mirror profiles; skew matrix; assert clients parse at authoritative dims and honour `Resized`/`WriterChanged` | 1 |
 | 8 | **`claim:"polite"`** | D5. Additive `attach` field, `busy` error, Mac wiring (attach as observer with a visible badge instead of stealing) | 7 |
 | 9 | **`G` policy wording + selection signals** | D6. Wording, plus removing any client-side "remote ⇒ `grid_diff`" heuristic if one has crept in | 7 |

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -11,7 +11,7 @@ use crate::protocol::{
 };
 use crate::resource::Registry;
 use crate::session::{
-    self, ClientBacklog, ClientEvent, ClientId, SessionEnded, SessionHandle, SessionMsg,
+    self, ClientBacklog, ClientEvent, ClientId, Metered, SessionEnded, SessionHandle, SessionMsg,
 };
 use crate::tombstone::{EndReason, Graveyard};
 use anyhow::{Context, Result};
@@ -401,11 +401,11 @@ struct Connection {
 
 enum Outbound {
     Control(Control),
-    Data(Bytes),
+    Data(Metered),
     Event(Event),
     Snapshot(Snapshot),
-    History(Bytes),
-    Grid(Bytes),
+    History(Metered),
+    Grid(Metered),
     File(Bytes),
 }
 
@@ -415,26 +415,33 @@ async fn write_outbound(
     backlog: Arc<ClientBacklog>,
 ) {
     while let Some(message) = rx.recv().await {
+        // A forced resync retires everything queued under the old epoch. Those
+        // payloads precede a snapshot that supersedes them, so writing them
+        // would only make the client that could not keep up wait longer.
+        if let Outbound::Data(payload) | Outbound::History(payload) | Outbound::Grid(payload) =
+            &message
+        {
+            if !backlog.is_current(payload) {
+                continue;
+            }
+        }
         let result = match message {
             Outbound::Control(control) => write_control(&mut wr, &control).await,
-            Outbound::Data(data) => {
-                let len = data.len();
-                let result = write_data(&mut wr, &data).await;
-                backlog.release(len);
+            Outbound::Data(payload) => {
+                let result = write_data(&mut wr, &payload.bytes).await;
+                backlog.release(&payload);
                 result
             }
             Outbound::Event(event) => write_event(&mut wr, &event).await,
             Outbound::Snapshot(snapshot) => write_snapshot(&mut wr, &snapshot).await,
             Outbound::History(payload) => {
-                let len = payload.len();
-                let result = write_history_payload(&mut wr, &payload).await;
-                backlog.release(len);
+                let result = write_history_payload(&mut wr, &payload.bytes).await;
+                backlog.release(&payload);
                 result
             }
             Outbound::Grid(payload) => {
-                let len = payload.len();
-                let result = write_grid_payload(&mut wr, &payload).await;
-                backlog.release(len);
+                let result = write_grid_payload(&mut wr, &payload.bytes).await;
+                backlog.release(&payload);
                 result
             }
             Outbound::File(payload) => write_file_payload(&mut wr, &payload).await,
@@ -1547,6 +1554,10 @@ fn subscribed_to(subscriptions: &HashSet<String>, event: &Event) -> bool {
         }
         Event::Resized { .. } => false,
         Event::Ready { .. } => false,
+        // Both are addressed to one attachment's stream, not to the roster: a
+        // resync is that client's own, and a stale VT only means anything to a
+        // client that was going to ask for a snapshot.
+        Event::Resynced { .. } | Event::VtStale { .. } => false,
         // Resource events are delivered on the subscriber's own channel, not
         // through the roster broadcast, so they never match here.
         Event::FsChanged { .. } | Event::GitChanged { .. } | Event::SearchResults { .. } => false,
@@ -1616,10 +1627,9 @@ async fn run_attach(
     let mut bridge = tokio::spawn(async move {
         while let Some(event) = client_events.recv().await {
             match event {
-                ClientEvent::Data(bytes) => {
-                    let len = bytes.len();
-                    if event_out.send(Outbound::Data(bytes)).is_err() {
-                        bridge_backlog.release(len);
+                ClientEvent::Data(payload) => {
+                    if event_out.send(Outbound::Data(payload.clone())).is_err() {
+                        bridge_backlog.release(&payload);
                         break;
                     }
                 }
@@ -1630,21 +1640,19 @@ async fn run_attach(
                 }
                 ClientEvent::Snapshot(_) => {}
                 ClientEvent::History(payload) if supports_scrollback => {
-                    let len = payload.len();
-                    if event_out.send(Outbound::History(payload)).is_err() {
-                        bridge_backlog.release(len);
+                    if event_out.send(Outbound::History(payload.clone())).is_err() {
+                        bridge_backlog.release(&payload);
                         break;
                     }
                 }
-                ClientEvent::History(payload) => bridge_backlog.release(payload.len()),
+                ClientEvent::History(payload) => bridge_backlog.release(&payload),
                 ClientEvent::Grid(payload) if supports_grid_diff => {
-                    let len = payload.len();
-                    if event_out.send(Outbound::Grid(payload)).is_err() {
-                        bridge_backlog.release(len);
+                    if event_out.send(Outbound::Grid(payload.clone())).is_err() {
+                        bridge_backlog.release(&payload);
                         break;
                     }
                 }
-                ClientEvent::Grid(payload) => bridge_backlog.release(payload.len()),
+                ClientEvent::Grid(payload) => bridge_backlog.release(&payload),
                 ClientEvent::Control(control) if negotiated => {
                     if event_out.send(Outbound::Control(control)).is_err() {
                         break;

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -730,6 +730,21 @@ pub enum Event {
         session: String,
         status: i32,
     },
+    /// This attachment's stream was cut and restarted at a fresh boundary. It
+    /// arrives after the `S`/`ready` pair that re-establishes JOIN, and it means
+    /// the bytes between the previous boundary and this one were never
+    /// delivered — the screen is right, but nothing scrolled past is recoverable.
+    Resynced {
+        session: String,
+        reason: String,
+    },
+    /// The host's VT no longer describes any boundary in this session's output,
+    /// so it can no longer answer a snapshot. Attach and resync fall back to
+    /// ring replay, which can open mid-escape.
+    VtStale {
+        session: String,
+        reason: String,
+    },
     /// A filesystem batch for an `fs:` resource (§C.10). `seq` is monotonic per
     /// resource and is what a reconnecting client passes back as `since`.
     /// `full_rescan` means the path set is not authoritative — re-walk what is

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -11,7 +11,7 @@ use crate::pty::Pty;
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::Arc;
 use std::thread::JoinHandle;
@@ -23,12 +23,29 @@ pub type ClientId = String;
 const RING_CAP: usize = 128 * 1024;
 const READ_CHUNK: usize = 64 * 1024;
 const CLIENT_BACKLOG_CAP: usize = 4 * 1024 * 1024;
+/// PTY bytes allowed to sit unparsed in the VT sidecar's command FIFO. The
+/// per-client budget stopped a slow socket from buying unbounded memory; this
+/// stops a slow *parse* from doing the same one hop upstream.
+const SIDECAR_QUEUE_CAP: usize = 16 * 1024 * 1024;
 pub const SCROLLBACK_STAGE_MAX_BYTES: usize = 1024 * 1024;
 pub const KEYFRAME_EVERY_FRAMES: u32 = 256;
+
+/// A payload admitted against a client's backlog. The epoch pins it to the
+/// reservation that let it through, so a forced resync can discard everything
+/// already queued for that client without corrupting the count.
+#[derive(Clone)]
+pub struct Metered {
+    pub bytes: Bytes,
+    epoch: u64,
+}
 
 /// Counts PTY bytes queued anywhere between a session and its socket writer.
 pub(crate) struct ClientBacklog {
     outstanding: AtomicUsize,
+    /// Bumped by a forced resync. Everything reserved under an older epoch is
+    /// stale: it precedes a snapshot that supersedes it, so it is dropped
+    /// undelivered and never released.
+    epoch: AtomicU64,
     dropped: AtomicBool,
 }
 
@@ -36,23 +53,53 @@ impl ClientBacklog {
     pub(crate) fn new() -> Self {
         Self {
             outstanding: AtomicUsize::new(0),
+            epoch: AtomicU64::new(0),
             dropped: AtomicBool::new(false),
         }
     }
 
-    fn try_reserve(&self, bytes: usize) -> bool {
+    fn reserve(&self, bytes: Bytes) -> Option<Metered> {
         self.outstanding
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
                 outstanding
-                    .checked_add(bytes)
+                    .checked_add(bytes.len())
                     .filter(|total| *total <= CLIENT_BACKLOG_CAP)
             })
-            .is_ok()
+            .ok()?;
+        Some(Metered {
+            bytes,
+            epoch: self.epoch.load(Ordering::Acquire),
+        })
     }
 
-    pub(crate) fn release(&self, bytes: usize) {
-        let previous = self.outstanding.fetch_sub(bytes, Ordering::Relaxed);
-        debug_assert!(previous >= bytes);
+    /// True once the client has consumed everything the session handed it.
+    #[cfg(test)]
+    fn is_drained(&self) -> bool {
+        self.outstanding.load(Ordering::Relaxed) == 0
+    }
+
+    /// Discard everything already queued for this client and start a new epoch.
+    /// The queued payloads are dropped where they sit rather than released, so
+    /// the counter is reset here instead of unwound.
+    fn begin_resync(&self) {
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        self.outstanding.store(0, Ordering::Release);
+    }
+
+    /// True while this payload still belongs to the client's current stream.
+    pub(crate) fn is_current(&self, payload: &Metered) -> bool {
+        payload.epoch == self.epoch.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn release(&self, payload: &Metered) {
+        if !self.is_current(payload) {
+            return;
+        }
+        let _ =
+            self.outstanding
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
+                    Some(outstanding.saturating_sub(payload.bytes.len()))
+                });
     }
 
     fn mark_dropped(&self) {
@@ -64,13 +111,44 @@ impl ClientBacklog {
     }
 }
 
+/// Counts PTY bytes queued for the VT sidecar but not yet parsed.
+struct SidecarQueue {
+    outstanding: AtomicUsize,
+}
+
+impl SidecarQueue {
+    fn new() -> Self {
+        Self {
+            outstanding: AtomicUsize::new(0),
+        }
+    }
+
+    fn try_reserve(&self, bytes: usize) -> bool {
+        self.outstanding
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
+                outstanding
+                    .checked_add(bytes)
+                    .filter(|total| *total <= SIDECAR_QUEUE_CAP)
+            })
+            .is_ok()
+    }
+
+    fn release(&self, bytes: usize) {
+        let _ =
+            self.outstanding
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
+                    Some(outstanding.saturating_sub(bytes))
+                });
+    }
+}
+
 /// Pushed to an attached connection task.
 #[derive(Clone)]
 pub enum ClientEvent {
-    Data(Bytes),
+    Data(Metered),
     Snapshot(Snapshot),
-    History(Bytes),
-    Grid(Bytes),
+    History(Metered),
+    Grid(Metered),
     Control(Control),
     Event(Event),
     Exited(i32),
@@ -158,13 +236,18 @@ struct ClientEntry {
     /// Attach-only history staging. Resize barriers discard any remainder and
     /// deliberately do not restage it; resize/reflow history is a later policy.
     staged_history: VecDeque<Bytes>,
+    /// Backlog strikes taken by this attachment. The first buys a forced
+    /// resync; the second is the drop. Strikes are never forgiven — the resync
+    /// already zeroed the count of what the client owes, so a second overflow
+    /// means it could not keep up even from a clean start.
+    backlog_strikes: u32,
 }
 
 enum ClientDelivery {
     Live,
     SnapshotPending {
         request_id: u64,
-        data: VecDeque<Bytes>,
+        data: VecDeque<Metered>,
         deferred: VecDeque<ClientEvent>,
     },
 }
@@ -228,6 +311,11 @@ struct Session {
     ring_bytes: usize,
     events: broadcast::Sender<Event>,
     sidecar_tx: Option<std_mpsc::Sender<SidecarCommand>>,
+    sidecar_queue: Arc<SidecarQueue>,
+    /// Set once the VT has been denied bytes it needed. The screen it holds no
+    /// longer describes any boundary in the output stream, so it can never
+    /// answer a snapshot again — attach and resync fall back to ring replay.
+    vt_stale: Option<String>,
 }
 
 impl Session {
@@ -287,6 +375,73 @@ impl Session {
         sent
     }
 
+    /// The one path that puts PTY bytes into the VT. It is budgeted, and the
+    /// only legal degrade is to stop feeding the VT and say so — dropping bytes
+    /// silently would leave `S` describing a screen that never occurred, and
+    /// blocking here would put the VT parse back on the fan-out path.
+    fn write_sidecar(&mut self, chunk: Bytes) {
+        if self.vt_stale.is_some() || self.sidecar_tx.is_none() {
+            return;
+        }
+        if !self.sidecar_queue.try_reserve(chunk.len()) {
+            self.mark_vt_stale(format!(
+                "VT sidecar fell more than {} MiB behind the PTY",
+                SIDECAR_QUEUE_CAP / (1024 * 1024)
+            ));
+            return;
+        }
+        let len = chunk.len();
+        if !self.send_sidecar(SidecarCommand::Write(chunk)) {
+            self.sidecar_queue.release(len);
+        }
+    }
+
+    fn mark_vt_stale(&mut self, reason: String) {
+        if self.vt_stale.is_some() {
+            return;
+        }
+        eprintln!(
+            "termiod: VT sidecar for session {} is stale: {reason}; snapshots now fall back to ring replay",
+            self.id
+        );
+        self.vt_stale = Some(reason.clone());
+        // Nothing more will reach the VT, so drain what is queued rather than
+        // let a wedged parse hold the memory.
+        self.send_sidecar(SidecarCommand::Shutdown);
+        self.sidecar_tx.take();
+        self.emit_event(Event::VtStale {
+            session: self.id.clone(),
+            reason: reason.clone(),
+        });
+        self.disconnect_grid_clients(&reason);
+        self.fallback_all_pending(&reason);
+    }
+
+    /// Ask the sidecar for one client's snapshot, or fail it straight into the
+    /// ring-replay fallback when the VT can no longer answer.
+    fn request_snapshot(&mut self, client_id: ClientId, request_id: u64, scrollback: bool) {
+        let refusal = self.vt_stale.clone().or_else(|| {
+            self.sidecar_tx
+                .is_none()
+                .then(|| "VT sidecar is unavailable".to_string())
+        });
+        if let Some(reason) = refusal {
+            self.finish_snapshot(&client_id, request_id, Err(reason));
+            return;
+        }
+        if !self.send_sidecar(SidecarCommand::Snapshot {
+            client_id: client_id.clone(),
+            request_id,
+            scrollback,
+        }) {
+            self.finish_snapshot(
+                &client_id,
+                request_id,
+                Err("VT sidecar is unavailable".to_string()),
+            );
+        }
+    }
+
     fn wants_grid_diffs(&self) -> bool {
         self.clients.values().any(|entry| entry.grid_diff)
     }
@@ -336,18 +491,45 @@ impl Session {
         // these requests are adjacent to the Resize command in the sidecar
         // FIFO, with no intervening Write command.
         for (client_id, request_id) in requests {
-            if !self.send_sidecar(SidecarCommand::Snapshot {
-                client_id: client_id.clone(),
-                request_id,
-                scrollback: false,
-            }) {
-                let _ = self.finish_snapshot(
-                    &client_id,
-                    request_id,
-                    Err("VT sidecar is unavailable".to_string()),
-                );
-            }
+            self.request_snapshot(client_id, request_id, false);
         }
+    }
+
+    /// D4(a): a client that outruns its backlog gets one forced resync before it
+    /// gets dropped. Everything already queued for it is discarded — that is the
+    /// point, since replaying megabytes to a client that could not keep up is
+    /// what put it here — and the snapshot that follows re-establishes JOIN at a
+    /// fresh boundary. No other client is touched.
+    fn force_resync(&mut self, client_id: &ClientId, reason: &str) {
+        let request_id = self.allocate_snapshot_request();
+        let session_id = self.id.clone();
+        let Some(entry) = self.clients.get_mut(client_id) else {
+            return;
+        };
+        entry.backlog_strikes += 1;
+        entry.staged_history.clear();
+        entry.backlog.begin_resync();
+        let previous = std::mem::replace(&mut entry.delivery, ClientDelivery::Live);
+        let mut deferred = match previous {
+            ClientDelivery::Live => VecDeque::new(),
+            // The buffered data was reserved under the epoch just retired, so it
+            // is dropped with the rest rather than replayed past the new `S`.
+            ClientDelivery::SnapshotPending { deferred, .. } => deferred,
+        };
+        deferred.push_back(ClientEvent::Event(Event::Resynced {
+            session: session_id,
+            reason: reason.to_string(),
+        }));
+        entry.delivery = ClientDelivery::SnapshotPending {
+            request_id,
+            data: VecDeque::new(),
+            deferred,
+        };
+        eprintln!(
+            "termiod: resyncing client {client_id} on session {}: {reason}",
+            self.id
+        );
+        self.request_snapshot(client_id.clone(), request_id, false);
     }
 
     fn queue_non_data(entry: &mut ClientEntry, event: ClientEvent) -> bool {
@@ -418,6 +600,7 @@ impl Session {
     /// Fan PTY output out to every attached client; drop dead ones.
     fn fan_out(&mut self, data: Bytes) {
         self.push_ring(data.clone());
+        let mut resync = Vec::new();
         let dead = self
             .clients
             .iter_mut()
@@ -428,30 +611,43 @@ impl Session {
                 if entry.grid_diff {
                     return None;
                 }
-                if !entry.backlog.try_reserve(data.len()) {
+                let Some(payload) = entry.backlog.reserve(data.clone()) else {
+                    if entry.backlog_strikes == 0 && entry.snapshot_capable {
+                        resync.push(id.clone());
+                        return None;
+                    }
                     entry.backlog.mark_dropped();
                     eprintln!(
-                        "termiod: dropping slow client {id} from session {}: output backlog exceeded {} MiB",
+                        "termiod: dropping slow client {id} from session {}: output backlog exceeded {} MiB again",
                         self.id,
                         CLIENT_BACKLOG_CAP / (1024 * 1024)
                     );
                     return Some(id.clone());
-                }
+                };
                 match &mut entry.delivery {
                     ClientDelivery::Live => {
-                        if entry.out.send(ClientEvent::Data(data.clone())).is_err() {
-                            entry.backlog.release(data.len());
+                        if entry.out.send(ClientEvent::Data(payload.clone())).is_err() {
+                            entry.backlog.release(&payload);
                             return Some(id.clone());
                         }
                     }
                     ClientDelivery::SnapshotPending { data: buffered, .. } => {
-                        buffered.push_back(data.clone());
+                        buffered.push_back(payload);
                     }
                 }
                 None
             })
             .collect();
         self.remove_dead(dead);
+        for client_id in resync {
+            self.force_resync(
+                &client_id,
+                &format!(
+                    "output backlog exceeded {} MiB",
+                    CLIENT_BACKLOG_CAP / (1024 * 1024)
+                ),
+            );
+        }
     }
 
     fn fan_out_grid(&mut self, grid: GridDiff) {
@@ -476,7 +672,7 @@ impl Session {
                     // client's S boundary, so the S supersedes it.
                     return None;
                 }
-                if !entry.backlog.try_reserve(payload.len()) {
+                let Some(metered) = entry.backlog.reserve(payload.clone()) else {
                     entry.backlog.mark_dropped();
                     eprintln!(
                         "termiod: dropping slow grid-diff client {id} from session {}: output backlog exceeded {} MiB",
@@ -484,9 +680,9 @@ impl Session {
                         CLIENT_BACKLOG_CAP / (1024 * 1024)
                     );
                     return Some(id.clone());
-                }
-                if entry.out.send(ClientEvent::Grid(payload.clone())).is_err() {
-                    entry.backlog.release(payload.len());
+                };
+                if entry.out.send(ClientEvent::Grid(metered.clone())).is_err() {
+                    entry.backlog.release(&metered);
                     return Some(id.clone());
                 }
                 None
@@ -536,21 +732,21 @@ impl Session {
         let Some(payload) = entry.staged_history.front() else {
             return Ok(false);
         };
-        if !entry.backlog.try_reserve(payload.len()) {
+        let Some(metered) = entry.backlog.reserve(payload.clone()) else {
             entry.backlog.mark_dropped();
             eprintln!(
                 "termiod: dropping slow client {client_id} from session {session_id}: scrollback backlog exceeded {} MiB",
                 CLIENT_BACKLOG_CAP / (1024 * 1024)
             );
             return Err(());
-        }
-        let payload = entry
-            .staged_history
-            .pop_front()
-            .expect("history payload disappeared after reservation");
-        let len = payload.len();
-        if entry.out.send(ClientEvent::History(payload)).is_err() {
-            entry.backlog.release(len);
+        };
+        entry.staged_history.pop_front();
+        if entry
+            .out
+            .send(ClientEvent::History(metered.clone()))
+            .is_err()
+        {
+            entry.backlog.release(&metered);
             return Err(());
         }
         Ok(!entry.staged_history.is_empty())
@@ -681,10 +877,9 @@ impl Session {
                 return false;
             }
         };
-        while let Some(bytes) = data.pop_front() {
-            let len = bytes.len();
-            if entry.out.send(ClientEvent::Data(bytes)).is_err() {
-                entry.backlog.release(len);
+        while let Some(payload) = data.pop_front() {
+            if entry.out.send(ClientEvent::Data(payload.clone())).is_err() {
+                entry.backlog.release(&payload);
                 release_buffered(&entry.backlog, data);
                 self.remove_finished_client(client_id);
                 return false;
@@ -792,7 +987,7 @@ impl Session {
         &mut self,
         client_id: &str,
         entry: ClientEntry,
-        buffered: VecDeque<Bytes>,
+        buffered: VecDeque<Metered>,
         deferred: VecDeque<ClientEvent>,
         error: &str,
     ) {
@@ -803,13 +998,13 @@ impl Session {
         release_buffered(&entry.backlog, buffered);
 
         for replay in &self.ring {
-            if !entry.backlog.try_reserve(replay.len()) {
+            let Some(metered) = entry.backlog.reserve(replay.clone()) else {
                 entry.backlog.mark_dropped();
                 self.remove_finished_client(client_id);
                 return;
-            }
-            if entry.out.send(ClientEvent::Data(replay.clone())).is_err() {
-                entry.backlog.release(replay.len());
+            };
+            if entry.out.send(ClientEvent::Data(metered.clone())).is_err() {
+                entry.backlog.release(&metered);
                 self.remove_finished_client(client_id);
                 return;
             }
@@ -956,9 +1151,9 @@ fn should_emit_keyframe(frame_seq: u32, every: u32) -> bool {
     every > 0 && frame_seq.is_multiple_of(every)
 }
 
-fn release_buffered(backlog: &ClientBacklog, data: VecDeque<Bytes>) {
-    for bytes in data {
-        backlog.release(bytes.len());
+fn release_buffered(backlog: &ClientBacklog, data: VecDeque<Metered>) {
+    for payload in data {
+        backlog.release(&payload);
     }
 }
 
@@ -1001,7 +1196,7 @@ pub fn spawn(
         }
     });
 
-    let (sidecar_tx, sidecar_snapshots, sidecar_thread) = spawn_sidecar(rows, cols)?;
+    let sidecar = spawn_sidecar(rows, cols)?;
 
     let (tx, rx) = mpsc::unbounded_channel();
     let session = Session {
@@ -1025,7 +1220,9 @@ pub fn spawn(
         ring: VecDeque::new(),
         ring_bytes: 0,
         events,
-        sidecar_tx: Some(sidecar_tx),
+        sidecar_tx: Some(sidecar.commands),
+        sidecar_queue: sidecar.queue,
+        vt_stale: None,
     };
 
     let waiter = tokio::task::spawn_blocking(move || {
@@ -1044,25 +1241,29 @@ pub fn spawn(
         rx,
         waiter,
         on_exit,
-        sidecar_snapshots,
-        sidecar_thread,
+        sidecar.results,
+        sidecar.thread,
     ));
     Ok(SessionHandle { id, tx })
 }
 
-fn spawn_sidecar(
-    rows: u16,
-    cols: u16,
-) -> anyhow::Result<(
-    std_mpsc::Sender<SidecarCommand>,
-    mpsc::UnboundedReceiver<SidecarResult>,
-    JoinHandle<()>,
-)> {
-    // Deliberately unbounded and fire-and-forget: PTY delivery must never wait
-    // for VT parsing. The consumer drains adjacent Bytes writes in batches.
-    // Only opt-in grid-diff clients depend on this consumer's progress.
+struct Sidecar {
+    commands: std_mpsc::Sender<SidecarCommand>,
+    results: mpsc::UnboundedReceiver<SidecarResult>,
+    queue: Arc<SidecarQueue>,
+    thread: JoinHandle<()>,
+}
+
+fn spawn_sidecar(rows: u16, cols: u16) -> anyhow::Result<Sidecar> {
+    // The channel itself stays unbounded and fire-and-forget — PTY delivery must
+    // never wait for VT parsing. `SidecarQueue` is the budget instead: the
+    // producer stops feeding the VT and declares it stale rather than blocking
+    // or letting a slow parse buy unbounded memory. The consumer drains
+    // adjacent Bytes writes in batches.
     let (command_tx, command_rx) = std_mpsc::channel::<SidecarCommand>();
     let (result_tx, result_rx) = mpsc::unbounded_channel::<SidecarResult>();
+    let queue = Arc::new(SidecarQueue::new());
+    let parsed = queue.clone();
     let thread = std::thread::Builder::new()
         .name("termiod-vt".to_string())
         .spawn(move || {
@@ -1094,12 +1295,14 @@ fn spawn_sidecar(
                         if let Some(terminal) = terminal.as_mut() {
                             terminal.vt_write(&bytes);
                         }
+                        parsed.release(bytes.len());
                         loop {
                             match command_rx.try_recv() {
                                 Ok(SidecarCommand::Write(bytes)) => {
                                     if let Some(terminal) = terminal.as_mut() {
                                         terminal.vt_write(&bytes);
                                     }
+                                    parsed.release(bytes.len());
                                 }
                                 Ok(command) => {
                                     pending = Some(command);
@@ -1195,7 +1398,12 @@ fn spawn_sidecar(
             }
         })
         .map_err(|error| anyhow::anyhow!("spawning VT sidecar thread: {error}"))?;
-    Ok((command_tx, result_rx, thread))
+    Ok(Sidecar {
+        commands: command_tx,
+        results: result_rx,
+        queue,
+        thread,
+    })
 }
 
 async fn run(
@@ -1256,8 +1464,9 @@ async fn run(
                     Ok(n) => {
                         let chunk = Bytes::copy_from_slice(&buf[..n]);
                         // This refcount clone + unbounded send is strictly
-                        // fire-and-forget. Fan-out never waits for VT parsing.
-                        session.send_sidecar(SidecarCommand::Write(chunk.clone()));
+                        // fire-and-forget. Fan-out never waits for VT parsing,
+                        // and it runs even when the VT has gone stale.
+                        session.write_sidecar(chunk.clone());
                         session.fan_out(chunk);
                     }
                     // Linux delivers EIO when the slave side closes.
@@ -1319,10 +1528,11 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> bool {
 
             if !snapshot {
                 for replay in &session.ring {
-                    if backlog.try_reserve(replay.len())
-                        && out.send(ClientEvent::Data(replay.clone())).is_err()
-                    {
-                        backlog.release(replay.len());
+                    let Some(metered) = backlog.reserve(replay.clone()) else {
+                        break;
+                    };
+                    if out.send(ClientEvent::Data(metered.clone())).is_err() {
+                        backlog.release(&metered);
                         break;
                     }
                 }
@@ -1346,6 +1556,7 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> bool {
                         ClientDelivery::Live
                     },
                     staged_history: VecDeque::new(),
+                    backlog_strikes: 0,
                 },
             );
             // Enabling precedes this client's in-band Snapshot request, so
@@ -1362,17 +1573,7 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> bool {
             });
 
             if let Some(request_id) = snapshot_request {
-                if !session.send_sidecar(SidecarCommand::Snapshot {
-                    client_id: id.clone(),
-                    request_id,
-                    scrollback,
-                }) {
-                    let _ = session.finish_snapshot(
-                        &id,
-                        request_id,
-                        Err("VT sidecar is unavailable".to_string()),
-                    );
-                }
+                session.request_snapshot(id.clone(), request_id, scrollback);
             }
 
             if session.writer != old_writer {
@@ -1455,27 +1656,79 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> bool {
 mod tests {
     use super::{
         handle_msg, scrollback_row_limit, should_emit_keyframe, spawn_sidecar, ClientBacklog,
-        ClientDelivery, ClientEntry, ClientEvent, Session, SessionMsg, SidecarCommand,
-        SidecarResult, CLIENT_BACKLOG_CAP, SCROLLBACK_STAGE_MAX_BYTES, SNAPSHOT_CELL_SIZE,
+        ClientDelivery, ClientEntry, ClientEvent, Session, SessionMsg, Sidecar, SidecarCommand,
+        SidecarQueue, SidecarResult, CLIENT_BACKLOG_CAP, SCROLLBACK_STAGE_MAX_BYTES,
+        SIDECAR_QUEUE_CAP, SNAPSHOT_CELL_SIZE,
     };
-    use crate::protocol::{Control, ErrorCode};
+    use crate::protocol::{Control, ErrorCode, Event};
     use crate::pty::Pty;
     use bytes::Bytes;
     use std::collections::{HashMap, VecDeque};
     use std::sync::{mpsc as std_mpsc, Arc};
-    use tokio::sync::{broadcast, mpsc};
+    use tokio::sync::{broadcast, mpsc, oneshot};
+
+    fn chunk(len: usize) -> Bytes {
+        Bytes::from(vec![b'x'; len])
+    }
 
     #[test]
     fn client_backlog_enforces_byte_cap() {
         let backlog = ClientBacklog::new();
 
-        assert!(backlog.try_reserve(CLIENT_BACKLOG_CAP - 1));
-        assert!(backlog.try_reserve(1));
-        assert!(!backlog.try_reserve(1));
+        let bulk = backlog
+            .reserve(chunk(CLIENT_BACKLOG_CAP - 1))
+            .expect("bulk reservation");
+        let last = backlog.reserve(chunk(1)).expect("last byte");
+        assert!(backlog.reserve(chunk(1)).is_none());
 
-        backlog.release(CLIENT_BACKLOG_CAP);
-        assert!(backlog.try_reserve(1));
-        backlog.release(1);
+        backlog.release(&bulk);
+        backlog.release(&last);
+        assert!(backlog.is_drained());
+        let after = backlog
+            .reserve(chunk(1))
+            .expect("reservation after release");
+        backlog.release(&after);
+    }
+
+    #[test]
+    fn resync_retires_queued_payloads_without_unwinding_the_count() {
+        let backlog = ClientBacklog::new();
+        let stale = backlog
+            .reserve(chunk(CLIENT_BACKLOG_CAP))
+            .expect("full reservation");
+        assert!(backlog.reserve(chunk(1)).is_none());
+
+        backlog.begin_resync();
+
+        // The queued payload is dropped where it sits, so the client starts the
+        // new epoch with the whole budget rather than waiting for a drain.
+        assert!(!backlog.is_current(&stale));
+        assert!(backlog.is_drained());
+        let fresh = backlog
+            .reserve(chunk(CLIENT_BACKLOG_CAP))
+            .expect("fresh reservation");
+
+        // A late release of a retired payload must not credit the new epoch.
+        backlog.release(&stale);
+        assert!(backlog.reserve(chunk(1)).is_none());
+        backlog.release(&fresh);
+        assert!(backlog.is_drained());
+    }
+
+    #[test]
+    fn sidecar_queue_stops_admitting_bytes_past_its_budget() {
+        let queue = SidecarQueue::new();
+
+        assert!(queue.try_reserve(SIDECAR_QUEUE_CAP));
+        assert!(!queue.try_reserve(1));
+
+        queue.release(SIDECAR_QUEUE_CAP);
+        assert!(queue.try_reserve(1));
+        queue.release(1);
+        // Releasing more than was reserved is a bug, not a panic: the VT thread
+        // and the session actor account independently.
+        queue.release(SIDECAR_QUEUE_CAP);
+        assert!(queue.try_reserve(SIDECAR_QUEUE_CAP));
     }
 
     #[test]
@@ -1498,7 +1751,14 @@ mod tests {
 
     #[test]
     fn resize_snapshot_request_is_an_exact_sidecar_fifo_boundary() {
-        let (sidecar, mut snapshots, thread) = spawn_sidecar(2, 16).unwrap();
+        let Sidecar {
+            commands: sidecar,
+            results: mut snapshots,
+            queue,
+            thread,
+        } = spawn_sidecar(2, 16).unwrap();
+        assert!(queue.try_reserve("BEFORE".len()));
+        assert!(queue.try_reserve("AFTER".len()));
         sidecar
             .send(SidecarCommand::Write(Bytes::from_static(b"BEFORE")))
             .unwrap();
@@ -1535,6 +1795,260 @@ mod tests {
 
         sidecar.send(SidecarCommand::Shutdown).unwrap();
         thread.join().unwrap();
+        // Every byte the session charged to the queue is credited back once the
+        // VT has parsed it, or the budget ratchets shut on a healthy session.
+        assert_eq!(
+            queue.outstanding.load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+    }
+
+    /// A session with no clients, a live sidecar, and a PTY that only has to
+    /// exist — none of the backlog paths touch it.
+    fn test_session(
+        sidecar_tx: std_mpsc::Sender<SidecarCommand>,
+        sidecar_queue: Arc<SidecarQueue>,
+    ) -> (Session, broadcast::Receiver<Event>) {
+        let pty = Arc::new(Pty::non_pty_for_resize_failure_test().unwrap());
+        let (input_tx, _input_rx) = mpsc::unbounded_channel();
+        let (events, event_rx) = broadcast::channel(64);
+        (
+            Session {
+                id: "session".to_string(),
+                name: "test".to_string(),
+                cwd: String::new(),
+                command: "cat".to_string(),
+                pid: 0,
+                rows: 24,
+                cols: 80,
+                created_unix: 0,
+                status: "unknown".to_string(),
+                title: None,
+                workstream: None,
+                pty,
+                input_tx,
+                clients: HashMap::new(),
+                writer: None,
+                next_seq: 0,
+                next_snapshot_request: 1,
+                ring: VecDeque::new(),
+                ring_bytes: 0,
+                events,
+                sidecar_tx: Some(sidecar_tx),
+                sidecar_queue,
+                vt_stale: None,
+            },
+            event_rx,
+        )
+    }
+
+    /// Hand the session the sidecar replies it is waiting on. `run` does this in
+    /// its select loop; the tests do it by hand so the barrier is deterministic.
+    /// The count is awaited rather than polled — the VT is a real thread, so a
+    /// `try_recv` here would race it and hide a working barrier as a hang.
+    async fn pump_sidecar(
+        session: &mut Session,
+        results: &mut mpsc::UnboundedReceiver<SidecarResult>,
+        expected: usize,
+    ) {
+        for _ in 0..expected {
+            let result = tokio::time::timeout(std::time::Duration::from_secs(10), results.recv())
+                .await
+                .expect("the VT sidecar never answered")
+                .expect("the VT sidecar hung up");
+            apply_sidecar(session, result);
+        }
+        while let Ok(result) = results.try_recv() {
+            apply_sidecar(session, result);
+        }
+    }
+
+    fn apply_sidecar(session: &mut Session, result: SidecarResult) {
+        match result {
+            SidecarResult::Snapshot {
+                client_id,
+                request_id,
+                result,
+            } => {
+                session.finish_snapshot(&client_id, request_id, result);
+            }
+            SidecarResult::Grid(grid) => session.fan_out_grid(grid),
+            SidecarResult::Keyframe(snapshot) => session.fan_out_keyframe(snapshot),
+        }
+    }
+
+    fn attach_snapshot_client(
+        session: &mut Session,
+        id: &str,
+    ) -> (mpsc::UnboundedReceiver<ClientEvent>, Arc<ClientBacklog>) {
+        let (client_tx, client_rx) = mpsc::unbounded_channel();
+        let backlog = Arc::new(ClientBacklog::new());
+        let (reply, _reply_rx) = oneshot::channel();
+        handle_msg(
+            session,
+            SessionMsg::AddClient {
+                id: id.to_string(),
+                interactive: false,
+                out: client_tx,
+                backlog: backlog.clone(),
+                snapshot: true,
+                scrollback: false,
+                grid_diff: false,
+                reply,
+            },
+        );
+        (client_rx, backlog)
+    }
+
+    /// D4(a): the first time a client outruns its budget it is resynced, not
+    /// dropped — the queued bytes are retired, a fresh `S`/`ready` pair
+    /// re-establishes JOIN, and `resynced` says why. The second overflow is the
+    /// drop, because a client that cannot keep up from a clean start is wedged.
+    #[tokio::test]
+    async fn backlog_pressure_resyncs_a_client_once_before_dropping_it() {
+        let Sidecar {
+            commands,
+            mut results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        let (mut session, _events) = test_session(commands, queue);
+        let (mut client, backlog) = attach_snapshot_client(&mut session, "slow");
+        pump_sidecar(&mut session, &mut results, 1).await;
+        // The attach snapshot: S, then ready.
+        assert!(matches!(
+            client.recv().await,
+            Some(ClientEvent::Snapshot(_))
+        ));
+        assert!(matches!(
+            client.recv().await,
+            Some(ClientEvent::Event(Event::Ready { .. }))
+        ));
+
+        // Nothing on the far end ever releases, so the budget fills for real.
+        let mib = chunk(1024 * 1024);
+        for _ in 0..(CLIENT_BACKLOG_CAP / mib.len()) {
+            session.fan_out(mib.clone());
+        }
+        assert!(backlog.reserve(chunk(1)).is_none(), "budget is not full");
+        assert!(session.clients.contains_key("slow"));
+
+        // The overflow chunk. It is not delivered — it is what the snapshot
+        // replaces — and the client survives it.
+        session.fan_out(mib.clone());
+        assert!(
+            session.clients.contains_key("slow"),
+            "the first overflow dropped the client instead of resyncing it"
+        );
+        assert!(
+            backlog.is_drained(),
+            "the resync did not retire the queued backlog"
+        );
+        pump_sidecar(&mut session, &mut results, 1).await;
+
+        let mut kinds = Vec::new();
+        while let Ok(event) = client.try_recv() {
+            kinds.push(match event {
+                ClientEvent::Data(_) => "D".to_string(),
+                ClientEvent::Snapshot(_) => "S".to_string(),
+                ClientEvent::Event(Event::Ready { .. }) => "ready".to_string(),
+                ClientEvent::Event(Event::Resynced { reason, .. }) => format!("resynced:{reason}"),
+                _ => "other".to_string(),
+            });
+        }
+        let boundary = kinds
+            .iter()
+            .position(|kind| kind == "S")
+            .expect("no fresh S after the forced resync");
+        assert_eq!(kinds[boundary + 1], "ready", "S was not followed by ready");
+        assert!(
+            kinds[boundary..]
+                .iter()
+                .any(|kind| kind.starts_with("resynced:output backlog exceeded")),
+            "the client was never told why its stream restarted: {kinds:?}"
+        );
+
+        // Second strike. The client starts from an empty budget and still
+        // cannot drain, so this time it goes.
+        for _ in 0..(CLIENT_BACKLOG_CAP / mib.len()) {
+            session.fan_out(mib.clone());
+        }
+        session.fan_out(mib.clone());
+        assert!(
+            !session.clients.contains_key("slow"),
+            "the second overflow did not drop the client"
+        );
+        assert!(backlog.is_dropped());
+
+        let _ = session.sidecar_tx.take();
+        let _ = tokio::task::spawn_blocking(move || thread.join()).await;
+    }
+
+    /// D4(b): the sidecar budget's only legal degrade. Bytes reach every client
+    /// unchanged; what stops is the VT, which then refuses snapshots instead of
+    /// answering one that describes a screen that never occurred.
+    #[tokio::test]
+    async fn an_over_budget_sidecar_goes_stale_without_costing_a_client_one_byte() {
+        let Sidecar {
+            commands,
+            mut results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        // Park the whole budget so the next PTY chunk cannot be admitted. This
+        // stands in for a VT parse that has stopped making progress.
+        assert!(queue.try_reserve(SIDECAR_QUEUE_CAP));
+        let (mut session, mut events) = test_session(commands, queue);
+        let (mut client, _backlog) = attach_snapshot_client(&mut session, "raw");
+        pump_sidecar(&mut session, &mut results, 1).await;
+        assert!(matches!(
+            client.recv().await,
+            Some(ClientEvent::Snapshot(_))
+        ));
+        assert!(matches!(
+            client.recv().await,
+            Some(ClientEvent::Event(Event::Ready { .. }))
+        ));
+
+        let chunk = Bytes::from_static(b"still mine\r\n");
+        session.write_sidecar(chunk.clone());
+        session.fan_out(chunk.clone());
+
+        assert!(session.vt_stale.is_some(), "the budget did not bite");
+        let mut announced = false;
+        while let Ok(event) = events.try_recv() {
+            announced |= matches!(event, Event::VtStale { .. });
+        }
+        assert!(announced, "the stale VT was never announced");
+        // The invariant this whole budget exists to protect: the client's bytes
+        // are not what gets sacrificed.
+        let mut delivered = Vec::new();
+        while let Ok(event) = client.try_recv() {
+            if let ClientEvent::Data(payload) = event {
+                delivered.extend_from_slice(&payload.bytes);
+            }
+        }
+        assert_eq!(delivered, chunk, "a stale VT cost the client PTY bytes");
+
+        // A client attaching now is told the truth by falling back to the ring
+        // rather than being handed a snapshot the VT can no longer vouch for.
+        // No sidecar round trip this time: a stale VT is refused in-process.
+        let (mut late, _late_backlog) = attach_snapshot_client(&mut session, "late");
+        pump_sidecar(&mut session, &mut results, 0).await;
+        let mut replayed = Vec::new();
+        let mut snapshots = 0;
+        while let Ok(event) = late.try_recv() {
+            match event {
+                ClientEvent::Snapshot(_) => snapshots += 1,
+                ClientEvent::Data(payload) => replayed.extend_from_slice(&payload.bytes),
+                _ => {}
+            }
+        }
+        assert_eq!(snapshots, 0, "a stale VT still answered a snapshot");
+        assert_eq!(replayed, chunk, "the ring-replay fallback did not run");
+
+        let _ = session.sidecar_tx.take();
+        let _ = tokio::task::spawn_blocking(move || thread.join()).await;
     }
 
     #[tokio::test]
@@ -1570,6 +2084,7 @@ mod tests {
                     grid_diff: false,
                     delivery: ClientDelivery::Live,
                     staged_history: VecDeque::new(),
+                    backlog_strikes: 0,
                 },
             )]),
             writer: Some("writer".to_string()),
@@ -1579,6 +2094,8 @@ mod tests {
             ring_bytes: 0,
             events,
             sidecar_tx: Some(sidecar_tx),
+            sidecar_queue: Arc::new(SidecarQueue::new()),
+            vt_stale: None,
         };
 
         assert!(!handle_msg(


### PR DESCRIPTION
The anti-100× invariant says byte delivery never blocks on the host-side VT parse, so the sidecar command channel is unbounded and fire-and-forget. That leaves a hole one hop upstream of the one `CLIENT_BACKLOG_CAP` already closed: a per-client budget stops a slow *socket* from buying unbounded memory, and nothing stopped a slow *parse* from doing the same thing with the entire PTY stream. This closes both residuals of D4 in the hot-path design doc.

## Sidecar budget — `vt_stale`, never a dropped byte

`SidecarQueue` charges every `Write` handed to the VT and credits it back once the VT thread has parsed it. At 16 MiB the session stops feeding the VT, marks it stale, emits `vt_stale`, disconnects grid-diff clients, and fails every pending and future snapshot into the ring-replay fallback that already exists.

`fan_out` is untouched. The only legal degrade is that snapshots get worse; output never does. Blocking here would put the VT parse back on the fan-out path, and dropping bytes silently would leave `S` describing a screen that never occurred.

Stale is sticky. Reseeding the VT from the 128 KiB ring once the queue drains is tempting and refused — the payload would claim a boundary it does not describe, which is exactly what JOIN exists to prevent. An honest recovery needs a marked baseline, and that is now written down as §F #7.

## Backlog degrade — resync once, then drop

`ClientBacklog` gains an epoch, and payloads become `Metered` (bytes + the epoch they were reserved under). A client that outruns its 4 MiB budget is resynced instead of dropped:

- `begin_resync()` bumps the epoch and zeroes what the client owes,
- the socket writer drops anything reserved under an older epoch (`is_current`),
- a fresh `S`/`ready` pair plus `E{ev:"resynced", reason}` re-establishes JOIN for that client alone.

Retiring the queued megabytes is the point, not a side effect: replaying them to a client that could not keep up is what put it there, and a phone coming out of a tunnel should rejoin at a screen rather than through a flood. A second overflow drops it — strikes are never forgiven, because the resync already zeroed the count, so overflowing again proves the client cannot keep up from a clean start. No other client is touched.

Deferred and stated in the doc: `H` is still attach-only, so a resynced client's scrollback is a hole it cannot see (D10).

## Unconfirmed, not a claimed bug

`begin_resync()` performs `epoch.fetch_add` and `outstanding.store(0)` as two independent atomic operations. In theory there is a narrow window between them: a `reserve` from the old epoch landing in that gap would have its count erased by the store that follows, undercounting once. The consequence is that the quota is slightly loose for one interval — not a correctness failure, and `saturating_sub` already absorbs the release side. Static reading cannot settle it either way; confirming or dismissing it needs a concurrency test that does not exist yet.

## Verification

Run locally on macOS with the CI-pinned Zig 0.16.0 and `DEVELOPER_DIR=/Library/Developer/CommandLineTools`:

- `cargo test` — **46 unit tests passed, 0 failed**, plus `join_invariant` (1), `snapshot_prologue` (2), `stdio_bridge` (1). Includes the four new ones: `resync_retires_queued_payloads_without_unwinding_the_count`, `sidecar_queue_stops_admitting_bytes_past_its_budget`, `backlog_pressure_resyncs_a_client_once_before_dropping_it`, `an_over_budget_sidecar_goes_stale_without_costing_a_client_one_byte`.
- `python3 smoke_test.py` — **84 checks passed, 0 failed**, `ALL CHECKS PASSED`.
- `python3 remote_smoke_test.py` — **8 checks passed**, `ALL CHECKS PASSED`.

`cargo fmt --check` reports drift in eleven files, all of it identical on a pristine `origin/main` and none of it in `session.rs`. Pre-existing, and CI does not run it.

Release Notes:

- A terminal session whose viewer falls behind now restarts that viewer's stream at a fresh screen instead of disconnecting it on the first stall.
- A session whose output outruns the host's terminal parser keeps delivering every byte, and says so instead of serving a screen it can no longer vouch for.