### PR TITLE
Clear the build warnings that had a safe fix

### DIFF
--- a/Sources/termio/CommandPalette/DebugWindowSnapshot.swift
+++ b/Sources/termio/CommandPalette/DebugWindowSnapshot.swift
@@ -51,6 +51,7 @@ enum DebugWindowSnapshot {
         }
     }
 
+    @MainActor
     private static func dump(_ view: NSView, depth: Int, into lines: inout [String]) {
         let indent = String(repeating: "  ", count: depth)
         var bits = "\(indent)\(type(of: view)) frame=\(view.frame)"

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -380,7 +380,9 @@ final class CompanionServer {
                     break
                 }
             }
-            self?.receive(on: connection)
+            // Re-arm on the main actor like every other branch above: the callback
+            // itself runs on the network queue, and `receive` reads main-actor state.
+            Task { @MainActor in self?.receive(on: connection) }
         }
     }
 

--- a/Sources/termio/Editor/Highlightr/Highlightr.swift
+++ b/Sources/termio/Editor/Highlightr/Highlightr.swift
@@ -15,6 +15,12 @@
 //   - startup theme "pojoaque" → "xcode" (only the two xcode themes ship)
 //   - Swift 6: `safeMainSync` boxes its closure to cross onto the main queue —
 //     the call is synchronous, so the captures never outlive the caller
+//   - two never-read initializations discarded with `_ =` to quiet the build
+//
+//  The `NSScanner` deprecations in `processHTMLString` are left as upstream
+//  wrote them: `scanLocation` is a UTF-16 offset the parser does arithmetic on,
+//  and the modern `String.Index` API is not a mechanical swap. Silent
+//  mistranslation there corrupts highlighting for no user-visible gain.
 //
 
 import Foundation
@@ -61,7 +67,7 @@ open class Highlightr
     public init?(highlightPath: String? = nil)
     {
         guard let jsContext = JSContext() else { return nil }
-        let window = JSValue(newObjectIn: jsContext)
+        _ = JSValue(newObjectIn: jsContext)
 
         let bundle = Bundle.termioResources
         self.bundle = bundle
@@ -71,7 +77,7 @@ open class Highlightr
         }
         
         guard let hgJs = try? String.init(contentsOfFile: hgPath) else { return nil }
-        let value = jsContext.evaluateScript(hgJs)
+        _ = jsContext.evaluateScript(hgJs)
         guard let hljs = jsContext.objectForKeyedSubscript("hljs") else { return nil }
 
         self.hljs = hljs

--- a/Sources/termio/Editor/MarkdownReaderView.swift
+++ b/Sources/termio/Editor/MarkdownReaderView.swift
@@ -136,7 +136,7 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
         }
 
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
-                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+                     decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
             if navigationAction.navigationType == .linkActivated,
                let url = navigationAction.request.url {
                 // In-page anchors scroll within the doc; external links open in the

--- a/Sources/termio/FileBrowser/FileSearchView.swift
+++ b/Sources/termio/FileBrowser/FileSearchView.swift
@@ -354,6 +354,7 @@ private struct NativeSearchField: NSViewRepresentable {
         }
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: NativeSearchField
         var lastFocusRequest = -1

--- a/Sources/termio/Info/TraceView.swift
+++ b/Sources/termio/Info/TraceView.swift
@@ -214,7 +214,7 @@ private struct TraceWebView: NSViewRepresentable {
         init(lastHTML: String) { self.lastHTML = lastHTML }
 
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
-                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+                     decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
             if navigationAction.navigationType == .linkActivated,
                let url = navigationAction.request.url, url.scheme != "about" {
                 NSWorkspace.shared.open(url)

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -1034,7 +1034,7 @@ private struct IssueWebView: NSViewRepresentable {
         init(lastHTML: String) { self.lastHTML = lastHTML }
 
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
-                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+                     decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
             if navigationAction.navigationType == .linkActivated,
                let url = navigationAction.request.url {
                 NSWorkspace.shared.open(url)
@@ -1105,7 +1105,9 @@ private final class IssueDetailWKWebView: WKWebView {
 /// on the cross-origin redirect to the signed CDN URL, matching `curl -L`'s default,
 /// so the presigned download isn't rejected.)
 final class GitHubAssetSchemeHandler: NSObject, WKURLSchemeHandler {
-    static let scheme = "x-termio-ghasset"
+    // nonisolated so the HTML rewriter, which runs off the main actor, can name
+    // the scheme it rewrites to. The value is an immutable string.
+    nonisolated static let scheme = "x-termio-ghasset"
 
     private var live = Set<ObjectIdentifier>()
     /// The one asset a media element is currently reading, held whole. WebKit walks a video

--- a/Sources/termio/Settings/LanguageSetting.swift
+++ b/Sources/termio/Settings/LanguageSetting.swift
@@ -68,6 +68,7 @@ enum LanguageOverride {
     /// Relaunches the bundled app by handing the reopen to a detached `open`
     /// that outlives the process; unbundled (`swift run`) there is nothing to
     /// reopen, so it just terminates.
+    @MainActor
     static func relaunch() {
         let bundleURL = Bundle.main.bundleURL
         if bundleURL.pathExtension == "app" {

--- a/Sources/termio/Settings/MobileSettingsTab.swift
+++ b/Sources/termio/Settings/MobileSettingsTab.swift
@@ -320,7 +320,7 @@ struct MobileSettingsTab: View {
                 addr, socklen_t(addr.pointee.sa_len),
                 &host, socklen_t(host.count), nil, 0, NI_NUMERICHOST
             ) == 0 else { continue }
-            let ip = String(cString: host)
+            let ip = String(decoding: host.prefix { $0 != 0 }.map(UInt8.init(bitPattern:)), as: UTF8.self)
             if !ip.hasPrefix("169.254."), !addresses.contains(ip) {
                 addresses.append(ip)
             }

--- a/Sources/termio/Terminal/Ghostty/PTYProcess.swift
+++ b/Sources/termio/Terminal/Ghostty/PTYProcess.swift
@@ -207,9 +207,10 @@ final class PTYProcess: @unchecked Sendable {
         pid = childPID
 
         // Reap the child asynchronously to fire onExit + observers.
+        let reapPID = childPID
         DispatchQueue.global().async { [weak self] in
             var status: Int32 = 0
-            waitpid(childPID, &status, 0)
+            waitpid(reapPID, &status, 0)
             self?.markChildExited()
             let code = (status & 0x7F) == 0 ? (status >> 8) & 0xFF : 128 + (status & 0x7F)
             DispatchQueue.main.async {
@@ -336,11 +337,12 @@ final class PTYProcess: @unchecked Sendable {
             // mouse reporting, or its scroll input goes nowhere.
             var replay = replayCap.map { Data(replayBuffer.suffix($0)) } ?? replayBuffer
             replay.append(modeCatchUpPreambleLocked())
-            if !replay.isEmpty {
+            let payload = replay
+            if !payload.isEmpty {
                 if let queue {
-                    queue.async { handler(replay) }
+                    queue.async { handler(payload) }
                 } else {
-                    handler(replay)
+                    handler(payload)
                 }
             }
         }
@@ -829,9 +831,9 @@ final class PTYProcess: @unchecked Sendable {
         let skip = childExited || childExecutable != nil
         lock.unlock()
         guard !skip, pid > 0 else { return }
-        var buffer = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
+        var buffer = [UInt8](repeating: 0, count: 4 * Int(MAXPATHLEN))
         guard proc_pidpath(pid, &buffer, UInt32(buffer.count)) > 0 else { return }
-        let path = String(cString: buffer)
+        let path = String(decoding: buffer.prefix { $0 != 0 }, as: UTF8.self)
         guard path != spawnExecutablePath else { return }
         var info = stat()
         let inode: ino_t? = stat(path, &info) == 0 ? info.st_ino : nil

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -85,7 +85,9 @@ enum PiSession {
         // Pi derives the folder from its *process* cwd, whose symlinks the kernel
         // resolved at chdir — canonicalize the same way (`/tmp` → `/private/tmp`).
         var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
-        let resolved = realpath(cwd, &buffer) != nil ? String(cString: buffer) : cwd
+        let resolved = realpath(cwd, &buffer) != nil
+            ? String(decoding: buffer.prefix { $0 != 0 }.map(UInt8.init(bitPattern:)), as: UTF8.self)
+            : cwd
         var encoded = resolved
         if encoded.hasPrefix("/") { encoded.removeFirst() }
         encoded = "--\(String(encoded.map { "/\\:".contains($0) ? "-" : $0 }))--"


### PR DESCRIPTION
`swift build` emitted 44 warnings; this takes it to 19.

Everything fixed here is either an annotation stating isolation the code already relied on, or a mechanical API swap. The one with a real bite: three `WKNavigationDelegate` implementations declared `decisionHandler` without `@MainActor`, so each "nearly matched" the requirement it was written to satisfy — the SDK marks that block `WK_SWIFT_UI_ACTOR`.

The rest: `DebugWindowSnapshot.dump` and `FileSearchView.Coordinator` are main-actor only and now say so; `GitHubAssetSchemeHandler.scheme` is an immutable string the off-actor HTML rewriter needs, so it is `nonisolated`; the companion's WebSocket read re-armed itself from the network queue while every other branch of the same callback hopped to the main actor first; `PTYProcess` captured two `var`s in concurrently-executing code where a `let` copy was meant; `String(cString:)` became `String(decoding:as:)` at three call sites; `LanguageOverride.relaunch` calls `NSApp.terminate` from a SwiftUI button and is now main-actor isolated.

What is deliberately left:

- **13 in the vendored Highlightr.** The `NSScanner` deprecations live in a parser doing arithmetic on `scanLocation`, a UTF-16 offset with no mechanical translation to `String.Index`. Getting it subtly wrong corrupts highlighting for no visible gain. Recorded in the file header alongside the other vendor deviations.
- **2 in `PTYProcess`.** The fix is making `Sink.handler` `@Sendable`, which reaches every `addSink` caller and belongs in its own change.
- **3 AppKit overrides** (`beginPreviewPanelControl`, `endPreviewPanelControl`, `drawBackground`) that are nonisolated in the SDK but only run on the main thread. `MainActor.assumeIsolated` turns each warning into a "sending risks data races" *error*, so silencing them needs an unsafe escape hatch, not an annotation.
- **1 in `HookListener`**, which needs a Sendable audit of its queue-confined state rather than a keyword.

Verified: `swift build` clean of everything above, `swift test` 377 tests pass.

Release Notes:
- None.