### PR TITLE
Move libghostty to ghostty 56e1f3a on both ends

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2e07b945a0d55b2a219d579e837f2e3b82f0e14a665851a385f3e1bc3e2f4708",
+  "originHash" : "87b9cee789842c15ff5379e0749ae4ccbc660164c76172e8d96f02fd3dcbd5ef",
   "pins" : [
     {
       "identity" : "highlightr",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "f2d4cbdf7a16bc5d917034f813f47c2a1c5dde97",
-        "version" : "1.0.16"
+        "revision" : "b35dabd15e2b096b58017b78eb5f404208c8f7c7",
+        "version" : "1.0.17"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // live resize" suspicion that briefly rolled this back to Lakr233 was a
         // misdiagnosis — the real bug was termio's own PTY spawn shape (see
         // docs/bug/terminal-resize-no-reflow-HANDOFF.md §0).
-        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.16"),
+        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.17"),
         // Sparkle powers in-app auto-update (the "Check for Updates…" menu item and
         // background update checks). It reads the appcast published with each GitHub
         // release; the matching EdDSA public key is embedded in packaging/Info.plist.

--- a/ios/TermioMobile.xcodeproj/project.pbxproj
+++ b/ios/TermioMobile.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 			repositoryURL = "https://github.com/termio-sh/libghostty-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.16;
+				minimumVersion = 1.0.17;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/termiod/Cargo.lock
+++ b/termiod/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 [[package]]
 name = "libghostty-vt"
 version = "0.2.1"
-source = "git+https://github.com/termio-sh/libghostty-rs?rev=7441da21c64a7b2391c92cbc47cc8a2269d13fda#7441da21c64a7b2391c92cbc47cc8a2269d13fda"
+source = "git+https://github.com/termio-sh/libghostty-rs?rev=04500f9f78edf487b6d218d951b0979c768fb7f0#04500f9f78edf487b6d218d951b0979c768fb7f0"
 dependencies = [
  "bitflags",
  "int-enum",
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 name = "libghostty-vt-sys"
 version = "0.2.1"
-source = "git+https://github.com/termio-sh/libghostty-rs?rev=7441da21c64a7b2391c92cbc47cc8a2269d13fda#7441da21c64a7b2391c92cbc47cc8a2269d13fda"
+source = "git+https://github.com/termio-sh/libghostty-rs?rev=04500f9f78edf487b6d218d951b0979c768fb7f0#04500f9f78edf487b6d218d951b0979c768fb7f0"
 
 [[package]]
 name = "log"

--- a/termiod/tests/snapshot_prologue.rs
+++ b/termiod/tests/snapshot_prologue.rs
@@ -156,6 +156,33 @@ fn an_alt_screen_host_still_lands_on_the_alternate_screen() {
     }
 }
 
+/// A cursor parked at the right margin carries pending wrap: the next
+/// printable character wraps to the following row instead of overwriting the
+/// last cell. The formatter used to land that cursor with CUP, which clears the
+/// flag, so a client that applied the payload and then received one more byte
+/// painted a different screen than the host. Whatever the payload does to place
+/// the cursor, the client has to keep printing where the host would.
+#[test]
+fn a_cursor_at_the_right_margin_keeps_its_pending_wrap() {
+    let mut host = VtTerminal::new(ROWS, COLS).expect("host terminal");
+    host.vt_write("w".repeat(usize::from(COLS)).as_bytes());
+    let payload = host.format_vt().expect("format_vt");
+
+    let mut client = VtTerminal::new(ROWS, COLS).expect("client terminal");
+    client.vt_write(&payload);
+
+    // The byte that tells the two screens apart. Both terminals are at the same
+    // point in the same stream, so they owe the same result.
+    host.vt_write(b"!");
+    client.vt_write(b"!");
+
+    let expected = host.snapshot().expect("host snapshot");
+    let actual = client.snapshot().expect("client snapshot");
+    if let Some(difference) = first_difference(&expected, &actual) {
+        panic!("the client diverged after one more byte at the right margin: {difference}");
+    }
+}
+
 #[test]
 fn snapshot_applies_identically_to_a_dirty_screen() {
     let payload = host_payload();

--- a/termiod/vt/Cargo.toml
+++ b/termiod/vt/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 # script. What stays here is termiod's own snapshot boundary: the wire cell is
 # ours, not the engine's.
 #
-# Pinned to termio-sh/libghostty-rs, our fork, which builds ghostty 9d8fbd1 —
-# the same one libghostty-swift 1.0.16 ships to the Mac and iOS clients, so the
-# host and its clients run one VT. That parity is why this engine was chosen
-# over alacritty_terminal in the first place.
+# Pinned to termio-sh/libghostty-rs, our fork, which builds ghostty 56e1f3a —
+# the same one libghostty-swift ships to the Mac and iOS clients, so the host
+# and its clients run one VT. That parity is why this engine was chosen over
+# alacritty_terminal in the first place.
 #
 # It has to be a fork rather than a rev bump: `libghostty-vt-sys` checks its
 # bindings in, so they must be regenerated against the ghostty they build.
@@ -23,6 +23,7 @@ publish = false
 #
 # Track libghostty-swift when it releases: its title carries the ghostty it
 # built (`1.0.16 · ghostty v1.3.1-1841-g9d8fbd1`), and that sha is the one to
-# match here.
+# match here. Since ghostty#13759 dropped iOS from the full build, that release
+# also carries a patch putting iOS back, so the two forks move together.
 [dependencies]
-libghostty-vt = { git = "https://github.com/termio-sh/libghostty-rs", rev = "7441da21c64a7b2391c92cbc47cc8a2269d13fda" }
+libghostty-vt = { git = "https://github.com/termio-sh/libghostty-rs", rev = "04500f9f78edf487b6d218d951b0979c768fb7f0" }

--- a/termiod/vt/src/lib.rs
+++ b/termiod/vt/src/lib.rs
@@ -227,16 +227,31 @@ impl VtTerminal {
         // row with CHA/HTS and leaves it wherever the last stop was, and
         // DECSTBM homes it. Re-assert the real position last so the client
         // lands where the session actually is.
-        let cursor_x = check(self.terminal.cursor_x(), "Terminal::cursor_x")?;
-        let cursor_y = check(self.terminal.cursor_y(), "Terminal::cursor_y")?;
-        formatted.extend_from_slice(
-            format!(
-                "\x1b[{};{}H",
-                cursor_y.saturating_add(1),
-                cursor_x.saturating_add(1)
-            )
-            .as_bytes(),
-        );
+        //
+        // Except when the cursor is holding pending wrap. A cursor at the right
+        // margin has not wrapped yet: the next printable character belongs on
+        // the following row, and CUP is exactly what clears that. ghostty#13876
+        // taught the formatter to restore the flag by reprinting the final cell,
+        // and re-asserting a position on top of that throws the restore away —
+        // the client then overwrites the last cell instead of wrapping, and its
+        // screen diverges from the host's on the very next byte. The formatter's
+        // own restore already leaves the cursor in the right place, so this owes
+        // nothing further.
+        if !check(
+            self.terminal.is_cursor_pending_wrap(),
+            "Terminal::is_cursor_pending_wrap",
+        )? {
+            let cursor_x = check(self.terminal.cursor_x(), "Terminal::cursor_x")?;
+            let cursor_y = check(self.terminal.cursor_y(), "Terminal::cursor_y")?;
+            formatted.extend_from_slice(
+                format!(
+                    "\x1b[{};{}H",
+                    cursor_y.saturating_add(1),
+                    cursor_x.saturating_add(1)
+                )
+                .as_bytes(),
+            );
+        }
         Ok(formatted)
     }
 


### PR DESCRIPTION
Both the Mac/iOS clients and the termiod sidecar move from ghostty 9d8fbd1 to 56e1f3a, 226 commits on, so host and clients keep running one VT.

The reason to move now is `terminal: preserve pending wrap in VT formatter` (ghostty#13876). A cursor at the right margin has not wrapped yet — the next printable character belongs on the following row — and the formatter used to land that cursor with CUP, which clears the flag. termiod's snapshot is formatter output replayed into a client terminal, so a client overwrote the last cell instead of wrapping and diverged from the host on the very next byte.

Pulling the fix was not enough on its own: `format_vt` appends its own CUP to re-assert the cursor after the formatter's state extras, and that threw the restore away. It now skips the re-assert when the cursor holds pending wrap. `tests/snapshot_prologue.rs` covers it and fails on the old pin either way.

Also in the gap: ~3x faster grapheme-heavy input, faster wide-character reflow on resize, and dedicated dirty-row iteration on the render state (not adopted here).

Both forks needed work to build 56e1f3a. libghostty-rs absorbed two C API drifts — every enum went `unsigned int` to `int`, and `ghostty_render_state_colors_get` folded into the generic getter. libghostty-swift needed iOS put back: ghostty#13759 removed it from the full build, so `Config.init` refused the target and `MetallibStep` no longer compiled the Metal shaders for it. Upstream no longer builds or tests the full Ghostty on iOS, so that patch is ours to carry.

Verified: `swift build` and `swift test` (316 tests) pass, `cargo test` in termiod passes (51 tests), all five libghostty-swift targets built, dev app relaunched on 1.0.17.

Release Notes:
- Terminal snapshots now keep a cursor parked at the right edge from overwriting that cell when a session is reattached.