### PR TITLE
docs: one path through termiod — RFC, adversarial review, handoff

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ from the real front matter).
 | active | bug | [iOS libghostty "non-functional" panel + surface-teardown crash — fix journey](bug/ios-ghostty-renderer-panic-and-teardown-uaf.md) |
 | active | design | ["Issue tracker 集成：inspector Issues tab（GitHub / Linear，per-project provider）"](design/20260726-issue-tracker-integration.md) |
 | active | design | ["Remote-access design lessons: sleep reachability, stable domains, identity, monetization"](design/20260705-remote-access-lessons.md) |
+| active | design | [Handoff — collapsing the two session paths into termiod](handoff/20260817-one-path-refactor.md) |
 | active | design | [iOS libghostty "non-functional" panel + teardown UAF — root-cause findings](design/20260706-ios-ghostty-renderer-panic-investigation-findings.md) |
 | active | design | [iOS terminal input & attachments](design/20260703-ios-terminal-input.md) |
 | active | design | [iOS TestFlight runbook — build, upload, and drive ASC from the API](runbook/ios-testflight-runbook.md) |
@@ -103,11 +104,13 @@ from the real front matter).
 | draft | rfc | [Fork libghostty-spm — own the wrapper, rent the engine?](rfcs/fork-libghostty-spm.md) |
 | draft | rfc | [Loose terminals as first-class entities](design/20260713-loose-terminal-entity.md) |
 | draft | rfc | [Onboarding —— 首次启动体验设计](design/20260630-onboarding.md) |
+| draft | rfc | [Review — One path, local sessions run through termiod too](rfcs/one-path-local-through-termiod.review-claude.md) |
 | fixed | bug | [New terminal opens unfocused (hollow cursor, beeps until clicked)](bug/terminal-focus-loss-on-new-session-mount.md) |
 | fixed | bug | [Terminal loses focus after window deactivation](bug/terminal-focus-loss-on-window-key.md) |
 | fixed | bug | [Terminal loses focus while the window stays key — sibling-render trigger](bug/terminal-focus-loss-on-sibling-render.md) |
 | in-progress | rfc | [可扩展 Agent —— 配置化定义 + 配置化 Hook](design/20260707-agent-extensibility.md) |
 | in-review | rfc | [Every machine is a device, every place you work is a project](rfcs/remote-to-device.md) |
+| in-review | rfc | [One path — local sessions run through termiod too](rfcs/one-path-local-through-termiod.md) |
 | in-review | rfc | [Split panes — Ghostty-style splits in the terminal column](rfcs/split-panes.md) |
 | resolved | bug | [iOS terminal fails "unauthorized" while the session list works (companion over tunnel)](bug/companion-terminal-unauthorized-over-tunnel.md) |
 <!-- END docs-index -->

--- a/docs/handoff/20260817-one-path-refactor.md
+++ b/docs/handoff/20260817-one-path-refactor.md
@@ -1,0 +1,146 @@
+---
+title: Handoff — collapsing the two session paths into termiod
+status: active
+type: design
+created: 2026-08-17
+updated: 2026-08-17
+related:
+  - ../rfcs/one-path-local-through-termiod.md
+  - ../rfcs/remote-to-device.md
+  - ../design/20260805-termiod-device-architecture.md
+---
+
+# Handoff — one path through termiod
+
+> Pick this up cold. Everything below is verified state, not recollection.
+
+## 1. The one idea that explains the rest
+
+termio runs sessions two ways: the Swift in-process `PTYProcess`, and the Rust
+`termiod` daemon behind `TERMIO_TERMIOD=1` (off by default). **Every bug this
+round was the same shape — the feature exists on the Swift path and has no
+counterpart on the termiod path:**
+
+| # | Symptom | Cause |
+| --- | --- | --- |
+| 1 | Every local terminal silently became remote | `TERMIO_TERMIOD_REMOTE` fallback on the wrong path |
+| 2 | Splitting a remote session gave a shell on the Mac | inheritance written on one path only |
+| 3 | Image paste did nothing remotely | local relies on the *agent* reading the Mac pasteboard |
+| 4 | File tree is SFTP, git shells out locally | `files`/`git` planes shipped daemon-side, never consumed |
+| 5 | Agent icon never changes on a remote session | `pty.foregroundProcessArguments()` is a local syscall; `pty == nil` under termiod |
+| 6 | `termio sessions send` cannot send a bare keypress | the CLI talks to the **Mac app**, not the daemon |
+
+All six become structurally impossible once there is one path. That is the
+whole justification; each individual fix is a patch on the mechanism that keeps
+producing them.
+
+Strategic addition: **the Swift local-PTY path can never run on Windows.** The
+Rust daemon can.
+
+## 2. State — verified 2026-08-17
+
+### Landed on main
+`termiod` is not a skeleton. Ten capabilities, all implemented daemon-side with
+smoke coverage: `events, send_wait, snapshot, scrollback, grid_diff, resources,
+fs_watch, files, upload, git`. Baseline: **46 unit + 84 smoke + 8 remote smoke**,
+CI green on macos + linux.
+
+Also landed this round: VT-sequence snapshots (client theme survives), the
+resource plane (§C.10 resumable subscriptions), fleet `list --host`,
+protocol-over-SSH `attach --host` with ControlMaster, launchd service, session
+tombstones, sidecar backpressure (#316), image-paste transfer plane (#308),
+device identity (`TermiodDevice`), and #314 which settled the RFC's two blocking
+questions.
+
+### The gap that matters
+The Mac app negotiates **two** of the ten capabilities (`snapshot`, `events`).
+`scrollback`, `grid_diff`, `files`, `upload`, `git` are implemented and unused.
+The daemon ran ahead; the client never caught up.
+
+### Open PRs on this line
+- **#310** — the device RFC. Conflicts resolved, `MERGEABLE`. **No longer
+  blocked**: #314 settled the Settings question (SSH and Devices tabs *coexist*,
+  split at the handshake — routes before `hello_ok`, identities after).
+- **#317** — ghostty formatter emits tabstops before the screen.
+
+### Uncommitted worktrees
+| Worktree | Contents | Call to make |
+| --- | --- | --- |
+| `device-context` | device is a store-level context; sidebar shows the device's own daemon roster; three UI fixes (title badge removed, switcher moved to top, New Terminal stops asking which machine) | **Ready — commit and open a PR** |
+| `one-path-design` | the RFC below + this handoff | commit with the RFC |
+| `one-path-review` | adversarial review in progress | wait for it |
+| `remote-to-device` | `DeviceSwitcher` — **already patched into `device-context`** | verify nothing unique, then discard |
+| `ios-device-rename` | `PairedMac` → `PairedDevice` | blocked on a real-device migration test (§5) |
+| `settings-file-watch`, `agent-a6effa8411d2998e7`, `editor-scrollaway-header` | unrelated lines | commit or discard — they are mines under the refactor |
+
+## 3. The plan
+
+`docs/rfcs/one-path-local-through-termiod.md` (869 lines). Verified: the
+inventory cites real file:line, not guessed names.
+
+Its most valuable finding, which no one anticipated: **deleting the in-process
+`PTYProcess` dismantles the iPhone mirror.** `CompanionServer`'s `PTYBridge` is
+typed on `PTYProcess` (`addSink`, `isAlternateScreenActive`,
+`claimHostOwnership`, …). Read the other way this is also the argument *for*
+doing it — the phone is a viewer mirroring another viewer, which protocol §H #9
+already condemned, and the only reason that wire survives is the Mac holding a
+`PTYProcess` the phone can tap.
+
+CLI split is §7 + Stage 6, deliberately not entangled with the PTY work.
+
+## 4. What to do next, in order
+
+1. **Merge #310.** Unblocked since #314.
+2. **Read the review** in `one-path-review` when it lands; expect it to move
+   stages around. Do not start implementing before reading it.
+3. **Commit `device-context`** and open a PR — it is finished and verified.
+4. **Clear the field (RFC Stage 0).** Every uncommitted worktree above touches
+   `TermioStore+TerminalSurface` / `PTYProcess` / `GitService` / `FileBrowser`,
+   which is exactly what the refactor rewrites. Each one gets committed or
+   discarded; none may stay.
+5. **Then implement**, stage by stage, verifying each against a criterion that
+   is not "it compiles".
+
+## 5. Traps that cost real time
+
+**"It compiles" proves nothing here.** All six bugs above passed every test that
+runs. Two of them shipped.
+
+**`swift test` cannot run at all** — 285 Swift 6 concurrency errors in
+`CompanionServer.swift` on `main` ([#311](https://github.com/termio-sh/termio/issues/311)).
+Every file under `Tests/termioTests/` compiles and never executes. Swift is only
+verifiable through `TERMIO_CHANNEL=dev ./scripts/build-app.sh`.
+
+**Do not set `DEVELOPER_DIR=…/CommandLineTools`** for that script — it dies on
+`xcstringstool not found`, which only ships with full Xcode.
+
+**`ZIG=…` as an environment variable does nothing.** `libghostty-vt-sys/build.rs`
+execs `zig` from `PATH`, and CI pins **0.16.0**:
+`export PATH=$HOME/.local/share/termiod-toolchains/zig-0.16.0:$PATH`
+
+**`termio sessions spawn` can silently drop the prompt** while still reporting
+`idle`/`done`. Confirm a transcript exists before believing an agent ran —
+`done` is not proof. One agent this round produced nothing and reported success.
+
+**Codex could not be driven at all** — four attempts, four different failures
+(hook-trust gate, no live terminal, prompt not delivered, cwd landed at `/`).
+The gate needs a bare `t` or `esc`, and `send` only emits text+Return. RFC §7
+fixes exactly this; until then a human has to press the key.
+
+**Concurrent smoke runs interfere** — they share `/tmp/termiod-smoke`. A lone
+failure that passes on rerun is contention, not a regression.
+
+## 6. Decided, do not reopen
+
+- Raw PTY bytes are teed; the host parses in parallel, never in between.
+  Superlogical converged on the identical design independently (primary sources,
+  not press paraphrase).
+- `G` grid diffs are never the default — a diff-fed client owns no real
+  scrollback and cannot select across history. That is a capability argument,
+  not bandwidth.
+- The host describes state and never decides presentation.
+- Never embed SSH or crypto; `~/.ssh/config` is authoritative — read it, never
+  override it.
+- A device's identity is its `host_id`; SSH is one route among several.
+- "Remote" is not a UI word. It describes the road, not the thing at the end.
+- Settings ▸ SSH and Settings ▸ Devices coexist, split at the handshake (#314).

--- a/docs/rfcs/one-path-local-through-termiod.md
+++ b/docs/rfcs/one-path-local-through-termiod.md
@@ -1,0 +1,870 @@
+---
+title: One path — local sessions run through termiod too
+status: in-review
+type: rfc
+created: 2026-08-17
+updated: 2026-08-17
+related:
+  - one-path-local-through-termiod.review-claude.md
+  - 20260805-termiod-device-architecture.md
+  - 20260730-termiod-session-protocol.md
+  - remote-to-device.md
+---
+
+# One path — local sessions run through termiod too
+
+> Move every server-side responsibility out of the Swift app into `termiod`, delete the in-process PTY path and the app's own control plane, and leave the Mac app as a viewer. This is step 5 of the device architecture's migration ladder, plus the two forks that ladder never named: the inspector panels and the `termio sessions` CLI.
+
+---
+
+## 0. Premise audit — what is still true
+
+The brief for this RFC cited five bugs as one shape. Three are still live; two
+were fixed while the argument was being made, and citing them as open would have
+been the second-order version of the same mistake. Checked against `main` at
+`b4e3e6c`:
+
+| Cited symptom | State | Evidence |
+| --- | --- | --- |
+| `TERMIO_TERMIOD_REMOTE` silently turns every local terminal remote | **Fixed** | The fallback is gone; the variable survives only as the diagnostic that picks which daemon `logTermiodRoster` inspects (`TermiodClient.swift:25-31`, `TermioStore+Termiod.swift:18-23`) |
+| Splitting a remote session drops the new pane on this Mac | **Fixed** | `Session.inheritDevice(from:)` (`Models.swift:344`), called at both split sites (`TermioStore+SplitPanes.swift:48,122`) |
+| Image paste has no route to a session on another machine | **Fixed for the device direction** | `upload.open`/`U`/`upload.commit` on their own control channel (`TermiodTransfer.swift`, `protocol.rs:449-514`); three other transfer directions remain unbuilt (device arch §8.10) |
+| File tree over SFTP, git through a local `Process`, while the daemon's `files`/`git` planes ship with smoke coverage | **Live** | `SSHFileSystemProvider.swift:249`, `GitService.swift:958-984`; 31 of the daemon's 86 smoke checks cover `fs.*`/`git*` and no Swift file names any of those verbs |
+| Agent icon never changes on a termiod session | **Live** | The detector sits inside `if let pty { … }` (`TermioStore+TerminalSurface.swift:390-426`, call at :413); on the termiod path `pty == nil` (:228-231) |
+
+Two of the five landing as point fixes is itself the argument. Each was repaired
+where it surfaced; none of them changed the shape that produced it, and the two
+that remain are the two nobody could fix locally, because they are not bugs —
+they are missing halves.
+
+**The shape, stated once.** A capability is implemented against the object the
+app happens to hold — a `PTYProcess`, a local path, a `Process` — and the
+termiod path holds a different object, so the capability is absent rather than
+broken. Nothing reports it. It is found by a user.
+
+There is also a second fork nobody has written down, and it is larger than the
+first: **two CLIs talking to two servers** (§7).
+
+---
+
+## 1. Inventory — what the Swift app does that belongs to a device
+
+The test used throughout, taken from device architecture §4.1: *would two people
+watching this session from two different machines expect to see the same
+answer?* Yes → the device owns it. No → the viewer owns it.
+
+### 1.1 Session and process plane
+
+| Responsibility | Swift today | termiod today |
+| --- | --- | --- |
+| Own the PTY, spawn with `login_tty` | `PTYProcess.swift:144-231` (`forkpty`) | **Has it** — `pty.rs:67-167`, same shape, deliberately |
+| Non-blocking writes, write backlog | `PTYProcess.swift:478-624` | **Has it** — `pty.rs:208-226` + per-client budget `session.rs:25` |
+| Resize / `TIOCSWINSZ`, host-vs-companion ownership | `PTYProcess.swift:626-742` | **Partial** — resize yes (`pty.rs:183`); the two-owner arbitration is a companion concept with no daemon counterpart |
+| Reap the child, report exit code + true runtime | `PTYProcess.swift:211-224` | **Has it** — `session_exited`, but the daemon reports no runtime; the client substitutes elapsed-since-attach (`TermiodClient.swift:887-891`) |
+| **Foreground process argv** (agent identity) | `PTYProcess.swift:866-874` — `tcgetpgrp` + `KERN_PROCARGS2` | **Missing** — no `tcgetpgrp` anywhere in `termiod/src` |
+| **Foreground job present?** (close confirmation) | `PTYProcess.swift:923-927` | **Missing** — `SessionInfo` (`protocol.rs:810-832`) has no such field |
+| **Child cwd** (loose-terminal cwd following) | `PTYProcess.swift:805-819` — `PROC_PIDVNODEPATHINFO` | **Missing** — `SessionInfo.cwd` is the *spawn* cwd, never re-read |
+| **Child executable identity** (self-update relaunch) | `PTYProcess.swift:827-857` | **Missing**, and acknowledged in the client as a known behaviour gap (`TermioStore+Termiod.swift:93-96`) |
+| **Orphan reaping** across an app crash | `PTYProcess.swift:953-…`, matched by `TERMIO_SESSION` + `TERM_PROGRAM=termio` in `ps -axEww` | **Mostly obviated** — a supervised daemon that keeps running has no orphans, and tombstones (`tombstone.rs:66-88`) record what a daemon crash lost. A `SIGKILL`ed *daemon* still strands children; see open question 4 |
+| Alt-screen / private-mode tracking for late attach | `PTYProcess.swift:356-441` (`modeResyncPreamble`) | **Superseded** — the `S` snapshot prologue does this correctly (`protocol.rs:398-417`, `tests/snapshot_prologue.rs`) |
+
+### 1.2 Workspace plane (files, git, search)
+
+| Responsibility | Swift today | termiod today |
+| --- | --- | --- |
+| Directory listing | Local `FileManager`; remote via SFTP over `ssh -s host sftp` (`SSHFileSystemProvider.swift:249`, `SFTPClient.swift`, 1,409 lines together) | **Has it** — `fs.list`, batched + speculative + `seq`-stamped (`protocol.rs:423`); 3 smoke checks |
+| File read / preview | Local read; SFTP read | **Has it** — `fs.read` + `F` chunks; 3 smoke checks |
+| Filesystem change notification | FSEvents (`FileTreeWatcher.swift`, `FolderEventStream.swift`); **no remote equivalent** | **Has it** — `fs:` resource, debounced, `full_rescan`/`git_meta`, resumable by cursor (`resource.rs`) |
+| Filename fuzzy finder | Local walk | **Has it** — `fs.match` with honest `coverage`; 4 smoke checks |
+| Content search | Local `git grep`/`grep` via `Process` (`ContentSearch.swift:97-105`) | **Has it** — `fs.search`, streamed + cancellable; 4 smoke checks |
+| Git status | `GitService.run` → `/usr/bin/git` (`GitService.swift:958-984`) | **Has it** — `git:` resource, Zed's two-axis vocabulary, delta batches; 6 smoke checks |
+| Git diff for one path | `GitService.diffText` | **Has it** — `git.diff`; 1 smoke check |
+| Git **history**, commit contents, branch compare, discard, `.gitignore` append, remote/PR URLs, clone info, stall fingerprint | `GitService.swift:80-944` — `log`, `commitChanges`, `compareContext`, `branchCompare`, `suggestedCompareBase`, `discard`, `appendToGitignore`, `remotePage`, `newPullRequestPage`, `gitHubRepoSlug`, `cloneInfo`, `stallFingerprint` | **Missing entirely** — `git.rs` is `run_status` + `run_diff` and nothing else |
+| Worktree enumeration and creation | `WorktreeService.swift` → `git worktree list` | **Missing** — device arch §8.11 (workspace registry) |
+
+The gap is narrower than it looks and wider than the panels admit: **the read
+path a file tree and a changes pane need is finished and tested on the device
+side and unwired on the client side.** The git *history* pane is the part that
+genuinely does not exist yet.
+
+Note the live inconsistency this leaves: `FileBrowserView` keys its remote tree
+on `session.sshHost` (`FileBrowserView.swift:53,70`) — the plain-`ssh`-in-a-local-PTY
+identity — so a *termiod* session on another machine matches neither branch and
+falls to `inspectorProjectPath`, which returns nil for a `.host` container
+(`TermioStore.swift:413-416`). The pane renders the string `"Remote session"`
+(`FileBrowserView.swift:297`) and does nothing. So there are three file-tree
+behaviours today (local, SFTP, dead) for two kinds of machine.
+
+### 1.3 Agent plane
+
+| Responsibility | Swift today | termiod today |
+| --- | --- | --- |
+| Status from hooks | `agent-status.sock` on **this Mac** (`scripts/termio:584`, `HookListener.swift`) | **Has the sink** — `set_status` control op and `E {ev:"status"}` fan-out; nothing routes a hook into it |
+| Status from screen rules | `AgentStatusRules` over the viewport, inside `if let pty` (`TermioStore+TerminalSurface.swift:356-366`) | **Missing** — but see §3: this is a viewer job and should stay |
+| Status from `OSC 9;4` progress | `OSCProgressScanner`, inside `if let pty` (:303-328) | **Missing** — a byte-stream scan; the viewer sees the same bytes, so it can stay client-side |
+| Hand-started agent promotion / demotion | `foregroundProcessArguments()` → `AgentCatalog` (:413-414) | **Missing** — §3 |
+| Transcript location and reading | `AgentSessionStore`, local disk enumerate + read | **Reachable via `fs.read`**, unwired |
+| Hook installation into agent config files | `HookListener`/`AgentStatusHooks`, writes under the Mac's `$HOME`, bakes an absolute `cliPath` (`HookListener.swift:289`) | **Missing** — §4 |
+
+### 1.4 Client-owned, and must stay that way
+
+Listed explicitly so the refactor has a stopping line: rendering, theme,
+palette, fonts; selection, scroll position, viewport; window and split layout;
+the project tree's *grouping and naming*; `termio://session/<uuid>` links;
+macOS notifications; **and the encoding of a human keypress** (§7.2).
+
+### 1.5 The consumers that break when `PTYProcess` stops being used in-process
+
+This is the part a "delete the fork" plan usually misses. Every reference to
+`ptyProcesses` and to `PTYProcess`'s API is a thing that must be replaced, not
+merely deleted:
+
+| Site | What it uses | Replacement |
+| --- | --- | --- |
+| `TermioStore+ProjectActions.swift:690` | `pty.hasForegroundJob` for the close confirmation | §3 — an additive `SessionInfo` field |
+| `TermioStore+ProjectActions.swift:609,704,741` | `pty.terminate()` | `kill` (already implemented both sides) |
+| `TermioStore.swift:721-731` | `terminateAllSessions` — already detaches termiod links, then SIGTERMs + SIGKILLs every `PTYProcess` | Only the `ptyProcesses` half is deleted; the detach half is the shipped behaviour and stays |
+| `CompanionServer.swift:107,145,1096` | `ptyForSession` returns a concrete `PTYProcess` | **The largest single item.** `PTYBridge` (`CompanionServer.swift:931-1041`) is typed on `PTYProcess` and calls `addSink`, `isAlternateScreenActive`, `modeResyncPreamble`, `resizeFromCompanion`, `claimHostOwnership`, `claimCompanionOwnership`. Deleting the in-process path with no replacement removes the iPhone mirror entirely |
+
+The companion dependency is the reason this RFC cannot be a single stage. It is
+also, read the other way, the argument for doing it: the phone is a viewer
+mirroring another viewer, which §H #9 already condemned, and the only reason
+that wire still exists is that the Mac holds a `PTYProcess` the phone can tap.
+
+---
+
+## 2. Target state
+
+```
+                 ┌──────────────── device ─────────────────┐
+                 │  termiod                                │
+   Mac app ──────┤   PTY · process · exit · foreground job │
+   iOS   ────────┤   workspace · files · git · search      │
+   CLI   ────────┤   session roster · agent status         │
+                 └─────────────────────────────────────────┘
+   each client:  rendering · theme · selection · viewport · layout · keypress encoding
+```
+
+Concretely, when this is done:
+
+1. `Sources/termio/Terminal/Ghostty/PTYProcess.swift` still exists but is used
+   by nothing in the session path. (Whether it is deleted or kept for a test
+   harness is a later, cheap decision.)
+2. `Termiod.isEnabled` does not exist. Opening a session on this Mac and on a
+   VPS run the same code, differing only in `TermiodRoute`.
+3. The inspector reads the workspace's device. There is no `SSHFileSystemProvider`.
+4. `termio sessions` speaks the session protocol, and works on a Linux box with
+   no Mac app in sight.
+5. A capability added to `termiod` is available on every machine at once. That
+   is the whole return on this work.
+
+**What this does not do**, so the scope is honest: it does not add QUIC, does
+not add discovery, does not make `grid_diff` a default, does not build the
+workspace registry (device arch §8.11 stays where it is), and does not rebuild
+the companion as a protocol client — it only stops the companion from blocking
+the deletion (§8, Stage 4).
+
+---
+
+## 3. Foreground-process detection on the device
+
+Three separate signals are read from the local PTY today and get conflated. They
+have different costs and different owners.
+
+| Signal | Read by | Cost | Needed for |
+| --- | --- | --- | --- |
+| **Is a job in the foreground?** | `tcgetpgrp(master) != child_pid` | one syscall, no allocation | Close confirmation (`closeConfirmationReason`) |
+| **What is the foreground argv?** | `tcgetpgrp` then `KERN_PROCARGS2` | a sysctl walk | Hand-started agent promotion, the sidebar icon |
+| **What is the child's cwd?** | `PROC_PIDVNODEPATHINFO` | a kernel struct read | Loose-terminal cwd following |
+
+### 3.1 Cross-platform mechanism
+
+`tcgetpgrp` is POSIX and works against the PTY **master** on both platforms; the
+per-platform part is only turning a pid into argv and a cwd.
+
+| | macOS | Linux |
+| --- | --- | --- |
+| Foreground pgid | `tcgetpgrp(master_fd)` | `tcgetpgrp(master_fd)` |
+| argv | `sysctl KERN_PROCARGS2` | `/proc/<pid>/cmdline` (NUL-separated) |
+| cwd | `proc_pidinfo(PROC_PIDVNODEPATHINFO)` | `readlink /proc/<pid>/cwd` |
+
+Precedent: this is exactly tmux's split (`osdep-darwin.c` uses `KERN_PROCARGS2`,
+`osdep-linux.c` reads `/proc/<pgrp>/cmdline`, both after `tcgetpgrp` on the pty
+fd). **Uncertain:** I have read the macOS half working in this repo
+(`PTYProcess.swift:859-874` records it as verified) but have not run
+`tcgetpgrp` on a Linux ptmx master in this codebase. The migration step below
+carries a test for it rather than an assumption.
+
+**Windows: no plan, and no pretence of one.** ConPTY has no controlling
+terminal, no process group, and no `tcgetpgrp`. `termiod`'s Unix dependency is
+concentrated (`libc::` appears 18× in `pty.rs`, 9× in `client.rs`, ≤2× in each
+of `session.rs`/`files.rs`/`paths.rs`/`service.rs`), so a port is bounded — but
+this field would be absent there, which is exactly the same shape as an old
+daemon that does not send it. One degrade path serves both.
+
+### 3.2 Wire shape
+
+Two additions, both additive within `proto:1` (`protocol.rs` treats unknown
+control ops and events as ignorable and `caps` as additive), so no version bump:
+
+```
+SessionInfo += foreground_job: bool?          # cheap, on every `list`
+E { ev: "foreground_changed", session, pid, argv: [...], cwd? }   # debounced push
+```
+
+Three rules the shape encodes:
+
+- **The host reports argv; the client decides which agent that is.** Mapping
+  argv → agent needs `AgentCatalog`, which is built from the *user's* manifests
+  on the viewer. A host that answered `"claude"` would have to be told about
+  every user-defined agent, and would be deciding presentation
+  (device arch §4). Sending argv keeps user-defined agents working on a box that
+  has never heard of them.
+- **It is a push, not a poll.** The Mac polls at 350 ms today because it is
+  free in-process. Over SSH, N sessions × 3 Hz is not free, and a poll cannot
+  see a transition it lands between. The daemon debounces on its own read loop
+  the way the Swift sink does now, and pushes only on change.
+- **It never touches `fan_out`.** The sampler runs on the session task's timer,
+  never inline in the byte path (§A). A `tcgetpgrp` between two `Write`s would
+  put a syscall on the one path the whole architecture exists to keep free.
+
+`foreground_job` rides `list` rather than an event because its consumer asks
+once, at close time, and a stale push is worse than a fresh question.
+
+**Skew rule, restated from `remote-to-device.decisions.md` §2:** an absent field
+preserves today's no-confirm behaviour. It must never be read as "unknown, so
+confirm" — that would tax every close on exactly the sessions the shipped rule
+deliberately exempts.
+
+### 3.3 What stays on the client
+
+`OSCProgressScanner` and `AgentStatusRules` read the **byte stream** and the
+**rendered viewport**. Every client already receives the bytes (that is the tee)
+and every client already has a libghostty holding the screen. Moving them to the
+host would make the host parse for a decision a viewer can make from data it
+already has, and would put the host's opinion of "working" on the wire where the
+viewer's own rules disagree. They stay.
+
+The consequence is worth stating because it looks like an inconsistency: **the
+screen-derived status signals already work on a termiod session today** — they
+are wired to `pty.addSink` only by accident of where the code was written, not
+because they need a PTY. Re-pointing them at the link's `onOutput` seam
+(`TermiodClient.swift:882`) is a small change and can land before anything else
+in this RFC.
+
+---
+
+## 4. Agent hooks when the agent is on another machine
+
+### 4.1 The chain today
+
+```
+agent hook  →  scripts/termio agent report working
+            →  nc -U "$HOME/Library/Application Support/termio/agent-status.sock"
+            →  HookListener  →  TermioStore
+```
+
+Routed by `TERMIO_SESSION`, which the local PTY carries
+(`TermioStore+TerminalSurface.swift:199`). Broadcast to both channel sockets so
+one installed hook serves a dev and a release app (`scripts/termio:581-587`).
+
+On another machine every link breaks: there is no `scripts/termio`, no
+`~/Library/Application Support`, and `TERMIO_SESSION` is deliberately withheld —
+"a hook that echoed it back would be reporting to a control socket on the wrong
+machine" (`TermioStore+Termiod.swift:68-70`). The exclusion is correct. It is
+also the whole problem.
+
+### 4.2 The chain after
+
+```
+agent hook  →  termiod set-status "$TERMIOD_SESSION" working
+            →  local unix socket, same box
+            →  E { ev:"status" }  →  every attached viewer
+```
+
+The hook reports to the machine it is running on, over a Unix socket, to a
+process that is already there. No SSH, no crypto, no reverse channel, no
+listening port. It is the same fan-out `set_status` already performs (smoke
+check 46), and `termiod set-status <target> <status> [--title]` already exists
+as a subcommand (`main.rs:91-100`) — on the binary that is already deployed.
+
+This also fixes a latent local defect: today a hook reports to the *app*, so a
+session that outlives the app has nowhere to report. After the change, status
+survives an app quit for the same reason the session does.
+
+**What has to be built:**
+
+1. **Stamp the real session id.** `pty.rs:114` sets `TERMIOD_SESSION=1` — a
+   marker, read by nothing. It must carry the session id. This is the whole
+   routing key.
+2. **Carry the rest of the payload.** The hook contract is not only status:
+   `{state, cwd, transcript_path?, conversation_id?, tool?}` (`scripts/termio:566-580`).
+   `set_status` carries `status` and `title`. The other four fields need adding
+   — additive optional fields on `SetStatus`, or the same fields on a
+   `workstream` update op. **Undecided**; the first is smaller and the second is
+   tidier, and nothing yet forces the choice.
+3. **Map the vocabulary.** The hook says `working|attention|done|idle`; the
+   protocol says `working|idle|needs_you|done|failed|unknown`. `attention → needs_you`
+   is the only translation. Put it in one place, on the device side, so a
+   third client cannot get it wrong.
+4. **Install hooks on the device.** `HookListener` writes agent config files
+   under the Mac's `$HOME` with an absolute `cliPath` baked in
+   (`HookListener.swift:289`). On a device that must happen on the device. The
+   cheapest shape that does not invent a mechanism: hook installation becomes a
+   `termiod` subcommand (`termiod agent install-hooks`), invoked over the
+   existing request plane, writing the same files with `cliPath` pointing at the
+   local `termiod`. **The manifest set is still the viewer's** — it is user
+   configuration — so the viewer sends the specs and the device writes them.
+
+**`termio agent report` stays exactly as spelled.** It is a published contract
+already baked into users' agent configs. It grows one branch: `TERMIOD_SESSION`
+set → speak to the daemon; otherwise → the legacy app socket, unchanged. Both
+can be true during migration and the broadcast is idempotent.
+
+**Open, and I do not have an answer:** an agent running inside a container or a
+sandbox on the device may not see the daemon's socket. Today the same agent
+cannot see the Mac's socket either, so nothing regresses — but "the socket is
+always reachable from the agent" is an assumption this design rests on and has
+not been tested against `docker exec`-style sessions.
+
+---
+
+## 5. Daemon lifecycle — the single point of failure
+
+Making `termiod` the only PTY owner is the one part of this RFC with no
+mitigating side. An in-process PTY dies with the app, which is at least a shared
+fate the user understands. This section is the list of what must be true before
+that trade is acceptable.
+
+### 5.1 What exists
+
+- **launchd (macOS).** `termiod service install|uninstall|status`, `RunAtLoad` +
+  `KeepAlive`, boot-out-then-bootstrap on reinstall, `TERMIOD_SOCK` forwarded
+  only if the caller pinned it (`service.rs`, three unit tests).
+- **Crash accounting.** `tombstone.rs` records `exited` / `killed` /
+  `daemon_lost` with identity, last workstream status, and timestamps, capped at
+  100, surviving a restart; 7 smoke checks. A session still on the on-disk
+  roster when a daemon starts was never buried, so the previous daemon died
+  under it.
+- **Version negotiation.** `hello` with `[min_proto, proto]`, hard refuse on no
+  overlap, additive `caps` (`protocol.rs:28-41`, 4 smoke checks).
+- **Backpressure.** Per-client 4 MiB budget, one forced resync, then drop
+  (`session.rs:25`, `daemon.rs:414-444`) — §F #10 is closed.
+
+### 5.2 What is missing, and each one is a release blocker
+
+1. **The daemon does not ship.** `scripts/build-app.sh` and
+   `.github/workflows/release.yml` do not mention `termiod`. There is a
+   `termiod.yml` CI workflow that builds and smoke-tests it, and nothing that
+   puts it in the `.app`. Worse, `Termiod.daemonBinaryPath()` defaults to
+   `FileManager.default.currentDirectoryPath + "/termiod/target/debug/termiod"`
+   (`TermiodClient.swift:58-64`) — a dev-tree path relative to a cwd a
+   Finder-launched app does not have. **A released build today cannot start a
+   daemon at all.** This must be first.
+2. **Dev and release share a daemon.** Nothing sets `TERMIOD_SOCK` per channel,
+   and both apps derive the socket from the same `TMPDIR`
+   (`TermiodClient.swift:40-53`). Today that is harmless because the flag is off
+   by default. After the fork is deleted, launching `termio-dev` shows — and can
+   kill — the release app's sessions. Device architecture §9.1 assumes these are
+   two devices; the code makes them one. *(Inferred from the path derivation, not
+   yet observed; Stage 1's criteria test it.)*
+3. **No systemd unit.** `termiod service` bails on non-macOS with a message
+   naming what to do by hand (`service.rs:121-127`). A Linux user daemon without
+   `loginctl enable-linger` is killed at logout, so sessions silently die between
+   SSH connections — the exact promise the product is built on.
+4. **Install is not content-addressed.** `remote deploy` `scp`s over
+   `~/.local/bin/termiod` (`remote.rs:223-227`), which is the `ETXTBSY` case
+   device arch §6 calls out, and the readiness probe is `test -x` with no version
+   check (`TermioStore+Termiod.swift:382-399`) — a stale daemon is caught only if
+   `hello` outright fails.
+5. **Tombstones are produced and never consumed.** No Swift file mentions them.
+   A session that died is simply absent from the roster, which is the failure
+   mode they were built to prevent.
+6. **A transport failure is reported as `exited`.** `handleStreamEnd` →
+   `deliverExitLocked(status: 1)` (`TermiodClient.swift:1145-1152`). The pane
+   reports a death that did not happen. This is device arch §5.1's `4b`, and it
+   is a prerequisite rather than a polish item: a daemon that restarts under a
+   running app must not look like every session dying.
+
+### 5.3 Is a tombstone enough?
+
+For the crash case, no — and the doc already knows it (§8.3: "Not done: the last
+screen"). A tombstone says *that* a session died and what its status was; the
+user's question is *what was on the screen*. Capturing it needs a snapshot
+request threaded through the sidecar's shutdown path, which a `SIGKILL` does not
+give you. The honest position: the last screen is recoverable on a **clean**
+daemon exit and not on a crash, and the tombstone should say which it was rather
+than implying an answer it does not have. `daemon_lost` already carries no
+invented exit status; the same discipline applies to the screen.
+
+For the **skew** case, tombstones are irrelevant and negotiation is enough. The
+failure that actually costs a user is not skew — it is (2) above, two channels
+racing for one session table.
+
+---
+
+## 6. Performance — is one more IPC hop acceptable?
+
+Measured (device arch §1, 2026-08-05): connect+hello **0.2 ms**, attach→first
+frame **2.2 ms**, echo **~1 ms** above in-process. Against a 16 ms frame budget,
+imperceptible. The throughput bench (`bench/bench_100x.py`) puts termiod at
+4.4–6.0× tmux and, more tellingly, shows termiod's throughput barely moving
+between plain and ANSI-heavy payloads.
+
+That is enough to proceed. Four places where it may not be, ranked by how much
+they worry me:
+
+1. **Echo under a flood, which is unmeasured.** The 1 ms figure is an idle-system
+   number. The interesting question is p95 keystroke echo *while* the same
+   session is emitting at rate — a socket wakeup competing with a read pump
+   competing with the sidecar. The daemon's own budget machinery says this was
+   thought about; the end-to-end number does not exist. **Criterion:** with a
+   `yes` flood running in the same session, p95 echo must stay under 16 ms.
+   Anything above that is visible as a dropped frame.
+2. **Connection-per-operation.** `withControlChannel` opens, hellos, requests,
+   and closes for every `list` and every `kill` (`TermiodClient.swift:733-751`),
+   and `TermiodSessionLink` owns a whole transport plus a dedicated
+   `Thread` per session (`TermiodClient.swift:1066-1109`). Locally that is
+   0.2 ms and a thread; over SSH without a warm ControlMaster it is 216–292 ms
+   *per pane*. This is device arch §5.1 `4a`/`4b`, and after the fork is deleted
+   it applies to every session on this Mac too.
+3. **Startup fan-in.** Surfaces mount lazily (`surface(for:in:)` is called from
+   `TerminalPane`'s body), so this is bounded by *visible* panes rather than by
+   the restored session count — but a window restored with a 4-way split is
+   still 4 connections, 4 handshakes and 4 thread starts on the launch path.
+   That is the thing to measure, not the per-attach figure.
+4. **The shared pipe.** Files, git, search and uploads ride the same connection
+   as keystrokes. The daemon has the head-of-line discipline (credit-of-one,
+   PTY frames drained first, 64 KiB caps — `protocol.rs:58-67`) and the client
+   currently exercises none of it, because the client uses none of those planes.
+   Wiring the panels (Stage 5) is when that discipline first gets tested.
+
+**Where the extra millisecond buys something back:** a session survives the app.
+That is not a consolation — an app relaunch today costs a full shell respawn and
+a lost screen, which is several orders of magnitude more than 1 ms.
+
+---
+
+## 7. The other fork — two CLIs, two servers
+
+This is a separate axis from the PTY fork and deserves its own stage. It is not
+"the CLI is missing a feature"; it is **the CLI is talking to the wrong server**.
+
+```
+scripts/termio (shell)  →  session-control.sock  →  TermioStore+SessionControl.swift  (Swift, 894 lines)
+termiod        (Rust)   →  termiod.sock          →  termiod/src/                      (Rust)
+```
+
+### 7.1 The symptom that names the problem
+
+`termio sessions send` cannot press a bare key. Its delivery is welded
+(`TermioStore+SessionControl.swift:400-402`):
+
+```swift
+_ = state.send(payload)                      // text through the surface
+try? await Task.sleep(for: .milliseconds(40))
+Self.pressReturn(on: surfaceHandle)          // then a synthetic Return key event
+```
+
+The comment above it explains why the weld is necessary *given the route
+chosen*: text goes through `ghostty_surface_text`, so a trailing `\r` in the
+payload arrives as a paste rather than a submit, and the submit has to be a real
+key event. (The same encoder is why `addSnippetToSelectedSessionPrompt` bypasses
+`state.send` entirely and writes raw bytes to the backend —
+`TermioStore.swift:353-372`. The workaround already exists in the codebase, one
+file away.)
+
+The cost is concrete: Codex's startup trust gate reads *"Press t to trust all;
+esc to close"*. `send "t"` presses `t` **and then Return**, which answers the
+next prompt too; `esc` cannot be expressed at all. Driving a sibling agent
+through that gate failed three times in one session and needed a human at the
+keyboard.
+
+`termiod send` has had `--no-enter` since it was written: it writes
+`text.join(" ").into_bytes()` to the PTY master and appends `\r` only when asked
+(`main.rs:285-296`). Same root cause, third occurrence: the capability exists on
+the device and the client path does not reach it.
+
+### 7.2 The boundary — and it is not "move everything"
+
+> **Encoding a human keypress is a viewer job. Writing bytes to a PTY is a
+> device job. The current `send` fails because it routes a byte write through
+> the keypress path.**
+
+⌘V, ⌃C, a dead key, an IME commit, kitty-protocol modifiers — all of these need
+an `NSEvent` and ghostty's key encoder. Rust has no `NSEvent` and must not grow
+a model of one; that is a nested window manager wearing a keyboard (§H #7).
+
+A CLI that wants to press `t` does not have a keypress. It has a byte. Routing
+it through a surface is not "reusing the input path" — it is asking the human
+encoder to reconstruct an intent that was never a keystroke, and the synthetic
+Return is the tell.
+
+### 7.3 Verb-by-verb
+
+Classified by the §1 test. "Device" means the answer is the same from any
+viewer; "viewer" means it names *this* window or *this* Mac.
+
+| Verb | Asks about | Today | After |
+| --- | --- | --- | --- |
+| `send` / `answer` | **Device** — bytes into a PTY | surface text path + synthetic Return (`:400-402`) | `termiod send`, verbatim bytes; `\r` appended only when asked |
+| `read` | **Device** — what is on that screen | client viewport scrape, requires a live surface (`:589-624`) | daemon snapshot; works for a session no viewer has ever opened |
+| `watch` | **Device** — status transitions | `SessionWatchHub` over the app socket (`SessionControl.swift:267-284`) | `subscribe {events:["status"]}` → `E` frames |
+| `list` | **Split** | app project tree + status (`:169-218`) | device answers sessions/status/cwd/agent/title (`SessionInfo` already carries all of it); viewer adds grouping and `termio://` links |
+| `spawn` / `run` | **Split** | app creates a `Session`, mounts a surface, then sends (`:252-322`) | device `create`; viewer places it in a project and a pane |
+| `close` | **Split** | `ptyProcesses[id].terminate()` + remove the row (`ProjectActions:704`) | device `kill`; viewer removes the row. The distinction detach≠kill becomes expressible |
+| `agent report` | **Device** | Mac's `agent-status.sock` | `termiod set-status` (§4) |
+| `focus` | **Viewer** — selects a pane in *this* window | app | **stays in the app** |
+| `notify` | **Viewer** — this Mac's Notification Center | app | **stays in the app** |
+
+Two verbs stay. Everything else moves, and `focus`/`notify` staying is not a
+residue — they are the two verbs that fail the two-observers test outright.
+
+**`send` keeps appending Enter by default.** "Type a prompt into a session" is
+what the verb documents and what every existing caller relies on; making a
+one-character payload silently mean something different would be magic. What
+changes is that the Enter becomes a `\r` **byte** instead of a synthetic key
+event, so it can be turned off: `send --no-enter`, spelled exactly as
+`termiod send` already spells it (`main.rs:88,292`). Byte-exact either way — no
+surface, no encoder, no 40 ms sleep. `esc` becomes expressible for the first
+time because it is just a byte too.
+
+Three sub-features need naming because they are not verbs:
+
+- **`send --wait`** (`:434-584`) waits on *status resting* plus a screen-change
+  fallback. Status is already an `E` event and `wait` is already a control op
+  (`protocol.rs:515`, smoke check 48). The screen fallback and the
+  stalled-prompt / occupant-gone heuristics are supervision policy and belong to
+  the client. **Undecided:** whether `wait`'s `until` set grows to cover the
+  stalled case or the client keeps polling; I have not thought this through far
+  enough to pick.
+- **`watch --state stalled`** is explicitly documented as "a watch-plane signal,
+  not a real status" and is computed from repo change plus transcript growth. It
+  is derived state over device facts; it stays on the client.
+- **Project scoping.** Every request today is resolved to a project via
+  `callerProject(session:cwd:)` (`:769-797`). On a device that becomes a
+  workspace, which is device arch §8.11 and not this RFC. Interim: the viewer
+  keeps doing the scoping and passes an explicit target to the device.
+
+### 7.4 The Linux payoff
+
+`termio sessions list` on a box with no Mac app has no server. After the move it
+has one — the same daemon that is already running the sessions. An agent
+supervising siblings from inside a VPS session gets the same verbs it has on the
+laptop, and `termiod` is one static binary. This is the same return as "local
+also goes through termiod", collected on a different surface.
+
+### 7.5 Coexistence during migration
+
+`scripts/termio` is a published contract; `termio agent report` is baked into
+users' agent config files by past releases (AGENTS.md names it as the public
+hook contract). It cannot be swapped wholesale.
+
+The shape that avoids a flag day: **`scripts/termio` becomes a router, one verb
+at a time.**
+
+```
+if TERMIOD_SESSION is set (or the resolved target names a device session):
+    speak the session protocol   →  termiod
+else:
+    speak the legacy request     →  app control socket
+```
+
+Per verb, the sequence is: implement on the daemon → route the verb → verify
+both branches → delete the Swift handler. The Swift control plane's last day is
+when its final case is unreachable — `handleSessionControl`'s switch
+(`:44-53`) is down to `focus` and `notify`, at which point those two stay and
+the streaming `watch` path (`SessionControl.swift:267`) goes with the rest.
+
+**Output shape is the compatibility surface, not just the verb.** `--json`
+replies carry `schema_version: 1` and a documented field set; a caller that
+parses them (an agent, a script) must not see the shape change under it. Each
+moved verb keeps its reply shape byte-for-byte until a deliberate, versioned
+change.
+
+---
+
+## 8. Migration
+
+Each stage is independently shippable, independently revertible, and carries a
+criterion that can be **run**. "It compiles" is not a criterion anywhere below.
+
+### Stage 0 — clear the field
+
+Not optional and not bookkeeping: the refactor rewrites `TermiodClient.swift`,
+`TermioStore+Termiod.swift`, `Models.swift`, `TermioStore.swift`,
+`TermioStore+ProjectActions.swift` and `SidebarView.swift`, and **three
+worktrees are holding uncommitted or unpushed edits to exactly those files.**
+
+The state, measured (2026-08-17):
+
+| Worktree | Branch | Uncommitted | Ahead of `main` | Pushed |
+| --- | --- | --- | --- | --- |
+| `termio` (main checkout) | `main` | 16 files | — | — |
+| `termio-worktrees/remote-to-device` | `feat/remote-to-device` | 9 files | 0 | no |
+| `.claude/worktrees/client-caps` | `feat/client-negotiates-all-caps` | clean | **2** | **no** |
+| `.claude/worktrees/device-context` | `feat/device-is-the-context` | 9 files | 3 (merges the above) | no |
+| `termio-worktrees/settings-file-watch` | `feat/settings-file-watch` | 10 files | 0 | no |
+| `.claude/worktrees/agent-a6effa84…` | `feat/theme-store` | 19 files | 0 | no |
+| `.claude/worktrees/editor-scrollaway-header` | — | 2 files | 2 | yes |
+| `.claude/worktrees/ios-device-rename` | `refactor/ios-device-concept` | 7 files | 0 | no |
+
+**The finding that changes the order of everything below:** the same change
+exists in three places, in three states of commit, and none of it is pushed.
+
+- `feat/client-negotiates-all-caps` holds **1,415 lines across 13 files**,
+  committed, never pushed, with no PR. Its two commits are precisely two items
+  from this RFC: *"consume the events the daemon was already sending"*
+  (negotiates `events`, routes `status`/`writer_changed`/`resized`, decodes
+  tombstones — closing §5.2 items 5 and part of 6) and *"put every machine in
+  one switcher and retire the word remote"*.
+- `feat/device-is-the-context` merged that branch and added 9 more uncommitted
+  files on top.
+- `feat/remote-to-device` holds an uncommitted **subset** of the same work —
+  its untracked `DeviceSwitcher.swift` is byte-identical to the one committed on
+  the caps branch — on a base 32 commits behind `main`.
+
+So the largest risk to this RFC is not merge conflict. It is that a
+reviewer looks at `main`, concludes the events plane is unwired, and rebuilds
+1,400 lines that already exist on a local branch.
+
+**Order, and the test for each:**
+
+1. **Land or kill `feat/client-negotiates-all-caps`.** It is a superset of two
+   stages below and it is committed. Rebase onto `main` (7 commits), push, PR.
+   Its own tests (`TermiodEventTests`, `TermiodStatusTests`, +51 lines of smoke)
+   are the criterion.
+2. **Collapse the two duplicates into it.** `feat/remote-to-device`'s
+   uncommitted work is a subset — discard it after confirming so with a diff,
+   do not merge it. `feat/device-is-the-context`'s 9 files are the only unique
+   content; commit them on top of (1).
+3. **Land or discard the unrelated dirty worktrees.** `theme-store` (19 files,
+   uncommitted, with `docs/rfcs/theme-store.md` existing untracked in *two*
+   worktrees), `settings-file-watch` (10), the `main` checkout's own 16, and
+   `editor-scrollaway-header` (2 files that do not match its branch name, one of
+   them an iOS app icon — inspect before assuming it is wanted).
+4. **Close the noise PRs.** PR #317 carries six `__pycache__/*.pyc` files it
+   should not; PR #310 is this RFC family's own predecessor and should merge or
+   close before a second RFC lands beside it.
+
+**Criterion for Stage 0:** `git worktree list` shows no worktree with
+uncommitted changes to any of `Sources/termio/Terminal/Termiod/*`,
+`Sources/termio/TermioStore/*`, `Sources/termio/App/Models.swift`,
+`Sources/termio/Terminal/Ghostty/PTYProcess.swift`; and every branch that is
+ahead of `main` is either pushed with a PR or deleted.
+
+**One thing Stage 0 does *not* need to clear.** No uncommitted change and no
+open PR touches `PTYProcess.swift`, `TermioStore+TerminalSurface.swift`,
+`GitService.swift`, or `FileBrowser/`. Only PR #73 touches a refactor-critical
+file at all (`TermioStore.swift`). The collision is concentrated in the
+*device-client* files, not the PTY and panel files — the brief assumed the
+opposite, and planning around the wrong set would have serialised work that can
+run in parallel.
+
+### Stage 1 — the daemon ships and is reachable
+
+Nothing below is safe until a released app can start a daemon.
+
+1. Build `termiod` in `release.yml` and copy it into the bundle
+   (`Contents/Resources/termiod` or `Contents/MacOS/`); sign and notarize it
+   with the app.
+2. `daemonBinaryPath()` resolves the bundled binary first, then
+   `TERMIO_TERMIOD_BIN`, and only then the dev tree.
+3. Derive `TERMIOD_SOCK` per channel so `termio-dev` and `termio` are two
+   devices, as device arch §9.1 already assumes.
+4. Ship the systemd `--user` unit + `enable-linger` guidance as
+   `termiod service install` on Linux.
+
+**Criteria (run, not read):**
+- On a machine with no checkout: install the notarized `.app`, launch it from
+  Finder, open a terminal, and `termiod service status` reports a live socket;
+  `ps -o comm= -p <daemon pid>` resolves to a path inside the `.app` bundle.
+- `codesign -vvv --deep --strict termio.app` passes with the daemon inside.
+- Launch `termio-dev` and `termio` together; each `termiod list` returns a
+  disjoint session set, and `hello_ok.host_id` differs between them.
+- On Linux: `termiod service install`, `loginctl terminate-user $USER`, log back
+  in, `termiod list` still shows the session created before logout.
+
+**Rollback:** the flag is still off by default; revert the bundling commit.
+
+### Stage 2 — the connection is an object
+
+Device arch §8.4. Prerequisite for every later stage because it is what stops a
+daemon restart from reading as N session deaths.
+
+- `4a`: put `ssh_multiplex_args()`'s option set — plus the `BatchMode` /
+  `ConnectTimeout` every other ssh call site already sets and this one does not
+  — on the app's own ssh invocation.
+- `4b`: a `TermiodConnection` per device owning transport, health and reconnect.
+  `TermiodSessionLink` becomes a client of it. `handleStreamEnd` stops calling
+  `deliverExitLocked`.
+
+**Criteria:**
+- With three panes open on one SSH device, `pgrep -lf 'ssh .*<alias>'` shows
+  **one** ssh process, not three.
+- `launchctl kickstart -k gui/$UID/sh.termio.termiod` while three local panes
+  are open: no pane shows "process exited"; all three show a reconnecting state
+  and then repaint from a snapshot with their shell history intact.
+- `termiod list` before and after that restart returns the same session ids.
+
+**Rollback:** self-contained; the link keeps working if the connection object is
+reverted.
+
+### Stage 3 — foreground parity (§3)
+
+`foreground_job` on `SessionInfo`, `foreground_changed` as an event, the
+Linux/macOS split behind one trait, argv → agent mapping staying on the client.
+
+**Criteria:**
+- New smoke checks: with `sleep 60` running, `list` reports
+  `foreground_job: true`; at a bare prompt, `false`. Run in `termiod`'s CI on
+  both macOS and Linux — this is the test that settles §3.1's uncertainty.
+- Start a shell session on a VPS, run `sleep 60`, press ⌘W: the same
+  confirmation a local shell gives today.
+- Type `claude` at a prompt in a *termiod* session; the sidebar row's icon
+  becomes Claude's within 1 s, and reverts on exit. (This is the bug from §0
+  that has no fix without this stage.)
+- A daemon built without the field: closing a shell with a live job shows **no**
+  dialog — today's behaviour, not a blanket confirm.
+
+**Rollback:** additive field; an app that ignores it behaves as before.
+
+### Stage 4 — the companion stops depending on `PTYProcess`
+
+The blocker identified in §1.5. `PTYBridge` takes a protocol
+(`sink`, `write`, `resize`, `alternateScreenActive`, `resyncPreamble`) that both
+`PTYProcess` and `TermiodSessionLink` satisfy. Not a rebuild of the companion —
+only enough to unblock the deletion.
+
+**Criteria:**
+- With `TERMIO_TERMIOD=1`, open a session on the phone, type, resize, background
+  and foreground the app: same behaviour as with the flag off. Verified on a
+  real device, not the simulator.
+- `grep -rn 'PTYProcess' Sources/termio/Companion/` returns nothing.
+
+**Rollback:** the protocol has one other conformer; revert to the concrete type.
+
+### Stage 5 — delete the fork
+
+Only now. Remove `Termiod.isEnabled` and every branch on it, the in-process
+`PTYProcess` construction, the flag-off alert (`TermioStore+Termiod.swift:471-477`),
+and the `ptyProcesses` half of `terminateAllSessions` (the detach half already
+ships).
+
+**Criteria:**
+- `grep -rn 'TERMIO_TERMIOD\b' Sources/ | wc -l` → 0.
+- `grep -rn 'PTYProcess(' Sources/ | wc -l` → 0.
+- Open a local terminal, run `sleep 300`, quit the app, relaunch: the pane
+  reattaches to the **same pid** (compare `termiod list --json`) with its screen
+  intact.
+- `swift test` green, including `SplitTreeTests` and the status tests.
+- Screen-recorded pass of: new terminal, new agent session, split, close with a
+  running job (dialog), close idle (no dialog), agent self-quit reverting to a
+  shell.
+
+**Rollback: this is the one stage that is hard to revert**, because it deletes
+the alternative. Mitigation is sequencing, not a switch: Stages 1–4 each remove
+a reason the flag existed, so by the time this lands the flag has been on by
+default for a full release cycle. Concretely — **ship Stage 4 with the flag
+defaulting to on and the env var able to force it off**, run one release, then
+delete in Stage 5. The escape hatch is a release rollback, not a runtime flag.
+
+### Stage 6 — the CLI moves, verb by verb (§7)
+
+Order chosen so the highest-pain verb lands first:
+
+1. `send` / `answer` — byte-exact injection.
+2. `read` — daemon snapshot.
+3. `watch` — `subscribe`.
+4. `list` — device fields from the daemon, grouping from the viewer.
+5. `spawn` / `run`, `close` — split as in §7.3.
+6. `agent report` → `set-status` (§4), and hook installation on the device.
+
+**Criteria:**
+- The one the brief asked for, made mechanical: create a session running
+  `cat -v`; `termio sessions send --no-enter <s> t` puts exactly `t` on the
+  screen with no `^M` and no second line, and plain `termio sessions send <s> t`
+  still shows `t` followed by a submit (the unchanged default). Then, on a real
+  Codex startup gate, `termio sessions send --no-enter <s> t` dismisses the
+  trust prompt and leaves the next prompt untouched, and
+  `termio sessions send --no-enter <s> $'\e'` closes it.
+- `termio sessions read <s>` returns the screen of a session that has **never**
+  been opened in a window (today: `not_live`).
+- On a Linux box with no Mac app: `termio sessions list` and
+  `termio sessions send` work against the local daemon.
+- Old-shape check: `termio sessions list --json` output is field-identical to
+  the pre-move build for the same session set.
+- After the last move, `handleSessionControl`'s switch contains `focus` and
+  `notify` and nothing else.
+
+**Rollback:** per verb — the router's legacy branch is still there until the
+Swift handler is deleted, and deleting each handler is its own commit.
+
+### Stage 7 — the panels move (device arch §8.9)
+
+File tree, search, and git status/diff read the workspace's device through the
+`files`/`git` planes. `SSHFileSystemProvider` and `SFTPClient` (1,409 lines) are
+deleted. `GitService`'s 12 history/compare/remote verbs are the part with no
+device counterpart and stay local until the daemon grows them — say so in the
+UI rather than showing an empty pane.
+
+**Criteria:**
+- The file tree renders for a session on a VPS, and expanding a directory that
+  has never been listed costs one round trip (measure with a request log).
+- `touch` a file on the VPS; it appears in the tree without a manual refresh.
+- ⌘⇧O finds a file on the VPS by name, and shows "still indexing" rather than
+  silently missing files while `coverage < 1.0`.
+- The git changes pane shows a VPS worktree edit with the correct two-axis
+  status.
+- `grep -rn 'SFTP' Sources/ | wc -l` → 0.
+
+---
+
+## 9. Risks and rollback
+
+| Risk | Why it is real | Mitigation |
+| --- | --- | --- |
+| **The daemon becomes release-critical and it has never shipped** | §5.2 item 1: the release pipeline does not build it and the fallback path is a dev tree | Stage 1 first, with a criterion that runs on a clean machine from a notarized build |
+| **A daemon crash loses every session at once** | Shared fate is replaced by a single point | launchd `KeepAlive` (shipped) + tombstones (shipped, must be consumed) + the honest admission that the last screen is unrecoverable on `SIGKILL` (§5.3) |
+| **Stage 5 is not revertible** | It deletes the alternative | Flag-on-by-default for one release before deletion; rollback is a release rollback |
+| **Rebuilding work that exists on an unpushed local branch** | 1,415 committed lines on `feat/client-negotiates-all-caps` with no PR | Stage 0 item 1, before anything else |
+| **The companion breaks silently** | `PTYBridge` is typed on the concrete class and no test covers the phone | Stage 4 gates Stage 5, with a real-device criterion |
+| **Anti-100× regression** | Adding foreground sampling and a status source to the daemon puts new work near the read loop | Every new sampler runs on its own task; the criterion is the existing `bench_100x.py` staying within its current band, run in CI before and after Stage 3 |
+| **`termio sessions` breaks an agent's script** | It is a published contract with a documented JSON shape | Per-verb routing with the legacy branch alive; field-identical `--json` output as a Stage 6 criterion |
+| **Dev and release fight over one session table** | Same socket derivation (§5.2 item 2) | Stage 1 item 3, with a criterion that checks `host_id` differs |
+| **Panels regress for local projects** | Stage 7 replaces a working local path with a round trip | `fs.list` replies are `seq`-stamped and clients cache indefinitely (§C.12), so a visited directory is 0-RTT; the criterion measures the cold expansion, and the local socket makes it sub-millisecond |
+
+---
+
+## 10. Open questions
+
+1. **Hook payload shape (§4.2 item 2).** Extend `SetStatus` with four optional
+   fields, or add a `workstream` update op? Nothing forces the choice yet.
+2. **Can an agent in a container reach the daemon socket?** The whole hook design
+   assumes yes. Untested against `docker exec`-style sessions. Nothing regresses
+   if the answer is no — the Mac's socket is equally unreachable today — but the
+   design would need a second route.
+3. **`send --wait`'s stalled-prompt heuristic (§7.3).** Grow `wait`'s `until`
+   set, or keep polling on the client? Undecided.
+4. **What replaces `reapStrayOrphans`?** A supervised daemon should have no
+   orphans, but *the daemon itself* can be `SIGKILL`ed and leave its children
+   re-parented to launchd. The current sweep matches on `TERMIO_SESSION` +
+   `TERM_PROGRAM=termio`; the daemon would need its own equivalent, and I have
+   not checked whether `KeepAlive` restarting the daemon adopts or races them.
+5. **Does `PTYProcess` survive at all?** After Stage 5 nothing constructs it. It
+   holds real learning (the `forkpty` shape, the non-blocking write backlog),
+   most of which `pty.rs` already mirrors. Delete or keep as a test fixture —
+   cheap either way, no need to decide now.
+6. **Linux `tcgetpgrp` on the ptmx master (§3.1).** Strong precedent, not
+   verified here. Stage 3's CI criterion is the verification, but if it fails the
+   Linux fallback is unclear — reading `/proc/<child>/stat`'s `tpgid` field is
+   the candidate and has not been checked.
+7. **Git history on the device.** 12 `GitService` verbs have no daemon
+   counterpart. Port them, or accept that history is a local-project feature
+   until someone asks? The read-only-by-design rule (§C.13) covers *mutation*;
+   it says nothing about history, which is read-only and genuinely missing.
+8. **When may the app require a `hello`?** Deprecation policy for v0-only
+   clients is listed as a human product call in the protocol doc's top five and
+   is still open. It becomes load-bearing the day the daemon ships in the app,
+   because then the version pair is *ours* and the skew window is a user's
+   upgrade lag rather than a developer's checkout.

--- a/docs/rfcs/one-path-local-through-termiod.review-claude.md
+++ b/docs/rfcs/one-path-local-through-termiod.review-claude.md
@@ -1,0 +1,664 @@
+---
+title: Review — One path, local sessions run through termiod too
+status: draft
+type: rfc
+created: 2026-08-17
+updated: 2026-08-17
+related:
+  - one-path-local-through-termiod.md
+  - 20260805-termiod-device-architecture.md
+  - 20260730-termiod-session-protocol.md
+---
+
+# Review — One path, local sessions run through termiod too
+
+Adversarial read of `docs/rfcs/one-path-local-through-termiod.md` at `b4e3e6c`.
+Every claim below was checked against the tree; where I could not check
+something I say so instead of guessing.
+
+---
+
+## Verdict
+
+**Implementable as an argument, not yet as a plan.** The diagnosis is right and
+the sourcing is unusually good — I spot-checked about 45 `file:line` citations
+and the large majority land exactly on the line claimed, including several that
+are easy to get wrong (`Models.swift:344`, `TerminalSurface.swift:199`,
+`SessionControl.swift:400-402`, `pty.rs:114`, `main.rs:91-100`,
+`HookListener.swift:289`). The Stage 0 worktree table is exact: I re-measured
+every dirty count and every ahead-of-`origin/main` count and they all match, the
+1,415-lines-across-13-files figure is exact, and `DeviceSwitcher.swift` really is
+byte-identical between two worktrees (`c51f8eca…`).
+
+Four things must be fixed before anyone builds from it:
+
+1. **Stage 2's central criterion asks the daemon for something it cannot do.**
+   Sessions do not survive a daemon restart — `tombstone.rs:178-211` buries every
+   one of them as `daemon_lost` on the next start. The criterion says three panes
+   repaint "with their shell history intact" after `launchctl kickstart -k`. They
+   will not. This is the whole single-point-of-failure argument, and §5 is
+   optimistic by one entire failure class. **(F1)**
+2. **§1.5's companion inventory is about half the real surface**, and Stage 4's
+   five-member protocol cannot be written as described — three of the members it
+   omits have no daemon counterpart and are not additive protocol work. **(F2)**
+3. **Stage 0's reassurance paragraph is false on the file the RFC itself calls
+   the largest single item.** Two open PRs touch `CompanionServer.swift`, and a
+   third change to it sits committed-but-unpushed in a `/private/tmp` worktree.
+   **(F3)**
+4. **Stage 0's first criterion cannot be run** (Swift tests do not run — issue
+   #311 is open — and the "+51 lines of smoke" it cites do not exist), and neither
+   can Stage 5's. **(F4)** The genuinely unrecoverable step is Stage 0, not
+   Stage 5. **(F5)**
+
+Fix those and the ladder is sound. §3, §4 and §7.2's boundary are the strongest
+parts and I found no design regression against the four invariants — the daemon
+already refuses to send OSC 4 for exactly the "host never decides presentation"
+reason (`vt/src/lib.rs:198-200`), and the fan-out really is fire-and-forget
+(`session.rs:1466-1469`).
+
+---
+
+## Citation audit
+
+Sampled ~45 citations. Wrong: 3. Inflated: 2. Everything else checked out, most
+to the exact line.
+
+| Claim | Verdict | Evidence |
+| --- | --- | --- |
+| "`libc::` appears 18× in `pty.rs`, 9× in `client.rs`, ≤2× in each of `session.rs`/`files.rs`/`paths.rs`/`service.rs`" (§3.1) | **不属实** — low | Actual: `pty.rs` **26**, `client.rs` **13**, `session.rs` **3** (breaks the "≤2×" bound), `files.rs`/`paths.rs`/`service.rs` 1 each. The *conclusion* (the Unix dependency is concentrated, so a port is bounded) survives; the numbers do not. Fix the numbers or drop them. |
+| "the `S` snapshot prologue does this correctly (`protocol.rs:398-417`, `tests/snapshot_prologue.rs`)" (§1.1) | **不属实** (citation) — low | `protocol.rs:398-417` is `Detach` / `Subscribe` / `SubscribeResource` / `UnsubscribeResource`. The prologue is `SNAPSHOT_PROLOGUE` + `VtTerminal::format_vt` in `vt/src/lib.rs:193-215`. The test half of the citation is right and the substance is right. |
+| "Its own tests (`TermiodEventTests`, `TermiodStatusTests`, **+51 lines of smoke**) are the criterion" (Stage 0 item 1) | **不属实** — medium, see F4 | `git show --stat 5c6ccf9` and `c504bee`: neither commit touches `termiod/smoke_test.py` at all. The two Swift test files are +287 lines. |
+| "31 of the daemon's 86 smoke checks cover `fs.*`/`git*`" (§0) | **夸大** — low | 86 checks total ✓. By verb: 22 (`files` gate + `fs.list`×3 + `fs.read`×3 + `fs.match`×4 + `git`×6 + `git.diff`×1 + `fs.search`×4). You reach 31 only by counting the 9 `upload:` checks, which are not what the row is about. Per-row counts in §1.2 are all exact. |
+| "No uncommitted change and no open PR touches … `GitService.swift`" (Stage 0) | **不属实** — low on its own, see F3 | `GitService.swift` is dirty in `feat/remote-to-device` (a one-line comment) and is changed by `feat/client-negotiates-all-caps` itself (2 lines). Materially harmless; the same sentence is badly wrong about `CompanionServer.swift`. |
+
+Verified exact, listed because they carry weight: `PTYProcess.swift:866`
+(`foregroundProcessArguments`), `:923` (`hasForegroundJob`), `:805`
+(`currentWorkingDirectory`), `:859-865` (records the macOS `tcgetpgrp`-on-master
+behaviour as verified); `TerminalSurface.swift:199`, `:228-231`, `:303-328`,
+`:390-426` with the call at `:413`; `TermiodClient.swift:40-53`, `:58-64`,
+`:733`, `:882`, `:1066-1109`, `:1145-1152`; `TermioStore+Termiod.swift:18-23`,
+`:68-70`, `:93-96`, `:382-399`, `:471-477`; `ProjectActions:609/690/704/741`;
+`TermioStore.swift:413-416`, `:721-731`; `FileBrowserView.swift:53/297`;
+`SessionControl.swift:44-53`, `:400-402`, `:769`; `pty.rs:67-167/114/183/208-226`;
+`session.rs:25`; `protocol.rs:423/515/810-832`; `service.rs:121-127`;
+`remote.rs:223-227`; `tombstone.rs:66-88`; `main.rs:88/91-100/292`;
+`scripts/termio:566-580/581-587/584`; `HookListener.swift:289`. Line counts are
+exact too: SFTP 1,409; `SessionControl` 894; `git.rs` really is `run_status` +
+`run_diff` and nothing else; no Swift file names an `fs.*`/`git*` verb; no Swift
+file consumes tombstones; `scripts/build-app.sh` and `release.yml` really do not
+mention `termiod`; `tcgetpgrp` really appears nowhere in `termiod/src`.
+
+§0's premise audit holds. Both "Fixed" rows are genuinely fixed — the
+`TERMIO_TERMIOD_REMOTE` fallback is gone, `inheritDevice` is called at both split
+sites, and image paste is wired end to end (`TerminalContextMenu.swift:187` →
+`TermiodTransfer.pasteImage:212` → `uploadToSessionScratch:32`).
+
+---
+
+## Findings
+
+### F1 — Stage 2's criterion is unachievable: a daemon restart destroys every session
+
+**属实 · blocker · `tombstone.rs:178-211`, `session.rs:1219-1226`**
+
+Stage 2 says:
+
+> `launchctl kickstart -k gui/$UID/sh.termio.termiod` while three local panes are
+> open: no pane shows "process exited"; all three show a reconnecting state and
+> then repaint from a snapshot with their shell history intact.
+> `termiod list` before and after that restart returns the same session ids.
+
+`Graveyard::open` runs at daemon start and does the opposite:
+
+```rust
+// tombstone.rs:195-210
+let orphans: Vec<RosterEntry> = read_json(&graveyard.roster_path).unwrap_or_default();
+for orphan in orphans.into_iter().rev() {
+    graves.insert(0, orphan.into_tombstone());
+}
+// The roster starts empty for this daemon: whatever the last one held is
+// now buried …
+```
+
+Every session the previous daemon held is buried as `daemon_lost`, and the new
+daemon starts with an empty table. There is no fd handoff and no re-exec —
+`grep -rn 'SCM_RIGHTS\|execve' termiod/src` returns nothing, and the PTY master
+is an `OwnedFd` inside the process (`pty.rs:98-101`). A restarted daemon *cannot*
+re-adopt those PTYs. After `kickstart -k`, `termiod list` returns an empty set
+plus three fresh tombstones, and the children are re-parented with a dead master.
+
+The RFC knows the fact and does not connect it. §5.1 explains `daemon_lost`
+correctly ("a session still on the on-disk roster when a daemon starts was never
+buried, so the previous daemon died under it"), and §5.3 concedes the last screen
+is unrecoverable on `SIGKILL`. Stage 2 then asks for shell history intact after a
+`SIGKILL`.
+
+Why this is a blocker rather than a wording fix: the whole reason Stage 5 is
+allowed to delete the alternative is that Stages 1–4 "each remove a reason the
+flag existed". Stage 2 was supposed to remove "a daemon restart looks like every
+session dying". It removes the *misreporting* (`handleStreamEnd` →
+`deliverExitLocked(status: 1)` at `TermiodClient.swift:1145-1152` is a real bug and
+worth fixing) but not the *dying*. Today an app crash and its shells share a fate
+the user understands. After Stage 5, a daemon crash kills every session on the
+machine across every window — strictly worse than today, with no shared-fate
+intuition to explain it.
+
+What the RFC has to add, minimum: a seventh §5.2 blocker stating plainly that
+session survival across a daemon restart does not exist, and an honest Stage 2
+criterion — panes enter a `daemon_lost` state named as such, not `exited`, and
+`termiod tombstones` explains each one. If survival is actually wanted, it is a
+design (supervisor process holding the masters, or `exec`-preserving re-exec) and
+belongs in this RFC, not in a criterion.
+
+Related, and also unanswered: there is no `reapStrayOrphans` on the Rust side.
+Open question 4 knows this; it does not know that F1 makes it fire on every
+daemon restart, not only on a crash.
+
+### F2 — §1.5's companion inventory is half the surface; Stage 4's protocol is not writable as specified
+
+**属实 · high · `CompanionServer.swift` (grep-verified line by line)**
+
+§1.5 says `PTYBridge` "calls `addSink`, `isAlternateScreenActive`,
+`modeResyncPreamble`, `resizeFromCompanion`, `claimHostOwnership`,
+`claimCompanionOwnership`", and Stage 4 proposes a protocol of
+`(sink, write, resize, alternateScreenActive, resyncPreamble)` — five members.
+
+The real call set, from `grep -rn` over `Sources/termio/Companion/`:
+
+| Member | Site | termiod counterpart |
+| --- | --- | --- |
+| `addSink(on:replayingBuffer:replayCap:)` | `:985` | **none** — see below |
+| `removeSink(token)` | `:1047` | none (no token model on the link) |
+| `isAlternateScreenActive` | `:979` | **none as a local query** |
+| `modeResyncPreamble()` | `:1006` | none as a local query |
+| `addResizeObserver` / `removeResizeObserver` | `:1015`, `:1049` | daemon `resized` event, unwired |
+| `resizeFromCompanion` | `:1041` | newest-writer-wins resize, different policy |
+| `jiggleResize` | `:1042`, `:1081` | **none** |
+| `claimCompanionOwnership` | `:295` (via `bridge.pty`) | writer token, different policy |
+| `addExitObserver` | `:345` | **single closure, already taken** |
+
+Three of these are not additive protocol work:
+
+- **`addSink(replayingBuffer:replayCap:)`** is not "a sink". It replays the PTY's
+  ring at attach, capped at 128 KiB, and the cap is load-bearing — the comment at
+  `:990-995` says replaying the whole 1 MB ring "can tip libghostty's allocator
+  into its panic screen on the cold attach". `TermiodSessionLink` has no ring and
+  no byte-capped replay verb; the daemon's ring is `RING_CAP = 128 KiB`
+  (`session.rs:23`) but no wire op asks for *N bytes of it*. Calling this "sink"
+  in a five-member protocol hides the hardest item in Stage 4.
+- **`addExitObserver`** is a *registry*. `TermiodSessionLink.onExit` is one
+  closure and `attachTermiodLink` already consumes it
+  (`TermioStore+Termiod.swift:90`). The companion needs a second observer. That is
+  a fan-out the link does not have, not a conformance.
+- **`jiggleResize`** is a local `TIOCSWINSZ` twiddle used precisely when the size
+  did *not* change, to force a repaint (`:1032-1038` explains why). A `resize` to
+  identical dimensions is a no-op on the daemon. There is no wire verb for "make
+  the child redraw".
+
+Two smaller corrections in the same area:
+
+- §1.1 calls `modeResyncPreamble` "**Superseded** — the `S` snapshot prologue does
+  this correctly". True for *attach*. `PTYBridge` needs `isAlternateScreenActive`
+  as a **local, synchronous query** to decide replay-vs-skip *before* any snapshot
+  is requested (`:979-1008`). The client has no VT state to answer it from.
+- §1.1 says the host-vs-companion resize arbitration "is a companion concept with
+  no daemon counterpart". It has a counterpart with different semantics — newest
+  interactive attach wins, with `writer_changed` fan-out (smoke checks 2, 9, 14,
+  42–44). Reconciling explicit-claim with newest-wins *is* Stage 4's design work,
+  and calling it "missing" skips it.
+
+Consequence for the ladder: Stage 4 is not "not a rebuild of the companion", it is
+a rebuild of `PTYBridge`. That is fine — it may even be the right thing, since
+§1.5 already argues the phone should stop mirroring a viewer — but it should be
+sized honestly, because Stage 5 is gated on it.
+
+### F3 — Stage 0's "one thing Stage 0 does not need to clear" is false, on the blocker file
+
+**不属实 · high · `gh pr list`, `git worktree list`**
+
+The RFC says:
+
+> No uncommitted change and no open PR touches `PTYProcess.swift`,
+> `TermioStore+TerminalSurface.swift`, `GitService.swift`, or `FileBrowser/`.
+> Only PR #73 touches a refactor-critical file at all (`TermioStore.swift`).
+
+Run today:
+
+- **PR #298** "Reap a phone whose companion link died without a FIN" — 4 files,
+  including `Sources/termio/Companion/CompanionServer.swift`.
+- **PR #296** "Read a session's conversation as a chat lens on the phone" — 17
+  files, including `Sources/termio/Companion/CompanionServer.swift`.
+
+`CompanionServer.swift` is the RFC's own "**largest single item**" (§1.5) and the
+entire premise of Stage 4. Two open PRs on it, one of them a 17-file feature, is
+exactly the collision Stage 0 exists to find.
+
+There is a third, worse one. `git worktree list` shows **22** worktrees; the RFC's
+table lists 8. Two of the unlisted ones are ahead of `origin/main` and unpushed:
+
+- `rebase/companion-link-resilience` — commit `a44fd9c`, `CompanionServer.swift`
+  +54 plus three iOS files — living in
+  `/private/tmp/claude-501/…/scratchpad/wt-298`. A temp directory. The OS may
+  delete it.
+- `poc/headless-input-plane` — commit `90f75dd`, 263 lines under
+  `poc/headless-input-plane/` spiking a structured input plane. That is §7.2's
+  subject matter, and the RFC's §7 does not know it exists.
+
+Seven more unlisted branches are ahead of `origin/main` but pushed
+(`feat/clickable-file-paths` +3, `feat/settings-file` +2, `docs/ios-agent-gui`,
+`feat/ios-chat-lens`, `ci/stats-skip-when-unconfigured`,
+`feat/tunelo-stable-subdomain`, `docs/remote-to-device-rfc`). Stage 0's criterion
+— "every branch that is ahead of `main` is either pushed with a PR or deleted" —
+is therefore roughly ten branches wider than the table implies, and the
+"parallelisable, collision is concentrated in device-client files" conclusion is
+wrong for the companion specifically.
+
+To be fair to the RFC: **the eight rows it does list are exact.** I re-measured
+dirty counts (16 / 9 / 0 / 9 / 10 / 19 / 2 / 7) and ahead-of-`origin/main` counts
+(0 / 0 / 2 / 3 / 0 / 0 / 2 / 0) and every one matches. The byte-identical
+`DeviceSwitcher.swift` claim is true (`shasum` `c51f8eca…` on both). The 1,415
+insertions across 13 files is exact. The `__pycache__` claim about PR #317 is
+exact (6 `.pyc` files). This finding is that the table stopped one `git worktree
+list` short, not that it is careless.
+
+### F4 — Stage 0's first criterion and Stage 5's criterion cannot be run
+
+**属实 · high · issue #311 (open), `git show --stat`**
+
+The RFC opens §8 with "Each stage … carries a criterion that can be **run**. 'It
+compiles' is not a criterion anywhere below." Then:
+
+- **Stage 0 item 1**: "Its own tests (`TermiodEventTests`, `TermiodStatusTests`,
+  +51 lines of smoke) are the criterion." Both named files are Swift tests.
+  `gh issue view 311` → **OPEN**, "Swift unit tests cannot run at all". And the
+  smoke lines that would have been the runnable half do not exist —
+  `git show --stat` on both commits of `feat/client-negotiates-all-caps` touches
+  `smoke_test.py` zero times.
+- **Stage 5**: "`swift test` green, including `SplitTreeTests` and the status
+  tests." Same problem, on the one stage that deletes the alternative.
+
+So the ladder's first gate and its point of no return both depend on a suite that
+does not compile. Either #311 becomes Stage 0 item 0 with its own criterion, or
+those two stages need criteria that can actually execute today. The daemon's own
+suite can: `termiod.yml` runs on both `macos-26` (`:40`) and `ubuntu-24.04-arm`
+(`:138`), so Stage 3's "run in `termiod`'s CI on both macOS and Linux" is
+genuinely executable — the RFC is right about that one.
+
+### F5 — the unrecoverable step is Stage 0, not Stage 5
+
+**属实 · high · Stage 0 items 2–3**
+
+Stage 5 is labelled "the one stage that is hard to revert" and is given a real
+mitigation (flag-on-by-default for a release, rollback is a release rollback).
+That is a sound answer, and it *is* recoverable — the commit is in history.
+
+Stage 0 is not. Item 2 says to "discard [`feat/remote-to-device`'s uncommitted
+work] after confirming so with a diff". Item 3 says "land or discard" the
+`theme-store` worktree's 19 uncommitted files, `settings-file-watch`'s 10, the
+`main` checkout's 16, and `editor-scrollaway-header`'s 2. **Uncommitted work has
+no reflog.** A `git checkout -- .` there is permanent. Stage 0 is the only step in
+the ladder with no rollback line, and it is the only genuinely irreversible one.
+
+Minimum fix: every "discard" becomes "commit on a throwaway `wip/<slug>` branch,
+then remove the worktree". Costs nothing and makes the step reversible.
+
+### F6 — §6 measures latency and never measures what the change actually costs: every local byte is parsed twice
+
+**夸大 by omission · medium · `session.rs:1219-1226`, `:1461-1469`, `:23-29`**
+
+The VT sidecar is not conditional. `session.rs:1223` constructs every session with
+`sidecar_tx: Some(sidecar.commands)`, and the read loop feeds it on every chunk:
+
+```rust
+// session.rs:1464-1469
+Ok(n) => {
+    let chunk = Bytes::copy_from_slice(&buf[..n]);
+    // This refcount clone + unbounded send is strictly
+    // fire-and-forget. Fan-out never waits for VT parsing …
+    session.write_sidecar(chunk.clone());
+```
+
+No `snapshot` negotiation gates it. So after this RFC, a **local** session's bytes
+are parsed twice — once by the `termiod-vt` thread (`session.rs:1267-1269`, one
+dedicated OS thread per session) and once by libghostty in the app — plus a
+128 KiB ring copy (`RING_CAP`, `:23`) and up to 16 MiB of sidecar queue budget
+(`SIDECAR_QUEUE_CAP`, `:29`). Today it is parsed once.
+
+The anti-100× invariant is **not** violated: byte delivery genuinely does not wait
+on the parse, and the degrade (`mark_vt_stale`, `:399`) is honest. This is not a
+design regression. But §6 answers "does it feel slower?" and never answers "what
+does it cost?", and `bench/bench_100x.py` cannot answer it either — it compares
+termiod against **tmux**, not termiod-plus-client against in-process.
+
+The multi-session case §6 skips entirely: a daemon holding 20 sessions runs 20 VT
+threads and 20 tokio tasks **whether or not any pane is attached**. §6 item 3's
+"surfaces mount lazily, so this is bounded by *visible* panes" bounds client
+connections, not daemon work. On a laptop this is the number that decides whether
+the change ships.
+
+Criteria to add, in the same spirit as the existing four:
+
+- `termiod` RSS and steady-state CPU with 20 idle sessions and no client attached,
+  against the in-process baseline of 20 sessions in the app.
+- CPU-seconds to consume a fixed 200 MB ANSI-heavy payload, in-process vs. daemon
+  + client, measured on the *pair*, not on the daemon alone.
+
+§6's existing item 1 (p95 echo under a `yes` flood, <16 ms) is the right latency
+criterion and should stay.
+
+### F7 — §7.3's `list` row contradicts §1.1 on `cwd`, and Stage 6's compat check cannot catch it
+
+**属实 · medium · `protocol.rs:810-831` vs `PTYProcess.swift:805`**
+
+§7.3 files `list` as "device answers sessions/status/cwd/agent/title (`SessionInfo`
+already carries all of it)". §1.1 files cwd as **Missing**: "`SessionInfo.cwd` is
+the *spawn* cwd, never re-read."
+
+Both are right about the field — `protocol.rs:812` has `pub cwd: String` — and only
+§1.1 is right about its value. Today `termio sessions list` reports the *followed*
+cwd for a loose terminal, because `TerminalSurface.swift:415` polls
+`pty.currentWorkingDirectory()` (`PROC_PIDVNODEPATHINFO`) on a 350 ms trailing
+debounce. Moving `list` to the device before Stage 3's cwd work regresses it.
+
+Worse, Stage 6's compatibility criterion is "`termio sessions list --json` output
+is field-identical to the pre-move build". Field-identical passes while the
+*values* silently rot. Field shape is the wrong compatibility test for a field
+whose semantics change.
+
+Fix: either order `list` after cwd lands on the device, or state that `list`
+returns the spawn cwd and the viewer overlays its own followed value, and change
+the criterion to compare values on a session that has `cd`'d.
+
+### F8 — §7.1's headline symptom has a two-line client fix, and the RFC names it without drawing the conclusion
+
+**属实 but 夸大 · medium · `TermioStore.swift:365-372` vs `SessionControl.swift:400-402`**
+
+The `send "t"` bug is real and the code quote is accurate. But `send` does not
+route through the surface because the CLI is talking to the wrong server. It
+routes through the surface because `sendText` calls `state.send`. One file away,
+`addSnippetToSelectedSessionPrompt` already writes verbatim bytes to the backend
+for exactly this reason:
+
+```swift
+// TermioStore.swift:359-364 — the comment
+/// The bytes go RAW into the PTY (the backend session's input), NOT through
+/// `state.send`: that routes into `ghostty_surface_text`, whose input encoder
+/// re-encodes the ESC of a hand-written `\e[200~` as an escape KEYPRESS …
+backend.sendInput(Data(("\u{1B}[200~" + text + "\u{1B}[201~").utf8))
+```
+
+`sendText` could call `backend.sendInput` today — no daemon, no protocol, no
+migration — and `--no-enter` and `esc` would both work. The RFC notices the
+workaround ("one file away") and still leads §7 with the symptom.
+
+This is not an argument against §7. `read` on a session no viewer has ever opened,
+and `termio sessions` on a Linux box with no Mac app, are motivations the client
+genuinely cannot supply, and they are the honest headline. Leading with a symptom
+that has a two-line client fix invites a reviewer to conclude the whole stage is
+optional. Reframe: ship the `sendInput` fix as a stopgap in Stage 0 or Stage 3,
+and lead §7 with `read` and Linux.
+
+### F9 — §4's "`termio agent report` stays exactly as spelled" is true on the Mac and false on the device
+
+**部分不属实 · medium · `scripts/termio:505-577`, `HookListener.swift:285-300`**
+
+`scripts/termio` is a Mac shell script that does not exist on the device — §4.1
+says so. §4.2 item 4 has hook installation become `termiod agent install-hooks`,
+writing config files with `cliPath` pointing at the local `termiod`. So on the
+device the agent's config says `termiod set-status`, not `termio agent report`.
+The published contract is preserved on the machine where it already worked and
+replaced on the machine where it is new. Say that, rather than "stays exactly as
+spelled".
+
+The under-scoping is concrete. `agent report` is not a status verb, it is a
+**stdin-mining** verb:
+
+- flags `--transcript`, `--conversation <id>`, `--conversation-from <field>`,
+  `--tool-from <field>`, `--reply` (`scripts/termio:515`, `:525-537`);
+- `mine_field` (`:203-207`) greps the agent's hook JSON off stdin, jq-free;
+- `--reply` prints `{}` on stdout because Cursor reads the hook's stdout as its
+  JSON reply (`:509`);
+- `HookListener.reportCommand` picks which flags to bake per `HookDialect`
+  (`:285-300`).
+
+§4.2 item 2 scopes only "carry the rest of the payload" on the wire. The
+extraction, the dialects, and the stdout-reply contract all have to be
+re-implemented in Rust, and none of that is named. `termiod set-status` today is
+`target`, `status`, `--title` (`main.rs:91-100`).
+
+Second, smaller: today one hook call fans out to **both** channel sockets
+(`scripts/termio:583-587`) so one install serves dev and release. §5.2 item 2
+deliberately splits dev and release onto different `TERMIOD_SOCK`s. After that
+split the daemon route is point-to-point, and "both can be true during migration
+and the broadcast is idempotent" (§4.2) no longer holds on the daemon branch.
+
+The RFC's open question 2 (containers) is the right question to have left open.
+
+### F10 — the third session kind is never inventoried: `session.sshHost`
+
+**属实 · medium · `ProjectActions:431`, `TerminalSurface.swift:165`, `FileBrowserView.swift:53`**
+
+`addSSHSession` — "New SSH Shell" in the sidebar (`SidebarView.swift:613`), the
+SSH settings tab, and three call sites in `App.swift` — runs a plain `ssh <host>`
+**inside a local PTY** (`TerminalSurface.swift:165`). §1 never lists it. §1.4 does
+not claim it. §2's "Opening a session on this Mac and on a VPS run the same code,
+differing only in `TermiodRoute`" does not account for it.
+
+After Stage 5 it would run inside a local *termiod* session, which works
+mechanically — but leaves two overlapping remote concepts (`sshHost` and
+`termiodRemoteHost`) that §2 claims to have collapsed into one.
+
+Stage 7 makes it sharper. It deletes `SSHFileSystemProvider` and `SFTPClient` with
+the criterion `grep -rn 'SFTP' Sources/ | wc -l` → 0. But the SFTP tree is keyed
+exactly on `session.sshHost` (`FileBrowserView.swift:53,70`) — the one of the three
+file-tree behaviours §1.2 identifies that actually *works*. An `sshHost` session's
+far end may have no `termiod` at all, so `fs.list` cannot replace it. §1.2 spots
+the "three behaviours for two kinds of machine" problem and Stage 7 deletes the
+working one without saying what replaces it. Either `addSSHSession` gets a stated
+fate (deprecated in favour of remote terminals? kept with SFTP?) or Stage 7's
+criterion is wrong.
+
+### F11 — §5's crash mitigation depends on a launchd job nothing installs
+
+**属实 · medium · `TermiodClient.swift:354-390`, `service.rs:79-95`**
+
+§9's risk table mitigates "a daemon crash loses every session at once" with
+"launchd `KeepAlive` (shipped)". §5.1 lists it under "what exists".
+
+But the app does not start the daemon through launchd. `spawnDaemon()`
+`posix_spawn`s `termiod serve` directly with `POSIX_SPAWN_SETSID` so it outlives
+the app (`:352-354`). `RunAtLoad`/`KeepAlive` exist only for a daemon installed by
+`termiod service install`, which nothing in the app — and nothing in Stage 1 —
+does. Stage 1's criteria check that `termiod service status` reports a live socket
+but never require the app to install the job.
+
+For an app-autostarted daemon, the headline mitigation is simply absent: it dies
+and stays dead until the next app launch.
+
+Two consequences §5.2 does not list:
+
+- **Two daemons on one machine.** An app-autostarted daemon inherits the app's
+  environment (`:381-385` says so, and says why — `TMPDIR` above all); a
+  launchd-started one inherits launchd's. If those differ, `socketPath()`
+  (`:40-53`) derives two different sockets and you get two daemons and two session
+  tables. That is §5.2 item 2's failure with a different cause, and per-channel
+  `TERMIOD_SOCK` (Stage 1 item 3) does not fix it.
+- **Local version skew the day the daemon ships in the bundle.** §5.2 item 4
+  covers *remote* install not being content-addressed. Once the daemon lives at
+  `termio.app/Contents/Resources/termiod`, a user who also ran
+  `termiod service install` has a launchd job pinned to an absolute path that an
+  app update or move invalidates — and `KeepAlive` will keep respawning whatever
+  is at that path. Open question 8 gestures at deprecation policy without naming
+  this mechanism.
+
+Add to Stage 1: the app installs or repairs the launchd job on first launch, and
+the criterion is `kill -9` the daemon, then `launchctl print
+gui/$UID/sh.termio.termiod` shows it respawned and `termiod list` answers.
+
+### F12 — §1.1 omits `lastInputAt`; §3.3's "small change" drops a guard that fixed a real bug
+
+**属实 · low-medium · `PTYProcess.swift:522`, `TerminalSurface.swift:325/344`, `TermioStore+AgentStatus.swift:234-241`**
+
+Two items the inventory missed, both of the RFC's own shape.
+
+`PTYProcess.lastInputAt` (`:522`) is read at `TerminalSurface.swift:344` and feeds
+`noteUserInput` → `lastUserInputAt`, the choke that keeps agent promotion quiet
+after input from *any* device — Mac keystroke, phone over the companion bridge, or
+synthetic `sessions send` text (the comment at `:339-343` spells out why it taps
+the PTY rather than the Mac surface's write callback). It is not in §1.1's table
+and `TermiodSessionLink` never timestamps writes. That is a sixth instance of
+"implemented against the object the app happens to hold", found in the file the
+RFC was already reading.
+
+Separately, §3.3 says re-pointing the screen-derived signals at `onOutput` "is a
+small change and can land before anything else in this RFC". The sink it moves off
+carries a guard with no analogue on the link:
+
+```swift
+// TerminalSurface.swift:325
+guard let self, let pty, self.ptyProcesses[session.id] === pty else { return }
+```
+
+The comment above it (`:318-324`) says this exists because a same-agent relaunch
+could otherwise let a dead PTY's queued `working` mark the replacement process.
+`relaunchSession` re-creates the termiod link too (`ProjectActions:741-748`), so
+the same race exists there. The change is small only if it carries the identity
+check — state that, or the "land it early, it's cheap" advice reintroduces a fixed
+bug.
+
+### F13 — Stage 1's `codesign` criterion is the wrong command
+
+**属实 · low · Stage 1**
+
+`codesign -vvv --deep --strict termio.app` — Apple deprecated `--deep` for
+*verification* and it does not validate nested code the way the flag name
+suggests. For a bundle with a nested daemon the criterion should be
+`codesign --verify --strict --verbose=4 termio.app` plus `spctl -a -vvv -t exec
+termio.app` against a notarized build. A criterion the RFC insists must be *run*
+should be a command that means what it says.
+
+Also worth noting: the rest of Stage 1's criteria require notarization
+credentials, so they are runnable only in CI or by a maintainer. Say which.
+
+---
+
+## Answers to the specific questions asked
+
+**Is the inventory complete?** No — F2 (companion, roughly half missing), F10
+(`session.sshHost`, absent entirely), F12 (`lastInputAt`). Two more the table
+skips: `App.swift:140`'s `PTYProcess.reapStrayOrphans()` appears in §1.1 and open
+question 4 but not in the §1.5 consumer table, and the whole exit-policy block at
+`TerminalSurface.swift:427-471` lives inside `if let pty` while the termiod
+counterpart (`TermioStore+Termiod.swift:90-107`) reimplements it minus the
+self-update branch — the RFC records the gap but not that the policy is
+duplicated in two places that must now be kept in sync.
+
+Adjacent same-shape gaps outside the session plane that §1 does not mention at
+all, offered as scope warnings rather than findings: `Settings/AgentAvailability.swift`
+probes locally whether an agent CLI is installed (a device question);
+`Companion/Usage/*` reads agent credentials and session logs off the Mac's disk,
+so a remote agent's usage is unreadable by construction; `Git/BranchModel.swift`
+watches the local repo. None of these blocks the RFC; all of them are the same
+bug shape waiting.
+
+**Cross-platform foreground detection (§3).** The mechanism is sound and the macOS
+half is verified in-repo — `PTYProcess.swift:859-865` records `tcgetpgrp` on a
+forkpty master as working on macOS, and `:869`/`:929` are the calls. `termiod/src`
+contains no `tcgetpgrp` today, so this is new Rust on *both* platforms, not a
+port. Two things the table is too clean about:
+
+- `tcgetpgrp` returns a **process group id**; `KERN_PROCARGS2` and
+  `/proc/<pid>/cmdline` want a **pid**. The Swift code gets away with passing the
+  pgid straight through (`PTYProcess.swift:871`) because the pgid equals the group
+  leader's pid. On Linux the same shortcut has a failure mode macOS does not
+  share: in `foo | bar`, the leader is `foo`, and if `foo` exits first,
+  `/proc/<pgid>/cmdline` is a zero-length read on the zombie — so the pane reports
+  no foreground command instead of `bar`. tmux handles this by scanning `/proc`
+  for a live group member. The one-line table row hides it, and open question 6's
+  proposed fallback (`/proc/<child>/stat`'s `tpgid`) solves a different problem
+  (finding the pgid, which `tcgetpgrp` already does) rather than this one.
+- The `E { … pid, argv }` event shape is right to send a pid, but §3.1's table says
+  the argv lookup takes the *pgid*. Pick one and be explicit about the
+  leader-is-a-zombie case.
+
+Stage 3's criterion is genuinely executable — `termiod.yml` runs macOS and Linux.
+I did not run `tcgetpgrp` on a Linux ptmx master; the RFC's hedge is the right
+posture and I have no evidence it fails.
+
+**Agent hooks (§3/§4).** See F9. The chain works mechanically — `set_status`
+exists, fans out (smoke check 46), and `TERMIOD_SESSION` becomes the routing key
+once `pty.rs:114` carries a real id — but the "published contract carries" claim
+does not survive, and the stdin-mining half of `agent report` is unscoped.
+
+**Daemon single point of failure (§5).** The six blockers listed are all real and
+all verified. Missing: F1 (the big one — sessions do not survive a restart at
+all), F11 (nothing installs launchd; two-daemons-one-machine; local version skew
+once the binary ships in the bundle). §5.3's honesty about the last screen is
+good and should be extended one step further to the session itself.
+
+**Performance (§6).** It does not evade high-frequency output — item 1 is exactly
+the right question, and the criterion (p95 echo < 16 ms under a `yes` flood) is
+well chosen. It does evade **cost**: F6, every local byte parsed twice plus a
+thread and a ring per session, and daemon-side work that scales with *sessions*,
+not with *visible panes*. Multi-session concurrency is named (item 3) but only as a
+startup-connection count, which is the smaller half.
+
+**CLI split (§7).** The boundary in §7.2 is drawn correctly and I could not find a
+verb filed on the wrong side. Human keypress encoding stays client-side (right —
+`TermioStore.swift:359-364` documents the exact re-encoding hazard that makes it
+non-negotiable), programmatic injection leaves the surface (right). `focus` and
+`notify` staying is right. Three things to add rather than change:
+
+- `read` moving to the device is a **behaviour change**, not a relocation. The
+  daemon's `S` describes the *active* screen; `SessionControl.swift:589` scrapes
+  the **viewport**, which follows the user's scrollback — and
+  `TerminalSurface.swift:281-286` documents that staleness as a known caveat.
+  Moving `read` silently fixes the caveat and changes the answer for a scrolled
+  pane. Stage 6's field-identical criterion will not catch it.
+- F7: `list`'s cwd.
+- §7.4 promises a Linux VPS agent "the same verbs it has on the laptop", while
+  §7.3 keeps `send --wait`'s screen-change fallback and `watch --state stalled` on
+  the client. Both cannot be true. On a box with no Mac app, `send --wait` degrades
+  to the `wait` control op's `until` set and loses the stalled-prompt heuristic —
+  which is the one supervising agents actually rely on. Name the degrade, or
+  resolve open question 3 before Stage 6 ships `send`.
+
+**Migration stages (§8).** F4 (two stages gate on a suite that does not compile),
+F5 (Stage 0 is the unrecoverable step, not Stage 5), F1 (Stage 2's criterion is
+unachievable), F13 (Stage 1's `codesign` line). The stages that *are* well
+specified: Stage 3's criteria are excellent — the "daemon built without the field
+shows **no** dialog" case is the kind of negative criterion most plans omit — and
+Stage 7's "one round trip per cold expansion, measured with a request log" and
+"`coverage < 1.0` shows *still indexing* rather than silently missing files" are
+both real and both runnable.
+
+---
+
+## What I checked and could not fault
+
+Recorded so the next reader does not re-do it.
+
+- The four invariants. Byte delivery does not block on VT parse
+  (`session.rs:1464-1469`, fire-and-forget with an explicit budget rather than
+  backpressure). The host does not decide presentation — `vt/src/lib.rs:198-200`
+  disables OSC 4 emission with the reason written down, and `tombstone.rs:62-64`
+  says the same about rendered text. No SSH or crypto is embedded; the deploy path
+  shells out to system `ssh`/`scp` (`remote.rs:223-227`) and
+  `performRemoteReadyCheck` sets `BatchMode=yes` so it can never prompt
+  (`TermioStore+Termiod.swift:384`). `grid_diff` stays opt-in and the RFC's §2
+  explicitly declines to change that. No chat UI is proposed.
+- §3.2's three rules — host reports argv, push not poll, sampler never touches
+  `fan_out` — are consistent with all of the above, and the skew rule ("an absent
+  field preserves today's no-confirm behaviour, never *unknown so confirm*") is
+  the right default given `closeConfirmationReason`'s deliberate agent exemption
+  (`ProjectActions:684-692`).
+- §5.2's six blockers: all six verified. Item 1 in particular —
+  `daemonBinaryPath()` really does fall back to
+  `currentDirectoryPath + "/termiod/target/debug/termiod"` (`:63`), and neither
+  `build-app.sh` nor `release.yml` mentions `termiod`. A released build genuinely
+  cannot start a daemon.
+- §7.1's diagnosis of the weld, and that `termiod send --no-enter` already does
+  the right thing (`main.rs:291-295`).
+- The `--no-enter` grep criterion in Stage 5 is well constructed:
+  `grep -rn 'TERMIO_TERMIOD\b'` correctly excludes `TERMIO_TERMIOD_BIN`, which
+  Stage 1 item 2 keeps.


### PR DESCRIPTION
Lands the three documents for the "one path through termiod" refactor on one branch: the 869-line RFC, the adversarial review of it, and the cold-start handoff. They were previously loose across two worktrees. `docs/README.md` is regenerated from front matter, so all three now appear in the index. The review's verdict is **"implementable as an argument, not yet as a plan"**, so the RFC is `in-review`, not `approved`. Docs only — no code changes.

Four blockers the review says must be fixed before anyone builds from the RFC:

1. **(F1)** Stage 2's central criterion asks the daemon for something it cannot do — sessions do not survive a daemon restart (`tombstone.rs:178-211` buries every one as `daemon_lost`), so three panes will not repaint "with their shell history intact" after `launchctl kickstart -k`.
2. **(F2)** §1.5's companion inventory is about half the real surface, and Stage 4's five-member protocol cannot be written as described — three omitted members have no daemon counterpart and are not additive protocol work.
3. **(F3)** Stage 0's reassurance paragraph is false on the file the RFC itself calls the largest single item: two open PRs touch `CompanionServer.swift`, and a third change to it sits committed-but-unpushed in a `/private/tmp` worktree.
4. **(F4/F5)** Stage 0's first criterion cannot be run (Swift tests do not run — issue #311 — and the "+51 lines of smoke" it cites do not exist), and neither can Stage 5's; the genuinely unrecoverable step is Stage 0, not Stage 5.