### PR TITLE
feat(sessions): press a named key with `sessions send --key`

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -43,9 +43,15 @@ struct ControlRequest: Decodable {
     /// sends false — the payload is itself the keypress a prompt is waiting on
     /// (a bare `t` at a trust gate), not a line to submit. Absent means submit.
     let enter: Bool?
+    /// `send`: named keys to press after the text, in order — `--key escape`,
+    /// `--key ctrl-c`. A key is not text: its bytes depend on the mode the program
+    /// negotiated (`ESC [ A` vs `ESC O A` for Up), so only Ghostty's key encoder can
+    /// produce them, and hand-writing them into `text` is right by luck at best.
+    /// See `SessionKeyPress`.
+    let keys: [String]?
 
     private enum CodingKeys: String, CodingKey {
-        case op, format, target, text, lines, agent, snapshot, wait, title, enter
+        case op, format, target, text, lines, agent, snapshot, wait, title, enter, keys
         case callerSession = "caller_session"
         case callerCwd = "caller_cwd"
         case timeoutMs = "timeout_ms"
@@ -53,7 +59,11 @@ struct ControlRequest: Decodable {
 
     var wantsJSON: Bool { format == "json" }
     var wantsWait: Bool { wait == true }
-    var wantsEnter: Bool { enter != false }
+    /// Naming a key suppresses the implicit Return as surely as `--no-enter` does:
+    /// the caller is being explicit about which keys to press, and appending one
+    /// they did not ask for would submit a menu they meant to escape.
+    var wantsEnter: Bool { enter != false && namedKeys.isEmpty }
+    var namedKeys: [String] { keys ?? [] }
 }
 
 /// A local Unix-domain socket the `termio sessions` CLI connects to. Unlike

--- a/Sources/termio/Agents/SessionKeyName.swift
+++ b/Sources/termio/Agents/SessionKeyName.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+/// A key named on `termio sessions send --key <name>`, resolved into the fields of
+/// one libghostty key event.
+///
+/// A key's bytes are not a property of the key — they are a property of the key
+/// *and the mode the program negotiated*. Up is `ESC [ A` in normal cursor mode and
+/// `ESC O A` in application mode; ctrl-c is `0x03` in legacy mode and `CSI 99;5u`
+/// under the kitty keyboard protocol every coding agent turns on. A caller who
+/// hand-writes `$'\e[A'` into `send` is guessing at one of those, and is right only
+/// by luck. So `--key` never produces bytes: it produces a key *event*, and
+/// Ghostty's own encoder decides the bytes from the live mode.
+///
+/// This is the exact mirror of the rule for text. Text must go into the PTY raw
+/// (`writeRaw`), untouched by the input encoder, or the ESC of a hand-written
+/// `ESC [ 200 ~` gets re-encoded as an Escape *keypress*. Keys must go *through*
+/// that encoder for the same reason. Two payloads, two paths, one principle: the
+/// encoder owns keys and nothing else.
+///
+/// The vocabulary is kitty's and tmux's, not a third dialect — both spellings of
+/// every modifier are accepted (`c-c` and `ctrl-c`, `s-tab` and `shift-tab`,
+/// `m-b` and `alt-b`) so a caller never has to guess which one this CLI speaks.
+struct SessionKeyPress: Equatable {
+    struct Modifiers: OptionSet, Equatable {
+        let rawValue: UInt8
+        init(rawValue: UInt8) { self.rawValue = rawValue }
+
+        static let shift = Modifiers(rawValue: 1 << 0)
+        static let control = Modifiers(rawValue: 1 << 1)
+        static let option = Modifiers(rawValue: 1 << 2)
+        static let command = Modifiers(rawValue: 1 << 3)
+
+        /// Modifiers that make the keypress a chord rather than typed text. With any
+        /// of these the event carries no `text` — Ghostty's encoder derives the
+        /// chord's bytes from the physical key and the mode (see `SessionKeyPress`).
+        static let chording: Modifiers = [.control, .option, .command]
+    }
+
+    /// The native macOS virtual keycode (`kVK_…`), the same number an `NSEvent`
+    /// would carry. Ghostty translates it into its own key enum, so it — not a
+    /// character — is what identifies the physical key.
+    let keycode: UInt32
+    let modifiers: Modifiers
+    /// The codepoint the key produces with no modifiers applied. Feeds the kitty
+    /// protocol's key reporting; zero for keys with no printable form.
+    let unshiftedCodepoint: UInt32
+    /// The text a real keystroke would have inserted, for an unmodified printable
+    /// key. Nil for every special key and every chord, where Ghostty's encoder
+    /// produces the bytes itself.
+    let text: String?
+
+    /// Return — the submit `send` appends to a prompt, and the key behind `--key enter`.
+    static let `return` = SessionKeyPress(
+        keycode: 0x24, modifiers: [], unshiftedCodepoint: 0, text: nil)
+
+    /// Whether pressing this actually puts bytes in the PTY — nil when it does,
+    /// otherwise why not, and what to press instead.
+    ///
+    /// Only Ctrl and Shift reach the program. Option is a text-composition modifier
+    /// on macOS (option-b types `∫`; it is not Meta+b), and Ghostty adds a real
+    /// Alt's ESC prefix only when `macos-option-as-alt` is on, which it is not by
+    /// default — so an Option chord composes no text, encodes no sequence, and
+    /// evaporates. Command drives the app, not the terminal. Both are refused
+    /// rather than pressed, because a `--key` that reports success and delivers
+    /// nothing is the exact failure this option exists to remove. Their names still
+    /// *parse*, so the caller gets this explanation instead of "unknown key".
+    var undeliverableReason: String? {
+        if modifiers.contains(.command) {
+            return "Command is an app shortcut, not a key the program in the "
+                + "terminal ever sees — ⌘C copies in Termio and sends no bytes."
+        }
+        if modifiers.contains(.option) {
+            let key = unshiftedCodepoint == 0
+                ? "<key>"
+                : String(UnicodeScalar(unshiftedCodepoint) ?? " ")
+            return "macOS types a character with Option (option-b is ∫), so Ghostty "
+                + "sends nothing for an Option chord unless macos-option-as-alt is "
+                + "on. A meta chord is ESC then the key: --key escape --key \(key)"
+        }
+        return nil
+    }
+
+    /// Resolves a name to a keypress, or nil if the name is not in the vocabulary.
+    /// Never guesses: an unrecognized name is an error the caller must see, never
+    /// text to send instead. Case-insensitive, and `-` and `+` are interchangeable
+    /// separators (tmux writes `C-c`, kitty writes `ctrl+c`).
+    static func parse(_ name: String) -> SessionKeyPress? {
+        let trimmed = name.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !trimmed.isEmpty else { return nil }
+
+        // Peel modifier prefixes off the front. A separator at the very start, or a
+        // head that names no modifier, or an empty tail all end the peel — so `-`,
+        // `ctrl--`, and `c-` mean the minus key, ctrl-minus, and (loudly) nothing.
+        var modifiers: Modifiers = []
+        var rest = Substring(trimmed)
+        while let separator = rest.firstIndex(where: { $0 == "-" || $0 == "+" }),
+              separator != rest.startIndex
+        {
+            guard let modifier = modifier(named: String(rest[rest.startIndex ..< separator]))
+            else { break }
+            let tail = rest[rest.index(after: separator)...]
+            guard !tail.isEmpty else { break }
+            modifiers.insert(modifier)
+            rest = tail
+        }
+
+        // `space` is the one printable key with a spelled-out name — nobody can type
+        // its character into an argument and see it survive the shell.
+        let key = rest == "space" ? " " : String(rest)
+        if let keycode = specialKeycodes[key] {
+            return SessionKeyPress(
+                keycode: keycode, modifiers: modifiers, unshiftedCodepoint: 0, text: nil)
+        }
+        guard let scalar = key.unicodeScalars.first, key.unicodeScalars.count == 1,
+              let keycode = printableKeycodes[Character(scalar)]
+        else { return nil }
+        // A chord carries no text; an unmodified (or merely shifted) printable key
+        // carries what a real keystroke would have typed, which is what makes the
+        // character appear rather than vanish into an unhandled binding.
+        var typed: String?
+        if modifiers.isDisjoint(with: .chording) {
+            typed = modifiers.contains(.shift) ? key.uppercased() : key
+        }
+        return SessionKeyPress(
+            keycode: keycode, modifiers: modifiers,
+            unshiftedCodepoint: scalar.value, text: typed)
+    }
+
+    private static func modifier(named head: String) -> Modifiers? {
+        switch head {
+        case "c", "ctrl", "control": return .control
+        case "s", "shift": return .shift
+        case "m", "alt", "meta", "opt", "option": return .option
+        case "d", "cmd", "command", "super", "win": return .command
+        default: return nil
+        }
+    }
+
+    /// The named keys, for the error a bad name earns. Grouped the way a caller
+    /// scans for one, not alphabetically.
+    static let vocabulary =
+        "enter, escape, tab, space, backspace, delete, insert, up, down, left, right, "
+        + "home, end, pageup, pagedown, f1–f12, a–z, 0–9, and punctuation — each "
+        + "optionally prefixed with ctrl-/c- or shift-/s- (e.g. ctrl-c, c-c, "
+        + "shift-tab). For a meta chord press ESC first: --key escape --key b"
+
+    /// Named keys with no printable form, as macOS virtual keycodes. Aliases cover
+    /// both dialects: kitty's `escape`/`backspace`/`pageup` and tmux's
+    /// `bspace`/`ppage`/`npage`/`ic`/`dc`.
+    private static let specialKeycodes: [String: UInt32] = [
+        "enter": 0x24, "return": 0x24, "cr": 0x24,
+        "escape": 0x35, "esc": 0x35,
+        "tab": 0x30,
+        "backspace": 0x33, "bspace": 0x33, "bs": 0x33,
+        "delete": 0x75, "del": 0x75, "dc": 0x75,
+        "insert": 0x72, "ic": 0x72,
+        "up": 0x7E, "down": 0x7D, "left": 0x7B, "right": 0x7C,
+        "home": 0x73, "end": 0x77,
+        "pageup": 0x74, "pgup": 0x74, "ppage": 0x74,
+        "pagedown": 0x79, "pgdn": 0x79, "npage": 0x79,
+        "f1": 0x7A, "f2": 0x78, "f3": 0x63, "f4": 0x76, "f5": 0x60, "f6": 0x61,
+        "f7": 0x62, "f8": 0x64, "f9": 0x65, "f10": 0x6D, "f11": 0x67, "f12": 0x6F,
+    ]
+
+    /// Printable keys of the ANSI US layout, as macOS virtual keycodes. Space rides
+    /// here rather than with the special keys because it *is* printable: `--key space`
+    /// types a space, `--key ctrl-space` is the NUL chord.
+    private static let printableKeycodes: [Character: UInt32] = [
+        "a": 0x00, "s": 0x01, "d": 0x02, "f": 0x03, "h": 0x04, "g": 0x05, "z": 0x06,
+        "x": 0x07, "c": 0x08, "v": 0x09, "b": 0x0B, "q": 0x0C, "w": 0x0D, "e": 0x0E,
+        "r": 0x0F, "y": 0x10, "t": 0x11, "o": 0x1F, "u": 0x20, "i": 0x22, "p": 0x23,
+        "l": 0x25, "j": 0x26, "k": 0x28, "n": 0x2D, "m": 0x2E,
+        "1": 0x12, "2": 0x13, "3": 0x14, "4": 0x15, "6": 0x16, "5": 0x17, "9": 0x19,
+        "7": 0x1A, "8": 0x1C, "0": 0x1D,
+        "=": 0x18, "-": 0x1B, "]": 0x1E, "[": 0x21, "'": 0x27, ";": 0x29, "\\": 0x2A,
+        ",": 0x2B, "/": 0x2C, ".": 0x2F, "`": 0x32,
+        " ": 0x31,
+    ]
+}

--- a/Sources/termio/Resources/skills/termio/SKILL.md
+++ b/Sources/termio/Resources/skills/termio/SKILL.md
@@ -44,9 +44,21 @@ id-prefix works too).
   single-line payload arrives verbatim, exactly as typed; a multi-line one is
   wrapped in bracketed paste so a TUI takes it as one block instead of
   submitting each line as its own turn. Add `--no-enter` when a gate wants a
-  bare keypress and no Return — a lone `t` to trust a folder, or `$'\e'` to
-  back out. `$'…'` is bash/zsh ANSI-C quoting and does nothing in plain `sh`;
-  from a POSIX shell use `"$(printf '\033')"` instead.
+  bare keypress and no Return — the lone `t` that trusts a folder.
+- `termio sessions send <link> --key <name>` — press a named key in that
+  session: `--key escape` to back out of a menu, `--key up --key enter` to
+  rerun its last entry, `--key ctrl-c` to interrupt. Repeatable and pressed
+  in the order named, after any text. Never hand-write escape bytes into the
+  text instead: a key's bytes depend on the mode the program negotiated (Up
+  is `ESC[A` in normal mode, `ESC O A` in application mode), and only the
+  terminal's key encoder knows which. Any `--key` suppresses the implicit
+  Return — name `--key enter` when you want one. Names follow kitty and tmux,
+  both spellings accepted: `enter`, `escape`, `tab`, `space`, `backspace`,
+  `delete`, `up`, `down`, `left`, `right`, `home`, `end`, `pageup`,
+  `pagedown`, `f1`–`f12`, single characters, and chords prefixed
+  `ctrl-`/`c-` or `shift-`/`s-`. Those two are the modifiers a program sees;
+  for a meta chord press ESC first (`--key escape --key b`). An unknown name
+  fails with the list; it is never sent as text.
 - `termio sessions read <link> [--lines N]` — the session's current
   screen. The result channel for `run` sessions (a plain command has no
   transcript; its screen is the result) — for agent replies keep using the

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -219,11 +219,37 @@ extension TermioStore {
     }
 
     private func sendText(_ request: ControlRequest, in project: Project) async -> Data {
-        guard let payload = request.text, !payload.isEmpty else {
-            return controlError(request, "no_text", "\(request.op) needs text to send.")
+        let payload = request.text ?? ""
+        // Named keys resolve before anything is typed: a bad name must cost the
+        // caller an error, never half a delivery. An unknown name is never sent as
+        // literal text — silently typing "escpae" into an agent is the failure mode
+        // this whole option exists to remove.
+        var keys: [SessionKeyPress] = []
+        for name in request.namedKeys {
+            guard let press = SessionKeyPress.parse(name) else {
+                return controlError(request, "bad_key",
+                    "Unknown key '\(name)'. Valid keys: \(SessionKeyPress.vocabulary).")
+            }
+            // A key this terminal cannot actually send is refused for the same
+            // reason a misspelled one is: the alternative is a call that reports
+            // success and delivers nothing.
+            if let reason = press.undeliverableReason {
+                return controlError(request, "bad_key", "'\(name)' can't be pressed. \(reason)")
+            }
+            keys.append(press)
+        }
+        guard !payload.isEmpty || !keys.isEmpty else {
+            return controlError(request, "no_text", "\(request.op) needs text or a --key to send.")
         }
         let token = request.target?.trimmingCharacters(in: .whitespaces) ?? ""
         if token.isEmpty {
+            // A spawn types its prompt into an agent that is still booting; there is
+            // no menu there to answer, and no way to time a keypress against a TUI
+            // that hasn't drawn yet. Keys address a session that already exists.
+            guard keys.isEmpty else {
+                return controlError(request, "no_target",
+                    "--key needs a session to press it in — run `termio sessions list`.")
+            }
             // A bare `send` addresses nobody: it starts a fresh agent session for
             // the prompt. `answer` has no such reading — a menu choice without its
             // session is a mistake, never a spawn.
@@ -236,7 +262,7 @@ extension TermioStore {
         switch resolveTarget(token, in: project) {
         case .found(let session):
             let state = surface(for: session, in: project)
-            return await deliver(payload, to: session, state: state, request: request)
+            return await deliver(payload, keys: keys, to: session, state: state, request: request)
         case .notFound:
             return controlError(request, "not_found", targetNotFoundMessage(request.target))
         case .ambiguous:
@@ -354,10 +380,10 @@ extension TermioStore {
     /// + a cursor to read the response from); with it, the call blocks until the
     /// turn settles and reports the outcome plus the transcript range it landed in.
     private func deliver(
-        _ payload: String, to session: Session, state: TerminalViewState,
-        request: ControlRequest
+        _ payload: String, keys: [SessionKeyPress] = [], to session: Session,
+        state: TerminalViewState, request: ControlRequest
     ) async -> Data {
-        guard await performDelivery(payload, to: session, state: state,
+        guard await performDelivery(payload, keys: keys, to: session, state: state,
                                     submit: request.wantsEnter) else {
             return controlError(request, "not_live",
                 "\(displayTitle(for: session)) has no live terminal yet — open it once in Termio.")
@@ -375,9 +401,12 @@ extension TermioStore {
     /// the existing-sibling reply path and the fresh-spawn detached delivery.
     /// `submit` is false for `--no-enter`, where the payload *is* the keypress a
     /// prompt is waiting on and a Return would answer a second question.
+    /// `keys` are the `--key` presses, fired after the text in the order named;
+    /// naming any of them also turns `submit` off, so nothing is pressed that the
+    /// caller did not ask for.
     private func performDelivery(
-        _ payload: String, to session: Session, state: TerminalViewState,
-        submit: Bool = true
+        _ payload: String, keys: [SessionKeyPress] = [], to session: Session,
+        state: TerminalViewState, submit: Bool = true
     ) async -> Bool {
         // The libghostty surface attaches lazily on the pane's first render, so a
         // session never shown in the UI has no surface yet. A background mount adds
@@ -402,7 +431,15 @@ extension TermioStore {
         // submit). `ghostty_surface_key` drives the surface directly, with no focus
         // or first-responder needed; this is exactly how Ghostty's own AppleScript
         // `send key` submits Enter.
-        Self.writeRaw(payload, to: state)
+        if !payload.isEmpty { Self.writeRaw(payload, to: state) }
+        // Named keys ride the same encoder as the Return above, for the same reason:
+        // only Ghostty knows whether this program wants `ESC [ A` or `ESC O A`. They
+        // fire in the order named, each after the same settle the submit takes, so a
+        // TUI that redraws between keystrokes keeps up.
+        for press in keys {
+            try? await Task.sleep(for: .milliseconds(40))
+            Self.pressKey(press, on: surfaceHandle)
+        }
         guard submit else { return true }
         try? await Task.sleep(for: .milliseconds(40))
         Self.pressReturn(on: surfaceHandle)
@@ -697,21 +734,53 @@ extension TermioStore {
     }
 
     /// Sends a Return key press (and release) to the surface — the submit a user makes
-    /// by pressing Enter. `keycode` is the native macOS virtual key for Return
-    /// (`kVK_Return`, 0x24) and `text` is left nil so Ghostty's own key encoder emits
-    /// the correct bytes for whatever keyboard mode the program negotiated.
+    /// by pressing Enter, and the shape every `--key` press takes.
     private static func pressReturn(on surface: ghostty_surface_t) {
+        pressKey(.return, on: surface)
+    }
+
+    /// Sends one key press (and release) to the surface. `keycode` is the native
+    /// macOS virtual key, exactly what an `NSEvent` would carry, and `text` is nil
+    /// for every special key and chord so Ghostty's own key encoder emits the
+    /// correct bytes for whatever keyboard mode the program negotiated — the whole
+    /// point of naming a key instead of hand-writing its escape sequence.
+    /// `ghostty_surface_key` drives the surface directly, with no focus or
+    /// first-responder needed.
+    private static func pressKey(_ press: SessionKeyPress, on surface: ghostty_surface_t) {
+        var mods = GHOSTTY_MODS_NONE.rawValue
+        if press.modifiers.contains(.shift) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
+        if press.modifiers.contains(.control) { mods |= GHOSTTY_MODS_CTRL.rawValue }
+        if press.modifiers.contains(.option) { mods |= GHOSTTY_MODS_ALT.rawValue }
+        if press.modifiers.contains(.command) { mods |= GHOSTTY_MODS_SUPER.rawValue }
+
         var event = ghostty_input_key_s()
         event.action = GHOSTTY_ACTION_PRESS
-        event.mods = GHOSTTY_MODS_NONE
-        event.consumed_mods = GHOSTTY_MODS_NONE
-        event.keycode = 0x24
-        event.text = nil
-        event.unshifted_codepoint = 0
+        event.mods = ghostty_input_mods_e(mods)
+        // Consumed modifiers are the ones the *keyboard layout* already spent
+        // producing text, which the encoder must then not encode a second time. A
+        // real NSEvent learns them from macOS; a synthetic press knows them exactly,
+        // because it decided the text itself: Shift, when it shifted a character,
+        // and nothing else. Marking Alt consumed here would eat the ESC prefix that
+        // makes `--key alt-b` a meta chord at all.
+        event.consumed_mods = ghostty_input_mods_e(
+            press.text == nil ? GHOSTTY_MODS_NONE.rawValue : (mods & GHOSTTY_MODS_SHIFT.rawValue))
+        event.keycode = press.keycode
+        event.unshifted_codepoint = press.unshiftedCodepoint
         event.composing = false
-        _ = ghostty_surface_key(surface, event)
-        event.action = GHOSTTY_ACTION_RELEASE
-        _ = ghostty_surface_key(surface, event)
+        // `text` must stay alive for the duration of the C call, so the press and
+        // release both happen inside the borrow.
+        let send: (UnsafePointer<CChar>?) -> Void = { text in
+            event.text = text
+            event.action = GHOSTTY_ACTION_PRESS
+            _ = ghostty_surface_key(surface, event)
+            event.action = GHOSTTY_ACTION_RELEASE
+            _ = ghostty_surface_key(surface, event)
+        }
+        if let text = press.text {
+            text.withCString { send($0) }
+        } else {
+            send(nil)
+        }
     }
 
     /// The success reply for a send/answer. Beyond confirming delivery, it hands back

--- a/Tests/termioTests/SessionKeyNameTests.swift
+++ b/Tests/termioTests/SessionKeyNameTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import termio
+
+/// `termio sessions send --key <name>` exists because a key's bytes are not a
+/// property of the key: Up is `ESC [ A` in normal cursor mode and `ESC O A` in
+/// application mode, and ctrl-c is `0x03` or `CSI 99;5u` depending on whether the
+/// program turned on the kitty keyboard protocol. Naming the key hands that choice
+/// to Ghostty's encoder. These tests pin the two halves that would quietly rot:
+/// the vocabulary a caller may type, and the refusal to guess when they typo it.
+final class SessionKeyNameTests: XCTestCase {
+    // MARK: - The vocabulary
+
+    func testNamesTheSpecialKeysCallersActuallyPress() {
+        // kVK_Escape, kVK_ANSI_Tab, kVK_UpArrow, kVK_ForwardDelete, kVK_F2.
+        XCTAssertEqual(SessionKeyPress.parse("escape")?.keycode, 0x35)
+        XCTAssertEqual(SessionKeyPress.parse("tab")?.keycode, 0x30)
+        XCTAssertEqual(SessionKeyPress.parse("up")?.keycode, 0x7E)
+        XCTAssertEqual(SessionKeyPress.parse("delete")?.keycode, 0x75)
+        XCTAssertEqual(SessionKeyPress.parse("f2")?.keycode, 0x78)
+    }
+
+    func testEnterIsTheSameKeypressSendAppendsItself() {
+        // `--key enter` and the implicit submit must be one mechanism, or the two
+        // drift and only one of them survives a mode change.
+        XCTAssertEqual(SessionKeyPress.parse("enter"), .return)
+        XCTAssertEqual(SessionKeyPress.parse("return"), .return)
+    }
+
+    func testBackspaceAndDeleteAreDifferentKeys() {
+        // kVK_Delete (backspace) vs kVK_ForwardDelete. macOS names them the other
+        // way round from every terminal, which is exactly how they get swapped.
+        XCTAssertEqual(SessionKeyPress.parse("backspace")?.keycode, 0x33)
+        XCTAssertEqual(SessionKeyPress.parse("delete")?.keycode, 0x75)
+    }
+
+    func testNamesAreCaseInsensitiveAndTrimmed() {
+        XCTAssertEqual(SessionKeyPress.parse("ESCAPE"), SessionKeyPress.parse("escape"))
+        XCTAssertEqual(SessionKeyPress.parse("  Escape "), SessionKeyPress.parse("escape"))
+    }
+
+    func testSpaceIsPrintableNotSpecial() {
+        // The only printable key with a spelled-out name: `--key space` types a
+        // space, `--key ctrl-space` is the NUL chord.
+        let space = SessionKeyPress.parse("space")
+        XCTAssertEqual(space?.keycode, 0x31)
+        XCTAssertEqual(space?.text, " ")
+        XCTAssertEqual(SessionKeyPress.parse("ctrl-space")?.text, nil)
+    }
+
+    // MARK: - Both dialects
+
+    func testTmuxAndKittyModifierSpellingsAgree() {
+        // A caller must never have to guess which dialect this CLI speaks.
+        XCTAssertEqual(SessionKeyPress.parse("c-c"), SessionKeyPress.parse("ctrl-c"))
+        XCTAssertEqual(SessionKeyPress.parse("s-tab"), SessionKeyPress.parse("shift-tab"))
+        XCTAssertEqual(SessionKeyPress.parse("m-b"), SessionKeyPress.parse("alt-b"))
+        XCTAssertEqual(SessionKeyPress.parse("ctrl+c"), SessionKeyPress.parse("ctrl-c"))
+        XCTAssertEqual(SessionKeyPress.parse("cmd-c"), SessionKeyPress.parse("super-c"))
+    }
+
+    func testChordsCarryModifiersAndNoText() {
+        // A chord's bytes come from the encoder, so the event carries the physical
+        // key and the modifier — never pre-typed text that would be inserted as-is.
+        let interrupt = SessionKeyPress.parse("ctrl-c")
+        XCTAssertEqual(interrupt?.keycode, 0x08)
+        XCTAssertEqual(interrupt?.modifiers, .control)
+        XCTAssertEqual(interrupt?.unshiftedCodepoint, UInt32(UnicodeScalar("c").value))
+        XCTAssertNil(interrupt?.text)
+    }
+
+    func testStackedModifiers() {
+        XCTAssertEqual(SessionKeyPress.parse("ctrl-shift-t")?.modifiers, [.control, .shift])
+        XCTAssertEqual(SessionKeyPress.parse("c-m-x")?.modifiers, [.control, .option])
+    }
+
+    func testOptionAndCommandChordsAreRefusedRatherThanPressedIntoTheVoid() {
+        // Verified against a live `cat -v`: `--key alt-b` puts nothing on the wire,
+        // because macOS spends Option composing text and Ghostty adds a real Alt's
+        // ESC prefix only under macos-option-as-alt. Command never reaches the
+        // program at all. Both parse — so the caller is told which modifier is the
+        // problem — and both are then refused, because a key that reports success
+        // and delivers nothing is exactly what --key exists to prevent.
+        XCTAssertNotNil(SessionKeyPress.parse("alt-b")?.undeliverableReason)
+        XCTAssertNotNil(SessionKeyPress.parse("m-b")?.undeliverableReason)
+        XCTAssertNotNil(SessionKeyPress.parse("cmd-c")?.undeliverableReason)
+        // …and the refusal names the substitute that does work.
+        XCTAssertEqual(SessionKeyPress.parse("alt-b")?.undeliverableReason?
+            .contains("--key escape --key b"), true)
+        // The modifiers that do reach the program stay pressable.
+        for name in ["ctrl-c", "shift-tab", "escape", "up", "t"] {
+            XCTAssertNil(SessionKeyPress.parse(name)?.undeliverableReason,
+                         "'\(name)' must stay pressable")
+        }
+    }
+
+    func testUnmodifiedPrintableKeyCarriesTheTextItWouldType() {
+        XCTAssertEqual(SessionKeyPress.parse("t")?.text, "t")
+        XCTAssertEqual(SessionKeyPress.parse("shift-t")?.text, "T")
+    }
+
+    func testSeparatorItselfIsAKeyNotAModifierSyntax() {
+        // `--key -` is the minus key and `--key ctrl--` is ctrl-minus: the peel
+        // must stop rather than eat the key it was meant to leave behind.
+        XCTAssertEqual(SessionKeyPress.parse("-")?.keycode, 0x1B)
+        XCTAssertEqual(SessionKeyPress.parse("ctrl--")?.keycode, 0x1B)
+        XCTAssertEqual(SessionKeyPress.parse("ctrl--")?.modifiers, .control)
+    }
+
+    // MARK: - Failing loudly
+
+    func testUnknownNamesResolveToNothing() {
+        // The whole point. A name this parser cannot place must reach the caller as
+        // an error — never fall through to being typed as literal text, which is
+        // how "escpae" ends up in an agent's prompt and nobody finds out.
+        for name in ["escpae", "", "   ", "ctrl-", "meta", "f13", "ctrl", "arrow-up", "ctrl-nope"] {
+            XCTAssertNil(SessionKeyPress.parse(name), "'\(name)' must not resolve")
+        }
+    }
+
+    func testMultiCharacterUnknownNamesAreNotTakenApart() {
+        // "yes" is text a caller might mean to send; it must not become the y key.
+        XCTAssertNil(SessionKeyPress.parse("yes"))
+    }
+
+    func testVocabularyErrorNamesTheKeysItRejects() {
+        // The error a bad name earns has to be actionable, so the listing must stay
+        // in step with what actually parses.
+        for name in ["enter", "escape", "tab", "space", "backspace", "delete", "up",
+                     "down", "left", "right", "home", "end", "pageup", "pagedown"]
+        {
+            XCTAssertTrue(SessionKeyPress.vocabulary.contains(name),
+                          "'\(name)' parses but is not offered in the error")
+            XCTAssertNotNil(SessionKeyPress.parse(name))
+        }
+        for index in 1 ... 12 {
+            XCTAssertNotNil(SessionKeyPress.parse("f\(index)"))
+        }
+    }
+
+    // MARK: - The wire
+
+    func testAnyNamedKeySuppressesTheImplicitReturn() throws {
+        // Naming a key is being explicit about keys; adding one the caller did not
+        // ask for would submit the menu they meant to escape.
+        XCTAssertTrue(try decode(#"{"op":"send"}"#).wantsEnter)
+        XCTAssertFalse(try decode(#"{"op":"send","enter":false}"#).wantsEnter)
+        XCTAssertFalse(try decode(#"{"op":"send","keys":["escape"]}"#).wantsEnter)
+        // An empty array is not a named key — it must not change the default.
+        XCTAssertTrue(try decode(#"{"op":"send","keys":[]}"#).wantsEnter)
+    }
+
+    func testKeysDecodeInTheOrderNamed() throws {
+        XCTAssertEqual(try decode(#"{"op":"send","keys":["up","enter"]}"#).namedKeys,
+                       ["up", "enter"])
+        XCTAssertEqual(try decode(#"{"op":"send"}"#).namedKeys, [])
+    }
+
+    private func decode(_ json: String) throws -> ControlRequest {
+        try JSONDecoder().decode(ControlRequest.self, from: Data(json.utf8))
+    }
+}

--- a/scripts/termio
+++ b/scripts/termio
@@ -48,6 +48,9 @@ options:
   --timeout <ms>   cap for --wait (default 300000, clamped 1000–600000); implies --wait
   --no-enter       for `send`: deliver the text as-is, with no Return after it —
                    the way to answer a gate that wants a bare keypress
+  --key <name>     for `send`: press a named key (escape, up, tab, ctrl-c, f2, …)
+                   after the text; repeatable, in order. Any --key suppresses the
+                   implicit Return
   --lines <n>      for `read`: keep only the last n screen rows
   --state <s,…>    for `watch`: comma-separated states to report (working, idle, done,
                    needs-you, stalled; default done,needs-you)
@@ -144,7 +147,8 @@ the last N rows. Scrollback is not included.
 EOF
             ;;
         send|answer) cat <<'EOF'
-usage: termio sessions send <session> "<text>" [--no-enter] [--wait [--timeout <ms>]] [--json]
+usage: termio sessions send <session> "<text>" [--key <name>]... [--no-enter]
+                            [--wait [--timeout <ms>]] [--json]
 
 Type text into an existing session and submit it with a real Return
 keypress — a prompt to drive it, or a menu choice ("1", "yes") to answer a
@@ -152,8 +156,24 @@ permission prompt. Addresses come from `termio sessions list` or a `spawn`
 reply — a termio://session link or bare id, copied verbatim.
 
 The text reaches the terminal verbatim, so --no-enter (no Return after it)
-delivers a bare keypress: the lone `t` a trust gate waits for, or an escape
-sequence written by the shell, e.g. `send <session> $'\e' --no-enter`.
+delivers a bare keypress: the lone `t` a trust gate waits for.
+
+--key presses a NAMED key, repeatable and in order, after the text:
+`send <session> --key escape` to back out of a menu, `--key up --key enter`
+to rerun the last entry. Use it instead of writing escape bytes yourself —
+a key's bytes depend on the mode the program negotiated (Up is ESC[A in
+normal mode, ESC O A in application mode), so only the terminal's own key
+encoder can get them right. Any --key suppresses the implicit Return; name
+`--key enter` when you want one. An unknown name is an error, never text.
+
+Key names follow kitty and tmux, both spellings accepted: enter, escape,
+tab, space, backspace, delete, insert, up, down, left, right, home, end,
+pageup, pagedown, f1–f12, and single characters — prefixed with ctrl-/c-
+or shift-/s- for chords (ctrl-c, c-c, shift-tab). Ctrl and Shift are the
+modifiers a program sees: macOS spends Option composing text (option-b is
+∫, not meta-b) and Command drives the app, so those chords are refused
+rather than silently dropped. A meta chord is ESC then the key:
+`--key escape --key b`.
 
 --wait holds the reply until the turn the text kicked off settles (or
 --timeout ms elapse; default 300000, clamped 1000–600000). The reply then
@@ -326,6 +346,7 @@ sessions() {
     states=""
     no_snapshot=0
     no_enter=0
+    keys_json=""
     wait=false
     timeout_ms=""
     lines=""
@@ -335,6 +356,13 @@ sessions() {
             --json) format=json ;;
             --no-snapshot) no_snapshot=1 ;;
             --no-enter) no_enter=1 ;;
+            --key)
+                [ $# -ge 2 ] || { echo "termio: --key needs a key name (e.g. escape, ctrl-c)" >&2; exit 1; }
+                # Order matters — the app presses them in the order named — so they
+                # accumulate into a JSON array rather than a set. The name itself is
+                # validated by the app, the one place that knows the vocabulary.
+                keys_json="${keys_json:+$keys_json,}\"$(json_escape "$2")\""
+                shift ;;
             --wait) wait=true ;;
             --timeout)
                 [ $# -ge 2 ] || { echo "termio: --timeout needs a value in ms" >&2; exit 1; }
@@ -441,6 +469,16 @@ sessions() {
             *) echo "termio: --no-enter applies to send only" >&2; exit 1 ;;
         esac
         extra_json="${extra_json:+$extra_json,}\"enter\":false"
+    fi
+
+    # --key, like --no-enter, only reads on a send to an existing session: a key is
+    # pressed against a TUI that is already drawn, and a booting agent has none.
+    if [ -n "$keys_json" ]; then
+        case "$op" in
+            send|answer) [ -n "$targets" ] || { echo "termio: --key needs a session to press it in" >&2; exit 1; } ;;
+            *) echo "termio: --key applies to send only" >&2; exit 1 ;;
+        esac
+        extra_json="${extra_json:+$extra_json,}\"keys\":[$keys_json]"
     fi
 
     if [ "$op" = watch ]; then

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -44,9 +44,21 @@ id-prefix works too).
   single-line payload arrives verbatim, exactly as typed; a multi-line one is
   wrapped in bracketed paste so a TUI takes it as one block instead of
   submitting each line as its own turn. Add `--no-enter` when a gate wants a
-  bare keypress and no Return — a lone `t` to trust a folder, or `$'\e'` to
-  back out. `$'…'` is bash/zsh ANSI-C quoting and does nothing in plain `sh`;
-  from a POSIX shell use `"$(printf '\033')"` instead.
+  bare keypress and no Return — the lone `t` that trusts a folder.
+- `termio sessions send <link> --key <name>` — press a named key in that
+  session: `--key escape` to back out of a menu, `--key up --key enter` to
+  rerun its last entry, `--key ctrl-c` to interrupt. Repeatable and pressed
+  in the order named, after any text. Never hand-write escape bytes into the
+  text instead: a key's bytes depend on the mode the program negotiated (Up
+  is `ESC[A` in normal mode, `ESC O A` in application mode), and only the
+  terminal's key encoder knows which. Any `--key` suppresses the implicit
+  Return — name `--key enter` when you want one. Names follow kitty and tmux,
+  both spellings accepted: `enter`, `escape`, `tab`, `space`, `backspace`,
+  `delete`, `up`, `down`, `left`, `right`, `home`, `end`, `pageup`,
+  `pagedown`, `f1`–`f12`, single characters, and chords prefixed
+  `ctrl-`/`c-` or `shift-`/`s-`. Those two are the modifiers a program sees;
+  for a meta chord press ESC first (`--key escape --key b`). An unknown name
+  fails with the list; it is never sent as text.
 - `termio sessions read <link> [--lines N]` — the session's current
   screen. The result channel for `run` sessions (a plain command has no
   transcript; its screen is the result) — for agent replies keep using the

--- a/web/landing/public/skill.md
+++ b/web/landing/public/skill.md
@@ -44,9 +44,21 @@ id-prefix works too).
   single-line payload arrives verbatim, exactly as typed; a multi-line one is
   wrapped in bracketed paste so a TUI takes it as one block instead of
   submitting each line as its own turn. Add `--no-enter` when a gate wants a
-  bare keypress and no Return — a lone `t` to trust a folder, or `$'\e'` to
-  back out. `$'…'` is bash/zsh ANSI-C quoting and does nothing in plain `sh`;
-  from a POSIX shell use `"$(printf '\033')"` instead.
+  bare keypress and no Return — the lone `t` that trusts a folder.
+- `termio sessions send <link> --key <name>` — press a named key in that
+  session: `--key escape` to back out of a menu, `--key up --key enter` to
+  rerun its last entry, `--key ctrl-c` to interrupt. Repeatable and pressed
+  in the order named, after any text. Never hand-write escape bytes into the
+  text instead: a key's bytes depend on the mode the program negotiated (Up
+  is `ESC[A` in normal mode, `ESC O A` in application mode), and only the
+  terminal's key encoder knows which. Any `--key` suppresses the implicit
+  Return — name `--key enter` when you want one. Names follow kitty and tmux,
+  both spellings accepted: `enter`, `escape`, `tab`, `space`, `backspace`,
+  `delete`, `up`, `down`, `left`, `right`, `home`, `end`, `pageup`,
+  `pagedown`, `f1`–`f12`, single characters, and chords prefixed
+  `ctrl-`/`c-` or `shift-`/`s-`. Those two are the modifiers a program sees;
+  for a meta chord press ESC first (`--key escape --key b`). An unknown name
+  fails with the list; it is never sent as text.
 - `termio sessions read <link> [--lines N]` — the session's current
   screen. The result channel for `run` sessions (a plain command has no
   transcript; its screen is the result) — for agent replies keep using the


### PR DESCRIPTION
A key's bytes are not a property of the key. Up is `ESC [ A` in normal cursor
mode and `ESC O A` in application mode; ctrl-c is `0x03` in legacy mode and
`CSI 99;5u` under the kitty keyboard protocol every coding agent turns on. So a
caller writing `send <id> $'\e[A' --no-enter` is hard-coding one of two answers
to a question only the terminal can settle, and is right by luck. The skill
taught exactly that, down to a `printf '\033'` fallback for POSIX shells — a
workaround for a missing option, documented as a technique.

`--key <name>` presses the key instead. It is the mirror of the rule #325
established for text: text must go into the PTY raw, untouched by the input
encoder, or the ESC of a hand-written `ESC [ 200 ~` is re-encoded as an Escape
keypress; keys must go *through* that encoder, for the same reason. Two
payloads, two paths, one principle — the encoder owns keys and nothing else.
The mechanism was already there, as `pressReturn`'s hard-coded `kVK_Return`;
this generalizes it to any key rather than opening a second path.

    termio sessions send <id> --key escape
    termio sessions send <id> "ls" --key enter
    termio sessions send <id> --key up --key enter

Naming a key suppresses the implicit Return. The caller is being explicit about
which keys to press, and appending one they did not ask for would submit the
menu they meant to escape — the same expectation tmux sets by never implying a
key. `--key` is repeatable and fires in the order named, after the text.

The vocabulary is kitty's and tmux's, not a third dialect, and accepts both
spellings of every modifier (`c-c` and `ctrl-c`, `s-tab` and `shift-tab`,
`m-b` and `alt-b`) so nobody has to guess which one this CLI speaks. An
unrecognized name is an error listing the valid ones, resolved before a single
byte is delivered: it is never sent as literal text, which is how `escpae`
would otherwise end up in an agent's prompt with nothing to show that it did.

`--paste`/`--no-paste` deliberately stay out. The implicit rule — single line
verbatim, multi-line wrapped in bracketed paste — is right, and is now
documented where a caller reads it.

Verified against a live `cat -v` in a dev-channel build:

| call | on the wire |
| --- | --- |
| `send <id> "hello world"` | `hello world` + Return (echoed back) |
| `send <id> --key escape` | `^[`, no Return |
| `send <id> "ls" --key enter` | `^[ls` submitted once |
| `send <id> $'alpha\nbeta'` | `^[[200~alpha\nbeta^[[201~` |
| `--key up --key down --key left --key right --key c-a --key tab --key space --key f2 --key shift-tab` | `^[[A^[[B^[[D^[[C^A<tab><space>^[OQ^[[Z` |
| `--key ctrl-c` | `^C` — `cat -v` exits, prompt returns |
| `--key escpae` | exit 1, names the vocabulary, screen unchanged |

Option and Command chords parse and are then refused. Verified: `--key alt-b`
puts *nothing* on the wire, because macOS spends Option composing text and
Ghostty adds a real Alt's ESC prefix only under `macos-option-as-alt`; Command
never reaches the program at all. Both now fail with the reason and the
substitute that works — `--key escape --key b`, which does emit `^[b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)