### PR TITLE
fix(build): refuse a TERMIO_CHANNEL build-app.sh cannot build

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -112,9 +112,13 @@ final class SessionControlListener: @unchecked Sendable {
         // a bare SwiftPM binary — no bundle id means `AppChannel.suffix` is empty,
         // so `swift run` during development lands on the *release* channel.
         if Self.isLive(path) {
+            // Name `dev`, not `<name>`: a placeholder reads as "any name works",
+            // and the reader's next move is usually TERMIO_CHANNEL=<name>
+            // ./scripts/build-app.sh — which builds no such channel.
             Self.log("""
                 another termio already answers at \(path) — leaving session control \
-                to it (set TERMIO_CHANNEL=<name> for a channel of your own)
+                to it (relaunch this process with TERMIO_CHANNEL=dev for a channel of \
+                its own; that steers this run, not how a bundle was built)
                 """)
             return
         }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -14,10 +14,12 @@
 #   open ./termio.app                 # launch it
 #
 # Environment overrides (used by the release workflow; all optional):
-#   TERMIO_CHANNEL   "dev" builds a side-by-side termio-dev.app (bundle id ….dev,
-#                    its own ~/.termio-dev state + companion port 8788, Sparkle
-#                    stripped) so it runs beside an installed release build. Default
-#                    is the release channel (./termio.app).
+#   TERMIO_CHANNEL   which identity to build; only two values exist. Unset (or
+#                    "release") builds ./termio.app. "dev" builds a side-by-side
+#                    termio-dev.app (bundle id ….dev, its own ~/.termio-dev state +
+#                    companion port 8788, Sparkle stripped) so it runs beside an
+#                    installed release build. Any other value is rejected — see
+#                    the channel check below for why.
 #   TERMIO_VERSION   CFBundleShortVersionString to stamp (default: keep Info.plist's)
 #   TERMIO_BUILD     CFBundleVersion to stamp; must increase across shipped builds
 #                    because Sparkle compares it (default: keep Info.plist's)
@@ -37,7 +39,30 @@ configuration="release"
 product_name="termio"
 # TERMIO_CHANNEL=dev builds a side-by-side dev app (termio-dev.app, id ….dev, its
 # own state dir + port, Sparkle stripped) so it can run beside an installed release.
-channel="${TERMIO_CHANNEL:-release}"
+# Unset or "release" builds the shipped identity. Lower-cased the way AppChannel
+# lower-cases it at runtime, so the two agree on what a channel name is.
+channel="$(printf '%s' "${TERMIO_CHANNEL:-release}" | tr '[:upper:]' '[:lower:]')"
+# Anything else must NOT fall through to the release branch below. Arbitrary
+# channel names are a *runtime* feature — AppChannel.suffix turns any plain name
+# into its own state dir, socket and companion port — but no bundle identity has
+# ever been built for a third channel, so a typo (or session control's advice to
+# take a channel of your own, read as build advice) used to hand back a bundle
+# stamped sh.termio.app with a CLI stamped
+# SUPPORT_DIR_NAME="termio": a build that silently drives the app you use daily,
+# down to `sessions send` typing into a live session. Refuse instead.
+if [[ "$channel" != "release" && "$channel" != "dev" ]]; then
+    cat >&2 <<EOF
+error: TERMIO_CHANNEL="${TERMIO_CHANNEL:-}" is not a channel this script can build.
+       Supported values:
+         unset (or "release")  ->  ./termio.app      (sh.termio.app,     CLI "termio")
+         dev                   ->  ./termio-dev.app  (sh.termio.app.dev, CLI "termio-dev")
+       A name of your own works when *running* termio (it picks a state directory,
+       control socket and companion port), but there is no bundle to build for it —
+       so this build would have taken the RELEASE identity and driven your daily app.
+       Re-run with TERMIO_CHANNEL=dev, or leave TERMIO_CHANNEL unset for a release build.
+EOF
+    exit 1
+fi
 if [[ "$channel" == "dev" ]]; then
     app_name="termio-dev"
     source_icon="$repo_root/packaging/AppIcon-dev.png"


### PR DESCRIPTION
`TERMIO_CHANNEL` reads like a free-form channel name, and at runtime it is one — `AppChannel.suffix` turns any plain name into its own state directory, control socket and companion port. `build-app.sh` only branched on the literal `dev`, and every other value fell through to the release branch in silence: `TERMIO_CHANNEL=v325 ./scripts/build-app.sh` handed back `termio.app` whose bundled CLI is stamped `SUPPORT_DIR_NAME="termio"` / `BUNDLE_ID="sh.termio.app"` — a build that drives the app you use daily, down to `sessions send` typing into a live session. Nothing warned.

Unset, empty and `release` still mean the release channel; `dev` still means the side-by-side bundle. Anything else exits 1 naming both and explaining why the given name cannot be built even though the app answers to it at run time.

Session control's message invited the mistake — the `<name>` placeholder reads as "any name works", and the reader's next move is to pass it to the build script. It now names `dev` and says the switch steers the run, not how a bundle was built. It is a stderr log, not a `localized(…)` key, so the string catalog is untouched (`scripts/check-strings.sh` passes).

`ios/dev-run.sh` and the two rebuild skills need no equivalent fix: dev-run.sh knows nothing about channels, and `macos-rebuild-dev` passes the literal `TERMIO_CHANNEL=dev`.

## Verification

- `TERMIO_CHANNEL=nonsense ./scripts/build-app.sh` → exit 1 before any compile, with the supported values and the reason.
- `TERMIO_CHANNEL=dev ./scripts/build-app.sh` → `termio-dev.app`, `CFBundleIdentifier=sh.termio.app.dev`, `Contents/Resources/termio-dev` stamped `SUPPORT_DIR_NAME="termio-dev"` / `BUNDLE_ID="sh.termio.app.dev"`.
- `./scripts/build-app.sh` → universal `termio.app` with the release identity.