### PR TITLE
Report terminal cell colour as a slot instead of host-resolved RGB

### DIFF
--- a/Sources/termio/Terminal/Termiod/TermiodSnapshot.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodSnapshot.swift
@@ -8,23 +8,40 @@ import Foundation
 /// an idle TUI), the daemon's authoritative VT hands us the *current* grid and
 /// we redraw exactly that frame, then live `D` bytes resume on top.
 ///
-/// The wire cell already carries fully resolved colours — the host VT folds
-/// `inverse` into an fg/bg swap and `invisible` into a zero codepoint before it
-/// packs the cell (see `termiod/vt/src/lib.rs`), and the `attributes` field is
-/// reserved-zero in this format version. So the synthesiser only needs
-/// truecolour SGR plus text; bold/underline/italic are intentionally not
-/// carried yet (a later additive wire extension).
+/// The host VT folds `inverse` into an fg/bg swap and `invisible` into a zero
+/// codepoint before it packs the cell (see `termiod/vt/src/lib.rs`), and the
+/// `attributes` field is reserved-zero in this format version, so
+/// bold/underline/italic are intentionally not carried here (they ride the v2
+/// VT payload, and this format can gain them additively).
+///
+/// Colour is *not* resolved by the host. Each cell names a slot — default,
+/// palette index, or an exact RGB the program itself chose — and this
+/// synthesiser re-emits the slot rather than a colour, so libghostty applies
+/// this viewer's theme. That is the whole point: a payload rendered by a
+/// light-theme surface and a dark-theme surface must not look the same.
 enum TermiodSnapshot {
+    /// Mirrors `WireColor` in `termiod/src/protocol.rs`.
+    enum Color: Equatable {
+        case `default`
+        case palette(UInt8)
+        case rgb(UInt8, UInt8, UInt8)
+
+        /// SGR parameters selecting this colour, given the base code for the
+        /// layer (30 foreground / 40 background).
+        func sgr(base: Int) -> String {
+            switch self {
+            // 39 / 49 hand the choice back to the terminal's own default.
+            case .default: return "\(base + 9)"
+            case .palette(let index): return "\(base + 8);5;\(index)"
+            case .rgb(let r, let g, let b): return "\(base + 8);2;\(r);\(g);\(b)"
+            }
+        }
+    }
+
     struct Cell: Equatable {
         var codepoint: UInt32
-        var foreground: (UInt8, UInt8, UInt8)
-        var background: (UInt8, UInt8, UInt8)
-
-        static func == (lhs: Cell, rhs: Cell) -> Bool {
-            lhs.codepoint == rhs.codepoint
-                && lhs.foreground == rhs.foreground
-                && lhs.background == rhs.background
-        }
+        var foreground: Color
+        var background: Color
     }
 
     struct Frame {
@@ -40,17 +57,25 @@ enum TermiodSnapshot {
         var vt: Data?
     }
 
-    /// Snapshot payload v1 (see `encode_snapshot_payload` in `protocol.rs`):
+    /// Snapshot payload v3 (see `encode_snapshot_payload` in `protocol.rs`):
     /// version:u8, rows/cols/cursor_x/cursor_y:u16be, alt_screen:u8,
     /// title_len:u16be, UTF-8 title, then row-major 16-byte cells —
-    /// codepoint:u32be, fg RGB, bg RGB, attributes:u16be, 4 reserved bytes.
-    static let formatVersion: UInt8 = 1
+    /// codepoint:u32be, fg colour (4), bg colour (4), attributes:u16be,
+    /// 2 reserved bytes. Each colour is a tag byte then its value, zero-padded.
+    ///
+    /// v1 carried host-resolved RGB and is not accepted: it could not say
+    /// "the client's default" or "palette index N", so it overrode the viewer's
+    /// theme by construction.
+    static let formatVersion: UInt8 = 3
     /// Payload v2 carries VT sequences instead of packed cells. Preferred: the
     /// host describes screen *content* and this client's libghostty decides how
     /// it looks, so the local theme, the ANSI palette, and bold/underline/OSC 8
-    /// all survive. v1 resolved colour host-side and overrode the theme.
+    /// all survive. Packed cells remain the fallback when the host's formatter
+    /// fails, and the seed for a grid-diff client.
     static let vtFormatVersion: UInt8 = 2
     static let cellSize = 16
+    static let colorTagPalette: UInt8 = 1
+    static let colorTagRGB: UInt8 = 2
 
     static func decode(_ payload: Data) -> Frame? {
         let bytes = [UInt8](payload)
@@ -91,6 +116,16 @@ enum TermiodSnapshot {
         let cellCount = rows * cols
         guard bytes.count == cellsOffset + cellCount * cellSize else { return nil }
 
+        // An unrecognised tag falls back to the terminal's default colour
+        // rather than failing the frame, so the host can add tags additively.
+        func color(_ start: Int) -> Color {
+            switch bytes[start] {
+            case colorTagPalette: return .palette(bytes[start + 1])
+            case colorTagRGB: return .rgb(bytes[start + 1], bytes[start + 2], bytes[start + 3])
+            default: return .default
+            }
+        }
+
         var cells = [Cell]()
         cells.reserveCapacity(cellCount)
         var offset = cellsOffset
@@ -99,8 +134,8 @@ enum TermiodSnapshot {
                 | UInt32(bytes[offset + 2]) << 8 | UInt32(bytes[offset + 3])
             cells.append(Cell(
                 codepoint: codepoint,
-                foreground: (bytes[offset + 4], bytes[offset + 5], bytes[offset + 6]),
-                background: (bytes[offset + 7], bytes[offset + 8], bytes[offset + 9])
+                foreground: color(offset + 4),
+                background: color(offset + 8)
             ))
             offset += cellSize
         }
@@ -150,9 +185,7 @@ enum TermiodSnapshot {
                     }
                     runEnd += 1
                 }
-                let (fr, fg, fb) = cell.foreground
-                let (br, bg, bb) = cell.background
-                output += "\u{1b}[38;2;\(fr);\(fg);\(fb);48;2;\(br);\(bg);\(bb)m"
+                output += "\u{1b}[\(cell.foreground.sgr(base: 30));\(cell.background.sgr(base: 40))m"
                 for index in column..<runEnd {
                     let point = frame.cells[row * frame.cols + index].codepoint
                     output.unicodeScalars.append(Unicode.Scalar(point == 0 ? 32 : point)

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -416,8 +416,13 @@ screen). *(libghostty's own `DECSTR` was measured incomplete — SGR, charsets,
 origin mode and autowrap survive it — which is why the explicit resets follow
 it rather than trusting it.)*
 
-Format v1 survives **only** for `grid_diff` clients, whose model is explicitly
-server-side state and which need cells to seed their grid.
+Packed cells survive **only** for `grid_diff` clients, whose model is explicitly
+server-side state and which need cells to seed their grid, and as the fallback
+when the formatter itself fails. Their colour is a **tagged slot**, not resolved
+RGB (payload v3, 2026-08-18): `{0: default} | {1: palette index} | {2: rgb}`, so
+even that path leaves the viewer's theme in charge. Format v1, which resolved
+colour host-side, is retired — it could not express "default" or "palette index
+N" at all, so it discarded what a client needs before the bytes ever left.
 
 **v1.1 `G` diffs are the bad-network degrade, not a faster default.** They are
 capability-gated (`grid_diff` requires `snapshot`), phone-first, and are the

--- a/docs/design/20260805-termiod-hot-path-and-client-classes.md
+++ b/docs/design/20260805-termiod-hot-path-and-client-classes.md
@@ -307,23 +307,37 @@ Superlogical's synced-viewport is the mirror image of the same judgement
 (**Announced**): shared scrolling ships as *additional opt-in frames*, never as
 the transport.
 
-**Known defect: the packed-cell path still ships resolved RGB.** The device doc
-§4 states the presentation boundary absolutely — "Host must not send: resolved
-RGB" — and the `S` v2 VT payload now honours it (`palette: false`). The packed
-cell encoding that seeds and updates a Mirror does not: snapshot payload v1 is
-`codepoint:u32be, foreground RGB, background RGB, attributes:u16be`
-(`protocol.rs`), so a Mirror is coloured by the *host's* palette and cannot
-apply the viewer's theme. The rule and the wire disagree, and the doc should not
-pretend otherwise.
+**Closed 2026-08-18: the packed-cell path shipped resolved RGB; it now ships
+tagged colour.** The device doc §4 states the presentation boundary absolutely —
+"Host must not send: resolved RGB" — and the `S` v2 VT payload honoured it
+(`palette: false`) while the packed cell that seeds and updates a Mirror did
+not: snapshot payload v1 was `codepoint:u32be, foreground RGB, background RGB,
+attributes:u16be`, so a Mirror was coloured by the *host's* palette and could
+not apply the viewer's theme.
 
-Priority is low precisely because §D.3 removed the pressure — no client is a
-Mirror by capability, so this only affects a Replica temporarily under pressure,
-where a wrong palette for a few seconds is the least of its problems. The fix
-when it comes is a tagged colour — `{0: default} | {1: palette index u8} |
-{2: rgb u24}` — which restores the boundary and shrinks the 16-byte cell at the
-same time, taking a bite out of the measured 8.6× as a side effect. Doing it
-before any client depends on Mirror keeps it additive; doing it after is a wire
-break.
+The fix is the tagged colour this section proposed — `{0: default} |
+{1: palette index u8} | {2: rgb}` — as `WireColor` in `protocol.rs` and
+`termiod_vt::Color` in `vt/src/lib.rs`, at snapshot payload **v3**, history
+**v2**, grid **v2**. Two findings from doing it:
+
+- **The loss was information, not just colour.** Resolved RGB cannot express
+  "the client's default" or "palette index N", so `Default` and `Palette(0)`
+  both packed as black and a themed red was indistinguishable from a program's
+  literal `#FF0000`. That is why v1 was retired rather than kept for
+  compatibility: every payload it produced had already discarded what a client
+  needs. Nothing consumed it — no client negotiates `grid_diff`, and a
+  `snapshot` client is served VT — so the break cost nothing.
+- **The viewport and the scrollback were extracting cells two different ways.**
+  `history_cell` read the unresolved style and applied `inverse`/`invisible`
+  itself; `viewport_cell` used the render state's flattened `fg_color`/
+  `bg_color`, which resolve palette indices through the host's palette. Both now
+  go through one `cell_from_parts`, so one screen cannot pack two ways.
+
+The cell stays 16 bytes; shrinking it (RLE spans, style split from text) remains
+the separate conditional item in §G PR 10. Regression tests: `vt/src/lib.rs`
+asserts each slot survives extraction and that `Default ≠ Palette(0)`;
+`protocol.rs` asserts the three tags round-trip distinctly and that an unknown
+tag degrades to `Default` rather than failing the frame.
 
 ### D.5 Writer and resize
 

--- a/termiod/Cargo.toml
+++ b/termiod/Cargo.toml
@@ -5,6 +5,13 @@ edition = "2021"
 description = "termiod — durable PTY session host (POC). Detach ≠ kill."
 license = "MIT"
 
+# `vt` is a workspace member, and a default one, so a bare `cargo test` — which
+# is what CI runs — covers the snapshot boundary's own tests. Without this it
+# silently tests only this package, and anything asserted inside `vt` never runs.
+[workspace]
+members = ["vt"]
+default-members = [".", "vt"]
+
 [[bin]]
 name = "termiod"
 path = "src/main.rs"

--- a/termiod/smoke_test.py
+++ b/termiod/smoke_test.py
@@ -70,10 +70,11 @@ def decode_snapshot(payload):
 
     Two formats share one header. v2 (raw-plane clients) carries VT sequences —
     the host describes content and the *client* decides colour, so there is no
-    cell grid to walk; the visible text is recovered by stripping escapes. v1
-    (grid_diff clients) carries packed cells and is walked directly.
+    cell grid to walk; the visible text is recovered by stripping escapes. v3
+    (grid_diff clients, and the formatter-failure fallback) carries packed cells
+    and is walked directly.
     """
-    if len(payload) < 12 or payload[0] not in (1, 2):
+    if len(payload) < 12 or payload[0] not in (2, 3):
         raise ValueError("invalid snapshot header")
     is_vt = payload[0] == 2
     rows, cols, cursor_x, cursor_y = struct.unpack(">HHHH", payload[1:9])
@@ -129,7 +130,7 @@ def decode_snapshot(payload):
 
 def decode_history(payload):
     """Decode the Phase 1d H payload into newest-first text rows."""
-    if len(payload) < 9 or payload[0] != 1:
+    if len(payload) < 9 or payload[0] != 2:
         raise ValueError("invalid history header")
     cols = struct.unpack(">H", payload[1:3])[0]
     first_offset = struct.unpack(">I", payload[3:7])[0]
@@ -206,7 +207,7 @@ def upload_credit_of_one(client, upload_id, body, chunk=64 * 1024 - 64, start=0)
 
 def decode_grid(payload):
     """Decode a Phase 1e G payload into its dirty full-width rows."""
-    if len(payload) < 16 or payload[0] != 1:
+    if len(payload) < 16 or payload[0] != 2:
         raise ValueError("invalid grid-diff header")
     frame_seq = struct.unpack(">I", payload[1:5])[0]
     rows, cols, cursor_x, cursor_y = struct.unpack(">HHHH", payload[5:13])

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -39,21 +39,30 @@ pub const HOST_CAPABILITIES: &[&str] = &[
     "upload",
     "git",
 ];
-pub const SNAPSHOT_FORMAT_VERSION: u8 = 1;
+/// Snapshot payload carrying packed cells.
+///
+/// v3 replaced v1's resolved-RGB cell with a tagged colour slot. v1 is gone
+/// rather than kept for compatibility: it could not express "the client's
+/// default" or "palette index N", so every payload it produced had already lost
+/// the information a client needs to apply its own theme. Nothing shipped
+/// consumed it — no client negotiates `grid_diff`, and a `snapshot` client is
+/// served VT (v2) — so retiring it costs nothing and carrying it would keep a
+/// format that is wrong by construction. Old clients hard-refuse on the version
+/// byte, which is the documented behaviour (§C.3: never limp).
+pub const SNAPSHOT_FORMAT_VERSION: u8 = 3;
 /// Snapshot payload carrying **VT sequences** instead of packed cells.
 ///
 /// This is the correct shape for the raw plane: the host says *what is on the
 /// screen* in the terminal's own language and the client's libghostty decides
-/// how it looks. Packed cells (v1) force the host to resolve colour, which
-/// overrides the viewer's theme and silently drops bold/underline/OSC 8. v1 is
-/// retained only for `grid_diff` clients, whose whole model is server-side
-/// state and which need cells to seed their grid.
+/// how it looks. Packed cells are retained only for `grid_diff` clients, whose
+/// whole model is server-side state and which need cells to seed their grid,
+/// and as the fallback when the formatter itself fails.
 pub const SNAPSHOT_FORMAT_VT: u8 = 2;
 pub const SNAPSHOT_CELL_SIZE: usize = 16;
-pub const HISTORY_FORMAT_VERSION: u8 = 1;
+pub const HISTORY_FORMAT_VERSION: u8 = 2;
 pub const HISTORY_HEADER_SIZE: usize = 9;
 pub const MAX_HISTORY_FRAME_SIZE: usize = 64 * 1024;
-pub const GRID_FORMAT_VERSION: u8 = 1;
+pub const GRID_FORMAT_VERSION: u8 = 2;
 pub const GRID_HEADER_SIZE: usize = 16;
 /// `F` chunk header: request id (u64be), offset (u64be), last flag (u8).
 pub const FILE_CHUNK_HEADER_SIZE: usize = 17;
@@ -103,12 +112,53 @@ pub struct FileChunk {
     pub data: Vec<u8>,
 }
 
-/// Engine-independent 16-byte cell representation used by snapshot v1.
+/// One cell's colour, as the program expressed it rather than as the host would
+/// paint it. Mirrors `termiod_vt::Color`; see that type for why the three
+/// variants are the whole point and not an encoding detail.
+///
+/// Wire form is 4 bytes: a tag byte then its value, zero-padded.
+/// `0` default (no value) · `1` palette (index in the first byte) · `2` rgb.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum WireColor {
+    #[default]
+    Default,
+    Palette(u8),
+    Rgb([u8; 3]),
+}
+
+pub const COLOR_TAG_DEFAULT: u8 = 0;
+pub const COLOR_TAG_PALETTE: u8 = 1;
+pub const COLOR_TAG_RGB: u8 = 2;
+
+impl WireColor {
+    fn encode(self) -> [u8; 4] {
+        match self {
+            WireColor::Default => [COLOR_TAG_DEFAULT, 0, 0, 0],
+            WireColor::Palette(index) => [COLOR_TAG_PALETTE, index, 0, 0],
+            WireColor::Rgb([r, g, b]) => [COLOR_TAG_RGB, r, g, b],
+        }
+    }
+
+    /// An unknown tag decodes as `Default` rather than failing the frame: the
+    /// tag space is meant to grow (a future indexed-style tag, say), and a cell
+    /// that falls back to the client's default colour is a far better outcome
+    /// than dropping a whole screen.
+    fn decode(bytes: &[u8]) -> Self {
+        match bytes[0] {
+            COLOR_TAG_PALETTE => WireColor::Palette(bytes[1]),
+            COLOR_TAG_RGB => WireColor::Rgb([bytes[1], bytes[2], bytes[3]]),
+            _ => WireColor::Default,
+        }
+    }
+}
+
+/// Engine-independent 16-byte cell representation used by packed snapshots,
+/// scrollback, and grid diffs.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WireCell {
     pub codepoint: u32,
-    pub foreground: [u8; 3],
-    pub background: [u8; 3],
+    pub foreground: WireColor,
+    pub background: WireColor,
     pub attributes: u16,
 }
 
@@ -989,11 +1039,11 @@ pub fn decode_file_chunk(payload: &[u8]) -> Result<FileChunk> {
     })
 }
 
-/// Snapshot payload v1:
+/// Snapshot payload v3:
 /// version:u8, rows/cols/cursor_x/cursor_y:u16be, alt_screen:u8,
 /// title_len:u16be, UTF-8 title, then row-major 16-byte cells. Each cell is
-/// codepoint:u32be, foreground RGB, background RGB, attributes:u16be, and
-/// four reserved zero bytes.
+/// codepoint:u32be, foreground colour (4), background colour (4),
+/// attributes:u16be, and two reserved zero bytes.
 pub fn encode_snapshot_payload(snapshot: &Snapshot) -> Result<Vec<u8>> {
     let vt = snapshot.vt.as_deref();
     let expected_cells = usize::from(snapshot.rows) * usize::from(snapshot.cols);
@@ -1297,13 +1347,17 @@ pub fn decode_grid_payload(payload: &[u8]) -> Result<GridDiff> {
     })
 }
 
+/// 16 bytes: codepoint u32be, foreground 4, background 4, attributes u16be,
+/// then 2 reserved. The cell stays 16 bytes wide so both decoders can keep
+/// indexing by offset; shrinking it (run-length spans, style split from text)
+/// is a separate, still-conditional optimisation.
 fn encode_cells(payload: &mut Vec<u8>, cells: &[WireCell]) {
     for cell in cells {
         payload.extend_from_slice(&cell.codepoint.to_be_bytes());
-        payload.extend_from_slice(&cell.foreground);
-        payload.extend_from_slice(&cell.background);
+        payload.extend_from_slice(&cell.foreground.encode());
+        payload.extend_from_slice(&cell.background.encode());
         payload.extend_from_slice(&cell.attributes.to_be_bytes());
-        payload.extend_from_slice(&[0; 4]);
+        payload.extend_from_slice(&[0; 2]);
     }
 }
 
@@ -1312,9 +1366,9 @@ fn decode_cells(payload: &[u8]) -> Vec<WireCell> {
         .chunks_exact(SNAPSHOT_CELL_SIZE)
         .map(|bytes| WireCell {
             codepoint: u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-            foreground: [bytes[4], bytes[5], bytes[6]],
-            background: [bytes[7], bytes[8], bytes[9]],
-            attributes: u16::from_be_bytes([bytes[10], bytes[11]]),
+            foreground: WireColor::decode(&bytes[4..8]),
+            background: WireColor::decode(&bytes[8..12]),
+            attributes: u16::from_be_bytes([bytes[12], bytes[13]]),
         })
         .collect()
 }
@@ -1400,10 +1454,11 @@ pub async fn read_frame<R: AsyncReadExt + Unpin>(r: &mut R) -> Result<Option<Fra
 #[cfg(test)]
 mod tests {
     use super::{
-        decode_file_chunk, decode_grid_payload, decode_history_payload, decode_snapshot_payload,
-        decode_upload_chunk, encode_file_chunk, encode_grid_payload, encode_history_payload,
-        encode_snapshot_payload, encode_upload_chunk, Control, FileChunk, GridDiff, GridRow,
-        HistoryChunk, Snapshot, UploadChunk, WireCell, FILE_CHUNK_HEADER_SIZE,
+        decode_cells, decode_file_chunk, decode_grid_payload, decode_history_payload,
+        decode_snapshot_payload, decode_upload_chunk, encode_cells, encode_file_chunk,
+        encode_grid_payload, encode_history_payload, encode_snapshot_payload, encode_upload_chunk,
+        Control, FileChunk, GridDiff, GridRow, HistoryChunk, Snapshot, UploadChunk, WireCell,
+        WireColor, COLOR_TAG_RGB, SNAPSHOT_CELL_SIZE, FILE_CHUNK_HEADER_SIZE,
         MAX_FILE_FRAME_SIZE, MAX_UPLOAD_FRAME_SIZE,
     };
 
@@ -1522,8 +1577,8 @@ mod tests {
             cells: vec![
                 WireCell {
                     codepoint: u32::from('A'),
-                    foreground: [1, 2, 3],
-                    background: [4, 5, 6],
+                    foreground: WireColor::Rgb([1, 2, 3]),
+                    background: WireColor::Palette(4),
                     attributes: 7,
                 },
                 WireCell::default(),
@@ -1532,6 +1587,55 @@ mod tests {
 
         let encoded = encode_snapshot_payload(&snapshot).unwrap();
         assert_eq!(decode_snapshot_payload(&encoded).unwrap(), snapshot);
+    }
+
+    /// The three colour slots must survive the round trip *as slots*. A cell
+    /// asking for the client's default and a cell asking for palette index 0
+    /// are different instructions, and the format that preceded this one
+    /// encoded both as black.
+    #[test]
+    fn wire_colors_round_trip_distinctly() {
+        let cells: Vec<WireCell> = [
+            WireColor::Default,
+            WireColor::Palette(0),
+            WireColor::Palette(255),
+            WireColor::Rgb([0, 0, 0]),
+            WireColor::Rgb([9, 8, 7]),
+        ]
+        .into_iter()
+        .map(|color| WireCell {
+            codepoint: u32::from('x'),
+            foreground: color,
+            background: color,
+            attributes: 0,
+        })
+        .collect();
+
+        let mut payload = Vec::new();
+        encode_cells(&mut payload, &cells);
+        assert_eq!(payload.len(), cells.len() * SNAPSHOT_CELL_SIZE);
+        assert_eq!(decode_cells(&payload), cells);
+
+        // Default and palette-0 must not collapse into one another.
+        assert_ne!(cells[0], cells[1]);
+        assert_ne!(
+            &payload[..SNAPSHOT_CELL_SIZE],
+            &payload[SNAPSHOT_CELL_SIZE..SNAPSHOT_CELL_SIZE * 2]
+        );
+    }
+
+    /// A tag this build does not know falls back to the client's default colour
+    /// rather than failing the frame, so the tag space can grow additively.
+    #[test]
+    fn unknown_color_tag_decodes_as_default() {
+        let mut payload = vec![0u8; SNAPSHOT_CELL_SIZE];
+        payload[4] = 200;
+        payload[8] = COLOR_TAG_RGB;
+        payload[9..12].copy_from_slice(&[1, 2, 3]);
+
+        let cells = decode_cells(&payload);
+        assert_eq!(cells[0].foreground, WireColor::Default);
+        assert_eq!(cells[0].background, WireColor::Rgb([1, 2, 3]));
     }
 
     #[test]
@@ -1565,8 +1669,8 @@ mod tests {
                     cells: vec![
                         WireCell {
                             codepoint: u32::from('A'),
-                            foreground: [1, 2, 3],
-                            background: [4, 5, 6],
+                            foreground: WireColor::Rgb([1, 2, 3]),
+                            background: WireColor::Palette(4),
                             attributes: 7,
                         },
                         WireCell::default(),

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -4,7 +4,7 @@
 
 use crate::protocol::{
     encode_grid_payload, encode_history_payload, Control, ErrorCode, Event, GridDiff, GridRow,
-    HistoryChunk, SessionInfo, Snapshot, WireCell, WorkstreamSpec, HISTORY_HEADER_SIZE,
+    HistoryChunk, SessionInfo, Snapshot, WireCell, WireColor, WorkstreamSpec, HISTORY_HEADER_SIZE,
     MAX_HISTORY_FRAME_SIZE, SNAPSHOT_CELL_SIZE,
 };
 use crate::pty::Pty;
@@ -910,12 +910,7 @@ impl Session {
             cells: engine
                 .cells
                 .into_iter()
-                .map(|cell| WireCell {
-                    codepoint: cell.codepoint,
-                    foreground: [cell.foreground.r, cell.foreground.g, cell.foreground.b],
-                    background: [cell.background.r, cell.background.g, cell.background.b],
-                    attributes: cell.attributes,
-                })
+                .map(wire_cell)
                 .collect(),
         }
     }
@@ -1111,11 +1106,19 @@ fn encode_scrollback_chunks(
     Ok(chunks)
 }
 
+fn wire_color(color: termiod_vt::Color) -> WireColor {
+    match color {
+        termiod_vt::Color::Default => WireColor::Default,
+        termiod_vt::Color::Palette(index) => WireColor::Palette(index),
+        termiod_vt::Color::Rgb(value) => WireColor::Rgb([value.r, value.g, value.b]),
+    }
+}
+
 fn wire_cell(cell: termiod_vt::Cell) -> WireCell {
     WireCell {
         codepoint: cell.codepoint,
-        foreground: [cell.foreground.r, cell.foreground.g, cell.foreground.b],
-        background: [cell.background.r, cell.background.g, cell.background.b],
+        foreground: wire_color(cell.foreground),
+        background: wire_color(cell.background),
         attributes: cell.attributes,
     }
 }

--- a/termiod/vt/src/lib.rs
+++ b/termiod/vt/src/lib.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 use libghostty_vt::fmt::{Format, Formatter, FormatterOptions};
 use libghostty_vt::render::{CellIterator, Dirty, RenderState, RowIterator};
 use libghostty_vt::screen::{CellContentTag, Screen};
-use libghostty_vt::style::{Palette, RgbColor, StyleColor};
+use libghostty_vt::style::{RgbColor, StyleColor};
 use libghostty_vt::terminal::{Point, PointCoordinate};
 use libghostty_vt::{Error, Terminal, TerminalOptions};
 
@@ -23,11 +23,40 @@ pub struct Rgb {
     pub b: u8,
 }
 
+/// A colour slot exactly as the program expressed it.
+///
+/// The host preserves *which* slot a cell asked for; the client decides what
+/// that slot looks like. Resolving here — looking a palette index up in the
+/// host's palette, or substituting the host's default foreground — bakes the
+/// host's theme into the wire and overrides the viewer's, which is the
+/// presentation boundary the whole design rests on (device architecture §4).
+///
+/// The three variants are not an encoding choice; they are the three things a
+/// terminal program can actually mean:
+///
+/// - `Default` — it named no colour, so the *client's* default applies.
+/// - `Palette` — it named a theme slot (`38;5;N`), so the *client's* palette
+///   resolves it. This is what lets one snapshot look right in a light theme
+///   and a dark one.
+/// - `Rgb` — it named an exact colour (`38;2;r;g;b`). That was the program's
+///   decision, not a theme's, and no client may reinterpret it.
+///
+/// Collapsing all three into RGB (what this type replaced) does not merely
+/// produce wrong colours: it destroys the distinction, so a client can no
+/// longer tell a themed red from a program's literal `#FF0000`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Color {
+    #[default]
+    Default,
+    Palette(u8),
+    Rgb(Rgb),
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Cell {
     pub codepoint: u32,
-    pub foreground: Rgb,
-    pub background: Rgb,
+    pub foreground: Color,
+    pub background: Color,
     pub attributes: u16,
 }
 
@@ -86,12 +115,12 @@ fn check<T>(result: std::result::Result<T, Error>, operation: &str) -> Result<T>
     result.map_err(|error| VtError(format!("{operation} failed: {error}")))
 }
 
-const DEFAULT_FOREGROUND: Rgb = Rgb {
-    r: 255,
-    g: 255,
-    b: 255,
-};
-const DEFAULT_BACKGROUND: Rgb = Rgb { r: 0, g: 0, b: 0 };
+/// `check` with a second label, joined **only when the call actually fails**.
+/// Per-cell code must not build the context string eagerly: these run once per
+/// cell per screen, so a `format!` argument is an allocation per cell.
+fn check_at<T>(result: std::result::Result<T, Error>, operation: &str, origin: &str) -> Result<T> {
+    result.map_err(|error| VtError(format!("{operation}({origin}) failed: {error}")))
+}
 
 /// What a snapshot payload must undo before it paints, so that applying it to a
 /// client screen in *any* prior state lands where applying it to a fresh
@@ -263,8 +292,6 @@ impl VtTerminal {
         let alt_screen =
             check(self.terminal.active_screen(), "Terminal::active_screen")? == Screen::Alternate;
         let title = self.title()?;
-        let foreground = self.default_foreground()?;
-        let background = self.default_background()?;
 
         let expected = usize::from(rows) * usize::from(cols);
         let mut cells = Vec::with_capacity(expected);
@@ -279,7 +306,7 @@ impl VtTerminal {
                 let mut cell_iteration =
                     check(self.row_cells.update(row), "CellIterator::update")?;
                 while let Some(cell) = cell_iteration.next() {
-                    cells.push(viewport_cell(cell, foreground, background)?);
+                    cells.push(viewport_cell(cell)?);
                 }
             }
             check(row.set_dirty(false), "RowIteration::set_dirty")?;
@@ -313,8 +340,6 @@ impl VtTerminal {
         let cursor_y = check(self.terminal.cursor_y(), "Terminal::cursor_y")?;
         let alt_screen =
             check(self.terminal.active_screen(), "Terminal::active_screen")? == Screen::Alternate;
-        let foreground = self.default_foreground()?;
-        let background = self.default_background()?;
 
         let mut dirty_rows = Vec::new();
         let mut row_index = 0u16;
@@ -332,7 +357,7 @@ impl VtTerminal {
                     let mut cell_iteration =
                         check(self.row_cells.update(row), "CellIterator::update")?;
                     while let Some(cell) = cell_iteration.next() {
-                        cells.push(viewport_cell(cell, foreground, background)?);
+                        cells.push(viewport_cell(cell)?);
                     }
                 }
                 if cells.len() != usize::from(cols) {
@@ -372,9 +397,6 @@ impl VtTerminal {
         }
 
         let cols = check(self.terminal.cols(), "Terminal::cols")?;
-        let default_fg = self.default_foreground()?;
-        let default_bg = self.default_background()?;
-        let palette = check(self.terminal.color_palette(), "Terminal::color_palette")?;
         let first_row = total_rows - capture_rows;
         let mut rows = Vec::with_capacity(capture_rows);
 
@@ -383,24 +405,12 @@ impl VtTerminal {
                 .map_err(|_| VtError("scrollback row exceeds u32 coordinate space".to_string()))?;
             let mut row = Vec::with_capacity(usize::from(cols));
             for x in 0..cols {
-                row.push(self.history_cell(x, y, default_fg, default_bg, &palette)?);
+                row.push(self.history_cell(x, y)?);
             }
             rows.push(row);
         }
 
         Ok(Scrollback { total_rows, rows })
-    }
-
-    fn default_foreground(&self) -> Result<Rgb> {
-        Ok(check(self.terminal.fg_color(), "Terminal::fg_color")?
-            .map(rgb)
-            .unwrap_or(DEFAULT_FOREGROUND))
-    }
-
-    fn default_background(&self) -> Result<Rgb> {
-        Ok(check(self.terminal.bg_color(), "Terminal::bg_color")?
-            .map(rgb)
-            .unwrap_or(DEFAULT_BACKGROUND))
     }
 
     fn title(&self) -> Result<Option<String>> {
@@ -412,81 +422,97 @@ impl VtTerminal {
         })
     }
 
-    fn history_cell(
-        &self,
-        x: u16,
-        y: u32,
-        default_fg: Rgb,
-        default_bg: Rgb,
-        palette: &Palette,
-    ) -> Result<Cell> {
+    fn history_cell(&self, x: u16, y: u32) -> Result<Cell> {
         let reference = check(
             self.terminal.grid_ref(Point::History(PointCoordinate { x, y })),
             "Terminal::grid_ref(history)",
         )?;
         let raw_cell = check(reference.cell(), "GridRef::cell(history)")?;
-        let style = check(reference.style(), "GridRef::style(history)")?;
-
-        let mut codepoint = check(raw_cell.codepoint(), "Cell::codepoint(history)")?;
-        let mut foreground = style_color(style.fg_color, default_fg, palette);
-        let mut background = style_color(style.bg_color, default_bg, palette);
-
-        // A bg-color-only cell carries its colour in the cell, not the style.
-        match check(raw_cell.content_tag(), "Cell::content_tag(history)")? {
-            CellContentTag::BgColorPalette => {
-                let index = check(
-                    raw_cell.bg_color_palette(),
-                    "Cell::bg_color_palette(history)",
-                )?;
-                background = rgb(palette.get(index));
-            }
-            CellContentTag::BgColorRgb => {
-                background = rgb(check(
-                    raw_cell.bg_color_rgb(),
-                    "Cell::bg_color_rgb(history)",
-                )?);
-            }
-            _ => {}
-        }
-        if style.inverse {
-            std::mem::swap(&mut foreground, &mut background);
-        }
-        if style.invisible {
-            codepoint = 0;
-        }
-
-        Ok(Cell {
-            codepoint,
-            foreground,
-            background,
-            // Attribute mapping is shared with viewport snapshots and remains
-            // reserved for a later additive wire-format extension.
-            attributes: 0,
-        })
+        let style = if check_at(raw_cell.has_styling(), "Cell::has_styling", "history")? {
+            Some(check(reference.style(), "GridRef::style(history)")?)
+        } else {
+            None
+        };
+        cell_from_parts(raw_cell, style, "history")
     }
 }
 
-/// Convert one cell of the live viewport. The engine has already flattened
-/// palette, RGB, and style sources into resolved colours here, so unlike
-/// `history_cell` this needs no content-tag dispatch.
-fn viewport_cell(
-    cell: &libghostty_vt::render::CellIteration<'_, '_>,
-    default_fg: Rgb,
-    default_bg: Rgb,
+/// Build one wire cell from the engine's raw cell plus its style, without
+/// resolving colour. Both the viewport and the scrollback go through here so
+/// the two cannot disagree — before this existed, history applied `inverse` and
+/// `invisible` itself while the viewport leaned on the render state's flattened
+/// accessors, so one screen could be packed two ways.
+///
+/// `style` is `None` for a cell that carries none, which is most of them.
+fn cell_from_parts(
+    raw_cell: libghostty_vt::screen::Cell,
+    style: Option<libghostty_vt::style::Style>,
+    origin: &str,
 ) -> Result<Cell> {
-    let raw_cell = check(cell.raw_cell(), "CellIteration::raw_cell")?;
+    let mut codepoint = check_at(raw_cell.codepoint(), "Cell::codepoint", origin)?;
+    // An unstyled cell names no colour, so both slots are the client's default
+    // and there is no inverse or invisible to apply.
+    let (mut foreground, mut background, inverse, invisible) = match style {
+        Some(style) => (
+            style_color(style.fg_color),
+            style_color(style.bg_color),
+            style.inverse,
+            style.invisible,
+        ),
+        None => (Color::Default, Color::Default, false, false),
+    };
+
+    // A bg-color-only cell carries its colour in the cell, not the style, so
+    // this dispatch is needed whether or not the cell is styled.
+    match check_at(raw_cell.content_tag(), "Cell::content_tag", origin)? {
+        CellContentTag::BgColorPalette => {
+            let index = check_at(raw_cell.bg_color_palette(), "Cell::bg_color_palette", origin)?;
+            background = Color::Palette(index.0);
+        }
+        CellContentTag::BgColorRgb => {
+            background = Color::Rgb(rgb(check_at(
+                raw_cell.bg_color_rgb(),
+                "Cell::bg_color_rgb",
+                origin,
+            )?));
+        }
+        _ => {}
+    }
+    if inverse {
+        std::mem::swap(&mut foreground, &mut background);
+    }
+    if invisible {
+        codepoint = 0;
+    }
+
     Ok(Cell {
-        codepoint: check(raw_cell.codepoint(), "Cell::codepoint")?,
-        foreground: check(cell.fg_color(), "CellIteration::fg_color")?
-            .map(rgb)
-            .unwrap_or(default_fg),
-        background: check(cell.bg_color(), "CellIteration::bg_color")?
-            .map(rgb)
-            .unwrap_or(default_bg),
-        // Phase 1a needs text and colors. Attribute mapping remains owned
-        // by this boundary and can fill these protocol bits additively.
+        codepoint,
+        foreground,
+        background,
+        // Bold, underline, italic and the rest still ride the `S` VT payload
+        // rather than these bits. The wire cell keeps reserved room for them so
+        // filling it in stays additive.
         attributes: 0,
     })
+}
+
+/// Convert one cell of the live viewport. Reads the *unresolved* style rather
+/// than the render state's `fg_color`/`bg_color`, which flatten palette indices
+/// through the host's palette and substitute the host's defaults — the exact
+/// resolution this boundary must not perform.
+fn viewport_cell(cell: &libghostty_vt::render::CellIteration<'_, '_>) -> Result<Cell> {
+    let raw_cell = check(cell.raw_cell(), "CellIteration::raw_cell")?;
+    // Materialising a `Style` copies three tagged colours plus nine flags across
+    // FFI and converts all of them, per cell. Most cells on a screen carry no
+    // style at all, and the engine exposes this predicate for exactly this
+    // reason: "avoids materializing the raw cell for renderers that only need
+    // to know whether fetching the full style is necessary."
+    let style = if check(cell.has_styling(), "CellIteration::has_styling")? {
+        Some(check(cell.style(), "CellIteration::style")?)
+    } else {
+        None
+    };
+    cell_from_parts(raw_cell, style, "viewport")
 }
 
 fn rgb(value: RgbColor) -> Rgb {
@@ -497,10 +523,67 @@ fn rgb(value: RgbColor) -> Rgb {
     }
 }
 
-fn style_color(color: StyleColor, fallback: Rgb, palette: &Palette) -> Rgb {
+fn style_color(color: StyleColor) -> Color {
     match color {
-        StyleColor::None => fallback,
-        StyleColor::Palette(index) => rgb(palette.get(index)),
-        StyleColor::Rgb(value) => rgb(value),
+        StyleColor::None => Color::Default,
+        StyleColor::Palette(index) => Color::Palette(index.0),
+        StyleColor::Rgb(value) => Color::Rgb(rgb(value)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Color, Rgb, VtTerminal};
+
+    fn screen(input: &str) -> Vec<super::Cell> {
+        let mut terminal = VtTerminal::new(1, 8).expect("terminal");
+        terminal.vt_write(input.as_bytes());
+        terminal.snapshot().expect("snapshot").cells
+    }
+
+    /// The boundary this type exists to hold: the host reports *which* colour
+    /// slot a cell asked for and never resolves it. Before the tagged colour,
+    /// all three of these packed as RGB — so a client could not tell an unstyled
+    /// cell from one explicitly painted with the host's palette, and applied the
+    /// host's theme either way.
+    #[test]
+    fn colors_are_reported_as_slots_not_resolved() {
+        // Unstyled: the client's own default foreground must apply.
+        assert_eq!(screen("a")[0].foreground, Color::Default);
+
+        // `31` is a theme slot, so the viewer's palette decides what red is.
+        assert_eq!(screen("\x1b[31ma")[0].foreground, Color::Palette(1));
+        assert_eq!(screen("\x1b[38;5;200ma")[0].foreground, Color::Palette(200));
+
+        // Truecolor is the program's own decision and stays exact.
+        assert_eq!(
+            screen("\x1b[38;2;9;8;7ma")[0].foreground,
+            Color::Rgb(Rgb { r: 9, g: 8, b: 7 })
+        );
+
+        // Background travels the same three roads.
+        assert_eq!(screen("a")[0].background, Color::Default);
+        assert_eq!(screen("\x1b[41ma")[0].background, Color::Palette(1));
+        assert_eq!(
+            screen("\x1b[48;2;1;2;3ma")[0].background,
+            Color::Rgb(Rgb { r: 1, g: 2, b: 3 })
+        );
+    }
+
+    /// Palette index 0 and "no colour named" are different instructions. The
+    /// resolved-RGB format collapsed both to black, which is what let a dark
+    /// theme's background silently become the client's foreground.
+    #[test]
+    fn default_is_distinct_from_palette_zero() {
+        assert_ne!(screen("a")[0].foreground, screen("\x1b[30ma")[0].foreground);
+    }
+
+    /// `inverse` is applied here, on slots, so it survives without either side
+    /// resolving a colour — and the viewport takes the same path as scrollback.
+    #[test]
+    fn inverse_swaps_slots() {
+        let cell = &screen("\x1b[31;7ma")[0];
+        assert_eq!(cell.background, Color::Palette(1));
+        assert_eq!(cell.foreground, Color::Default);
     }
 }


### PR DESCRIPTION
The packed cell resolved colour on the host — palette indices through the host's palette, unset colours to the host's white on black — so a client repainted the host's theme instead of its own. The `S` VT payload already honoured the presentation boundary with `palette: false`; the cell path contradicted it, and `docs/design/20260805-termiod-hot-path-and-client-classes.md` §D.4 recorded it as a known defect.

What the old format cost was information, not just colour: resolved RGB cannot express "the client's default" or "palette index N", so a default cell and palette 0 both packed as black, and a themed red was indistinguishable from a program's own literal `#FF0000`. Colour is now the slot the program named — `{0 default | 1 palette index | 2 rgb}` — at snapshot payload v3, history v2 and grid v2. v1 is retired rather than carried: every payload it produced had already discarded what a client needs, and nothing consumed it, since no client negotiates `grid_diff` and a `snapshot` client is served VT.

Two things surfaced while doing it:

- **Extraction disagreed with itself.** `history_cell` read the unresolved style and applied `inverse`/`invisible`, while `viewport_cell` used the render state's flattened accessors — so one screen could pack two ways depending on whether a row had scrolled. Both share `cell_from_parts` now.
- **The vt crate's tests never ran.** `vt` was a path dependency and not a workspace member, so the bare `cargo test` the workflow runs covered only the root package. It is a default member now, in its own commit.

## Verification

- `cargo test` — 57 pass, including new assertions that each slot survives extraction, that `Default ≠ Palette(0)`, that the three tags round-trip distinctly, and that an unknown tag degrades to `Default` rather than failing the frame
- `python3 smoke_test.py` — 84 checks, all pass
- `cargo build --release` and `swift build` clean
- Extraction cost A/B'd against the old path in one binary: **0.201 ms vs 0.216 ms** per 50×200 snapshot. The first cut of this was 2.81× slower — a `format!` per check per cell, and materialising a `Style` for every cell — both fixed before this branch.
- Hot path untouched by construction: `fan_out` is `push_ring` plus a byte `send` with zero VT.

Not verified: a live packed-cell repaint on screen. It is reachable only via `grid_diff`, which no client negotiates, or a formatter failure; and `swift test` cannot run at all (#311). The Swift decoder is covered by build and review only.

Release Notes:
- Remote sessions keep your own theme when the daemon falls back to its packed-cell snapshot format, instead of repainting in the host machine's colours.