### PR TITLE
Ignore Python bytecode caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ ios/build-sim/
 # Per-project termio session state
 /.termio/
 
+# Python bytecode caches left by the repo's own scripts (download stats, icon
+# generation, the termiod smoke tests and bench).
+__pycache__/
+
 # LaTeX build intermediates (talk decks under docs/talks/)
 *.aux
 *.nav


### PR DESCRIPTION
Running any of the repo's python scripts (`scripts/download_stats.py`, `scripts/gen_langicons.py`, `skills/dia-source-analysis/scripts/extract-sourcemaps.py`, `termiod/smoke_test.py`, `termiod/remote_smoke_test.py`, `termiod/bench/bench_100x.py`) leaves a `__pycache__` next to it, and nothing kept those out of a `git add -A`. None are tracked today; this keeps it that way.

Release Notes:

- None.