### PR TITLE
Switch devices from the sidebar footer

### DIFF
--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -118,6 +118,248 @@ struct DeviceSwitcherMenuContent: View {
     }
 }
 
+// MARK: - Devices as spaces
+
+/// The mark a device carries wherever it is drawn small enough that its name
+/// won't fit — today the footer dots.
+///
+/// A color is not decoration here. The whole class of accident this app has to
+/// prevent is "I thought I was local, I was on the VPS": the panes now refuse to
+/// show the wrong machine's files, and the mark is the cue that arrives *before*
+/// the mistake, without the user reading a label.
+///
+/// The hue comes from the terminal theme (`ChromeTheme.deviceTints`), never from
+/// a palette of our own, and the index is derived from the device's identity so
+/// a machine keeps the same mark across launches, themes, and windows.
+enum DeviceTint {
+    static func color(for device: KnownDevice, chrome: ChromeTheme?) -> Color {
+        // This Mac is deliberately unhued. It is the machine you are on when you
+        // are not thinking about machines, so it reads as the absence of a mark
+        // and every tinted dot means "somewhere else".
+        guard !device.isLocal else { return .secondary }
+        guard let tints = chrome?.deviceTints, !tints.isEmpty else {
+            return Self.systemTints[index(for: device, count: Self.systemTints.count)]
+        }
+        return tints[index(for: device, count: tints.count)]
+    }
+
+    /// Used only when no terminal theme is selected, so the chrome is on the
+    /// system appearance and has no palette to borrow from.
+    private static let systemTints: [Color] = [.green, .yellow, .blue, .purple, .teal]
+
+    private static func index(for device: KnownDevice, count: Int) -> Int {
+        // The `host_id` once a handshake has revealed one, the alias until then —
+        // the same bootstrap/stable split `KnownDevice` carries. A device whose id
+        // arrives later therefore *can* change mark once, which is the honest
+        // outcome: before the handshake we did not know which machine it was.
+        let identity = device.deviceID ?? device.alias ?? ""
+        // FNV-1a rather than `hashValue`: Swift seeds its hasher per process, so a
+        // hashed index would repaint every device on every launch.
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in identity.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x100_0000_01b3
+        }
+        return Int(hash % UInt64(max(count, 1)))
+    }
+}
+
+/// One source of truth for moving between devices, so the header menu, the
+/// footer dots, and the trackpad swipe can never disagree about the order or
+/// about which machine is current.
+@MainActor
+enum DeviceSpaces {
+    /// The devices a user can move between, in the order every surface shows
+    /// them: this Mac first, then the machines it has worked on.
+    static func ordered(in store: TermioStore) -> [KnownDevice] {
+        DeviceRoster.known(in: store)
+    }
+
+    /// The device `step` places away from the current one, or `nil` at either
+    /// end. Deliberately not wrapping: a swipe that runs off the end should feel
+    /// like a wall, not teleport to the far side of the list.
+    static func neighbor(step: Int, in store: TermioStore) -> KnownDevice? {
+        let devices = ordered(in: store)
+        guard let current = devices.firstIndex(where: { $0.alias == store.currentDeviceAlias })
+        else { return nil }
+        let target = current + step
+        guard devices.indices.contains(target) else { return nil }
+        return devices[target]
+    }
+
+    static func select(_ device: KnownDevice, in store: TermioStore) {
+        store.switchToDevice(device)
+    }
+}
+
+/// The footer strip: one mark per device, the current one drawn as a capsule
+/// that slides between them. Arc's space dots, which is the interaction this
+/// borrows — a switcher small enough to live permanently at the bottom of the
+/// column, so moving between machines costs a click rather than a menu.
+///
+/// Absent entirely with one device, matching the header control: a single dot is
+/// a decoration for a decision the user never took.
+struct DeviceSpaceDots: View {
+    @EnvironmentObject var store: TermioStore
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let chrome: ChromeTheme?
+    /// Slides the current-device capsule between the dots — the same
+    /// matched-geometry pill the inspector's pane switch uses, so the two
+    /// switchers in this window move alike.
+    @Namespace private var markNamespace
+
+    var body: some View {
+        let devices = DeviceSpaces.ordered(in: store)
+        if devices.count > 1 {
+            HStack(spacing: 10) {
+                ForEach(devices) { device in
+                    Circle()
+                        .fill(Color.secondary.opacity(0.28))
+                        .frame(width: 5, height: 5)
+                        .matchedGeometryEffect(id: device.id, in: markNamespace)
+                        // A dot is a 5pt target; the row is 22pt tall, so take the
+                        // whole height as the hit area rather than asking for a
+                        // pixel-accurate click.
+                        .frame(width: 18, height: 22)
+                        .contentShape(Rectangle())
+                        .onTapGesture { DeviceSpaces.select(device, in: store) }
+                        .help(device.name)
+                }
+            }
+            .background(alignment: .leading) { currentMark(devices: devices) }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 4)
+            .animation(reduceMotion ? nil : .snappy(duration: 0.24, extraBounce: 0.12),
+                       value: store.currentDeviceAlias)
+        }
+    }
+
+    /// The tinted capsule riding the current device's dot. Non-source, so it
+    /// takes that dot's frame and animates across when the device changes.
+    @ViewBuilder
+    private func currentMark(devices: [KnownDevice]) -> some View {
+        let current = DeviceRoster.current(store, known: devices)
+        Capsule(style: .continuous)
+            .fill(DeviceTint.color(for: current, chrome: chrome))
+            .frame(width: 14, height: 5)
+            .matchedGeometryEffect(id: current.id, in: markNamespace, isSource: false)
+    }
+}
+
+/// Turns a horizontal two-finger swipe anywhere over the sidebar into a device
+/// change — the other half of Arc's spaces gesture, and the reason the dots can
+/// stay as small as they are.
+///
+/// Mounted as a background so it never takes part in hit testing: the sidebar's
+/// rows keep every click and drag they already had. The gesture is read from a
+/// local scroll monitor instead, filtered to events over this view's own bounds.
+///
+/// Three guards keep it from eating the list's vertical scrolling, which is the
+/// only way this could do damage:
+///
+/// 1. trackpad only (`hasPreciseScrollingDeltas`) — a mouse wheel never switches
+///    machines;
+/// 2. the horizontal travel must dominate the vertical by a wide margin;
+/// 3. an event is swallowed only once the gesture has already committed, so a
+///    scroll that merely drifts sideways still scrolls the list.
+struct DeviceSpaceSwipe: NSViewRepresentable {
+    /// `-1` for the device above the current one in the list, `+1` for below.
+    let onSwipe: (Int) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        context.coordinator.observe(view)
+        return view
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        context.coordinator.onSwipe = onSwipe
+    }
+
+    static func dismantleNSView(_ view: NSView, coordinator: Coordinator) {
+        coordinator.stop()
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(onSwipe: onSwipe) }
+
+    @MainActor
+    final class Coordinator {
+        /// How far the fingers must travel sideways to change machine. Roughly a
+        /// third of a comfortable swipe: far enough that a diagonal scroll never
+        /// reaches it, short enough that the gesture doesn't feel like dragging.
+        private static let commitDistance: CGFloat = 55
+        /// How much the horizontal travel must beat the vertical by. The sidebar
+        /// is a tall scrolling list, so this is the guard that matters.
+        private static let dominance: CGFloat = 2.5
+
+        var onSwipe: (Int) -> Void
+        private weak var view: NSView?
+        private var monitor: Any?
+        private var travel = CGSize.zero
+        private var committed = false
+
+        init(onSwipe: @escaping (Int) -> Void) {
+            self.onSwipe = onSwipe
+        }
+
+        func observe(_ view: NSView) {
+            self.view = view
+            // The verdict crosses the isolation boundary, not the event: `NSEvent`
+            // is not `Sendable`, so it stays on this side and only a `Bool` comes
+            // back out.
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+                guard let self else { return event }
+                let swallow = MainActor.assumeIsolated { self.swallows(event) }
+                return swallow ? nil : event
+            }
+        }
+
+        func stop() {
+            if let monitor { NSEvent.removeMonitor(monitor) }
+            monitor = nil
+        }
+
+        /// Whether this event belongs to a device swipe and must not also reach
+        /// the list underneath.
+        private func swallows(_ event: NSEvent) -> Bool {
+            guard event.hasPreciseScrollingDeltas, let view, let window = view.window,
+                  event.window === window
+            else { return false }
+            let point = view.convert(event.locationInWindow, from: nil)
+            guard view.bounds.contains(point) else { return false }
+
+            switch event.phase {
+            case .began, .mayBegin:
+                travel = .zero
+                committed = false
+            case .ended, .cancelled:
+                // The tail of a committed gesture is swallowed too: letting it
+                // through is what would fling the list sideways-then-down after
+                // the machine had already changed.
+                let wasCommitted = committed
+                travel = .zero
+                committed = false
+                return wasCommitted
+            default:
+                break
+            }
+
+            guard !committed else { return true }
+            travel.width += event.scrollingDeltaX
+            travel.height += event.scrollingDeltaY
+            guard abs(travel.width) > Self.commitDistance,
+                  abs(travel.width) > abs(travel.height) * Self.dominance
+            else { return false }
+
+            committed = true
+            // Fingers left means "bring the next machine in from the right", the
+            // direction macOS uses for page-back/forward everywhere else.
+            onSwipe(travel.width < 0 ? 1 : -1)
+            return true
+        }
+    }
+}
+
 /// The device switcher, in the sidebar's own toolbar region: which machine you
 /// are on, and the control that changes it. It sits in the strip above the list
 /// rather than in a row of its own, next to the navigator toggle and the sidebar's

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -283,6 +283,19 @@ struct SidebarView: View {
         .listStyle(.sidebar)
         .environment(\.defaultMinListRowHeight, 1)
         .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 360)
+        // The device marks ride under the list rather than in it: a row that is
+        // not a session is a row the tree has to explain (the same reasoning that
+        // keeps the device *name* up in the toolbar band), and an inset keeps the
+        // list scrolling its full height behind them.
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            DeviceSpaceDots(chrome: chrome)
+        }
+        // A two-finger swipe over the column moves to the machine either side of
+        // this one. Mounted as a background so it takes no clicks from the rows.
+        .background(DeviceSpaceSwipe { step in
+            guard let device = DeviceSpaces.neighbor(step: step, in: store) else { return }
+            DeviceSpaces.select(device, in: store)
+        })
     }
 
     /// The current device's own roster: the sessions **that machine** reports,

--- a/Sources/termio/Theme/ChromeTheme.swift
+++ b/Sources/termio/Theme/ChromeTheme.swift
@@ -24,6 +24,13 @@ struct ChromeTheme {
     /// Whether the theme reads as dark, so the window can match its system
     /// appearance (traffic lights, scrollbars) to the theme.
     let isDark: Bool
+    /// Hues a device can be marked with, in a fixed order (see `DeviceTint`).
+    ///
+    /// Drawn from the theme's own ANSI colors rather than a palette of our own,
+    /// for the reason this whole type exists: a second palette drifts from the
+    /// terminal's. Red is deliberately absent — it reads as an error everywhere
+    /// else in the app, and a machine is not one.
+    let deviceTints: [Color]
 
     /// Ink guaranteed to contrast a background: dimmed white over dark, dimmed black over light.
     /// The lesson this encodes (learned in the editor gutter): contrast must come from the
@@ -65,6 +72,15 @@ struct ChromeTheme {
             ?? definition.selectionBackground.flatMap(Color.init(hex:))
             ?? foreground
         self.isDark = dark
+        // Green, yellow, blue, magenta, cyan — the bright half (palette 10-14),
+        // which is the half that survives a dark background. A slot the theme
+        // leaves undefined drops out rather than becoming a default hue that
+        // belongs to no theme; if every one is missing, the accent stands in so a
+        // device always has a mark.
+        let tints = [10, 11, 12, 13, 14]
+            .compactMap { definition.palette[$0] }
+            .compactMap(Color.init(hex:))
+        self.deviceTints = tints.isEmpty ? [self.accent] : tints
     }
 
     /// WCAG contrast ratio between two opaque colors (1…21). Colors that can't be

--- a/Tests/termioTests/DeviceTintTests.swift
+++ b/Tests/termioTests/DeviceTintTests.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import XCTest
+@testable import termio
+
+/// The mark a device carries in the sidebar footer (`DeviceTint`).
+///
+/// The invariant worth pinning is the one the whole device vocabulary rests on:
+/// a mark follows the *machine*, not the road taken to it. A tint keyed by alias
+/// would give one box three different colors as the user moves between a LAN
+/// name, a WAN name, and a tailnet name — which is worse than no mark at all,
+/// because the cue would then be actively misleading.
+@MainActor
+final class DeviceTintTests: XCTestCase {
+    /// Two aliases that resolved to one `host_id` are one machine, so they carry
+    /// one mark.
+    func testOneDeviceReachedByTwoAliasesKeepsOneMark() {
+        let lan = KnownDevice(alias: "vps-lan", deviceID: "device-a")
+        let tailnet = KnownDevice(alias: "vps-tailnet", deviceID: "device-a")
+
+        XCTAssertEqual(DeviceTint.color(for: lan, chrome: nil),
+                       DeviceTint.color(for: tailnet, chrome: nil))
+    }
+
+    /// This Mac is the machine you are on when you are not thinking about
+    /// machines: it stays unhued, so every colored dot means "somewhere else".
+    func testThisMacIsUnhued() {
+        XCTAssertEqual(DeviceTint.color(for: .thisMac, chrome: nil), Color.secondary)
+        XCTAssertNotEqual(DeviceTint.color(for: KnownDevice(alias: "ukvps", deviceID: nil),
+                                           chrome: nil),
+                          Color.secondary)
+    }
+
+    /// With no terminal theme selected there is no palette to borrow from; the
+    /// fallback must still answer rather than trap on an empty collection.
+    func testAnswersWithNoThemeSelected() {
+        let device = KnownDevice(alias: "ukvps", deviceID: nil)
+        XCTAssertEqual(DeviceTint.color(for: device, chrome: nil),
+                       DeviceTint.color(for: device, chrome: nil))
+    }
+}


### PR DESCRIPTION
The device switcher is a pull-down in the toolbar band. Moving between machines is a menu, and once the menu closes nothing on screen says which machine the sidebar is showing — the cue is a word you have to read, in a band you stopped looking at.

Browsers solved this shape years ago for spaces. This takes the two halves of it that fit a sidebar: a row of marks at the foot of the column, and a two-finger swipe across it.

### The mark is a correctness cue

The accident this app exists to prevent is reading a diff, searching a symbol, or running a command against the wrong box. A color arrives before the mistake does, without being read.

Two rules keep it from becoming a second design system:

- **The hue comes from the terminal theme** (`ChromeTheme.deviceTints`, the bright half of the ANSI palette), never from a palette of our own — the same reason `ChromeTheme` exists at all. Red is left out; it means "error" everywhere else in the app, and a machine is not one.
- **The index comes from the device identity**, the `host_id` when a handshake has revealed one and the alias until then. One box answering to a LAN name, a WAN name, and a tailnet name keeps one mark, and the mark survives relaunch (FNV-1a, not `hashValue`, which Swift seeds per process).

This Mac is deliberately unhued, so every colored dot means "somewhere else".

### The swipe cannot eat the list

The sidebar is a tall scrolling list, so the gesture is filtered three ways:

1. trackpad only (`hasPreciseScrollingDeltas`) — a mouse wheel never switches machines;
2. horizontal travel must beat vertical by 2.5×;
3. an event is swallowed only after the gesture has already committed, so a scroll that merely drifts sideways still scrolls the list.

It is mounted as a background view and reads a filtered local scroll monitor, so it takes part in no hit testing and the rows keep every click and drag they had.

### One place decides

`DeviceSpaces` holds the order, the neighbor, and the select, so the header menu, the dots, and the swipe cannot disagree about which machine is current.

### Deliberately not built

The interactive peek carousel — dragging the neighbor machine's list in under your fingers. It needs a per-device roster snapshot to render the incoming page, and the roster is fetched on switch today, so a peeked page would slide in empty. That is worse than a clean switch. It becomes possible once a device's roster is cached rather than re-asked.

Swiping past either end walls rather than wrapping, matching macOS page-back/forward.

### Verification

`swift build` and `swift test` (386 tests, 3 new pinning the identity-not-alias rule) pass, and the dev app builds and signs.

**Not verified visually.** Screen Recording permission is missing on this machine, so I could not see the result. Needs a human pass on: the dots' size and spacing against the sidebar's material, whether the capsule slide reads at 0.24s, the tint's legibility in a light theme, and that the swipe never steals a vertical scroll in practice.

Release Notes:
- Switch machines from a row of marks at the foot of the sidebar, or by swiping across it with two fingers. Each machine carries a color drawn from your terminal theme, so the sidebar says which one it is showing without being read.
