### PR TITLE
Open a project that lives on another device

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -896,6 +896,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.presentOpenProjectPanel()
     }
 
+    /// A device row of the Open Project submenu — the machine's alias rides in
+    /// `representedObject`. Termio can't browse that box, so the panel asks for a
+    /// repository to clone onto it or a path already there.
+    @objc func openProjectOnDevice(_ sender: NSMenuItem) {
+        guard let alias = sender.representedObject as? String else { return }
+        store.presentRemoteProjectPanel(
+            on: KnownDevice(
+                alias: alias,
+                deviceID: TermiodDeviceRegistry.shared.deviceID(for: TermiodRoute(sshAlias: alias))))
+    }
+
     /// File ▸ New Terminal (⌘T) — a shell in the focused session's directory, beside
     /// that session (see `addTerminalHere`). Reached via the responder chain (the menu
     /// item targets `nil`), like the other app actions.
@@ -1526,6 +1537,7 @@ enum DeviceMenuTag {
     static let newTerminalAtHome = 7302
     static let connectTo = 7303
     static let workspace = 7304
+    static let openProject = 7305
 }
 
 /// The "Workspace ▸" item — the scopes, with the current one checked, and where the
@@ -1596,6 +1608,8 @@ extension AppDelegate: NSMenuDelegate {
             fillNewSSHMenu(menu)
         case localized("Connect to…"):
             fillConnectToMenu(menu)
+        case localized("Open Project"):
+            fillOpenProjectMenu(menu)
         case localized("Workspace"):
             fillWorkspaceMenu(menu)
         default:
@@ -1621,6 +1635,8 @@ extension AppDelegate: NSMenuDelegate {
                 item.isHidden = DeviceRoster.unusedAliases(known: known).isEmpty
             case DeviceMenuTag.workspace:
                 item.isHidden = !store.hasMultipleWorkspaces
+            case DeviceMenuTag.openProject:
+                refreshOpenProjectItem(item, known: known)
             default:
                 continue
             }
@@ -1658,6 +1674,71 @@ extension AppDelegate: NSMenuDelegate {
             : #selector(newTerminalHere(_:))
         item.target = self
         if let command { item.applyShortcut(for: command) }
+    }
+
+    /// The same single-device collapse applied to "Open Project…": a plain verb
+    /// while this Mac is the only machine, a device submenu once there is anywhere
+    /// else to put a project.
+    ///
+    /// Unlike New Terminal, this one *does* grow the submenu, because a project is
+    /// filed rather than entered: the workspace the row lands in has no device of
+    /// its own to inherit, so where the checkout lives is a choice only this menu
+    /// can carry. Picking This Mac is today's folder picker, unchanged.
+    ///
+    /// The shortcut travels to the This Mac row so ⌘O still opens a local folder
+    /// (AppKit's key-equivalent sweep descends submenus, the same behaviour the
+    /// New Chat menu relies on).
+    private func refreshOpenProjectItem(_ item: NSMenuItem, known: [KnownDevice]) {
+        guard !openProjectDevices(known: known).isEmpty else {
+            item.title = localized("Open Project…")
+            item.submenu = nil
+            item.action = #selector(openProject(_:))
+            item.target = self
+            item.applyShortcut(for: .openProject)
+            return
+        }
+        // The ellipsis moves to the rows: it is each of those that opens a panel,
+        // and a parent that only reveals a submenu never carries one. A submenu
+        // item's own key equivalent never fires, so ⌘O travels to the This Mac row
+        // (see `fillOpenProjectMenu`).
+        item.title = localized("Open Project")
+        item.action = nil
+        item.keyEquivalent = ""
+        item.keyEquivalentModifierMask = []
+        // Attached once and filled by the delegate on open, like the other device
+        // submenus. Replacing the menu object on every pass would swap it out from
+        // under AppKit's key-equivalent sweep, which is what finds ⌘O in there.
+        guard item.submenu?.title != localized("Open Project") else { return }
+        let submenu = NSMenu(title: localized("Open Project"))
+        submenu.delegate = self
+        item.submenu = submenu
+    }
+
+    /// The machines a project can be opened on: one worked on before, plus one from
+    /// `~/.ssh/config` never reached. Opening a project on a box is itself a first
+    /// contact — `ensureRemoteReady` installs termiod on the way — so the list is
+    /// the same one `Clone to <device>…` offers.
+    private func openProjectDevices(known: [KnownDevice]) -> [KnownDevice] {
+        known.filter { !$0.isLocal }
+            + DeviceRoster.unusedAliases(known: known).map { KnownDevice(alias: $0, deviceID: nil) }
+    }
+
+    private func fillOpenProjectMenu(_ menu: NSMenu) {
+        let local = menu.addItem(
+            withTitle: localized("This Mac…"), action: #selector(openProject(_:)), keyEquivalent: "")
+        local.target = self
+        local.applyShortcut(for: .openProject)
+        menu.addItem(.separator())
+        for device in openProjectDevices(known: DeviceRoster.known(in: store)) {
+            // The machine's own name, so nothing here is translated — it is the
+            // alias out of the user's `~/.ssh/config`.
+            let row = menu.addItem(
+                withTitle: "\(device.name)…",
+                action: #selector(openProjectOnDevice(_:)),
+                keyEquivalent: "")
+            row.target = self
+            row.representedObject = device.alias
+        }
     }
 
     /// Fills the Session menu: the cycling and close verbs, then a live jump
@@ -1997,13 +2078,17 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
         menu.addItem(terminal)
         menu.addItem(makeNewChatItem())
         menu.addItem(makeNewSSHItem())
-        let folder = NSMenuItem(title: localized("Open Project…"), action: #selector(openFolder(_:)), keyEquivalent: "")
-        folder.target = self
+        // Targets the AppDelegate, like the terminal row above, so the delegate can
+        // reshape it into a device submenu on open (`refreshOpenProjectItem`) —
+        // both this and the File menu's row then go through one builder.
+        let folder = NSMenuItem(title: localized("Open Project…"),
+                                action: #selector(AppDelegate.openProject(_:)),
+                                keyEquivalent: "")
+        folder.target = NSApp.delegate as? AppDelegate
+        folder.tag = DeviceMenuTag.openProject
         menu.addItem(folder)
         return menu
     }
-
-    @objc private func openFolder(_ sender: Any?) { store.presentOpenProjectPanel() }
 
     /// The `.inspectorTabs` item's menu form, shown in the toolbar's `»` overflow menu when the
     /// inspector section is too narrow to hold the glass cluster — the panes stay switchable
@@ -2357,11 +2442,13 @@ private func buildMainMenu() -> NSMenu {
     // decides what the sidebar lists and which repo the panes read.
     fileMenu.addItem(makeWorkspaceItem())
     fileMenu.addItem(.separator())
+    // Tagged so the delegate can grow it into a device submenu when there is
+    // somewhere other than this Mac to put a project (see `refreshOpenProjectItem`).
     fileMenu.addItem(
         withTitle: localized("Open Project…"),
         action: #selector(AppDelegate.openProject(_:)),
         command: .openProject
-    )
+    ).tag = DeviceMenuTag.openProject
     fileMenu.addItem(.separator())
     // The two branch verbs that fit termio's read-only git surface, with
     // GitHub Desktop's Branch-menu bindings: creating a worktree (termio's

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -169,11 +169,40 @@ struct Project: Identifiable, Hashable, Codable {
     /// `TermioStore.adoptDevice` promotes each one the first time its alias
     /// resolves to a device.
     var remoteCheckouts: [String: String] = [:]
+
+    /// The machine this project's checkout lives on — the `~/.ssh/config` alias —
+    /// or `nil` for a folder on this Mac.
+    ///
+    /// A project used to be a folder on this Mac by definition, so `path` was
+    /// always this Mac's to read. It no longer is: `Open Project ▸ <device>` files
+    /// a repo that exists only on another box, and `path` then names a directory
+    /// over there. Everything that reads local disk — the branch probe, Reveal in
+    /// Finder, worktrees, the recents list — is gated on this being `nil`.
+    ///
+    /// The alias is the *bootstrap* identity, the one that exists before anything
+    /// has connected (device architecture §9.5); `deviceID` is what it turns out
+    /// to be.
+    var deviceAlias: String?
+
+    /// The `host_id` the alias turned out to reach, learned by the first
+    /// handshake and `nil` until then.
+    var deviceID: String?
 }
 
 extension Project {
     private enum CodingKeys: String, CodingKey {
         case id, workspaceID, name, path, branch, sessions, worktrees, pinned, remoteCheckouts
+        case deviceAlias, deviceID
+    }
+
+    /// Whether this project's checkout is on another machine, so nothing here may
+    /// read `path` off local disk.
+    var isOnAnotherDevice: Bool { deviceAlias != nil }
+
+    /// The machine the checkout lives on, or `nil` for this Mac — what the row's
+    /// mark and the empty states name.
+    var device: KnownDevice? {
+        deviceAlias.map { KnownDevice(alias: $0, deviceID: deviceID) }
     }
 
     /// Missing collection and flag keys take their pre-feature defaults so older
@@ -197,6 +226,8 @@ extension Project {
         pinned = try container.decodeIfPresent(Bool.self, forKey: .pinned) ?? false
         remoteCheckouts =
             try container.decodeIfPresent([String: String].self, forKey: .remoteCheckouts) ?? [:]
+        deviceAlias = try container.decodeIfPresent(String.self, forKey: .deviceAlias)
+        deviceID = try container.decodeIfPresent(String.self, forKey: .deviceID)
     }
 
     /// The recorded checkout for one machine, addressed by device where the app
@@ -210,6 +241,18 @@ extension Project {
     func remoteCheckout(device deviceID: String?, alias: String) -> String? {
         if let deviceID, let path = remoteCheckouts[deviceID] { return path }
         return remoteCheckouts[alias]
+    }
+
+    /// Whether this project *is* the directory `path` on that machine — the test
+    /// behind "opening the same folder twice reopens the row you already have".
+    ///
+    /// Matched by device identity once both ends know it, so a box reached by a
+    /// second alias doesn't open a duplicate row for the same checkout, and by
+    /// alias until the first handshake resolves one.
+    func isCheckout(at path: String, on alias: String, device deviceID: String?) -> Bool {
+        guard isOnAnotherDevice, self.path == path else { return false }
+        if let deviceID, let mine = self.deviceID { return deviceID == mine }
+        return deviceAlias == alias
     }
 }
 

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -251,6 +251,96 @@
         }
       }
     },
+    "Open Project": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开项目"
+          }
+        }
+      }
+    },
+    "This Mac…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机…"
+          }
+        }
+      }
+    },
+    "Open a Project on %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 %@ 上打开项目"
+          }
+        }
+      }
+    },
+    "Termio can’t browse another machine’s files. Clone a repository onto %@, or enter a folder that’s already there.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termio 无法浏览另一台机器上的文件。把一个仓库克隆到 %@，或者输入一个已经在那里的文件夹。"
+          }
+        }
+      }
+    },
+    "Clone a Repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆仓库"
+          }
+        }
+      }
+    },
+    "Open a Folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开文件夹"
+          }
+        }
+      }
+    },
+    "Enter an absolute path": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请输入绝对路径"
+          }
+        }
+      }
+    },
+    "Termio opens the folder on %@ exactly as typed, so the path has to start with “/”. “~” isn’t expanded.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termio 会按你输入的原样打开 %@ 上的文件夹，所以路径必须以“/”开头，“~”不会展开。"
+          }
+        }
+      }
+    },
+    "Checked out on %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检出在 %@"
+          }
+        }
+      }
+    },
     "Inspector Pane": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -176,6 +176,8 @@
 	<string>Chats</string>
 	<key>Check for Updates…</key>
 	<string>Check for Updates…</string>
+	<key>Checked out on %@</key>
+	<string>Checked out on %@</string>
 	<key>Choose a different name.</key>
 	<string>Choose a different name.</string>
 	<key>Choose a name for this workspace.</key>
@@ -192,6 +194,8 @@
 	<string>Choose…</string>
 	<key>Clear</key>
 	<string>Clear</string>
+	<key>Clone a Repository</key>
+	<string>Clone a Repository</string>
 	<key>Clone to</key>
 	<string>Clone to</string>
 	<key>Close</key>
@@ -384,6 +388,8 @@
 	<string>Enter Code on GitHub</string>
 	<key>Enter a host from your ~/.ssh/config, or a user@host to connect to.</key>
 	<string>Enter a host from your ~/.ssh/config, or a user@host to connect to.</string>
+	<key>Enter an absolute path</key>
+	<string>Enter an absolute path</string>
 	<key>Every paired iPhone is signed out and must re-scan the new QR to reconnect.</key>
 	<string>Every paired iPhone is signed out and must re-scan the new QR to reconnect.</string>
 	<key>Expand Results</key>
@@ -694,6 +700,8 @@
 	<string>Open</string>
 	<key>Open Link</key>
 	<string>Open Link</string>
+	<key>Open Project</key>
+	<string>Open Project</string>
 	<key>Open Project…</key>
 	<string>Open Project…</string>
 	<key>Open Quickly…</key>
@@ -702,6 +710,10 @@
 	<string>Open System Settings</string>
 	<key>Open Themes Folder…</key>
 	<string>Open Themes Folder…</string>
+	<key>Open a Folder</key>
+	<string>Open a Folder</string>
+	<key>Open a Project on %@</key>
+	<string>Open a Project on %@</string>
 	<key>Open in %@</key>
 	<string>Open in %@</string>
 	<key>Open in Browser</key>
@@ -980,10 +992,14 @@
 	<string>Termio can show %@'s token usage and plan limits by reading its local session logs and its `credentials/kimi-code.json` sign-in. Nothing is read until you allow it.</string>
 	<key>Termio can show %@'s token usage and plan limits by reading its local session logs and its sign-in from your login Keychain. Nothing is read until you allow it; macOS will ask once about the Keychain.</key>
 	<string>Termio can show %@'s token usage and plan limits by reading its local session logs and its sign-in from your login Keychain. Nothing is read until you allow it; macOS will ask once about the Keychain.</string>
+	<key>Termio can’t browse another machine’s files. Clone a repository onto %@, or enter a folder that’s already there.</key>
+	<string>Termio can’t browse another machine’s files. Clone a repository onto %@, or enter a folder that’s already there.</string>
 	<key>Termio could not append to the repository’s .gitignore. Check its permissions and try again.</key>
 	<string>Termio could not append to the repository’s .gitignore. Check its permissions and try again.</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio is open source — star the repo, report bugs, and request features.</string>
+	<key>Termio opens the folder on %@ exactly as typed, so the path has to start with “/”. “~” isn’t expanded.</key>
+	<string>Termio opens the folder on %@ exactly as typed, so the path has to start with “/”. “~” isn’t expanded.</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</string>
 	<key>Test</key>
@@ -1028,6 +1044,8 @@
 	<string>Thicken glyphs</string>
 	<key>This Mac</key>
 	<string>This Mac</string>
+	<key>This Mac…</key>
+	<string>This Mac…</string>
 	<key>This branch and the base branch share no commits.</key>
 	<string>This branch and the base branch share no commits.</string>
 	<key>This branch has no commits yet.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -176,6 +176,8 @@
 	<string>聊天</string>
 	<key>Check for Updates…</key>
 	<string>检查更新…</string>
+	<key>Checked out on %@</key>
+	<string>检出在 %@</string>
 	<key>Choose a different name.</key>
 	<string>请选取其他名称。</string>
 	<key>Choose a name for this workspace.</key>
@@ -192,6 +194,8 @@
 	<string>选取…</string>
 	<key>Clear</key>
 	<string>清除</string>
+	<key>Clone a Repository</key>
+	<string>克隆仓库</string>
 	<key>Clone to</key>
 	<string>克隆到</string>
 	<key>Close</key>
@@ -384,6 +388,8 @@
 	<string>在 GitHub 上输入代码</string>
 	<key>Enter a host from your ~/.ssh/config, or a user@host to connect to.</key>
 	<string>输入 ~/.ssh/config 中的主机，或要连接的 user@host。</string>
+	<key>Enter an absolute path</key>
+	<string>请输入绝对路径</string>
 	<key>Every paired iPhone is signed out and must re-scan the new QR to reconnect.</key>
 	<string>所有已配对的 iPhone 都会退出登录，需重新扫描新的二维码才能重新连接。</string>
 	<key>Expand Results</key>
@@ -694,6 +700,8 @@
 	<string>打开</string>
 	<key>Open Link</key>
 	<string>打开链接</string>
+	<key>Open Project</key>
+	<string>打开项目</string>
 	<key>Open Project…</key>
 	<string>打开项目…</string>
 	<key>Open Quickly…</key>
@@ -702,6 +710,10 @@
 	<string>打开“系统设置”</string>
 	<key>Open Themes Folder…</key>
 	<string>打开主题文件夹…</string>
+	<key>Open a Folder</key>
+	<string>打开文件夹</string>
+	<key>Open a Project on %@</key>
+	<string>在 %@ 上打开项目</string>
 	<key>Open in %@</key>
 	<string>在 %@ 中打开</string>
 	<key>Open in Browser</key>
@@ -980,10 +992,14 @@
 	<string>Termio 可通过读取 %@ 的本地会话日志及其 `credentials/kimi-code.json` 登录信息，显示其 token 用量和套餐限额。在你允许之前不会读取任何内容。</string>
 	<key>Termio can show %@'s token usage and plan limits by reading its local session logs and its sign-in from your login Keychain. Nothing is read until you allow it; macOS will ask once about the Keychain.</key>
 	<string>Termio 可通过读取 %@ 的本地会话日志及登录钥匙串中的登录信息，显示其 token 用量和套餐限额。在你允许之前不会读取任何内容；macOS 会就钥匙串询问一次。</string>
+	<key>Termio can’t browse another machine’s files. Clone a repository onto %@, or enter a folder that’s already there.</key>
+	<string>Termio 无法浏览另一台机器上的文件。把一个仓库克隆到 %@，或者输入一个已经在那里的文件夹。</string>
 	<key>Termio could not append to the repository’s .gitignore. Check its permissions and try again.</key>
 	<string>Termio 无法将内容追加到该仓库的 .gitignore。请检查其权限后重试。</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio 是开源软件：欢迎给仓库加星标、报告 bug 和提出功能请求。</string>
+	<key>Termio opens the folder on %@ exactly as typed, so the path has to start with “/”. “~” isn’t expanded.</key>
+	<string>Termio 会按你输入的原样打开 %@ 上的文件夹，所以路径必须以“/”开头，“~”不会展开。</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio 会随 macOS 外观变化在两者间切换；将槽位留在默认值即可使用 Termio 自带的画布。“浏览主题”可以从 50 个精选配色中安装一个，你放进主题文件夹的 Ghostty 格式文件也会出现在这里。</string>
 	<key>Test</key>
@@ -1028,6 +1044,8 @@
 	<string>加粗字形</string>
 	<key>This Mac</key>
 	<string>本机</string>
+	<key>This Mac…</key>
+	<string>本机…</string>
 	<key>This branch and the base branch share no commits.</key>
 	<string>这个分支和基础分支没有共同的提交。</string>
 	<key>This branch has no commits yet.</key>

--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -213,7 +213,9 @@ func cloneToDeviceMenuItem(
                         message: localized("This folder has no git “origin” remote to clone."))
                     return
                 }
-                store.cloneOnRemote(host: alias, info: info, project: projectID)
+                store.cloneOnRemote(
+                    host: alias, info: info,
+                    into: projectID.map(TermioStore.RemoteCloneDestination.existing))
             }
         }
     }

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -649,14 +649,37 @@ private struct ProjectHeader: View {
         isCollapsed ? .folder : .folderOpen
     }
 
+    /// The machine this project's checkout lives on, when that is not this Mac.
+    /// `nil` inside a machine's own fallback workspace for the same reason a
+    /// session row's mark is: the workspace already *is* that machine.
+    private var remoteDevice: KnownDevice? {
+        guard !store.currentWorkspace.isDeviceFallback else { return nil }
+        return project.device
+    }
+
+    /// Adding a session to a project on another machine means adding it *there*.
+    /// A remote session is a login shell on the far box (`makeTermiodLink` hands
+    /// the remote empty argv), so the terminal is the only verb this row offers —
+    /// see `headerPresets`, which is why no agent preset reaches this.
     private func addSession(_ preset: AgentPreset) {
+        if let alias = project.deviceAlias {
+            store.addRemoteTerminal(host: alias, project: project.id)
+            return
+        }
         store.addSession(to: project.id, agent: preset, worktreePath: worktree?.path)
+    }
+
+    /// What the hover cluster and the agents submenu offer. A project on another
+    /// machine offers a terminal only: Termio can't launch an agent over there,
+    /// and a row of agent buttons that silently open shells would claim otherwise.
+    private var headerPresets: [AgentPreset] {
+        project.isOnAnotherDevice ? [.terminal] : headerSessionPresets(settings)
     }
 
     /// Width the trailing quick-add icons occupy (button frame 22 + 3 spacing each), so
     /// the hovered label can fade out exactly under them rather than guessing.
     private var quickAddClusterWidth: CGFloat {
-        let count = headerSessionPresets(settings).count
+        let count = headerPresets.count
         guard count > 0 else { return 0 }
         return CGFloat(count) * 22 + CGFloat(count - 1) * 3
     }
@@ -669,6 +692,11 @@ private struct ProjectHeader: View {
     /// Finder actions are about a project's directory — so its menu is
     /// just the terminal action and Close All Terminals.
     private var menuItems: [SidebarMenuItem] {
+        // A project on another machine has one place its sessions can run, so the
+        // verb names it outright instead of offering a device submenu whose rows
+        // would all be wrong but one. The agents submenu is absent for the same
+        // reason `headerPresets` drops them: nothing launches an agent over there.
+        if project.isOnAnotherDevice { return remoteMenuItems }
         var items: [SidebarMenuItem] = [
             newTerminalMenuItem(store: store, project: project) { addSession(.terminal) },
             .submenu(localized("New Agent Session"), enabledAgentPresets(settings)
@@ -715,6 +743,31 @@ private struct ProjectHeader: View {
         }
         items.append(.action(localized("Reveal in Finder")) {
             NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: project.path)
+        })
+        items.append(.separator)
+        items.append(.action(localized("Remove Project")) { store.removeProject(project.id) })
+        return items
+    }
+
+    /// The menu for a project whose checkout is on another machine. Every verb
+    /// that reads this Mac's disk is absent rather than disabled — New Worktree,
+    /// Clone to (the folder to clone from isn't here), Reveal in Finder — because
+    /// there is nothing on this Mac for them to act on. Filing and removal are
+    /// bookkeeping about the row, so they stay.
+    private var remoteMenuItems: [SidebarMenuItem] {
+        var items: [SidebarMenuItem] = [
+            .action(localized("New Terminal")) { addSession(.terminal) },
+            .separator,
+            .action(project.pinned ? localized("Unpin") : localized("Pin to Top")) {
+                store.togglePinned(project.id)
+            },
+        ]
+        if let move = moveToWorkspaceMenuItem(store: store, project: project) {
+            items.append(move)
+        }
+        items.append(.action(localized("Copy Path")) {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(project.path, forType: .string)
         })
         items.append(.separator)
         items.append(.action(localized("Remove Project")) { store.removeProject(project.id) })
@@ -771,6 +824,16 @@ private struct ProjectHeader: View {
                 HugeIconView(icon: .gitBranch, size: 10, color: .secondary)
                     .help(localized("Git worktree"))
             }
+            // The machine the checkout lives on, when that is not this Mac — the
+            // same tinted dot in the same hue a session row carries, because it
+            // says the same thing about the same machine. A local project carries
+            // nothing: being on your own Mac is the absence of a mark.
+            if let device = remoteDevice {
+                Circle()
+                    .fill(DeviceTint.color(for: device, chrome: chrome))
+                    .frame(width: 6, height: 6)
+                    .help(localized("Checked out on \(device.name)"))
+            }
         }
         // On hover the trailing icons would otherwise sit on top of a long project
         // name (the label takes the whole row at rest), so the name's tail reads as a
@@ -796,7 +859,7 @@ private struct ProjectHeader: View {
         // lifecycle actions live in the right-click menu rather than inline.
         .overlay(alignment: .trailing) {
             HStack(spacing: 3) {
-                ForEach(headerSessionPresets(settings)) { preset in
+                ForEach(headerPresets) { preset in
                     AgentQuickAddButton(preset: preset, chrome: chrome) {
                         addSession(preset)
                     }

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -218,6 +218,11 @@ extension TermioStore {
                 projects[index].remoteCheckouts[device.id] = legacy
                 projects[index].remoteCheckouts[alias] = nil
             }
+            // And what a project *on* this machine turned out to be sitting on,
+            // so two aliases for one box stop reading as two places.
+            if projects[index].deviceAlias == alias, projects[index].deviceID != device.id {
+                projects[index].deviceID = device.id
+            }
             for sessionIndex in projects[index].sessions.indices
             where projects[index].sessions[sessionIndex].termiodRemoteHost == alias
                 && projects[index].sessions[sessionIndex].deviceID != device.id {
@@ -687,7 +692,7 @@ extension TermioStore {
 
     /// The flag-off explainer: the remote feature is entirely the termiod backend,
     /// so without `TERMIO_TERMIOD=1` there's nothing to attach to.
-    private func presentTermiodDisabledAlert() {
+    func presentTermiodDisabledAlert() {
         let alert = NSAlert()
         alert.messageText = "Remote terminals need the termiod backend"
         alert.informativeText = "Set TERMIO_TERMIOD=1 and relaunch termio to open sessions on a remote host."
@@ -707,6 +712,22 @@ extension TermioStore {
 
     // MARK: - Clone to a device
 
+    /// Where a finished remote clone is filed.
+    ///
+    /// The two cases differ in *when* the project exists. `Clone to <device>…`
+    /// starts from a row that is already in the sidebar and only records the
+    /// correspondence; `Open Project ▸ <device> ▸ Clone…` has no row yet, and can't
+    /// make one up front — the clone's absolute path on the far machine is only
+    /// known once `git clone` has run and reported it, and a project row pointing
+    /// at a directory nobody has confirmed is the guess this avoids.
+    enum RemoteCloneDestination {
+        /// A project already in the tree: the clone is recorded as its checkout on
+        /// that machine.
+        case existing(Project.ID)
+        /// A project made from the clone itself, filed under `workspace`.
+        case new(name: String, workspace: Workspace.ID)
+    }
+
     /// Clones a project's `origin` **onto** `host` (git clone runs on the remote,
     /// not an rsync from the Mac — decided with the user), then opens a remote
     /// terminal inside the freshly cloned directory. The clone is `ssh <host> 'git
@@ -718,7 +739,11 @@ extension TermioStore {
     /// `info` comes from `GitService.cloneInfo` (origin URL, derived repo name,
     /// unpushed count). The whole feature is the termiod backend, so the flag-off
     /// case explains instead of opening a dead pane.
-    func cloneOnRemote(host: String, info: GitService.CloneInfo, project projectID: UUID? = nil) {
+    func cloneOnRemote(
+        host: String,
+        info: GitService.CloneInfo,
+        into destination: RemoteCloneDestination? = nil
+    ) {
         let host = host.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !host.isEmpty else { return }
         guard Termiod.isEnabled else {
@@ -750,7 +775,7 @@ extension TermioStore {
                 self.presentRemoteSetupFailure(host: host, message: error.message)
             case .success(let device):
                 self.performRemoteClone(
-                    host: host, device: device.id, info: info, project: projectID)
+                    host: host, device: device.id, info: info, into: destination)
             }
         }
     }
@@ -761,7 +786,7 @@ extension TermioStore {
         host: String,
         device deviceID: String,
         info: GitService.CloneInfo,
-        project projectID: UUID? = nil
+        into destination: RemoteCloneDestination? = nil
     ) {
         let hud = RemoteSetupHUD(message: "Cloning \(info.repositoryName) on \(host)…")
         hud.show()
@@ -805,19 +830,44 @@ extension TermioStore {
                 let clonedPath = clone.standardOutput
                     .split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
                     .last(where: { !$0.isEmpty })
-                // Record the local↔remote correspondence this clone just
-                // established, so it is a lasting link rather than a one-shot
-                // action: later remote terminals for this project land here
-                // without cloning again. Keyed by the *machine*, so reaching it by
-                // a different alias tomorrow still finds the clone.
-                if let projectID, let path = clonedPath,
-                   let index = self.projects.firstIndex(where: { $0.id == projectID }) {
-                    self.projects[index].remoteCheckouts[deviceID] = path
-                }
+                let projectID = self.fileClone(
+                    at: clonedPath, on: host, device: deviceID, into: destination)
                 self.createRemoteTerminalSession(
                     host: host, device: deviceID, cwd: clonedPath, title: name, project: projectID
                 )
             }
+        }
+    }
+
+    /// Files a finished clone and returns the project its first terminal belongs
+    /// under, or `nil` when there is none — the session then lands in the
+    /// machine's own workspace, which is where a terminal with no project goes.
+    ///
+    /// Recording the checkout is what makes the clone a lasting link rather than a
+    /// one-shot action: later remote terminals for this project land there without
+    /// cloning again. Keyed by the *machine*, so reaching it by a different alias
+    /// tomorrow still finds the clone.
+    private func fileClone(
+        at clonedPath: String?,
+        on alias: String,
+        device deviceID: String,
+        into destination: RemoteCloneDestination?
+    ) -> Project.ID? {
+        guard let destination else { return nil }
+        switch destination {
+        case .existing(let id):
+            guard let path = clonedPath,
+                  let index = projects.firstIndex(where: { $0.id == id })
+            else { return id }
+            projects[index].remoteCheckouts[deviceID] = path
+            return id
+        case .new(let name, let workspace):
+            // No path means the clone landed somewhere we couldn't read back, and
+            // a project row whose directory is a guess is worse than no row: the
+            // terminal still opens on the machine, just without one.
+            guard let path = clonedPath else { return nil }
+            return addRemoteProject(
+                name: name, at: path, on: alias, device: deviceID, workspace: workspace)
         }
     }
 }

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -546,7 +546,9 @@ extension TermioStore {
     func addProject(at url: URL) {
         let path = url.standardizedFileURL.path
         settings.noteRecentProject(name: url.lastPathComponent, path: path)
-        if let existing = projects.first(where: { $0.path == path }) {
+        // Matched among this Mac's projects only: a checkout on another machine
+        // can carry the same path string and is not the same folder.
+        if let existing = projects.first(where: { !$0.isOnAnotherDevice && $0.path == path }) {
             selectedSessionID = existing.sessions.first?.id
             return
         }
@@ -561,6 +563,129 @@ extension TermioStore {
         projects.append(project)
         selectedSessionID = project.sessions.first?.id
         resolveBranchLabel(for: project.id, at: path)
+    }
+
+    // MARK: - A project on another machine
+
+    /// Opens a project that lives on `device`, which Termio cannot browse.
+    ///
+    /// There is no remote file picker, and this deliberately does not fake one:
+    /// `fs.list` is unbuilt on the client, and a panel that guesses at a directory
+    /// list would be a worse lie than a text field. So the two honest ways to name
+    /// a folder over there are to clone a repository onto the machine — which
+    /// creates the directory, so its path is known afterwards — or to type a path
+    /// that is already on it.
+    func presentRemoteProjectPanel(on device: KnownDevice) {
+        guard let alias = device.alias else {
+            presentOpenProjectPanel()
+            return
+        }
+        // Checked before the panel rather than after it: the whole feature is the
+        // termiod backend, so with the flag off there is nothing to ask about, and
+        // asking anyway would leave a project row for a checkout nothing can open.
+        guard Termiod.isEnabled else {
+            presentTermiodDisabledAlert()
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = localized("Open a Project on \(alias)")
+        alert.informativeText = localized(
+            "Termio can’t browse another machine’s files. Clone a repository onto \(alias), or enter a folder that’s already there.")
+        alert.addButton(withTitle: localized("Open"))
+        alert.addButton(withTitle: localized("Cancel"))
+
+        let fields = RemoteProjectFields()
+        alert.accessoryView = fields.view
+        alert.window.initialFirstResponder = fields.field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let entry = fields.field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !entry.isEmpty else { return }
+        if fields.isCloning {
+            cloneProject(from: entry, on: alias)
+        } else {
+            openRemoteProject(at: entry, on: alias)
+        }
+    }
+
+    /// Clones `originURL` onto `alias` and files the result as a project in the
+    /// current workspace. Reuses the same clone `Clone to <device>…` runs — deploy
+    /// gate, HUD, verbatim remote stderr — rather than a second path that would
+    /// drift from it.
+    private func cloneProject(from originURL: String, on alias: String) {
+        let name = GitService.repositoryName(fromRemote: originURL)
+        // `unpushedCommits: nil` skips the divergence warning, correctly: the URL
+        // *is* the origin, so there is no local branch that could be ahead of it.
+        let info = GitService.CloneInfo(
+            originURL: originURL, repositoryName: name, unpushedCommits: nil)
+        cloneOnRemote(
+            host: alias, info: info,
+            into: .new(name: name, workspace: currentWorkspace.id))
+    }
+
+    /// Files a directory that is already on `alias` as a project, then opens its
+    /// first terminal. That terminal is also the check: the daemon fails visibly
+    /// if the path isn't there, rather than the row quietly pointing at nothing.
+    private func openRemoteProject(at entry: String, on alias: String) {
+        // termiod spawns the shell with a raw `chdir` and expands neither `~` nor a
+        // relative path (termiod/src/session.rs `Pty::spawn`), so anything else
+        // would start the shell somewhere the user did not name.
+        guard entry.hasPrefix("/") else {
+            let alert = NSAlert()
+            alert.messageText = localized("Enter an absolute path")
+            alert.informativeText = localized(
+                "Termio opens the folder on \(alias) exactly as typed, so the path has to start with “/”. “~” isn’t expanded.")
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: localized("OK"))
+            alert.runModal()
+            return
+        }
+        var path = entry
+        while path.count > 1, path.hasSuffix("/") { path.removeLast() }
+        let name = (path as NSString).lastPathComponent
+        let id = addRemoteProject(
+            name: name.isEmpty ? alias : name,
+            at: path,
+            on: alias,
+            device: TermiodDeviceRegistry.shared.deviceID(for: TermiodRoute(sshAlias: alias)),
+            workspace: currentWorkspace.id)
+        addRemoteTerminal(host: alias, project: id)
+    }
+
+    /// Adds a project whose checkout is on another machine, in `workspace` — a
+    /// normal project row, marked with its device. Reopening the same directory on
+    /// the same machine selects the row that is already there.
+    ///
+    /// No branch probe and no recents entry: both read this Mac's disk, and this
+    /// project's folder is not on it.
+    @discardableResult
+    func addRemoteProject(
+        name: String, at path: String, on alias: String, device deviceID: String?,
+        workspace: Workspace.ID
+    ) -> Project.ID {
+        if let existing = projects.first(where: { $0.isCheckout(at: path, on: alias, device: deviceID) }) {
+            selectedSessionID = existing.sessions.first?.id
+            return existing.id
+        }
+        var project = Project(
+            workspaceID: workspace,
+            name: name,
+            path: path,
+            // No local git to ask, and the daemon reports no branch yet. The em
+            // dash is the same "not a repo we can read" mark a plain folder gets,
+            // and it is what keeps the worktree verbs off this row.
+            branch: "—",
+            sessions: []
+        )
+        project.deviceAlias = alias
+        project.deviceID = deviceID
+        // The checkout `New Terminal` reads. Keyed by device once a handshake has
+        // said which one this alias reaches, by alias until then —
+        // `remoteCheckout(device:alias:)` answers from either, and `adoptDevice`
+        // promotes the alias key when the machine finally identifies itself.
+        project.remoteCheckouts[deviceID ?? alias] = path
+        projects.append(project)
+        return project.id
     }
 
     /// Removes a project from the sidebar: tears down every session's live surface
@@ -800,5 +925,49 @@ extension TermioStore {
         let data = output.fileHandleForReading.readDataToEndOfFile()
         return String(data: data, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+}
+
+/// The two ways to name a directory on a machine Termio cannot browse, as the
+/// accessory view of `presentRemoteProjectPanel`.
+///
+/// A class rather than a few locals because the segmented control needs a target
+/// that outlives the call that builds it — the alert runs modally and the switch
+/// has to keep answering while it is up.
+@MainActor
+private final class RemoteProjectFields: NSObject {
+    let view = NSStackView()
+    let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
+    private let mode = NSSegmentedControl(
+        labels: [localized("Clone a Repository"), localized("Open a Folder")],
+        trackingMode: .selectOne, target: nil, action: nil)
+
+    /// Whether the entry is a repository to clone rather than a folder to open.
+    var isCloning: Bool { mode.selectedSegment == 0 }
+
+    override init() {
+        super.init()
+        mode.selectedSegment = 0
+        mode.target = self
+        mode.action = #selector(modeChanged)
+        view.orientation = .vertical
+        view.alignment = .leading
+        view.spacing = 8
+        view.addArrangedSubview(mode)
+        view.addArrangedSubview(field)
+        field.widthAnchor.constraint(equalToConstant: 320).isActive = true
+        mode.widthAnchor.constraint(equalToConstant: 320).isActive = true
+        // NSAlert lays its accessory out by frame, so the stack has to carry its
+        // own measured height rather than a number guessed here — a control that
+        // grows with the user's text size would otherwise be clipped.
+        view.frame = NSRect(origin: .zero, size: view.fittingSize)
+        modeChanged()
+    }
+
+    /// The placeholder is the only thing that changes: one field either way, so
+    /// switching never loses what was typed into the other one. Neither example is
+    /// localized — a URL and an absolute path read the same in every language.
+    @objc private func modeChanged() {
+        field.placeholderString = isCloning ? "https://github.com/owner/repo.git" : "/srv/api"
     }
 }

--- a/Sources/termio/Welcome/WelcomeView.swift
+++ b/Sources/termio/Welcome/WelcomeView.swift
@@ -106,7 +106,12 @@ struct WelcomeView: View {
     private var recentEntries: [RecentProject] {
         var seen = Set<String>()
         var out: [RecentProject] = []
-        for project in store.orderedProjects where seen.insert(project.path).inserted {
+        // Local projects only: a row here reopens its path with `addProject`,
+        // which is this Mac's folder picker's verb. A checkout on another machine
+        // has no local folder to reopen, and the path would land as a local
+        // project pointing at a directory that isn't here.
+        for project in store.orderedProjects
+        where !project.isOnAnotherDevice && seen.insert(project.path).inserted {
             out.append(RecentProject(name: project.name, path: project.path))
         }
         for recent in settings.recentProjects where seen.insert(recent.path).inserted {

--- a/Tests/termioTests/RemoteProjectTests.swift
+++ b/Tests/termioTests/RemoteProjectTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import termio
+
+/// A project whose checkout is on another machine.
+///
+/// The identity question is the one worth pinning: a box commonly answers to a
+/// LAN name, a WAN name, and a tailnet name, so matching a checkout by the alias
+/// it was reached through would open a second row for the same directory the day
+/// the user changes networks.
+@MainActor
+final class RemoteProjectTests: XCTestCase {
+    private func remote(_ path: String, alias: String, device: String? = nil) -> Project {
+        var project = Project(
+            workspaceID: UUID(), name: "api", path: path, branch: "—", sessions: [])
+        project.deviceAlias = alias
+        project.deviceID = device
+        project.remoteCheckouts[device ?? alias] = path
+        return project
+    }
+
+    func testSameDirectoryOnTheSameDeviceIsTheSameCheckout() {
+        let project = remote("/srv/api", alias: "vps-lan", device: "device-a")
+
+        XCTAssertTrue(project.isCheckout(at: "/srv/api", on: "vps-lan", device: "device-a"))
+        XCTAssertTrue(project.isCheckout(at: "/srv/api", on: "vps-tailnet", device: "device-a"),
+                      "one machine reached by a second alias is still one checkout")
+        XCTAssertFalse(project.isCheckout(at: "/srv/web", on: "vps-lan", device: "device-a"),
+                       "a different directory on the same machine is a different checkout")
+        XCTAssertFalse(project.isCheckout(at: "/srv/api", on: "other", device: "device-b"))
+    }
+
+    /// Until a handshake resolves a `host_id` the alias is all there is — the same
+    /// bootstrap/stable split `KnownDevice` carries.
+    func testAliasMatchesUntilADeviceResolvesIt() {
+        let project = remote("/srv/api", alias: "vps-lan")
+
+        XCTAssertTrue(project.isCheckout(at: "/srv/api", on: "vps-lan", device: nil))
+        XCTAssertTrue(project.isCheckout(at: "/srv/api", on: "vps-lan", device: "device-a"),
+                      "a device this row hasn’t learned yet can’t disprove the alias")
+        XCTAssertFalse(project.isCheckout(at: "/srv/api", on: "vps-wan", device: nil))
+    }
+
+    /// A folder on this Mac is never a remote checkout, however the paths line up —
+    /// the local project row and a same-named directory on a VPS are two places.
+    func testALocalProjectIsNeverARemoteCheckout() {
+        let local = Project(
+            workspaceID: UUID(), name: "api", path: "/srv/api", branch: "main", sessions: [])
+
+        XCTAssertFalse(local.isOnAnotherDevice)
+        XCTAssertNil(local.device)
+        XCTAssertFalse(local.isCheckout(at: "/srv/api", on: "vps-lan", device: "device-a"))
+    }
+
+    /// The checkout a remote terminal opens in resolves through the device key when
+    /// one is known and the alias key until then, so the row works before and after
+    /// the machine identifies itself.
+    func testTheSeededCheckoutResolvesBothWays() {
+        let known = remote("/srv/api", alias: "vps-lan", device: "device-a")
+        XCTAssertEqual(known.remoteCheckout(device: "device-a", alias: "vps-lan"), "/srv/api")
+
+        let unresolved = remote("/srv/api", alias: "vps-lan")
+        XCTAssertEqual(unresolved.remoteCheckout(device: nil, alias: "vps-lan"), "/srv/api")
+        XCTAssertEqual(unresolved.remoteCheckout(device: "device-a", alias: "vps-lan"), "/srv/api",
+                       "a device key that isn’t recorded yet falls back to the alias")
+    }
+
+    /// The device fields survive a round trip, and a project written before them
+    /// still decodes as a folder on this Mac.
+    func testDeviceSurvivesEncodingAndOlderStateFilesStayLocal() throws {
+        let project = remote("/srv/api", alias: "vps-lan", device: "device-a")
+        let decoded = try JSONDecoder().decode(
+            Project.self, from: try JSONEncoder().encode(project))
+
+        XCTAssertEqual(decoded.deviceAlias, "vps-lan")
+        XCTAssertEqual(decoded.deviceID, "device-a")
+        XCTAssertTrue(decoded.isOnAnotherDevice)
+
+        let older = """
+        {"id":"\(UUID().uuidString)","name":"api","path":"/Users/me/api",
+         "branch":"main","sessions":[]}
+        """
+        let legacy = try JSONDecoder().decode(Project.self, from: Data(older.utf8))
+        XCTAssertFalse(legacy.isOnAnotherDevice)
+    }
+}


### PR DESCRIPTION
**Stacked on #345** (`feat/workspaces`), which is itself stacked on #343. Review that one first.

A workspace can already span machines. What it couldn't hold was the repo those sessions work in: a project was a folder on this Mac by definition, and `Open Project…` ran an `NSOpenPanel` and stopped there. The only way a checkout got onto another box was `Clone to <device>…` from a row that already existed here.

## What changes for the user

- `Open Project…` grows a device axis once there is anywhere else to put a project: **This Mac…**, then every machine worked on, then the `~/.ssh/config` aliases never reached. With one machine it stays the plain verb it is today.
- **This Mac…** is today's folder picker, unchanged, and keeps ⌘O.
- A device asks for one of two things: a repository URL to clone onto that box, or an absolute path already on it.
- The new project lands in the current workspace as a normal project row, carrying its machine's tinted dot — the same mark, in the same hue, a session row already gets.
- Its **New Terminal** opens in that checkout. Opening the same directory on the same machine twice reopens the row you already have.

## No remote file browser

There is none, on purpose. `fs.list` is unbuilt on the client — Stage 1 of `docs/rfcs/one-workspace-source.md`, whose review is request-changes — so a directory picker for another box would be a guess wearing a browser's clothes. Typing a path is the honest affordance, and the panel says which of the two things it's asking for:

> Termio can't browse another machine's files. Clone a repository onto ukvps, or enter a folder that's already there.

A relative or `~` path is refused with the reason: termiod spawns the shell with a raw `chdir` and expands neither, so anything else would start the shell somewhere the user didn't name.

## How

`Project` gains `deviceAlias` / `deviceID` — the same bootstrap/stable split `KnownDevice` and the fallback workspaces carry. `path` then names a directory over there, so everything that reads local disk stands down for such a row: the branch probe, the recents list on the welcome screen, New Worktree, Clone to, and Reveal in Finder (which becomes Copy Path). The header offers a terminal and no agents — a remote session is a login shell on the far box (`makeTermiodLink` hands the remote empty argv), so agent buttons would claim something that isn't built.

The clone reuses `cloneOnRemote` rather than adding a second clone path; it now takes a `RemoteCloneDestination` saying where to file the result. The two cases differ in *when* the project exists — `Clone to <device>…` starts from a row and records the checkout against it, while this starts with no row and can't invent one up front, because the clone's absolute path on the far machine is only known once `git clone` has reported it. `adoptDevice` promotes a project's alias to its `host_id` the first time the machine identifies itself, beside the checkout promotion already there.

## Verified

- `swift build`, `swift test` (410 tests, 0 failures), `./scripts/check-strings.sh` all pass. `RemoteProjectTests` pins the identity rule (one machine reached by two aliases is one checkout; the alias matches until a `host_id` resolves it), that a local project is never a remote checkout, that the seeded checkout resolves through either key, and that a project written before these fields still decodes as local.
- `TERMIO_CHANNEL=dev ./scripts/build-app.sh` then `open -n ./termio-dev.app --env TERMIO_TERMIOD=1`: launches clean and stays up, no crash reports.
- **Not verified at runtime, and not visually.** Screen Recording permission is missing, so `screencapture` fails. I also could not confirm the menu through accessibility scripting: another dev build with the same bundle id (`sh.termio.app.dev`) was running on this machine and holds the menu bar, and `lsappinfo` reported `loginwindow` as frontmost, so what came back was not reliably this build's menu.

  What needs human eyes, with a machine in `~/.ssh/config`:
  - **File ▸ Open Project** reads as a submenu with This Mac… first, a separator, then each machine, and ⌘O still opens the local folder picker from the closed menu.
  - The same row in the sidebar's `+` menu.
  - The panel's layout — the segmented Clone a Repository / Open a Folder switch above one text field, sized by `fittingSize` inside the alert.
  - A remote project row's device dot: size, placement beside the worktree branch glyph, and that its hue matches the same machine's session rows.

Release Notes:
Open Project… can now open a project that lives on another machine. Pick a device and either clone a repository onto it or enter a folder that's already there; the project appears in your current workspace like any other, marked with that machine's colour, and its terminals open in that checkout. Termio doesn't browse another machine's files, so the folder is named rather than picked.