### PR TITLE
Attach to a session from a browser

### DIFF
--- a/.github/workflows/ghostty-pin.yml
+++ b/.github/workflows/ghostty-pin.yml
@@ -1,0 +1,66 @@
+name: ghostty pin
+
+# One ghostty across the host, the Mac, and the browser.
+#
+# The Replica contract says the browser runs the same VT state machine as
+# termiod's sidecar and as the Mac app. Three files assert that, none of them
+# can see the other two, and every one of them is a hop away from the sha it
+# implies: a libghostty-rs rev whose build.rs carries GHOSTTY_COMMIT, a
+# libghostty-swift version whose release body records the sha it built, and the
+# wasm the web root serves. Bump one and miss another and everything still
+# builds — the browser just disagrees with the host about grapheme width,
+# autowrap, or a kitty keyboard sequence, on a VPS, in front of a user.
+#
+# Deliberately its own workflow rather than a job in termiod.yml: path filters
+# are per workflow, and Package.resolved has no business spinning up the Zig and
+# musl runners.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "web/client/ghostty-pin.json"
+      - "termiod/vt/Cargo.toml"
+      - "Package.swift"
+      - "Package.resolved"
+      - "scripts/check-ghostty-pin.sh"
+      - "scripts/ghostty-wasm.sh"
+      - ".github/workflows/ghostty-pin.yml"
+  pull_request:
+    paths:
+      - "web/client/ghostty-pin.json"
+      - "termiod/vt/Cargo.toml"
+      - "Package.swift"
+      - "Package.resolved"
+      - "scripts/check-ghostty-pin.sh"
+      - "scripts/ghostty-wasm.sh"
+      - ".github/workflows/ghostty-pin.yml"
+
+concurrency:
+  group: ghostty-pin-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pins-agree:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Resolves all three pins to a ghostty sha and diffs them. Reads the
+      # libghostty-rs build.rs from raw.githubusercontent and the
+      # libghostty-swift release body from the API — the Swift side records its
+      # ghostty sha nowhere else.
+      - name: Check the pins agree
+        run: scripts/check-ghostty-pin.sh
+
+      # The artifact is content-addressed by the full commit sha, so this URL is
+      # stable while the `tip` tag it was cut from is not. Fetching it here means
+      # a blob aged out of the bucket surfaces on a PR rather than on the box at
+      # deploy time, and that the recorded sha256 still describes what is served.
+      - name: Fetch and verify the pinned ghostty-vt.wasm
+        run: |
+          scripts/ghostty-wasm.sh fetch
+          scripts/ghostty-wasm.sh verify

--- a/docs/design/20260818-termiod-web-client-ghostty-wasm.md
+++ b/docs/design/20260818-termiod-web-client-ghostty-wasm.md
@@ -1,0 +1,1039 @@
+---
+title: Termiod web client on official Ghostty WASM (Linux first)
+status: draft
+type: rfc
+created: 2026-08-18
+updated: 2026-08-18
+related:
+  - 20260730-termiod-session-protocol.md
+  - 20260805-termiod-hot-path-and-client-classes.md
+  - 20260805-termiod-device-architecture.md
+  - 20260730-termiod-session-mux.md
+  - 20260708-session-daemon-architecture.md
+---
+
+# Termiod web client on official Ghostty WASM (Linux first)
+
+> The browser is a Replica. It speaks the existing Session Protocol over WSS to a Linux `termiod`, runs official `ghostty-vt.wasm` as its VT, and paints through a renderer seam we own — Canvas 2D in v1, WebGPU in v2. React owns the shell and never the frame. No second protocol, no host-side grid encoder, no WebTransport.
+
+**Author:** —  
+**Date:** 2026-08-18  
+**Status:** Draft
+
+---
+
+## Overview
+
+A Linux box already runs `termiod` and already speaks the framed Session Protocol over a Unix socket and over `ssh … termiod stdio`. What it cannot do is talk to a browser: browsers have no Unix sockets and must not embed SSH. This RFC is the missing *implementation* design for that last pipe.
+
+The protocol work is done. [termiod-session-protocol.md](20260730-termiod-session-protocol.md) §D already names WSS as a binding of the same messages. [termiod-hot-path-and-client-classes.md](20260805-termiod-hot-path-and-client-classes.md) §D.3 already decided the web client is a **Replica**: official `libghostty-vt` as standalone Wasm, raw `D` in steady state, no fourth client class. `grid_diff` is not selected on the grounds that the client is a browser. WebTransport stays refused because a Replica needs ordered bytes, not datagrams.
+
+What this document decides is how the browser loads `ghostty-vt.wasm`, **who paints and through what seam**, **where React's boundary is**, how WSS binds on a Linux box without becoming a second protocol or a DIY TLS stack, how a pairing token authenticates that bind, and what we will not invent.
+
+Linux is first because that is the VPS / devbox case: the session already lives on the box, and a phone or a borrowed laptop reaching `https://box/termio` is one hop to that device, not a hop through a Mac.
+
+**The renderer decision, up front, so nothing below has to hedge:** v1 paints with a Canvas 2D renderer we own, written directly against the official render-state C ABI, behind an explicit `TerminalRenderer` seam. **WebGPU is v2** — scheduled, specified, implementing the same seam, with a capability probe that falls back to the v1 renderer when `navigator.gpu` is absent. The reasoning, including why we are not borrowing anyone's renderer, is in [Renderer](#renderer-one-seam-two-implementations) and [Alternatives](#alternatives-considered) §G / §H.
+
+---
+
+## Background & Motivation
+
+### Current state
+
+`termiod` is a Unix-socket daemon. `daemon::serve` (`termiod/src/daemon.rs`) binds `$XDG_RUNTIME_DIR/termiod/termiod.sock` (or `TERMIOD_SOCK`) at mode `0600` and never a TCP port. [DEPLOY.md](../../termiod/DEPLOY.md) is explicit: no public bind, SSH is the access-control boundary, whoever can `ssh` as that user can reach the daemon.
+
+Three pipes already carry the same 5-byte framing (`[kind:u8][len:u32be][payload]`, `termiod/src/protocol.rs`):
+
+| Pipe | How | Who uses it |
+| --- | --- | --- |
+| Unix socket | `UnixListener` in `serve()` | local CLI, Mac app |
+| SSH stdio | `termiod stdio` splices stdin/stdout onto the socket (`client.rs`) without parsing a single frame | Mac app / CLI via `ssh <host> termiod stdio` |
+| WSS | **not built** | this RFC |
+
+Attach is already the Replica shape. A client that advertises `snapshot` + `scrollback` in `Control::Hello` gets `Control::Attached`, then one `S` (format v2, VT sequences with `palette: false`), then `Event::Ready { session }`, then newest-first `H` chunks interleavable with live `D`. Resize is the same barrier (`SessionMsg::Resize` + `Snapshot` adjacent on the sidecar FIFO). `grid_diff` exists and is legal only under pressure. None of this changes.
+
+### Why the web client is now cheap
+
+Two things landed outside this repo in August 2026:
+
+1. Ghostty ships a pre-built `ghostty-vt.wasm` in GitHub releases (Mitchell, 2026-08-14). Every major browser can load it. It is VT parse + terminal state only. It does not ship a renderer.
+2. Several independent projects already wire that Wasm into a page (`coder/ghostty-web`, `@wterm/ghostty`, Restty, browstty). The recurring shape is identical: host sends bytes, JS writes them into the Wasm, a renderer paints from the render state, a client-side `KeyEncoder` turns key events back into bytes.
+
+A third thing is more important than either, and it is what changed the renderer decision in this revision: **libghostty-vt's public C ABI already contains a render-state API designed for exactly this job, and it exists at the commit `termiod/vt` pins.** See [What the official ABI already gives us](#what-the-official-abi-already-gives-us). We are not guessing at exports any more.
+
+The July 8 daemon architecture still described the wire as host-side grid diffs with ghostty-web's 16-byte cell as the frame. That was **superseded** on 2026-08-08 by the raw-`D` Replica model. This RFC follows the later protocol. ghostty-web remains useful as a *reference* for the JS/Wasm calling pattern. It is not a description of what rides the socket, and — as of this revision — it is not the renderer either.
+
+### Pain
+
+A user with a VPS can already `termiod remote open ukvps` from a Mac. They cannot open the same session from a browser on that box, from a Chromebook, or from a phone that is not a satellite of a Mac. Device architecture §2.1 forbids the Mac-in-the-middle path. The companion WebSocket is a second protocol and the cautionary tale ([session-protocol.md](20260730-termiod-session-protocol.md) §H #9). WSS of *this* protocol is the remaining pipe.
+
+---
+
+## Goals & Non-Goals
+
+### Goals
+
+1. A browser Replica attaches to a Linux `termiod` over WSS and renders a live session with official `ghostty-vt.wasm` pinned to the same ghostty commit as `termiod/vt`.
+2. The bytes on that WSS are the existing framed Session Protocol. A recorded Unix-socket transcript must replay against the WSS binding (the §C.9 acceptance test, one more pipe).
+3. Auth is a pairing token, an Origin allowlist, plus optional Tailscale Serve / Caddy in front. No accounts. No hosted control plane.
+4. Theme is viewer-injected. One snapshot fed to a light page and a dark page must look different, **and a theme switch after load must re-resolve every visible cell** (device architecture §4).
+5. Paint goes through one `TerminalRenderer` seam. Replacing the Canvas 2D implementation with a WebGPU one changes one file and no caller.
+6. React owns the shell. No terminal cell, cursor position, dirty row, or byte count is React state, and the surface component renders once per attach, not once per frame.
+7. Linux VPS deploy is documented on top of the existing `termiod remote deploy` + linger unit, including a durable WSS start path that survives `spawn_daemon` and the systemd unit.
+
+### Non-goals
+
+- Replacing the Mac or iOS apps.
+- A chat UI. The terminal is the interface.
+- Implementing SSH, TLS, or any crypto in the browser or in `termiod`.
+- A hosted Termio cloud, a relay that terminates `hello`, or any control plane we run.
+- Selecting `grid_diff` on the grounds that the client is a browser or the pipe is remote.
+- Forking Ghostty, or waiting for Superlogical to open-source their renderer.
+- **WebGPU in v1.** It is v2, with a dated seam and a measured entry trigger, not an open-ended "later quality investment." See [Renderer](#renderer-one-seam-two-implementations).
+- **A glyph atlas, text shaping, ligatures, subpixel/LCD antialiasing, procedural box-drawing geometry, and Kitty graphics in v1.** These are the WebGPU bill of materials, not incidental polish; they arrive with v2 or not at all.
+- A WebGL2 renderer. Two implementations of the seam, not three. See [Alternatives](#alternatives-considered) §H.
+- Clipboard, image paste, or Superlogical-style extra data channels, unless the existing protocol already has the verb (it does not, for clipboard).
+- A nested window manager in the page that the host knows about. Splits, if any, are a later client concern and never cross the wire.
+- Server-side rendering, a Node runtime on the box, or any React framework. The web root is a static build.
+- Channel-id multiplexing (device architecture §5.1 / §8.7 step 4c). One WebSocket is one channel. We do not wait for 4c to ship the first attach.
+- Serving a plain tty / compat sink.
+
+---
+
+## Prior art survey
+
+Research date: 2026-08-18. Superlogical wire details stay **Unknown**; nothing below guesses at them.
+
+### Official Ghostty
+
+- **2026-08-14, Mitchell Hashimoto** ([x.com/mitchellh/status/2088378990998524206](https://x.com/mitchellh/status/2088378990998524206)): pre-built `ghostty-vt.wasm` now ships in Ghostty GitHub releases. Fastest optimized builds. Compatible with every major browser going back years.
+- **2026-08-14, Mitchell** ([x.com/mitchellh/status/2088380975118250065](https://x.com/mitchellh/status/2088380975118250065)): libghostty-vt is VT parse + terminal state only. **It does not ship a web renderer.** Superlogical built their own on the Wasm; "out of scope for libghostty-vt"; "We might open source it. I'm not sure yet. We use libghostty for our web interface (which is fully working already)."
+- **2026-08-17, Mitchell** ([x.com/mitchellh/status/2089351136839090387](https://x.com/mitchellh/status/2089351136839090387)): Wasm memory pool replaced Zig `std.heap.MemoryPool`; 75% less required terminal memory, no throughput hit.
+- Published benches vs xterm.js (M4 Max, 80×24): IO long-lines 1023 vs 144 MB/s; mixed 543 vs 121; reflow ~9000 vs 1605 resizes/s; incremental scroll 76923 vs 19084 render-state updates/s. These are **library** numbers, not mux numbers, and they measure the VT, not paint.
+- Mitchell's harness comparing libghostty-vt to xterm.js via the *same* xterm.js WebGL renderer (to isolate VT cost) is "pulled out in its own repo but I haven't published it yet" (2026-08-17).
+
+### What the official ABI already gives us
+
+Verified 2026-08-18 by reading the headers **at `56e1f3a`**, the exact commit `termiod/vt/Cargo.toml` pins (committed 2026-08-17). This is the load-bearing survey result: the previous revision of this RFC treated "does the pinned Wasm export enough?" as an open question and borrowed a renderer to route around it. It exports enough.
+
+| Header @ `56e1f3a` | What it gives the browser |
+| --- | --- |
+| `include/ghostty/vt/render.h` | The whole render-state API. Two-phase update (`begin_update` / `end_update`) so the parse side is never blocked by paint. Global dirty as `FALSE` / `PARTIAL` / `FULL`. Per-row dirty flags. A row iterator and a per-row cells iterator. `ghostty_render_state_clean()` to clear both dirty layers after a frame. |
+| `render.h`, row-cells data kinds | `…_ROW_CELLS_DATA_STYLE` → the cell's **unresolved** `GhosttyStyle`. `…_DATA_HAS_STYLING` → a cheap predicate so unstyled cells never materialise a style. `…_DATA_GRAPHEMES_UTF8` → the full grapheme cluster as UTF-8 into a caller buffer. `…_DATA_SELECTED` per cell, and `…_ROW_DATA_SELECTION` as a row-local range (the header itself recommends the range for span renderers). |
+| `render.h`, `…_ROW_DATA_CELLS_RAW` | A borrowed view of a whole row's raw cell values in **one call**, documented as the bulk path "for callers with expensive call boundaries (e.g. WebAssembly embedders)." This is the Wasm-boundary batching lesson, now an official export instead of folklore. |
+| `include/ghostty/vt/style.h` | `GHOSTTY_STYLE_COLOR_NONE` / `_PALETTE` / `_RGB`. A tagged colour, one-for-one with `WireColor` in `termiod/src/protocol.rs`. |
+| `render.h`, `GhosttyRenderStateColors` | Default fg/bg, cursor colour + `cursor_has_value`, and the active `GhosttyColorRgb palette[256]`. |
+| `render.h`, `GhosttyRenderStateCursor` | Viewport x/y with a `viewport_has_value` guard, wide-tail flag, visible, blinking, password-input, and visual style (bar / block / underline / hollow block). |
+| `include/ghostty/vt/key/encoder.h`, `key/event.h` | The KeyEncoder as a public C API. ghostty-web already drives exactly these symbols (`ghostty_key_encoder_new` / `_setopt` / `_encode`), so their code is a worked example of calling the official thing, not a patch we need. |
+| `include/ghostty/vt/wasm.h` | `ghostty_wasm_alloc` / `_free` / `_alloc_opaque` / `_take_opaque`, plus `ghostty_type_json` for discovering pointer width, `size_t` width, byte order, and struct sizes at runtime. |
+| `include/ghostty/vt/modes.h` | `GHOSTTY_MODE_SYNC_OUTPUT` = mode 2026. Synchronized output is queryable, not something the adapter has to infer. |
+
+Two of these deserve to be called out because they change design decisions elsewhere in this document.
+
+**The colour trap has an official name.** The same row-cells iterator exposes `…_DATA_BG_COLOR` and `…_DATA_FG_COLOR`, and its own doc comment says they resolve "palette indices through the palette." That is the resolution the presentation boundary forbids. `termiod/vt/src/lib.rs` already hit this and already documented the fix in Rust: *"Reads the unresolved style rather than the render state's `fg_color`/`bg_color`, which flatten palette indices through the host's palette and substitute the host's defaults — the exact resolution this boundary must not perform."* The browser renderer is a direct port of that choice. Reading `…_DATA_STYLE` is correct; reading `…_DATA_FG_COLOR` is a design regression with a constant name attached to it.
+
+**"Resize detaches TypedArray views" has an official mitigation.** `wasm.h` documents it precisely: an exported function may grow linear memory; numeric pointers and handles stay valid, but any `ArrayBuffer` / `DataView` / typed array created before the growth may not cover live memory. The rule it gives is *reacquire `exports.memory.buffer` immediately before every host-side access, and recreate cached views whenever buffer identity **or** byte length changes*. That is a discipline in the binding layer, not only a reason to pause the render loop. We do both: the binding never caches a view across an allocating call, **and** the render loop still quiesces for the resize barrier, because the barrier exists for protocol reasons (`R` → `S` → `ready`) independent of memory growth.
+
+### The recurring web-terminal shape
+
+Nobody who can load the Wasm puts the VT in JavaScript. The library never owns the socket. Resize is a barrier. The Wasm is fetched (~400 KB), not inlined. Scrollback is often a **byte budget**, not a line count. OSC 8, OSC 10/11, and mode 2026 have to be plumbed through the adapter.
+
+```
+PTY / session host
+    │  raw bytes (or a thin framed protocol)
+    ▼
+browser JS: term.write(bytes)
+    │
+    ▼
+libghostty-vt.wasm   ← parse + grid + scrollback + modes
+    │  render state: dirty rows, tagged-colour cells, cursor
+    ▼
+renderer (Canvas 2D / WebGPU)   ← NOT in libghostty-vt
+    │
+keyboard → KeyEncoder → onData → bytes back to host
+```
+
+### Concrete packages
+
+1. **Official `ghostty-vt.wasm`** (ghostty-org releases, August 2026). The long-term VT binary and, per the table above, the long-term render-state and key-encoder ABI. This is the source of truth *at a pinned commit* — see [VT source](#vt-source).
+
+2. **`coder/ghostty-web`** — [github.com/coder/ghostty-web](https://github.com/coder/ghostty-web). MIT, 2727★, last push 2026-07-02. Drop-in xterm.js API. ~400 KB Wasm, zero runtime deps, Canvas 2D renderer, built for Coder Mux. **Zero WebSocket / PTY inside the library.** Builds from Ghostty source + `patches/ghostty-wasm-api.patch`; the README says it "will eventually consume a native Ghostty WASM distribution once available." KeyEncoder is client-side and already calls the official `ghostty_key_encoder_*` symbols. `lib/renderer.ts` is one 1001-line `CanvasRenderer`: dirty rows via `isRowDirty(y)` / `clearDirty()`, per-row redraw that also repaints the row above and below to survive glyph overflow, `requestAnimationFrame` for paint, resize pauses the loop.
+
+   **And its cell model is pre-resolved 24-bit RGB.** `GhosttyCell` carries `fg_r/fg_g/fg_b` and `bg_r/bg_g/bg_b`. The palette is handed to the Wasm once, at `ghostty_terminal_new_with_config` (`palette[16]` as `u32×16`). `setTheme()` rebuilds a JS-side `this.palette` array and nothing else, so cells already parsed keep the construction-time palette; the renderer even sniffs `bg_r === 0 && bg_g === 0 && bg_b === 0` as "this is the default background." A page built on this passes the light/dark test at load and fails the theme-switch test forever after. This is the `palette: false` trap in a second place, and the previous revision of this RFC picked it as the v1 renderer without noticing. Retained here as a **reference implementation**, not a dependency.
+
+3. **Restty** — [github.com/wiedymi/restty](https://github.com/wiedymi/restty). MIT, 392★, last push 2026-07-17, 521 commits, self-described "early-release." libghostty-vt in Wasm + **WebGPU with a WebGL2 fallback** + TypeScript text shaping, with an xterm.js compatibility wrapper. The closest existing art to a WebGPU terminal on this VT, and the reason this RFC can cost a WebGPU renderer from a bill of materials instead of a guess. Detailed below.
+
+4. **`@wterm/ghostty`** — [wterm.dev/ghostty](https://wterm.dev/ghostty). `GhosttyCore.load({ wasmPath, scrollbackLimit, foregroundColor, backgroundColor })`. Builds libghostty from ghostty-org source (v1.3.1 in `zig/build.zig.zon`); patches `page.zig` / `PageList.zig` to replace posix.mmap / Mach VM with `std.heap.wasm_allocator` behind `isWasm()`. Thin export layer `zig/src/wasm_api.zig` (~300 lines, ~20 JS functions). Commits the Wasm so consumers do not need Zig. TypeScript bindings + `TerminalCore` adapter; DOM renderer stays core-agnostic. ~400 KB fetched. Cells come as **pre-resolved 24-bit RGB**; theme must be injected at load. Scrollback limit is **bytes**, default 10000 (too small). Reports discarded oldest rows so a DOM renderer can keep anchors. Mode 2026 generation is exposed.
+
+5. **browstty** — Zig Wasm module wrapping libghostty.
+
+6. **webterm** (rcarmo) — dashboard + live tiles on ghostty-web. Useful as a "many sessions at once" UI reference, not as a protocol.
+
+7. **RemoteTTYs** — ghostty-web + Go agent, no open ports / NAT traversal. Different trust story than termiod (we already have SSH / tailnet).
+
+8. **vscode-bootty, obsidian-ghostty-terminal, onyx-shell, jupyterlab-ghostty-terminal** — same Wasm-in-the-page pattern inside a host app.
+
+9. **X, 2026-08-15**: [@sujeetgholap](https://x.com/sujeetgholap/status/2088580266143199680) embeds a TUI (`/mcp`) inside Pi-web-UI inside **wterm running WASM-compiled ghostty**. No need to port the TUI to HTML.
+
+10. **X, 2026-08-11**: @tanaysoni_ — `@wterm/ghostty` packages Ghostty's core; libghostty-vt parses escapes and keeps cursor, colours, alt screens, Unicode, scrollback.
+
+11. **awesome-libghostty** web section: [github.com/Uzaaft/awesome-libghostty](https://github.com/Uzaaft/awesome-libghostty).
+
+### Restty, read properly
+
+Restty is the existence proof that WebGPU on libghostty-vt works, and it is also the invoice. Findings, from the repository tree and its own `docs/internals/`:
+
+**Pipeline.** Four passes per frame: background quads plus selection rectangles; glyphs as textured quads from a shared atlas, instanced; decorations (underline, strikethrough, overline); cursor (block / bar / underline, with blink state). WebGPU is primary, WebGL2 is the fallback, and the two "maintain the same data layout" with equivalent shaders — but they are still two shader languages and two render-tick code paths (`src/renderer/shaders/glyph-wgsl.ts` and `glyph-gl.ts`; `render-tick-webgpu*.ts` and `render-tick-webgl*.ts`).
+
+**Atlas.** Grayscale raster atlas with hinting, optional LCD subpixel atlas behind a separate shader. **No SDF/MSDF** — a deliberate decision recorded in `docs/internals/decisions.md`. Atlas resizing plus LRU eviction when full. Uploads via `queue.writeTexture` (WebGPU) or `texSubImage2D` (WebGL). A separate colour-glyph atlas exists for emoji.
+
+**Damage.** "If the RenderState exposes dirty rows, only update instance buffers for dirty rows." Full redraw on palette change, resize, or the full-dirty flag. That is the same dirty-row contract `render.h` exports, which is why the seam below can be identical for both implementations.
+
+**Shaping and ligatures.** Ligatures on by default, drawn as shaped glyphs across cell ranges with the per-cell glyph suppressed inside the run. Cursor and selection are drawn as **overlays** precisely so they do not break a ligature run. Around it: `ligature-runs.ts`, `fallback-layout.ts`, `glyph-coverage.ts`, a font-resource store, a font picker with classification, and Nerd Font range/metric constraint tables.
+
+**Box drawing is not a font problem.** `src/renderer/shapes/` draws box drawing (including dashed, diagonal, rounded corners), block elements, braille, and powerline **procedurally**, with a classifier and a fallback. Ten-plus files, because monospace fonts do not cover these consistently and Ghostty itself draws them.
+
+**What that adds up to.** Restty is ~970 files. The WebGPU pixels are a small fraction of it; the glyph pipeline, the font machinery, and the shape geometry are the bulk. It also ships a pane manager, a plugin host, a search UI, IME handling, scrollbars, context menus, and Kitty graphics — a second application framework, most of which collides with what React owns here and with "no nested window manager."
+
+**Why we cannot vendor it, specifically.** Two hard blockers, neither about quality:
+
+- Its Wasm is built from a **patched ghostty submodule** — `docs/internals/decisions.md` records stubbing `BoldColor` in `style.zig`, removing `build_config` imports, and skipping font imports in `quirks.zig` — at an unpinned commit. That is a second VT at a different revision from `termiod/vt`, which is the divergence [Alternatives §A](#a-xtermjs-as-the-vt-and-the-renderer) rejects xterm.js for.
+- **The compiled Wasm is base64-inlined into the JS bundle.** `src/wasm/embedded.ts` is 2,789,665 bytes. This RFC budgets ~400 KB *fetched* and served as `application/wasm`, versioned in the web root next to a pinned ghostty sha. Inlining is the opposite of that on every axis.
+
+Restty's palette handling, by contrast, is the shape we want and better than either JS-cell library: its Zig wrapper exports `restty_set_palette`, `restty_set_default_colors`, and `restty_reset_palette`, and it ships the full Ghostty theme catalogue. That is a *design* we adopt — the palette lives on the client side of the boundary and is replaceable at runtime — implemented against the official ABI rather than a patched one.
+
+### WebGPU availability, measured against a Linux-first document
+
+From the GPU for the Web working group's own [Implementation Status](https://github.com/gpuweb/gpuweb/wiki/Implementation-Status), read 2026-08-18:
+
+| Browser | Windows | macOS | Linux | Mobile |
+| --- | --- | --- | --- | --- |
+| Chrome / Edge | ✅ 113+ | ✅ 113+ | ⚠️ **behind flags** — needs `--enable-unsafe-webgpu --ozone-platform=x11 --use-angle=vulkan --enable-features=Vulkan,VulkanFromANGLE` | ✅ Android 121+ (GPU-dependent) |
+| Firefox | ✅ 141+ | ✅ 145+ (Apple Silicon), 147+ (Intel) | 👷 **Nightly only**; Mozilla "expects to ship on Linux in 2026" | 👷 behind a flag |
+| Safari | — | ✅ 26+ | — | ✅ iOS / iPadOS 26+ |
+
+Read that table against this document's own title. The RFC is Linux first, and its Pain section names, as a case to fix, "a browser **on that box**." On that box today, neither stable Chrome nor stable Firefox gives you WebGPU without command-line flags. The phone (Safari 26), the Chromebook, and a borrowed Mac or Windows laptop all have it; the Linux desktop that the daemon is deployed on does not.
+
+### Superlogical (context only)
+
+Web client is first-class. Current revs use **websockets over HTTP** so the browser works (2026-07-31, **Announced**). Custom bidirectional data protocol for clipboard etc. (2026-08-17, **Announced**). Their renderer is custom and may or may not become OSS. We do not guess their frames, and we do not wait for the renderer.
+
+### What the July 8 doc got right, and what it did not
+
+§11 of [session-daemon-architecture.md](20260708-session-daemon-architecture.md) correctly extracted six lessons from ghostty-web: transport is not in the library; batch across the Wasm boundary; KeyEncoder is a pure function; resize is a barrier; the client is headless-testable. Those still hold — and three of them are now official exports (`…_ROW_DATA_CELLS_RAW`, `key/encoder.h`, `wasm.h`'s memory-growth rule) rather than lessons we have to remember.
+
+It then said the daemon→client frame *is* ghostty-web's dirty-row `get_viewport()` and that "no protocol invention is required." That sentence described a Mirror. The protocol that shipped is a Replica. The web client consumes `S` + `D`, not a 16-byte cell stream, and putting a grid encoder between the PTY and the browser would violate the anti-100× invariant on purpose.
+
+---
+
+## Proposed Design
+
+### The picture
+
+```mermaid
+flowchart LR
+  subgraph device ["Linux device"]
+    PTY["PTY + process"]
+    T["termiod<br/>sidecar VT for S/H only"]
+    SOCK["Unix socket 0600"]
+    WSS["opt-in WSS<br/>loopback :8790"]
+    PTY -->|tee raw bytes| SOCK
+    PTY -.->|parallel, never between| T
+    SOCK --> WSS
+  end
+
+  subgraph edge ["TLS you already have"]
+    TS["Tailscale Serve or Caddy<br/>mount /termio → /"]
+  end
+
+  subgraph browser ["Browser Replica"]
+    APP["React shell<br/>roster · badges · theme"]
+    JS["framed Session Protocol JS"]
+    WASM["ghostty-vt.wasm @ 56e1f3a"]
+    R["TerminalRenderer seam<br/>Canvas 2D v1 · WebGPU v2"]
+    K["KeyEncoder"]
+    APP -.->|attach / detach / palette<br/>never per frame| JS
+    JS -->|S.vt + D bytes| WASM
+    WASM -->|dirty rows · tagged cells · cursor| R
+    K -->|D bytes| JS
+  end
+
+  WSS --> TS
+  TS -->|WSS + pairing token| APP
+```
+
+One hop: browser → (TLS terminator) → loopback WSS → the same accept path `handle_conn` already runs for a Unix socket. The Mac is not on this path. The browser is a client of this device, the same way the Mac app is a client of this device ([device-architecture.md](20260805-termiod-device-architecture.md) §2.1).
+
+### Client class: Replica
+
+The web client negotiates `snapshot` and `scrollback`. It does **not** negotiate `grid_diff` on the grounds that it is a browser. `G` remains legal later if a measured backlog or an explicit "bounded bandwidth" control trips the hot-path §D.4 signals. Illegal: selecting `G` on transport class.
+
+```
+hello caps = ["events", "snapshot", "scrollback"]
+client     = "termio-web/<version>"
+role       = attach   (one WebSocket per session)
+```
+
+A second WebSocket with `role: control` lists, creates, and subscribes to the roster. That is the same split `protocol.rs` already has (`ChannelRole::Control` / `ChannelRole::Attach`). We do not invent channel ids for v1. `daemon.rs` currently ignores `role` (`role: _` in `handle_conn`); the web client still sends the honest value.
+
+Control-channel sequence (existing ops, no new verbs):
+
+```
+→ C Hello {proto:1, role:"control", caps:["events"], client:"termio-web/…"}
+← C HelloOk {host_id, client_id, caps}
+→ C List {seq:1}
+← C Sessions {sessions, tombstones, re:1}
+→ C Subscribe {events:["roster","status"], seq:2}
+← C Ok {re:2}
+← E Roster {session, action, info}
+← E Status {session, status, title?}
+```
+
+`Event::Roster` and `Event::Status` already exist (`protocol.rs`). Status values match the CLI: `working` / `idle` / `needs_you` / `done` / `failed` / `unknown`. The page must not poll `list` as its live path.
+
+Steady state on the attach socket is raw `D` in both directions. The host's sidecar VT (`termiod/vt`) is consulted only to build `S` / `H`. The browser's Wasm VT parses the same bytes. Two state machines, one log. That is the anti-100× invariant applied to a third client, not a new architecture.
+
+Default attach mode is **`observe`**. Opening the page while a Mac holds the write token must not steal it (`recompute_writer` promotes the newest `AttachMode::Interact`). A **Take input** control closes the observe attachment and opens a new attach WebSocket with `mode: interact` (there is no promote verb; `Control::Attach` sets mode once per channel). **Release** does the reverse: detach the interact socket and reattach as observe. `claim: "polite"` is specified in the hot-path doc and is **not** on `Control::Attach`; the web client does not invent it.
+
+### VT source
+
+**Pinned binary:** `ghostty-vt.wasm` built from **ghostty `56e1f3a`** — the same commit `termiod/vt/Cargo.toml` names (`libghostty-vt` via `termio-sh/libghostty-rs` @ `04500f9…`, "the same one libghostty-swift ships to the Mac and iOS clients, so the host and its clients run one VT"). An unpinned "latest official release" is a second parser, which is why alternative A rejects xterm.js.
+
+Prefer a Ghostty GitHub-release artifact of that commit when one exists. If the release tarball is a different sha, build the Wasm from `56e1f3a` and put it in the versioned web root. Bumping the host VT means bumping this Wasm in the same change. A skew test feeds one `S` into the host sidecar and the Wasm and diffs the resulting grid.
+
+Fetched as a static asset (~400 KB), served with `Content-Type: application/wasm`. Never inlined into JS. Never embedded in the musl binary. Never base64'd into a bundle (see Restty).
+
+**No forked or patched Wasm, at any point.** The previous revision allowed ghostty-web's patched Wasm as a temporary fallback "if official exports fall short on day one." The exports do not fall short: [What the official ABI already gives us](#what-the-official-abi-already-gives-us) enumerates render state, dirty tracking, tagged colours, cursor, selection, grapheme clusters, the key encoder, the Wasm allocation helpers, and mode 2026 — all present at `56e1f3a`. If a specific gap is found during PR 3, the answer is a Ghostty upstream issue and a named workaround in the binding layer, not a second Wasm binary in the web root.
+
+**The JS binding layer is ours, and it is thin.** One module that owns: instantiate, `ghostty_terminal_vt_write`, render-state update, the row/cell iterators, the key encoder, and the memory-growth discipline from `wasm.h`. It has no DOM, no socket, and no React import, so it is headless-testable — the ghostty-web lesson, kept. ghostty-web's `lib/ghostty.ts` is the worked example for the calling convention; we read it, we do not ship it.
+
+### Renderer: one seam, two implementations
+
+**v1 paints with a Canvas 2D renderer we own. v2 is WebGPU, implementing the same seam. There is no third renderer and no borrowed one.**
+
+#### Why not WebGPU in v1
+
+Three findings, in order of how much they moved the decision.
+
+1. **On the platform in this document's title, WebGPU is not available.** Per the gpuweb status table above: Chrome on Linux needs `--enable-unsafe-webgpu … VulkanFromANGLE`; Firefox on Linux is Nightly-only. A WebGPU-only v1 cannot be demonstrated in a browser on the box it was just deployed to. So "WebGPU in v1" is not one renderer — it is WebGPU *plus* a fallback, in v1, before any human has seen a terminal in this client at all. PR 3 exists to prove the pipe paints; gating that on two renderers inverts the risk order the PR plan is built on.
+
+2. **The cost of a WebGPU terminal renderer is the glyph pipeline, not the GPU.** Restty's own tree is the bill of materials: glyph atlas builder + rectangle packing + LRU eviction + atlas resize; a second colour atlas for emoji; font resource store, font picker, fallback layout, glyph coverage, Nerd Font metric constraints; ligature run shaping with per-cell suppression inside runs; cursor and selection promoted to overlays so they do not break those runs; and ten-plus files of *procedural* box-drawing, block-element, braille, and powerline geometry, because fonts do not cover those consistently. Then four passes and a shader set. None of that is optional for a renderer that looks like Ghostty, and none of it is on the critical path to "the browser can attach to a VPS session."
+
+3. **There is nothing to borrow under our rules.** Restty is the only mature WebGPU implementation on this VT, it is MIT, and it is still unusable here: its Wasm is a patched ghostty submodule at an unpinned commit, and `src/wasm/embedded.ts` base64-inlines 2.79 MB of it into the JS bundle. Taking it means taking a second VT and a second application framework (panes, plugins, search UI, IME). Extracting only its renderer means extracting the glyph pipeline from a codebase whose pipeline is coupled to its own Wasm ABI — which is writing one, with extra steps.
+
+None of that says WebGPU is wrong. It says WebGPU is a **quality investment with a defined bill of materials that should be paid deliberately, against a seam, after the pipe is proven** — not a prerequisite for the first attach. Which is why it is scheduled below rather than described as "later."
+
+#### Why the v1 renderer is ours and not ghostty-web's
+
+The previous revision's answer was "vendor ghostty-web's Canvas." That is now rejected on evidence: ghostty-web's cells are pre-resolved 24-bit RGB, its palette is fixed at terminal construction, and `setTheme()` cannot re-resolve what the Wasm already flattened. Goal 4 and PR 4's own acceptance test ("theme switch does not leave stale RGB") fail against it. Vendoring it would mean either accepting a broken presentation boundary or rewriting its cell path — at which point we have written the renderer anyway, on top of a dependency we now have to maintain a fork of.
+
+Writing it directly on `render.h` is *less* code than that, because the ABI hands us exactly the loop we want: `update()` → check global dirty → walk the row iterator → skip clean rows → per row, take the selection range once and iterate cells → per cell, `HAS_STYLING` then `…_DATA_STYLE` for the tagged colour and `…_DATA_GRAPHEMES_UTF8` for the text → `fillText` → `ghostty_render_state_clean()`. ghostty-web's 1001-line `CanvasRenderer` is the upper bound on that file's size, and it carries link detection, scrollback, and selection management that live elsewhere in our design.
+
+#### The seam
+
+One interface. Both implementations satisfy it; nothing above it knows which is loaded.
+
+```ts
+// shape, not a shipped API
+type TaggedColor =
+  | { tag: "default" }
+  | { tag: "palette"; index: number }   // 0–255, unresolved
+  | { tag: "rgb"; r: number; g: number; b: number };
+
+interface Palette {                      // the VIEWER's theme, never the host's
+  background: Rgb;
+  foreground: Rgb;
+  cursor?: Rgb;
+  ansi: Rgb[];                           // 256 entries
+}
+
+interface RenderFrame {
+  dirty: "none" | "partial" | "full";
+  cols: number; rows: number;
+  cursor: CursorState;                   // style, blink, visible, wide-tail, viewport x/y + has_value
+  rows_: RowView[];                      // dirty flag, row-local selection range, cells
+}
+
+interface TerminalRenderer {
+  measure(font: FontSpec): CellMetrics;               // cellWidth, cellHeight, baseline
+  setGeometry(g: Geometry): void;                     // cols, rows, cell metrics, devicePixelRatio
+  setPalette(p: Palette): void;                       // forces a full redraw
+  draw(frame: RenderFrame, history?: RowView[]): void;
+  dispose(): void;
+}
+```
+
+Rules that make the swap a swap:
+
+- **The renderer resolves colour; the Wasm never does.** It reads `…_ROW_CELLS_DATA_STYLE` and resolves the tag against the `Palette` it was given. Reading `…_DATA_FG_COLOR` / `…_DATA_BG_COLOR` is forbidden and is a reviewable line in a diff. A `{ tag: "default" }` cell paints the viewer's default, not black.
+- **The renderer never owns state it can be told about.** No socket, no Wasm handle, no React import, no `setTimeout` loop of its own. It is called; it does not call.
+- **Damage comes in, never derived.** The renderer does not diff grids. `dirty: "full"` and `setPalette` mean repaint everything; `dirty: "partial"` means repaint flagged rows (plus the neighbours needed for glyph overflow, which is the renderer's business).
+- **History and viewport are the same cell shape.** Pre-attach `H` rows decode to `WireColor`, the viewport decodes to `GhosttyStyle` colours, and `TaggedColor` is both. The renderer paints them with one code path, which is what resolves the old open question about how `H` reaches the screen — see [Theme / palette](#theme--palette).
+- **No view outlives an allocating call.** The `wasm.h` rule lives in the binding, and `RowView`/cell data is valid only for the duration of one `draw()`. A renderer that stashes a typed array across frames is the detached-view bug with extra latency.
+- **The seam is frozen when PR 4 lands.** If the WebGPU implementation needs a signature change, that is evidence the v1 seam was wrong; fix it in v1 and re-land, do not branch the interface.
+
+#### Canvas 2D, v1
+
+One file. `fillText` per run of same-style cells, a background pass per row before text, per-`(codepoint, style)` glyph caching only if measurement shows it pays, `devicePixelRatio`-aware backing store, dirty-row repaint including the row above and below (ghostty-web's glyph-overflow lesson, which we take even though we do not take their code). Selection and cursor as overlays drawn after text, so the v2 ligature rule is already respected by the v1 layout. Box drawing comes from the font in v1.
+
+Where it will hurt, said plainly so nobody is surprised: a full-viewport repaint at large geometry — a fast `cat`, an agent dumping a build log, a `tmux`-style full-screen redraw — is `cols × rows` `fillText` calls, and Canvas 2D text is the slow path in every browser. This is the specific thing v2 fixes.
+
+#### WebGPU, v2
+
+Same seam, new implementation, plus the pipeline Restty documents: grayscale raster glyph atlas with LRU eviction and resize (no SDF), instanced textured quads, background/glyph/decoration/cursor passes, shaped ligature runs with cursor and selection as overlays, procedural box-drawing and block/braille/powerline geometry, and a separate colour atlas for emoji.
+
+**Availability is a probe, never a requirement.** At startup: `navigator.gpu?.requestAdapter()`. Null adapter, thrown error, or lost device at any later point → construct the Canvas 2D renderer and continue. The page never shows a "your browser does not support WebGPU" wall and never tells a user to relaunch their browser with Chromium flags; a Linux Firefox user gets a working terminal and does not learn that a second renderer exists. Device loss mid-session recreates through the seam and repaints from `dirty: "full"`, since the terminal state lives in the Wasm and not in the renderer.
+
+**The entry trigger is measured, not calendar-based.** v1 ships with a frame-time counter behind the existing observability rules (stderr-parseable client-side counters, no metrics system). WebGPU is scheduled when either holds on the reference geometry (200×50, `devicePixelRatio` 2):
+
+- p95 full-redraw frame time exceeds 16.7 ms, or
+- sustained scroll (a `find /` class output at link speed) holds below 30 fps for more than a second.
+
+Both are expected to trip. The point of writing them down is that PR 6 lands against a number, and that if they do not trip, we have learned something worth knowing before spending the atlas.
+
+**WebGL2 is not on this path.** Restty ships WebGPU + WebGL2, and their equivalence is real — but a third implementation means a third set of glyph-pipeline bugs, and the fallback we need for correctness already exists as v1. If measurement after v2 shows the Canvas fallback is the *common* case rather than the edge (plausible if Linux-desktop browsers dominate the traffic), that is the moment to reconsider, with data.
+
+### React: where the boundary is
+
+React owns the shell. It does not own the frame. The rule that decides every case below: **anything that changes at PTY rate lives behind a ref; anything that changes at human rate is React state.**
+
+**React owns:** the session list from the control channel, roster and `Event::Status` tint on rows, the writer / observer badge, Take input and Release, the theme toggle, connection and reconnect state, the empty and error surfaces (`Event::Resynced`, `Event::VtStale`, `error { code }`, failed Wasm instantiation), and layout.
+
+**React never owns:** a cell, a row, a dirty flag, cursor position, scroll offset, byte counters, or anything else read out of the render state. None of these are `useState`, none are in a context, none are props.
+
+#### The surface component
+
+```tsx
+// shape, not a shipped API
+const TerminalSurface = memo(function TerminalSurface({ sessionId, wsUrl }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const handleRef  = useRef<SurfaceHandle | null>(null);   // wasm + renderer + encoder + socket
+
+  useEffect(() => {                                        // attach / detach
+    let disposed = false;
+    const handle = createSurface({ canvas: canvasRef.current!, wsUrl, sessionId });
+    handleRef.current = handle;
+    return () => { disposed = true; handleRef.current = null; handle.dispose(); };
+  }, [sessionId, wsUrl]);                                  // identity only — never per-frame values
+
+  useLayoutEffect(() => {                                  // geometry → resize barrier
+    const observer = new ResizeObserver(() => handleRef.current?.fit());
+    observer.observe(canvasRef.current!.parentElement!);
+    return () => observer.disconnect();
+  }, []);
+
+  return <canvas ref={canvasRef} />;                       // exactly one node, no children
+});
+```
+
+- `SurfaceHandle` owns the Wasm terminal, the `TerminalRenderer`, the `KeyEncoder`, the WebSocket, and the `requestAnimationFrame` loop. React holds a ref to it and nothing else.
+- The effect dependency array is `[sessionId, wsUrl]` — identities, not values that move. A prop that changes per frame is the bug this whole section exists to prevent, and `memo` makes it visible rather than merely slow.
+- **`dispose()` must be idempotent and complete**: close the socket, free the Wasm terminal, cancel the rAF, disconnect observers. React 19 StrictMode double-invokes effects in development; a surface that leaks a socket or a `ghostty_terminal_free` on the first mount/unmount/mount cycle will leak one per session switch in production too. There is a test for this.
+- **Changing session remounts.** `<TerminalSurface key={sessionId} …>`. Session identity follows the surface; we do not try to re-point a live handle at a different attach.
+
+#### Data flowing out of the loop
+
+The loop needs to tell React a few things — writer flag, authoritative dims, title, status, connection state, last error. These go through one subscription read with `useSyncExternalStore`, coalesced, at human rate:
+
+- The handle keeps a plain mutable snapshot object and a listener set.
+- It notifies on *transitions* only — writer changed, title changed, `Resynced` arrived — never on `D`, never per frame.
+- Anything that would notify more than a few times a second is throttled at the handle, not in a React effect.
+
+#### Theme
+
+Theme switching is an imperative call, not a re-render: `handleRef.current?.setPalette(palette)` in an effect keyed on the theme value. The renderer forces a full repaint and re-resolves every tagged colour. No cell is re-created, no Wasm terminal is torn down, and the canvas does not remount. This is the mechanism that makes Goal 4's second half — "a theme switch after load must re-resolve every visible cell" — a one-line call instead of a reload.
+
+#### Input
+
+The canvas is focusable and takes `keydown` directly; the handle feeds the event to the `KeyEncoder` and writes the resulting bytes as `D`. React never sees a keystroke. IME goes through a hidden, visually-clipped `<textarea>` positioned at the cursor by the handle — the standard web-terminal shape — with `compositionstart` / `compositionend` handled in the handle, not in React state.
+
+#### Why React at all
+
+`web/landing` already ships React 19.2.8 and the repo already has conventions for it. The shell is a list, a few badges, a toggle, and some error surfaces — genuinely small — but it is exactly the kind of small that grows a hand-rolled DOM-diffing layer if you refuse a framework. One framework, one set of conventions, vendored the same way everything else is. React is also the right shape for the boundary this section draws: the escape hatch to imperative code (a ref plus effects) is a first-class, well-understood pattern rather than a workaround.
+
+**No framework beyond React.** No router (one page, one origin, `?session=` on the URL), no state library (one subscription), no component library, no CSS framework, no CDN. Vendored under the same rule as `Sources/termio/Editor/Highlightr/`: upstream license in a vendor `README.md`.
+
+### Theme / palette
+
+The host already does the right thing on `S`. `VtTerminal::format_vt` (`termiod/vt/src/lib.rs`) sets `.with_palette(false)` so the payload carries `38;5;N` indices and never OSC 4. The prologue is inside `snapshot.vt` (`SNAPSHOT_PROLOGUE`). Decode the `S` frame first (`decode_snapshot_payload`); write **only** `snapshot.vt` into the Wasm. Do not write the 12-byte header, the title, or the length prefix, and do not prepend `ESC[2J ESC[H`.
+
+The chain is now tagged end to end, and every link is verifiable in source:
+
+```
+program's SGR
+  → host libghostty-vt: StyleColor::{None,Palette,Rgb}   (termiod/vt/src/lib.rs::style_color)
+  → wire: WireColor::{Default,Palette,Rgb}               (termiod/src/protocol.rs, 16-byte cell)
+  → browser libghostty-vt: GHOSTTY_STYLE_COLOR_{NONE,PALETTE,RGB}   (style.h @ 56e1f3a)
+  → TerminalRenderer.setPalette(viewer's theme) resolves to pixels
+```
+
+Nothing in that chain resolves a palette index except the last step, which holds the viewer's theme. Two ways to break it, both named so they are reviewable:
+
+- Reading `…_ROW_CELLS_DATA_FG_COLOR` / `…_DATA_BG_COLOR` from the render state. They are resolved by definition; the header says so.
+- Passing a palette into the Wasm at construction and treating the result as the client's colours — the ghostty-web / `@wterm` trap. We pass the viewer's palette to the *renderer*, not to the terminal.
+
+The test is device architecture §4's: feed one `S` to a light page and a dark page; they must look different. Plus the half that previously had no mechanism behind it: switch theme on a live attached page and every visible cell must change, including palette-indexed ones, without a reload.
+
+**History (`H`) resolves the same way, and this is no longer an open question.** `H` is packed cells, not VT: `HISTORY_FORMAT_VERSION = 2`, header `version:u8, cols:u16be, first_offset:u32be, row_count:u16be`, then 16-byte cells with `WireColor` tags (`0` default / `1` palette index / `2` rgb). Decode with `decode_history_payload`. Do **not** feed the `H` payload to the Wasm. Because `WireColor` and `GhosttyStyle`'s colour tag are the same three cases, decoded `H` rows are already the seam's `RowView` shape: the renderer paints them above the viewport, in the viewer's palette, from its own scrollback buffer, through the same code path as live rows. The Wasm owns only what it parses after `snapshot.vt`. Resize snapshots do not restage `H` (protocol §C.6); that hole is named, not fixed here.
+
+`attributes` on the wire cell is reserved-zero today (`termiod/vt/src/lib.rs`: *"Bold, underline, italic and the rest still ride the `S` VT payload rather than these bits"*). So `H` rows paint without bold/underline/italic while viewport rows carry full styling from `GhosttyStyle`. That asymmetry is visible on screen at the history boundary. It is a wire-format gap to close additively later, not a renderer bug, and the renderer must not invent styling to hide it.
+
+### Input
+
+Client-side KeyEncoder against the official `key/encoder.h` + `key/event.h`. Structured `KeyboardEvent` → escape bytes, including DECCKM / kitty flags the Wasm is already tracking. The host accepts raw PTY bytes on the attach write path (`SessionMsg::Input` in `run_attach`). There is no structured-key verb to invent.
+
+The **write token** is `AttachMode`, not the pairing secret. `mode: interact` claims it (newest-claim-wins, `recompute_writer`). `mode: observe` never claims. Observer `D` / `R` is answered `error { code: "not_writer" }`. No CRDT.
+
+### Resize
+
+The same barrier as the Mac. Required in the first PR that paints a terminal (PR 3), for two independent reasons: the protocol needs it, and `wasm.h` documents that an allocating export may grow linear memory out from under any cached typed array.
+
+1. Quiesce the render loop.
+2. If this attachment is the writer, send an `R` frame (`rows u16 BE · cols u16 BE`).
+3. Wait for a fresh `S` and `Event::Ready`.
+4. Decode `S`, write `snapshot.vt`. Resume `D`.
+
+The binding layer additionally never caches a view across an allocating call, per `wasm.h`: reacquire `exports.memory.buffer` and rebuild any view whose backing buffer identity **or** byte length changed. The barrier and the discipline are both required; neither substitutes for the other.
+
+Observers do not send `R`. They parse at the authoritative dims on `Control::Attached { rows, cols }` and on `Event::Resized`, and letterbox their CSS viewport. Parsing at the window size is a conformance bug, not a protocol one (hot-path §D.5).
+
+React's part in this is `ResizeObserver` in a `useLayoutEffect` calling `handle.fit()`. The barrier runs in the handle. No React state changes during a resize.
+
+### Scrollback budget
+
+`@wterm/ghostty`'s default of 10_000 *bytes* is a toy. The host already stages at most `SCROLLBACK_STAGE_MAX_BYTES` (1 MiB) of encoded `H` (`session.rs`). The Wasm scrollback budget is 1 MiB as well, measured in bytes, not lines. Ghostty pages internally; we do not pretend we know the line count. The renderer's own `H` buffer is bounded by the same 1 MiB, because that is all the host will ever stage.
+
+### Synchronized output and hyperlinks
+
+Mode 2026 is `GHOSTTY_MODE_SYNC_OUTPUT` in `modes.h` at the pin, so the binding queries it rather than inferring it: while the mode is set, the render loop coalesces and paints one frame at the end of the block. OSC 8 hyperlinks are plumbed so links are clickable, following the same `@retroactive` policy the Mac app uses for opening them (preview or browser, never a silent navigation). Neither is a protocol change.
+
+### Where WSS lives
+
+**Opt-in listener inside `termiod`, loopback only.** TLS stays in Tailscale Serve or Caddy. `termiod` does not grow a TLS stack. Default port is **8790**, not the companion ports (8787 release / 8788 dev).
+
+```
+termiod serve --wss 127.0.0.1:8790 --wss-origin https://box.tailnet.ts.net [--web-root DIR]
+```
+
+Without a WSS bind (no flag, no env, no `wss.bind` file), behaviour is unchanged: Unix socket only, the DEPLOY.md contract.
+
+**Bind rule:** parse the address as `IpAddr` and refuse anything for which `is_loopback()` is false (`127.0.0.0/8` and `::1`). `--wss 0.0.0.0:…`, `[::]:8790`, `192.168.1.10:8790`, and a hostname that resolves off-loopback are all refused at flag parse, with the same wording in `--help` and in `DEPLOY.md`. This is stronger than "refuse `0.0.0.0`."
+
+**Path map:** the GET/Upgrade handler accepts an optional `/termio` prefix and then the same tree. `GET /ws` and `GET /termio/ws` are the same Upgrade. `GET /` and `GET /termio/` are the same `index.html`. A second `/termio` after that is `404`, not a loop.
+
+| Public URL | What termiod accepts |
+| --- | --- |
+| `https://box/termio/` | `GET /` **or** `GET /termio/` |
+| `https://box/termio/ws` | `GET /ws` **or** `GET /termio/ws` (Upgrade) |
+| `https://box/termio/ghostty-vt.wasm` | `GET /ghostty-vt.wasm` **or** `GET /termio/ghostty-vt.wasm` |
+
+Caddy `handle_path /termio/*` strips, so termiod sees `/` and `/ws`. Tailscale Serve `--set-path=/termio` is a public mount, not a strip ([tailscale#6571](https://github.com/tailscale/tailscale/issues/6571) is still open for prefix stripping). Those requests arrive as `/termio/` and `/termio/ws`. The optional-prefix rule is why the recommended Serve one-liner stays `--set-path=/termio` and still works. Do not tell the operator to add a rewrite.
+
+`GET /termio` (no slash) 302s to `/termio/`. The React build is emitted with a relative base so every asset — bundle, Wasm, font — resolves under whichever prefix served `index.html`. Absolute `/assets/…` paths break the Tailscale Serve mount and are a build-config bug, not a runtime one. Empty-state: "Couldn't load the terminal engine. Check that `ghostty-vt.wasm` is served as `application/wasm`."
+
+**Durable start.** `Cmd::Serve` is a unit variant today (`main.rs`). `client::spawn_daemon()` execs `termiod serve` with no arguments. The documented systemd unit is `ExecStart=%h/.local/bin/termiod serve`. A flag that only lives on one foreground argv dies on the next crash restart.
+
+PR 1 lands this, not PR 5:
+
+1. `serve()` reads a bind, in order: `--wss`, then `TERMIOD_WSS`, then `state_dir()/wss.bind`. First present valid loopback address wins. Missing all three → no TCP listener.
+2. Explicit `serve --wss ADDR` **with** `pair.token` writes `state_dir()/wss.bind` (mode `0600`) so the next `spawn_daemon` / bare `termiod serve` brings WSS back.
+3. Explicit `serve --wss ADDR` **without** `pair.token`: do **not** write `wss.bind`, print `run termiod pair`, exit non-zero. The operator asked for a WSS process that cannot authenticate; refuse the whole start.
+4. Inherited bind (`TERMIOD_WSS` or `wss.bind`) **without** `pair.token`: bind the Unix socket, skip TCP, log `wss skipped: no pair.token`. `spawn_daemon` and a crash restart must not take down `handle_conn`.
+5. `TERMIOD_WSS` overrides the file for one process (tests, a one-shot).
+6. Removing the file and the env and the flag turns WSS off. `termiod pair --wss-off` deletes the file.
+7. `DEPLOY.md` gains the linger unit snippet with `ExecStart` and `Environment=` shown below.
+
+Why in-process rather than a second binary:
+
+- `termiod stdio` (`client.rs`) is already the splice we need: it copies bytes onto the socket and understands no frames. WSS is the same splice with an HTTP Upgrade and a pairing check in front. The WSS handler copies to a connected `UnixStream` the way `stdio` does, so `handle_conn` stays Unix-only.
+- One daemon process is the VPS story. Deploy now copies a versioned web root *next to* the binary; it still does not add a second long-running unit.
+- A sidecar that only bridges is a valid *deployment*, not a second product: Caddy or Tailscale Serve *is* that sidecar. We do not write a `termiod-wss` crate.
+
+The WebSocket is a reliable ordered byte pipe. Binary messages are chunks of the same 5-byte framed stream and are concatenated on both ends. We do **not** map one WebSocket message to one protocol frame — that would be a second framing, and a recorded Unix-socket transcript would not replay. Text messages are a protocol error; close the socket. Max frame stays 16 MiB; `D` should stay ≤ 64 KiB (`MAX_DATA_FRAME_SIZE`).
+
+**Idle:** `termiod` sends a WebSocket ping every 30 seconds. A missing pong is a detach (close the splice), not a `kill`. Quiet shells produce no `D` for long stretches; Tailscale Serve and Caddy both idle-timeout upstreams. Transport pings are how a tab left open stays a live attachment.
+
+One WebSocket is one channel (protocol §D). Several sessions in one page open several sockets. Head-of-line on one stream is accepted: a Replica needs ordered bytes. Multi-session HOL is N sockets, which browsers permit. That is why WebTransport stays refused.
+
+```mermaid
+sequenceDiagram
+  participant B as Browser
+  participant C as Caddy / Tailscale Serve
+  participant W as termiod loopback :8790
+  participant U as Unix socket / handle_conn
+
+  B->>C: GET /termio/
+  C->>W: GET / or GET /termio/
+  W-->>B: static build + wasm
+  B->>C: GET /termio/ws (Upgrade, Sec-WebSocket-Protocol)
+  C->>W: GET /ws or GET /termio/ws
+  W->>W: Origin allowlist + pairing token
+  W->>U: splice bytes
+  Note over B,U: from here, frames are the Session Protocol
+  loop every 30s
+    W-->>B: WS ping
+    B-->>W: WS pong
+  end
+```
+
+### Auth
+
+No accounts. No hosted IdP. The Unix socket stays `0600` and is not exposed.
+
+The pairing token authenticates the *pipe*. It is not the write token.
+
+- 24 random bytes, base64url, minted **only** by `termiod pair`. `--wss` never mints.
+- Stored `0600` at `state_dir()/pair.token` (beside `host.id`, `termiod/src/paths.rs`), so two daemons on two sockets do not share a secret.
+- `termiod pair` prints the current token, minting if the file is missing.
+- Missing `pair.token` is split:
+  - Explicit `serve --wss`: refuse to write `wss.bind`, print `run termiod pair`, exit non-zero.
+  - Inherited `wss.bind` / `TERMIOD_WSS`: bind Unix, skip TCP, log `wss skipped: no pair.token`. Never take down `handle_conn`.
+- `termiod pair --rotate` writes a new token. The WSS task watches `pair.token` with `notify` (already in `termiod/Cargo.toml`). On change it reloads the secret and closes every live splice (detach, not kill). Future Upgrades must present the new secret. If no daemon is running, `--rotate` just writes the file; the next `serve` picks it up. No new control op.
+- Presented on the WebSocket *before any frame is forwarded*, as `Sec-WebSocket-Protocol: termiod.<token>`. The canonical page URL is `https://box/termio/#t=<token>` (trailing slash). `GET /termio` 302s to `/termio/`. JS reads `location.hash`, stashes the secret in `sessionStorage`, clears the hash, and offers the secret as the subprotocol. **`?t=` is not accepted on `/ws` or `/termio/ws`.** A query string on the Upgrade line is the log leak the subprotocol exists to close. `Sec-WebSocket-Protocol` still appears in proxy header logs; rotate remains the mitigation.
+- Origin check, in addition to the token. Algorithm:
+  1. Reject a missing, `null`, or `file://` Origin.
+  2. If `--wss-origin` / `TERMIOD_WSS_ORIGIN` is set (repeatable / comma-separated), Origin must match one entry exactly (scheme + host + port, with default 80/443 filled in).
+  3. Else default "same-origin": parse Origin and the request `Host` as authorities. Compare host case-insensitively and port (Origin default 80 for `http`, 443 for `https`; `Host` without a port is 80 on an http listener). `Host` is `host[:port]`, not a raw string equal to Origin's host. Reject if the host is a raw bind address (`127.0.0.1`, `localhost`, `[::1]`) unless Origin's host is also loopback.
+  4. A TLS terminator in front **must** pass `--wss-origin https://<public-host>`. Default same-origin against `Host: 127.0.0.1:8790` rejects `Origin: https://box.tailnet.ts.net`. That is the recommended product path, so the recipes below include the flag.
+
+  Worked examples:
+
+  | Request | Config | Result |
+  | --- | --- | --- |
+  | `Origin: http://127.0.0.1:8790`, `Host: 127.0.0.1:8790` | no `--wss-origin` | allow (host `127.0.0.1` = `127.0.0.1`, port 8790 = 8790, both loopback) |
+  | `Origin: https://box.tailnet.ts.net`, `Host: 127.0.0.1:8790` | no `--wss-origin` | reject (public Origin vs loopback Host) |
+  | `Origin: https://box.tailnet.ts.net`, `Host: 127.0.0.1:8790` | `--wss-origin https://box.tailnet.ts.net` | allow (step 2 exact match; default port 443) |
+  | `Origin: https://box.tailnet.ts.net:443`, same Host | `--wss-origin https://box.tailnet.ts.net` | allow (443 is the default, so the entries match) |
+- Unauthenticated sockets get silence and a short close. We do not reuse `CompanionControl` or that wire.
+
+SSH keys never enter the browser. TLS is Tailscale Serve (borrowed tailnet identity) or Caddy (the operator's own certificates). `termiod` does not ship a CA, pin a cert, or speak HTTPS.
+
+`CreateSpec.env` / `argv` / `D` still must not traverse a third-party relay in the clear (protocol §C.8). Tailscale Serve and a Caddy on the same box are user-owned legs. A public relay that terminates TLS and can read frames is out of v1.
+
+### Linux deploy
+
+Existing path is unchanged ([termiod/DEPLOY.md](../../termiod/DEPLOY.md)), then WSS is layered on. PR 1 updates `DEPLOY.md`; do not leave the unit snippet to PR 5.
+
+```sh
+termiod remote deploy my-vps          # binary + versioned web root (see Data Model)
+ssh my-vps loginctl enable-linger $USER
+ssh my-vps ~/.local/bin/termiod pair  # mint; prints the token
+```
+
+Linger unit (`~/.config/systemd/user/termiod.service`), the form that survives `spawn_daemon` and a crash:
+
+```ini
+[Unit]
+Description=termiod session host
+[Service]
+ExecStart=%h/.local/bin/termiod serve --wss 127.0.0.1:8790 --wss-origin https://box.tailnet.ts.net --web-root %h/.local/share/termiod/web/current
+Environment=TERMIOD_WSS=127.0.0.1:8790
+Restart=on-failure
+[Install]
+WantedBy=default.target
+```
+
+`ExecStart` writes `wss.bind` on first start (only if `pair.token` exists); `Environment=` covers a `spawn_daemon` child that execs bare `termiod serve`. Either alone is enough; both is what the canary ships. If `web/current` is missing, `serve` logs and serves no files; WSS can still bind. Today's `remote deploy` only scp's `~/.local/bin/termiod` — the versioned web root is new work in PR 5, not a layout that already exists.
+
+Recommended front: **Tailscale Serve**. It is borrowed identity, no DIY certificate, and it is the same trust plane the protocol doc already wants for QUIC later. Serve proxies only `http://127.0.0.1` — which matches the loopback bind.
+
+```sh
+tailscale serve --bg --https=443 --set-path=/termio http://127.0.0.1:8790
+```
+
+`--set-path=/termio` stays. Serve does not strip, so those requests arrive as `/termio/` and `/termio/ws`; termiod accepts both `/ws` and `/termio/ws`. Caddy is the fallback for an operator who already terminates TLS. `handle_path` *does* strip `/termio`:
+
+```
+# /etc/caddy/Caddyfile — do not ship Caddy
+box.example {
+    handle_path /termio/* {
+        reverse_proxy 127.0.0.1:8790
+    }
+}
+```
+
+The operator still passes `--wss-origin https://box.example` (or `https://box.tailnet.ts.net`). The user opens `https://<host>/termio/#t=<token>` (trailing slash; `/termio` redirects). The control socket lists sessions, and the page opens one attach WebSocket as **observe**. Detach is closing the tab; it is not `kill`.
+
+### What the page is
+
+A small React app: session list (control `list` + `subscribe`), one `<TerminalSurface>`, theme toggle, a visible writer / observer badge, Take input / Release. Not a rewrite of the Mac sidebar. Not a chat column. Workstream `Event::Status` can tint a row because those events already exist; we do not invent a new status source.
+
+Deep links stay `termio://session/<uuid>` on native clients. The web equivalent is a query on this origin (`?session=<id>` on the page URL, not on `/ws`), not a new scheme.
+
+Do not open the build as `file://`. `file://` Origins are `null` and fail the Origin check.
+
+### Clipboard and extra channels
+
+Out of v1. The protocol has no clipboard frame. The transfer plane (`upload.open` / `U` / `upload.commit`) is for file bytes, not for a browser clipboard API. Superlogical's custom bidirectional data protocol is **Unknown** and stays unused.
+
+---
+
+## Attach sequence
+
+Same messages as Unix and SSH. Real names from `termiod/src/protocol.rs`.
+
+```mermaid
+sequenceDiagram
+  participant B as Browser Replica
+  participant H as termiod
+
+  B->>H: C Hello {proto:1, min_proto:1, role:"attach",<br/>caps:["events","snapshot","scrollback"],<br/>client:"termio-web/0.x"}
+  H-->>B: C HelloOk {proto:1, caps:[…], host_id, host, client_id}
+  B->>H: C Attach {target, mode:"observe", rows, cols, seq}
+  H-->>B: C Attached {id, name, session_id, writer:false, rows, cols, re}
+  Note over H: begin_snapshot_barrier — PTY is not paused
+  H-->>B: S  format v2 — decode, write snapshot.vt only
+  H-->>B: E Ready {session}
+  par live bytes
+    H-->>B: D  raw PTY
+    Note over B: no D upstream while observe
+  and attach-only history
+    H-->>B: H  decode_history_payload → RowView, painted by the renderer
+  end
+```
+
+Take input is a second attach on a new socket (`mode: interact`); the observe socket closes first. Writer resize then follows the existing barrier (`R` → `Resized` → `S` → `Ready`).
+
+Notes that bite if the JS is sloppy:
+
+- The web client must send `hello` first so it can negotiate `snapshot`+`scrollback`. A first frame that is not Control is `proto_error`. A first Control that is not `hello` is the legacy v0 path (`negotiated: false` in `handle_conn`) and will not receive `S`.
+- Decode the `S` payload (`decode_snapshot_payload`); write `snapshot.vt` into the Wasm. The reference CLI and the Mac already apply that body without a client-side prelude (`session.rs` `finish_snapshot`, tests in `termiod/tests/snapshot_prologue.rs`).
+- `Event::Ready` is what ends the barrier. Do not resume the render loop on the first `D`.
+- `H` is attach-only cells and never goes into the Wasm. A later `Event::Resynced` restores the screen and leaves history as a hole (hot-path §F.4 / D10). The page should not pretend otherwise.
+- `Event::VtStale` means snapshots fall back to the 128 KiB ring and can open mid-escape. Surface it in the React chrome, not only in the console.
+- Authoritative dims are on `Attached` and `Resized`, not on the CSS size of the canvas.
+
+A protocol-smoke page (PR 2, no Wasm, no renderer) is the control sequence plus this attach sequence with frame kinds logged. If that page can `hello` / `list` / `attach` / print `S` then `ready` then a `D`, the pipe is real.
+
+---
+
+## API / Interface Changes
+
+### `termiod` CLI
+
+| Addition | Purpose |
+| --- | --- |
+| `termiod serve --wss 127.0.0.1:8790` | Opt-in loopback WebSocket. Writes `wss.bind` only when `pair.token` exists. Refuses any non-loopback `IpAddr`. Without a token: no write, print `run termiod pair`, exit non-zero. |
+| `TERMIOD_WSS` / `state_dir()/wss.bind` | Durable bind so `spawn_daemon` and bare `serve` keep listening. Missing token: Unix still binds, TCP skipped. |
+| `termiod serve --web-root DIR` | Tiny GET jail. Unit/deploy point this at `…/web/current`. Optional; Caddy can serve files instead. |
+| `termiod serve --wss-origin ORIGIN` / `TERMIOD_WSS_ORIGIN` | Repeatable allowlist. Required in front of a TLS terminator. |
+| `termiod pair` | Mint if missing, print the token. |
+| `termiod pair --rotate` | New token. Running WSS task (`notify` on the file) closes live splices. No daemon: just write the file. |
+| `termiod pair --wss-off` | Delete `wss.bind`. Next `serve` is Unix-only. |
+
+No new `hello` capability. WSS is a pipe. The Replica's caps are the ones that already exist: `events`, `snapshot`, `scrollback`.
+
+`Control::Attach` does not gain fields. `claim: "polite"` stays a later additive change from the hot-path doc.
+
+### Browser surface (not a new wire)
+
+A small JS codec that already has a twin in Rust (`read_frame` / `write_control` / `write_data` / `write_resize` / `decode_snapshot_payload` / `decode_history_payload`). Port the 5-byte framing and the `S` v2 / `H` v2 layouts. Do not invent JSON-over-WS for `D`.
+
+```js
+// shape, not a shipped API — page URL is https://host/termio/#t=…
+const token = location.hash.replace(/^#t=/, "");
+const u = new URL("ws", new URL(".", location.href));
+u.protocol = location.protocol === "https:" ? "wss:" : "ws:";
+const ws = new WebSocket(u, ["termiod." + token]);
+ws.binaryType = "arraybuffer";
+// concatenate binary messages → read_frame loop
+// write_control({ op: "hello", proto: 1, min_proto: 1, role: "attach",
+//                 caps: ["events", "snapshot", "scrollback"],
+//                 client: "termio-web/0.1.0" })
+// on S: const snap = decode_snapshot_payload(payload); term.write(snap.vt)
+```
+
+Four modules, four responsibilities, no cycles:
+
+| Module | Owns | Must not know about |
+| --- | --- | --- |
+| `protocol/` | framing, control JSON, `S` / `H` decode | DOM, Wasm, React |
+| `vt/` | Wasm instantiate, write, render-state read, key encoder, memory-growth discipline | sockets, DOM, React |
+| `renderer/` | `TerminalRenderer` — `canvas2d.ts` in v1, `webgpu.ts` in v2 | sockets, Wasm handles, React |
+| `app/` | React shell, `SurfaceHandle`, rAF loop, wiring | the inside of any of the above |
+
+### Web build
+
+- **Vendored, no CDN.** React and React DOM are vendored into the web source tree with upstream licenses in a vendor `README.md`, same rule as `Sources/termio/Editor/Highlightr/`. Match the version `web/landing` already ships (React 19.2.8) so there is one React in the repo.
+- **Static output only.** No SSR, no Node runtime on the box, no framework server. The build emits `index.html`, hashed `.js` / `.css`, `ghostty-vt.wasm`, and at most one `.woff2`. Nothing else is served.
+- **Relative base.** Assets resolve relative to whatever prefix served `index.html`, so `/termio/` under Tailscale Serve and `/` under Caddy `handle_path` are the same build.
+- **No source maps in the web root.** The GET jail's MIME map has no entry for `.map`, so a stray one 403s rather than leaking sources; the build should not emit them into the deployed tree in the first place.
+
+### Host rustc surface
+
+New dependency:
+
+```toml
+tokio-tungstenite = { version = "0.26", default-features = false, features = ["handshake"] }
+```
+
+No `connect`, no `native-tls`, no `rustls`. The listener is `tokio::net::TcpListener` on a loopback address. This is the WS framing, not a crypto stack.
+
+`--web-root` is a tiny GET handler in the same accept loop, not a framework:
+
+- Root-jailed to `DIR`. Reject `..` and any path whose canonical form escapes `DIR` (including symlink escape).
+- Strip one optional `/termio` prefix, then route. `GET /ws` and `GET /termio/ws` Upgrade. `GET /termio` 302s to `/termio/`.
+- Explicit MIME map: `html` → `text/html`, `js` → `text/javascript`, `css` → `text/css`, `wasm` → `application/wasm`, `svg` → `image/svg+xml`, `woff2` → `font/woff2`, `ttf` → `font/ttf`. Anything else is `403`.
+- No directory listing. `GET /` and `GET /termio/` → `index.html`.
+- Missing `DIR` / missing `current`: log, serve no files, WSS can still bind.
+
+`handle_conn` stays on `UnixStream`. The WSS task authenticates, then splices onto a connected `UnixStream`. That keeps the accept path `tests/stdio_bridge.rs` already covers. WSS replay is a **new** test (`termiod/tests/wss_bridge.rs`): a rustc client that does HTTP Upgrade + subprotocol and replays the same framed transcript `stdio_bridge.rs` uses. Do not pretend that file talks WebSocket.
+
+### What does not change
+
+Framing. `HOST_CAPABILITIES`. `CreateSpec`. Writer policy. Snapshot prologue. Sidecar FIFO / JOIN. `CLIENT_BACKLOG_CAP` (4 MiB). `SIDECAR_QUEUE_CAP` (16 MiB). Ring (128 KiB). Unix socket permissions. SSH as the trust plane.
+
+`remote deploy` **does** change: it copies the versioned web root as well as the musl binary.
+
+---
+
+## Data Model Changes
+
+None on disk for sessions. New files beside `host.id`:
+
+| File | Mode | Writer |
+| --- | --- | --- |
+| `pair.token` | `0600` | `termiod pair` / `pair --rotate` |
+| `wss.bind` | `0600` | `serve --wss` |
+
+Rotating the token does not touch the roster, the graveyard, or any PTY. A running WSS task watching the file drops live splices; a stopped daemon just gets a new file.
+
+Web assets live in a **versioned** directory, e.g. `~/.local/share/termiod/web/<termiod-version>-<ghostty-56e1f3a>/`, with `current` flipped atomically. This layout is **new in PR 5**. Today's `remote deploy` only installs `~/.local/bin/termiod` (device arch §6 specified content-addressed binaries; that install path is not shipped). The unit and the deploy contract point `--web-root` at `%h/.local/share/termiod/web/current`. Missing `current` → log, serve no files, WSS can still bind. We do not bake `ghostty-vt.wasm` into the musl binary, and we do not base64 it into the JS bundle.
+
+Nothing about the renderer choice reaches disk. A v2 build with WebGPU ships the same directory layout with a larger bundle; the daemon cannot tell.
+
+No schema migration. Old daemons without a WSS bind stay valid. New clients talking to an old daemon over SSH / Unix are unaffected.
+
+---
+
+## Alternatives Considered
+
+### A. xterm.js as the VT and the renderer
+
+xterm.js is the default web terminal. It parses in JavaScript, ships a well-worn addon ecosystem, and would attach to a byte pump in an afternoon.
+
+It is the wrong VT. The Replica contract is "the same state machine as the host and the Mac." xterm.js will diverge on grapheme width, autowrap, kitty keyboard, and obscure CSI — the exact reason v1 rejected `alacritty_terminal` as the host sidecar and required `libghostty-vt` (`session-protocol.md` §C.6). Mitchell's own benches exist *because* the Wasm VT is the point. We would also be choosing `G` or living with a second parser. Rejected. An unpinned official Wasm is the same rejection; that is why the pin is `56e1f3a`.
+
+### B. ghostty-web as the client, or as the vendored v1 renderer
+
+Ship their demo shape: their Wasm, their Canvas, their `Terminal`, our protocol spliced into `onData` / `write`. Fastest path to pixels, and what the previous revision of this RFC picked.
+
+Three problems, one of which is disqualifying.
+
+- Their Wasm is a fork (`patches/ghostty-wasm-api.patch`) and the long-term binary is the pinned official `56e1f3a` Wasm.
+- Their library contains no session protocol — which is correct — but treating the demo's `/ws` byte-pump as a product pipe would be a second protocol, the thing this RFC exists not to do.
+- **Their cell state is pre-resolved 24-bit RGB.** `GhosttyCell` is `fg_r/fg_g/fg_b` + `bg_r/bg_g/bg_b`; the palette is fixed at `ghostty_terminal_new_with_config`; `setTheme()` rebuilds a JS array that cannot reach cells the Wasm already flattened; the renderer sniffs `#000000` as "default background." That fails Goal 4's theme-switch half and PR 4's own acceptance test. It is the same `palette: false` trap this document already rejects `@wterm/ghostty` for — we simply had not read far enough into ghostty-web to see it.
+
+**Rejected as the client, as the Wasm, and as the renderer. Retained as the reference implementation** for the Wasm calling convention, the KeyEncoder wiring, the dirty-row + glyph-overflow repaint trick, and the resize barrier.
+
+### C. `@wterm/ghostty` as the VT + DOM renderer
+
+Better selection and accessibility than a raw canvas. Theme fields at `load()`. Mode 2026 already exposed. Scrollback-discard events already exist.
+
+Cells are pre-resolved 24-bit RGB. Their default scrollback is 10 KB. Their Wasm is another patch of an older Ghostty (v1.3.1). Theme injection at load passes the light/dark test *until the user switches theme*, at which point every on-screen cell is stale RGB. **Rejected**, on the same ground as B, which it shares.
+
+### D. Host-side `G` only, selected on transport class
+
+The obvious 2026-07 reading, and the one the hot-path doc exists to kill. A Mirror has no native scrollback or selection beyond the rows the host chose to send. Measured 2026-08-05, `G` cost 8.6× more than raw `D` on a 300-line scroll (50,423 B vs 435,573 B). Selecting `G` on the grounds that the client is a browser is illegal under §D.4. Rejected.
+
+A JS grid encoder *on the host* "to help the browser" is the same idea with the anti-100× invariant broken in our process. Also rejected.
+
+### E. Superlogical-style unpublished custom renderer
+
+Their web UI is real (**Announced**). Their renderer may become OSS. Their frames are **Unknown**. Waiting is not a plan, and copying an unpublished protocol is forbidden (session-protocol §H #10, this repo's evidence policy). If they publish an MIT renderer that consumes libghostty-vt Wasm and lets us inject a palette, we re-evaluate as a *borrow* against the seam. Not an entry ticket.
+
+### F. Sidecar-only WSS, `termiod` stays Unix-socket-only
+
+A tiny process (or Caddy alone) that speaks TLS + WSS and splices to the socket. Cleanest isolation. Extra unit to supervise, extra binary to deploy, and we would still write the pairing check somewhere.
+
+**Accepted as a deployment:** Tailscale Serve / Caddy *is* the sidecar, and `--web-root` is optional because they can serve files. **Rejected as the only bind:** the loopback listener belongs in `termiod` so pairing lives next to `host.id` and `spawn_daemon` can bring WSS back from `wss.bind` without a second process.
+
+### G. Restty as the v1 renderer
+
+The closest existing art, and a serious candidate: MIT, libghostty-vt in Wasm, WebGPU with a WebGL2 fallback, real text shaping, ligatures, procedural box drawing, a full Ghostty theme catalogue, and a palette ABI (`restty_set_palette` / `_set_default_colors` / `_reset_palette`) that is the *correct* shape for our presentation boundary — better than either JS-cell library above.
+
+Rejected for v1 on four facts, none of them about quality:
+
+1. Its Wasm is built from a **patched ghostty submodule** at an unpinned commit (stubbed `BoldColor`, removed `build_config` imports, skipped font imports in `quirks.zig`). That is a second VT at a different revision from `termiod/vt`, which is precisely why §A rejects xterm.js.
+2. That Wasm is **base64-inlined into the JS bundle**: `src/wasm/embedded.ts` is 2,789,665 bytes. This RFC serves ~400 KB of Wasm as `application/wasm` from a versioned web root keyed by ghostty sha. Inlining defeats the MIME rule, the cache story, the size budget, and the pin.
+3. It is a second **application framework**, not a renderer: pane manager, plugin host, search UI, IME, scrollbars, context menus, Kitty graphics. Its panes collide with "no nested window manager" and with React owning the shell.
+4. Its renderer is coupled to its own Wasm ABI, so "extract just the renderer" is "port the glyph pipeline onto a different ABI" — which is writing one.
+
+**Retained as the reference for v2.** Its `docs/internals/rendering.md` and its `src/renderer/shapes/` tree are the bill of materials PR 6 is estimated from, and the decisions it records (raster atlas over SDF; ligature runs with cursor and selection as overlays; dirty-row instance-buffer updates) are the ones we expect to reach independently.
+
+### H. WebGPU as the v1 renderer, with a fallback
+
+The stack this work was directed at, and the alternative that had to be argued rather than assumed. Concretely: build the WebGPU renderer first, probe `navigator.gpu`, and fall back to Canvas 2D (or WebGL2) where it is missing.
+
+Rejected for v1, scheduled as v2, for the three reasons in [Renderer](#why-not-webgpu-in-v1): WebGPU is not available in stable Chrome or stable Firefox **on Linux**, the platform this document is named after and deploys to; a Ghostty-quality WebGPU renderer is a glyph atlas + shaping + font fallback + procedural box-drawing stack, which Restty's tree prices honestly; and there is nothing borrowable under our vendoring rules, so every line is ours to write and maintain.
+
+The decisive framing: because the fallback is mandatory on the primary platform, "WebGPU in v1" is not one renderer — it is **two renderers before the first attach has ever painted**. PR 3's job is to prove the pipe. Doing it behind an atlas inverts the risk order deliberately built into the PR plan, where each PR leaves `termiod` useful if the next never lands.
+
+What we take from this alternative instead of deferring it wholesale: the seam is designed now, in v1, specifically so the WebGPU implementation is a file and not a rewrite; the probe-and-fall-back behaviour is specified now rather than discovered later; and PR 6 exists in the plan with a measured entry trigger rather than the previous revision's "later quality investment."
+
+### I. No UI framework — vanilla DOM for the shell
+
+The shell is a list, three controls, and a few error surfaces. Tempting, and it saves a vendored dependency.
+
+Rejected. The parts of the shell that grow — roster diffs from `Event::Roster`, status tint from `Event::Status`, connection-state transitions, multiple attached sessions — are exactly list reconciliation, and a hand-rolled version of it is a worse React. The repo already ships React 19.2.8 in `web/landing`, so this is one framework across the repo rather than a new one. React also gives the imperative boundary this design needs (`useRef` + effects) as a documented pattern rather than an escape hatch.
+
+Preact and Solid would both work and would both be smaller. They would also be a second framework in the repo for a page this small. Not worth it.
+
+---
+
+## Security & Privacy
+
+| Threat | Severity | Mitigation |
+| --- | --- | --- |
+| Pairing token in a URL or proxy log | High | Page bootstrap is `#t=` (not sent to the server), read once into `sessionStorage` and cleared from the hash. Upgrade uses `Sec-WebSocket-Protocol` only — no `?t=` on `/ws`. Rotate. Header logs still see the subprotocol |
+| Cross-origin page attaching as the user | High | Origin algorithm above; reject `null` / `file://`; `--wss-origin` required behind a terminator |
+| Non-loopback TCP bind | High | Refuse any `IpAddr` where `is_loopback()` is false. Default remains Unix-only. DEPLOY.md's "do not socat the socket" still applies |
+| DIY TLS / baked certificates | High | Not implemented. Tailscale Serve or the operator's Caddy |
+| SSH private key in JS | High | Never. The browser is not an SSH client |
+| Token file readable by another uid | Medium | `0600` in `state_dir()`, same rule as the socket and `host.id` |
+| Other uids on the box can reach the loopback port | Medium | The Unix socket is `0600` in a `0700` dir; `127.0.0.1:8790` is not. The token carries that ACL alone. Optional `SO_PEERCRED` later. Do not pretend `0600` applies to the TCP listener |
+| XSS in the shell exfiltrating the token | Medium | Small app, **vendored** deps (no CDN), React's default escaping, no `dangerouslySetInnerHTML` anywhere, terminal text never reaches the DOM as markup (it is painted to a canvas), `sessionStorage`, GET jail (no `..`, no symlink escape, no listing, no `.map`) |
+| Third-party relay reading `D` / `CreateSpec.env` | High | Out of v1. User-owned tailnet or same-box reverse proxy only |
+| Public bind without a token (forgotten `pair`) | High | `termiod pair` is the only mint. Explicit `--wss` without a token refuses to write `wss.bind` and exits. Inherited bind without a token skips TCP and still serves Unix |
+| Confused deputy: a tab that is an observer sending `D` | Low | Host already answers `not_writer`. Default attach is `observe` |
+| Wasm MIME wrong (`application/octet-stream`) | Medium | Explicit `application/wasm` in the GET jail; add a smoke check |
+| OSC 8 hyperlink pointing somewhere hostile | Low | Links open through an explicit user action with the target shown, never auto-navigation; same policy as the Mac app |
+
+Threat model in one sentence: possession of the pairing token plus a route to the loopback WSS is shell access as that uid. That is the Unix-socket sentence from DEPLOY.md with two deltas named: the token stands in for filesystem credentials, and every local uid can hit the TCP port.
+
+---
+
+## Observability
+
+The daemon already prints `termiod listening on <sock>` and `termiod: connection error: …`. Extend that, nothing more:
+
+- `termiod wss listening on 127.0.0.1:8790` at start (only after `pair.token` exists).
+- `wss skipped: no pair.token` when an inherited bind cannot authenticate; Unix still listens.
+- One line per Upgrade: origin, authenticated or rejected, then the `client_id` once `HelloOk` lands. Never the raw token.
+- One line when a ping goes unanswered: `wss detach (no pong)` — splice closes, session lives.
+- One line on `pair.token` change: `wss rotate: dropped N splices`.
+- Existing attach / resize / `resynced` / `vt_stale` / backlog-drop lines apply unchanged; they are session events, not transport events.
+
+No new metrics system. If we need a count, it is `wss_accepts` / `wss_reject_auth` / `wss_reject_origin` / `wss_detach_idle` on stderr, parseable, not a Prometheus endpoint.
+
+Client-side: the protocol-smoke page logs frame kinds and sizes. The React shell surfaces `Event::Resynced`, `Event::VtStale`, and `error { code }` in the chrome, not only in the console. A 400 KB Wasm that failed to instantiate is an empty-state sentence: "Couldn't load the terminal engine. Check that `ghostty-vt.wasm` is served as `application/wasm`."
+
+Renderer counters, because PR 6 needs a number to justify itself: which implementation is loaded (`canvas2d` / `webgpu`), frames painted, full redraws, p50/p95 frame time, and dropped frames — read from a dev-only panel and from the console, never sent anywhere. These are the inputs to the WebGPU entry trigger.
+
+---
+
+## Rollout Plan
+
+No feature flag service. The flag is a missing bind.
+
+1. **Linux VPS canary.** `remote deploy` the new binary *and* the versioned web root. `termiod pair`, then the linger unit with `--wss 127.0.0.1:8790 --wss-origin https://<tailnet-name>`. Tailscale Serve as above. Protocol-smoke page first, then the Wasm Replica. Pair token rotated after the test.
+2. **Documented Caddy path** for operators without a tailnet, still loopback, still `--wss-origin`.
+3. **Mac local WSS** only if it is useful (browser on the same Mac talking to the local daemon). Same bind rule, same token, same `--wss-origin` if anything fronts it. Sparkle / release-channel concerns do not apply to `termiod`. Do not put WSS on the companion port (8787 release / 8788 dev); the default is 8790 because those ports are a different protocol.
+4. **Rollback:** `termiod pair --wss-off` and restart, or drop `--wss` / `TERMIOD_WSS` from the unit. Sessions that were attached via WSS detach; they do not die. The Unix and SSH pipes keep working. `pair.token` can stay; nothing reads it if the listener is down.
+
+Staged rollout of the *client*: PR 2's smoke page can ship to a VPS before any Wasm exists. That is the canary. The renderer has no rollout of its own — v2 is a probe inside one build, not a channel.
+
+---
+
+## Open Questions
+
+1. **What is the honest cell-metric story for a fallback font on a Linux box?** v1 measures with `ctx.measureText` and one bundled `woff2`. A user with a different monospace preference gets whatever the browser resolves. Font selection, local-font access, and Nerd Font coverage are v2 concerns with the atlas; the question is whether v1 needs a font *picker* or just a bundled default. Decide in PR 3 by looking at a real session with powerline glyphs in it.
+2. **Does the wire's reserved-zero `attributes` field need to be filled before v2?** History rows paint without bold/underline/italic while viewport rows carry them. It is visible at the history boundary. Filling `attributes` is additive on the wire and cheap on both ends; the question is whether it belongs to this RFC's PR plan or to a protocol change of its own. Not a renderer decision either way.
+3. **What is the actual p95 frame time of the Canvas 2D renderer at 200×50?** The WebGPU entry trigger is written against a number nobody has measured yet. PR 3 ships the counter; PR 6 is argued from what it says.
+
+Resolved since the previous revision, recorded here so they are not reopened:
+
+- *"Does the `56e1f3a` Wasm export enough?"* — Yes. Render state with two-phase update and two dirty layers, row and cell iterators, bulk `CELLS_RAW` for Wasm hosts, tagged `GhosttyStyle` colours, cursor struct, row-local selection, grapheme UTF-8, the key encoder, `wasm.h` allocation helpers, and `GHOSTTY_MODE_SYNC_OUTPUT` — all present at the pinned commit. No patched Wasm at any point.
+- *"How does `H` enter the Wasm VT?"* — It does not. `WireColor` and the render state's tagged style are the same three cases, so decoded `H` rows are already the seam's row shape and the renderer paints them above the viewport from its own buffer.
+- *"`--web-root` vs Caddy-serves-files"* — PR 1 ships the tiny GET jail; Caddy remains a valid way to serve the same tree. Embedding the Wasm in the musl binary stays rejected, and so does base64-inlining it into JS.
+
+Sharing ACLs, phone-direct-over-WSS as a replacement for the companion wire, and `claim: "polite"` are real questions. They belong to the docs that already ask them.
+
+---
+
+## Key Decisions
+
+1. **The web client is a Replica.** `hello` caps are `snapshot` + `scrollback`. Steady state is raw `D`. `G` is not selected *on the grounds that* the client is a browser. `G` stays a measured-pressure valve. There is no fourth client class.
+2. **This is not a new protocol.** WSS carries the existing 5-byte framed Session Protocol as a concatenated binary byte stream. One WebSocket is one channel. WebTransport stays refused.
+3. **Official `ghostty-vt.wasm` @ `56e1f3a` is the VT, unpatched.** Same ghostty commit as `termiod/vt`. The render-state, style, key-encoder, mode, and Wasm-helper ABIs all exist at that commit, so there is no temporary forked Wasm and no `wasmPath` escape hatch. Fetched as ~400 KB of `application/wasm`; never inlined, never base64'd, never baked into the musl binary.
+4. **We own the renderer, behind one seam.** `TerminalRenderer` takes a viewer `Palette`, a damage-tagged `RenderFrame`, and optional decoded `H` rows, and paints. **v1 is Canvas 2D. v2 is WebGPU**, same seam, with `navigator.gpu` probed and the v1 renderer as the fallback — WebGPU is not available in stable Chrome or Firefox on Linux, so the fallback is permanent, not transitional. No WebGL2. No vendored renderer: ghostty-web's cells are resolved RGB and Restty inlines 2.79 MB of patched Wasm.
+5. **The seam is frozen at PR 4 and the WebGPU work must not change it.** If it must, the v1 seam was wrong and gets fixed in v1 first.
+6. **Theme is resolved by the renderer, from the viewer's palette, at the last step.** The host stays `palette: false` on `S`. The browser reads `…_ROW_CELLS_DATA_STYLE` (tagged) and never `…_DATA_FG_COLOR` / `…_DATA_BG_COLOR` (resolved). A theme switch is `setPalette` + full repaint, not a reload. Adapters that bake a palette we cannot replace are disqualified — which now includes ghostty-web.
+7. **React owns the shell and never the frame.** Session list, badges, theme toggle, Take input / Release, error surfaces. The surface component renders one `<canvas>`, holds the Wasm + renderer + encoder + socket in a ref, and re-renders only when the session identity changes. Loop→React updates are coalesced through one `useSyncExternalStore` subscription at human rate. `dispose()` is idempotent because StrictMode double-invokes effects. Vendored React 19.2.8, no CDN, static build, no SSR.
+8. **WSS is an opt-in loopback listener inside `termiod`.** Default remains Unix-socket only. Bind must `is_loopback()`. Default port 8790. Durable via `TERMIOD_WSS` / `state_dir()/wss.bind`. TLS is Tailscale Serve or Caddy. `tokio-tungstenite` with `default-features = false, features = ["handshake"]`.
+9. **Auth is a pairing token plus an Origin allowlist.** `termiod pair` mints. Explicit `--wss` without a token exits without writing `wss.bind`; an inherited bind skips TCP and keeps Unix up. Page bootstrap is `/termio/#t=`. Upgrade is the subprotocol; no `?t=` on `/ws`. `--wss-origin` is required behind a terminator. No accounts, no DIY PKI, no SSH keys in the browser. Companion wire is not reused.
+10. **Input is client-side KeyEncoder** against the official `key/encoder.h`. Host already accepts raw bytes. No structured-key verb.
+11. **Resize is the existing barrier**, and the binding never caches a typed array across an allocating call (`wasm.h`). Quiesce, `R`, wait for `S` + `ready`, resume. Required in the first paint PR.
+12. **`H` never enters the Wasm.** Decoded `WireColor` rows are the seam's row shape; the renderer paints history above the viewport in the viewer's palette.
+13. **Linux first, one hop to the device.** The browser attaches to the box's `termiod`. The Mac is not a gateway. Channel-id multiplexing is not a prerequisite.
+14. **Clipboard and extra data channels are out of v1.** Do not invent Superlogical's unpublished protocol.
+15. **Pairing token authenticates the pipe. `mode: interact` claims the write token** (newest wins, `recompute_writer`). `mode: observe` never claims. The page defaults to observe and may attach either way. No CRDT.
+
+---
+
+## PR Plan
+
+Each PR is independently mergeable and leaves `termiod` useful if the next one never lands. A broken splice is not debugged through a canvas.
+
+| # | PR | What lands | Done when | Depends |
+| --- | --- | --- | --- | --- |
+| 1 | **WSS binding + pairing + durable start (Linux)** | Loopback listener (`is_loopback()`), Origin algorithm (authority + port), `pair` / `pair --rotate` / `pair --wss-off`, `notify` watch on `pair.token` to drop live splices, optional `/termio` prefix on GET/Upgrade, `--wss` writes `wss.bind` only when the token exists (else exit, no write); inherited bind without token skips TCP and keeps Unix, `TERMIOD_WSS`, splice onto the Unix socket, 30s WS ping / missing pong = detach, tiny GET jail (`--web-root` → `…/web/current`: root-jailed, no `..`, no symlink escape, MIME map including `woff2` and *excluding* `.map`, no listing), `tokio-tungstenite` `default-features=false, features=["handshake"]`, `DEPLOY.md` unit snippet + Serve `--set-path=/termio` / Caddy `handle_path` recipes with `--wss-origin` and port 8790, `termiod/tests/wss_bridge.rs` | `wss_bridge.rs` does Upgrade + subprotocol against `/ws` and `/termio/ws` and replays the framed transcript; explicit `--wss` without a token exits and does not write `wss.bind`; inherited bind without a token still accepts Unix; `notify` rotate drops a live splice; `GET /` and `GET /termio/` from `--web-root` return `index.html` | — |
+| 2 | **Static protocol-smoke page** | Tiny HTML+JS codec, same origin via `--web-root` (no `file://`): control `hello` + `list` + `subscribe`, attach `hello` + `attach mode=observe`, log frame kinds. No Wasm, no React, no renderer | A browser at `https://box/termio/#t=…` (or loopback behind `--wss-origin`) shows `hello_ok`, `sessions`, `attached`, `S`, `ready`, then `D` for a running `top` | 1 |
+| 3 | **Pinned Wasm + Canvas 2D renderer behind the seam** | `ghostty-vt.wasm` @ `56e1f3a` in the versioned web root; `vt/` binding (instantiate, write, render-state read, key encoder, `wasm.h` memory-growth discipline); `TerminalRenderer` interface + `canvas2d.ts` reading `…_DATA_STYLE` only; `protocol/` codec; `snapshot.vt` + `D` into the Wasm; KeyEncoder into `D` upstream; **resize barrier** (quiesce → `R` → `S`/`ready`); default observe; 1 MiB scrollback budget; `H` decoded to `RowView` and painted above the viewport; frame-time counters | Attach shows the current screen; window resize does not throw on detached views and repaints correctly; observer cannot type; writer can; history rows appear above the viewport in the viewer's colours; no call site reads `…_DATA_FG_COLOR` / `…_DATA_BG_COLOR` | 2 |
+| 4 | **React shell + theme injection; seam frozen** | React 19.2.8 vendored + static build with relative base; session list from control `list` + `subscribe`; roster/status tint; writer/observer badge; Take input / Release (reattach as `interact` / `observe`); `<TerminalSurface>` with ref-held handle, `ResizeObserver`, idempotent `dispose()`; `useSyncExternalStore` for coalesced loop→React updates; theme toggle → `setPalette` + full repaint; host-vs-Wasm `S` skew test | One snapshot looks different in light and dark; **switching theme on a live attach re-resolves every visible cell, including palette-indexed ones, with no reload and no remount**; a `StrictMode` mount/unmount/mount leaks no socket and no Wasm terminal; a render-count test shows `<TerminalSurface>` rendering once per attach while `D` flows | 3 |
+| 5 | **Deploy copies the web root** | `termiod remote deploy` scp's `web/<ver>-<56e1f3a>/` and flips `current` (this layout does not exist today); Caddy / Serve recipes verified on a clean VPS | `remote deploy` + Serve + `/termio/#t=` opens a session on a clean VPS without a second repo checkout | 4 |
+| 6 | **WebGPU renderer (v2)** | `webgpu.ts` implementing the **unchanged** seam: grayscale raster glyph atlas with packing, LRU eviction and resize; colour atlas for emoji; instanced quads; background / glyph / decoration / cursor passes; shaped ligature runs with cursor and selection as overlays; procedural box-drawing, block, braille and powerline geometry; `navigator.gpu` probe with silent fallback to `canvas2d.ts`; device-loss recovery via full redraw | WebGPU and Canvas 2D produce visually equivalent frames on a fixture corpus; a browser without `navigator.gpu` (stable Firefox on Linux) gets a working terminal and no warning; device loss recovers without a reattach; p95 frame time at 200×50 beats v1 by the margin the counters said it should; **the seam file is unchanged in the diff** | 5, and the PR 3 counters tripping the entry trigger |
+
+PR 1 has no terminal UI. PR 2 has no Wasm. PR 3 is the first time a human sees a terminal, and it must survive a resize. PR 6 is the only PR in this plan that may be deferred indefinitely without stranding anything, which is the whole point of putting the seam in PR 3.
+
+---
+
+## Risks
+
+| # | Risk | Severity | Mitigation |
+| --- | --- | --- | --- |
+| 1 | Wasm typed-array views detach when an export grows linear memory | High | `wasm.h` discipline in the binding (reacquire `memory.buffer`, rebuild views on identity *or* length change) **and** the PR 3 resize barrier. Neither substitutes for the other |
+| 2 | 400 KB Wasm + React + a font on first paint | Medium | Fetch, do not inline; hashed assets and cache headers; smoke page in PR 2 pays none of it |
+| 3 | Head-of-line on one WSS stream | Low (accepted) | Replica needs ordered bytes. N sessions = N sockets |
+| 4 | Pairing token leakage (logs, Referer, screenshots) | High | `#t=` on the page, read once and cleared; subprotocol on `/ws`; no `?t=`; rotate |
+| 5 | Wrong Wasm MIME type | Medium | Explicit `application/wasm` in the GET jail; PR 2/3 smoke |
+| 6 | Bundler mangles the Wasm URL or emits absolute asset paths | Medium | Relative base in the build; explicit `wasmPath` resolved from `import.meta.url`; verified behind both Serve (`/termio/`) and Caddy (`/`); no CDN |
+| 7 | Scrollback budget too small | Medium | 1 MiB, matching `SCROLLBACK_STAGE_MAX_BYTES`, not wterm's 10_000 |
+| 8 | Palette resolved before the viewer's theme is applied | High | Read `…_ROW_CELLS_DATA_STYLE`, never `…_DATA_FG_COLOR` / `…_DATA_BG_COLOR`; host `S` stays `palette: false`; `H` v2 is tagged `WireColor`; PR 4's theme-switch test is the regressor. This is the failure that disqualified ghostty-web and `@wterm` |
+| 9 | JS grid encoder on the host "to help the browser" | High | Forbidden. Review any PR that parses VT on the way to WSS |
+| 10 | Scope creep into a second companion wire | High | No `CompanionControl`. No JSON `D`. The smoke page is the regressor |
+| 11 | React re-renders the surface per frame | High | `memo` + ref-held handle + identity-only effect deps + coalesced `useSyncExternalStore`; a render-count test in PR 4 asserts one render per attach under live `D` |
+| 12 | StrictMode double-invoke leaks a socket or a Wasm terminal per session switch | Medium | `dispose()` closes the socket, frees the terminal, cancels the rAF, disconnects observers; PR 4 tests a mount/unmount/mount cycle |
+| 13 | `tokio-tungstenite` pulled in with TLS / `connect` | Medium | `default-features = false, features = ["handshake"]` in PR 1 |
+| 14 | Auto-start daemon comes back without WSS | High | `wss.bind` + `TERMIOD_WSS`; unit snippet in PR 1 |
+| 15 | Idle proxy drops a quiet tab | Medium | 30s WS ping; missing pong = detach |
+| 16 | Host VT and Wasm VT diverge | High | Pin both to ghostty `56e1f3a`; skew test on `S` in PR 4 |
+| 17 | Canvas 2D is too slow on a fast scroll at large geometry | Medium (expected) | Named, measured, and the entry ticket for PR 6 rather than a surprise. Dirty-row repaint keeps the common case cheap; the trigger is p95 > 16.7 ms or sustained scroll < 30 fps at 200×50 |
+| 18 | WebGPU unavailable on the very box the daemon runs on (stable Chrome and Firefox on Linux) | High if v1 depended on it | It does not. v1 has no GPU dependency; v2 probes `navigator.gpu` and falls back silently to the v1 renderer. No warning banner, no "enable this flag" nag |
+| 19 | The WebGPU work needs to change the seam | Medium | Treated as evidence the v1 seam was wrong: fix it in v1, re-land, then implement. PR 6's done-when includes "the seam file is unchanged in the diff" |
+| 20 | The glyph-pipeline estimate for PR 6 is wrong | Medium | Estimated from Restty's actual tree (atlas + packing + eviction, colour atlas, font fallback and coverage, ligature runs, ten-plus files of procedural shapes, four passes), not from a shader-sized guess. If PR 6 outgrows that, it stops and the trigger is re-argued — v1 keeps working throughout |
+
+---
+
+## References
+
+- [termiod Session Protocol](20260730-termiod-session-protocol.md) — framing, `hello` / attach, `S` → `ready` → `H` / `D`, WSS as a later binding, WebTransport refused
+- [Hot path, attach join point, and client classes](20260805-termiod-hot-path-and-client-classes.md) §D.3–D.4 — web client is a Replica; `G` is a pressure valve
+- [Device architecture](20260805-termiod-device-architecture.md) — every UI is a client of a device; presentation boundary; WSS as §8.7
+- [termiod session mux](20260730-termiod-session-mux.md) — one protocol, Unix / SSH / WSS are pipes
+- [Session daemon architecture](20260708-session-daemon-architecture.md) §11 — ghostty-web client lessons; **grid-diff-as-wire superseded 2026-08-08**
+- `termiod/src/protocol.rs` — `Control::Hello` / `HelloOk` / `Attach` / `Attached`, `Event::Ready` / `Roster` / `Status`, `SNAPSHOT_FORMAT_VERSION = 3` (packed cells) / `SNAPSHOT_FORMAT_VT = 2`, `HISTORY_FORMAT_VERSION = 2`, `GRID_FORMAT_VERSION = 2`, `SNAPSHOT_CELL_SIZE = 16`, `WireColor` tags `0`/`1`/`2`
+- `termiod/src/daemon.rs` — `serve`, `handle_conn` (hello vs legacy v0), `run_attach`
+- `termiod/src/session.rs` — `finish_snapshot`, JOIN barrier, `SCROLLBACK_STAGE_MAX_BYTES`
+- `termiod/src/client.rs` — `stdio()` splice, `spawn_daemon()`, reference attach
+- `termiod/vt/Cargo.toml` — ghostty `56e1f3a` via `libghostty-rs` @ `04500f9…`
+- `termiod/vt/src/lib.rs` — `format_vt`, `.with_palette(false)`, `SNAPSHOT_PROLOGUE`, `viewport_cell` (*"Reads the unresolved style rather than the render state's `fg_color`/`bg_color`"*), `attributes: 0` reserved-zero
+- **libghostty-vt C ABI @ `56e1f3a`** — `include/ghostty/vt/render.h` (render state, two-phase update, dirty layers, row/cell iterators, `…_ROW_DATA_CELLS_RAW`, `GhosttyRenderStateColors`, `GhosttyRenderStateCursor`, row-local selection), `style.h` (`GHOSTTY_STYLE_COLOR_NONE` / `_PALETTE` / `_RGB`), `wasm.h` (allocation helpers, `ghostty_type_json`, memory-growth rule), `key/encoder.h` + `key/event.h`, `modes.h` (`GHOSTTY_MODE_SYNC_OUTPUT`)
+- [termiod/ARCHITECTURE.md](../../termiod/ARCHITECTURE.md), [termiod/DEPLOY.md](../../termiod/DEPLOY.md)
+- Official `ghostty-vt.wasm`: Ghostty GitHub releases; Mitchell 2026-08-14 [2088378990998524206](https://x.com/mitchellh/status/2088378990998524206), [2088380975118250065](https://x.com/mitchellh/status/2088380975118250065)
+- [coder/ghostty-web](https://github.com/coder/ghostty-web) — MIT; `lib/renderer.ts` Canvas 2D with dirty rows; `lib/ghostty.ts` official `ghostty_key_encoder_*` calls; cells are resolved RGB (`fg_r`/`bg_r`), palette fixed at `ghostty_terminal_new_with_config`
+- [wiedymi/restty](https://github.com/wiedymi/restty) — MIT; WebGPU + WebGL2 on libghostty-vt; `docs/internals/rendering.md` (four passes, atlas + LRU eviction, dirty-row instance updates), `docs/internals/decisions.md` (raster atlas over SDF, ligature overlays, patched ghostty submodule), `src/wasm/embedded.ts` (2.79 MB base64-inlined Wasm), `src/renderer/shapes/` (procedural box drawing)
+- [@wterm/ghostty](https://wterm.dev/ghostty)
+- [awesome-libghostty](https://github.com/Uzaaft/awesome-libghostty) web section
+- [gpuweb Implementation Status](https://github.com/gpuweb/gpuweb/wiki/Implementation-Status) — WebGPU per browser and OS; Chrome on Linux behind flags, Firefox on Linux Nightly-only
+- Superlogical: **Announced** web-over-WebSocket; renderer and frames **Unknown**

--- a/scripts/check-ghostty-pin.sh
+++ b/scripts/check-ghostty-pin.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Fail when the browser, the host, and the Mac would run different ghostty.
+#
+# The Replica contract is "the same state machine as the host and the Mac." That
+# is asserted in three files that cannot see each other, each one hop away from
+# the sha it actually implies:
+#
+#   termiod/vt/Cargo.toml   libghostty-rs rev -> build.rs GHOSTTY_COMMIT
+#   Package.resolved        libghostty-swift version -> release body sha
+#   web/client/ghostty-pin  the ghostty-vt.wasm the web root serves
+#
+# Bump one and forget another and nothing breaks loudly: the daemon builds, the
+# app builds, the page loads, and the browser silently disagrees with the host
+# about grapheme width, autowrap, or a kitty keyboard sequence. No existing test
+# looks at more than one of the three. This one resolves all three and diffs
+# them.
+#
+# Usage: scripts/check-ghostty-pin.sh
+#
+# Network: two unauthenticated GETs (raw.githubusercontent.com and the GitHub
+# releases API). The libghostty-rs leg reads a local cargo checkout first when
+# one is present, so a warm dev machine usually needs one request.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pin_file="$repo_root/web/client/ghostty-pin.json"
+vt_cargo="$repo_root/termiod/vt/Cargo.toml"
+resolved="$repo_root/Package.resolved"
+
+fail() {
+  echo "::error::$*" >&2
+  echo "error: $*" >&2
+  exit 1
+}
+
+fetch() {
+  curl -fsSL --max-time 60 "$1"
+}
+
+for path in "$pin_file" "$vt_cargo" "$resolved"; do
+  [ -f "$path" ] || fail "missing $path"
+done
+
+# ── Declared: what web/client/ghostty-pin.json says the browser runs ─────────
+declared="$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as handle:
+    print(json.load(handle)["ghostty_sha"])
+' "$pin_file")"
+
+[[ "$declared" =~ ^[0-9a-f]{40}$ ]] ||
+  fail "ghostty_pin.ghostty_sha is not a full 40-char sha: $declared"
+
+# The artifact URL is content-addressed by that sha; a mismatch means the pin was
+# half-edited and a fetch would install a different engine than the file claims.
+python3 -c '
+import json, sys
+with open(sys.argv[1]) as handle:
+    pin = json.load(handle)
+url, sha = pin["artifact"]["url"], pin["ghostty_sha"]
+if sha not in url:
+    raise SystemExit(f"artifact.url does not carry ghostty_sha {sha}:\n  {url}")
+' "$pin_file" || fail "web/client/ghostty-pin.json is internally inconsistent"
+
+# ── Leg 1: termiod's sidecar VT (Rust) ───────────────────────────────────────
+rs_rev="$(sed -n 's/.*libghostty-rs".*rev = "\([0-9a-f]\{40\}\)".*/\1/p' "$vt_cargo" | head -1)"
+[ -n "$rs_rev" ] || fail "could not read the libghostty-rs rev out of $vt_cargo"
+
+rs_build_rs=""
+for checkout in "$HOME"/.cargo/git/checkouts/libghostty-rs-*/"${rs_rev:0:7}"; do
+  candidate="$checkout/crates/libghostty-vt-sys/build.rs"
+  if [ -f "$candidate" ]; then
+    rs_build_rs="$(cat "$candidate")"
+    break
+  fi
+done
+if [ -z "$rs_build_rs" ]; then
+  rs_build_rs="$(fetch "https://raw.githubusercontent.com/termio-sh/libghostty-rs/$rs_rev/crates/libghostty-vt-sys/build.rs")" ||
+    fail "could not read build.rs from libghostty-rs @ $rs_rev"
+fi
+rs_sha="$(printf '%s' "$rs_build_rs" |
+  sed -n 's/^const GHOSTTY_COMMIT: &str = "\([0-9a-f]\{40\}\)";$/\1/p' | head -1)"
+[ -n "$rs_sha" ] || fail "libghostty-rs @ $rs_rev has no parseable GHOSTTY_COMMIT"
+
+# ── Leg 2: the Mac and iOS clients (Swift) ───────────────────────────────────
+swift_version="$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as handle:
+    resolved = json.load(handle)
+for entry in resolved["pins"]:
+    if entry["identity"] == "libghostty-swift":
+        print(entry["state"]["version"])
+        break
+else:
+    raise SystemExit("libghostty-swift is not pinned in Package.resolved")
+' "$resolved")" || fail "could not read the libghostty-swift version out of $resolved"
+
+release_json="$(fetch "https://api.github.com/repos/termio-sh/libghostty-swift/releases/tags/$swift_version")" ||
+  fail "could not read the libghostty-swift $swift_version release. The ghostty sha it
+built is recorded only in the release body, so this check cannot run offline."
+
+swift_sha="$(printf '%s' "$release_json" | python3 -c '
+import json, re, sys
+body = json.load(sys.stdin).get("body") or ""
+match = re.search(r"ghostty sha:\s*([0-9a-f]{40})", body)
+print(match.group(1) if match else "")
+')"
+[ -n "$swift_sha" ] ||
+  fail "libghostty-swift $swift_version release body has no 'Built from ghostty sha:' line"
+
+# ── Verdict ─────────────────────────────────────────────────────────────────
+printf '%-34s %s\n' \
+  "web/client/ghostty-pin.json" "$declared" \
+  "termiod/vt (libghostty-rs ${rs_rev:0:7})" "$rs_sha" \
+  "Package.resolved (swift $swift_version)" "$swift_sha"
+
+if [ "$declared" != "$rs_sha" ] || [ "$declared" != "$swift_sha" ]; then
+  fail "ghostty pins disagree — the browser would render a different VT than the host and the Mac.
+Bump all three in one change:
+  termiod/vt/Cargo.toml    rev of termio-sh/libghostty-rs (its build.rs carries GHOSTTY_COMMIT)
+  Package.swift            termio-sh/libghostty-swift version, then resolve
+  web/client/ghostty-pin.json  ghostty_sha + artifact url/sha256/bytes
+Refresh the wasm with: scripts/ghostty-wasm.sh fetch --force"
+fi
+
+echo "ok — one ghostty across the host, the Mac, and the browser"
+
+# ── Optional: the installed binary is the one the pin describes ─────────────
+wasm="$repo_root/web/client/public/ghostty-vt.wasm"
+if [ -f "$wasm" ]; then
+  "$repo_root/scripts/ghostty-wasm.sh" verify
+else
+  echo "note: $wasm not fetched yet (scripts/ghostty-wasm.sh fetch)"
+fi

--- a/scripts/ghostty-wasm.sh
+++ b/scripts/ghostty-wasm.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# Put the pinned ghostty-vt.wasm where the web client can serve it.
+#
+# The browser Replica runs official libghostty-vt as its VT. "Official" is not
+# enough on its own: the wasm ships only on ghostty's rolling `tip` pre-release,
+# so the release tag is a moving target while termiod/vt and the Mac are pinned
+# to one commit. Ghostty's release job also copies each build to a
+# content-addressed bucket keyed by the full commit sha, and that path is what
+# this script fetches — the official binary, at the commit we pinned, forever.
+#
+# Usage:
+#   scripts/ghostty-wasm.sh fetch [--force]   download + verify + install (default)
+#   scripts/ghostty-wasm.sh verify            hash the installed file against the pin
+#   scripts/ghostty-wasm.sh build [--out P]   build from ghostty source at the pin
+#   scripts/ghostty-wasm.sh path              print where the artifact lands
+#
+# Where it lands:
+#   web/client/public/ghostty-vt.wasm — Vite copies public/ into dist/ verbatim,
+#   so the built tree has it at the web root next to index.html. It is gitignored:
+#   a 900 KB binary belongs in the versioned web root on the box, not in git.
+#   scripts/stage-web-root.sh is what assembles that root.
+#
+# The pin lives in web/client/ghostty-pin.json. scripts/check-ghostty-pin.sh
+# proves it agrees with libghostty-rs and libghostty-swift.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pin_file="$repo_root/web/client/ghostty-pin.json"
+dest="$repo_root/web/client/public/ghostty-vt.wasm"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+pin() {
+  python3 -c '
+import json, sys
+with open(sys.argv[1]) as handle:
+    pin = json.load(handle)
+node = pin
+for key in sys.argv[2].split("."):
+    node = node[key]
+print(node if not isinstance(node, list) else " ".join(node))
+' "$pin_file" "$1"
+}
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+[ -f "$pin_file" ] || die "missing pin file: $pin_file"
+
+command="${1:-fetch}"
+shift || true
+
+case "$command" in
+  path)
+    echo "$dest"
+    ;;
+
+  verify)
+    [ -f "$dest" ] || die "not installed: $dest (run: scripts/ghostty-wasm.sh fetch)"
+    want="$(pin artifact.sha256)"
+    got="$(sha256_of "$dest")"
+    if [ "$want" != "$got" ]; then
+      die "sha256 mismatch for $dest
+  expected $want
+  actual   $got
+This is a different ghostty than the host and the Mac run. Re-fetch, do not ship."
+    fi
+    echo "ghostty-vt.wasm ok — $(pin ghostty_describe) ($(pin ghostty_sha))"
+    echo "  $dest"
+    echo "  sha256 $got  bytes $(wc -c <"$dest" | tr -d ' ')"
+    ;;
+
+  fetch)
+    force=""
+    [ "${1:-}" = "--force" ] && force=1
+    url="$(pin artifact.url)"
+    want="$(pin artifact.sha256)"
+
+    if [ -z "$force" ] && [ -f "$dest" ] && [ "$(sha256_of "$dest")" = "$want" ]; then
+      echo "ghostty-vt.wasm already at $(pin ghostty_sha), nothing to do"
+      exit 0
+    fi
+
+    mkdir -p "$(dirname "$dest")"
+    tmp="$dest.download.$$"
+    trap 'rm -f "$tmp"' EXIT
+
+    echo "fetching $url"
+    curl -fsSL --max-time 300 -o "$tmp" "$url" ||
+      die "download failed. The tip bucket keeps blobs by commit, but not forever —
+if this 404s, build from source instead: scripts/ghostty-wasm.sh build"
+
+    got="$(sha256_of "$tmp")"
+    [ "$want" = "$got" ] || die "sha256 mismatch from $url
+  expected $want
+  actual   $got"
+
+    # A truncated or HTML-error body hashes differently, so this is belt and
+    # braces — but a wasm that is not a wasm is worth naming precisely.
+    head -c 4 "$tmp" | od -An -tx1 | tr -d ' \n' | grep -q '^0061736d' ||
+      die "downloaded file is not a WebAssembly module (bad magic)"
+
+    mv -f "$tmp" "$dest"
+    trap - EXIT
+    echo "installed $dest"
+    echo "  $(pin ghostty_describe)  sha256 $got  bytes $(wc -c <"$dest" | tr -d ' ')"
+    ;;
+
+  build)
+    out="$dest"
+    if [ "${1:-}" = "--out" ]; then
+      out="${2:?--out needs a path}"
+    fi
+    sha="$(pin ghostty_sha)"
+    work="${GHOSTTY_WASM_WORKDIR:-${TMPDIR:-/tmp}/termio-ghostty-wasm}"
+    src="$work/ghostty-src"
+
+    command -v zig >/dev/null 2>&1 || die "zig not on PATH.
+CI pins $(pin source_build.zig):
+  export PATH=\$HOME/.local/share/termiod-toolchains/zig-$(pin source_build.zig):\$PATH"
+    command -v wasm-opt >/dev/null 2>&1 || die "wasm-opt not on PATH (brew install binaryen).
+Without it zig emits a ~4.2 MB module with debug info; ghostty's own release job
+runs wasm-opt to get the ~900 KB artifact, and so must we."
+
+    mkdir -p "$work"
+    if [ ! -d "$src/.git" ]; then
+      git clone --filter=blob:none --no-checkout "$(pin source_build.repo)" "$src"
+    fi
+    git -C "$src" fetch --filter=blob:none origin "$sha" 2>/dev/null || true
+    git -C "$src" checkout --detach "$sha"
+
+    read -r -a build_args <<<"$(pin source_build.zig_build_args)"
+    read -r -a opt_args <<<"$(pin source_build.wasm_opt_args)"
+
+    (cd "$src" && zig build "${build_args[@]}" \
+      --prefix "$work/prefix" \
+      --cache-dir "$work/zig-cache")
+
+    mkdir -p "$(dirname "$out")"
+    wasm-opt "${opt_args[@]}" "$work/prefix/bin/ghostty-vt.wasm" -o "$out"
+
+    built="$(sha256_of "$out")"
+    echo "built $out"
+    echo "  ghostty $sha  sha256 $built  bytes $(wc -c <"$out" | tr -d ' ')"
+    echo
+
+    # This build is reproducible: zig 0.16.0 + binaryen 132 on an arm64 Mac
+    # reproduced the published Linux CI artifact byte for byte. So a match here
+    # is a second, independent proof that the pinned blob really is this commit —
+    # which matters, because ghostty publishes no minisign signature under the
+    # content-addressed path.
+    if [ "$built" = "$(pin artifact.sha256)" ]; then
+      echo "byte-identical to the pinned artifact — the published blob is this commit"
+    else
+      echo "This differs from the pinned artifact's sha256. Reproducibility depends on"
+      echo "the zig and binaryen versions (pin: zig $(pin source_build.zig), binaryen"
+      echo "$(pin source_build.wasm_opt)), so a different toolchain is the likely cause"
+      echo "and not tampering. Compare the export table and ghostty_type_json before"
+      echo "trusting it, and if it replaces the pin, update artifact.sha256/bytes in"
+      echo "web/client/ghostty-pin.json and say in the commit that it is locally built."
+    fi
+    ;;
+
+  *)
+    die "unknown command: $command (fetch | verify | build | path)"
+    ;;
+esac

--- a/scripts/stage-web-root.sh
+++ b/scripts/stage-web-root.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Assemble the versioned web root termiod's `--web-root` serves.
+#
+# Layout, matching the deploy contract:
+#
+#   <root>/<termiod-version>-g<ghostty-sha7>/   index.html, assets/…, ghostty-vt.wasm
+#   <root>/current -> <termiod-version>-g<ghostty-sha7>
+#
+# The directory name carries both versions because both can change without the
+# other: a termiod release with the same VT, or a ghostty bump with the same
+# daemon. `current` is what the systemd unit points at
+# (`%h/.local/share/termiod/web/current`), so a deploy writes a new directory and
+# flips one symlink; a rollback flips it back. Missing `current` is not fatal —
+# termiod logs and serves no files, and WSS still binds.
+#
+# Usage:
+#   scripts/stage-web-root.sh [--root DIR] [--dist DIR] [--keep N] [--no-build]
+#
+#   --root     where the versioned tree goes. Default web/client/webroot,
+#              which is what you scp to ~/.local/share/termiod/web/ on the box.
+#   --dist     the built client. Default web/client/dist.
+#   --keep     how many older versions to leave behind. Default 3.
+#   --no-build use an existing --dist instead of running the client build.
+#
+# What it refuses to stage, and why each one is a real deploy bug:
+#   · a missing or wrong-sha ghostty-vt.wasm — the browser would run a different
+#     VT than the host and the Mac
+#   · any *.map — the GET jail has no `.map` MIME entry, so a stray one 403s
+#     instead of leaking sources, but it should not be in the tree at all
+#   · any file whose extension the GET jail's MIME map does not carry — it would
+#     403 at runtime, which is a broken page found by a user rather than by this
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+client="$repo_root/web/client"
+root="$client/webroot"
+dist="$client/dist"
+keep=3
+build=1
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root) root="${2:?--root needs a path}"; shift 2 ;;
+    --dist) dist="${2:?--dist needs a path}"; shift 2 ;;
+    --keep) keep="${2:?--keep needs a count}"; shift 2 ;;
+    --no-build) build=""; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+# The GET jail's map, verbatim from the design: anything else is a 403 at
+# runtime, so it must not reach the tree.
+served_extensions="html js css wasm svg woff2 ttf"
+
+ghostty_sha="$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as handle:
+    print(json.load(handle)["ghostty_sha"])
+' "$client/ghostty-pin.json")"
+termiod_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "$repo_root/termiod/Cargo.toml" | head -1)"
+[ -n "$termiod_version" ] || die "could not read the termiod version out of termiod/Cargo.toml"
+
+version_dir="$termiod_version-g${ghostty_sha:0:7}"
+target="$root/$version_dir"
+
+"$repo_root/scripts/ghostty-wasm.sh" fetch
+
+if [ -n "$build" ]; then
+  command -v pnpm >/dev/null 2>&1 || die "pnpm not on PATH (or pass --no-build)"
+  (cd "$client" && pnpm install --frozen-lockfile && pnpm build)
+fi
+
+[ -d "$dist" ] || die "no built client at $dist"
+[ -f "$dist/index.html" ] || die "$dist has no index.html"
+
+# The wasm reaches dist/ through Vite's public/ passthrough. Assert rather than
+# assume: a public/ that was never populated produces a page that loads and then
+# fails at instantiate with a 404 dressed as a MIME error.
+[ -f "$dist/ghostty-vt.wasm" ] ||
+  die "$dist/ghostty-vt.wasm is missing — public/ was not populated before the build"
+
+pinned_sha256="$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as handle:
+    print(json.load(handle)["artifact"]["sha256"])
+' "$client/ghostty-pin.json")"
+if command -v sha256sum >/dev/null 2>&1; then
+  built_sha256="$(sha256sum "$dist/ghostty-vt.wasm" | cut -d' ' -f1)"
+else
+  built_sha256="$(shasum -a 256 "$dist/ghostty-vt.wasm" | cut -d' ' -f1)"
+fi
+[ "$pinned_sha256" = "$built_sha256" ] ||
+  die "$dist/ghostty-vt.wasm is not the pinned build
+  expected $pinned_sha256
+  actual   $built_sha256"
+
+strays="$(find "$dist" -type f -name '*.map' -print)"
+[ -z "$strays" ] || die "source maps in the deploy tree:
+$strays
+vite.config.ts sets sourcemap:false; something re-enabled it."
+
+not_served=()
+for ext in $served_extensions; do
+  not_served+=(-not -name "*.$ext")
+done
+unservable="$(find "$dist" -type f "${not_served[@]}" -print)"
+[ -z "$unservable" ] || die "files the GET jail's MIME map cannot serve (they would 403):
+$unservable"
+
+# Stage beside the target, then rename: a half-copied directory must never be
+# reachable through `current`.
+mkdir -p "$root"
+staging="$root/.staging.$$"
+rm -rf "$staging"
+cp -R "$dist" "$staging"
+rm -rf "$target"
+mv "$staging" "$target"
+
+# Flip `current`. On GNU coreutils `mv -T` is a rename(2) and genuinely atomic.
+# BSD mv has no -T, and the naive `mv -f newlink current` follows the existing
+# symlink and buries the new link INSIDE the old version directory — measured,
+# not theorised. `ln -sfn` is unlink+symlink: a microsecond with no `current`,
+# during which termiod serves no files rather than the wrong ones.
+link="$root/.current.$$"
+ln -s "$version_dir" "$link"
+if mv -T "$link" "$root/current" 2>/dev/null; then
+  :
+else
+  rm -f "$link"
+  ln -sfn "$version_dir" "$root/current"
+fi
+
+if [ "$keep" -gt 0 ]; then
+  # shellcheck disable=SC2012
+  ls -1dt "$root"/*-g* 2>/dev/null | tail -n "+$((keep + 1))" | while read -r old; do
+    [ "$old" = "$target" ] && continue
+    echo "pruning $(basename "$old")"
+    rm -rf "$old"
+  done
+fi
+
+echo
+echo "staged $root/current -> $version_dir"
+find "$target" -type f -print | sed "s|^$target/|  |" | sort
+echo
+echo "Ship it with:"
+echo "  rsync -a --delete $root/$version_dir/ <host>:~/.local/share/termiod/web/$version_dir/"
+echo "  ssh <host> 'ln -sfn $version_dir ~/.local/share/termiod/web/current'"
+echo "and point the unit at ~/.local/share/termiod/web/current."

--- a/termiod/Cargo.lock
+++ b/termiod/Cargo.lock
@@ -151,6 +151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +186,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,10 +227,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "inotify"
@@ -344,6 +409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +445,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -426,6 +535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +565,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "socket2"
@@ -491,6 +617,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "futures-util",
  "libc",
  "notify",
  "serde",
@@ -498,6 +625,7 @@ dependencies = [
  "sha2",
  "termiod-vt",
  "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -505,6 +633,26 @@ name = "termiod-vt"
 version = "0.1.0"
 dependencies = [
  "libghostty-vt",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -535,6 +683,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +722,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -573,6 +756,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "winapi-util"
@@ -671,6 +863,32 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"

--- a/termiod/Cargo.toml
+++ b/termiod/Cargo.toml
@@ -27,6 +27,14 @@ sha2 = "0.10"
 notify = { version = "8", default-features = false, features = ["macos_fsevent"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
+# WebSocket framing for the browser pipe, and nothing else: no `connect`, no
+# `native-tls`, no `rustls`. TLS stays in Tailscale Serve or Caddy, because
+# "never embed crypto" is the trust story, not a performance opinion.
+tokio-tungstenite = { version = "0.26", default-features = false, features = ["handshake"] }
+# The Sink/Stream halves of that socket. Already in the tree underneath
+# tokio-tungstenite; named here only because splitting the stream needs the
+# extension traits. No executor, no io, no compat shims.
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 
 [profile.release]
 opt-level = "z"

--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -5,6 +5,11 @@ own OpenSSH, and SSH is also the access-control boundary. The remote daemon
 listens on a **Unix socket only** — never a TCP port, never `0.0.0.0`. This
 covers issues **#171** (deploy + remote attach) and **#172** (`remote open`).
 
+There is one opt-in exception, off unless you ask for it: a **loopback**
+WebSocket listener so a browser on the box (or behind your own TLS terminator)
+can attach to the same sessions. See
+[Reaching a session from a browser](#optional-reaching-a-session-from-a-browser).
+
 ## Hands-on: test the remote terminal from a Mac, step by step
 
 Everything below assumes an SSH alias in `~/.ssh/config` (the examples use
@@ -160,6 +165,90 @@ ssh my-vps systemctl --user enable --now termiod
 
 This is strictly optional; on-demand start is the supported default.
 
+## Optional: reaching a session from a browser
+
+Off by default. Without `--wss`, `TERMIOD_WSS`, or a `wss.bind` file, nothing
+below is running and the Unix-socket contract above is unchanged.
+
+The listener is **loopback only** and there is no TLS in termiod: anything not
+`127.0.0.0/8` or `::1` is refused when the flag is parsed. TLS and the public
+name come from Tailscale Serve or your own Caddy, which you already trust with
+the rest of the box.
+
+```sh
+ssh my-vps loginctl enable-linger $USER
+ssh my-vps ~/.local/bin/termiod pair       # mint and print the pairing token
+```
+
+The token is 24 random bytes at `state_dir()/pair.token`, mode 0600, beside the
+socket. It authenticates the *pipe*, not the write token — attaching as
+`interact` is what claims input. `termiod pair` prints the current one,
+`termiod pair --rotate` replaces it and drops every open web attachment
+(a detach; the sessions keep running), and `termiod pair --wss-off` forgets the
+remembered bind so the next start is Unix-only.
+
+Then the unit. Both lines matter: `ExecStart` is what a `systemctl restart`
+runs, and `Environment=` is what a daemon auto-started by a client inherits,
+since that path execs a bare `termiod serve`.
+
+```ini
+# ~/.config/systemd/user/termiod.service
+[Unit]
+Description=termiod session host
+[Service]
+ExecStart=%h/.local/bin/termiod serve --wss 127.0.0.1:8790 --wss-origin https://box.tailnet.ts.net --web-root %h/.local/share/termiod/web/current
+Environment=TERMIOD_WSS=127.0.0.1:8790
+Restart=on-failure
+[Install]
+WantedBy=default.target
+```
+
+`serve --wss` remembers the address in `state_dir()/wss.bind` (0600) so a crash
+restart brings the browser pipe back. Two unpaired cases, deliberately
+different: an explicit `--wss` with no `pair.token` refuses the whole start and
+writes nothing, while an *inherited* bind with no token logs
+`wss skipped: no pair.token`, skips TCP, and keeps serving the Unix socket —
+a missing token must not cost you the Mac and the CLI.
+
+Put TLS in front. Tailscale Serve is the recommended one: borrowed tailnet
+identity, no certificate of your own, and it proxies only `http://127.0.0.1`,
+which is exactly what termiod binds.
+
+```sh
+tailscale serve --bg --https=443 --set-path=/termio http://127.0.0.1:8790
+```
+
+Serve publishes the mount rather than stripping it, so requests arrive as
+`/termio/` and `/termio/ws`; Caddy's `handle_path` strips it and they arrive as
+`/` and `/ws`. termiod accepts both, so neither recipe needs a rewrite:
+
+```
+# Caddyfile — Caddy is your choice, not a termiod dependency
+box.example {
+    handle_path /termio/* {
+        reverse_proxy 127.0.0.1:8790
+    }
+}
+```
+
+Either way, pass `--wss-origin https://<public-host>`. A terminator rewrites
+`Host`, so the default same-origin check would reject the browser's real
+Origin.
+
+Open `https://<host>/termio/#t=<token>` — with the trailing slash; `/termio`
+redirects to it. The token rides the URL fragment, which is never sent to a
+server, and then the WebSocket subprotocol; it is never a query parameter,
+because a query parameter is a credential in every access log. Closing the tab
+is a detach, not a kill.
+
+| Concern | Position |
+| --- | --- |
+| Bind | Loopback only, enforced at parse. Default 8790 — not the companion ports (8787 / 8788), which are a different protocol. |
+| Auth | Pairing token (`Sec-WebSocket-Protocol`) plus an Origin allowlist. Both checked before a byte reaches a session. |
+| TLS | Tailscale Serve or your Caddy. termiod ships no CA, pins no certificate, and speaks no HTTPS. |
+| Other local users | The socket is 0600 in a 0700 directory; a TCP port is not. On a shared box the token is the only ACL — rotate it. |
+| Blast radius | The token plus a route to the port is shell access as that uid, the same sentence as the Unix socket above. |
+
 ## Reconnect workflow
 
 ```sh
@@ -175,7 +264,7 @@ Session survives: SSH disconnects, laptop sleep, network drops. It ends only on
 
 | Concern | Position |
 | --- | --- |
-| Listener | Unix socket under `$XDG_RUNTIME_DIR/termiod/` (or uid-tmp), mode 0600. **No TCP, no public port.** |
+| Listener | Unix socket under `$XDG_RUNTIME_DIR/termiod/` (or uid-tmp), mode 0600. **No public port** — the optional `--wss` listener is loopback only and token-gated. |
 | Auth / ACL | **SSH.** Whoever can `ssh my-vps` as your user can reach your daemon — same trust as a shell. |
 | Credentials | Your ssh-agent / `~/.ssh` keys. termiod stores and transmits none. |
 | Multi-user | Socket is per-uid and 0600; another user on the box can't connect. |

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -306,8 +306,11 @@ impl Manager {
 }
 
 /// Run the daemon: bind the socket and accept forever.
-pub async fn serve() -> Result<()> {
+pub async fn serve(wss_options: crate::wss::ServeOptions) -> Result<()> {
     paths::ensure_runtime_dir()?;
+    // Decided before anything binds: an explicit `--wss` that cannot
+    // authenticate refuses the whole start rather than coming up half-armed.
+    let wss_config = crate::wss::plan(&wss_options)?;
     let sock_path = paths::socket_path()?;
 
     if sock_path.exists() {
@@ -366,6 +369,25 @@ pub async fn serve() -> Result<()> {
     }
 
     eprintln!("termiod listening on {}", sock_path.display());
+
+    // The browser's pipe. It authenticates and then connects to the socket above
+    // like any other client, so `handle_conn` stays Unix-only and the accept
+    // path the bridge tests already cover does not fork.
+    //
+    // The watcher is held here for the life of the process: dropping it stops
+    // the watch, and a rotate would then not drop live splices.
+    let _token_watcher = match wss_config {
+        Some(config) => {
+            let (rotate, watcher) = crate::wss::watch_token()?;
+            tokio::spawn(async move {
+                if let Err(error) = crate::wss::serve(config, rotate).await {
+                    eprintln!("termiod: wss error: {error:#}");
+                }
+            });
+            Some(watcher)
+        }
+        None => None,
+    };
 
     {
         let sock_path = sock_path.clone();

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -19,6 +19,7 @@ mod resource;
 mod service;
 mod session;
 mod tombstone;
+mod wss;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -43,7 +43,31 @@ struct Cli {
 #[derive(Subcommand)]
 enum Cmd {
     /// Run the session host in the foreground (usually auto-started).
-    Serve,
+    Serve {
+        /// Also accept browsers on this loopback address (for example
+        /// `127.0.0.1:8790`). Refused for anything reachable from the network:
+        /// put Tailscale Serve or Caddy in front, since termiod does not
+        /// terminate TLS. Remembered in `wss.bind` so a restart keeps it.
+        #[arg(long, value_name = "ADDR")]
+        wss: Option<String>,
+        /// Origin allowed to open a WebSocket. Repeatable. Required behind a
+        /// TLS terminator, whose Host header is not the browser's origin.
+        #[arg(long, value_name = "ORIGIN")]
+        wss_origin: Vec<String>,
+        /// Serve the web client's static files from this directory.
+        #[arg(long, value_name = "DIR")]
+        web_root: Option<std::path::PathBuf>,
+    },
+
+    /// Print the pairing token browsers use, minting it if it does not exist.
+    Pair {
+        /// Replace the token. Open web attachments detach; sessions live on.
+        #[arg(long)]
+        rotate: bool,
+        /// Forget the remembered WSS bind. The next `serve` is Unix-only.
+        #[arg(long)]
+        wss_off: bool,
+    },
 
     /// Create a new session and print its id.
     Create {
@@ -168,7 +192,20 @@ enum Cmd {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
-        Cmd::Serve => daemon::serve().await,
+        Cmd::Serve {
+            wss,
+            wss_origin,
+            web_root,
+        } => {
+            daemon::serve(wss::ServeOptions {
+                wss,
+                origins: wss_origin,
+                web_root,
+            })
+            .await
+        }
+
+        Cmd::Pair { rotate, wss_off } => wss::pair(rotate, wss_off),
 
         Cmd::Create { name, cwd, argv } => {
             let (rows, cols) = client::term_size();

--- a/termiod/src/wss.rs
+++ b/termiod/src/wss.rs
@@ -20,14 +20,39 @@
 //!    root, no traversal, no symlink escape, no directory listing, an explicit
 //!    MIME map. Anything past that belongs to the reverse proxy.
 
+use std::io::{Read, Write};
 use std::net::{IpAddr, SocketAddr};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
+use bytes::Bytes;
+use futures_util::stream::{SplitSink, StreamExt};
+use futures_util::SinkExt;
+use notify::{RecursiveMode, Watcher};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UnixStream};
+use tokio::sync::watch;
+use tokio_tungstenite::tungstenite::error::ProtocolError;
+use tokio_tungstenite::tungstenite::handshake::derive_accept_key;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, Message, Role};
+use tokio_tungstenite::tungstenite::Error as WsError;
+use tokio_tungstenite::WebSocketStream;
 
 use crate::paths;
+
+/// One read of the Unix socket. An IO chunk size, deliberately *not* a frame
+/// boundary: a chunk may split a protocol frame anywhere and may carry several.
+const SPLICE_CHUNK: usize = 64 * 1024;
+
+/// How often the host pings a quiet tab. Both Tailscale Serve and Caddy
+/// idle-timeout upstreams, and a shell can be silent for hours, so transport
+/// pings are what keep a left-open tab a live attachment.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Where the pairing secret lives, beside the socket like every other
 /// per-daemon file (`host.id`, the graveyard). Two daemons on two sockets must
@@ -106,8 +131,212 @@ pub fn load_token() -> Result<Option<String>> {
     }
 }
 
+/// base64url without padding. Twenty-four bytes divide evenly into four-byte
+/// groups, so there is no tail case to get wrong and no reason to take a
+/// dependency for thirty-two characters.
+fn base64url(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b = [
+            chunk[0],
+            *chunk.get(1).unwrap_or(&0),
+            *chunk.get(2).unwrap_or(&0),
+        ];
+        let bits = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+        let indices = [
+            (bits >> 18) & 0x3f,
+            (bits >> 12) & 0x3f,
+            (bits >> 6) & 0x3f,
+            bits & 0x3f,
+        ];
+        for (position, index) in indices.iter().enumerate() {
+            if position <= chunk.len() {
+                out.push(ALPHABET[*index as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+fn mint_token() -> Result<String> {
+    let mut random = [0u8; 24];
+    std::fs::File::open("/dev/urandom")
+        .context("opening OS random source")?
+        .read_exact(&mut random)
+        .context("reading OS random source")?;
+    Ok(base64url(&random))
+}
+
+/// Write a per-daemon file at 0600. Through a temp file and a rename, because
+/// `OpenOptions::mode` is ignored when the file already exists — rotating onto
+/// a file someone once chmod'd would otherwise keep the looser mode.
+fn write_private_file(path: &Path, contents: &str) -> Result<()> {
+    let temp = path.with_extension("tmp");
+    let _ = std::fs::remove_file(&temp);
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&temp)
+        .with_context(|| format!("creating {}", temp.display()))?;
+    file.write_all(contents.as_bytes())
+        .with_context(|| format!("writing {}", temp.display()))?;
+    file.sync_all()
+        .with_context(|| format!("syncing {}", temp.display()))?;
+    drop(file);
+    std::fs::rename(&temp, path)
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+/// `termiod pair` — the only thing that mints. `--wss` never does: a listener
+/// that can invent its own credential is a listener with no credential.
+pub fn pair(rotate: bool, wss_off: bool) -> Result<()> {
+    paths::ensure_runtime_dir()?;
+
+    if wss_off {
+        let path = bind_path()?;
+        match std::fs::remove_file(&path) {
+            Ok(()) => eprintln!("termiod: wss off — removed {}", path.display()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!("termiod: wss already off");
+            }
+            Err(error) => {
+                return Err(error).with_context(|| format!("removing {}", path.display()))
+            }
+        }
+        return Ok(());
+    }
+
+    let path = token_path()?;
+    let existing = load_token()?;
+    let token = match existing {
+        Some(token) if !rotate => token,
+        _ => {
+            let token = mint_token()?;
+            write_private_file(&path, &token)?;
+            if rotate {
+                // The running daemon notices through `notify` and drops its live
+                // splices. Detach, not kill: the sessions do not care.
+                eprintln!("termiod: rotated — open web attachments will detach");
+            }
+            token
+        }
+    };
+    println!("{token}");
+    Ok(())
+}
+
+/// What `termiod serve` was told about the web pipe, before any of it is
+/// resolved against the environment or the remembered file.
+#[derive(Debug, Default, Clone)]
+pub struct ServeOptions {
+    pub wss: Option<String>,
+    pub origins: Vec<String>,
+    pub web_root: Option<PathBuf>,
+}
+
+fn origins_from_env() -> Vec<String> {
+    std::env::var("TERMIOD_WSS_ORIGIN")
+        .map(|value| {
+            value
+                .split(',')
+                .map(|part| part.trim().to_string())
+                .filter(|part| !part.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Decide whether this process listens on TCP at all, and remember the answer.
+///
+/// The rules exist because a flag that only lives on one foreground argv dies
+/// on the next crash restart, and because the two ways to be unpaired are not
+/// the same mistake:
+///
+/// - An **explicit** `--wss` without `pair.token` is an operator asking for a
+///   listener that cannot authenticate. Refuse the whole start, write nothing.
+/// - An **inherited** bind without `pair.token` is a restart of something that
+///   used to work. Skip TCP, keep the Unix socket, say so on stderr. Bringing
+///   down `handle_conn` because the token went missing would turn a web-pipe
+///   problem into a lost Mac and a lost CLI.
+pub fn plan(options: &ServeOptions) -> Result<Option<WssConfig>> {
+    let explicit = options.wss.is_some();
+    let Some(bind) = resolve_bind(options.wss.as_deref())? else {
+        return Ok(None);
+    };
+
+    if load_token()?.is_none() {
+        if explicit {
+            bail!(
+                "--wss {bind} needs a pairing token: run `termiod pair` first.\n\
+                 Nothing was written to {} — a WSS listener that cannot authenticate is a hole, \
+                 not a degraded mode.",
+                bind_path()?.display()
+            );
+        }
+        eprintln!("termiod: wss skipped: no pair.token");
+        return Ok(None);
+    }
+
+    if explicit {
+        let path = bind_path()?;
+        write_private_file(&path, &bind.to_string())
+            .with_context(|| format!("remembering the wss bind in {}", path.display()))?;
+    }
+
+    let mut origins = options.origins.clone();
+    origins.extend(origins_from_env());
+    origins.retain(|entry| !entry.trim().is_empty());
+    origins.dedup();
+
+    Ok(Some(WssConfig {
+        bind,
+        origins,
+        web_root: options.web_root.clone(),
+    }))
+}
+
+/// Watch `pair.token` and bump a counter on every change.
+///
+/// The directory is watched rather than the file: an atomic rotate replaces the
+/// inode, and a watch on the old inode would never fire again. The caller keeps
+/// the returned watcher alive — dropping it silently stops the watch.
+pub fn watch_token() -> Result<(watch::Receiver<u64>, notify::RecommendedWatcher)> {
+    let path = token_path()?;
+    let name = path
+        .file_name()
+        .map(|name| name.to_os_string())
+        .unwrap_or_default();
+    let directory = paths::state_dir()?;
+    let (sender, receiver) = watch::channel(0u64);
+
+    let mut watcher = notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
+        let Ok(event) = event else { return };
+        // Matched on the file name, not the whole path: FSEvents reports
+        // `/private/var/...` where `state_dir()` says `/var/...`, and a
+        // canonicalisation mismatch would silently disarm rotation. The watch
+        // is non-recursive on one directory, so the name is unambiguous.
+        if event
+            .paths
+            .iter()
+            .any(|changed| changed.file_name() == Some(name.as_os_str()))
+        {
+            sender.send_modify(|generation| *generation += 1);
+        }
+    })
+    .context("starting the pair.token watcher")?;
+    watcher
+        .watch(&directory, RecursiveMode::NonRecursive)
+        .with_context(|| format!("watching {}", directory.display()))?;
+
+    Ok((receiver, watcher))
+}
+
 /// One parsed request head. Only what the two decisions need: route, upgrade or
-/// not, and the three headers that gate the splice.
+/// not, and the headers that gate the splice or complete the handshake.
 #[derive(Debug, Default)]
 struct RequestHead {
     method: String,
@@ -116,6 +345,11 @@ struct RequestHead {
     origin: Option<String>,
     upgrade: bool,
     protocols: Vec<String>,
+    /// `Sec-WebSocket-Key`. Absent ⇒ 400; there is nothing to derive an accept
+    /// key from.
+    key: Option<String>,
+    /// `Sec-WebSocket-Version`. Anything but "13" ⇒ 426 Upgrade Required.
+    version: Option<String>,
 }
 
 fn parse_head(raw: &str) -> Option<RequestHead> {
@@ -146,6 +380,8 @@ fn parse_head(raw: &str) -> Option<RequestHead> {
                     .filter(|part| !part.is_empty())
                     .collect();
             }
+            "sec-websocket-key" => head.key = Some(value.to_string()),
+            "sec-websocket-version" => head.version = Some(value.to_string()),
             _ => {}
         }
     }
@@ -265,6 +501,17 @@ fn token_from_protocols(protocols: &[String], token: &str) -> Option<String> {
         .cloned()
 }
 
+/// The client offers `["termiod.v1", "termiod.token.<token>"]`. The token entry
+/// authenticates; the *selected* protocol is `termiod.v1` and never the token
+/// entry, because the selected value is echoed into a response header that
+/// every proxy in front of us logs.
+fn selected_protocol(protocols: &[String]) -> Option<&'static str> {
+    protocols
+        .iter()
+        .any(|entry| entry == "termiod.v1")
+        .then_some("termiod.v1")
+}
+
 /// Strip the optional `/termio` mount prefix. Tailscale Serve's `--set-path`
 /// publishes rather than strips, so requests arrive with the prefix; Caddy's
 /// `handle_path` strips it and they arrive without. Accepting both is what lets
@@ -368,25 +615,226 @@ async fn read_head(stream: &mut TcpStream) -> Option<(String, Vec<u8>)> {
     }
 }
 
-pub async fn serve(config: WssConfig) -> Result<()> {
+type WsSink = SplitSink<WebSocketStream<TcpStream>, Message>;
+
+/// Close the WebSocket with a reason the browser can read in `onclose`. Errors
+/// are ignored on purpose: this runs on paths where the peer is already gone.
+async fn close_ws(sink: &mut WsSink, code: CloseCode, reason: &str) {
+    let _ = sink
+        .send(Message::Close(Some(CloseFrame {
+            code,
+            reason: reason.into(),
+        })))
+        .await;
+    let _ = sink.flush().await;
+}
+
+/// Finish the WebSocket handshake on an already-gated connection, then splice it
+/// onto a fresh Unix-socket channel until either side ends.
+///
+/// Everything that authenticates has already happened: loopback bind, Origin
+/// allowlist, pairing token. This function authenticates nothing and parses no
+/// protocol frame — it is `client::stdio()` with an HTTP Upgrade in front. The
+/// 5-byte framing stays inside the payload, WebSocket message boundaries are
+/// deliberately not frame boundaries, and a transcript recorded over the Unix
+/// socket replays byte-identical here.
+async fn splice(
+    mut stream: TcpStream,
+    head: &RequestHead,
+    mut rotate: watch::Receiver<u64>,
+) -> Result<()> {
+    let Some(key) = head.key.clone() else {
+        write_simple(&mut stream, "400 Bad Request", "missing Sec-WebSocket-Key").await;
+        return Ok(());
+    };
+    if head.version.as_deref() != Some("13") {
+        let body = "this endpoint speaks WebSocket version 13";
+        let response = format!(
+            "HTTP/1.1 426 Upgrade Required\r\nSec-WebSocket-Version: 13\r\n\
+             Content-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\n\
+             Connection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+        let _ = stream.flush().await;
+        return Ok(());
+    }
+
+    // `read_head` already consumed the request, so the 101 is written by hand
+    // rather than by tungstenite's server handshake. The accept key is still
+    // tungstenite's SHA-1 + base64; we write no crypto of our own.
+    let mut response = String::from(
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n",
+    );
+    response.push_str(&format!(
+        "Sec-WebSocket-Accept: {}\r\n",
+        derive_accept_key(key.as_bytes())
+    ));
+    if let Some(selected) = selected_protocol(&head.protocols) {
+        response.push_str(&format!("Sec-WebSocket-Protocol: {selected}\r\n"));
+    }
+    response.push_str("\r\n");
+    stream
+        .write_all(response.as_bytes())
+        .await
+        .context("writing the websocket handshake response")?;
+    stream.flush().await.ok();
+    // One line per accepted Upgrade, and never the token. The `client_id` the
+    // observability plan also wants would mean reading a frame on the way past,
+    // which is the one thing this function must not do.
+    eprintln!(
+        "termiod: wss upgrade accepted origin={}",
+        head.origin.as_deref().unwrap_or("-")
+    );
+
+    let websocket = WebSocketStream::from_raw_socket(stream, Role::Server, None).await;
+    let (mut ws_write, mut ws_read) = websocket.split();
+
+    let socket_path = paths::socket_path()?;
+    let unix = match UnixStream::connect(&socket_path).await {
+        Ok(unix) => unix,
+        Err(error) => {
+            // A clean close beats a hung tab: the browser learns the host is
+            // gone instead of waiting on a socket that will never speak.
+            close_ws(&mut ws_write, CloseCode::Error, "session host unavailable").await;
+            return Err(error)
+                .with_context(|| format!("connecting to {}", socket_path.display()));
+        }
+    };
+    let (mut unix_read, mut unix_write) = unix.into_split();
+
+    let mut chunk = vec![0u8; SPLICE_CHUNK];
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ping.tick().await; // the first tick is immediate; the pipe is not idle yet
+    let mut awaiting_pong = false;
+
+    loop {
+        tokio::select! {
+            incoming = ws_read.next() => match incoming {
+                None => {
+                    // Half-close upstream so the daemon sees a detach, not a kill.
+                    let _ = unix_write.shutdown().await;
+                    return Ok(());
+                }
+                Some(Err(error)) => {
+                    let _ = unix_write.shutdown().await;
+                    // A closed tab is not an incident. Anything else is.
+                    return match error {
+                        WsError::ConnectionClosed
+                        | WsError::AlreadyClosed
+                        | WsError::Protocol(ProtocolError::ResetWithoutClosingHandshake) => Ok(()),
+                        other => Err(other.into()),
+                    };
+                }
+                Some(Ok(Message::Binary(bytes))) => {
+                    // Verbatim. No byte is inspected, counted into a frame, or
+                    // buffered on a frame boundary. An empty payload is a legal
+                    // no-op.
+                    unix_write
+                        .write_all(&bytes)
+                        .await
+                        .context("writing browser bytes to the session socket")?;
+                }
+                Some(Ok(Message::Text(_))) => {
+                    close_ws(&mut ws_write, CloseCode::Unsupported, "binary frames only").await;
+                    let _ = unix_write.shutdown().await;
+                    bail!("wss: text message — the browser is speaking a dialect");
+                }
+                Some(Ok(Message::Ping(payload))) => {
+                    ws_write.send(Message::Pong(payload)).await?;
+                }
+                Some(Ok(Message::Pong(_))) => awaiting_pong = false,
+                Some(Ok(Message::Close(_))) => {
+                    let _ = unix_write.shutdown().await;
+                    let _ = ws_write.flush().await;
+                    return Ok(());
+                }
+                Some(Ok(Message::Frame(_))) => {}
+            },
+
+            read = unix_read.read(&mut chunk) => match read {
+                Ok(0) => {
+                    close_ws(&mut ws_write, CloseCode::Normal, "session closed").await;
+                    return Ok(());
+                }
+                Ok(count) => {
+                    // Feed-then-flush, awaited: a slow browser applies
+                    // backpressure to this socket instead of growing an
+                    // unbounded queue in our process. What happens next is the
+                    // daemon's CLIENT_BACKLOG_CAP decision, not ours.
+                    ws_write
+                        .feed(Message::Binary(Bytes::copy_from_slice(&chunk[..count])))
+                        .await?;
+                    ws_write.flush().await?;
+                }
+                Err(error) => {
+                    close_ws(&mut ws_write, CloseCode::Error, "session host error").await;
+                    return Err(error).context("reading the session socket");
+                }
+            },
+
+            _ = ping.tick() => {
+                if awaiting_pong {
+                    eprintln!("termiod: wss detach (no pong)");
+                    close_ws(&mut ws_write, CloseCode::Away, "no pong").await;
+                    let _ = unix_write.shutdown().await;
+                    return Ok(());
+                }
+                ws_write.send(Message::Ping(Bytes::new())).await?;
+                awaiting_pong = true;
+            },
+
+            _ = rotate.changed() => {
+                close_ws(&mut ws_write, CloseCode::Policy, "token rotated").await;
+                let _ = unix_write.shutdown().await;
+                return Ok(());
+            },
+        }
+    }
+}
+
+pub async fn serve(config: WssConfig, rotate: watch::Receiver<u64>) -> Result<()> {
     let listener = TcpListener::bind(config.bind)
         .await
         .with_context(|| format!("binding {}", config.bind))?;
     eprintln!("termiod: wss listening on {}", config.bind);
+
+    // Live splices, so a rotate can report what it cost. Detach, never kill.
+    let live = Arc::new(AtomicUsize::new(0));
+    {
+        let live = live.clone();
+        let mut rotate = rotate.clone();
+        tokio::spawn(async move {
+            while rotate.changed().await.is_ok() {
+                eprintln!(
+                    "termiod: wss rotate: dropped {} splices",
+                    live.load(Ordering::Relaxed)
+                );
+            }
+        });
+    }
 
     loop {
         let Ok((stream, _peer)) = listener.accept().await else {
             continue;
         };
         let config = config.clone();
+        let rotate = rotate.clone();
+        let live = live.clone();
         tokio::spawn(async move {
-            handle(stream, config).await;
+            handle(stream, config, rotate, live).await;
         });
     }
 }
 
-async fn handle(mut stream: TcpStream, config: WssConfig) {
-    let Some((raw_head, _rest)) = read_head(&mut stream).await else {
+async fn handle(
+    mut stream: TcpStream,
+    config: WssConfig,
+    rotate: watch::Receiver<u64>,
+    live: Arc<AtomicUsize>,
+) {
+    let Some((raw_head, rest)) = read_head(&mut stream).await else {
         return;
     };
     let Some(head) = parse_head(&raw_head) else {
@@ -394,6 +842,18 @@ async fn handle(mut stream: TcpStream, config: WssConfig) {
         return;
     };
     let path = route(&head.path).to_string();
+
+    // `GET /termio` without the slash: redirect rather than serve, or every
+    // relative asset in the page resolves one directory too high. The build is
+    // emitted with a relative base precisely so one bundle works under both
+    // mounts, and that only holds from the trailing slash.
+    if head.path.split('?').next() == Some("/termio") {
+        let response = "HTTP/1.1 302 Found\r\nLocation: /termio/\r\nContent-Length: 0\r\n\
+                        Connection: close\r\n\r\n";
+        let _ = stream.write_all(response.as_bytes()).await;
+        let _ = stream.flush().await;
+        return;
+    }
 
     if !head.upgrade {
         if head.method != "GET" {
@@ -411,24 +871,38 @@ async fn handle(mut stream: TcpStream, config: WssConfig) {
         write_simple(&mut stream, "404 Not Found", "not found").await;
         return;
     }
+    let origin = head.origin.clone().unwrap_or_else(|| "-".to_string());
     if !origin_allowed(&head, &config.origins) {
-        // Deliberately terse: a rejected origin learns nothing about which of
-        // the checks it failed.
+        // Terse on the wire, specific in the log: the caller learns nothing
+        // about which check it failed, the operator learns everything.
+        eprintln!("termiod: wss reject (origin) origin={origin}");
         write_simple(&mut stream, "403 Forbidden", "forbidden").await;
         return;
     }
     let Ok(Some(token)) = load_token() else {
+        eprintln!("termiod: wss reject (unpaired) origin={origin}");
         write_simple(&mut stream, "503 Service Unavailable", "not paired").await;
         return;
     };
     let Some(_accepted) = token_from_protocols(&head.protocols, &token) else {
+        eprintln!("termiod: wss reject (token) origin={origin}");
         write_simple(&mut stream, "401 Unauthorized", "unauthorized").await;
         return;
     };
+    // Anything sent before the 101 would be lost when the stream is handed to
+    // the WebSocket codec. No browser pipelines an Upgrade; something that does
+    // is confused, and silently dropping its first frames is worse than saying so.
+    if !rest.is_empty() {
+        write_simple(&mut stream, "400 Bad Request", "data before the handshake").await;
+        return;
+    }
 
-    // Handshake and splice land in the next commit; the gate above is what had
-    // to be right first.
-    let _ = UnixStream::connect(paths::socket_path().unwrap_or_default()).await;
+    live.fetch_add(1, Ordering::Relaxed);
+    let result = splice(stream, &head, rotate).await;
+    live.fetch_sub(1, Ordering::Relaxed);
+    if let Err(error) = result {
+        eprintln!("termiod: wss splice error: {error:#}");
+    }
 }
 
 #[cfg(test)]
@@ -443,7 +917,50 @@ mod tests {
             origin: origin.map(str::to_string),
             upgrade: true,
             protocols: Vec::new(),
+            key: Some("dGhlIHNhbXBsZSBub25jZQ==".into()),
+            version: Some("13".into()),
         }
+    }
+
+    /// The token must never be the value we echo back: `Sec-WebSocket-Protocol`
+    /// appears in every proxy access log in front of us.
+    #[test]
+    fn the_selected_subprotocol_is_never_the_token() {
+        let offered = vec!["termiod.v1".to_string(), "termiod.token.abc123".to_string()];
+        assert_eq!(selected_protocol(&offered), Some("termiod.v1"));
+        assert_eq!(selected_protocol(&["termiod.token.abc123".to_string()]), None);
+        assert_eq!(selected_protocol(&[]), None);
+    }
+
+    #[test]
+    fn the_handshake_headers_are_parsed() {
+        let raw = "GET /termio/ws HTTP/1.1\r\nHost: 127.0.0.1:8790\r\nUpgrade: websocket\r\n\
+                   Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\
+                   Sec-WebSocket-Protocol: termiod.v1, termiod.token.abc123";
+        let head = parse_head(raw).expect("head");
+        assert!(head.upgrade);
+        assert_eq!(head.key.as_deref(), Some("dGhlIHNhbXBsZSBub25jZQ=="));
+        assert_eq!(head.version.as_deref(), Some("13"));
+        assert_eq!(head.protocols.len(), 2);
+        assert_eq!(route(&head.path), "/ws");
+        // RFC 6455's own worked example, so a wrong accept key fails here and
+        // not in a browser console.
+        assert_eq!(
+            derive_accept_key(head.key.as_deref().unwrap_or_default().as_bytes()),
+            "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+        );
+    }
+
+    #[test]
+    fn tokens_are_base64url_without_padding() {
+        assert_eq!(base64url(b""), "");
+        assert_eq!(base64url(&[0xff, 0xff, 0xff]), "____");
+        assert_eq!(base64url(b"a"), "YQ");
+        assert_eq!(base64url(b"ab"), "YWI");
+        assert_eq!(base64url(b"abc"), "YWJj");
+        let token = mint_token().expect("mint");
+        assert_eq!(token.len(), 32, "24 random bytes are 32 base64url characters");
+        assert!(token.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
     }
 
     #[test]

--- a/termiod/src/wss.rs
+++ b/termiod/src/wss.rs
@@ -1,0 +1,558 @@
+//! WSS binding — the browser's pipe to the same framed protocol.
+//!
+//! This is a *transport*, not a second protocol. A WebSocket binary message
+//! carries protocol bytes and nothing else: the 5-byte framing stays inside the
+//! payload, so a recorded transcript replays byte-identical here, over the Unix
+//! socket, and over `termiod stdio` (§C.9). Message boundaries are deliberately
+//! **not** frame boundaries — leaning on them would make the web a dialect, and
+//! the companion wire already taught us what that costs.
+//!
+//! Three rules this module exists to enforce, none of them negotiable:
+//!
+//! 1. **Loopback only.** The bind address is parsed and refused unless
+//!    `is_loopback()`. TLS lives in Tailscale Serve or Caddy in front; `termiod`
+//!    never grows a TLS stack, because "never embed crypto" is a trust choice
+//!    and not a performance one.
+//! 2. **Authenticate before the splice.** Origin allowlist plus a pairing token,
+//!    both checked on the handshake, before a single byte reaches the session
+//!    socket.
+//! 3. **Serve files, do not be a web server.** The GET side is a jail: a fixed
+//!    root, no traversal, no symlink escape, no directory listing, an explicit
+//!    MIME map. Anything past that belongs to the reverse proxy.
+
+use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UnixStream};
+
+use crate::paths;
+
+/// Where the pairing secret lives, beside the socket like every other
+/// per-daemon file (`host.id`, the graveyard). Two daemons on two sockets must
+/// not share one token.
+pub fn token_path() -> Result<PathBuf> {
+    Ok(paths::state_dir()?.join("pair.token"))
+}
+
+/// The remembered bind, so a crash restart or a bare `termiod serve` from
+/// systemd brings WSS back. A flag that only lives on one foreground argv dies
+/// on the next restart.
+pub fn bind_path() -> Result<PathBuf> {
+    Ok(paths::state_dir()?.join("wss.bind"))
+}
+
+#[derive(Debug, Clone)]
+pub struct WssConfig {
+    pub bind: SocketAddr,
+    /// Exact origins to allow. Empty means "same-origin against the request's
+    /// own Host", which is what a loopback / `ssh -L` setup wants.
+    pub origins: Vec<String>,
+    pub web_root: Option<PathBuf>,
+}
+
+/// Parse and **refuse anything that is not loopback**. Stronger than rejecting
+/// `0.0.0.0`: a LAN address, a public address, or a hostname that resolves off
+/// loopback are all errors here, at parse time, with the same wording the
+/// `--help` and DEPLOY.md carry.
+pub fn parse_bind(value: &str) -> Result<SocketAddr> {
+    let addr: SocketAddr = value
+        .parse()
+        .with_context(|| format!("`{value}` is not a host:port address"))?;
+    if !addr.ip().is_loopback() {
+        bail!(
+            "--wss must bind a loopback address (127.0.0.0/8 or ::1); `{}` is reachable from the \
+             network. Put Tailscale Serve or Caddy in front instead — termiod does not terminate TLS."
+        , value);
+    }
+    Ok(addr)
+}
+
+/// Resolve the bind from flag, then env, then the remembered file. First
+/// present *valid* value wins; absent everywhere means no TCP listener at all
+/// and the DEPLOY.md contract is unchanged.
+pub fn resolve_bind(flag: Option<&str>) -> Result<Option<SocketAddr>> {
+    if let Some(value) = flag {
+        return Ok(Some(parse_bind(value)?));
+    }
+    if let Ok(value) = std::env::var("TERMIOD_WSS") {
+        if !value.trim().is_empty() {
+            return Ok(Some(parse_bind(value.trim())?));
+        }
+    }
+    let path = bind_path()?;
+    if let Ok(contents) = std::fs::read_to_string(&path) {
+        let value = contents.trim();
+        if !value.is_empty() {
+            return Ok(Some(parse_bind(value)?));
+        }
+    }
+    Ok(None)
+}
+
+/// Read the pairing secret. `None` means the daemon may not accept a WebSocket:
+/// there is nothing to authenticate with, and an unauthenticated splice onto a
+/// PTY is not a degraded mode, it is a hole.
+pub fn load_token() -> Result<Option<String>> {
+    let path = token_path()?;
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            let token = contents.trim().to_string();
+            Ok(if token.is_empty() { None } else { Some(token) })
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("reading {}", path.display())),
+    }
+}
+
+/// One parsed request head. Only what the two decisions need: route, upgrade or
+/// not, and the three headers that gate the splice.
+#[derive(Debug, Default)]
+struct RequestHead {
+    method: String,
+    path: String,
+    host: Option<String>,
+    origin: Option<String>,
+    upgrade: bool,
+    protocols: Vec<String>,
+}
+
+fn parse_head(raw: &str) -> Option<RequestHead> {
+    let mut lines = raw.split("\r\n");
+    let mut request_line = lines.next()?.split_whitespace();
+    let mut head = RequestHead {
+        method: request_line.next()?.to_string(),
+        path: request_line.next()?.to_string(),
+        ..RequestHead::default()
+    };
+
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        let (name, value) = match line.split_once(':') {
+            Some((name, value)) => (name.trim().to_ascii_lowercase(), value.trim()),
+            None => continue,
+        };
+        match name.as_str() {
+            "host" => head.host = Some(value.to_string()),
+            "origin" => head.origin = Some(value.to_string()),
+            "upgrade" => head.upgrade = value.eq_ignore_ascii_case("websocket"),
+            "sec-websocket-protocol" => {
+                head.protocols = value
+                    .split(',')
+                    .map(|part| part.trim().to_string())
+                    .filter(|part| !part.is_empty())
+                    .collect();
+            }
+            _ => {}
+        }
+    }
+    Some(head)
+}
+
+/// An authority as the Origin check compares them: host plus an explicit port,
+/// with the scheme's default filled in so `https://box` and `box:443` match.
+fn authority(host: &str, default_port: u16) -> (String, u16) {
+    let host = host.trim();
+    // IPv6 literals are bracketed, and the colon inside them is not a port.
+    if let Some(rest) = host.strip_prefix('[') {
+        if let Some((inside, tail)) = rest.split_once(']') {
+            let port = tail
+                .strip_prefix(':')
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(default_port);
+            return (inside.to_ascii_lowercase(), port);
+        }
+    }
+    match host.rsplit_once(':') {
+        Some((name, port)) if port.chars().all(|c| c.is_ascii_digit()) && !port.is_empty() => {
+            (name.to_ascii_lowercase(), port.parse().unwrap_or(default_port))
+        }
+        _ => (host.to_ascii_lowercase(), default_port),
+    }
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>().map(|ip| ip.is_loopback()).unwrap_or(false)
+}
+
+/// The Origin algorithm from the RFC, in order.
+///
+/// A missing Origin is rejected rather than waved through: a browser always
+/// sends one on a cross-document WebSocket, so its absence means the caller is
+/// not the page we serve, and this is the only check standing between a hostile
+/// page and someone's shell.
+fn origin_allowed(head: &RequestHead, allowed: &[String]) -> bool {
+    let origin = match head.origin.as_deref() {
+        Some(value) if !value.is_empty() && value != "null" => value,
+        _ => return false,
+    };
+    let (scheme, rest) = match origin.split_once("://") {
+        Some(parts) => parts,
+        None => return false,
+    };
+    let default_port = match scheme {
+        "https" => 443,
+        "http" => 80,
+        _ => return false, // file://, ws://, anything else
+    };
+
+    if !allowed.is_empty() {
+        // Explicit allowlist: compare scheme, host, and port exactly, with the
+        // scheme default filled in on both sides so `https://box` == `https://box:443`.
+        let (origin_host, origin_port) = authority(rest, default_port);
+        return allowed.iter().any(|entry| {
+            match entry.trim().split_once("://") {
+                Some((entry_scheme, entry_rest)) if entry_scheme == scheme => {
+                    let (host, port) = authority(entry_rest, default_port);
+                    host == origin_host && port == origin_port
+                }
+                _ => false,
+            }
+        });
+    }
+
+    // Default same-origin: the Origin's authority must equal the request's own
+    // Host authority. A TLS terminator in front rewrites Host, which is exactly
+    // why it must pass --wss-origin instead of relying on this branch.
+    let host = match head.host.as_deref() {
+        Some(value) => value,
+        None => return false,
+    };
+    let (origin_host, origin_port) = authority(rest, default_port);
+    // The listener is plain HTTP, so a Host with no port means 80.
+    let (host_name, host_port) = authority(host, 80);
+    if origin_host != host_name || origin_port != host_port {
+        return false;
+    }
+    // A raw loopback Host is only same-origin with a loopback Origin — this is
+    // the `ssh -L` case, and it must not become a way for any page to reach a
+    // daemon by naming 127.0.0.1.
+    if is_loopback_host(&host_name) {
+        return is_loopback_host(&origin_host);
+    }
+    true
+}
+
+/// Constant-time-ish comparison. The token is compared on every handshake and
+/// a naive `==` leaks its length and prefix through timing; this is cheap
+/// enough that there is no reason to take that risk.
+fn secret_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+/// The token rides the WebSocket **subprotocol**, never the query string: a
+/// URL lands in logs, in `Referer`, and in screenshots, and this one is a key
+/// to a shell.
+fn token_from_protocols(protocols: &[String], token: &str) -> Option<String> {
+    protocols
+        .iter()
+        .find(|entry| {
+            entry
+                .strip_prefix("termiod.token.")
+                .map(|value| secret_eq(value, token))
+                .unwrap_or(false)
+        })
+        .cloned()
+}
+
+/// Strip the optional `/termio` mount prefix. Tailscale Serve's `--set-path`
+/// publishes rather than strips, so requests arrive with the prefix; Caddy's
+/// `handle_path` strips it and they arrive without. Accepting both is what lets
+/// one recipe work behind either without telling the operator to add a rewrite.
+fn route(path: &str) -> &str {
+    let path = path.split('?').next().unwrap_or(path);
+    match path.strip_prefix("/termio") {
+        Some("") => "/",
+        Some(rest) if rest.starts_with('/') => rest,
+        Some(_) => path,
+        None => path,
+    }
+}
+
+fn content_type(path: &Path) -> &'static str {
+    match path.extension().and_then(|e| e.to_str()).unwrap_or("") {
+        "html" => "text/html; charset=utf-8",
+        "js" | "mjs" => "text/javascript; charset=utf-8",
+        "css" => "text/css; charset=utf-8",
+        "json" => "application/json; charset=utf-8",
+        // Explicit, because a Wasm served as octet-stream fails
+        // `instantiateStreaming` with an error that reads like a build problem.
+        "wasm" => "application/wasm",
+        "woff2" => "font/woff2",
+        "svg" => "image/svg+xml",
+        "png" => "image/png",
+        "webp" => "image/webp",
+        "ico" => "image/x-icon",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Resolve a request path inside the web root, or `None` if it escapes.
+///
+/// Canonicalising both sides is what closes symlink traversal — a `..` filter
+/// alone does not, because a symlink inside the root can point anywhere.
+fn resolve_asset(root: &Path, request: &str) -> Option<PathBuf> {
+    let relative = request.trim_start_matches('/');
+    let relative = if relative.is_empty() { "index.html" } else { relative };
+    // Source maps are excluded outright: they are build output that describes
+    // the client to anyone who asks, and nothing in the product needs them.
+    if relative.ends_with(".map") || relative.contains("..") {
+        return None;
+    }
+    let root = root.canonicalize().ok()?;
+    let candidate = root.join(relative).canonicalize().ok()?;
+    if !candidate.starts_with(&root) || !candidate.is_file() {
+        return None;
+    }
+    Some(candidate)
+}
+
+async fn write_simple(stream: &mut TcpStream, status: &str, body: &str) {
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\n\
+         Connection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.flush().await;
+}
+
+async fn serve_asset(stream: &mut TcpStream, root: &Path, request: &str) {
+    let Some(path) = resolve_asset(root, request) else {
+        write_simple(stream, "404 Not Found", "not found").await;
+        return;
+    };
+    let Ok(body) = std::fs::read(&path) else {
+        write_simple(stream, "404 Not Found", "not found").await;
+        return;
+    };
+    let header = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        content_type(&path),
+        body.len()
+    );
+    let _ = stream.write_all(header.as_bytes()).await;
+    let _ = stream.write_all(&body).await;
+    let _ = stream.flush().await;
+}
+
+/// Read the request head. Bounded: a client that never sends `\r\n\r\n` must
+/// not be able to grow this buffer, and a head this large is not a browser.
+async fn read_head(stream: &mut TcpStream) -> Option<(String, Vec<u8>)> {
+    const MAX_HEAD: usize = 16 * 1024;
+    let mut buffer = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 1024];
+    loop {
+        let read = stream.read(&mut chunk).await.ok()?;
+        if read == 0 {
+            return None;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+        if let Some(end) = buffer.windows(4).position(|w| w == b"\r\n\r\n") {
+            let head = String::from_utf8_lossy(&buffer[..end]).into_owned();
+            return Some((head, buffer[end + 4..].to_vec()));
+        }
+        if buffer.len() > MAX_HEAD {
+            return None;
+        }
+    }
+}
+
+pub async fn serve(config: WssConfig) -> Result<()> {
+    let listener = TcpListener::bind(config.bind)
+        .await
+        .with_context(|| format!("binding {}", config.bind))?;
+    eprintln!("termiod: wss listening on {}", config.bind);
+
+    loop {
+        let Ok((stream, _peer)) = listener.accept().await else {
+            continue;
+        };
+        let config = config.clone();
+        tokio::spawn(async move {
+            handle(stream, config).await;
+        });
+    }
+}
+
+async fn handle(mut stream: TcpStream, config: WssConfig) {
+    let Some((raw_head, _rest)) = read_head(&mut stream).await else {
+        return;
+    };
+    let Some(head) = parse_head(&raw_head) else {
+        write_simple(&mut stream, "400 Bad Request", "bad request").await;
+        return;
+    };
+    let path = route(&head.path).to_string();
+
+    if !head.upgrade {
+        if head.method != "GET" {
+            write_simple(&mut stream, "405 Method Not Allowed", "method not allowed").await;
+            return;
+        }
+        match config.web_root.as_deref() {
+            Some(root) => serve_asset(&mut stream, root, &path).await,
+            None => write_simple(&mut stream, "404 Not Found", "no web root configured").await,
+        }
+        return;
+    }
+
+    if path != "/ws" {
+        write_simple(&mut stream, "404 Not Found", "not found").await;
+        return;
+    }
+    if !origin_allowed(&head, &config.origins) {
+        // Deliberately terse: a rejected origin learns nothing about which of
+        // the checks it failed.
+        write_simple(&mut stream, "403 Forbidden", "forbidden").await;
+        return;
+    }
+    let Ok(Some(token)) = load_token() else {
+        write_simple(&mut stream, "503 Service Unavailable", "not paired").await;
+        return;
+    };
+    let Some(_accepted) = token_from_protocols(&head.protocols, &token) else {
+        write_simple(&mut stream, "401 Unauthorized", "unauthorized").await;
+        return;
+    };
+
+    // Handshake and splice land in the next commit; the gate above is what had
+    // to be right first.
+    let _ = UnixStream::connect(paths::socket_path().unwrap_or_default()).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn head(origin: Option<&str>, host: Option<&str>) -> RequestHead {
+        RequestHead {
+            method: "GET".into(),
+            path: "/ws".into(),
+            host: host.map(str::to_string),
+            origin: origin.map(str::to_string),
+            upgrade: true,
+            protocols: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn bind_refuses_anything_reachable_from_the_network() {
+        assert!(parse_bind("127.0.0.1:8790").is_ok());
+        assert!(parse_bind("[::1]:8790").is_ok());
+        assert!(parse_bind("127.0.0.2:8790").is_ok());
+        for reachable in ["0.0.0.0:8790", "[::]:8790", "192.168.1.10:8790"] {
+            assert!(parse_bind(reachable).is_err(), "{reachable} must be refused");
+        }
+    }
+
+    #[test]
+    fn origin_must_be_present_and_http() {
+        let allowed: Vec<String> = Vec::new();
+        assert!(!origin_allowed(&head(None, Some("127.0.0.1:8790")), &allowed));
+        assert!(!origin_allowed(&head(Some("null"), Some("127.0.0.1:8790")), &allowed));
+        assert!(!origin_allowed(&head(Some("file://"), Some("127.0.0.1:8790")), &allowed));
+    }
+
+    /// The `ssh -L` case: browser at http://localhost:8790 against a loopback
+    /// bind, with no --wss-origin flag at all.
+    #[test]
+    fn loopback_is_same_origin_with_itself() {
+        let allowed: Vec<String> = Vec::new();
+        assert!(origin_allowed(
+            &head(Some("http://localhost:8790"), Some("localhost:8790")),
+            &allowed
+        ));
+        assert!(origin_allowed(
+            &head(Some("http://127.0.0.1:8790"), Some("127.0.0.1:8790")),
+            &allowed
+        ));
+        // A public page may not reach a daemon by naming loopback.
+        assert!(!origin_allowed(
+            &head(Some("https://evil.example"), Some("127.0.0.1:8790")),
+            &allowed
+        ));
+    }
+
+    #[test]
+    fn explicit_allowlist_fills_in_the_scheme_default_port() {
+        let allowed = vec!["https://box.tailnet.ts.net".to_string()];
+        assert!(origin_allowed(
+            &head(Some("https://box.tailnet.ts.net"), Some("127.0.0.1:8790")),
+            &allowed
+        ));
+        assert!(origin_allowed(
+            &head(Some("https://box.tailnet.ts.net:443"), Some("127.0.0.1:8790")),
+            &allowed
+        ));
+        // Same host, wrong scheme and wrong port are both misses.
+        assert!(!origin_allowed(
+            &head(Some("http://box.tailnet.ts.net"), Some("127.0.0.1:8790")),
+            &allowed
+        ));
+        assert!(!origin_allowed(
+            &head(Some("https://box.tailnet.ts.net:8443"), Some("127.0.0.1:8790")),
+            &allowed
+        ));
+    }
+
+    #[test]
+    fn the_mount_prefix_is_optional_and_does_not_nest() {
+        assert_eq!(route("/ws"), "/ws");
+        assert_eq!(route("/termio/ws"), "/ws");
+        assert_eq!(route("/"), "/");
+        assert_eq!(route("/termio/"), "/");
+        assert_eq!(route("/ghostty-vt.wasm"), "/ghostty-vt.wasm");
+        assert_eq!(route("/termio/ghostty-vt.wasm"), "/ghostty-vt.wasm");
+        // A second prefix is a real path, not another strip.
+        assert_eq!(route("/termio/termio/ws"), "/termio/ws");
+        // A prefix that is only a name fragment is left alone.
+        assert_eq!(route("/termiodocs"), "/termiodocs");
+    }
+
+    #[test]
+    fn token_rides_the_subprotocol_and_must_match_exactly() {
+        let protocols = vec!["termiod.v1".into(), "termiod.token.abc123".into()];
+        assert!(token_from_protocols(&protocols, "abc123").is_some());
+        assert!(token_from_protocols(&protocols, "abc124").is_none());
+        assert!(token_from_protocols(&protocols, "abc1234").is_none());
+        assert!(token_from_protocols(&[], "abc123").is_none());
+    }
+
+    #[test]
+    fn the_asset_jail_refuses_traversal_and_source_maps() {
+        let dir = std::env::temp_dir().join(format!("termiod-wss-jail-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(dir.join("sub"));
+        std::fs::write(dir.join("index.html"), b"<!doctype html>").unwrap();
+        std::fs::write(dir.join("app.js.map"), b"{}").unwrap();
+        std::fs::write(dir.join("sub").join("app.js"), b"//").unwrap();
+
+        assert!(resolve_asset(&dir, "/").is_some(), "root serves index.html");
+        assert!(resolve_asset(&dir, "/sub/app.js").is_some());
+        assert!(resolve_asset(&dir, "/app.js.map").is_none(), "source maps are excluded");
+        assert!(resolve_asset(&dir, "/../etc/passwd").is_none());
+        assert!(resolve_asset(&dir, "/sub/../../etc/passwd").is_none());
+        assert!(resolve_asset(&dir, "/nope.js").is_none());
+        // A directory is not an asset, and there is no listing.
+        assert!(resolve_asset(&dir, "/sub").is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn wasm_gets_its_own_mime_type() {
+        assert_eq!(content_type(Path::new("a/ghostty-vt.wasm")), "application/wasm");
+        assert_eq!(content_type(Path::new("a/index.html")), "text/html; charset=utf-8");
+        assert_eq!(content_type(Path::new("a/font.woff2")), "font/woff2");
+    }
+}

--- a/termiod/tests/wss_bridge.rs
+++ b/termiod/tests/wss_bridge.rs
@@ -1,0 +1,803 @@
+//! §C.9 acceptance for the WSS binding: the browser's pipe is the *same*
+//! protocol, not a dialect of it.
+//!
+//! `stdio_bridge.rs` proves it for `termiod stdio`. This file proves it for the
+//! WebSocket, and adds the two things only a WebSocket can get wrong:
+//!
+//! - **Message boundaries are not frame boundaries.** One protocol frame is
+//!   sent split across three binary messages, and two frames are sent packed
+//!   into one. Both must reach the daemon intact, because that is the only
+//!   reason a transcript recorded over the Unix socket replays here.
+//! - **The token is never echoed.** The selected subprotocol is `termiod.v1`;
+//!   `Sec-WebSocket-Protocol` lands in every proxy access log in front of us.
+//!
+//! The equality assertion is a real one: the same session, attached over the
+//! Unix socket and over WSS, must produce a byte-identical `S` payload.
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UnixStream};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::Message;
+
+const BIN: &str = env!("CARGO_BIN_EXE_termiod");
+const SETTLE: Duration = Duration::from_secs(10);
+
+fn frame(kind: u8, payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(5 + payload.len());
+    out.push(kind);
+    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Pull whole frames out of an accumulating byte buffer. This is the codec the
+/// browser will run, and the reason it is here rather than in the assertions is
+/// that a WebSocket message carries an arbitrary slice of the stream.
+fn drain_frames(buffer: &mut Vec<u8>, into: &mut Vec<(u8, Vec<u8>)>) {
+    loop {
+        if buffer.len() < 5 {
+            return;
+        }
+        let length =
+            u32::from_be_bytes([buffer[1], buffer[2], buffer[3], buffer[4]]) as usize;
+        if buffer.len() < 5 + length {
+            return;
+        }
+        let kind = buffer[0];
+        let payload = buffer[5..5 + length].to_vec();
+        buffer.drain(..5 + length);
+        into.push((kind, payload));
+    }
+}
+
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("probe port");
+    let port = listener.local_addr().expect("probe addr").port();
+    drop(listener);
+    port
+}
+
+struct Daemon {
+    child: Option<Child>,
+    dir: PathBuf,
+    socket: String,
+    port: u16,
+    token: String,
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn state_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("termiod-wss-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("state dir");
+    dir
+}
+
+fn pair(socket: &str) -> String {
+    let output = Command::new(BIN)
+        .arg("pair")
+        .env("TERMIOD_SOCK", socket)
+        .output()
+        .expect("pair");
+    assert!(output.status.success(), "pair failed: {output:?}");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// A daemon with the web pipe armed: a pairing token, then `serve --wss` on a
+/// loopback port nobody else has.
+fn start_daemon(tag: &str) -> Daemon {
+    let dir = state_dir(tag);
+    let socket = dir.join("termiod.sock").to_string_lossy().into_owned();
+    let token = pair(&socket);
+    let port = free_port();
+
+    let child = Command::new(BIN)
+        .args(["serve", "--wss", &format!("127.0.0.1:{port}")])
+        .env("TERMIOD_SOCK", &socket)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn serve --wss");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !std::path::Path::new(&socket).exists() {
+        assert!(Instant::now() < deadline, "daemon never bound the socket");
+        std::thread::sleep(Duration::from_millis(30));
+    }
+    while std::net::TcpStream::connect(("127.0.0.1", port)).is_err() {
+        assert!(Instant::now() < deadline, "daemon never bound the wss port");
+        std::thread::sleep(Duration::from_millis(30));
+    }
+
+    Daemon {
+        child: Some(child),
+        dir,
+        socket,
+        port,
+        token,
+    }
+}
+
+/// A session whose screen is fixed after one line, so two attaches a second
+/// apart see the same grid and the `S` payloads are comparable byte for byte.
+///
+/// Live `D` is produced on demand instead: `sleep` never reads stdin, so
+/// anything injected with `termiod send` comes straight back off the tty's own
+/// echo, after `ready`, without disturbing the settled screen first.
+fn create_session(socket: &str, name: &str, alive_seconds: u32) {
+    let created = Command::new(BIN)
+        .args([
+            "create",
+            "--name",
+            name,
+            "--",
+            "bash",
+            "--norc",
+            "-c",
+            &format!("printf 'WSS_ACCEPTANCE_MARK\\r\\n'; sleep {alive_seconds}"),
+        ])
+        .env("TERMIOD_SOCK", socket)
+        .output()
+        .expect("create");
+    assert!(created.status.success(), "create failed: {created:?}");
+    // Let the marker land before anyone attaches, so the snapshot is settled.
+    std::thread::sleep(Duration::from_millis(600));
+}
+
+fn send(socket: &str, name: &str, text: &str) {
+    let sent = Command::new(BIN)
+        .args(["send", name, text])
+        .env("TERMIOD_SOCK", socket)
+        .output()
+        .expect("send");
+    assert!(sent.status.success(), "send failed: {sent:?}");
+}
+
+fn hello() -> Vec<u8> {
+    frame(
+        b'C',
+        br#"{"op":"hello","proto":1,"min_proto":1,"role":"attach","caps":["events","snapshot","scrollback"],"client":"termio-web/test"}"#,
+    )
+}
+
+fn attach(name: &str) -> Vec<u8> {
+    frame(
+        b'C',
+        format!(r#"{{"op":"attach","target":"{name}","rows":24,"cols":80,"mode":"observe"}}"#)
+            .as_bytes(),
+    )
+}
+
+fn contains(payload: &[u8], needle: &str) -> bool {
+    String::from_utf8_lossy(payload).contains(needle)
+}
+
+/// `Event::Ready` is what ends the attach barrier — not the first `D`. The
+/// transcript is complete there, on both pipes, by definition.
+fn transcript_is_complete(frames: &[(u8, Vec<u8>)]) -> bool {
+    frames
+        .iter()
+        .any(|(kind, payload)| *kind == b'E' && contains(payload, "\"ev\":\"ready\""))
+}
+
+async fn unix_transcript(socket: &str, name: &str) -> Vec<(u8, Vec<u8>)> {
+    let mut stream = UnixStream::connect(socket).await.expect("unix connect");
+    stream.write_all(&hello()).await.expect("hello");
+    stream.write_all(&attach(name)).await.expect("attach");
+
+    let mut buffer = Vec::new();
+    let mut frames = Vec::new();
+    let mut chunk = vec![0u8; 64 * 1024];
+    let deadline = tokio::time::Instant::now() + SETTLE;
+    while !transcript_is_complete(&frames) {
+        let read = tokio::time::timeout_at(deadline, stream.read(&mut chunk))
+            .await
+            .expect("unix transcript timed out")
+            .expect("unix read");
+        assert!(read > 0, "daemon closed the unix socket early");
+        buffer.extend_from_slice(&chunk[..read]);
+        drain_frames(&mut buffer, &mut frames);
+    }
+    frames
+}
+
+async fn open_socket(
+    daemon: &Daemon,
+    path: &str,
+) -> (
+    tokio_tungstenite::WebSocketStream<TcpStream>,
+    tokio_tungstenite::tungstenite::handshake::client::Response,
+) {
+    let mut request = format!("ws://127.0.0.1:{}{path}", daemon.port)
+        .into_client_request()
+        .expect("request");
+    request.headers_mut().insert(
+        "origin",
+        format!("http://127.0.0.1:{}", daemon.port)
+            .parse()
+            .expect("origin"),
+    );
+    request.headers_mut().insert(
+        "sec-websocket-protocol",
+        format!("termiod.v1, termiod.token.{}", daemon.token)
+            .parse()
+            .expect("subprotocol"),
+    );
+    let tcp = TcpStream::connect(("127.0.0.1", daemon.port))
+        .await
+        .expect("tcp connect");
+    tokio_tungstenite::client_async(request, tcp)
+        .await
+        .expect("websocket handshake")
+}
+
+/// Read binary messages, reassemble frames, and stop when `until` says so. The
+/// leftover buffer is kept: a message may end mid-frame, which is the whole
+/// point.
+async fn wss_frames_until(
+    websocket: &mut tokio_tungstenite::WebSocketStream<TcpStream>,
+    buffer: &mut Vec<u8>,
+    until: impl Fn(&[(u8, Vec<u8>)]) -> bool,
+) -> Vec<(u8, Vec<u8>)> {
+    let mut frames = Vec::new();
+    let deadline = tokio::time::Instant::now() + SETTLE;
+    while !until(&frames) {
+        let message = tokio::time::timeout_at(deadline, websocket.next())
+            .await
+            .expect("wss transcript timed out")
+            .expect("websocket closed early")
+            .expect("websocket error");
+        match message {
+            Message::Binary(bytes) => {
+                buffer.extend_from_slice(&bytes);
+                drain_frames(buffer, &mut frames);
+            }
+            Message::Ping(_) | Message::Pong(_) => {}
+            other => panic!("unexpected message from the host: {other:?}"),
+        }
+    }
+    frames
+}
+
+async fn wss_frames(
+    websocket: &mut tokio_tungstenite::WebSocketStream<TcpStream>,
+) -> Vec<(u8, Vec<u8>)> {
+    let mut buffer = Vec::new();
+    wss_frames_until(websocket, &mut buffer, transcript_is_complete).await
+}
+
+#[tokio::test]
+async fn framed_protocol_is_byte_identical_over_the_wss_binding() {
+    let daemon = start_daemon("replay");
+    create_session(&daemon.socket, "wsssession", 30);
+
+    let over_unix = unix_transcript(&daemon.socket, "wsssession").await;
+
+    let (mut websocket, response) = open_socket(&daemon, "/ws").await;
+    assert_eq!(
+        response
+            .headers()
+            .get("sec-websocket-protocol")
+            .map(|value| value.to_str().unwrap_or_default()),
+        Some("termiod.v1"),
+        "the selected subprotocol must be the version, never the token"
+    );
+
+    // One frame, three messages. If the host treated a message as a frame this
+    // is where the whole design would fall over.
+    let hello = hello();
+    for slice in [&hello[..2], &hello[2..7], &hello[7..]] {
+        websocket
+            .send(Message::Binary(slice.to_vec().into()))
+            .await
+            .expect("send hello slice");
+    }
+    websocket
+        .send(Message::Binary(attach("wsssession").into()))
+        .await
+        .expect("send attach");
+
+    let mut leftover = Vec::new();
+    let over_wss =
+        wss_frames_until(&mut websocket, &mut leftover, transcript_is_complete).await;
+
+    // The attach sequence, in order. Roster and status events are published on
+    // their own schedule and may or may not land inside a given window, so they
+    // are not part of what the two pipes have to agree on.
+    let sequence = |frames: &[(u8, Vec<u8>)]| -> String {
+        frames
+            .iter()
+            .filter(|(kind, payload)| *kind != b'E' || contains(payload, "\"ev\":\"ready\""))
+            .map(|(kind, _)| *kind as char)
+            .collect()
+    };
+    assert_eq!(
+        sequence(&over_unix),
+        sequence(&over_wss),
+        "the two pipes produced different frame sequences"
+    );
+    assert_eq!(sequence(&over_wss), "CCSE", "hello_ok, attached, S, ready");
+
+    let snapshot = |frames: &[(u8, Vec<u8>)]| {
+        frames
+            .iter()
+            .find(|(kind, _)| *kind == b'S')
+            .map(|(_, payload)| payload.clone())
+            .expect("no S frame")
+    };
+    assert_eq!(
+        snapshot(&over_unix),
+        snapshot(&over_wss),
+        "the same session produced different snapshots on the two pipes"
+    );
+
+    assert!(over_wss.iter().any(|(kind, payload)| *kind == b'C'
+        && contains(payload, "\"op\":\"hello_ok\"")));
+    assert!(over_wss.iter().any(|(kind, payload)| *kind == b'C'
+        && contains(payload, "\"op\":\"attached\"")));
+
+    // Live D after the barrier: the tty echoes what `send` injects, so bytes
+    // travel PTY → daemon → splice → browser with nothing in between parsing
+    // them.
+    send(&daemon.socket, "wsssession", "LIVE_D_MARK");
+    let live = wss_frames_until(&mut websocket, &mut leftover, |frames| {
+        frames
+            .iter()
+            .any(|(kind, payload)| *kind == b'D' && contains(payload, "LIVE_D_MARK"))
+    })
+    .await;
+    assert!(live.iter().any(|(kind, _)| *kind == b'D'));
+}
+
+/// Tailscale Serve publishes `/termio` rather than stripping it, so the same
+/// build has to work at both mounts — and two frames packed into one message
+/// must arrive as two frames.
+#[tokio::test]
+async fn the_mount_prefix_and_a_packed_message_reach_the_same_daemon() {
+    let daemon = start_daemon("mount");
+    create_session(&daemon.socket, "mountsession", 30);
+
+    let (mut websocket, _response) = open_socket(&daemon, "/termio/ws").await;
+    let mut packed = hello();
+    packed.extend_from_slice(&attach("mountsession"));
+    websocket
+        .send(Message::Binary(packed.into()))
+        .await
+        .expect("send packed frames");
+
+    let frames = wss_frames(&mut websocket).await;
+    assert!(frames
+        .iter()
+        .any(|(kind, payload)| *kind == b'C' && contains(payload, "\"op\":\"hello_ok\"")));
+    assert!(frames
+        .iter()
+        .any(|(kind, payload)| *kind == b'C' && contains(payload, "\"op\":\"attached\"")));
+    assert!(frames.iter().any(|(kind, _)| *kind == b'S'));
+}
+
+/// 300 KB in one breath: several `D` frames, many 64 KiB socket reads, and no
+/// alignment between the two. If the splice ever re-chunked on frame boundaries
+/// — or lost a byte at a message edge — this is where it would show.
+#[tokio::test]
+async fn a_burst_larger_than_one_chunk_stays_framed() {
+    let daemon = start_daemon("burst");
+    let created = Command::new(BIN)
+        .args(["create", "--name", "burstsession", "--", "bash", "--norc", "-i"])
+        .env("TERMIOD_SOCK", &daemon.socket)
+        .output()
+        .expect("create");
+    assert!(created.status.success(), "create failed: {created:?}");
+    std::thread::sleep(Duration::from_millis(600));
+
+    let (mut websocket, _response) = open_socket(&daemon, "/ws").await;
+    let mut packed = hello();
+    packed.extend_from_slice(&attach("burstsession"));
+    websocket
+        .send(Message::Binary(packed.into()))
+        .await
+        .expect("send");
+    let mut leftover = Vec::new();
+    wss_frames_until(&mut websocket, &mut leftover, transcript_is_complete).await;
+
+    // The quotes keep the sentinel out of the tty's echo of the command line,
+    // so the wait below ends on the burst's tail and not on its own request.
+    send(
+        &daemon.socket,
+        "burstsession",
+        "head -c 300000 /dev/zero | tr '\\0' x; echo BURST\"_\"END",
+    );
+    let frames = wss_frames_until(&mut websocket, &mut leftover, |frames| {
+        frames
+            .iter()
+            .any(|(kind, payload)| *kind == b'D' && contains(payload, "BURST_END"))
+    })
+    .await;
+
+    let data: Vec<&(u8, Vec<u8>)> = frames.iter().filter(|(kind, _)| *kind == b'D').collect();
+    let total: usize = data.iter().map(|(_, payload)| payload.len()).sum();
+    assert!(total >= 300_000, "only {total} bytes of the burst arrived");
+    assert!(data.len() > 1, "a 300 KB burst is more than one D frame");
+    for (_, payload) in &data {
+        assert!(
+            payload.len() <= 64 * 1024,
+            "a D frame exceeded MAX_DATA_FRAME_SIZE: {}",
+            payload.len()
+        );
+    }
+}
+
+/// A text message means someone is speaking a dialect. Close, do not guess.
+#[tokio::test]
+async fn a_text_message_is_a_protocol_error() {
+    let daemon = start_daemon("text");
+
+    let (mut websocket, _response) = open_socket(&daemon, "/ws").await;
+    websocket
+        .send(Message::Text("{\"op\":\"hello\"}".into()))
+        .await
+        .expect("send text");
+
+    let deadline = tokio::time::Instant::now() + SETTLE;
+    loop {
+        let message = tokio::time::timeout_at(deadline, websocket.next())
+            .await
+            .expect("no close after a text message");
+        match message {
+            Some(Ok(Message::Close(frame))) => {
+                assert_eq!(
+                    frame.map(|frame| frame.code),
+                    Some(CloseCode::Unsupported),
+                    "a text message must close 1003"
+                );
+                return;
+            }
+            Some(Ok(_)) => continue,
+            Some(Err(_)) | None => return, // an abrupt close is the same verdict
+        }
+    }
+}
+
+/// Rule 3 of the durable-start contract: an operator asking for a listener that
+/// cannot authenticate gets no listener, no `wss.bind`, and a non-zero exit.
+#[test]
+fn explicit_wss_without_a_token_refuses_to_start() {
+    let dir = state_dir("notoken");
+    let socket = dir.join("termiod.sock");
+    let port = free_port();
+
+    let output = Command::new(BIN)
+        .args(["serve", "--wss", &format!("127.0.0.1:{port}")])
+        .env("TERMIOD_SOCK", &socket)
+        .output()
+        .expect("serve");
+
+    assert!(!output.status.success(), "serve should have refused to start");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("termiod pair"),
+        "the error must name the fix, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!dir.join("wss.bind").exists(), "wss.bind must not be written");
+    assert!(!socket.exists(), "the whole start is refused, socket included");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Rule 4: a *remembered* bind without a token is a restart of something that
+/// used to work. Skip TCP, keep the Unix socket — `spawn_daemon` must not take
+/// down the Mac and the CLI because a token went missing.
+#[test]
+fn an_inherited_bind_without_a_token_still_serves_unix() {
+    let dir = state_dir("inherited");
+    let socket = dir.join("termiod.sock");
+    let port = free_port();
+    std::fs::write(dir.join("wss.bind"), format!("127.0.0.1:{port}")).expect("wss.bind");
+
+    let mut child = Command::new(BIN)
+        .arg("serve")
+        .env("TERMIOD_SOCK", &socket)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn serve");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !socket.exists() {
+        assert!(Instant::now() < deadline, "unix socket never appeared");
+        std::thread::sleep(Duration::from_millis(30));
+    }
+    std::thread::sleep(Duration::from_millis(200));
+    assert!(
+        std::net::TcpStream::connect(("127.0.0.1", port)).is_err(),
+        "TCP must stay closed without a pairing token"
+    );
+
+    let listed = Command::new(BIN)
+        .args(["list", "--json"])
+        .env("TERMIOD_SOCK", &socket)
+        .output()
+        .expect("list");
+    assert!(listed.status.success(), "the unix socket must still answer");
+
+    let _ = child.kill();
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    let _ = child.wait();
+    assert!(
+        stderr.contains("wss skipped: no pair.token"),
+        "the skip must be visible on stderr, got: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `pair` mints once and then prints the same secret; `--rotate` replaces it and
+/// `--wss-off` forgets the bind. All three at 0600, beside the socket.
+#[test]
+fn pair_mints_rotates_and_turns_the_bind_off() {
+    let dir = state_dir("pair");
+    let socket = dir.join("termiod.sock").to_string_lossy().into_owned();
+
+    let first = pair(&socket);
+    assert_eq!(first.len(), 32);
+    assert_eq!(first, pair(&socket), "pair prints, it does not re-mint");
+
+    use std::os::unix::fs::PermissionsExt;
+    let mode = std::fs::metadata(dir.join("pair.token"))
+        .expect("token file")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o600, "the token is a credential");
+
+    let rotated = Command::new(BIN)
+        .args(["pair", "--rotate"])
+        .env("TERMIOD_SOCK", &socket)
+        .output()
+        .expect("rotate");
+    assert!(rotated.status.success());
+    let second = String::from_utf8_lossy(&rotated.stdout).trim().to_string();
+    assert_ne!(first, second, "--rotate must replace the token");
+
+    std::fs::write(dir.join("wss.bind"), "127.0.0.1:8790").expect("wss.bind");
+    let off = Command::new(BIN)
+        .args(["pair", "--wss-off"])
+        .env("TERMIOD_SOCK", &socket)
+        .output()
+        .expect("wss-off");
+    assert!(off.status.success());
+    assert!(!dir.join("wss.bind").exists(), "--wss-off forgets the bind");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Rotating the token drops live splices. Detach, not kill: the session is
+/// still there afterwards.
+#[tokio::test]
+async fn rotating_the_token_drops_a_live_splice() {
+    let daemon = start_daemon("rotate");
+    create_session(&daemon.socket, "rotatesession", 30);
+
+    let (mut websocket, _response) = open_socket(&daemon, "/ws").await;
+    let mut packed = hello();
+    packed.extend_from_slice(&attach("rotatesession"));
+    websocket
+        .send(Message::Binary(packed.into()))
+        .await
+        .expect("send");
+    let frames = wss_frames(&mut websocket).await;
+    assert!(frames.iter().any(|(kind, _)| *kind == b'S'));
+
+    let rotated = Command::new(BIN)
+        .args(["pair", "--rotate"])
+        .env("TERMIOD_SOCK", &daemon.socket)
+        .output()
+        .expect("rotate");
+    assert!(rotated.status.success());
+
+    let deadline = tokio::time::Instant::now() + SETTLE;
+    let mut closed = false;
+    while !closed {
+        let message = tokio::time::timeout_at(deadline, websocket.next())
+            .await
+            .expect("the splice outlived the token");
+        match message {
+            Some(Ok(Message::Close(_))) | Some(Err(_)) | None => closed = true,
+            Some(Ok(_)) => {}
+        }
+    }
+
+    // The session survives its viewer.
+    let listed = Command::new(BIN)
+        .args(["list", "--json"])
+        .env("TERMIOD_SOCK", &daemon.socket)
+        .output()
+        .expect("list");
+    assert!(
+        String::from_utf8_lossy(&listed.stdout).contains("rotatesession"),
+        "rotate is a detach, not a kill"
+    );
+}
+
+/// A quiet shell produces no `D` for hours and both Tailscale Serve and Caddy
+/// idle-timeout upstreams, so the transport ping is what keeps a left-open tab
+/// a live attachment — and an unanswered one is a detach, never a kill.
+///
+/// Ignored by default: two 30-second ticks is a minute of wall clock, which
+/// does not belong in the default run. Run it with
+/// `cargo test --test wss_bridge -- --ignored`.
+#[test]
+#[ignore]
+fn an_unanswered_ping_detaches_the_splice() {
+    let daemon = start_daemon("ping");
+    // Outlives two ping ticks, so "the session survived" is a real assertion.
+    create_session(&daemon.socket, "pingsession", 120);
+
+    // A hand-rolled client, because every WebSocket library answers a ping for
+    // you and the point here is to not answer one.
+    let mut stream =
+        std::net::TcpStream::connect(("127.0.0.1", daemon.port)).expect("connect");
+    let request = format!(
+        "GET /ws HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nUpgrade: websocket\r\n\
+         Connection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+         Sec-WebSocket-Version: 13\r\nOrigin: http://127.0.0.1:{port}\r\n\
+         Sec-WebSocket-Protocol: termiod.v1, termiod.token.{token}\r\n\r\n",
+        port = daemon.port,
+        token = daemon.token
+    );
+    stream.write_all(request.as_bytes()).expect("upgrade");
+
+    let mut head = Vec::new();
+    let mut byte = [0u8; 1];
+    while !head.ends_with(b"\r\n\r\n") {
+        assert_eq!(stream.read(&mut byte).expect("head"), 1, "closed mid-head");
+        head.push(byte[0]);
+    }
+    let head = String::from_utf8_lossy(&head).into_owned();
+    assert!(head.starts_with("HTTP/1.1 101"), "{head}");
+    assert!(
+        head.contains("Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo="),
+        "{head}"
+    );
+    assert!(head.contains("Sec-WebSocket-Protocol: termiod.v1"), "{head}");
+    assert!(!head.contains(&daemon.token), "the token must not be echoed");
+
+    stream
+        .set_read_timeout(Some(Duration::from_secs(100)))
+        .expect("timeout");
+    let mut read_exact = |buffer: &mut [u8]| stream.read_exact(buffer).is_ok();
+
+    let (mut pings, mut closed) = (0, false);
+    let started = Instant::now();
+    while !closed {
+        let mut header = [0u8; 2];
+        if !read_exact(&mut header) {
+            break; // the host hung up without a close frame; still a detach
+        }
+        let length = usize::from(header[1] & 0x7f);
+        let length = match length {
+            126 => {
+                let mut extended = [0u8; 2];
+                assert!(read_exact(&mut extended));
+                usize::from(u16::from_be_bytes(extended))
+            }
+            127 => {
+                let mut extended = [0u8; 8];
+                assert!(read_exact(&mut extended));
+                u64::from_be_bytes(extended) as usize
+            }
+            short => short,
+        };
+        let mut payload = vec![0u8; length];
+        assert!(read_exact(&mut payload));
+        match header[0] & 0x0f {
+            0x9 => pings += 1,
+            0x8 => closed = true,
+            _ => {}
+        }
+    }
+
+    assert!(pings >= 1, "the host never pinged a quiet splice");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= Duration::from_secs(45),
+        "detached after {elapsed:?} — that is not two 30s ticks"
+    );
+
+    let listed = Command::new(BIN)
+        .args(["list", "--json"])
+        .env("TERMIOD_SOCK", &daemon.socket)
+        .output()
+        .expect("list");
+    assert!(
+        String::from_utf8_lossy(&listed.stdout).contains("pingsession"),
+        "a missing pong is a detach, not a kill"
+    );
+}
+
+/// The web root is a jail, and the Wasm has to arrive as `application/wasm` or
+/// `instantiateStreaming` fails with an error that reads like a build problem.
+#[test]
+fn the_web_root_serves_index_at_both_mounts() {
+    let dir = state_dir("webroot");
+    let socket = dir.join("termiod.sock").to_string_lossy().into_owned();
+    let root = dir.join("web");
+    std::fs::create_dir_all(&root).expect("web root");
+    std::fs::write(root.join("index.html"), b"<!doctype html>termio").expect("index");
+    std::fs::write(root.join("ghostty-vt.wasm"), b"\0asm").expect("wasm");
+    let token = pair(&socket);
+    let port = free_port();
+
+    let mut child = Command::new(BIN)
+        .args([
+            "serve",
+            "--wss",
+            &format!("127.0.0.1:{port}"),
+            "--web-root",
+            &root.to_string_lossy(),
+        ])
+        .env("TERMIOD_SOCK", &socket)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn serve");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while std::net::TcpStream::connect(("127.0.0.1", port)).is_err() {
+        assert!(Instant::now() < deadline, "wss port never came up");
+        std::thread::sleep(Duration::from_millis(30));
+    }
+    assert!(!token.is_empty());
+
+    let get = |path: &str| -> String {
+        let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connect");
+        stream
+            .write_all(
+                format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n")
+                    .as_bytes(),
+            )
+            .expect("request");
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).expect("response");
+        String::from_utf8_lossy(&response).into_owned()
+    };
+
+    for path in ["/", "/termio/"] {
+        let response = get(path);
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "{path}: {response}");
+        assert!(response.contains("termio"), "{path} did not serve index.html");
+    }
+    for path in ["/ghostty-vt.wasm", "/termio/ghostty-vt.wasm"] {
+        assert!(
+            get(path).contains("Content-Type: application/wasm"),
+            "{path} must carry the Wasm MIME type"
+        );
+    }
+    assert!(
+        get("/termio").starts_with("HTTP/1.1 302"),
+        "/termio redirects to /termio/ so relative assets resolve"
+    );
+    assert!(get("/../../etc/passwd").starts_with("HTTP/1.1 404"));
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/web/client/.gitignore
+++ b/web/client/.gitignore
@@ -1,0 +1,14 @@
+node_modules/
+dist/
+coverage/
+*.tsbuildinfo
+
+# The pinned ghostty-vt.wasm is fetched into the public root by the build
+# tooling, not committed here; the versioned web root on the box is what ships.
+# scripts/ghostty-wasm.sh puts it there and verifies its sha256 against
+# ghostty-pin.json, which IS committed — the pin is the artifact's identity.
+public/ghostty-vt.wasm
+
+# The assembled versioned web root (`<termiod-version>-g<sha7>/` + `current`),
+# built by scripts/stage-web-root.sh and rsync'd to the box. Deploy output.
+webroot/

--- a/web/client/ghostty-pin.json
+++ b/web/client/ghostty-pin.json
@@ -1,0 +1,74 @@
+{
+  "$comment": [
+    "The one declared ghostty commit for the browser Replica's VT.",
+    "",
+    "The browser must run the SAME state machine as the host sidecar and the Mac,",
+    "or the Replica contract is a lie: three parsers disagreeing on grapheme width,",
+    "autowrap, and kitty keyboard, with no test catching it. Three places pin that",
+    "commit today and none of them can see the other two:",
+    "",
+    "  termiod/vt/Cargo.toml  -> libghostty-rs rev -> build.rs GHOSTTY_COMMIT",
+    "  Package.resolved       -> libghostty-swift version -> release body sha",
+    "  this file              -> the ghostty-vt.wasm the web root serves",
+    "",
+    "scripts/check-ghostty-pin.sh resolves all three and fails when they disagree.",
+    "Bumping the host VT means bumping this file in the same change.",
+    "",
+    "artifact.url is content-addressed by the FULL commit sha, so it is stable even",
+    "though the `tip` release tag it was cut from is not. Ghostty publishes no",
+    "minisign signature under that path (only under the moving tag), so integrity",
+    "here is artifact.sha256, recorded once and verified on every fetch.",
+    "",
+    "The artifact was checked against a from-source build at the same commit:",
+    "identical export table (180 entries) and byte-identical ghostty_type_json."
+  ],
+
+  "ghostty_sha": "56e1f3a62e26407e8c020ef5881df3e8584be20f",
+  "ghostty_describe": "v1.3.1-2067-g56e1f3a",
+
+  "artifact": {
+    "name": "ghostty-vt.wasm",
+    "url": "https://tip.files.ghostty.org/56e1f3a62e26407e8c020ef5881df3e8584be20f/ghostty-vt.wasm",
+    "sha256": "2efd051d15cf45974cfcabde7582c5b4a520ead5259544826338ef1d2a07bff8",
+    "bytes": 902275,
+    "optimize": "ReleaseFast",
+    "content_type": "application/wasm"
+  },
+
+  "source_build": {
+    "$comment": [
+      "The fallback, for a commit whose blob has aged out of the tip bucket.",
+      "Reproduces ghostty's own release-tip.yml wasm job. zig 0.16.0 is what",
+      "ghostty's flake.nix pins and what .github/workflows/termiod.yml installs;",
+      "wasm-opt comes from binaryen (`brew install binaryen`) and is what turns a",
+      "4.2 MB debug-info build into the 902,275-byte artifact above.",
+      "",
+      "Measured: this build is REPRODUCIBLE. zig 0.16.0 + binaryen 132 on an",
+      "arm64 Mac produced sha256 2efd051d… — byte for byte the artifact ghostty's",
+      "Linux CI published. That is the integrity proof standing in for the",
+      "minisign signature that the content-addressed path does not carry.",
+      "Reproducibility is a property of those two toolchain versions, so a",
+      "mismatch under different ones is toolchain drift, not tampering; fall back",
+      "to comparing the export table and ghostty_type_json in that case."
+    ],
+    "repo": "https://github.com/ghostty-org/ghostty.git",
+    "zig": "0.16.0",
+    "wasm_opt": "132",
+    "reproduced_by": "zig 0.16.0 + binaryen 132, aarch64-macos, 2026-08-18",
+    "zig_build_args": [
+      "-Demit-lib-vt",
+      "-Dtarget=wasm32-freestanding",
+      "-Doptimize=ReleaseFast"
+    ],
+    "wasm_opt_args": [
+      "-O3",
+      "--strip-dwarf",
+      "--enable-simd",
+      "--enable-bulk-memory",
+      "--enable-sign-ext",
+      "--enable-nontrapping-float-to-int",
+      "--enable-multivalue",
+      "--enable-reference-types"
+    ]
+  }
+}

--- a/web/client/index.html
+++ b/web/client/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <!-- The page bootstrap carries the pairing token in the fragment. A
+         no-referrer policy keeps it out of any request this page makes. -->
+    <meta name="referrer" content="no-referrer" />
+    <meta name="color-scheme" content="light dark" />
+    <title>termio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/app/main.tsx"></script>
+  </body>
+</html>

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "termio-web-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Browser Replica for termiod: framed Session Protocol over WSS, official ghostty-vt.wasm as the VT.",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "wasm": "../../scripts/ghostty-wasm.sh fetch",
+    "webroot": "../../scripts/stage-web-root.sh"
+  },
+  "dependencies": {
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
+  },
+  "devDependencies": {
+    "@types/node": "^26",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^5",
+    "jsdom": "^26",
+    "typescript": "^6",
+    "vite": "^7",
+    "vitest": "^3"
+  }
+}

--- a/web/client/pnpm-lock.yaml
+++ b/web/client/pnpm-lock.yaml
@@ -1,0 +1,1800 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
+    devDependencies:
+      '@types/node':
+        specifier: ^26
+        version: 26.2.0
+      '@types/react':
+        specifier: ^19
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.4(@types/react@19.2.18)
+      '@vitejs/plugin-react':
+        specifier: ^5
+        version: 5.2.0(vite@7.3.6(@types/node@26.2.0))
+      jsdom:
+        specifier: ^26
+        version: 26.1.0
+      typescript:
+        specifier: ^6
+        version: 6.0.3
+      vite:
+        specifier: ^7
+        version: 7.3.6(@types/node@26.2.0)
+      vitest:
+        specifier: ^3
+        version: 3.2.7(@types/node@26.2.0)(jsdom@26.1.0)
+
+packages:
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  baseline-browser-mapping@2.11.15:
+    resolution: {integrity: sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  electron-to-chromium@1.5.409:
+    resolution: {integrity: sha512-ChI4N44d0B4A6C8prnNjMOaGgE59fUyEVYcRYm2XEXIjMbbvF5i9UL1cblDbpGqiU0uS8FE8UcKxqZqTXdmzbQ==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
+
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.8
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@26.2.0':
+    dependencies:
+      undici-types: 8.3.0
+
+  '@types/react-dom@19.2.4(@types/react@19.2.18)':
+    dependencies:
+      '@types/react': 19.2.18
+
+  '@types/react@19.2.18':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@26.2.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.6(@types/node@26.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@26.2.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@26.2.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  agent-base@7.1.4: {}
+
+  assertion-error@2.0.1: {}
+
+  baseline-browser-mapping@2.11.15: {}
+
+  browserslist@4.28.8:
+    dependencies:
+      baseline-browser-mapping: 2.11.15
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.409
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001809: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  convert-source-map@2.0.0: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
+
+  electron-to-chromium@1.5.409: {}
+
+  entities@6.0.1: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.18: {}
+
+  node-releases@2.0.53: {}
+
+  nwsapi@2.2.24: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  punycode@2.3.1: {}
+
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
+  react-refresh@0.18.0: {}
+
+  react@19.2.8: {}
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  typescript@6.0.3: {}
+
+  undici-types@8.3.0: {}
+
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
+    dependencies:
+      browserslist: 4.28.8
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite-node@3.2.4(@types/node@26.2.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@26.2.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@26.2.0):
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
+      fsevents: 2.3.3
+
+  vitest@3.2.7(@types/node@26.2.0)(jsdom@26.1.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@26.2.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@26.2.0)
+      vite-node: 3.2.4(@types/node@26.2.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.21.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}

--- a/web/client/pnpm-workspace.yaml
+++ b/web/client/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# pnpm 10 blocks package build scripts by default. Vite's bundler needs
+# esbuild's, so it is allowed explicitly rather than by turning the guard off —
+# the same shape web/landing uses.
+allowBuilds:
+  esbuild: true

--- a/web/client/src/app/App.test.tsx
+++ b/web/client/src/app/App.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+import { StrictMode, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KIND } from "../protocol/frame";
+import { encodeJsonFrame } from "../protocol/testTranscript";
+
+// The Wasm is fetched over the network and instantiated from a MIME type, so the
+// shell test stubs the binding rather than the transport under it. Everything
+// below the shell has its own tests.
+vi.mock("../vt", async () => {
+  const actual = await vi.importActual<typeof import("../vt")>("../vt");
+  return { ...actual, instantiate: vi.fn() };
+});
+
+const vt = await import("../vt");
+const { App } = await import("./App");
+
+const STUB_BINDING = {
+  libraryVersion: "test",
+  commit: null,
+  createTerminal: () => {
+    throw new Error("no terminal in the shell test");
+  },
+  createKeyEncoder: () => {
+    throw new Error("no encoder in the shell test");
+  },
+  dispose: () => {},
+} as unknown as import("../vt").VtBinding;
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+class StubSocket {
+  static instances: StubSocket[] = [];
+  readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+  readonly sent: Uint8Array[] = [];
+  binaryType = "";
+  readyState = 1;
+  closed = false;
+
+  constructor(
+    readonly url: string,
+    readonly protocols: string[],
+  ) {
+    StubSocket.instances.push(this);
+  }
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+    if (type === "open") listener({});
+  }
+  removeEventListener(): void {}
+  send(data: Uint8Array): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.closed = true;
+    this.readyState = 3;
+  }
+  deliver(bytes: Uint8Array): void {
+    const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    for (const listener of [...(this.listeners.get("message") ?? [])]) {
+      listener({ data: buffer });
+    }
+  }
+  controls(): Record<string, unknown>[] {
+    return this.sent
+      .filter((frame) => frame[0] === KIND.CONTROL)
+      .map(
+        (frame) =>
+          JSON.parse(new TextDecoder().decode(frame.subarray(5))) as Record<string, unknown>,
+      );
+  }
+}
+
+function session(id: string, created: number) {
+  return {
+    id,
+    name: id,
+    cwd: "/home/me",
+    command: "zsh",
+    pid: 1,
+    rows: 24,
+    cols: 80,
+    clients: 0,
+    created_unix: created,
+    alive: true,
+    status: "idle",
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+beforeEach(() => {
+  StubSocket.instances = [];
+  (globalThis as { WebSocket: unknown }).WebSocket = StubSocket;
+  // jsdom ships no 2D context; the renderer only needs a recording one, and
+  // without it `createSurface` would report "no 2D context" and never attach.
+  HTMLCanvasElement.prototype.getContext = (() => ({
+    setTransform() {},
+    fillRect() {},
+    strokeRect() {},
+    fillText() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    measureText: (text: string) => ({
+      width: text.length * 8,
+      fontBoundingBoxAscent: 8,
+      fontBoundingBoxDescent: 2,
+    }),
+    fillStyle: "",
+    strokeStyle: "",
+    font: "",
+    globalAlpha: 1,
+    lineWidth: 1,
+    textBaseline: "alphabetic",
+  })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+  window.location.hash = "#t=pair-token";
+  vi.mocked(vt.instantiate).mockReset();
+  vi.mocked(vt.instantiate).mockResolvedValue(STUB_BINDING);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  window.sessionStorage.clear();
+});
+
+/**
+ * Async because the Wasm binding is loaded in an effect: without flushing the
+ * microtask queue the shell is still on "Loading the terminal engine…" and no
+ * surface has mounted.
+ */
+async function mount(): Promise<void> {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+  });
+}
+
+describe("the shell", () => {
+  it("takes the token out of the fragment and never puts it in a URL", async () => {
+    await mount();
+    expect(window.location.hash).toBe("");
+    expect(window.sessionStorage.getItem("termio.pair.token")).toBe("pair-token");
+    const socket = StubSocket.instances.find((instance) => !instance.closed);
+    expect(socket?.protocols).toEqual(["termiod.v1", "termiod.token.pair-token"]);
+    expect(socket?.url).not.toContain("pair-token");
+  });
+
+  it("opens exactly one live control socket under StrictMode", async () => {
+    await mount();
+    const live = StubSocket.instances.filter((instance) => !instance.closed);
+    expect(live).toHaveLength(1);
+    expect(live[0]?.controls()[0]).toMatchObject({ op: "hello", role: "control" });
+  });
+
+  it("lists sessions from the roster and attaches to the newest as an observer", async () => {
+    await mount();
+    const control = StubSocket.instances.find((instance) => !instance.closed);
+    act(() => {
+      control?.deliver(
+        encodeJsonFrame(KIND.CONTROL, {
+          op: "hello_ok",
+          proto: 1,
+          caps: [],
+          host_id: "h",
+          host: "box",
+          client_id: "c",
+        }),
+      );
+      control?.deliver(
+        encodeJsonFrame(KIND.CONTROL, {
+          op: "sessions",
+          sessions: [session("older", 10), session("newest", 90)],
+        }),
+      );
+    });
+
+    expect(container?.textContent).toContain("newest");
+    expect(container?.textContent).toContain("older");
+
+    const attach = StubSocket.instances.filter((instance) => !instance.closed).at(-1);
+    expect(attach).not.toBe(control);
+    expect(attach?.controls()[0]).toMatchObject({
+      op: "hello",
+      role: "attach",
+      caps: ["events", "snapshot", "scrollback"],
+    });
+    expect(container?.textContent).toContain("Observing");
+  });
+
+  it("Take input closes the observe socket and opens a new interact attach", async () => {
+    await mount();
+    const control = StubSocket.instances.find((instance) => !instance.closed);
+    act(() => {
+      control?.deliver(
+        encodeJsonFrame(KIND.CONTROL, {
+          op: "hello_ok",
+          proto: 1,
+          caps: [],
+          host_id: "h",
+          host: "box",
+          client_id: "c",
+        }),
+      );
+      control?.deliver(
+        encodeJsonFrame(KIND.CONTROL, { op: "sessions", sessions: [session("only", 1)] }),
+      );
+    });
+    const observe = StubSocket.instances.filter((instance) => !instance.closed).at(-1);
+    act(() => {
+      observe?.deliver(
+        encodeJsonFrame(KIND.CONTROL, {
+          op: "hello_ok",
+          proto: 1,
+          caps: [],
+          host_id: "h",
+          host: "box",
+          client_id: "c",
+        }),
+      );
+    });
+    expect(observe?.controls()[1]).toMatchObject({ op: "attach", mode: "observe" });
+
+    const take = [...(container?.querySelectorAll("button") ?? [])].find(
+      (button) => button.textContent === "Take input",
+    );
+    expect(take).toBeDefined();
+    act(() => take?.click());
+
+    // There is no promote verb: the observe channel is closed and a new socket
+    // attaches with `mode: interact`.
+    expect(observe?.closed).toBe(true);
+    const interact = StubSocket.instances.filter((instance) => !instance.closed).at(-1);
+    expect(interact).not.toBe(observe);
+    act(() => {
+      interact?.deliver(
+        encodeJsonFrame(KIND.CONTROL, {
+          op: "hello_ok",
+          proto: 1,
+          caps: [],
+          host_id: "h",
+          host: "box",
+          client_id: "c",
+        }),
+      );
+    });
+    expect(interact?.controls()[1]).toMatchObject({ op: "attach", mode: "interact" });
+  });
+
+  it("shows the engine's own sentence when the Wasm will not load", async () => {
+    vi.mocked(vt.instantiate).mockRejectedValue(new vt.VtLoadError("bad mime"));
+    await mount();
+    expect(container?.textContent).toContain("Couldn't load the terminal engine.");
+    expect(container?.textContent).toContain("application/wasm");
+  });
+
+  it("asks for the pairing link when there is no token", async () => {
+    window.location.hash = "";
+    window.sessionStorage.clear();
+    await mount();
+    expect(container?.textContent).toContain("termiod pair");
+    expect(StubSocket.instances).toHaveLength(0);
+  });
+});

--- a/web/client/src/app/App.tsx
+++ b/web/client/src/app/App.tsx
@@ -1,0 +1,308 @@
+/**
+ * The shell. A session list, a badge, two buttons, a theme toggle, and the
+ * error surfaces — and not one cell, dirty flag or byte counter among them.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { SessionInfo } from "../protocol/control";
+import { channelUrl } from "../protocol/socket";
+import type { RendererStats } from "../renderer/types";
+import { instantiate, VtLoadError, type VtBinding } from "../vt";
+import { sessionFromLocation, takeToken, wasmUrl } from "./bootstrap";
+import { createControlClient, sessionLabel, type RosterState } from "./control";
+import { TerminalSurface } from "./TerminalSurface";
+import { chromeTokens } from "./chrome";
+import { buildPalette, preferredTheme, type ThemeName } from "./theme";
+import {
+  createRosterBridge,
+  createSurfaceBridge,
+  useRosterState,
+  useSurfaceState,
+  type SurfaceBridge,
+} from "./surfaceStore";
+
+export const CLIENT_NAME = "termio-web/0.1.0";
+
+type BindingState =
+  | { status: "loading" }
+  | { status: "ready"; binding: VtBinding }
+  | { status: "failed"; message: string };
+
+export function App(): React.JSX.Element {
+  const [theme, setTheme] = useState<ThemeName>(preferredTheme);
+  const palette = useMemo(() => buildPalette(theme), [theme]);
+
+  const token = useMemo(
+    () =>
+      takeToken(window.location, safeSessionStorage(), () => {
+        history.replaceState(null, "", window.location.pathname + window.location.search);
+      }),
+    [],
+  );
+  const wsUrl = useMemo(() => channelUrl(new URL(window.location.href)).toString(), []);
+
+  const [binding, setBinding] = useState<BindingState>({ status: "loading" });
+  useEffect(() => {
+    let disposed = false;
+    let loaded: VtBinding | null = null;
+    instantiate({ url: wasmUrl(document.baseURI) })
+      .then((value) => {
+        loaded = value;
+        if (disposed) {
+          value.dispose();
+          return;
+        }
+        setBinding({ status: "ready", binding: value });
+      })
+      .catch((error: unknown) => {
+        if (disposed) return;
+        setBinding({
+          status: "failed",
+          message:
+            error instanceof VtLoadError
+              ? error.userMessage
+              : `Couldn't load the terminal engine. ${String(error)}`,
+        });
+      });
+    return () => {
+      disposed = true;
+      loaded?.dispose();
+    };
+  }, []);
+
+  if (!token) return <TokenGate />;
+  return (
+    <Shell
+      theme={theme}
+      onTheme={setTheme}
+      palette={palette}
+      token={token}
+      wsUrl={wsUrl}
+      binding={binding}
+    />
+  );
+}
+
+interface ShellProps {
+  theme: ThemeName;
+  onTheme: (theme: ThemeName) => void;
+  palette: ReturnType<typeof buildPalette>;
+  token: string;
+  wsUrl: string;
+  binding: BindingState;
+}
+
+function Shell(props: ShellProps): React.JSX.Element {
+  const { theme, onTheme, palette, token, wsUrl, binding } = props;
+
+  // The control socket is opened in an effect, never during render: StrictMode
+  // renders twice, and a `createControlClient` in a `useMemo` would open two
+  // WebSockets and dispose one.
+  const rosterBridge = useMemo(createRosterBridge, []);
+  useEffect(() => {
+    const client = createControlClient({ url: new URL(wsUrl), token, client: CLIENT_NAME });
+    rosterBridge.attach(client);
+    return () => {
+      rosterBridge.attach(null);
+      client.dispose();
+    };
+  }, [wsUrl, token, rosterBridge]);
+  const roster = useRosterState(rosterBridge);
+
+  const [selected, setSelected] = useState<string | null>(() =>
+    sessionFromLocation(window.location),
+  );
+  const [mode, setMode] = useState<"observe" | "interact">("observe");
+
+  // The page opens on something rather than nothing, but never re-picks under
+  // the user: a roster update must not move them to a different session.
+  const active = selected ?? roster.sessions[0]?.id ?? null;
+  useEffect(() => {
+    if (selected === null && roster.sessions[0]) setSelected(roster.sessions[0].id);
+  }, [selected, roster.sessions]);
+
+  const bridge = useMemo(createSurfaceBridge, []);
+  const surface = useSurfaceState(bridge);
+
+  const choose = useCallback((id: string) => {
+    setSelected(id);
+    // A different session is a different attachment, and the write token does
+    // not travel with the click.
+    setMode("observe");
+    const url = new URL(window.location.href);
+    url.searchParams.set("session", id);
+    history.replaceState(null, "", url.pathname + url.search);
+  }, []);
+
+  return (
+    <div className="app" style={chromeTokens(palette) as React.CSSProperties}>
+      <aside className="sidebar">
+        <header className="sidebar-head">
+          <span className="brand">termio</span>
+          <button
+            type="button"
+            className="ghost"
+            onClick={() => onTheme(theme === "dark" ? "light" : "dark")}
+            title="Switch theme"
+          >
+            {theme === "dark" ? "Light" : "Dark"}
+          </button>
+        </header>
+        <SessionList roster={roster} active={active} onChoose={choose} onRetry={() => rosterBridge.current()?.refresh()} />
+      </aside>
+
+      <main className="main">
+        <header className="toolbar">
+          <span className="title">{surface.title ?? surface.name ?? "No session"}</span>
+          <span className={`badge ${surface.writer ? "badge-writer" : "badge-observer"}`}>
+            {surface.writer ? "Writing" : "Observing"}
+          </span>
+          <span className="dims">
+            {surface.cols}×{surface.rows}
+          </span>
+          <span className="spacer" />
+          {mode === "observe" ? (
+            <button type="button" onClick={() => setMode("interact")} disabled={!active}>
+              Take input
+            </button>
+          ) : (
+            <button type="button" onClick={() => setMode("observe")}>
+              Release
+            </button>
+          )}
+        </header>
+
+        {/* The attach barrier holds paint until `Event::Ready`, so without this
+            the stage is a blank canvas with nothing to explain it. */}
+        {active && (surface.phase === "connecting" || surface.phase === "attaching") ? (
+          <p className="notice">Attaching…</p>
+        ) : null}
+        {surface.notice ? <p className="notice">{surface.notice}</p> : null}
+        {surface.error ? <p className="notice notice-error">{surface.error}</p> : null}
+        {roster.error ? <p className="notice notice-error">{roster.error}</p> : null}
+        {surface.scrollOffsetRows > 0 ? (
+          <p className="notice">
+            Scrolled {surface.scrollOffsetRows} rows into history — type to jump back.
+          </p>
+        ) : null}
+
+        <RendererStatsPanel bridge={bridge} />
+
+        <div className="stage">
+          {binding.status === "failed" ? (
+            <p className="empty">{binding.message}</p>
+          ) : binding.status === "loading" ? (
+            <p className="empty">Loading the terminal engine…</p>
+          ) : !active ? (
+            <p className="empty">No sessions on this host yet. Start one with `termiod new`.</p>
+          ) : (
+            <TerminalSurface
+              // Identity is (session, mode): taking input is a new socket with
+              // `mode: interact`, which the protocol only lets you set once per
+              // channel — so it is a remount, not a re-render.
+              key={`${active}:${mode}`}
+              sessionId={active}
+              wsUrl={wsUrl}
+              token={token}
+              mode={mode}
+              binding={binding.binding}
+              palette={palette}
+              client={CLIENT_NAME}
+              bridge={bridge}
+            />
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function SessionList(props: {
+  roster: RosterState;
+  active: string | null;
+  onChoose: (id: string) => void;
+  onRetry: () => void;
+}): React.JSX.Element {
+  const { roster, active, onChoose, onRetry } = props;
+  if (roster.phase === "connecting") return <p className="empty">Connecting…</p>;
+  if (roster.sessions.length === 0) {
+    return (
+      <div className="empty">
+        <p>No sessions.</p>
+        <button type="button" onClick={onRetry}>
+          Refresh
+        </button>
+      </div>
+    );
+  }
+  return (
+    <ul className="sessions">
+      {roster.sessions.map((session) => (
+        <li key={session.id}>
+          <button
+            type="button"
+            className={`session ${session.id === active ? "session-active" : ""}`}
+            onClick={() => onChoose(session.id)}
+          >
+            <span className={`dot status-${statusClass(session)}`} />
+            <span className="session-name">{sessionLabel(session)}</span>
+            <span className="session-cwd">{session.cwd}</span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * The counters the WebGPU entry trigger is argued from: p95 full-redraw frame
+ * time over 16.7 ms, or sustained scroll below 30 fps. Opt-in with `?stats=1`,
+ * read here and in the console, and sent nowhere.
+ */
+function RendererStatsPanel({ bridge }: { bridge: SurfaceBridge }): React.JSX.Element | null {
+  const enabled = useMemo(() => new URLSearchParams(window.location.search).has("stats"), []);
+  const [stats, setStats] = useState<RendererStats | null>(null);
+  useEffect(() => {
+    if (!enabled) return;
+    // One second, not one frame: this is chrome, and the surface is memoised
+    // against exactly this kind of tick.
+    const timer = setInterval(() => setStats(bridge.current()?.stats() ?? null), 1000);
+    return () => clearInterval(timer);
+  }, [enabled, bridge]);
+  if (!enabled || !stats) return null;
+  return (
+    <p className="notice">
+      {stats.implementation} · {stats.framesPainted} frames ({stats.fullRedraws} full) · p50{" "}
+      {stats.frameTimeP50Ms.toFixed(2)} ms · p95 {stats.frameTimeP95Ms.toFixed(2)} ms ·{" "}
+      {stats.droppedFrames} over budget
+    </p>
+  );
+}
+
+function statusClass(session: SessionInfo): string {
+  if (!session.alive) return "dead";
+  return session.status.replace(/[^a-z_]/g, "") || "unknown";
+}
+
+function TokenGate(): React.JSX.Element {
+  return (
+    <div className="app" style={chromeTokens(buildPalette("dark")) as React.CSSProperties}>
+      <div className="gate">
+        <h1>termio</h1>
+        <p>
+          This page needs the pairing token from the host. Run <code>termiod pair</code> on the box
+          and open the link it prints, which ends in <code>#t=…</code>.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function safeSessionStorage(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}

--- a/web/client/src/app/TerminalSurface.test.tsx
+++ b/web/client/src/app/TerminalSurface.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+import { Profiler, StrictMode, act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Palette } from "../renderer/types";
+import type { VtBinding } from "../vt";
+import { TerminalSurface } from "./TerminalSurface";
+import type { SurfaceHandle, SurfaceState } from "./surface";
+import { createSurfaceBridge, IDLE_SURFACE_STATE, useSurfaceState } from "./surfaceStore";
+import { buildPalette } from "./theme";
+
+// React 19 wants this to route act() through the test scheduler.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+interface FakeHandle extends SurfaceHandle {
+  push(patch: Partial<SurfaceState>): void;
+  disposals: number;
+  palettes: Palette[];
+}
+
+const created: FakeHandle[] = [];
+
+function fakeHandle(): FakeHandle {
+  const listeners = new Set<() => void>();
+  let state: SurfaceState = IDLE_SURFACE_STATE;
+  const handle: FakeHandle = {
+    disposals: 0,
+    palettes: [],
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    snapshot: () => state,
+    fit() {},
+    setPalette(palette) {
+      handle.palettes.push(palette);
+    },
+    setFont() {},
+    paste() {},
+    stats: () => null,
+    dispose() {
+      handle.disposals += 1;
+    },
+    push(patch) {
+      state = { ...state, ...patch };
+      for (const listener of [...listeners]) listener();
+    },
+  };
+  return handle;
+}
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+function mount(element: React.ReactNode): void {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  created.length = 0;
+});
+
+function props(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: "session-1",
+    wsUrl: "wss://box.example/termio/ws",
+    token: "t",
+    mode: "observe" as const,
+    binding: {} as VtBinding,
+    palette: buildPalette("dark"),
+    client: "termio-web/test",
+    createHandle: (() => {
+      const handle = fakeHandle();
+      created.push(handle);
+      return handle;
+    }) as unknown as never,
+    ...overrides,
+  };
+}
+
+describe("TerminalSurface lifecycle", () => {
+  it("leaks nothing across StrictMode's double invoke", () => {
+    const bridge = createSurfaceBridge();
+    mount(
+      <StrictMode>
+        <TerminalSurface {...props()} bridge={bridge} />
+      </StrictMode>,
+    );
+
+    // StrictMode mounts, unmounts and remounts the effect. Every handle it
+    // created must have been disposed except the live one.
+    expect(created.length).toBeGreaterThanOrEqual(2);
+    const live = created.at(-1);
+    expect(created.slice(0, -1).every((handle) => handle.disposals === 1)).toBe(true);
+    expect(live?.disposals).toBe(0);
+    expect(bridge.current()).toBe(live);
+
+    act(() => root?.unmount());
+    expect(live?.disposals).toBe(1);
+    expect(bridge.current()).toBeNull();
+    root = null;
+  });
+
+  it("remounts on a session change and disposes the old attach", () => {
+    const bridge = createSurfaceBridge();
+    function Host(): React.JSX.Element {
+      const [id, setId] = useState("session-1");
+      return (
+        <>
+          <button type="button" onClick={() => setId("session-2")}>
+            switch
+          </button>
+          <TerminalSurface key={id} {...props({ sessionId: id })} bridge={bridge} />
+        </>
+      );
+    }
+    mount(<Host />);
+    const first = created.at(-1);
+    act(() => {
+      container?.querySelector("button")?.click();
+    });
+    expect(first?.disposals).toBe(1);
+    expect(created.at(-1)).not.toBe(first);
+    expect(bridge.current()).toBe(created.at(-1));
+  });
+
+  it("switches theme imperatively, without remounting the canvas", () => {
+    const bridge = createSurfaceBridge();
+    const dark = buildPalette("dark");
+    const light = buildPalette("light");
+    function Host(): React.JSX.Element {
+      const [palette, setPalette] = useState(dark);
+      return (
+        <>
+          <button type="button" onClick={() => setPalette(light)}>
+            theme
+          </button>
+          <TerminalSurface {...props()} palette={palette} bridge={bridge} />
+        </>
+      );
+    }
+    mount(<Host />);
+    const handle = created.at(-1);
+    const canvas = container?.querySelector("canvas");
+    const attaches = created.length;
+
+    act(() => {
+      container?.querySelector("button")?.click();
+    });
+    expect(handle?.palettes.at(-1)).toBe(light);
+    // No new attach, and the same canvas node.
+    expect(created).toHaveLength(attaches);
+    expect(container?.querySelector("canvas")).toBe(canvas);
+  });
+});
+
+describe("the React boundary", () => {
+  it("state from the loop re-renders the chrome and never the surface", () => {
+    const bridge = createSurfaceBridge();
+    let chromeRenders = 0;
+    let surfaceCommits = 0;
+
+    function Chrome(): React.JSX.Element {
+      const state = useSurfaceState(bridge);
+      chromeRenders += 1;
+      return <span>{state.writer ? "Writing" : "Observing"}</span>;
+    }
+
+    mount(
+      <>
+        <Chrome />
+        <Profiler
+          id="surface"
+          onRender={(_id, phase) => {
+            if (phase === "update") surfaceCommits += 1;
+          }}
+        >
+          <TerminalSurface {...props()} bridge={bridge} />
+        </Profiler>
+      </>,
+    );
+
+    const handle = created.at(-1);
+    const canvas = container?.querySelector("canvas");
+    const chromeBefore = chromeRenders;
+
+    act(() => {
+      for (let i = 0; i < 100; i += 1) handle?.push({ title: `title ${i}` });
+      handle?.push({ writer: true });
+    });
+
+    // The chrome saw it…
+    expect(container?.textContent).toContain("Writing");
+    expect(chromeRenders).toBeGreaterThan(chromeBefore);
+    // …and the surface subtree committed no update at all: it holds a ref, not
+    // state, so nothing arriving at PTY rate can reach it.
+    expect(surfaceCommits).toBe(0);
+    expect(container?.querySelector("canvas")).toBe(canvas);
+    expect(created).toHaveLength(1);
+  });
+
+  it("and the counter above is not vacuous: a real prop change does commit", () => {
+    const bridge = createSurfaceBridge();
+    let surfaceCommits = 0;
+    function Host(): React.JSX.Element {
+      const [mode, setMode] = useState<"observe" | "interact">("observe");
+      return (
+        <>
+          <button type="button" onClick={() => setMode("interact")}>
+            take
+          </button>
+          <Profiler
+            id="surface"
+            onRender={(_id, phase) => {
+              if (phase === "update") surfaceCommits += 1;
+            }}
+          >
+            <TerminalSurface {...props()} mode={mode} bridge={bridge} />
+          </Profiler>
+        </>
+      );
+    }
+    mount(<Host />);
+    act(() => {
+      container?.querySelector("button")?.click();
+    });
+    expect(surfaceCommits).toBeGreaterThan(0);
+  });
+});

--- a/web/client/src/app/TerminalSurface.tsx
+++ b/web/client/src/app/TerminalSurface.tsx
@@ -1,0 +1,98 @@
+/**
+ * One canvas, one attach, one ref.
+ *
+ * This component renders exactly once per attach. It reads no surface state, so
+ * nothing that happens at PTY rate — not a byte, not a title, not a cursor
+ * move — can make it render again. The chrome that *does* show those things
+ * subscribes to the bridge instead, which is why the boundary holds.
+ */
+
+import { memo, useEffect, useLayoutEffect, useRef } from "react";
+
+import type { AttachMode } from "../protocol/control";
+import type { Palette } from "../renderer/types";
+import type { VtBinding } from "../vt";
+import { createSurface, type SurfaceHandle } from "./surface";
+import type { SurfaceBridge } from "./surfaceStore";
+
+export interface TerminalSurfaceProps {
+  sessionId: string;
+  /** A string, not a URL: the effect deps are identities and must compare by value. */
+  wsUrl: string;
+  token: string;
+  mode: AttachMode;
+  binding: VtBinding;
+  palette: Palette;
+  client: string;
+  bridge: SurfaceBridge;
+  /** Injected by tests so the surface can be driven without a WebSocket. */
+  createHandle?: typeof createSurface;
+}
+
+export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurfaceProps) {
+  const { sessionId, wsUrl, token, mode, binding, palette, client, bridge } = props;
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const boxRef = useRef<HTMLDivElement>(null);
+  const handleRef = useRef<SurfaceHandle | null>(null);
+
+  // Everything the attach needs but must not re-run for. A change to any of
+  // these between renders takes effect on the next attach, which is what the
+  // remount key is for.
+  const latest = useRef({ token, mode, binding, palette, client, create: props.createHandle });
+  latest.current = { token, mode, binding, palette, client, create: props.createHandle };
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const { token: t, mode: m, binding: b, palette: p, client: c, create } = latest.current;
+    const handle = (create ?? createSurface)({
+      canvas,
+      container: boxRef.current,
+      url: new URL(wsUrl),
+      token: t,
+      target: sessionId,
+      mode: m,
+      binding: b,
+      palette: p,
+      client: c,
+    });
+    handleRef.current = handle;
+    bridge.attach(handle);
+    return () => {
+      handleRef.current = null;
+      bridge.attach(null);
+      // Idempotent by contract: StrictMode runs this cleanup and then the
+      // effect again on the very first mount.
+      handle.dispose();
+    };
+    // Identity only. A value that moves per frame in here is the bug this
+    // whole component exists to prevent.
+  }, [sessionId, wsUrl, bridge]);
+
+  useLayoutEffect(() => {
+    const box = boxRef.current;
+    if (!box || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => handleRef.current?.fit());
+    observer.observe(box);
+    return () => observer.disconnect();
+  }, []);
+
+  // A theme switch is an imperative call, not a re-render: no cell is
+  // re-created, the Wasm is not told, and the canvas does not remount.
+  useEffect(() => {
+    handleRef.current?.setPalette(palette);
+  }, [palette]);
+
+  return (
+    <div className="surface" ref={boxRef}>
+      <canvas
+        className="surface-canvas"
+        ref={canvasRef}
+        tabIndex={0}
+        onMouseDown={(event) => {
+          event.currentTarget.focus();
+        }}
+      />
+    </div>
+  );
+});

--- a/web/client/src/app/__fixtures__/harness.ts
+++ b/web/client/src/app/__fixtures__/harness.ts
@@ -1,0 +1,377 @@
+/**
+ * A whole client with no browser in it.
+ *
+ * The surface takes its channel, its renderer, its clock and its frame
+ * scheduler as options precisely so this file can exist: every test below
+ * drives a real `SurfaceHandle`, a real protocol codec and the real vt binding
+ * (over the fake ghostty exports), and the only things faked are the four
+ * seams the design already draws.
+ */
+
+import { FrameReader, KIND, type Frame } from "../../protocol/frame";
+import type { Channel, ChannelOptions } from "../../protocol/socket";
+import {
+  concat,
+  encodeJsonFrame,
+  encodeSnapshotVtPayload,
+} from "../../protocol/testTranscript";
+import { encodeFrame } from "../../protocol/frame";
+import type {
+  CellMetrics,
+  FontSpec,
+  Geometry,
+  Palette,
+  RendererStats,
+  RenderFrame,
+  RowView,
+  TerminalRenderer,
+} from "../../renderer/types";
+import { createFakeGhostty, type FakeGhostty } from "../../vt/__fixtures__/fakeGhostty";
+import { bindingFromExports, type VtBinding, type VtTerminal } from "../../vt";
+import { createSurface, type SurfaceHandle, type SurfaceOptions } from "../surface";
+import { buildPalette } from "../theme";
+
+export class FakeChannel implements Channel {
+  readonly options: ChannelOptions;
+  readonly outgoing: Frame[] = [];
+  readonly rawOutgoing: Uint8Array[] = [];
+  closed = false;
+  private readonly reader = new FrameReader((frame) => this.outgoing.push(frame));
+
+  constructor(options: ChannelOptions) {
+    this.options = options;
+  }
+
+  send(frame: Uint8Array): void {
+    this.rawOutgoing.push(frame);
+    this.reader.push(frame);
+  }
+  sendControl(msg: Parameters<Channel["sendControl"]>[0]): void {
+    this.send(encodeJsonFrame(KIND.CONTROL, msg));
+  }
+  sendData(bytes: Uint8Array): void {
+    this.send(encodeFrame(KIND.DATA, bytes));
+  }
+  sendResize(rows: number, cols: number): void {
+    const payload = new Uint8Array(4);
+    new DataView(payload.buffer).setUint16(0, rows);
+    new DataView(payload.buffer).setUint16(2, cols);
+    this.send(encodeFrame(KIND.RESIZE, payload));
+  }
+  get readyState(): number {
+    return this.closed ? 3 : 1;
+  }
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Host → client, through a real FrameReader so chunking is exercised. */
+  deliver(...chunks: Uint8Array[]): void {
+    deliverThrough(this.options, concat(chunks));
+  }
+
+  /**
+   * The client's own Control frames, read off the raw bytes.
+   *
+   * `FrameReader` decodes the host's half of the vocabulary — `hello_ok`,
+   * `sessions`, `attached` — so a client `hello` comes back through it as
+   * `{op:"unknown"}`. The wire is JSON either way, and the test wants to assert
+   * what actually went out.
+   */
+  control(index: number): Record<string, unknown> {
+    const controls = this.rawOutgoing.filter((frame) => frame[0] === KIND.CONTROL);
+    const frame = controls[index];
+    if (!frame) throw new Error(`no outgoing Control frame ${index}`);
+    return JSON.parse(new TextDecoder().decode(frame.subarray(5))) as Record<string, unknown>;
+  }
+
+  kinds(): number[] {
+    return this.outgoing.map((frame) => frame.kind);
+  }
+
+  data(): Uint8Array[] {
+    return this.outgoing
+      .filter((frame): frame is Extract<Frame, { kind: typeof KIND.DATA }> => frame.kind === KIND.DATA)
+      .map((frame) => frame.data);
+  }
+}
+
+function deliverThrough(options: ChannelOptions, bytes: Uint8Array): void {
+  const reader = new FrameReader(options.onFrame);
+  reader.push(bytes);
+  if (reader.pending !== 0) {
+    throw new Error(`test delivered ${reader.pending} trailing bytes`);
+  }
+}
+
+export interface DrawCall {
+  dirty: RenderFrame["dirty"];
+  scrollOffsetRows: number;
+  cursorVisible: boolean;
+  /** Text of every row, viewport then history, so a test can assert pixels-ish. */
+  viewport: string[];
+  history: string[];
+}
+
+export class RecordingRenderer implements TerminalRenderer {
+  readonly draws: DrawCall[] = [];
+  readonly palettes: Palette[] = [];
+  geometry: Geometry | null = null;
+  disposed = 0;
+  cell: CellMetrics = { widthPx: 8, heightPx: 16, baselinePx: 12 };
+
+  measure(_font: FontSpec): CellMetrics {
+    return this.cell;
+  }
+  setGeometry(geometry: Geometry): void {
+    this.geometry = geometry;
+  }
+  setPalette(palette: Palette): void {
+    this.palettes.push(palette);
+  }
+  draw(frame: RenderFrame, history?: RowView[]): void {
+    this.draws.push({
+      dirty: frame.dirty,
+      scrollOffsetRows: frame.scrollOffsetRows,
+      cursorVisible: frame.cursor.visible,
+      viewport: frame.rows_.map(rowText),
+      history: (history ?? []).map(rowText),
+    });
+  }
+  dispose(): void {
+    this.disposed += 1;
+  }
+  stats(): RendererStats {
+    return {
+      implementation: "canvas2d",
+      framesPainted: this.draws.length,
+      fullRedraws: 0,
+      droppedFrames: 0,
+      frameTimeP50Ms: 0,
+      frameTimeP95Ms: 0,
+    };
+  }
+}
+
+function rowText(row: RowView): string {
+  return row.cells
+    .map((cell) =>
+      cell.grapheme ?? (cell.codepoint === 0 ? " " : String.fromCodePoint(cell.codepoint)),
+    )
+    .join("")
+    .replace(/\s+$/, "");
+}
+
+/** A canvas-shaped object with a listener table and a measurable parent. */
+export class FakeCanvas {
+  readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+  parentElement = { clientWidth: 640, clientHeight: 384 } as unknown as HTMLElement;
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+  dispatch(type: string, event: unknown): void {
+    for (const listener of [...(this.listeners.get(type) ?? [])]) listener(event);
+  }
+  listenerCount(): number {
+    let total = 0;
+    for (const set of this.listeners.values()) total += set.size;
+    return total;
+  }
+}
+
+export interface Harness {
+  surface: SurfaceHandle;
+  channel: FakeChannel;
+  canvas: FakeCanvas;
+  renderer: RecordingRenderer;
+  fake: FakeGhostty;
+  binding: VtBinding;
+  /** Every byte written into the Wasm, in order. */
+  writes: Uint8Array[];
+  terminals: VtTerminal[];
+  runFrame(): void;
+  advance(ms: number): void;
+  dispose(): void;
+}
+
+export interface HarnessOptions {
+  mode?: "observe" | "interact";
+  palette?: Palette;
+  /** A canvas-shaped object of the caller's own, for the integration test. */
+  canvas?: HTMLCanvasElement;
+  /** Build the real Canvas 2D renderer over `canvas` instead of recording. */
+  realRenderer?: boolean;
+  overrides?: Partial<SurfaceOptions>;
+}
+
+export function createHarness(options: HarnessOptions = {}): Harness {
+  const fake = createFakeGhostty();
+  const inner = bindingFromExports(fake.exports);
+  const writes: Uint8Array[] = [];
+  const terminals: VtTerminal[] = [];
+  const binding: VtBinding = {
+    ...inner,
+    createTerminal(terminalOptions) {
+      const terminal = inner.createTerminal(terminalOptions);
+      const write = terminal.write.bind(terminal);
+      terminal.write = (bytes: Uint8Array) => {
+        writes.push(bytes.slice());
+        write(bytes);
+      };
+      terminals.push(terminal);
+      return terminal;
+    },
+  };
+
+  const canvas = (options.canvas as unknown as FakeCanvas | undefined) ?? new FakeCanvas();
+  const renderer = new RecordingRenderer();
+  let channel: FakeChannel | null = null;
+  const pending: (() => void)[] = [];
+  let clock = 1_000;
+
+  const surface = createSurface({
+    canvas: canvas as unknown as HTMLCanvasElement,
+    url: new URL("wss://box.example/termio/ws"),
+    token: "test-token",
+    target: "session-1",
+    mode: options.mode ?? "observe",
+    binding,
+    palette: options.palette ?? buildPalette("dark"),
+    client: "termio-web/test",
+    open: (channelOptions) => {
+      channel = new FakeChannel(channelOptions);
+      return channel;
+    },
+    ...(options.realRenderer ? {} : { createRenderer: () => renderer }),
+    requestFrame: (callback) => pending.push(callback),
+    cancelFrame: () => {
+      pending.length = 0;
+    },
+    now: () => clock,
+    ...options.overrides,
+  });
+
+  if (!channel) throw new Error("the surface never opened a channel");
+
+  return {
+    surface,
+    channel,
+    canvas,
+    renderer,
+    fake,
+    binding,
+    writes,
+    terminals,
+    runFrame(): void {
+      const callbacks = pending.splice(0, pending.length);
+      for (const callback of callbacks) callback();
+    },
+    advance(ms: number): void {
+      clock += ms;
+    },
+    dispose(): void {
+      surface.dispose();
+      inner.dispose();
+    },
+  };
+}
+
+// ── host-side frames the tests replay ───────────────────────────────────────
+
+export function helloOk(): Uint8Array {
+  return encodeJsonFrame(KIND.CONTROL, {
+    op: "hello_ok",
+    proto: 1,
+    caps: ["events", "snapshot", "scrollback"],
+    host_id: "host-1",
+    host: "box",
+    client_id: "client-9",
+  });
+}
+
+export function attached(overrides: Record<string, unknown> = {}): Uint8Array {
+  return encodeJsonFrame(KIND.CONTROL, {
+    op: "attached",
+    id: "session-1",
+    name: "shell",
+    session_id: "session-1",
+    writer: false,
+    rows: 6,
+    cols: 20,
+    re: 1,
+    ...overrides,
+  });
+}
+
+export function snapshot(vt: string, rows = 6, cols = 20, title = ""): Uint8Array {
+  return encodeFrame(
+    KIND.SNAPSHOT,
+    encodeSnapshotVtPayload({ rows, cols, title }, new TextEncoder().encode(vt)),
+  );
+}
+
+export function ready(): Uint8Array {
+  return encodeJsonFrame(KIND.EVENT, { ev: "ready", session: "session-1" });
+}
+
+export function data(text: string): Uint8Array {
+  return encodeFrame(KIND.DATA, new TextEncoder().encode(text));
+}
+
+export function event(value: Record<string, unknown>): Uint8Array {
+  return encodeJsonFrame(KIND.EVENT, value);
+}
+
+export function control(value: Record<string, unknown>): Uint8Array {
+  return encodeJsonFrame(KIND.CONTROL, value);
+}
+
+/** The frozen attach shape: hello_ok → attached → S → ready. */
+export function completeAttach(
+  harness: { channel: FakeChannel },
+  options: { writer?: boolean; vt?: string; rows?: number; cols?: number } = {},
+): void {
+  harness.channel.deliver(helloOk());
+  harness.channel.deliver(
+    attached({
+      writer: options.writer ?? false,
+      rows: options.rows ?? 6,
+      cols: options.cols ?? 20,
+    }),
+  );
+  harness.channel.deliver(
+    snapshot(options.vt ?? "hello", options.rows ?? 6, options.cols ?? 20),
+  );
+  harness.channel.deliver(ready());
+}
+
+export function keyEvent(overrides: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+  let prevented = false;
+  return {
+    key: overrides.key,
+    code: overrides.code ?? `Key${overrides.key.toUpperCase()}`,
+    ctrlKey: overrides.ctrlKey ?? false,
+    altKey: overrides.altKey ?? false,
+    shiftKey: overrides.shiftKey ?? false,
+    metaKey: overrides.metaKey ?? false,
+    repeat: false,
+    isComposing: false,
+    location: 0,
+    getModifierState: () => false,
+    preventDefault: () => {
+      prevented = true;
+    },
+    get defaultPrevented() {
+      return prevented;
+    },
+  } as unknown as KeyboardEvent;
+}

--- a/web/client/src/app/bootstrap.test.ts
+++ b/web/client/src/app/bootstrap.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { forgetToken, sessionFromLocation, takeToken, wasmUrl } from "./bootstrap";
+
+class MemoryStorage {
+  private readonly map = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  get size(): number {
+    return this.map.size;
+  }
+}
+
+describe("token bootstrap", () => {
+  it("takes the token from the fragment, stashes it, and clears the hash", () => {
+    const storage = new MemoryStorage();
+    let cleared = false;
+    const token = takeToken(
+      { href: "https://box/termio/#t=abc123", hash: "#t=abc123", search: "" },
+      storage,
+      () => {
+        cleared = true;
+      },
+    );
+    expect(token).toBe("abc123");
+    expect(cleared).toBe(true);
+    // A reload with no fragment still finds it.
+    expect(takeToken({ href: "https://box/termio/", hash: "", search: "" }, storage)).toBe(
+      "abc123",
+    );
+  });
+
+  it("percent-decodes a base64url token that got encoded on the way in", () => {
+    const storage = new MemoryStorage();
+    expect(
+      takeToken({ href: "", hash: "#t=a%2Bb%2Fc", search: "" }, storage),
+    ).toBe("a+b/c");
+  });
+
+  it("survives a storage that refuses to store", () => {
+    const hostile = {
+      getItem(): string | null {
+        throw new Error("blocked");
+      },
+      setItem(): void {
+        throw new Error("blocked");
+      },
+      removeItem(): void {
+        throw new Error("blocked");
+      },
+    };
+    expect(takeToken({ href: "", hash: "#t=abc", search: "" }, hostile)).toBe("abc");
+    expect(takeToken({ href: "", hash: "", search: "" }, hostile)).toBeNull();
+    expect(() => forgetToken(hostile)).not.toThrow();
+  });
+
+  it("has no token without a fragment and without storage", () => {
+    expect(takeToken({ href: "https://box/termio/", hash: "", search: "" }, null)).toBeNull();
+  });
+});
+
+describe("asset and deep-link URLs", () => {
+  it("resolves the Wasm against the mount that served the page, not the bundle", () => {
+    // Under Tailscale Serve the page is at /termio/ and the bundle is one level
+    // down in assets/; resolving from the module URL would ask for
+    // /termio/assets/ghostty-vt.wasm and 404.
+    expect(wasmUrl("https://box/termio/").href).toBe("https://box/termio/ghostty-vt.wasm");
+    expect(wasmUrl("https://box/").href).toBe("https://box/ghostty-vt.wasm");
+    expect(wasmUrl("https://box/termio/index.html").href).toBe(
+      "https://box/termio/ghostty-vt.wasm",
+    );
+  });
+
+  it("reads the session deep link off the query, never off /ws", () => {
+    expect(
+      sessionFromLocation({ href: "", hash: "", search: "?session=abc-123" }),
+    ).toBe("abc-123");
+    expect(sessionFromLocation({ href: "", hash: "", search: "" })).toBeNull();
+  });
+});

--- a/web/client/src/app/bootstrap.ts
+++ b/web/client/src/app/bootstrap.ts
@@ -1,0 +1,78 @@
+/**
+ * Page bootstrap: the pairing token, the Wasm URL, and the session deep link.
+ *
+ * Everything here is a pure function of a location-shaped object so it can be
+ * tested without a browser, and so nothing in the app reads globals directly.
+ */
+
+const TOKEN_STORAGE_KEY = "termio.pair.token";
+
+export interface LocationLike {
+  href: string;
+  hash: string;
+  search: string;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/**
+ * The canonical page URL is `https://box/termio/#t=<token>`. The fragment is
+ * never sent to a server, so it is the only part of a URL a credential may ride
+ * in; it is read once, moved into sessionStorage, and cleared so a screenshot
+ * or a shared URL bar does not carry it.
+ *
+ * `clearHash` is the caller's business (it is `history.replaceState` in the
+ * browser and a no-op in a test), because this module owns no DOM.
+ */
+export function takeToken(
+  location: LocationLike,
+  storage: StorageLike | null,
+  clearHash?: () => void,
+): string | null {
+  const fromHash = /^#t=(.+)$/.exec(location.hash);
+  if (fromHash?.[1]) {
+    const token = decodeURIComponent(fromHash[1]);
+    try {
+      storage?.setItem(TOKEN_STORAGE_KEY, token);
+    } catch {
+      // Private-mode storage refusals are survivable: the token stays in
+      // memory for this page load and a reload asks for the link again.
+    }
+    clearHash?.();
+    return token;
+  }
+  try {
+    return storage?.getItem(TOKEN_STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function forgetToken(storage: StorageLike | null): void {
+  try {
+    storage?.removeItem(TOKEN_STORAGE_KEY);
+  } catch {
+    // Nothing to do; the next load will ask for a fresh link.
+  }
+}
+
+/**
+ * The Wasm sits at the web root, next to `index.html`, and the bundle sits one
+ * level down in `assets/`. Resolving it from `import.meta.url` — the shape the
+ * frozen contract sketched — would therefore ask for `assets/ghostty-vt.wasm`
+ * and 404 under both mounts. The document base is the prefix that actually
+ * served the page: `/` behind Caddy's `handle_path`, `/termio/` behind
+ * Tailscale Serve.
+ */
+export function wasmUrl(baseHref: string): URL {
+  return new URL("ghostty-vt.wasm", baseHref);
+}
+
+/** The web equivalent of `termio://session/<uuid>`: a query on this origin. */
+export function sessionFromLocation(location: LocationLike): string | null {
+  return new URLSearchParams(location.search).get("session");
+}

--- a/web/client/src/app/bridge.ts
+++ b/web/client/src/app/bridge.ts
@@ -1,0 +1,62 @@
+/**
+ * The one shape that connects an imperative object to React.
+ *
+ * A `SurfaceHandle` and a `ControlClient` are both created inside effects —
+ * they open sockets, and opening a socket during render is how StrictMode's
+ * double invoke turns into two live connections and one leak. React cannot
+ * subscribe to something that does not exist yet, so it subscribes to a bridge
+ * that outlives every attach, and the effect plugs the source into it.
+ *
+ * `getSnapshot` returns a cached object. Building a fresh one per call is the
+ * classic `useSyncExternalStore` infinite-render bug.
+ */
+
+import { useSyncExternalStore } from "react";
+
+export interface ExternalStore<S> {
+  subscribe(listener: () => void): () => void;
+  snapshot(): S;
+}
+
+export interface Bridge<T extends ExternalStore<S>, S> {
+  attach(source: T | null): void;
+  subscribe(listener: () => void): () => void;
+  getSnapshot(): S;
+  /** The live source, for the imperative calls — `setPalette`, `refresh`. */
+  current(): T | null;
+}
+
+export function createBridge<T extends ExternalStore<S>, S>(idle: S): Bridge<T, S> {
+  const listeners = new Set<() => void>();
+  let source: T | null = null;
+  let unsubscribe: (() => void) | null = null;
+  let snapshot: S = idle;
+
+  const publish = (): void => {
+    snapshot = source ? source.snapshot() : idle;
+    for (const listener of [...listeners]) listener();
+  };
+
+  return {
+    attach(next: T | null): void {
+      unsubscribe?.();
+      source = next;
+      unsubscribe = next ? next.subscribe(publish) : null;
+      publish();
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSnapshot(): S {
+      return snapshot;
+    },
+    current(): T | null {
+      return source;
+    },
+  };
+}
+
+export function useBridge<T extends ExternalStore<S>, S>(bridge: Bridge<T, S>): S {
+  return useSyncExternalStore(bridge.subscribe, bridge.getSnapshot, bridge.getSnapshot);
+}

--- a/web/client/src/app/chrome.ts
+++ b/web/client/src/app/chrome.ts
@@ -1,0 +1,120 @@
+/**
+ * Chrome colours, derived from the terminal palette rather than invented.
+ *
+ * This is a port of `Sources/termio/Theme/ChromeTheme.swift`, and the reason it
+ * exists is the reason that file exists: termio keeps **one** source of colour
+ * truth. The Mac chrome does not own a palette — it derives the sidebar, the
+ * toolbar, and its text from the terminal theme the user picked, so the seam
+ * between chrome and terminal never shows and the two cannot drift apart.
+ *
+ * The first cut of this client did the opposite: a second palette of hardcoded
+ * greys (`#141414`, `#1b1b1b`, `#2a2a2a`) sitting next to a canvas painted from
+ * `buildPalette()`. Two palettes, one screen — so the chrome clashed with the
+ * terminal at every theme, and a future theme would have had to be defined
+ * twice. That is the same class of mistake as resolving colour host-side: a
+ * value invented where it should have been derived.
+ *
+ * The numbers below are lifted from ChromeTheme.swift deliberately, comments
+ * and all, so a reader can diff the two and see they agree.
+ */
+
+import type { Palette, Rgb } from "../renderer/types";
+
+const clamp = (value: number) => Math.max(0, Math.min(255, Math.round(value)));
+
+const css = (color: Rgb) => `rgb(${color.r} ${color.g} ${color.b})`;
+
+const rgba = (color: Rgb, alpha: number) =>
+  `rgb(${color.r} ${color.g} ${color.b} / ${alpha})`;
+
+/** Mix `color` toward `toward` by `amount`, the Swift `blended(with:amount:)`. */
+function blend(color: Rgb, toward: Rgb, amount: number): Rgb {
+  return {
+    r: clamp(color.r + (toward.r - color.r) * amount),
+    g: clamp(color.g + (toward.g - color.g) * amount),
+    b: clamp(color.b + (toward.b - color.b) * amount),
+  };
+}
+
+/** WCAG relative luminance — used only to pick between two candidate accents. */
+function luminance({ r, g, b }: Rgb): number {
+  const channel = (value: number) => {
+    const v = value / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (high + 0.05) / (low + 0.05);
+}
+
+const WHITE: Rgb = { r: 255, g: 255, b: 255 };
+const BLACK: Rgb = { r: 0, g: 0, b: 0 };
+
+/**
+ * A theme reads as dark when its background is darker than its foreground.
+ * Cheaper and more honest than a luminance threshold, which mislabels the
+ * mid-grey themes.
+ */
+export function isDarkPalette(palette: Palette): boolean {
+  return luminance(palette.background) < luminance(palette.foreground);
+}
+
+/**
+ * The CSS custom properties the stylesheet consumes. Every one is a function of
+ * the palette; none is a literal.
+ */
+export function chromeTokens(palette: Palette): Record<string, string> {
+  const dark = isDarkPalette(palette);
+  const { background, foreground } = palette;
+
+  // Lift the sidebar a touch off the terminal background — lighter in a dark
+  // theme, darker in a light one, like VSCode's activity bar.
+  const panel = blend(background, dark ? WHITE : BLACK, dark ? 0.06 : 0.04);
+  // A second, smaller step for anything that sits on the panel (buttons).
+  const raised = blend(panel, dark ? WHITE : BLACK, dark ? 0.05 : 0.035);
+
+  // One alpha for both brightnesses is too thin over a light panel, so only the
+  // light side is lifted — muted chrome text needs 3.0 contrast and the dark
+  // themes already clear it at 0.6.
+  const secondaryAlpha = dark ? 0.6 : 0.75;
+
+  // The active row reads as accent-tinted, and a theme whose ANSI blue is too
+  // deep to survive its own background must use its bright blue instead: take
+  // whichever of palette 4 and 12 contrasts the background more.
+  const accent =
+    contrast(palette.ansi[12], background) > contrast(palette.ansi[4], background)
+      ? palette.ansi[12]
+      : palette.ansi[4];
+
+  return {
+    "--bg": css(background),
+    "--panel": css(panel),
+    "--raised": css(raised),
+    // Hairlines are ink at low alpha, never a fixed grey: a fixed line goes
+    // invisible on a dark theme and turns into a black bar on a light one.
+    "--line": rgba(dark ? WHITE : BLACK, dark ? 0.09 : 0.08),
+    "--line-strong": rgba(dark ? WHITE : BLACK, dark ? 0.16 : 0.14),
+    "--text": css(foreground),
+    "--muted": rgba(foreground, secondaryAlpha),
+    "--faint": rgba(foreground, dark ? 0.38 : 0.5),
+    "--accent": css(accent),
+    "--accent-soft": rgba(accent, dark ? 0.18 : 0.14),
+    // Hover and selection are ink over the panel, so they hold at any theme.
+    "--hover": rgba(dark ? WHITE : BLACK, dark ? 0.06 : 0.045),
+    // Translucent chrome. The terminal scrolls under the toolbar rather than
+    // being walled off by it, which is what makes the app read as one surface.
+    "--material": rgba(panel, dark ? 0.72 : 0.68),
+    "--shadow": dark ? "0 1px 3px rgb(0 0 0 / 0.5)" : "0 1px 3px rgb(0 0 0 / 0.12)",
+    "--scheme": dark ? "dark" : "light",
+    // Status dots come from the terminal palette too, so a theme's green is the
+    // green you see in the sidebar.
+    "--status-working": css(accent),
+    "--status-needs-you": css(palette.ansi[3]),
+    "--status-done": css(palette.ansi[2]),
+    "--status-failed": css(palette.ansi[1]),
+    "--status-dead": rgba(foreground, 0.25),
+  };
+}

--- a/web/client/src/app/control.test.ts
+++ b/web/client/src/app/control.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionInfo } from "../protocol/control";
+import { KIND } from "../protocol/frame";
+import { createControlClient, sessionLabel, type ControlClient } from "./control";
+import { FakeChannel, control, event, helloOk } from "./__fixtures__/harness";
+
+function session(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: "s1",
+    name: "shell",
+    cwd: "/home/me",
+    command: "zsh",
+    pid: 1,
+    rows: 24,
+    cols: 80,
+    clients: 0,
+    created_unix: 100,
+    alive: true,
+    status: "idle",
+    ...overrides,
+  };
+}
+
+function harness(): { client: ControlClient; channel: FakeChannel } {
+  let channel: FakeChannel | null = null;
+  const client = createControlClient({
+    url: new URL("wss://box.example/termio/ws"),
+    token: "t",
+    client: "termio-web/test",
+    open: (options) => {
+      channel = new FakeChannel(options);
+      return channel;
+    },
+  });
+  if (!channel) throw new Error("no channel");
+  return { client, channel };
+}
+
+describe("control channel", () => {
+  it("says hello as a control role and then subscribes rather than polling", () => {
+    const { client, channel } = harness();
+    expect(channel.control(0)).toMatchObject({
+      op: "hello",
+      role: "control",
+      caps: ["events"],
+    });
+
+    channel.deliver(helloOk());
+    expect(channel.control(1)).toMatchObject({ op: "list" });
+    expect(channel.control(2)).toMatchObject({
+      op: "subscribe",
+      events: ["roster", "status"],
+    });
+    // Three frames, and no timer anywhere: the roster is event-driven.
+    expect(channel.outgoing).toHaveLength(3);
+    client.dispose();
+  });
+
+  it("orders sessions newest first and applies roster deltas", () => {
+    const { client, channel } = harness();
+    const notified: number[] = [];
+    client.subscribe(() => notified.push(client.snapshot().sessions.length));
+
+    channel.deliver(helloOk());
+    channel.deliver(
+      control({
+        op: "sessions",
+        sessions: [session({ id: "old", created_unix: 10 }), session({ id: "new", created_unix: 90 })],
+      }),
+    );
+    expect(client.snapshot().sessions.map((item) => item.id)).toEqual(["new", "old"]);
+
+    channel.deliver(
+      event({
+        ev: "roster",
+        session: "third",
+        action: "created",
+        info: session({ id: "third", created_unix: 200 }),
+      }),
+    );
+    expect(client.snapshot().sessions.map((item) => item.id)).toEqual(["third", "new", "old"]);
+
+    channel.deliver(event({ ev: "roster", session: "new", action: "removed" }));
+    expect(client.snapshot().sessions.map((item) => item.id)).toEqual(["third", "old"]);
+    expect(notified.length).toBeGreaterThan(0);
+    client.dispose();
+  });
+
+  it("tints a row from Event::Status without re-listing", () => {
+    const { client, channel } = harness();
+    channel.deliver(helloOk());
+    channel.deliver(control({ op: "sessions", sessions: [session({ id: "s1" })] }));
+    const before = channel.outgoing.length;
+
+    channel.deliver(
+      event({ ev: "status", session: "s1", status: "needs_you", title: "waiting on you" }),
+    );
+    expect(client.snapshot().sessions[0]).toMatchObject({
+      status: "needs_you",
+      title: "waiting on you",
+    });
+    expect(channel.outgoing).toHaveLength(before);
+    client.dispose();
+  });
+
+  it("keeps the snapshot identity stable when nothing changed", () => {
+    const { client, channel } = harness();
+    channel.deliver(helloOk());
+    channel.deliver(control({ op: "sessions", sessions: [session()] }));
+    const first = client.snapshot();
+    // `useSyncExternalStore` tears if getSnapshot returns a new object per call.
+    expect(client.snapshot()).toBe(first);
+
+    channel.deliver(event({ ev: "status", session: "unknown-session", status: "working" }));
+    expect(client.snapshot()).toBe(first);
+    client.dispose();
+  });
+
+  it("surfaces a handshake refusal instead of retrying forever", () => {
+    const { client, channel } = harness();
+    channel.deliver(control({ op: "hello_err", code: "incompatible", supported: [2] }));
+    expect(client.snapshot().phase).toBe("error");
+    expect(client.snapshot().error).toContain("incompatible");
+    client.dispose();
+  });
+
+  it("never sends a frame that is not a Control", () => {
+    const { client, channel } = harness();
+    channel.deliver(helloOk());
+    expect(new Set(channel.kinds())).toEqual(new Set([KIND.CONTROL]));
+    client.dispose();
+  });
+});
+
+describe("sessionLabel", () => {
+  it("prefers the title, then the name, then the command", () => {
+    expect(sessionLabel(session({ title: "claude: fixing tests" }))).toBe("claude: fixing tests");
+    expect(sessionLabel(session({ title: "  " }))).toBe("shell");
+    expect(sessionLabel(session({ name: "", command: "htop" }))).toBe("htop");
+  });
+});

--- a/web/client/src/app/control.ts
+++ b/web/client/src/app/control.ts
@@ -1,0 +1,219 @@
+/**
+ * The control channel: one WebSocket that lists sessions and then lives on
+ * `subscribe`, so the page never polls `list` as its live path.
+ *
+ * The store shape is the `useSyncExternalStore` contract — a listener set and a
+ * snapshot that is replaced, never mutated — because React must be able to tell
+ * that the roster changed without any component owning it.
+ */
+
+import type { Frame } from "../protocol/frame";
+import { KIND } from "../protocol/frame";
+import type {
+  ControlIn,
+  Event as ProtocolEvent,
+  SessionInfo,
+} from "../protocol/control";
+import { openChannel, type Channel, type ChannelOptions } from "../protocol/socket";
+
+export type ConnectionPhase = "connecting" | "ready" | "closed" | "error";
+
+export interface RosterState {
+  phase: ConnectionPhase;
+  sessions: SessionInfo[];
+  hostId: string | null;
+  host: string | null;
+  error: string | null;
+}
+
+export interface ControlClient {
+  subscribe(listener: () => void): () => void;
+  snapshot(): RosterState;
+  /** A manual re-`list`. The roster is event-driven; this is the retry button. */
+  refresh(): void;
+  dispose(): void;
+}
+
+export interface ControlOptions {
+  url: URL;
+  token: string;
+  client: string;
+  /** Injected in tests. Defaults to the real WebSocket channel. */
+  open?: (options: ChannelOptions) => Channel;
+}
+
+/** What React sees before the effect that opens the socket has run. */
+export const IDLE_ROSTER_STATE: RosterState = Object.freeze({
+  phase: "connecting",
+  sessions: [],
+  hostId: null,
+  host: null,
+  error: null,
+});
+
+export function createControlClient(options: ControlOptions): ControlClient {
+  const open = options.open ?? openChannel;
+  const listeners = new Set<() => void>();
+  let state: RosterState = IDLE_ROSTER_STATE;
+  let disposed = false;
+  let seq = 0;
+
+  const update = (patch: Partial<RosterState>): void => {
+    state = { ...state, ...patch };
+    for (const listener of [...listeners]) listener();
+  };
+
+  const replaceSession = (id: string, next: SessionInfo | null): void => {
+    const sessions = state.sessions.filter((session) => session.id !== id);
+    if (next) sessions.push(next);
+    sessions.sort(byCreated);
+    update({ sessions });
+  };
+
+  const patchSession = (id: string, patch: Partial<SessionInfo>): void => {
+    let changed = false;
+    const sessions = state.sessions.map((session) => {
+      if (session.id !== id) return session;
+      changed = true;
+      return { ...session, ...patch };
+    });
+    if (changed) update({ sessions });
+  };
+
+  // Assigned immediately below. A frame cannot arrive before `open` returns on
+  // a real WebSocket, and the null guard is what keeps that from being a
+  // load-bearing assumption.
+  let channel: Channel | null = null;
+
+  const onControl = (message: ControlIn): void => {
+    switch (message.op) {
+      case "hello_ok":
+        update({ phase: "ready", hostId: message.host_id, host: message.host, error: null });
+        seq += 1;
+        channel?.sendControl({ op: "list", seq });
+        seq += 1;
+        channel?.sendControl({ op: "subscribe", events: ["roster", "status"], seq });
+        return;
+      case "hello_err":
+        update({
+          phase: "error",
+          error: `host refused the handshake (${message.code}); it speaks protocol ${message.supported.join(", ")}`,
+        });
+        return;
+      case "sessions":
+        update({ sessions: [...message.sessions].sort(byCreated) });
+        return;
+      case "error":
+        update({ error: `${message.code}: ${message.message}` });
+        return;
+      case "exited":
+        patchSession(message.id, { alive: false, status: "done" });
+        return;
+      default:
+        return;
+    }
+  };
+
+  const onEvent = (event: ProtocolEvent): void => {
+    switch (event.ev) {
+      case "roster":
+        if (event.action === "removed") {
+          replaceSession(event.session, null);
+        } else if (event.info) {
+          replaceSession(event.session, event.info);
+        }
+        return;
+      case "status":
+        patchSession(event.session, {
+          status: event.status,
+          ...(event.title === undefined ? {} : { title: event.title }),
+        });
+        return;
+      case "session_exited":
+        patchSession(event.session, { alive: false });
+        return;
+      case "writer_changed":
+        patchSession(event.session, { writer_client_id: event.writer ?? null });
+        return;
+      case "resized":
+        patchSession(event.session, { rows: event.rows, cols: event.cols });
+        return;
+      default:
+        return;
+    }
+  };
+
+  channel = open({
+    url: options.url,
+    token: options.token,
+    onFrame(frame: Frame): void {
+      if (disposed) return;
+      if (frame.kind === KIND.CONTROL) {
+        onControl(frame.control as ControlIn);
+      } else if (frame.kind === KIND.EVENT) {
+        onEvent(frame.event);
+      }
+      // Every other kind belongs to an attach channel and is not an error here.
+    },
+    onClose(info): void {
+      if (disposed) return;
+      update({
+        phase: "closed",
+        error:
+          info.code === 1000 || info.code === 1005
+            ? state.error
+            : `connection closed (${info.code}${info.reason ? `: ${info.reason}` : ""})`,
+      });
+    },
+    onError(error): void {
+      if (disposed) return;
+      update({ phase: "error", error: error.message });
+    },
+  });
+
+  channel.sendControl({
+    op: "hello",
+    proto: 1,
+    min_proto: 1,
+    role: "control",
+    caps: ["events"],
+    client: options.client,
+  });
+
+  const live = channel;
+
+  return {
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    snapshot(): RosterState {
+      return state;
+    },
+    refresh(): void {
+      if (disposed) return;
+      seq += 1;
+      live.sendControl({ op: "list", seq });
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      listeners.clear();
+      live.close();
+    },
+  };
+}
+
+/** Newest first, which is what a person opening the page is looking for. */
+function byCreated(a: SessionInfo, b: SessionInfo): number {
+  if (a.created_unix !== b.created_unix) return b.created_unix - a.created_unix;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/** What the shell shows on a row, derived rather than stored. */
+export function sessionLabel(session: SessionInfo): string {
+  const title = session.title?.trim();
+  if (title) return title;
+  if (session.name.trim()) return session.name;
+  return session.command || session.id.slice(0, 8);
+}

--- a/web/client/src/app/integration.test.ts
+++ b/web/client/src/app/integration.test.ts
@@ -1,0 +1,177 @@
+/**
+ * The whole client, end to end, with no browser in it.
+ *
+ * Every other test in this directory replaces one layer with a fake. This one
+ * replaces none of them: real protocol codec, real vt binding (over the fake
+ * ghostty exports), real Canvas 2D renderer. The only stand-in is the 2D
+ * context, which records its draw calls instead of rasterising them — the
+ * renderer touches nothing else.
+ *
+ * What it is here to prove is the presentation boundary: one snapshot, two
+ * themes, and the palette-indexed cell that came off the wire as `38;5;1`
+ * paints a different colour in each — after load, with no reload, no remount,
+ * and nothing re-parsed.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { openChannel } from "../protocol/socket";
+import type { Channel, ChannelOptions } from "../protocol/socket";
+import type { SurfaceHandle } from "./surface";
+import { buildPalette } from "./theme";
+import { FakeCanvas, FakeChannel, completeAttach, createHarness } from "./__fixtures__/harness";
+
+interface FillText {
+  text: string;
+  fill: string;
+}
+
+class RecordingContext {
+  readonly fills: FillText[] = [];
+  readonly rects: { fill: string }[] = [];
+  fillStyle = "";
+  strokeStyle = "";
+  font = "";
+  globalAlpha = 1;
+  lineWidth = 1;
+  textBaseline = "alphabetic";
+  letterSpacing = "0px";
+
+  setTransform(): void {}
+  fillRect(): void {
+    this.rects.push({ fill: this.fillStyle });
+  }
+  strokeRect(): void {}
+  fillText(text: string): void {
+    this.fills.push({ text, fill: this.fillStyle });
+  }
+  measureText(text: string): {
+    width: number;
+    fontBoundingBoxAscent: number;
+    fontBoundingBoxDescent: number;
+  } {
+    return { width: text.length * 8, fontBoundingBoxAscent: 8, fontBoundingBoxDescent: 2 };
+  }
+  beginPath(): void {}
+  moveTo(): void {}
+  lineTo(): void {}
+  stroke(): void {}
+}
+
+class PaintingCanvas extends FakeCanvas {
+  readonly context = new RecordingContext();
+  width = 0;
+  height = 0;
+  style = { width: "", height: "" };
+  getContext(): RecordingContext {
+    return this.context;
+  }
+}
+
+function paintedText(context: RecordingContext): string {
+  return context.fills.map((fill) => fill.text).join("");
+}
+
+function fillOf(context: RecordingContext, text: string): string | undefined {
+  return context.fills.find((fill) => fill.text.includes(text))?.fill;
+}
+
+describe("one snapshot, painted for real", () => {
+  function stack(): {
+    surface: SurfaceHandle;
+    canvas: PaintingCanvas;
+    channel: FakeChannel;
+    frame: () => void;
+    dispose: () => void;
+  } {
+    // Reuse the harness's fake ghostty + channel, but let the surface build the
+    // real Canvas 2D renderer over the recording context.
+    const canvas = new PaintingCanvas();
+    const inner = createHarness({
+      canvas: canvas as unknown as HTMLCanvasElement,
+      realRenderer: true,
+    });
+    return {
+      surface: inner.surface,
+      canvas,
+      channel: inner.channel,
+      frame: inner.runFrame,
+      dispose: inner.dispose,
+    };
+  }
+
+  it("resolves a palette index against the viewer's theme, at the last step", () => {
+    const { surface, canvas, channel, frame, dispose } = stack();
+    // `38;5;1` — the tagged form the host emits with `palette: false`.
+    completeAttach({ channel }, { vt: "\u001b[38;5;1mred\u001b[m", rows: 3, cols: 8 });
+    frame();
+
+    expect(paintedText(canvas.context)).toContain("red");
+    const dark = buildPalette("dark");
+    expect(fillOf(canvas.context, "red")).toBe(cssOf(dark.ansi[1]));
+
+    // The theme switch: one imperative call, everything re-resolved.
+    const light = buildPalette("light");
+    canvas.context.fills.length = 0;
+    surface.setPalette(light);
+    frame();
+
+    expect(paintedText(canvas.context)).toContain("red");
+    expect(fillOf(canvas.context, "red")).toBe(cssOf(light.ansi[1]));
+    expect(cssOf(light.ansi[1])).not.toBe(cssOf(dark.ansi[1]));
+    dispose();
+  });
+
+  it("paints the default background from the viewer's theme, never black", () => {
+    const { canvas, channel, frame, dispose } = stack();
+    completeAttach({ channel }, { vt: "plain", rows: 3, cols: 8 });
+    frame();
+    const light = buildPalette("light");
+    expect(canvas.context.rects.some((rect) => rect.fill === cssOf(light.background))).toBe(
+      false,
+    );
+    expect(
+      canvas.context.rects.some((rect) => rect.fill === cssOf(buildPalette("dark").background)),
+    ).toBe(true);
+    dispose();
+  });
+});
+
+describe("the real socket wiring", () => {
+  it("offers termiod.v1 and the token as subprotocols, and never a query string", () => {
+    const opened: { url: string; protocols: string[] }[] = [];
+    class StubSocket {
+      binaryType = "";
+      readyState = 0;
+      constructor(url: string, protocols: string[]) {
+        opened.push({ url, protocols });
+      }
+      addEventListener(): void {}
+      send(): void {}
+      close(): void {}
+    }
+    const previous = globalThis.WebSocket;
+    (globalThis as { WebSocket: unknown }).WebSocket = StubSocket;
+    try {
+      const channel: Channel = openChannel({
+        url: new URL("wss://box.example/termio/ws"),
+        token: "s3cret",
+        onFrame: () => {},
+        onClose: () => {},
+        onError: () => {},
+      } satisfies ChannelOptions);
+      expect(opened[0]?.url).toBe("wss://box.example/termio/ws");
+      expect(opened[0]?.protocols).toEqual(["termiod.v1", "termiod.token.s3cret"]);
+      expect(opened[0]?.url).not.toContain("t=");
+      channel.close();
+    } finally {
+      (globalThis as { WebSocket: unknown }).WebSocket = previous;
+    }
+  });
+});
+
+function cssOf(color: { r: number; g: number; b: number } | undefined): string {
+  if (!color) throw new Error("palette entry missing");
+  const packed = (color.r << 16) | (color.g << 8) | color.b;
+  return `#${packed.toString(16).padStart(6, "0")}`;
+}

--- a/web/client/src/app/main.tsx
+++ b/web/client/src/app/main.tsx
@@ -1,0 +1,19 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("index.html is missing #root");
+}
+
+// StrictMode stays on in development for the reason the design gives: it
+// double-invokes effects, and a surface that leaks a socket or a Wasm terminal
+// on a mount/unmount/mount cycle leaks one per session switch in production.
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/web/client/src/app/styles.css
+++ b/web/client/src/app/styles.css
@@ -1,0 +1,380 @@
+/* The chrome only. Terminal pixels come from the canvas, and no terminal text
+   ever reaches the DOM as markup.
+
+   Every colour here is a custom property set by `chromeTokens()` from the
+   terminal palette — there are no literal colours in this file. That is the
+   rule `ChromeTheme.swift` enforces on the Mac, and the reason the chrome sits
+   flush with the terminal instead of clashing with it at every theme. */
+
+:root {
+  color-scheme: var(--scheme, dark);
+
+  /* One spacing step, so nothing is a magic number. */
+  --gap: 4px;
+
+  /* Continuous corners, matching the Mac's 5/6/7/8pt ladder. Small radii read
+     as precise; large ones read as a consumer app and fight the terminal grid. */
+  --r-sm: 5px;
+  --r-md: 7px;
+  --r-lg: 10px;
+
+  /* Critically damped, no overshoot — the default for anything that did not
+     follow a gesture. Overshoot on a menu that merely appeared feels wrong. */
+  --ease: cubic-bezier(0.32, 0.72, 0, 1);
+  --fast: 120ms;
+  --slow: 260ms;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  /* The platform font ships optical sizing and tracking tables already. */
+  font: 13px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 232px minmax(0, 1fr);
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+}
+
+/* ── Sidebar ───────────────────────────────────────────────────────────── */
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--panel);
+  /* A hairline of ink, not a grey bar. The panel step already separates the
+     columns; this only sharpens the seam. */
+  box-shadow: inset -1px 0 0 var(--line);
+}
+
+.sidebar-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap);
+  padding: 10px 12px;
+  /* No divider. The scroll edge below does the separating, and only where
+     content actually passes under the header. */
+}
+
+.brand {
+  font-size: 12px;
+  font-weight: 590;
+  /* Small text wants a touch of positive tracking; large text wants negative.
+     A single letter-spacing for everything is wrong somewhere. */
+  letter-spacing: 0.02em;
+  color: var(--muted);
+}
+
+.sessions {
+  list-style: none;
+  margin: 0;
+  padding: 2px 8px 8px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  /* Fade content into the header instead of drawing a rule under it. */
+  mask-image: linear-gradient(to bottom, transparent, #000 10px);
+}
+
+.session {
+  display: grid;
+  grid-template-columns: 7px minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  gap: 1px 9px;
+  width: 100%;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: default;
+  font: inherit;
+  transition: background var(--fast) var(--ease);
+}
+
+.session:hover {
+  background: var(--hover);
+}
+
+/* Feedback belongs on the press, not the release. */
+.session:active {
+  background: var(--line-strong);
+}
+
+.session-active,
+.session-active:hover {
+  background: var(--accent-soft);
+}
+
+.session-active .session-name {
+  color: var(--text);
+  font-weight: 590;
+}
+
+.session-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-cwd {
+  grid-column: 2;
+  min-width: 0;
+  color: var(--faint);
+  font-size: 11px;
+  letter-spacing: 0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dot {
+  grid-row: 1 / span 2;
+  align-self: center;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--status-dead);
+}
+
+.status-working {
+  background: var(--status-working);
+}
+.status-needs_you {
+  background: var(--status-needs-you);
+  /* The one thing in the app allowed to ask for attention. Slow enough not to
+     nag, and it is the only animation that loops. */
+  animation: pulse 2s var(--ease) infinite;
+}
+.status-done {
+  background: var(--status-done);
+}
+.status-failed {
+  background: var(--status-failed);
+}
+.status-dead {
+  background: var(--status-dead);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+/* ── Main ──────────────────────────────────────────────────────────────── */
+
+.main {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.toolbar {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  /* A translucent layer the terminal passes under, not an opaque strip that
+     eats a band of the window. */
+  background: var(--material);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  box-shadow: inset 0 -1px 0 var(--line);
+}
+
+.title {
+  font-weight: 590;
+  letter-spacing: -0.005em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dims {
+  color: var(--faint);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.badge {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--hover);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 510;
+  letter-spacing: 0.01em;
+}
+
+.badge-writer {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.spacer {
+  flex: 1;
+}
+
+button {
+  padding: 4px 11px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  background: var(--raised);
+  color: var(--text);
+  font: inherit;
+  font-weight: 510;
+  cursor: default;
+  transition:
+    background var(--fast) var(--ease),
+    transform var(--fast) var(--ease);
+}
+
+button:hover:not(:disabled) {
+  background: var(--hover);
+}
+
+button:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+button:disabled {
+  opacity: 0.4;
+}
+
+button.ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted);
+}
+
+.notice {
+  margin: 0;
+  padding: 7px 12px;
+  background: var(--panel);
+  box-shadow: inset 0 -1px 0 var(--line);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.notice-error {
+  color: var(--status-failed);
+}
+
+.stage {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.surface {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.surface-canvas {
+  display: block;
+  outline: none;
+}
+
+.empty,
+.gate {
+  margin: auto;
+  padding: 32px;
+  max-width: 44ch;
+  color: var(--muted);
+}
+
+.empty {
+  text-align: center;
+  text-wrap: balance;
+}
+
+code {
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--hover);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.92em;
+}
+
+/* ── Accessibility ─────────────────────────────────────────────────────── */
+
+/* Reduced motion is not "no feedback" — it is the same feedback without the
+   vestibular part. The press scale and the attention pulse go; colour stays. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  button:active:not(:disabled) {
+    transform: none;
+  }
+}
+
+/* Frost the material rather than removing the layer, so hierarchy survives. */
+@media (prefers-reduced-transparency: reduce) {
+  .toolbar {
+    background: var(--panel);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .toolbar,
+  .notice {
+    background: var(--panel);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .session-active,
+  .session-active:hover {
+    outline: 1px solid var(--accent);
+  }
+
+  .badge {
+    outline: 1px solid var(--line-strong);
+  }
+}

--- a/web/client/src/app/surface.test.ts
+++ b/web/client/src/app/surface.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from "vitest";
+
+import { KIND, encodeFrame } from "../protocol/frame";
+import { cell, encodeHistoryPayload } from "../protocol/testTranscript";
+import { buildPalette } from "./theme";
+import { createSurface } from "./surface";
+import {
+  FakeCanvas,
+  attached,
+  completeAttach,
+  createHarness,
+  data,
+  event,
+  helloOk,
+  keyEvent,
+  ready,
+  snapshot,
+} from "./__fixtures__/harness";
+
+const decoder = new TextDecoder();
+
+describe("attach sequence", () => {
+  it("sends hello first, as an attach Replica", () => {
+    const harness = createHarness();
+    const hello = harness.channel.control(0);
+    expect(harness.channel.outgoing).toHaveLength(1);
+    expect(hello).toMatchObject({
+      op: "hello",
+      proto: 1,
+      min_proto: 1,
+      role: "attach",
+      caps: ["events", "snapshot", "scrollback"],
+    });
+    // `grid_diff` is never advertised on the grounds that the client is a
+    // browser. This is the line that keeps that true.
+    expect(hello.caps).not.toContain("grid_diff");
+    harness.dispose();
+  });
+
+  it("attaches as an observer with explicit dims", () => {
+    const harness = createHarness();
+    harness.channel.deliver(helloOk());
+    expect(harness.channel.control(1)).toMatchObject({
+      op: "attach",
+      target: "session-1",
+      // The host default is `interact`; opening a page must not steal the write
+      // token, so the mode is always sent.
+      mode: "observe",
+      // 640×384 over 8×16 cells.
+      cols: 80,
+      rows: 24,
+    });
+    harness.dispose();
+  });
+
+  it("writes exactly snapshot.vt into the Wasm — no header, no prelude", () => {
+    const harness = createHarness();
+    harness.channel.deliver(helloOk(), attached(), snapshot("boot line", 6, 20, "a title"));
+    expect(harness.writes).toHaveLength(1);
+    expect(decoder.decode(harness.writes[0])).toBe("boot line");
+    harness.dispose();
+  });
+
+  it("ends the barrier on Event::Ready, not on the first D", () => {
+    const harness = createHarness();
+    harness.channel.deliver(helloOk(), attached(), snapshot("one"), data("two"));
+    harness.runFrame();
+    // Two writes reached the Wasm, but nothing painted: the barrier is still up.
+    expect(harness.writes.map((bytes) => decoder.decode(bytes))).toEqual(["one", "two"]);
+    expect(harness.renderer.draws).toHaveLength(0);
+
+    harness.channel.deliver(ready());
+    harness.runFrame();
+    expect(harness.renderer.draws).toHaveLength(1);
+    expect(harness.surface.snapshot().phase).toBe("live");
+    harness.dispose();
+  });
+
+  it("takes its dims from Attached, not from the canvas", () => {
+    const harness = createHarness();
+    completeAttach(harness, { rows: 6, cols: 20 });
+    const state = harness.surface.snapshot();
+    expect([state.rows, state.cols]).toEqual([6, 20]);
+    // The canvas is 640×384 — 80×24 cells — and the grid is letterboxed inside
+    // it rather than reparsed at the window size.
+    expect(harness.renderer.geometry).toMatchObject({ rows: 6, cols: 20 });
+    expect(harness.renderer.geometry?.padding).toEqual({ top: 144, left: 240 });
+    harness.dispose();
+  });
+
+  it("paints the snapshot's text", () => {
+    const harness = createHarness();
+    completeAttach(harness, { vt: "ready>" });
+    harness.runFrame();
+    expect(harness.renderer.draws[0]?.viewport[0]).toBe("ready>");
+    harness.dispose();
+  });
+});
+
+describe("live bytes", () => {
+  it("paints once for a burst rather than once per frame", () => {
+    const harness = createHarness();
+    completeAttach(harness);
+    harness.runFrame();
+    const before = harness.renderer.draws.length;
+
+    harness.channel.deliver(data("a"), data("b"), data("c"));
+    harness.runFrame();
+    expect(harness.renderer.draws).toHaveLength(before + 1);
+
+    // Nothing new arrived; the loop must not repaint.
+    harness.runFrame();
+    expect(harness.renderer.draws).toHaveLength(before + 1);
+    harness.dispose();
+  });
+
+  it("skips the frames a mode-2026 block is mid-way through", () => {
+    const harness = createHarness();
+    completeAttach(harness);
+    harness.runFrame();
+    const before = harness.renderer.draws.length;
+
+    harness.channel.deliver(data("\u001b[?2026h"), data("half a screen"));
+    harness.runFrame();
+    expect(harness.renderer.draws).toHaveLength(before);
+
+    harness.channel.deliver(data("\u001b[?2026l"));
+    harness.runFrame();
+    expect(harness.renderer.draws).toHaveLength(before + 1);
+    harness.dispose();
+  });
+
+  it("skips G, F and U frames instead of failing on them", () => {
+    const harness = createHarness();
+    completeAttach(harness);
+    harness.channel.deliver(
+      encodeFrame(KIND.GRID, new Uint8Array(16)),
+      encodeFrame(KIND.FILE, new Uint8Array(4)),
+      encodeFrame(KIND.UPLOAD, new Uint8Array(4)),
+    );
+    expect(harness.surface.snapshot().error).toBeNull();
+    harness.dispose();
+  });
+});
+
+describe("input", () => {
+  it("an observer sends nothing", () => {
+    const harness = createHarness();
+    completeAttach(harness, { writer: false });
+    harness.canvas.dispatch("keydown", keyEvent({ key: "a" }));
+    expect(harness.channel.data()).toHaveLength(0);
+    harness.dispose();
+  });
+
+  it("a writer sends the encoder's bytes as D", () => {
+    const harness = createHarness({ mode: "interact" });
+    completeAttach(harness, { writer: true });
+    harness.canvas.dispatch("keydown", keyEvent({ key: "a" }));
+    const sent = harness.channel.data();
+    expect(sent).toHaveLength(1);
+    expect(decoder.decode(sent[0])).toBe("a");
+    harness.dispose();
+  });
+
+  it("takes the cursor-key mode from the VT rather than guessing", () => {
+    const harness = createHarness({ mode: "interact" });
+    completeAttach(harness, { writer: true });
+    harness.canvas.dispatch("keydown", keyEvent({ key: "ArrowUp", code: "ArrowUp" }));
+    expect(decoder.decode(harness.channel.data()[0])).toBe("\u001b[A");
+
+    // The program turns DECCKM on; the next arrow key must change shape.
+    harness.channel.deliver(data("\u001b[?1h"));
+    harness.canvas.dispatch("keydown", keyEvent({ key: "ArrowUp", code: "ArrowUp" }));
+    expect(decoder.decode(harness.channel.data()[1])).toBe("\u001bOA");
+    harness.dispose();
+  });
+});
+
+describe("resize barrier", () => {
+  it("a writer sends R and paints nothing until S and ready", () => {
+    const harness = createHarness({ mode: "interact" });
+    completeAttach(harness, { writer: true, rows: 6, cols: 20 });
+    harness.runFrame();
+    const painted = harness.renderer.draws.length;
+
+    harness.canvas.parentElement = { clientWidth: 320, clientHeight: 160 } as HTMLElement;
+    harness.surface.fit();
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const resize = harness.channel.outgoing.find((frame) => frame.kind === KIND.RESIZE);
+        expect(resize).toMatchObject({ kind: KIND.RESIZE, rows: 10, cols: 40 });
+        // Quiesced: the terminal is NOT resized here, because the host decides
+        // the dims and says so in the snapshot.
+        expect(harness.terminals[0]?.cols).toBe(20);
+
+        harness.channel.deliver(data("mid-flight"));
+        harness.runFrame();
+        expect(harness.renderer.draws).toHaveLength(painted);
+
+        harness.channel.deliver(snapshot("after", 10, 40), ready());
+        harness.runFrame();
+        expect(harness.terminals[0]?.cols).toBe(40);
+        expect(harness.renderer.draws.length).toBeGreaterThan(painted);
+        expect(harness.surface.snapshot().cols).toBe(40);
+        harness.dispose();
+        resolve();
+      }, 120);
+    });
+  });
+
+  it("an observer never sends R", () => {
+    const harness = createHarness();
+    completeAttach(harness, { writer: false });
+    harness.canvas.parentElement = { clientWidth: 320, clientHeight: 160 } as HTMLElement;
+    harness.surface.fit();
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(harness.channel.kinds()).not.toContain(KIND.RESIZE);
+        harness.dispose();
+        resolve();
+      }, 120);
+    });
+  });
+
+  it("follows Event::Resized when someone else resizes the session", () => {
+    const harness = createHarness();
+    completeAttach(harness, { rows: 6, cols: 20 });
+    harness.channel.deliver(
+      event({ ev: "resized", session: "session-1", rows: 8, cols: 30 }),
+    );
+    expect(harness.terminals[0]?.cols).toBe(30);
+    expect(harness.surface.snapshot().rows).toBe(8);
+    harness.dispose();
+  });
+});
+
+describe("history", () => {
+  function historyFrame(cols: number, firstOffset: number, texts: string[]): Uint8Array {
+    const cells = texts.flatMap((text) =>
+      Array.from({ length: cols }, (_, x) =>
+        cell({ codepoint: text.codePointAt(x) ?? 0x20 }),
+      ),
+    );
+    return encodeFrame(
+      KIND.HISTORY,
+      encodeHistoryPayload(cols, firstOffset, texts.length, cells),
+    );
+  }
+
+  it("paints H rows above the viewport once scrolled, never through the Wasm", () => {
+    const harness = createHarness();
+    completeAttach(harness, { vt: "live", rows: 6, cols: 4 });
+    const wasmWrites = harness.writes.length;
+
+    harness.channel.deliver(historyFrame(4, 1, ["old1", "old2"]));
+    // `H` is cells, not VT: nothing about it reaches the Wasm.
+    expect(harness.writes).toHaveLength(wasmWrites);
+    expect(harness.surface.snapshot().historyRows).toBe(2);
+
+    harness.canvas.dispatch("wheel", wheelEvent(-120));
+    harness.runFrame();
+    const draw = harness.renderer.draws.at(-1);
+    expect(draw?.scrollOffsetRows).toBe(2);
+    expect(draw?.history).toContain("old1");
+    harness.dispose();
+  });
+
+  it("drops history and says so on Event::Resynced", () => {
+    const harness = createHarness();
+    completeAttach(harness, { rows: 6, cols: 4 });
+    harness.channel.deliver(historyFrame(4, 1, ["old1"]));
+    expect(harness.surface.snapshot().historyRows).toBe(1);
+
+    harness.channel.deliver(
+      event({ ev: "resynced", session: "session-1", reason: "backlog" }),
+    );
+    const state = harness.surface.snapshot();
+    expect(state.historyRows).toBe(0);
+    expect(state.notice).toContain("resynced");
+    harness.dispose();
+  });
+});
+
+describe("theme", () => {
+  it("re-resolves through the renderer without touching the Wasm", () => {
+    const harness = createHarness();
+    completeAttach(harness);
+    const wasmWrites = harness.writes.length;
+    const light = buildPalette("light");
+
+    harness.surface.setPalette(light);
+    expect(harness.renderer.palettes.at(-1)).toBe(light);
+    // No re-parse, no re-attach, no terminal teardown.
+    expect(harness.writes).toHaveLength(wasmWrites);
+    expect(harness.terminals).toHaveLength(1);
+    harness.dispose();
+  });
+});
+
+describe("lifecycle", () => {
+  it("dispose is idempotent and leaves nothing behind", () => {
+    const harness = createHarness();
+    completeAttach(harness);
+    harness.runFrame();
+    expect(harness.canvas.listenerCount()).toBeGreaterThan(0);
+
+    harness.surface.dispose();
+    harness.surface.dispose();
+
+    expect(harness.channel.closed).toBe(true);
+    expect(harness.canvas.listenerCount()).toBe(0);
+    expect(harness.renderer.disposed).toBe(1);
+    // Every Wasm allocation the terminal and encoder made is back.
+    expect(harness.fake.liveAllocations()).toBe(0);
+  });
+
+  it("says so plainly when the browser gives it no 2D context", () => {
+    let opened = false;
+    const surface = createSurface({
+      canvas: new FakeCanvas() as unknown as HTMLCanvasElement,
+      url: new URL("wss://box.example/termio/ws"),
+      token: "t",
+      target: "session-1",
+      mode: "observe",
+      binding: {} as never,
+      palette: buildPalette("dark"),
+      client: "termio-web/test",
+      createRenderer: () => null,
+      open: () => {
+        opened = true;
+        throw new Error("a surface with no renderer must not open a socket");
+      },
+      requestFrame: () => 0,
+      cancelFrame: () => {},
+    });
+    expect(surface.snapshot().phase).toBe("error");
+    expect(surface.snapshot().error).toContain("2D canvas context");
+    expect(opened).toBe(false);
+    // And it still tears down cleanly rather than throwing on a null renderer.
+    expect(() => surface.dispose()).not.toThrow();
+  });
+
+  it("surfaces vt_stale in the chrome", () => {
+    const harness = createHarness();
+    completeAttach(harness);
+    harness.channel.deliver(
+      event({ ev: "vt_stale", session: "session-1", reason: "ring" }),
+    );
+    expect(harness.surface.snapshot().notice).toContain("degraded");
+    harness.dispose();
+  });
+
+  it("notifies on transitions, never per byte", () => {
+    const harness = createHarness();
+    let notifications = 0;
+    harness.surface.subscribe(() => {
+      notifications += 1;
+    });
+    completeAttach(harness);
+    harness.runFrame();
+    const afterAttach = notifications;
+
+    for (let i = 0; i < 50; i += 1) harness.channel.deliver(data("x"));
+    harness.runFrame();
+    expect(notifications).toBe(afterAttach);
+    harness.dispose();
+  });
+});
+
+function wheelEvent(deltaY: number): WheelEvent {
+  return {
+    deltaY,
+    deltaMode: 0,
+    preventDefault: () => {},
+  } as unknown as WheelEvent;
+}

--- a/web/client/src/app/surface.ts
+++ b/web/client/src/app/surface.ts
@@ -1,0 +1,722 @@
+/**
+ * `SurfaceHandle` — everything that moves at PTY rate.
+ *
+ * It owns the attach WebSocket, the Wasm terminal, the renderer, the key
+ * encoder, the history buffer and the rAF loop. React holds a ref to one of
+ * these and nothing else: no cell, no dirty flag, no cursor position and no
+ * byte counter is ever React state. What React is allowed to see is
+ * `snapshot()`, which changes on transitions (writer, title, dims, an error)
+ * and never per frame.
+ *
+ * The module imports no React and touches no DOM beyond the canvas it was
+ * handed and the key events landing on it.
+ */
+
+import type { AttachMode, ControlIn, Event as ProtocolEvent } from "../protocol/control";
+import type { Frame } from "../protocol/frame";
+import { KIND } from "../protocol/frame";
+import type { HistoryChunk, Snapshot } from "../protocol/payloads";
+import { openChannel, type Channel, type ChannelOptions } from "../protocol/socket";
+import type {
+  FontSpec,
+  Palette,
+  RendererFactory,
+  RendererStats,
+  RowView,
+  TerminalRenderer,
+} from "../renderer/types";
+import { createCanvas2dRenderer } from "../renderer/canvas2d";
+import type { KeyEncoder, VtBinding, VtTerminal } from "../vt";
+
+/** Matching the host's `SCROLLBACK_STAGE_MAX_BYTES`. Bytes, never lines. */
+export const SCROLLBACK_BYTES = 1024 * 1024;
+
+/**
+ * A hard cap on retained history rows. The host stages at most 1 MiB of `H`,
+ * so at 80 columns this is already more rows than it will ever send; it exists
+ * so a 1-column session cannot turn that budget into a million objects.
+ */
+const MAX_HISTORY_ROWS = 4096;
+
+const DEFAULT_FONT: FontSpec = {
+  family:
+    'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
+  sizePx: 13,
+  weightNormal: 400,
+  weightBold: 700,
+  lineHeight: 1.35,
+};
+
+/** Roughly one xterm blink period. The renderer owns no timer, so this is ours. */
+const BLINK_INTERVAL_MS = 530;
+const TITLE_POLL_MS = 250;
+const FIT_DEBOUNCE_MS = 80;
+
+export interface SurfaceState {
+  phase: "connecting" | "attaching" | "live" | "closed" | "error";
+  sessionId: string | null;
+  name: string | null;
+  title: string | null;
+  mode: AttachMode;
+  writer: boolean;
+  rows: number;
+  cols: number;
+  /** `Event::Resynced` / `Event::VtStale`, surfaced in the chrome, not the console. */
+  notice: string | null;
+  error: string | null;
+  scrollOffsetRows: number;
+  historyRows: number;
+}
+
+export interface SurfaceHandle {
+  subscribe(listener: () => void): () => void;
+  snapshot(): SurfaceState;
+  /** Re-measure the container; the writer runs the resize barrier from here. */
+  fit(): void;
+  setPalette(palette: Palette): void;
+  setFont(font: FontSpec): void;
+  paste(text: string): void;
+  stats(): RendererStats | null;
+  dispose(): void;
+}
+
+export interface SurfaceOptions {
+  canvas: HTMLCanvasElement;
+  /** The box the grid is measured against. Defaults to the canvas' parent. */
+  container?: HTMLElement | null;
+  url: URL;
+  token: string;
+  /** Session id or name — `Control::Attach.target`. */
+  target: string;
+  mode: AttachMode;
+  binding: VtBinding;
+  palette: Palette;
+  client: string;
+  font?: FontSpec;
+  createRenderer?: RendererFactory;
+  /** Injected in tests, all of them. Nothing here reads a global. */
+  open?: (options: ChannelOptions) => Channel;
+  requestFrame?: (callback: () => void) => number;
+  cancelFrame?: (handle: number) => void;
+  now?: () => number;
+}
+
+/** What React sees before the effect that opens the attach has run. */
+export const IDLE_SURFACE_STATE: SurfaceState = Object.freeze({
+  phase: "connecting",
+  sessionId: null,
+  name: null,
+  title: null,
+  mode: "observe",
+  writer: false,
+  rows: 24,
+  cols: 80,
+  notice: null,
+  error: null,
+  scrollOffsetRows: 0,
+  historyRows: 0,
+});
+
+export function createSurface(options: SurfaceOptions): SurfaceHandle {
+  return new Surface(options);
+}
+
+class Surface implements SurfaceHandle {
+  private readonly options: SurfaceOptions;
+  private readonly canvas: HTMLCanvasElement;
+  private readonly listeners = new Set<() => void>();
+  private readonly requestFrame: (callback: () => void) => number;
+  private readonly cancelFrame: (handle: number) => void;
+  private readonly now: () => number;
+
+  private renderer: TerminalRenderer | null = null;
+  private rendererStats: (() => RendererStats) | null = null;
+  private channel: Channel | null = null;
+  private terminal: VtTerminal | null = null;
+  private encoder: KeyEncoder | null = null;
+
+  private font: FontSpec;
+  private palette: Palette;
+  private frameHandle: number | null = null;
+  private fitTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  /**
+   * The resize barrier. Set on attach and whenever this client sends `R`;
+   * cleared by `Event::Ready`. While it is set the loop paints nothing, which
+   * is what "quiesce" means here — the socket keeps draining and bytes keep
+   * reaching the Wasm, because a snapshot supersedes whatever they drew.
+   */
+  private barrier = true;
+  private needsPaint = false;
+  private seq = 0;
+
+  private blinkOn = true;
+  private lastBlinkAt = 0;
+  private lastTitleCheck = 0;
+
+  /** Index 0 is the row immediately above the viewport. */
+  private history: (RowView | undefined)[] = [];
+  private scrollOffset = 0;
+
+  private state: SurfaceState;
+
+  constructor(options: SurfaceOptions) {
+    this.options = options;
+    this.canvas = options.canvas;
+    this.font = options.font ?? DEFAULT_FONT;
+    this.palette = options.palette;
+    this.requestFrame =
+      options.requestFrame ?? ((callback) => requestAnimationFrame(callback));
+    this.cancelFrame = options.cancelFrame ?? ((handle) => cancelAnimationFrame(handle));
+    this.now = options.now ?? (() => Date.now());
+
+    this.state = {
+      phase: "connecting",
+      sessionId: null,
+      name: null,
+      title: null,
+      mode: options.mode,
+      writer: false,
+      rows: 24,
+      cols: 80,
+      notice: null,
+      error: null,
+      scrollOffsetRows: 0,
+      historyRows: 0,
+    };
+
+    const factory = options.createRenderer ?? createCanvas2dRenderer;
+    const renderer = factory(this.canvas, this.font);
+    if (!renderer) {
+      this.patch({
+        phase: "error",
+        error: "This browser gave us no 2D canvas context, so there is nothing to paint on.",
+      });
+      return;
+    }
+    this.renderer = renderer;
+    this.rendererStats = () => renderer.stats();
+    renderer.setPalette(this.palette);
+
+    const measured = this.measureGrid();
+    this.state = { ...this.state, rows: measured.rows, cols: measured.cols };
+
+    this.canvas.addEventListener("keydown", this.onKeyDown);
+    this.canvas.addEventListener("keyup", this.onKeyUp);
+    this.canvas.addEventListener("paste", this.onPaste as EventListener);
+    this.canvas.addEventListener("wheel", this.onWheel, { passive: false });
+
+    const open = options.open ?? openChannel;
+    this.channel = open({
+      url: options.url,
+      token: options.token,
+      onFrame: this.onFrame,
+      onClose: (info) => {
+        if (this.disposed) return;
+        this.patch({
+          phase: "closed",
+          error:
+            info.code === 1000 || info.code === 1005
+              ? this.state.error
+              : `attach closed (${info.code}${info.reason ? `: ${info.reason}` : ""})`,
+        });
+      },
+      onError: (error) => {
+        if (this.disposed) return;
+        this.patch({ phase: "error", error: error.message });
+      },
+    });
+
+    this.channel.sendControl({
+      op: "hello",
+      proto: 1,
+      min_proto: 1,
+      role: "attach",
+      // `grid_diff` is deliberately absent: a Replica asks for snapshots and
+      // scrollback, and never for a host-side grid on the grounds that it is a
+      // browser.
+      caps: ["events", "snapshot", "scrollback"],
+      client: options.client,
+    });
+
+    this.frameHandle = this.requestFrame(this.tick);
+  }
+
+  // ── the frame loop ────────────────────────────────────────────────────────
+
+  private readonly tick = (): void => {
+    if (this.disposed) return;
+    this.frameHandle = this.requestFrame(this.tick);
+
+    const terminal = this.terminal;
+    const renderer = this.renderer;
+    if (!terminal || !renderer || this.barrier) return;
+
+    const now = this.now();
+    if (now - this.lastBlinkAt >= BLINK_INTERVAL_MS) {
+      this.lastBlinkAt = now;
+      this.blinkOn = !this.blinkOn;
+      // Only a blinking cursor needs the repaint, and only the loop knows the
+      // phase; the seam hands the renderer no timer on purpose.
+      this.needsPaint = true;
+    }
+
+    if (!this.needsPaint) return;
+    // Mode 2026: inside a synchronized-output block the program is mid-update.
+    // `needsPaint` stays set, so the frame lands on the tick after it clears.
+    if (terminal.syncOutputActive()) return;
+
+    this.needsPaint = false;
+    const scroll = this.scrollOffset;
+    const history = this.visibleHistory(scroll, this.state.rows);
+    terminal.readFrame((frame) => {
+      frame.scrollOffsetRows = scroll;
+      if (frame.cursor.blinking && !this.blinkOn) frame.cursor.visible = false;
+      renderer.draw(frame, history);
+    });
+  };
+
+  // ── protocol ──────────────────────────────────────────────────────────────
+
+  private readonly onFrame = (frame: Frame): void => {
+    if (this.disposed) return;
+    switch (frame.kind) {
+      case KIND.CONTROL:
+        this.onControl(frame.control as ControlIn);
+        return;
+      case KIND.EVENT:
+        this.onEvent(frame.event);
+        return;
+      case KIND.SNAPSHOT:
+        this.onSnapshot(frame.snapshot);
+        return;
+      case KIND.DATA:
+        this.onData(frame.data);
+        return;
+      case KIND.HISTORY:
+        this.onHistory(frame.history);
+        return;
+      default:
+        // `G` / `F` / `U`: never negotiated by this client. A frame we did not
+        // ask for is skipped, not an error.
+        return;
+    }
+  };
+
+  private onControl(message: ControlIn): void {
+    switch (message.op) {
+      case "hello_ok": {
+        this.seq += 1;
+        this.patch({ phase: "attaching" });
+        this.channel?.sendControl({
+          op: "attach",
+          target: this.options.target,
+          rows: this.state.rows,
+          cols: this.state.cols,
+          // Always explicit. The host's own default is `interact`, and opening
+          // a page must not steal the write token from a Mac.
+          mode: this.options.mode,
+          seq: this.seq,
+        });
+        return;
+      }
+      case "hello_err":
+        this.patch({
+          phase: "error",
+          error: `host refused the handshake (${message.code})`,
+        });
+        return;
+      case "attached":
+        this.onAttached(message);
+        return;
+      case "error":
+        this.patch({ error: `${message.code}: ${message.message}` });
+        return;
+      case "exited":
+        this.patch({ phase: "closed", notice: `session exited (status ${message.status})` });
+        return;
+      default:
+        return;
+    }
+  }
+
+  private onAttached(message: Extract<ControlIn, { op: "attached" }>): void {
+    const rows = message.rows;
+    const cols = message.cols;
+    // AUTHORITATIVE dims. An observer parses at these and letterboxes; parsing
+    // at the window size is a conformance bug.
+    this.ensureTerminal(rows, cols);
+    this.applyGeometry(rows, cols);
+    this.barrier = true;
+    this.patch({
+      phase: "attaching",
+      sessionId: message.session_id || message.id,
+      name: message.name,
+      writer: message.writer,
+      rows,
+      cols,
+    });
+  }
+
+  private onEvent(event: ProtocolEvent): void {
+    switch (event.ev) {
+      case "ready":
+        // This, not the first `D`, is what ends the barrier.
+        this.barrier = false;
+        this.needsPaint = true;
+        this.patch({ phase: "live" });
+        return;
+      case "resized": {
+        // Someone else resized the session. The dims are authoritative; the
+        // terminal follows them immediately rather than waiting on a snapshot
+        // that may not be addressed to us.
+        this.ensureTerminal(event.rows, event.cols);
+        this.terminal?.resize(event.rows, event.cols);
+        this.applyGeometry(event.rows, event.cols);
+        this.needsPaint = true;
+        this.patch({ rows: event.rows, cols: event.cols });
+        return;
+      }
+      case "writer_changed":
+        return;
+      case "status":
+        if (event.title !== undefined) this.patch({ title: event.title });
+        return;
+      case "resynced":
+        // The screen comes back; history does not. Saying so is the honest
+        // surface — the page must not pretend the hole is not there.
+        this.history = [];
+        this.scrollOffset = 0;
+        this.patch({
+          notice: `resynced (${event.reason}); scrollback above this point is gone`,
+          scrollOffsetRows: 0,
+          historyRows: 0,
+        });
+        return;
+      case "vt_stale":
+        this.patch({
+          notice: `snapshots are degraded (${event.reason}); the screen may be incomplete`,
+        });
+        return;
+      case "session_exited":
+        this.patch({ phase: "closed", notice: `session exited (status ${event.status})` });
+        return;
+      default:
+        return;
+    }
+  }
+
+  private onSnapshot(snapshot: Snapshot): void {
+    const terminal = this.ensureTerminal(snapshot.rows, snapshot.cols);
+    if (!terminal) return;
+    if (terminal.rows !== snapshot.rows || terminal.cols !== snapshot.cols) {
+      terminal.resize(snapshot.rows, snapshot.cols);
+      this.applyGeometry(snapshot.rows, snapshot.cols);
+    }
+    if (snapshot.vt) {
+      // EXACTLY these bytes: not the header, not the title, not the length
+      // prefix, and no client-side `ESC[2J ESC[H`. The prologue is inside.
+      terminal.write(snapshot.vt);
+      this.needsPaint = true;
+    } else {
+      // v3 packed cells. A Replica that negotiated `snapshot` is always sent
+      // v2; arriving here means the host answered a question we did not ask.
+      this.patch({
+        notice: "host sent a packed-cell snapshot; this client renders VT snapshots",
+      });
+    }
+    this.patch({ rows: snapshot.rows, cols: snapshot.cols, title: snapshot.title || null });
+  }
+
+  private onData(data: Uint8Array): void {
+    const terminal = this.terminal;
+    if (!terminal || data.length === 0) return;
+    terminal.write(data);
+    this.needsPaint = true;
+
+    const now = this.now();
+    if (now - this.lastTitleCheck >= TITLE_POLL_MS) {
+      this.lastTitleCheck = now;
+      const title = terminal.title();
+      if (title !== this.state.title) this.patch({ title });
+    }
+  }
+
+  private onHistory(chunk: HistoryChunk): void {
+    // `H` never enters the Wasm. Its rows are already the seam's shape, and the
+    // renderer paints them through the same path as live rows.
+    for (const row of chunk.rows) {
+      const distance = -row.y - 1;
+      if (distance < 0 || distance >= MAX_HISTORY_ROWS) continue;
+      this.history[distance] = row;
+    }
+    this.patch({ historyRows: this.historyDepth() });
+    if (this.scrollOffset > 0) this.needsPaint = true;
+  }
+
+  // ── geometry and the resize barrier ───────────────────────────────────────
+
+  fit(): void {
+    if (this.disposed || !this.renderer) return;
+    if (this.fitTimer !== null) clearTimeout(this.fitTimer);
+    this.fitTimer = setTimeout(() => {
+      this.fitTimer = null;
+      this.applyFit();
+    }, FIT_DEBOUNCE_MS);
+  }
+
+  private applyFit(): void {
+    if (this.disposed || !this.renderer) return;
+    const measured = this.measureGrid();
+    if (!this.state.writer || !this.channel || !this.terminal) {
+      // An observer never sends `R`. It keeps parsing at the authoritative dims
+      // and letterboxes whatever box the CSS gave it.
+      this.applyGeometry(this.state.rows, this.state.cols);
+      this.needsPaint = true;
+      return;
+    }
+    if (measured.rows === this.state.rows && measured.cols === this.state.cols) {
+      this.applyGeometry(this.state.rows, this.state.cols);
+      return;
+    }
+    // The barrier: quiesce, send `R`, wait for `S` + `ready`. The terminal is
+    // NOT resized here — the snapshot carries the dims the host settled on.
+    this.barrier = true;
+    this.channel.sendResize(measured.rows, measured.cols);
+  }
+
+  private measureGrid(): { rows: number; cols: number } {
+    const renderer = this.renderer;
+    if (!renderer) return { rows: this.state.rows, cols: this.state.cols };
+    const cell = renderer.measure(this.font);
+    const box = this.options.container ?? this.canvas.parentElement;
+    const width = box?.clientWidth ?? 0;
+    const height = box?.clientHeight ?? 0;
+    const cols = Math.max(1, Math.floor(width / cell.widthPx) || this.state.cols);
+    const rows = Math.max(1, Math.floor(height / cell.heightPx) || this.state.rows);
+    return { rows, cols };
+  }
+
+  private applyGeometry(rows: number, cols: number): void {
+    const renderer = this.renderer;
+    if (!renderer) return;
+    const cell = renderer.measure(this.font);
+    const box = this.options.container ?? this.canvas.parentElement;
+    const width = box?.clientWidth ?? cols * cell.widthPx;
+    const height = box?.clientHeight ?? rows * cell.heightPx;
+    // Letterboxing: the grid is the session's, the box is the browser's, and
+    // the difference is padding rather than a reparse at the window size.
+    const left = Math.max(0, Math.floor((width - cols * cell.widthPx) / 2));
+    const top = Math.max(0, Math.floor((height - rows * cell.heightPx) / 2));
+    renderer.setGeometry({
+      cols,
+      rows,
+      cell,
+      devicePixelRatio: typeof devicePixelRatio === "number" ? devicePixelRatio : 1,
+      padding: { top, left },
+    });
+    this.needsPaint = true;
+  }
+
+  // ── input ─────────────────────────────────────────────────────────────────
+
+  private readonly onKeyDown = (event: KeyboardEvent): void => {
+    this.sendKey(event, "down");
+  };
+
+  private readonly onKeyUp = (event: KeyboardEvent): void => {
+    this.sendKey(event, "up");
+  };
+
+  private sendKey(event: KeyboardEvent, phase: "down" | "up"): void {
+    if (this.disposed) return;
+    const terminal = this.terminal;
+    const channel = this.channel;
+    if (!terminal || !channel) return;
+    // Observers never send `D`. The host would answer `not_writer`; not sending
+    // it is the same rule stated on this side of the wire.
+    if (!this.state.writer) return;
+
+    const encoder = this.ensureEncoder();
+    if (!encoder) return;
+    // Modes come from the VT after every write batch rather than being guessed:
+    // DECCKM and the kitty flags are the terminal's state, not the app's.
+    encoder.setModes(terminal.keyEncoderModes());
+    const bytes = encoder.encode(event, phase);
+    if (bytes.length === 0) return;
+    event.preventDefault();
+    channel.sendData(bytes);
+    if (this.scrollOffset !== 0) {
+      this.scrollOffset = 0;
+      this.needsPaint = true;
+      this.patch({ scrollOffsetRows: 0 });
+    }
+  }
+
+  private readonly onPaste = (event: ClipboardEvent): void => {
+    const text = event.clipboardData?.getData("text");
+    if (!text) return;
+    event.preventDefault();
+    this.paste(text);
+  };
+
+  paste(text: string): void {
+    if (this.disposed || !this.state.writer) return;
+    const terminal = this.terminal;
+    const channel = this.channel;
+    if (!terminal || !channel) return;
+    const encoder = this.ensureEncoder();
+    if (!encoder) return;
+    encoder.setModes(terminal.keyEncoderModes());
+    const bytes = encoder.encodePaste(text);
+    if (bytes.length > 0) channel.sendData(bytes);
+  }
+
+  private readonly onWheel = (event: WheelEvent): void => {
+    const depth = this.historyDepth();
+    if (depth === 0) return;
+    // deltaMode 1 is lines, 0 is pixels. Three lines a notch is the platform
+    // convention everywhere that has one.
+    const lines = event.deltaMode === 1 ? event.deltaY : event.deltaY / 40;
+    const next = clamp(this.scrollOffset - Math.round(lines), 0, depth);
+    if (next === this.scrollOffset) return;
+    event.preventDefault();
+    this.scrollOffset = next;
+    this.needsPaint = true;
+    this.patch({ scrollOffsetRows: next });
+  };
+
+  // ── plumbing ──────────────────────────────────────────────────────────────
+
+  private ensureTerminal(rows: number, cols: number): VtTerminal | null {
+    if (this.terminal) return this.terminal;
+    if (this.disposed) return null;
+    try {
+      this.terminal = this.options.binding.createTerminal({
+        rows,
+        cols,
+        scrollbackBytes: SCROLLBACK_BYTES,
+      });
+    } catch (error) {
+      this.patch({ phase: "error", error: describe(error) });
+      return null;
+    }
+    return this.terminal;
+  }
+
+  private ensureEncoder(): KeyEncoder | null {
+    if (this.encoder) return this.encoder;
+    try {
+      this.encoder = this.options.binding.createKeyEncoder();
+    } catch (error) {
+      this.patch({ error: describe(error) });
+      return null;
+    }
+    return this.encoder;
+  }
+
+  private historyDepth(): number {
+    // Only the contiguous run above the viewport is scrollable; a hole means
+    // the chunk that fills it has not arrived yet.
+    let depth = 0;
+    while (this.history[depth] !== undefined) depth += 1;
+    return depth;
+  }
+
+  private visibleHistory(scroll: number, rows: number): RowView[] | undefined {
+    if (scroll <= 0) return undefined;
+    const visible: RowView[] = [];
+    for (let distance = 0; distance < scroll && distance < this.history.length; distance += 1) {
+      const row = this.history[distance];
+      if (!row) continue;
+      // `y + scrollOffsetRows` is the screen line; anything off the top is the
+      // renderer's to clip, but not sending it saves the map insert.
+      if (row.y + scroll >= 0 && row.y + scroll < rows) visible.push(row);
+    }
+    return visible.length > 0 ? visible : undefined;
+  }
+
+  private patch(patch: Partial<SurfaceState>): void {
+    let changed = false;
+    for (const [key, value] of Object.entries(patch)) {
+      if (this.state[key as keyof SurfaceState] !== value) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) return;
+    this.state = { ...this.state, ...patch };
+    for (const listener of [...this.listeners]) listener();
+  }
+
+  // ── public surface ────────────────────────────────────────────────────────
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  snapshot(): SurfaceState {
+    return this.state;
+  }
+
+  setPalette(palette: Palette): void {
+    this.palette = palette;
+    // One call, a full repaint, every tagged colour re-resolved. No cell is
+    // re-created and the Wasm never hears about it.
+    this.renderer?.setPalette(palette);
+    this.needsPaint = true;
+  }
+
+  setFont(font: FontSpec): void {
+    this.font = font;
+    this.renderer?.measure(font);
+    this.applyGeometry(this.state.rows, this.state.cols);
+  }
+
+  stats(): RendererStats | null {
+    return this.rendererStats?.() ?? null;
+  }
+
+  /**
+   * Idempotent and complete: StrictMode double-invokes effects, so a second
+   * call must be a no-op rather than a double free, and the first must leave
+   * behind no socket, no Wasm terminal, no listener and no scheduled frame.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.frameHandle !== null) {
+      this.cancelFrame(this.frameHandle);
+      this.frameHandle = null;
+    }
+    if (this.fitTimer !== null) {
+      clearTimeout(this.fitTimer);
+      this.fitTimer = null;
+    }
+    this.canvas.removeEventListener("keydown", this.onKeyDown);
+    this.canvas.removeEventListener("keyup", this.onKeyUp);
+    this.canvas.removeEventListener("paste", this.onPaste as EventListener);
+    this.canvas.removeEventListener("wheel", this.onWheel);
+    this.channel?.close();
+    this.channel = null;
+    this.encoder?.dispose();
+    this.encoder = null;
+    this.terminal?.dispose();
+    this.terminal = null;
+    this.renderer?.dispose();
+    this.renderer = null;
+    this.rendererStats = null;
+    this.history = [];
+    this.listeners.clear();
+  }
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return value < low ? low : value > high ? high : value;
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/web/client/src/app/surfaceStore.ts
+++ b/web/client/src/app/surfaceStore.ts
@@ -1,0 +1,32 @@
+/**
+ * The two bridges the shell holds: one for the attach surface, one for the
+ * control channel's roster. Both are the same mechanism (see `bridge.ts`).
+ *
+ * This module is the React side of the boundary; `surface.ts` and `control.ts`
+ * import nothing from here, which is what keeps them headless-testable.
+ */
+
+import { createBridge, useBridge, type Bridge } from "./bridge";
+import { IDLE_ROSTER_STATE, type ControlClient, type RosterState } from "./control";
+import { IDLE_SURFACE_STATE, type SurfaceHandle, type SurfaceState } from "./surface";
+
+export { IDLE_ROSTER_STATE, IDLE_SURFACE_STATE };
+
+export type SurfaceBridge = Bridge<SurfaceHandle, SurfaceState>;
+export type RosterBridge = Bridge<ControlClient, RosterState>;
+
+export function createSurfaceBridge(): SurfaceBridge {
+  return createBridge<SurfaceHandle, SurfaceState>(IDLE_SURFACE_STATE);
+}
+
+export function createRosterBridge(): RosterBridge {
+  return createBridge<ControlClient, RosterState>(IDLE_ROSTER_STATE);
+}
+
+export function useSurfaceState(bridge: SurfaceBridge): SurfaceState {
+  return useBridge(bridge);
+}
+
+export function useRosterState(bridge: RosterBridge): RosterState {
+  return useBridge(bridge);
+}

--- a/web/client/src/app/theme.ts
+++ b/web/client/src/app/theme.ts
@@ -1,0 +1,110 @@
+/**
+ * The viewer's theme, and the only place in the client that decides what a
+ * colour looks like.
+ *
+ * Every palette here is handed to the *renderer*, never to the Wasm. A cell
+ * that says `{tag:"palette", index:4}` is still saying that after this module
+ * runs; what changes is which four bytes the renderer paints for it. That is
+ * why a theme toggle is one `setPalette` call and not a reload.
+ */
+
+import type { Palette, Rgb } from "../renderer/types";
+
+export type ThemeName = "light" | "dark";
+
+const rgb = (r: number, g: number, b: number): Rgb => ({ r, g, b });
+
+/**
+ * Indices 0–15 are the theme's own. 16–255 are the xterm cube and grey ramp,
+ * which every terminal on earth agrees on and no theme redefines, so they are
+ * generated once and shared.
+ */
+const DARK_BASE: Rgb[] = [
+  rgb(0x1c, 0x1c, 0x1c), // black
+  rgb(0xe0, 0x5c, 0x59), // red
+  rgb(0x76, 0xc0, 0x7a), // green
+  rgb(0xd8, 0xb0, 0x5f), // yellow
+  rgb(0x64, 0x9d, 0xd8), // blue
+  rgb(0xb4, 0x82, 0xd8), // magenta
+  rgb(0x5f, 0xbd, 0xbd), // cyan
+  rgb(0xc9, 0xc9, 0xc9), // white
+  rgb(0x5c, 0x5c, 0x5c), // bright black
+  rgb(0xff, 0x78, 0x75),
+  rgb(0x92, 0xdd, 0x96),
+  rgb(0xf2, 0xcb, 0x77),
+  rgb(0x80, 0xb8, 0xf2),
+  rgb(0xcf, 0x9d, 0xf2),
+  rgb(0x7a, 0xd8, 0xd8),
+  rgb(0xf2, 0xf2, 0xf2),
+];
+
+const LIGHT_BASE: Rgb[] = [
+  rgb(0x2b, 0x2b, 0x2b),
+  rgb(0xc0, 0x3a, 0x38),
+  rgb(0x36, 0x8a, 0x3d),
+  rgb(0x9a, 0x72, 0x11),
+  rgb(0x2c, 0x66, 0xa8),
+  rgb(0x82, 0x4b, 0xa8),
+  rgb(0x2b, 0x82, 0x82),
+  rgb(0x63, 0x63, 0x63),
+  rgb(0x55, 0x55, 0x55),
+  rgb(0xd6, 0x4d, 0x4a),
+  rgb(0x45, 0xa1, 0x4c),
+  rgb(0xb3, 0x88, 0x1c),
+  rgb(0x3a, 0x7b, 0xc7),
+  rgb(0x99, 0x5f, 0xc7),
+  rgb(0x35, 0x9b, 0x9b),
+  rgb(0x1a, 0x1a, 0x1a),
+];
+
+const CUBE_STEPS = [0, 95, 135, 175, 215, 255];
+
+function extendedRamp(): Rgb[] {
+  const out: Rgb[] = [];
+  for (let r = 0; r < 6; r += 1) {
+    for (let g = 0; g < 6; g += 1) {
+      for (let b = 0; b < 6; b += 1) {
+        out.push(rgb(CUBE_STEPS[r] ?? 0, CUBE_STEPS[g] ?? 0, CUBE_STEPS[b] ?? 0));
+      }
+    }
+  }
+  for (let step = 0; step < 24; step += 1) {
+    const level = 8 + step * 10;
+    out.push(rgb(level, level, level));
+  }
+  return out;
+}
+
+const EXTENDED = extendedRamp();
+
+const THEMES: Record<ThemeName, { background: Rgb; foreground: Rgb; cursor: Rgb; base: Rgb[] }> = {
+  dark: {
+    background: rgb(0x14, 0x14, 0x14),
+    foreground: rgb(0xd8, 0xd8, 0xd8),
+    cursor: rgb(0xd8, 0xd8, 0xd8),
+    base: DARK_BASE,
+  },
+  light: {
+    background: rgb(0xfb, 0xfb, 0xfb),
+    foreground: rgb(0x1f, 0x1f, 0x1f),
+    cursor: rgb(0x1f, 0x1f, 0x1f),
+    base: LIGHT_BASE,
+  },
+};
+
+/** Exactly 256 entries. The renderer throws on a short one, and it is right to. */
+export function buildPalette(theme: ThemeName): Palette {
+  const spec = THEMES[theme];
+  return {
+    background: spec.background,
+    foreground: spec.foreground,
+    cursor: spec.cursor,
+    ansi: [...spec.base, ...EXTENDED],
+  };
+}
+
+export function preferredTheme(): ThemeName {
+  const query =
+    typeof matchMedia === "function" ? matchMedia("(prefers-color-scheme: light)") : null;
+  return query?.matches ? "light" : "dark";
+}

--- a/web/client/src/protocol/colors.ts
+++ b/web/client/src/protocol/colors.ts
@@ -1,0 +1,49 @@
+import { ProtocolError } from "./errors";
+
+/**
+ * A colour SLOT, as the program asked for it — never as anyone resolved it.
+ * One-for-one with `WireColor` in protocol.rs and with
+ * GHOSTTY_STYLE_COLOR_{NONE,PALETTE,RGB} in style.h. The only code allowed to
+ * turn one of these into pixels is a TerminalRenderer holding the viewer's
+ * Palette.
+ *
+ * Wire form is 4 bytes: tag, then value, zero-padded.
+ *   0 default (no value) · 1 palette (index in byte 1) · 2 rgb (bytes 1..3)
+ * An unknown tag decodes to `{ tag: "default" }` and never fails the frame —
+ * matching WireColor::decode, which is deliberate: the tag space grows, and a
+ * cell falling back to the viewer's default beats dropping a screen.
+ */
+export type TaggedColor =
+  | { tag: "default" }
+  | { tag: "palette"; index: number } // 0–255, UNRESOLVED
+  | { tag: "rgb"; r: number; g: number; b: number };
+
+export const COLOR_TAG_DEFAULT = 0;
+export const COLOR_TAG_PALETTE = 1;
+export const COLOR_TAG_RGB = 2;
+
+/** Frozen singleton so a screenful of untouched cells shares one object. */
+export const DEFAULT_COLOR: TaggedColor = Object.freeze({
+  tag: "default",
+} as const);
+
+export function decodeColor(bytes: Uint8Array, offset: number): TaggedColor {
+  if (offset < 0 || offset + 4 > bytes.length) {
+    throw new ProtocolError(
+      `colour at offset ${offset} runs past ${bytes.length} bytes`,
+    );
+  }
+  switch (bytes[offset]) {
+    case COLOR_TAG_PALETTE:
+      return { tag: "palette", index: bytes[offset + 1] };
+    case COLOR_TAG_RGB:
+      return {
+        tag: "rgb",
+        r: bytes[offset + 1],
+        g: bytes[offset + 2],
+        b: bytes[offset + 3],
+      };
+    default:
+      return DEFAULT_COLOR;
+  }
+}

--- a/web/client/src/protocol/control.test.ts
+++ b/web/client/src/protocol/control.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "vitest";
+import { decodeControl, decodeEvent, encodeControlPayload } from "./control";
+import type { ControlOut, SessionInfo } from "./control";
+import { ProtocolError } from "./errors";
+
+const encode = (value: unknown): Uint8Array =>
+  new TextEncoder().encode(JSON.stringify(value));
+
+const sessionRow: SessionInfo = {
+  id: "s1",
+  name: "shell",
+  cwd: "/home/me",
+  command: "zsh",
+  pid: 4242,
+  rows: 24,
+  cols: 80,
+  clients: 1,
+  created_unix: 1_760_000_000,
+  alive: true,
+  status: "working",
+};
+
+describe("encodeControlPayload", () => {
+  it("writes the ops with the field names serde expects", () => {
+    const hello: ControlOut = {
+      op: "hello",
+      proto: 1,
+      min_proto: 1,
+      role: "attach",
+      caps: ["events", "snapshot", "scrollback"],
+      client: "termio-web/0.1.0",
+    };
+    expect(JSON.parse(new TextDecoder().decode(encodeControlPayload(hello)))).toEqual(
+      {
+        op: "hello",
+        proto: 1,
+        min_proto: 1,
+        role: "attach",
+        caps: ["events", "snapshot", "scrollback"],
+        client: "termio-web/0.1.0",
+      },
+    );
+  });
+
+  it("never advertises grid_diff", () => {
+    const hello: ControlOut = {
+      op: "hello",
+      proto: 1,
+      min_proto: 1,
+      role: "attach",
+      caps: ["events", "snapshot", "scrollback"],
+      client: "termio-web/0.1.0",
+    };
+    expect(hello.caps).not.toContain("grid_diff");
+  });
+
+  it("sends attach mode explicitly, because the host default is interact", () => {
+    const attach: ControlOut = {
+      op: "attach",
+      target: "s1",
+      rows: 24,
+      cols: 80,
+      mode: "observe",
+      seq: 2,
+    };
+    const json = JSON.parse(
+      new TextDecoder().decode(encodeControlPayload(attach)),
+    ) as Record<string, unknown>;
+    expect(json["mode"]).toBe("observe");
+  });
+
+  it("omits an absent seq rather than sending null", () => {
+    const json = JSON.parse(
+      new TextDecoder().decode(encodeControlPayload({ op: "list" })),
+    ) as Record<string, unknown>;
+    expect("seq" in json).toBe(false);
+  });
+});
+
+describe("decodeControl", () => {
+  it("decodes hello_ok", () => {
+    expect(
+      decodeControl(
+        encode({
+          op: "hello_ok",
+          proto: 1,
+          caps: ["events", "snapshot"],
+          host_id: "h",
+          host: "box",
+          client_id: "c",
+        }),
+      ),
+    ).toEqual({
+      op: "hello_ok",
+      proto: 1,
+      caps: ["events", "snapshot"],
+      host_id: "h",
+      host: "box",
+      client_id: "c",
+    });
+  });
+
+  it("decodes hello_err with the supported list", () => {
+    expect(
+      decodeControl(
+        encode({ op: "hello_err", code: "incompatible", supported: [1] }),
+      ),
+    ).toEqual({ op: "hello_err", code: "incompatible", supported: [1] });
+  });
+
+  it("decodes attached and keeps rows/cols as the authoritative dims", () => {
+    const message = decodeControl(
+      encode({
+        op: "attached",
+        id: "s1",
+        name: "shell",
+        session_id: "s1",
+        writer: false,
+        rows: 40,
+        cols: 120,
+        re: 3,
+      }),
+    );
+    expect(message).toEqual({
+      op: "attached",
+      id: "s1",
+      name: "shell",
+      session_id: "s1",
+      writer: false,
+      rows: 40,
+      cols: 120,
+      re: 3,
+    });
+  });
+
+  it("falls back to the v0 id when a host omits session_id", () => {
+    const message = decodeControl(
+      encode({ op: "attached", id: "s9", name: "shell" }),
+    );
+    if (message.op !== "attached") throw new Error("expected attached");
+    expect(message.session_id).toBe("s9");
+    expect(message.writer).toBe(false);
+    expect(message.rows).toBe(24);
+    expect(message.cols).toBe(80);
+  });
+
+  it("decodes sessions, filling the host's serde defaults", () => {
+    const message = decodeControl(
+      encode({
+        op: "sessions",
+        sessions: [
+          { ...sessionRow, status: undefined, agent_id: null },
+          { ...sessionRow, id: "s2", attached_clients: 2 },
+        ],
+        re: 1,
+      }),
+    );
+    if (message.op !== "sessions") throw new Error("expected sessions");
+    expect(message.sessions.length).toBe(2);
+    expect(message.sessions[0].status).toBe("unknown");
+    expect(message.sessions[0].agent_id).toBeNull();
+    expect(message.sessions[1].attached_clients).toBe(2);
+    expect(message.re).toBe(1);
+    expect(message.tombstones).toBeUndefined();
+  });
+
+  it("keeps tombstones opaque", () => {
+    const message = decodeControl(
+      encode({
+        op: "sessions",
+        sessions: [],
+        tombstones: [{ id: "dead", reason: "exited" }],
+      }),
+    );
+    if (message.op !== "sessions") throw new Error("expected sessions");
+    expect(message.tombstones).toEqual([{ id: "dead", reason: "exited" }]);
+  });
+
+  it("decodes the typed error model", () => {
+    expect(
+      decodeControl(
+        encode({
+          op: "error",
+          re: 4,
+          code: "not_writer",
+          message: "observer cannot write",
+          retryable: false,
+        }),
+      ),
+    ).toEqual({
+      op: "error",
+      re: 4,
+      code: "not_writer",
+      message: "observer cannot write",
+      retryable: false,
+    });
+  });
+
+  it("maps an unrecognised error code to internal, matching the serde default", () => {
+    const message = decodeControl(
+      encode({ op: "error", code: "teapot", message: "?", retryable: true }),
+    );
+    if (message.op !== "error") throw new Error("expected error");
+    expect(message.code).toBe("internal");
+  });
+
+  it("decodes ok and exited", () => {
+    expect(decodeControl(encode({ op: "ok", re: 2 }))).toEqual({
+      op: "ok",
+      re: 2,
+    });
+    expect(decodeControl(encode({ op: "exited", id: "s1", status: 0 }))).toEqual(
+      { op: "exited", id: "s1", status: 0 },
+    );
+  });
+
+  it("decodes an unknown op to unknown rather than throwing", () => {
+    expect(decodeControl(encode({ op: "resize_claim", session: "s1" }))).toEqual(
+      { op: "unknown" },
+    );
+    expect(decodeControl(encode({ op: "hello", proto: 1 }))).toEqual({
+      op: "unknown",
+    });
+    expect(decodeControl(encode(["not", "an", "object"]))).toEqual({
+      op: "unknown",
+    });
+  });
+
+  it("throws on a payload that is not JSON", () => {
+    expect(() => decodeControl(new TextEncoder().encode("{"))).toThrow(
+      ProtocolError,
+    );
+  });
+
+  it("throws on a payload that is not UTF-8", () => {
+    expect(() => decodeControl(new Uint8Array([0xff, 0xfe]))).toThrow(
+      ProtocolError,
+    );
+  });
+});
+
+describe("decodeEvent", () => {
+  it("decodes the attach-path events", () => {
+    expect(decodeEvent(encode({ ev: "ready", session: "s1" }))).toEqual({
+      ev: "ready",
+      session: "s1",
+    });
+    expect(
+      decodeEvent(encode({ ev: "resized", session: "s1", rows: 30, cols: 100 })),
+    ).toEqual({ ev: "resized", session: "s1", rows: 30, cols: 100 });
+    expect(
+      decodeEvent(encode({ ev: "resynced", session: "s1", reason: "backlog" })),
+    ).toEqual({ ev: "resynced", session: "s1", reason: "backlog" });
+    expect(
+      decodeEvent(encode({ ev: "vt_stale", session: "s1", reason: "ring" })),
+    ).toEqual({ ev: "vt_stale", session: "s1", reason: "ring" });
+    expect(
+      decodeEvent(encode({ ev: "session_exited", session: "s1", status: 130 })),
+    ).toEqual({ ev: "session_exited", session: "s1", status: 130 });
+  });
+
+  it("decodes status with and without a title", () => {
+    expect(
+      decodeEvent(
+        encode({ ev: "status", session: "s1", status: "needs_you", title: "?" }),
+      ),
+    ).toEqual({ ev: "status", session: "s1", status: "needs_you", title: "?" });
+    const bare = decodeEvent(
+      encode({ ev: "status", session: "s1", status: "idle" }),
+    );
+    expect(bare).toEqual({ ev: "status", session: "s1", status: "idle" });
+    expect("title" in bare).toBe(false);
+  });
+
+  it("decodes writer_changed with a null writer", () => {
+    expect(
+      decodeEvent(encode({ ev: "writer_changed", session: "s1", writer: null })),
+    ).toEqual({ ev: "writer_changed", session: "s1", writer: null });
+  });
+
+  it("decodes a roster delta and its session info", () => {
+    const event = decodeEvent(
+      encode({
+        ev: "roster",
+        session: "s1",
+        action: "added",
+        info: sessionRow,
+      }),
+    );
+    if (event.ev !== "roster") throw new Error("expected roster");
+    expect(event.action).toBe("added");
+    expect(event.info?.command).toBe("zsh");
+  });
+
+  it("drops an unknown event", () => {
+    expect(decodeEvent(encode({ ev: "fs_changed", resource: "fs:/x" }))).toEqual(
+      { ev: "unknown" },
+    );
+  });
+});

--- a/web/client/src/protocol/control.ts
+++ b/web/client/src/protocol/control.ts
@@ -1,0 +1,352 @@
+/**
+ * Control (`C`) and Event (`E`) payloads: JSON, tagged the way serde tags them
+ * in `termiod/src/protocol.rs`. Control is `{"op": <snake_case>}` and Event is
+ * `{"ev": <snake_case>}`; field names are the Rust field names verbatim, so
+ * `JSON.parse` output *is* the type with no rename layer in between.
+ */
+import { ProtocolError } from "./errors";
+
+export type ChannelRole = "control" | "attach";
+export type AttachMode = "interact" | "observe";
+
+export type ErrorCode =
+  | "incompatible"
+  | "proto_error"
+  | "no_such_session"
+  | "not_writer"
+  | "already_exited"
+  | "create_failed"
+  | "denied"
+  | "busy"
+  | "internal";
+
+/** `termiod list`'s row. Optional fields are `#[serde(default)]` host-side. */
+export interface SessionInfo {
+  id: string;
+  name: string;
+  cwd: string;
+  command: string;
+  pid: number;
+  rows: number;
+  cols: number;
+  clients: number;
+  created_unix: number;
+  alive: boolean;
+  status: string; // working | idle | needs_you | done | failed | unknown
+  agent_id?: string | null;
+  title?: string | null;
+  attached_clients?: number;
+  writer_client_id?: string | null;
+}
+
+/** Opaque to the web client: it lists tombstones, it does not read them. */
+export interface Tombstone {
+  [key: string]: unknown;
+}
+
+/** ─── Client → host. These are the ONLY ops the web client may send. ─── */
+export type ControlOut =
+  | {
+      op: "hello";
+      proto: 1;
+      min_proto: 1;
+      role: ChannelRole;
+      /** control channel: ["events"] · attach channel: ["events","snapshot","scrollback"].
+       *  `grid_diff` is never advertised on the grounds that the client is a browser. */
+      caps: string[];
+      client: string; // "termio-web/<version>"
+    }
+  | { op: "list"; seq?: number }
+  | { op: "subscribe"; events: string[]; seq?: number } // ["roster","status"]
+  | {
+      op: "attach";
+      target: string; // session id or name
+      rows: number;
+      cols: number;
+      mode: AttachMode; // ALWAYS sent explicitly; the host default is "interact"
+      seq?: number;
+    }
+  | { op: "detach"; seq?: number };
+
+/** ─── Host → client. Anything else decodes to { op: "unknown" }. ─── */
+export type ControlIn =
+  | {
+      op: "hello_ok";
+      proto: number;
+      caps: string[];
+      host_id: string;
+      host: string;
+      client_id: string;
+    }
+  | { op: "hello_err"; code: ErrorCode; supported: number[] }
+  | {
+      op: "sessions";
+      sessions: SessionInfo[];
+      tombstones?: Tombstone[];
+      re?: number;
+    }
+  | {
+      op: "attached";
+      id: string; // v0 field, retained
+      name: string;
+      session_id: string; // canonical v0.1 field — use this one
+      writer: boolean;
+      rows: number; // AUTHORITATIVE dims; not the canvas size
+      cols: number;
+      re?: number;
+    }
+  | { op: "ok"; re?: number } // the reply to `subscribe` and `detach`
+  | {
+      op: "error";
+      re?: number;
+      code: ErrorCode;
+      message: string;
+      retryable: boolean;
+    }
+  | { op: "exited"; id: string; status: number }
+  | { op: "unknown" };
+
+export type Control = ControlOut | ControlIn;
+
+/** ─── Events. Unknown `ev` values decode to { ev: "unknown" } and are dropped. ─── */
+export type Event =
+  | { ev: "ready"; session: string }
+  | { ev: "status"; session: string; status: string; title?: string | null }
+  | { ev: "writer_changed"; session: string; writer?: string | null }
+  | { ev: "resized"; session: string; rows: number; cols: number }
+  | { ev: "session_exited"; session: string; status: number }
+  | { ev: "resynced"; session: string; reason: string }
+  | { ev: "vt_stale"; session: string; reason: string }
+  | { ev: "roster"; session: string; action: string; info?: SessionInfo | null }
+  | { ev: "unknown" };
+
+const UNKNOWN_CONTROL: ControlIn = { op: "unknown" };
+const UNKNOWN_EVENT: Event = { ev: "unknown" };
+
+const ERROR_CODES = new Set<string>([
+  "incompatible",
+  "proto_error",
+  "no_such_session",
+  "not_writer",
+  "already_exited",
+  "create_failed",
+  "denied",
+  "busy",
+  "internal",
+]);
+
+const decoder = new TextDecoder("utf-8", { fatal: true });
+const encoder = new TextEncoder();
+
+function parseJson(payload: Uint8Array, what: string): unknown {
+  let text: string;
+  try {
+    text = decoder.decode(payload);
+  } catch {
+    throw new ProtocolError(`${what} payload is not UTF-8`);
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new ProtocolError(
+      `invalid ${what} JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function str(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function num(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function bool(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v) => typeof v === "string") : [];
+}
+
+/** An unrecognised code is `internal`, matching `ErrorCode`'s serde default. */
+function errorCode(value: unknown): ErrorCode {
+  return typeof value === "string" && ERROR_CODES.has(value)
+    ? (value as ErrorCode)
+    : "internal";
+}
+
+/** Present only when the host sent it, so `exactOptionalPropertyTypes` holds. */
+function optionalSeq(source: Record<string, unknown>): { re?: number } {
+  return typeof source["re"] === "number" ? { re: source["re"] } : {};
+}
+
+function sessionInfo(value: unknown): SessionInfo | null {
+  const row = record(value);
+  if (!row) return null;
+  const info: SessionInfo = {
+    id: str(row["id"]),
+    name: str(row["name"]),
+    cwd: str(row["cwd"]),
+    command: str(row["command"]),
+    pid: num(row["pid"]),
+    rows: num(row["rows"], 24),
+    cols: num(row["cols"], 80),
+    clients: num(row["clients"]),
+    created_unix: num(row["created_unix"]),
+    alive: bool(row["alive"]),
+    // `#[serde(default = "default_status")]` host-side.
+    status: str(row["status"], "unknown"),
+  };
+  if ("agent_id" in row) info.agent_id = row["agent_id"] as string | null;
+  if ("title" in row) info.title = row["title"] as string | null;
+  if (typeof row["attached_clients"] === "number") {
+    info.attached_clients = row["attached_clients"];
+  }
+  if ("writer_client_id" in row) {
+    info.writer_client_id = row["writer_client_id"] as string | null;
+  }
+  return info;
+}
+
+/**
+ * Decode a `C` payload. Only the host → client ops are recognised; a client's
+ * own op read back off a transcript is `{ op: "unknown" }`, which is the
+ * contract, not a gap. Missing `#[serde(default)]` fields are filled with the
+ * host's own defaults so the returned object really matches its declared type.
+ */
+export function decodeControl(payload: Uint8Array): ControlIn {
+  const message = record(parseJson(payload, "control"));
+  if (!message) return UNKNOWN_CONTROL;
+  switch (message["op"]) {
+    case "hello_ok":
+      return {
+        op: "hello_ok",
+        proto: num(message["proto"]),
+        caps: strings(message["caps"]),
+        host_id: str(message["host_id"]),
+        host: str(message["host"]),
+        client_id: str(message["client_id"]),
+      };
+    case "hello_err":
+      return {
+        op: "hello_err",
+        code: errorCode(message["code"]),
+        supported: Array.isArray(message["supported"])
+          ? message["supported"].filter((v) => typeof v === "number")
+          : [],
+      };
+    case "sessions": {
+      const sessions = Array.isArray(message["sessions"])
+        ? message["sessions"]
+            .map(sessionInfo)
+            .filter((row): row is SessionInfo => row !== null)
+        : [];
+      const tombstones = Array.isArray(message["tombstones"])
+        ? message["tombstones"]
+            .map(record)
+            .filter((row): row is Record<string, unknown> => row !== null)
+        : undefined;
+      return {
+        op: "sessions",
+        sessions,
+        ...(tombstones ? { tombstones } : {}),
+        ...optionalSeq(message),
+      };
+    }
+    case "attached": {
+      const id = str(message["id"]);
+      return {
+        op: "attached",
+        id,
+        name: str(message["name"]),
+        // `session_id` is `#[serde(default)]`, so a v0-era host omits it and
+        // the v0 `id` field is the only session identity on the frame.
+        session_id: str(message["session_id"]) || id,
+        writer: bool(message["writer"]),
+        rows: num(message["rows"], 24),
+        cols: num(message["cols"], 80),
+        ...optionalSeq(message),
+      };
+    }
+    case "ok":
+      return { op: "ok", ...optionalSeq(message) };
+    case "error":
+      return {
+        op: "error",
+        code: errorCode(message["code"]),
+        message: str(message["message"]),
+        retryable: bool(message["retryable"]),
+        ...optionalSeq(message),
+      };
+    case "exited":
+      return {
+        op: "exited",
+        id: str(message["id"]),
+        status: num(message["status"]),
+      };
+    default:
+      return UNKNOWN_CONTROL;
+  }
+}
+
+/** Decode an `E` payload. Unknown `ev` values are dropped, never fatal. */
+export function decodeEvent(payload: Uint8Array): Event {
+  const message = record(parseJson(payload, "event"));
+  if (!message) return UNKNOWN_EVENT;
+  const session = str(message["session"]);
+  switch (message["ev"]) {
+    case "ready":
+      return { ev: "ready", session };
+    case "status": {
+      const event: Event = {
+        ev: "status",
+        session,
+        status: str(message["status"], "unknown"),
+      };
+      if ("title" in message) event.title = message["title"] as string | null;
+      return event;
+    }
+    case "writer_changed": {
+      const event: Event = { ev: "writer_changed", session };
+      if ("writer" in message) event.writer = message["writer"] as string | null;
+      return event;
+    }
+    case "resized":
+      return {
+        ev: "resized",
+        session,
+        rows: num(message["rows"], 24),
+        cols: num(message["cols"], 80),
+      };
+    case "session_exited":
+      return { ev: "session_exited", session, status: num(message["status"]) };
+    case "resynced":
+      return { ev: "resynced", session, reason: str(message["reason"]) };
+    case "vt_stale":
+      return { ev: "vt_stale", session, reason: str(message["reason"]) };
+    case "roster": {
+      const event: Event = {
+        ev: "roster",
+        session,
+        action: str(message["action"]),
+      };
+      if ("info" in message) event.info = sessionInfo(message["info"]);
+      return event;
+    }
+    default:
+      return UNKNOWN_EVENT;
+  }
+}
+
+/** JSON body of a client → host control message, ready to frame. */
+export function encodeControlPayload(msg: ControlOut): Uint8Array {
+  return encoder.encode(JSON.stringify(msg));
+}

--- a/web/client/src/protocol/errors.ts
+++ b/web/client/src/protocol/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * `ProtocolError` lives in its own module so `colors.ts` and `payloads.ts` can
+ * throw it without importing `frame.ts`, which imports them back to decode `S`
+ * and `H`. `frame.ts` re-exports it, so the contract's
+ * `import { ProtocolError } from "./frame"` still resolves.
+ */
+export class ProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProtocolError";
+  }
+}

--- a/web/client/src/protocol/frame.test.ts
+++ b/web/client/src/protocol/frame.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it } from "vitest";
+import {
+  FrameReader,
+  KIND,
+  MAX_DATA_FRAME_SIZE,
+  MAX_FRAME_SIZE,
+  ProtocolError,
+  encodeControl,
+  encodeData,
+  encodeFrame,
+  encodeResize,
+} from "./frame";
+import type { Frame } from "./frame";
+import {
+  cell,
+  concat,
+  encodeHistoryPayload,
+  encodeJsonFrame,
+  encodeSnapshotVtPayload,
+} from "./testTranscript";
+
+function collect(): { frames: Frame[]; reader: FrameReader } {
+  const frames: Frame[] = [];
+  return { frames, reader: new FrameReader((frame) => frames.push(frame)) };
+}
+
+/**
+ * The attach transcript, byte for byte: hello / hello_ok / attach / attached,
+ * one VT snapshot, `ready`, then live D interleaved with a newest-first H
+ * chunk. This is the sequence the RFC freezes, encoded once and replayed under
+ * every chunking below.
+ */
+function attachTranscript(): Uint8Array {
+  return concat([
+    encodeControl({
+      op: "hello",
+      proto: 1,
+      min_proto: 1,
+      role: "attach",
+      caps: ["events", "snapshot", "scrollback"],
+      client: "termio-web/0.1.0",
+    }),
+    encodeJsonFrame(KIND.CONTROL, {
+      op: "hello_ok",
+      proto: 1,
+      caps: ["events", "snapshot", "scrollback"],
+      host_id: "host-1",
+      host: "box",
+      client_id: "client-1",
+    }),
+    encodeControl({
+      op: "attach",
+      target: "shell",
+      rows: 24,
+      cols: 80,
+      mode: "observe",
+      seq: 1,
+    }),
+    encodeJsonFrame(KIND.CONTROL, {
+      op: "attached",
+      id: "s1",
+      name: "shell",
+      session_id: "s1",
+      writer: false,
+      rows: 24,
+      cols: 80,
+      re: 1,
+    }),
+    encodeFrame(
+      KIND.SNAPSHOT,
+      encodeSnapshotVtPayload(
+        { rows: 2, cols: 4, title: "zsh" },
+        new TextEncoder().encode("[2J[Hhello"),
+      ),
+    ),
+    encodeJsonFrame(KIND.EVENT, { ev: "ready", session: "s1" }),
+    ...encodeData(new TextEncoder().encode("$ ls\r\n")),
+    encodeFrame(
+      KIND.HISTORY,
+      encodeHistoryPayload(2, 0, 1, [
+        cell({ codepoint: 0x68 }),
+        cell({ codepoint: 0x69 }),
+      ]),
+    ),
+    encodeResize(30, 100),
+  ]);
+}
+
+/** Deterministic pseudo-random split points; a fixed seed keeps failures replayable. */
+function splits(total: number, seed: number): number[] {
+  const sizes: number[] = [];
+  let state = seed;
+  let remaining = total;
+  while (remaining > 0) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    const size = Math.min(remaining, 1 + (state % 7));
+    sizes.push(size);
+    remaining -= size;
+  }
+  return sizes;
+}
+
+describe("encodeFrame", () => {
+  it("writes kind then a big-endian length", () => {
+    const frame = encodeFrame(KIND.DATA, new Uint8Array([1, 2, 3]));
+    expect(Array.from(frame)).toEqual([0x44, 0, 0, 0, 3, 1, 2, 3]);
+  });
+
+  it("uses the ASCII letters the Rust constants use", () => {
+    expect(KIND.CONTROL).toBe("C".charCodeAt(0));
+    expect(KIND.DATA).toBe("D".charCodeAt(0));
+    expect(KIND.RESIZE).toBe("R".charCodeAt(0));
+    expect(KIND.EVENT).toBe("E".charCodeAt(0));
+    expect(KIND.SNAPSHOT).toBe("S".charCodeAt(0));
+    expect(KIND.HISTORY).toBe("H".charCodeAt(0));
+    expect(KIND.GRID).toBe("G".charCodeAt(0));
+    expect(KIND.FILE).toBe("F".charCodeAt(0));
+    expect(KIND.UPLOAD).toBe("U".charCodeAt(0));
+  });
+
+  it("encodes a four-byte resize payload", () => {
+    expect(Array.from(encodeResize(24, 80))).toEqual([
+      0x52, 0, 0, 0, 4, 0, 24, 0, 80,
+    ]);
+  });
+
+  it("refuses a dimension that is not a u16", () => {
+    expect(() => encodeResize(-1, 80)).toThrow(ProtocolError);
+    expect(() => encodeResize(24, 70000)).toThrow(ProtocolError);
+  });
+});
+
+describe("encodeData", () => {
+  it("splits at MAX_DATA_FRAME_SIZE, mirroring write_data", () => {
+    const bytes = new Uint8Array(MAX_DATA_FRAME_SIZE * 2 + 7).fill(0x61);
+    const frames = encodeData(bytes);
+    expect(frames.length).toBe(3);
+    expect(frames[0].length).toBe(5 + MAX_DATA_FRAME_SIZE);
+    expect(frames[2].length).toBe(5 + 7);
+  });
+
+  it("turns empty input into one empty D frame", () => {
+    const frames = encodeData(new Uint8Array(0));
+    expect(frames.length).toBe(1);
+    expect(Array.from(frames[0])).toEqual([0x44, 0, 0, 0, 0]);
+  });
+
+  it("round-trips a split payload back to the original bytes", () => {
+    const bytes = new Uint8Array(MAX_DATA_FRAME_SIZE + 1000);
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = index & 0xff;
+    }
+    const { frames, reader } = collect();
+    reader.push(concat(encodeData(bytes)));
+    const rejoined = concat(
+      frames.map((frame) => {
+        if (frame.kind !== KIND.DATA) throw new Error("expected D");
+        return frame.data;
+      }),
+    );
+    expect(rejoined).toEqual(bytes);
+  });
+});
+
+describe("FrameReader", () => {
+  it("emits every frame of the attach transcript in order", () => {
+    const { frames, reader } = collect();
+    reader.push(attachTranscript());
+    expect(frames.map((frame) => frame.kind)).toEqual([
+      KIND.CONTROL,
+      KIND.CONTROL,
+      KIND.CONTROL,
+      KIND.CONTROL,
+      KIND.SNAPSHOT,
+      KIND.EVENT,
+      KIND.DATA,
+      KIND.HISTORY,
+      KIND.RESIZE,
+    ]);
+    expect(reader.pending).toBe(0);
+  });
+
+  /**
+   * A WebSocket message boundary is not a frame boundary. Every split of the
+   * same transcript — one byte at a time, random runs, one giant message —
+   * must produce the identical frame sequence, or a transcript recorded over
+   * the Unix socket does not replay here.
+   */
+  it("is invariant under arbitrary chunk boundaries", () => {
+    const transcript = attachTranscript();
+    const reference = collect();
+    reference.reader.push(transcript);
+    const expected = JSON.stringify(reference.frames, replacer);
+
+    const chunkings: number[][] = [
+      [transcript.length],
+      new Array<number>(transcript.length).fill(1),
+      [1, transcript.length - 1],
+      [transcript.length - 1, 1],
+      [4, transcript.length - 4], // splits the very first header
+      [5, transcript.length - 5], // header exactly, then the body
+      splits(transcript.length, 7),
+      splits(transcript.length, 1337),
+      splits(transcript.length, 20260818),
+    ];
+
+    for (const sizes of chunkings) {
+      const { frames, reader } = collect();
+      let offset = 0;
+      for (const size of sizes) {
+        reader.push(transcript.subarray(offset, offset + size));
+        offset += size;
+      }
+      expect(offset).toBe(transcript.length);
+      expect(reader.pending).toBe(0);
+      expect(JSON.stringify(frames, replacer)).toBe(expected);
+    }
+  });
+
+  it("holds a partial frame and reports it as pending", () => {
+    const { frames, reader } = collect();
+    const frame = encodeFrame(KIND.DATA, new Uint8Array([9, 9, 9]));
+    reader.push(frame.subarray(0, 6));
+    expect(frames.length).toBe(0);
+    expect(reader.pending).toBe(6);
+    reader.push(frame.subarray(6));
+    expect(frames.length).toBe(1);
+    expect(reader.pending).toBe(0);
+  });
+
+  it("accepts several frames inside one message", () => {
+    const { frames, reader } = collect();
+    reader.push(
+      concat([
+        encodeFrame(KIND.DATA, new Uint8Array([1])),
+        encodeFrame(KIND.DATA, new Uint8Array([2])),
+        encodeFrame(KIND.DATA, new Uint8Array([3])),
+      ]),
+    );
+    expect(frames.length).toBe(3);
+  });
+
+  it("accepts an ArrayBuffer as well as a view", () => {
+    const { frames, reader } = collect();
+    const frame = encodeFrame(KIND.DATA, new Uint8Array([7]));
+    const buffer = new ArrayBuffer(frame.length);
+    new Uint8Array(buffer).set(frame);
+    reader.push(buffer);
+    expect(frames.length).toBe(1);
+  });
+
+  it("reads a view that does not start at byte zero of its buffer", () => {
+    const { frames, reader } = collect();
+    const frame = encodeFrame(KIND.DATA, new Uint8Array([5, 6]));
+    const padded = new Uint8Array(frame.length + 8);
+    padded.set(frame, 4);
+    reader.push(padded.subarray(4, 4 + frame.length));
+    expect(frames.length).toBe(1);
+    if (frames[0].kind !== KIND.DATA) throw new Error("expected D");
+    expect(Array.from(frames[0].data)).toEqual([5, 6]);
+  });
+
+  it("hands D payloads out as copies that survive later pushes", () => {
+    const { frames, reader } = collect();
+    reader.push(encodeFrame(KIND.DATA, new Uint8Array([1, 2, 3])));
+    if (frames[0].kind !== KIND.DATA) throw new Error("expected D");
+    const first = frames[0].data;
+    reader.push(encodeFrame(KIND.DATA, new Uint8Array([9, 9, 9])));
+    expect(Array.from(first)).toEqual([1, 2, 3]);
+  });
+
+  it("keeps G, F and U as raw payloads instead of failing", () => {
+    const { frames, reader } = collect();
+    reader.push(
+      concat([
+        encodeFrame(KIND.GRID, new Uint8Array([2, 0, 0])),
+        encodeFrame(KIND.FILE, new Uint8Array(17)),
+        encodeFrame(KIND.UPLOAD, new Uint8Array([1, 0x61, 0, 0, 0, 0, 0, 0, 0, 0])),
+      ]),
+    );
+    expect(frames.map((frame) => frame.kind)).toEqual([
+      KIND.GRID,
+      KIND.FILE,
+      KIND.UPLOAD,
+    ]);
+  });
+
+  it("throws on an unknown kind and never resynchronises", () => {
+    const { reader } = collect();
+    expect(() => reader.push(new Uint8Array([0x5a, 0, 0, 0, 0]))).toThrow(
+      ProtocolError,
+    );
+  });
+
+  it("throws on a length over MAX_FRAME_SIZE before buffering the body", () => {
+    const { reader } = collect();
+    const header = new Uint8Array(5);
+    header[0] = KIND.DATA;
+    const oversize = MAX_FRAME_SIZE + 1;
+    header[1] = (oversize >>> 24) & 0xff;
+    header[2] = (oversize >>> 16) & 0xff;
+    header[3] = (oversize >>> 8) & 0xff;
+    header[4] = oversize & 0xff;
+    expect(() => reader.push(header)).toThrow(/exceeds maximum/);
+  });
+
+  it("rejects a resize frame that is not four bytes", () => {
+    const { reader } = collect();
+    expect(() => reader.push(encodeFrame(KIND.RESIZE, new Uint8Array(3)))).toThrow(
+      ProtocolError,
+    );
+  });
+
+  it("drops buffered bytes on reset", () => {
+    const { frames, reader } = collect();
+    reader.push(new Uint8Array([KIND.DATA, 0, 0, 0, 4]));
+    expect(reader.pending).toBe(5);
+    reader.reset();
+    expect(reader.pending).toBe(0);
+    reader.push(encodeFrame(KIND.DATA, new Uint8Array([1])));
+    expect(frames.length).toBe(1);
+  });
+
+  it("survives a frame emitted from inside an onFrame callback", () => {
+    const seen: number[] = [];
+    const reader: FrameReader = new FrameReader((frame) => {
+      seen.push(frame.kind);
+      if (seen.length === 1) {
+        reader.push(encodeFrame(KIND.DATA, new Uint8Array([42])));
+      }
+    });
+    reader.push(
+      concat([
+        encodeFrame(KIND.DATA, new Uint8Array([1])),
+        encodeFrame(KIND.DATA, new Uint8Array([2])),
+      ]),
+    );
+    expect(seen.length).toBe(3);
+    expect(reader.pending).toBe(0);
+  });
+});
+
+/** Typed arrays do not survive JSON on their own; compare them as plain arrays. */
+function replacer(_key: string, value: unknown): unknown {
+  return value instanceof Uint8Array ? Array.from(value) : value;
+}

--- a/web/client/src/protocol/frame.ts
+++ b/web/client/src/protocol/frame.ts
@@ -1,0 +1,251 @@
+/**
+ * The 5-byte framing, `[kind:u8][len:u32be][payload]`, ported from
+ * `termiod/src/protocol.rs`. It is the same framing on a Unix socket, on SSH
+ * stdio, and inside WebSocket binary messages — which is the whole reason a
+ * transcript recorded over one pipe replays byte-identical over another.
+ */
+import type { Control, Event, ControlOut } from "./control";
+import { decodeControl, decodeEvent, encodeControlPayload } from "./control";
+import { ProtocolError } from "./errors";
+import type { HistoryChunk, Snapshot } from "./payloads";
+import { decodeHistoryPayload, decodeSnapshotPayload } from "./payloads";
+
+export { ProtocolError };
+export type { Control, ControlOut, Event, HistoryChunk, Snapshot };
+
+/** Frame kinds, verbatim from termiod/src/protocol.rs. ASCII letters, not an enum. */
+export const KIND = {
+  CONTROL: 0x43, // 'C'
+  DATA: 0x44, // 'D'
+  RESIZE: 0x52, // 'R'
+  EVENT: 0x45, // 'E'
+  SNAPSHOT: 0x53, // 'S'
+  HISTORY: 0x48, // 'H'
+  GRID: 0x47, // 'G'
+  FILE: 0x46, // 'F'
+  UPLOAD: 0x55, // 'U'
+} as const;
+export type FrameKind = (typeof KIND)[keyof typeof KIND];
+
+export const MAX_FRAME_SIZE = 16 * 1024 * 1024;
+export const MAX_DATA_FRAME_SIZE = 64 * 1024;
+export const PROTOCOL_VERSION = 1;
+
+/** `G` is skipped, not decoded; the sizes are here for the frozen contract. */
+export const GRID_FORMAT_VERSION = 2;
+export const GRID_HEADER_SIZE = 16;
+
+// Re-exported rather than restated: one definition per constant, so a wire
+// format cannot drift between the module that decodes it and the module that
+// names it.
+export {
+  SNAPSHOT_FORMAT_VERSION,
+  SNAPSHOT_FORMAT_VT,
+  SNAPSHOT_CELL_SIZE,
+  HISTORY_FORMAT_VERSION,
+  HISTORY_HEADER_SIZE,
+  MAX_HISTORY_FRAME_SIZE,
+} from "./payloads";
+export { COLOR_TAG_DEFAULT, COLOR_TAG_PALETTE, COLOR_TAG_RGB } from "./colors";
+
+const HEADER_SIZE = 5;
+
+const KNOWN_KINDS = new Set<number>(Object.values(KIND));
+
+/**
+ * One decoded frame. `G`/`F`/`U` keep their raw payload: the web client
+ * negotiates none of `grid_diff` / `files` / `upload` in v1, and a frame it did
+ * not ask for must be skipped, never treated as an error.
+ */
+export type Frame =
+  | { kind: typeof KIND.CONTROL; control: Control }
+  | { kind: typeof KIND.DATA; data: Uint8Array }
+  | { kind: typeof KIND.RESIZE; rows: number; cols: number }
+  | { kind: typeof KIND.EVENT; event: Event }
+  | { kind: typeof KIND.SNAPSHOT; snapshot: Snapshot }
+  | { kind: typeof KIND.HISTORY; history: HistoryChunk }
+  | { kind: typeof KIND.GRID; payload: Uint8Array }
+  | { kind: typeof KIND.FILE; payload: Uint8Array }
+  | { kind: typeof KIND.UPLOAD; payload: Uint8Array };
+
+function decodeFrame(kind: number, payload: Uint8Array): Frame {
+  switch (kind) {
+    case KIND.CONTROL:
+      return { kind: KIND.CONTROL, control: decodeControl(payload) };
+    case KIND.DATA:
+      return { kind: KIND.DATA, data: payload };
+    case KIND.RESIZE:
+      if (payload.length !== 4) {
+        throw new ProtocolError("malformed resize frame");
+      }
+      return {
+        kind: KIND.RESIZE,
+        rows: (payload[0] << 8) | payload[1],
+        cols: (payload[2] << 8) | payload[3],
+      };
+    case KIND.EVENT:
+      return { kind: KIND.EVENT, event: decodeEvent(payload) };
+    case KIND.SNAPSHOT:
+      return { kind: KIND.SNAPSHOT, snapshot: decodeSnapshotPayload(payload) };
+    case KIND.HISTORY:
+      return { kind: KIND.HISTORY, history: decodeHistoryPayload(payload) };
+    case KIND.GRID:
+      return { kind: KIND.GRID, payload };
+    case KIND.FILE:
+      return { kind: KIND.FILE, payload };
+    case KIND.UPLOAD:
+      return { kind: KIND.UPLOAD, payload };
+    default:
+      throw new ProtocolError(`unknown frame kind 0x${kind.toString(16)}`);
+  }
+}
+
+function asBytes(chunk: ArrayBuffer | ArrayBufferView): Uint8Array {
+  if (ArrayBuffer.isView(chunk)) {
+    return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+  }
+  return new Uint8Array(chunk);
+}
+
+/**
+ * Reassembles the framed byte stream out of WebSocket messages.
+ *
+ * WebSocket message boundaries are NOT frame boundaries. `push` accepts an
+ * arbitrary chunk — one message may hold three frames, one frame may span four
+ * messages — and emits whole frames in order. This is the single reason a
+ * transcript recorded over the Unix socket replays byte-identical here.
+ *
+ * Throws `ProtocolError` on an unknown kind or a length over MAX_FRAME_SIZE;
+ * the caller closes the socket. It never resynchronises: a corrupt stream is
+ * a dead stream.
+ */
+export class FrameReader {
+  private readonly onFrame: (frame: Frame) => void;
+  private buffer = new Uint8Array(0);
+  private cursor = 0;
+
+  constructor(onFrame: (frame: Frame) => void) {
+    this.onFrame = onFrame;
+  }
+
+  /** Bytes buffered but not yet a whole frame. Tests assert this is 0 at EOF. */
+  get pending(): number {
+    return this.buffer.length - this.cursor;
+  }
+
+  reset(): void {
+    this.buffer = new Uint8Array(0);
+    this.cursor = 0;
+  }
+
+  push(chunk: ArrayBuffer | ArrayBufferView): void {
+    this.append(asBytes(chunk));
+    // Re-read `buffer`/`cursor` on every iteration: `onFrame` is allowed to
+    // push again (a reply arriving on the same tick), and a cached view of the
+    // buffer would silently drop those bytes.
+    for (;;) {
+      if (this.pending < HEADER_SIZE) return;
+      const start = this.cursor;
+      const kind = this.buffer[start];
+      const length =
+        this.buffer[start + 1] * 0x1000000 +
+        ((this.buffer[start + 2] << 16) |
+          (this.buffer[start + 3] << 8) |
+          this.buffer[start + 4]);
+      if (length > MAX_FRAME_SIZE) {
+        throw new ProtocolError(
+          `frame length ${length} exceeds maximum ${MAX_FRAME_SIZE}`,
+        );
+      }
+      // The kind check happens before the body is complete so a garbage stream
+      // dies on the first bad byte instead of after buffering 16 MiB of it.
+      if (!KNOWN_KINDS.has(kind)) {
+        throw new ProtocolError(`unknown frame kind 0x${kind.toString(16)}`);
+      }
+      if (this.pending < HEADER_SIZE + length) return;
+      const bodyStart = start + HEADER_SIZE;
+      // `slice` copies: a decoded `D` payload outlives this buffer, and the
+      // buffer is compacted underneath it.
+      const payload = this.buffer.slice(bodyStart, bodyStart + length);
+      this.cursor = bodyStart + length;
+      this.compact();
+      this.onFrame(decodeFrame(kind, payload));
+    }
+  }
+
+  private append(bytes: Uint8Array): void {
+    if (bytes.length === 0) return;
+    const kept = this.pending;
+    const merged = new Uint8Array(kept + bytes.length);
+    merged.set(this.buffer.subarray(this.cursor), 0);
+    merged.set(bytes, kept);
+    this.buffer = merged;
+    this.cursor = 0;
+  }
+
+  private compact(): void {
+    if (this.cursor === 0) return;
+    if (this.cursor === this.buffer.length) {
+      this.buffer = new Uint8Array(0);
+      this.cursor = 0;
+      return;
+    }
+    this.buffer = this.buffer.slice(this.cursor);
+    this.cursor = 0;
+  }
+}
+
+/** [kind:u8][len:u32be][payload]. Throws over MAX_FRAME_SIZE. */
+export function encodeFrame(kind: FrameKind, payload: Uint8Array): Uint8Array {
+  if (payload.length > MAX_FRAME_SIZE) {
+    throw new ProtocolError(
+      `frame payload too large: ${payload.length} > ${MAX_FRAME_SIZE}`,
+    );
+  }
+  const frame = new Uint8Array(HEADER_SIZE + payload.length);
+  frame[0] = kind;
+  frame[1] = (payload.length >>> 24) & 0xff;
+  frame[2] = (payload.length >>> 16) & 0xff;
+  frame[3] = (payload.length >>> 8) & 0xff;
+  frame[4] = payload.length & 0xff;
+  frame.set(payload, HEADER_SIZE);
+  return frame;
+}
+
+export function encodeControl(msg: ControlOut): Uint8Array {
+  return encodeFrame(KIND.CONTROL, encodeControlPayload(msg));
+}
+
+/** Splits at MAX_DATA_FRAME_SIZE, mirroring `write_data`. Empty input → one empty D frame. */
+export function encodeData(bytes: Uint8Array): Uint8Array[] {
+  if (bytes.length === 0) {
+    return [encodeFrame(KIND.DATA, bytes)];
+  }
+  const frames: Uint8Array[] = [];
+  for (let offset = 0; offset < bytes.length; offset += MAX_DATA_FRAME_SIZE) {
+    frames.push(
+      encodeFrame(
+        KIND.DATA,
+        bytes.subarray(offset, offset + MAX_DATA_FRAME_SIZE),
+      ),
+    );
+  }
+  return frames;
+}
+
+/** 4-byte payload: rows u16be, cols u16be. */
+export function encodeResize(rows: number, cols: number): Uint8Array {
+  const payload = new Uint8Array(4);
+  payload[0] = (checkDimension(rows, "rows") >>> 8) & 0xff;
+  payload[1] = rows & 0xff;
+  payload[2] = (checkDimension(cols, "cols") >>> 8) & 0xff;
+  payload[3] = cols & 0xff;
+  return encodeFrame(KIND.RESIZE, payload);
+}
+
+function checkDimension(value: number, what: string): number {
+  if (!Number.isInteger(value) || value < 0 || value > 0xffff) {
+    throw new ProtocolError(`${what} must be a u16, got ${value}`);
+  }
+  return value;
+}

--- a/web/client/src/protocol/payloads.test.ts
+++ b/web/client/src/protocol/payloads.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_COLOR, decodeColor } from "./colors";
+import { ProtocolError } from "./errors";
+import {
+  MAX_HISTORY_FRAME_SIZE,
+  SNAPSHOT_CELL_SIZE,
+  decodeHistoryPayload,
+  decodeSnapshotPayload,
+} from "./payloads";
+import {
+  cell,
+  encodeHistoryPayload,
+  encodeSnapshotCellsPayload,
+  encodeSnapshotVtPayload,
+} from "./testTranscript";
+
+describe("decodeColor", () => {
+  it("keeps a palette index unresolved", () => {
+    const bytes = new Uint8Array([1, 42, 0, 0]);
+    expect(decodeColor(bytes, 0)).toEqual({ tag: "palette", index: 42 });
+  });
+
+  it("reads an rgb triple", () => {
+    const bytes = new Uint8Array([2, 0x11, 0x22, 0x33]);
+    expect(decodeColor(bytes, 0)).toEqual({
+      tag: "rgb",
+      r: 0x11,
+      g: 0x22,
+      b: 0x33,
+    });
+  });
+
+  it("falls back to default on an unknown tag instead of failing the frame", () => {
+    expect(decodeColor(new Uint8Array([9, 1, 2, 3]), 0)).toBe(DEFAULT_COLOR);
+    expect(decodeColor(new Uint8Array([0, 0, 0, 0]), 0)).toBe(DEFAULT_COLOR);
+  });
+
+  it("reads at an offset", () => {
+    const bytes = new Uint8Array([0, 0, 0, 0, 1, 7, 0, 0]);
+    expect(decodeColor(bytes, 4)).toEqual({ tag: "palette", index: 7 });
+  });
+});
+
+describe("decodeSnapshotPayload — v2 VT", () => {
+  const vt = new TextEncoder().encode("[2J[H$ ");
+
+  it("returns the VT body and nothing around it", () => {
+    const snapshot = decodeSnapshotPayload(
+      encodeSnapshotVtPayload(
+        {
+          rows: 24,
+          cols: 80,
+          cursorX: 2,
+          cursorY: 0,
+          altScreen: false,
+          title: "zsh — termio",
+        },
+        vt,
+      ),
+    );
+    expect(snapshot.format).toBe(2);
+    expect(snapshot.rows).toBe(24);
+    expect(snapshot.cols).toBe(80);
+    expect(snapshot.cursorX).toBe(2);
+    expect(snapshot.cursorY).toBe(0);
+    expect(snapshot.altScreen).toBe(false);
+    expect(snapshot.title).toBe("zsh — termio");
+    expect(snapshot.cells).toBeUndefined();
+    // Exactly the VT bytes: no header, no title, no length prefix, no
+    // client-side ESC[2J ESC[H prelude.
+    expect(snapshot.vt).toEqual(vt);
+  });
+
+  it("copies the VT out of the frame buffer", () => {
+    const payload = encodeSnapshotVtPayload({ rows: 1, cols: 1 }, vt);
+    const snapshot = decodeSnapshotPayload(payload);
+    payload.fill(0);
+    expect(snapshot.vt).toEqual(vt);
+  });
+
+  it("reads the alt-screen flag", () => {
+    const snapshot = decodeSnapshotPayload(
+      encodeSnapshotVtPayload({ rows: 1, cols: 1, altScreen: true }, vt),
+    );
+    expect(snapshot.altScreen).toBe(true);
+  });
+
+  it("refuses a vt length that disagrees with the body", () => {
+    const payload = encodeSnapshotVtPayload({ rows: 1, cols: 1 }, vt);
+    payload[payload.length - vt.length - 1] += 1;
+    expect(() => decodeSnapshotPayload(payload)).toThrow(/expected/);
+  });
+});
+
+describe("decodeSnapshotPayload — v3 packed cells", () => {
+  it("decodes tagged colours without resolving them", () => {
+    const cells = [
+      cell({ codepoint: 0x68, foreground: { tag: "palette", index: 4 } }),
+      cell({
+        codepoint: 0x69,
+        background: { tag: "rgb", r: 1, g: 2, b: 3 },
+        attributes: 0b101,
+      }),
+    ];
+    const snapshot = decodeSnapshotPayload(
+      encodeSnapshotCellsPayload({ rows: 1, cols: 2, title: "t" }, cells),
+    );
+    expect(snapshot.format).toBe(3);
+    expect(snapshot.vt).toBeUndefined();
+    expect(snapshot.cells?.length).toBe(2);
+    expect(snapshot.cells?.[0]).toEqual({
+      codepoint: 0x68,
+      foreground: { tag: "palette", index: 4 },
+      background: DEFAULT_COLOR,
+      attributes: 0,
+      selected: false,
+    });
+    expect(snapshot.cells?.[1]).toEqual({
+      codepoint: 0x69,
+      foreground: DEFAULT_COLOR,
+      background: { tag: "rgb", r: 1, g: 2, b: 3 },
+      attributes: 0b101,
+      selected: false,
+    });
+  });
+
+  it("carries no grapheme or underline field on a packed cell", () => {
+    const snapshot = decodeSnapshotPayload(
+      encodeSnapshotCellsPayload({ rows: 1, cols: 1 }, [cell()]),
+    );
+    expect(snapshot.cells?.[0] && "grapheme" in snapshot.cells[0]).toBe(false);
+    expect(snapshot.cells?.[0] && "underline" in snapshot.cells[0]).toBe(false);
+  });
+
+  it("refuses a cell count that disagrees with rows × cols", () => {
+    const payload = encodeSnapshotCellsPayload({ rows: 2, cols: 2 }, [
+      cell(),
+      cell(),
+    ]);
+    expect(() => decodeSnapshotPayload(payload)).toThrow(/expected/);
+  });
+});
+
+describe("decodeSnapshotPayload — malformed", () => {
+  it("rejects a short header", () => {
+    expect(() => decodeSnapshotPayload(new Uint8Array(11))).toThrow(
+      /malformed snapshot header/,
+    );
+  });
+
+  it("rejects an unsupported version byte", () => {
+    const payload = encodeSnapshotCellsPayload({ rows: 0, cols: 0 }, []);
+    payload[0] = 1; // v1 was retired rather than kept for compatibility.
+    expect(() => decodeSnapshotPayload(payload)).toThrow(
+      /unsupported snapshot payload version 1/,
+    );
+  });
+
+  it("rejects an alt-screen byte that is not 0 or 1", () => {
+    const payload = encodeSnapshotCellsPayload({ rows: 0, cols: 0 }, []);
+    payload[9] = 2;
+    expect(() => decodeSnapshotPayload(payload)).toThrow(/alt-screen/);
+  });
+
+  it("rejects a title that runs past the payload", () => {
+    const payload = encodeSnapshotCellsPayload({ rows: 0, cols: 0 }, []);
+    payload[10] = 0xff;
+    expect(() => decodeSnapshotPayload(payload)).toThrow(/title exceeds/);
+  });
+
+  it("rejects a title that is not UTF-8", () => {
+    const payload = encodeSnapshotVtPayload(
+      { rows: 1, cols: 1, title: "ab" },
+      new Uint8Array(0),
+    );
+    payload[12] = 0xff;
+    expect(() => decodeSnapshotPayload(payload)).toThrow(/not UTF-8/);
+  });
+});
+
+describe("decodeHistoryPayload", () => {
+  it("orders rows newest first with negative viewport y", () => {
+    const cols = 2;
+    const rows = [
+      [cell({ codepoint: 0x61 }), cell({ codepoint: 0x62 })], // newest
+      [cell({ codepoint: 0x63 }), cell({ codepoint: 0x64 })],
+      [cell({ codepoint: 0x65 }), cell({ codepoint: 0x66 })], // oldest
+    ];
+    // `first_offset` is one-based on the wire: the host's first chunk carries 1
+    // and means "starting one row above the viewport".
+    const chunk = decodeHistoryPayload(
+      encodeHistoryPayload(cols, 1, rows.length, rows.flat()),
+    );
+    expect(chunk.cols).toBe(2);
+    expect(chunk.firstOffset).toBe(1);
+    expect(chunk.rowCount).toBe(3);
+    expect(chunk.rows.map((row) => row.y)).toEqual([-1, -2, -3]);
+    expect(chunk.rows[0].cells.map((c) => c.codepoint)).toEqual([0x61, 0x62]);
+    expect(chunk.rows[2].cells.map((c) => c.codepoint)).toEqual([0x65, 0x66]);
+  });
+
+  it("offsets y by first_offset so a second chunk stacks above the first", () => {
+    // A 3-row first chunk (first_offset 1) is followed by first_offset 4.
+    const chunk = decodeHistoryPayload(
+      encodeHistoryPayload(1, 4, 2, [cell(), cell()]),
+    );
+    expect(chunk.rows.map((row) => row.y)).toEqual([-4, -5]);
+  });
+
+  it("keeps history colours as slots", () => {
+    const chunk = decodeHistoryPayload(
+      encodeHistoryPayload(1, 0, 1, [
+        cell({
+          codepoint: 0x7a,
+          foreground: { tag: "palette", index: 200 },
+          background: { tag: "rgb", r: 9, g: 8, b: 7 },
+        }),
+      ]),
+    );
+    expect(chunk.rows[0].cells[0].foreground).toEqual({
+      tag: "palette",
+      index: 200,
+    });
+    expect(chunk.rows[0].cells[0].background).toEqual({
+      tag: "rgb",
+      r: 9,
+      g: 8,
+      b: 7,
+    });
+  });
+
+  it("marks decoded history rows dirty and unselected", () => {
+    const chunk = decodeHistoryPayload(
+      encodeHistoryPayload(1, 0, 1, [cell()]),
+    );
+    expect(chunk.rows[0].dirty).toBe(true);
+    expect(chunk.rows[0].selection).toBeUndefined();
+    expect(chunk.rows[0].cells[0].selected).toBe(false);
+  });
+
+  it("rejects a short header", () => {
+    expect(() => decodeHistoryPayload(new Uint8Array(8))).toThrow(
+      /malformed history header/,
+    );
+  });
+
+  it("rejects an unsupported version", () => {
+    const payload = encodeHistoryPayload(1, 0, 1, [cell()]);
+    payload[0] = 1;
+    expect(() => decodeHistoryPayload(payload)).toThrow(
+      /unsupported history payload version 1/,
+    );
+  });
+
+  it("rejects zero rows or columns", () => {
+    const payload = encodeHistoryPayload(1, 0, 1, [cell()]);
+    payload[7] = 0;
+    payload[8] = 0;
+    expect(() => decodeHistoryPayload(payload)).toThrow(/non-zero/);
+  });
+
+  it("rejects a cell count that disagrees with the header", () => {
+    const payload = encodeHistoryPayload(2, 0, 1, [cell(), cell()]);
+    expect(() => decodeHistoryPayload(payload.subarray(0, payload.length - 1))).toThrow(
+      /expected/,
+    );
+  });
+
+  it("rejects a payload over the 64 KiB history cap", () => {
+    const payload = new Uint8Array(MAX_HISTORY_FRAME_SIZE + 1);
+    payload[0] = 2;
+    expect(() => decodeHistoryPayload(payload)).toThrow(ProtocolError);
+  });
+
+  it("uses the same 16-byte cell as the snapshot", () => {
+    expect(SNAPSHOT_CELL_SIZE).toBe(16);
+    const payload = encodeHistoryPayload(1, 0, 1, [cell()]);
+    expect(payload.length).toBe(9 + SNAPSHOT_CELL_SIZE);
+  });
+});

--- a/web/client/src/protocol/payloads.ts
+++ b/web/client/src/protocol/payloads.ts
@@ -1,0 +1,253 @@
+/**
+ * The two packed-binary payloads a Replica decodes: `S` (snapshot) and `H`
+ * (history). Both are ports of `termiod/src/protocol.rs`, and both stay inside
+ * the presentation boundary: a colour on this wire is a slot, never a pixel.
+ */
+import type { CellView, RowView } from "../renderer/types";
+import { DEFAULT_COLOR, decodeColor } from "./colors";
+import { ProtocolError } from "./errors";
+
+export const SNAPSHOT_FORMAT_VERSION = 3; // packed cells
+export const SNAPSHOT_FORMAT_VT = 2; // VT sequences
+export const SNAPSHOT_CELL_SIZE = 16;
+export const SNAPSHOT_HEADER_SIZE = 12;
+export const HISTORY_FORMAT_VERSION = 2;
+export const HISTORY_HEADER_SIZE = 9;
+export const MAX_HISTORY_FRAME_SIZE = 64 * 1024;
+
+/**
+ * Snapshot payload. v2 carries VT sequences and v3 carries packed cells; any
+ * other version byte throws. A Replica always receives v2, because it
+ * negotiated `snapshot` — v3 exists for grid_diff clients and as the
+ * formatter's own fallback, and decoding it is a correctness requirement, not
+ * a code path the web client drives.
+ *
+ * Header: version u8, rows u16be, cols u16be, cursor_x u16be, cursor_y u16be,
+ * alt_screen u8, title_len u16be, UTF-8 title.
+ *   v2 body: vt_len u32be, then vt_len bytes.
+ *   v3 body: rows*cols packed 16-byte cells, row-major.
+ */
+export interface Snapshot {
+  format: 2 | 3;
+  rows: number;
+  cols: number;
+  cursorX: number;
+  cursorY: number;
+  altScreen: boolean;
+  title: string;
+  /** Present iff format === 2. Write EXACTLY these bytes into the Wasm — not
+   *  the header, not the title, not the length prefix, and never a
+   *  client-side `ESC[2J ESC[H` prelude. The prologue is already inside. */
+  vt?: Uint8Array;
+  /** Present iff format === 3. */
+  cells?: CellView[];
+}
+
+/**
+ * History payload v2. Header: version u8, cols u16be, first_offset u32be,
+ * row_count u16be, then row_count*cols packed 16-byte cells, row-major.
+ *
+ * Rows are ordered NEWEST FIRST. `firstOffset` is the distance above the
+ * snapshot viewport of this chunk's first row, so row i of this chunk sits at
+ * viewport-relative y = -(firstOffset + i + 1).
+ *
+ * `rows` is already the seam's shape: H never enters the Wasm, the renderer
+ * paints these through the same code path as live rows.
+ *
+ * `attributes` on the wire is reserved-zero today, so history rows carry no
+ * bold/underline/italic. Do not invent styling to hide the seam at the history
+ * boundary — that asymmetry is a named wire-format gap.
+ */
+export interface HistoryChunk {
+  cols: number;
+  firstOffset: number;
+  rowCount: number;
+  rows: RowView[];
+}
+
+const utf8 = new TextDecoder("utf-8", { fatal: true });
+
+function readU16(payload: Uint8Array, offset: number): number {
+  return (payload[offset] << 8) | payload[offset + 1];
+}
+
+function readU32(payload: Uint8Array, offset: number): number {
+  return (
+    payload[offset] * 0x1000000 +
+    ((payload[offset + 1] << 16) | (payload[offset + 2] << 8) | payload[offset + 3])
+  );
+}
+
+function readBool(payload: Uint8Array, offset: number, what: string): boolean {
+  const value = payload[offset];
+  if (value !== 0 && value !== 1) {
+    throw new ProtocolError(`invalid ${what} value ${value}`);
+  }
+  return value === 1;
+}
+
+function readTitle(payload: Uint8Array, start: number, end: number): string {
+  try {
+    return utf8.decode(payload.subarray(start, end));
+  } catch {
+    throw new ProtocolError("snapshot title is not UTF-8");
+  }
+}
+
+/** A blank cell in the seam's shape, ready for `decodeCell` to fill. */
+function blankCell(): CellView {
+  return {
+    codepoint: 0,
+    foreground: DEFAULT_COLOR,
+    background: DEFAULT_COLOR,
+    attributes: 0,
+    selected: false,
+  };
+}
+
+/**
+ * One packed cell, 16 bytes: codepoint u32be, foreground 4, background 4,
+ * attributes u16be, 2 reserved.
+ */
+export function decodeCell(
+  payload: Uint8Array,
+  offset: number,
+  into: CellView,
+): void {
+  if (offset < 0 || offset + SNAPSHOT_CELL_SIZE > payload.length) {
+    throw new ProtocolError(
+      `cell at offset ${offset} runs past ${payload.length} bytes`,
+    );
+  }
+  into.codepoint = readU32(payload, offset);
+  into.foreground = decodeColor(payload, offset + 4);
+  into.background = decodeColor(payload, offset + 8);
+  into.attributes = readU16(payload, offset + 12);
+  into.selected = false;
+  // A packed cell is a single codepoint with no program-set underline colour;
+  // leaving the optional fields off keeps a decoded row and a live row the
+  // same shape rather than two shapes that happen to look alike.
+  delete into.grapheme;
+  delete into.underline;
+}
+
+function decodeCells(
+  payload: Uint8Array,
+  offset: number,
+  count: number,
+): CellView[] {
+  const cells: CellView[] = new Array<CellView>(count);
+  for (let index = 0; index < count; index += 1) {
+    const cell = blankCell();
+    decodeCell(payload, offset + index * SNAPSHOT_CELL_SIZE, cell);
+    cells[index] = cell;
+  }
+  return cells;
+}
+
+export function decodeSnapshotPayload(payload: Uint8Array): Snapshot {
+  if (payload.length < SNAPSHOT_HEADER_SIZE) {
+    throw new ProtocolError("malformed snapshot header");
+  }
+  const version = payload[0];
+  if (version !== SNAPSHOT_FORMAT_VT && version !== SNAPSHOT_FORMAT_VERSION) {
+    throw new ProtocolError(`unsupported snapshot payload version ${version}`);
+  }
+  const rows = readU16(payload, 1);
+  const cols = readU16(payload, 3);
+  const cursorX = readU16(payload, 5);
+  const cursorY = readU16(payload, 7);
+  const altScreen = readBool(payload, 9, "snapshot alt-screen");
+  const titleLength = readU16(payload, 10);
+  const bodyOffset = SNAPSHOT_HEADER_SIZE + titleLength;
+  if (bodyOffset > payload.length) {
+    throw new ProtocolError("snapshot title exceeds payload");
+  }
+  const title = readTitle(payload, SNAPSHOT_HEADER_SIZE, bodyOffset);
+
+  if (version === SNAPSHOT_FORMAT_VT) {
+    const body = payload.subarray(bodyOffset);
+    if (body.length < 4) {
+      throw new ProtocolError("malformed snapshot vt length");
+    }
+    const vtLength = readU32(body, 0);
+    if (body.length !== 4 + vtLength) {
+      throw new ProtocolError(
+        `snapshot vt payload has ${body.length - 4} bytes, expected ${vtLength}`,
+      );
+    }
+    return {
+      format: 2,
+      rows,
+      cols,
+      cursorX,
+      cursorY,
+      altScreen,
+      title,
+      // Copied out: the caller writes these into the Wasm long after the
+      // frame buffer they arrived in has been recycled.
+      vt: body.slice(4),
+    };
+  }
+
+  const cellCount = rows * cols;
+  const expected = bodyOffset + cellCount * SNAPSHOT_CELL_SIZE;
+  if (payload.length !== expected) {
+    throw new ProtocolError(
+      `snapshot payload has ${payload.length} bytes, expected ${expected}`,
+    );
+  }
+  return {
+    format: 3,
+    rows,
+    cols,
+    cursorX,
+    cursorY,
+    altScreen,
+    title,
+    cells: decodeCells(payload, bodyOffset, cellCount),
+  };
+}
+
+export function decodeHistoryPayload(payload: Uint8Array): HistoryChunk {
+  if (payload.length < HISTORY_HEADER_SIZE) {
+    throw new ProtocolError("malformed history header");
+  }
+  if (payload.length > MAX_HISTORY_FRAME_SIZE) {
+    throw new ProtocolError(
+      `history payload too large: ${payload.length} > ${MAX_HISTORY_FRAME_SIZE}`,
+    );
+  }
+  if (payload[0] !== HISTORY_FORMAT_VERSION) {
+    throw new ProtocolError(`unsupported history payload version ${payload[0]}`);
+  }
+  const cols = readU16(payload, 1);
+  const firstOffset = readU32(payload, 3);
+  const rowCount = readU16(payload, 7);
+  if (cols === 0 || rowCount === 0) {
+    throw new ProtocolError("history chunks require non-zero columns and rows");
+  }
+  const expected = HISTORY_HEADER_SIZE + cols * rowCount * SNAPSHOT_CELL_SIZE;
+  if (payload.length !== expected) {
+    throw new ProtocolError(
+      `history payload has ${payload.length} bytes, expected ${expected}`,
+    );
+  }
+
+  const rows: RowView[] = new Array<RowView>(rowCount);
+  for (let index = 0; index < rowCount; index += 1) {
+    const offset = HISTORY_HEADER_SIZE + index * cols * SNAPSHOT_CELL_SIZE;
+    rows[index] = {
+      // Newest first, and `first_offset` is ONE-BASED: `encode_scrollback_chunks`
+      // (termiod/src/session.rs) starts it at 1 and advances it by `row_count`,
+      // so a chunk with `first_offset: 1` begins at the row immediately above
+      // the viewport — viewport-relative y of -1. Treating it as zero-based
+      // leaves y = -1 permanently empty and pushes every history row one line
+      // too far up; that was measured against a live daemon, not inferred.
+      y: -(firstOffset + index),
+      dirty: true,
+      cells: decodeCells(payload, offset, cols),
+    };
+  }
+  return { cols, firstOffset, rowCount, rows };
+}

--- a/web/client/src/protocol/socket.test.ts
+++ b/web/client/src/protocol/socket.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Frame } from "./frame";
+import { KIND, encodeFrame } from "./frame";
+import {
+  SUBPROTOCOL,
+  TOKEN_SUBPROTOCOL_PREFIX,
+  channelUrl,
+  openChannel,
+} from "./socket";
+import { concat, encodeJsonFrame } from "./testTranscript";
+
+/** Just enough WebSocket to drive `openChannel` without a network. */
+class FakeWebSocket {
+  static last: FakeWebSocket | null = null;
+
+  readonly url: string;
+  readonly protocols: string[];
+  binaryType = "blob";
+  readyState = 0;
+  readonly sent: Uint8Array[] = [];
+  closed: { code: number; reason: string } | null = null;
+  private readonly listeners = new Map<string, ((event: unknown) => void)[]>();
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url;
+    this.protocols =
+      protocols === undefined
+        ? []
+        : Array.isArray(protocols)
+          ? protocols
+          : [protocols];
+    FakeWebSocket.last = this;
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    const bucket = this.listeners.get(type) ?? [];
+    bucket.push(listener);
+    this.listeners.set(type, bucket);
+  }
+
+  send(data: Uint8Array): void {
+    if (this.readyState !== 1) throw new Error("InvalidStateError");
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = 3;
+    this.closed = { code: code ?? 1005, reason: reason ?? "" };
+  }
+
+  emit(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.emit("open", {});
+  }
+
+  /** The browser hands over an ArrayBuffer, so copy the view into its own. */
+  deliver(bytes: Uint8Array): void {
+    this.emit("message", { data: bytes.slice().buffer });
+  }
+}
+
+const original = (globalThis as { WebSocket?: unknown }).WebSocket;
+
+beforeEach(() => {
+  (globalThis as { WebSocket?: unknown }).WebSocket = FakeWebSocket;
+  FakeWebSocket.last = null;
+});
+
+afterEach(() => {
+  (globalThis as { WebSocket?: unknown }).WebSocket = original;
+});
+
+interface Harness {
+  frames: Frame[];
+  closes: { code: number; reason: string }[];
+  errors: Error[];
+  socket: FakeWebSocket;
+  channel: ReturnType<typeof openChannel>;
+}
+
+function harness(token = "s3cret"): Harness {
+  const frames: Frame[] = [];
+  const closes: { code: number; reason: string }[] = [];
+  const errors: Error[] = [];
+  const channel = openChannel({
+    url: new URL("wss://box.tailnet.ts.net/termio/ws"),
+    token,
+    onFrame: (frame) => frames.push(frame),
+    onClose: (info) => closes.push(info),
+    onError: (error) => errors.push(error),
+  });
+  const socket = FakeWebSocket.last;
+  if (!socket) throw new Error("no socket was constructed");
+  return { frames, closes, errors, socket, channel };
+}
+
+describe("channelUrl", () => {
+  it("resolves ws against the prefix that served index.html", () => {
+    expect(
+      channelUrl(new URL("https://box.tailnet.ts.net/termio/")).toString(),
+    ).toBe("wss://box.tailnet.ts.net/termio/ws");
+    expect(channelUrl(new URL("http://127.0.0.1:8790/")).toString()).toBe(
+      "ws://127.0.0.1:8790/ws",
+    );
+    expect(
+      channelUrl(new URL("https://box.example/termio/?session=s1")).toString(),
+    ).toBe("wss://box.example/termio/ws");
+  });
+});
+
+describe("openChannel", () => {
+  it("offers termiod.v1 then the token subprotocol, and nothing else", () => {
+    const { socket } = harness("tok-123");
+    expect(socket.protocols).toEqual([SUBPROTOCOL, "termiod.token.tok-123"]);
+    expect(TOKEN_SUBPROTOCOL_PREFIX).toBe("termiod.token.");
+  });
+
+  it("never puts the token in the URL", () => {
+    const { socket } = harness("tok-123");
+    expect(socket.url).toBe("wss://box.tailnet.ts.net/termio/ws");
+    expect(socket.url).not.toContain("tok-123");
+  });
+
+  it("reads binary messages as ArrayBuffers", () => {
+    const { socket } = harness();
+    expect(socket.binaryType).toBe("arraybuffer");
+  });
+
+  it("holds frames written before the handshake and flushes them in order", () => {
+    const { socket, channel } = harness();
+    channel.sendControl({
+      op: "hello",
+      proto: 1,
+      min_proto: 1,
+      role: "attach",
+      caps: ["events", "snapshot", "scrollback"],
+      client: "termio-web/0.1.0",
+    });
+    channel.sendResize(24, 80);
+    expect(socket.sent.length).toBe(0);
+    socket.open();
+    expect(socket.sent.length).toBe(2);
+    expect(socket.sent[0][0]).toBe(KIND.CONTROL);
+    expect(socket.sent[1][0]).toBe(KIND.RESIZE);
+  });
+
+  it("splits sendData at the data frame cap", () => {
+    const { socket, channel } = harness();
+    socket.open();
+    channel.sendData(new Uint8Array(64 * 1024 + 1));
+    expect(socket.sent.length).toBe(2);
+  });
+
+  it("reassembles frames across message boundaries", () => {
+    const { socket, frames, channel } = harness();
+    socket.open();
+    const transcript = concat([
+      encodeJsonFrame(KIND.CONTROL, {
+        op: "hello_ok",
+        proto: 1,
+        caps: [],
+        host_id: "h",
+        host: "box",
+        client_id: "c",
+      }),
+      encodeFrame(KIND.DATA, new TextEncoder().encode("hi")),
+      encodeJsonFrame(KIND.EVENT, { ev: "ready", session: "s1" }),
+    ]);
+    for (let offset = 0; offset < transcript.length; offset += 3) {
+      socket.deliver(transcript.subarray(offset, offset + 3));
+    }
+    expect(frames.map((frame) => frame.kind)).toEqual([
+      KIND.CONTROL,
+      KIND.DATA,
+      KIND.EVENT,
+    ]);
+    expect(channel.readyState).toBe(1);
+  });
+
+  it("treats a text message as a protocol error and closes with 1003", () => {
+    const { socket, errors } = harness();
+    socket.open();
+    socket.emit("message", { data: "hello" });
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toMatch(/text message/);
+    expect(socket.closed?.code).toBe(1003);
+  });
+
+  it("closes with 1002 on a malformed stream and stops reading", () => {
+    const { socket, errors, frames } = harness();
+    socket.open();
+    socket.deliver(new Uint8Array([0x5a, 0, 0, 0, 0]));
+    expect(errors.length).toBe(1);
+    expect(socket.closed?.code).toBe(1002);
+    socket.deliver(encodeFrame(KIND.DATA, new Uint8Array([1])));
+    expect(frames.length).toBe(0);
+  });
+
+  it("reports the close code and reason", () => {
+    const { socket, closes } = harness();
+    socket.open();
+    socket.emit("close", { code: 1008, reason: "token rotated" });
+    expect(closes).toEqual([{ code: 1008, reason: "token rotated" }]);
+  });
+
+  it("closes cleanly on detach", () => {
+    const { socket, channel } = harness();
+    socket.open();
+    channel.close();
+    expect(socket.closed?.code).toBe(1000);
+  });
+});

--- a/web/client/src/protocol/socket.ts
+++ b/web/client/src/protocol/socket.ts
@@ -1,0 +1,166 @@
+/**
+ * One WebSocket = one protocol channel. No multiplexing, no channel ids:
+ * several sessions in one page are several sockets.
+ */
+import type { ControlOut } from "./control";
+import { ProtocolError } from "./errors";
+import type { Frame } from "./frame";
+import {
+  FrameReader,
+  encodeControl,
+  encodeData,
+  encodeResize,
+} from "./frame";
+
+/**
+ * Subprotocols offered, in this order and no others. The token entry is what
+ * `token_from_protocols` in `termiod/src/wss.rs` matches; `termiod.v1` is the
+ * one the server selects and echoes back, so the credential never lands in a
+ * response header a proxy will log.
+ */
+export const SUBPROTOCOL = "termiod.v1";
+export const TOKEN_SUBPROTOCOL_PREFIX = "termiod.token.";
+
+export interface ChannelOptions {
+  url: URL; // new URL("ws", new URL(".", location.href)), scheme swapped to wss:/ws:
+  token: string;
+  onFrame: (frame: Frame) => void;
+  onClose: (info: { code: number; reason: string }) => void;
+  onError: (error: Error) => void;
+}
+
+export interface Channel {
+  send(frame: Uint8Array): void; // already-encoded frame bytes
+  sendControl(msg: ControlOut): void;
+  sendData(bytes: Uint8Array): void; // splits at MAX_DATA_FRAME_SIZE
+  sendResize(rows: number, cols: number): void;
+  readonly readyState: number;
+  close(): void;
+}
+
+/**
+ * TypeScript has modelled `Uint8Array` as possibly SharedArrayBuffer-backed
+ * since 5.7, and `WebSocket.send` takes only the non-shared form. Every frame
+ * here comes from `encodeFrame`, which allocates its own plain ArrayBuffer, so
+ * this narrows a type the encoder already guarantees. It copies nothing.
+ */
+function sendable(frame: Uint8Array): Uint8Array<ArrayBuffer> {
+  return frame as Uint8Array<ArrayBuffer>;
+}
+
+/**
+ * The token NEVER rides the query string. `?t=` on /ws is refused host-side.
+ * The page reads it once from `location.hash` (`#t=…`), stashes it in
+ * sessionStorage, and clears the hash.
+ *
+ * `binaryType` is "arraybuffer". A text message from the host is a protocol
+ * error: close and surface it.
+ */
+export function openChannel(options: ChannelOptions): Channel {
+  const socket = new WebSocket(options.url.toString(), [
+    SUBPROTOCOL,
+    `${TOKEN_SUBPROTOCOL_PREFIX}${options.token}`,
+  ]);
+  socket.binaryType = "arraybuffer";
+
+  // Frames written before the handshake completes are held here rather than
+  // thrown away: `hello` has to be the first frame on the socket, and the
+  // caller should not have to wait on an open event to say so.
+  let backlog: Uint8Array[] | null = [];
+  let failed = false;
+
+  const reader = new FrameReader(options.onFrame);
+
+  /** One fault path: report, then close. A dead stream is never resumed. */
+  const fail = (error: Error, code: number): void => {
+    if (failed) return;
+    failed = true;
+    options.onError(error);
+    reader.reset();
+    try {
+      socket.close(code, error.message.slice(0, 120));
+    } catch {
+      // A socket that is already closing has nothing to say about it.
+    }
+  };
+
+  socket.addEventListener("open", () => {
+    const queued = backlog ?? [];
+    backlog = null;
+    for (const frame of queued) {
+      socket.send(sendable(frame));
+    }
+  });
+
+  socket.addEventListener("message", (event: MessageEvent) => {
+    if (failed) return;
+    if (typeof event.data === "string") {
+      // A text message means someone is speaking a dialect. 1003 is
+      // "unsupported data", which is exactly what happened.
+      fail(new ProtocolError("host sent a text message"), 1003);
+      return;
+    }
+    try {
+      reader.push(event.data as ArrayBuffer);
+    } catch (error) {
+      fail(
+        error instanceof Error ? error : new ProtocolError(String(error)),
+        1002,
+      );
+    }
+  });
+
+  socket.addEventListener("error", () => {
+    // The browser deliberately gives no detail here; the close event that
+    // follows carries the code.
+    options.onError(new Error("websocket error"));
+  });
+
+  socket.addEventListener("close", (event: CloseEvent) => {
+    backlog = null;
+    options.onClose({ code: event.code, reason: event.reason });
+  });
+
+  const send = (frame: Uint8Array): void => {
+    if (failed) return;
+    if (backlog) {
+      backlog.push(frame);
+      return;
+    }
+    socket.send(sendable(frame));
+  };
+
+  return {
+    send,
+    sendControl(msg: ControlOut): void {
+      send(encodeControl(msg));
+    },
+    sendData(bytes: Uint8Array): void {
+      for (const frame of encodeData(bytes)) {
+        send(frame);
+      }
+    },
+    sendResize(rows: number, cols: number): void {
+      send(encodeResize(rows, cols));
+    },
+    get readyState(): number {
+      return socket.readyState;
+    },
+    close(): void {
+      backlog = null;
+      socket.close(1000, "detach");
+    },
+  };
+}
+
+/**
+ * `wss:` for an `https:` page, `ws:` otherwise, against the prefix that served
+ * `index.html` — `/` behind Caddy's `handle_path`, `/termio/` behind Tailscale
+ * Serve. An absolute path here is the build-config bug the relative base
+ * exists to prevent.
+ */
+export function channelUrl(pageUrl: URL): URL {
+  const url = new URL("ws", new URL(".", pageUrl));
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url;
+}

--- a/web/client/src/protocol/testTranscript.ts
+++ b/web/client/src/protocol/testTranscript.ts
@@ -1,0 +1,158 @@
+/**
+ * Host-side encoders, for tests only.
+ *
+ * The client never writes an `S` or an `H` — the daemon does — so these mirror
+ * `encode_snapshot_payload` / `encode_history_payload` in
+ * `termiod/src/protocol.rs` closely enough that a decode test is testing the
+ * wire format rather than its own inverse.
+ */
+import type { TaggedColor } from "./colors";
+import { COLOR_TAG_PALETTE, COLOR_TAG_RGB } from "./colors";
+import { KIND, encodeFrame } from "./frame";
+import {
+  HISTORY_FORMAT_VERSION,
+  HISTORY_HEADER_SIZE,
+  SNAPSHOT_CELL_SIZE,
+  SNAPSHOT_FORMAT_VERSION,
+  SNAPSHOT_FORMAT_VT,
+} from "./payloads";
+
+export interface WireCell {
+  codepoint: number;
+  foreground: TaggedColor;
+  background: TaggedColor;
+  attributes: number;
+}
+
+export function cell(overrides: Partial<WireCell> = {}): WireCell {
+  return {
+    codepoint: 0x20,
+    foreground: { tag: "default" },
+    background: { tag: "default" },
+    attributes: 0,
+    ...overrides,
+  };
+}
+
+function writeColor(out: number[], color: TaggedColor): void {
+  switch (color.tag) {
+    case "palette":
+      out.push(COLOR_TAG_PALETTE, color.index, 0, 0);
+      break;
+    case "rgb":
+      out.push(COLOR_TAG_RGB, color.r, color.g, color.b);
+      break;
+    default:
+      out.push(0, 0, 0, 0);
+  }
+}
+
+function writeU16(out: number[], value: number): void {
+  out.push((value >>> 8) & 0xff, value & 0xff);
+}
+
+function writeU32(out: number[], value: number): void {
+  out.push(
+    (value >>> 24) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 8) & 0xff,
+    value & 0xff,
+  );
+}
+
+function writeBytes(out: number[], bytes: Uint8Array): void {
+  for (const byte of bytes) {
+    out.push(byte);
+  }
+}
+
+function writeCells(out: number[], cells: WireCell[]): void {
+  for (const item of cells) {
+    writeU32(out, item.codepoint);
+    writeColor(out, item.foreground);
+    writeColor(out, item.background);
+    writeU16(out, item.attributes);
+    out.push(0, 0);
+  }
+}
+
+export interface SnapshotHeader {
+  rows: number;
+  cols: number;
+  cursorX?: number;
+  cursorY?: number;
+  altScreen?: boolean;
+  title?: string;
+}
+
+export function encodeSnapshotVtPayload(
+  header: SnapshotHeader,
+  vt: Uint8Array,
+): Uint8Array {
+  const out: number[] = [SNAPSHOT_FORMAT_VT];
+  const title = new TextEncoder().encode(header.title ?? "");
+  writeU16(out, header.rows);
+  writeU16(out, header.cols);
+  writeU16(out, header.cursorX ?? 0);
+  writeU16(out, header.cursorY ?? 0);
+  out.push(header.altScreen ? 1 : 0);
+  writeU16(out, title.length);
+  writeBytes(out, title);
+  writeU32(out, vt.length);
+  writeBytes(out, vt);
+  return new Uint8Array(out);
+}
+
+export function encodeSnapshotCellsPayload(
+  header: SnapshotHeader,
+  cells: WireCell[],
+): Uint8Array {
+  const out: number[] = [SNAPSHOT_FORMAT_VERSION];
+  const title = new TextEncoder().encode(header.title ?? "");
+  writeU16(out, header.rows);
+  writeU16(out, header.cols);
+  writeU16(out, header.cursorX ?? 0);
+  writeU16(out, header.cursorY ?? 0);
+  out.push(header.altScreen ? 1 : 0);
+  writeU16(out, title.length);
+  writeBytes(out, title);
+  writeCells(out, cells);
+  return new Uint8Array(out);
+}
+
+export function encodeHistoryPayload(
+  cols: number,
+  firstOffset: number,
+  rowCount: number,
+  cells: WireCell[],
+): Uint8Array {
+  const out: number[] = [HISTORY_FORMAT_VERSION];
+  writeU16(out, cols);
+  writeU32(out, firstOffset);
+  writeU16(out, rowCount);
+  writeCells(out, cells);
+  const payload = new Uint8Array(out);
+  const expected = HISTORY_HEADER_SIZE + cols * rowCount * SNAPSHOT_CELL_SIZE;
+  if (payload.length !== expected) {
+    throw new Error(`test history payload is ${payload.length}, want ${expected}`);
+  }
+  return payload;
+}
+
+export function encodeJsonFrame(
+  kind: typeof KIND.CONTROL | typeof KIND.EVENT,
+  value: unknown,
+): Uint8Array {
+  return encodeFrame(kind, new TextEncoder().encode(JSON.stringify(value)));
+}
+
+export function concat(chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}

--- a/web/client/src/renderer/canvas2d.test.ts
+++ b/web/client/src/renderer/canvas2d.test.ts
@@ -1,0 +1,552 @@
+import { describe, expect, it } from "vitest";
+
+import { createCanvas2dRenderer } from "./canvas2d";
+import { ATTR } from "./types";
+import type {
+  CellView,
+  CursorState,
+  FontSpec,
+  Geometry,
+  Palette,
+  RenderFrame,
+  Rgb,
+  RowView,
+  TaggedColor,
+  TerminalRenderer,
+  RendererStats,
+} from "./types";
+
+/**
+ * The renderer only ever touches the canvas it was handed, so a recording
+ * context is a complete stand-in — no jsdom, no `canvas` native module, and the
+ * assertions are about the draw calls rather than about pixels.
+ */
+type Op =
+  | { op: "fillRect"; x: number; y: number; w: number; h: number; fill: string }
+  | { op: "fillText"; text: string; x: number; y: number; fill: string; font: string; alpha: number }
+  | { op: "strokeRect"; x: number; y: number; w: number; h: number; stroke: string }
+  | { op: "stroke"; stroke: string }
+  | { op: "setTransform"; scaleX: number; scaleY: number };
+
+const CELL_ADVANCE = 8;
+
+class RecordingContext {
+  ops: Op[] = [];
+  fillStyle = "";
+  strokeStyle = "";
+  font = "";
+  globalAlpha = 1;
+  lineWidth = 1;
+  textBaseline = "alphabetic";
+  letterSpacing = "0px";
+
+  setTransform(a: number, _b: number, _c: number, d: number, _e: number, _f: number): void {
+    this.ops.push({ op: "setTransform", scaleX: a, scaleY: d });
+  }
+
+  fillRect(x: number, y: number, w: number, h: number): void {
+    this.ops.push({ op: "fillRect", x, y, w, h, fill: this.fillStyle });
+  }
+
+  strokeRect(x: number, y: number, w: number, h: number): void {
+    this.ops.push({ op: "strokeRect", x, y, w, h, stroke: this.strokeStyle });
+  }
+
+  fillText(text: string, x: number, y: number): void {
+    this.ops.push({ op: "fillText", text, x, y, fill: this.fillStyle, font: this.font, alpha: this.globalAlpha });
+  }
+
+  measureText(text: string): {
+    width: number;
+    fontBoundingBoxAscent: number;
+    fontBoundingBoxDescent: number;
+  } {
+    return {
+      width: text.length * CELL_ADVANCE,
+      fontBoundingBoxAscent: 8,
+      fontBoundingBoxDescent: 2,
+    };
+  }
+
+  beginPath(): void {}
+  moveTo(): void {}
+  lineTo(): void {}
+  stroke(): void {
+    this.ops.push({ op: "stroke", stroke: this.strokeStyle });
+  }
+}
+
+interface Harness {
+  renderer: TerminalRenderer & { stats(): RendererStats };
+  context: RecordingContext;
+  canvas: { width: number; height: number; style: { width: string; height: string } };
+}
+
+const FONT: FontSpec = {
+  family: "monospace",
+  sizePx: 10,
+  weightNormal: 400,
+  weightBold: 700,
+  lineHeight: 1.2,
+};
+
+const CELL = { widthPx: CELL_ADVANCE, heightPx: 12, baselinePx: 9 };
+
+function harness(geometry?: Partial<Geometry>): Harness {
+  const context = new RecordingContext();
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: { width: "", height: "" },
+    getContext: () => context,
+  };
+  const renderer = createCanvas2dRenderer(canvas as unknown as HTMLCanvasElement, FONT);
+  if (!renderer) throw new Error("canvas2d factory returned null");
+  renderer.setGeometry({
+    cols: 4,
+    rows: 3,
+    cell: CELL,
+    devicePixelRatio: 1,
+    ...geometry,
+  });
+  return { renderer, context, canvas };
+}
+
+function rgb(r: number, g: number, b: number): Rgb {
+  return { r, g, b };
+}
+
+function palette(background: Rgb, foreground: Rgb, ansiFill: Rgb): Palette {
+  return {
+    background,
+    foreground,
+    ansi: Array.from({ length: 256 }, () => ansiFill),
+  };
+}
+
+const DEFAULT: TaggedColor = { tag: "default" };
+
+interface CellOverrides {
+  fg?: TaggedColor;
+  bg?: TaggedColor;
+  underline?: TaggedColor;
+  attributes?: number;
+  selected?: boolean;
+  grapheme?: string;
+}
+
+function cell(text: string, over: CellOverrides = {}): CellView {
+  const view: CellView = {
+    codepoint: text === "" ? 0 : (text.codePointAt(0) ?? 0),
+    foreground: over.fg ?? DEFAULT,
+    background: over.bg ?? DEFAULT,
+    attributes: over.attributes ?? 0,
+    selected: over.selected ?? false,
+  };
+  if (over.grapheme !== undefined) view.grapheme = over.grapheme;
+  if (over.underline !== undefined) view.underline = over.underline;
+  return view;
+}
+
+function row(y: number, cells: CellView[], options: { dirty?: boolean; selection?: { start: number; end: number } } = {}): RowView {
+  const view: RowView = { y, dirty: options.dirty ?? true, cells };
+  if (options.selection) view.selection = options.selection;
+  return view;
+}
+
+const NO_CURSOR: CursorState = {
+  hasValue: false,
+  x: 0,
+  y: 0,
+  visible: false,
+  blinking: false,
+  passwordInput: false,
+  wideTail: false,
+  style: "block",
+};
+
+function frame(rows: RowView[], options: Partial<RenderFrame> = {}): RenderFrame {
+  return {
+    dirty: "full",
+    cols: 4,
+    rows: 3,
+    cursor: NO_CURSOR,
+    rows_: rows,
+    overrides: {},
+    scrollOffsetRows: 0,
+    ...options,
+  };
+}
+
+function texts(ops: Op[]): Array<{ text: string; x: number; y: number; fill: string; font: string; alpha: number }> {
+  const found: Array<{ text: string; x: number; y: number; fill: string; font: string; alpha: number }> = [];
+  for (const op of ops) if (op.op === "fillText") found.push(op);
+  return found;
+}
+
+function rects(ops: Op[]): Array<{ x: number; y: number; w: number; h: number; fill: string }> {
+  const found: Array<{ x: number; y: number; w: number; h: number; fill: string }> = [];
+  for (const op of ops) if (op.op === "fillRect") found.push(op);
+  return found;
+}
+
+describe("canvas2d renderer", () => {
+  it("paints a default-slot cell in the viewer's colours, never black", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0x10, 0x18, 0x20), rgb(0xf0, 0xf0, 0xf0), rgb(0, 0, 0)));
+    context.ops = [];
+
+    renderer.draw(frame([row(0, [cell("A")])]));
+
+    const background = rects(context.ops)[0];
+    expect(background.fill).toBe("#101820");
+    const glyph = texts(context.ops).find((op) => op.text === "A");
+    expect(glyph?.fill).toBe("#f0f0f0");
+  });
+
+  it("resolves a palette index through the viewer's palette, and re-resolves it on setPalette", () => {
+    const { renderer, context } = harness();
+    const light = palette(rgb(0xff, 0xff, 0xff), rgb(0x20, 0x20, 0x20), rgb(0xaa, 0x00, 0x00));
+    renderer.setPalette(light);
+    const cells = [cell("x", { fg: { tag: "palette", index: 1 } })];
+
+    context.ops = [];
+    renderer.draw(frame([row(0, cells)]));
+    expect(texts(context.ops).find((op) => op.text === "x")?.fill).toBe("#aa0000");
+
+    // The theme switch: the same cells, no reload, no remount, no new frame
+    // from the VT — and every visible cell comes back in the new palette.
+    const dark = palette(rgb(0x00, 0x00, 0x00), rgb(0xdd, 0xdd, 0xdd), rgb(0x00, 0x88, 0xff));
+    renderer.setPalette(dark);
+    context.ops = [];
+    renderer.draw(frame([row(0, cells, { dirty: false })], { dirty: "none" }));
+
+    expect(texts(context.ops).find((op) => op.text === "x")?.fill).toBe("#0088ff");
+    expect(rects(context.ops)[0].fill).toBe("#000000");
+  });
+
+  it("honours program colour overrides without touching the viewer's palette", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0x10, 0x10, 0x10), rgb(0xee, 0xee, 0xee), rgb(0, 0, 0)));
+    context.ops = [];
+
+    renderer.draw(
+      frame([row(0, [cell("A")])], {
+        overrides: { background: rgb(0x33, 0x22, 0x11), foreground: rgb(0x01, 0x02, 0x03) },
+      }),
+    );
+
+    expect(rects(context.ops)[0].fill).toBe("#332211");
+    expect(texts(context.ops).find((op) => op.text === "A")?.fill).toBe("#010203");
+  });
+
+  it("repaints only damaged rows and their neighbours on a partial frame", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    const rows = [
+      row(0, [cell("a")], { dirty: false }),
+      row(1, [cell("b")], { dirty: false }),
+      row(2, [cell("c")], { dirty: true }),
+    ];
+    renderer.draw(frame(rows));
+
+    context.ops = [];
+    renderer.draw(frame(rows, { dirty: "partial" }));
+
+    const painted = texts(context.ops).map((op) => op.text);
+    expect(painted).toContain("c");
+    expect(painted).toContain("b"); // the neighbour, for glyph overflow
+    expect(painted).not.toContain("a");
+  });
+
+  it("paints history rows above the viewport through the same path", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(frame([row(0, [cell("v")])], { scrollOffsetRows: 1 }), [row(-1, [cell("h")])]);
+
+    const painted = texts(context.ops);
+    const history = painted.find((op) => op.text === "h");
+    const viewport = painted.find((op) => op.text === "v");
+    // -1 + scrollOffsetRows 1 = line 0; 0 + 1 = line 1. One arithmetic, both
+    // row sources.
+    expect(history?.y).toBe(CELL.baselinePx);
+    expect(viewport?.y).toBe(CELL.heightPx + CELL.baselinePx);
+  });
+
+  it("draws no glyph for a wide spacer but still paints its background", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(
+      frame([
+        row(0, [
+          cell("あ", { attributes: ATTR.WIDE }),
+          cell("", { attributes: ATTR.WIDE_SPACER, bg: { tag: "rgb", r: 0x12, g: 0x34, b: 0x56 } }),
+        ]),
+      ]),
+    );
+
+    expect(texts(context.ops).map((op) => op.text)).toEqual(["あ"]);
+    const spacer = rects(context.ops).find((op) => op.fill === "#123456");
+    expect(spacer).toBeDefined();
+    expect(spacer?.x).toBe(CELL.widthPx);
+  });
+
+  it("swaps foreground and background for a selected span", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0x00, 0x00, 0x00), rgb(0xff, 0xff, 0xff), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(frame([row(0, [cell("a"), cell("b")], { selection: { start: 1, end: 2 } })]));
+
+    const selectedBackground = rects(context.ops).find((op) => op.fill === "#ffffff" && op.x === CELL.widthPx);
+    expect(selectedBackground).toBeDefined();
+    expect(texts(context.ops).find((op) => op.text === "b")?.fill).toBe("#000000");
+    expect(texts(context.ops).find((op) => op.text === "a")?.fill).toBe("#ffffff");
+  });
+
+  it("falls back to the per-cell selected flag when the row has no range", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0x00, 0x00, 0x00), rgb(0xff, 0xff, 0xff), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(frame([row(0, [cell("a"), cell("b", { selected: true })])]));
+
+    expect(texts(context.ops).find((op) => op.text === "b")?.fill).toBe("#000000");
+  });
+
+  it("sizes the backing store by devicePixelRatio and draws in CSS pixels", () => {
+    const { canvas, context } = harness({ devicePixelRatio: 2, cols: 4, rows: 3 });
+
+    expect(canvas.width).toBe(4 * CELL.widthPx * 2);
+    expect(canvas.height).toBe(3 * CELL.heightPx * 2);
+    expect(canvas.style.width).toBe(`${4 * CELL.widthPx}px`);
+    const transform = context.ops.find((op) => op.op === "setTransform");
+    expect(transform).toEqual({ op: "setTransform", scaleX: 2, scaleY: 2 });
+  });
+
+  it("offsets every row by the geometry padding", () => {
+    const { renderer, context } = harness({ padding: { top: 5, left: 7 } });
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(frame([row(0, [cell("A")])]));
+
+    expect(texts(context.ops).find((op) => op.text === "A")?.x).toBe(7);
+  });
+
+  it("paints a block cursor over its cell and redraws the glyph in the cell background", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette({
+      background: rgb(0, 0, 0),
+      foreground: rgb(0xff, 0xff, 0xff),
+      cursor: rgb(0x00, 0xff, 0x00),
+      ansi: Array.from({ length: 256 }, () => rgb(1, 1, 1)),
+    });
+    context.ops = [];
+
+    renderer.draw(
+      frame([row(0, [cell("A"), cell("B")])], {
+        cursor: { ...NO_CURSOR, hasValue: true, visible: true, x: 1, y: 0 },
+      }),
+    );
+
+    const cursorRect = rects(context.ops).find((op) => op.fill === "#00ff00");
+    expect(cursorRect).toEqual({ op: "fillRect", x: CELL.widthPx, y: 0, w: CELL.widthPx, h: CELL.heightPx, fill: "#00ff00" });
+    // The glyph is drawn twice: once in the text pass, once inverted over the
+    // cursor block.
+    expect(texts(context.ops).filter((op) => op.text === "B" && op.fill === "#000000")).toHaveLength(1);
+  });
+
+  it("paints nothing for a cursor that is off the viewport or suppressed", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(0x00, 0xff, 0x00)));
+
+    renderer.draw(frame([row(0, [cell("A")])], { cursor: { ...NO_CURSOR } }));
+    context.ops = [];
+    renderer.draw(
+      frame([row(0, [cell("A")], { dirty: false })], {
+        dirty: "none",
+        cursor: { ...NO_CURSOR, hasValue: true, visible: true, passwordInput: true },
+      }),
+    );
+
+    expect(context.ops).toHaveLength(0);
+  });
+
+  it("repaints the line the cursor left even when no row is dirty", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    const rows = [row(0, [cell("a")], { dirty: false }), row(1, [cell("b")], { dirty: false }), row(2, [cell("c")], { dirty: false })];
+    renderer.draw(frame(rows, { cursor: { ...NO_CURSOR, hasValue: true, visible: true, x: 0, y: 0 } }));
+
+    context.ops = [];
+    renderer.draw(
+      frame(rows, { dirty: "none", cursor: { ...NO_CURSOR, hasValue: true, visible: true, x: 0, y: 2 } }),
+    );
+
+    const painted = texts(context.ops).map((op) => op.text);
+    expect(painted).toContain("a"); // the line the cursor left
+    expect(painted).toContain("c"); // the line it arrived on
+    expect(painted).not.toContain("b");
+  });
+
+  it("skips a clean frame entirely", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    renderer.draw(frame([row(0, [cell("A")])]));
+
+    context.ops = [];
+    renderer.draw(frame([row(0, [cell("A")], { dirty: false })], { dirty: "none" }));
+
+    expect(context.ops).toHaveLength(0);
+  });
+
+  it("forces a full repaint when the view scrolls", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    const rows = [row(0, [cell("a")], { dirty: false }), row(1, [cell("b")], { dirty: false })];
+    renderer.draw(frame(rows));
+
+    context.ops = [];
+    renderer.draw(frame(rows, { dirty: "none", scrollOffsetRows: 1 }));
+
+    const painted = texts(context.ops).map((op) => op.text);
+    expect(painted).toContain("a");
+    expect(painted).toContain("b");
+  });
+
+  it("carries bold, italic and faint into the glyph draw", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(
+      frame([
+        row(0, [
+          cell("A", { attributes: ATTR.BOLD }),
+          cell("B", { attributes: ATTR.ITALIC }),
+          cell("C", { attributes: ATTR.FAINT }),
+        ]),
+      ]),
+    );
+
+    const painted = texts(context.ops);
+    expect(painted.find((op) => op.text === "A")?.font).toBe("700 10px monospace");
+    expect(painted.find((op) => op.text === "B")?.font).toBe("italic 400 10px monospace");
+    expect(painted.find((op) => op.text === "C")?.alpha).toBeLessThan(1);
+  });
+
+  it("draws an underline in the program's underline colour", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(
+      frame([
+        row(0, [cell("A", { attributes: ATTR.UNDERLINE, underline: { tag: "rgb", r: 0xff, g: 0x00, b: 0x88 } })]),
+      ]),
+    );
+
+    const underline = rects(context.ops).find((op) => op.fill === "#ff0088");
+    expect(underline).toBeDefined();
+    expect(underline?.h).toBeGreaterThan(0);
+    expect(underline?.h).toBeLessThan(CELL.heightPx);
+  });
+
+  it("groups a same-style ASCII run into one fillText and keeps it on the grid", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(frame([row(0, [cell("a"), cell("b"), cell("c"), cell("d")])]));
+
+    expect(texts(context.ops)).toEqual([
+      { op: "fillText", text: "abcd", x: 0, y: CELL.baselinePx, fill: "#ffffff", font: "400 10px monospace", alpha: 1 },
+    ]);
+  });
+
+  it("stops grouping runs when the layout cell width is not the font's advance", () => {
+    // A caller that rounds the measured advance up lays out on a grid the font
+    // does not walk on; a whole-run fillText would drift right across the row.
+    const { renderer, context } = harness({ cell: { widthPx: CELL_ADVANCE + 1, heightPx: 12, baselinePx: 9 } });
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(frame([row(0, [cell("a"), cell("b")])]));
+
+    expect(texts(context.ops).map((op) => [op.text, op.x])).toEqual([
+      ["a", 0],
+      ["b", CELL_ADVANCE + 1],
+    ]);
+  });
+
+  it("breaks a run at a grapheme cluster and draws it at its own column", () => {
+    const { renderer, context } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    context.ops = [];
+
+    renderer.draw(frame([row(0, [cell("a"), cell("e", { grapheme: "é" }), cell("b")])]));
+
+    expect(texts(context.ops).map((op) => [op.text, op.x])).toEqual([
+      ["a", 0],
+      ["é", CELL.widthPx],
+      ["b", CELL.widthPx * 2],
+    ]);
+  });
+
+  it("throws on a palette that is not exactly 256 entries", () => {
+    const { renderer } = harness();
+    expect(() =>
+      renderer.setPalette({
+        background: rgb(0, 0, 0),
+        foreground: rgb(255, 255, 255),
+        ansi: Array.from({ length: 16 }, () => rgb(1, 1, 1)),
+      }),
+    ).toThrow(/256/);
+  });
+
+  it("throws rather than painting before it has been told the palette", () => {
+    const { renderer } = harness();
+    expect(() => renderer.draw(frame([row(0, [cell("A")])]))).toThrow(/setPalette/);
+  });
+
+  it("disposes idempotently and refuses to draw afterwards", () => {
+    const { renderer } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    renderer.dispose();
+    renderer.dispose();
+    expect(() => renderer.draw(frame([row(0, [cell("A")])]))).toThrow(/dispose/);
+  });
+
+  it("reports its implementation and counts what it painted", () => {
+    const { renderer } = harness();
+    renderer.setPalette(palette(rgb(0, 0, 0), rgb(255, 255, 255), rgb(1, 1, 1)));
+    renderer.draw(frame([row(0, [cell("A")])]));
+    renderer.draw(frame([row(0, [cell("A")], { dirty: true })], { dirty: "partial" }));
+
+    const stats = renderer.stats();
+    expect(stats.implementation).toBe("canvas2d");
+    expect(stats.framesPainted).toBe(2);
+    expect(stats.fullRedraws).toBe(1);
+    expect(stats.frameTimeP50Ms).toBeGreaterThanOrEqual(0);
+    expect(stats.frameTimeP95Ms).toBeGreaterThanOrEqual(stats.frameTimeP50Ms);
+  });
+
+  it("returns null when the canvas has no 2D context", () => {
+    const canvas = { getContext: () => null } as unknown as HTMLCanvasElement;
+    expect(createCanvas2dRenderer(canvas, FONT)).toBeNull();
+  });
+
+  it("measures a cell from the font it is given", () => {
+    const { renderer } = harness();
+    const metrics = renderer.measure({ ...FONT, sizePx: 20, lineHeight: 1.5 });
+    expect(metrics.widthPx).toBe(CELL_ADVANCE);
+    expect(metrics.heightPx).toBe(30);
+    expect(metrics.baselinePx).toBeGreaterThan(0);
+    expect(metrics.baselinePx).toBeLessThanOrEqual(metrics.heightPx);
+  });
+});

--- a/web/client/src/renderer/canvas2d.ts
+++ b/web/client/src/renderer/canvas2d.ts
@@ -1,0 +1,711 @@
+import { ATTR } from "./types";
+import type {
+  CellMetrics,
+  CellView,
+  FontSpec,
+  Geometry,
+  Palette,
+  RenderFrame,
+  RendererFactory,
+  RendererStats,
+  Rgb,
+  RowView,
+  TaggedColor,
+  TerminalRenderer,
+} from "./types";
+
+/**
+ * Canvas 2D implementation of the `TerminalRenderer` seam.
+ *
+ * It knows about a canvas, a font, a viewer `Palette`, and the damage it is
+ * handed. It has no socket, no Wasm handle, no React import, and no timer of
+ * its own: `draw()` is called by the app's rAF loop and never calls back.
+ *
+ * Colour resolution happens here and nowhere else. A `{tag:"palette"}` cell
+ * looks up the *viewer's* `ansi[index]`, so one snapshot painted against a
+ * light palette and a dark palette differs, and `setPalette` re-resolves every
+ * visible cell with no reload — the presentation boundary that disqualified
+ * ghostty-web (pre-resolved RGB cells) and `@wterm` (palette baked into the
+ * Wasm at construction).
+ *
+ * Where it will hurt, said plainly: a full-viewport repaint at large geometry
+ * is `cols × rows` worth of glyph drawing, and Canvas 2D text is the slow path
+ * in every browser. That is the named cost this renderer accepts and the thing
+ * the WebGPU implementation of this same seam is scheduled to fix.
+ */
+
+/** One 60 Hz vsync. A paint longer than this dropped a frame. */
+const FRAME_BUDGET_MS = 1000 / 60;
+
+/** Frame times kept for the p50 / p95 counters — four seconds at 60 Hz. */
+const FRAME_TIME_SAMPLES = 240;
+
+/** FAINT is drawn as reduced alpha; the wire carries no faint colour. */
+const FAINT_ALPHA = 0.6;
+
+interface ResolvedDefaults {
+  foreground: Rgb;
+  background: Rgb;
+  cursor: Rgb;
+}
+
+interface CursorMark {
+  line: number;
+  x: number;
+  width: number;
+}
+
+function now(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
+function packRgb(color: Rgb): number {
+  return ((color.r & 255) << 16) | ((color.g & 255) << 8) | (color.b & 255);
+}
+
+function sameRgb(a: Rgb, b: Rgb): boolean {
+  return a.r === b.r && a.g === b.g && a.b === b.b;
+}
+
+function fontString(font: FontSpec, bold: boolean, italic: boolean): string {
+  const weight = bold ? font.weightBold : font.weightNormal;
+  return `${italic ? "italic " : ""}${weight} ${font.sizePx}px ${font.family}`;
+}
+
+function finiteOr(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+/**
+ * A cell whose glyph can be drawn as part of a multi-cell `fillText` run.
+ *
+ * Runs are the difference between one call per cell and one call per style
+ * change, but they only stay on the grid while the font's own advance matches
+ * the cell width (checked in `measure`) and the text is single-codepoint
+ * ASCII. A grapheme cluster, a wide glyph, or a font whose advance drifts is
+ * drawn cell by cell, which cannot drift because each cell carries its own x.
+ */
+function isRunnable(cell: CellView): boolean {
+  if (cell.grapheme !== undefined) return false;
+  if ((cell.attributes & (ATTR.WIDE | ATTR.WIDE_SPACER)) !== 0) return false;
+  return cell.codepoint >= 0x20 && cell.codepoint <= 0x7e;
+}
+
+function cellText(cell: CellView): string {
+  if (cell.grapheme !== undefined) return cell.grapheme;
+  if (cell.codepoint === 0 || cell.codepoint === 0x20) return "";
+  return String.fromCodePoint(cell.codepoint);
+}
+
+class Canvas2dRenderer implements TerminalRenderer {
+  private readonly canvas: HTMLCanvasElement;
+  private readonly context: CanvasRenderingContext2D;
+
+  private font: FontSpec;
+  private metrics: CellMetrics;
+  private geometry: Geometry | null = null;
+  private palette: Palette | null = null;
+
+  /** The font's advance matches the cell width, so `fillText` runs stay on grid. */
+  private runsStayOnGrid = false;
+  /** Per-cell advance measured over a multi-cell sample of the active font. */
+  private sampleAdvancePx = 0;
+
+  private needsFullRedraw = true;
+  private lastScrollOffsetRows = 0;
+  private lastDefaults: ResolvedDefaults | null = null;
+  private lastCursor: CursorMark | null = null;
+
+  /** Per-row scratch, sized to `cols` and reused; never handed to a caller. */
+  private foregroundScratch: string[] = [];
+  private backgroundScratch: string[] = [];
+
+  private readonly colorCache = new Map<number, string>();
+
+  private framesPainted = 0;
+  private fullRedraws = 0;
+  private droppedFrames = 0;
+  private readonly frameTimes: number[] = [];
+
+  private disposed = false;
+
+  constructor(canvas: HTMLCanvasElement, context: CanvasRenderingContext2D, font: FontSpec) {
+    this.canvas = canvas;
+    this.context = context;
+    this.font = font;
+    this.metrics = this.measure(font);
+  }
+
+  measure(font: FontSpec): CellMetrics {
+    const context = this.context;
+    this.font = font;
+    this.applyLetterSpacing(font);
+    context.font = fontString(font, false, false);
+
+    const single = context.measureText("M");
+    const spacing = this.letterSpacingIsHonoured() ? 0 : (font.letterSpacingPx ?? 0);
+    const widthPx = Math.max(1, finiteOr(single.width, font.sizePx * 0.6) + spacing);
+
+    const ascent = finiteOr(single.fontBoundingBoxAscent, font.sizePx * 0.8);
+    const descent = finiteOr(single.fontBoundingBoxDescent, font.sizePx * 0.2);
+    const heightPx = Math.max(1, Math.round(font.sizePx * font.lineHeight));
+    const baselinePx = Math.min(
+      heightPx,
+      Math.max(1, Math.round((heightPx - (ascent + descent)) / 2 + ascent)),
+    );
+
+    // Eight cells of the same glyph: if the run lands where eight cell widths
+    // say it should, whole-run `fillText` is safe. A quarter of a pixel of
+    // total drift over eight cells is the tolerance, because drift accumulates
+    // across a row and a row can be 200 cells wide.
+    const sampleCount = 8;
+    const sample = context.measureText("M".repeat(sampleCount));
+    this.sampleAdvancePx = finiteOr(sample.width, widthPx * sampleCount) / sampleCount + spacing;
+    this.evaluateRunSafety(widthPx);
+
+    this.metrics = { widthPx, heightPx, baselinePx };
+    this.needsFullRedraw = true;
+    return this.metrics;
+  }
+
+  setGeometry(geometry: Geometry): void {
+    this.geometry = geometry;
+    this.metrics = geometry.cell;
+    // The caller may lay out on a rounded cell width, which is a different
+    // number from the one `measure` returned; runs are only safe against the
+    // width actually being painted on.
+    this.evaluateRunSafety(geometry.cell.widthPx);
+
+    const ratio = geometry.devicePixelRatio > 0 ? geometry.devicePixelRatio : 1;
+    const padding = geometry.padding ?? { top: 0, left: 0 };
+    // Padding is letterboxing, so it exists on both sides of the grid; the CSS
+    // box the renderer sizes itself to is the grid plus that box.
+    const cssWidth = padding.left * 2 + geometry.cols * geometry.cell.widthPx;
+    const cssHeight = padding.top * 2 + geometry.rows * geometry.cell.heightPx;
+    const backingWidth = Math.max(1, Math.round(cssWidth * ratio));
+    const backingHeight = Math.max(1, Math.round(cssHeight * ratio));
+
+    // Assigning width/height resets the whole context state, so it is done
+    // first and the transform is re-established after.
+    if (this.canvas.width !== backingWidth) this.canvas.width = backingWidth;
+    if (this.canvas.height !== backingHeight) this.canvas.height = backingHeight;
+    const style = this.canvas.style as CSSStyleDeclaration | undefined;
+    if (style) {
+      style.width = `${cssWidth}px`;
+      style.height = `${cssHeight}px`;
+    }
+
+    // Everything below draws in CSS pixels; the backing store carries the ratio.
+    this.context.setTransform(ratio, 0, 0, ratio, 0, 0);
+    this.needsFullRedraw = true;
+  }
+
+  setPalette(palette: Palette): void {
+    if (palette.ansi.length !== 256) {
+      throw new Error(
+        `Palette.ansi must have exactly 256 entries, got ${palette.ansi.length}. ` +
+          "A short palette is a theme bug; clamping it would paint the wrong colour silently.",
+      );
+    }
+    this.palette = palette;
+    this.colorCache.clear();
+    // The whole theme-switch mechanism: every visible cell, including every
+    // palette-indexed one, re-resolves on the next draw. No reload, no remount,
+    // no re-parse.
+    this.needsFullRedraw = true;
+  }
+
+  draw(frame: RenderFrame, history?: RowView[]): void {
+    if (this.disposed) throw new Error("Canvas2dRenderer.draw after dispose");
+    const geometry = this.geometry;
+    if (!geometry) throw new Error("Canvas2dRenderer.draw before setGeometry");
+    const palette = this.palette;
+    if (!palette) throw new Error("Canvas2dRenderer.draw before setPalette");
+
+    const started = now();
+    const defaults: ResolvedDefaults = {
+      foreground: frame.overrides.foreground ?? palette.foreground,
+      background: frame.overrides.background ?? palette.background,
+      cursor: frame.overrides.cursor ?? palette.cursor ?? frame.overrides.foreground ?? palette.foreground,
+    };
+
+    const cursorMark = this.cursorMark(frame, geometry);
+    const defaultsChanged =
+      this.lastDefaults === null ||
+      !sameRgb(this.lastDefaults.foreground, defaults.foreground) ||
+      !sameRgb(this.lastDefaults.background, defaults.background) ||
+      !sameRgb(this.lastDefaults.cursor, defaults.cursor);
+    // Scrolling moves every row to a different screen line; the damage flags
+    // describe the grid, not the line it lands on.
+    const scrolled = frame.scrollOffsetRows !== this.lastScrollOffsetRows;
+    const full = this.needsFullRedraw || frame.dirty === "full" || scrolled || defaultsChanged;
+
+    const cursorMoved = !sameCursorMark(this.lastCursor, cursorMark);
+    if (!full && frame.dirty === "none" && !cursorMoved) {
+      this.lastScrollOffsetRows = frame.scrollOffsetRows;
+      return;
+    }
+
+    const context = this.context;
+    this.applyLetterSpacing(this.font);
+    context.textBaseline = "alphabetic";
+    context.globalAlpha = 1;
+
+    const byLine = new Map<number, RowView>();
+    collectRows(byLine, history, frame.scrollOffsetRows, geometry.rows);
+    collectRows(byLine, frame.rows_, frame.scrollOffsetRows, geometry.rows);
+
+    let lines: number[];
+    if (full) {
+      const padding = geometry.padding ?? { top: 0, left: 0 };
+      context.fillStyle = this.css(defaults.background);
+      context.fillRect(
+        0,
+        0,
+        padding.left * 2 + geometry.cols * geometry.cell.widthPx,
+        padding.top * 2 + geometry.rows * geometry.cell.heightPx,
+      );
+      lines = [];
+      for (let line = 0; line < geometry.rows; line += 1) lines.push(line);
+      this.fullRedraws += 1;
+    } else {
+      const damaged = new Set<number>();
+      markDamage(damaged, history, frame.scrollOffsetRows, geometry.rows);
+      markDamage(damaged, frame.rows_, frame.scrollOffsetRows, geometry.rows);
+      // The cursor is an overlay, so the line it left and the line it arrived
+      // on repaint even when the grid under them did not change.
+      if (this.lastCursor && this.lastCursor.line < geometry.rows) damaged.add(this.lastCursor.line);
+      if (cursorMark) damaged.add(cursorMark.line);
+      lines = Array.from(damaged).sort((a, b) => a - b);
+    }
+
+    for (const line of lines) {
+      const row = byLine.get(line);
+      if (row) {
+        this.paintRow(line, row, geometry, defaults);
+      } else if (!full) {
+        // A damaged line with no row behind it (a neighbour past the end of
+        // history) still has last frame's pixels on it.
+        const padding = geometry.padding ?? { top: 0, left: 0 };
+        context.fillStyle = this.css(defaults.background);
+        context.fillRect(
+          padding.left,
+          padding.top + line * geometry.cell.heightPx,
+          geometry.cols * geometry.cell.widthPx,
+          geometry.cell.heightPx,
+        );
+      }
+    }
+
+    if (cursorMark) {
+      const row = byLine.get(cursorMark.line);
+      this.paintCursor(frame, cursorMark, row, geometry, defaults);
+    }
+
+    this.needsFullRedraw = false;
+    this.lastScrollOffsetRows = frame.scrollOffsetRows;
+    this.lastDefaults = defaults;
+    this.lastCursor = cursorMark;
+
+    const elapsed = now() - started;
+    this.framesPainted += 1;
+    if (elapsed > FRAME_BUDGET_MS) this.droppedFrames += 1;
+    this.frameTimes.push(elapsed);
+    if (this.frameTimes.length > FRAME_TIME_SAMPLES) this.frameTimes.shift();
+  }
+
+  dispose(): void {
+    // Idempotent: React 19 StrictMode double-invokes effects, so the second
+    // call has to be a no-op rather than a second teardown.
+    if (this.disposed) return;
+    this.disposed = true;
+    this.geometry = null;
+    this.palette = null;
+    this.lastDefaults = null;
+    this.lastCursor = null;
+    this.colorCache.clear();
+    this.foregroundScratch = [];
+    this.backgroundScratch = [];
+  }
+
+  stats(): RendererStats {
+    const sorted = this.frameTimes.slice().sort((a, b) => a - b);
+    return {
+      implementation: "canvas2d",
+      framesPainted: this.framesPainted,
+      fullRedraws: this.fullRedraws,
+      droppedFrames: this.droppedFrames,
+      frameTimeP50Ms: percentile(sorted, 0.5),
+      frameTimeP95Ms: percentile(sorted, 0.95),
+    };
+  }
+
+  private paintRow(line: number, row: RowView, geometry: Geometry, defaults: ResolvedDefaults): void {
+    const context = this.context;
+    const { widthPx, heightPx, baselinePx } = geometry.cell;
+    const padding = geometry.padding ?? { top: 0, left: 0 };
+    const top = padding.top + line * heightPx;
+    const left = padding.left;
+    const count = Math.min(row.cells.length, geometry.cols);
+    const defaultBackground = this.css(defaults.background);
+
+    if (this.foregroundScratch.length < count) {
+      this.foregroundScratch.length = count;
+      this.backgroundScratch.length = count;
+    }
+
+    // Background pass. The row starts as the viewer's default background, then
+    // every run that differs is filled over it, so a shrinking line does not
+    // leave last frame's pixels behind.
+    context.fillStyle = defaultBackground;
+    context.fillRect(left, top, geometry.cols * widthPx, heightPx);
+
+    let runStart = -1;
+    let runColor = "";
+    for (let column = 0; column < count; column += 1) {
+      const cell = row.cells[column];
+      const selected = isSelected(row, cell, column);
+      let foreground = this.resolve(cell.foreground, defaults.foreground);
+      let background = this.resolve(cell.background, defaults.background);
+      if (selected) {
+        // The seam's Palette carries no selection colour, so selection is a
+        // slot swap: it reads as selected in every theme without inventing one.
+        const swap = foreground;
+        foreground = background;
+        background = swap;
+      }
+      const foregroundCss = this.css(foreground);
+      const backgroundCss = this.css(background);
+      this.foregroundScratch[column] = foregroundCss;
+      this.backgroundScratch[column] = backgroundCss;
+
+      if (backgroundCss === runColor) continue;
+      if (runStart >= 0 && runColor !== defaultBackground) {
+        context.fillStyle = runColor;
+        context.fillRect(left + runStart * widthPx, top, (column - runStart) * widthPx, heightPx);
+      }
+      runStart = column;
+      runColor = backgroundCss;
+    }
+    if (runStart >= 0 && runColor !== defaultBackground) {
+      context.fillStyle = runColor;
+      context.fillRect(left + runStart * widthPx, top, (count - runStart) * widthPx, heightPx);
+    }
+
+    // Text pass.
+    const baseline = top + baselinePx;
+    let textStart = -1;
+    let text = "";
+    let textColor = "";
+    let textFont = "";
+    let textAlpha = 1;
+    const flush = (): void => {
+      if (textStart < 0 || text === "") {
+        textStart = -1;
+        text = "";
+        return;
+      }
+      context.fillStyle = textColor;
+      context.font = textFont;
+      context.globalAlpha = textAlpha;
+      context.fillText(text, left + textStart * widthPx, baseline);
+      context.globalAlpha = 1;
+      textStart = -1;
+      text = "";
+    };
+
+    for (let column = 0; column < count; column += 1) {
+      const cell = row.cells[column];
+      if ((cell.attributes & ATTR.WIDE_SPACER) !== 0) {
+        // The spacer's background was already painted; its glyph belongs to the
+        // WIDE cell to its left.
+        flush();
+        continue;
+      }
+      const glyph = cellText(cell);
+      if (glyph === "") {
+        flush();
+        continue;
+      }
+      const foregroundCss = this.foregroundScratch[column];
+      const cellFont = fontString(
+        this.font,
+        (cell.attributes & ATTR.BOLD) !== 0,
+        (cell.attributes & ATTR.ITALIC) !== 0,
+      );
+      const alpha = (cell.attributes & ATTR.FAINT) !== 0 ? FAINT_ALPHA : 1;
+
+      if (!this.runsStayOnGrid || !isRunnable(cell)) {
+        flush();
+        context.fillStyle = foregroundCss;
+        context.font = cellFont;
+        context.globalAlpha = alpha;
+        context.fillText(glyph, left + column * widthPx, baseline);
+        context.globalAlpha = 1;
+        continue;
+      }
+
+      if (
+        textStart >= 0 &&
+        (foregroundCss !== textColor || cellFont !== textFont || alpha !== textAlpha)
+      ) {
+        flush();
+      }
+      if (textStart < 0) {
+        textStart = column;
+        textColor = foregroundCss;
+        textFont = cellFont;
+        textAlpha = alpha;
+      }
+      text += glyph;
+    }
+    flush();
+
+    this.paintDecorations(row, count, left, top, geometry, defaults);
+  }
+
+  private paintDecorations(
+    row: RowView,
+    count: number,
+    left: number,
+    top: number,
+    geometry: Geometry,
+    defaults: ResolvedDefaults,
+  ): void {
+    const context = this.context;
+    const { widthPx, heightPx, baselinePx } = geometry.cell;
+    const thickness = Math.max(1, Math.round(this.font.sizePx / 14));
+    const decorated =
+      ATTR.UNDERLINE | ATTR.UNDERCURL | ATTR.STRIKETHROUGH | ATTR.OVERLINE;
+
+    for (let column = 0; column < count; column += 1) {
+      const cell = row.cells[column];
+      if ((cell.attributes & decorated) === 0) continue;
+
+      const selected = isSelected(row, cell, column);
+      const base = selected
+        ? this.resolve(cell.background, defaults.background)
+        : this.resolve(cell.foreground, defaults.foreground);
+      const lineColor =
+        cell.underline !== undefined && !selected
+          ? this.css(this.resolve(cell.underline, base))
+          : this.css(base);
+      const x = left + column * widthPx;
+      const width = (cell.attributes & ATTR.WIDE) !== 0 ? widthPx * 2 : widthPx;
+
+      if ((cell.attributes & ATTR.OVERLINE) !== 0) {
+        context.fillStyle = lineColor;
+        context.fillRect(x, top, width, thickness);
+      }
+      if ((cell.attributes & ATTR.STRIKETHROUGH) !== 0) {
+        context.fillStyle = lineColor;
+        context.fillRect(x, top + Math.round(baselinePx * 0.6), width, thickness);
+      }
+      if ((cell.attributes & ATTR.UNDERLINE) !== 0) {
+        context.fillStyle = lineColor;
+        context.fillRect(x, top + Math.min(heightPx - thickness, baselinePx + thickness), width, thickness);
+      }
+      if ((cell.attributes & ATTR.UNDERCURL) !== 0) {
+        // A zigzag, not a shaped curl: the honest v1 shape, replaced when the
+        // WebGPU implementation brings real geometry.
+        const y = top + Math.min(heightPx - thickness * 2, baselinePx + thickness);
+        context.strokeStyle = lineColor;
+        context.lineWidth = thickness;
+        context.beginPath();
+        context.moveTo(x, y + thickness);
+        const steps = 4;
+        for (let step = 1; step <= steps; step += 1) {
+          context.lineTo(x + (width * step) / steps, y + (step % 2 === 0 ? thickness : 0));
+        }
+        context.stroke();
+      }
+    }
+  }
+
+  private paintCursor(
+    frame: RenderFrame,
+    mark: CursorMark,
+    row: RowView | undefined,
+    geometry: Geometry,
+    defaults: ResolvedDefaults,
+  ): void {
+    const context = this.context;
+    const { widthPx, heightPx, baselinePx } = geometry.cell;
+    const padding = geometry.padding ?? { top: 0, left: 0 };
+    const x = padding.left + mark.x * widthPx;
+    const y = padding.top + mark.line * heightPx;
+    const width = mark.width * widthPx;
+    const color = this.css(defaults.cursor);
+
+    switch (frame.cursor.style) {
+      case "bar":
+        context.fillStyle = color;
+        context.fillRect(x, y, Math.max(1, Math.round(widthPx / 8)), heightPx);
+        return;
+      case "underline":
+        context.fillStyle = color;
+        context.fillRect(
+          x,
+          y + heightPx - Math.max(1, Math.round(heightPx / 12)),
+          width,
+          Math.max(1, Math.round(heightPx / 12)),
+        );
+        return;
+      case "hollow_block":
+        context.strokeStyle = color;
+        context.lineWidth = 1;
+        context.strokeRect(x + 0.5, y + 0.5, width - 1, heightPx - 1);
+        return;
+      case "block": {
+        context.fillStyle = color;
+        context.fillRect(x, y, width, heightPx);
+        const cell = row?.cells[mark.x];
+        if (!cell) return;
+        const glyph = cellText(cell);
+        if (glyph === "") return;
+        // The glyph is redrawn in the cell's own background so a block cursor
+        // does not hide the character it sits on.
+        context.fillStyle = this.css(this.resolve(cell.background, defaults.background));
+        context.font = fontString(
+          this.font,
+          (cell.attributes & ATTR.BOLD) !== 0,
+          (cell.attributes & ATTR.ITALIC) !== 0,
+        );
+        context.fillText(glyph, x, y + baselinePx);
+        return;
+      }
+    }
+  }
+
+  private cursorMark(frame: RenderFrame, geometry: Geometry): CursorMark | null {
+    const cursor = frame.cursor;
+    // `hasValue` false means the cursor is not on the viewport at all; x/y are
+    // not to be clamped into range, they are to be ignored.
+    if (!cursor.hasValue || !cursor.visible || cursor.passwordInput) return null;
+    const line = cursor.y + frame.scrollOffsetRows;
+    if (line < 0 || line >= geometry.rows) return null;
+    if (cursor.x < 0 || cursor.x >= geometry.cols) return null;
+    const row = frame.rows_.find((candidate) => candidate.y === cursor.y);
+    const cell = row?.cells[cursor.x];
+    const wide = !cursor.wideTail && cell !== undefined && (cell.attributes & ATTR.WIDE) !== 0;
+    const width = wide && cursor.x + 1 < geometry.cols ? 2 : 1;
+    return { line, x: cursor.x, width };
+  }
+
+  /**
+   * The one place a colour slot becomes pixels. `default` is the viewer's
+   * default — never black — and `palette` is an index into the *viewer's*
+   * theme, resolved here rather than anywhere upstream.
+   */
+  private resolve(color: TaggedColor, fallback: Rgb): Rgb {
+    switch (color.tag) {
+      case "default":
+        return fallback;
+      case "palette": {
+        const palette = this.palette;
+        if (!palette) return fallback;
+        const entry = palette.ansi[color.index & 255];
+        return entry ?? fallback;
+      }
+      case "rgb":
+        return color;
+    }
+  }
+
+  private css(color: Rgb): string {
+    const key = packRgb(color);
+    const cached = this.colorCache.get(key);
+    if (cached !== undefined) return cached;
+    const value = `#${key.toString(16).padStart(6, "0")}`;
+    this.colorCache.set(key, value);
+    return value;
+  }
+
+  /**
+   * Drift accumulates across a row, and a row can be 200 cells wide, so the
+   * tolerance is a quarter of a pixel over the whole sample rather than per
+   * cell. A font that misses it is drawn cell by cell, which cannot drift.
+   */
+  private evaluateRunSafety(cellWidthPx: number): void {
+    const sampleCount = 8;
+    this.runsStayOnGrid =
+      this.sampleAdvancePx > 0 &&
+      Math.abs(this.sampleAdvancePx - cellWidthPx) < 0.25 / sampleCount;
+  }
+
+  private applyLetterSpacing(font: FontSpec): void {
+    if (!this.letterSpacingIsHonoured()) return;
+    const context = this.context as CanvasRenderingContext2D & { letterSpacing: string };
+    context.letterSpacing = `${font.letterSpacingPx ?? 0}px`;
+  }
+
+  private letterSpacingIsHonoured(): boolean {
+    const context = this.context as CanvasRenderingContext2D & { letterSpacing?: string };
+    return typeof context.letterSpacing === "string";
+  }
+}
+
+function sameCursorMark(a: CursorMark | null, b: CursorMark | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.line === b.line && a.x === b.x && a.width === b.width;
+}
+
+function isSelected(row: RowView, cell: CellView, column: number): boolean {
+  // render.h recommends the row-local range for span renderers and documents
+  // that it agrees with the per-cell flag; the flag is the fallback.
+  if (row.selection) return column >= row.selection.start && column < row.selection.end;
+  return cell.selected;
+}
+
+function collectRows(
+  into: Map<number, RowView>,
+  rows: RowView[] | undefined,
+  scrollOffsetRows: number,
+  lineCount: number,
+): void {
+  if (!rows) return;
+  for (const row of rows) {
+    const line = row.y + scrollOffsetRows;
+    if (line < 0 || line >= lineCount) continue;
+    into.set(line, row);
+  }
+}
+
+function markDamage(
+  into: Set<number>,
+  rows: RowView[] | undefined,
+  scrollOffsetRows: number,
+  lineCount: number,
+): void {
+  if (!rows) return;
+  for (const row of rows) {
+    if (!row.dirty) continue;
+    const line = row.y + scrollOffsetRows;
+    // The neighbours come along because a tall glyph, a descender, or an
+    // italic overhangs its own row — ghostty-web's lesson, taken without
+    // taking their code.
+    for (let candidate = line - 1; candidate <= line + 1; candidate += 1) {
+      if (candidate >= 0 && candidate < lineCount) into.add(candidate);
+    }
+  }
+}
+
+function percentile(sorted: number[], fraction: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * fraction) - 1));
+  return sorted[index];
+}
+
+/**
+ * Canvas 2D is available wherever a 2D context is. `null` is returned only when
+ * the context cannot be had at all, which is the same "not available here"
+ * signal the WebGPU factory will use — the caller tries one factory, then the
+ * next, and the page never shows a wall.
+ */
+export const createCanvas2dRenderer: RendererFactory = (canvas, font) => {
+  const context = canvas.getContext("2d", { alpha: false });
+  if (!context) return null;
+  return new Canvas2dRenderer(canvas, context, font);
+};

--- a/web/client/src/renderer/seam.test.ts
+++ b/web/client/src/renderer/seam.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The seam's rules are review rules, so they are asserted on the source rather
+ * than on behaviour. A renderer that reads a host-resolved colour, imports
+ * React, or grows a timer of its own still passes every pixel test; it just
+ * stops being swappable for a WebGPU implementation.
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Comments are stripped first: the seam file *names* the forbidden accessors
+ * in the prohibition itself, and a guard that cannot tell a rule from a call
+ * would forbid writing the rule down.
+ */
+function withoutComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+function sources(): Array<{ name: string; text: string }> {
+  return readdirSync(here)
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+    .map((name) => ({ name, text: withoutComments(readFileSync(join(here, name), "utf8")) }));
+}
+
+describe("renderer seam", () => {
+  it("ships types.ts and canvas2d.ts and nothing that is not a renderer", () => {
+    expect(sources().map((file) => file.name).sort()).toEqual(["canvas2d.ts", "types.ts"]);
+  });
+
+  it("never reads a host-resolved colour", () => {
+    for (const file of sources()) {
+      // `…_ROW_CELLS_DATA_STYLE` is the unresolved slot; the FG/BG accessors
+      // flatten palette indices through someone else's palette, which is the
+      // resolution this boundary exists to prevent.
+      expect(file.text, file.name).not.toMatch(/DATA_FG_COLOR|DATA_BG_COLOR/);
+    }
+  });
+
+  it("owns no socket, no Wasm handle, no React and no timer", () => {
+    for (const file of sources()) {
+      expect(file.text, file.name).not.toMatch(/\bWebSocket\b/);
+      expect(file.text, file.name).not.toMatch(/\bWebAssembly\b/);
+      expect(file.text, file.name).not.toMatch(/requestAnimationFrame|setInterval|setTimeout/);
+      expect(file.text, file.name).not.toMatch(/from "react/);
+    }
+  });
+
+  it("imports nothing across a module boundary except types", () => {
+    for (const file of sources()) {
+      const imports = file.text.matchAll(/^import\s+(type\s+)?[^;]*?from\s+"([^"]+)";/gm);
+      for (const match of imports) {
+        const isTypeOnly = match[1] !== undefined;
+        const specifier = match[2];
+        const local = specifier.startsWith("./");
+        expect(local || isTypeOnly, `${file.name} imports ${specifier} as a value`).toBe(true);
+      }
+    }
+  });
+});

--- a/web/client/src/renderer/types.ts
+++ b/web/client/src/renderer/types.ts
@@ -1,0 +1,199 @@
+import type { TaggedColor } from "../protocol/colors";
+export type { TaggedColor };
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/**
+ * The VIEWER's theme. Never the host's, never the program's, never one baked
+ * into the Wasm at construction. This is the only place a palette index
+ * becomes a pixel.
+ */
+export interface Palette {
+  background: Rgb;
+  foreground: Rgb;
+  cursor?: Rgb;
+  ansi: Rgb[]; // EXACTLY 256 entries; shorter is a throw, not a clamp
+}
+
+/**
+ * Paint-time decoration only. `inverse` and `invisible` are NOT here: the vt
+ * binding applies them while reading a cell, exactly as
+ * `termiod/vt/src/lib.rs::cell_from_parts` does (swap fg/bg on inverse; blank
+ * the codepoint on invisible), so a viewport row and a decoded history row
+ * cannot disagree about what a cell looks like.
+ */
+export const ATTR = {
+  BOLD: 1 << 0,
+  FAINT: 1 << 1,
+  ITALIC: 1 << 2,
+  UNDERLINE: 1 << 3,
+  UNDERCURL: 1 << 4,
+  STRIKETHROUGH: 1 << 5,
+  OVERLINE: 1 << 6,
+  BLINK: 1 << 7,
+  /** This cell is the left half of a double-width grapheme. */
+  WIDE: 1 << 8,
+  /** Spacer trailing a WIDE cell. Paint background only; draw no glyph. */
+  WIDE_SPACER: 1 << 9,
+} as const;
+
+/**
+ * One cell. Objects in a RowView are POOLED and mutated in place between
+ * frames — read them during `draw()` and never retain one.
+ */
+export interface CellView {
+  /** 0 = blank. Use `grapheme` when present. */
+  codepoint: number;
+  /** The full grapheme cluster, present only when the cell is not a single
+   *  codepoint (…_DATA_GRAPHEMES_UTF8). History cells never set it. */
+  grapheme?: string;
+  foreground: TaggedColor;
+  background: TaggedColor;
+  /** Program-set underline colour (SGR 58). Absent = use `foreground`. */
+  underline?: TaggedColor;
+  attributes: number; // ATTR bitmask
+  selected: boolean;
+}
+
+export interface RowView {
+  /**
+   * Viewport row index, 0 = top. History rows are NEGATIVE: -1 is the row
+   * immediately above the viewport.
+   */
+  y: number;
+  dirty: boolean;
+  /** Row-local, half-open column range. Absent = nothing selected on this row.
+   *  render.h's own doc recommends the range over per-cell flags for span
+   *  renderers; `CellView.selected` is the per-cell fallback and the two agree. */
+  selection?: { start: number; end: number };
+  /** Length === frame.cols. Valid only for the duration of one `draw()`. */
+  cells: CellView[];
+}
+
+export type CursorStyle = "block" | "bar" | "underline" | "hollow_block";
+
+export interface CursorState {
+  /** render.h's `viewport_has_value`. false = the cursor is not on the
+   *  viewport; paint nothing and do not clamp x/y into range. */
+  hasValue: boolean;
+  x: number;
+  y: number;
+  visible: boolean;
+  blinking: boolean;
+  /** Password input is in progress; a renderer may suppress the cursor. */
+  passwordInput: boolean;
+  /** The cursor sits on the tail half of a wide grapheme. */
+  wideTail: boolean;
+  style: CursorStyle;
+}
+
+/**
+ * Colours the PROGRAM set (OSC 10 / 11 / 12), which are program intent and
+ * therefore honoured, as distinct from the engine's configured defaults, which
+ * are the presentation boundary's business and must never be read. The vt
+ * binding is responsible for telling the two apart; an absent field means "the
+ * program said nothing — use the viewer's Palette".
+ */
+export interface ColorOverrides {
+  foreground?: Rgb;
+  background?: Rgb;
+  cursor?: Rgb;
+}
+
+export interface RenderFrame {
+  /** Global dirty, from render.h: FALSE / PARTIAL / FULL. */
+  dirty: "none" | "partial" | "full";
+  cols: number;
+  rows: number;
+  cursor: CursorState;
+  /** Viewport rows, top to bottom. Name kept verbatim from the RFC. */
+  rows_: RowView[];
+  overrides: ColorOverrides;
+  /**
+   * How many rows the view is scrolled up from the live bottom; 0 = live.
+   * A row (viewport or history) with index `y` paints on screen line
+   * `y + scrollOffsetRows`. One number, one arithmetic, both row sources.
+   */
+  scrollOffsetRows: number;
+}
+
+export interface FontSpec {
+  family: string; // CSS font-family list
+  sizePx: number;
+  weightNormal: number; // 400
+  weightBold: number; // 700
+  lineHeight: number; // multiplier on the font's line box
+  letterSpacingPx?: number;
+}
+
+export interface CellMetrics {
+  widthPx: number;
+  heightPx: number;
+  baselinePx: number;
+}
+
+export interface Geometry {
+  cols: number;
+  rows: number;
+  cell: CellMetrics;
+  devicePixelRatio: number;
+  /** Letterboxing when the CSS box is larger than cols×rows — an observer
+   *  parses at the AUTHORITATIVE dims from `attached`/`resized` and pads,
+   *  it does not reparse at the window size. */
+  padding?: { top: number; left: number };
+}
+
+/**
+ * The seam. Canvas 2D satisfies it in v1; WebGPU satisfies the same interface
+ * in v2 and nothing above it learns which is loaded.
+ *
+ * Rules that make the swap a swap:
+ *  - The renderer resolves colour; the Wasm never does. It reads
+ *    `…_ROW_CELLS_DATA_STYLE` (already resolved into TaggedColor by the
+ *    binding) against the Palette it was given. Reading
+ *    `…_DATA_FG_COLOR` / `…_DATA_BG_COLOR` anywhere is a reviewable line in a
+ *    diff. `{tag:"default"}` paints the viewer's default, never black.
+ *  - The renderer never owns state it can be told about: no socket, no Wasm
+ *    handle, no React import, no timer of its own. It is called; it does not
+ *    call.
+ *  - Damage comes in, never derived. It does not diff grids. "full" and
+ *    `setPalette` mean repaint everything; "partial" means repaint flagged
+ *    rows plus whatever neighbours glyph overflow needs — that part is the
+ *    renderer's own business.
+ *  - No view outlives an allocating call. RowView/CellView data is valid for
+ *    the duration of one `draw()`. Stashing a typed array across frames is the
+ *    detached-view bug with extra latency.
+ */
+export interface TerminalRenderer {
+  measure(font: FontSpec): CellMetrics;
+  setGeometry(g: Geometry): void;
+  /** Forces a full redraw. This is the whole theme-switch mechanism. */
+  setPalette(p: Palette): void;
+  /** `history` rows carry negative `y`. Both arrays paint through one path. */
+  draw(frame: RenderFrame, history?: RowView[]): void;
+  dispose(): void;
+}
+
+/** Dev-only counters; the inputs to the WebGPU entry trigger. Never sent anywhere. */
+export interface RendererStats {
+  implementation: "canvas2d" | "webgpu";
+  framesPainted: number;
+  fullRedraws: number;
+  droppedFrames: number;
+  frameTimeP50Ms: number;
+  frameTimeP95Ms: number;
+}
+
+/**
+ * `null` means "not available here" — that is the whole WebGPU probe. The
+ * caller tries webgpu, gets null on a Linux Firefox, and constructs canvas2d.
+ * The page shows no wall, no banner, and no "enable this flag" nag.
+ */
+export type RendererFactory = (
+  canvas: HTMLCanvasElement,
+  font: FontSpec,
+) => (TerminalRenderer & { stats(): RendererStats }) | null;

--- a/web/client/src/vt/__fixtures__/fakeGhostty.ts
+++ b/web/client/src/vt/__fixtures__/fakeGhostty.ts
@@ -1,0 +1,1044 @@
+/**
+ * A stand-in for `ghostty-vt.wasm` that speaks the same C ABI.
+ *
+ * The real Wasm is a build artifact placed in the web root by the deploy
+ * tooling; it is not in the repository and CI has no zig toolchain, so the
+ * binding is tested against this instead. What matters is that the parts that
+ * can be wrong here are the parts the binding is responsible for:
+ *
+ *  - It runs on a real `WebAssembly.Memory` and really grows it on write, so a
+ *    typed array cached across a call really is detached.
+ *  - It lays its structs out at exactly the offsets its manifest publishes, so
+ *    a binding that hardcodes an offset fails.
+ *  - It returns INVALID_VALUE if the render state is read before
+ *    `end_update`, so the two-phase bracket is enforced rather than assumed.
+ *  - It refuses a `ghostty_wasm_free` with the wrong length, so the wasm.h
+ *    allocation contract is checked instead of trusted.
+ *
+ * It is not a terminal emulator. Its VT parsing covers what the tests write.
+ */
+
+import type { GhosttyExports } from "../exports";
+import { buildLayouts, buildManifest, CELL_BITS, ENUMS, type Layouts } from "./layout";
+
+const PAGE_BYTES = 65536;
+const NULL = 0;
+
+type FakeColor =
+  | { tag: "none" }
+  | { tag: "palette"; index: number }
+  | { tag: "rgb"; r: number; g: number; b: number };
+
+export interface FakeStyle {
+  fg: FakeColor;
+  bg: FakeColor;
+  underlineColor: FakeColor;
+  bold: boolean;
+  italic: boolean;
+  faint: boolean;
+  blink: boolean;
+  inverse: boolean;
+  invisible: boolean;
+  strikethrough: boolean;
+  overline: boolean;
+  underline: number;
+}
+
+export interface FakeCell {
+  contentTag: number;
+  codepoint: number;
+  palette: number;
+  rgb: { r: number; g: number; b: number };
+  styleId: number;
+  wide: number;
+  grapheme: string | null;
+}
+
+export interface FakeTerminal {
+  cols: number;
+  rows: number;
+  cells: FakeCell[][];
+  styles: Map<number, FakeStyle>;
+  nextStyleId: number;
+  currentStyleId: number;
+  cursor: {
+    x: number;
+    y: number;
+    hasValue: boolean;
+    wideTail: boolean;
+    visible: boolean;
+    blinking: boolean;
+    passwordInput: boolean;
+    visualStyle: number;
+  };
+  title: string | null;
+  colorForeground: { r: number; g: number; b: number } | null;
+  colorBackground: { r: number; g: number; b: number } | null;
+  colorCursor: { r: number; g: number; b: number } | null;
+  modes: Map<number, boolean>;
+  kittyFlags: number;
+  scrollbackBytes: number;
+  fullDirty: boolean;
+  dirtyRows: Set<number>;
+  selection: { row: number; start: number; end: number } | null;
+}
+
+interface FakeRenderState {
+  terminal: FakeTerminal | null;
+  ready: boolean;
+  dirty: number;
+  dirtyRows: Set<number>;
+  cellsScratch: number;
+  cellsScratchBytes: number;
+}
+
+interface FakeRowIterator {
+  state: FakeRenderState | null;
+  y: number;
+}
+
+interface FakeCellIterator {
+  state: FakeRenderState | null;
+  y: number;
+  x: number;
+}
+
+interface FakeKeyEncoder {
+  cursorKeyApplication: boolean;
+  keypadKeyApplication: boolean;
+  altEscPrefix: boolean;
+  kittyFlags: number;
+}
+
+interface FakeKeyEvent {
+  action: number;
+  key: number;
+  mods: number;
+  consumedMods: number;
+  composing: boolean;
+  utf8: string;
+  unshiftedCodepoint: number;
+}
+
+export interface FakeGhostty {
+  exports: GhosttyExports;
+  layouts: Layouts;
+  memory: WebAssembly.Memory;
+  terminal(handle: number): FakeTerminal;
+  keyEncoder(handle: number): FakeKeyEncoder;
+  keyEvent(handle: number): FakeKeyEvent;
+  /** Every terminal created so far, in creation order. */
+  terminals(): FakeTerminal[];
+  liveAllocations(): number;
+  growCount(): number;
+  poke(terminal: FakeTerminal, y: number, x: number, cell: Partial<FakeCell>): void;
+  defineStyle(terminal: FakeTerminal, style: Partial<FakeStyle>): number;
+  markDirty(terminal: FakeTerminal, y: number): void;
+}
+
+export interface FakeOptions {
+  /** Extra leading padding in every sized struct; shifts every offset. */
+  padding?: number;
+  /** Grow linear memory on every vt_write, detaching any cached view. */
+  growOnWrite?: boolean;
+  /**
+   * Grow linear memory on every allocation, including the ones a frame read
+   * makes for itself. This is the mid-frame detach: it happens between the
+   * bulk cell read and the style read, which is exactly where a cached view
+   * would be used.
+   */
+  growOnAlloc?: boolean;
+}
+
+export function createFakeGhostty(options: FakeOptions = {}): FakeGhostty {
+  const growOnWrite = options.growOnWrite ?? true;
+  const growOnAlloc = options.growOnAlloc ?? false;
+  const layouts = buildLayouts(options.padding ?? 0);
+  const memory = new WebAssembly.Memory({ initial: 2 });
+
+  let bump = 1024;
+  let growCount = 0;
+  // The manifest is written before any binding exists; growing under it would
+  // only move the fixture's own bytes around.
+  let manifestReady = false;
+  const allocations = new Map<number, number>();
+
+  function bytes(): Uint8Array {
+    return new Uint8Array(memory.buffer);
+  }
+  function view(): DataView {
+    return new DataView(memory.buffer);
+  }
+  function grow(pages: number): void {
+    memory.grow(pages);
+    growCount += 1;
+  }
+  function alloc(length: number): number {
+    if (length === 0) return NULL;
+    const size = (length + 15) & ~15;
+    if (bump + size > memory.buffer.byteLength) {
+      grow(Math.ceil((bump + size - memory.buffer.byteLength) / PAGE_BYTES) + 1);
+    }
+    const pointer = bump;
+    bump += size;
+    allocations.set(pointer, length);
+    bytes().fill(0, pointer, pointer + size);
+    if (growOnAlloc && manifestReady) grow(1);
+    return pointer;
+  }
+  function free(pointer: number, length: number): void {
+    if (pointer === NULL) return;
+    const recorded = allocations.get(pointer);
+    if (recorded === undefined) {
+      throw new Error(`fake ghostty: free of unknown pointer ${pointer}`);
+    }
+    if (recorded !== length) {
+      throw new Error(
+        `fake ghostty: free(${pointer}, ${length}) but it was allocated with ${recorded}`,
+      );
+    }
+    allocations.delete(pointer);
+  }
+
+  const manifest = buildManifest(layouts);
+  const manifestBytes = new TextEncoder().encode(manifest);
+  const manifestPointer = alloc(manifestBytes.length + 1);
+  bytes().set(manifestBytes, manifestPointer);
+  // The manifest allocation is permanent; drop it from the ledger so a test
+  // asserting "everything was freed" is not tripped by it.
+  allocations.delete(manifestPointer);
+  manifestReady = true;
+
+  const handles = new Map<number, unknown>();
+  let nextHandle = 0x1000;
+  function store(value: unknown): number {
+    const handle = nextHandle;
+    nextHandle += 8;
+    handles.set(handle, value);
+    return handle;
+  }
+  function load<T>(handle: number, what: string): T {
+    const value = handles.get(handle);
+    if (value === undefined) {
+      throw new Error(`fake ghostty: ${what} handle ${handle} is not live`);
+    }
+    return value as T;
+  }
+
+  const createdTerminals: FakeTerminal[] = [];
+
+  function blankCell(): FakeCell {
+    return {
+      contentTag: ENUMS.GhosttyCellContentTag.CODEPOINT,
+      codepoint: 0,
+      palette: 0,
+      rgb: { r: 0, g: 0, b: 0 },
+      styleId: 0,
+      wide: ENUMS.GhosttyCellWide.NARROW,
+      grapheme: null,
+    };
+  }
+
+  function makeGrid(rows: number, cols: number): FakeCell[][] {
+    return Array.from({ length: rows }, () =>
+      Array.from({ length: cols }, blankCell),
+    );
+  }
+
+  function newTerminal(cols: number, rows: number): FakeTerminal {
+    return {
+      cols,
+      rows,
+      cells: makeGrid(rows, cols),
+      styles: new Map(),
+      nextStyleId: 1,
+      currentStyleId: 0,
+      cursor: {
+        x: 0,
+        y: 0,
+        hasValue: true,
+        wideTail: false,
+        visible: true,
+        blinking: true,
+        passwordInput: false,
+        visualStyle: ENUMS.GhosttyRenderStateCursorVisualStyle.BLOCK,
+      },
+      title: null,
+      colorForeground: null,
+      colorBackground: null,
+      colorCursor: null,
+      modes: new Map(),
+      kittyFlags: 0,
+      scrollbackBytes: 0,
+      fullDirty: true,
+      dirtyRows: new Set(),
+      selection: null,
+    };
+  }
+
+  function defaultStyle(): FakeStyle {
+    return {
+      fg: { tag: "none" },
+      bg: { tag: "none" },
+      underlineColor: { tag: "none" },
+      bold: false,
+      italic: false,
+      faint: false,
+      blink: false,
+      inverse: false,
+      invisible: false,
+      strikethrough: false,
+      overline: false,
+      underline: ENUMS.GhosttySgrUnderline.NONE,
+    };
+  }
+
+  function styleKey(style: FakeStyle): string {
+    return JSON.stringify(style);
+  }
+
+  function internStyle(terminal: FakeTerminal, style: FakeStyle): number {
+    if (styleKey(style) === styleKey(defaultStyle())) return 0;
+    for (const [id, existing] of terminal.styles) {
+      if (styleKey(existing) === styleKey(style)) return id;
+    }
+    const id = terminal.nextStyleId;
+    terminal.nextStyleId += 1;
+    terminal.styles.set(id, style);
+    return id;
+  }
+
+  function currentStyle(terminal: FakeTerminal): FakeStyle {
+    const style = terminal.styles.get(terminal.currentStyleId);
+    return style === undefined ? defaultStyle() : { ...style };
+  }
+
+  function markDirty(terminal: FakeTerminal, y: number): void {
+    terminal.dirtyRows.add(y);
+  }
+
+  function packCell(cell: FakeCell): { low: number; high: number } {
+    let low = 0;
+    let high = 0;
+    const put = (lsb: number, width: number, value: number): void => {
+      const masked = width === 32 ? value >>> 0 : value & ((1 << width) - 1);
+      if (lsb >= 32) {
+        high |= masked << (lsb - 32);
+        high >>>= 0;
+        return;
+      }
+      const room = 32 - lsb;
+      if (width <= room) {
+        low = (low | (masked << lsb)) >>> 0;
+        return;
+      }
+      low = (low | ((masked % 2 ** room) * 2 ** lsb)) >>> 0;
+      high = (high | Math.floor(masked / 2 ** room)) >>> 0;
+    };
+
+    put(CELL_BITS.content_tag.lsb, CELL_BITS.content_tag.width, cell.contentTag);
+    const contentLsb = CELL_BITS.content.lsb;
+    if (
+      cell.contentTag === ENUMS.GhosttyCellContentTag.CODEPOINT ||
+      cell.contentTag === ENUMS.GhosttyCellContentTag.CODEPOINT_GRAPHEME
+    ) {
+      put(contentLsb, 21, cell.codepoint);
+    } else if (cell.contentTag === ENUMS.GhosttyCellContentTag.BG_COLOR_PALETTE) {
+      put(contentLsb, 8, cell.palette);
+    } else {
+      put(contentLsb + 0, 8, cell.rgb.r);
+      put(contentLsb + 8, 8, cell.rgb.g);
+      put(contentLsb + 16, 8, cell.rgb.b);
+    }
+    put(CELL_BITS.style_id.lsb, CELL_BITS.style_id.width, cell.styleId);
+    put(CELL_BITS.wide.lsb, CELL_BITS.wide.width, cell.wide);
+    return { low, high };
+  }
+
+  function writeColor(pointer: number, color: { r: number; g: number; b: number }): void {
+    const data = view();
+    data.setUint8(pointer + layouts.colorRgb.offsets["r"]!, color.r);
+    data.setUint8(pointer + layouts.colorRgb.offsets["g"]!, color.g);
+    data.setUint8(pointer + layouts.colorRgb.offsets["b"]!, color.b);
+  }
+
+  function writeStyleColor(pointer: number, color: FakeColor): void {
+    const data = view();
+    const tagOffset = layouts.styleColor.offsets["tag"]!;
+    const valueOffset = layouts.styleColor.offsets["value"]!;
+    if (color.tag === "palette") {
+      data.setInt32(pointer + tagOffset, ENUMS.GhosttyStyleColorTag.PALETTE, true);
+      data.setUint8(
+        pointer + valueOffset + layouts.styleColorValue.offsets["palette"]!,
+        color.index,
+      );
+      return;
+    }
+    if (color.tag === "rgb") {
+      data.setInt32(pointer + tagOffset, ENUMS.GhosttyStyleColorTag.RGB, true);
+      writeColor(pointer + valueOffset, color);
+      return;
+    }
+    data.setInt32(pointer + tagOffset, ENUMS.GhosttyStyleColorTag.NONE, true);
+  }
+
+  function parseVt(terminal: FakeTerminal, text: string): void {
+    let index = 0;
+    const advance = (): void => {
+      terminal.cursor.x += 1;
+      if (terminal.cursor.x >= terminal.cols) {
+        terminal.cursor.x = 0;
+        terminal.cursor.y = Math.min(terminal.cursor.y + 1, terminal.rows - 1);
+      }
+    };
+    while (index < text.length) {
+      const character = text[index]!;
+      if (character === "\x1b") {
+        index = parseEscape(terminal, text, index);
+        continue;
+      }
+      index += 1;
+      if (character === "\n") {
+        terminal.cursor.y = Math.min(terminal.cursor.y + 1, terminal.rows - 1);
+        continue;
+      }
+      if (character === "\r") {
+        terminal.cursor.x = 0;
+        continue;
+      }
+      const row = terminal.cells[terminal.cursor.y];
+      if (row === undefined) continue;
+      const cell = row[terminal.cursor.x];
+      if (cell === undefined) continue;
+      cell.contentTag = ENUMS.GhosttyCellContentTag.CODEPOINT;
+      cell.codepoint = character.codePointAt(0) ?? 0;
+      cell.styleId = terminal.currentStyleId;
+      cell.grapheme = null;
+      markDirty(terminal, terminal.cursor.y);
+      advance();
+    }
+  }
+
+  function parseEscape(terminal: FakeTerminal, text: string, start: number): number {
+    const next = text[start + 1];
+    if (next === "[") {
+      let index = start + 2;
+      let parameters = "";
+      while (index < text.length && !/[a-zA-Z]/.test(text[index]!)) {
+        parameters += text[index];
+        index += 1;
+      }
+      const final = text[index] ?? "";
+      index += 1;
+      applyCsi(terminal, parameters, final);
+      return index;
+    }
+    if (next === "]") {
+      let index = start + 2;
+      let body = "";
+      while (index < text.length && text[index] !== "\x07") {
+        body += text[index];
+        index += 1;
+      }
+      index += 1;
+      applyOsc(terminal, body);
+      return index;
+    }
+    return start + 1;
+  }
+
+  function applyCsi(terminal: FakeTerminal, parameters: string, final: string): void {
+    if (parameters.startsWith("?") && (final === "h" || final === "l")) {
+      for (const raw of parameters.slice(1).split(";")) {
+        const mode = Number.parseInt(raw, 10);
+        if (Number.isFinite(mode)) terminal.modes.set(mode, final === "h");
+      }
+      return;
+    }
+    if (final === "m") {
+      applySgr(terminal, parameters);
+      return;
+    }
+    if (final === "H") {
+      const [row = "1", column = "1"] = parameters.split(";");
+      terminal.cursor.y = Math.max(0, Number.parseInt(row, 10) - 1);
+      terminal.cursor.x = Math.max(0, Number.parseInt(column, 10) - 1);
+      return;
+    }
+    if (final === "J") {
+      terminal.cells = makeGrid(terminal.rows, terminal.cols);
+      terminal.fullDirty = true;
+    }
+  }
+
+  function applySgr(terminal: FakeTerminal, parameters: string): void {
+    const style = currentStyle(terminal);
+    const codes = (parameters === "" ? "0" : parameters)
+      .split(";")
+      .map((value) => Number.parseInt(value, 10));
+    for (let index = 0; index < codes.length; index += 1) {
+      const code = codes[index]!;
+      if (code === 0) Object.assign(style, defaultStyle());
+      else if (code === 1) style.bold = true;
+      else if (code === 2) style.faint = true;
+      else if (code === 3) style.italic = true;
+      else if (code === 4) style.underline = ENUMS.GhosttySgrUnderline.SINGLE;
+      else if (code === 5) style.blink = true;
+      else if (code === 7) style.inverse = true;
+      else if (code === 8) style.invisible = true;
+      else if (code === 9) style.strikethrough = true;
+      else if (code === 53) style.overline = true;
+      else if (code >= 30 && code <= 37) style.fg = { tag: "palette", index: code - 30 };
+      else if (code === 39) style.fg = { tag: "none" };
+      else if (code >= 40 && code <= 47) style.bg = { tag: "palette", index: code - 40 };
+      else if (code === 49) style.bg = { tag: "none" };
+      else if (code === 38 || code === 48 || code === 58) {
+        const kind = codes[index + 1];
+        const target: FakeColor =
+          kind === 5
+            ? { tag: "palette", index: codes[index + 2] ?? 0 }
+            : {
+                tag: "rgb",
+                r: codes[index + 2] ?? 0,
+                g: codes[index + 3] ?? 0,
+                b: codes[index + 4] ?? 0,
+              };
+        if (code === 38) style.fg = target;
+        else if (code === 48) style.bg = target;
+        else style.underlineColor = target;
+        index += kind === 5 ? 2 : 4;
+      }
+    }
+    terminal.currentStyleId = internStyle(terminal, style);
+  }
+
+  function applyOsc(terminal: FakeTerminal, body: string): void {
+    const separator = body.indexOf(";");
+    if (separator < 0) return;
+    const command = body.slice(0, separator);
+    const value = body.slice(separator + 1);
+    if (command === "0" || command === "2") {
+      terminal.title = value;
+      return;
+    }
+    const color = parseOscColor(value);
+    if (color === null) return;
+    if (command === "10") terminal.colorForeground = color;
+    else if (command === "11") terminal.colorBackground = color;
+    else if (command === "12") terminal.colorCursor = color;
+  }
+
+  function parseOscColor(
+    value: string,
+  ): { r: number; g: number; b: number } | null {
+    const hex = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(value);
+    if (hex === null) return null;
+    return {
+      r: Number.parseInt(hex[1]!, 16),
+      g: Number.parseInt(hex[2]!, 16),
+      b: Number.parseInt(hex[3]!, 16),
+    };
+  }
+
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+
+  function encodeKey(encoderState: FakeKeyEncoder, event: FakeKeyEvent): string {
+    const keys = ENUMS.GhosttyKey;
+    if (event.action === ENUMS.GhosttyKeyAction.RELEASE && encoderState.kittyFlags === 0) {
+      return "";
+    }
+    if (event.key === keys.ENTER) return "\r";
+    if (event.key === keys.TAB) return "\t";
+    if (event.key === keys.BACKSPACE) return "\x7f";
+    if (event.key === keys.ESCAPE) return "\x1b";
+    const arrows: Record<number, string> = {
+      [keys.ARROW_UP]: "A",
+      [keys.ARROW_DOWN]: "B",
+      [keys.ARROW_RIGHT]: "C",
+      [keys.ARROW_LEFT]: "D",
+    };
+    const arrow = arrows[event.key];
+    if (arrow !== undefined) {
+      return encoderState.cursorKeyApplication ? `\x1bO${arrow}` : `\x1b[${arrow}`;
+    }
+    const ctrl = (event.mods & 0b10) !== 0;
+    const alt = (event.mods & 0b100) !== 0;
+    if (ctrl && event.utf8.length === 1) {
+      const code = event.utf8.charCodeAt(0);
+      if (code >= 0x40 && code <= 0x7f) {
+        return String.fromCharCode(code & 0x1f);
+      }
+    }
+    if (event.utf8.length === 0) return "";
+    if (alt && encoderState.altEscPrefix) return `\x1b${event.utf8}`;
+    return event.utf8;
+  }
+
+  function writeOut(
+    text: string,
+    buffer: number,
+    capacity: number,
+    writtenSlot: number,
+  ): number {
+    const encoded = encoder.encode(text);
+    if (encoded.length > capacity) {
+      view().setUint32(writtenSlot, encoded.length, true);
+      return ENUMS.GhosttyResult.OUT_OF_SPACE;
+    }
+    if (encoded.length > 0) bytes().set(encoded, buffer);
+    view().setUint32(writtenSlot, encoded.length, true);
+    return ENUMS.GhosttyResult.SUCCESS;
+  }
+
+  const exports: GhosttyExports = {
+    memory,
+
+    ghostty_wasm_alloc: alloc,
+    ghostty_wasm_free: free,
+    ghostty_wasm_alloc_opaque: () => alloc(4),
+    ghostty_wasm_free_opaque: (slot: number) => free(slot, 4),
+    ghostty_wasm_take_opaque: (slot: number) => {
+      const value = view().getUint32(slot, true);
+      view().setUint32(slot, 0, true);
+      return value;
+    },
+
+    ghostty_type_json: () => manifestPointer,
+
+    ghostty_terminal_new: (_allocator, outTerminal, cols, rows) => {
+      const terminal = newTerminal(cols, rows);
+      createdTerminals.push(terminal);
+      view().setUint32(outTerminal, store(terminal), true);
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_terminal_free: (handle) => {
+      handles.delete(handle);
+    },
+    ghostty_terminal_resize: (handle, cols, rows) => {
+      const terminal = load<FakeTerminal>(handle, "terminal");
+      terminal.cols = cols;
+      terminal.rows = rows;
+      terminal.cells = makeGrid(rows, cols);
+      terminal.cursor.x = Math.min(terminal.cursor.x, cols - 1);
+      terminal.cursor.y = Math.min(terminal.cursor.y, rows - 1);
+      terminal.fullDirty = true;
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_terminal_vt_write: (handle, data, length) => {
+      const terminal = load<FakeTerminal>(handle, "terminal");
+      const text = decoder.decode(bytes().subarray(data, data + length));
+      parseVt(terminal, text);
+      // The real thing allocates pages as the screen fills. Growing here is
+      // what makes a cached view in the binding a detached view.
+      if (growOnWrite) grow(1);
+    },
+    ghostty_terminal_set: (handle, option, value) => {
+      const terminal = load<FakeTerminal>(handle, "terminal");
+      if (option === ENUMS.GhosttyTerminalOption.SCROLLBACK_MAX_BYTES) {
+        terminal.scrollbackBytes = view().getUint32(value, true);
+        return ENUMS.GhosttyResult.SUCCESS;
+      }
+      return ENUMS.GhosttyResult.INVALID_VALUE;
+    },
+    ghostty_terminal_get: (handle, data, out) => {
+      const terminal = load<FakeTerminal>(handle, "terminal");
+      const results = ENUMS.GhosttyResult;
+      const kinds = ENUMS.GhosttyTerminalData;
+      if (data === kinds.TITLE) {
+        if (terminal.title === null) return results.NO_VALUE;
+        const encoded = encoder.encode(terminal.title);
+        const pointer = alloc(encoded.length);
+        bytes().set(encoded, pointer);
+        allocations.delete(pointer); // borrowed by the caller, freed by nobody
+        const data32 = view();
+        data32.setUint32(out + layouts.string.offsets["ptr"]!, pointer, true);
+        data32.setUint32(out + layouts.string.offsets["len"]!, encoded.length, true);
+        return results.SUCCESS;
+      }
+      if (data === kinds.MODE) {
+        const mode = view().getUint16(out + layouts.modeConfig.offsets["mode"]!, true);
+        const value = terminal.modes.get(mode & 0x7fff) ?? false;
+        view().setUint8(out + layouts.modeConfig.offsets["value"]!, value ? 1 : 0);
+        return results.SUCCESS;
+      }
+      if (data === kinds.KITTY_KEYBOARD_FLAGS) {
+        view().setUint8(out, terminal.kittyFlags);
+        return results.SUCCESS;
+      }
+      const color =
+        data === kinds.COLOR_FOREGROUND
+          ? terminal.colorForeground
+          : data === kinds.COLOR_BACKGROUND
+            ? terminal.colorBackground
+            : data === kinds.COLOR_CURSOR
+              ? terminal.colorCursor
+              : undefined;
+      if (color === undefined) return results.INVALID_VALUE;
+      if (color === null) return results.NO_VALUE;
+      writeColor(out, color);
+      return results.SUCCESS;
+    },
+
+    ghostty_render_state_new: (_allocator, outState) => {
+      const state: FakeRenderState = {
+        terminal: null,
+        ready: false,
+        dirty: ENUMS.GhosttyRenderStateDirty.FALSE,
+        dirtyRows: new Set(),
+        cellsScratch: NULL,
+        cellsScratchBytes: 0,
+      };
+      view().setUint32(outState, store(state), true);
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_render_state_free: (handle) => {
+      const state = handles.get(handle) as FakeRenderState | undefined;
+      if (state !== undefined && state.cellsScratch !== NULL) {
+        free(state.cellsScratch, state.cellsScratchBytes);
+      }
+      handles.delete(handle);
+    },
+    ghostty_render_state_begin_update: (stateHandle, terminalHandle) => {
+      const state = load<FakeRenderState>(stateHandle, "render state");
+      const terminal = load<FakeTerminal>(terminalHandle, "terminal");
+      state.terminal = terminal;
+      state.ready = false;
+      if (terminal.fullDirty) state.dirty = ENUMS.GhosttyRenderStateDirty.FULL;
+      else if (terminal.dirtyRows.size > 0 && state.dirty !== ENUMS.GhosttyRenderStateDirty.FULL) {
+        state.dirty = ENUMS.GhosttyRenderStateDirty.PARTIAL;
+      }
+      for (const y of terminal.dirtyRows) state.dirtyRows.add(y);
+      terminal.fullDirty = false;
+      terminal.dirtyRows.clear();
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_render_state_end_update: (stateHandle) => {
+      const state = load<FakeRenderState>(stateHandle, "render state");
+      state.ready = true;
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_render_state_clean: (stateHandle) => {
+      const state = load<FakeRenderState>(stateHandle, "render state");
+      state.dirty = ENUMS.GhosttyRenderStateDirty.FALSE;
+      state.dirtyRows.clear();
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_render_state_get: (stateHandle, data, out) => {
+      const state = load<FakeRenderState>(stateHandle, "render state");
+      const results = ENUMS.GhosttyResult;
+      // render.h: "Every begin must be completed with end_update before the
+      // render state is read."
+      if (!state.ready || state.terminal === null) return results.INVALID_VALUE;
+      const kinds = ENUMS.GhosttyRenderStateData;
+      const data32 = view();
+      if (data === kinds.DIRTY) {
+        data32.setInt32(out, state.dirty, true);
+        return results.SUCCESS;
+      }
+      if (data === kinds.COLS) {
+        data32.setUint16(out, state.terminal.cols, true);
+        return results.SUCCESS;
+      }
+      if (data === kinds.ROWS) {
+        data32.setUint16(out, state.terminal.rows, true);
+        return results.SUCCESS;
+      }
+      if (data === kinds.CURSOR) {
+        const cursor = state.terminal.cursor;
+        const offsets = layouts.cursor.offsets;
+        if (data32.getUint32(out + offsets["size"]!, true) !== layouts.cursor.size) {
+          return results.INVALID_VALUE;
+        }
+        data32.setUint8(out + offsets["viewport_has_value"]!, cursor.hasValue ? 1 : 0);
+        data32.setUint16(out + offsets["viewport_x"]!, cursor.x, true);
+        data32.setUint16(out + offsets["viewport_y"]!, cursor.y, true);
+        data32.setUint8(out + offsets["wide_tail"]!, cursor.wideTail ? 1 : 0);
+        data32.setUint8(out + offsets["visible"]!, cursor.visible ? 1 : 0);
+        data32.setUint8(out + offsets["blinking"]!, cursor.blinking ? 1 : 0);
+        data32.setUint8(out + offsets["password_input"]!, cursor.passwordInput ? 1 : 0);
+        data32.setInt32(out + offsets["visual_style"]!, cursor.visualStyle, true);
+        return results.SUCCESS;
+      }
+      if (data === kinds.ROW_ITERATOR) {
+        const iterator = load<FakeRowIterator>(
+          data32.getUint32(out, true),
+          "row iterator",
+        );
+        iterator.state = state;
+        iterator.y = -1;
+        return results.SUCCESS;
+      }
+      return results.INVALID_VALUE;
+    },
+
+    ghostty_render_state_row_iterator_new: (_allocator, outIterator) => {
+      const iterator: FakeRowIterator = { state: null, y: -1 };
+      view().setUint32(outIterator, store(iterator), true);
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_render_state_row_iterator_free: (handle) => {
+      handles.delete(handle);
+    },
+    ghostty_render_state_row_iterator_next: (handle) => {
+      const iterator = load<FakeRowIterator>(handle, "row iterator");
+      const terminal = iterator.state?.terminal;
+      if (terminal === undefined || terminal === null) return 0;
+      if (iterator.y + 1 >= terminal.rows) return 0;
+      iterator.y += 1;
+      return 1;
+    },
+    ghostty_render_state_row_get: (handle, data, out) => {
+      const iterator = load<FakeRowIterator>(handle, "row iterator");
+      const state = iterator.state;
+      const terminal = state?.terminal;
+      const results = ENUMS.GhosttyResult;
+      if (state === null || terminal === undefined || terminal === null) {
+        return results.INVALID_VALUE;
+      }
+      const kinds = ENUMS.GhosttyRenderStateRowData;
+      const data32 = view();
+      if (data === kinds.DIRTY) {
+        data32.setUint8(out, state.dirtyRows.has(iterator.y) ? 1 : 0);
+        return results.SUCCESS;
+      }
+      if (data === kinds.SELECTION) {
+        const offsets = layouts.rowSelection.offsets;
+        if (
+          data32.getUint32(out + offsets["size"]!, true) !== layouts.rowSelection.size
+        ) {
+          return results.INVALID_VALUE;
+        }
+        const selection = terminal.selection;
+        if (selection === null || selection.row !== iterator.y) return results.NO_VALUE;
+        data32.setUint16(out + offsets["start_x"]!, selection.start, true);
+        data32.setUint16(out + offsets["end_x"]!, selection.end, true);
+        return results.SUCCESS;
+      }
+      if (data === kinds.CELLS) {
+        const cells = load<FakeCellIterator>(data32.getUint32(out, true), "cell iterator");
+        cells.state = state;
+        cells.y = iterator.y;
+        cells.x = 0;
+        return results.SUCCESS;
+      }
+      if (data === kinds.CELLS_RAW) {
+        const row = terminal.cells[iterator.y];
+        if (row === undefined) return results.INVALID_VALUE;
+        const needed = row.length * 8;
+        if (state.cellsScratchBytes < needed) {
+          if (state.cellsScratch !== NULL) {
+            free(state.cellsScratch, state.cellsScratchBytes);
+          }
+          state.cellsScratch = alloc(needed);
+          state.cellsScratchBytes = needed;
+        }
+        const writer = view();
+        for (let x = 0; x < row.length; x += 1) {
+          const packed = packCell(row[x]!);
+          writer.setUint32(state.cellsScratch + x * 8, packed.low, true);
+          writer.setUint32(state.cellsScratch + x * 8 + 4, packed.high, true);
+        }
+        const offsets = layouts.cellsView.offsets;
+        writer.setUint32(out + offsets["ptr"]!, state.cellsScratch, true);
+        writer.setUint32(out + offsets["len"]!, row.length, true);
+        return results.SUCCESS;
+      }
+      return results.INVALID_VALUE;
+    },
+
+    ghostty_render_state_row_cells_new: (_allocator, outCells) => {
+      const cells: FakeCellIterator = { state: null, y: 0, x: 0 };
+      view().setUint32(outCells, store(cells), true);
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_render_state_row_cells_free: (handle) => {
+      handles.delete(handle);
+    },
+    ghostty_render_state_row_cells_select: (handle, x) => {
+      const cells = load<FakeCellIterator>(handle, "cell iterator");
+      const terminal = cells.state?.terminal;
+      if (terminal === undefined || terminal === null) {
+        return ENUMS.GhosttyResult.INVALID_VALUE;
+      }
+      if (x >= terminal.cols) return ENUMS.GhosttyResult.INVALID_VALUE;
+      cells.x = x;
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_render_state_row_cells_get: (handle, data, out) => {
+      const cells = load<FakeCellIterator>(handle, "cell iterator");
+      const terminal = cells.state?.terminal;
+      const results = ENUMS.GhosttyResult;
+      if (terminal === undefined || terminal === null) return results.INVALID_VALUE;
+      const cell = terminal.cells[cells.y]?.[cells.x];
+      if (cell === undefined) return results.INVALID_VALUE;
+      const kinds = ENUMS.GhosttyRenderStateRowCellsData;
+      const data32 = view();
+      if (data === kinds.STYLE) {
+        const offsets = layouts.style.offsets;
+        if (data32.getUint32(out + offsets["size"]!, true) !== layouts.style.size) {
+          return results.INVALID_VALUE;
+        }
+        const style = terminal.styles.get(cell.styleId) ?? defaultStyle();
+        writeStyleColor(out + offsets["fg_color"]!, style.fg);
+        writeStyleColor(out + offsets["bg_color"]!, style.bg);
+        writeStyleColor(out + offsets["underline_color"]!, style.underlineColor);
+        data32.setUint8(out + offsets["bold"]!, style.bold ? 1 : 0);
+        data32.setUint8(out + offsets["italic"]!, style.italic ? 1 : 0);
+        data32.setUint8(out + offsets["faint"]!, style.faint ? 1 : 0);
+        data32.setUint8(out + offsets["blink"]!, style.blink ? 1 : 0);
+        data32.setUint8(out + offsets["inverse"]!, style.inverse ? 1 : 0);
+        data32.setUint8(out + offsets["invisible"]!, style.invisible ? 1 : 0);
+        data32.setUint8(out + offsets["strikethrough"]!, style.strikethrough ? 1 : 0);
+        data32.setUint8(out + offsets["overline"]!, style.overline ? 1 : 0);
+        data32.setInt32(out + offsets["underline"]!, style.underline, true);
+        return results.SUCCESS;
+      }
+      if (data === kinds.GRAPHEMES_UTF8) {
+        const offsets = layouts.buffer.offsets;
+        const pointer = data32.getUint32(out + offsets["ptr"]!, true);
+        const capacity = data32.getUint32(out + offsets["cap"]!, true);
+        const text = cell.grapheme ?? "";
+        const encoded = encoder.encode(text);
+        if (encoded.length > capacity) {
+          data32.setUint32(out + offsets["len"]!, encoded.length, true);
+          return results.OUT_OF_SPACE;
+        }
+        if (encoded.length > 0) bytes().set(encoded, pointer);
+        data32.setUint32(out + offsets["len"]!, encoded.length, true);
+        return results.SUCCESS;
+      }
+      // FG_COLOR and BG_COLOR are deliberately not implemented: reading them is
+      // the presentation-boundary violation this client must never commit, so a
+      // binding that tries gets INVALID_VALUE and a failing test.
+      return results.INVALID_VALUE;
+    },
+
+    ghostty_key_encoder_new: (_allocator, outEncoder) => {
+      const encoderState: FakeKeyEncoder = {
+        cursorKeyApplication: false,
+        keypadKeyApplication: false,
+        altEscPrefix: false,
+        kittyFlags: 0,
+      };
+      view().setUint32(outEncoder, store(encoderState), true);
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_key_encoder_free: (handle) => {
+      handles.delete(handle);
+    },
+    ghostty_key_encoder_setopt: (handle, option, value) => {
+      const encoderState = load<FakeKeyEncoder>(handle, "key encoder");
+      const options = ENUMS.GhosttyKeyEncoderOption;
+      const byte = view().getUint8(value);
+      if (option === options.CURSOR_KEY_APPLICATION) {
+        encoderState.cursorKeyApplication = byte !== 0;
+      } else if (option === options.KEYPAD_KEY_APPLICATION) {
+        encoderState.keypadKeyApplication = byte !== 0;
+      } else if (option === options.ALT_ESC_PREFIX) {
+        encoderState.altEscPrefix = byte !== 0;
+      } else if (option === options.KITTY_FLAGS) {
+        encoderState.kittyFlags = byte;
+      }
+    },
+    ghostty_key_encoder_encode: (
+      encoderHandle,
+      eventHandle,
+      outBuffer,
+      outBufferSize,
+      outLength,
+    ) => {
+      const encoderState = load<FakeKeyEncoder>(encoderHandle, "key encoder");
+      const event = load<FakeKeyEvent>(eventHandle, "key event");
+      return writeOut(
+        encodeKey(encoderState, event),
+        outBuffer,
+        outBufferSize,
+        outLength,
+      );
+    },
+
+    ghostty_key_event_new: (_allocator, outEvent) => {
+      const event: FakeKeyEvent = {
+        action: ENUMS.GhosttyKeyAction.PRESS,
+        key: ENUMS.GhosttyKey.UNIDENTIFIED,
+        mods: 0,
+        consumedMods: 0,
+        composing: false,
+        utf8: "",
+        unshiftedCodepoint: 0,
+      };
+      view().setUint32(outEvent, store(event), true);
+      return ENUMS.GhosttyResult.SUCCESS;
+    },
+    ghostty_key_event_free: (handle) => {
+      handles.delete(handle);
+    },
+    ghostty_key_event_set_action: (handle, action) => {
+      load<FakeKeyEvent>(handle, "key event").action = action;
+    },
+    ghostty_key_event_set_key: (handle, key) => {
+      load<FakeKeyEvent>(handle, "key event").key = key;
+    },
+    ghostty_key_event_set_mods: (handle, mods) => {
+      load<FakeKeyEvent>(handle, "key event").mods = mods;
+    },
+    ghostty_key_event_set_consumed_mods: (handle, mods) => {
+      load<FakeKeyEvent>(handle, "key event").consumedMods = mods;
+    },
+    ghostty_key_event_set_composing: (handle, composing) => {
+      load<FakeKeyEvent>(handle, "key event").composing = composing !== 0;
+    },
+    ghostty_key_event_set_utf8: (handle, pointer, length) => {
+      const event = load<FakeKeyEvent>(handle, "key event");
+      event.utf8 =
+        pointer === NULL || length === 0
+          ? ""
+          : decoder.decode(bytes().subarray(pointer, pointer + length));
+    },
+    ghostty_key_event_set_unshifted_codepoint: (handle, codepoint) => {
+      load<FakeKeyEvent>(handle, "key event").unshiftedCodepoint = codepoint;
+    },
+
+    ghostty_paste_encode: (data, dataLength, bracketed, buffer, bufferLength, outWritten) => {
+      const raw =
+        data === NULL || dataLength === 0
+          ? ""
+          : decoder.decode(bytes().subarray(data, data + dataLength));
+      const safe = raw.replace(/[\x00\x1b\x7f]/g, " ");
+      const text =
+        bracketed !== 0
+          ? `\x1b[200~${safe}\x1b[201~`
+          : safe.replace(/\n/g, "\r");
+      return writeOut(text, buffer, bufferLength, outWritten);
+    },
+  } as GhosttyExports;
+
+  // `ghostty_render_state_row_cells_next` exists in the header and is
+  // deliberately absent here: cells are read in bulk with CELLS_RAW and
+  // positioned with `select`, so a binding that walked the per-cell iterator
+  // would fail against this fixture rather than quietly costing a call per cell.
+
+  return {
+    exports,
+    layouts,
+    memory,
+    terminal: (handle: number) => load<FakeTerminal>(handle, "terminal"),
+    keyEncoder: (handle: number) => load<FakeKeyEncoder>(handle, "key encoder"),
+    keyEvent: (handle: number) => load<FakeKeyEvent>(handle, "key event"),
+    terminals: () => [...createdTerminals],
+    liveAllocations: () => allocations.size,
+    growCount: () => growCount,
+    poke: (terminal, y, x, cell) => {
+      const row = terminal.cells[y];
+      if (row === undefined) throw new Error(`fake ghostty: no row ${y}`);
+      const existing = row[x];
+      if (existing === undefined) throw new Error(`fake ghostty: no cell ${x}`);
+      Object.assign(existing, cell);
+      markDirty(terminal, y);
+    },
+    defineStyle: (terminal, style) =>
+      internStyle(terminal, { ...defaultStyle(), ...style }),
+    markDirty,
+  };
+}

--- a/web/client/src/vt/__fixtures__/layout.ts
+++ b/web/client/src/vt/__fixtures__/layout.ts
@@ -1,0 +1,478 @@
+/**
+ * wasm32 C layouts for the fixture module, plus the manifest that describes
+ * them.
+ *
+ * The fixture writes its structs at exactly the offsets it publishes here, so
+ * the binding under test is genuinely manifest-driven: shift a layout and the
+ * binding has to follow, or the test fails. `padding` exists for that test.
+ */
+
+export interface FieldSpec {
+  name: string;
+  size: number;
+  align: number;
+  type: string;
+}
+
+export interface Layout {
+  size: number;
+  align: number;
+  offsets: Record<string, number>;
+  fields: Record<string, { offset: number; size: number; type: string }>;
+}
+
+export function layoutStruct(fields: FieldSpec[]): Layout {
+  let offset = 0;
+  let maxAlign = 1;
+  const offsets: Record<string, number> = {};
+  const described: Record<string, { offset: number; size: number; type: string }> =
+    {};
+  for (const field of fields) {
+    offset = align(offset, field.align);
+    offsets[field.name] = offset;
+    described[field.name] = {
+      offset,
+      size: field.size,
+      type: field.type,
+    };
+    offset += field.size;
+    maxAlign = Math.max(maxAlign, field.align);
+  }
+  return {
+    size: align(offset, maxAlign),
+    align: maxAlign,
+    offsets,
+    fields: described,
+  };
+}
+
+function align(value: number, to: number): number {
+  const remainder = value % to;
+  return remainder === 0 ? value : value + (to - remainder);
+}
+
+const USIZE = { size: 4, align: 4 };
+const I32 = { size: 4, align: 4 };
+const U16 = { size: 2, align: 2 };
+const BOOL = { size: 1, align: 1 };
+const U8 = { size: 1, align: 1 };
+const U64 = { size: 8, align: 8 };
+
+export interface Layouts {
+  colorRgb: Layout;
+  styleColorValue: Layout;
+  styleColor: Layout;
+  style: Layout;
+  cursor: Layout;
+  rowSelection: Layout;
+  cellsView: Layout;
+  string: Layout;
+  buffer: Layout;
+  modeConfig: Layout;
+}
+
+/**
+ * `padding` prepends a dummy leading field to every sized struct, which moves
+ * every offset in the manifest without changing any field's meaning.
+ */
+export function buildLayouts(padding = 0): Layouts {
+  const pad: FieldSpec[] =
+    padding > 0
+      ? [{ name: "_fixture_pad", size: padding, align: 8, type: "u8" }]
+      : [];
+
+  const colorRgb = layoutStruct([
+    { name: "r", ...U8, type: "u8" },
+    { name: "g", ...U8, type: "u8" },
+    { name: "b", ...U8, type: "u8" },
+  ]);
+  const styleColorValue = layoutStruct([
+    { name: "palette", ...U8, type: "GhosttyColorPaletteIndex" },
+  ]);
+  // A union: every member sits at offset 0 and the whole thing is u64-sized.
+  styleColorValue.fields["rgb"] = { offset: 0, size: 3, type: "GhosttyColorRgb" };
+  styleColorValue.offsets["rgb"] = 0;
+  styleColorValue.size = U64.size;
+  styleColorValue.align = U64.align;
+
+  const styleColor = layoutStruct([
+    { name: "tag", ...I32, type: "GhosttyStyleColorTag" },
+    {
+      name: "value",
+      size: styleColorValue.size,
+      align: styleColorValue.align,
+      type: "GhosttyStyleColorValue",
+    },
+  ]);
+
+  const style = layoutStruct([
+    ...pad,
+    { name: "size", ...USIZE, type: "usize" },
+    {
+      name: "fg_color",
+      size: styleColor.size,
+      align: styleColor.align,
+      type: "GhosttyStyleColor",
+    },
+    {
+      name: "bg_color",
+      size: styleColor.size,
+      align: styleColor.align,
+      type: "GhosttyStyleColor",
+    },
+    {
+      name: "underline_color",
+      size: styleColor.size,
+      align: styleColor.align,
+      type: "GhosttyStyleColor",
+    },
+    { name: "bold", ...BOOL, type: "bool" },
+    { name: "italic", ...BOOL, type: "bool" },
+    { name: "faint", ...BOOL, type: "bool" },
+    { name: "blink", ...BOOL, type: "bool" },
+    { name: "inverse", ...BOOL, type: "bool" },
+    { name: "invisible", ...BOOL, type: "bool" },
+    { name: "strikethrough", ...BOOL, type: "bool" },
+    { name: "overline", ...BOOL, type: "bool" },
+    { name: "underline", ...I32, type: "i32" },
+  ]);
+
+  const cursor = layoutStruct([
+    ...pad,
+    { name: "size", ...USIZE, type: "usize" },
+    { name: "viewport_has_value", ...BOOL, type: "bool" },
+    { name: "viewport_x", ...U16, type: "u16" },
+    { name: "viewport_y", ...U16, type: "u16" },
+    { name: "wide_tail", ...BOOL, type: "bool" },
+    { name: "visible", ...BOOL, type: "bool" },
+    { name: "blinking", ...BOOL, type: "bool" },
+    { name: "password_input", ...BOOL, type: "bool" },
+    {
+      name: "visual_style",
+      ...I32,
+      type: "GhosttyRenderStateCursorVisualStyle",
+    },
+  ]);
+
+  const rowSelection = layoutStruct([
+    ...pad,
+    { name: "size", ...USIZE, type: "usize" },
+    { name: "start_x", ...U16, type: "u16" },
+    { name: "end_x", ...U16, type: "u16" },
+  ]);
+
+  const cellsView = layoutStruct([
+    { name: "ptr", size: 4, align: 4, type: "pointer" },
+    { name: "len", ...USIZE, type: "usize" },
+  ]);
+
+  const string = layoutStruct([
+    { name: "ptr", size: 4, align: 4, type: "pointer" },
+    { name: "len", ...USIZE, type: "usize" },
+  ]);
+
+  const buffer = layoutStruct([
+    { name: "ptr", size: 4, align: 4, type: "pointer" },
+    { name: "cap", ...USIZE, type: "usize" },
+    { name: "len", ...USIZE, type: "usize" },
+  ]);
+
+  const modeConfig = layoutStruct([
+    { name: "mode", ...U16, type: "GhosttyMode" },
+    { name: "value", ...BOOL, type: "bool" },
+  ]);
+
+  return {
+    colorRgb,
+    styleColorValue,
+    styleColor,
+    style,
+    cursor,
+    rowSelection,
+    cellsView,
+    string,
+    buffer,
+    modeConfig,
+  };
+}
+
+/** Real values, copied from the headers at ghostty `56e1f3a`. */
+export const ENUMS = {
+  GhosttyResult: {
+    SUCCESS: 0,
+    OUT_OF_MEMORY: -1,
+    INVALID_VALUE: -2,
+    OUT_OF_SPACE: -3,
+    NO_VALUE: -4,
+    IO_ERROR: -5,
+    LIMIT_EXCEEDED: -6,
+    RESULT_MAX_VALUE: 2147483647,
+  },
+  GhosttyRenderStateData: {
+    INVALID: 0,
+    COLS: 1,
+    ROWS: 2,
+    DIRTY: 3,
+    ROW_ITERATOR: 4,
+    COLOR_BACKGROUND: 5,
+    COLOR_FOREGROUND: 6,
+    COLOR_CURSOR: 7,
+    COLOR_CURSOR_HAS_VALUE: 8,
+    COLOR_PALETTE: 9,
+    CURSOR_VISUAL_STYLE: 10,
+    CURSOR_VISIBLE: 11,
+    CURSOR_BLINKING: 12,
+    CURSOR_PASSWORD_INPUT: 13,
+    CURSOR_VIEWPORT_HAS_VALUE: 14,
+    CURSOR_VIEWPORT_X: 15,
+    CURSOR_VIEWPORT_Y: 16,
+    CURSOR_VIEWPORT_WIDE_TAIL: 17,
+    CURSOR: 18,
+    COLORS: 19,
+    MAX_VALUE: 2147483647,
+  },
+  GhosttyRenderStateDirty: { FALSE: 0, PARTIAL: 1, FULL: 2, MAX_VALUE: 2147483647 },
+  GhosttyRenderStateCursorVisualStyle: {
+    BAR: 0,
+    BLOCK: 1,
+    UNDERLINE: 2,
+    BLOCK_HOLLOW: 3,
+    MAX_VALUE: 2147483647,
+  },
+  GhosttyRenderStateRowData: {
+    INVALID: 0,
+    DIRTY: 1,
+    RAW: 2,
+    CELLS: 3,
+    SELECTION: 4,
+    CELLS_RAW: 5,
+    MAX_VALUE: 2147483647,
+  },
+  GhosttyRenderStateRowCellsData: {
+    INVALID: 0,
+    RAW: 1,
+    STYLE: 2,
+    GRAPHEMES_LEN: 3,
+    GRAPHEMES_BUF: 4,
+    BG_COLOR: 5,
+    FG_COLOR: 6,
+    SELECTED: 7,
+    HAS_STYLING: 8,
+    GRAPHEMES_UTF8: 9,
+    MAX_VALUE: 2147483647,
+  },
+  GhosttyTerminalData: {
+    INVALID: 0,
+    COLS: 1,
+    ROWS: 2,
+    KITTY_KEYBOARD_FLAGS: 8,
+    TITLE: 12,
+    COLOR_FOREGROUND: 18,
+    COLOR_BACKGROUND: 19,
+    COLOR_CURSOR: 20,
+    MODE: 37,
+    MAX_VALUE: 2147483647,
+  },
+  GhosttyTerminalOption: {
+    USERDATA: 0,
+    SCROLLBACK_MAX_BYTES: 27,
+    MAX_VALUE: 2147483647,
+  },
+  GhosttyKeyEncoderOption: {
+    CURSOR_KEY_APPLICATION: 0,
+    KEYPAD_KEY_APPLICATION: 1,
+    IGNORE_KEYPAD_WITH_NUMLOCK: 2,
+    ALT_ESC_PREFIX: 3,
+    MODIFY_OTHER_KEYS_STATE_2: 4,
+    KITTY_FLAGS: 5,
+    MACOS_OPTION_AS_ALT: 6,
+    BACKARROW_KEY_MODE: 7,
+    MAX_VALUE: 2147483647,
+  },
+  GhosttyKeyAction: { RELEASE: 0, PRESS: 1, REPEAT: 2, MAX_VALUE: 2147483647 },
+  GhosttyCellContentTag: {
+    CODEPOINT: 0,
+    CODEPOINT_GRAPHEME: 1,
+    BG_COLOR_PALETTE: 2,
+    BG_COLOR_RGB: 3,
+    TAG_MAX_VALUE: 2147483647,
+  },
+  GhosttyCellWide: {
+    NARROW: 0,
+    WIDE: 1,
+    SPACER_TAIL: 2,
+    SPACER_HEAD: 3,
+    MAX_VALUE: 2147483647,
+  },
+  GhosttyStyleColorTag: {
+    NONE: 0,
+    PALETTE: 1,
+    RGB: 2,
+    TAG_MAX_VALUE: 2147483647,
+  },
+  GhosttySgrUnderline: {
+    NONE: 0,
+    SINGLE: 1,
+    DOUBLE: 2,
+    CURLY: 3,
+    DOTTED: 4,
+    DASHED: 5,
+    MAX_VALUE: 2147483647,
+  },
+  /** A representative slice of GhosttyKey, with the real values. */
+  GhosttyKey: {
+    UNIDENTIFIED: 0,
+    BACKQUOTE: 1,
+    BACKSLASH: 2,
+    BRACKET_LEFT: 3,
+    BRACKET_RIGHT: 4,
+    COMMA: 5,
+    DIGIT_0: 6,
+    DIGIT_1: 7,
+    DIGIT_2: 8,
+    DIGIT_9: 15,
+    EQUAL: 16,
+    A: 20,
+    B: 21,
+    C: 22,
+    Z: 45,
+    MINUS: 46,
+    PERIOD: 47,
+    QUOTE: 48,
+    SEMICOLON: 49,
+    SLASH: 50,
+    ALT_LEFT: 51,
+    ALT_RIGHT: 52,
+    BACKSPACE: 53,
+    CAPS_LOCK: 54,
+    CONTROL_LEFT: 56,
+    CONTROL_RIGHT: 57,
+    ENTER: 58,
+    META_LEFT: 59,
+    SHIFT_LEFT: 61,
+    SHIFT_RIGHT: 62,
+    SPACE: 63,
+    TAB: 64,
+    DELETE: 68,
+    END: 69,
+    HOME: 71,
+    INSERT: 72,
+    PAGE_DOWN: 73,
+    PAGE_UP: 74,
+    ARROW_DOWN: 75,
+    ARROW_LEFT: 76,
+    ARROW_RIGHT: 77,
+    ARROW_UP: 78,
+    NUMPAD_0: 80,
+    NUMPAD_7: 87,
+    NUMPAD_ADD: 90,
+    ESCAPE: 120,
+    F1: 121,
+    F12: 132,
+    MAX_VALUE: 2147483647,
+  },
+} as const;
+
+/** GhosttyCell, packed into a u64 exactly as `page.zig` declares it. */
+export const CELL_BITS = {
+  content_tag: { lsb: 0, width: 2, type: "GhosttyCellContentTag" },
+  content: {
+    kind: "union" as const,
+    lsb: 2,
+    width: 24,
+    tag: "content_tag",
+    arms: {
+      CODEPOINT: {
+        kind: "packed" as const,
+        width: 24,
+        bits: { codepoint: { lsb: 0, width: 21, type: "u21" } },
+      },
+      CODEPOINT_GRAPHEME: {
+        kind: "packed" as const,
+        width: 24,
+        bits: { codepoint: { lsb: 0, width: 21, type: "u21" } },
+      },
+      BG_COLOR_PALETTE: {
+        kind: "packed" as const,
+        width: 24,
+        bits: { index: { lsb: 0, width: 8, type: "GhosttyColorPaletteIndex" } },
+      },
+      BG_COLOR_RGB: {
+        kind: "packed" as const,
+        width: 24,
+        bits: {
+          r: { lsb: 0, width: 8, type: "u8" },
+          g: { lsb: 8, width: 8, type: "u8" },
+          b: { lsb: 16, width: 8, type: "u8" },
+        },
+      },
+    },
+  },
+  style_id: { lsb: 26, width: 16, type: "GhosttyStyleId" },
+  wide: { lsb: 42, width: 2, type: "GhosttyCellWide" },
+  protected: { lsb: 44, width: 1, type: "bool" },
+  hyperlink: { lsb: 45, width: 1, type: "bool" },
+  semantic_content: { lsb: 46, width: 2, type: "GhosttyCellSemanticContent" },
+};
+
+export function buildManifest(layouts: Layouts): string {
+  const types: Record<string, unknown> = {
+    GhosttyColorRgb: structDescriptor(layouts.colorRgb),
+    GhosttyStyleColorValue: {
+      kind: "union",
+      size: layouts.styleColorValue.size,
+      align: layouts.styleColorValue.align,
+      fields: layouts.styleColorValue.fields,
+    },
+    GhosttyStyleColor: structDescriptor(layouts.styleColor),
+    GhosttyStyle: structDescriptor(layouts.style),
+    GhosttyRenderStateCursor: structDescriptor(layouts.cursor),
+    GhosttyRenderStateRowSelection: structDescriptor(layouts.rowSelection),
+    GhosttyCellsView: structDescriptor(layouts.cellsView),
+    GhosttyString: structDescriptor(layouts.string),
+    GhosttyBuffer: structDescriptor(layouts.buffer),
+    GhosttyTerminalModeConfig: structDescriptor(layouts.modeConfig),
+    GhosttyCell: {
+      kind: "packed",
+      size: 8,
+      align: 8,
+      underlying: "u64",
+      bits: CELL_BITS,
+    },
+  };
+  for (const [name, values] of Object.entries(ENUMS)) {
+    types[name] = {
+      kind: "enum",
+      size: 4,
+      align: 4,
+      underlying: "i32",
+      prefix: `GHOSTTY_${name.toUpperCase()}_`,
+      values,
+    };
+  }
+  return JSON.stringify({
+    schema: 1,
+    abi: {
+      target: "wasm32-freestanding-none",
+      os: "freestanding",
+      environment: "none",
+      pointer_size: 4,
+      usize_size: 4,
+      max_alignment: 16,
+      endian: "little",
+    },
+    library_version: "0.0.0-fixture",
+    commit: "56e1f3a62e26407e8c020ef5881df3e8584be20f",
+    dirty: false,
+    types,
+  });
+}
+
+function structDescriptor(layout: Layout): unknown {
+  return {
+    kind: "struct",
+    size: layout.size,
+    align: layout.align,
+    fields: layout.fields,
+  };
+}

--- a/web/client/src/vt/abi.ts
+++ b/web/client/src/vt/abi.ts
@@ -1,0 +1,499 @@
+/**
+ * The manifest, resolved once into the handful of numbers this binding uses.
+ *
+ * Everything here is looked up by NAME at instantiate time. No enum value, no
+ * struct offset, and no cell bit position is written down in this repository:
+ * they come from `ghostty_type_json` in the Wasm that is actually loaded, so a
+ * binary built from a different ghostty commit either resolves correctly or
+ * fails here with the name that went missing.
+ */
+
+import {
+  extractBits,
+  ManifestError,
+  TypeManifest,
+  type BitLayout,
+  type StructLayout,
+  type UnionBits,
+} from "./typeJson";
+
+export interface ColorRgbLayout {
+  size: number;
+  r: number;
+  g: number;
+  b: number;
+}
+
+export interface StyleColorLayout {
+  size: number;
+  tag: number;
+  /** Offset of the palette index inside the whole GhosttyStyleColor. */
+  paletteValue: number;
+  /** Offset of the RGB triple inside the whole GhosttyStyleColor. */
+  rgbValue: number;
+}
+
+export interface StyleLayout {
+  size: number;
+  sizeField: number;
+  foreground: number;
+  background: number;
+  underlineColor: number;
+  bold: number;
+  italic: number;
+  faint: number;
+  blink: number;
+  inverse: number;
+  invisible: number;
+  strikethrough: number;
+  overline: number;
+  underline: number;
+}
+
+export interface CursorLayout {
+  size: number;
+  sizeField: number;
+  viewportHasValue: number;
+  viewportX: number;
+  viewportY: number;
+  wideTail: number;
+  visible: number;
+  blinking: number;
+  passwordInput: number;
+  visualStyle: number;
+}
+
+export interface RowSelectionLayout {
+  size: number;
+  sizeField: number;
+  startX: number;
+  endX: number;
+}
+
+export interface PairLayout {
+  size: number;
+  ptr: number;
+  len: number;
+}
+
+export interface BufferLayout {
+  size: number;
+  ptr: number;
+  cap: number;
+  len: number;
+}
+
+export interface ModeConfigLayout {
+  size: number;
+  mode: number;
+  value: number;
+}
+
+export interface CellBits {
+  contentTag: { lsb: number; width: number };
+  content: UnionBits;
+  styleId: { lsb: number; width: number };
+  wide: { lsb: number; width: number };
+  /** Codepoint field inside the CODEPOINT arm. */
+  codepointInContent: { lsb: number; width: number };
+  /** The same field inside the CODEPOINT_GRAPHEME arm, read separately rather
+   *  than assumed identical: the manifest describes each arm on its own. */
+  graphemeCodepointInContent: { lsb: number; width: number };
+  paletteInContent: { lsb: number; width: number };
+  rgbInContent: {
+    r: { lsb: number; width: number };
+    g: { lsb: number; width: number };
+    b: { lsb: number; width: number };
+  };
+}
+
+export interface ResolvedAbi {
+  manifest: TypeManifest;
+
+  result: {
+    success: number;
+    noValue: number;
+    outOfSpace: number;
+    /** Code → name, for error messages only. */
+    names: Map<number, string>;
+  };
+
+  renderStateData: {
+    cols: number;
+    rows: number;
+    dirty: number;
+    rowIterator: number;
+    cursor: number;
+  };
+  renderStateDirty: { none: number; partial: number; full: number };
+  cursorVisualStyle: {
+    bar: number;
+    block: number;
+    underline: number;
+    hollowBlock: number;
+  };
+  rowData: {
+    dirty: number;
+    cells: number;
+    selection: number;
+    cellsRaw: number;
+  };
+  rowCellsData: { style: number; graphemesUtf8: number };
+  terminalData: {
+    title: number;
+    mode: number;
+    kittyKeyboardFlags: number;
+    colorForeground: number;
+    colorBackground: number;
+    colorCursor: number;
+  };
+  terminalOption: { scrollbackMaxBytes: number };
+  keyEncoderOption: {
+    cursorKeyApplication: number;
+    keypadKeyApplication: number;
+    altEscPrefix: number;
+    kittyFlags: number;
+  };
+  keyAction: { press: number; release: number; repeat: number };
+  /** Every GhosttyKey by manifest name, e.g. `A`, `ARROW_LEFT`, `NUMPAD_7`. */
+  keys: Record<string, number>;
+  cellContentTag: {
+    codepoint: number;
+    codepointGrapheme: number;
+    bgColorPalette: number;
+    bgColorRgb: number;
+  };
+  cellWide: {
+    narrow: number;
+    wide: number;
+    spacerTail: number;
+    spacerHead: number;
+  };
+  styleColorTag: { none: number; palette: number; rgb: number };
+  sgrUnderline: {
+    none: number;
+    single: number;
+    double: number;
+    curly: number;
+    dotted: number;
+    dashed: number;
+  };
+
+  colorRgb: ColorRgbLayout;
+  styleColor: StyleColorLayout;
+  style: StyleLayout;
+  cursor: CursorLayout;
+  rowSelection: RowSelectionLayout;
+  cellsView: PairLayout;
+  string: PairLayout;
+  buffer: BufferLayout;
+  modeConfig: ModeConfigLayout;
+  cell: CellBits;
+  /** Bytes in one packed cell, from the manifest rather than `sizeof(u64)`. */
+  cellSize: number;
+}
+
+function offset(layout: StructLayout, owner: string, field: string): number {
+  const value = layout.fields[field];
+  if (value === undefined) {
+    throw new ManifestError(`${owner} has no field ${field}`);
+  }
+  return value.offset;
+}
+
+function scalar(
+  bits: Record<string, BitLayout>,
+  owner: string,
+  name: string,
+): { lsb: number; width: number } {
+  const bit = bits[name];
+  if (bit === undefined) {
+    throw new ManifestError(`${owner} has no bit field ${name}`);
+  }
+  if (bit.kind !== "scalar") {
+    throw new ManifestError(`${owner}.${name} is a union, expected a scalar`);
+  }
+  return { lsb: bit.lsb, width: bit.width };
+}
+
+function armBits(
+  union: UnionBits,
+  armName: string,
+  field: string,
+): { lsb: number; width: number } {
+  const arm = union.arms[armName];
+  if (arm === undefined || arm === null) {
+    throw new ManifestError(`GhosttyCell content arm ${armName} is missing`);
+  }
+  return scalar(arm.bits, `GhosttyCell content ${armName}`, field);
+}
+
+export function resolveAbi(manifest: TypeManifest): ResolvedAbi {
+  manifest.assertWasm32LittleEndian();
+
+  const resultValues = manifest.enumValues("GhosttyResult");
+  const names = new Map<number, string>();
+  for (const [name, value] of Object.entries(resultValues)) {
+    if (!names.has(value)) names.set(value, name);
+  }
+
+  const styleColorStruct = manifest.struct("GhosttyStyleColor");
+  const styleColorValueUnion = manifest.union("GhosttyStyleColorValue");
+  const valueField = styleColorStruct.fields["value"];
+  if (valueField === undefined) {
+    throw new ManifestError("GhosttyStyleColor has no field value");
+  }
+  const paletteMember = styleColorValueUnion.fields["palette"];
+  const rgbMember = styleColorValueUnion.fields["rgb"];
+  if (paletteMember === undefined || rgbMember === undefined) {
+    throw new ManifestError(
+      "GhosttyStyleColorValue is missing its palette or rgb member",
+    );
+  }
+
+  const colorRgbStruct = manifest.struct("GhosttyColorRgb");
+  const styleStruct = manifest.struct("GhosttyStyle");
+  const cursorStruct = manifest.struct("GhosttyRenderStateCursor");
+  const selectionStruct = manifest.struct("GhosttyRenderStateRowSelection");
+  const cellsViewStruct = manifest.struct("GhosttyCellsView");
+  const stringStruct = manifest.struct("GhosttyString");
+  const bufferStruct = manifest.struct("GhosttyBuffer");
+  const modeConfigStruct = manifest.struct("GhosttyTerminalModeConfig");
+
+  const cellPacked = manifest.packed("GhosttyCell");
+  const content = cellPacked.bits["content"];
+  if (content === undefined || content.kind !== "union") {
+    throw new ManifestError("GhosttyCell.content is not a tagged union");
+  }
+
+  return {
+    manifest,
+    result: {
+      success: manifest.enumValue("GhosttyResult", "SUCCESS"),
+      noValue: manifest.enumValue("GhosttyResult", "NO_VALUE"),
+      outOfSpace: manifest.enumValue("GhosttyResult", "OUT_OF_SPACE"),
+      names,
+    },
+    renderStateData: {
+      cols: manifest.enumValue("GhosttyRenderStateData", "COLS"),
+      rows: manifest.enumValue("GhosttyRenderStateData", "ROWS"),
+      dirty: manifest.enumValue("GhosttyRenderStateData", "DIRTY"),
+      rowIterator: manifest.enumValue("GhosttyRenderStateData", "ROW_ITERATOR"),
+      cursor: manifest.enumValue("GhosttyRenderStateData", "CURSOR"),
+    },
+    renderStateDirty: {
+      none: manifest.enumValue("GhosttyRenderStateDirty", "FALSE"),
+      partial: manifest.enumValue("GhosttyRenderStateDirty", "PARTIAL"),
+      full: manifest.enumValue("GhosttyRenderStateDirty", "FULL"),
+    },
+    cursorVisualStyle: {
+      bar: manifest.enumValue("GhosttyRenderStateCursorVisualStyle", "BAR"),
+      block: manifest.enumValue("GhosttyRenderStateCursorVisualStyle", "BLOCK"),
+      underline: manifest.enumValue(
+        "GhosttyRenderStateCursorVisualStyle",
+        "UNDERLINE",
+      ),
+      hollowBlock: manifest.enumValue(
+        "GhosttyRenderStateCursorVisualStyle",
+        "BLOCK_HOLLOW",
+      ),
+    },
+    rowData: {
+      dirty: manifest.enumValue("GhosttyRenderStateRowData", "DIRTY"),
+      cells: manifest.enumValue("GhosttyRenderStateRowData", "CELLS"),
+      selection: manifest.enumValue("GhosttyRenderStateRowData", "SELECTION"),
+      cellsRaw: manifest.enumValue("GhosttyRenderStateRowData", "CELLS_RAW"),
+    },
+    rowCellsData: {
+      style: manifest.enumValue("GhosttyRenderStateRowCellsData", "STYLE"),
+      graphemesUtf8: manifest.enumValue(
+        "GhosttyRenderStateRowCellsData",
+        "GRAPHEMES_UTF8",
+      ),
+    },
+    terminalData: {
+      title: manifest.enumValue("GhosttyTerminalData", "TITLE"),
+      mode: manifest.enumValue("GhosttyTerminalData", "MODE"),
+      kittyKeyboardFlags: manifest.enumValue(
+        "GhosttyTerminalData",
+        "KITTY_KEYBOARD_FLAGS",
+      ),
+      colorForeground: manifest.enumValue(
+        "GhosttyTerminalData",
+        "COLOR_FOREGROUND",
+      ),
+      colorBackground: manifest.enumValue(
+        "GhosttyTerminalData",
+        "COLOR_BACKGROUND",
+      ),
+      colorCursor: manifest.enumValue("GhosttyTerminalData", "COLOR_CURSOR"),
+    },
+    terminalOption: {
+      scrollbackMaxBytes: manifest.enumValue(
+        "GhosttyTerminalOption",
+        "SCROLLBACK_MAX_BYTES",
+      ),
+    },
+    keyEncoderOption: {
+      cursorKeyApplication: manifest.enumValue(
+        "GhosttyKeyEncoderOption",
+        "CURSOR_KEY_APPLICATION",
+      ),
+      keypadKeyApplication: manifest.enumValue(
+        "GhosttyKeyEncoderOption",
+        "KEYPAD_KEY_APPLICATION",
+      ),
+      altEscPrefix: manifest.enumValue(
+        "GhosttyKeyEncoderOption",
+        "ALT_ESC_PREFIX",
+      ),
+      kittyFlags: manifest.enumValue("GhosttyKeyEncoderOption", "KITTY_FLAGS"),
+    },
+    keyAction: {
+      press: manifest.enumValue("GhosttyKeyAction", "PRESS"),
+      release: manifest.enumValue("GhosttyKeyAction", "RELEASE"),
+      repeat: manifest.enumValue("GhosttyKeyAction", "REPEAT"),
+    },
+    keys: manifest.enumValues("GhosttyKey"),
+    cellContentTag: {
+      codepoint: manifest.enumValue("GhosttyCellContentTag", "CODEPOINT"),
+      codepointGrapheme: manifest.enumValue(
+        "GhosttyCellContentTag",
+        "CODEPOINT_GRAPHEME",
+      ),
+      bgColorPalette: manifest.enumValue(
+        "GhosttyCellContentTag",
+        "BG_COLOR_PALETTE",
+      ),
+      bgColorRgb: manifest.enumValue("GhosttyCellContentTag", "BG_COLOR_RGB"),
+    },
+    cellWide: {
+      narrow: manifest.enumValue("GhosttyCellWide", "NARROW"),
+      wide: manifest.enumValue("GhosttyCellWide", "WIDE"),
+      spacerTail: manifest.enumValue("GhosttyCellWide", "SPACER_TAIL"),
+      spacerHead: manifest.enumValue("GhosttyCellWide", "SPACER_HEAD"),
+    },
+    styleColorTag: {
+      none: manifest.enumValue("GhosttyStyleColorTag", "NONE"),
+      palette: manifest.enumValue("GhosttyStyleColorTag", "PALETTE"),
+      rgb: manifest.enumValue("GhosttyStyleColorTag", "RGB"),
+    },
+    sgrUnderline: {
+      none: manifest.enumValue("GhosttySgrUnderline", "NONE"),
+      single: manifest.enumValue("GhosttySgrUnderline", "SINGLE"),
+      double: manifest.enumValue("GhosttySgrUnderline", "DOUBLE"),
+      curly: manifest.enumValue("GhosttySgrUnderline", "CURLY"),
+      dotted: manifest.enumValue("GhosttySgrUnderline", "DOTTED"),
+      dashed: manifest.enumValue("GhosttySgrUnderline", "DASHED"),
+    },
+
+    colorRgb: {
+      size: colorRgbStruct.size,
+      r: offset(colorRgbStruct, "GhosttyColorRgb", "r"),
+      g: offset(colorRgbStruct, "GhosttyColorRgb", "g"),
+      b: offset(colorRgbStruct, "GhosttyColorRgb", "b"),
+    },
+    styleColor: {
+      size: styleColorStruct.size,
+      tag: offset(styleColorStruct, "GhosttyStyleColor", "tag"),
+      paletteValue: valueField.offset + paletteMember.offset,
+      rgbValue: valueField.offset + rgbMember.offset,
+    },
+    style: {
+      size: styleStruct.size,
+      sizeField: offset(styleStruct, "GhosttyStyle", "size"),
+      foreground: offset(styleStruct, "GhosttyStyle", "fg_color"),
+      background: offset(styleStruct, "GhosttyStyle", "bg_color"),
+      underlineColor: offset(styleStruct, "GhosttyStyle", "underline_color"),
+      bold: offset(styleStruct, "GhosttyStyle", "bold"),
+      italic: offset(styleStruct, "GhosttyStyle", "italic"),
+      faint: offset(styleStruct, "GhosttyStyle", "faint"),
+      blink: offset(styleStruct, "GhosttyStyle", "blink"),
+      inverse: offset(styleStruct, "GhosttyStyle", "inverse"),
+      invisible: offset(styleStruct, "GhosttyStyle", "invisible"),
+      strikethrough: offset(styleStruct, "GhosttyStyle", "strikethrough"),
+      overline: offset(styleStruct, "GhosttyStyle", "overline"),
+      underline: offset(styleStruct, "GhosttyStyle", "underline"),
+    },
+    cursor: {
+      size: cursorStruct.size,
+      sizeField: offset(cursorStruct, "GhosttyRenderStateCursor", "size"),
+      viewportHasValue: offset(
+        cursorStruct,
+        "GhosttyRenderStateCursor",
+        "viewport_has_value",
+      ),
+      viewportX: offset(cursorStruct, "GhosttyRenderStateCursor", "viewport_x"),
+      viewportY: offset(cursorStruct, "GhosttyRenderStateCursor", "viewport_y"),
+      wideTail: offset(cursorStruct, "GhosttyRenderStateCursor", "wide_tail"),
+      visible: offset(cursorStruct, "GhosttyRenderStateCursor", "visible"),
+      blinking: offset(cursorStruct, "GhosttyRenderStateCursor", "blinking"),
+      passwordInput: offset(
+        cursorStruct,
+        "GhosttyRenderStateCursor",
+        "password_input",
+      ),
+      visualStyle: offset(
+        cursorStruct,
+        "GhosttyRenderStateCursor",
+        "visual_style",
+      ),
+    },
+    rowSelection: {
+      size: selectionStruct.size,
+      sizeField: offset(
+        selectionStruct,
+        "GhosttyRenderStateRowSelection",
+        "size",
+      ),
+      startX: offset(
+        selectionStruct,
+        "GhosttyRenderStateRowSelection",
+        "start_x",
+      ),
+      endX: offset(selectionStruct, "GhosttyRenderStateRowSelection", "end_x"),
+    },
+    cellsView: {
+      size: cellsViewStruct.size,
+      ptr: offset(cellsViewStruct, "GhosttyCellsView", "ptr"),
+      len: offset(cellsViewStruct, "GhosttyCellsView", "len"),
+    },
+    string: {
+      size: stringStruct.size,
+      ptr: offset(stringStruct, "GhosttyString", "ptr"),
+      len: offset(stringStruct, "GhosttyString", "len"),
+    },
+    buffer: {
+      size: bufferStruct.size,
+      ptr: offset(bufferStruct, "GhosttyBuffer", "ptr"),
+      cap: offset(bufferStruct, "GhosttyBuffer", "cap"),
+      len: offset(bufferStruct, "GhosttyBuffer", "len"),
+    },
+    modeConfig: {
+      size: modeConfigStruct.size,
+      mode: offset(modeConfigStruct, "GhosttyTerminalModeConfig", "mode"),
+      value: offset(modeConfigStruct, "GhosttyTerminalModeConfig", "value"),
+    },
+    cell: {
+      contentTag: scalar(cellPacked.bits, "GhosttyCell", "content_tag"),
+      content,
+      styleId: scalar(cellPacked.bits, "GhosttyCell", "style_id"),
+      wide: scalar(cellPacked.bits, "GhosttyCell", "wide"),
+      codepointInContent: armBits(content, "CODEPOINT", "codepoint"),
+      graphemeCodepointInContent: armBits(
+        content,
+        "CODEPOINT_GRAPHEME",
+        "codepoint",
+      ),
+      paletteInContent: armBits(content, "BG_COLOR_PALETTE", "index"),
+      rgbInContent: {
+        r: armBits(content, "BG_COLOR_RGB", "r"),
+        g: armBits(content, "BG_COLOR_RGB", "g"),
+        b: armBits(content, "BG_COLOR_RGB", "b"),
+      },
+    },
+    cellSize: cellPacked.size,
+  };
+}
+
+export { extractBits };

--- a/web/client/src/vt/boundary.test.ts
+++ b/web/client/src/vt/boundary.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function bindingSources(): { name: string; source: string }[] {
+  return readdirSync(here)
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+    .map((name) => ({ name, source: readFileSync(join(here, name), "utf8") }));
+}
+
+describe("presentation boundary", () => {
+  /**
+   * The failure that disqualified ghostty-web and `@wterm/ghostty`, as a
+   * reviewable line in a diff.
+   *
+   * `…_ROW_CELLS_DATA_FG_COLOR` and `…_DATA_BG_COLOR` resolve palette indices
+   * through the palette — render.h's own doc comment says so. That resolution
+   * belongs to the viewer's theme, in the renderer, and a cell that arrives
+   * pre-resolved can never be re-themed without a reload. The fixture answers
+   * both with INVALID_VALUE, and this test keeps them out of the source in the
+   * first place.
+   */
+  it("never names the resolved-colour reads", () => {
+    for (const { name, source } of bindingSources()) {
+      // The quoted form is how a manifest lookup would name them; prose about
+      // why they are forbidden uses backticks and is what this file wants to
+      // keep.
+      expect(source, `${name} reads a resolved colour`).not.toMatch(/"FG_COLOR"/);
+      expect(source, `${name} reads a resolved colour`).not.toMatch(/"BG_COLOR"/);
+      // The cell's own BG_COLOR_PALETTE tag is a slot and is fine; the render
+      // state's COLOR_PALETTE and its COLORS struct carry the engine's
+      // palette[256] and are not.
+      expect(source, `${name} reads the engine palette`).not.toMatch(
+        /"COLOR_PALETTE"/,
+      );
+      expect(source, `${name} reads the engine colour block`).not.toMatch(
+        /"COLORS"/,
+      );
+    }
+  });
+
+  /**
+   * The other half of the same trap: handing a palette to the terminal at
+   * construction and treating what comes back as the client's colours. The
+   * viewer's Palette goes to the RENDERER; the Wasm never sees one.
+   */
+  it("never sets a palette or a default colour on the terminal", () => {
+    for (const { name, source } of bindingSources()) {
+      expect(source, `${name} configures engine colours`).not.toMatch(
+        /ghostty_terminal_set\(\s*[^)]*COLOR/,
+      );
+    }
+  });
+});

--- a/web/client/src/vt/context.ts
+++ b/web/client/src/vt/context.ts
@@ -1,0 +1,134 @@
+/**
+ * The per-instance plumbing shared by the terminal and the key encoder: the
+ * exports, the memory discipline, the resolved manifest, and the small typed
+ * reads. Every read here refetches the memory view first, which is the whole
+ * point of routing them through one place.
+ */
+
+import { resolveAbi, type ResolvedAbi } from "./abi";
+import { GhosttyError, type GhosttyExports } from "./exports";
+import { createMem, type Mem } from "./memory";
+import { TypeManifest } from "./typeJson";
+
+export interface BindingContext {
+  readonly exports: GhosttyExports;
+  readonly mem: Mem;
+  readonly abi: ResolvedAbi;
+
+  /** Throws on any result other than SUCCESS. */
+  check(operation: string, code: number): void;
+  /** True on SUCCESS, false on NO_VALUE, throws on anything else. */
+  hasValue(operation: string, code: number): boolean;
+
+  /**
+   * Run a constructor that writes its handle into an out-parameter slot.
+   * `wasm.h`'s opaque-slot dance, in one place instead of at five call sites.
+   */
+  createHandle(operation: string, create: (slot: number) => number): number;
+
+  readU8(ptr: number): number;
+  readU16(ptr: number): number;
+  readU32(ptr: number): number;
+  readI32(ptr: number): number;
+  readBool(ptr: number): boolean;
+  writeU8(ptr: number, value: number): void;
+  writeU16(ptr: number, value: number): void;
+  writeU32(ptr: number, value: number): void;
+  /** `size_t` is 4 bytes here; the manifest assertion at load guarantees it. */
+  writeUsize(ptr: number, value: number): void;
+  readUsize(ptr: number): number;
+  /** Reads a NUL-terminated C string. Only used for `ghostty_type_json`. */
+  readCString(ptr: number): string;
+}
+
+export function createContext(exports: GhosttyExports): BindingContext {
+  const mem = createMem(exports);
+
+  const jsonPointer = exports.ghostty_type_json();
+  if (jsonPointer === 0) {
+    throw new Error("ghostty_type_json returned NULL");
+  }
+  const manifest = TypeManifest.parse(readCString(mem, jsonPointer));
+  const abi = resolveAbi(manifest);
+
+  function describe(code: number): string {
+    return abi.result.names.get(code) ?? "UNKNOWN";
+  }
+
+  return {
+    exports,
+    mem,
+    abi,
+    check(operation: string, code: number): void {
+      if (code !== abi.result.success) {
+        throw new GhosttyError(operation, code, describe(code));
+      }
+    },
+    hasValue(operation: string, code: number): boolean {
+      if (code === abi.result.success) return true;
+      if (code === abi.result.noValue) return false;
+      throw new GhosttyError(operation, code, describe(code));
+    },
+    createHandle(operation: string, create: (slot: number) => number): number {
+      const slot = mem.alloc(abi.manifest.abi.pointerSize);
+      try {
+        const code = create(slot);
+        if (code !== abi.result.success) {
+          throw new GhosttyError(operation, code, describe(code));
+        }
+        const handle = exports.ghostty_wasm_take_opaque(slot);
+        if (handle === 0) {
+          throw new Error(`${operation} reported success but produced no handle`);
+        }
+        return handle;
+      } finally {
+        mem.free(slot, abi.manifest.abi.pointerSize);
+      }
+    },
+    readU8(ptr: number): number {
+      return mem.view().getUint8(ptr);
+    },
+    readU16(ptr: number): number {
+      return mem.view().getUint16(ptr, true);
+    },
+    readU32(ptr: number): number {
+      return mem.view().getUint32(ptr, true);
+    },
+    readI32(ptr: number): number {
+      return mem.view().getInt32(ptr, true);
+    },
+    readBool(ptr: number): boolean {
+      return mem.view().getUint8(ptr) !== 0;
+    },
+    writeU8(ptr: number, value: number): void {
+      mem.view().setUint8(ptr, value);
+    },
+    writeU16(ptr: number, value: number): void {
+      mem.view().setUint16(ptr, value, true);
+    },
+    writeU32(ptr: number, value: number): void {
+      mem.view().setUint32(ptr, value, true);
+    },
+    writeUsize(ptr: number, value: number): void {
+      mem.view().setUint32(ptr, value, true);
+    },
+    readUsize(ptr: number): number {
+      return mem.view().getUint32(ptr, true);
+    },
+    readCString(ptr: number): string {
+      return readCString(mem, ptr);
+    },
+  };
+}
+
+function readCString(mem: Mem, ptr: number): string {
+  // The manifest is the only C string this binding reads, and its length is
+  // not reported anywhere, so the terminator has to be found by scanning. The
+  // scan runs over a live view and calls nothing in between, so the view
+  // cannot go stale underneath it.
+  const view = mem.view();
+  const total = view.byteLength;
+  let end = ptr;
+  while (end < total && view.getUint8(end) !== 0) end += 1;
+  return mem.decodeUtf8(ptr, end - ptr);
+}

--- a/web/client/src/vt/exports.ts
+++ b/web/client/src/vt/exports.ts
@@ -1,0 +1,145 @@
+/**
+ * The `ghostty-vt.wasm` export surface this binding calls.
+ *
+ * Names and argument orders are the official C ABI at ghostty `56e1f3a` — the
+ * commit `termiod/vt/Cargo.toml` pins through `termio-sh/libghostty-rs @
+ * 04500f9`. `size_t`, pointers, and handles are all 32-bit numbers on wasm32;
+ * `bool` crosses as 0/1; every `GhosttyResult` is an `i32`.
+ *
+ * Nothing here is optional and nothing is polyfilled: a Wasm missing one of
+ * these is not a degraded mode, it is the wrong binary.
+ */
+export interface GhosttyExports {
+  memory: WebAssembly.Memory;
+
+  /** wasm.h helpers. Present only in the Wasm build, which is the only build here. */
+  ghostty_wasm_alloc: (len: number) => number;
+  ghostty_wasm_free: (ptr: number, len: number) => void;
+  ghostty_wasm_alloc_opaque: () => number;
+  ghostty_wasm_free_opaque: (slot: number) => void;
+  ghostty_wasm_take_opaque: (slot: number) => number;
+
+  /** NUL-terminated JSON. See typeJson.ts. */
+  ghostty_type_json: () => number;
+
+  ghostty_terminal_new: (
+    allocator: number,
+    outTerminal: number,
+    cols: number,
+    rows: number,
+  ) => number;
+  ghostty_terminal_free: (terminal: number) => void;
+  ghostty_terminal_resize: (
+    terminal: number,
+    cols: number,
+    rows: number,
+    cellWidthPx: number,
+    cellHeightPx: number,
+  ) => number;
+  ghostty_terminal_vt_write: (
+    terminal: number,
+    data: number,
+    len: number,
+  ) => void;
+  ghostty_terminal_set: (
+    terminal: number,
+    option: number,
+    value: number,
+  ) => number;
+  ghostty_terminal_get: (
+    terminal: number,
+    data: number,
+    out: number,
+  ) => number;
+
+  ghostty_render_state_new: (allocator: number, outState: number) => number;
+  ghostty_render_state_free: (state: number) => void;
+  ghostty_render_state_begin_update: (
+    state: number,
+    terminal: number,
+  ) => number;
+  ghostty_render_state_end_update: (state: number) => number;
+  ghostty_render_state_clean: (state: number) => number;
+  ghostty_render_state_get: (
+    state: number,
+    data: number,
+    out: number,
+  ) => number;
+
+  ghostty_render_state_row_iterator_new: (
+    allocator: number,
+    outIterator: number,
+  ) => number;
+  ghostty_render_state_row_iterator_free: (iterator: number) => void;
+  ghostty_render_state_row_iterator_next: (iterator: number) => number;
+  ghostty_render_state_row_get: (
+    iterator: number,
+    data: number,
+    out: number,
+  ) => number;
+
+  ghostty_render_state_row_cells_new: (
+    allocator: number,
+    outCells: number,
+  ) => number;
+  ghostty_render_state_row_cells_free: (cells: number) => void;
+  ghostty_render_state_row_cells_select: (cells: number, x: number) => number;
+  ghostty_render_state_row_cells_get: (
+    cells: number,
+    data: number,
+    out: number,
+  ) => number;
+
+  ghostty_key_encoder_new: (allocator: number, outEncoder: number) => number;
+  ghostty_key_encoder_free: (encoder: number) => void;
+  ghostty_key_encoder_setopt: (
+    encoder: number,
+    option: number,
+    value: number,
+  ) => void;
+  ghostty_key_encoder_encode: (
+    encoder: number,
+    event: number,
+    outBuf: number,
+    outBufSize: number,
+    outLen: number,
+  ) => number;
+
+  ghostty_key_event_new: (allocator: number, outEvent: number) => number;
+  ghostty_key_event_free: (event: number) => void;
+  ghostty_key_event_set_action: (event: number, action: number) => void;
+  ghostty_key_event_set_key: (event: number, key: number) => void;
+  ghostty_key_event_set_mods: (event: number, mods: number) => void;
+  ghostty_key_event_set_consumed_mods: (event: number, mods: number) => void;
+  ghostty_key_event_set_composing: (event: number, composing: number) => void;
+  ghostty_key_event_set_utf8: (
+    event: number,
+    utf8: number,
+    len: number,
+  ) => void;
+  ghostty_key_event_set_unshifted_codepoint: (
+    event: number,
+    codepoint: number,
+  ) => void;
+
+  ghostty_paste_encode: (
+    data: number,
+    dataLen: number,
+    bracketed: number,
+    buf: number,
+    bufLen: number,
+    outWritten: number,
+  ) => number;
+}
+
+/** `GhosttyResult`, from types.h. Read by name out of the manifest at runtime. */
+export const RESULT_SUCCESS = 0;
+
+export class GhosttyError extends Error {
+  readonly code: number;
+  constructor(operation: string, code: number, codeName: string) {
+    super(`${operation} failed: ${codeName} (${code})`);
+    this.name = "GhosttyError";
+    this.code = code;
+  }
+}

--- a/web/client/src/vt/index.test.ts
+++ b/web/client/src/vt/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { createFakeGhostty } from "./__fixtures__/fakeGhostty";
+import { buildLayouts, buildManifest } from "./__fixtures__/layout";
+import type { GhosttyExports } from "./exports";
+import { bindingFromExports, instantiate, VtLoadError } from "./index";
+
+describe("bindingFromExports", () => {
+  it("names the export that is missing rather than failing later at a call", () => {
+    const fake = createFakeGhostty();
+    const exports = { ...fake.exports } as Record<string, unknown>;
+    delete exports["ghostty_render_state_row_cells_select"];
+    expect(() => bindingFromExports(exports as unknown as GhosttyExports)).toThrow(
+      /ghostty_render_state_row_cells_select/,
+    );
+  });
+
+  it("refuses a Wasm whose ABI is not the one this client was built against", () => {
+    const fake = createFakeGhostty();
+    const wrong = JSON.parse(buildManifest(buildLayouts())) as {
+      abi: Record<string, unknown>;
+    };
+    wrong.abi["pointer_size"] = 8;
+    const json = JSON.stringify(wrong);
+
+    // Republish the manifest through the same export the binding reads.
+    const bytes = new TextEncoder().encode(json);
+    const pointer = fake.exports.ghostty_wasm_alloc(bytes.length + 1);
+    new Uint8Array(fake.memory.buffer).set(bytes, pointer);
+    const exports: GhosttyExports = {
+      ...fake.exports,
+      ghostty_type_json: () => pointer,
+    };
+
+    expect(() => bindingFromExports(exports)).toThrow(VtLoadError);
+  });
+
+  it("carries the empty-state sentence on every load failure", () => {
+    const error = new VtLoadError("anything");
+    expect(error.userMessage).toBe(
+      "Couldn't load the terminal engine. Check that `ghostty-vt.wasm` is served as `application/wasm`.",
+    );
+  });
+});
+
+describe("instantiate", () => {
+  it("fails loudly, and as a VtLoadError, when the fetch or the MIME type is wrong", async () => {
+    // No fallback to arrayBuffer(): a wrong Content-Type has to surface here
+    // rather than as a silent second 400 KB download.
+    await expect(
+      instantiate({ url: new URL("https://example.invalid/ghostty-vt.wasm") }),
+    ).rejects.toBeInstanceOf(VtLoadError);
+  });
+});

--- a/web/client/src/vt/index.ts
+++ b/web/client/src/vt/index.ts
@@ -1,0 +1,191 @@
+/**
+ * The VT binding: official `ghostty-vt.wasm`, wrapped thinly.
+ *
+ * This module has no DOM beyond `KeyboardEvent`, no socket, and no React
+ * import, which is what keeps it headless-testable — the one ghostty-web lesson
+ * that survives. Nothing above it learns which ghostty symbols exist.
+ */
+
+import { createContext, type BindingContext } from "./context";
+import type { GhosttyExports } from "./exports";
+import { createKeyEncoder, type KeyEncoder } from "./keyEncoder";
+import { createTerminal, type TerminalOptions, type VtTerminal } from "./terminal";
+
+export type { KeyEncoder, KeyEncoderModes } from "./keyEncoder";
+export type { TerminalOptions, VtTerminal } from "./terminal";
+export type { Mem } from "./memory";
+export { GhosttyError } from "./exports";
+export { ManifestError, TypeManifest } from "./typeJson";
+
+/** The empty-state sentence the page shows, verbatim. */
+const USER_MESSAGE =
+  "Couldn't load the terminal engine. Check that `ghostty-vt.wasm` is served as `application/wasm`.";
+
+export class VtLoadError extends Error {
+  readonly userMessage: string;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "VtLoadError";
+    this.userMessage = USER_MESSAGE;
+  }
+}
+
+export interface VtBinding {
+  createTerminal(options: TerminalOptions): VtTerminal;
+  createKeyEncoder(): KeyEncoder;
+  dispose(): void;
+  /** ghostty's own version string from the manifest. Diagnostics only. */
+  readonly libraryVersion: string;
+  /** The ghostty commit the Wasm was built from, when the build recorded one. */
+  readonly commit: string | null;
+}
+
+/** Every export this binding calls. A Wasm missing one is the wrong binary. */
+const REQUIRED_EXPORTS: readonly (keyof GhosttyExports)[] = [
+  "memory",
+  "ghostty_wasm_alloc",
+  "ghostty_wasm_free",
+  "ghostty_wasm_alloc_opaque",
+  "ghostty_wasm_free_opaque",
+  "ghostty_wasm_take_opaque",
+  "ghostty_type_json",
+  "ghostty_terminal_new",
+  "ghostty_terminal_free",
+  "ghostty_terminal_resize",
+  "ghostty_terminal_vt_write",
+  "ghostty_terminal_set",
+  "ghostty_terminal_get",
+  "ghostty_render_state_new",
+  "ghostty_render_state_free",
+  "ghostty_render_state_begin_update",
+  "ghostty_render_state_end_update",
+  "ghostty_render_state_clean",
+  "ghostty_render_state_get",
+  "ghostty_render_state_row_iterator_new",
+  "ghostty_render_state_row_iterator_free",
+  "ghostty_render_state_row_iterator_next",
+  "ghostty_render_state_row_get",
+  "ghostty_render_state_row_cells_new",
+  "ghostty_render_state_row_cells_free",
+  "ghostty_render_state_row_cells_select",
+  "ghostty_render_state_row_cells_get",
+  "ghostty_key_encoder_new",
+  "ghostty_key_encoder_free",
+  "ghostty_key_encoder_setopt",
+  "ghostty_key_encoder_encode",
+  "ghostty_key_event_new",
+  "ghostty_key_event_free",
+  "ghostty_key_event_set_action",
+  "ghostty_key_event_set_key",
+  "ghostty_key_event_set_mods",
+  "ghostty_key_event_set_consumed_mods",
+  "ghostty_key_event_set_composing",
+  "ghostty_key_event_set_utf8",
+  "ghostty_key_event_set_unshifted_codepoint",
+  "ghostty_paste_encode",
+];
+
+/**
+ * Instantiate once per page.
+ *
+ * Uses `WebAssembly.instantiateStreaming` and does NOT fall back to
+ * `arrayBuffer()`. A wrong MIME type has to fail loudly here, because the
+ * alternative is a silent 400 KB re-download and a deploy bug that never
+ * surfaces — the GET jail serves `.wasm` as `application/wasm`, and if it did
+ * not, we want to hear about it on the first load rather than never.
+ */
+export async function instantiate(options: { url: URL }): Promise<VtBinding> {
+  let instance: WebAssembly.Instance;
+  try {
+    const result = await WebAssembly.instantiateStreaming(
+      fetch(options.url, { credentials: "same-origin" }),
+      wasmImports(),
+    );
+    instance = result.instance;
+  } catch (error) {
+    throw new VtLoadError(
+      `could not instantiate ${options.url.href}: ${String(error)}`,
+      { cause: error },
+    );
+  }
+  return bindingFromExports(instance.exports as unknown as GhosttyExports);
+}
+
+/**
+ * The same binding over an already-instantiated module.
+ *
+ * `instantiate` is a thin fetch in front of this. Splitting them is what lets
+ * the tests drive the whole ABI — memory growth, the manifest, the render-state
+ * bracket — without a browser and without shipping a copy of the Wasm into the
+ * test runner.
+ */
+export function bindingFromExports(exports: GhosttyExports): VtBinding {
+  for (const name of REQUIRED_EXPORTS) {
+    if (exports[name] === undefined) {
+      throw new VtLoadError(`ghostty-vt.wasm is missing the export ${name}`);
+    }
+  }
+
+  let context: BindingContext;
+  try {
+    context = createContext(exports);
+  } catch (error) {
+    throw new VtLoadError(
+      `ghostty-vt.wasm ABI is not the one this client was built against: ${String(error)}`,
+      { cause: error },
+    );
+  }
+
+  const terminals = new Set<VtTerminal>();
+  const encoders = new Set<KeyEncoder>();
+  let disposed = false;
+
+  return {
+    libraryVersion: context.abi.manifest.libraryVersion,
+    commit: context.abi.manifest.commit,
+    createTerminal(options: TerminalOptions): VtTerminal {
+      if (disposed) throw new Error("binding is disposed");
+      const terminal = createTerminal(context, options);
+      terminals.add(terminal);
+      return wrapDisposable(terminal, () => terminals.delete(terminal));
+    },
+    createKeyEncoder(): KeyEncoder {
+      if (disposed) throw new Error("binding is disposed");
+      const encoder = createKeyEncoder(context);
+      encoders.add(encoder);
+      return wrapDisposable(encoder, () => encoders.delete(encoder));
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      // The Wasm instance itself is garbage; what leaks without this is every
+      // terminal and encoder the page forgot to dispose.
+      for (const terminal of [...terminals]) terminal.dispose();
+      for (const encoder of [...encoders]) encoder.dispose();
+      terminals.clear();
+      encoders.clear();
+    },
+  };
+}
+
+function wrapDisposable<T extends { dispose(): void }>(
+  value: T,
+  onDispose: () => void,
+): T {
+  const original = value.dispose.bind(value);
+  value.dispose = () => {
+    original();
+    onDispose();
+  };
+  return value;
+}
+
+/**
+ * Release builds of `ghostty-vt.wasm` compile logging out entirely and import
+ * nothing; a debug build imports `env.log`. Supplying the no-op costs nothing
+ * and keeps a debug binary from failing to instantiate.
+ */
+function wasmImports(): WebAssembly.Imports {
+  return { env: { log: () => {} } };
+}

--- a/web/client/src/vt/keyEncoder.test.ts
+++ b/web/client/src/vt/keyEncoder.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import { createFakeGhostty } from "./__fixtures__/fakeGhostty";
+import { ENUMS } from "./__fixtures__/layout";
+import { bindingFromExports } from "./index";
+import {
+  manifestKeyName,
+  printableText,
+  unshiftedCodepoint,
+  type KeyEncoder,
+} from "./keyEncoder";
+
+const decoder = new TextDecoder();
+
+interface FakeKeyboardEvent {
+  code: string;
+  key: string;
+  shiftKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+  repeat?: boolean;
+  isComposing?: boolean;
+}
+
+/**
+ * A KeyboardEvent-shaped literal. The binding only reads `code`, `key`, the
+ * modifier flags, `repeat`, `isComposing`, and `getModifierState`, so the tests
+ * stay in the node realm rather than dragging in jsdom for a property bag.
+ */
+function keyEvent(event: FakeKeyboardEvent): KeyboardEvent {
+  return {
+    code: event.code,
+    key: event.key,
+    shiftKey: event.shiftKey ?? false,
+    ctrlKey: event.ctrlKey ?? false,
+    altKey: event.altKey ?? false,
+    metaKey: event.metaKey ?? false,
+    repeat: event.repeat ?? false,
+    isComposing: event.isComposing ?? false,
+    getModifierState: () => false,
+  } as unknown as KeyboardEvent;
+}
+
+function withEncoder<T>(run: (encoder: KeyEncoder) => T): T {
+  const fake = createFakeGhostty();
+  const binding = bindingFromExports(fake.exports);
+  const encoder = binding.createKeyEncoder();
+  try {
+    return run(encoder);
+  } finally {
+    binding.dispose();
+    expect(fake.liveAllocations()).toBe(0);
+  }
+}
+
+function text(bytes: Uint8Array): string {
+  return decoder.decode(bytes);
+}
+
+describe("manifestKeyName", () => {
+  it("translates DOM codes into the manifest's key names", () => {
+    expect(manifestKeyName("KeyA")).toBe("A");
+    expect(manifestKeyName("Digit1")).toBe("DIGIT_1");
+    expect(manifestKeyName("ArrowLeft")).toBe("ARROW_LEFT");
+    expect(manifestKeyName("NumpadAdd")).toBe("NUMPAD_ADD");
+    expect(manifestKeyName("Numpad7")).toBe("NUMPAD_7");
+    expect(manifestKeyName("ControlLeft")).toBe("CONTROL_LEFT");
+    expect(manifestKeyName("BracketRight")).toBe("BRACKET_RIGHT");
+    expect(manifestKeyName("IntlBackslash")).toBe("INTL_BACKSLASH");
+    expect(manifestKeyName("Escape")).toBe("ESCAPE");
+  });
+
+  it("leaves the function row alone rather than splitting F1 into F_1", () => {
+    expect(manifestKeyName("F1")).toBe("F1");
+    expect(manifestKeyName("F12")).toBe("F12");
+  });
+});
+
+describe("printableText", () => {
+  it("reports the character a key produced", () => {
+    expect(printableText(keyEvent({ code: "KeyA", key: "a" }))).toBe("a");
+    expect(printableText(keyEvent({ code: "Digit1", key: "!" }))).toBe("!");
+  });
+
+  it("reports nothing for named keys, controls, and macOS function codes", () => {
+    // key/event.h forbids C0, DEL, and the U+F700–U+F8FF private-use range.
+    expect(printableText(keyEvent({ code: "Enter", key: "Enter" }))).toBeNull();
+    expect(printableText(keyEvent({ code: "KeyC", key: "" }))).toBeNull();
+    expect(printableText(keyEvent({ code: "F1", key: "" }))).toBeNull();
+  });
+});
+
+describe("unshiftedCodepoint", () => {
+  it("derives the unshifted character from the physical key", () => {
+    expect(unshiftedCodepoint(keyEvent({ code: "KeyA", key: "A", shiftKey: true }))).toBe(
+      "a".codePointAt(0),
+    );
+    expect(unshiftedCodepoint(keyEvent({ code: "Digit1", key: "!", shiftKey: true }))).toBe(
+      "1".codePointAt(0),
+    );
+    expect(unshiftedCodepoint(keyEvent({ code: "Enter", key: "Enter" }))).toBe(0);
+  });
+});
+
+describe("KeyEncoder", () => {
+  it("encodes a plain key press to its bytes", () => {
+    withEncoder((encoder) => {
+      expect(text(encoder.encode(keyEvent({ code: "KeyA", key: "a" }), "down"))).toBe("a");
+      expect(text(encoder.encode(keyEvent({ code: "Enter", key: "Enter" }), "down"))).toBe(
+        "\r",
+      );
+    });
+  });
+
+  it("encodes control keys from the modifier bits, not from the text", () => {
+    withEncoder((encoder) => {
+      const bytes = encoder.encode(
+        keyEvent({ code: "KeyC", key: "c", ctrlKey: true }),
+        "down",
+      );
+      expect([...bytes]).toEqual([0x03]);
+    });
+  });
+
+  it("sends nothing for a key release under the legacy encoding", () => {
+    withEncoder((encoder) => {
+      expect(encoder.encode(keyEvent({ code: "KeyA", key: "a" }), "up").length).toBe(0);
+    });
+  });
+
+  it("follows DECCKM when the terminal changes it", () => {
+    withEncoder((encoder) => {
+      const event = keyEvent({ code: "ArrowUp", key: "ArrowUp" });
+      expect(text(encoder.encode(event, "down"))).toBe("\x1b[A");
+
+      encoder.setModes({
+        cursorKeyApplication: true,
+        keypadApplication: false,
+        kittyFlags: 0,
+        altSendsEscape: false,
+        bracketedPaste: false,
+      });
+      expect(text(encoder.encode(event, "down"))).toBe("\x1bOA");
+    });
+  });
+
+  it("prefixes alt with ESC only when the mode says so", () => {
+    withEncoder((encoder) => {
+      const event = keyEvent({ code: "KeyB", key: "b", altKey: true });
+      expect(text(encoder.encode(event, "down"))).toBe("b");
+
+      encoder.setModes({
+        cursorKeyApplication: false,
+        keypadApplication: false,
+        kittyFlags: 0,
+        altSendsEscape: true,
+        bracketedPaste: false,
+      });
+      expect(text(encoder.encode(event, "down"))).toBe("\x1bb");
+    });
+  });
+
+  it("passes an unknown code through as UNIDENTIFIED and falls back to the text", () => {
+    withEncoder((encoder) => {
+      expect(
+        text(encoder.encode(keyEvent({ code: "MediaSelect", key: "x" }), "down")),
+      ).toBe("x");
+    });
+  });
+
+  it("wraps a paste only when bracketed paste is on", () => {
+    withEncoder((encoder) => {
+      expect(text(encoder.encodePaste("ls\n"))).toBe("ls\r");
+
+      encoder.setModes({
+        cursorKeyApplication: false,
+        keypadApplication: false,
+        kittyFlags: 0,
+        altSendsEscape: false,
+        bracketedPaste: true,
+      });
+      expect(text(encoder.encodePaste("ls\n"))).toBe("\x1b[200~ls\n\x1b[201~");
+    });
+  });
+
+  it("grows its buffer instead of truncating a long paste", () => {
+    withEncoder((encoder) => {
+      const long = "x".repeat(4096);
+      expect(text(encoder.encodePaste(long))).toBe(long);
+    });
+  });
+
+  it("is idempotent on dispose", () => {
+    const fake = createFakeGhostty();
+    const binding = bindingFromExports(fake.exports);
+    const encoder = binding.createKeyEncoder();
+    encoder.dispose();
+    expect(() => encoder.dispose()).not.toThrow();
+    expect(() => encoder.encode(keyEvent({ code: "KeyA", key: "a" }), "down")).toThrow(
+      /disposed/,
+    );
+    binding.dispose();
+    expect(fake.liveAllocations()).toBe(0);
+  });
+
+  it("hands the encoder the modes the terminal reports", () => {
+    const fake = createFakeGhostty();
+    const binding = bindingFromExports(fake.exports);
+    const terminal = binding.createTerminal({
+      rows: 2,
+      cols: 4,
+      scrollbackBytes: 1024,
+    });
+    const encoder = binding.createKeyEncoder();
+    terminal.write(new TextEncoder().encode("\x1b[?1h"));
+    encoder.setModes(terminal.keyEncoderModes());
+
+    const handles = fake.terminals();
+    expect(handles.length).toBe(1);
+    expect(text(encoder.encode(keyEvent({ code: "ArrowLeft", key: "ArrowLeft" }), "down"))).toBe(
+      "\x1bOD",
+    );
+    expect(ENUMS.GhosttyKey.ARROW_LEFT).toBe(76);
+    binding.dispose();
+  });
+});

--- a/web/client/src/vt/keyEncoder.ts
+++ b/web/client/src/vt/keyEncoder.ts
@@ -1,0 +1,346 @@
+/**
+ * The official `key/encoder.h` + `key/event.h`, wrapped so a DOM event never
+ * leaves this module and the app never builds a GhosttyKeyEvent by hand.
+ *
+ * The encoder is a pure function of (event, modes): it holds no socket, no
+ * terminal handle, and no opinion about what the bytes are for. Modes come from
+ * `VtTerminal.keyEncoderModes()` after each write batch, so DECCKM and the
+ * kitty flags are read from the VT rather than guessed at.
+ */
+
+import type { BindingContext } from "./context";
+
+export interface KeyEncoderModes {
+  cursorKeyApplication: boolean; // DECCKM
+  keypadApplication: boolean; // DECKPAM
+  kittyFlags: number; // 0 = legacy encoding
+  altSendsEscape: boolean;
+  bracketedPaste: boolean;
+}
+
+export interface KeyEncoder {
+  setModes(modes: KeyEncoderModes): void;
+  /** PTY bytes for one key event. Empty (length 0) = send nothing. */
+  encode(event: KeyboardEvent, phase: "down" | "up"): Uint8Array;
+  /** Bracketed-paste wrapping when the mode is set, raw bytes otherwise. */
+  encodePaste(text: string): Uint8Array;
+  dispose(): void;
+}
+
+/** `GhosttyMods` bits, from key/event.h. Not in the manifest: they are #defines. */
+const MODS_SHIFT = 1 << 0;
+const MODS_CTRL = 1 << 1;
+const MODS_ALT = 1 << 2;
+const MODS_SUPER = 1 << 3;
+const MODS_CAPS_LOCK = 1 << 4;
+const MODS_NUM_LOCK = 1 << 5;
+const MODS_SHIFT_SIDE = 1 << 6;
+const MODS_CTRL_SIDE = 1 << 7;
+const MODS_ALT_SIDE = 1 << 8;
+const MODS_SUPER_SIDE = 1 << 9;
+
+const ENCODE_BUFFER_BYTES = 128;
+const EMPTY = new Uint8Array(0);
+const utf8Encoder = new TextEncoder();
+
+export function createKeyEncoder(context: BindingContext): KeyEncoder {
+  return new WasmKeyEncoder(context);
+}
+
+class WasmKeyEncoder implements KeyEncoder {
+  private readonly context: BindingContext;
+  private encoder: number;
+  private event: number;
+  private outBuffer: number;
+  private outCapacity: number;
+  private readonly optionValue: number;
+  private readonly optionValueSize: number;
+  private readonly writtenSlot: number;
+  private readonly writtenSlotSize: number;
+  private modes: KeyEncoderModes = {
+    cursorKeyApplication: false,
+    keypadApplication: false,
+    kittyFlags: 0,
+    altSendsEscape: false,
+    bracketedPaste: false,
+  };
+  private disposed = false;
+
+  constructor(context: BindingContext) {
+    this.context = context;
+    const { exports, mem, abi } = context;
+    this.encoder = context.createHandle("ghostty_key_encoder_new", (slot) =>
+      exports.ghostty_key_encoder_new(0, slot),
+    );
+    let event = 0;
+    try {
+      event = context.createHandle("ghostty_key_event_new", (slot) =>
+        exports.ghostty_key_event_new(0, slot),
+      );
+    } catch (error) {
+      exports.ghostty_key_encoder_free(this.encoder);
+      this.encoder = 0;
+      throw error;
+    }
+    this.event = event;
+    this.outCapacity = ENCODE_BUFFER_BYTES;
+    this.outBuffer = mem.alloc(this.outCapacity);
+    this.optionValueSize = abi.manifest.abi.maxAlignment;
+    this.optionValue = mem.alloc(this.optionValueSize);
+    this.writtenSlotSize = abi.manifest.abi.usizeSize;
+    this.writtenSlot = mem.alloc(this.writtenSlotSize);
+  }
+
+  setModes(modes: KeyEncoderModes): void {
+    this.assertUsable();
+    this.modes = modes;
+    const { exports, abi } = this.context;
+    this.setBoolOption(
+      abi.keyEncoderOption.cursorKeyApplication,
+      modes.cursorKeyApplication,
+    );
+    this.setBoolOption(
+      abi.keyEncoderOption.keypadKeyApplication,
+      modes.keypadApplication,
+    );
+    this.setBoolOption(abi.keyEncoderOption.altEscPrefix, modes.altSendsEscape);
+    // GhosttyKittyKeyFlags is a u8 bitmask, not a bool.
+    this.context.writeU8(this.optionValue, modes.kittyFlags & 0xff);
+    exports.ghostty_key_encoder_setopt(
+      this.encoder,
+      abi.keyEncoderOption.kittyFlags,
+      this.optionValue,
+    );
+  }
+
+  encode(event: KeyboardEvent, phase: "down" | "up"): Uint8Array {
+    this.assertUsable();
+    const { exports, abi, mem } = this.context;
+
+    const action =
+      phase === "up"
+        ? abi.keyAction.release
+        : event.repeat
+          ? abi.keyAction.repeat
+          : abi.keyAction.press;
+    exports.ghostty_key_event_set_action(this.event, action);
+    exports.ghostty_key_event_set_key(this.event, this.keyFor(event));
+    const mods = modsFor(event);
+    exports.ghostty_key_event_set_mods(this.event, mods);
+    // Nothing in the browser tells us which modifiers a layout already consumed
+    // to produce `event.key`, so none are reported as consumed.
+    exports.ghostty_key_event_set_consumed_mods(this.event, 0);
+    exports.ghostty_key_event_set_composing(this.event, event.isComposing ? 1 : 0);
+    exports.ghostty_key_event_set_unshifted_codepoint(
+      this.event,
+      unshiftedCodepoint(event),
+    );
+
+    const text = printableText(event);
+    let textPointer = 0;
+    let textLength = 0;
+    if (text !== null) {
+      const bytes = utf8Encoder.encode(text);
+      textLength = bytes.length;
+      textPointer = mem.alloc(textLength);
+      mem.u8(textPointer, textLength).set(bytes);
+    }
+    try {
+      exports.ghostty_key_event_set_utf8(this.event, textPointer, textLength);
+      return this.encodeCurrentEvent();
+    } finally {
+      // The event does not take ownership of the text, and it is not read
+      // again after `encode` returns.
+      exports.ghostty_key_event_set_utf8(this.event, 0, 0);
+      if (textPointer !== 0) mem.free(textPointer, textLength);
+    }
+  }
+
+  encodePaste(text: string): Uint8Array {
+    this.assertUsable();
+    const { exports, abi, mem } = this.context;
+    const bytes = utf8Encoder.encode(text);
+    // `ghostty_paste_encode` modifies the input in place (it replaces unsafe
+    // control bytes), so the input has to live in Wasm memory, not in a view of
+    // a JS buffer.
+    const dataLength = bytes.length;
+    const data = dataLength === 0 ? 0 : mem.alloc(dataLength);
+    if (data !== 0) mem.u8(data, dataLength).set(bytes);
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        this.context.writeUsize(this.writtenSlot, 0);
+        const code = exports.ghostty_paste_encode(
+          data,
+          dataLength,
+          this.modes.bracketedPaste ? 1 : 0,
+          this.outBuffer,
+          this.outCapacity,
+          this.writtenSlot,
+        );
+        const written = this.context.readUsize(this.writtenSlot);
+        if (code === abi.result.success) {
+          return written === 0 ? EMPTY : mem.copyOut(this.outBuffer, written);
+        }
+        if (code !== abi.result.outOfSpace) {
+          this.context.check("ghostty_paste_encode", code);
+          return EMPTY;
+        }
+        this.growOutBuffer(written);
+      }
+      return EMPTY;
+    } finally {
+      if (data !== 0) mem.free(data, dataLength);
+    }
+  }
+
+  dispose(): void {
+    // Idempotent on purpose: React 19 StrictMode double-invokes effects, and a
+    // second free of the same handle is a corrupt allocator, not a warning.
+    if (this.disposed) return;
+    this.disposed = true;
+    const { exports, mem } = this.context;
+    exports.ghostty_key_event_free(this.event);
+    exports.ghostty_key_encoder_free(this.encoder);
+    mem.free(this.outBuffer, this.outCapacity);
+    mem.free(this.optionValue, this.optionValueSize);
+    mem.free(this.writtenSlot, this.writtenSlotSize);
+    this.event = 0;
+    this.encoder = 0;
+    this.outBuffer = 0;
+    this.outCapacity = 0;
+  }
+
+  private assertUsable(): void {
+    if (this.disposed) throw new Error("key encoder is disposed");
+  }
+
+  private setBoolOption(option: number, value: boolean): void {
+    const { exports } = this.context;
+    this.context.writeU8(this.optionValue, value ? 1 : 0);
+    exports.ghostty_key_encoder_setopt(this.encoder, option, this.optionValue);
+  }
+
+  private encodeCurrentEvent(): Uint8Array {
+    const { exports, abi, mem } = this.context;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      this.context.writeUsize(this.writtenSlot, 0);
+      const code = exports.ghostty_key_encoder_encode(
+        this.encoder,
+        this.event,
+        this.outBuffer,
+        this.outCapacity,
+        this.writtenSlot,
+      );
+      const written = this.context.readUsize(this.writtenSlot);
+      if (code === abi.result.success) {
+        // Not every key produces output: unmodified modifier keys encode to
+        // nothing, and that is a zero-length result, not an error.
+        return written === 0 ? EMPTY : mem.copyOut(this.outBuffer, written);
+      }
+      if (code !== abi.result.outOfSpace) {
+        this.context.check("ghostty_key_encoder_encode", code);
+        return EMPTY;
+      }
+      this.growOutBuffer(written);
+    }
+    return EMPTY;
+  }
+
+  private growOutBuffer(required: number): void {
+    const { mem } = this.context;
+    mem.free(this.outBuffer, this.outCapacity);
+    this.outCapacity = Math.max(required, this.outCapacity * 2);
+    this.outBuffer = mem.alloc(this.outCapacity);
+  }
+
+  private keyFor(event: KeyboardEvent): number {
+    const name = manifestKeyName(event.code);
+    const keys = this.context.abi.keys;
+    const value = name === null ? undefined : keys[name];
+    if (value !== undefined) return value;
+    const unidentified = keys["UNIDENTIFIED"];
+    return unidentified ?? 0;
+  }
+}
+
+/**
+ * `KeyboardEvent.code` → the manifest's GhosttyKey name.
+ *
+ * The two vocabularies are the same physical-key list in different spellings:
+ * `KeyA` / `Digit1` / `ArrowLeft` / `NumpadAdd` against `A` / `DIGIT_1` /
+ * `ARROW_LEFT` / `NUMPAD_ADD`. Splitting camel humps and digit runs turns one
+ * into the other for every key except the function row, where `F1` must not
+ * become `F_1`. Anything left over resolves to UNIDENTIFIED, which the encoder
+ * handles by falling back to the event's text.
+ */
+export function manifestKeyName(code: string): string | null {
+  if (code.length === 0) return null;
+  if (/^F\d{1,2}$/.test(code)) return code;
+  const parts = code
+    .replace(/([a-z])([A-Z])/g, "$1_$2")
+    .replace(/([A-Za-z])(\d)/g, "$1_$2")
+    .toUpperCase();
+  // `KeyA` becomes `KEY_A`, but the manifest names it `A`: the C prefix
+  // `GHOSTTY_KEY_` is already stripped out of every manifest name.
+  return parts.startsWith("KEY_") ? parts.slice(4) : parts;
+}
+
+function modsFor(event: KeyboardEvent): number {
+  let mods = 0;
+  if (event.shiftKey) mods |= MODS_SHIFT;
+  if (event.ctrlKey) mods |= MODS_CTRL;
+  if (event.altKey) mods |= MODS_ALT;
+  if (event.metaKey) mods |= MODS_SUPER;
+  if (typeof event.getModifierState === "function") {
+    if (event.getModifierState("CapsLock")) mods |= MODS_CAPS_LOCK;
+    if (event.getModifierState("NumLock")) mods |= MODS_NUM_LOCK;
+  }
+  // The side bits are only meaningful for the modifier key events themselves,
+  // where `code` says which one moved.
+  if (event.code.endsWith("Right")) {
+    if (event.code.startsWith("Shift")) mods |= MODS_SHIFT_SIDE;
+    else if (event.code.startsWith("Control")) mods |= MODS_CTRL_SIDE;
+    else if (event.code.startsWith("Alt")) mods |= MODS_ALT_SIDE;
+    else if (event.code.startsWith("Meta")) mods |= MODS_SUPER_SIDE;
+  }
+  return mods;
+}
+
+/**
+ * The text the key produced, or null when there is none to report.
+ *
+ * key/event.h is explicit about what must not be passed: C0 controls, DEL, and
+ * the macOS private-use function-key range. Those cases pass NULL and let the
+ * encoder work from the logical key, which is also what `Enter`, `ArrowUp`, and
+ * every other named key do — their `event.key` is a word, not a character.
+ */
+export function printableText(event: KeyboardEvent): string | null {
+  const key = event.key;
+  if (typeof key !== "string" || key.length === 0) return null;
+  const codepoint = key.codePointAt(0);
+  if (codepoint === undefined) return null;
+  // A named key is longer than the one grapheme it would otherwise be.
+  if ([...key].length > 1) return null;
+  if (codepoint < 0x20 || codepoint === 0x7f) return null;
+  if (codepoint >= 0xf700 && codepoint <= 0xf8ff) return null;
+  return key;
+}
+
+/**
+ * The codepoint the key would produce with no modifiers, for the kitty
+ * protocol's unshifted field.
+ *
+ * Derived from `code` for the keys where the physical position names the
+ * character on any Latin layout, and from the lowercased `key` otherwise. A
+ * non-Latin layout gets the second path, which is a known approximation: the
+ * browser exposes no unshifted-character API, and inventing a layout table
+ * would be worse than the approximation.
+ */
+export function unshiftedCodepoint(event: KeyboardEvent): number {
+  const code = event.code;
+  if (/^Key[A-Z]$/.test(code)) return code.charCodeAt(3) + 0x20;
+  if (/^Digit\d$/.test(code)) return code.charCodeAt(5);
+  const text = printableText(event);
+  if (text === null) return 0;
+  return text.toLowerCase().codePointAt(0) ?? 0;
+}

--- a/web/client/src/vt/memory.test.ts
+++ b/web/client/src/vt/memory.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { createMem, OutOfMemoryError, type WasmMemoryExports } from "./memory";
+
+function exportsFor(memory: { buffer: ArrayBuffer }): WasmMemoryExports {
+  return {
+    memory: memory as WebAssembly.Memory,
+    ghostty_wasm_alloc: () => 0,
+    ghostty_wasm_free: () => {},
+  };
+}
+
+describe("Mem", () => {
+  it("rebuilds its view when growth replaces the buffer", () => {
+    // The classic detach: WebAssembly.Memory.grow() hands back a new
+    // ArrayBuffer and every view made before it reads zeroes forever.
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const mem = createMem(exportsFor(memory));
+
+    mem.u8(0, 4).set([1, 2, 3, 4]);
+    const before = mem.u8(0, 4).slice();
+    expect([...before]).toEqual([1, 2, 3, 4]);
+
+    memory.grow(1);
+
+    // A binding that cached the view would read zeroes here.
+    expect([...mem.u8(0, 4)]).toEqual([1, 2, 3, 4]);
+    // And the view has to cover the new memory, not the old length.
+    const end = memory.buffer.byteLength - 4;
+    mem.u8(end, 4).set([9, 9, 9, 9]);
+    expect([...mem.u8(end, 4)]).toEqual([9, 9, 9, 9]);
+  });
+
+  it("rebuilds its view when the buffer keeps its identity and grows", () => {
+    // The case identity alone misses: a resizable ArrayBuffer grows in place,
+    // so `buffer === cachedBuffer` stays true while byteLength moves. Without
+    // the length half of the check, every read past the old end throws.
+    // Resizable ArrayBuffers are ES2024 and the project's `lib` is ES2022, so
+    // the constructor is reached through a cast rather than by widening the lib
+    // for one test.
+    const ResizableArrayBuffer = ArrayBuffer as unknown as {
+      new (
+        byteLength: number,
+        options: { maxByteLength: number },
+      ): ArrayBuffer & { resize(byteLength: number): void };
+    };
+    const buffer = new ResizableArrayBuffer(16, { maxByteLength: 64 });
+    const memory = { buffer };
+    const mem = createMem(exportsFor(memory));
+
+    expect(mem.u8(0, 16).length).toBe(16);
+    const identityBefore = mem.view().buffer;
+
+    buffer.resize(64);
+    expect(memory.buffer).toBe(identityBefore);
+
+    expect(() => mem.u8(48, 16)).not.toThrow();
+    expect(mem.view().byteLength).toBe(64);
+  });
+
+  it("copies out of linear memory so the result survives the next call", () => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const mem = createMem(exportsFor(memory));
+    mem.u8(8, 3).set([7, 8, 9]);
+
+    const copy = mem.copyOut(8, 3);
+    memory.grow(1);
+
+    expect([...copy]).toEqual([7, 8, 9]);
+  });
+
+  it("refuses a read that runs past the end of memory", () => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const mem = createMem(exportsFor(memory));
+    expect(() => mem.u8(memory.buffer.byteLength - 2, 8)).toThrow(RangeError);
+  });
+
+  it("turns a NULL allocation into an error instead of a pointer at zero", () => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const mem = createMem({
+      memory,
+      ghostty_wasm_alloc: () => 0,
+      ghostty_wasm_free: () => {},
+    });
+    expect(() => mem.alloc(32)).toThrow(OutOfMemoryError);
+  });
+});

--- a/web/client/src/vt/memory.ts
+++ b/web/client/src/vt/memory.ts
@@ -1,0 +1,115 @@
+/**
+ * The only legal way to touch Wasm linear memory from the host side.
+ *
+ * `wasm.h` states the rule this file exists to enforce: "An exported function
+ * may grow Wasm linear memory when it allocates. Numeric pointers and handles
+ * remain valid, but JavaScript ArrayBuffer, DataView, and typed-array objects
+ * created before the growth may no longer cover the live memory. Reacquire
+ * `exports.memory.buffer` immediately before every host-side memory access. A
+ * host that caches views should recreate them whenever either the buffer
+ * identity or its byte length changes."
+ *
+ * Nothing else in `src/vt/` is allowed to hold an `ArrayBuffer`, a `DataView`,
+ * or a typed array in a field, a closure, or a returned object.
+ */
+
+export interface WasmMemoryExports {
+  memory: WebAssembly.Memory;
+  ghostty_wasm_alloc: (len: number) => number;
+  ghostty_wasm_free: (ptr: number, len: number) => void;
+}
+
+export interface Mem {
+  /** A view over `len` bytes at `ptr`. Valid until the next call into Wasm. */
+  u8(ptr: number, len: number): Uint8Array;
+  /** A DataView over all of linear memory. Valid until the next call into Wasm. */
+  view(): DataView;
+  /** `ghostty_wasm_alloc`. Returns a numeric pointer, which survives growth. */
+  alloc(size: number): number;
+  /** `ghostty_wasm_free`, with the exact length that was allocated. */
+  free(ptr: number, size: number): void;
+  /** Copies out of linear memory into a fresh JS buffer that survives growth. */
+  copyOut(ptr: number, len: number): Uint8Array;
+  /** Decodes UTF-8 out of linear memory into a JS string. */
+  decodeUtf8(ptr: number, len: number): string;
+}
+
+export class OutOfMemoryError extends Error {
+  constructor(size: number) {
+    super(`ghostty_wasm_alloc(${size}) returned NULL`);
+    this.name = "OutOfMemoryError";
+  }
+}
+
+const utf8 = new TextDecoder("utf-8", { fatal: false });
+
+export function createMem(exports: WasmMemoryExports): Mem {
+  // The cache is keyed on both the buffer identity and its byte length, and
+  // both checks are load-bearing:
+  //
+  //  - Identity alone misses the resizable-ArrayBuffer case. When the module's
+  //    memory is backed by a growable buffer (`memory.toResizableBuffer()`, or
+  //    any engine that grows in place), `memory.buffer` keeps the same object
+  //    across a `memory.grow` and only its `byteLength` moves. A view cached on
+  //    identity would then be a short view over a longer memory: every read past
+  //    the old end silently returns nothing, and `new Uint8Array(buffer, ptr,
+  //    len)` for a pointer beyond the old length throws RangeError.
+  //  - Length alone misses the classic detach case, where growth hands back a
+  //    brand-new ArrayBuffer that happens to be the same length as an earlier
+  //    one — after a shrink-then-grow, or simply because the previous buffer was
+  //    detached and replaced. Reading through the detached view yields zeroes
+  //    with no error at all, which is the worst failure available here.
+  //
+  // `wasm.h` therefore says "either the buffer identity or its byte length" and
+  // this cache checks exactly that, on every access.
+  let cachedBuffer: ArrayBuffer | null = null;
+  let cachedLength = 0;
+  let cachedBytes: Uint8Array | null = null;
+  let cachedView: DataView | null = null;
+
+  function refresh(): void {
+    const buffer = exports.memory.buffer;
+    if (buffer === cachedBuffer && buffer.byteLength === cachedLength) return;
+    cachedBuffer = buffer;
+    cachedLength = buffer.byteLength;
+    cachedBytes = new Uint8Array(buffer);
+    cachedView = new DataView(buffer);
+  }
+
+  return {
+    u8(ptr: number, len: number): Uint8Array {
+      refresh();
+      if (cachedBytes === null) throw new Error("wasm memory unavailable");
+      if (ptr < 0 || len < 0 || ptr + len > cachedLength) {
+        throw new RangeError(
+          `wasm read of ${len} bytes at ${ptr} runs past ${cachedLength} bytes of memory`,
+        );
+      }
+      return cachedBytes.subarray(ptr, ptr + len);
+    },
+    view(): DataView {
+      refresh();
+      if (cachedView === null) throw new Error("wasm memory unavailable");
+      return cachedView;
+    },
+    alloc(size: number): number {
+      const ptr = exports.ghostty_wasm_alloc(size);
+      if (ptr === 0) throw new OutOfMemoryError(size);
+      return ptr;
+    },
+    free(ptr: number, size: number): void {
+      exports.ghostty_wasm_free(ptr, size);
+    },
+    copyOut(ptr: number, len: number): Uint8Array {
+      // slice(), not subarray(): the caller keeps this past the next call into
+      // Wasm, which is exactly when the backing buffer can go away.
+      return this.u8(ptr, len).slice();
+    },
+    decodeUtf8(ptr: number, len: number): string {
+      if (len === 0) return "";
+      // TextDecoder copies into a fresh string, so decoding straight off the
+      // live view is safe as long as nothing calls into Wasm in between.
+      return utf8.decode(this.u8(ptr, len));
+    },
+  };
+}

--- a/web/client/src/vt/terminal.test.ts
+++ b/web/client/src/vt/terminal.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, it } from "vitest";
+
+import { ATTR, type CellView, type RenderFrame } from "../renderer/types";
+import { createFakeGhostty, type FakeGhostty } from "./__fixtures__/fakeGhostty";
+import { ENUMS } from "./__fixtures__/layout";
+import { bindingFromExports, type VtBinding } from "./index";
+import type { VtTerminal } from "./terminal";
+
+const encoder = new TextEncoder();
+
+interface Harness {
+  fake: FakeGhostty;
+  binding: VtBinding;
+  terminal: VtTerminal;
+}
+
+function harness(
+  options: {
+    padding?: number;
+    rows?: number;
+    cols?: number;
+    growOnAlloc?: boolean;
+  } = {},
+): Harness {
+  const fakeOptions: { padding?: number; growOnAlloc?: boolean } = {};
+  if (options.padding !== undefined) fakeOptions.padding = options.padding;
+  if (options.growOnAlloc !== undefined) fakeOptions.growOnAlloc = options.growOnAlloc;
+  const fake = createFakeGhostty(fakeOptions);
+  const binding = bindingFromExports(fake.exports);
+  const terminal = binding.createTerminal({
+    rows: options.rows ?? 4,
+    cols: options.cols ?? 8,
+    scrollbackBytes: 1024 * 1024,
+  });
+  return { fake, binding, terminal };
+}
+
+function write(terminal: VtTerminal, text: string): void {
+  terminal.write(encoder.encode(text));
+}
+
+/** The rows the renderer would repaint, as plain text. */
+function textOf(frame: RenderFrame, y: number): string {
+  const row = frame.rows_[y];
+  if (row === undefined) return "";
+  return row.cells
+    .map((cell) => (cell.codepoint === 0 ? " " : String.fromCodePoint(cell.codepoint)))
+    .join("")
+    .trimEnd();
+}
+
+function cellAt(frame: RenderFrame, y: number, x: number): CellView {
+  const cell = frame.rows_[y]?.cells[x];
+  if (cell === undefined) throw new Error(`no cell at ${x},${y}`);
+  return cell;
+}
+
+describe("VtTerminal.readFrame", () => {
+  it("turns written bytes into painted rows", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "hi\r\nthere");
+
+    terminal.readFrame((frame) => {
+      expect(frame.rows).toBe(4);
+      expect(frame.cols).toBe(8);
+      expect(textOf(frame, 0)).toBe("hi");
+      expect(textOf(frame, 1)).toBe("there");
+      expect(frame.cursor.hasValue).toBe(true);
+      expect(frame.cursor.style).toBe("block");
+    });
+    binding.dispose();
+  });
+
+  it("reports colour as an unresolved slot, never as pixels", () => {
+    const { terminal, binding } = harness();
+    // 31 is a theme slot, 38;2 is the program's own literal colour, and an
+    // unstyled cell names no colour at all. The renderer resolves the first,
+    // must not reinterpret the second, and paints the viewer's default for the
+    // third. This is the whole presentation boundary in one assertion.
+    write(terminal, "a\x1b[31mb\x1b[38;2;9;8;7mc\x1b[m");
+
+    terminal.readFrame((frame) => {
+      expect(cellAt(frame, 0, 0).foreground).toEqual({ tag: "default" });
+      expect(cellAt(frame, 0, 1).foreground).toEqual({ tag: "palette", index: 1 });
+      expect(cellAt(frame, 0, 2).foreground).toEqual({
+        tag: "rgb",
+        r: 9,
+        g: 8,
+        b: 7,
+      });
+    });
+    binding.dispose();
+  });
+
+  it("keeps palette 0 distinct from no colour at all", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "\x1b[30ma\x1b[mb");
+    terminal.readFrame((frame) => {
+      expect(cellAt(frame, 0, 0).foreground).toEqual({ tag: "palette", index: 0 });
+      expect(cellAt(frame, 0, 1).foreground).toEqual({ tag: "default" });
+    });
+    binding.dispose();
+  });
+
+  it("applies inverse by swapping slots, the way the host does", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "\x1b[31;7ma");
+    terminal.readFrame((frame) => {
+      const cell = cellAt(frame, 0, 0);
+      expect(cell.background).toEqual({ tag: "palette", index: 1 });
+      expect(cell.foreground).toEqual({ tag: "default" });
+    });
+    binding.dispose();
+  });
+
+  it("blanks an invisible cell instead of leaving the renderer to guess", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "\x1b[8ma");
+    terminal.readFrame((frame) => {
+      expect(cellAt(frame, 0, 0).codepoint).toBe(0);
+    });
+    binding.dispose();
+  });
+
+  it("maps SGR decorations onto the seam's attribute bits", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "\x1b[1;3;4;9ma");
+    terminal.readFrame((frame) => {
+      const cell = cellAt(frame, 0, 0);
+      expect(cell.attributes & ATTR.BOLD).toBeTruthy();
+      expect(cell.attributes & ATTR.ITALIC).toBeTruthy();
+      expect(cell.attributes & ATTR.UNDERLINE).toBeTruthy();
+      expect(cell.attributes & ATTR.STRIKETHROUGH).toBeTruthy();
+      expect(cell.attributes & ATTR.UNDERCURL).toBeFalsy();
+    });
+    binding.dispose();
+  });
+
+  it("carries the program's underline colour as its own slot", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "\x1b[4;58;5;42ma");
+    terminal.readFrame((frame) => {
+      expect(cellAt(frame, 0, 0).underline).toEqual({ tag: "palette", index: 42 });
+    });
+    binding.dispose();
+  });
+
+  it("reads a background-only cell out of the cell's own content tag", () => {
+    const { fake, terminal, binding } = harness();
+    const model = fake.terminals()[0];
+    if (model === undefined) throw new Error("no fake terminal");
+    fake.poke(model, 0, 0, {
+      contentTag: ENUMS.GhosttyCellContentTag.BG_COLOR_PALETTE,
+      palette: 200,
+    });
+    fake.poke(model, 0, 1, {
+      contentTag: ENUMS.GhosttyCellContentTag.BG_COLOR_RGB,
+      rgb: { r: 1, g: 2, b: 3 },
+    });
+
+    terminal.readFrame((frame) => {
+      expect(cellAt(frame, 0, 0).background).toEqual({ tag: "palette", index: 200 });
+      expect(cellAt(frame, 0, 1).background).toEqual({ tag: "rgb", r: 1, g: 2, b: 3 });
+    });
+    binding.dispose();
+  });
+
+  it("flags wide cells and their spacers", () => {
+    const { fake, terminal, binding } = harness();
+    const model = fake.terminals()[0];
+    if (model === undefined) throw new Error("no fake terminal");
+    fake.poke(model, 0, 0, { codepoint: 0x4e00, wide: ENUMS.GhosttyCellWide.WIDE });
+    fake.poke(model, 0, 1, { wide: ENUMS.GhosttyCellWide.SPACER_TAIL });
+
+    terminal.readFrame((frame) => {
+      expect(cellAt(frame, 0, 0).attributes & ATTR.WIDE).toBeTruthy();
+      expect(cellAt(frame, 0, 1).attributes & ATTR.WIDE_SPACER).toBeTruthy();
+    });
+    binding.dispose();
+  });
+
+  it("reads a grapheme cluster, growing the buffer when the cluster is long", () => {
+    const { fake, terminal, binding } = harness();
+    const model = fake.terminals()[0];
+    if (model === undefined) throw new Error("no fake terminal");
+    const long = `e${"́".repeat(80)}`; // far past the 64-byte starting buffer
+    fake.poke(model, 0, 0, {
+      contentTag: ENUMS.GhosttyCellContentTag.CODEPOINT_GRAPHEME,
+      codepoint: 0x65,
+      grapheme: long,
+    });
+
+    terminal.readFrame((frame) => {
+      expect(cellAt(frame, 0, 0).grapheme).toBe(long);
+    });
+    binding.dispose();
+  });
+
+  it("reports the row-local selection as a half-open range and per-cell flags", () => {
+    const { fake, terminal, binding } = harness();
+    const model = fake.terminals()[0];
+    if (model === undefined) throw new Error("no fake terminal");
+    write(terminal, "abcdef");
+    model.selection = { row: 0, start: 1, end: 3 };
+
+    terminal.readFrame((frame) => {
+      // render.h reports an inclusive end column; the seam wants half-open.
+      expect(frame.rows_[0]?.selection).toEqual({ start: 1, end: 4 });
+      expect(cellAt(frame, 0, 0).selected).toBe(false);
+      expect(cellAt(frame, 0, 1).selected).toBe(true);
+      expect(cellAt(frame, 0, 3).selected).toBe(true);
+      expect(cellAt(frame, 0, 4).selected).toBe(false);
+    });
+    binding.dispose();
+  });
+
+  it("reports damage instead of making the renderer derive it", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "first");
+    terminal.readFrame((frame) => {
+      expect(frame.dirty).toBe("full");
+    });
+
+    terminal.readFrame((frame) => {
+      expect(frame.dirty).toBe("none");
+    });
+
+    write(terminal, "\x1b[2;1Hsecond");
+    terminal.readFrame((frame) => {
+      expect(frame.dirty).toBe("partial");
+      expect(frame.rows_[0]?.dirty).toBe(false);
+      expect(frame.rows_[1]?.dirty).toBe(true);
+    });
+    binding.dispose();
+  });
+
+  it("surfaces only the colours the program set", () => {
+    const { terminal, binding } = harness();
+    terminal.readFrame((frame) => {
+      // Nothing set: the viewer's Palette decides, so there is no override to
+      // report — and specifically not the engine's own default colours.
+      expect(frame.overrides).toEqual({});
+    });
+
+    write(terminal, "\x1b]11;#102030\x07");
+    terminal.readFrame((frame) => {
+      expect(frame.overrides.background).toEqual({ r: 0x10, g: 0x20, b: 0x30 });
+      expect(frame.overrides.foreground).toBeUndefined();
+    });
+    binding.dispose();
+  });
+
+  it("survives a write that grows linear memory mid-frame", () => {
+    const { fake, terminal, binding } = harness();
+    const growsBefore = fake.growCount();
+    write(terminal, "abc");
+    write(terminal, "def");
+    expect(fake.growCount()).toBeGreaterThan(growsBefore);
+
+    terminal.readFrame((frame) => {
+      expect(textOf(frame, 0)).toBe("abcdef");
+    });
+    binding.dispose();
+  });
+
+  it("survives memory growth in the middle of building a frame", () => {
+    // Every allocation grows linear memory here, including the ones the
+    // grapheme retry makes while the frame is being built. A binding that held
+    // a view across those calls reads a detached buffer — zeroes, silently.
+    const { fake, terminal, binding } = harness({ growOnAlloc: true });
+    const model = fake.terminals()[0];
+    if (model === undefined) throw new Error("no fake terminal");
+    write(terminal, "\x1b[31ma");
+    const cluster = `e${"́".repeat(80)}`;
+    fake.poke(model, 0, 1, {
+      contentTag: ENUMS.GhosttyCellContentTag.CODEPOINT_GRAPHEME,
+      codepoint: 0x65,
+      grapheme: cluster,
+    });
+
+    const growsBefore = fake.growCount();
+    terminal.readFrame((frame) => {
+      expect(cellAt(frame, 0, 0).foreground).toEqual({ tag: "palette", index: 1 });
+      expect(cellAt(frame, 0, 1).grapheme).toBe(cluster);
+    });
+    expect(fake.growCount()).toBeGreaterThan(growsBefore);
+    binding.dispose();
+  });
+
+  it("follows the manifest when the struct layout moves", () => {
+    // Same ABI, every sized struct shifted by 16 bytes. A binding with a
+    // hardcoded offset reads a style out of padding and this fails.
+    const { terminal, binding } = harness({ padding: 16 });
+    write(terminal, "\x1b[31;1ma");
+    terminal.readFrame((frame) => {
+      const cell = cellAt(frame, 0, 0);
+      expect(cell.foreground).toEqual({ tag: "palette", index: 1 });
+      expect(cell.attributes & ATTR.BOLD).toBeTruthy();
+    });
+    binding.dispose();
+  });
+
+  it("refuses to write or dispose from inside visit", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "a");
+    terminal.readFrame(() => {
+      expect(() => write(terminal, "b")).toThrow(/inside readFrame/);
+      expect(() => terminal.resize(2, 2)).toThrow(/inside readFrame/);
+      expect(() => terminal.dispose()).toThrow(/inside readFrame/);
+      expect(() => terminal.readFrame(() => 0)).toThrow(/not reentrant/);
+    });
+    binding.dispose();
+  });
+
+  it("leaves the damage standing when visit throws", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "a");
+    expect(() =>
+      terminal.readFrame(() => {
+        throw new Error("renderer blew up");
+      }),
+    ).toThrow("renderer blew up");
+
+    // Not cleaned: the frame was never painted, so the next one repaints it.
+    terminal.readFrame((frame) => {
+      expect(frame.dirty).toBe("full");
+    });
+    binding.dispose();
+  });
+
+  it("returns what visit returns", () => {
+    const { terminal, binding } = harness();
+    const rows = terminal.readFrame((frame) => frame.rows_.length);
+    expect(rows).toBe(4);
+    binding.dispose();
+  });
+
+  it("repaints everything after a resize", () => {
+    const { terminal, binding } = harness();
+    write(terminal, "abc");
+    terminal.readFrame(() => {});
+
+    terminal.resize(2, 4);
+    expect(terminal.rows).toBe(2);
+    expect(terminal.cols).toBe(4);
+    terminal.readFrame((frame) => {
+      expect(frame.dirty).toBe("full");
+      expect(frame.rows).toBe(2);
+      expect(frame.cols).toBe(4);
+      expect(frame.rows_.length).toBe(2);
+      expect(frame.rows_[0]?.cells.length).toBe(4);
+    });
+    binding.dispose();
+  });
+});
+
+describe("VtTerminal state reads", () => {
+  it("reports the OSC title, and null when the program set none", () => {
+    const { terminal, binding } = harness();
+    expect(terminal.title()).toBeNull();
+    write(terminal, "\x1b]2;build\x07");
+    expect(terminal.title()).toBe("build");
+    binding.dispose();
+  });
+
+  it("queries synchronized output rather than inferring it", () => {
+    const { terminal, binding } = harness();
+    expect(terminal.syncOutputActive()).toBe(false);
+    write(terminal, "\x1b[?2026h");
+    expect(terminal.syncOutputActive()).toBe(true);
+    write(terminal, "\x1b[?2026l");
+    expect(terminal.syncOutputActive()).toBe(false);
+    binding.dispose();
+  });
+
+  it("reads the key-encoder modes off the VT", () => {
+    const { fake, terminal, binding } = harness();
+    expect(terminal.keyEncoderModes()).toEqual({
+      cursorKeyApplication: false,
+      keypadApplication: false,
+      kittyFlags: 0,
+      altSendsEscape: false,
+      bracketedPaste: false,
+    });
+
+    write(terminal, "\x1b[?1h\x1b[?2004h");
+    const model = fake.terminals()[0];
+    if (model === undefined) throw new Error("no fake terminal");
+    model.kittyFlags = 0b101;
+
+    expect(terminal.keyEncoderModes()).toEqual({
+      cursorKeyApplication: true,
+      keypadApplication: false,
+      kittyFlags: 0b101,
+      altSendsEscape: false,
+      bracketedPaste: true,
+    });
+    binding.dispose();
+  });
+});
+
+describe("lifecycle", () => {
+  it("is idempotent on dispose, the way StrictMode needs", () => {
+    const { terminal, binding } = harness();
+    terminal.dispose();
+    expect(() => terminal.dispose()).not.toThrow();
+    expect(() => terminal.write(encoder.encode("a"))).toThrow(/disposed/);
+    binding.dispose();
+  });
+
+  it("frees every allocation it made", () => {
+    const fake = createFakeGhostty();
+    const binding = bindingFromExports(fake.exports);
+    const terminal = binding.createTerminal({
+      rows: 3,
+      cols: 4,
+      scrollbackBytes: 1024,
+    });
+    write(terminal, "hello");
+    terminal.readFrame(() => {});
+    terminal.dispose();
+    // The fixture's allocator refuses a free with the wrong length, so a clean
+    // ledger here also means every free used the length it allocated with.
+    expect(fake.liveAllocations()).toBe(0);
+    binding.dispose();
+  });
+
+  it("disposes terminals the page forgot when the binding goes away", () => {
+    const fake = createFakeGhostty();
+    const binding = bindingFromExports(fake.exports);
+    binding.createTerminal({ rows: 2, cols: 2, scrollbackBytes: 1024 });
+    binding.dispose();
+    expect(fake.liveAllocations()).toBe(0);
+  });
+
+  it("reports the manifest's version and commit for diagnostics", () => {
+    const fake = createFakeGhostty();
+    const binding = bindingFromExports(fake.exports);
+    expect(binding.commit).toBe("56e1f3a62e26407e8c020ef5881df3e8584be20f");
+    binding.dispose();
+  });
+});

--- a/web/client/src/vt/terminal.ts
+++ b/web/client/src/vt/terminal.ts
@@ -1,0 +1,925 @@
+/**
+ * The Wasm terminal: bytes in, one render frame out.
+ *
+ * The presentation boundary lives in `readCell` below. Cell colour is read from
+ * `GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_STYLE` — the *unresolved* `GhosttyStyle`
+ * — and from the cell's own background content tag. It is never read from
+ * `…_DATA_FG_COLOR` / `…_DATA_BG_COLOR`, whose own doc comment says they
+ * resolve "palette indices through the palette": that resolution is the
+ * viewer's, and doing it here is the bug that disqualified ghostty-web and
+ * `@wterm/ghostty`. Neither constant appears in this file, and neither may.
+ *
+ * `termiod/vt/src/lib.rs::cell_from_parts` is the Rust twin of `readCell`, down
+ * to applying `inverse` and `invisible` here rather than leaving them for the
+ * renderer, so a live viewport row and a decoded history row cannot disagree
+ * about what a cell looks like.
+ */
+
+import type {
+  CellView,
+  ColorOverrides,
+  CursorState,
+  CursorStyle,
+  RenderFrame,
+  Rgb,
+  RowView,
+  TaggedColor,
+} from "../renderer/types";
+// ATTR is a value, not a type, and this is the one runtime import `src/vt/`
+// takes from the seam. The alternative is a second copy of the bitmask, and two
+// definitions of the same bits is exactly the drift the seam exists to prevent.
+import { ATTR } from "../renderer/types";
+
+import type { BindingContext } from "./context";
+import type { KeyEncoderModes } from "./keyEncoder";
+import { extractBits } from "./typeJson";
+
+export interface TerminalOptions {
+  rows: number;
+  cols: number;
+  /**
+   * BYTES, not lines — Ghostty pages internally and we do not pretend to know
+   * a line count. The caller passes 1 MiB, matching the host's
+   * SCROLLBACK_STAGE_MAX_BYTES.
+   */
+  scrollbackBytes: number;
+}
+
+export interface VtTerminal {
+  readonly rows: number;
+  readonly cols: number;
+  write(bytes: Uint8Array): void;
+  resize(rows: number, cols: number): void;
+  readFrame<T>(visit: (frame: RenderFrame) => T): T;
+  syncOutputActive(): boolean;
+  title(): string | null;
+  keyEncoderModes(): KeyEncoderModes;
+  dispose(): void;
+}
+
+/**
+ * Not imported from `protocol/colors.ts`: `src/vt/` must not depend on protocol
+ * runtime code. The shape is the seam's `TaggedColor`, and the renderer reads
+ * `tag`, never object identity, so one frozen singleton per module is a shared
+ * allocation saving rather than a second definition of anything.
+ */
+const DEFAULT_COLOR: TaggedColor = Object.freeze({ tag: "default" as const });
+
+/** DEC private modes, by their VT numbers. These are the standard, not an ABI. */
+const MODE_CURSOR_KEYS = 1; // DECCKM
+const MODE_KEYPAD_KEYS = 66; // DECKPAM / application keypad
+const MODE_ALT_ESC_PREFIX = 1036;
+const MODE_BRACKETED_PASTE = 2004;
+const MODE_SYNC_OUTPUT = 2026;
+
+/**
+ * Cell metrics handed to `ghostty_terminal_resize`. The VT only uses them for
+ * in-band size reports (mode 2048); termiod's own sidecar passes the same 8×16
+ * so a session reports one geometry no matter which client resized it.
+ */
+const CELL_WIDTH_PX = 8;
+const CELL_HEIGHT_PX = 16;
+
+interface StyleRead {
+  foreground: TaggedColor;
+  background: TaggedColor;
+  underline: TaggedColor | null;
+  attributes: number;
+  inverse: boolean;
+  invisible: boolean;
+}
+
+export function createTerminal(
+  context: BindingContext,
+  options: TerminalOptions,
+): VtTerminal {
+  return new WasmTerminal(context, options);
+}
+
+class WasmTerminal implements VtTerminal {
+  private readonly context: BindingContext;
+  private terminal: number;
+  private renderState: number;
+  private rowIterator: number;
+  private cellIterator: number;
+
+  /** One pointer-sized slot, reused for every "populate this handle" call. */
+  private readonly slot: number;
+  private readonly slotSize: number;
+  /** Big enough for every sized struct this binding reads. */
+  private readonly scratch: number;
+  private readonly scratchSize: number;
+  private graphemeBuffer: number;
+  private graphemeCapacity: number;
+
+  private rowsValue: number;
+  private colsValue: number;
+  private disposed = false;
+  private visiting = false;
+
+  private readonly rowPool: RowView[] = [];
+  private readonly styleCache = new Map<number, StyleRead>();
+  private readonly frame: RenderFrame;
+
+  constructor(context: BindingContext, options: TerminalOptions) {
+    if (options.rows <= 0 || options.cols <= 0) {
+      throw new RangeError(
+        `terminal geometry ${options.cols}x${options.rows} must be positive`,
+      );
+    }
+    this.context = context;
+    const { exports, abi, mem } = context;
+
+    this.rowsValue = options.rows;
+    this.colsValue = options.cols;
+
+    this.terminal = context.createHandle("ghostty_terminal_new", (slot) =>
+      exports.ghostty_terminal_new(0, slot, options.cols, options.rows),
+    );
+
+    let renderState = 0;
+    let rowIterator = 0;
+    let cellIterator = 0;
+    let slot = 0;
+    let scratch = 0;
+    let graphemeBuffer = 0;
+    try {
+      renderState = context.createHandle("ghostty_render_state_new", (out) =>
+        exports.ghostty_render_state_new(0, out),
+      );
+      rowIterator = context.createHandle(
+        "ghostty_render_state_row_iterator_new",
+        (out) => exports.ghostty_render_state_row_iterator_new(0, out),
+      );
+      cellIterator = context.createHandle(
+        "ghostty_render_state_row_cells_new",
+        (out) => exports.ghostty_render_state_row_cells_new(0, out),
+      );
+
+      this.slotSize = abi.manifest.abi.pointerSize;
+      slot = mem.alloc(this.slotSize);
+      this.scratchSize = Math.max(
+        abi.style.size,
+        abi.cursor.size,
+        abi.rowSelection.size,
+        abi.cellsView.size,
+        abi.string.size,
+        abi.buffer.size,
+        abi.modeConfig.size,
+        abi.colorRgb.size,
+        8,
+      );
+      scratch = mem.alloc(this.scratchSize);
+      this.graphemeCapacity = 64;
+      graphemeBuffer = mem.alloc(this.graphemeCapacity);
+    } catch (error) {
+      if (cellIterator !== 0) exports.ghostty_render_state_row_cells_free(cellIterator);
+      if (rowIterator !== 0) exports.ghostty_render_state_row_iterator_free(rowIterator);
+      if (renderState !== 0) exports.ghostty_render_state_free(renderState);
+      if (slot !== 0) mem.free(slot, abi.manifest.abi.pointerSize);
+      exports.ghostty_terminal_free(this.terminal);
+      this.terminal = 0;
+      throw error;
+    }
+
+    this.renderState = renderState;
+    this.rowIterator = rowIterator;
+    this.cellIterator = cellIterator;
+    this.slot = slot;
+    this.scratch = scratch;
+    this.graphemeBuffer = graphemeBuffer;
+
+    this.setScrollbackBytes(options.scrollbackBytes);
+
+    this.frame = {
+      dirty: "full",
+      cols: this.colsValue,
+      rows: this.rowsValue,
+      cursor: {
+        hasValue: false,
+        x: 0,
+        y: 0,
+        visible: false,
+        blinking: false,
+        passwordInput: false,
+        wideTail: false,
+        style: "block",
+      },
+      rows_: this.rowPool,
+      overrides: {},
+      // The Wasm viewport is never scrolled in v1: history arrives as `H`
+      // frames and the renderer paints it from its own buffer, so the live
+      // viewport is always at the bottom.
+      scrollOffsetRows: 0,
+    };
+  }
+
+  get rows(): number {
+    return this.rowsValue;
+  }
+
+  get cols(): number {
+    return this.colsValue;
+  }
+
+  write(bytes: Uint8Array): void {
+    this.assertUsable("write");
+    if (bytes.length === 0) return;
+    const { exports, mem } = this.context;
+    // ALLOCATING: this may grow linear memory. The `set` below therefore takes
+    // its view AFTER the alloc, and nothing cached from before it survives.
+    const pointer = mem.alloc(bytes.length);
+    try {
+      mem.u8(pointer, bytes.length).set(bytes);
+      exports.ghostty_terminal_vt_write(this.terminal, pointer, bytes.length);
+    } finally {
+      mem.free(pointer, bytes.length);
+    }
+  }
+
+  resize(rows: number, cols: number): void {
+    this.assertUsable("resize");
+    if (rows <= 0 || cols <= 0) {
+      throw new RangeError(`terminal geometry ${cols}x${rows} must be positive`);
+    }
+    const { exports } = this.context;
+    this.context.check(
+      "ghostty_terminal_resize",
+      exports.ghostty_terminal_resize(
+        this.terminal,
+        cols,
+        rows,
+        CELL_WIDTH_PX,
+        CELL_HEIGHT_PX,
+      ),
+    );
+    this.rowsValue = rows;
+    this.colsValue = cols;
+    // Pooled rows are indexed by y and sized to the old column count; a resize
+    // invalidates both, and the next frame is FULL anyway.
+    this.rowPool.length = 0;
+  }
+
+  readFrame<T>(visit: (frame: RenderFrame) => T): T {
+    this.assertUsable("readFrame");
+    if (this.visiting) {
+      throw new Error("readFrame is not reentrant");
+    }
+    const { exports } = this.context;
+
+    // render.h: "Every begin must be completed with a
+    // ghostty_render_state_end_update call before the render state is read."
+    // So the bracket is begin → end → read → visit → clean, not
+    // begin → read → end.
+    this.context.check(
+      "ghostty_render_state_begin_update",
+      exports.ghostty_render_state_begin_update(this.renderState, this.terminal),
+    );
+    this.context.check(
+      "ghostty_render_state_end_update",
+      exports.ghostty_render_state_end_update(this.renderState),
+    );
+
+    const frame = this.buildFrame();
+
+    this.visiting = true;
+    let result: T;
+    try {
+      result = visit(frame);
+    } finally {
+      this.visiting = false;
+    }
+
+    // Only after the frame was actually consumed: if `visit` threw, the damage
+    // stands and the next frame repaints it.
+    this.context.check(
+      "ghostty_render_state_clean",
+      exports.ghostty_render_state_clean(this.renderState),
+    );
+    return result;
+  }
+
+  syncOutputActive(): boolean {
+    this.assertUsable("syncOutputActive");
+    return this.readMode(MODE_SYNC_OUTPUT);
+  }
+
+  title(): string | null {
+    this.assertUsable("title");
+    const { exports, abi, mem } = this.context;
+    const code = exports.ghostty_terminal_get(
+      this.terminal,
+      abi.terminalData.title,
+      this.scratch,
+    );
+    if (!this.context.hasValue("ghostty_terminal_get(TITLE)", code)) return null;
+    const pointer = this.context.readU32(this.scratch + abi.string.ptr);
+    const length = this.context.readUsize(this.scratch + abi.string.len);
+    if (pointer === 0 || length === 0) return null;
+    return mem.decodeUtf8(pointer, length);
+  }
+
+  keyEncoderModes(): KeyEncoderModes {
+    this.assertUsable("keyEncoderModes");
+    const { exports, abi } = this.context;
+    const flagsCode = exports.ghostty_terminal_get(
+      this.terminal,
+      abi.terminalData.kittyKeyboardFlags,
+      this.scratch,
+    );
+    const kittyFlags = this.context.hasValue(
+      "ghostty_terminal_get(KITTY_KEYBOARD_FLAGS)",
+      flagsCode,
+    )
+      ? this.context.readU8(this.scratch)
+      : 0;
+    return {
+      cursorKeyApplication: this.readMode(MODE_CURSOR_KEYS),
+      keypadApplication: this.readMode(MODE_KEYPAD_KEYS),
+      kittyFlags,
+      altSendsEscape: this.readMode(MODE_ALT_ESC_PREFIX),
+      bracketedPaste: this.readMode(MODE_BRACKETED_PASTE),
+    };
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    if (this.visiting) {
+      throw new Error("dispose called from inside readFrame");
+    }
+    this.disposed = true;
+    const { exports, mem } = this.context;
+    exports.ghostty_render_state_row_cells_free(this.cellIterator);
+    exports.ghostty_render_state_row_iterator_free(this.rowIterator);
+    exports.ghostty_render_state_free(this.renderState);
+    exports.ghostty_terminal_free(this.terminal);
+    mem.free(this.slot, this.slotSize);
+    mem.free(this.scratch, this.scratchSize);
+    mem.free(this.graphemeBuffer, this.graphemeCapacity);
+    this.cellIterator = 0;
+    this.rowIterator = 0;
+    this.renderState = 0;
+    this.terminal = 0;
+    this.graphemeBuffer = 0;
+    this.graphemeCapacity = 0;
+    this.rowPool.length = 0;
+    this.styleCache.clear();
+  }
+
+  private assertUsable(operation: string): void {
+    if (this.disposed) {
+      throw new Error(`${operation} called on a disposed terminal`);
+    }
+    // The reentrancy guard is not a debug aid: `write`, `resize`, and every
+    // allocation may grow linear memory, and the frame handed to `visit` is a
+    // set of views onto the memory that growth replaces.
+    if (this.visiting && operation !== "readFrame") {
+      throw new Error(`${operation} called from inside readFrame`);
+    }
+  }
+
+  private setScrollbackBytes(bytes: number): void {
+    const { exports, abi, mem } = this.context;
+    const pointer = mem.alloc(abi.manifest.abi.usizeSize);
+    try {
+      this.context.writeUsize(pointer, bytes);
+      this.context.check(
+        "ghostty_terminal_set(SCROLLBACK_MAX_BYTES)",
+        exports.ghostty_terminal_set(
+          this.terminal,
+          abi.terminalOption.scrollbackMaxBytes,
+          pointer,
+        ),
+      );
+    } finally {
+      mem.free(pointer, abi.manifest.abi.usizeSize);
+    }
+  }
+
+  private readMode(mode: number): boolean {
+    const { exports, abi } = this.context;
+    // GhosttyMode packs the number in bits 0–14 and the ANSI flag in bit 15.
+    // Every mode read here is a DEC private mode, so the flag stays clear.
+    this.context.writeU16(this.scratch + abi.modeConfig.mode, mode);
+    this.context.writeU8(this.scratch + abi.modeConfig.value, 0);
+    const code = exports.ghostty_terminal_get(
+      this.terminal,
+      abi.terminalData.mode,
+      this.scratch,
+    );
+    if (!this.context.hasValue(`ghostty_terminal_get(MODE ${mode})`, code)) {
+      return false;
+    }
+    return this.context.readBool(this.scratch + abi.modeConfig.value);
+  }
+
+  private buildFrame(): RenderFrame {
+    const { exports, abi } = this.context;
+    const frame = this.frame;
+
+    this.context.check(
+      "ghostty_render_state_get(DIRTY)",
+      exports.ghostty_render_state_get(
+        this.renderState,
+        abi.renderStateData.dirty,
+        this.scratch,
+      ),
+    );
+    const dirtyValue = this.context.readI32(this.scratch);
+    frame.dirty =
+      dirtyValue === abi.renderStateDirty.full
+        ? "full"
+        : dirtyValue === abi.renderStateDirty.partial
+          ? "partial"
+          : "none";
+
+    this.context.check(
+      "ghostty_render_state_get(COLS)",
+      exports.ghostty_render_state_get(
+        this.renderState,
+        abi.renderStateData.cols,
+        this.scratch,
+      ),
+    );
+    frame.cols = this.context.readU16(this.scratch);
+    this.context.check(
+      "ghostty_render_state_get(ROWS)",
+      exports.ghostty_render_state_get(
+        this.renderState,
+        abi.renderStateData.rows,
+        this.scratch,
+      ),
+    );
+    frame.rows = this.context.readU16(this.scratch);
+
+    this.readCursor(frame.cursor);
+    this.readOverrides(frame.overrides);
+    this.readRows(frame);
+    return frame;
+  }
+
+  private readCursor(cursor: CursorState): void {
+    const { exports, abi } = this.context;
+    this.context.writeUsize(this.scratch + abi.cursor.sizeField, abi.cursor.size);
+    this.context.check(
+      "ghostty_render_state_get(CURSOR)",
+      exports.ghostty_render_state_get(
+        this.renderState,
+        abi.renderStateData.cursor,
+        this.scratch,
+      ),
+    );
+    const hasValue = this.context.readBool(
+      this.scratch + abi.cursor.viewportHasValue,
+    );
+    cursor.hasValue = hasValue;
+    // render.h: when viewport_has_value is false, x / y / wide_tail contain
+    // undefined data. Report zeroes rather than clamping garbage into range.
+    cursor.x = hasValue ? this.context.readU16(this.scratch + abi.cursor.viewportX) : 0;
+    cursor.y = hasValue ? this.context.readU16(this.scratch + abi.cursor.viewportY) : 0;
+    cursor.wideTail = hasValue
+      ? this.context.readBool(this.scratch + abi.cursor.wideTail)
+      : false;
+    cursor.visible = this.context.readBool(this.scratch + abi.cursor.visible);
+    cursor.blinking = this.context.readBool(this.scratch + abi.cursor.blinking);
+    cursor.passwordInput = this.context.readBool(
+      this.scratch + abi.cursor.passwordInput,
+    );
+    cursor.style = this.cursorStyle(
+      this.context.readI32(this.scratch + abi.cursor.visualStyle),
+    );
+  }
+
+  private cursorStyle(value: number): CursorStyle {
+    const { cursorVisualStyle } = this.context.abi;
+    if (value === cursorVisualStyle.bar) return "bar";
+    if (value === cursorVisualStyle.underline) return "underline";
+    if (value === cursorVisualStyle.hollowBlock) return "hollow_block";
+    return "block";
+  }
+
+  /**
+   * Colours the PROGRAM set with OSC 10 / 11 / 12, and nothing else.
+   *
+   * This reads the TERMINAL's colours, not the render state's. The terminal is
+   * constructed without any default foreground, background, or cursor colour,
+   * and the getter documents that it returns NO_VALUE "if no color is
+   * configured (neither a default nor an OSC override)". So a value here means
+   * a program asked for it, which is program intent and is honoured; absence
+   * means the viewer's Palette decides. The render state's own colours would
+   * answer with the engine's built-in defaults, which are exactly the
+   * presentation-boundary values this binding must never pass on.
+   *
+   * `GhosttyRenderStateColors.palette[256]` is never read at all.
+   */
+  private readOverrides(overrides: ColorOverrides): void {
+    const { abi } = this.context;
+    const foreground = this.readTerminalColor(abi.terminalData.colorForeground);
+    const background = this.readTerminalColor(abi.terminalData.colorBackground);
+    const cursor = this.readTerminalColor(abi.terminalData.colorCursor);
+    if (foreground === null) delete overrides.foreground;
+    else overrides.foreground = foreground;
+    if (background === null) delete overrides.background;
+    else overrides.background = background;
+    if (cursor === null) delete overrides.cursor;
+    else overrides.cursor = cursor;
+  }
+
+  private readTerminalColor(data: number): Rgb | null {
+    const { exports, abi } = this.context;
+    const code = exports.ghostty_terminal_get(this.terminal, data, this.scratch);
+    if (!this.context.hasValue("ghostty_terminal_get(COLOR)", code)) return null;
+    return {
+      r: this.context.readU8(this.scratch + abi.colorRgb.r),
+      g: this.context.readU8(this.scratch + abi.colorRgb.g),
+      b: this.context.readU8(this.scratch + abi.colorRgb.b),
+    };
+  }
+
+  private readRows(frame: RenderFrame): void {
+    const { exports, abi } = this.context;
+    if (frame.dirty === "none") {
+      // Nothing changed; the pool still describes the last frame and the
+      // renderer is told so by `dirty`.
+      for (const row of this.rowPool) row.dirty = false;
+      return;
+    }
+
+    // The iterator object is pre-allocated and re-pointed at each snapshot by
+    // passing the slot that holds its handle.
+    this.context.writeU32(this.slot, this.rowIterator);
+    this.context.check(
+      "ghostty_render_state_get(ROW_ITERATOR)",
+      exports.ghostty_render_state_get(
+        this.renderState,
+        abi.renderStateData.rowIterator,
+        this.slot,
+      ),
+    );
+
+    const full = frame.dirty === "full";
+    let y = 0;
+    while (exports.ghostty_render_state_row_iterator_next(this.rowIterator) !== 0) {
+      const row = this.rowAt(y, frame.cols);
+      this.context.check(
+        "ghostty_render_state_row_get(DIRTY)",
+        exports.ghostty_render_state_row_get(
+          this.rowIterator,
+          abi.rowData.dirty,
+          this.scratch,
+        ),
+      );
+      row.dirty = full || this.context.readBool(this.scratch);
+      this.readSelection(row);
+      if (row.dirty) {
+        this.readRowCells(row, frame.cols);
+      }
+      y += 1;
+    }
+    // A shrunk viewport leaves stale rows in the pool; drop them so `rows_`
+    // never describes a row the render state no longer has.
+    if (this.rowPool.length > y) this.rowPool.length = y;
+  }
+
+  private rowAt(y: number, cols: number): RowView {
+    let row = this.rowPool[y];
+    if (row === undefined) {
+      row = { y, dirty: true, cells: [] };
+      this.rowPool[y] = row;
+    }
+    row.y = y;
+    const cells = row.cells;
+    while (cells.length < cols) {
+      cells.push({
+        codepoint: 0,
+        foreground: DEFAULT_COLOR,
+        background: DEFAULT_COLOR,
+        attributes: 0,
+        selected: false,
+      });
+    }
+    if (cells.length > cols) cells.length = cols;
+    return row;
+  }
+
+  private readSelection(row: RowView): void {
+    const { exports, abi } = this.context;
+    this.context.writeUsize(
+      this.scratch + abi.rowSelection.sizeField,
+      abi.rowSelection.size,
+    );
+    const code = exports.ghostty_render_state_row_get(
+      this.rowIterator,
+      abi.rowData.selection,
+      this.scratch,
+    );
+    if (!this.context.hasValue("ghostty_render_state_row_get(SELECTION)", code)) {
+      delete row.selection;
+      return;
+    }
+    const start = this.context.readU16(this.scratch + abi.rowSelection.startX);
+    // render.h reports an inclusive end column; the seam's range is half-open.
+    const end = this.context.readU16(this.scratch + abi.rowSelection.endX) + 1;
+    row.selection = { start, end };
+  }
+
+  private readRowCells(row: RowView, cols: number): void {
+    const { exports, abi } = this.context;
+
+    // The bulk path: one call for the whole row. render.h documents CELLS_RAW
+    // as the read "for callers with expensive call boundaries (e.g.
+    // WebAssembly embedders)", which is this caller exactly.
+    this.context.check(
+      "ghostty_render_state_row_get(CELLS_RAW)",
+      exports.ghostty_render_state_row_get(
+        this.rowIterator,
+        abi.rowData.cellsRaw,
+        this.scratch,
+      ),
+    );
+    const cellsPointer = this.context.readU32(this.scratch + abi.cellsView.ptr);
+    const available = this.context.readUsize(this.scratch + abi.cellsView.len);
+    const count = Math.min(available, cols);
+
+    this.styleCache.clear();
+    let cellsHandleReady = false;
+    const selection = row.selection;
+
+    for (let x = 0; x < count; x += 1) {
+      // The view is refetched per cell because reading a style or a grapheme
+      // calls back into Wasm, and any such call may have grown memory.
+      const view = this.context.mem.view();
+      const base = cellsPointer + x * abi.cellSize;
+      const low = view.getUint32(base, true);
+      const high = view.getUint32(base + 4, true);
+
+      const cell = row.cells[x];
+      if (cell === undefined) continue;
+      const styleId = this.decodeRawCell(low, high, cell);
+
+      if (styleId !== 0) {
+        if (!cellsHandleReady) {
+          this.pointCellIteratorAtRow();
+          cellsHandleReady = true;
+        }
+        this.applyStyle(cell, x, styleId);
+      }
+
+      if (this.needsGrapheme(low, high)) {
+        if (!cellsHandleReady) {
+          this.pointCellIteratorAtRow();
+          cellsHandleReady = true;
+        }
+        const text = this.readGrapheme(x);
+        if (text !== null && cell.codepoint !== 0) cell.grapheme = text;
+      }
+
+      cell.selected =
+        selection !== undefined && x >= selection.start && x < selection.end;
+    }
+
+    for (let x = count; x < cols; x += 1) {
+      const cell = row.cells[x];
+      if (cell === undefined) continue;
+      resetCell(cell);
+    }
+  }
+
+  private pointCellIteratorAtRow(): void {
+    const { exports, abi } = this.context;
+    this.context.writeU32(this.slot, this.cellIterator);
+    this.context.check(
+      "ghostty_render_state_row_get(CELLS)",
+      exports.ghostty_render_state_row_get(
+        this.rowIterator,
+        abi.rowData.cells,
+        this.slot,
+      ),
+    );
+  }
+
+  /**
+   * Decode the packed cell. Returns the style id, which is zero for a cell that
+   * carries no style — the same cheap predicate `…_DATA_HAS_STYLING` answers,
+   * without paying a call across the boundary for every cell on the screen.
+   */
+  private decodeRawCell(low: number, high: number, cell: CellView): number {
+    const { cell: bits, cellContentTag, cellWide } = this.context.abi;
+    resetCell(cell);
+
+    const contentTag = extract(low, high, bits.contentTag);
+    const content = bits.content;
+    if (contentTag === cellContentTag.codepoint) {
+      cell.codepoint = extractInContent(low, high, content, bits.codepointInContent);
+    } else if (contentTag === cellContentTag.codepointGrapheme) {
+      cell.codepoint = extractInContent(
+        low,
+        high,
+        content,
+        bits.graphemeCodepointInContent,
+      );
+    } else if (contentTag === cellContentTag.bgColorPalette) {
+      cell.background = {
+        tag: "palette",
+        index: extractInContent(low, high, content, bits.paletteInContent),
+      };
+    } else if (contentTag === cellContentTag.bgColorRgb) {
+      cell.background = {
+        tag: "rgb",
+        r: extractInContent(low, high, content, bits.rgbInContent.r),
+        g: extractInContent(low, high, content, bits.rgbInContent.g),
+        b: extractInContent(low, high, content, bits.rgbInContent.b),
+      };
+    }
+
+    const wide = extract(low, high, bits.wide);
+    if (wide === cellWide.wide) cell.attributes |= ATTR.WIDE;
+    else if (wide === cellWide.spacerTail || wide === cellWide.spacerHead) {
+      cell.attributes |= ATTR.WIDE_SPACER;
+    }
+
+    return extract(low, high, bits.styleId);
+  }
+
+  private needsGrapheme(low: number, high: number): boolean {
+    const { cell: bits, cellContentTag } = this.context.abi;
+    return extract(low, high, bits.contentTag) === cellContentTag.codepointGrapheme;
+  }
+
+  private applyStyle(cell: CellView, x: number, styleId: number): void {
+    const style = this.styleFor(x, styleId);
+
+    // A cell whose content tag carried a background keeps it: the background
+    // lives in the cell, not the style, and the cell wins. Same order as
+    // termiod's `cell_from_parts`.
+    const cellBackground = cell.background;
+    let foreground = style.foreground;
+    let background =
+      cellBackground.tag === "default" ? style.background : cellBackground;
+
+    if (style.inverse) {
+      const swap = foreground;
+      foreground = background;
+      background = swap;
+    }
+    cell.foreground = foreground;
+    cell.background = background;
+    cell.attributes |= style.attributes;
+    if (style.underline !== null) cell.underline = style.underline;
+    else delete cell.underline;
+    if (style.invisible) {
+      cell.codepoint = 0;
+      delete cell.grapheme;
+    }
+  }
+
+  /**
+   * Styles are cached for the duration of one row. A row lives in one page and
+   * a style id is a page-local index, so two rows may use the same id for
+   * different styles — which is why this cache is cleared per row and not per
+   * frame.
+   */
+  private styleFor(x: number, styleId: number): StyleRead {
+    const cached = this.styleCache.get(styleId);
+    if (cached !== undefined) return cached;
+    const style = this.readStyle(x);
+    this.styleCache.set(styleId, style);
+    return style;
+  }
+
+  private readStyle(x: number): StyleRead {
+    const { exports, abi } = this.context;
+    this.context.check(
+      "ghostty_render_state_row_cells_select",
+      exports.ghostty_render_state_row_cells_select(this.cellIterator, x),
+    );
+    this.context.writeUsize(this.scratch + abi.style.sizeField, abi.style.size);
+    this.context.check(
+      "ghostty_render_state_row_cells_get(STYLE)",
+      exports.ghostty_render_state_row_cells_get(
+        this.cellIterator,
+        abi.rowCellsData.style,
+        this.scratch,
+      ),
+    );
+
+    let attributes = 0;
+    if (this.context.readBool(this.scratch + abi.style.bold)) attributes |= ATTR.BOLD;
+    if (this.context.readBool(this.scratch + abi.style.faint)) attributes |= ATTR.FAINT;
+    if (this.context.readBool(this.scratch + abi.style.italic)) attributes |= ATTR.ITALIC;
+    if (this.context.readBool(this.scratch + abi.style.blink)) attributes |= ATTR.BLINK;
+    if (this.context.readBool(this.scratch + abi.style.strikethrough)) {
+      attributes |= ATTR.STRIKETHROUGH;
+    }
+    if (this.context.readBool(this.scratch + abi.style.overline)) {
+      attributes |= ATTR.OVERLINE;
+    }
+    const underline = this.context.readI32(this.scratch + abi.style.underline);
+    if (underline === abi.sgrUnderline.curly) attributes |= ATTR.UNDERCURL;
+    else if (underline !== abi.sgrUnderline.none) attributes |= ATTR.UNDERLINE;
+
+    const underlineColor = this.readStyleColor(this.scratch + abi.style.underlineColor);
+    return {
+      foreground: this.readStyleColor(this.scratch + abi.style.foreground),
+      background: this.readStyleColor(this.scratch + abi.style.background),
+      underline: underlineColor.tag === "default" ? null : underlineColor,
+      attributes,
+      inverse: this.context.readBool(this.scratch + abi.style.inverse),
+      invisible: this.context.readBool(this.scratch + abi.style.invisible),
+    };
+  }
+
+  /**
+   * A colour SLOT. `GHOSTTY_STYLE_COLOR_{NONE,PALETTE,RGB}` maps one-for-one
+   * onto the seam's TaggedColor, and the palette index is passed through
+   * UNRESOLVED: only a renderer holding the viewer's Palette may turn it into
+   * a pixel.
+   */
+  private readStyleColor(pointer: number): TaggedColor {
+    const { abi } = this.context;
+    const tag = this.context.readI32(pointer + abi.styleColor.tag);
+    if (tag === abi.styleColorTag.palette) {
+      return {
+        tag: "palette",
+        index: this.context.readU8(pointer + abi.styleColor.paletteValue),
+      };
+    }
+    if (tag === abi.styleColorTag.rgb) {
+      const base = pointer + abi.styleColor.rgbValue;
+      return {
+        tag: "rgb",
+        r: this.context.readU8(base + abi.colorRgb.r),
+        g: this.context.readU8(base + abi.colorRgb.g),
+        b: this.context.readU8(base + abi.colorRgb.b),
+      };
+    }
+    return DEFAULT_COLOR;
+  }
+
+  private readGrapheme(x: number): string | null {
+    const { exports, abi, mem } = this.context;
+    this.context.check(
+      "ghostty_render_state_row_cells_select",
+      exports.ghostty_render_state_row_cells_select(this.cellIterator, x),
+    );
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      this.context.writeU32(this.scratch + abi.buffer.ptr, this.graphemeBuffer);
+      this.context.writeUsize(this.scratch + abi.buffer.cap, this.graphemeCapacity);
+      this.context.writeUsize(this.scratch + abi.buffer.len, 0);
+      const code = exports.ghostty_render_state_row_cells_get(
+        this.cellIterator,
+        abi.rowCellsData.graphemesUtf8,
+        this.scratch,
+      );
+      if (code === abi.result.success) {
+        const length = this.context.readUsize(this.scratch + abi.buffer.len);
+        const pointer = this.context.readU32(this.scratch + abi.buffer.ptr);
+        return length === 0 ? null : mem.decodeUtf8(pointer, length);
+      }
+      if (code !== abi.result.outOfSpace) {
+        this.context.check(
+          "ghostty_render_state_row_cells_get(GRAPHEMES_UTF8)",
+          code,
+        );
+        return null;
+      }
+      // OUT_OF_SPACE reports the required length in `len`.
+      const required = this.context.readUsize(this.scratch + abi.buffer.len);
+      mem.free(this.graphemeBuffer, this.graphemeCapacity);
+      this.graphemeCapacity = Math.max(required, this.graphemeCapacity * 2);
+      this.graphemeBuffer = mem.alloc(this.graphemeCapacity);
+    }
+    return null;
+  }
+}
+
+function resetCell(cell: CellView): void {
+  cell.codepoint = 0;
+  cell.foreground = DEFAULT_COLOR;
+  cell.background = DEFAULT_COLOR;
+  cell.attributes = 0;
+  cell.selected = false;
+  delete cell.grapheme;
+  delete cell.underline;
+}
+
+function extract(
+  low: number,
+  high: number,
+  field: { lsb: number; width: number },
+): number {
+  return extractBits(low, high, field.lsb, field.width);
+}
+
+function extractInContent(
+  low: number,
+  high: number,
+  content: { lsb: number; width: number },
+  field: { lsb: number; width: number },
+): number {
+  // Arm bit positions are relative to the union's own value, so the two
+  // offsets add. The union is at most 32 bits wide inside the cell, which
+  // keeps this in Number range without a BigInt.
+  return extractBits(low, high, content.lsb + field.lsb, field.width);
+}

--- a/web/client/src/vt/typeJson.test.ts
+++ b/web/client/src/vt/typeJson.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { buildLayouts, buildManifest } from "./__fixtures__/layout";
+import { extractBits, ManifestError, TypeManifest } from "./typeJson";
+
+const manifestJson = buildManifest(buildLayouts());
+
+describe("TypeManifest", () => {
+  it("reads struct offsets and enum values by name", () => {
+    const manifest = TypeManifest.parse(manifestJson);
+    expect(manifest.field("GhosttyStyle", "size").offset).toBe(0);
+    expect(manifest.field("GhosttyStyle", "fg_color").offset).toBe(8);
+    expect(manifest.enumValue("GhosttyStyleColorTag", "PALETTE")).toBe(1);
+    expect(manifest.enumValue("GhosttyRenderStateRowData", "CELLS_RAW")).toBe(5);
+  });
+
+  it("describes the packed cell as bit fields, including the tagged union", () => {
+    const manifest = TypeManifest.parse(manifestJson);
+    const cell = manifest.packed("GhosttyCell");
+    expect(cell.underlying).toBe("u64");
+    const content = cell.bits["content"];
+    expect(content?.kind).toBe("union");
+    if (content?.kind !== "union") throw new Error("content is not a union");
+    expect(content.tag).toBe("content_tag");
+    expect(content.arms["BG_COLOR_RGB"]?.bits["g"]).toEqual({
+      kind: "scalar",
+      lsb: 8,
+      width: 8,
+      type: "u8",
+    });
+  });
+
+  it("refuses a 64-bit manifest rather than reading every struct at the wrong offset", () => {
+    const wide = JSON.parse(manifestJson) as { abi: Record<string, unknown> };
+    wide.abi["pointer_size"] = 8;
+    wide.abi["usize_size"] = 8;
+    const manifest = TypeManifest.parse(JSON.stringify(wide));
+    expect(() => manifest.assertWasm32LittleEndian()).toThrow(ManifestError);
+  });
+
+  it("refuses a big-endian manifest", () => {
+    const swapped = JSON.parse(manifestJson) as { abi: Record<string, unknown> };
+    swapped.abi["endian"] = "big";
+    const manifest = TypeManifest.parse(JSON.stringify(swapped));
+    expect(() => manifest.assertWasm32LittleEndian()).toThrow(ManifestError);
+  });
+
+  it("names the missing type when the Wasm is from another commit", () => {
+    const stripped = JSON.parse(manifestJson) as {
+      types: Record<string, unknown>;
+    };
+    delete stripped.types["GhosttyStyle"];
+    const manifest = TypeManifest.parse(JSON.stringify(stripped));
+    expect(() => manifest.struct("GhosttyStyle")).toThrow(/GhosttyStyle/);
+  });
+
+  it("rejects a schema it does not know", () => {
+    expect(() => TypeManifest.parse(JSON.stringify({ schema: 2 }))).toThrow(
+      ManifestError,
+    );
+  });
+});
+
+describe("extractBits", () => {
+  it("reads a field that sits entirely in the low half", () => {
+    expect(extractBits(0b1101, 0, 0, 2)).toBe(0b01);
+    expect(extractBits(0b1101, 0, 2, 2)).toBe(0b11);
+  });
+
+  it("reads a field that straddles the two halves", () => {
+    // style_id is 16 bits at lsb 26: 6 bits in `low`, 10 in `high`.
+    const low = 0b1111_1100_0000_0000_0000_0000_0000_0000 >>> 0;
+    const high = 0b11 >>> 0;
+    // 6 low bits set (63) plus 2 high bits at weight 64 → 63 + 192.
+    expect(extractBits(low, high, 26, 16)).toBe(255);
+  });
+
+  it("reads a field that sits entirely in the high half", () => {
+    expect(extractBits(0, 0b1100, 34, 2)).toBe(0b11);
+  });
+});

--- a/web/client/src/vt/typeJson.ts
+++ b/web/client/src/vt/typeJson.ts
@@ -1,0 +1,401 @@
+/**
+ * The ABI type manifest returned by `ghostty_type_json`.
+ *
+ * Every offset, struct size, enum value, and packed-cell bit position this
+ * module uses is read out of this manifest at instantiate time rather than
+ * hardcoded. `render.h` requires it for the packed cell — "Bit positions aren't
+ * protected by ABI, so callers should parse them out of the manifest from
+ * `ghostty_type_json`" — and once the manifest has to be parsed for the cell,
+ * taking struct offsets from anywhere else would mean two sources of truth for
+ * one build. A Wasm built from a different ghostty commit then fails loudly
+ * here instead of decoding a style out of the wrong four bytes.
+ */
+
+/** The subset of `abi` this binding depends on. */
+export interface AbiInfo {
+  target: string;
+  pointerSize: number;
+  usizeSize: number;
+  maxAlignment: number;
+  endian: "little" | "big";
+}
+
+export interface FieldLayout {
+  offset: number;
+  size: number;
+  /** `"array"`, `"pointer"`, a `GhosttyX` name, or a primitive like `u16`. */
+  type: string;
+  /** Element type for `array` / `pointer` fields. */
+  elem?: string;
+  /** Element count for `array` fields. */
+  count?: number;
+  /** Sibling field naming the active arm, for tagged-union fields. */
+  tag?: string;
+  /** Tag value name → member name, `null` when the arm carries no payload. */
+  arms?: Record<string, string | null>;
+}
+
+export interface StructLayout {
+  size: number;
+  align: number;
+  fields: Record<string, FieldLayout>;
+}
+
+export interface ScalarBits {
+  kind: "scalar";
+  /** Least-significant bit, relative to the containing value. */
+  lsb: number;
+  width: number;
+  type: string;
+}
+
+export interface UnionArm {
+  width: number;
+  bits: Record<string, BitLayout>;
+}
+
+export interface UnionBits {
+  kind: "union";
+  lsb: number;
+  width: number;
+  /** Name of the sibling bit field holding the active arm. */
+  tag: string;
+  /** Tag value name → inline arm layout, `null` for a payload-free arm. */
+  arms: Record<string, UnionArm | null>;
+}
+
+export type BitLayout = ScalarBits | UnionBits;
+
+export interface PackedLayout {
+  size: number;
+  underlying: string;
+  bits: Record<string, BitLayout>;
+}
+
+export class ManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ManifestError";
+  }
+}
+
+interface RawDescriptor {
+  kind?: unknown;
+  size?: unknown;
+  align?: unknown;
+  underlying?: unknown;
+  fields?: unknown;
+  bits?: unknown;
+  values?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireNumber(value: unknown, what: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new ManifestError(`${what} is not a number`);
+  }
+  return value;
+}
+
+function requireString(value: unknown, what: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ManifestError(`${what} is not a string`);
+  }
+  return value;
+}
+
+function parseField(name: string, raw: unknown): FieldLayout {
+  if (!isRecord(raw)) {
+    throw new ManifestError(`field ${name} is not an object`);
+  }
+  const field: FieldLayout = {
+    offset: requireNumber(raw["offset"], `field ${name}.offset`),
+    size: requireNumber(raw["size"], `field ${name}.size`),
+    type: requireString(raw["type"], `field ${name}.type`),
+  };
+  if (typeof raw["elem"] === "string") field.elem = raw["elem"];
+  if (typeof raw["count"] === "number") field.count = raw["count"];
+  if (typeof raw["tag"] === "string") field.tag = raw["tag"];
+  if (isRecord(raw["arms"])) {
+    const arms: Record<string, string | null> = {};
+    for (const [key, value] of Object.entries(raw["arms"])) {
+      arms[key] = typeof value === "string" ? value : null;
+    }
+    field.arms = arms;
+  }
+  return field;
+}
+
+function parseBits(owner: string, raw: unknown): Record<string, BitLayout> {
+  if (!isRecord(raw)) {
+    throw new ManifestError(`${owner}.bits is not an object`);
+  }
+  const bits: Record<string, BitLayout> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    if (!isRecord(value)) {
+      throw new ManifestError(`${owner}.bits.${name} is not an object`);
+    }
+    const lsb = requireNumber(value["lsb"], `${owner}.bits.${name}.lsb`);
+    const width = requireNumber(value["width"], `${owner}.bits.${name}.width`);
+    if (value["kind"] === "union") {
+      const rawArms = value["arms"];
+      if (!isRecord(rawArms)) {
+        throw new ManifestError(`${owner}.bits.${name}.arms is not an object`);
+      }
+      const arms: Record<string, UnionArm | null> = {};
+      for (const [armName, armValue] of Object.entries(rawArms)) {
+        if (armValue === null || armValue === undefined) {
+          arms[armName] = null;
+          continue;
+        }
+        if (!isRecord(armValue)) {
+          throw new ManifestError(
+            `${owner}.bits.${name}.arms.${armName} is not an object`,
+          );
+        }
+        arms[armName] = {
+          width: requireNumber(
+            armValue["width"],
+            `${owner}.bits.${name}.arms.${armName}.width`,
+          ),
+          bits: parseBits(`${owner}.${name}.${armName}`, armValue["bits"]),
+        };
+      }
+      bits[name] = {
+        kind: "union",
+        lsb,
+        width,
+        tag: requireString(value["tag"], `${owner}.bits.${name}.tag`),
+        arms,
+      };
+      continue;
+    }
+    bits[name] = {
+      kind: "scalar",
+      lsb,
+      width,
+      type: requireString(value["type"], `${owner}.bits.${name}.type`),
+    };
+  }
+  return bits;
+}
+
+/**
+ * A parsed manifest, indexed by type name.
+ *
+ * Lookups throw rather than returning `undefined`: a missing type or field is
+ * a skew bug between this binding and the Wasm it was handed, and the only
+ * useful thing to do with it is fail at instantiate with the name in the
+ * message.
+ */
+export class TypeManifest {
+  readonly abi: AbiInfo;
+  readonly libraryVersion: string;
+  readonly commit: string | null;
+  private readonly types: Record<string, RawDescriptor>;
+
+  private constructor(
+    abi: AbiInfo,
+    libraryVersion: string,
+    commit: string | null,
+    types: Record<string, RawDescriptor>,
+  ) {
+    this.abi = abi;
+    this.libraryVersion = libraryVersion;
+    this.commit = commit;
+    this.types = types;
+  }
+
+  static parse(json: string): TypeManifest {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(json);
+    } catch (error) {
+      throw new ManifestError(
+        `ghostty_type_json did not return JSON: ${String(error)}`,
+      );
+    }
+    if (!isRecord(parsed)) {
+      throw new ManifestError("manifest is not an object");
+    }
+    if (parsed["schema"] !== 1) {
+      throw new ManifestError(
+        `manifest schema ${String(parsed["schema"])} is not 1`,
+      );
+    }
+    const rawAbi = parsed["abi"];
+    if (!isRecord(rawAbi)) {
+      throw new ManifestError("manifest has no abi object");
+    }
+    const endian = rawAbi["endian"];
+    if (endian !== "little" && endian !== "big") {
+      throw new ManifestError(`manifest endian ${String(endian)} is unknown`);
+    }
+    const abi: AbiInfo = {
+      target: requireString(rawAbi["target"], "abi.target"),
+      pointerSize: requireNumber(rawAbi["pointer_size"], "abi.pointer_size"),
+      usizeSize: requireNumber(rawAbi["usize_size"], "abi.usize_size"),
+      maxAlignment: requireNumber(rawAbi["max_alignment"], "abi.max_alignment"),
+      endian,
+    };
+    const rawTypes = parsed["types"];
+    if (!isRecord(rawTypes)) {
+      throw new ManifestError("manifest has no types object");
+    }
+    const types: Record<string, RawDescriptor> = {};
+    for (const [name, value] of Object.entries(rawTypes)) {
+      if (!isRecord(value)) {
+        throw new ManifestError(`type ${name} is not an object`);
+      }
+      types[name] = value as RawDescriptor;
+    }
+    const commit = parsed["commit"];
+    return new TypeManifest(
+      abi,
+      typeof parsed["library_version"] === "string"
+        ? parsed["library_version"]
+        : "unknown",
+      typeof commit === "string" ? commit : null,
+      types,
+    );
+  }
+
+  /**
+   * The checks that make a wrong Wasm a loud failure instead of a corrupt
+   * screen. A 64-bit manifest would put every struct field this binding reads
+   * at the wrong offset, and a big-endian one would invert every integer.
+   */
+  assertWasm32LittleEndian(): void {
+    if (this.abi.pointerSize !== 4 || this.abi.usizeSize !== 4) {
+      throw new ManifestError(
+        `expected a 32-bit ABI, got pointer_size ${this.abi.pointerSize} / usize_size ${this.abi.usizeSize}`,
+      );
+    }
+    if (this.abi.endian !== "little") {
+      throw new ManifestError(`expected a little-endian ABI, got ${this.abi.endian}`);
+    }
+  }
+
+  private descriptor(name: string, kind: string): RawDescriptor {
+    const descriptor = this.types[name];
+    if (descriptor === undefined) {
+      throw new ManifestError(`manifest has no type ${name}`);
+    }
+    if (descriptor.kind !== kind) {
+      throw new ManifestError(
+        `manifest type ${name} is a ${String(descriptor.kind)}, expected a ${kind}`,
+      );
+    }
+    return descriptor;
+  }
+
+  struct(name: string): StructLayout {
+    const descriptor = this.descriptor(name, "struct");
+    const rawFields = descriptor.fields;
+    if (!isRecord(rawFields)) {
+      throw new ManifestError(`struct ${name} has no fields`);
+    }
+    const fields: Record<string, FieldLayout> = {};
+    for (const [fieldName, raw] of Object.entries(rawFields)) {
+      fields[fieldName] = parseField(`${name}.${fieldName}`, raw);
+    }
+    return {
+      size: requireNumber(descriptor.size, `${name}.size`),
+      align: requireNumber(descriptor.align, `${name}.align`),
+      fields,
+    };
+  }
+
+  field(structName: string, fieldName: string): FieldLayout {
+    const field = this.struct(structName).fields[fieldName];
+    if (field === undefined) {
+      throw new ManifestError(`struct ${structName} has no field ${fieldName}`);
+    }
+    return field;
+  }
+
+  union(name: string): StructLayout {
+    const descriptor = this.descriptor(name, "union");
+    const rawFields = descriptor.fields;
+    if (!isRecord(rawFields)) {
+      throw new ManifestError(`union ${name} has no fields`);
+    }
+    const fields: Record<string, FieldLayout> = {};
+    for (const [fieldName, raw] of Object.entries(rawFields)) {
+      fields[fieldName] = parseField(`${name}.${fieldName}`, raw);
+    }
+    return {
+      size: requireNumber(descriptor.size, `${name}.size`),
+      align: requireNumber(descriptor.align, `${name}.align`),
+      fields,
+    };
+  }
+
+  enumValues(name: string): Record<string, number> {
+    const descriptor = this.descriptor(name, "enum");
+    const rawValues = descriptor.values;
+    if (!isRecord(rawValues)) {
+      throw new ManifestError(`enum ${name} has no values`);
+    }
+    const values: Record<string, number> = {};
+    for (const [key, value] of Object.entries(rawValues)) {
+      values[key] = requireNumber(value, `${name}.${key}`);
+    }
+    return values;
+  }
+
+  enumValue(name: string, key: string): number {
+    const value = this.enumValues(name)[key];
+    if (value === undefined) {
+      throw new ManifestError(`enum ${name} has no value ${key}`);
+    }
+    return value;
+  }
+
+  packed(name: string): PackedLayout {
+    const descriptor = this.descriptor(name, "packed");
+    return {
+      size: requireNumber(descriptor.size, `${name}.size`),
+      underlying: requireString(descriptor.underlying, `${name}.underlying`),
+      bits: parseBits(name, descriptor.bits),
+    };
+  }
+}
+
+/**
+ * Extract a bit field from a 64-bit value split into two 32-bit halves.
+ *
+ * The packed cell is a `u64`, and the fields this binding reads (content tag,
+ * codepoint, style id, wide) all fit in 32 bits — but they do not all sit in
+ * the low half, so the extraction has to span the halves. Doing it on two
+ * numbers rather than a `BigInt` keeps the per-cell path allocation-free: a
+ * 200×50 viewport at 60 fps is 600k cells a second, and a BigInt per cell is
+ * 600k garbage objects a second.
+ */
+export function extractBits(
+  low: number,
+  high: number,
+  lsb: number,
+  width: number,
+): number {
+  if (width > 32) {
+    throw new ManifestError(`bit field of width ${width} exceeds 32 bits`);
+  }
+  const mask = width === 32 ? 0xffffffff : (1 << width) - 1;
+  if (lsb >= 32) {
+    return (high >>> (lsb - 32)) & mask;
+  }
+  const lowPart = low >>> lsb;
+  const takenFromLow = 32 - lsb;
+  if (width <= takenFromLow) {
+    return lowPart & mask;
+  }
+  // The field straddles the halves: the low bits come from `low`, the rest
+  // from the bottom of `high`. `* 2 ** takenFromLow` rather than `<<` because
+  // a shift of 32 is a no-op in JS and the sum can exceed 2^31.
+  const highPart = high & ((1 << (width - takenFromLow)) - 1);
+  return lowPart + highPart * 2 ** takenFromLow;
+}

--- a/web/client/tsconfig.json
+++ b/web/client/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/web/client/vite.config.ts
+++ b/web/client/vite.config.ts
@@ -1,0 +1,30 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// The same build is served at `/` (Caddy `handle_path` strips the mount) and at
+// `/termio/` (Tailscale Serve publishes the prefix without stripping), so every
+// asset URL has to be relative to whatever prefix served index.html. An
+// absolute `/assets/…` is a build-config bug that only shows up behind Serve.
+export default defineConfig({
+  base: "./",
+  plugins: [react()],
+  build: {
+    target: "es2022",
+    // The GET jail has no `.map` MIME entry, and source maps describe the
+    // client to anyone who asks. They are not emitted into the deployed tree.
+    sourcemap: false,
+    // Nothing is inlined as a data: URI. The Wasm is fetched as
+    // `application/wasm` and the font as `font/woff2`; base64 into the bundle
+    // is the Restty failure this design rejects by name.
+    assetsInlineLimit: 0,
+    modulePreload: { polyfill: false },
+  },
+  test: {
+    // Node by default; a file that needs a DOM opts in with
+    // `// @vitest-environment jsdom` at the top. Protocol and codec tests must
+    // stay in the plain realm so `ArrayBuffer` identity is not jsdom's.
+    environment: "node",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});


### PR DESCRIPTION
A browser cannot speak SSH and has no Unix socket, so it was the one client `termiod` could not serve. This adds the WSS binding it needs and the client that rides it — proven end to end against a Linux VPS through `ssh -L`, with no certificate and no reverse proxy.

Draft: one confirmed bug and two open questions below.

## What it is, and is not

The browser is a **Replica**, not a new client class. It runs the same libghostty-vt the Mac and the daemon run, compiled to Wasm at the same pinned commit, consumes the same raw `D` bytes, and negotiates the same capabilities. WSS is a *transport* — the 5-byte framing rides inside binary messages, and message boundaries are deliberately not frame boundaries. `termiod/tests/wss_bridge.rs` splits `hello` across three messages, packs two frames into one, and asserts byte-identity with the Unix path.

No grid encoder. Nothing parses VT on the way to the socket.

## The three rules the daemon side enforces

- **Loopback only.** `--wss` refuses any address where `is_loopback()` is false, at flag-parse time — a LAN address and a hostname resolving off-loopback are errors, not warnings. TLS stays in Tailscale Serve or Caddy; the daemon does not grow a TLS stack.
- **Authenticate before the splice.** Origin allowlist plus a pairing token on the handshake. The token rides the WebSocket subprotocol, never a query string — a URL lands in logs, in `Referer`, and in screenshots, and this one opens a shell. The server selects `termiod.v1` rather than echoing the token, so the secret never appears in a response header.
- **Serve files, do not be a web server.** Canonicalised root, no traversal, no symlink escape, no listing, source maps excluded, explicit `application/wasm`.

Absent a bind, behaviour is unchanged: Unix socket only, DEPLOY.md contract intact.

## Colour is a slot, resolved once

Cells are read as unresolved slots — `default`, palette index, or an exact rgb the program chose — and resolved in exactly one place, the renderer's palette. That is what makes a theme switch re-resolve every visible cell with no reload, and why neither ghostty-web's nor `@wterm`'s cell path could be borrowed: both hand out pre-resolved 24-bit RGB.

The chrome obeys the same rule one layer up: `chrome.ts` derives sidebar, toolbar and text from the terminal palette, porting the arithmetic in `ChromeTheme.swift`. There are no literal colours in the stylesheet.

## One ghostty across three ends

`scripts/check-ghostty-pin.sh` reads the sha from `ghostty-pin.json`, `libghostty-rs`, and `libghostty-swift`, and fails when they disagree. Drift there is a rendering divergence between the browser and the Mac showing the same session, and nothing else in the repo would catch it because each end is individually correct. Runs in CI.

## Verified

- `cargo test` — **77 passed, 0 failed**, including `wss_bridge.rs`
- `pnpm test` — **219 passed** (18 files); `pnpm build` — 268 KB, 83 KB gzipped
- **Live on Linux**: cross-compiled aarch64-musl, deployed to a VPS, attached through `ssh -L`. `GET /` 200, wasm 200 `application/wasm` (byte-identical to the Mac's), WS without Origin 403, WS with token **101**.
- Three adversarial reviews — presentation boundary, protocol fidelity, lifecycle — each reading code rather than claims.

## Known bug — blocks undraft

**A revoked write token freezes the canvas permanently.** `surface.ts` drops `Event::WriterChanged`, so the client keeps believing it holds the token; the next resize sends `R`, the host answers `not_writer` with no `S` and no `Ready`, and the barrier never lowers. `Ready` is per-client, so no other attach clears it either. Found independently by two reviewers, one with a passing repro.

Second trigger, independent of the writer bug: **any** host rejection of an `R` — including `TIOCSWINSZ` failure via `reject_resize` — leaves the barrier up.

Fix is small: keep `client_id` from `hello_ok` and compare it on `writer_changed`; treat an `error` arriving while the barrier is up as barrier-lowering.

## Open questions

1. **Subprotocol format deviates from the RFC.** Shipped as `termiod.token.<token>`; the RFC says `termiod.<token>`, which cannot coexist with its own suggestion of a `termiod.v1` version subprotocol (that would parse as a token named "v1"). One line each side if you prefer the RFC's wording.
2. **React is npm-pinned, not vendored under the tree.** The RFC asks for the Highlightr rule. Pinned-exact deps bundled by Vite satisfy "no CDN" and "static output"; they do not satisfy "committed under the tree". The license file is owed either way.

## Not in this PR

The client negotiates `events` only. `files`, `git`, `upload`, `resources`, `fs_watch` and `scrollback` are implemented daemon-side and unconsumed — so no file tree, no git pane, no `create`/`kill`. That is client work on top of this, not more protocol.

WebGPU is PR 6 in the RFC's plan. The `TerminalRenderer` seam is frozen here so it lands as a file, not a rewrite.

Release Notes:
- Attach to your sessions from a browser. Run `termiod pair` on the box, start the daemon with `--wss`, and open the printed link — over `ssh -L` it needs no certificate.