### PR TITLE
Judge the early client by where it gets, not when

### DIFF
--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1881,6 +1881,14 @@ mod tests {
         session: &mut Session,
         id: &str,
     ) -> (mpsc::UnboundedReceiver<ClientEvent>, Arc<ClientBacklog>) {
+        attach_client(session, id, true)
+    }
+
+    fn attach_client(
+        session: &mut Session,
+        id: &str,
+        snapshot: bool,
+    ) -> (mpsc::UnboundedReceiver<ClientEvent>, Arc<ClientBacklog>) {
         let (client_tx, client_rx) = mpsc::unbounded_channel();
         let backlog = Arc::new(ClientBacklog::new());
         let (reply, _reply_rx) = oneshot::channel();
@@ -1891,13 +1899,103 @@ mod tests {
                 interactive: false,
                 out: client_tx,
                 backlog: backlog.clone(),
-                snapshot: true,
+                snapshot,
                 scrollback: false,
                 grid_diff: false,
                 reply,
             },
         );
         (client_rx, backlog)
+    }
+
+    /// What a client got, in the order it got it. `ClientEvent` carries wire
+    /// payloads and no `Debug`, so the assertions compare this instead.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Received {
+        Data(Vec<u8>),
+        Snapshot,
+        Ready,
+    }
+
+    /// Everything waiting for a client, minus the control traffic an attach
+    /// emits — delivery order is what the barrier can break, not the greeting.
+    fn drain(client: &mut mpsc::UnboundedReceiver<ClientEvent>) -> Vec<Received> {
+        let mut seen = Vec::new();
+        while let Ok(event) = client.try_recv() {
+            match event {
+                ClientEvent::Data(payload) => seen.push(Received::Data(payload.bytes.to_vec())),
+                ClientEvent::Snapshot(_) => seen.push(Received::Snapshot),
+                ClientEvent::Event(Event::Ready { .. }) => seen.push(Received::Ready),
+                _ => {}
+            }
+        }
+        seen
+    }
+
+    /// JOIN's second half (§C.5): an attaching client may not affect anyone
+    /// else's delivery. `tests/join_invariant.rs` can only observe that through
+    /// two consumers racing a flood, where a reader that is merely behind looks
+    /// exactly like a stall — so it proves the joining client's boundary and
+    /// leaves this to a test that can hold the barrier open on purpose.
+    ///
+    /// Here the snapshot request is never answered, so the joining client sits
+    /// in `SnapshotPending` for the whole test. Any stall the barrier imposed on
+    /// the live client — for a moment or forever — is a missing `Data` below.
+    #[tokio::test]
+    async fn a_pending_snapshot_never_holds_up_another_client() {
+        let Sidecar {
+            commands,
+            mut results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        let (mut session, _events) = test_session(commands, queue);
+
+        // The control: never negotiates `snapshot`, so it stays `Live`.
+        let (mut live, _live_backlog) = attach_client(&mut session, "live", false);
+        session.fan_out(Bytes::from_static(b"before"));
+        assert_eq!(
+            drain(&mut live),
+            vec![Received::Data(b"before".to_vec())],
+            "the live client did not receive its pre-attach bytes"
+        );
+
+        // The barrier opens here and is deliberately left open.
+        let (mut joining, _joining_backlog) = attach_client(&mut session, "joining", true);
+        assert!(
+            matches!(
+                session.clients["joining"].delivery,
+                ClientDelivery::SnapshotPending { .. }
+            ),
+            "the joining client is not behind a barrier, so this proves nothing"
+        );
+
+        session.fan_out(Bytes::from_static(b"during"));
+        assert_eq!(
+            drain(&mut live),
+            vec![Received::Data(b"during".to_vec())],
+            "the pending snapshot held up the live client"
+        );
+        assert!(
+            drain(&mut joining).is_empty(),
+            "the joining client received its stream before the S that opens it"
+        );
+
+        // The other half of the invariant: those bytes were buffered, not lost.
+        // Once the snapshot lands they follow it, in order.
+        pump_sidecar(&mut session, &mut results, 1).await;
+        assert_eq!(
+            drain(&mut joining),
+            vec![
+                Received::Snapshot,
+                Received::Ready,
+                Received::Data(b"during".to_vec())
+            ],
+            "the snapshot boundary and the bytes buffered behind it did not line up"
+        );
+
+        let _ = session.sidecar_tx.take();
+        let _ = tokio::task::spawn_blocking(move || thread.join()).await;
     }
 
     /// D4(a): the first time a client outruns its budget it is resynced, not

--- a/termiod/tests/join_invariant.rs
+++ b/termiod/tests/join_invariant.rs
@@ -317,11 +317,12 @@ fn attaching_mid_flood_joins_the_stream_exactly_once() {
         }
     }
 
+    // The early client keeps reading: it is still the control for the second
+    // half of the invariant, and where it has got to is judged below, once the
+    // boundary is known.
     let _ = late.kill();
-    let _ = early.kill();
     drop(frames);
     let _ = late_reader.join();
-    let _ = early_reader.join();
 
     let snapshot = snapshot.expect("no S snapshot for the late client");
     assert_eq!(
@@ -377,11 +378,36 @@ fn attaching_mid_flood_joins_the_stream_exactly_once() {
 
     // The early client must be untouched by the barrier: attaching a second
     // client may not pause the PTY, drop bytes, or replay them.
-    let early_snapshot = early_bytes.lock().expect("early bytes").clone();
-    let early_counters: Vec<u64> = stream_lines(&early_snapshot)
-        .iter()
-        .filter_map(|line| parse_counter(line))
-        .collect();
+    //
+    // "Untouched" is about delivery, not about wall-clock position. This client
+    // is reading the flood from its very first byte while the late one joined
+    // 40k lines in, so on a slow or loaded machine it is legitimately behind at
+    // any instant — comparing the two positions the moment the late client is
+    // satisfied measures the reader, not the barrier. So drain until it passes
+    // the boundary. A barrier that really blocked it never gets there, and the
+    // deadline is what reports that.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let early_counters = loop {
+        let seen = early_bytes.lock().expect("early bytes").clone();
+        let counters: Vec<u64> = stream_lines(&seen)
+            .iter()
+            .filter_map(|line| parse_counter(line))
+            .collect();
+        if counters.last().is_some_and(|high| *high >= first_counter) {
+            break counters;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the early client stalled at {:?} and never reached {first_counter}, where the \
+             late client joined — the barrier blocked another client's delivery",
+            counters.last()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    };
+
+    let _ = early.kill();
+    let _ = early_reader.join();
+
     assert!(
         early_counters.len() > LINES_PAST_BOUNDARY,
         "the early client received too little output to judge: {}",
@@ -389,10 +415,4 @@ fn attaching_mid_flood_joins_the_stream_exactly_once() {
     );
     // Ring replay can open the stream mid-line; only whole counters are judged.
     assert_consecutive(&early_counters[1..], "the early client");
-    let early_high = *early_counters.last().expect("early counters");
-    assert!(
-        early_high >= first_counter,
-        "the early client stalled at {early_high} while the late client joined at \
-         {first_counter} — the barrier blocked another client's delivery"
-    );
 }


### PR DESCRIPTION
`attaching_mid_flood_joins_the_stream_exactly_once` has been red on the Linux runner while passing everywhere else — it was already failing on main before today's libghostty bump. Both failures read the same:

```
the early client stalled at 39895 while the late client joined at 40574 — the barrier blocked another client's delivery
```

The barrier is innocent. The early client attaches before the flood and reads it from the very first byte; the late client joins ~40k lines in and stops as soon as it has 100 lines past its boundary. Comparing the two positions at that instant asks whether the early client's *consumer* — socket, bridge process, pipe, reader thread — had caught up to a producer that never paused. On a fast machine it has; on a loaded runner it has not, and the test called that a stall.

Reproduced with no barrier involvement at all by sleeping 400µs per frame in the early reader: same assertion, same message, and `assert_consecutive` still clean — which is the tell, since the stream was intact, just short.

The fix drains the early client until it passes the boundary, with a 30s deadline. A barrier that genuinely blocked it never gets there and the deadline reports that; ordering and exactly-once stay enforced by `assert_consecutive` over everything the client received. Verified both directions — the slow-reader variant fails before this change and passes after.

Release Notes:
- None.