### PR TITLE
The device is the context

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -587,6 +587,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
         let folder = store.session(id)?.worktreePath ?? project.path
         window.title = abbreviatingHome(folder)
+        // Deliberately no machine here. `subtitle` renders beside the title in
+        // the titlebar, so naming the device put it in two places at once — the
+        // sidebar already says which machine you are on, and repeating it above
+        // the terminal read as clutter rather than as reassurance.
         window.subtitle = ""
     }
 
@@ -2139,6 +2143,7 @@ private struct BranchPickerToolbarView: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 7) {
+            DeviceBadge()
             VStack(alignment: .leading, spacing: 0) {
                 Text(title)
                     .font(.headline)
@@ -2161,6 +2166,69 @@ private struct BranchPickerToolbarView: View {
         // measured view without shrinking or moving the Text glyphs, allowing them to paint past the
         // toolbar item's trailing edge. Default centering preserves the existing short-title position.
         .frame(minWidth: Self.titleWidthFloor, maxWidth: Self.titleWidthCeiling)
+    }
+}
+
+/// Which machine this window is on, in the window's own chrome.
+///
+/// The one thing a user must never have to work out. A terminal looks the same
+/// wherever its process runs, so without a persistent statement of the device the
+/// only cue is memory — and memory is what fails right before someone runs a
+/// destructive command on the wrong box. VS Code and Zed both spend a permanent
+/// corner of the window on this for the same reason.
+///
+/// It names the **selected session's** device when there is one, and the current
+/// device otherwise, because the question it answers is "where do my keystrokes
+/// go", not "what did I last pick from a menu". The two only differ while a row
+/// from another machine is still on screen.
+///
+/// Hidden while this Mac is the only machine known: there is no other answer for
+/// it to distinguish, and a chip that always reads the same is furniture.
+private struct DeviceBadge: View {
+    @EnvironmentObject var store: TermioStore
+    @Environment(\.controlActiveState) private var controlActive
+
+    private var device: KnownDevice {
+        let session = store.selectedSessionID.flatMap(store.session)
+        guard let session, let host = session.termiodRemoteHost ?? session.sshHost else {
+            return store.currentDevice
+        }
+        return KnownDevice(alias: host, deviceID: session.deviceID)
+    }
+
+    var body: some View {
+        let known = DeviceRoster.known(in: store)
+        if known.count > 1 {
+            let device = device
+            Menu {
+                DeviceSwitcherMenuContent()
+            } label: {
+                HStack(spacing: 4) {
+                    HugeIconView(icon: .serverStack, size: 12,
+                                 color: device.isLocal ? .secondary : .primary)
+                    Text(device.name)
+                        .font(.subheadline)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        // Another machine is the state worth noticing, so it is
+                        // the one that gets ink. This Mac stays quiet.
+                        .fill(device.isLocal
+                              ? Color.secondary.opacity(0.12)
+                              : Color.accentColor.opacity(0.22))
+                )
+                .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .opacity(controlActive == .inactive ? 0.6 : 1)
+            .help(localized("Sessions here run on \(device.name)"))
+        }
     }
 }
 

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -138,11 +138,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Sweep up session processes a previous instance stranded (crash,
         // force-quit, dev rebuild's kill -9) before this run adds its own.
         PTYProcess.reapStrayOrphans()
-        // Termiod mode: report which persisted sessions are still alive in the
-        // daemon (and will reattach when surfaced) before any pane mounts.
-        if Termiod.isEnabled {
-            store.logTermiodRoster()
-        }
+        // Ask the device the last run ended on what is running on it, before any
+        // pane mounts — the sidebar draws that answer, and a session that did not
+        // survive is a tombstone rather than a silently missing row.
+        store.refreshDeviceSessions()
         // Task-completion notifications: the delegate must be installed before a
         // notification click can arrive, so wire it before any session runs.
         TaskNotificationCenter.shared.activate(store: store)
@@ -932,7 +931,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// box is also saying that is where you are about to work.
     @objc func connectToDevice(_ sender: NSMenuItem) {
         guard let alias = sender.representedObject as? String else { return }
-        settings.currentDeviceAlias = alias
+        store.switchToDevice(KnownDevice(alias: alias, deviceID: nil))
         store.addRemoteTerminal(host: alias)
     }
 

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1571,39 +1571,17 @@ extension AppDelegate: NSMenuDelegate {
         atHome: Bool,
         command: KeyCommandID?
     ) {
-        let localAction = atHome
+        // Always a plain verb, however many machines are known. New Terminal
+        // opens on the device you are looking at — the switcher already made
+        // that choice, and asking again turns one decision into two. It also
+        // kept the count of known machines visible in a menu that is about
+        // starting a shell, not about picking a computer.
+        item.submenu = nil
+        item.action = atHome
             ? #selector(newScratchTerminal(_:))
             : #selector(newTerminalHere(_:))
-        guard known.count > 1 else {
-            item.submenu = nil
-            item.action = localAction
-            item.target = self
-            if let command { item.applyShortcut(for: command) }
-            return
-        }
-        item.action = nil
-        item.target = nil
-        item.keyEquivalent = ""
-        item.keyEquivalentModifierMask = []
-        let current = DeviceRoster.current(settings, known: known)
-        let submenu = NSMenu(title: item.title)
-        for device in known {
-            let row: NSMenuItem
-            if let alias = device.alias {
-                row = submenu.addItem(
-                    withTitle: device.name,
-                    action: #selector(newRemoteTerminalHost(_:)),
-                    keyEquivalent: ""
-                )
-                row.representedObject = alias
-            } else {
-                row = submenu.addItem(
-                    withTitle: device.name, action: localAction, keyEquivalent: "")
-            }
-            row.target = self
-            if let command, device.id == current.id { row.applyShortcut(for: command) }
-        }
-        item.submenu = submenu
+        item.target = self
+        if let command { item.applyShortcut(for: command) }
     }
 
     /// Fills the Session menu: the cycling and close verbs, then a live jump

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -2143,7 +2143,6 @@ private struct BranchPickerToolbarView: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 7) {
-            DeviceBadge()
             VStack(alignment: .leading, spacing: 0) {
                 Text(title)
                     .font(.headline)
@@ -2166,69 +2165,6 @@ private struct BranchPickerToolbarView: View {
         // measured view without shrinking or moving the Text glyphs, allowing them to paint past the
         // toolbar item's trailing edge. Default centering preserves the existing short-title position.
         .frame(minWidth: Self.titleWidthFloor, maxWidth: Self.titleWidthCeiling)
-    }
-}
-
-/// Which machine this window is on, in the window's own chrome.
-///
-/// The one thing a user must never have to work out. A terminal looks the same
-/// wherever its process runs, so without a persistent statement of the device the
-/// only cue is memory — and memory is what fails right before someone runs a
-/// destructive command on the wrong box. VS Code and Zed both spend a permanent
-/// corner of the window on this for the same reason.
-///
-/// It names the **selected session's** device when there is one, and the current
-/// device otherwise, because the question it answers is "where do my keystrokes
-/// go", not "what did I last pick from a menu". The two only differ while a row
-/// from another machine is still on screen.
-///
-/// Hidden while this Mac is the only machine known: there is no other answer for
-/// it to distinguish, and a chip that always reads the same is furniture.
-private struct DeviceBadge: View {
-    @EnvironmentObject var store: TermioStore
-    @Environment(\.controlActiveState) private var controlActive
-
-    private var device: KnownDevice {
-        let session = store.selectedSessionID.flatMap(store.session)
-        guard let session, let host = session.termiodRemoteHost ?? session.sshHost else {
-            return store.currentDevice
-        }
-        return KnownDevice(alias: host, deviceID: session.deviceID)
-    }
-
-    var body: some View {
-        let known = DeviceRoster.known(in: store)
-        if known.count > 1 {
-            let device = device
-            Menu {
-                DeviceSwitcherMenuContent()
-            } label: {
-                HStack(spacing: 4) {
-                    HugeIconView(icon: .serverStack, size: 12,
-                                 color: device.isLocal ? .secondary : .primary)
-                    Text(device.name)
-                        .font(.subheadline)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-                .padding(.horizontal, 7)
-                .padding(.vertical, 3)
-                .background(
-                    RoundedRectangle(cornerRadius: 5, style: .continuous)
-                        // Another machine is the state worth noticing, so it is
-                        // the one that gets ink. This Mac stays quiet.
-                        .fill(device.isLocal
-                              ? Color.secondary.opacity(0.12)
-                              : Color.accentColor.opacity(0.22))
-                )
-                .contentShape(Rectangle())
-            }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
-            .opacity(controlActive == .inactive ? 0.6 : 1)
-            .help(localized("Sessions here run on \(device.name)"))
-        }
     }
 }
 

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -911,13 +911,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.addSSHSession(host: alias)
     }
 
-    /// A host row of the New Remote Terminal submenu (File menu and the toolbar
-    /// `+` share it). No project context here, so the session is host-scoped:
-    /// remote `$HOME`, grouped under Terminals like any loose shell. Unlike
-    /// `newSSHHost`, the session lives in that host's `termiod` and survives
+    /// A device row of the New Terminal submenu (File menu and the toolbar `+`
+    /// share it). No project context here, so the session starts at that machine's
+    /// `$HOME` and is grouped under its own block like any loose shell. Unlike
+    /// `newSSHHost`, the session lives in that device's `termiod` and survives
     /// both the connection and this app quitting.
     @objc func newRemoteTerminalHost(_ sender: NSMenuItem) {
         guard let alias = sender.representedObject as? String else { return }
+        store.addRemoteTerminal(host: alias)
+    }
+
+    /// A row of the Connect to… submenu — first contact with a machine from
+    /// `~/.ssh/config`. Opening a terminal on it is the connection: `termiod` is
+    /// installed there if missing, the handshake records which device the alias
+    /// reaches, and the machine becomes the current device, because reaching for a
+    /// box is also saying that is where you are about to work.
+    @objc func connectToDevice(_ sender: NSMenuItem) {
+        guard let alias = sender.representedObject as? String else { return }
+        settings.currentDeviceAlias = alias
         store.addRemoteTerminal(host: alias)
     }
 
@@ -1449,15 +1460,25 @@ private func makeNewChatItem() -> NSMenuItem {
     return item
 }
 
-/// The "New Remote Terminal ▸" parent item, filled the same lazy way as the
-/// others. Host-scoped here: a global `+` has no project context, so the session
-/// starts at the remote `$HOME` and lands in the Terminals section — exactly
-/// what "New Terminal" does locally. The project-scoped variant (which opens
-/// inside that repo's remote checkout) lives on the sidebar's project rows.
+/// Items whose shape depends on how many devices exist are found by tag when
+/// their menu opens: the File menu and the toolbar `+` each own one, and
+/// everything around it has to survive the refresh, so the item is reconfigured
+/// in place rather than the menu rebuilt.
+enum DeviceMenuTag {
+    static let newTerminal = 7301
+    static let newTerminalAtHome = 7302
+    static let connectTo = 7303
+}
+
+/// The "Connect to… ▸" parent item — the verb that reaches a machine used before,
+/// filled the same lazy way as the others with the `~/.ssh/config` aliases no
+/// device answers to yet. Hidden while there are none (see `refreshDeviceItems`):
+/// a row listing nothing is the dead end this replaces.
 @MainActor
-private func makeNewRemoteTerminalItem() -> NSMenuItem {
-    let item = NSMenuItem(title: "New Remote Terminal", action: nil, keyEquivalent: "")
-    let submenu = NSMenu(title: "New Remote Terminal")
+private func makeConnectToItem() -> NSMenuItem {
+    let item = NSMenuItem(title: localized("Connect to…"), action: nil, keyEquivalent: "")
+    item.tag = DeviceMenuTag.connectTo
+    let submenu = NSMenu(title: localized("Connect to…"))
     submenu.delegate = NSApp.delegate as? AppDelegate
     item.submenu = submenu
     return item
@@ -1476,20 +1497,110 @@ private func makeNewSSHItem() -> NSMenuItem {
 }
 
 extension AppDelegate: NSMenuDelegate {
-    /// Fills the lazily-populated menus this delegate serves, told apart by
-    /// title: the Session menu, New Chat, and New SSH Connection.
+    /// Serves every menu this delegate is attached to, told apart by title. Most
+    /// are filled from scratch on each open — the Session menu, New Chat, New SSH
+    /// Connection, Connect to…. The File menu and the toolbar `+` instead hold a
+    /// few device-aware items among items this delegate does not own, so they are
+    /// refreshed in place.
     func menuNeedsUpdate(_ menu: NSMenu) {
+        // The two device-aware menus are refreshed in place: they hold items this
+        // delegate doesn't own, so emptying them would take the rest of the menu
+        // with it.
+        switch menu.title {
+        case localized("File"), localized("New Session"):
+            refreshDeviceItems(in: menu)
+            return
+        default:
+            break
+        }
         menu.removeAllItems()
         switch menu.title {
         case localized("Session"):
             fillSessionMenu(menu)
         case localized("New SSH Connection"):
             fillNewSSHMenu(menu)
-        case "New Remote Terminal":
-            fillNewRemoteTerminalMenu(menu)
+        case localized("Connect to…"):
+            fillConnectToMenu(menu)
         default:
             fillNewChatMenu(menu)
         }
+    }
+
+    /// Reshapes every device-aware item this menu carries, each time it opens, so
+    /// a machine that came or went since the last look is reflected without any
+    /// change-notification plumbing.
+    private func refreshDeviceItems(in menu: NSMenu) {
+        // AppKit runs this during its key-equivalent sweep as well as on open, so
+        // the roster is read once per pass rather than once per item — reading
+        // `~/.ssh/config` for "Connect to…" is the expensive half.
+        let known = DeviceRoster.known(in: store)
+        for item in menu.items {
+            switch item.tag {
+            case DeviceMenuTag.newTerminal:
+                refreshNewTerminalItem(item, known: known, atHome: false, command: .newTerminal)
+            case DeviceMenuTag.newTerminalAtHome:
+                refreshNewTerminalItem(item, known: known, atHome: true, command: nil)
+            case DeviceMenuTag.connectTo:
+                item.isHidden = DeviceRoster.unusedAliases(known: known).isEmpty
+            default:
+                continue
+            }
+        }
+    }
+
+    /// The single-device collapse, applied to one "new terminal" item: a plain
+    /// verb while this Mac is the only machine, a device submenu once there is
+    /// more than one. Someone who never leaves their laptop never sees a device
+    /// anywhere, which is the whole point of doing this in the menu rather than
+    /// with a permanent picker.
+    ///
+    /// The shortcut travels with the shape — on one device it sits on the item
+    /// itself, on several it moves to the current device's row — so ⌘T keeps
+    /// opening a terminal on the machine the switcher says you are working on.
+    /// (AppKit's key-equivalent sweep descends submenus, which is what makes the
+    /// second form work at all; the New Chat menu leans on the same behaviour.)
+    ///
+    /// A remote row always starts at that machine's `$HOME`: "here" names a
+    /// directory on this Mac, and it does not exist over there.
+    private func refreshNewTerminalItem(
+        _ item: NSMenuItem,
+        known: [KnownDevice],
+        atHome: Bool,
+        command: KeyCommandID?
+    ) {
+        let localAction = atHome
+            ? #selector(newScratchTerminal(_:))
+            : #selector(newTerminalHere(_:))
+        guard known.count > 1 else {
+            item.submenu = nil
+            item.action = localAction
+            item.target = self
+            if let command { item.applyShortcut(for: command) }
+            return
+        }
+        item.action = nil
+        item.target = nil
+        item.keyEquivalent = ""
+        item.keyEquivalentModifierMask = []
+        let current = DeviceRoster.current(settings, known: known)
+        let submenu = NSMenu(title: item.title)
+        for device in known {
+            let row: NSMenuItem
+            if let alias = device.alias {
+                row = submenu.addItem(
+                    withTitle: device.name,
+                    action: #selector(newRemoteTerminalHost(_:)),
+                    keyEquivalent: ""
+                )
+                row.representedObject = alias
+            } else {
+                row = submenu.addItem(
+                    withTitle: device.name, action: localAction, keyEquivalent: "")
+            }
+            row.target = self
+            if let command, device.id == current.id { row.applyShortcut(for: command) }
+        }
+        item.submenu = submenu
     }
 
     /// Fills the Session menu: the cycling and close verbs, then a live jump
@@ -1643,27 +1754,20 @@ extension AppDelegate: NSMenuDelegate {
         add.target = self
     }
 
-    /// One row per `~/.ssh/config` alias, opening a durable termiod session on
-    /// that host. An empty config says so rather than showing a dead submenu.
-    private func fillNewRemoteTerminalMenu(_ menu: NSMenu) {
-        let hosts = SSHConfigFile.hosts()
-        guard !hosts.isEmpty else {
-            let empty = menu.addItem(
-                withTitle: "No SSH hosts in ~/.ssh/config",
-                action: nil,
-                keyEquivalent: ""
-            )
-            empty.isEnabled = false
-            return
-        }
-        for host in hosts {
+    /// One row per `~/.ssh/config` alias no device answers to yet. Connecting
+    /// opens a terminal there, which installs `termiod` on the way
+    /// (`ensureRemoteReady`) and teaches the app which machine the alias reaches —
+    /// after which it is a device and moves out of this menu.
+    private func fillConnectToMenu(_ menu: NSMenu) {
+        let known = DeviceRoster.known(in: store)
+        for alias in DeviceRoster.unusedAliases(known: known) {
             let item = menu.addItem(
-                withTitle: host.alias,
-                action: #selector(newRemoteTerminalHost(_:)),
+                withTitle: alias,
+                action: #selector(connectToDevice(_:)),
                 keyEquivalent: ""
             )
             item.target = self
-            item.representedObject = host.alias
+            item.representedObject = alias
         }
     }
 }
@@ -1793,13 +1897,18 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     /// has no referent — the directory-following New Terminal is ⌘T, pressed with the
     /// terminal in front of you.
     func makeNewSessionMenu() -> NSMenu {
-        let menu = NSMenu()
+        // Titled and delegated so the AppDelegate can reshape the terminal item on
+        // open: one machine keeps it a plain verb, a second grows it into a device
+        // submenu (see `refreshNewTerminalItem`). Its rows target the AppDelegate,
+        // which is where both the local and the per-device actions live.
+        let menu = NSMenu(title: localized("New Session"))
+        menu.delegate = NSApp.delegate as? AppDelegate
         let terminal = NSMenuItem(title: localized("New Terminal at Home"),
-                                  action: #selector(newTerminal(_:)), keyEquivalent: "")
-        terminal.target = self
+                                  action: #selector(AppDelegate.newScratchTerminal(_:)),
+                                  keyEquivalent: "")
+        terminal.target = NSApp.delegate as? AppDelegate
+        terminal.tag = DeviceMenuTag.newTerminalAtHome
         menu.addItem(terminal)
-        // Directly under New Terminal: same verb, other machine.
-        menu.addItem(makeNewRemoteTerminalItem())
         menu.addItem(makeNewChatItem())
         menu.addItem(makeNewSSHItem())
         let folder = NSMenuItem(title: localized("Open Project…"), action: #selector(openFolder(_:)), keyEquivalent: "")
@@ -1808,7 +1917,6 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
         return menu
     }
 
-    @objc private func newTerminal(_ sender: Any?) { store.addScratchTerminal() }
     @objc private func openFolder(_ sender: Any?) { store.presentOpenProjectPanel() }
 
     /// The `.inspectorTabs` item's menu form, shown in the toolbar's `»` overflow menu when the
@@ -2104,6 +2212,10 @@ private func buildMainMenu() -> NSMenu {
     let fileItem = NSMenuItem()
     mainMenu.addItem(fileItem)
     let fileMenu = NSMenu(title: localized("File"))
+    // Device-aware items are reshaped on open (see `refreshDeviceItems`) — that's
+    // what collapses New Terminal to a plain verb on a one-machine install and
+    // grows it into a device submenu once there is a second.
+    fileMenu.delegate = NSApp.delegate as? AppDelegate
     // Keeps the `+` new-terminal action reachable when the navigator is collapsed and its toolbar
     // button is hidden (see `setNavigatorItemsVisible`). ⌘T is safe: TUI programs drive off Ctrl,
     // never Cmd, so it can't shadow a key a terminal app wants.
@@ -2111,7 +2223,7 @@ private func buildMainMenu() -> NSMenu {
         withTitle: localized("New Terminal"),
         action: #selector(AppDelegate.newTerminalHere(_:)),
         command: .newTerminal
-    )
+    ).tag = DeviceMenuTag.newTerminal
     // The always-`$HOME` terminal, kept as its own verb now that ⌘T follows the
     // focused session's directory.
     fileMenu.addItem(
@@ -2124,13 +2236,14 @@ private func buildMainMenu() -> NSMenu {
     // sits on the resolved default's row, so the shortcut stays one-press and the
     // menu names the agent it will open.
     fileMenu.addItem(makeNewChatItem())
-    // New Remote Terminal ▸ a durable termiod session on an ssh-config host —
-    // the remote counterpart of New Terminal, and unlike New SSH Connection it
-    // outlives both the connection and the app.
-    fileMenu.addItem(makeNewRemoteTerminalItem())
     // New SSH Connection ▸ one row per `~/.ssh/config` host, plus Add Host… for
     // machines not in it yet (filled on open by the AppDelegate — see `makeNewSSHItem`).
     fileMenu.addItem(makeNewSSHItem())
+    // Connect to… ▸ the machines in `~/.ssh/config` termio hasn't worked on yet.
+    // Finder's own split: reaching a machine is a verb in a menu, while what termio
+    // knows *about* a machine belongs in Settings. Hidden while there is nothing
+    // left to reach.
+    fileMenu.addItem(makeConnectToItem())
     fileMenu.addItem(.separator())
     fileMenu.addItem(
         withTitle: localized("Open Project…"),

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -327,6 +327,20 @@ struct Session: Identifiable, Hashable, Codable {
     /// is nil.
     var termiodRemoteCwd: String?
 
+    /// The name this session answers to **inside its device's daemon**, when that
+    /// is not this session's own uuid.
+    ///
+    /// Sessions Termio opens are named with their uuid, which is what makes
+    /// reattach-after-relaunch work: `attach` resolves the name first, so the row
+    /// finds the same process. A session Termio did **not** open already had a
+    /// name before this app ever saw it — started from the `termiod` CLI, or by a
+    /// phone — and adopting it means keeping that name, because the name is how
+    /// the daemon is asked for that exact PTY. Renaming it to a fresh uuid would
+    /// spawn a second session beside the one the user was pointing at.
+    ///
+    /// `nil` for every session this app created, which is nearly all of them.
+    var termiodSessionName: String?
+
     /// Adopt another session's machine — both halves of it.
     ///
     /// A device has two identities during its life (device architecture §9.5):
@@ -385,7 +399,7 @@ struct Session: Identifiable, Hashable, Codable {
     private enum CodingKeys: String, CodingKey {
         case id, title, agent, createdAt, worktreePath, resumeID, launched, launchedAt,
              liveTitle, lastWorkingDirectory, spawnDirectory, sshHost, pinned,
-             termiodRemoteHost, termiodRemoteCwd, deviceID
+             termiodRemoteHost, termiodRemoteCwd, deviceID, termiodSessionName
     }
 
     /// Custom decoding so state files written before the resume fields existed still
@@ -410,6 +424,8 @@ struct Session: Identifiable, Hashable, Codable {
         termiodRemoteHost = try container.decodeIfPresent(String.self, forKey: .termiodRemoteHost)
         termiodRemoteCwd = try container.decodeIfPresent(String.self, forKey: .termiodRemoteCwd)
         deviceID = try container.decodeIfPresent(String.self, forKey: .deviceID)
+        termiodSessionName = try container.decodeIfPresent(
+            String.self, forKey: .termiodSessionName)
     }
 }
 

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -113,10 +113,10 @@ struct Project: Identifiable, Hashable, Codable {
     /// Where this project lives on each **device** it has been cloned to, keyed
     /// by that device's `host_id` → absolute remote path.
     ///
-    /// This is what makes "New Remote Terminal" from a *project* row mean "this
-    /// repo, over there" rather than "a shell in the remote `$HOME`". The local
-    /// `path` is meaningless on the remote box, so the correspondence has to be
-    /// recorded when `Clone on Remote…` establishes it.
+    /// This is what makes "New Terminal ▸ <device>" from a *project* row mean "this
+    /// repo, over there" rather than "a shell in that device's `$HOME`". The local
+    /// `path` is meaningless on the other box, so the correspondence has to be
+    /// recorded when `Clone to <device>…` establishes it.
     ///
     /// Keyed by device rather than by SSH alias because one machine commonly
     /// answers to several aliases (`vps-lan`, `vps-wan`, a tailnet name): keyed by
@@ -321,7 +321,7 @@ struct Session: Identifiable, Hashable, Codable {
     var deviceID: String?
 
     /// The remote working directory a `termiodRemoteHost` session spawns its shell
-    /// in — set by "Clone on Remote…" to the freshly cloned directory (`~/<repo>`)
+    /// in — set by "Clone to <device>…" to the freshly cloned directory (`~/<repo>`)
     /// so the terminal opens straight inside it. `nil` (the common case) lets the
     /// remote login shell start at its own `$HOME`. Ignored when `termiodRemoteHost`
     /// is nil.

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -814,7 +814,7 @@ enum GitService {
         }
     }
 
-    /// What "Clone on Remote…" needs to know about a checkout: the `origin`
+    /// What "Clone to <device>…" needs to know about a checkout: the `origin`
     /// URL to hand `git clone` on the remote, a repo name derived from it (the
     /// clone's directory), and how many local commits are ahead of the upstream
     /// (they live only on this Mac and won't travel with a fresh clone — the

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5604,6 +5604,116 @@
           }
         }
       }
+    },
+    "Also Running": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其他运行中"
+          }
+        }
+      }
+    },
+    "Clone to": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆到"
+          }
+        }
+      }
+    },
+    "Connect to…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接到…"
+          }
+        }
+      }
+    },
+    "Ended": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已结束"
+          }
+        }
+      }
+    },
+    "New Session": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建会话"
+          }
+        }
+      }
+    },
+    "Opened outside Termio on this device": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在这台设备上由 Termio 之外打开"
+          }
+        }
+      }
+    },
+    "Termio isn’t running sessions through termiod.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termio 目前没有通过 termiod 运行会话。"
+          }
+        }
+      }
+    },
+    "The session host went away": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "承载会话的进程消失了"
+          }
+        }
+      }
+    },
+    "The sidebar shows this device’s sessions": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "侧栏显示的是这台设备的会话"
+          }
+        }
+      }
+    },
+    "This Mac": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机"
+          }
+        }
+      }
+    },
+    "This folder has no git “origin” remote to clone.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个文件夹没有 git “origin” 远程，无法克隆。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -110,6 +110,8 @@
 	<string>Allow Keychain Access…</string>
 	<key>Allow Usage Access</key>
 	<string>Allow Usage Access</string>
+	<key>Also Running</key>
+	<string>Also Running</string>
 	<key>An older install points at %@. Update it to this version of Termio.</key>
 	<string>An older install points at %@. Update it to this version of Termio.</string>
 	<key>Anyone</key>
@@ -184,6 +186,8 @@
 	<string>Choose…</string>
 	<key>Clear</key>
 	<string>Clear</string>
+	<key>Clone to</key>
+	<string>Clone to</string>
 	<key>Close</key>
 	<string>Close</string>
 	<key>Close (Esc)</key>
@@ -232,6 +236,8 @@
 	<string>Connect GitHub</string>
 	<key>Connect iPhone</key>
 	<string>Connect iPhone</string>
+	<key>Connect to…</key>
+	<string>Connect to…</string>
 	<key>Connect your GitHub account to read this project’s issues and pull requests here.</key>
 	<string>Connect your GitHub account to read this project’s issues and pull requests here.</string>
 	<key>Connected</key>
@@ -364,6 +370,8 @@
 	<string>Enable</string>
 	<key>Enable Claude Code, Codex, Kimi, or Grok in the Agents tab to see their usage here.</key>
 	<string>Enable Claude Code, Codex, Kimi, or Grok in the Agents tab to see their usage here.</string>
+	<key>Ended</key>
+	<string>Ended</string>
 	<key>Enter Code on GitHub</key>
 	<string>Enter Code on GitHub</string>
 	<key>Enter a host from your ~/.ssh/config, or a user@host to connect to.</key>
@@ -558,6 +566,8 @@
 	<string>New SSH Connection</string>
 	<key>New SSH Connection…</key>
 	<string>New SSH Connection…</string>
+	<key>New Session</key>
+	<string>New Session</string>
 	<key>New Terminal</key>
 	<string>New Terminal</string>
 	<key>New Terminal at Home</key>
@@ -684,6 +694,8 @@
 	<string>Open in Editor</string>
 	<key>Open on GitHub</key>
 	<string>Open on GitHub</string>
+	<key>Opened outside Termio on this device</key>
+	<string>Opened outside Termio on this device</string>
 	<key>Padding: %lld pt</key>
 	<string>Padding: %lld pt</string>
 	<key>Pair your iPhone and remote access</key>
@@ -948,6 +960,8 @@
 	<string>Termio could not append to the repository’s .gitignore. Check its permissions and try again.</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio is open source — star the repo, report bugs, and request features.</string>
+	<key>Termio isn’t running sessions through termiod.</key>
+	<string>Termio isn’t running sessions through termiod.</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</string>
 	<key>Test</key>
@@ -972,6 +986,10 @@
 	<string>The project and session list. Kept separate from the terminal font, and need not be monospaced.</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
 	<string>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</string>
+	<key>The session host went away</key>
+	<string>The session host went away</string>
+	<key>The sidebar shows this device’s sessions</key>
+	<string>The sidebar shows this device’s sessions</string>
 	<key>The termio command-line tool, agent skill, and notifications</key>
 	<string>The termio command-line tool, agent skill, and notifications</string>
 	<key>The working tree is clean.</key>
@@ -984,6 +1002,8 @@
 	<string>Themes</string>
 	<key>Thicken glyphs</key>
 	<string>Thicken glyphs</string>
+	<key>This Mac</key>
+	<string>This Mac</string>
 	<key>This branch and the base branch share no commits.</key>
 	<string>This branch and the base branch share no commits.</string>
 	<key>This branch has no commits yet.</key>
@@ -996,6 +1016,8 @@
 	<string>This diff is too large to show here — open the file on GitHub.</string>
 	<key>This file is binary — open it on GitHub to view.</key>
 	<string>This file is binary — open it on GitHub to view.</string>
+	<key>This folder has no git “origin” remote to clone.</key>
+	<string>This folder has no git “origin” remote to clone.</string>
 	<key>This host sent a name the file tree can’t show.</key>
 	<string>This host sent a name the file tree can’t show.</string>
 	<key>This month</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -110,6 +110,8 @@
 	<string>允许访问钥匙串…</string>
 	<key>Allow Usage Access</key>
 	<string>允许访问用量</string>
+	<key>Also Running</key>
+	<string>其他运行中</string>
 	<key>An older install points at %@. Update it to this version of Termio.</key>
 	<string>旧的安装指向 %@。请将其更新到此版本的 Termio。</string>
 	<key>Anyone</key>
@@ -184,6 +186,8 @@
 	<string>选取…</string>
 	<key>Clear</key>
 	<string>清除</string>
+	<key>Clone to</key>
+	<string>克隆到</string>
 	<key>Close</key>
 	<string>关闭</string>
 	<key>Close (Esc)</key>
@@ -232,6 +236,8 @@
 	<string>连接 GitHub</string>
 	<key>Connect iPhone</key>
 	<string>连接 iPhone</string>
+	<key>Connect to…</key>
+	<string>连接到…</string>
 	<key>Connect your GitHub account to read this project’s issues and pull requests here.</key>
 	<string>连接你的 GitHub 账户，即可在此查看该项目的 issues 和 PR。</string>
 	<key>Connected</key>
@@ -364,6 +370,8 @@
 	<string>启用</string>
 	<key>Enable Claude Code, Codex, Kimi, or Grok in the Agents tab to see their usage here.</key>
 	<string>在 Agents 标签页中启用 Claude Code、Codex、Kimi 或 Grok，即可在此查看其用量。</string>
+	<key>Ended</key>
+	<string>已结束</string>
 	<key>Enter Code on GitHub</key>
 	<string>在 GitHub 上输入代码</string>
 	<key>Enter a host from your ~/.ssh/config, or a user@host to connect to.</key>
@@ -558,6 +566,8 @@
 	<string>新建 SSH 连接</string>
 	<key>New SSH Connection…</key>
 	<string>新建 SSH 连接…</string>
+	<key>New Session</key>
+	<string>新建会话</string>
 	<key>New Terminal</key>
 	<string>新建终端</string>
 	<key>New Terminal at Home</key>
@@ -684,6 +694,8 @@
 	<string>在编辑器中打开</string>
 	<key>Open on GitHub</key>
 	<string>在 GitHub 上打开</string>
+	<key>Opened outside Termio on this device</key>
+	<string>在这台设备上由 Termio 之外打开</string>
 	<key>Padding: %lld pt</key>
 	<string>边距：%lld 点</string>
 	<key>Pair your iPhone and remote access</key>
@@ -948,6 +960,8 @@
 	<string>Termio 无法将内容追加到该仓库的 .gitignore。请检查其权限后重试。</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio 是开源软件：欢迎给仓库加星标、报告 bug 和提出功能请求。</string>
+	<key>Termio isn’t running sessions through termiod.</key>
+	<string>Termio 目前没有通过 termiod 运行会话。</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio 会随 macOS 外观变化在两者间切换；将槽位留在默认值即可使用 Termio 自带的画布。“浏览主题”可以从 50 个精选配色中安装一个，你放进主题文件夹的 Ghostty 格式文件也会出现在这里。</string>
 	<key>Test</key>
@@ -972,6 +986,10 @@
 	<string>项目与会话列表。与终端字体分开设置，无需等宽字体。</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
 	<string>~/.ssh 中的公钥。可拷贝一个粘贴到服务器的 authorized_keys——私钥永远不会被读取。</string>
+	<key>The session host went away</key>
+	<string>承载会话的进程消失了</string>
+	<key>The sidebar shows this device’s sessions</key>
+	<string>侧栏显示的是这台设备的会话</string>
 	<key>The termio command-line tool, agent skill, and notifications</key>
 	<string>termio 命令行工具、Agent 技能与通知</string>
 	<key>The working tree is clean.</key>
@@ -984,6 +1002,8 @@
 	<string>主题</string>
 	<key>Thicken glyphs</key>
 	<string>加粗字形</string>
+	<key>This Mac</key>
+	<string>本机</string>
 	<key>This branch and the base branch share no commits.</key>
 	<string>这个分支和基础分支没有共同的提交。</string>
 	<key>This branch has no commits yet.</key>
@@ -996,6 +1016,8 @@
 	<string>此差异太大，无法在此显示，请在 GitHub 上打开该文件。</string>
 	<key>This file is binary — open it on GitHub to view.</key>
 	<string>此文件为二进制文件，请在 GitHub 上打开查看。</string>
+	<key>This folder has no git “origin” remote to clone.</key>
+	<string>这个文件夹没有 git “origin” 远程，无法克隆。</string>
 	<key>This host sent a name the file tree can’t show.</key>
 	<string>该主机返回了文件树无法显示的名称。</string>
 	<key>This month</key>

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -135,6 +135,7 @@ final class AppSettings: ObservableObject {
         static let recentProjects = "welcome.recentProjects"
         static let lastChatAgent = "chats.lastAgent"
         static let defaultChatAgent = "chats.defaultAgent"
+        static let currentDevice = "devices.current"
     }
 
     // MARK: Appearance
@@ -209,6 +210,18 @@ final class AppSettings: ObservableObject {
     /// which also falls back gracefully when the pinned agent is later disabled.
     @Published var defaultChatAgentID: String? {
         didSet { store.set(defaultChatAgentID, forKey: Key.defaultChatAgent) }
+    }
+
+    /// The device new terminals open on, held as the `~/.ssh/config` alias that
+    /// reaches it — `nil` for this Mac. It is a route, not an identity: the stable
+    /// one is the daemon's `host_id`, and only a handshake knows it, while this has
+    /// to answer the instant a menu is built.
+    ///
+    /// State rather than a preference (it is a place, not a taste), so it lives in
+    /// `defaults` and never reaches `settings.json`. An alias that no longer
+    /// matches a known machine resolves back to this Mac — see `DeviceRoster`.
+    @Published var currentDeviceAlias: String? {
+        didSet { defaults.set(currentDeviceAlias, forKey: Key.currentDevice) }
     }
 
     /// The most a project can be opened is capped so the Recent column stays a
@@ -569,6 +582,7 @@ final class AppSettings: ObservableObject {
             .flatMap { try? JSONDecoder().decode([RecentProject].self, from: $0) } ?? []
         lastChatAgentID = defaults.string(forKey: Key.lastChatAgent)
         defaultChatAgentID = store.string(Key.defaultChatAgent)
+        currentDeviceAlias = defaults.string(forKey: Key.currentDevice)
     }
 
     /// Effective command for an agent: the user's override if it's non-empty,

--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -2,31 +2,6 @@ import AppKit
 import SwiftUI
 import TermioShared
 
-/// A machine Termio can put a session on, as the interface names it. This Mac is
-/// one, and so is every box the user has already worked on — the word "remote"
-/// describes the road, not the thing at the end of it, so it appears nowhere.
-///
-/// The identity carried here is the `~/.ssh/config` alias, not the device's
-/// `host_id`, because a menu is built synchronously and the id only exists after
-/// a handshake. That is the same bootstrap/stable split `Project.sshHost` and
-/// `Project.deviceID` already record (device architecture §9.5): the alias is
-/// what a row is born from, `deviceID` is what it turns out to be. Two aliases
-/// that resolve to one machine therefore still show as two rows — merging them
-/// is §9.5's job and is deliberately not done here.
-struct KnownDevice: Identifiable, Hashable {
-    /// The alias this device is reached by, or `nil` for this Mac.
-    let alias: String?
-    /// The `host_id` a handshake revealed, `nil` until one has run.
-    let deviceID: String?
-
-    var isLocal: Bool { alias == nil }
-    /// The switcher and every menu row name a device this way. This Mac has no
-    /// alias to show, and the host never supplies a display name (device
-    /// architecture §4), so the client picks one.
-    var name: String { alias ?? localized("This Mac") }
-    var id: String { alias ?? "" }
-}
-
 /// Which machines the interface knows about, and which ones it could reach but
 /// hasn't. The split follows the ownership rule: the *known* list is state Termio
 /// produced itself (a completed handshake, a session it opened), while the
@@ -54,8 +29,9 @@ enum DeviceRoster {
                 if let host = session.termiodRemoteHost { aliases.insert(host) }
             }
         }
-        // This Mac always leads: it is the device the user is looking at.
-        return [KnownDevice(alias: nil, deviceID: nil)]
+        // This Mac always leads — not because it is special, but because it is the
+        // one machine that is always there.
+        return [.thisMac]
             + aliases.sorted().map { KnownDevice(alias: $0, deviceID: deviceIDByAlias[$0]) }
     }
 

--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -67,10 +67,10 @@ enum DeviceRoster {
     }
 }
 
-/// The rows every device switcher shows, wherever it is mounted — the sidebar's
-/// indicator and the window's own device badge are two openings onto the same
-/// menu, because there is one current device and it would be a bug for two
-/// controls to disagree about it.
+/// The rows every device switcher shows, wherever it is mounted. The sidebar's
+/// indicator is the only opening today; the rows live here rather than inside it
+/// because there is one current device, and it would be a bug for two controls to
+/// disagree about which one it is.
 struct DeviceSwitcherMenuContent: View {
     @EnvironmentObject var store: TermioStore
 

--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -1,0 +1,239 @@
+import AppKit
+import SwiftUI
+import TermioShared
+
+/// A machine Termio can put a session on, as the interface names it. This Mac is
+/// one, and so is every box the user has already worked on — the word "remote"
+/// describes the road, not the thing at the end of it, so it appears nowhere.
+///
+/// The identity carried here is the `~/.ssh/config` alias, not the device's
+/// `host_id`, because a menu is built synchronously and the id only exists after
+/// a handshake. That is the same bootstrap/stable split `Project.sshHost` and
+/// `Project.deviceID` already record (device architecture §9.5): the alias is
+/// what a row is born from, `deviceID` is what it turns out to be. Two aliases
+/// that resolve to one machine therefore still show as two rows — merging them
+/// is §9.5's job and is deliberately not done here.
+struct KnownDevice: Identifiable, Hashable {
+    /// The alias this device is reached by, or `nil` for this Mac.
+    let alias: String?
+    /// The `host_id` a handshake revealed, `nil` until one has run.
+    let deviceID: String?
+
+    var isLocal: Bool { alias == nil }
+    /// The switcher and every menu row name a device this way. This Mac has no
+    /// alias to show, and the host never supplies a display name (device
+    /// architecture §4), so the client picks one.
+    var name: String { alias ?? localized("This Mac") }
+    var id: String { alias ?? "" }
+}
+
+/// Which machines the interface knows about, and which ones it could reach but
+/// hasn't. The split follows the ownership rule: the *known* list is state Termio
+/// produced itself (a completed handshake, a session it opened), while the
+/// reachable-but-unused list is read straight out of `~/.ssh/config`, which stays
+/// the only host database Termio has and is never written to.
+@MainActor
+enum DeviceRoster {
+    /// This Mac, then every machine Termio has actually worked on, by alias.
+    ///
+    /// A machine qualifies two ways: a `hello_ok` recorded it in the device
+    /// registry, or a session in the tree says it runs there. The second source
+    /// matters on the launch after an upgrade — a state file can name a host the
+    /// registry has not re-learned yet, and a device the user can see sessions on
+    /// must not be missing from the switcher.
+    static func known(in store: TermioStore) -> [KnownDevice] {
+        var deviceIDByAlias: [String: String] = [:]
+        for device in TermiodDeviceRegistry.shared.all {
+            for alias in device.routes.compactMap(\.sshAlias) {
+                deviceIDByAlias[alias] = device.id
+            }
+        }
+        var aliases = Set(deviceIDByAlias.keys)
+        for project in store.projects {
+            for session in project.sessions {
+                if let host = session.termiodRemoteHost { aliases.insert(host) }
+            }
+        }
+        // This Mac always leads: it is the device the user is looking at.
+        return [KnownDevice(alias: nil, deviceID: nil)]
+            + aliases.sorted().map { KnownDevice(alias: $0, deviceID: deviceIDByAlias[$0]) }
+    }
+
+    /// The `~/.ssh/config` aliases no known device answers to — what "Connect to…"
+    /// offers. Order follows the config file; duplicates (one alias named in two
+    /// blocks) collapse to the first.
+    static func unusedAliases(known: [KnownDevice]) -> [String] {
+        var seen = Set(known.compactMap(\.alias))
+        var result: [String] = []
+        for alias in SSHConfigFile.hosts().map(\.alias) where !seen.contains(alias) {
+            seen.insert(alias)
+            result.append(alias)
+        }
+        return result
+    }
+
+    /// Every machine a repo could be cloned to: the known ones first, then the
+    /// aliases that have never been used. Cloning is itself a first contact —
+    /// `ensureRemoteReady` installs `termiod` on the way — so an unused alias is a
+    /// legitimate target here even though it is not yet a device.
+    static func cloneTargets(in store: TermioStore) -> [KnownDevice] {
+        let known = known(in: store)
+        return known.filter { !$0.isLocal }
+            + unusedAliases(known: known).map { KnownDevice(alias: $0, deviceID: nil) }
+    }
+
+    /// The device new work lands on, resolved against the machines that actually
+    /// exist. A stored alias that no longer matches anything (the user deleted the
+    /// `Host` block, or closed the last session on it) falls back to this Mac
+    /// rather than silently aiming at nothing.
+    static func current(_ settings: AppSettings, known: [KnownDevice]) -> KnownDevice {
+        known.first { $0.alias == settings.currentDeviceAlias } ?? known[0]
+    }
+}
+
+/// The sidebar's device indicator: which machine new work lands on, and the
+/// switcher that changes it. Quiet by design — it names the device and nothing
+/// else — and absent entirely while this Mac is the only one, so a user who never
+/// leaves their laptop never sees it.
+struct DeviceIndicator: View {
+    @EnvironmentObject var store: TermioStore
+    @EnvironmentObject var settings: AppSettings
+
+    var body: some View {
+        let known = DeviceRoster.known(in: store)
+        // The single-device collapse. Not "hidden but present": with one machine
+        // there is no switch to make, and a row that always reads "This Mac" is a
+        // label for a decision the user never took.
+        if known.count > 1 {
+            let current = DeviceRoster.current(settings, known: known)
+            let unused = DeviceRoster.unusedAliases(known: known)
+            Divider()
+            Menu {
+                // An inline Picker is what draws the checkmark on the current
+                // device; a row of Buttons would leave the switcher unable to say
+                // which machine is selected.
+                Picker("", selection: selection) {
+                    ForEach(known) { device in
+                        Text(device.name).tag(device.id)
+                    }
+                }
+                .pickerStyle(.inline)
+                .labelsHidden()
+                if !unused.isEmpty {
+                    Divider()
+                    Menu(localized("Connect to…")) {
+                        ForEach(unused, id: \.self) { alias in
+                            Button(alias) { connect(to: alias) }
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    HugeIconView(icon: .serverStack, size: 13, color: .secondary)
+                    Text(current.name)
+                        .font(settings.interfaceFont)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 4)
+                    HugeIconView(icon: .chevronRight, size: 7.5, color: .secondary,
+                                 lineWidthOverride: 1.75)
+                        .rotationEffect(.degrees(90))
+                }
+                .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .help(localized("New terminals open on this device"))
+        }
+    }
+
+    private var selection: Binding<String> {
+        Binding(
+            get: { settings.currentDeviceAlias ?? "" },
+            set: { settings.currentDeviceAlias = $0.isEmpty ? nil : $0 }
+        )
+    }
+
+    /// First contact with a machine from `~/.ssh/config`: open a terminal on it
+    /// (which installs `termiod` there if it is missing) and make it the current
+    /// device, so the connection the user just asked for is also where their next
+    /// terminal goes.
+    private func connect(to alias: String) {
+        settings.currentDeviceAlias = alias
+        store.addRemoteTerminal(host: alias)
+    }
+}
+
+// MARK: - Menu construction
+
+/// The "New Terminal" verb, device-aware: a plain action while this Mac is the
+/// only machine, a device submenu once there is more than one. `local` is what
+/// the row for this Mac does, which differs per call site (a project's directory,
+/// the Terminals section, `$HOME`).
+///
+/// `project` scopes the remote rows the way the row it hangs off is scoped: from a
+/// project it means "this repo, over there" and opens in the checkout that project
+/// recorded for the device, so a machine the repo isn't on yet says so instead of
+/// dropping a `$HOME` shell somewhere unexpected.
+@MainActor
+func newTerminalMenuItem(
+    store: TermioStore,
+    project: Project? = nil,
+    local: @escaping () -> Void
+) -> SidebarMenuItem {
+    let known = DeviceRoster.known(in: store)
+    guard known.count > 1 else { return .action(localized("New Terminal"), local) }
+    let projectID = project?.id
+    return .submenu(localized("New Terminal"), known.map { device in
+        guard let alias = device.alias else { return .action(device.name, local) }
+        // A project row says which machines already hold this repo, so the menu
+        // answers "where does this exist?" before you click. The checkout is keyed
+        // by device, so ask the registry for the identity learned earlier and let
+        // the lookup fall back to the alias when this box has never been reached.
+        let cloned = project?.remoteCheckout(device: device.deviceID, alias: alias) != nil
+        let label = project == nil || cloned ? device.name : "\(device.name) — not cloned yet"
+        return .action(label) { store.addRemoteTerminal(host: alias, project: projectID) }
+    })
+}
+
+/// "Clone to <device>…": the project's `origin` is `git clone`d **on** that
+/// machine, then a terminal opens inside the clone. `nil` when there is nowhere to
+/// clone to — an empty `~/.ssh/config` and no device ever reached — because a
+/// disabled row explaining an empty config is the dead end this replaces.
+///
+/// Only meaningful for a git checkout with a remote. Origin presence is resolved
+/// at click time (async): the menu is built synchronously and a git call per
+/// right-click would stall the sidebar, so a folder with no origin alerts rather
+/// than silently doing nothing.
+@MainActor
+func cloneToDeviceMenuItem(
+    store: TermioStore,
+    folder: String,
+    project projectID: UUID? = nil
+) -> SidebarMenuItem? {
+    let targets = DeviceRoster.cloneTargets(in: store)
+    guard !targets.isEmpty else { return nil }
+    let clone = { (device: KnownDevice) in
+        { @MainActor in
+            guard let alias = device.alias else { return }
+            Task { @MainActor in
+                guard let info = await GitService.cloneInfo(in: folder) else {
+                    store.presentRemoteSetupFailure(
+                        host: alias,
+                        message: localized("This folder has no git “origin” remote to clone."))
+                    return
+                }
+                store.cloneOnRemote(host: alias, info: info, project: projectID)
+            }
+        }
+    }
+    // One machine needs no submenu — the verb names it outright, which is also the
+    // only form that reads as a sentence.
+    if targets.count == 1, let only = targets.first {
+        return .action(localized("Clone to \(only.name)…"), clone(only))
+    }
+    return .submenu(localized("Clone to"), targets.map { .action($0.name, clone($0)) })
+}

--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -58,19 +58,70 @@ enum DeviceRoster {
             + unusedAliases(known: known).map { KnownDevice(alias: $0, deviceID: nil) }
     }
 
-    /// The device new work lands on, resolved against the machines that actually
+    /// The device the app is on, resolved against the machines that actually
     /// exist. A stored alias that no longer matches anything (the user deleted the
     /// `Host` block, or closed the last session on it) falls back to this Mac
     /// rather than silently aiming at nothing.
-    static func current(_ settings: AppSettings, known: [KnownDevice]) -> KnownDevice {
-        known.first { $0.alias == settings.currentDeviceAlias } ?? known[0]
+    static func current(_ store: TermioStore, known: [KnownDevice]) -> KnownDevice {
+        known.first { $0.alias == store.currentDeviceAlias } ?? .thisMac
     }
 }
 
-/// The sidebar's device indicator: which machine new work lands on, and the
-/// switcher that changes it. Quiet by design — it names the device and nothing
-/// else — and absent entirely while this Mac is the only one, so a user who never
-/// leaves their laptop never sees it.
+/// The rows every device switcher shows, wherever it is mounted — the sidebar's
+/// indicator and the window's own device badge are two openings onto the same
+/// menu, because there is one current device and it would be a bug for two
+/// controls to disagree about it.
+struct DeviceSwitcherMenuContent: View {
+    @EnvironmentObject var store: TermioStore
+
+    var body: some View {
+        let known = DeviceRoster.known(in: store)
+        let unused = DeviceRoster.unusedAliases(known: known)
+        // An inline Picker is what draws the checkmark on the current device; a
+        // row of Buttons would leave the switcher unable to say which machine is
+        // selected.
+        Picker("", selection: selection) {
+            ForEach(known) { device in
+                Text(device.name).tag(device.id)
+            }
+        }
+        .pickerStyle(.inline)
+        .labelsHidden()
+        Divider()
+        Button(localized("Refresh")) { store.refreshDeviceSessions() }
+        if !unused.isEmpty {
+            Divider()
+            Menu(localized("Connect to…")) {
+                ForEach(unused, id: \.self) { alias in
+                    Button(alias) { connect(to: alias) }
+                }
+            }
+        }
+    }
+
+    private var selection: Binding<String> {
+        Binding(
+            get: { store.currentDeviceAlias ?? "" },
+            set: { alias in
+                store.switchToDevice(
+                    KnownDevice(alias: alias.isEmpty ? nil : alias, deviceID: nil))
+            }
+        )
+    }
+
+    /// First contact with a machine from `~/.ssh/config`: enter it, then open a
+    /// terminal on it — which is what installs `termiod` there if it is missing.
+    /// Reaching for a box is also saying that is where you are about to work.
+    private func connect(to alias: String) {
+        store.switchToDevice(KnownDevice(alias: alias, deviceID: nil))
+        store.addRemoteTerminal(host: alias)
+    }
+}
+
+/// The sidebar's device indicator: which machine you are on, and the switcher
+/// that changes it. Quiet by design — it names the device and nothing else — and
+/// absent entirely while this Mac is the only one, so a user who never leaves
+/// their laptop never sees it.
 struct DeviceIndicator: View {
     @EnvironmentObject var store: TermioStore
     @EnvironmentObject var settings: AppSettings
@@ -81,28 +132,10 @@ struct DeviceIndicator: View {
         // there is no switch to make, and a row that always reads "This Mac" is a
         // label for a decision the user never took.
         if known.count > 1 {
-            let current = DeviceRoster.current(settings, known: known)
-            let unused = DeviceRoster.unusedAliases(known: known)
+            let current = DeviceRoster.current(store, known: known)
             Divider()
             Menu {
-                // An inline Picker is what draws the checkmark on the current
-                // device; a row of Buttons would leave the switcher unable to say
-                // which machine is selected.
-                Picker("", selection: selection) {
-                    ForEach(known) { device in
-                        Text(device.name).tag(device.id)
-                    }
-                }
-                .pickerStyle(.inline)
-                .labelsHidden()
-                if !unused.isEmpty {
-                    Divider()
-                    Menu(localized("Connect to…")) {
-                        ForEach(unused, id: \.self) { alias in
-                            Button(alias) { connect(to: alias) }
-                        }
-                    }
-                }
+                DeviceSwitcherMenuContent()
             } label: {
                 HStack(spacing: 6) {
                     HugeIconView(icon: .serverStack, size: 13, color: .secondary)
@@ -122,24 +155,8 @@ struct DeviceIndicator: View {
             .menuIndicator(.hidden)
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
-            .help(localized("New terminals open on this device"))
+            .help(localized("The sidebar shows this device’s sessions"))
         }
-    }
-
-    private var selection: Binding<String> {
-        Binding(
-            get: { settings.currentDeviceAlias ?? "" },
-            set: { settings.currentDeviceAlias = $0.isEmpty ? nil : $0 }
-        )
-    }
-
-    /// First contact with a machine from `~/.ssh/config`: open a terminal on it
-    /// (which installs `termiod` there if it is missing) and make it the current
-    /// device, so the connection the user just asked for is also where their next
-    /// terminal goes.
-    private func connect(to alias: String) {
-        settings.currentDeviceAlias = alias
-        store.addRemoteTerminal(host: alias)
     }
 }
 

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -109,7 +109,7 @@ struct SidebarView: View {
     @State private var pinnedCollapsed = false
     /// Whether the "Projects" section is folded shut.
     @State private var projectsCollapsed = false
-    /// Whether the "Remote" section (the machines) is folded shut.
+    /// Whether the "Devices" section (the other machines) is folded shut.
     @State private var hostsCollapsed = false
 
     // Chrome colors borrowed from the selected terminal theme; `nil` keeps the
@@ -165,135 +165,142 @@ struct SidebarView: View {
         let hasTerminals = terminals.contains { !$0.sessions.isEmpty }
         let hasChats = chats.contains { !$0.sessions.isEmpty }
         let hasHosts = !hosts.isEmpty
-        return List {
-            // Nudge when agents are running but the status hooks are off — without them
-            // the sidebar spinner stays dark. One tap enables (and reinstalls) them.
-            if !settings.agentHooksEnabled && store.isRunningAnyAgent {
-                AgentHooksOffBanner { settings.agentHooksEnabled = true }
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
-            }
-            // The top "Pinned" working set, under its own section header: pinned projects
-            // as full blocks, then pinned worktrees as mini-blocks (header + their
-            // sessions), then pinned sessions as shortcut rows — each nested entry tagged
-            // with its origin breadcrumb. Nested items stay in the tree below too; only
-            // whole projects move up here. This curated working set sits at the very top —
-            // above the ephemeral Terminals/Chats funnels — because it's the items the user
-            // deliberately elevated (mirroring the iOS "Needs You" strip at the home top).
-            if hasPinned {
-                SidebarSectionHeader(
-                    title: localized("Pinned"),
-                    chrome: chrome,
-                    isCollapsed: pinnedCollapsed,
-                    isFirstSection: true,
-                    toggleCollapsed: {
-                        withAnimation(.easeInOut(duration: 0.18)) { pinnedCollapsed.toggle() }
+        return VStack(spacing: 0) {
+            List {
+                // Nudge when agents are running but the status hooks are off — without them
+                // the sidebar spinner stays dark. One tap enables (and reinstalls) them.
+                if !settings.agentHooksEnabled && store.isRunningAnyAgent {
+                    AgentHooksOffBanner { settings.agentHooksEnabled = true }
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(Color.clear)
+                }
+                // The top "Pinned" working set, under its own section header: pinned projects
+                // as full blocks, then pinned worktrees as mini-blocks (header + their
+                // sessions), then pinned sessions as shortcut rows — each nested entry tagged
+                // with its origin breadcrumb. Nested items stay in the tree below too; only
+                // whole projects move up here. This curated working set sits at the very top —
+                // above the ephemeral Terminals/Chats funnels — because it's the items the user
+                // deliberately elevated (mirroring the iOS "Needs You" strip at the home top).
+                if hasPinned {
+                    SidebarSectionHeader(
+                        title: localized("Pinned"),
+                        chrome: chrome,
+                        isCollapsed: pinnedCollapsed,
+                        isFirstSection: true,
+                        toggleCollapsed: {
+                            withAnimation(.easeInOut(duration: 0.18)) { pinnedCollapsed.toggle() }
+                        }
+                    )
+                    if !pinnedCollapsed {
+                        ForEach(pinnedProjects) { projectBlock($0) }
+                        ForEach(pinnedWorktrees) { entry in
+                            pinnedWorktreeBlock(project: entry.project, worktree: entry.worktree)
+                        }
+                        ForEach(pinnedSessions) { entry in
+                            SessionRow(session: entry.session, chrome: chrome, leadingIndent: 16,
+                                       breadcrumb: breadcrumb(for: entry.session, in: entry.project))
+                        }
                     }
-                )
-                if !pinnedCollapsed {
-                    ForEach(pinnedProjects) { projectBlock($0) }
-                    ForEach(pinnedWorktrees) { entry in
-                        pinnedWorktreeBlock(project: entry.project, worktree: entry.worktree)
+                }
+                // The loose-terminals funnel, as a section (not a project folder): its
+                // header carries the New/Close actions; its sessions render below. Hidden
+                // entirely while it holds no terminals — an empty section label is just
+                // noise (a new loose terminal reappears the section, via the + / File menu).
+                ForEach(terminals.filter { !$0.sessions.isEmpty }) { term in
+                    SidebarSectionHeader(
+                        title: localized("Terminals"),
+                        chrome: chrome,
+                        isCollapsed: collapsedProjects.contains(term.id),
+                        isFirstSection: !hasPinned,
+                        toggleCollapsed: { toggleCollapsed(term.id) },
+                        menuItems: [
+                            newTerminalMenuItem(store: store) {
+                                store.addSession(to: term.id, agent: .terminal)
+                            },
+                            .separator,
+                            .action(localized("Close All Terminals")) { store.removeProject(term.id) },
+                        ]
+                    )
+                    if !collapsedProjects.contains(term.id) {
+                        let sessions = primarySessions(for: term)
+                        let marks = splitLinkMarks(for: sessions)
+                        ForEach(sessions) { session in
+                            SessionRow(session: session, chrome: chrome, splitLink: marks[session.id])
+                        }
                     }
-                    ForEach(pinnedSessions) { entry in
-                        SessionRow(session: entry.session, chrome: chrome, leadingIndent: 16,
-                                   breadcrumb: breadcrumb(for: entry.session, in: entry.project))
+                }
+                // The loose-agents funnel — the agent-side twin of Terminals, paired
+                // directly above Projects (the "Chats vs Projects" split: one-off agent
+                // sessions vs. real folder-scoped work). Every scratch agent shares one
+                // `.chats` container rooted at `~/.termio/chats`; its header offers a single
+                // "New Chat" (the default agent — see `addDefaultChat`) plus a Close All,
+                // mirroring the Terminals header's "New Terminal". Hidden while empty.
+                ForEach(chats.filter { !$0.sessions.isEmpty }) { chat in
+                    SidebarSectionHeader(
+                        title: localized("Chats"),
+                        chrome: chrome,
+                        isCollapsed: collapsedProjects.contains(chat.id),
+                        isFirstSection: !hasPinned && !hasTerminals,
+                        toggleCollapsed: { toggleCollapsed(chat.id) },
+                        menuItems: [
+                            .action(localized("New Chat")) { store.addDefaultChat() },
+                            .separator,
+                            .action(localized("Close All Chats")) { store.removeProject(chat.id) },
+                        ]
+                    )
+                    if !collapsedProjects.contains(chat.id) {
+                        let sessions = primarySessions(for: chat)
+                        let marks = splitLinkMarks(for: sessions)
+                        ForEach(sessions) { session in
+                            SessionRow(session: session, chrome: chrome, splitLink: marks[session.id])
+                        }
+                    }
+                }
+                // The other machines, under their own section — one block per device,
+                // each with its sessions nested. A device is a *place* you work, peer to
+                // a project rather than a variant of one, so it gets a container of its
+                // own instead of being filed among this Mac's loose terminals.
+                if hasHosts {
+                    SidebarSectionHeader(
+                        title: localized("Devices"),
+                        chrome: chrome,
+                        isCollapsed: hostsCollapsed,
+                        isFirstSection: !hasPinned && !hasTerminals && !hasChats,
+                        toggleCollapsed: {
+                            withAnimation(.easeInOut(duration: 0.18)) { hostsCollapsed.toggle() }
+                        }
+                    )
+                    if !hostsCollapsed {
+                        ForEach(hosts) { hostBlock($0) }
+                    }
+                }
+                // The user's opened projects, under their own section header — the same
+                // section treatment as Terminals and Pinned, one tier above the folder rows.
+                if !others.isEmpty {
+                    SidebarSectionHeader(
+                        title: localized("Projects"),
+                        chrome: chrome,
+                        isCollapsed: projectsCollapsed,
+                        isFirstSection: !hasPinned && !hasTerminals && !hasChats && !hasHosts,
+                        toggleCollapsed: {
+                            withAnimation(.easeInOut(duration: 0.18)) { projectsCollapsed.toggle() }
+                        }
+                    )
+                    if !projectsCollapsed {
+                        ForEach(others) { projectBlock($0) }
                     }
                 }
             }
-            // The loose-terminals funnel, as a section (not a project folder): its
-            // header carries the New/Close actions; its sessions render below. Hidden
-            // entirely while it holds no terminals — an empty section label is just
-            // noise (a new loose terminal reappears the section, via the + / File menu).
-            ForEach(terminals.filter { !$0.sessions.isEmpty }) { term in
-                SidebarSectionHeader(
-                    title: localized("Terminals"),
-                    chrome: chrome,
-                    isCollapsed: collapsedProjects.contains(term.id),
-                    isFirstSection: !hasPinned,
-                    toggleCollapsed: { toggleCollapsed(term.id) },
-                    menuItems: [
-                        .action(localized("New Terminal")) { store.addSession(to: term.id, agent: .terminal) },
-                        remoteTerminalMenuItem(store: store),
-                        .separator,
-                        .action(localized("Close All Terminals")) { store.removeProject(term.id) },
-                    ]
-                )
-                if !collapsedProjects.contains(term.id) {
-                    let sessions = primarySessions(for: term)
-                    let marks = splitLinkMarks(for: sessions)
-                    ForEach(sessions) { session in
-                        SessionRow(session: session, chrome: chrome, splitLink: marks[session.id])
-                    }
-                }
-            }
-            // The loose-agents funnel — the agent-side twin of Terminals, paired
-            // directly above Projects (the "Chats vs Projects" split: one-off agent
-            // sessions vs. real folder-scoped work). Every scratch agent shares one
-            // `.chats` container rooted at `~/.termio/chats`; its header offers a single
-            // "New Chat" (the default agent — see `addDefaultChat`) plus a Close All,
-            // mirroring the Terminals header's "New Terminal". Hidden while empty.
-            ForEach(chats.filter { !$0.sessions.isEmpty }) { chat in
-                SidebarSectionHeader(
-                    title: localized("Chats"),
-                    chrome: chrome,
-                    isCollapsed: collapsedProjects.contains(chat.id),
-                    isFirstSection: !hasPinned && !hasTerminals,
-                    toggleCollapsed: { toggleCollapsed(chat.id) },
-                    menuItems: [
-                        .action(localized("New Chat")) { store.addDefaultChat() },
-                        .separator,
-                        .action(localized("Close All Chats")) { store.removeProject(chat.id) },
-                    ]
-                )
-                if !collapsedProjects.contains(chat.id) {
-                    let sessions = primarySessions(for: chat)
-                    let marks = splitLinkMarks(for: sessions)
-                    ForEach(sessions) { session in
-                        SessionRow(session: session, chrome: chrome, splitLink: marks[session.id])
-                    }
-                }
-            }
-            // The machines, under their own section — one block per host, each with
-            // its sessions nested. A remote box is a *place* you work, peer to a
-            // project rather than a variant of one, so it gets a container of its own
-            // instead of being filed among loose local terminals.
-            if hasHosts {
-                SidebarSectionHeader(
-                    title: "Remote",
-                    chrome: chrome,
-                    isCollapsed: hostsCollapsed,
-                    isFirstSection: !hasPinned && !hasTerminals && !hasChats,
-                    toggleCollapsed: {
-                        withAnimation(.easeInOut(duration: 0.18)) { hostsCollapsed.toggle() }
-                    }
-                )
-                if !hostsCollapsed {
-                    ForEach(hosts) { hostBlock($0) }
-                }
-            }
-            // The user's opened projects, under their own section header — the same
-            // section treatment as Terminals and Pinned, one tier above the folder rows.
-            if !others.isEmpty {
-                SidebarSectionHeader(
-                    title: localized("Projects"),
-                    chrome: chrome,
-                    isCollapsed: projectsCollapsed,
-                    isFirstSection: !hasPinned && !hasTerminals && !hasChats && !hasHosts,
-                    toggleCollapsed: {
-                        withAnimation(.easeInOut(duration: 0.18)) { projectsCollapsed.toggle() }
-                    }
-                )
-                if !projectsCollapsed {
-                    ForEach(others) { projectBlock($0) }
-                }
-            }
+            // The native macOS `.sidebar` source list — its own Liquid Glass material, full-height
+            // behind the traffic lights. (We previously painted the column ourselves to dodge a macOS 26
+            // full-screen round-trip bug, but per the design call we're back to the stock sidebar.)
+            .listStyle(.sidebar)
+            .environment(\.defaultMinListRowHeight, 1)
+            // Which machine new terminals land on, pinned under the tree — the one
+            // piece of chrome that has to stay legible while the list scrolls. It
+            // draws nothing at all while this Mac is the only known device.
+            DeviceIndicator()
         }
-        // The native macOS `.sidebar` source list — its own Liquid Glass material, full-height
-        // behind the traffic lights. (We previously painted the column ourselves to dodge a macOS 26
-        // full-screen round-trip bug, but per the design call we're back to the stock sidebar.)
-        .listStyle(.sidebar)
-        .environment(\.defaultMinListRowHeight, 1)
         .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 360)
     }
 
@@ -596,8 +603,9 @@ private struct ProjectHeader: View {
     private var menuItems: [SidebarMenuItem] {
         if isTerminalsHeader {
             return [
-                .action(localized("New Terminal")) { store.addSession(to: project.id, agent: .terminal) },
-                remoteTerminalMenuItem(store: store),
+                newTerminalMenuItem(store: store) {
+                    store.addSession(to: project.id, agent: .terminal)
+                },
                 .separator,
                 .action(localized("Close All Terminals")) { store.removeProject(project.id) },
             ]
@@ -607,7 +615,7 @@ private struct ProjectHeader: View {
         // worktree/Finder/git rows — none of them mean anything for a box over there.
         if isHostHeader, let alias = project.sshHost {
             return [
-                .action("New Remote Terminal") {
+                .action(localized("New Terminal")) {
                     store.addRemoteTerminal(host: alias, cwd: project.path == "~" ? nil : project.path)
                 },
                 .action("New SSH Shell") { store.addSSHSession(host: alias) },
@@ -616,16 +624,17 @@ private struct ProjectHeader: View {
             ]
         }
         var items: [SidebarMenuItem] = [
-            .action(localized("New Terminal")) { addSession(.terminal) },
-            remoteTerminalMenuItem(store: store, project: project),
+            newTerminalMenuItem(store: store, project: project) { addSession(.terminal) },
             .submenu(localized("New Agent Session"), enabledAgentPresets(settings)
                 .filter { $0 != .terminal }
                 .map { preset in .agent(preset) { addSession(preset) } }),
         ]
         if let worktree {
-            items.append(.separator)
-            items.append(
-                cloneOnRemoteMenuItem(store: store, folder: worktree.path, project: project.id))
+            if let cloneTo = cloneToDeviceMenuItem(
+                store: store, folder: worktree.path, project: project.id) {
+                items.append(.separator)
+                items.append(cloneTo)
+            }
             items.append(.separator)
             items.append(.action(worktree.pinned ? localized("Unpin") : localized("Pin")) {
                 store.toggleWorktreePinned(worktree.id)
@@ -644,8 +653,10 @@ private struct ProjectHeader: View {
         // Only for git repositories (a worktree needs one; "—" marks a non-repo folder).
         if project.branch != "—" {
             items.append(.action(localized("New Worktree")) { store.addWorktree(from: project.id) })
-            items.append(
-                cloneOnRemoteMenuItem(store: store, folder: project.path, project: project.id))
+            if let cloneTo = cloneToDeviceMenuItem(
+                store: store, folder: project.path, project: project.id) {
+                items.append(cloneTo)
+            }
         }
         items.append(.separator)
         items.append(.action(project.pinned ? localized("Unpin") : localized("Pin to Top")) {
@@ -776,74 +787,6 @@ private struct ProjectHeader: View {
 @MainActor
 func enabledAgentPresets(_ settings: AppSettings) -> [AgentPreset] {
     settings.orderedAgents(AgentPreset.allCases.filter(settings.isAgentEnabled))
-}
-
-/// The "New Remote Terminal ▸" submenu: one row per `~/.ssh/config` alias (the
-/// single source of truth for hosts), each opening a durable termiod session on
-/// that host. An empty config shows a disabled explainer instead of a dead
-/// submenu.
-///
-/// Scope follows the row it hangs off. From a **project** row it means "this
-/// repo, over there": the session opens in the checkout `Clone on Remote…`
-/// recorded for that host and appears under that project. From the Terminals
-/// section (`project == nil`) it is host-scoped and starts at the remote
-/// `$HOME`. Hosts the project hasn't been cloned to are shown but explain
-/// themselves on click, rather than being hidden — the fix (`Clone on Remote…`)
-/// is one menu away and hiding the row would just look broken.
-@MainActor
-func remoteTerminalMenuItem(store: TermioStore, project: Project? = nil) -> SidebarMenuItem {
-    let hosts = SSHConfigFile.hosts()
-    guard !hosts.isEmpty else {
-        return .submenu("New Remote Terminal", [.disabled("No SSH hosts in ~/.ssh/config")])
-    }
-    let projectID = project?.id
-    return .submenu("New Remote Terminal", hosts.map { host in
-        // Checkouts are keyed by device, but a menu is built synchronously and has
-        // no connection to spend resolving the alias — so ask the registry for a
-        // device learned earlier, and let the lookup fall back to the alias when
-        // this box has never been reached.
-        let deviceID = TermiodDeviceRegistry.shared.deviceID(for: .ssh(host.alias))
-        let cloned = project?.remoteCheckout(device: deviceID, alias: host.alias) != nil
-        // A project row shows which hosts already hold this repo, so the menu
-        // answers "where does this exist?" before you click.
-        let label = project == nil || cloned ? host.alias : "\(host.alias) — not cloned yet"
-        return .action(label) {
-            store.addRemoteTerminal(host: host.alias, project: projectID)
-        }
-    })
-}
-
-/// The "Clone on Remote… ▸" submenu: pick an ssh-config host, and the project's
-/// `origin` is `git clone`d **on** that host, then a remote terminal opens inside
-/// the clone. Only meaningful for a git checkout with a remote — origin presence
-/// is resolved at click time (async), because the menu is built synchronously and
-/// a git call per right-click would stall the sidebar; a folder with no origin
-/// alerts instead of silently doing nothing. An empty ssh config disables it.
-@MainActor
-func cloneOnRemoteMenuItem(
-    store: TermioStore,
-    folder: String,
-    project projectID: UUID? = nil
-) -> SidebarMenuItem {
-    let hosts = SSHConfigFile.hosts()
-    guard !hosts.isEmpty else {
-        return .submenu("Clone on Remote", [.disabled("No SSH hosts in ~/.ssh/config")])
-    }
-    return .submenu("Clone on Remote", hosts.map { host in
-        .action(host.alias) {
-            // Resolve origin/unpushed off-main, then hand off to the store action;
-            // no origin means nothing to clone, so say so rather than no-op.
-            Task { @MainActor in
-                guard let info = await GitService.cloneInfo(in: folder) else {
-                    store.presentRemoteSetupFailure(
-                        host: host.alias,
-                        message: "This folder has no git \"origin\" remote to clone.")
-                    return
-                }
-                store.cloneOnRemote(host: host.alias, info: info, project: projectID)
-            }
-        }
-    })
 }
 
 /// A project-like header always offers a shell, followed by each coding agent the

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -109,8 +109,8 @@ struct SidebarView: View {
     @State private var pinnedCollapsed = false
     /// Whether the "Projects" section is folded shut.
     @State private var projectsCollapsed = false
-    /// Whether the "Devices" section (the other machines) is folded shut.
-    @State private var hostsCollapsed = false
+    /// Whether the current device's own roster section is folded shut.
+    @State private var deviceWorldCollapsed = false
 
     // Chrome colors borrowed from the selected terminal theme; `nil` keeps the
     // default system look untouched.
@@ -133,13 +133,14 @@ struct SidebarView: View {
         // the rest. A project's membership in the pinned group is itself the pin cue, so
         // pinned rows carry no per-row badge. Both groups keep the user's chosen sort
         // (already applied by `orderedProjects`, which we only partition here — never reorder).
-        let ordered = store.orderedProjects
+        // The sidebar shows one device's world, and `store.currentDevice` says
+        // which. On another machine none of this Mac's own containers apply —
+        // switching is not a filter over one list, it is a different machine's
+        // state — so they are not built at all and the device's own roster
+        // (`deviceWorldSection`) is the whole list.
+        let ordered = store.isShowingThisMac ? store.orderedProjects : []
         let terminals = ordered.filter { $0.kind == .terminals }
         let chats = ordered.filter { $0.kind == .chats }
-        // One block per machine, in the Remote section. A host with no sessions left
-        // is dropped the same way the funnels are — closing a box's last session
-        // closes the box (reopening it is one click in New SSH Connection).
-        let hosts = ordered.filter { $0.kind == .host && !$0.sessions.isEmpty }
         // Only real `.folder` projects populate the Pinned working set and the Projects
         // list; the two loose funnels (Terminals, Chats) render as their own sections.
         let pinnedProjects = ordered.filter { $0.kind == .folder && $0.pinned }
@@ -156,7 +157,7 @@ struct SidebarView: View {
         // so the working set never shows the same session twice.
         let pinnedSessions: [PinnedSessionEntry] = others.flatMap { project in
             project.sessions.filter { session in
-                guard session.pinned else { return false }
+                guard session.pinned, store.isOnCurrentDevice(session) else { return false }
                 if let wp = session.worktreePath, pinnedWorktreePaths.contains(wp) { return false }
                 return true
             }.map { PinnedSessionEntry(project: project, session: $0) }
@@ -164,8 +165,12 @@ struct SidebarView: View {
         let hasPinned = !pinnedProjects.isEmpty || !pinnedWorktrees.isEmpty || !pinnedSessions.isEmpty
         let hasTerminals = terminals.contains { !$0.sessions.isEmpty }
         let hasChats = chats.contains { !$0.sessions.isEmpty }
-        let hasHosts = !hosts.isEmpty
         return VStack(spacing: 0) {
+            // Which machine you are on, above everything it contains. The list
+            // below is that device's world, so the device has to be read first —
+            // pinned under the tree it was a footnote to state it should have
+            // been announcing. Draws nothing while this Mac is the only device.
+            DeviceIndicator()
             List {
                 // Nudge when agents are running but the status hooks are off — without them
                 // the sidebar spinner stays dark. One tap enables (and reinstalls) them.
@@ -256,24 +261,6 @@ struct SidebarView: View {
                         }
                     }
                 }
-                // The other machines, under their own section — one block per device,
-                // each with its sessions nested. A device is a *place* you work, peer to
-                // a project rather than a variant of one, so it gets a container of its
-                // own instead of being filed among this Mac's loose terminals.
-                if hasHosts {
-                    SidebarSectionHeader(
-                        title: localized("Devices"),
-                        chrome: chrome,
-                        isCollapsed: hostsCollapsed,
-                        isFirstSection: !hasPinned && !hasTerminals && !hasChats,
-                        toggleCollapsed: {
-                            withAnimation(.easeInOut(duration: 0.18)) { hostsCollapsed.toggle() }
-                        }
-                    )
-                    if !hostsCollapsed {
-                        ForEach(hosts) { hostBlock($0) }
-                    }
-                }
                 // The user's opened projects, under their own section header — the same
                 // section treatment as Terminals and Pinned, one tier above the folder rows.
                 if !others.isEmpty {
@@ -281,7 +268,7 @@ struct SidebarView: View {
                         title: localized("Projects"),
                         chrome: chrome,
                         isCollapsed: projectsCollapsed,
-                        isFirstSection: !hasPinned && !hasTerminals && !hasChats && !hasHosts,
+                        isFirstSection: !hasPinned && !hasTerminals && !hasChats,
                         toggleCollapsed: {
                             withAnimation(.easeInOut(duration: 0.18)) { projectsCollapsed.toggle() }
                         }
@@ -290,18 +277,108 @@ struct SidebarView: View {
                         ForEach(others) { projectBlock($0) }
                     }
                 }
+                // What the device itself says is running. On another machine this is
+                // the whole sidebar; on this Mac it is the sessions the daemon holds
+                // that no row above accounts for.
+                deviceWorldSection(isFirstSection: !hasPinned && !hasTerminals && !hasChats
+                    && others.isEmpty)
             }
             // The native macOS `.sidebar` source list — its own Liquid Glass material, full-height
             // behind the traffic lights. (We previously painted the column ourselves to dodge a macOS 26
             // full-screen round-trip bug, but per the design call we're back to the stock sidebar.)
             .listStyle(.sidebar)
             .environment(\.defaultMinListRowHeight, 1)
-            // Which machine new terminals land on, pinned under the tree — the one
-            // piece of chrome that has to stay legible while the list scrolls. It
-            // draws nothing at all while this Mac is the only known device.
-            DeviceIndicator()
         }
         .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 360)
+    }
+
+    /// The current device's own roster: the sessions **that machine** reports,
+    /// under a header that names it.
+    ///
+    /// This is the list `list` returned, not a local array narrowed by alias. The
+    /// difference shows the moment a session was started somewhere else — from the
+    /// `termiod` CLI on the box, or by a phone — because such a session appears
+    /// here and could not appear in anything derived from this Mac's state file.
+    ///
+    /// On this Mac the sections above already draw the app's own rows, so only the
+    /// sessions they do not account for are listed; on any other device this is
+    /// the entire sidebar.
+    @ViewBuilder
+    private func deviceWorldSection(isFirstSection: Bool) -> some View {
+        let device = store.currentDevice
+        let showingThisMac = store.isShowingThisMac
+        let rows = store.deviceWorld().filter { row in
+            guard showingThisMac else { return true }
+            // A row the local sections already drew would be a duplicate; what is
+            // left is what only the daemon knows about.
+            if case .running(_, nil) = row { return true }
+            return false
+        }
+        // On this Mac an empty extra list is nothing to report — the sidebar above
+        // is already the answer. On another device the section is the sidebar, so
+        // it stays and says what it is waiting for.
+        if !showingThisMac || !rows.isEmpty {
+            SidebarSectionHeader(
+                title: showingThisMac ? localized("Also Running") : device.name,
+                chrome: chrome,
+                isCollapsed: deviceWorldCollapsed,
+                isFirstSection: isFirstSection,
+                toggleCollapsed: {
+                    withAnimation(.easeInOut(duration: 0.18)) { deviceWorldCollapsed.toggle() }
+                },
+                menuItems: deviceWorldMenuItems(device)
+            )
+            if !deviceWorldCollapsed {
+                if !showingThisMac, let note = deviceRosterNote() {
+                    DeviceNoteRow(text: note, chrome: chrome)
+                }
+                ForEach(rows) { row in
+                    switch row {
+                    case .running(let information, let session):
+                        if let session {
+                            SessionRow(session: session, chrome: chrome)
+                        } else {
+                            // A session on this device with no row here. Opening it
+                            // is adoption, not creation: it keeps the name the
+                            // device gave it so the attach lands on that PTY.
+                            DeviceOnlySessionRow(information: information, chrome: chrome)
+                        }
+                    case .notStarted(let session):
+                        SessionRow(session: session, chrome: chrome)
+                    case .ended(let session, let tombstone):
+                        EndedSessionRow(session: session, tombstone: tombstone, chrome: chrome)
+                    }
+                }
+            }
+        }
+    }
+
+    private func deviceWorldMenuItems(_ device: KnownDevice) -> [SidebarMenuItem] {
+        var items: [SidebarMenuItem] = []
+        if let alias = device.alias {
+            items.append(.action(localized("New Terminal")) { store.addRemoteTerminal(host: alias) })
+            items.append(.separator)
+        }
+        items.append(.action(localized("Refresh")) { store.refreshDeviceSessions() })
+        return items
+    }
+
+    /// What to say when the device has not produced a list: it is being asked, it
+    /// refused, or there is no session host to ask. Each is a different fact and
+    /// none of them is "no sessions".
+    private func deviceRosterNote() -> String? {
+        switch store.deviceSessions {
+        case .unavailable:
+            return localized("Termio isn’t running sessions through termiod.")
+        case .loading:
+            return localized("Asking \(store.currentDevice.name)…")
+        case .failed(let message):
+            return message
+        case .ready(let sessions):
+            return sessions.live.isEmpty && store.deviceWorld().isEmpty
+                ? localized("Nothing is running on \(store.currentDevice.name).")
+                : nil
+        }
     }
 
     /// One project's rows: its header, then (unless folded) its primary-checkout
@@ -333,7 +410,7 @@ struct SidebarView: View {
                 )
                 if !collapsedWorktrees.contains(worktree.id) {
                     let sessions = project.sessions.filter {
-                        $0.worktreePath == worktree.path
+                        $0.worktreePath == worktree.path && store.isOnCurrentDevice($0)
                     }
                     let splitMarks = splitLinkMarks(for: sessions)
                     ForEach(sessions) { session in
@@ -345,26 +422,6 @@ struct SidebarView: View {
                         )
                     }
                 }
-            }
-        }
-    }
-
-    /// One machine's rows: its header, then (unless folded) its sessions. A host has
-    /// no worktrees — git layout is a local-disk concern, and the remote checkout a
-    /// session works in is the session's own `termiodRemoteCwd` — so the block is
-    /// flatter than a project's.
-    @ViewBuilder
-    private func hostBlock(_ host: Project) -> some View {
-        ProjectHeader(
-            project: host,
-            isCollapsed: collapsedProjects.contains(host.id),
-            toggleCollapsed: { toggleCollapsed(host.id) },
-            chrome: chrome
-        )
-        if !collapsedProjects.contains(host.id) {
-            let marks = splitLinkMarks(for: host.sessions)
-            ForEach(host.sessions) { session in
-                SessionRow(session: session, chrome: chrome, splitLink: marks[session.id])
             }
         }
     }
@@ -384,7 +441,9 @@ struct SidebarView: View {
             breadcrumb: project.name
         )
         if !collapsedWorktrees.contains(worktree.id) {
-            let sessions = project.sessions.filter { $0.worktreePath == worktree.path }
+            let sessions = project.sessions.filter {
+                $0.worktreePath == worktree.path && store.isOnCurrentDevice($0)
+            }
             let splitMarks = splitLinkMarks(for: sessions)
             ForEach(sessions) { session in
                 SessionRow(session: session, chrome: chrome, leadingIndent: 16,
@@ -429,8 +488,13 @@ struct SidebarView: View {
     /// verbatim. Once the folder layer exists, only sessions anchored to the primary
     /// checkout remain shallow.
     private func primarySessions(for project: Project) -> [Session] {
-        guard !project.worktrees.isEmpty else { return project.sessions }
-        return project.sessions.filter {
+        // A project is a folder on one machine, but a session opened from its row
+        // can run on another ("New Terminal ▸ <device>"). That session belongs to
+        // the device it runs on and shows up in that device's world, so drawing it
+        // here as well would put one session in two machines' sidebars.
+        let sessions = project.sessions.filter(store.isOnCurrentDevice)
+        guard !project.worktrees.isEmpty else { return sessions }
+        return sessions.filter {
             $0.worktreePath == nil || $0.worktreePath == project.path
         }
     }
@@ -1255,6 +1319,162 @@ private struct SessionRow: View {
                 .animation(nil, value: isDropTarget)
         )
         .animation(.easeInOut(duration: 0.12), value: isHovering)
+    }
+}
+
+/// A quiet line under a device's header saying why there are no rows — reaching
+/// the machine, the reason it could not be reached, or that nothing runs there.
+/// A device is across a network, so "we do not know yet" is a real answer and
+/// gets said rather than being drawn as an empty list.
+private struct DeviceNoteRow: View {
+    @EnvironmentObject var settings: AppSettings
+    let text: String
+    let chrome: ChromeTheme?
+
+    var body: some View {
+        Text(text)
+            .font(settings.interfaceFont)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .padding(.vertical, settings.interfaceRowPadding)
+            .padding(.leading, 16)
+            .listRowBackground(
+                SidebarRowHighlight(isSelected: false, isHovering: false, chrome: chrome))
+    }
+}
+
+/// A session the **device** reports that this app has no row for — started from
+/// the `termiod` CLI on that machine, or by another client.
+///
+/// Its existence is the proof the list is the device's and not this Mac's: no
+/// amount of filtering a local array can produce a row for a session this app
+/// never created. Everything shown comes off the wire — the daemon's title, its
+/// command, its directory on that machine.
+///
+/// Clicking it adopts it (see `TermioStore.adoptDeviceSession`), which gives the
+/// session a row here and attaches to the PTY that is already running rather
+/// than starting a second one beside it.
+private struct DeviceOnlySessionRow: View {
+    @EnvironmentObject var store: TermioStore
+    @EnvironmentObject var settings: AppSettings
+    let information: Termiod.SessionInformation
+    let chrome: ChromeTheme?
+    @State private var isHovering = false
+
+    private var title: String {
+        if let title = information.title, !title.isEmpty { return title }
+        return information.name
+    }
+
+    /// What the device says the row is doing, in the fewest words that stay true:
+    /// the command, and the directory it runs in on that machine.
+    private var detail: String {
+        let directory = information.cwd.isEmpty
+            ? "" : URL(fileURLWithPath: information.cwd).lastPathComponent
+        return [information.command, directory]
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            HugeIconView(icon: .terminal, size: 15, color: .secondary)
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(title)
+                    .font(settings.interfaceFont)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if !detail.isEmpty {
+                    Text(detail)
+                        .font(settings.interfaceFont)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            Spacer(minLength: 4)
+            if information.attachedClients > 0 {
+                // Someone else is watching this session. Worth saying out loud —
+                // the write token is single-holder, so opening it may not hand
+                // over the keyboard.
+                HugeIconView(icon: .view, size: 13, color: .secondary)
+            }
+        }
+        .padding(.vertical, settings.interfaceRowPadding)
+        .padding(.leading, 16)
+        .contentShape(Rectangle())
+        .help(information.cwd.isEmpty
+              ? localized("Opened outside Termio on this device")
+              : localized("Opened outside Termio, in \(information.cwd)"))
+        .onHover { isHovering = $0 }
+        .simultaneousGesture(TapGesture().onEnded { store.adoptDeviceSession(information) })
+        .background(SidebarRowContextMenu(items: [
+            .action(localized("Open")) { store.adoptDeviceSession(information) },
+        ]))
+        .listRowBackground(
+            SidebarRowHighlight(isSelected: false, isHovering: isHovering, chrome: chrome)
+                .animation(.easeInOut(duration: 0.12), value: isHovering))
+    }
+}
+
+/// A row whose session the device buried. The reason is the host's word
+/// (`exited` · `killed` · `daemon_lost`) turned into something a person reads —
+/// the host describes state and never decides presentation.
+///
+/// It stays clickable: opening it spawns the session again under the same name,
+/// which is what the user means by clicking a row that used to work.
+private struct EndedSessionRow: View {
+    @EnvironmentObject var store: TermioStore
+    @EnvironmentObject var settings: AppSettings
+    let session: Session
+    let tombstone: Termiod.SessionTombstone
+    let chrome: ChromeTheme?
+    @State private var isHovering = false
+
+    private var isSelected: Bool { store.selectedSessionID == session.id }
+
+    private var reason: String {
+        switch tombstone.reason {
+        case "exited":
+            guard let status = tombstone.exitStatus else { return localized("Ended") }
+            return status == 0 ? localized("Ended") : localized("Ended — exit \(status)")
+        case "killed": return localized("Closed")
+        case "daemon_lost": return localized("The session host went away")
+        default: return tombstone.reason
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            AgentIconView(agent: store.effectiveAgent(for: session), size: 15)
+                .frame(width: 16)
+                .opacity(0.5)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(store.displayTitle(for: session))
+                    .font(settings.interfaceFont)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(reason)
+                    .font(settings.interfaceFont)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 4)
+        }
+        .padding(.vertical, settings.interfaceRowPadding)
+        .padding(.leading, 16)
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .simultaneousGesture(TapGesture().onEnded { store.selectedSessionID = session.id })
+        .background(SidebarRowContextMenu(items: [
+            .action(localized("Close Session")) { store.requestCloseSession(session.id) },
+        ]))
+        .listRowBackground(
+            SidebarRowHighlight(isSelected: isSelected, isHovering: isHovering, chrome: chrome)
+                .animation(.easeInOut(duration: 0.12), value: isHovering))
     }
 }
 

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -87,6 +87,25 @@ extension TermioStore {
         link.onDevice = { [weak self] device in
             self?.adoptDevice(device, forRoute: link.route)
         }
+        // The `events` half of the negotiated capabilities. Status is the one
+        // that matters: an agent running on a VPS reports to the daemon that
+        // owns its PTY, and this is the only path by which that reaches the Mac
+        // — the hook socket is on the wrong machine, which is exactly why
+        // `presentationEnvironment` withholds `TERMIO_SESSION` from a remote.
+        link.onStatus = { [weak self] status in
+            self?.applyTermiodStatus(status, for: session.id)
+        }
+        // The link itself acts on this (it stops sending `R` frames the daemon
+        // would reject, and re-asserts the grid when the token returns). Logged
+        // here because a demoted pane looks identical to a live one on screen —
+        // saying it out loud is what makes a silently-ignored keystroke
+        // explainable. Showing it in the pane is a client-UI step, not taken here.
+        link.onWriter = { writer in
+            Log.termiod.info("""
+            session \(session.id.uuidString, privacy: .public) is now \
+            \(writer ? "the writer" : "an observer", privacy: .public)
+            """)
+        }
         link.onExit = { [weak self, weak inMemory] code, runtimeMilliseconds in
             self?.termiodLinks[session.id] = nil
             self?.lastScreenActivity[session.id] = nil
@@ -107,6 +126,60 @@ extension TermioStore {
         }
         termiodLinks[session.id] = link
         link.start()
+    }
+
+    // MARK: - Host-reported workstream status
+
+    /// Lands an `E status` event on the session's row. The vocabulary is the
+    /// protocol's (`working · idle · needs_you · done · failed · unknown`, §4);
+    /// the mapping to a dot, a spinner, or a notification is this client's and
+    /// deliberately mirrors `applyStatusReport` arm for arm, so a session behaves
+    /// the same whether its status came from a local hook or from the daemon.
+    ///
+    /// Unlike the hook path there is no correlation guesswork: the event arrived
+    /// on this session's own attach channel, so it can only be about this
+    /// session. That is also why it is not gated on `effectiveAgent` — a remote
+    /// terminal is created as a plain `.terminal` row (the agent runs over
+    /// there), and gating would silently discard every status a VPS agent
+    /// reports, which is the entire reason this path exists.
+    func applyTermiodStatus(_ report: Termiod.StatusPayload, for id: Session.ID) {
+        guard session(id) != nil else { return }
+        // The workstream title is the agent's own label for what it is doing.
+        // It shares `liveTitle` with the OSC 0/2 channel — same field, last
+        // writer wins — because both answer the same question about the row.
+        if let title = report.title, !title.isEmpty { setLiveTitle(title, for: id) }
+        // A host that is speaking for this session is exactly the condition the
+        // screen-driven promotion stands down for (`hookQuietWindow`): the
+        // precise signal outranks the heuristic that exists in its absence.
+        if ["working", "idle", "needs_you", "done", "failed"].contains(report.status) {
+            lastHookReportAt[id] = Date()
+        }
+        switch report.status {
+        case "working":
+            setStatus(.working, for: id)
+            lastWorkingAt[id] = Date()
+        case "needs_you":
+            clearWorking(id)
+            flagBlockingAttention(for: id)
+        case "done":
+            clearWorking(id)
+            setStatus(.done, for: id)
+        case "idle":
+            clearWorking(id)
+            setStatus(.idle, for: id)
+        case "failed":
+            // Not `.done`: a green "ready for you" dot on a run that failed
+            // reads as success. Not `flagBlockingAttention` either — a failure
+            // has no resolving transition, so its dot should clear when the user
+            // looks at the row, which is what a plain `.needsAttention` does.
+            clearWorking(id)
+            setStatus(isViewing(id) ? .idle : .needsAttention, for: id)
+        default:
+            // `unknown` is the daemon's default for a session nobody has
+            // reported on. Writing it would overwrite what the local signals
+            // worked out, so it is left alone.
+            break
+        }
     }
 
     // MARK: - Device identity
@@ -167,10 +240,21 @@ extension TermioStore {
             project.sessions.map { $0.id.uuidString }
         })
         let route = TermiodRoute(sshAlias: Termiod.remoteHost)
-        DispatchQueue.global(qos: .utility).async {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
             do {
-                let live = try Termiod.listSessions(route: route)
-                // The handshake `listSessions` just performed recorded this
+                let roster = try Termiod.roster(route: route)
+                let live = roster.sessions
+                // The graveyard is the other half of the answer, and the half
+                // that explains an empty list. Recorded before the live rows are
+                // logged so `termiodEndReason` is populated by the time anything
+                // asks why a row it restored has no session behind it.
+                let tombstones = roster.tombstones
+                DispatchQueue.main.async {
+                    MainActor.assumeIsolated {
+                        self?.recordTombstones(tombstones, persisted: persistedNames)
+                    }
+                }
+                // The handshake `roster` just performed recorded this
                 // route's device; naming it here is the visible proof that the
                 // app knows *which machine* it is talking to, not just a socket.
                 if let device = TermiodDeviceRegistry.shared.device(for: route) {
@@ -200,6 +284,41 @@ extension TermioStore {
                 """)
             }
         }
+    }
+
+    // MARK: - Tombstones
+
+    /// Files the daemon's graveyard, and says out loud what happened to any row
+    /// this app restored whose session did not survive.
+    ///
+    /// The tombstone list is capped host-side (100, newest first), so this keeps
+    /// what it is given rather than accumulating forever, and only for names
+    /// that map to a session this app knows — another client's sessions are not
+    /// this app's story to tell.
+    func recordTombstones(_ tombstones: [Termiod.SessionTombstone], persisted: Set<String>) {
+        termiodTombstones = Dictionary(
+            tombstones.filter { persisted.contains($0.name) }.map { ($0.name, $0) },
+            uniquingKeysWith: { first, _ in first } // newest first: the first wins
+        )
+        for tombstone in termiodTombstones.values.sorted(by: { $0.endedUnix > $1.endedUnix }) {
+            Log.termiod.info("""
+            termiod session name=\(tombstone.name, privacy: .public) ended: \
+            \(tombstone.reason, privacy: .public) \
+            (status \(tombstone.status, privacy: .public), \
+            exit \(tombstone.exitStatus.map(String.init) ?? "unknown", privacy: .public))
+            """)
+        }
+    }
+
+    /// How a session's termiod counterpart died, if it did. `nil` for a session
+    /// that is running, that never ran, or whose tombstone has aged out of the
+    /// daemon's capped graveyard.
+    ///
+    /// The reason is the host's word (`exited` · `killed` · `daemon_lost`);
+    /// turning it into something a person reads is the caller's job, because the
+    /// host describes state and never decides presentation.
+    func termiodEndReason(for id: Session.ID) -> Termiod.SessionTombstone? {
+        termiodTombstones[id.uuidString]
     }
 
     // MARK: - Remote terminals (per-session SSH host)

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -42,7 +42,9 @@ extension TermioStore {
                 rows: UInt16(clamping: lastHostGridRows),
                 cols: UInt16(clamping: lastHostGridColumns))
         return TermiodSessionLink(
-            sessionName: session.id.uuidString,
+            // Its uuid for a session Termio opened; the name it already had for
+            // one adopted off the device's roster (see `Session.termiodSessionName`).
+            sessionName: daemonSessionName(for: session),
             specification: specification,
             route: route,
             rows: lastHostGridRows,
@@ -86,6 +88,11 @@ extension TermioStore {
         // machine it is on, with no extra round trip.
         link.onDevice = { [weak self] device in
             self?.adoptDevice(device, forRoute: link.route)
+            // An attach that succeeded is proof the session is running now, which
+            // outranks a grave dug before it. Without this, a row whose session
+            // was buried and then reopened keeps reading "ended" until the next
+            // roster arrives — the app disagreeing with the terminal beside it.
+            self?.termiodTombstones[link.sessionName] = nil
         }
         // The `events` half of the negotiated capabilities. Status is the one
         // that matters: an agent running on a VPS reports to the daemon that
@@ -226,62 +233,97 @@ extension TermioStore {
         }
     }
 
-    /// Startup roster check over a control-role channel: which persisted
-    /// sessions have a live counterpart in the daemon (and will therefore
-    /// reattach when surfaced) versus which will spawn fresh. Purely
-    /// diagnostic — the attach-by-name above is what actually decides.
+    // MARK: - The current device's roster
+
+    /// Asks the **current device** what is running on it, and publishes the answer.
     ///
-    /// Only this Mac's own device is asked. Reaching every known route at launch
-    /// would put an SSH round trip (216–292 ms cold) on the startup path for a
-    /// diagnostic; the cross-device roster is a deliberate later step, not a
-    /// side effect of logging.
-    func logTermiodRoster() {
+    /// This is the only source of the session list a device's world is drawn from.
+    /// It is a `list` over that device's own control channel — for this Mac a Unix
+    /// socket, for anything else `ssh <alias> termiod stdio` — so the same code
+    /// path serves every machine and this Mac is not a special case. What comes
+    /// back includes sessions this app never opened, which is the difference
+    /// between reading a device's state and filtering your own.
+    ///
+    /// Runs off the main thread (an SSH round trip is 216–292 ms cold) and drops
+    /// its reply if the user has moved on to another device meanwhile.
+    func refreshDeviceSessions() {
+        guard Termiod.isEnabled else {
+            deviceSessions = .unavailable
+            return
+        }
+        let device = currentDevice
+        let route = device.route
         let persistedNames = Set(projects.flatMap { project in
-            project.sessions.map { $0.id.uuidString }
+            project.sessions.map(daemonSessionName(for:))
         })
-        let route = TermiodRoute(sshAlias: Termiod.remoteHost)
-        DispatchQueue.global(qos: .utility).async { [weak self] in
+        deviceSessionsGeneration += 1
+        let generation = deviceSessionsGeneration
+        deviceSessions = .loading
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let outcome: Result<Termiod.SessionsPayload, Error>
             do {
-                let roster = try Termiod.roster(route: route)
-                let live = roster.sessions
-                // The graveyard is the other half of the answer, and the half
-                // that explains an empty list. Recorded before the live rows are
-                // logged so `termiodEndReason` is populated by the time anything
-                // asks why a row it restored has no session behind it.
-                let tombstones = roster.tombstones
-                DispatchQueue.main.async {
-                    MainActor.assumeIsolated {
-                        self?.recordTombstones(tombstones, persisted: persistedNames)
-                    }
-                }
-                // The handshake `roster` just performed recorded this
-                // route's device; naming it here is the visible proof that the
-                // app knows *which machine* it is talking to, not just a socket.
-                if let device = TermiodDeviceRegistry.shared.device(for: route) {
-                    Log.termiod.info("""
-                    device \(device.id, privacy: .public) \
-                    running \(device.daemonVersion, privacy: .public) \
-                    reachable via \(route.description, privacy: .public); \
-                    known routes: \
-                    \(device.routes.map(\.description).joined(separator: ", "), privacy: .public)
-                    """)
-                }
-                for information in live where information.alive {
-                    let verdict = persistedNames.contains(information.name)
-                        ? "will reattach" : "no matching app session"
-                    Log.termiod.info("""
-                    live termiod session name=\(information.name, privacy: .public) \
-                    pid=\(information.pid, privacy: .public) — \(verdict, privacy: .public)
-                    """)
-                }
-                if live.isEmpty {
-                    Log.termiod.info("no live termiod sessions at startup")
-                }
+                outcome = .success(try Termiod.roster(route: route))
             } catch {
-                Log.termiod.error("""
-                startup roster list failed: \
-                \(error.localizedDescription, privacy: .public)
+                outcome = .failure(error)
+            }
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    guard let self, self.deviceSessionsGeneration == generation else { return }
+                    self.applyRoster(outcome, from: device, route: route,
+                                     persisted: persistedNames)
+                }
+            }
+        }
+    }
+
+    private func applyRoster(
+        _ outcome: Result<Termiod.SessionsPayload, Error>,
+        from device: KnownDevice,
+        route: TermiodRoute,
+        persisted: Set<String>
+    ) {
+        switch outcome {
+        case .failure(let error):
+            deviceSessions = .failed(error.localizedDescription)
+            Log.termiod.error("""
+            roster of \(route.description, privacy: .public) failed: \
+            \(error.localizedDescription, privacy: .public)
+            """)
+        case .success(let payload):
+            let live = payload.sessions.filter(\.alive)
+            // The graveyard is the other half of the answer, and the half that
+            // explains an empty list. Recorded before anything reads the rows so
+            // `termiodEndReason` is populated by the time the sidebar asks why a
+            // row it restored has no session behind it.
+            recordTombstones(payload.tombstones, live: live, persisted: persisted)
+            deviceSessions = .ready(
+                DeviceSessions(live: live, tombstones: payload.tombstones))
+            // The handshake `roster` just performed recorded this route's device;
+            // naming it here is the visible proof that the app knows *which
+            // machine* it is talking to, not just a socket.
+            if let identified = TermiodDeviceRegistry.shared.device(for: route) {
+                adoptDevice(identified, forRoute: route)
+                Log.termiod.info("""
+                device \(identified.id, privacy: .public) \
+                running \(identified.daemonVersion, privacy: .public) \
+                reachable via \(route.description, privacy: .public); \
+                known routes: \
+                \(identified.routes.map(\.description).joined(separator: ", "), privacy: .public)
                 """)
+            }
+            for information in live {
+                let verdict = persisted.contains(information.name)
+                    ? "has a row here" : "opened elsewhere"
+                Log.termiod.info("""
+                live session on \(device.name, privacy: .public): \
+                name=\(information.name, privacy: .public) \
+                pid=\(information.pid, privacy: .public) \
+                status=\(information.status, privacy: .public) — \
+                \(verdict, privacy: .public)
+                """)
+            }
+            if live.isEmpty {
+                Log.termiod.info("no live sessions on \(device.name, privacy: .public)")
             }
         }
     }
@@ -291,16 +333,25 @@ extension TermioStore {
     /// Files the daemon's graveyard, and says out loud what happened to any row
     /// this app restored whose session did not survive.
     ///
-    /// The tombstone list is capped host-side (100, newest first), so this keeps
-    /// what it is given rather than accumulating forever, and only for names
-    /// that map to a session this app knows — another client's sessions are not
-    /// this app's story to tell.
-    func recordTombstones(_ tombstones: [Termiod.SessionTombstone], persisted: Set<String>) {
-        termiodTombstones = Dictionary(
-            tombstones.filter { persisted.contains($0.name) }.map { ($0.name, $0) },
-            uniquingKeysWith: { first, _ in first } // newest first: the first wins
-        )
-        for tombstone in termiodTombstones.values.sorted(by: { $0.endedUnix > $1.endedUnix }) {
+    /// Merged rather than replaced, because each device buries its own dead and a
+    /// switch must not erase what the machine you just left told you. A name that
+    /// came back **live** in this reply loses its tombstone: the session was
+    /// restarted under the same name, so the grave is stale.
+    ///
+    /// Only names that map to a session this app knows are kept — another
+    /// client's sessions are not this app's story to tell, and the host caps the
+    /// list at 100 anyway.
+    func recordTombstones(
+        _ tombstones: [Termiod.SessionTombstone],
+        live: [Termiod.SessionInformation],
+        persisted: Set<String>
+    ) {
+        for information in live { termiodTombstones[information.name] = nil }
+        let liveNames = Set(live.map(\.name))
+        // Newest first, so the first tombstone for a name is the one to keep.
+        for tombstone in tombstones.reversed()
+        where persisted.contains(tombstone.name) && !liveNames.contains(tombstone.name) {
+            termiodTombstones[tombstone.name] = tombstone
             Log.termiod.info("""
             termiod session name=\(tombstone.name, privacy: .public) ended: \
             \(tombstone.reason, privacy: .public) \
@@ -318,7 +369,61 @@ extension TermioStore {
     /// turning it into something a person reads is the caller's job, because the
     /// host describes state and never decides presentation.
     func termiodEndReason(for id: Session.ID) -> Termiod.SessionTombstone? {
-        termiodTombstones[id.uuidString]
+        guard let session = session(id) else { return nil }
+        return termiodTombstones[daemonSessionName(for: session)]
+    }
+
+    // MARK: - Adopting a session the device already had
+
+    /// Takes a session the **device** reports but this app has no row for, and
+    /// gives it one.
+    ///
+    /// This is what makes the roster more than a read-only display: a session
+    /// started from `termiod` on the box, or by a phone, is a session on that
+    /// device, and a viewer of that device should be able to open it. The row
+    /// keeps the name the device gave it (`termiodSessionName`) instead of being
+    /// renamed to a fresh uuid, because the name is how the daemon is asked for
+    /// that exact PTY.
+    func adoptDeviceSession(_ information: Termiod.SessionInformation) {
+        guard Termiod.isEnabled else {
+            presentTermiodDisabledAlert()
+            return
+        }
+        let device = currentDevice
+        var session = Session(title: information.title ?? information.name, agent: .terminal)
+        session.termiodSessionName = information.name.isEmpty ? information.id : information.name
+        session.termiodRemoteHost = device.alias
+        session.deviceID = device.deviceID
+        session.termiodRemoteCwd = information.cwd.isEmpty ? nil : information.cwd
+        // Filed where the device's other rows live: its own block for another
+        // machine, the loose funnel for this one. Both are viewer-side containers;
+        // the workspace a session really belongs to is the device's to say, and
+        // it cannot say it yet (device architecture §2.2).
+        let containerID: Project.ID
+        if let alias = device.alias {
+            containerID = hostContainer(for: alias, remoteRoot: session.termiodRemoteCwd)
+        } else if let terminals = projects.first(where: { $0.kind == .terminals }) {
+            containerID = terminals.id
+        } else {
+            let container = Project(
+                name: "Terminals",
+                path: FileManager.default.homeDirectoryForCurrentUser.path,
+                branch: "—",
+                sessions: [session],
+                kind: .terminals
+            )
+            projects.append(container)
+            selectedSessionID = session.id
+            return
+        }
+        guard let index = projects.firstIndex(where: { $0.id == containerID }) else {
+            Log.termiod.error("""
+            adopting \(information.name, privacy: .public) found no container to file it under
+            """)
+            return
+        }
+        projects[index].sessions.append(session)
+        selectedSessionID = session.id
     }
 
     // MARK: - Remote terminals (per-session SSH host)
@@ -418,6 +523,9 @@ extension TermioStore {
         // learns its device on first attach.
         session.deviceID = deviceID
         session.termiodRemoteCwd = cwd
+        // Selecting it below is what enters the machine (see the selection's
+        // `didSet`), so a terminal opened on another device never lands in a world
+        // the window is not showing.
 
         // A remote terminal opened from a project belongs to that project — the
         // row you clicked is the row it appears under. Everything else belongs to

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -336,7 +336,7 @@ extension TermioStore {
     /// otherwise the first `termiod stdio` over SSH would fail and the pane would
     /// sit dead.
     ///
-    /// `cwd` (used by "Clone on Remote…") is the remote directory the shell spawns
+    /// `cwd` (used by "Clone to <device>…") is the remote directory the shell spawns
     /// in; `title` overrides the sidebar label (the host alias by default, or a
     /// repo name for a clone).
     func addRemoteTerminal(
@@ -367,7 +367,7 @@ extension TermioStore {
                 var title = title
                 // Opened from a project row: the user means "this repo, on that
                 // machine". The local path doesn't exist over there, so the only
-                // honest answer is the checkout `Clone on Remote…` recorded.
+                // honest answer is the checkout `Clone to <device>…` recorded.
                 // Without one, say so rather than silently dropping a `$HOME`
                 // shell into the Terminals bucket — that mismatch between where
                 // you clicked and what you got is exactly the confusion this
@@ -388,14 +388,14 @@ extension TermioStore {
         }
     }
 
-    /// The project has never been cloned to this host, so there is nothing to
+    /// The project has never been cloned to this device, so there is nothing to
     /// `cd` into. Name the action that would fix it.
     private func presentRemoteCheckoutMissing(host: String, project: String) {
         let alert = NSAlert()
         alert.messageText = "\(project) isn't on \(host) yet"
         alert.informativeText =
-            "Use \"Clone on Remote… ▸ \(host)\" first. termio then remembers where the "
-            + "clone lives and opens future remote terminals inside it."
+            "Use \"Clone to \(host)…\" first. Termio then remembers where the "
+            + "clone lives and opens future terminals on \(host) inside it."
         alert.alertStyle = .informational
         alert.addButton(withTitle: "OK")
         alert.runModal()
@@ -605,7 +605,7 @@ extension TermioStore {
         alert.runModal()
     }
 
-    // MARK: - Clone on Remote
+    // MARK: - Clone to a device
 
     /// Clones a project's `origin` **onto** `host` (git clone runs on the remote,
     /// not an rsync from the Mac — decided with the user), then opens a remote

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -10,11 +10,37 @@ import Foundation
 ///
 /// Framing is `[kind: u8][length: u32 big-endian][payload]`. Control payloads
 /// are JSON; `D` (data) is raw PTY bytes and `R` (resize) is rows/cols as two
-/// big-endian u16. This client negotiates no optional capability yet — without
-/// `snapshot` the daemon bootstraps an attach with a ring-buffer byte replay,
-/// which is the accepted (possibly torn) repaint for this slice; the clean `S`
-/// snapshot path is the next one.
+/// big-endian u16.
 enum Termiod {
+    /// What this client offers on an **attach** channel, and — the part that
+    /// matters — who consumes each. A capability is a promise to handle the
+    /// frames it unlocks: offering one with nothing behind it is worse than not
+    /// offering it, because the daemon then spends bandwidth on frames that are
+    /// dropped on the floor. The daemon's full set is `HOST_CAPABILITIES` in
+    /// termiod/src/protocol.rs; the stance on every one of them:
+    ///
+    /// | Capability   | Offered | Consumer |
+    /// | ------------ | ------- | -------- |
+    /// | `snapshot`   | yes     | `S` → `TermiodSnapshot.render` → the surface's repaint |
+    /// | `events`     | yes     | `E` → `TermiodSessionLink.onStatus` (agent status), `applyWriter` (write gating), `applyAuthoritativeGrid` (§C.5 dimensions) |
+    /// | `scrollback` | no      | `H` carries packed cells to inject *above* the viewport; a byte-stream surface has nowhere to put them |
+    /// | `grid_diff`  | no      | `G` would make the host resolve every cell's colour, which overrides the viewer's theme — the §A/§H regression this client exists not to repeat |
+    /// | `send_wait`  | no      | `send`/`wait` are control-channel verbs; the app injects through its own attach channel |
+    /// | `resources`  | no      | `subscribe_resource` — the file tree and git panes are the consumers, on their own channel |
+    /// | `fs_watch`   | no      | ditto |
+    /// | `files`      | no      | ditto |
+    /// | `upload`     | no      | remote paste; rides a control channel, not an attachment |
+    /// | `git`        | no      | ditto |
+    ///
+    /// A later plane opens its own channel and passes its own `caps` to
+    /// `withControlChannel` — capabilities are per-connection, so nothing here
+    /// has to grow for the file tree or git to land.
+    static let attachCapabilities = ["snapshot", "events"]
+
+    /// What a plain control channel (`list`, `kill`) offers: nothing. Both verbs
+    /// are unconditional, and tombstones ride the `sessions` reply un-gated.
+    static let controlCapabilities: [String] = []
+
     /// Checked once — the flag flips the app's session backend wholesale, so a
     /// mid-run change could not be honored anyway.
     static let isEnabled = ProcessInfo.processInfo.environment["TERMIO_TERMIOD"] == "1"
@@ -568,6 +594,21 @@ enum Termiod {
 
     struct SessionsPayload: Decodable {
         let sessions: [SessionInformation]
+        /// Sessions that have died, newest first. Absent on a daemon too old to
+        /// bury them, which is why it decodes to an empty list rather than
+        /// failing the reply.
+        let tombstones: [SessionTombstone]
+
+        private enum CodingKeys: String, CodingKey {
+            case sessions, tombstones
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            sessions = try container.decode([SessionInformation].self, forKey: .sessions)
+            tombstones = try container.decodeIfPresent(
+                [SessionTombstone].self, forKey: .tombstones) ?? []
+        }
     }
 
     /// The subset of `termiod list` this client acts on; unknown fields are
@@ -579,6 +620,110 @@ enum Termiod {
         let alive: Bool
     }
 
+    /// A dead session, as the daemon buried it (termiod/src/tombstone.rs). This
+    /// is the only answer to "where did my session go?": a daemon that died
+    /// takes every PTY with it, and without a tombstone the roster just comes
+    /// back empty, which reads as "nothing was running".
+    ///
+    /// `reason` stays a string, not an enum, so a later daemon can bury a
+    /// session for a reason this build has never heard of without the reply
+    /// failing to decode. The host names the cause; the words shown to a person
+    /// are the client's to choose (see `TermioStore.termiodEndReason(for:)`).
+    struct SessionTombstone: Decodable, Sendable, Hashable {
+        let id: String
+        /// The termiod session name — which, for sessions this app created, is
+        /// the app `Session.ID` uuid string. That is what ties a tombstone back
+        /// to a row in the sidebar.
+        let name: String
+        let cwd: String
+        let command: String
+        /// `exited` · `killed` · `daemon_lost`, or whatever a newer daemon adds.
+        let reason: String
+        /// The process's exit code. Absent for `daemon_lost` — the daemon that
+        /// would have reaped the child died first, so there is no honest answer.
+        let exitStatus: Int32?
+        let createdUnix: UInt64
+        let endedUnix: UInt64
+        let agentID: String?
+        let title: String?
+        /// The workstream status the session last reported. A session that died
+        /// while `needs_you` is a different story from one that died `idle`.
+        let status: String
+
+        private enum CodingKeys: String, CodingKey {
+            case id, name, cwd, command, reason, exitStatus, createdUnix, endedUnix
+            case agentID = "agentId"
+            case title, status
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            cwd = try container.decodeIfPresent(String.self, forKey: .cwd) ?? ""
+            command = try container.decodeIfPresent(String.self, forKey: .command) ?? ""
+            reason = try container.decodeIfPresent(String.self, forKey: .reason) ?? "unknown"
+            exitStatus = try container.decodeIfPresent(Int32.self, forKey: .exitStatus)
+            createdUnix = try container.decodeIfPresent(UInt64.self, forKey: .createdUnix) ?? 0
+            endedUnix = try container.decodeIfPresent(UInt64.self, forKey: .endedUnix) ?? 0
+            agentID = try container.decodeIfPresent(String.self, forKey: .agentID)
+            title = try container.decodeIfPresent(String.self, forKey: .title)
+            status = try container.decodeIfPresent(String.self, forKey: .status) ?? "unknown"
+        }
+    }
+
+    /// Who owns the write token now. `writer` is a daemon-scoped client id, so
+    /// the only client that can tell whether it is the writer is the one that
+    /// remembers its own `client_id` from `hello_ok`.
+    struct WriterChangedPayload: Decodable, Sendable {
+        let session: String
+        let writer: String?
+    }
+
+    /// The authoritative PTY grid after a resize. Every client is required to
+    /// parse at these dimensions (§C.5) — an observer whose window is a
+    /// different size wraps the same bytes differently and diverges.
+    struct ResizedPayload: Decodable, Sendable {
+        let session: String
+        let rows: UInt16
+        let cols: UInt16
+    }
+
+    /// A workstream status delta — `working · idle · needs_you · done · failed ·
+    /// unknown` (§4). The host reports the *state*; which dot, which words, and
+    /// whether it fires a notification are entirely the client's call.
+    struct StatusPayload: Decodable, Sendable {
+        let session: String
+        let status: String
+        let title: String?
+    }
+
+    struct SessionExitedPayload: Decodable, Sendable {
+        let session: String
+        let status: Int32
+    }
+
+    /// Decoded `E` frames. Unknown events become `.unknown` and are ignored,
+    /// matching the protocol's additive-evolution rule.
+    enum IncomingEvent {
+        case ready(String)
+        case status(StatusPayload)
+        case writerChanged(WriterChangedPayload)
+        case resized(ResizedPayload)
+        case sessionExited(SessionExitedPayload)
+        case unknown(String)
+    }
+
+    private struct EventTag: Decodable {
+        let ev: String
+    }
+
+    /// Every event names its session and nothing else is required — enough to
+    /// decode `ready`, and the shape any future session-scoped event shares.
+    private struct SessionScopedPayload: Decodable {
+        let session: String
+    }
+
     /// Decoded control frames the client reacts to. Anything else — unknown
     /// ops, responses this slice doesn't consume — becomes `.unknown` and is
     /// ignored, matching the protocol's additive-evolution rule.
@@ -588,6 +733,11 @@ enum Termiod {
         case attached(AttachedPayload)
         case exited(ExitedPayload)
         case sessions(SessionsPayload)
+        /// The addressed half of `writer_changed`: sent to one client to tell it
+        /// who owns size now (§C.5). Same payload shape, so it feeds the same
+        /// handler — a client that only listened to the broadcast would still be
+        /// correct, and one that only listened to this would not.
+        case resizeClaim(WriterChangedPayload)
         case error(ErrorPayload)
         case unknown(String)
     }
@@ -613,6 +763,8 @@ enum Termiod {
             return .exited(try decoder.decode(ExitedPayload.self, from: payload))
         case "sessions":
             return .sessions(try decoder.decode(SessionsPayload.self, from: payload))
+        case "resize_claim":
+            return .resizeClaim(try decoder.decode(WriterChangedPayload.self, from: payload))
         case "error":
             return .error(try decoder.decode(ErrorPayload.self, from: payload))
         default:
@@ -620,22 +772,57 @@ enum Termiod {
         }
     }
 
+    /// Decodes an `E` frame. Same additive contract as `decodeControl`: an event
+    /// this build has never heard of is `.unknown`, never a decode failure.
+    static func decodeEvent(_ payload: Data) throws -> IncomingEvent {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let tag = try decoder.decode(EventTag.self, from: payload)
+        switch tag.ev {
+        case "ready":
+            return .ready(try decoder.decode(SessionScopedPayload.self, from: payload).session)
+        case "status":
+            return .status(try decoder.decode(StatusPayload.self, from: payload))
+        case "writer_changed":
+            return .writerChanged(try decoder.decode(WriterChangedPayload.self, from: payload))
+        case "resized":
+            return .resized(try decoder.decode(ResizedPayload.self, from: payload))
+        case "session_exited":
+            return .sessionExited(try decoder.decode(SessionExitedPayload.self, from: payload))
+        default:
+            return .unknown(tag.ev)
+        }
+    }
+
     // MARK: - Handshake and control channel
 
-    /// Sends `hello` and waits for `hello_ok`. An attach channel offers the
-    /// `snapshot` capability so a reattach bootstraps from the daemon's
-    /// authoritative VT (one clean `S` repaint) instead of ring replay; the
-    /// control channel negotiates nothing. `scrollback`/`grid_diff` stay
-    /// unoffered — a byte-stream surface can neither inject history above the
-    /// viewport nor consume dirty-row diffs (a deeper libghostty integration).
+    /// Everything one handshake settles. A connection is not just a pipe to a
+    /// machine: it is a pipe with an identity (`clientID`) and a contract
+    /// (`capabilities`), and both are needed to act correctly afterwards —
+    /// `writer_changed` names a client id, so a client that forgot its own
+    /// cannot tell whether the token is its.
+    struct Handshake: Sendable {
+        let device: TermiodDevice
+        /// This connection's daemon-assigned id. Per-connection: it changes on
+        /// every reattach and must never be persisted.
+        let clientID: String
+        /// What the daemon actually granted — always a subset of what was
+        /// offered, and empty on a daemon too old to answer. Check it before
+        /// waiting on a frame the host may never send.
+        let capabilities: Set<String>
+    }
+
+    /// Sends `hello` and waits for `hello_ok`. Callers pass the capabilities
+    /// they have consumers for — `attachCapabilities` for a session channel,
+    /// and whatever a later plane needs for its own (see that table).
     ///
-    /// Returns the **device** on the other end. This is the only moment a route's
-    /// destination is knowable: a handshake is what turns `ssh vps-wan` from a
-    /// string into a machine, and recording it here means every path that reaches
-    /// a daemon — attach, list, kill — teaches the registry for free.
+    /// The handshake is also the only moment a route's destination is knowable:
+    /// it is what turns `ssh vps-wan` from a string into a machine, and
+    /// recording it here means every path that reaches a daemon — attach, list,
+    /// kill — teaches the registry for free.
     @discardableResult
     static func performHello(_ transport: Transport, role: String,
-                             caps: [String] = []) throws -> TermiodDevice {
+                             caps: [String] = []) throws -> Handshake {
         let hello = HelloOperation(
             proto: protocolVersion,
             minProto: protocolVersion,
@@ -648,8 +835,20 @@ enum Termiod {
         guard reply.kind == .control else { throw TermiodClientError.malformedFrame }
         switch try decodeControl(reply.payload) {
         case .helloOk(let payload):
-            return TermiodDeviceRegistry.shared.record(
+            let device = TermiodDeviceRegistry.shared.record(
                 hostID: payload.hostId, daemonVersion: payload.host, route: transport.route)
+            // An offer the daemon dropped is not an error — negotiate, never
+            // lockstep — but it does change what this connection can expect, so
+            // it is worth saying out loud once per channel.
+            let refused = Set(caps).subtracting(payload.caps)
+            if !refused.isEmpty {
+                Log.termiod.info("""
+                \(role, privacy: .public) channel to \(device.id, privacy: .public) \
+                declined capabilities: \(refused.sorted().joined(separator: ", "), privacy: .public)
+                """)
+            }
+            return Handshake(
+                device: device, clientID: payload.clientId, capabilities: Set(payload.caps))
         case .helloError(let message):
             throw TermiodClientError.handshakeRejected(message)
         case .error(let payload):
@@ -661,14 +860,21 @@ enum Termiod {
 
     /// One-shot control request: connect, hello as `control`, run `body`,
     /// close. Used for `list` at startup and `kill` on Close Session.
-    private static func withControlChannel<Result>(
+    ///
+    /// `caps` is the seam for the planes that come next: a file tree opens this
+    /// with `["resources", "files"]`, a git pane adds `"git"`, and neither has
+    /// to touch the attach path to do it. `body` receives the handshake so it
+    /// can check what was actually granted before it asks for anything.
+    @discardableResult
+    static func withControlChannel<Result>(
         route: TermiodRoute = .local,
-        _ body: (Transport) throws -> Result
+        caps: [String] = controlCapabilities,
+        _ body: (Transport, Handshake) throws -> Result
     ) throws -> Result {
         let transport = try Transport.open(route)
         defer { transport.close() }
-        try performHello(transport, role: "control")
-        return try body(transport)
+        let handshake = try performHello(transport, role: "control", caps: caps)
+        return try body(transport, handshake)
     }
 
     /// Connect, shake hands, hang up: the cheapest question you can ask a route,
@@ -678,11 +884,16 @@ enum Termiod {
     static func probeDevice(route: TermiodRoute) throws -> TermiodDevice {
         let transport = try Transport.open(route)
         defer { transport.close() }
-        return try performHello(transport, role: "control")
+        return try performHello(transport, role: "control").device
     }
 
-    static func listSessions(route: TermiodRoute = .local) throws -> [SessionInformation] {
-        try withControlChannel(route: route) { transport in
+    /// The daemon's answer to "what is running?" — which, to be honest, has to
+    /// include what *was* running: a daemon that died takes every session with
+    /// it, and a live list alone would report that as "nothing". The tombstones
+    /// ride the same reply, so there is no second round trip and no window where
+    /// the two disagree.
+    static func roster(route: TermiodRoute = .local) throws -> SessionsPayload {
+        try withControlChannel(route: route) { transport, _ in
             try writeFrame(transport.writeDescriptor, kind: .control,
                            payload: encodeControl(ListOperation(seq: 1)))
             while true {
@@ -690,7 +901,7 @@ enum Termiod {
                 guard frame.kind == .control else { continue }
                 switch try decodeControl(frame.payload) {
                 case .sessions(let payload):
-                    return payload.sessions
+                    return payload
                 case .error(let payload):
                     throw TermiodClientError.requestFailed(payload.message)
                 default:
@@ -706,7 +917,7 @@ enum Termiod {
     static func killSession(target: String, route: TermiodRoute = .local) {
         DispatchQueue.global(qos: .utility).async {
             do {
-                try withControlChannel(route: route) { transport in
+                try withControlChannel(route: route) { transport, _ in
                     try writeFrame(transport.writeDescriptor, kind: .control,
                                    payload: encodeControl(KillOperation(id: target, seq: 1)))
                     // One reply either way; "no such session" just means the
@@ -771,6 +982,14 @@ enum TermiodClientError: LocalizedError {
     }
 }
 
+/// A terminal grid. A named pair rather than a tuple so "is the PTY already
+/// this size?" is one comparison the compiler checks, on a path where getting
+/// it wrong costs every viewer a repaint.
+struct TerminalGrid: Equatable, Sendable {
+    let rows: UInt16
+    let cols: UInt16
+}
+
 /// One session's attach channel: the termiod-backed stand-in for what
 /// `PTYProcess` is on the in-process path. Owns the socket, forwards surface
 /// input as `D` frames and grid changes as `R` frames, and delivers the
@@ -788,18 +1007,28 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// daemon, `.ssh(alias)` for another box. The framed protocol and every other
     /// field are identical either way; only how the pipe is opened differs.
     let route: TermiodRoute
-    private let initialRows: UInt16
-    private let initialCols: UInt16
     private let startedAt = Date()
 
     private var transport: Termiod.Transport?
     private var attached = false
     private var isWriter = false
+    /// This connection's daemon-assigned id, from `hello_ok`. Without it a
+    /// `writer_changed` naming `c_41` is unreadable — the whole point of the
+    /// event is telling *this* client whether the token is still its.
+    private var clientID: String?
     /// Keystrokes typed during the connect/attach window — flushed, in order,
     /// the moment the channel is writable so nothing the user typed is lost.
     private var pendingInput = Data()
-    /// The latest grid reported before attach completed; applied once writable.
-    private var pendingResize: (rows: UInt16, cols: UInt16)?
+    /// The grid this client wants the PTY to be, updated by every `resize`
+    /// whether or not it can be sent yet.
+    private var desiredGrid: TerminalGrid
+    /// The last grid actually written as an `R` frame, so a redundant resize
+    /// isn't re-sent while the daemon is still applying the first one.
+    private var sentGrid: TerminalGrid?
+    /// The PTY's real size, from `attached` and then every `E resized`. This is
+    /// the authority — §C.5: a client that parses at its own window size instead
+    /// of this one wraps the same bytes differently and diverges from the host.
+    private var authoritativeGrid: TerminalGrid?
     /// Set on any deliberate teardown so the reader's EOF is not misread as a
     /// daemon crash.
     private var closed = false
@@ -819,6 +1048,20 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// child's true runtime; elapsed-since-attach serves ghostty's
     /// abnormal-exit heuristic the same way).
     var onExit: ((Int32, UInt64) -> Void)?
+    /// The session's workstream status as the host reports it (`working`,
+    /// `needs_you`, …) with the workstream title when one rides along. Fired on
+    /// the main queue for every `E status`.
+    ///
+    /// This is the only status channel a *remote* agent has: hooks on a VPS
+    /// cannot reach this Mac's control socket, so they report to the daemon that
+    /// owns the session and it fans the event down every attachment. The host
+    /// names the state and nothing more — which dot, which words, and whether a
+    /// notification fires stay entirely on this side.
+    var onStatus: ((Termiod.StatusPayload) -> Void)?
+    /// Whether this client currently holds the write token, on the main queue,
+    /// on every genuine change. The link already gates its own `R` frames on
+    /// this; the callback is for the UI that has to say "read-only" out loud.
+    var onWriter: ((Bool) -> Void)?
 
     init(sessionName: String,
          specification: Termiod.CreateSpecification,
@@ -828,8 +1071,7 @@ final class TermiodSessionLink: @unchecked Sendable {
         self.sessionName = sessionName
         self.specification = specification
         self.route = route
-        initialRows = UInt16(clamping: rows)
-        initialCols = UInt16(clamping: cols)
+        desiredGrid = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
     }
 
     /// Kicks off connect → hello → attach in the background. The caller wires
@@ -839,13 +1081,17 @@ final class TermiodSessionLink: @unchecked Sendable {
             do {
                 let channel = try Termiod.Transport.open(route)
                 transport = channel
-                let device = try Termiod.performHello(channel, role: "attach", caps: ["snapshot"])
+                let handshake = try Termiod.performHello(
+                    channel, role: "attach", caps: Termiod.attachCapabilities)
+                clientID = handshake.clientID
+                let device = handshake.device
                 DispatchQueue.main.async { [self] in onDevice?(device) }
+                let requested = desiredGrid
                 let payload = try Termiod.attachPayload(
                     target: sessionName,
                     specification: specification,
-                    rows: pendingResize?.rows ?? initialRows,
-                    cols: pendingResize?.cols ?? initialCols
+                    rows: requested.rows,
+                    cols: requested.cols
                 )
                 try Termiod.writeFrame(channel.writeDescriptor, kind: .control, payload: payload)
                 let reply = try Termiod.readFrame(channel.readDescriptor)
@@ -856,18 +1102,22 @@ final class TermiodSessionLink: @unchecked Sendable {
                 }
                 attached = true
                 isWriter = attachedPayload.writer
+                // `attached` reports the session's size *before* this attach is
+                // applied; the daemon then resizes to what a writer asked for and
+                // announces it as `E resized`. Seeding from the reply means an
+                // observer — which never triggers that resize — still knows the
+                // grid its bytes are wrapped at.
+                authoritativeGrid = TerminalGrid(
+                    rows: attachedPayload.rows, cols: attachedPayload.cols)
+                if isWriter { sentGrid = requested }
                 Log.termiod.info("""
                 attached session=\(self.sessionName, privacy: .public) \
                 device=\(device.id, privacy: .public) \
                 route=\(self.route.description, privacy: .public) \
                 writer=\(attachedPayload.writer, privacy: .public) \
+                caps=\(handshake.capabilities.sorted().joined(separator: ","), privacy: .public) \
                 \(attachedPayload.rows, privacy: .public)x\(attachedPayload.cols, privacy: .public)
                 """)
-                if let resize = pendingResize, isWriter {
-                    try Termiod.writeFrame(channel.writeDescriptor, kind: .resize,
-                                           payload: Self.resizePayload(resize.rows, resize.cols))
-                }
-                pendingResize = nil
                 // Only a writer may inject the keystrokes buffered during connect;
                 // an observer's input would be rejected frame-by-frame by the
                 // daemon. (This client always attaches `interact` today, so it is
@@ -908,19 +1158,16 @@ final class TermiodSessionLink: @unchecked Sendable {
     }
 
     func resize(rows: Int, cols: Int) {
-        let size = (rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
+        let size = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
         workQueue.async { [self] in
             guard !closed else { return }
-            guard attached else {
-                pendingResize = size
-                return
-            }
+            desiredGrid = size
+            guard attached else { return }
             // Observers must not resize the shared PTY out from under the
             // writer; the daemon would reject the frame anyway.
-            guard isWriter, let transport else { return }
+            guard isWriter else { return }
             do {
-                try Termiod.writeFrame(transport.writeDescriptor, kind: .resize,
-                                       payload: Self.resizePayload(size.rows, size.cols))
+                try sendResizeLocked(size)
             } catch {
                 Log.termiod.error("""
                 resize of \(self.sessionName, privacy: .public) failed: \
@@ -928,6 +1175,23 @@ final class TermiodSessionLink: @unchecked Sendable {
                 """)
             }
         }
+    }
+
+    /// Writes one `R` frame, unless the PTY is already that size and nothing
+    /// else is in flight. The skip is not a micro-optimisation: a resize is a
+    /// **barrier** host-side (§C.5) — the session quiesces, resizes, and emits a
+    /// fresh `S` keyframe to every attachment — so re-asserting a size the PTY
+    /// already has costs a full repaint for every viewer.
+    ///
+    /// Must run on `workQueue`.
+    private func sendResizeLocked(_ size: TerminalGrid) throws {
+        guard let transport else { return }
+        // Confirmed at this size, and nothing else on the wire that would move
+        // it away: the frame would be a pure no-op with a repaint attached.
+        if authoritativeGrid == size, sentGrid == nil || sentGrid == size { return }
+        sentGrid = size
+        try Termiod.writeFrame(transport.writeDescriptor, kind: .resize,
+                               payload: Self.resizePayload(size.rows, size.cols))
     }
 
     /// Leaves the stream but keeps the session alive in the daemon — the
@@ -995,6 +1259,10 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// error, or the session's exit notice.
     private func startReader(_ socket: Int32) {
         let thread = Thread { [weak self] in
+            // A frame kind this client never negotiated is a host bug, not
+            // traffic — logged once per kind so a misbehaving daemon is visible
+            // without a stream of identical lines.
+            var reportedUnexpected = Set<Termiod.FrameKind>()
             while true {
                 let frame: (kind: Termiod.FrameKind, payload: Data)
                 do {
@@ -1025,11 +1293,20 @@ final class TermiodSessionLink: @unchecked Sendable {
                     }
                 case .control:
                     if self.handleControl(frame.payload) { return }
-                case .event, .resize, .history, .grid:
-                    // `ready` (an `E` event) marks snapshot-complete but needs no
-                    // action — serial ordering already sequences S then D. The
-                    // rest is unnegotiated in this slice and safe to skip.
-                    break
+                case .event:
+                    if self.handleEvent(frame.payload) { return }
+                case .resize, .history, .grid:
+                    // `R` is client-to-host only, and `H`/`G` require the
+                    // `scrollback`/`grid_diff` capabilities this client
+                    // deliberately does not offer (see `attachCapabilities`).
+                    // Receiving one means the host sent a frame nobody asked
+                    // for — say so instead of dropping it silently.
+                    if reportedUnexpected.insert(frame.kind).inserted {
+                        Log.termiod.error("""
+                        unnegotiated \(String(UnicodeScalar(frame.kind.rawValue)), privacy: .public) \
+                        frame on \(self.sessionName, privacy: .public) — ignored
+                        """)
+                    }
                 }
             }
         }
@@ -1056,6 +1333,9 @@ final class TermiodSessionLink: @unchecked Sendable {
                 deliverExitLocked(status: exit.status)
             }
             return true
+        case .resizeClaim(let claim):
+            applyWriter(claim.writer)
+            return false
         case .error(let failure):
             Log.termiod.error("""
             daemon error on \(self.sessionName, privacy: .public): \
@@ -1064,6 +1344,102 @@ final class TermiodSessionLink: @unchecked Sendable {
             return false
         default:
             return false
+        }
+    }
+
+    /// Routes one `E` frame. Returns true when the reader should stop.
+    ///
+    /// Unlocked by the `events` capability, and each arm is why it is offered:
+    /// `status` is the product's core signal (an agent on a VPS has no other way
+    /// to reach this Mac), `writer_changed` keeps write gating honest as the
+    /// token moves, and `resized` carries the authoritative dimensions §C.5
+    /// requires every client to know.
+    private func handleEvent(_ payload: Data) -> Bool {
+        let event: Termiod.IncomingEvent
+        do {
+            event = try Termiod.decodeEvent(payload)
+        } catch {
+            Log.termiod.error("""
+            undecodable event frame on \(self.sessionName, privacy: .public): \
+            \(error.localizedDescription, privacy: .public)
+            """)
+            return false
+        }
+        switch event {
+        case .status(let status):
+            DispatchQueue.main.async { [self] in onStatus?(status) }
+        case .writerChanged(let change):
+            applyWriter(change.writer)
+        case .resized(let size):
+            applyAuthoritativeGrid(TerminalGrid(rows: size.rows, cols: size.cols))
+        case .sessionExited(let exit):
+            // The `exited` control frame says the same thing and normally lands
+            // first; both funnel into the same idempotent delivery, so whichever
+            // arrives is enough and neither can double-report.
+            workQueue.async { [self] in
+                teardownLocked()
+                deliverExitLocked(status: exit.status)
+            }
+            return true
+        case .ready:
+            // Snapshot-complete. No action: this reader is serial, so `S` has
+            // already been rendered by the time this frame is read.
+            break
+        case .unknown(let name):
+            Log.termiod.debug("""
+            ignoring \(name, privacy: .public) event on \(self.sessionName, privacy: .public)
+            """)
+        }
+        return false
+    }
+
+    /// Applies a writer-token change. The daemon names the writer by client id,
+    /// so this is the one comparison that tells this connection whether its `D`
+    /// and `R` frames will be honoured or answered with `not_writer`.
+    ///
+    /// Promotion re-asserts the grid: a client that was demoted stopped sending
+    /// resizes, so the PTY can be any size by the time the token comes back.
+    private func applyWriter(_ writer: String?) {
+        workQueue.async { [self] in
+            guard !closed else { return }
+            let mine = writer != nil && writer == clientID
+            guard mine != isWriter else { return }
+            isWriter = mine
+            Log.termiod.info("""
+            write token on \(self.sessionName, privacy: .public) \
+            \(mine ? "claimed" : "lost", privacy: .public)
+            """)
+            if mine {
+                do {
+                    try sendResizeLocked(desiredGrid)
+                } catch {
+                    Log.termiod.error("""
+                    reclaiming size on \(self.sessionName, privacy: .public) failed: \
+                    \(error.localizedDescription, privacy: .public)
+                    """)
+                }
+            }
+            DispatchQueue.main.async { [self] in onWriter?(mine) }
+        }
+    }
+
+    /// Records the PTY's real size. Two things read it: `sendResizeLocked`, so a
+    /// size the PTY already has never costs a barrier repaint, and the check
+    /// below — the PTY only diverges from what this client asked for when
+    /// another client owns the token, and that is the §C.5 case where this
+    /// window is wrapping bytes at the wrong width. Letterboxing the viewport
+    /// against it is the client-side step this foundation leaves open.
+    private func applyAuthoritativeGrid(_ grid: TerminalGrid) {
+        workQueue.async { [self] in
+            guard authoritativeGrid != grid else { return }
+            authoritativeGrid = grid
+            guard grid != desiredGrid else { return }
+            Log.termiod.info("""
+            \(self.sessionName, privacy: .public) PTY is now \
+            \(grid.rows, privacy: .public)x\(grid.cols, privacy: .public); \
+            this client renders \
+            \(self.desiredGrid.rows, privacy: .public)x\(self.desiredGrid.cols, privacy: .public)
+            """)
         }
     }
 

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -45,17 +45,6 @@ enum Termiod {
     /// mid-run change could not be honored anyway.
     static let isEnabled = ProcessInfo.processInfo.environment["TERMIO_TERMIOD"] == "1"
 
-    /// A dev/diagnostic host: which daemon `logTermiodRoster` inspects.
-    ///
-    /// It deliberately does **not** decide where sessions run. Host selection is
-    /// per-session (`Session.termiodRemoteHost`, set by the New Terminal device
-    /// picker and "Clone to <device>…"); when this was also a fallback it turned
-    /// every ordinary local terminal into a remote one.
-    static let remoteHost: String? = {
-        let host = ProcessInfo.processInfo.environment["TERMIO_TERMIOD_REMOTE"]
-        return (host?.isEmpty == false) ? host : nil
-    }()
-
     static let protocolVersion: UInt32 = 1
 
     /// Mirrors termiod/src/paths.rs exactly — both sides must derive the same
@@ -620,7 +609,7 @@ enum Termiod {
         let message: String
     }
 
-    struct SessionsPayload: Decodable {
+    struct SessionsPayload: Decodable, Sendable {
         let sessions: [SessionInformation]
         /// Sessions that have died, newest first. Absent on a daemon too old to
         /// bury them, which is why it decodes to an empty list rather than
@@ -639,13 +628,55 @@ enum Termiod {
         }
     }
 
-    /// The subset of `termiod list` this client acts on; unknown fields are
-    /// ignored so the daemon can grow the record additively.
-    struct SessionInformation: Decodable {
+    /// One row of `termiod list` — a session as the **device** describes it.
+    ///
+    /// This carries enough to draw a row without consulting anything on this Mac,
+    /// which is the point: a session the app never opened (started from the CLI,
+    /// or by another client) still has a name, a directory, a command, and an
+    /// agent status, and all four come from the machine it runs on. Unknown
+    /// fields are ignored and every field the daemon added after v0 decodes
+    /// optionally, so an older host degrades to blanks instead of a decode error.
+    struct SessionInformation: Decodable, Sendable, Hashable {
         let id: String
         let name: String
         let pid: Int32
         let alive: Bool
+        /// The directory the process runs in, **on the device**. Never a path on
+        /// this Mac, which is why it is only ever shown, never opened.
+        let cwd: String
+        let command: String
+        /// The workstream status the session last reported — `working · idle ·
+        /// needs_you · done · failed · unknown` (§4). The host names the state;
+        /// which dot it becomes is the client's call.
+        let status: String
+        let agentID: String?
+        /// The title the agent reported, when it reported one.
+        let title: String?
+        let createdUnix: UInt64
+        /// How many clients are attached right now. A non-zero count on a session
+        /// this app has no row for means someone else is watching it.
+        let attachedClients: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case id, name, pid, alive, cwd, command, status, title, createdUnix
+            case agentID = "agentId"
+            case attachedClients
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            pid = try container.decodeIfPresent(Int32.self, forKey: .pid) ?? 0
+            alive = try container.decodeIfPresent(Bool.self, forKey: .alive) ?? true
+            cwd = try container.decodeIfPresent(String.self, forKey: .cwd) ?? ""
+            command = try container.decodeIfPresent(String.self, forKey: .command) ?? ""
+            status = try container.decodeIfPresent(String.self, forKey: .status) ?? "unknown"
+            agentID = try container.decodeIfPresent(String.self, forKey: .agentID)
+            title = try container.decodeIfPresent(String.self, forKey: .title)
+            createdUnix = try container.decodeIfPresent(UInt64.self, forKey: .createdUnix) ?? 0
+            attachedClients = try container.decodeIfPresent(Int.self, forKey: .attachedClients) ?? 0
+        }
     }
 
     /// A dead session, as the daemon buried it (termiod/src/tombstone.rs). This
@@ -1071,7 +1102,10 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// through it — so no lock is needed.
     private let workQueue = DispatchQueue(label: "sh.termio.termiod.link", qos: .userInitiated)
 
-    private let sessionName: String
+    /// The name this channel attached under — the app session's uuid, or the
+    /// name a session already had on the device when it was adopted. Readable
+    /// because the store keys its tombstones by it.
+    let sessionName: String
     private let specification: Termiod.CreateSpecification
     /// The road to the device this session lives on — `.local` for this Mac's
     /// daemon, `.ssh(alias)` for another box. The framed protocol and every other

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -48,8 +48,8 @@ enum Termiod {
     /// A dev/diagnostic host: which daemon `logTermiodRoster` inspects.
     ///
     /// It deliberately does **not** decide where sessions run. Host selection is
-    /// per-session (`Session.termiodRemoteHost`, set by the New Remote Terminal
-    /// picker and "Clone on Remote…"); when this was also a fallback it turned
+    /// per-session (`Session.termiodRemoteHost`, set by the New Terminal device
+    /// picker and "Clone to <device>…"); when this was also a fallback it turned
     /// every ordinary local terminal into a remote one.
     static let remoteHost: String? = {
         let host = ProcessInfo.processInfo.environment["TERMIO_TERMIOD_REMOTE"]

--- a/Sources/termio/TermioStore/DeviceContext.swift
+++ b/Sources/termio/TermioStore/DeviceContext.swift
@@ -1,0 +1,242 @@
+import Foundation
+
+/// A machine Termio can work on, as the interface names it. This Mac is one, and
+/// so is every box the user has already reached — the word "remote" describes the
+/// road, not the thing at the end of it, so it appears nowhere.
+///
+/// The identity carried here is the `~/.ssh/config` alias, not the device's
+/// `host_id`, because a menu is built synchronously and the id only exists after
+/// a handshake. That is the same bootstrap/stable split `Project.sshHost` and
+/// `Project.deviceID` already record (device architecture §9.5): the alias is
+/// what a row is born from, `deviceID` is what it turns out to be. Two aliases
+/// that resolve to one machine therefore still show as two rows — merging them
+/// is §9.5's job and is deliberately not done here.
+///
+/// Lives at the store layer, not in the sidebar, because the device is not a
+/// sidebar control: it is the context every panel reads (`TermioStore.currentDevice`).
+struct KnownDevice: Identifiable, Hashable {
+    /// The alias this device is reached by, or `nil` for this Mac.
+    let alias: String?
+    /// The `host_id` a handshake revealed, `nil` until one has run.
+    let deviceID: String?
+
+    /// This Mac — a device like any other, distinguished only by having no alias
+    /// to reach it by. Nothing branches on this; it is the route that differs
+    /// (a Unix socket instead of `ssh <alias>`), and `TermiodRoute` already
+    /// carries that difference.
+    static let thisMac = KnownDevice(alias: nil, deviceID: nil)
+
+    var isLocal: Bool { alias == nil }
+    /// The switcher and every menu row name a device this way. This Mac has no
+    /// alias to show, and the host never supplies a display name (device
+    /// architecture §4), so the client picks one.
+    var name: String { alias ?? localized("This Mac") }
+    var id: String { alias ?? "" }
+
+    var route: TermiodRoute { TermiodRoute(sshAlias: alias) }
+}
+
+/// What one device says is running on it, as of the last `list`.
+///
+/// The device's reply is the authority for **which sessions exist**. Nothing in
+/// this app may substitute a locally-filtered array for it: filtering the Mac's
+/// own session list by alias would encode "all sessions are really this Mac's,
+/// tagged with where they went", which is the model the device architecture
+/// exists to replace (§2.1 — the Mac may hold nothing a viewer needs).
+struct DeviceSessions: Sendable {
+    /// Live sessions, in the order the device reported them.
+    var live: [Termiod.SessionInformation]
+    /// Sessions the device buried, newest first. The only answer to "where did my
+    /// session go?" — a daemon that died takes every PTY with it, and without
+    /// these the roster just comes back empty, which reads as "nothing ran".
+    var tombstones: [Termiod.SessionTombstone]
+}
+
+/// Whether the current device has answered yet, and what it said. A device is
+/// reached over a network, so "we do not know" is a real state and is shown as
+/// one rather than being flattened into an empty list.
+enum DeviceSessionsState {
+    /// The daemon backend is off (`TERMIO_TERMIOD` unset), so no device — this
+    /// Mac included — has a session host to ask.
+    case unavailable
+    case loading
+    case ready(DeviceSessions)
+    /// The device could not be reached, or refused. Carries what to tell the user.
+    case failed(String)
+
+    var sessions: DeviceSessions? {
+        if case .ready(let sessions) = self { return sessions }
+        return nil
+    }
+}
+
+/// One row of the current device's world.
+///
+/// The order of the cases is the order of authority. `running` comes from the
+/// device's `list` reply and is the only case that can assert a process exists;
+/// the other two describe rows this viewer authored whose process the device does
+/// not report, which is a different claim and is drawn differently.
+enum DeviceWorldRow: Identifiable {
+    /// A process the device says is running. The `Session` is this viewer's own
+    /// record of it — a title, a pin, an agent — and is `nil` for a session
+    /// started by the CLI or another client, which is exactly the case that
+    /// proves the list is not a local array.
+    case running(Termiod.SessionInformation, Session?)
+    /// A row this viewer authored that the device has no process for. Remote
+    /// sessions spawn on first attach (`create_if_missing`), so a session created
+    /// but never opened lives only here until it is clicked.
+    case notStarted(Session)
+    /// A row whose process the device buried, with the reason it gave.
+    case ended(Session, Termiod.SessionTombstone)
+
+    var id: String {
+        switch self {
+        case .running(let information, _): return "live:\(information.id)"
+        case .notStarted(let session): return "idle:\(session.id.uuidString)"
+        case .ended(let session, _): return "dead:\(session.id.uuidString)"
+        }
+    }
+
+    /// This viewer's record of the row, when it has one.
+    var session: Session? {
+        switch self {
+        case .running(_, let session): return session
+        case .notStarted(let session), .ended(let session, _): return session
+        }
+    }
+}
+
+extension TermioStore {
+    /// The device the app is currently looking at. Every panel takes its data
+    /// from here: switching is not a filter over one list, it is a different
+    /// machine's world.
+    var currentDevice: KnownDevice {
+        KnownDevice(
+            alias: currentDeviceAlias,
+            deviceID: TermiodDeviceRegistry.shared.deviceID(
+                for: TermiodRoute(sshAlias: currentDeviceAlias))
+        )
+    }
+
+    /// Enters a device: the app stops showing the machine it was on and starts
+    /// showing this one.
+    ///
+    /// Three things move together, and they have to, or the window says one thing
+    /// while the panes show another:
+    ///
+    /// 1. the context (`currentDeviceAlias`), which the sidebar and the window
+    ///    chrome read;
+    /// 2. the selection — a session on the machine you just left is not part of
+    ///    this world, and leaving it on screen is precisely the "thought I was
+    ///    local, was actually remote" accident;
+    /// 3. the roster, re-asked of the device now in front of you.
+    func switchToDevice(_ device: KnownDevice) {
+        guard currentDeviceAlias != device.alias else {
+            // Same device, but the user asked — treat it as "refresh this one".
+            refreshDeviceSessions()
+            return
+        }
+        currentDeviceAlias = device.alias
+        // Persistence only. The live truth is the published property above; the
+        // defaults entry exists so the next launch starts where this one ended.
+        settings.currentDeviceAlias = device.alias
+        // Clearing beats guessing: with no session on the new device the detail
+        // pane shows the welcome state, which is the honest picture of a machine
+        // you have not opened anything on yet.
+        selectedSessionID = firstSession(onDevice: device)?.id
+        refreshDeviceSessions()
+    }
+
+    /// Follows a session onto its machine. Called from the selection's `didSet`,
+    /// so it must not move the selection back — it changes the context only.
+    func enterDevice(of id: Session.ID) {
+        guard let session = session(id) else { return }
+        let alias = session.termiodRemoteHost ?? session.sshHost
+        guard alias != currentDeviceAlias else { return }
+        currentDeviceAlias = alias
+        settings.currentDeviceAlias = alias
+        refreshDeviceSessions()
+    }
+
+    /// The current device's rows: what the device reports, then the rows this
+    /// viewer holds that it did not.
+    ///
+    /// Running sessions lead and keep the device's own ordering — the device is
+    /// the authority for that list, so its order is the list's order. Everything
+    /// after is this app's own bookkeeping about rows the device did not mention.
+    func deviceWorld() -> [DeviceWorldRow] {
+        let device = currentDevice
+        let mine = sessions(authoredFor: device)
+        var rows: [DeviceWorldRow] = []
+        var claimed: Set<Session.ID> = []
+
+        for information in deviceSessions.sessions?.live ?? [] where information.alive {
+            let session = mine.first { daemonSessionName(for: $0) == information.name }
+            if let session { claimed.insert(session.id) }
+            rows.append(.running(information, session))
+        }
+
+        // A session the device did not list is not automatically gone: it may
+        // never have been started. The tombstone is what tells the two apart, so
+        // it decides which row gets drawn.
+        for session in mine where !claimed.contains(session.id) {
+            if let tombstone = termiodEndReason(for: session) {
+                rows.append(.ended(session, tombstone))
+            } else {
+                rows.append(.notStarted(session))
+            }
+        }
+        return rows
+    }
+
+    /// Whether the sidebar should draw this Mac's own workspaces — its projects,
+    /// worktrees, and loose funnels. They are the local device's state, and they
+    /// belong to the local device's context only.
+    var isShowingThisMac: Bool { currentDevice.isLocal }
+
+    /// The sessions this viewer authored **for** a device: its own records, which
+    /// decorate the device's roster but never stand in for it. Reading this in
+    /// place of `deviceSessions` is the mistake this comment exists to prevent —
+    /// it cannot see a session another client started, and it believes in
+    /// sessions whose process died while the app was closed.
+    func sessions(authoredFor device: KnownDevice) -> [Session] {
+        projects.flatMap { project in
+            project.sessions.filter { isAuthored($0, for: device) }
+        }
+    }
+
+    /// Whether a session belongs to the device the app is on. Panels use this to
+    /// scope their own containers; nothing may use it to build a session list.
+    func isOnCurrentDevice(_ session: Session) -> Bool {
+        isAuthored(session, for: currentDevice)
+    }
+
+    private func isAuthored(_ session: Session, for device: KnownDevice) -> Bool {
+        // Which machine the session is *about*. A durable termiod session names
+        // it directly; a plain `ssh` terminal runs its PTY here but exists to put
+        // the user on that box, so it belongs to the same place. `nil` is this Mac.
+        let alias = session.termiodRemoteHost ?? session.sshHost
+        // Matched by device identity once both ends know it, so a box reached by
+        // a second alias is still the same machine — and by alias until the first
+        // handshake resolves one, the bootstrap/stable split `KnownDevice` carries.
+        if alias != nil, let deviceID = device.deviceID, let sessionDevice = session.deviceID {
+            return deviceID == sessionDevice
+        }
+        return alias == device.alias
+    }
+
+    private func firstSession(onDevice device: KnownDevice) -> Session? {
+        sessions(authoredFor: device).first
+    }
+
+    /// The name this session carries inside a daemon. Sessions the app created are
+    /// named with their own uuid, which is what makes reattach-after-relaunch
+    /// work; an adopted session keeps the name it already had on the device.
+    func daemonSessionName(for session: Session) -> String {
+        session.termiodSessionName ?? session.id.uuidString
+    }
+
+    func termiodEndReason(for session: Session) -> Termiod.SessionTombstone? {
+        termiodTombstones[daemonSessionName(for: session)]
+    }
+}

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -189,7 +189,10 @@ extension TermioStore {
         return raw
     }
 
-    private func clearWorking(_ id: Session.ID) {
+    /// Not private: the termiod status path (`applyTermiodStatus`) ends a turn
+    /// through the same door, so the two cannot drift on what "stopped working"
+    /// clears.
+    func clearWorking(_ id: Session.ID) {
         setCurrentTool(nil, for: id)
         lastWorkingAt[id] = nil
         promotionStreak[id] = nil

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -286,7 +286,17 @@ extension TermioStore {
     /// another `Terminal N` row there and selects it (the same grow-in-place a
     /// project's own header buttons do). The section persists like any project, so
     /// it reappears on relaunch (the shells themselves restart fresh).
-    func addScratchTerminal() { addScratchSession(agent: .terminal) }
+    func addScratchTerminal() {
+        // On the device you are looking at, not on whichever machine happens to
+        // run the app. Without this the verb silently means "on this Mac" while
+        // the sidebar shows another device's world — the same class of mismatch
+        // that let an environment variable turn local terminals remote.
+        if let alias = currentDevice.alias {
+            addRemoteTerminal(host: alias)
+            return
+        }
+        addScratchSession(agent: .terminal)
+    }
 
     /// Opens a terminal where the user already is — New Terminal (⌘T). The shell
     /// starts in the focused session's working directory and the row lands beside it:
@@ -300,6 +310,13 @@ extension TermioStore {
     /// to the session's own anchor — and to `$HOME` with nothing focused, which is
     /// what New Terminal at Home does on purpose.
     func addTerminalHere() {
+        // "Here" is a directory on this Mac and does not exist on another
+        // machine, so on a remote device the verb degrades to that device's
+        // `$HOME` rather than pointing at a path that isn't there.
+        if let alias = currentDevice.alias {
+            addRemoteTerminal(host: alias)
+            return
+        }
         guard let id = selectedSessionID,
               let project = project(for: id),
               let session = session(id) else {

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -399,7 +399,7 @@ extension TermioStore {
     /// survives a rename and two sessions on the same box always land together.
     ///
     /// `remoteRoot` records where on that box the sessions work; the first caller to
-    /// name a real directory wins (a `Clone on Remote…` knows the checkout path, a
+    /// name a real directory wins (a `Clone to <device>…` knows the checkout path, a
     /// bare terminal only knows `~`), so opening a shell later never demotes a host
     /// that already points at a repo.
     @discardableResult

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -709,6 +709,16 @@ final class TermioStore: ObservableObject {
     /// session's attach channel into the local termiod daemon, which owns the
     /// PTY so the session outlives this app instance.
     var termiodLinks: [Session.ID: TermiodSessionLink] = [:]
+    /// Why a termiod session died, keyed by the daemon's session name — which,
+    /// for sessions this app created, is the `Session.ID` uuid string. Learned
+    /// from the roster reply (`Termiod.roster`), which carries the daemon's
+    /// graveyard alongside the live list.
+    ///
+    /// A session that is simply *missing* is indistinguishable from one that
+    /// never existed; a tombstone is the difference between "gone" and "the
+    /// daemon died under it while your agent was mid-turn". Read it with
+    /// `termiodEndReason(for:)`.
+    var termiodTombstones: [String: Termiod.SessionTombstone] = [:]
 
     /// App-quit teardown: without this, session children outlive the app — the
     /// closing PTY's SIGHUP is swallowed by agent TUIs, and they pile up as

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -37,6 +37,12 @@ final class TermioStore: ObservableObject {
                 applyInspectorState(selectedSessionID.flatMap { inspectorStates[$0] } ?? InspectorState())
             }
             if let id = selectedSessionID {
+                // Looking at a session is being on its machine. Every path that
+                // moves the selection — a deep link, the palette, a notification,
+                // a split, a freshly opened remote terminal — lands here, so this
+                // is the one place the context has to follow, and the window can
+                // never name one device while showing another's terminal.
+                enterDevice(of: id)
                 // A mid-turn `.working` keeps its spinner; only the resting
                 // "your turn" states are answered by looking.
                 markSeen(id)
@@ -720,6 +726,27 @@ final class TermioStore: ObservableObject {
     /// `termiodEndReason(for:)`.
     var termiodTombstones: [String: Termiod.SessionTombstone] = [:]
 
+    /// Which device the app is looking at, as the alias that reaches it (`nil` is
+    /// this Mac). **The** context: the sidebar, the window chrome, and every panel
+    /// added later read `currentDevice` rather than deciding for themselves.
+    ///
+    /// It lives here and not in `AppSettings` because it is live state with
+    /// consequences, not a preference — settings keeps a copy purely so the next
+    /// launch starts where this one ended. Written only through
+    /// `switchToDevice(_:)`, which moves the selection and the roster with it.
+    @Published var currentDeviceAlias: String?
+
+    /// What the current device last said is running on it. `unavailable` until a
+    /// device has been asked, which is also the resting state with the daemon
+    /// backend off.
+    @Published var deviceSessions: DeviceSessionsState = .unavailable
+
+    /// Guards against a slow reply from a device the user has already left: every
+    /// request stamps this counter and a reply that no longer matches is dropped.
+    /// Without it, switching away during an SSH round trip repaints the sidebar
+    /// with the previous machine's sessions.
+    var deviceSessionsGeneration = 0
+
     /// App-quit teardown: without this, session children outlive the app — the
     /// closing PTY's SIGHUP is swallowed by agent TUIs, and they pile up as
     /// launchd orphans across restarts. Graceful signals first, a short
@@ -889,6 +916,20 @@ final class TermioStore: ObservableObject {
         self.settings = settings
         self.projects = projects
         self.selectedSessionID = projects.first?.sessions.first?.id
+        // The machine the app opens on: the one the session it is about to show
+        // runs on, and the device the last run ended on when it shows nothing.
+        //
+        // The session outranks the stored alias because it is a fact about
+        // something running, while the alias is only where the user last was, and
+        // the two can disagree — a state file older than the alias beside it, a
+        // device dropped from `~/.ssh/config` since. A window that opens naming
+        // one machine while showing another's terminal is the confusion the
+        // device badge exists to prevent. (A later selection realigns the context
+        // through the selection's `didSet`; this covers the first one, which is
+        // assigned before that `didSet` is armed.)
+        let opening = projects.first?.sessions.first
+        self.currentDeviceAlias = opening.map { $0.termiodRemoteHost ?? $0.sshHost }
+            ?? settings.currentDeviceAlias
         let storedColumns = UserDefaults.standard.integer(forKey: Self.hostGridColumnsKey)
         let storedRows = UserDefaults.standard.integer(forKey: Self.hostGridRowsKey)
         self.lastHostGridColumns = storedColumns > 0 ? storedColumns : 80

--- a/Tests/termioTests/TermiodEventTests.swift
+++ b/Tests/termioTests/TermiodEventTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import termio
+
+/// The frames the Mac client negotiates for and now acts on. Decoding is where a
+/// protocol client silently goes wrong: a field renamed on the wire, or an event
+/// this build has never seen, must degrade to "ignored", never to a dropped
+/// status or a dead reader. The payloads below are the daemon's own JSON
+/// (termiod/src/protocol.rs `Event` / `Control`), spelled exactly as it emits it.
+final class TermiodEventTests: XCTestCase {
+    private func event(_ json: String) throws -> Termiod.IncomingEvent {
+        try Termiod.decodeEvent(Data(json.utf8))
+    }
+
+    private func control(_ json: String) throws -> Termiod.IncomingControl {
+        try Termiod.decodeControl(Data(json.utf8))
+    }
+
+    /// The event this whole capability exists for: an agent on another machine
+    /// reporting a turn boundary, with its workstream title riding along.
+    func testStatusCarriesTheStateAndTitle() throws {
+        guard case .status(let status) = try event(
+            #"{"ev":"status","session":"s_1","status":"needs_you","title":"pick a branch"}"#)
+        else { return XCTFail("expected a status event") }
+        XCTAssertEqual(status.session, "s_1")
+        XCTAssertEqual(status.status, "needs_you")
+        XCTAssertEqual(status.title, "pick a branch")
+    }
+
+    /// The daemon omits `title` when a session has none — an absent field is not
+    /// an empty title and must not fail the decode.
+    func testStatusWithoutATitleDecodes() throws {
+        guard case .status(let status) = try event(
+            #"{"ev":"status","session":"s_1","status":"working"}"#)
+        else { return XCTFail("expected a status event") }
+        XCTAssertNil(status.title)
+    }
+
+    /// `writer_changed` names a client id, which is only meaningful next to the
+    /// one `hello_ok` handed this connection.
+    func testWriterChangedNamesAClient() throws {
+        guard case .writerChanged(let change) = try event(
+            #"{"ev":"writer_changed","session":"s_1","writer":"c_41"}"#)
+        else { return XCTFail("expected a writer_changed event") }
+        XCTAssertEqual(change.writer, "c_41")
+    }
+
+    /// Nobody holds the token — the last interactive client detached. `null` is
+    /// a legitimate value here, not a missing field.
+    func testWriterChangedWithNoWriterDecodes() throws {
+        guard case .writerChanged(let change) = try event(
+            #"{"ev":"writer_changed","session":"s_1","writer":null}"#)
+        else { return XCTFail("expected a writer_changed event") }
+        XCTAssertNil(change.writer)
+    }
+
+    func testResizedCarriesTheAuthoritativeGrid() throws {
+        guard case .resized(let size) = try event(
+            #"{"ev":"resized","session":"s_1","rows":40,"cols":120}"#)
+        else { return XCTFail("expected a resized event") }
+        XCTAssertEqual(size.rows, 40)
+        XCTAssertEqual(size.cols, 120)
+    }
+
+    func testReadyAndSessionExitedDecode() throws {
+        guard case .ready(let session) = try event(#"{"ev":"ready","session":"s_1"}"#)
+        else { return XCTFail("expected a ready event") }
+        XCTAssertEqual(session, "s_1")
+
+        guard case .sessionExited(let exit) = try event(
+            #"{"ev":"session_exited","session":"s_1","status":137}"#)
+        else { return XCTFail("expected a session_exited event") }
+        XCTAssertEqual(exit.status, 137)
+    }
+
+    /// Additive evolution: an event from a newer daemon is ignored by name, not
+    /// by killing the reader that carries the session's bytes.
+    func testAnUnknownEventIsIgnoredByName() throws {
+        guard case .unknown(let name) = try event(
+            #"{"ev":"approval_requested","session":"s_1","tool":"Bash"}"#)
+        else { return XCTFail("expected an unknown event") }
+        XCTAssertEqual(name, "approval_requested")
+    }
+
+    /// The addressed half of the writer handover. It shares the payload shape
+    /// with the broadcast, and the client feeds both to one handler.
+    func testResizeClaimDecodesLikeAWriterChange() throws {
+        guard case .resizeClaim(let claim) = try control(
+            #"{"op":"resize_claim","session":"s_1","writer":"c_41"}"#)
+        else { return XCTFail("expected a resize_claim control") }
+        XCTAssertEqual(claim.writer, "c_41")
+    }
+
+    /// A dead session's record. `daemon_lost` is the case tombstones exist for,
+    /// and the one with no exit status to report — nobody was left to reap the
+    /// child, so the field is absent rather than zero.
+    func testSessionsReplyCarriesTombstones() throws {
+        guard case .sessions(let payload) = try control("""
+        {"op":"sessions","sessions":[],"tombstones":[
+          {"id":"s_9","name":"9F1C-…","cwd":"/home/me/termio","command":"claude",
+           "reason":"daemon_lost","created_unix":1786880000,"ended_unix":1786886075,
+           "agent_id":"claude","title":"fix #164","status":"working"}]}
+        """) else { return XCTFail("expected a sessions reply") }
+        XCTAssertEqual(payload.tombstones.count, 1)
+        let grave = try XCTUnwrap(payload.tombstones.first)
+        XCTAssertEqual(grave.reason, "daemon_lost")
+        XCTAssertNil(grave.exitStatus)
+        XCTAssertEqual(grave.status, "working")
+        XCTAssertEqual(grave.agentID, "claude")
+    }
+
+    /// A daemon too old to bury anything answers without the field. The live
+    /// list is still the answer to the question asked, so the reply must decode.
+    func testSessionsReplyWithoutTombstonesDecodes() throws {
+        guard case .sessions(let payload) = try control("""
+        {"op":"sessions","sessions":[
+          {"id":"s_1","name":"demo","pid":4242,"alive":true}]}
+        """) else { return XCTFail("expected a sessions reply") }
+        XCTAssertEqual(payload.sessions.count, 1)
+        XCTAssertTrue(payload.tombstones.isEmpty)
+    }
+
+    /// Negotiation, not lockstep: a `hello_ok` from a daemon that predates
+    /// capability reporting leaves the client with an empty set, not an error.
+    func testHelloOkWithoutCapsDecodes() throws {
+        guard case .helloOk(let hello) = try control("""
+        {"op":"hello_ok","proto":1,"host_id":"h_1","host":"termiod/0.1.0 linux-aarch64",
+         "client_id":"c_7"}
+        """) else { return XCTFail("expected hello_ok") }
+        XCTAssertEqual(hello.clientId, "c_7")
+        XCTAssertTrue(hello.caps.isEmpty)
+    }
+}

--- a/Tests/termioTests/TermiodStatusTests.swift
+++ b/Tests/termioTests/TermiodStatusTests.swift
@@ -1,0 +1,155 @@
+import AppKit
+import XCTest
+@testable import termio
+
+/// `TermioStore.applyTermiodStatus` — where a host-reported workstream state
+/// becomes a row's status. The host names the state and this side decides what
+/// it looks like, so these tests pin the *decisions*: which state settles as a
+/// calm cue, which demands attention, and which is not the host's to make.
+@MainActor
+final class TermiodStatusTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // The attention arms ask whether the user is looking, which reads
+        // `NSApp` — nil in a bare test process until something asks for the
+        // shared application.
+        _ = NSApplication.shared
+    }
+
+    private func makeStore(with session: Session) -> TermioStore {
+        let project = Project(name: "termio", path: "/code/termio", branch: "main",
+                              sessions: [session], kind: .folder)
+        let defaults = UserDefaults(suiteName: "termiod-status-\(UUID().uuidString)")
+        return TermioStore(projects: [project],
+                           settings: AppSettings(defaults: defaults ?? .standard))
+    }
+
+    private func status(_ state: String, title: String? = nil) -> Termiod.StatusPayload {
+        Termiod.StatusPayload(session: "s_1", status: state, title: title)
+    }
+
+    /// A remote terminal is a plain `.terminal` row — the agent runs on the far
+    /// machine. Gating on the local agent kind, as the hook path does, would
+    /// discard every status a VPS agent reports, which is the entire reason this
+    /// path exists.
+    func testWorkingSpinsAPlainRemoteTerminalRow() {
+        var session = Session(title: "ukvps", agent: .terminal)
+        session.termiodRemoteHost = "ukvps"
+        let store = makeStore(with: session)
+
+        store.applyTermiodStatus(status("working"), for: session.id)
+
+        XCTAssertEqual(store.status(for: session.id), .working)
+    }
+
+    func testDoneAndIdleSettleTheRow() {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+
+        store.applyTermiodStatus(status("working"), for: session.id)
+        store.applyTermiodStatus(status("done"), for: session.id)
+        XCTAssertEqual(store.status(for: session.id), .done)
+
+        store.applyTermiodStatus(status("idle"), for: session.id)
+        XCTAssertEqual(store.status(for: session.id), .idle)
+    }
+
+    /// A failed run is not a green "ready for you" dot. It settles as attention
+    /// the user can dismiss by looking, unlike a genuine blocking prompt.
+    func testFailedAsksForAttentionRatherThanReadingAsSuccess() {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+
+        store.applyTermiodStatus(status("working"), for: session.id)
+        store.applyTermiodStatus(status("failed"), for: session.id)
+
+        XCTAssertEqual(store.status(for: session.id), .needsAttention)
+        XCTAssertFalse(store.blockingAttention.contains(session.id))
+    }
+
+    /// `needs_you` is an observable blocking condition, so its dot is recorded
+    /// as blocking and survives a click — reading a permission prompt is not
+    /// answering it.
+    func testNeedsYouIsRecordedAsBlocking() {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+
+        store.applyTermiodStatus(status("needs_you"), for: session.id)
+
+        XCTAssertEqual(store.status(for: session.id), .needsAttention)
+        XCTAssertTrue(store.blockingAttention.contains(session.id))
+    }
+
+    /// `unknown` is the daemon's default for a session nobody has reported on.
+    /// Writing it would erase what the local signals worked out.
+    func testUnknownLeavesTheRowAlone() {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+
+        store.applyTermiodStatus(status("working"), for: session.id)
+        store.applyTermiodStatus(status("unknown"), for: session.id)
+
+        XCTAssertEqual(store.status(for: session.id), .working)
+    }
+
+    /// The workstream title is the agent's own label for the row, and lands in
+    /// the same place the OSC 0/2 title does.
+    func testTheWorkstreamTitleLandsOnTheRow() {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+
+        store.applyTermiodStatus(status("working", title: "fix #164"), for: session.id)
+
+        XCTAssertEqual(store.runtimes[session.id]?.liveTitle, "fix #164")
+    }
+
+    /// A report addressed to a session this app does not have is not this app's
+    /// story — it must not mint a runtime for a row that isn't there.
+    func testAReportForAnUnknownSessionIsDropped() {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+        let stranger = UUID()
+
+        store.applyTermiodStatus(status("working"), for: stranger)
+
+        XCTAssertNil(store.runtimes[stranger])
+    }
+
+    // MARK: - Tombstones
+
+    private func tombstone(name: String, reason: String) throws -> Termiod.SessionTombstone {
+        let json = """
+        {"id":"s_1","name":"\(name)","cwd":"/code","command":"claude","reason":"\(reason)",
+         "created_unix":1786880000,"ended_unix":1786886075,"status":"working"}
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(Termiod.SessionTombstone.self, from: Data(json.utf8))
+    }
+
+    /// The reason a row's session died is addressable from the row.
+    func testAnEndReasonIsFoundBySessionID() throws {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+        let name = session.id.uuidString
+
+        store.recordTombstones(
+            [try tombstone(name: name, reason: "daemon_lost")], persisted: [name])
+
+        XCTAssertEqual(store.termiodEndReason(for: session.id)?.reason, "daemon_lost")
+    }
+
+    /// Another client's sessions share the daemon but not the sidebar. Keeping
+    /// their graves would put rows in this map that no row can ever ask about.
+    func testTombstonesForOtherClientsSessionsAreNotKept() throws {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+
+        store.recordTombstones(
+            [try tombstone(name: "someone-elses-session", reason: "exited")],
+            persisted: [session.id.uuidString])
+
+        XCTAssertTrue(store.termiodTombstones.isEmpty)
+        XCTAssertNil(store.termiodEndReason(for: session.id))
+    }
+}

--- a/Tests/termioTests/TermiodStatusTests.swift
+++ b/Tests/termioTests/TermiodStatusTests.swift
@@ -127,6 +127,17 @@ final class TermiodStatusTests: XCTestCase {
         return try decoder.decode(Termiod.SessionTombstone.self, from: Data(json.utf8))
     }
 
+    private func live(name: String) throws -> Termiod.SessionInformation {
+        let json = """
+        {"id":"s_1","name":"\(name)","pid":42,"alive":true,"cwd":"/code",
+         "command":"claude","status":"working","agent_id":null,"title":null,
+         "created_unix":1786880000,"attached_clients":1}
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(Termiod.SessionInformation.self, from: Data(json.utf8))
+    }
+
     /// The reason a row's session died is addressable from the row.
     func testAnEndReasonIsFoundBySessionID() throws {
         let session = Session(title: "agent", agent: .terminal)
@@ -134,9 +145,25 @@ final class TermiodStatusTests: XCTestCase {
         let name = session.id.uuidString
 
         store.recordTombstones(
-            [try tombstone(name: name, reason: "daemon_lost")], persisted: [name])
+            [try tombstone(name: name, reason: "daemon_lost")], live: [], persisted: [name])
 
         XCTAssertEqual(store.termiodEndReason(for: session.id)?.reason, "daemon_lost")
+    }
+
+    /// A name that comes back alive buries its own grave. Tombstones merge rather
+    /// than replace, so without this a session restarted under the same name would
+    /// keep wearing the end reason of the run before it.
+    func testALiveNameLosesItsTombstone() throws {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+        let name = session.id.uuidString
+
+        store.recordTombstones(
+            [try tombstone(name: name, reason: "daemon_lost")], live: [], persisted: [name])
+        XCTAssertNotNil(store.termiodEndReason(for: session.id))
+
+        store.recordTombstones([], live: [try live(name: name)], persisted: [name])
+        XCTAssertNil(store.termiodEndReason(for: session.id))
     }
 
     /// Another client's sessions share the daemon but not the sidebar. Keeping
@@ -147,7 +174,7 @@ final class TermiodStatusTests: XCTestCase {
 
         store.recordTombstones(
             [try tombstone(name: "someone-elses-session", reason: "exited")],
-            persisted: [session.id.uuidString])
+            live: [], persisted: [session.id.uuidString])
 
         XCTAssertTrue(store.termiodTombstones.isEmpty)
         XCTAssertNil(store.termiodEndReason(for: session.id))


### PR DESCRIPTION
The interface had a device *preference* — where the next terminal would land — and one list, this Mac's, with other machines' sessions hung off a "Devices" section beside it. That is device-as-hierarchy: every session is really this Mac's, tagged with where it went. It is the model the device architecture exists to replace (§2.1 — the Mac may hold nothing a viewer needs).

The device becomes the context instead. It lives on the store, the sidebar draws whatever machine you are on, and everything that opens a terminal opens it there.

### What changes

- **`KnownDevice` moves out of the sidebar** into `TermioStore/DeviceContext.swift`. This Mac is `.thisMac`, a device like any other whose only distinction is having no alias to reach it by. `switchToDevice` moves the context, the selection and the roster together; selecting a session enters that session's machine, so the window can never name one device while showing another's terminal.
- **The sidebar shows the device's own roster.** `refreshDeviceSessions` asks the current device `list` over its own control channel — a Unix socket here, `ssh <alias> termiod stdio` elsewhere — and publishes the answer. On another machine that reply is the whole sidebar; on this Mac it adds only what the local sections do not account for, under "Also Running". A session started from the `termiod` CLI or by a phone therefore appears, which is the thing no amount of filtering a local array can produce. Clicking it adopts it, keeping the name the device gave it so the attach lands on that PTY instead of spawning a second one.
- **"We do not know yet" is a real state** and gets said — asking, refused with the reason, or no session host to ask. None of those is "no sessions".
- **Three chrome fixes.** The device indicator moves from the foot of the sidebar to its head, since everything below it is that device's world. New Terminal loses its per-machine submenu and is a plain verb again — the switcher already made that choice. The window's toolbar gains a device badge, and the native `subtitle` stays empty with a comment saying why.

### Subsumes `feat/client-negotiates-all-caps`

That branch is merged in here, so it does not need a PR of its own. It is the two commits below the three new ones: the client was negotiating one capability out of ten and dropping four frame kinds on the floor, so every `E` frame the daemon sent — agent status, writer changes, the authoritative grid size, tombstones — arrived and was discarded. Agent status on a session running elsewhere never appeared at all. Verified end to end against the ukvps VPS.

### Verification

`TERMIO_CHANNEL=dev ./scripts/build-app.sh` is green, and each of the three commits builds on its own so the no-squash merge leaves main bisectable.

`swift test` was not run: it does not compile on main either (#311).

Refs: #164, #170