### PR TITLE
Let `sessions send` deliver a keypress, not only a line of text

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -39,9 +39,13 @@ struct ControlRequest: Decodable {
     /// Optional banner title for the `notify` op; defaults to the calling agent's
     /// name when absent.
     let title: String?
+    /// `send`/`answer`: whether to submit the text with a Return. `--no-enter`
+    /// sends false — the payload is itself the keypress a prompt is waiting on
+    /// (a bare `t` at a trust gate), not a line to submit. Absent means submit.
+    let enter: Bool?
 
     private enum CodingKeys: String, CodingKey {
-        case op, format, target, text, lines, agent, snapshot, wait, title
+        case op, format, target, text, lines, agent, snapshot, wait, title, enter
         case callerSession = "caller_session"
         case callerCwd = "caller_cwd"
         case timeoutMs = "timeout_ms"
@@ -49,6 +53,7 @@ struct ControlRequest: Decodable {
 
     var wantsJSON: Bool { format == "json" }
     var wantsWait: Bool { wait == true }
+    var wantsEnter: Bool { enter != false }
 }
 
 /// A local Unix-domain socket the `termio sessions` CLI connects to. Unlike

--- a/Sources/termio/Resources/skills/termio/SKILL.md
+++ b/Sources/termio/Resources/skills/termio/SKILL.md
@@ -40,7 +40,9 @@ id-prefix works too).
   be able to see and take over the process.
 - `termio sessions send <link> "<text>"` — type text into that existing
   sibling and submit it with a real Return keypress. Send a prompt to drive
-  it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
+  it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. Add
+  `--no-enter` when the gate wants a bare keypress and no Return — a lone
+  `t` to trust a folder, or `$'\e'` to back out.
 - `termio sessions read <link> [--lines N]` — the session's current
   screen. The result channel for `run` sessions (a plain command has no
   transcript; its screen is the result) — for agent replies keep using the

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -357,7 +357,8 @@ extension TermioStore {
         _ payload: String, to session: Session, state: TerminalViewState,
         request: ControlRequest
     ) async -> Data {
-        guard await performDelivery(payload, to: session, state: state) else {
+        guard await performDelivery(payload, to: session, state: state,
+                                    submit: request.wantsEnter) else {
             return controlError(request, "not_live",
                 "\(displayTitle(for: session)) has no live terminal yet — open it once in Termio.")
         }
@@ -372,8 +373,11 @@ extension TermioStore {
 
     /// Types `payload` into a session's live surface and submits it. Shared by
     /// the existing-sibling reply path and the fresh-spawn detached delivery.
+    /// `submit` is false for `--no-enter`, where the payload *is* the keypress a
+    /// prompt is waiting on and a Return would answer a second question.
     private func performDelivery(
-        _ payload: String, to session: Session, state: TerminalViewState
+        _ payload: String, to session: Session, state: TerminalViewState,
+        submit: Bool = true
     ) async -> Bool {
         // The libghostty surface attaches lazily on the pane's first render, so a
         // session never shown in the UI has no surface yet. A background mount adds
@@ -391,16 +395,45 @@ extension TermioStore {
         }
         guard let surfaceHandle = Self.rawSurface(from: state) else { return false }
 
-        // Type the prompt through the text path (fine for the body), then submit
-        // with a real Return *key event*. A trailing "\r" in the text is delivered
-        // as a bracketed paste, which an agent TUI (Claude Code) reads as a newline
-        // — never a submit. `ghostty_surface_key` drives the surface directly, with
-        // no focus or first-responder needed; this is exactly how Ghostty's own
-        // AppleScript `send key` submits Enter.
-        _ = state.send(payload)
+        // Write the payload as raw PTY bytes, then submit with a real Return *key
+        // event* — `pressReturn` leaves the encoding to Ghostty, which emits what
+        // the program's keyboard mode expects, and a "\r" appended to the payload
+        // cannot (an agent TUI reads one inside a paste as a newline, never a
+        // submit). `ghostty_surface_key` drives the surface directly, with no focus
+        // or first-responder needed; this is exactly how Ghostty's own AppleScript
+        // `send key` submits Enter.
+        Self.writeRaw(payload, to: state)
+        guard submit else { return true }
         try? await Task.sleep(for: .milliseconds(40))
         Self.pressReturn(on: surfaceHandle)
         return true
+    }
+
+    /// Puts `payload` into the session's PTY as raw bytes, NOT through
+    /// `state.send`: that routes into `ghostty_surface_text`, whose input encoder
+    /// re-encodes a hand-written ESC as an escape KEYPRESS (CSI 27u under the
+    /// kitty keyboard protocol agents enable) and frames everything as a paste.
+    /// A `send` could therefore only ever deliver *text* — never the bare `t` a
+    /// Codex trust gate is waiting on, never an `esc` to back out of a menu. Raw
+    /// input is the same path the file tree's "Add to Chat" takes
+    /// (`addSnippetToSelectedSessionPrompt`), for the same reason.
+    ///
+    /// A payload carrying newlines keeps its bracketed-paste framing — added here,
+    /// in the PTY bytes, where it means what it says — so a multi-line prompt still
+    /// lands as one pasted block instead of submitting line by line. A single-line
+    /// payload goes verbatim, which is what makes a lone keypress possible.
+    ///
+    /// Anything but the in-memory backend (no host-managed PTY to write to) falls
+    /// back to the surface, which is better than dropping the send.
+    private static func writeRaw(_ payload: String, to state: TerminalViewState) {
+        guard case let .inMemory(backend) = state.configuration.backend else {
+            _ = state.send(payload)
+            return
+        }
+        let bytes = payload.contains("\n")
+            ? "\u{1B}[200~" + payload + "\u{1B}[201~"
+            : payload
+        backend.sendInput(Data(bytes.utf8))
     }
 
     /// Blocks until the session the prompt was sent to finishes its turn — or stops

--- a/scripts/termio
+++ b/scripts/termio
@@ -46,6 +46,8 @@ options:
                    the final status and the transcript line range to read
                    (exit 0 settled, 1 error — including a stalled/vanished session, 3 timed out)
   --timeout <ms>   cap for --wait (default 300000, clamped 1000–600000); implies --wait
+  --no-enter       for `send`: deliver the text as-is, with no Return after it —
+                   the way to answer a gate that wants a bare keypress
   --lines <n>      for `read`: keep only the last n screen rows
   --state <s,…>    for `watch`: comma-separated states to report (working, idle, done,
                    needs-you, stalled; default done,needs-you)
@@ -142,12 +144,16 @@ the last N rows. Scrollback is not included.
 EOF
             ;;
         send|answer) cat <<'EOF'
-usage: termio sessions send <session> "<text>" [--wait [--timeout <ms>]] [--json]
+usage: termio sessions send <session> "<text>" [--no-enter] [--wait [--timeout <ms>]] [--json]
 
 Type text into an existing session and submit it with a real Return
 keypress — a prompt to drive it, or a menu choice ("1", "yes") to answer a
 permission prompt. Addresses come from `termio sessions list` or a `spawn`
 reply — a termio://session link or bare id, copied verbatim.
+
+The text reaches the terminal verbatim, so --no-enter (no Return after it)
+delivers a bare keypress: the lone `t` a trust gate waits for, or an escape
+sequence written by the shell, e.g. `send <session> $'\e' --no-enter`.
 
 --wait holds the reply until the turn the text kicked off settles (or
 --timeout ms elapse; default 300000, clamped 1000–600000). The reply then
@@ -185,14 +191,17 @@ SOCKET="$HOME/Library/Application Support/$SUPPORT_DIR_NAME/session-control.sock
 
 # JSON-escape a string for embedding in a request: backslashes, double quotes,
 # tabs, and newlines (which would otherwise break the single-line JSON object).
-# Every other C0 control byte is stripped outright — prompts are text for agent
-# TUIs, control bytes in them are never intentional, and one raw byte would make
-# the whole request undecodable.
+# ESC survives, as a JSON \u001b escape: an escape sequence is exactly the kind of
+# keypress `send --no-enter` exists to deliver (esc to back out of a menu, an arrow
+# key), and it reaches the PTY verbatim on the far side. Every other C0 byte is
+# stripped outright: they are never intentional in a prompt, and one raw byte
+# would make the whole request undecodable.
 json_escape() {
     tab=$(printf '\t')
+    esc=$(printf '\033')
     printf '%s' "$1" \
+        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e "s/$tab/\\\\t/g" -e "s/$esc/\\\\u001b/g" \
         | tr -d '\000-\010\013-\037' \
-        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e "s/$tab/\\\\t/g" \
         | awk 'BEGIN { ORS = "" } { if (NR > 1) printf "\\n"; printf "%s", $0 }'
 }
 
@@ -316,6 +325,7 @@ sessions() {
     text=""
     states=""
     no_snapshot=0
+    no_enter=0
     wait=false
     timeout_ms=""
     lines=""
@@ -324,6 +334,7 @@ sessions() {
         case "$1" in
             --json) format=json ;;
             --no-snapshot) no_snapshot=1 ;;
+            --no-enter) no_enter=1 ;;
             --wait) wait=true ;;
             --timeout)
                 [ $# -ge 2 ] || { echo "termio: --timeout needs a value in ms" >&2; exit 1; }
@@ -420,6 +431,16 @@ sessions() {
         if [ -z "${TERMIO_CLI_TIMEOUT:-}" ]; then
             CLIENT_TIMEOUT=$(( ${timeout_ms:-300000} / 1000 + 30 ))
         fi
+    fi
+
+    # --no-enter only reads on a send to an existing session: a spawn's prompt has
+    # to be submitted or the fresh agent just sits on a filled composer.
+    if [ "$no_enter" -eq 1 ]; then
+        case "$op" in
+            send|answer) [ -n "$targets" ] || { echo "termio: --no-enter needs a session to send to" >&2; exit 1; } ;;
+            *) echo "termio: --no-enter applies to send only" >&2; exit 1 ;;
+        esac
+        extra_json="${extra_json:+$extra_json,}\"enter\":false"
     fi
 
     if [ "$op" = watch ]; then

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -40,7 +40,9 @@ id-prefix works too).
   be able to see and take over the process.
 - `termio sessions send <link> "<text>"` — type text into that existing
   sibling and submit it with a real Return keypress. Send a prompt to drive
-  it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
+  it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. Add
+  `--no-enter` when the gate wants a bare keypress and no Return — a lone
+  `t` to trust a folder, or `$'\e'` to back out.
 - `termio sessions read <link> [--lines N]` — the session's current
   screen. The result channel for `run` sessions (a plain command has no
   transcript; its screen is the result) — for agent replies keep using the

--- a/web/landing/public/skill.md
+++ b/web/landing/public/skill.md
@@ -40,7 +40,9 @@ id-prefix works too).
   be able to see and take over the process.
 - `termio sessions send <link> "<text>"` — type text into that existing
   sibling and submit it with a real Return keypress. Send a prompt to drive
-  it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt.
+  it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. Add
+  `--no-enter` when the gate wants a bare keypress and no Return — a lone
+  `t` to trust a folder, or `$'\e'` to back out.
 - `termio sessions read <link> [--lines N]` — the session's current
   screen. The result channel for `run` sessions (a plain command has no
   transcript; its screen is the result) — for agent replies keep using the


### PR DESCRIPTION
`termio sessions send` typed its payload through `state.send`, which routes into `ghostty_surface_text` — the input encoder that re-encodes a hand-written ESC as an escape KEYPRESS (CSI 27u under the kitty keyboard protocol agents enable) and frames everything else as a paste. `addSnippetToSelectedSessionPrompt` already writes RAW bytes for exactly that reason and documents it; the control path never got the same treatment, so `send` could deliver text plus Return and nothing else. A Codex trust gate waiting on a bare `t` was undrivable.

Delivery now writes to the backend session's input directly:

- A payload carrying newlines keeps its bracketed-paste framing, added in the PTY bytes where it means what it says, so a multi-line prompt still lands as one pasted block instead of submitting line by line. A single-line payload goes verbatim — what makes a lone keypress possible.
- Return is unchanged: a real key event through Ghostty's encoder, never a carriage return in the payload. A backend that isn't the in-memory one still falls back to the surface.
- `--no-enter` completes the pair, since a keypress followed by Return answers a second question. It applies to a `send` at an existing session; a spawn's prompt has to be submitted or the fresh agent just sits on a filled composer.
- The CLI's JSON escaper carries ESC across as a `\u001b` escape instead of stripping it with the other C0 bytes, so `termio sessions send <session> $'\e' --no-enter` reaches the PTY as one escape.

The skill copy is updated in all three mirrors together.

Verified with `TERMIO_CHANNEL=dev ./scripts/build-app.sh`. Not run: `swift test` — the suite does not compile on main (#311).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
