### PR TITLE
Ignore background blur at full opacity

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -639,14 +639,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// terminal's own background so the transparent title bar sits flush with the
     /// terminal instead of showing the system window grey. Re-run on every settings
     /// change, so the title bar tracks the terminal theme live.
-    ///
-    /// Blur is deliberately excluded from the predicate: it only softens what shows
-    /// through a transparent background, so at full opacity it is a no-op and must
-    /// not keep the window translucent. Including it left the title bar stuck
-    /// transparent when a leftover blur value survived an Opacity return to 100%.
     private func applyWindowTransparency() {
         guard let window else { return }
-        let translucent = settings.backgroundOpacity < 1.0
+        let translucent = settings.isBackgroundTranslucent
         window.isOpaque = !translucent
         // Resolve the terminal background to a *static* color for the window's current
         // appearance, rather than handing the window the dynamic (appearance-resolving) color.

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -639,9 +639,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// terminal's own background so the transparent title bar sits flush with the
     /// terminal instead of showing the system window grey. Re-run on every settings
     /// change, so the title bar tracks the terminal theme live.
+    ///
+    /// Blur is deliberately excluded from the predicate: it only softens what shows
+    /// through a transparent background, so at full opacity it is a no-op and must
+    /// not keep the window translucent. Including it left the title bar stuck
+    /// transparent when a leftover blur value survived an Opacity return to 100%.
     private func applyWindowTransparency() {
         guard let window else { return }
-        let translucent = settings.backgroundOpacity < 1.0 || settings.backgroundBlur > 0
+        let translucent = settings.backgroundOpacity < 1.0
         window.isOpaque = !translucent
         // Resolve the terminal background to a *static* color for the window's current
         // appearance, rather than handing the window the dynamic (appearance-resolving) color.

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -287,6 +287,12 @@ final class AppSettings: ObservableObject {
         didSet { store.set(backgroundBlur, forKey: Key.backgroundBlur) }
     }
 
+    /// Whether the window and the surfaces in it must stay see-through. Opacity is the
+    /// only input: blur softens what shows through a transparent background, so reading
+    /// it here left a stored blur value holding the window transparent after opacity
+    /// went back to full — with the Blur stepper disabled at that point, unfixable.
+    var isBackgroundTranslucent: Bool { backgroundOpacity < 1.0 }
+
     // MARK: Terminal
 
     /// Scrollback buffer size in megabytes. Agents emit a lot of output, so the

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -332,10 +332,12 @@ struct TerminalPane: View {
         }
     }
 
-    /// True when the user has dialed the background below full opacity or enabled
-    /// blur, so the surface, window, and title bar must stay see-through.
+    /// True when the user has dialed the background below full opacity, so the
+    /// surface, window, and title bar must stay see-through. Blur is excluded —
+    /// it only softens what shows through a transparent background, so at full
+    /// opacity it is a no-op and must not keep the surface see-through.
     private var isTranslucent: Bool {
-        settings.backgroundOpacity < 1.0 || settings.backgroundBlur > 0
+        settings.backgroundOpacity < 1.0
     }
 
     /// The terminal background fill, or clear when translucent — then the surface and

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -332,18 +332,10 @@ struct TerminalPane: View {
         }
     }
 
-    /// True when the user has dialed the background below full opacity, so the
-    /// surface, window, and title bar must stay see-through. Blur is excluded —
-    /// it only softens what shows through a transparent background, so at full
-    /// opacity it is a no-op and must not keep the surface see-through.
-    private var isTranslucent: Bool {
-        settings.backgroundOpacity < 1.0
-    }
-
     /// The terminal background fill, or clear when translucent — then the surface and
     /// window stay see-through.
     private var paneBackground: Color {
-        isTranslucent ? .clear : Color(nsColor: settings.terminalBackgroundColor)
+        settings.isBackgroundTranslucent ? .clear : Color(nsColor: settings.terminalBackgroundColor)
     }
 }
 


### PR DESCRIPTION
## Problem

The window's translucency predicate was `backgroundOpacity < 1.0 || backgroundBlur > 0`. `backgroundBlur` only softens what shows through a transparent background, so at 100% opacity it is a no-op — yet a leftover blur value (e.g. `60`) kept the window and title bar translucent after Opacity was slid back to 100%. The Blur stepper is disabled at full opacity, so the stuck value was invisible and unfixable from the UI, and it survived restarts because the value is persisted in `settings.json`.

Fixes #333.

## Change

Drive translucency from `backgroundOpacity` alone, in both places that compute it:

- `App.applyWindowTransparency()` — window `isOpaque` / `backgroundColor`.
- `TerminalPane.isTranslucent` — the pane background fill.

Blur is still passed through to Ghostty unchanged, so it keeps its normal effect whenever opacity is below full.

## Release Notes:

- Fixed the title bar and window staying transparent after returning Opacity to 100% when a Blur value was left set.
