### PR TITLE
Put the device switcher in the sidebar's toolbar

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1080,8 +1080,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// when the sidebar is collapsed — matching Finder/Xcode, which drop their sidebar buttons with
     /// the sidebar, and freeing the horizontal room that otherwise forces NSToolbar's `»` overflow.
     /// The paired flexible space (which right-aligns the two against the sidebar divider) is inserted
-    /// and removed *with* them. When open the region reads `toggleNavigator, flex, sortProjects,
-    /// newTerminal | sidebarTrackingSeparator`. Mirrors `setInspectorSwitchVisible`.
+    /// and removed *with* them, as is the device switcher that leads the region. When open the region
+    /// reads `toggleNavigator, deviceSwitcher, flex, sortProjects, newTerminal |
+    /// sidebarTrackingSeparator`. Mirrors `setInspectorSwitchVisible`.
     private func setNavigatorItemsVisible(_ visible: Bool) {
         guard let toolbar = window?.toolbar else { return }
         func index(of id: NSToolbarItem.Identifier) -> Int? {
@@ -1094,16 +1095,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         defer { NSAnimationContext.endGrouping() }
         if visible {
             guard index(of: .sortProjects) == nil, let sep = index(of: .sidebarTrackingSeparator) else { return }
-            // Insert in reverse at the separator's index so the final order is flex, sortProjects, newTerminal.
+            // Insert in reverse at the separator's index so the final order is deviceSwitcher, flex,
+            // sortProjects, newTerminal.
             toolbar.insertItem(withItemIdentifier: .newTerminal, at: sep)
             toolbar.insertItem(withItemIdentifier: .sortProjects, at: sep)
             toolbar.insertItem(withItemIdentifier: .flexibleSpace, at: sep)
+            toolbar.insertItem(withItemIdentifier: .deviceSwitcher, at: sep)
         } else {
             // Only clean up when the buttons are actually present (nothing to remove at launch with
             // the sidebar already collapsed). Re-find each id after every removal — indices shift.
             guard let sortIdx = index(of: .sortProjects) else { return }
             toolbar.removeItem(at: sortIdx)
             if let i = index(of: .newTerminal) { toolbar.removeItem(at: i) }
+            if let i = index(of: .deviceSwitcher) { toolbar.removeItem(at: i) }
             // Drop the flexible space that right-aligned them (the one just before the sidebar separator).
             if let sep = index(of: .sidebarTrackingSeparator), sep > 0,
                toolbar.items[sep - 1].itemIdentifier == .flexibleSpace {
@@ -1975,7 +1979,9 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        defaultIdentifiers + [.sortProjects, .newTerminal, .inspectorTrackingSeparator, .inspectorTabs]
+        defaultIdentifiers + [
+            .deviceSwitcher, .sortProjects, .newTerminal, .inspectorTrackingSeparator, .inspectorTabs,
+        ]
     }
 
     func toolbar(
@@ -1994,6 +2000,24 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             // the system animation. `nil` target routes up the responder chain to the split
             // controller (the window's content view controller), so no custom action is needed.
             item.action = #selector(NSSplitViewController.toggleSidebar(_:))
+            return item
+        case .deviceSwitcher:
+            // The machine the sidebar is listing, at the head of the sidebar's own toolbar region —
+            // the band above the column it scopes. Borderless SwiftUI rather than an
+            // `NSMenuToolbarItem` so the one device menu has one definition
+            // (`DeviceSwitcherMenuContent`) instead of an AppKit copy that can drift from it, and so
+            // the control can name the device: this toolbar is `.iconOnly`, which drops item titles.
+            // It draws nothing while this Mac is the only device, which is also when the sidebar
+            // region has the least room to spare.
+            let item = NSToolbarItem(itemIdentifier: .deviceSwitcher)
+            item.label = localized("Device")
+            item.toolTip = localized("Choose which device the sidebar shows")
+            let host = NSHostingView(rootView: DeviceSwitcherToolbarView()
+                .environmentObject(store)
+                .environmentObject(settings))
+            host.sizingOptions = [.intrinsicContentSize]
+            item.view = host
+            item.isBordered = false
             return item
         case .sortProjects:
             // A pull-down that sets how the sidebar orders projects (Recent Activity /
@@ -2097,6 +2121,7 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
 
 private extension NSToolbarItem.Identifier {
     static let toggleNavigator = NSToolbarItem.Identifier("TermioToggleNavigator")
+    static let deviceSwitcher = NSToolbarItem.Identifier("TermioDeviceSwitcher")
     static let sortProjects = NSToolbarItem.Identifier("TermioSortProjects")
     static let newTerminal = NSToolbarItem.Identifier("TermioNewTerminal")
     static let inspectorTabs = NSToolbarItem.Identifier("TermioInspectorTabs")

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -11,6 +11,26 @@
         }
       }
     },
+    "Choose which device the sidebar shows": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择侧栏显示哪台设备"
+          }
+        }
+      }
+    },
+    "Device": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备"
+          }
+        }
+      }
+    },
     "Takes effect after Termio relaunches.": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -182,6 +182,8 @@
 	<string>Choose another branch to compare with.</string>
 	<key>Choose how projects are ordered</key>
 	<string>Choose how projects are ordered</string>
+	<key>Choose which device the sidebar shows</key>
+	<string>Choose which device the sidebar shows</string>
 	<key>Choose…</key>
 	<string>Choose…</string>
 	<key>Clear</key>
@@ -334,6 +336,8 @@
 	<string>Delete…</string>
 	<key>Detached at %@</key>
 	<string>Detached at %@</string>
+	<key>Device</key>
+	<string>Device</string>
 	<key>Discard %lld Files…</key>
 	<string>Discard %lld Files…</string>
 	<key>Discard Changes</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -182,6 +182,8 @@
 	<string>请另选一个用于对比的分支。</string>
 	<key>Choose how projects are ordered</key>
 	<string>选取项目的排序方式</string>
+	<key>Choose which device the sidebar shows</key>
+	<string>选择侧栏显示哪台设备</string>
 	<key>Choose…</key>
 	<string>选取…</string>
 	<key>Clear</key>
@@ -334,6 +336,8 @@
 	<string>删除…</string>
 	<key>Detached at %@</key>
 	<string>已分离于 %@</string>
+	<key>Device</key>
+	<string>设备</string>
 	<key>Discard %lld Files…</key>
 	<string>放弃 %lld 个文件的更改…</string>
 	<key>Discard Changes</key>

--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -68,7 +68,7 @@ enum DeviceRoster {
 }
 
 /// The rows every device switcher shows, wherever it is mounted. The sidebar's
-/// indicator is the only opening today; the rows live here rather than inside it
+/// toolbar control is the only opening today; the rows live here rather than in it
 /// because there is one current device, and it would be a bug for two controls to
 /// disagree about which one it is.
 struct DeviceSwitcherMenuContent: View {
@@ -118,45 +118,61 @@ struct DeviceSwitcherMenuContent: View {
     }
 }
 
-/// The sidebar's device indicator: which machine you are on, and the switcher
-/// that changes it. Quiet by design — it names the device and nothing else — and
-/// absent entirely while this Mac is the only one, so a user who never leaves
-/// their laptop never sees it.
-struct DeviceIndicator: View {
+/// The device switcher, in the sidebar's own toolbar region: which machine you
+/// are on, and the control that changes it. It sits in the strip above the list
+/// rather than in a row of its own, next to the navigator toggle and the sidebar's
+/// other actions — the band belongs to the column below it, and a first row that
+/// is not a session is a row the tree has to explain.
+///
+/// Quiet by design — it names the device and nothing else — and absent entirely
+/// while this Mac is the only one, so a user who never leaves their laptop never
+/// sees it.
+struct DeviceSwitcherToolbarView: View {
     @EnvironmentObject var store: TermioStore
     @EnvironmentObject var settings: AppSettings
+    @Environment(\.controlActiveState) private var controlActive
+
+    /// Long aliases truncate rather than push the sort and `+` buttons toward
+    /// NSToolbar's `»` overflow: the sidebar region has only the room the
+    /// navigator's minimum thickness gives it.
+    private static let nameWidthCeiling: CGFloat = 130
 
     var body: some View {
         let known = DeviceRoster.known(in: store)
         // The single-device collapse. Not "hidden but present": with one machine
-        // there is no switch to make, and a row that always reads "This Mac" is a
-        // label for a decision the user never took.
+        // there is no switch to make, and a control that always reads "This Mac"
+        // is a label for a decision the user never took.
         if known.count > 1 {
             let current = DeviceRoster.current(store, known: known)
-            Divider()
             Menu {
                 DeviceSwitcherMenuContent()
             } label: {
-                HStack(spacing: 6) {
-                    HugeIconView(icon: .serverStack, size: 13, color: .secondary)
+                HStack(spacing: 5) {
+                    // Sized against the toolbar's own glyphs (the navigator toggle, the
+                    // sort pull-down) rather than shrunk to fit beside them, and set in
+                    // the sidebar's interface font — this control belongs to that column.
+                    HugeIconView(icon: .serverStack, size: 15, color: color)
                     Text(current.name)
                         .font(settings.interfaceFont)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(color)
                         .lineLimit(1)
                         .truncationMode(.middle)
-                    Spacer(minLength: 4)
-                    HugeIconView(icon: .chevronRight, size: 7.5, color: .secondary,
+                    HugeIconView(icon: .chevronRight, size: 8, color: color,
                                  lineWidthOverride: 1.75)
                         .rotationEffect(.degrees(90))
                 }
+                .frame(maxWidth: Self.nameWidthCeiling)
                 .contentShape(Rectangle())
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+            .fixedSize()
             .help(localized("The sidebar shows this device’s sessions"))
         }
+    }
+
+    private var color: Color {
+        controlActive == .inactive ? Color(nsColor: .disabledControlTextColor) : .secondary
     }
 }
 

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -165,130 +165,123 @@ struct SidebarView: View {
         let hasPinned = !pinnedProjects.isEmpty || !pinnedWorktrees.isEmpty || !pinnedSessions.isEmpty
         let hasTerminals = terminals.contains { !$0.sessions.isEmpty }
         let hasChats = chats.contains { !$0.sessions.isEmpty }
-        return VStack(spacing: 0) {
-            // Which machine you are on, above everything it contains. The list
-            // below is that device's world, so the device has to be read first —
-            // pinned under the tree it was a footnote to state it should have
-            // been announcing. Draws nothing while this Mac is the only device.
-            DeviceIndicator()
-            List {
-                // Nudge when agents are running but the status hooks are off — without them
-                // the sidebar spinner stays dark. One tap enables (and reinstalls) them.
-                if !settings.agentHooksEnabled && store.isRunningAnyAgent {
-                    AgentHooksOffBanner { settings.agentHooksEnabled = true }
-                        .listRowSeparator(.hidden)
-                        .listRowBackground(Color.clear)
-                }
-                // The top "Pinned" working set, under its own section header: pinned projects
-                // as full blocks, then pinned worktrees as mini-blocks (header + their
-                // sessions), then pinned sessions as shortcut rows — each nested entry tagged
-                // with its origin breadcrumb. Nested items stay in the tree below too; only
-                // whole projects move up here. This curated working set sits at the very top —
-                // above the ephemeral Terminals/Chats funnels — because it's the items the user
-                // deliberately elevated (mirroring the iOS "Needs You" strip at the home top).
-                if hasPinned {
-                    SidebarSectionHeader(
-                        title: localized("Pinned"),
-                        chrome: chrome,
-                        isCollapsed: pinnedCollapsed,
-                        isFirstSection: true,
-                        toggleCollapsed: {
-                            withAnimation(.easeInOut(duration: 0.18)) { pinnedCollapsed.toggle() }
-                        }
-                    )
-                    if !pinnedCollapsed {
-                        ForEach(pinnedProjects) { projectBlock($0) }
-                        ForEach(pinnedWorktrees) { entry in
-                            pinnedWorktreeBlock(project: entry.project, worktree: entry.worktree)
-                        }
-                        ForEach(pinnedSessions) { entry in
-                            SessionRow(session: entry.session, chrome: chrome, leadingIndent: 16,
-                                       breadcrumb: breadcrumb(for: entry.session, in: entry.project))
-                        }
-                    }
-                }
-                // The loose-terminals funnel, as a section (not a project folder): its
-                // header carries the New/Close actions; its sessions render below. Hidden
-                // entirely while it holds no terminals — an empty section label is just
-                // noise (a new loose terminal reappears the section, via the + / File menu).
-                ForEach(terminals.filter { !$0.sessions.isEmpty }) { term in
-                    SidebarSectionHeader(
-                        title: localized("Terminals"),
-                        chrome: chrome,
-                        isCollapsed: collapsedProjects.contains(term.id),
-                        isFirstSection: !hasPinned,
-                        toggleCollapsed: { toggleCollapsed(term.id) },
-                        menuItems: [
-                            newTerminalMenuItem(store: store) {
-                                store.addSession(to: term.id, agent: .terminal)
-                            },
-                            .separator,
-                            .action(localized("Close All Terminals")) { store.removeProject(term.id) },
-                        ]
-                    )
-                    if !collapsedProjects.contains(term.id) {
-                        let sessions = primarySessions(for: term)
-                        let marks = splitLinkMarks(for: sessions)
-                        ForEach(sessions) { session in
-                            SessionRow(session: session, chrome: chrome, splitLink: marks[session.id])
-                        }
-                    }
-                }
-                // The loose-agents funnel — the agent-side twin of Terminals, paired
-                // directly above Projects (the "Chats vs Projects" split: one-off agent
-                // sessions vs. real folder-scoped work). Every scratch agent shares one
-                // `.chats` container rooted at `~/.termio/chats`; its header offers a single
-                // "New Chat" (the default agent — see `addDefaultChat`) plus a Close All,
-                // mirroring the Terminals header's "New Terminal". Hidden while empty.
-                ForEach(chats.filter { !$0.sessions.isEmpty }) { chat in
-                    SidebarSectionHeader(
-                        title: localized("Chats"),
-                        chrome: chrome,
-                        isCollapsed: collapsedProjects.contains(chat.id),
-                        isFirstSection: !hasPinned && !hasTerminals,
-                        toggleCollapsed: { toggleCollapsed(chat.id) },
-                        menuItems: [
-                            .action(localized("New Chat")) { store.addDefaultChat() },
-                            .separator,
-                            .action(localized("Close All Chats")) { store.removeProject(chat.id) },
-                        ]
-                    )
-                    if !collapsedProjects.contains(chat.id) {
-                        let sessions = primarySessions(for: chat)
-                        let marks = splitLinkMarks(for: sessions)
-                        ForEach(sessions) { session in
-                            SessionRow(session: session, chrome: chrome, splitLink: marks[session.id])
-                        }
-                    }
-                }
-                // The user's opened projects, under their own section header — the same
-                // section treatment as Terminals and Pinned, one tier above the folder rows.
-                if !others.isEmpty {
-                    SidebarSectionHeader(
-                        title: localized("Projects"),
-                        chrome: chrome,
-                        isCollapsed: projectsCollapsed,
-                        isFirstSection: !hasPinned && !hasTerminals && !hasChats,
-                        toggleCollapsed: {
-                            withAnimation(.easeInOut(duration: 0.18)) { projectsCollapsed.toggle() }
-                        }
-                    )
-                    if !projectsCollapsed {
-                        ForEach(others) { projectBlock($0) }
-                    }
-                }
-                // What the device itself says is running. On another machine this is
-                // the whole sidebar; on this Mac it is the sessions the daemon holds
-                // that no row above accounts for.
-                deviceWorldSection(isFirstSection: !hasPinned && !hasTerminals && !hasChats
-                    && others.isEmpty)
+        return List {
+            // Nudge when agents are running but the status hooks are off — without them
+            // the sidebar spinner stays dark. One tap enables (and reinstalls) them.
+            if !settings.agentHooksEnabled && store.isRunningAnyAgent {
+                AgentHooksOffBanner { settings.agentHooksEnabled = true }
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
             }
-            // The native macOS `.sidebar` source list — its own Liquid Glass material, full-height
-            // behind the traffic lights. (We previously painted the column ourselves to dodge a macOS 26
-            // full-screen round-trip bug, but per the design call we're back to the stock sidebar.)
-            .listStyle(.sidebar)
-            .environment(\.defaultMinListRowHeight, 1)
+            // The top "Pinned" working set, under its own section header: pinned projects
+            // as full blocks, then pinned worktrees as mini-blocks (header + their
+            // sessions), then pinned sessions as shortcut rows — each nested entry tagged
+            // with its origin breadcrumb. Nested items stay in the tree below too; only
+            // whole projects move up here. This curated working set sits at the very top —
+            // above the ephemeral Terminals/Chats funnels — because it's the items the user
+            // deliberately elevated (mirroring the iOS "Needs You" strip at the home top).
+            if hasPinned {
+                SidebarSectionHeader(
+                    title: localized("Pinned"),
+                    chrome: chrome,
+                    isCollapsed: pinnedCollapsed,
+                    isFirstSection: true,
+                    toggleCollapsed: {
+                        withAnimation(.easeInOut(duration: 0.18)) { pinnedCollapsed.toggle() }
+                    }
+                )
+                if !pinnedCollapsed {
+                    ForEach(pinnedProjects) { projectBlock($0) }
+                    ForEach(pinnedWorktrees) { entry in
+                        pinnedWorktreeBlock(project: entry.project, worktree: entry.worktree)
+                    }
+                    ForEach(pinnedSessions) { entry in
+                        SessionRow(session: entry.session, chrome: chrome, leadingIndent: 16,
+                                   breadcrumb: breadcrumb(for: entry.session, in: entry.project))
+                    }
+                }
+            }
+            // The loose-terminals funnel, as a section (not a project folder): its
+            // header carries the New/Close actions; its sessions render below. Hidden
+            // entirely while it holds no terminals — an empty section label is just
+            // noise (a new loose terminal reappears the section, via the + / File menu).
+            ForEach(terminals.filter { !$0.sessions.isEmpty }) { term in
+                SidebarSectionHeader(
+                    title: localized("Terminals"),
+                    chrome: chrome,
+                    isCollapsed: collapsedProjects.contains(term.id),
+                    isFirstSection: !hasPinned,
+                    toggleCollapsed: { toggleCollapsed(term.id) },
+                    menuItems: [
+                        newTerminalMenuItem(store: store) {
+                            store.addSession(to: term.id, agent: .terminal)
+                        },
+                        .separator,
+                        .action(localized("Close All Terminals")) { store.removeProject(term.id) },
+                    ]
+                )
+                if !collapsedProjects.contains(term.id) {
+                    let sessions = primarySessions(for: term)
+                    let marks = splitLinkMarks(for: sessions)
+                    ForEach(sessions) { session in
+                        SessionRow(session: session, chrome: chrome, splitLink: marks[session.id])
+                    }
+                }
+            }
+            // The loose-agents funnel — the agent-side twin of Terminals, paired
+            // directly above Projects (the "Chats vs Projects" split: one-off agent
+            // sessions vs. real folder-scoped work). Every scratch agent shares one
+            // `.chats` container rooted at `~/.termio/chats`; its header offers a single
+            // "New Chat" (the default agent — see `addDefaultChat`) plus a Close All,
+            // mirroring the Terminals header's "New Terminal". Hidden while empty.
+            ForEach(chats.filter { !$0.sessions.isEmpty }) { chat in
+                SidebarSectionHeader(
+                    title: localized("Chats"),
+                    chrome: chrome,
+                    isCollapsed: collapsedProjects.contains(chat.id),
+                    isFirstSection: !hasPinned && !hasTerminals,
+                    toggleCollapsed: { toggleCollapsed(chat.id) },
+                    menuItems: [
+                        .action(localized("New Chat")) { store.addDefaultChat() },
+                        .separator,
+                        .action(localized("Close All Chats")) { store.removeProject(chat.id) },
+                    ]
+                )
+                if !collapsedProjects.contains(chat.id) {
+                    let sessions = primarySessions(for: chat)
+                    let marks = splitLinkMarks(for: sessions)
+                    ForEach(sessions) { session in
+                        SessionRow(session: session, chrome: chrome, splitLink: marks[session.id])
+                    }
+                }
+            }
+            // The user's opened projects, under their own section header — the same
+            // section treatment as Terminals and Pinned, one tier above the folder rows.
+            if !others.isEmpty {
+                SidebarSectionHeader(
+                    title: localized("Projects"),
+                    chrome: chrome,
+                    isCollapsed: projectsCollapsed,
+                    isFirstSection: !hasPinned && !hasTerminals && !hasChats,
+                    toggleCollapsed: {
+                        withAnimation(.easeInOut(duration: 0.18)) { projectsCollapsed.toggle() }
+                    }
+                )
+                if !projectsCollapsed {
+                    ForEach(others) { projectBlock($0) }
+                }
+            }
+            // What the device itself says is running. On another machine this is
+            // the whole sidebar; on this Mac it is the sessions the daemon holds
+            // that no row above accounts for.
+            deviceWorldSection(isFirstSection: !hasPinned && !hasTerminals && !hasChats
+                && others.isEmpty)
         }
+        // The native macOS `.sidebar` source list — its own Liquid Glass material, full-height
+        // behind the traffic lights. (We previously painted the column ourselves to dodge a macOS 26
+        // full-screen round-trip bug, but per the design call we're back to the stock sidebar.)
+        .listStyle(.sidebar)
+        .environment(\.defaultMinListRowHeight, 1)
         .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 360)
     }
 


### PR DESCRIPTION
The device switcher was a row of its own above the sidebar list, so the first thing in the sidebar was not a session. It now sits in the sidebar's own toolbar region, right after the navigator toggle: `toggleNavigator, deviceSwitcher, ⟷, sortProjects, newTerminal | separator`.

It goes in as a borderless SwiftUI item rather than an `NSMenuToolbarItem` — the toolbar is `.iconOnly`, which drops item titles, and an AppKit copy of the device menu would be free to drift from `DeviceSwitcherMenuContent`. The icon is sized against the toolbar's own glyphs and the name is set in the sidebar's interface font, capped at 130pt with a middle ellipsis so a long alias never pushes the sort and `+` buttons into NSToolbar's `»` overflow.

It is inserted and removed with the sidebar's other actions, so collapsing the navigator still empties the region, and it still draws nothing while this Mac is the only device.

`swift build` and `swift test` (366 tests) pass; `scripts/check-strings.sh` is clean with the two new keys in the catalog.

Release Notes:

- The device switcher moved into the sidebar's toolbar, above the sessions it scopes.