### PR TITLE
feat(termiod): ship the daemon inside the app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ env:
   # inset — the window title lands flush against the sidebar divider. Keep this in
   # step with the local dev toolchain until the toolbar is adapted to the 26.5 chrome.
   DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
+  # build-app.sh builds termiod into the bundle, and its VT engine is compiled by
+  # Zig from our libghostty fork. Pinned with its published checksum, exactly as
+  # .github/workflows/termiod.yml pins it — keep the two in step.
+  ZIG_VERSION: "0.16.0"
+  ZIG_SHA256_AARCH64_MACOS: "b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489"
   # The DMG lives at $DOWNLOAD_BASE_URL/v<version>/termio.dmg (immutable) with a
   # stable $DOWNLOAD_BASE_URL/termio.dmg copy; the appcast at $DOWNLOAD_BASE_URL/
   # appcast.xml (matches SUFeedURL in packaging/Info.plist).
@@ -77,8 +82,23 @@ jobs:
             -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
 
-      # build-app.sh embeds + signs Sparkle and Developer-ID-signs the bundle with
-      # the hardened runtime, so the output is ready to notarize.
+      # `libghostty-vt-sys` invokes `zig` by name and honours no env override, so
+      # the toolchain has to land on PATH under exactly that name. build-app.sh
+      # points the daemon's build at the Command Line Tools SDK itself — Xcode 26's
+      # libSystem.tbd is arm64e-only and Zig cannot link against it — and leaves
+      # DEVELOPER_DIR above intact for the Swift build.
+      - name: Install Zig (for termiod's VT engine)
+        run: |
+          url="https://ziglang.org/download/${ZIG_VERSION}/zig-aarch64-macos-${ZIG_VERSION}.tar.xz"
+          curl -fsSL "$url" -o "$RUNNER_TEMP/zig.tar.xz"
+          echo "${ZIG_SHA256_AARCH64_MACOS}  $RUNNER_TEMP/zig.tar.xz" | shasum -a 256 -c -
+          mkdir -p "$RUNNER_TEMP/zig"
+          tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP/zig" --strip-components=1
+          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+
+      # build-app.sh embeds + signs Sparkle, builds and signs termiod into
+      # Contents/Resources, and Developer-ID-signs the bundle with the hardened
+      # runtime, so the output is ready to notarize.
       - name: Build signed app bundle
         env:
           SIGN_IDENTITY: "Developer ID Application"

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -67,15 +67,78 @@ enum Termiod {
         return "\(base)/termiod-\(getuid())/termiod.sock"
     }
 
-    /// The daemon binary used for autostart: `TERMIO_TERMIOD_BIN` when set,
-    /// else the dev build inside the working tree the app was launched from.
-    /// One resolution point so autostart and diagnostics can never disagree.
+    /// The daemon's name inside the bundle. Unlike the `termio` CLI it is not
+    /// renamed per channel: the CLI is symlinked onto PATH, where a dev copy
+    /// would clobber the release one, while the daemon is only ever executed by
+    /// absolute path out of the bundle that ships it. (Keeping the two channels'
+    /// *sessions* apart is `TERMIOD_SOCK`, a separate axis.)
+    static let daemonBinaryName = "termiod"
+
+    /// The daemon binary used for autostart. One resolution point so autostart
+    /// and diagnostics can never disagree, in this order:
+    ///
+    /// 1. `TERMIO_TERMIOD_BIN` — the development override, unchanged.
+    /// 2. `Contents/Resources/termiod` in the running `.app` — what a shipped
+    ///    build uses. `Bundle.main`, never `Bundle.module`: SwiftPM bakes the
+    ///    latter with the build machine's path and it does not survive into a
+    ///    shipped bundle.
+    /// 3. `termiod/target/{release,debug}/termiod` in the checkout the running
+    ///    binary lives in, so a bare `swift build` binary — which has no bundle
+    ///    at all, the case `CommandLineTool.bundledURL` answers `nil` for —
+    ///    still finds the daemon a developer just built.
+    ///
+    /// The checkout fallback is anchored at the *binary*, not at
+    /// `currentDirectoryPath`. A Finder-launched app has cwd `/`, which is how
+    /// the previous fallback resolved `/termiod/target/debug/termiod` and why no
+    /// released build could ever start a daemon.
     static func daemonBinaryPath() -> String {
         let environment = ProcessInfo.processInfo.environment
         if let explicit = environment["TERMIO_TERMIOD_BIN"], !explicit.isEmpty {
             return explicit
         }
-        return FileManager.default.currentDirectoryPath + "/termiod/target/debug/termiod"
+        var candidates: [String] = []
+        if let bundled = Bundle.main.url(forResource: daemonBinaryName, withExtension: nil) {
+            candidates.append(bundled.path)
+        }
+        let executableDirectory = (Bundle.main.executableURL ?? Bundle.main.bundleURL)
+            .deletingLastPathComponent()
+        candidates += developmentDaemonCandidates(near: executableDirectory)
+        let fileManager = FileManager.default
+        if let usable = candidates.first(where: { fileManager.isExecutableFile(atPath: $0) }) {
+            return usable
+        }
+        // Nothing exists yet: name the bundle location a shipped build should
+        // have had, so `daemonBinaryMissing` reports the path worth fixing.
+        return candidates.first
+            ?? Bundle.main.bundleURL
+                .appendingPathComponent("Contents/Resources/\(daemonBinaryName)").path
+    }
+
+    /// `termiod` builds inside the checkout the running binary sits in, nearest
+    /// first, release before debug. The search walks up from `directory` looking
+    /// for the marker that identifies the repo root — `termiod/Cargo.toml` —
+    /// which places it correctly for both `.build/<triple>/debug/termio` and an
+    /// `.app` assembled at the repo root. Empty when there is no checkout above
+    /// the binary, which is the shipped case.
+    ///
+    /// Separate from `daemonBinaryPath()` so it can be tested without a bundle.
+    static func developmentDaemonCandidates(near directory: URL) -> [String] {
+        let fileManager = FileManager.default
+        var current = directory.standardizedFileURL
+        // Deep enough for `.build/<triple>/debug/` and for an `.app`'s
+        // `Contents/MacOS/`, shallow enough never to walk to `/`.
+        for _ in 0 ..< 8 {
+            let root = current.appendingPathComponent("termiod")
+            if fileManager.isReadableFile(atPath: root.appendingPathComponent("Cargo.toml").path) {
+                return ["release", "debug"].map {
+                    root.appendingPathComponent("target/\($0)/\(daemonBinaryName)").path
+                }
+            }
+            let parent = current.deletingLastPathComponent().standardizedFileURL
+            if parent.path == current.path { break }
+            current = parent
+        }
+        return []
     }
 
     // MARK: - Socket

--- a/Tests/termioTests/TermiodDaemonBinaryTests.swift
+++ b/Tests/termioTests/TermiodDaemonBinaryTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import termio
+
+/// `Termiod.developmentDaemonCandidates` — the checkout half of daemon
+/// resolution. The bundle half cannot be tested from `swift test` (the test
+/// process has no `.app`, which is exactly the case the checkout half exists
+/// for), so what is pinned here is the fallback that must keep a developer
+/// working and, above all, that resolution is anchored at the running binary
+/// rather than at the working directory: a Finder-launched app has cwd `/`, and
+/// the previous fallback resolved `/termiod/target/debug/termiod` there — the
+/// reason no released build could start a daemon.
+final class TermiodDaemonBinaryTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("termiod-resolution-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+        try super.tearDownWithError()
+    }
+
+    private func makeCheckout(at directory: URL) throws {
+        let daemon = directory.appendingPathComponent("termiod")
+        try FileManager.default.createDirectory(at: daemon, withIntermediateDirectories: true)
+        try Data("[package]\nname = \"termiod\"\n".utf8)
+            .write(to: daemon.appendingPathComponent("Cargo.toml"))
+    }
+
+    /// The `.build/<triple>/debug/termio` case: a bare SwiftPM binary sitting
+    /// three levels below the checkout it was built in.
+    func testFindsTheCheckoutAboveASwiftPMBinary() throws {
+        try makeCheckout(at: root)
+        let binaryDirectory = root.appendingPathComponent(".build/arm64-apple-macosx/debug")
+        try FileManager.default.createDirectory(at: binaryDirectory, withIntermediateDirectories: true)
+
+        let candidates = Termiod.developmentDaemonCandidates(near: binaryDirectory)
+
+        XCTAssertEqual(candidates, [
+            root.appendingPathComponent("termiod/target/release/termiod").path,
+            root.appendingPathComponent("termiod/target/debug/termiod").path,
+        ], "release before debug, both anchored at the checkout, not at the cwd")
+    }
+
+    /// The `.app`-assembled-at-the-repo-root case: `Contents/MacOS` is two
+    /// levels down, and the daemon in the checkout is the right answer when the
+    /// bundle carries none (a dev build made without a Rust toolchain).
+    func testFindsTheCheckoutAboveAnAppBundle() throws {
+        try makeCheckout(at: root)
+        let binaryDirectory = root.appendingPathComponent("termio-dev.app/Contents/MacOS")
+        try FileManager.default.createDirectory(at: binaryDirectory, withIntermediateDirectories: true)
+
+        XCTAssertEqual(Termiod.developmentDaemonCandidates(near: binaryDirectory).first,
+                       root.appendingPathComponent("termiod/target/release/termiod").path)
+    }
+
+    /// The shipped case: an app in /Applications has no checkout above it, and
+    /// answering with a path anyway is what produced `/termiod/target/debug/termiod`.
+    func testAnswersNothingWithNoCheckoutAbove() throws {
+        let binaryDirectory = root.appendingPathComponent("Applications/termio.app/Contents/MacOS")
+        try FileManager.default.createDirectory(at: binaryDirectory, withIntermediateDirectories: true)
+
+        XCTAssertEqual(Termiod.developmentDaemonCandidates(near: binaryDirectory), [])
+    }
+
+    /// The walk stops rather than running to `/`: a `termiod/Cargo.toml` far
+    /// enough above the binary is somebody else's checkout, not this build's.
+    func testStopsWalkingBeforeTheFilesystemRoot() throws {
+        try makeCheckout(at: root)
+        let deep = root.appendingPathComponent("a/b/c/d/e/f/g/h/i")
+        try FileManager.default.createDirectory(at: deep, withIntermediateDirectories: true)
+
+        XCTAssertEqual(Termiod.developmentDaemonCandidates(near: deep), [])
+    }
+
+    /// The development override outranks everything, including a bundled daemon
+    /// — it is what a developer sets to run a build they just made.
+    func testEnvironmentOverrideWins() throws {
+        let override = root.appendingPathComponent("my-termiod").path
+        setenv("TERMIO_TERMIOD_BIN", override, 1)
+        defer { unsetenv("TERMIO_TERMIOD_BIN") }
+
+        XCTAssertEqual(Termiod.daemonBinaryPath(), override)
+    }
+}

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -6,8 +6,13 @@
 # no bundle, so macOS shows a generic Dock icon. This script builds the release
 # binary and wraps it in a `.app` bundle whose Info.plist + AppIcon.icns give it
 # a proper name and Dock icon, then embeds Sparkle (which SwiftPM links but does
-# NOT bundle on its own) under Contents/Frameworks. The release bundle is universal
+# NOT bundle on its own) under Contents/Frameworks. It also builds the `termiod`
+# session daemon (Rust + a Zig-built VT engine) into Contents/Resources, so a
+# shipped app carries the session host it starts. The release bundle is universal
 # (arm64 + x86_64) so one DMG runs on Apple silicon and Intel Macs alike.
+#
+# Requires: full Xcode (xcstringstool), and — for the daemon — Rust and Zig. A
+# release build fails without them; a dev build says so and ships without one.
 #
 # Usage:
 #   ./scripts/build-app.sh            # ad-hoc-signed release build into ./termio.app
@@ -193,6 +198,87 @@ if [[ -n "${TERMIO_VERSION:-}" ]]; then
 fi
 chmod +x "$resources_dir/$cli_name"
 
+# Ship the session daemon inside the bundle, beside the CLI. `termiod` owns the
+# PTY for every session the app opens through it, and the app resolves it out of
+# Contents/Resources (`Termiod.daemonBinaryPath`). Nothing shipped it before:
+# a released build looked for a debug artifact relative to its working directory,
+# which for a Finder launch is "/", so it could never start a daemon at all.
+#
+# Built one slice per architecture and lipo'd exactly like the app binary — the
+# release DMG is universal, and an arm64-only daemon inside it is a daemon an
+# Intel Mac cannot execute. It keeps the name `termiod` on both channels: unlike
+# the CLI it is never symlinked onto PATH, only executed by absolute path out of
+# the bundle that ships it.
+daemon_name="termiod"
+daemon_dest="$resources_dir/$daemon_name"
+
+# The VT engine is built by Zig from our libghostty fork, and `libghostty-vt-sys`
+# invokes `zig` by name and honours no env override — so it has to be found on
+# PATH. Homebrew leaves it unlinked whenever a second `zig@N` formula holds the
+# link, so check its prefix before concluding it is absent.
+zig_bin=""
+if command -v zig >/dev/null 2>&1; then
+    zig_bin="$(dirname "$(command -v zig)")"
+else
+    brew_zig="$(brew --prefix zig 2>/dev/null || true)"
+    [[ -n "$brew_zig" && -x "$brew_zig/bin/zig" ]] && zig_bin="$brew_zig/bin"
+fi
+
+daemon_toolchain_missing=""
+command -v cargo >/dev/null 2>&1 || daemon_toolchain_missing="cargo"
+[[ -n "$zig_bin" ]] || daemon_toolchain_missing="${daemon_toolchain_missing:+$daemon_toolchain_missing and }zig"
+
+if [[ -n "$daemon_toolchain_missing" ]]; then
+    # A release without a daemon is a release with no session backend, so it
+    # fails. A dev build degrades instead: TERMIO_TERMIOD is opt-in, so a
+    # contributor with no Rust/Zig toolchain still gets a working app.
+    if [[ "$channel" != "dev" ]]; then
+        echo "error: cannot build termiod — $daemon_toolchain_missing not found." >&2
+        echo "       Rust: https://rustup.rs — Zig: brew install zig (termiod/README.md)." >&2
+        exit 1
+    fi
+    echo "==> Skipping termiod: $daemon_toolchain_missing not found — this dev build cannot start a daemon"
+else
+    # Xcode 26's libSystem.tbd advertises arm64e only and Zig cannot link against
+    # it (the build dies in a wall of "undefined symbol: _malloc"); the Command
+    # Line Tools SDK is the fix, same as .github/workflows/termiod.yml. Scoped to
+    # the cargo build alone — the Swift build above needs full Xcode, whose
+    # xcstringstool compiles the String Catalog.
+    daemon_developer_dir="${DEVELOPER_DIR:-}"
+    if [[ -d /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk ]]; then
+        daemon_developer_dir=/Library/Developer/CommandLineTools
+    fi
+
+    daemon_slices=()
+    for arch in "${architectures[@]}"; do
+        # Rust spells Apple silicon `aarch64`; lipo and uname spell it `arm64`.
+        rust_target="$arch-apple-darwin"
+        [[ "$arch" == "arm64" ]] && rust_target="aarch64-apple-darwin"
+        echo "==> Building $daemon_name ($rust_target)"
+        (
+            cd "$repo_root/termiod"
+            export PATH="$zig_bin:$PATH"
+            [[ -n "$daemon_developer_dir" ]] && export DEVELOPER_DIR="$daemon_developer_dir"
+            # The cross slice's std is not installed by default on a fresh
+            # machine or a CI runner; a non-rustup cargo just skips this.
+            rustup target add "$rust_target" >/dev/null 2>&1 || true
+            cargo build --release --target "$rust_target"
+        )
+        daemon_slices+=("$repo_root/termiod/target/$rust_target/release/$daemon_name")
+    done
+
+    lipo -create "${daemon_slices[@]}" -output "$daemon_dest"
+    chmod +x "$daemon_dest"
+    daemon_archs="$(lipo -archs "$daemon_dest")"
+    for required_arch in "${architectures[@]}"; do
+        if [[ " $daemon_archs " != *" $required_arch "* ]]; then
+            echo "error: bundled $daemon_name is missing the $required_arch slice — has [$daemon_archs]" >&2
+            exit 1
+        fi
+    done
+    echo "==> Bundled $daemon_name architectures: $daemon_archs"
+fi
+
 # Stamp version / build number when the release workflow supplies them. The
 # binary's rpath already resolves @rpath/Sparkle.framework via @executable_path
 # below, so embedding is purely a copy + one rpath entry.
@@ -269,10 +355,16 @@ for component in \
     [[ -e "$component" ]] && codesign "${sign_args[@]}" "$component"
 done
 codesign "${sign_args[@]}" "$sparkle"
+# The daemon is a nested Mach-O like Sparkle's helpers, so it is sealed before the
+# outer app for the same reason — and with the same hardened runtime, because
+# notarization rejects any executable inside the bundle that lacks it.
+[[ -e "$daemon_dest" ]] && codesign "${sign_args[@]}" "$daemon_dest"
 # Seal the outer app last so CodeResources covers the embedded framework. NOT
 # --deep: the framework's components are already individually signed above.
 codesign "${sign_args[@]}" "$app_dir"
-codesign --verify --deep --strict "$app_dir"
+# Not --deep here either: Apple deprecated it for verification, and it does not
+# check nested code the way the name suggests. --strict is what does.
+codesign --verify --strict --verbose=2 "$app_dir"
 
 echo "==> Done: $app_dir"
 echo "    Launch with:  open \"$app_dir\""


### PR DESCRIPTION
Stage 1 items 1 and 2 of `docs/rfcs/one-path-local-through-termiod.md`: a shipped Termio carries its own `termiod`. Nothing else from Stage 1 — no launchd install/repair, no per-channel `TERMIOD_SOCK` or label, no update/version-skew handling, and `TERMIO_TERMIOD` stays opt-in.

## The bug

`daemonBinaryPath()` fell back to `currentDirectoryPath + "/termiod/target/debug/termiod"`. A Finder-launched app has cwd `/`, so that resolved `/termiod/target/debug/termiod` — a path that has never existed on any user's machine. Nothing put a daemon in the bundle either: neither `build-app.sh` nor `release.yml` mentioned `termiod`. A released build could not start a daemon at all.

## What changed

- **`scripts/build-app.sh`** builds `termiod` into `Contents/Resources/termiod`, beside the `termio` CLI it already ships. One slice per architecture, `lipo`'d and asserted the same way the app binary's slices are. Signed before the outer seal with the same identity and `--options runtime`, in the inside-out order Sparkle's helpers established. The verification line drops `--deep`.
- **`daemonBinaryPath()`** resolves `TERMIO_TERMIOD_BIN` → the bundled binary → `termiod/target/{release,debug}` in the checkout the *running binary* lives in. Anchored at the binary, never at the cwd.
- **`release.yml`** installs the pinned Zig (checksummed, same pin as `termiod.yml`) so the build step can compile the VT engine.
- Five tests on the checkout half of the resolution.

## Slicing — decided, not inherited from `cargo build`

The daemon is **universal**, `lipo`'d from `aarch64-apple-darwin` + `x86_64-apple-darwin`, and the build fails if a slice is missing. A host-native daemon inside a universal app would be an Intel Mac that cannot open a terminal — the same bug moved to a different set of users. The dev channel builds the host arch alone, exactly as it does for the app binary.

Gate, needs no credentials, runs anywhere:

```
$ lipo -archs termio.app/Contents/Resources/termiod
x86_64 arm64
```

## Two things a PR build cannot validate

1. **`release.yml` only runs on tags.** The Zig step and the daemon's path through notarization are not exercised by any PR. On the next tagged release a maintainer should watch: the *Install Zig* step's checksum line; `==> Bundled termiod architectures: x86_64 arm64` in the build log (the build aborts if not); and — the one that can only fail there — `xcrun notarytool log` for the submission listing **zero** issues against `Contents/Resources/termiod`. A daemon signed after the outer seal, or without the hardened runtime, fails at exactly that point and nowhere earlier. If it does fail, revert this commit: the flag is still off by default.
2. **`x86_64-apple-darwin` on the runner.** `build-app.sh` runs `rustup target add` itself, so no CI step was added for it; that path is only exercised on a tag build. Verified locally that both slices build and `lipo` produces a universal daemon.

The DMG grows by ~5 MB (2.5 MB per slice).

## Verification

```
$ TERMIO_CHANNEL=dev ./scripts/build-app.sh
==> Bundled termiod architectures: arm64

$ codesign --verify --strict --verbose=4 termio-dev.app
termio-dev.app: valid on disk
termio-dev.app: satisfies its Designated Requirement

$ codesign -d --verbose=2 termio-dev.app/Contents/Resources/termiod
Identifier=termiod
CodeDirectory v=20500 ... flags=0x10000(runtime)
Authority=Developer ID Application: Jiwei Yuan (5Y27G7B6D8)
```

The resolution proven from a bundle, launched from `/` with `TERMIO_TERMIOD_BIN` unset — the Finder condition the old fallback failed:

```
$ cd / && env -u TERMIO_TERMIOD_BIN TERMIO_TERMIOD=1 \
    TERMIOD_SOCK=/tmp/proof/termiod.sock \
    …/termio-dev.app/Contents/MacOS/termio &

$ ps -o pid=,ppid=,comm= -p <daemon pid>
91189 91187 …/termio-dev.app/Contents/Resources/termiod

$ TERMIOD_SOCK=/tmp/proof/termiod.sock …/Contents/Resources/termiod list
ID         NAME       PID CLIENTS SIZE  COMMAND
8678b0a1   3C2F6B22…  91192     1 47x61 /bin/zsh -il
```

`swift test`: 371 tests, 0 failures, 2 skipped.

## Build cost

`build-app.sh` now needs Rust and Zig. A release build fails loudly without them; a dev build says so and ships without a daemon, because `TERMIO_TERMIOD` is opt-in and a contributor with neither toolchain should still get a working app. The cargo build is pointed at the Command Line Tools SDK (Xcode 26's libSystem is arm64e-only and Zig cannot link against it) while the Swift build keeps full Xcode for `xcstringstool`. Zig is found via `brew --prefix zig` when it is installed but unlinked.

## One deviation from the RFC's wording

Stage 1 item 2 says "the bundled binary first, then `TERMIO_TERMIOD_BIN`". This ships the override first: a development override that loses to the bundle cannot override anything, and the bundle is still what every shipped build resolves.