### PR TITLE
Root the inspector panes at the session's device

### DIFF
--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -47,15 +47,24 @@ struct FileBrowserView: View {
     /// parking pattern as `GitPanelModel`; replayed once when the pane is next visible.
     @State private var pendingWatcherRefresh = false
 
-    /// The host of the selected session when it is an SSH session. Non-nil means the
-    /// local disk isn't this session's disk: `inspectorProjectPath` resolves to nil,
-    /// so the watcher, the root read, and the drop target all stand down on their own.
-    private var sshHost: String? {
-        store.selectedSessionID.flatMap(store.session)?.sshHost
+    /// Where the selected session's files live, and on which machine — see
+    /// `TermioStore.inspectorCheckout`. Nothing in this pane may ask the session
+    /// how it was opened instead: that question named the road rather than the
+    /// machine, and answered "local" for a session running on another box.
+    private var checkout: Checkout? { store.inspectorCheckout }
+
+    /// The checkout when it is on another machine, which is every case this pane
+    /// has no way to read yet. Non-nil means every local read, watch, git probe,
+    /// and mutation below must stay off — `projectPath` is nil for the same
+    /// checkout, which is what holds them off.
+    private var deviceCheckout: Checkout? {
+        checkout.flatMap { $0.isOnAnotherDevice ? $0 : nil }
     }
 
-    /// The directory the tree is rooted at — see `TermioStore.inspectorProjectPath`.
-    private var projectPath: String? { store.inspectorProjectPath }
+    /// The directory the tree is rooted at *on this Mac*, and `nil` for a session on
+    /// any other machine — so the watcher, the root read, the git badge, the drop
+    /// target, and every create/rename/delete all stand down together.
+    private var projectPath: String? { checkout?.localRoot }
 
     var body: some View {
         ZStack {
@@ -65,10 +74,12 @@ struct FileBrowserView: View {
             // and loses the tree's disclosure state besides (#207). Same
             // always-mounted-under-an-opaque-overlay shape as `InspectorRoot`.
             Group {
-                if let host = sshHost {
+                if let host = checkout?.sftpAlias {
                     // Fresh identity per host, so tree state never leaks between hosts.
                     RemoteFileTreeView(host: host)
                         .id(host)
+                } else if let deviceCheckout {
+                    unavailable(pane: localized("Files"), on: deviceCheckout)
                 } else {
                     VStack(spacing: 0) {
                         if let root { header(root: root) }
@@ -106,6 +117,9 @@ struct FileBrowserView: View {
         // this only catches drops that miss every row. No panel-wide target ring —
         // dragging a row out is itself a `URL` drag, so a whole-panel highlight would
         // be a false positive; the folder rows light up individually instead.
+        // A checkout on another device has no local root, so the drop is refused:
+        // the alternative is landing a file on this Mac under a session that runs
+        // somewhere else, which is the whole defect this pane's checkout fixes.
         .dropDestination(for: URL.self) { urls, _ in
             guard let projectPath else { return false }
             return receive(urls, into: URL(fileURLWithPath: projectPath))
@@ -213,8 +227,8 @@ struct FileBrowserView: View {
         case .files:
             EmptyView()
         case .search:
-            if sshHost != nil {
-                remoteUnavailable(pane: localized("Search"))
+            if let deviceCheckout {
+                unavailable(pane: localized("Search"), on: deviceCheckout)
             } else if let root {
                 FileSearchView(
                     rootURL: root.url,
@@ -228,8 +242,8 @@ struct FileBrowserView: View {
                 noProject
             }
         case .changes:
-            if sshHost != nil {
-                remoteUnavailable(pane: localized("Changes"))
+            if let deviceCheckout {
+                unavailable(pane: localized("Changes"), on: deviceCheckout)
             } else if let repoRoot = projectPath {
                 // Fresh identity per repo, so the panel model (selection, draft message,
                 // PR status) resets cleanly when the selected project moves.
@@ -246,8 +260,8 @@ struct FileBrowserView: View {
                 noProject
             }
         case .issues:
-            if sshHost != nil {
-                remoteUnavailable(pane: localized("Issues"))
+            if let deviceCheckout {
+                unavailable(pane: localized("Issues"), on: deviceCheckout)
             } else if let repoRoot = projectPath {
                 // Fresh identity per repo, like Changes: the panel model (connection
                 // phase, binding, list, pushed-in detail) resets when the project moves.
@@ -290,13 +304,20 @@ struct FileBrowserView: View {
         }
     }
 
-    /// What a pane that only reads local disk shows for an SSH session. Honest about
-    /// the gap rather than showing the Mac's own files under a remote session.
-    private func remoteUnavailable(pane: String) -> some View {
-        PaneEmptyState(
-            localized("Remote session"),
+    /// What a pane that only reads local disk shows for a checkout on another
+    /// machine: the machine, named. Naming it is the whole point — the alternative
+    /// this replaces was the Mac's own files, git status, and search results shown
+    /// under a session running somewhere else, with nothing saying so. An empty
+    /// pane is allowed here; a wrong one is not.
+    private func unavailable(pane: String, on checkout: Checkout) -> some View {
+        // `host:/path` is how the same pair is written everywhere else a developer
+        // meets it (`scp`, `rsync`), so the root rides along when it is known.
+        let device = checkout.device.name
+        let title = checkout.root.map { "\(device):\($0)" } ?? device
+        return PaneEmptyState(
+            title,
             icon: .serverStack,
-            message: localized("\(pane) isn’t available for SSH sessions yet.")
+            message: localized("\(pane) isn’t available on this device yet.")
         )
     }
 

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -81,8 +81,8 @@ struct InspectorTabsToolbar: View {
             .onAppear { withAnimation(.easeOut(duration: 0.25)) { appeared = true } }
             // Re-probe when the selection moves or the General switch flips; keyed so
             // the check doesn't rerun on unrelated store churn.
-            .task(id: "\(settings.githubIntegrationEnabled)|\(store.inspectorProjectPath ?? "")") {
-                if let path = store.inspectorProjectPath, settings.githubIntegrationEnabled {
+            .task(id: "\(settings.githubIntegrationEnabled)|\(store.inspectorCheckout?.localRoot ?? "")") {
+                if let path = store.inspectorCheckout?.localRoot, settings.githubIntegrationEnabled {
                     hasGitHubRemote = await GitService.gitHubRepoSlug(in: path) != nil
                 } else {
                     hasGitHubRemote = false

--- a/Sources/termio/Info/SessionInfoView.swift
+++ b/Sources/termio/Info/SessionInfoView.swift
@@ -17,11 +17,14 @@ struct SessionInfoView: View {
         store.selectedSessionID.flatMap { store.project(for: $0) }
     }
 
-    /// Where the session runs: its worktree if it has one, else the project root.
-    /// A loose terminal reports its live cwd (the session's own mutable path)
-    /// rather than the container's `$HOME` fallback.
+    /// Where the session runs *on this Mac*: its worktree if it has one, else the
+    /// project root. A loose terminal reports its live cwd (the session's own
+    /// mutable path) rather than the container's `$HOME` fallback. `nil` for a
+    /// session on another device — Copy Path, Reveal in Finder, and the forge
+    /// probe below all act on local disk, and `remoteLocation` names that case
+    /// instead.
     private var workingDirectory: String? {
-        store.inspectorProjectPath
+        store.inspectorCheckout?.localRoot
     }
 
     /// Where a remote session runs, as `host:path` — the remote counterpart of

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5245,22 +5245,12 @@
         }
       }
     },
-    "Remote session": {
+    "%@ isn’t available on this device yet.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "远程会话"
-          }
-        }
-      }
-    },
-    "%@ isn’t available for SSH sessions yet.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 暂不支持 SSH 会话。"
+            "value": "%@ 暂不支持这台设备。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -16,8 +16,8 @@
 	<string>%@ is a light theme in the %@ slot.</string>
 	<key>%@ isn’t a UTF-8 text file.</key>
 	<string>%@ isn’t a UTF-8 text file.</string>
-	<key>%@ isn’t available for SSH sessions yet.</key>
-	<string>%@ isn’t available for SSH sessions yet.</string>
+	<key>%@ isn’t available on this device yet.</key>
+	<string>%@ isn’t available on this device yet.</string>
 	<key>%@ isn’t on your PATH</key>
 	<string>%@ isn’t on your PATH</string>
 	<key>%@ opened %@</key>
@@ -796,8 +796,6 @@
 	<string>Reload</string>
 	<key>Remote</key>
 	<string>Remote</string>
-	<key>Remote session</key>
-	<string>Remote session</string>
 	<key>Remove</key>
 	<string>Remove</string>
 	<key>Remove Project</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -16,8 +16,8 @@
 	<string>“%@”是浅色主题，与“%@”插槽不匹配。</string>
 	<key>%@ isn’t a UTF-8 text file.</key>
 	<string>%@ 不是 UTF-8 文本文件。</string>
-	<key>%@ isn’t available for SSH sessions yet.</key>
-	<string>%@ 暂不支持 SSH 会话。</string>
+	<key>%@ isn’t available on this device yet.</key>
+	<string>%@ 暂不支持这台设备。</string>
 	<key>%@ isn’t on your PATH</key>
 	<string>%@ 不在 PATH 中</string>
 	<key>%@ opened %@</key>
@@ -796,8 +796,6 @@
 	<string>重新载入</string>
 	<key>Remote</key>
 	<string>远程</string>
-	<key>Remote session</key>
-	<string>远程会话</string>
 	<key>Remove</key>
 	<string>移除</string>
 	<key>Remove Project</key>

--- a/Sources/termio/TermioStore/DeviceContext.swift
+++ b/Sources/termio/TermioStore/DeviceContext.swift
@@ -36,6 +36,70 @@ struct KnownDevice: Identifiable, Hashable {
     var route: TermiodRoute { TermiodRoute(sshAlias: alias) }
 }
 
+/// The directory the inspector's panes read, and the machine it lives on.
+///
+/// The panes used to decide that by asking `session.sshHost`, which names *the
+/// road taken* rather than the machine at the end of it. A termiod session has no
+/// `sshHost`, so it matched no remote branch and fell through to the local
+/// project's path: a session running on another box showed this Mac's files, git
+/// status, search results, and issues with nothing on screen saying so.
+///
+/// A checkout is a repo on a machine — the pair the panes need. It is not the
+/// sidebar's `Workspace`, which is the scope the user chooses and can span
+/// machines; one workspace holds checkouts on several devices.
+///
+/// Identity is the device, not the alias it was reached by. The same machine
+/// answering to a LAN name, a WAN name, and a tailnet name is one checkout, not
+/// three — so `device` carries the `host_id` once a handshake has revealed one and
+/// falls back to the alias only until then, the same bootstrap/stable split
+/// `KnownDevice` and `isAuthored(_:for:)` already use.
+struct Checkout: Hashable {
+    /// The machine the root lives on. `KnownDevice.thisMac` for a local session.
+    let device: KnownDevice
+    /// The checkout root on that device — the project or worktree directory
+    /// locally, the recorded checkout or spawn directory on another device.
+    /// `nil` when the device is known but the root is not (a terminal opened on a
+    /// box outside any recorded checkout).
+    let root: String?
+    /// The `~/.ssh/config` alias whose files the shipped read-only SFTP tree can
+    /// still show, set only for a plain `ssh` session — a box reached without a
+    /// daemon. This is the SFTP adapter, not a route the panes may branch on:
+    /// deleting the SFTP client deletes this property with it.
+    let sftpAlias: String?
+
+    /// The path this Mac's `FileManager` may read for this checkout, and `nil`
+    /// for every checkout on another device — which is what stops the tree, the
+    /// watcher, the drop target, the git probe, and every mutation from running
+    /// against a session that is not on this machine.
+    ///
+    /// The direct-local adapter the one-source migration retires: when the panes
+    /// read a device's files through `fs.*`, each caller moves to that client and
+    /// this property goes away rather than becoming a permanent local special case.
+    var localRoot: String? { device.isLocal ? root : nil }
+
+    /// Whether this checkout lives on another machine, so a pane with no way to
+    /// read it must say which one instead of showing this Mac's.
+    var isOnAnotherDevice: Bool { !device.isLocal }
+
+    /// The machine, as an identity rather than a route: the `host_id` once a
+    /// handshake has revealed one, the alias until then, and the empty string for
+    /// this Mac.
+    var deviceIdentity: String { device.deviceID ?? device.alias ?? "" }
+
+    /// Two references name the same checkout when they name the same device and
+    /// the same root. Compared by identity, so one box reached by a LAN name, a WAN
+    /// name, and a tailnet name stays one checkout instead of forking into three —
+    /// and `sftpAlias` is left out entirely, being an adapter rather than identity.
+    static func == (lhs: Checkout, rhs: Checkout) -> Bool {
+        lhs.deviceIdentity == rhs.deviceIdentity && lhs.root == rhs.root
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(deviceIdentity)
+        hasher.combine(root)
+    }
+}
+
 /// What one device says is running on it, as of the last `list`.
 ///
 /// The device's reply is the authority for **which sessions exist**. Nothing in

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -358,10 +358,11 @@ final class TermioStore: ObservableObject {
 
     /// The Issues model for the currently selected session's repo, or `nil` when none has
     /// loaded yet — the detail overlay then falls back to the list rather than fetching an
-    /// issue against the wrong repo. Keyed on `inspectorProjectPath`, the exact string
-    /// `IssuesView` is created with (see `FileBrowserView.projectPath`).
+    /// issue against the wrong repo. Keyed on the checkout's local root, the exact
+    /// string `IssuesView` is created with (see `FileBrowserView`) — a checkout on
+    /// another device has none, and so has no model, because the pane never runs.
     var issuesModel: IssuesPanelModel? {
-        inspectorProjectPath.flatMap { issuesModels[$0] }
+        inspectorCheckout?.localRoot.flatMap { issuesModels[$0] }
     }
 
     /// The git pane's inner mode (Changes / History) per repo root — the same continuity
@@ -447,33 +448,82 @@ final class TermioStore: ObservableObject {
     /// changes" without the inspector being open.
     @Published var gitChangeCount = 0
 
-    /// The directory the inspector panes root at: the selected session's worktree if it
-    /// has one, otherwise its project folder. `nil` when nothing is selected or the
-    /// selected session is SSH — its filesystem is remote, not this Mac's.
-    /// A loose terminal roots at its *live* cwd instead (falling back to the cwd
-    /// persisted from the last run, then `$HOME`) — the session owns its path, so
-    /// the tree, search, and changes panes all follow a `cd`. Real projects keep
-    /// their stable root; the anchor is the point of a project.
-    /// A session on a remote host has no local root at all — its files live on the
-    /// other box — so it reports `nil` and the panes show their empty state rather
-    /// than a local directory that merely shares a name with the remote one.
-    var inspectorProjectPath: String? {
+    /// What the inspector panes read: the selected session's checkout — a root and
+    /// the device that root lives on. Derived here, once, so no pane has to ask a
+    /// session which road it was opened by (see `Checkout`).
+    ///
+    /// The machine is `termiodRemoteHost ?? sshHost`, the pair `DeviceContext`
+    /// already trusts. A durable termiod session names its box directly; a plain
+    /// `ssh` terminal runs its PTY here but exists to put the user on that box, so
+    /// it belongs to the same place.
+    ///
+    /// The candidate local root comes from the slot: a project session takes its
+    /// worktree if it has one and the project folder otherwise, a loose terminal
+    /// takes its *live* cwd (falling back to the cwd persisted from the last run,
+    /// then `$HOME`) so the tree, search, and changes panes follow a `cd`, and a
+    /// loose chat takes the scoped scratch directory. Whether that candidate is
+    /// this Mac's to read is the checkout's answer, not the slot's.
+    var inspectorCheckout: Checkout? {
         guard let id = selectedSessionID, let slot = locate(id) else { return nil }
         let session = self[slot]
-        // A session that runs on another machine has no *local* root: its files
-        // live over there, and pointing the panes at a local path that merely
-        // shares a name would be worse than showing nothing.
-        guard session.sshHost == nil, session.termiodRemoteHost == nil else { return nil }
+        let project: Project?
+        let localRoot: String?
         switch slot {
         case .project(let index, _):
-            return session.worktreePath ?? projects[index].path
+            project = projects[index]
+            localRoot = session.worktreePath ?? projects[index].path
         case .terminals:
-            return workingDirectory(for: id)
+            project = nil
+            localRoot = workingDirectory(for: id)
                 ?? session.lastWorkingDirectory
                 ?? Self.looseTerminalRoot
         case .chats:
-            return Self.looseChatRoot
+            project = nil
+            localRoot = Self.looseChatRoot
         }
+        let alias = session.termiodRemoteHost ?? session.sshHost
+        return Self.checkout(
+            for: session,
+            in: project,
+            localRoot: localRoot,
+            // The route's device, for a session that has never attached and so
+            // carries none of its own.
+            routeDeviceID: alias.flatMap {
+                TermiodDeviceRegistry.shared.deviceID(for: TermiodRoute(sshAlias: $0))
+            })
+    }
+
+    /// The checkout derivation itself, free of the store so the case that started
+    /// this — a session on another machine filed under a local project — can be
+    /// tested without a window.
+    ///
+    /// `localRoot` is the candidate the tree would have used, and is dropped whole
+    /// for a session on another box: a local path that merely shares a name with
+    /// the remote one is worse than showing nothing.
+    static func checkout(for session: Session, in project: Project?,
+                         localRoot: String?, routeDeviceID: String?) -> Checkout {
+        guard let alias = session.termiodRemoteHost ?? session.sshHost else {
+            return Checkout(device: .thisMac, root: localRoot, sftpAlias: nil)
+        }
+        // Identity first, route second: a session that has attached knows the
+        // `host_id` it reached, and the alias only stands in until it has.
+        let device = KnownDevice(alias: alias, deviceID: session.deviceID ?? routeDeviceID)
+        return Checkout(
+            device: device,
+            root: remoteRoot(for: session, in: project, on: device),
+            // Only a plain `ssh` terminal — a box reached without a daemon — has
+            // files the SFTP tree can still show.
+            sftpAlias: session.sshHost)
+    }
+
+    /// Where a session on another device is rooted, as far as this viewer can tell
+    /// without asking the device: the directory the session was spawned in, else
+    /// the checkout recorded for that device when the session sits under a project.
+    private static func remoteRoot(for session: Session, in project: Project?,
+                                   on device: KnownDevice) -> String? {
+        if let cwd = session.termiodRemoteCwd { return cwd }
+        guard let alias = device.alias, let project else { return nil }
+        return project.remoteCheckout(device: device.deviceID, alias: alias)
     }
 
     /// Whether the trailing inspector panel is expanded. Mirrored from the AppKit

--- a/Tests/termioTests/InspectorCheckoutTests.swift
+++ b/Tests/termioTests/InspectorCheckoutTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import termio
+
+/// The inspector's checkout derivation (`TermioStore.checkout(for:in:…)`).
+///
+/// The case that matters is destructive rather than cosmetic: a session running
+/// on another machine used to resolve to the local project's path, so the Files,
+/// Search, Changes, and Issues panes showed this Mac's filesystem under a shell
+/// on someone else's box. Every test here asserts that a checkout on another
+/// device offers this Mac nothing to read.
+@MainActor
+final class InspectorCheckoutTests: XCTestCase {
+    private func project(_ path: String, checkouts: [String: String] = [:]) -> Project {
+        var project = Project(
+            workspaceID: UUID(), name: "repo", path: path, branch: "main", sessions: [])
+        project.remoteCheckouts = checkouts
+        return project
+    }
+
+    private func derive(_ session: Session, in project: Project?,
+                        localRoot: String?, routeDeviceID: String? = nil) -> Checkout {
+        TermioStore.checkout(for: session, in: project, localRoot: localRoot,
+                             routeDeviceID: routeDeviceID)
+    }
+
+    /// The defect itself: a termiod session filed under the local project it was
+    /// opened from has no `sshHost`, so it used to match no remote branch and fall
+    /// through to the Mac's path.
+    func testRemoteSessionUnderALocalProjectOffersNoLocalRoot() {
+        var session = Session(title: "ukvps", agent: .terminal)
+        session.termiodRemoteHost = "ukvps"
+        session.deviceID = "device-a"
+        session.termiodRemoteCwd = "/srv/api"
+
+        let checkout = derive(session, in: project("/Users/me/api"), localRoot: "/Users/me/api")
+
+        XCTAssertNil(checkout.localRoot, "a session on another box may never read this Mac")
+        XCTAssertTrue(checkout.isOnAnotherDevice)
+        XCTAssertEqual(checkout.device.name, "ukvps", "the empty state names the machine")
+        XCTAssertEqual(checkout.root, "/srv/api")
+        XCTAssertNil(checkout.sftpAlias, "a daemon session is not an SFTP one")
+    }
+
+    /// With no spawn directory recorded, the project's checkout for that device is
+    /// the root — and a session filed outside any project has none at all rather
+    /// than borrowing the local path it sits beside.
+    func testRemoteRootFallsBackToTheDeviceCheckout() {
+        var session = Session(title: "ukvps", agent: .terminal)
+        session.termiodRemoteHost = "ukvps"
+        session.deviceID = "device-a"
+
+        let underProject = derive(session,
+                                  in: project("/Users/me/api", checkouts: ["device-a": "/srv/api"]),
+                                  localRoot: "/Users/me/api")
+        XCTAssertEqual(underProject.root, "/srv/api")
+
+        let loose = derive(session, in: nil, localRoot: NSHomeDirectory())
+        XCTAssertNil(loose.root)
+        XCTAssertNil(loose.localRoot)
+    }
+
+    /// A plain `ssh` terminal runs its PTY here, but it exists to put the user on
+    /// that box: it is that machine's checkout, and only its Files pane still has
+    /// the read-only SFTP tree to show.
+    func testPlainSSHSessionIsTheBoxItReaches() {
+        var session = Session(title: "shell", agent: .terminal)
+        session.sshHost = "ukvps"
+
+        let checkout = derive(session, in: project("/Users/me/api"), localRoot: "/Users/me/api")
+
+        XCTAssertNil(checkout.localRoot)
+        XCTAssertEqual(checkout.sftpAlias, "ukvps")
+    }
+
+    /// A local session is untouched: whatever root its slot supplies is the root,
+    /// and this Mac may read it.
+    func testLocalSessionKeepsItsRoot() {
+        let plain = derive(Session(title: "shell", agent: .terminal),
+                           in: project("/Users/me/api"), localRoot: "/Users/me/api")
+        XCTAssertEqual(plain.localRoot, "/Users/me/api")
+        XCTAssertFalse(plain.isOnAnotherDevice)
+
+        let worktree = derive(Session(title: "shell", agent: .terminal),
+                              in: project("/Users/me/api"), localRoot: "/Users/me/api-fix")
+        XCTAssertEqual(worktree.localRoot, "/Users/me/api-fix")
+
+        let loose = derive(Session(title: "shell", agent: .terminal),
+                           in: nil, localRoot: "/Users/me/elsewhere")
+        XCTAssertEqual(loose.localRoot, "/Users/me/elsewhere")
+    }
+
+    /// The identity is the device, not the road to it: the same box reached by a
+    /// LAN name and a tailnet name is one checkout, or every alias would fork the
+    /// same directory into a checkout of its own.
+    func testOneDeviceReachedByTwoAliasesIsOneCheckout() {
+        func session(alias: String) -> Session {
+            var session = Session(title: alias, agent: .terminal)
+            session.termiodRemoteHost = alias
+            session.deviceID = "device-a"
+            session.termiodRemoteCwd = "/srv/api"
+            return session
+        }
+
+        let lan = derive(session(alias: "vps-lan"), in: nil, localRoot: nil)
+        let tailnet = derive(session(alias: "vps-tailnet"), in: nil, localRoot: nil)
+
+        XCTAssertEqual(lan, tailnet)
+        XCTAssertEqual(Set([lan, tailnet]).count, 1)
+    }
+
+    /// Until a handshake resolves a `host_id` the alias is all there is, so two
+    /// aliases stay two checkouts — the same bootstrap split `KnownDevice` carries.
+    func testAliasesStayDistinctUntilADeviceResolvesThem() {
+        func session(alias: String) -> Session {
+            var session = Session(title: alias, agent: .terminal)
+            session.termiodRemoteHost = alias
+            return session
+        }
+
+        XCTAssertNotEqual(derive(session(alias: "vps-lan"), in: nil, localRoot: nil),
+                          derive(session(alias: "vps-wan"), in: nil, localRoot: nil))
+    }
+}


### PR DESCRIPTION
**Stacked on #345** (`feat/workspaces`), which is itself stacked on #343. Review that one first; this branches off it, so merging it leaves this a clean rebase.

A session running on another machine showed **this Mac's** files, git status, search results and issues. Nothing on screen said so — the tree just quietly rooted at a local directory that shared a name with the remote one, and dropping a file on it wrote to the wrong box.

The four panes gated on `session.sshHost`. That names *the road taken*, not the machine at the end of it: a termiod session has no `sshHost`, so it matched no remote branch and fell straight through to the local project's path.

## What changes for the user

- Files, Search, Changes and Issues under a session on another machine show an empty state that names the machine — `ukvps:/srv/api` — instead of this Mac's directory.
- A plain `ssh` session keeps the read-only SFTP tree it already had.
- Dropping a file on the panel is refused for a session on another box, rather than landing it here.
- Local sessions are untouched: worktree, project folder, and a loose terminal following its live `cd` all behave as before.

## How

One value in the store, `Checkout` — a `KnownDevice` plus a root — replaces `inspectorProjectPath`. Every consumer reads it:

| Consumer | Reads |
| --- | --- |
| The four pane gates | `isOnAnotherDevice` |
| The drop target, root refresh, file watcher, git badge | `localRoot` |
| The Issues GitHub probe (`InspectorTabsToolbar`) | `localRoot` |
| The `issuesModel` registry key | `localRoot` |
| The Info pane's Copy Path / Reveal in Finder / forge probe | `localRoot` |

`localRoot` is `nil` for every checkout on another device, so all of them stand down together. There is no fallback to the local path — that fallback *is* the defect.

Identity is the device, not the alias it was reached by: one box answering to a LAN name and a tailnet name is one checkout, matched by `host_id` once a handshake has revealed one and by alias until then, the same bootstrap/stable split `KnownDevice` already carries.

The name `Checkout` rather than `Workspace`: #345 gives Workspace to the sidebar scope, which spans machines. A checkout is a repo on a machine, and one workspace can hold several.

`grep -rn "sshHost" Sources/termio/FileBrowser/` now prints nothing — no pane asks how a session was opened.

## Verified

- `swift build`, `swift test` (408 tests, 0 failures), `./scripts/check-strings.sh` all pass. `InspectorCheckoutTests` pins the five cases: a remote session filed under a local project yields no local root, the device checkout is the remote fallback, a plain `ssh` session keeps its SFTP alias, local sessions are unchanged, and one device reached by two aliases is one checkout.
- `TERMIO_CHANNEL=dev ./scripts/build-app.sh` then `open ./termio-dev.app --env TERMIO_TERMIOD=1`: launches clean and stays up, no crash reports, no new errors in `log show`.
- **Not visually verified.** Screen Recording permission is missing on this machine, so `screencapture` fails and I could not see the window. What needs human eyes: the new empty state's `device:/path` title in each of the four panes, and that a local session's tree still draws exactly as before.

Release Notes:
The Files, Search, Changes and Issues panes now follow the machine a session runs on. A session on another device shows an empty state naming that machine and its directory, instead of this Mac's files, git status and issues.