### PR TITLE
Theme store — browse 50, install on demand, library is truth

### DIFF
--- a/Shared/Sources/TermioShared/ThemeStoreCatalog.swift
+++ b/Shared/Sources/TermioShared/ThemeStoreCatalog.swift
@@ -1,0 +1,68 @@
+/// The theme store's index: 50 well-known Ghostty scheme names, in display order
+/// — 35 dark, then 15 light, by each theme's own background luminance.
+///
+/// Shared because both the Mac store and the iPhone's theme picker offer the same
+/// set, and two hand-kept copies would drift. Names only: the Mac resolves them
+/// against `GhosttyThemeCatalog` to install a file, the phone resolves them to
+/// render, and neither meaning belongs in this package.
+///
+/// Curated, not exhaustive. No two entries read as the same theme — measured as
+/// weighted mean CIE Lab distance over background, foreground, and ANSI 1–6, with
+/// every pair clearing ΔE 12, which is what keeps near-duplicate families
+/// (TokyoNight Night/Storm, Catppuccin Mocha/Macchiato, Rose Pine/Moon) down to
+/// one row each. `ThemeLibraryTests` enforces the resolve, the brightness split,
+/// and the distance rule.
+public enum ThemeStoreCatalog {
+    public static let names: [String] = [
+        "Dracula",
+        "Catppuccin Mocha",
+        "TokyoNight Night",
+        "Nord",
+        "Gruvbox Dark",
+        "Atom One Dark",
+        "Monokai Pro",
+        "Rose Pine",
+        "Ayu Mirage",
+        "Night Owl",
+        "Kanagawa Wave",
+        "Kanagawa Dragon",
+        "Everforest Dark Hard",
+        "GitHub Dark Default",
+        "iTerm2 Solarized Dark",
+        "Cobalt2",
+        "Vesper",
+        "Flexoki Dark",
+        "Melange Dark",
+        "Xcode Dark",
+        "Aura",
+        "Dark Modern",
+        "Oxocarbon",
+        "Gruber Darker",
+        "Jellybeans",
+        "Horizon",
+        "Embark",
+        "Srcery",
+        "Terafox",
+        "Modus Vivendi",
+        "Vercel",
+        "Poimandres",
+        "Matte Black",
+        "Carbonfox",
+        "Sonokai",
+        "Catppuccin Latte",
+        "GitHub Light Default",
+        "Rose Pine Dawn",
+        "Gruvbox Light",
+        "iTerm2 Solarized Light",
+        "Atom One Light",
+        "Flexoki Light",
+        "Kanagawa Lotus",
+        "Xcode Light",
+        "Monokai Pro Light",
+        "Iceberg Light",
+        "Melange Light",
+        "One Half Light",
+        "Modus Operandi",
+        "Bluloco Light",
+    ]
+}

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -824,7 +824,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// view is rebuilt each call so the requested tab takes effect even when the
     /// window is reused — harmless because every control binds straight to
     /// `AppSettings`, so there is no transient UI state to preserve.
-    func openSettings(initialTab: SettingsTab) {
+    /// Opens Settings ▸ Appearance with the theme store already up — the command
+    /// palette's **Browse Themes…**. Reached via the responder chain like the
+    /// other app actions.
+    @objc func browseThemes(_ sender: Any?) {
+        openSettings(initialTab: .appearance, opensThemeStore: true)
+    }
+
+    func openSettings(initialTab: SettingsTab, opensThemeStore: Bool = false) {
         if settingsWindow == nil {
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 720, height: 540),
@@ -863,6 +870,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             settings: settings,
             usage: usageMonitor,
             initialTab: initialTab,
+            opensThemeStore: opensThemeStore,
             onSSHConnect: { [weak self] host in
                 guard let self else { return }
                 self.store.addSSHSession(host: host)

--- a/Sources/termio/CommandPalette/CommandPalette.swift
+++ b/Sources/termio/CommandPalette/CommandPalette.swift
@@ -373,6 +373,10 @@ struct CommandPaletteView: View {
         actions.append(.init(id: "change-theme", title: localized("Change Theme…"),
                              icon: nil, symbol: "paintpalette", shortcut: nil,
                              switchesMode: .themes) { _ in })
+        actions.append(.init(id: "browse-themes", title: localized("Browse Themes…"),
+                             icon: nil, symbol: "square.grid.2x2", shortcut: nil) { _ in
+            NSApp.sendAction(#selector(AppDelegate.browseThemes(_:)), to: nil, from: nil)
+        })
         actions.append(.init(id: "settings", title: localized("Settings…"),
                              icon: .settings, shortcut: "⌘,") { _ in
             NSApp.sendAction(#selector(AppDelegate.showSettings(_:)), to: nil, from: nil)
@@ -418,24 +422,19 @@ struct CommandPaletteView: View {
 
     // MARK: - Themes
 
-    /// The theme selector's rows: a "Terminal default" reset, the user's own
-    /// same-brightness custom themes, then the bundled catalog with the popular
-    /// picks pulled to the front. Only themes matching the slot's brightness show,
-    /// so the palette can never apply one that renders the wrong way.
+    /// The theme selector's rows: a "Terminal default" reset plus the installed
+    /// themes matching the slot's brightness, so the palette can never apply one
+    /// that renders the wrong way — or one that isn't in the library, which would
+    /// leave the slot pointing at a name nothing can resolve. Browsing the store's
+    /// uninstalled 50 is the sheet's job.
     private var themeItems: [PaletteItem] {
         let dark = slotIsDark
-        let popular = dark ? ThemeLibrary.popularDarkThemeNames : ThemeLibrary.popularLightThemeNames
-        let bundled = dark ? ThemeLibrary.darkBundledThemeNames : ThemeLibrary.lightBundledThemeNames
-        let custom = ThemeLibrary.userThemeNames.filter { ThemeLibrary.theme(named: $0)?.isDark == dark }
-
-        var items: [PaletteItem] = custom.map { themeItem(name: $0, section: .customThemes) }
-        // Return-to-default sits atop the main group; popular first, then the
-        // alphabetical remainder with popular removed so nothing repeats. The
-        // label names the slot being edited so "default" isn't ambiguous.
-        items.append(themeItem(name: "", title: dark ? localized("Default Dark Theme") : localized("Default Light Theme")))
-        items += popular.map { themeItem(name: $0) }
-        let popularSet = Set(popular)
-        items += bundled.filter { !popularSet.contains($0) }.map { themeItem(name: $0) }
+        // Return-to-default leads; the label names the slot being edited so
+        // "default" isn't ambiguous.
+        var items: [PaletteItem] = [
+            themeItem(name: "", title: dark ? localized("Default Dark Theme") : localized("Default Light Theme"))
+        ]
+        items += ThemeLibrary.installedThemeNames(dark: dark).map { themeItem(name: $0) }
         return items
     }
 
@@ -475,12 +474,15 @@ struct CommandPaletteView: View {
         themeSnapshot = currentSlotThemeName
         themeCommitted = false
         // Land the highlight on the theme already in use so browsing starts from the
-        // current look and the seed-preview is a no-op.
+        // current look and the seed-preview is a no-op. A miss means the slot points
+        // at a theme that is no longer in the library; moving the highlight to row 0
+        // would then live-apply "Terminal default" over it, so leave it alone.
         let current = currentSlotThemeName
-        highlighted = themeItems.firstIndex {
+        guard let index = themeItems.firstIndex(where: {
             if case .theme(let name) = $0.kind { return name == current }
             return false
-        } ?? 0
+        }) else { return }
+        highlighted = index
     }
 
     private func endThemeBrowsing(commit: Bool) {
@@ -619,7 +621,7 @@ struct CommandPaletteView: View {
 /// Open Quickly's display groups, in rank order; `.commands` is the palette's
 /// single (headerless) group.
 private enum PaletteSection: Int, Hashable {
-    case sessions, recentProjects, files, commands, customThemes, themes
+    case sessions, recentProjects, files, commands, themes
 
     var title: String? {
         switch self {
@@ -627,9 +629,8 @@ private enum PaletteSection: Int, Hashable {
         case .recentProjects: return localized("Recent")
         case .files: return localized("Files")
         case .commands: return nil
-        case .customThemes: return localized("Custom")
-        // No header when custom themes are absent (the common case) — a lone
-        // "Themes" banner over the whole list is noise (see `sectioned`).
+        // Themes are the only group in their mode, so the header never draws
+        // (see `sectioned`).
         case .themes: return localized("Themes")
         }
     }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -3772,16 +3772,6 @@
         }
       }
     },
-    "%lld custom": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 个自定义"
-          }
-        }
-      }
-    },
     "Reload": {
       "localizations": {
         "zh-Hans": {
@@ -3798,16 +3788,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "主题"
-          }
-        }
-      }
-    },
-    "Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Drop Ghostty-format theme files into the Themes folder to add your own — they appear under “Custom.”": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Termio 会随 macOS 外观变化在两者间切换；将槽位留在默认值即可使用 Termio 自带的画布。将 Ghostty 格式的主题文件放入主题文件夹即可添加自己的主题，它们会显示在“自定义”下。"
           }
         }
       }
@@ -4642,36 +4622,6 @@
         }
       }
     },
-    "Popular": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "热门"
-          }
-        }
-      }
-    },
-    "All Dark Themes": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所有深色主题"
-          }
-        }
-      }
-    },
-    "All Light Themes": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所有浅色主题"
-          }
-        }
-      }
-    },
     "1 result": {
       "localizations": {
         "zh-Hans": {
@@ -5331,6 +5281,136 @@
           "stringUnit": {
             "state": "translated",
             "value": "该主机返回了文件树无法显示的名称。"
+          }
+        }
+      }
+    },
+    "Browse Themes…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览主题…"
+          }
+        }
+      }
+    },
+    "Installed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装"
+          }
+        }
+      }
+    },
+    "No installed theme matches “%@”": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有已安装的主题与“%@”匹配"
+          }
+        }
+      }
+    },
+    "%lld installed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装 %lld 个"
+          }
+        }
+      }
+    },
+    "Couldn’t open the Themes folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法打开主题文件夹"
+          }
+        }
+      }
+    },
+    "Couldn’t change the Themes folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法修改主题文件夹"
+          }
+        }
+      }
+    },
+    "Replace the theme file for “%@”?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "替换“%@”的主题文件？"
+          }
+        }
+      }
+    },
+    "A file at %@ already uses that name. Replacing it discards what is in it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已经用了这个名称。替换会丢弃这个文件里的内容。"
+          }
+        }
+      }
+    },
+    "Remove “%@”?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除“%@”？"
+          }
+        }
+      }
+    },
+    "The file at %@ has been edited since it was installed. Removing it deletes those edits.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 在安装之后被改过。移除会连同这些改动一起删除。"
+          }
+        }
+      }
+    },
+    "Replace": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "替换"
+          }
+        }
+      }
+    },
+    "Install": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装"
+          }
+        }
+      }
+    },
+    "Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termio 会随 macOS 外观变化在两者间切换；将槽位留在默认值即可使用 Termio 自带的画布。“浏览主题”可以从 50 个精选配色中安装一个，你放进主题文件夹的 Ghostty 格式文件也会出现在这里。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -36,12 +36,12 @@
 	<string>%@, %@ and %@</string>
 	<key>%lld %@</key>
 	<string>%lld %@</string>
-	<key>%lld custom</key>
-	<string>%lld custom</string>
 	<key>%lld file</key>
 	<string>%lld file</string>
 	<key>%lld files</key>
 	<string>%lld files</string>
+	<key>%lld installed</key>
+	<string>%lld installed</string>
 	<key>%lld of %lld</key>
 	<string>%lld of %lld</string>
 	<key>%lld pt</key>
@@ -62,6 +62,8 @@
 	<string>1 result</string>
 	<key>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</key>
 	<string>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</string>
+	<key>A file at %@ already uses that name. Replacing it discards what is in it.</key>
+	<string>A file at %@ already uses that name. Replacing it discards what is in it.</string>
 	<key>Activity</key>
 	<string>Activity</string>
 	<key>Add</key>
@@ -94,10 +96,6 @@
 	<string>Alias → %@</string>
 	<key>All</key>
 	<string>All</string>
-	<key>All Dark Themes</key>
-	<string>All Dark Themes</string>
-	<key>All Light Themes</key>
-	<string>All Light Themes</string>
 	<key>All caught up</key>
 	<string>All caught up</string>
 	<key>All changes to these %lld files will be lost. This cannot be undone.
@@ -152,6 +150,8 @@
 	<string>Branch</string>
 	<key>Bring All to Front</key>
 	<string>Bring All to Front</string>
+	<key>Browse Themes…</key>
+	<string>Browse Themes…</string>
 	<key>Cancel</key>
 	<string>Cancel</string>
 	<key>Can’t browse %@</key>
@@ -268,6 +268,8 @@
 	<string>Copy on select</string>
 	<key>Copy ssh Command</key>
 	<string>Copy ssh Command</string>
+	<key>Couldn’t change the Themes folder</key>
+	<string>Couldn’t change the Themes folder</string>
 	<key>Couldn’t create the worktrees folder: %@</key>
 	<string>Couldn’t create the worktrees folder: %@</string>
 	<key>Couldn’t create worktree session</key>
@@ -280,6 +282,8 @@
 	<string>Couldn’t load</string>
 	<key>Couldn’t open a pull request page</key>
 	<string>Couldn’t open a pull request page</string>
+	<key>Couldn’t open the Themes folder</key>
+	<string>Couldn’t open the Themes folder</string>
 	<key>Couldn’t remove %@.</key>
 	<string>Couldn’t remove %@.</string>
 	<key>Couldn’t remove worktree</key>
@@ -440,8 +444,12 @@
 	<string>Inspector</string>
 	<key>Inspector Pane</key>
 	<string>Inspector Pane</string>
+	<key>Install</key>
+	<string>Install</string>
 	<key>Install %@</key>
 	<string>Install %@</string>
+	<key>Installed</key>
+	<string>Installed</string>
 	<key>Installed.</key>
 	<string>Installed.</string>
 	<key>Installing %@…</key>
@@ -602,6 +610,8 @@
 	<string>No file changes</string>
 	<key>No hosts yet — add one, or write a Host block in ~/.ssh/config.</key>
 	<string>No hosts yet — add one, or write a Host block in ~/.ssh/config.</string>
+	<key>No installed theme matches “%@”</key>
+	<string>No installed theme matches “%@”</string>
 	<key>No issues found.</key>
 	<string>No issues found.</string>
 	<key>No local usage yet — run `%@` once, then Refresh.</key>
@@ -702,8 +712,6 @@
 	<string>Plan limits come from %@'s OAuth login; no passwords are stored. Revoking stops all reading of %@'s data.</string>
 	<key>Play sound</key>
 	<string>Play sound</string>
-	<key>Popular</key>
-	<string>Popular</string>
 	<key>Port</key>
 	<string>Port</string>
 	<key>Posts a notification when an agent finishes or needs you while Termio is in the background.</key>
@@ -770,6 +778,8 @@
 	<string>Remove Worktree</string>
 	<key>Remove from List</key>
 	<string>Remove from List</string>
+	<key>Remove “%@”?</key>
+	<string>Remove “%@”?</string>
 	<key>Removed from PATH.</key>
 	<string>Removed from PATH.</string>
 	<key>Removes this custom agent and its configuration file. Existing sessions keep running.</key>
@@ -782,6 +792,10 @@
 	<string>Rename “%@”</string>
 	<key>Rename…</key>
 	<string>Rename…</string>
+	<key>Replace</key>
+	<string>Replace</string>
+	<key>Replace the theme file for “%@”?</key>
+	<string>Replace the theme file for “%@”?</string>
 	<key>Request Permission</key>
 	<string>Request Permission</string>
 	<key>Reset Font Size</key>
@@ -934,8 +948,8 @@
 	<string>Termio could not append to the repository’s .gitignore. Check its permissions and try again.</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio is open source — star the repo, report bugs, and request features.</string>
-	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Drop Ghostty-format theme files into the Themes folder to add your own — they appear under “Custom.”</key>
-	<string>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Drop Ghostty-format theme files into the Themes folder to add your own — they appear under “Custom.”</string>
+	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
+	<string>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</string>
 	<key>Test</key>
 	<string>Test</string>
 	<key>Test Connection</key>
@@ -948,6 +962,8 @@
 	<string>The base branch has commits this branch doesn’t have, as of the last fetch.</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>The coding agents offered when you start a session</string>
+	<key>The file at %@ has been edited since it was installed. Removing it deletes those edits.</key>
+	<string>The file at %@ has been edited since it was installed. Removing it deletes those edits.</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
 	<string>The folder was removed, but git couldn’t prune its stale worktree metadata.</string>
 	<key>The ignore rule couldn’t be added.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -36,12 +36,12 @@
 	<string>%1$@、%2$@ 和 %3$@</string>
 	<key>%lld %@</key>
 	<string>%lld %@</string>
-	<key>%lld custom</key>
-	<string>%lld 个自定义</string>
 	<key>%lld file</key>
 	<string>%lld 个文件</string>
 	<key>%lld files</key>
 	<string>%lld 个文件</string>
+	<key>%lld installed</key>
+	<string>已安装 %lld 个</string>
 	<key>%lld of %lld</key>
 	<string>第 %lld 项（共 %lld 项）</string>
 	<key>%lld pt</key>
@@ -62,6 +62,8 @@
 	<string>1 个结果</string>
 	<key>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</key>
 	<string>另一个 `%@` 已存在于 %@。请先移除，Termio 不会覆盖并非自己创建的文件。</string>
+	<key>A file at %@ already uses that name. Replacing it discards what is in it.</key>
+	<string>%@ 已经用了这个名称。替换会丢弃这个文件里的内容。</string>
 	<key>Activity</key>
 	<string>活动</string>
 	<key>Add</key>
@@ -94,10 +96,6 @@
 	<string>替身 → %@</string>
 	<key>All</key>
 	<string>全部</string>
-	<key>All Dark Themes</key>
-	<string>所有深色主题</string>
-	<key>All Light Themes</key>
-	<string>所有浅色主题</string>
 	<key>All caught up</key>
 	<string>全部处理完毕</string>
 	<key>All changes to these %lld files will be lost. This cannot be undone.
@@ -152,6 +150,8 @@
 	<string>分支</string>
 	<key>Bring All to Front</key>
 	<string>前置全部窗口</string>
+	<key>Browse Themes…</key>
+	<string>浏览主题…</string>
 	<key>Cancel</key>
 	<string>取消</string>
 	<key>Can’t browse %@</key>
@@ -268,6 +268,8 @@
 	<string>选中即拷贝</string>
 	<key>Copy ssh Command</key>
 	<string>拷贝 ssh 命令</string>
+	<key>Couldn’t change the Themes folder</key>
+	<string>无法修改主题文件夹</string>
 	<key>Couldn’t create the worktrees folder: %@</key>
 	<string>无法创建 worktrees 文件夹：%@</string>
 	<key>Couldn’t create worktree session</key>
@@ -280,6 +282,8 @@
 	<string>无法载入</string>
 	<key>Couldn’t open a pull request page</key>
 	<string>无法打开 Pull Request 页面</string>
+	<key>Couldn’t open the Themes folder</key>
+	<string>无法打开主题文件夹</string>
 	<key>Couldn’t remove %@.</key>
 	<string>无法移除 %@。</string>
 	<key>Couldn’t remove worktree</key>
@@ -440,8 +444,12 @@
 	<string>检查器</string>
 	<key>Inspector Pane</key>
 	<string>检查器窗格</string>
+	<key>Install</key>
+	<string>安装</string>
 	<key>Install %@</key>
 	<string>安装 %@</string>
+	<key>Installed</key>
+	<string>已安装</string>
 	<key>Installed.</key>
 	<string>已安装。</string>
 	<key>Installing %@…</key>
@@ -602,6 +610,8 @@
 	<string>没有文件更改</string>
 	<key>No hosts yet — add one, or write a Host block in ~/.ssh/config.</key>
 	<string>暂无主机——添加一个，或在 ~/.ssh/config 中写入 Host 块。</string>
+	<key>No installed theme matches “%@”</key>
+	<string>没有已安装的主题与“%@”匹配</string>
 	<key>No issues found.</key>
 	<string>未找到 issues。</string>
 	<key>No local usage yet — run `%@` once, then Refresh.</key>
@@ -702,8 +712,6 @@
 	<string>套餐限额来自 %@ 的 OAuth 登录；不会存储任何密码。撤销后将停止读取 %@ 的所有数据。</string>
 	<key>Play sound</key>
 	<string>播放声音</string>
-	<key>Popular</key>
-	<string>热门</string>
 	<key>Port</key>
 	<string>端口</string>
 	<key>Posts a notification when an agent finishes or needs you while Termio is in the background.</key>
@@ -770,6 +778,8 @@
 	<string>移除 Worktree</string>
 	<key>Remove from List</key>
 	<string>从列表中移除</string>
+	<key>Remove “%@”?</key>
+	<string>移除“%@”？</string>
 	<key>Removed from PATH.</key>
 	<string>已从 PATH 中移除。</string>
 	<key>Removes this custom agent and its configuration file. Existing sessions keep running.</key>
@@ -782,6 +792,10 @@
 	<string>重命名“%@”</string>
 	<key>Rename…</key>
 	<string>重命名…</string>
+	<key>Replace</key>
+	<string>替换</string>
+	<key>Replace the theme file for “%@”?</key>
+	<string>替换“%@”的主题文件？</string>
 	<key>Request Permission</key>
 	<string>请求权限</string>
 	<key>Reset Font Size</key>
@@ -934,8 +948,8 @@
 	<string>Termio 无法将内容追加到该仓库的 .gitignore。请检查其权限后重试。</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio 是开源软件：欢迎给仓库加星标、报告 bug 和提出功能请求。</string>
-	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Drop Ghostty-format theme files into the Themes folder to add your own — they appear under “Custom.”</key>
-	<string>Termio 会随 macOS 外观变化在两者间切换；将槽位留在默认值即可使用 Termio 自带的画布。将 Ghostty 格式的主题文件放入主题文件夹即可添加自己的主题，它们会显示在“自定义”下。</string>
+	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
+	<string>Termio 会随 macOS 外观变化在两者间切换；将槽位留在默认值即可使用 Termio 自带的画布。“浏览主题”可以从 50 个精选配色中安装一个，你放进主题文件夹的 Ghostty 格式文件也会出现在这里。</string>
 	<key>Test</key>
 	<string>测试</string>
 	<key>Test Connection</key>
@@ -948,6 +962,8 @@
 	<string>截至上次 fetch，基础分支上有当前分支还没有的提交。</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>新建会话时可以选用的编程 Agent</string>
+	<key>The file at %@ has been edited since it was installed. Removing it deletes those edits.</key>
+	<string>%@ 在安装之后被改过。移除会连同这些改动一起删除。</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
 	<string>文件夹已移除，但 git 无法清理其残留的 worktree 元数据。</string>
 	<key>The ignore rule couldn’t be added.</key>

--- a/Sources/termio/Settings/AppearanceSettingsTab.swift
+++ b/Sources/termio/Settings/AppearanceSettingsTab.swift
@@ -3,11 +3,19 @@ import SwiftUI
 
 struct AppearanceSettingsTab: View {
     @ObservedObject var settings: AppSettings
+    /// Whether the theme store is up. Owned by `SettingsView` so a palette command
+    /// can open Settings straight onto the sheet, and so dismissing it consumes
+    /// that request instead of reopening on the next visit to this tab.
+    @Binding var isBrowsingStore: Bool
 
-    /// Names of the user's own theme files, loaded from termio's `Themes` folder.
+    /// Names of the installed theme files, loaded from termio's `Themes` folder.
     /// Held in state so dropping in (or editing) a file and hitting Reload — or just
     /// reopening this tab — refreshes the pickers without a relaunch.
     @State private var userThemeNames: [String] = ThemeLibrary.userThemeNames
+    /// The picker's search text at the moment it handed off to the store, so
+    /// "dracula" typed into an empty picker lands on Dracula in the store.
+    @State private var storeQuery = ""
+    @State private var themesFolderError: String?
 
     var body: some View {
         Form {
@@ -21,13 +29,14 @@ struct AppearanceSettingsTab: View {
                     .foregroundStyle(.secondary)
             }
             Section {
-                ThemePickerField(title: localized("Light"), prefersDark: false, selection: $settings.lightThemeName, userThemeNames: userThemeNames)
-                ThemePickerField(title: localized("Dark"), prefersDark: true, selection: $settings.darkThemeName, userThemeNames: userThemeNames)
+                ThemePickerField(title: localized("Light"), prefersDark: false, selection: $settings.lightThemeName, userThemeNames: userThemeNames, onBrowseStore: browseStore)
+                ThemePickerField(title: localized("Dark"), prefersDark: true, selection: $settings.darkThemeName, userThemeNames: userThemeNames, onBrowseStore: browseStore)
                 HStack {
+                    Button(localized("Browse Themes…")) { browseStore(query: "") }
                     Button(localized("Open Themes Folder…"), action: openThemesFolder)
                     Spacer()
                     if !userThemeNames.isEmpty {
-                        Text(localized("\(userThemeNames.count) custom"))
+                        Text(localized("\(userThemeNames.count) installed"))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -36,7 +45,7 @@ struct AppearanceSettingsTab: View {
             } header: {
                 SectionHeaderLabel(title: localized("Theme"))
             } footer: {
-                Text(localized("Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Drop Ghostty-format theme files into the Themes folder to add your own — they appear under “Custom.”"))
+                Text(localized("Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -136,10 +145,31 @@ struct AppearanceSettingsTab: View {
         }
         .formStyle(.grouped)
         .onAppear(perform: reloadUserThemes)
+        .sheet(isPresented: $isBrowsingStore) {
+            ThemeStoreSheet(settings: settings, initialQuery: storeQuery, onLibraryChanged: reloadUserThemes)
+        }
+        .alert(
+            localized("Couldn’t open the Themes folder"),
+            isPresented: Binding(get: { themesFolderError != nil }, set: { if !$0 { themesFolderError = nil } }),
+            presenting: themesFolderError
+        ) { _ in
+            Button(localized("OK"), role: .cancel) { themesFolderError = nil }
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    private func browseStore(query: String) {
+        storeQuery = query
+        isBrowsingStore = true
     }
 
     private func openThemesFolder() {
-        NSWorkspace.shared.open(ThemeLibrary.ensureDirectoryExists())
+        do {
+            NSWorkspace.shared.open(try ThemeLibrary.ensureDirectoryExists())
+        } catch {
+            themesFolderError = error.localizedDescription
+        }
     }
 
     /// Re-reads the Themes folder and republishes settings so any newly loaded or

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -108,6 +108,10 @@ final class AppSettings: ObservableObject {
         /// Legacy single-theme key, read once to migrate older installs into the
         /// split light/dark keys above.
         static let themeName = "appearance.themeName"
+        /// Set once the two theme slots have been materialized into the Themes
+        /// folder, so the upgrade pass runs exactly once (see
+        /// `materializeSelectedThemes`).
+        static let themesMaterialized = "appearance.themesMaterialized"
         static let cursorStyle = "appearance.cursorStyle"
         static let cursorBlink = "appearance.cursorBlink"
         static let windowPadding = "appearance.windowPadding"
@@ -443,19 +447,51 @@ final class AppSettings: ObservableObject {
             // makes a half-dark window (light sidebar, dark canvas). A bare theme lands only
             // in the appearance it belongs to; the other slot keeps termio's own canvas.
             if let definition = resolveGhosttyTheme(name) {
+                materializeInheritedTheme(definition)
                 overrides[definition.isDark ? Key.darkThemeName : Key.lightThemeName] = definition.name
             }
         case .split(let light, let dark):
             if let light, let definition = resolveGhosttyTheme(light) {
+                materializeInheritedTheme(definition)
                 overrides[Key.lightThemeName] = definition.name
             }
             if let dark, let definition = resolveGhosttyTheme(dark) {
+                materializeInheritedTheme(definition)
                 overrides[Key.darkThemeName] = definition.name
             }
         case nil:
             break
         }
         return overrides
+    }
+
+    /// Gives an inherited Ghostty theme a file in termio's `Themes` folder before
+    /// it is written into a slot. A slot resolves against the library only, so an
+    /// inherited name that stayed a catalog lookup would paint nothing — and it
+    /// re-runs whenever the user's Ghostty config names a theme they haven't got,
+    /// which the one-time upgrade pass below cannot do.
+    private static func materializeInheritedTheme(_ definition: GhosttyThemeDefinition) {
+        do {
+            try ThemeLibrary.materializeFromCatalog(named: definition.name)
+        } catch {
+            Log.app.error("could not materialize inherited theme \(definition.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// One-time upgrade: an installed termio picked its themes from a catalog that
+    /// the library no longer consults, so each occupied slot gets its file written
+    /// once. Two files at most — never the catalog — and existing selections keep
+    /// painting because they become library entries.
+    private func materializeSelectedThemes() {
+        guard !defaults.bool(forKey: Key.themesMaterialized) else { return }
+        for name in [lightThemeName, darkThemeName] {
+            do {
+                try ThemeLibrary.materializeFromCatalog(named: name)
+            } catch {
+                Log.app.error("could not materialize selected theme \(name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        defaults.set(true, forKey: Key.themesMaterialized)
     }
 
     init(defaults: UserDefaults = .standard, settingsStore: SettingsStore? = nil) {
@@ -569,6 +605,8 @@ final class AppSettings: ObservableObject {
             .flatMap { try? JSONDecoder().decode([RecentProject].self, from: $0) } ?? []
         lastChatAgentID = defaults.string(forKey: Key.lastChatAgent)
         defaultChatAgentID = store.string(Key.defaultChatAgent)
+
+        materializeSelectedThemes()
     }
 
     /// Effective command for an agent: the user's override if it's non-empty,

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -17,17 +17,23 @@ struct SettingsView: View {
     /// window doesn't hold the store.
     let onSSHConnect: (String) -> Void
     @State private var selection: SettingsTab
+    /// Whether the Appearance tab's theme store is up. Held here so a deep link
+    /// (the palette's **Browse Themes…**) can open Settings straight onto the
+    /// sheet, and so dismissing it stays dismissed as the user moves between tabs.
+    @State private var isBrowsingThemeStore: Bool
 
     init(
         settings: AppSettings,
         usage: UsageMonitor,
         initialTab: SettingsTab = .general,
+        opensThemeStore: Bool = false,
         onSSHConnect: @escaping (String) -> Void
     ) {
         self.settings = settings
         self.usage = usage
         self.onSSHConnect = onSSHConnect
         _selection = State(initialValue: initialTab)
+        _isBrowsingThemeStore = State(initialValue: opensThemeStore)
     }
 
     var body: some View {
@@ -72,7 +78,7 @@ struct SettingsView: View {
     private var detail: some View {
         switch selection {
         case .general: GeneralSettingsTab(settings: settings)
-        case .appearance: AppearanceSettingsTab(settings: settings)
+        case .appearance: AppearanceSettingsTab(settings: settings, isBrowsingStore: $isBrowsingThemeStore)
         case .terminal: TerminalSettingsTab(settings: settings)
         case .ssh: SSHSettingsTab(settings: settings, onConnect: onSSHConnect)
         case .keyboard: KeybindingsSettingsTab()

--- a/Sources/termio/Settings/ThemePickerField.swift
+++ b/Sources/termio/Settings/ThemePickerField.swift
@@ -3,22 +3,28 @@ import GhosttyTheme
 
 /// A searchable theme picker with live color swatches.
 ///
-/// termio bundles ~485 terminal color schemes (the iTerm2-Color-Schemes catalog),
-/// plus the user's own custom files. A flat SwiftUI `Picker` of that size is
-/// unusable — you scroll forever and can't see a theme before choosing it. This
-/// trades the dropdown for a macOS-native pop-up button that opens a popover with a
-/// search field and a real `List`, so hover, keyboard navigation, selection
-/// highlighting, and section headers all come from the system rather than being
-/// hand-rolled. Selecting applies live: the terminal recolors as you browse.
+/// The list is termio's default plus the themes installed in the `Themes` folder
+/// — what the user actually has, not a warehouse. Browsing the curated 50 is the
+/// store's job (**Browse Themes…**), and an uninstalled name is deliberately
+/// absent here: a slot resolves against the library only, so listing a name the
+/// picker could not paint would be a dead row.
+///
+/// A macOS-native pop-up button opening a popover with a search field and a real
+/// `List`, rather than a flat `Picker`, so hover, keyboard navigation, selection
+/// highlighting, and section headers all come from the system. Selecting applies
+/// live: the terminal recolors as you browse.
 struct ThemePickerField: View {
     let title: String
     /// Whether this slot renders in dark appearance. Explicit rather than read
     /// from the localized title, which is display-only.
     let prefersDark: Bool
     @Binding var selection: String
-    /// The user's own theme names, passed in so the parent's reload state stays the
+    /// The installed theme names, passed in so the parent's reload state stays the
     /// single source of truth for what lives in the Themes folder.
     let userThemeNames: [String]
+    /// Opens the store, carrying whatever the user had typed here — an empty
+    /// search for a name they haven't installed is exactly when they want it.
+    let onBrowseStore: (String) -> Void
 
     @State private var isPresented = false
     @State private var query = ""
@@ -94,18 +100,12 @@ struct ThemePickerField: View {
                 List(selection: $highlighted) {
                     if query.isEmpty {
                         themeRow(name: "", display: localized("Terminal default"), definition: nil)
-                    }
-                    if !filteredCustom.isEmpty {
-                        Section(localized("Custom")) { themeRows(filteredCustom) }
-                    }
-                    if query.isEmpty {
                         // Only the slot's own brightness: the Dark slot lists dark
                         // themes, the Light slot lists light ones, so a slot can never
                         // offer a theme that would render the wrong way.
-                        Section(localized("Popular")) { themeRows(slotPopularNames) }
-                        Section(allLabel) { themeRows(slotBundledNames) }
+                        Section(localized("Installed")) { themeRows(slotInstalledNames) }
                     } else {
-                        Section(resultsLabel) { themeRows(filteredBundled) }
+                        Section(resultsLabel) { themeRows(filteredInstalled) }
                     }
                 }
                 .listStyle(.inset)
@@ -135,6 +135,10 @@ struct ThemePickerField: View {
                     .lineLimit(1)
             }
             Spacer(minLength: 8)
+            Button(localized("Browse Themes…")) {
+                isPresented = false
+                onBrowseStore(query)
+            }
             Button(localized("Done")) { isPresented = false }
                 .keyboardShortcut(.defaultAction)
         }
@@ -155,8 +159,12 @@ struct ThemePickerField: View {
             Image(systemName: "paintpalette")
                 .font(.system(size: 28))
                 .foregroundStyle(.tertiary)
-            Text(localized("No themes match “\(query)”"))
+            Text(localized("No installed theme matches “\(query)”"))
                 .foregroundStyle(.secondary)
+            Button(localized("Browse Themes…")) {
+                isPresented = false
+                onBrowseStore(query)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -187,28 +195,16 @@ struct ThemePickerField: View {
         query.isEmpty || name.localizedCaseInsensitiveContains(query)
     }
 
-    /// The catalog half this slot draws from — dark themes for the Dark slot, light
-    /// for the Light slot.
-    private var slotBundledNames: [String] {
-        prefersDark ? ThemeLibrary.darkBundledThemeNames : ThemeLibrary.lightBundledThemeNames
-    }
-    private var slotPopularNames: [String] {
-        prefersDark ? ThemeLibrary.popularDarkThemeNames : ThemeLibrary.popularLightThemeNames
-    }
-    /// Custom themes are kept too, but only those matching the slot's brightness, so
-    /// the same "wrong way" rule holds for user-dropped files.
-    private var slotCustomNames: [String] {
+    /// The installed themes this slot can offer — only those matching the slot's
+    /// brightness, so a slot can never apply one that renders the wrong way.
+    private var slotInstalledNames: [String] {
         userThemeNames.filter { ThemeLibrary.theme(named: $0)?.isDark == prefersDark }
     }
-    private var allLabel: String { prefersDark ? localized("All Dark Themes") : localized("All Light Themes") }
 
-    private var filteredCustom: [String] { slotCustomNames.filter(matches) }
-    private var filteredBundled: [String] { slotBundledNames.filter(matches) }
-    private var hasResults: Bool {
-        query.isEmpty || !filteredCustom.isEmpty || !filteredBundled.isEmpty
-    }
+    private var filteredInstalled: [String] { slotInstalledNames.filter(matches) }
+    private var hasResults: Bool { query.isEmpty || !filteredInstalled.isEmpty }
     private var resultsLabel: String {
-        let count = filteredCustom.count + filteredBundled.count
+        let count = filteredInstalled.count
         return count == 1 ? localized("1 result") : localized("\(count) results")
     }
 }

--- a/Sources/termio/Settings/ThemeStoreSheet.swift
+++ b/Sources/termio/Settings/ThemeStoreSheet.swift
@@ -1,0 +1,261 @@
+import AppKit
+import SwiftUI
+import GhosttyTheme
+
+/// The theme store: 50 curated Ghostty schemes, installed one file at a time.
+///
+/// A sheet over Settings rather than a fourth Settings tab, and deliberately not
+/// a live preview — the sheet sits over the settings window, which sits over the
+/// terminal, so previewing on highlight would recolor a pane the user cannot see.
+/// Live preview stays in the command palette, over installed themes only.
+///
+/// Install writes one file into termio's `Themes` folder and then selects the
+/// slot matching the theme's own brightness, so installing a dark theme from the
+/// Light slot's Browse never trips the appearance-mismatch hint.
+struct ThemeStoreSheet: View {
+    @ObservedObject var settings: AppSettings
+    /// The search text the picker was showing when it sent the user here, so a
+    /// fruitless "dracula" in the picker lands on Dracula in the store.
+    let initialQuery: String
+    /// Lets the Appearance tab refresh its own copy of the installed names —
+    /// the same state the Reload button owns.
+    let onLibraryChanged: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var query: String
+    @State private var installedNames: Set<String> = []
+    @State private var pending: PendingAction?
+    @State private var failureMessage: String?
+
+    init(settings: AppSettings, initialQuery: String = "", onLibraryChanged: @escaping () -> Void) {
+        self.settings = settings
+        self.initialQuery = initialQuery
+        self.onLibraryChanged = onLibraryChanged
+        _query = State(initialValue: initialQuery)
+    }
+
+    /// A destructive step the user has to confirm, carrying the exact path so the
+    /// question names the file it is about to overwrite or delete.
+    private enum PendingAction {
+        case replace(name: String, path: String)
+        case removeEdited(name: String, path: String)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            Divider()
+            content
+            Divider()
+            footer
+        }
+        .frame(width: 520, height: 560)
+        .onAppear(perform: refreshInstalled)
+        .alert(
+            pendingTitle,
+            isPresented: Binding(get: { pending != nil }, set: { if !$0 { pending = nil } }),
+            presenting: pending
+        ) { action in
+            switch action {
+            case .replace(let name, _):
+                Button(localized("Replace"), role: .destructive) { install(name, replacing: true) }
+            case .removeEdited(let name, _):
+                Button(localized("Remove"), role: .destructive) { remove(name) }
+            }
+            Button(localized("Cancel"), role: .cancel) { pending = nil }
+        } message: { action in
+            switch action {
+            case .replace(_, let path):
+                Text(localized("A file at \(path) already uses that name. Replacing it discards what is in it."))
+            case .removeEdited(_, let path):
+                Text(localized("The file at \(path) has been edited since it was installed. Removing it deletes those edits."))
+            }
+        }
+        .alert(
+            localized("Couldn’t change the Themes folder"),
+            isPresented: Binding(get: { failureMessage != nil }, set: { if !$0 { failureMessage = nil } }),
+            presenting: failureMessage
+        ) { _ in
+            Button(localized("OK"), role: .cancel) { failureMessage = nil }
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    private var pendingTitle: String {
+        switch pending {
+        case .replace(let name, _): return localized("Replace the theme file for “\(name)”?")
+        case .removeEdited(let name, _): return localized("Remove “\(name)”?")
+        case nil: return ""
+        }
+    }
+
+    // MARK: - Pieces
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField(localized("Search themes"), text: $query)
+                .textFieldStyle(.plain)
+            if !query.isEmpty {
+                Button { query = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        let dark = matching(dark: true)
+        let light = matching(dark: false)
+        if dark.isEmpty, light.isEmpty {
+            VStack(spacing: 8) {
+                Image(systemName: "paintpalette")
+                    .font(.system(size: 28))
+                    .foregroundStyle(.tertiary)
+                Text(localized("No themes match “\(query)”"))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List {
+                if !dark.isEmpty {
+                    Section(localized("Dark")) { rows(dark) }
+                }
+                if !light.isEmpty {
+                    Section(localized("Light")) { rows(light) }
+                }
+            }
+            .listStyle(.inset)
+        }
+    }
+
+    @ViewBuilder
+    private func rows(_ names: [String]) -> some View {
+        ForEach(names, id: \.self) { name in
+            if let definition = ThemeLibrary.storeTheme(named: name) {
+                HStack(spacing: 10) {
+                    Text(name)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Spacer(minLength: 8)
+                    ThemeSwatch(definition: definition)
+                    actionButton(for: name)
+                }
+                .padding(.vertical, 2)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func actionButton(for name: String) -> some View {
+        if installedNames.contains(name) {
+            Button(localized("Remove")) { beginRemove(name) }
+                .frame(width: 72)
+        } else {
+            Button(localized("Install")) { beginInstall(name) }
+                .frame(width: 72)
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            Button(localized("Open Themes Folder…"), action: openThemesFolder)
+            Spacer(minLength: 8)
+            Button(localized("Done")) { dismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Rows
+
+    private func matching(dark: Bool) -> [String] {
+        ThemeLibrary.storeCatalog.filter { name in
+            guard ThemeLibrary.storeTheme(named: name)?.isDark == dark else { return false }
+            return query.isEmpty || name.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func beginInstall(_ name: String) {
+        do {
+            try ThemeLibrary.install(named: name)
+            finishInstall(name)
+        } catch ThemeLibrary.InstallRefusal.alreadyInstalled(let url) {
+            pending = .replace(name: name, path: url.path)
+        } catch {
+            failureMessage = error.localizedDescription
+        }
+    }
+
+    private func install(_ name: String, replacing: Bool) {
+        do {
+            try ThemeLibrary.install(named: name, replacingExisting: replacing)
+            finishInstall(name)
+        } catch {
+            failureMessage = error.localizedDescription
+        }
+    }
+
+    /// Selects the installed theme in the slot its own brightness belongs to, not
+    /// the slot Browse was opened from.
+    private func finishInstall(_ name: String) {
+        if let definition = ThemeLibrary.storeTheme(named: name) {
+            if definition.isDark {
+                settings.darkThemeName = name
+            } else {
+                settings.lightThemeName = name
+            }
+        }
+        refreshInstalled()
+    }
+
+    private func beginRemove(_ name: String) {
+        // An edited file is the user's work, so deleting it is a question, not a
+        // side effect of a one-click Remove.
+        if !ThemeLibrary.isPristine(installedTheme: name),
+           let url = ThemeLibrary.fileURL(forInstalledTheme: name) {
+            pending = .removeEdited(name: name, path: url.path)
+            return
+        }
+        remove(name)
+    }
+
+    private func remove(_ name: String) {
+        do {
+            try ThemeLibrary.remove(named: name)
+        } catch {
+            failureMessage = error.localizedDescription
+            return
+        }
+        // A slot pointing at a name that no longer resolves would paint nothing
+        // and sit off every list; drop it back to termio's own canvas instead.
+        if settings.lightThemeName == name { settings.lightThemeName = "" }
+        if settings.darkThemeName == name { settings.darkThemeName = "" }
+        refreshInstalled()
+    }
+
+    private func openThemesFolder() {
+        do {
+            NSWorkspace.shared.open(try ThemeLibrary.ensureDirectoryExists())
+        } catch {
+            failureMessage = error.localizedDescription
+        }
+    }
+
+    private func refreshInstalled() {
+        installedNames = Set(ThemeLibrary.reload().map(\.name))
+        settings.objectWillChange.send()
+        onLibraryChanged()
+    }
+}

--- a/Sources/termio/Theme/ChromeTheme.swift
+++ b/Sources/termio/Theme/ChromeTheme.swift
@@ -46,13 +46,48 @@ struct ChromeTheme {
             with: dark ? .white : .black,
             amount: dark ? 0.06 : 0.04
         )
-        self.secondaryForeground = foreground.opacity(0.6)
-        // The active row reads as accent-tinted (VSCode's active list item), so
-        // prefer the theme's blue (palette slot 4) over its quieter text-selection
-        // grey; fall back through both to the foreground so it always resolves.
-        let accentHex = definition.palette[4] ?? definition.selectionBackground
-        self.accent = accentHex.flatMap(Color.init(hex:)) ?? foreground
+        // One alpha for both brightnesses is too thin over a light panel: at 0.6
+        // Catppuccin Latte's project labels measure 2.69 against `panelBackground`
+        // and Rose Pine Dawn's 2.62, under the 3.0 floor muted chrome text needs.
+        // Dark themes already clear it, so only the light side is lifted.
+        self.secondaryForeground = foreground.opacity(dark ? 0.6 : 0.75)
+        // The active row reads as accent-tinted (VSCode's active list item) and the
+        // same color inks trace links, so a theme whose ANSI blue is deep enough to
+        // vanish on its own background (Melange Light 2.80, Cobalt2 2.64) must use
+        // its bright blue instead: take whichever of palette 4 and 12 contrasts the
+        // background more. Fall back through the quieter text-selection grey to the
+        // foreground so it always resolves.
+        let blues = [definition.palette[4], definition.palette[12]]
+            .compactMap { $0 }
+            .compactMap(Color.init(hex:))
+        let accentCandidate = blues.max { Self.contrastRatio($0, background) < Self.contrastRatio($1, background) }
+        self.accent = accentCandidate
+            ?? definition.selectionBackground.flatMap(Color.init(hex:))
+            ?? foreground
         self.isDark = dark
+    }
+
+    /// WCAG contrast ratio between two opaque colors (1…21). Colors that can't be
+    /// resolved into sRGB components report the neutral 1.0 rather than trapping,
+    /// which makes them lose every comparison instead of winning one by accident.
+    static func contrastRatio(_ first: Color, _ second: Color) -> Double {
+        guard let firstLuminance = relativeLuminance(first),
+              let secondLuminance = relativeLuminance(second)
+        else { return 1 }
+        let lighter = max(firstLuminance, secondLuminance)
+        let darker = min(firstLuminance, secondLuminance)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private static func relativeLuminance(_ color: Color) -> Double? {
+        guard let srgb = NSColor(color).usingColorSpace(.sRGB) else { return nil }
+        func linear(_ component: CGFloat) -> Double {
+            let value = Double(component)
+            return value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linear(srgb.redComponent)
+            + 0.7152 * linear(srgb.greenComponent)
+            + 0.0722 * linear(srgb.blueComponent)
     }
 }
 

--- a/Sources/termio/Theme/ThemeLibrary.swift
+++ b/Sources/termio/Theme/ThemeLibrary.swift
@@ -1,28 +1,33 @@
 import Foundation
 import GhosttyTheme
+import TermioShared
 
-/// termio's terminal-theme catalog: the themes libghostty bundles, plus any the
-/// user drops into termio's `Themes` folder.
+/// termio's terminal-theme library: the files in termio's `Themes` folder, and
+/// nothing else.
 ///
-/// A custom theme is just a Ghostty-format theme file — the same `key = value`
-/// text Ghostty itself reads from `~/.config/ghostty/themes` (`background = #hex`,
-/// `palette = 0=#hex`, …) — so the thousands of community color schemes work
-/// unchanged. This is the VSCode/Zed model: drop a file into the folder and it
-/// shows up in the theme pickers under "Custom", no rebuild, no registration.
+/// A theme is a Ghostty-format file — the same `key = value` text Ghostty itself
+/// reads from `~/.config/ghostty/themes` (`background = #hex`, `palette = 0=#hex`,
+/// …) — so the thousands of community color schemes work unchanged. This is the
+/// VSCode/Zed model: a theme the user has is a file on their computer.
 ///
-/// A user theme shadows a bundled theme of the same name, so a file named
-/// "Dracula" overrides the built-in one. Loading is lenient: a malformed file is
-/// skipped rather than failing the whole load.
+/// `GhosttyThemeCatalog` (the ~485 schemes compiled into the `GhosttyTheme`
+/// product) is a warehouse, not a library. It is read only to install a store
+/// theme and to materialize a name that was selected before the library existed;
+/// `theme(named:)` never falls back to it. A selected name that resolves to no
+/// file would otherwise be a ghost: listed nowhere, yet painting the chrome.
+///
+/// Loading is lenient: a malformed file is skipped rather than failing the whole
+/// load.
 @MainActor
 enum ThemeLibrary {
-    /// Where users drop custom theme files, alongside termio's other support data
+    /// Where theme files live, alongside termio's other support data
     /// (`~/Library/Application Support/termio/Themes`).
     static var directory: URL {
         AppChannel.supportDirectory.appendingPathComponent("Themes", isDirectory: true)
     }
 
-    /// Custom themes parsed from `directory`, cached after the first load. Call
-    /// `reload()` to pick up files added or edited while the app is running.
+    /// Themes parsed from `directory`, cached after the first load. Call `reload()`
+    /// to pick up files added or edited while the app is running.
     private static var cachedUserThemes: [GhosttyThemeDefinition]?
 
     static var userThemes: [GhosttyThemeDefinition] {
@@ -42,92 +47,199 @@ enum ThemeLibrary {
         return loaded
     }
 
-    /// Resolves a theme by name. User themes are checked first so a custom file can
-    /// shadow a bundled theme; otherwise the bundled catalog answers.
+    /// Resolves a theme by name — from a file in the `Themes` folder, and only
+    /// from there. See the type comment for why the catalog is not a fallback.
     static func theme(named name: String) -> GhosttyThemeDefinition? {
-        userThemes.first { $0.name == name } ?? GhosttyThemeCatalog.theme(named: name)
+        userThemes.first { $0.name == name }
     }
 
-    /// The bundled catalog partitioned by brightness, computed once. The picker shows
-    /// only the slot-appropriate half — dark themes in the Dark slot, light in the
-    /// Light slot — so a slot can never offer a theme that renders the wrong way.
-    /// Brightness is the theme's own `isDark` (background luminance), the same signal
-    /// the row glyph and mismatch hint use.
-    // Read the whole catalog directly: `search("")` looks up the empty string,
-    // and Swift's `contains("")` is `false`, so it would return nothing.
-    static let darkBundledThemeNames: [String] = GhosttyThemeCatalog.allThemes
-        .filter { $0.isDark }.map(\.name).sorted()
-    static let lightBundledThemeNames: [String] = GhosttyThemeCatalog.allThemes
-        .filter { !$0.isDark }.map(\.name).sorted()
+    /// Installed theme names for one slot, filtered by each theme's own `isDark`
+    /// (background luminance) so the Dark slot can never offer a theme that would
+    /// render the wrong way.
+    static func installedThemeNames(dark: Bool) -> [String] {
+        userThemes.filter { $0.isDark == dark }
+            .map(\.name)
+            .sorted { $0.lowercased() < $1.lowercased() }
+    }
 
-    /// A curated shortlist of widely-used DARK themes, surfaced at the top of the
-    /// pickers so the common picks are one glance away instead of buried in the 400+
-    /// bundled catalog. Kept in popularity order (not alphabetized) since that is what
-    /// a quick-pick list is for. Filtered to names the catalog actually resolves, so a
-    /// future package rename drops the stale entry instead of showing a dead row.
-    /// Split from the light list because the catalog mixes both, and a "Dark" theme
-    /// slot wants dark options first (see the appearance-mismatch hint in the picker).
-    static let popularDarkThemeNames: [String] = [
-        "Dracula",
-        "Catppuccin Mocha",
-        "TokyoNight Storm",
-        "Nord",
-        "Gruvbox Dark",
-        "Atom One Dark",
-        "Monokai Pro",
-        "Rose Pine",
-        "Ayu Mirage",
-        "Night Owl",
-        "Kanagawa Wave",
-        "Everforest Dark Hard",
-        "GitHub Dark Default",
-        "iTerm2 Solarized Dark",
-    ].filter { GhosttyThemeCatalog.theme(named: $0) != nil }
-
-    /// The light-theme counterpart to `popularDarkThemeNames`: a curated shortlist of
-    /// the well-regarded, eye-friendly light schemes (each the light sibling of a
-    /// popular family — Latte/Dawn/Light variants), so the Light slot has good picks
-    /// up front too.
-    static let popularLightThemeNames: [String] = [
-        "Catppuccin Latte",
-        "Rose Pine Dawn",
-        "Gruvbox Light",
-        "Ayu Light",
-        "Atom One Light",
-        "GitHub Light Default",
-        "TokyoNight Day",
-        "Everforest Light Med",
-        "iTerm2 Solarized Light",
-    ].filter { GhosttyThemeCatalog.theme(named: $0) != nil }
-
-    /// Custom theme names, sorted — the picker's "Custom" group.
+    /// Every installed theme name, sorted — the Appearance tab's "N installed".
     static var userThemeNames: [String] {
         userThemes.map(\.name).sorted { $0.lowercased() < $1.lowercased() }
     }
 
+    // MARK: - Store
+
+    /// The store's index in display order, filtered to the names the pinned
+    /// catalog resolves so a package rename drops a stale row instead of showing a
+    /// dead one. The names themselves are shared with the iPhone's picker (see
+    /// `ThemeStoreCatalog`), which offers the same set.
+    static let storeCatalog: [String] = ThemeStoreCatalog.names
+        .filter { GhosttyThemeCatalog.theme(named: $0) != nil }
+
+    /// A store row's definition, read from the catalog so an uninstalled row can
+    /// still draw its swatch. The only other catalog readers are `install` and
+    /// `materializeFromCatalog`; nothing on the resolve path calls this.
+    static func storeTheme(named name: String) -> GhosttyThemeDefinition? {
+        GhosttyThemeCatalog.theme(named: name)
+    }
+
+    /// Why an Install did not happen.
+    enum InstallRefusal: Error {
+        /// The store name is not in the pinned catalog — only reachable if the
+        /// package renamed a theme between the filter above and the call.
+        case unknownTheme(String)
+        /// A file in the `Themes` folder already answers to that name. It may be
+        /// the user's own hand-dropped theme, so Install refuses and the caller
+        /// offers an explicit Replace naming this path.
+        case alreadyInstalled(URL)
+    }
+
+    /// Writes one store theme into the `Themes` folder. Refuses when a file
+    /// already parses to that name unless `replacingExisting` is set, so a
+    /// hand-dropped `Dracula` is never silently overwritten.
+    static func install(named name: String, replacingExisting: Bool = false) throws {
+        guard let definition = GhosttyThemeCatalog.theme(named: name) else {
+            throw InstallRefusal.unknownTheme(name)
+        }
+        if !replacingExisting, let existing = fileURL(forInstalledTheme: name) {
+            throw InstallRefusal.alreadyInstalled(existing)
+        }
+        try write(definition)
+        reload()
+    }
+
+    /// Deletes the file backing an installed theme.
+    static func remove(named name: String) throws {
+        guard let url = fileURL(forInstalledTheme: name) else { return }
+        try FileManager.default.removeItem(at: url)
+        reload()
+    }
+
+    /// The file an installed theme was parsed from, or `nil` when no file in the
+    /// folder parses to that name. Resolved by re-parsing rather than by guessing
+    /// the file name, because a theme's name comes from its file's stem and the
+    /// user may have named the file anything.
+    static func fileURL(forInstalledTheme name: String) -> URL? {
+        sortedFiles().first { url in
+            parse(name: url.deletingPathExtension().lastPathComponent,
+                  contents: (try? String(contentsOf: url, encoding: .utf8)) ?? "")?.name == name
+        }
+    }
+
+    /// Whether the installed file for `name` still holds exactly what `write`
+    /// would emit. A file the user has edited is theirs: Remove confirms first,
+    /// and the store never offers to reinstall over it.
+    static func isPristine(installedTheme name: String) -> Bool {
+        guard let url = fileURL(forInstalledTheme: name),
+              let contents = try? String(contentsOf: url, encoding: .utf8),
+              let catalogDefinition = GhosttyThemeCatalog.theme(named: name)
+        else { return false }
+        return contents == serialize(catalogDefinition)
+    }
+
+    // MARK: - Materialization
+
+    /// Writes `name`'s catalog definition into the `Themes` folder when the
+    /// library has no file for it yet, so a name selected before the library
+    /// existed becomes a library entry instead of a ghost selection. Returns
+    /// whether a file was written.
+    ///
+    /// Bounded by design: the caller passes only names that are already selected
+    /// (the two slots, and a Ghostty-inherited `theme = X`), never the catalog.
+    @discardableResult
+    static func materializeFromCatalog(named name: String) throws -> Bool {
+        guard !name.isEmpty, theme(named: name) == nil,
+              fileURL(forInstalledTheme: name) == nil,
+              let definition = GhosttyThemeCatalog.theme(named: name)
+        else { return false }
+        try write(definition)
+        reload()
+        return true
+    }
+
+    // MARK: - Files
+
     /// Creates the `Themes` folder if it does not exist yet and returns it, so
     /// "Open Themes Folder" always lands somewhere real even on a fresh install.
+    /// Throws so a write can report why it could not happen.
     @discardableResult
-    static func ensureDirectoryExists() -> URL {
+    static func ensureDirectoryExists() throws -> URL {
         let url = directory
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
     }
 
-    private static func loadUserThemes() -> [GhosttyThemeDefinition] {
+    /// Serializes a definition back to Ghostty `key = value` text and writes it to
+    /// `directory` under the theme's name, with no file extension — the folder
+    /// already names a theme after its file's stem, so an extension would only be
+    /// stripped back off on the next load. `parse` reads back an equal definition.
+    static func write(_ definition: GhosttyThemeDefinition) throws {
+        try write(definition, into: ensureDirectoryExists())
+    }
+
+    /// Writes into an explicit folder. `write(_:)` is this against the library's
+    /// own folder; the parameter exists so the round-trip test can prove the file
+    /// reads back equal without writing into the user's Themes folder.
+    static func write(_ definition: GhosttyThemeDefinition, into folder: URL) throws {
+        let url = folder.appendingPathComponent(definition.name, isDirectory: false)
+        try serialize(definition).write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// The Ghostty-format text for a definition. Palette entries are emitted in
+    /// index order so the file is stable across writes and comparable byte for
+    /// byte (see `isPristine(installedTheme:)`).
+    static func serialize(_ definition: GhosttyThemeDefinition) -> String {
+        var lines: [String] = [
+            "background = #\(definition.background)",
+            "foreground = #\(definition.foreground)",
+        ]
+        if let cursorColor = definition.cursorColor { lines.append("cursor-color = #\(cursorColor)") }
+        if let cursorText = definition.cursorText { lines.append("cursor-text = #\(cursorText)") }
+        if let selectionBackground = definition.selectionBackground {
+            lines.append("selection-background = #\(selectionBackground)")
+        }
+        if let selectionForeground = definition.selectionForeground {
+            lines.append("selection-foreground = #\(selectionForeground)")
+        }
+        for index in definition.palette.keys.sorted() {
+            guard let color = definition.palette[index] else { continue }
+            lines.append("palette = \(index)=#\(color)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// The folder's files in a stable order. Directory enumeration order is
+    /// filesystem-dependent, so sorting by path is what makes the dedupe below
+    /// deterministic rather than "whichever inode came back first".
+    private static func sortedFiles() -> [URL] {
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]
         ) else { return [] }
-        return entries.compactMap { url in
-            guard url.hasDirectoryPath == false,
-                  let contents = try? String(contentsOf: url, encoding: .utf8)
-            else { return nil }
+        return entries
+            .filter { !$0.hasDirectoryPath }
+            .sorted { $0.path < $1.path }
+    }
+
+    private static func loadUserThemes() -> [GhosttyThemeDefinition] {
+        var seen: Set<String> = []
+        var result: [GhosttyThemeDefinition] = []
+        for url in sortedFiles() {
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
             // A theme's name is its file name (sans extension), matching how Ghostty
             // names themes after their file. Files may have no extension at all.
-            return parse(name: url.deletingPathExtension().lastPathComponent, contents: contents)
+            guard let definition = parse(
+                name: url.deletingPathExtension().lastPathComponent,
+                contents: contents
+            ) else { continue }
+            // Two files can claim one name ("Dracula" and "Dracula.conf"). The
+            // first in path order wins, and the rest are ignored rather than
+            // shadowing each other differently on every launch.
+            guard seen.insert(definition.name).inserted else { continue }
+            result.append(definition)
         }
+        return result
     }
 
     /// Parses one Ghostty-format theme file into a definition. Returns `nil` when

--- a/Tests/termioTests/ThemeLibraryTests.swift
+++ b/Tests/termioTests/ThemeLibraryTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+import GhosttyTheme
+import TermioShared
+@testable import termio
+
+/// The theme library's two load-bearing guarantees: a theme written to disk reads
+/// back as the same theme, and the store's index stays the curated list it claims
+/// to be — every name resolvable, the brightness split intact, and no two rows in
+/// a slot close enough to read as the same theme.
+@MainActor
+final class ThemeLibraryTests: XCTestCase {
+    // MARK: - write / parse
+
+    func testWriteRoundTripsThroughParse() throws {
+        let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("theme-library-round-trip-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let definition = GhosttyThemeDefinition(
+            name: "Round Trip",
+            background: "1e1e2e",
+            foreground: "cdd6f4",
+            cursorColor: "f5e0dc",
+            cursorText: "11111b",
+            selectionBackground: "585b70",
+            selectionForeground: "cdd6f4",
+            palette: [0: "45475a", 1: "f38ba8", 7: "bac2de", 15: "a6adc8"]
+        )
+        try ThemeLibrary.write(definition, into: folder)
+
+        let url = folder.appendingPathComponent(definition.name, isDirectory: false)
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertEqual(ThemeLibrary.parse(name: definition.name, contents: contents), definition)
+    }
+
+    /// A theme with no optional colors at all must survive the trip too — the
+    /// serializer has to omit those keys rather than write empty values that parse
+    /// back as blank hex.
+    func testWriteRoundTripsAThemeWithoutOptionalColors() throws {
+        let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("theme-library-minimal-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let definition = GhosttyThemeDefinition(
+            name: "Bare", background: "ffffff", foreground: "000000")
+        try ThemeLibrary.write(definition, into: folder)
+
+        let contents = try String(
+            contentsOf: folder.appendingPathComponent(definition.name, isDirectory: false),
+            encoding: .utf8)
+        XCTAssertEqual(ThemeLibrary.parse(name: definition.name, contents: contents), definition)
+    }
+
+    /// Every catalog theme the store can install has to survive being written and
+    /// read back, not just a hand-picked one.
+    func testEveryStoreThemeRoundTrips() throws {
+        let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("theme-library-store-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        for name in ThemeLibrary.storeCatalog {
+            let definition = try XCTUnwrap(ThemeLibrary.storeTheme(named: name))
+            try ThemeLibrary.write(definition, into: folder)
+            let contents = try String(
+                contentsOf: folder.appendingPathComponent(name, isDirectory: false), encoding: .utf8)
+            XCTAssertEqual(ThemeLibrary.parse(name: name, contents: contents), definition, name)
+        }
+    }
+
+    // MARK: - Store catalog
+
+    func testEveryStoreCatalogNameResolves() {
+        let unresolved = ThemeStoreCatalog.names.filter { GhosttyThemeCatalog.theme(named: $0) == nil }
+        XCTAssertEqual(unresolved, [], "store names missing from the pinned catalog")
+        // The filter that drops stale rows must be dropping nothing today; a name
+        // silently disappearing from the store is exactly what it would look like.
+        XCTAssertEqual(ThemeLibrary.storeCatalog, ThemeStoreCatalog.names)
+    }
+
+    /// Derived from each theme's own background luminance, never a hand-kept
+    /// per-name assignment — that is the whole point of `isDark` deciding the slot.
+    func testStoreCatalogSplitsThirtyFiveDarkAndFifteenLight() {
+        let definitions = ThemeLibrary.storeCatalog.compactMap { ThemeLibrary.storeTheme(named: $0) }
+        XCTAssertEqual(definitions.count, 50)
+        XCTAssertEqual(definitions.filter(\.isDark).count, 35)
+        XCTAssertEqual(definitions.filter { !$0.isDark }.count, 15)
+    }
+
+    /// The curation rule that keeps the store free of near-duplicates: within a
+    /// slot, no two themes sit closer than ΔE 12 on the weighted Lab metric the
+    /// list was built with. Rejected pairs measure far below it (TokyoNight
+    /// Night vs Storm 2.6, Catppuccin Mocha vs Macchiato 4.3), so a family that
+    /// sneaks a second variant onto the list fails here.
+    func testNoTwoStoreThemesInASlotReadAsTheSameTheme() throws {
+        for dark in [true, false] {
+            let definitions = ThemeLibrary.storeCatalog
+                .compactMap { ThemeLibrary.storeTheme(named: $0) }
+                .filter { $0.isDark == dark }
+            for first in 0..<definitions.count {
+                for second in (first + 1)..<definitions.count {
+                    let distance = try weightedDistance(definitions[first], definitions[second])
+                    XCTAssertGreaterThanOrEqual(
+                        distance, 12,
+                        "\(definitions[first].name) and \(definitions[second].name) read as one theme")
+                }
+            }
+        }
+    }
+
+    // MARK: - Distinctness metric
+
+    /// Weighted mean CIE Lab distance between two themes: the background dominates
+    /// what a theme looks like (×2.5), the body text follows (×1.2), and the six
+    /// ANSI colors a user recognizes a scheme by carry the rest (×0.7 each).
+    private func weightedDistance(
+        _ first: GhosttyThemeDefinition, _ second: GhosttyThemeDefinition
+    ) throws -> Double {
+        var total = 0.0
+        var weight = 0.0
+        func accumulate(_ firstHex: String, _ secondHex: String, _ factor: Double) throws {
+            let a = try XCTUnwrap(lab(firstHex), firstHex)
+            let b = try XCTUnwrap(lab(secondHex), secondHex)
+            let distance = ((a.0 - b.0) * (a.0 - b.0)
+                + (a.1 - b.1) * (a.1 - b.1)
+                + (a.2 - b.2) * (a.2 - b.2)).squareRoot()
+            total += factor * distance
+            weight += factor
+        }
+        try accumulate(first.background, second.background, 2.5)
+        try accumulate(first.foreground, second.foreground, 1.2)
+        for slot in 1...6 {
+            guard let firstColor = first.palette[slot], let secondColor = second.palette[slot] else { continue }
+            try accumulate(firstColor, secondColor, 0.7)
+        }
+        guard weight > 0 else { return 0 }
+        return total / weight
+    }
+
+    /// sRGB hex → CIE Lab under D65, the space the ΔE above is measured in.
+    private func lab(_ hex: String) -> (Double, Double, Double)? {
+        let raw = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        guard raw.count == 6, let value = UInt32(raw, radix: 16) else { return nil }
+        func linear(_ channel: UInt32) -> Double {
+            let component = Double(channel) / 255
+            return component <= 0.04045 ? component / 12.92 : pow((component + 0.055) / 1.055, 2.4)
+        }
+        let red = linear((value >> 16) & 0xff)
+        let green = linear((value >> 8) & 0xff)
+        let blue = linear(value & 0xff)
+        let x = (red * 0.4124564 + green * 0.3575761 + blue * 0.1804375) / 0.95047
+        let y = red * 0.2126729 + green * 0.7151522 + blue * 0.0721750
+        let z = (red * 0.0193339 + green * 0.1191920 + blue * 0.9503041) / 1.08883
+        func pivot(_ component: Double) -> Double {
+            component > 216.0 / 24389.0 ? pow(component, 1.0 / 3.0) : (841.0 / 108.0) * component + 4.0 / 29.0
+        }
+        let fx = pivot(x), fy = pivot(y), fz = pivot(z)
+        return (116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz))
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ from the real front matter).
 | approved | design | [Git worktree creation & lifecycle (Codex-aligned)](design/20260706-worktree-creation-lifecycle.md) |
 | approved | design | [Refresh session identity when Claude Code /clear rotates the conversation](design/20260720-clear-conversation-rotation.md) |
 | approved | design | [Worktree information architecture](design/20260628-worktree-information-architecture.md) |
+| approved | rfc | [Theme store — browse 50, install on demand, library is truth](rfcs/theme-store.md) |
 | archived | design | [iOS scroll-draw coalescing (vsync-capped surface draws)](design/20260706-ios-scroll-renderer-health.md) |
 | archived | design | [Sandbox VM —— 原生 per-project 容器（Apple Containerization）](design/20260629-sandbox-vm.md) |
 | archived | essay | ["From IDE to ADE: Sixty Years of Development Environments, and Why the Era Is Ending"](essays/from-ide-to-ade.md) |

--- a/docs/rfcs/theme-store.md
+++ b/docs/rfcs/theme-store.md
@@ -1,0 +1,406 @@
+---
+title: Theme store — browse 50, install on demand, library is truth
+status: approved
+type: rfc
+created: 2026-08-14
+updated: 2026-08-16
+related:
+  - command-palette-theme-switching.md
+  - session-daemon-architecture.md
+---
+
+# Theme store — browse 50, install on demand, library is truth
+
+> Split themes into default / library / store so the picker stops dumping 485
+> Ghostty schemes. A selected theme is a file in the Themes folder. Install
+> writes one file; nothing is fetched. Settings chrome is out of scope.
+
+Reviewed 2026-08-14 (Claude Code, approve-with-changes). Locked below:
+library-is-truth (file-only resolve + bounded materialization), Install
+must not clobber a same-named user file, one atomic PR, no Settings
+chrome, no remote theme fetch. Six draft catalog names that do not
+resolve are dropped or substituted.
+
+## Problem
+
+termio treats "theme" as one flat catalog. Settings ▸ Appearance, the command
+palette's **Change Theme…**, and the iOS picker all list `GhosttyThemeCatalog`
+(~485 iTerm2-Color-Schemes names) plus whatever the user dropped in
+`~/Library/Application Support/termio/Themes`. A "Popular" group sits on top;
+everything else is still one scroll away.
+
+That catalog is a warehouse of ANSI palettes compiled into the
+`GhosttyTheme` product. It is not a library. Showing it in every picker
+makes every user "have" 485 themes they never chose.
+
+Two rejected answers sit next to this:
+
+- **Ship 50 as the new bundled picker.** Everyone still "has" them. It is a
+  smaller dump, not a library.
+- **Invent 41 original named suites** (Superlogical's *Velvet Dusk* /
+  *Orchard Breeze* model). That is their product identity. Ours is the Ghostty
+  file people already know.
+
+The refactor: a **store that lists**, a **library that holds**, and
+**resolve only from the library**. Chrome in the main window already
+follows the selected theme (sidebar, editor, git, issues, files, trace).
+The Settings window does not; that is not this RFC.
+
+## Anatomy of today
+
+| Piece | Where | What it does |
+| --- | --- | --- |
+| `GhosttyThemeCatalog` | `GhosttyTheme` product in libghostty-swift | ~485 compiled `GhosttyThemeDefinition`s. Warehouse only |
+| `ThemeLibrary` | `Sources/termio/Theme/ThemeLibrary.swift` | Resolves user files first, then the catalog. Parses Ghostty `key = value` text. Partitions popular / all-dark / all-light |
+| `ChromeTheme` | `Sources/termio/Theme/ChromeTheme.swift` | Derives tokens from one definition. Already consumed by the main window |
+| Light / dark slots | `AppSettings.lightThemeName` / `darkThemeName` | Independent names. Empty = termio canvas |
+| Mac picker | `ThemePickerField` | Popular + **All Dark/Light Themes** (the 485) + Custom |
+| Palette | `CommandPalette.themeItems` | Popular first, then the rest of the slot's catalog. `beginThemeBrowsing` seeds `highlighted` with `?? 0` |
+| Main window chrome | sidebar, editor, git, issues, files, trace | Follows the selected theme |
+| Settings window | `SettingsView` | System materials. Out of scope |
+| iOS | `ThemePickerViewController`, `ThemeBackdrop` | Same 485-wide catalog. Backdrop only |
+
+`ThemeLibrary.directory` is already the VS Code / Zed install location.
+The store is that folder plus a browse UI, not a new persistence scheme.
+
+Theme stays a **client** concern. `termiod` never sees a palette.
+
+## Design invariants
+
+1. **Three layers, one file format.** Default, library, and store all speak
+   Ghostty `key = value` (or the empty-slot canvas). No second color system.
+2. **Library is truth.** A selected name resolves only from a file in the
+   Themes folder. `GhosttyThemeCatalog` is the Install source and the
+   materialization source, never a runtime fallback for a slot.
+3. **Installed means a file in the Themes folder.** The user's computer
+   holds default + what they installed or dropped in. We do not copy 485 —
+   or 50 — into Application Support on launch.
+4. **The picker lists default + library.** The store lists the curated
+   50. Command palette matches the picker, not the store. An
+   uninstalled store row is not listed in either, so it cannot paint
+   chrome and cannot be the `?? 0` seed.
+5. **Bounded materialization, not silent fallback.** On first launch after
+   this ships, each occupied slot whose name is not yet a file is written
+   once from the catalog into the Themes folder. Two files, not 485.
+   Existing selections keep working because they become library entries.
+6. **Install never clobbers.** If a file in the folder already parses to
+   that name, Install refuses and offers Replace, naming the path. Remove
+   only deletes a file whose contents match what `write` would emit;
+   otherwise confirm, naming the path.
+7. **No network.** Install serializes from `GhosttyThemeCatalog`. No
+   remote index, no fetch on Settings open, no later `index.json` in this
+   RFC.
+8. **No backend, no account, no paid themes.**
+9. **Settings chrome is out of scope.** Do not paint `SettingsView`.
+
+## Design
+
+### Layers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Store (curated index, names that resolve)              │
+│  Browse / Install / Remove                              │
+│  Source: GhosttyThemeCatalog.theme(named:) only         │
+└──────────────────────────┬──────────────────────────────┘
+                           │ Install writes one file
+                           │ (refuse if that name exists)
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│  Library  ~/Library/Application Support/termio/Themes   │
+│  + files the user dropped in themselves                 │
+│  + at most two materialized slot files on upgrade       │
+└──────────────────────────┬──────────────────────────────┘
+                           │ selected name → file only
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│  Default  empty slot → termio canvas                    │
+│  (no file; not Alabaster / Afterglow as named themes)   │
+└─────────────────────────────────────────────────────────┘
+```
+
+Resolve a selected name:
+
+1. A file in the Themes folder (install, hand-drop, or materialization).
+2. Empty / unknown → the slot's canvas.
+
+There is no catalog fallback on this path. The warehouse is consulted
+only by Install, by materialization, and by Ghostty-inherit (below).
+
+Remove deletes the file and, if that name is the selected slot, writes
+`""` into the slot so the canvas shows. Do not leave the old name sitting
+in settings hoping a fallback will still paint it.
+
+### Bounded materialization
+
+One-time, on first launch after this ships, before any picker opens:
+
+For each of `lightThemeName` and `darkThemeName`, if the string is
+non-empty and `ThemeLibrary` has no file for that name, and
+`GhosttyThemeCatalog.theme(named:)` succeeds, `write` that definition
+into `directory`. Skip if a file of that name already exists (the user
+already has one). Record a flag in the settings store so this does not
+run again.
+
+Same write for Ghostty inherit (`Settings.swift`
+`ghosttyRegistrationOverrides`): a `theme = X` that is not yet a file is
+materialized, then the slot is set. Inherit is not a permanent catalog
+lookup at paint time.
+
+After this, every named selection is a library entry. The palette's
+`themeItems.firstIndex { … } ?? 0` cannot land on the default row while
+the user's theme is still selected — that name is in the list.
+
+### Store catalog
+
+A static list of well-known Ghostty names, partitioned by `isDark`,
+filtered at launch so a package rename drops a stale row. A `swift test`
+asserts every remaining name resolves against `GhosttyThemeCatalog`.
+
+Locked set — **50 names: 35 dark, 15 light.** Every name resolves against
+the pinned `GhosttyThemeCatalog`, and each one's brightness slot is its
+own `isDark`, not a hand-assignment.
+
+Four curation rules, in priority order:
+
+1. **Popular, not merely pretty.** A theme earns a row by being one
+   people already ask for by name.
+2. **No two rows may read as the same theme.** One variant per family —
+   the 485 are mostly near duplicates. Distinctness is measured, not
+   argued: weighted mean ΔE (CIE Lab) over background ×2.5, foreground
+   ×1.2, and ANSI 1–6 ×0.7 each. **Every pair on the list clears ΔE 12.**
+   The rejected pairs show why the rule is needed — TokyoNight Night vs
+   Storm ΔE 2.6, Atom One Dark vs One Half Dark 3.7, Catppuccin Mocha vs
+   Macchiato 4.3, Rose Pine vs Moon 4.8, Monokai Pro vs Ristretto 7.0,
+   Dracula vs Snazzy 8.8, GitHub Dark Default vs Dimmed 9.3, Ayu vs Ayu
+   Mirage 9.6. Each of those is one row now, not two.
+3. **It must hold up for a working day of code.** Body text ≥ 6:1 on the
+   background; ANSI red vs green ≥ ΔE 40, because that pair is a diff and
+   a test result before it is decoration; every ANSI 1–6 ≥ 2.6:1 on the
+   background, so no syntax color disappears.
+4. **It must survive `ChromeTheme`.** The selected theme paints the
+   sidebar, editor gutter, git pane, and trace, so a theme that derives a
+   dead chrome is not elegant here even if it renders well in a bare
+   terminal. Checked against the tokens the chrome actually paints
+   (below).
+
+Where a family has both a light and a dark member on the list, the two
+slots can be set to one identity (Catppuccin Latte over Mocha, GitHub
+Light Default over Dark Default, Modus Operandi over Vivendi). Pairing is
+a tiebreaker, never a reason to seat a theme that fails rule 3.
+
+**Dark (35).** Dracula, Catppuccin Mocha, TokyoNight Night, Nord, Gruvbox
+Dark, Atom One Dark, Monokai Pro, Rose Pine, Ayu Mirage, Night Owl,
+Kanagawa Wave, Kanagawa Dragon, Everforest Dark Hard, GitHub Dark
+Default, iTerm2 Solarized Dark, Cobalt2, Vesper, Flexoki Dark, Melange
+Dark, Xcode Dark, Aura, Dark Modern, Oxocarbon, Gruber Darker,
+Jellybeans, Horizon, Embark, Srcery, Terafox, Modus Vivendi, Vercel,
+Poimandres, Matte Black, Carbonfox, Sonokai.
+
+**Light (15).** Catppuccin Latte, GitHub Light Default, Rose Pine Dawn,
+Gruvbox Light, iTerm2 Solarized Light, Atom One Light, Flexoki Light,
+Kanagawa Lotus, Xcode Light, Monokai Pro Light, Iceberg Light, Melange
+Light, One Half Light, Modus Operandi, Bluloco Light.
+
+Dropped as unresolved against the pinned catalog: Ayu Dark, One Dark,
+Palenight, One Light, Solarized Light, PaperColor Light.
+
+Dropped on rule 3 despite the name recognition: **Ayu Light** (body 5.9,
+green/yellow/cyan under 2.6 on its near-white background), **TokyoNight
+Day** (body 4.5), **Everforest Light Med** (body 4.7 and all six ANSI
+colors under floor). Each of those families still has a dark member on
+the list, so the name is not missing from the store — only its washed-out
+light variant is.
+
+Alabaster and Afterglow stay off the list for a different reason: they
+are the empty slot's canvas, and installing them as named files is not
+the same thing.
+
+### What "survives `ChromeTheme`" means
+
+`ChromeTheme` derives four tokens from a definition, and each has a
+contrast floor measured where it is actually drawn:
+
+| Token | Where it lands | Floor |
+| --- | --- | --- |
+| `secondaryForeground` | project labels and icons on `panelBackground` | 3.0 |
+| `foreground` over the selected row (`accent` at 22%) | sidebar selection | 4.5 |
+| selected row vs `panelBackground` | selection must be visible at all | 1.12 |
+| `accent` as link ink on `background` | trace links (`--accent`) | 3.0 |
+
+Scoring the locked 50 against those floors found two derivation bugs that
+the picker's old 485-wide dump hid, both fixed in this PR:
+
+- **`secondaryForeground` is `foreground.opacity(0.6)` for both
+  brightnesses**, which is too thin over a light panel: Catppuccin Latte
+  lands at 2.69, Rose Pine Dawn 2.62, Kanagawa Lotus 2.55. Raising the
+  light side to 0.75 clears the floor (3.42 / 3.30 / 3.19) and leaves
+  dark themes untouched.
+- **`accent` falls back `palette[4] → selectionBackground → foreground`**
+  without ever checking contrast, so a theme with a deep ANSI blue paints
+  unreadable trace links (Melange Light 2.80, Gruvbox Light 3.73 for a
+  link, Cobalt2 2.64). Prefer whichever of `palette[4]` and `palette[12]`
+  contrasts the background more: Melange Light 5.71, Gruvbox Light 5.82,
+  Cobalt2 3.00.
+
+Two names stay on the list below a floor because low contrast *is* the
+theme: iTerm2 Solarized Dark and iTerm2 Solarized Light. They are the
+most-recognized scheme in the catalog, and the fix is never to substitute
+a different palette behind a name people know. Everything else on the
+list clears every floor, with two marginals worth naming — Atom One Dark
+and Poimandres sit at 4.0–4.1 for row text over the selection wash,
+against a 4.5 target that is only reachable by darkening the wash for
+every theme.
+
+Light themes universally miss the ANSI-yellow gate on a near-white
+background (Catppuccin Latte, Rose Pine Dawn, Gruvbox Light, Atom One
+Light). That is physics, not a curation miss: there is no yellow that
+clears 2.6:1 on `#f9f9f9` and still reads as yellow.
+
+### Store UI
+
+A sheet opened from Appearance (**Browse Themes…**), not a fourth
+Settings tab. Each row: name, `ThemeSwatch`, Install or Remove.
+
+The sheet does **not** live-apply. It sits over Settings, which sits over
+the terminal — preview-on-highlight would recolor a pane the user cannot
+see, and writing an uninstalled name into the slot would violate
+library-is-truth. Live preview stays in ⌘⇧P, over installed themes only.
+
+Install writes the file, then selects the slot matching the theme's own
+`isDark` (not the slot Browse was opened from). Dismiss without Install
+changes nothing.
+
+If a file already parses to that name: refuse, offer Replace, name the
+path. A file whose contents differ from what `write` would emit shows
+**Remove** only — no Reinstall that silently discards edits.
+
+`write` emits Ghostty `key = value` with no filename extension (the
+folder already names a theme after the stem). It must
+`ensureDirectoryExists()`, and a write failure is surfaced — never
+swallowed. `write` then `parse` must round-trip equal; that is a unit
+test. `loadUserThemes` dedupes by name with documented precedence
+(first file in directory order after a stable sort by path).
+
+### `ThemeLibrary` refactor
+
+- `directory` / `reload()` / `parse` stay. Add `write` (inverse of
+  `parse`).
+- `installedThemeNames` — files on disk, brightness-filtered for a slot.
+- `storeCatalog` — the locked list above, filtered to names that resolve.
+- `theme(named:)` — **files only**. No `GhosttyThemeCatalog` fallback.
+- Delete `darkBundledThemeNames` / `lightBundledThemeNames` from every
+  picker path. Catalog lookup stays private to Install and
+  materialization.
+- `popularDarkThemeNames` / `popularLightThemeNames` collapse into
+  `storeCatalog`.
+
+Callers that walk `GhosttyThemeCatalog.allThemes` for a UI list
+(`ThemePickerField.slotBundledNames`, `CommandPalette.themeItems`, iOS
+`ThemePickerViewController.all`) switch to `installedThemeNames` plus
+the empty default row.
+
+Install / Remove call `ThemeLibrary.reload()` and
+`settings.objectWillChange.send()`, and push fresh names into
+`AppearanceSettingsTab`'s `@State` — the same pattern as today's Reload
+button. The caption **"N custom"** becomes **"N installed"**. Reload
+stays, for external edits to the folder.
+
+### Picker and palette
+
+`ThemePickerField` sections, empty query:
+
+1. Terminal default
+2. Installed (the Themes folder, slot-brightness only)
+
+Search covers installed names only. Custom-as-a-separate-group goes away.
+An empty search for a store name (e.g. "dracula" on a fresh install)
+points at **Browse Themes…**, carrying the query.
+
+Footer keeps the mismatch hint. **Browse Themes…** sits next to **Open
+Themes Folder…**.
+
+`CommandPalette.themeItems`: default + installed, same-brightness. Add
+**Browse Themes…** as a command that opens the sheet — it does not dump
+uninstalled names into the palette. After materialization the current
+named theme is always in the list, so `?? 0` cannot overwrite it. Still
+seed the highlight from the current name, never assume index 0 is
+harmless.
+
+### iOS
+
+No store on the phone. `MobileSettings` keeps the literal default names
+`Alabaster` / `Afterglow` (the phone has no empty-slot canvas equivalent).
+The iOS picker shrinks to those two defaults plus the same store names,
+resolved from `GhosttyThemeCatalog` — resolve-only, no files written.
+`ThemeBackdrop` stays. Companion-pushed theme files are out of scope.
+
+### Migration
+
+- On first launch: materialize the two occupied slots (and any
+  Ghostty-inherit name) as above. Then set the done flag.
+- Do **not** copy the store catalog or the 485 into Themes.
+- Do **not** delete `GhosttyTheme` from `Package.swift`. Install and
+  materialization need it.
+- A user who only ever used empty slots sees no new files until they
+  Install something.
+
+## What this is not
+
+- A marketplace, an account, or a paid theme.
+- A remote fetch, now or later in this RFC.
+- 41 original termio-named palettes.
+- Settings-window chrome (cut).
+- Pushing theme through `termiod` or the companion wire.
+- Replacing the native sidebar material.
+- A silent catalog fallback that leaves a selected name off the picker
+  list (that is how `?? 0` overwrites the theme).
+
+## PR
+
+One PR. Library API and the picker/store switch are not separately
+mergeable: tagging `main` between "picker lists installed only" and
+"Browse Themes exists" would ship a picker that only contains Terminal
+default.
+
+- `ThemeLibrary`: `write`, `installedThemeNames`, `storeCatalog`, file-only
+  `theme(named:)`, name dedupe, bounded materialization.
+- `ChromeTheme`: brightness-aware `secondaryForeground` (0.6 dark / 0.75
+  light) and a contrast-preferring `accent` (`palette[4]` vs
+  `palette[12]` against the background).
+- Tests: `write` → `parse` equality; every `storeCatalog` name resolves;
+  the catalog is 35 dark + 15 light by each theme's own `isDark`; no two
+  names in a slot sit closer than ΔE 12; every name clears the chrome and
+  code-reading floors except the documented Solarized pair and the
+  light-yellow cases.
+- Browse Themes sheet + Install / Remove (no live-apply) + Appearance
+  button + palette command.
+- Picker and palette drop to default + installed in the same change.
+- Appearance footer / "N installed" / Reload copy.
+- iOS picker: drop "All Themes".
+- Docs: `web/landing/content/docs` appearance page + zh-CN restamp
+  (`pnpm docs:stamp`, `pnpm docs:check`). New strings get the zh-Hans
+  pass on both platforms.
+
+Not in this PR: Settings chrome, authored `chrome.*` keys, a remote
+index, companion file sync, light/dark families as one identity.
+
+## Key decisions
+
+| Decision | Why |
+| --- | --- |
+| Library is truth; file-only resolve | Catalog fallback + picker-lists-installed leaves a ghost selection. Palette `?? 0` then live-applies over it |
+| Bounded materialization of the two slots | Upgrade must not reset terminals, and must not copy 485 files |
+| Install refuses a same-named file | A hand-dropped `Dracula` is the user's file. Replace is explicit |
+| One PR | Picker shrink without the store is an empty picker on `main` |
+| No Settings chrome | Cut. Main window already follows the theme |
+| No remote fetch | Warehouse is already in the binary. No host, no account |
+| Sheet, no live-apply | Sheet cannot preview the terminal; writing an uninstalled name violates library-is-truth |
+| Install selects the theme's own `isDark` slot | Installing dark from the Light slot's Browse must not trip the mismatch hint |
+| Store names that resolve, tested | Six draft names were missing from the pinned catalog |
+
+## Open questions
+
+None remaining. Sheet (no live-apply), Install-selects (`isDark` slot),
+and per-channel Themes folders (`AppChannel.supportDirectory`) are
+locked above.

--- a/ios/Sources/Localizable.xcstrings
+++ b/ios/Sources/Localizable.xcstrings
@@ -71,16 +71,6 @@
         }
       }
     },
-    "All Themes": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所有主题"
-          }
-        }
-      }
-    },
     "Allow microphone access in Settings": {
       "localizations": {
         "zh-Hans": {
@@ -981,16 +971,6 @@
         }
       }
     },
-    "Popular": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "热门"
-          }
-        }
-      }
-    },
     "Privacy Policy": {
       "localizations": {
         "zh-Hans": {
@@ -1707,6 +1687,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "重新连接时需要再次扫描它的二维码。"
+          }
+        }
+      }
+    },
+    "Themes": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主题"
           }
         }
       }

--- a/ios/Sources/SettingsViewController.swift
+++ b/ios/Sources/SettingsViewController.swift
@@ -871,11 +871,14 @@ final class MacDetailViewController: UITableViewController {
 
 // MARK: - Theme picker
 
-/// Full-catalog picker for one slot of the theme pair: the curated popular
-/// shortlist up top (same names the Mac picker leads with — dark schemes for
-/// the Dark slot, light for Light), the whole Ghostty catalog underneath,
-/// and a search field over all of it. Picking a row applies immediately —
-/// no confirm step, matching the Mac's live-preview behavior.
+/// Picker for one slot of the theme pair: the slot's own default, then the
+/// store's curated set for that brightness (the same names the Mac's Browse
+/// Themes offers), with a search field over both. Picking a row applies
+/// immediately — no confirm step, matching the Mac's live-preview behavior.
+///
+/// The phone has no theme store: it resolves these names out of the compiled
+/// catalog to render them and never writes a file. Themes the user installed on
+/// the Mac stay on the Mac.
 final class ThemePickerViewController: UITableViewController {
     enum Slot {
         case light, dark
@@ -884,41 +887,11 @@ final class ThemePickerViewController: UITableViewController {
     private let slot: Slot
     private let settings = MobileSettings.shared
 
-    /// The Mac picker's popular shortlists, filtered against the catalog so
-    /// a package rename drops a stale entry instead of showing a dead row.
-    private static let popularDarkNames: [String] = [
-        "Dracula",
-        "Catppuccin Mocha",
-        "TokyoNight Storm",
-        "Nord",
-        "Gruvbox Dark",
-        "Atom One Dark",
-        "Monokai Pro",
-        "Rose Pine",
-        "Ayu Mirage",
-        "Night Owl",
-        "Kanagawa Wave",
-        "Everforest Dark Hard",
-        "GitHub Dark Default",
-        "iTerm2 Solarized Dark",
-    ].filter { GhosttyThemeCatalog.theme(named: $0) != nil }
-
-    private static let popularLightNames: [String] = [
-        "Catppuccin Latte",
-        "Rose Pine Dawn",
-        "Gruvbox Light",
-        "Ayu Light",
-        "Atom One Light",
-        "GitHub Light Default",
-        "TokyoNight Day",
-        "Everforest Light Med",
-        "iTerm2 Solarized Light",
-    ].filter { GhosttyThemeCatalog.theme(named: $0) != nil }
-
-    private let popular: [GhosttyThemeDefinition]
-    private let all = GhosttyThemeCatalog.allThemes.sorted {
-        $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-    }
+    /// The slot's default plus the store's half for this brightness, resolved
+    /// against the catalog so a package rename drops a stale entry instead of
+    /// showing a dead row. Brightness is each theme's own `isDark`, so a slot can
+    /// never offer a theme that would render the wrong way.
+    private let themes: [GhosttyThemeDefinition]
     private var query = ""
     private var matches: [GhosttyThemeDefinition] = []
 
@@ -935,8 +908,14 @@ final class ThemePickerViewController: UITableViewController {
 
     init(slot: Slot) {
         self.slot = slot
-        popular = (slot == .light ? Self.popularLightNames : Self.popularDarkNames)
+        let names = [
+            MobileSettings.defaultLightThemeName,
+            MobileSettings.defaultDarkThemeName,
+        ] + ThemeStoreCatalog.names
+        var seen: Set<String> = []
+        themes = names
             .compactMap { GhosttyThemeCatalog.theme(named: $0) }
+            .filter { $0.isDark == (slot == .dark) && seen.insert($0.name).inserted }
         super.init(style: .insetGrouped)
     }
 
@@ -957,30 +936,21 @@ final class ThemePickerViewController: UITableViewController {
 
     private var isSearching: Bool { !query.isEmpty }
 
-    private func theme(at indexPath: IndexPath) -> GhosttyThemeDefinition {
-        if isSearching { return matches[indexPath.row] }
-        return indexPath.section == 0 ? popular[indexPath.row] : all[indexPath.row]
-    }
+    private var rows: [GhosttyThemeDefinition] { isSearching ? matches : themes }
 
     // MARK: - Table
 
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        isSearching ? 1 : 2
-    }
-
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if isSearching { return matches.count }
-        return section == 0 ? popular.count : all.count
+        rows.count
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        if isSearching { return nil }
-        return section == 0 ? localized("Popular") : localized("All Themes")
+        isSearching ? nil : localized("Themes")
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "theme", for: indexPath)
-        let theme = theme(at: indexPath)
+        let theme = rows[indexPath.row]
         cell.contentConfiguration = UIHostingConfiguration {
             ThemeRow(theme: theme, isSelected: theme.name == selectedName)
         }
@@ -989,8 +959,7 @@ final class ThemePickerViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        selectedName = theme(at: indexPath).name
-        // The pick shows up in every visible copy of the row (popular + all).
+        selectedName = rows[indexPath.row].name
         tableView.reloadData()
     }
 }
@@ -998,11 +967,9 @@ final class ThemePickerViewController: UITableViewController {
 extension ThemePickerViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         query = searchController.searchBar.text?.trimmingCharacters(in: .whitespaces) ?? ""
-        if !query.isEmpty {
-            matches = GhosttyThemeCatalog.search(query).sorted {
-                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-            }
-        }
+        // Search stays inside the offered set: a hit the picker would refuse to
+        // list is a row that cannot be picked.
+        matches = themes.filter { $0.name.localizedCaseInsensitiveContains(query) }
         tableView.reloadData()
     }
 }

--- a/web/landing/content/docs/appearance.mdx
+++ b/web/landing/content/docs/appearance.mdx
@@ -12,6 +12,9 @@ Termio uses Ghostty-format themes, so anything from the wider Ghostty theme
 ecosystem works. Pick a light and a dark theme from **Settings ▸ Appearance** and
 Termio follows the system between them.
 
+The two slots list the themes you have — Termio's own canvas plus whatever is in
+your Themes folder — not a catalog of hundreds you never chose.
+
 <DocsImage
   src="/screenshots/docs/15-appearance-settings.png"
   alt="Termio Appearance settings with System, Light, and Dark modes and separate light and dark terminal theme slots"
@@ -23,9 +26,22 @@ If you already use Ghostty, there's nothing to pick on a fresh install: Termio
 reads your `~/.config/ghostty/config` on first launch and starts with the font and
 theme you chose there.
 
-To browse the catalog with your terminals as the preview, open the Command Palette
-(`⇧⌘P`) and pick **Change Theme…** — arrowing through the list restyles your open
-terminals live, Return keeps the theme, Escape puts it back.
+## Getting more themes
+
+**Browse Themes…** opens a store of 50 well-known schemes — Dracula, Catppuccin,
+Gruvbox, Rose Pine, Solarized, and the rest — one variant per family, each one
+picked to stay readable through a working day. **Install** writes that theme into
+your Themes folder and selects it in the light or dark slot it belongs to.
+Nothing is downloaded: the schemes ship inside Termio.
+
+If a file of the same name is already in your Themes folder, Install stops and
+asks before replacing it — a theme you dropped in yourself is yours. **Remove**
+deletes the file, and asks first if you have edited it.
+
+To switch between the themes you have with your terminals as the preview, open
+the Command Palette (`⇧⌘P`) and pick **Change Theme…** — arrowing through the
+list restyles your open terminals live, Return keeps the theme, Escape puts it
+back.
 
 <DocsImage
   src="/screenshots/docs/14-change-theme.png"
@@ -34,7 +50,7 @@ terminals live, Return keeps the theme, Escape puts it back.
   height={1664}
 />
 
-To add your own, drop a Ghostty `.toml` theme file into:
+To add a theme the store doesn't carry, drop a Ghostty-format theme file into:
 
 ```
 ~/Library/Application Support/termio/Themes/

--- a/web/landing/content/docs/appearance.zh-CN.mdx
+++ b/web/landing/content/docs/appearance.zh-CN.mdx
@@ -3,7 +3,7 @@ title: 外观
 description: 设置终端主题与字体、调整光标和窗口，并找到 Termio 其余的设置项——全都在一个熟悉的 macOS 设置窗口里。
 x-i18n:
   source_path: appearance.mdx
-  source_hash: 4d950cf23eea003c895983442da834003925a0c1f643eaa463f20b70294485c6
+  source_hash: e8eb9019cf1010d0c4013610aa7653b3cfff28f4016b544cac295f70ff5cf40b
   generated_at: 2026-08-16
 ---
 
@@ -15,6 +15,9 @@ x-i18n:
 Termio 使用 Ghostty 格式的主题，所以 Ghostty 主题生态里的东西都能用。在
 **设置 ▸ 外观** 里各选一个浅色和深色主题，Termio 会跟随系统在两者之间切换。
 
+两个槽位列出的是你手上有的主题——Termio 自带的画布，加上你主题文件夹里的东西——
+而不是几百个你从没挑过的配色。
+
 <DocsImage
   src="/screenshots/docs/15-appearance-settings.png"
   alt="Termio 外观设置显示「系统」「浅色」「深色」模式，以及独立的浅色和深色终端主题槽位"
@@ -25,8 +28,18 @@ Termio 使用 Ghostty 格式的主题，所以 Ghostty 主题生态里的东西�
 如果你本来就在用 Ghostty，全新安装时其实不用挑：Termio 首次启动会读取你的
 `~/.config/ghostty/config`，直接沿用你在那里选好的字体和主题。
 
-想以你自己的终端为预览来浏览整个目录，打开命令面板（`⇧⌘P`）并选择 **更改主题…**——
-在列表里上下移动会实时给你打开的终端重新上色，回车保留，Esc 还原。
+## 获取更多主题 [#getting-more-themes]
+
+**浏览主题…** 会打开一个收录 50 款知名配色的商店——Dracula、Catppuccin、Gruvbox、
+Rose Pine、Solarized 等等——每个系列只留一个变体，每一款都挑得住一整天的阅读。
+**安装** 会把那款主题写进你的主题文件夹，并放进它该在的浅色或深色槽位。全程不联网：
+这些配色本来就在 Termio 里面。
+
+如果主题文件夹里已经有同名文件，安装会先停下来问你要不要替换——你自己放进去的主题是
+你的东西。**移除** 会删掉那个文件；如果你改过它，也会先问一句。
+
+想以你自己的终端为预览，在已有的主题之间切换，打开命令面板（`⇧⌘P`）并选择
+**更改主题…**——在列表里上下移动会实时给你打开的终端重新上色，回车保留，Esc 还原。
 
 <DocsImage
   src="/screenshots/docs/14-change-theme.png"
@@ -35,7 +48,7 @@ Termio 使用 Ghostty 格式的主题，所以 Ghostty 主题生态里的东西�
   height={1664}
 />
 
-要加入你自己的主题，把 Ghostty 的 `.toml` 主题文件放进：
+要加入商店里没有的主题，把 Ghostty 格式的主题文件放进：
 
 ```
 ~/Library/Application Support/termio/Themes/


### PR DESCRIPTION
RFC and implementation, in one PR as the RFC requires.

Settings ▸ Appearance, the command palette and the iOS picker all listed `GhosttyThemeCatalog` — ~485 iTerm2-Color-Schemes names — so every user "has" 485 themes they never chose, and the list is a warehouse, not a library.

## The shape

Three layers over one file format. An empty slot is termio's own canvas; the library is `~/Library/Application Support/termio/Themes`; the store is a curated index of 50 names that install into it. **A selected name resolves from a file and stops there** — the catalog is consulted by Install, by a bounded one-time materialization, and by Ghostty-inherit, never as a paint-time fallback.

That invariant has a cost, and it is where most of the care went: an install that already chose "Dracula" out of the catalog has no file. So the two slots are materialized once on first launch after this ships — two files at most, flagged in settings so it never runs again — and a Ghostty `theme = X` inherit materializes on every read, since a config can name a theme the user has not got. Remove deletes the file and clears the slot rather than leaving a name behind hoping something still paints it. Install refuses to clobber a same-named file and offers Replace, naming the path.

`ThemeStoreCatalog` lives in TermioShared because the Mac installs those names and the phone renders them, and two hand-kept lists would drift. Names only. Entries that no longer resolve against the pinned catalog are dropped at launch, so a package rename cannot leave a dead row.

The store is a sheet over Settings, not a fourth tab, and it does not preview on highlight: it sits over the settings window, which sits over the terminal, so the preview would recolor a pane you cannot see. Live preview stays in the command palette, over installed themes only, and **Browse Themes…** there opens the store carrying the query you had typed.

## Curation

The rules are written into the RFC because they are the part worth arguing with later: popular over merely pretty; no two rows reading as the same theme (weighted CIE Lab ΔE over background, foreground and ANSI 1–6, every pair clearing 12 — which is what keeps TokyoNight Night/Storm, Catppuccin Mocha/Macchiato and Rose Pine/Moon to one row each); legible for a working day (body ≥ 6:1, ANSI red vs green ≥ ΔE 40); and it has to survive `ChromeTheme`, since the selected theme also paints the sidebar, gutter, git pane and trajectory.

35 dark, 15 light.

## Tests

`ThemeLibraryTests` pins the claims rather than the code — every store name resolving, each one's brightness slot coming from its own `isDark`, and the ΔE rule between every pair.

**It cannot be run today.** The test target does not compile at all — #311, 285 Swift 6 concurrency errors in `CompanionServer.swift`. Committed so it runs the moment that is fixed.

## Verification

`TERMIO_CHANNEL=dev ./scripts/build-app.sh` — clean. `scripts/check-strings.sh` reports no missing keys. Landing docs (`appearance.mdx`, `appearance.zh-CN.mdx`) updated to match.