### PR TITLE
Drop what the workspace refactor left behind

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -942,10 +942,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// A row of the Workspace submenu — the scope the sidebar shows and the panes
     /// follow.
     @objc func switchToWorkspace(_ sender: NSMenuItem) {
-        guard let raw = sender.representedObject as? String, let id = UUID(uuidString: raw),
-              let workspace = store.workspaces.first(where: { $0.id == id })
+        guard let raw = sender.representedObject as? String, let id = UUID(uuidString: raw)
         else { return }
-        WorkspaceSpaces.select(workspace, in: store)
+        store.switchToWorkspace(id)
     }
 
     /// The submenu's trailing "New Workspace…" row.
@@ -1100,10 +1099,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// and removed *with* them. When open the region reads `toggleNavigator, workspaceSwitcher, flex,
     /// sortProjects, newTerminal | sidebarTrackingSeparator`. Mirrors `setInspectorSwitchVisible`.
     ///
-    /// The device switcher is the exception: it does not leave with the sidebar, it *moves* across the
-    /// tracking separator to the head of the content region. A collapsed sidebar is exactly when the
-    /// window is only a terminal, and a terminal looks the same on every machine — dropping the one
-    /// control that says which machine would remove the answer at the moment it is least guessable.
+    /// The workspace switcher is the exception: it does not leave with the sidebar, it *moves* across
+    /// the tracking separator to the head of the content region. A collapsed sidebar is exactly when
+    /// the window is only a terminal, and a terminal looks the same in every scope — dropping the one
+    /// control that says which workspace would remove the answer at the moment it is least guessable.
     /// (Dia does the same with its profile indicator: one mount in the sidebar, another in the tab
     /// dock for when the sidebar is away.)
     private func setNavigatorItemsVisible(_ visible: Bool) {
@@ -1828,7 +1827,7 @@ extension AppDelegate: NSMenuDelegate {
     /// is the one no terminal program can want (Cmd is off-limits to a TUI) and that
     /// nothing else in termio takes.
     private func fillWorkspaceMenu(_ menu: NSMenu) {
-        for (index, workspace) in WorkspaceSpaces.ordered(in: store).enumerated() {
+        for (index, workspace) in store.orderedWorkspaces.enumerated() {
             let item = menu.addItem(
                 withTitle: workspace.name,
                 action: #selector(switchToWorkspace(_:)),

--- a/Sources/termio/FileBrowser/FileTreeCache.swift
+++ b/Sources/termio/FileBrowser/FileTreeCache.swift
@@ -51,19 +51,6 @@ final class FileTreeCache {
         }
     }
 
-    /// Forgets one root — used when its directory is gone, so a stale tree can
-    /// never be handed back for a path that no longer exists.
-    func forget(_ url: URL) {
-        let key = Self.key(url)
-        roots[key] = nil
-        order.removeAll { $0 == key }
-    }
-
-    func removeAll() {
-        roots.removeAll()
-        order.removeAll()
-    }
-
     private func touch(_ key: String) {
         order.removeAll { $0 == key }
         order.append(key)

--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -57,14 +57,6 @@ enum DeviceRoster {
         return known.filter { !$0.isLocal }
             + unusedAliases(known: known).map { KnownDevice(alias: $0, deviceID: nil) }
     }
-
-    /// The device the app is on, resolved against the machines that actually
-    /// exist. A stored alias that no longer matches anything (the user deleted the
-    /// `Host` block, or closed the last session on it) falls back to this Mac
-    /// rather than silently aiming at nothing.
-    static func current(_ store: TermioStore, known: [KnownDevice]) -> KnownDevice {
-        known.first { $0.alias == store.currentDeviceAlias } ?? .thisMac
-    }
 }
 
 // A device has no "open" verb of its own. Reaching a machine is always the side
@@ -99,7 +91,7 @@ extension KnownDevice {
 }
 
 /// The mark a device carries wherever it is drawn small enough that its name
-/// won't fit — today the footer dots.
+/// won't fit — today the dot on a session row that runs elsewhere.
 ///
 /// A color is not decoration here. The whole class of accident this app has to
 /// prevent is "I thought I was local, I was on the VPS": the panes now refuse to
@@ -179,7 +171,7 @@ func newTerminalMenuItem(
 /// workspace the project is already in is a dead click.
 @MainActor
 func moveToWorkspaceMenuItem(store: TermioStore, project: Project) -> SidebarMenuItem? {
-    let targets = WorkspaceSpaces.ordered(in: store).filter { $0.id != project.workspaceID }
+    let targets = store.orderedWorkspaces.filter { $0.id != project.workspaceID }
     guard !targets.isEmpty else { return nil }
     return .submenu(localized("Move to Workspace"), targets.map { workspace in
         .action(workspace.name) { store.moveProject(project.id, toWorkspace: workspace.id) }

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -181,9 +181,9 @@ struct SidebarView: View {
         // breadcrumb, so the row says where clicking will take you.
         let waitingElsewhere = elsewhereNeedingYou(currentWorkspace: workspace.id)
         // Whether any row in this column wears a machine mark. A machine's own
-        // workspace already says which machine it is — in the toolbar band and in
-        // the footer dot — so marking each of its rows repeats one fact down the
-        // whole column. Decided here, once, and handed to the rows.
+        // workspace already says which machine it is, in the toolbar band above
+        // the column, so marking each of its rows repeats one fact down the whole
+        // column. Decided here, once, and handed to the rows.
         let marksDevice = !workspace.isDeviceFallback
         let hasPinned = !pinnedProjects.isEmpty || !pinnedWorktrees.isEmpty
             || !pinnedSessions.isEmpty || !waitingElsewhere.isEmpty
@@ -333,17 +333,10 @@ struct SidebarView: View {
     @ViewBuilder
     private func alsoRunningSection(isFirstSection: Bool) -> some View {
         let device = store.currentDevice
-        // Only what the device reports that this app has no row for. Every session
-        // the app authored draws in its own workspace now — including the ones on
-        // other machines, which wear that machine's mark — so anything with a
-        // record here would be a duplicate.
-        let rows = store.deviceWorld().filter { row in
-            if case .running(_, nil) = row { return true }
-            return false
-        }
         // Deliberately not scoped by workspace: this is the machine's own claim
         // about what is running, and it is the only place a session started
         // outside Termio can appear at all.
+        let rows = store.deviceOnlySessions()
         if !rows.isEmpty {
             SidebarSectionHeader(
                 title: device.isLocal
@@ -358,13 +351,10 @@ struct SidebarView: View {
                 menuItems: alsoRunningMenuItems(device)
             )
             if !alsoRunningCollapsed {
-                ForEach(rows) { row in
-                    // A session on this device with no row here. Opening it is
-                    // adoption, not creation: it keeps the name the device gave it
-                    // so the attach lands on that PTY.
-                    if case .running(let information, nil) = row {
-                        DeviceOnlySessionRow(information: information, chrome: chrome)
-                    }
+                // Opening one of these is adoption, not creation: it keeps the
+                // name the device gave it so the attach lands on that PTY.
+                ForEach(rows, id: \.id) { information in
+                    DeviceOnlySessionRow(information: information, chrome: chrome)
                 }
             }
         }
@@ -1072,9 +1062,9 @@ private struct SessionRow: View {
     private var isSelected: Bool { store.selectedSessionID == session.id }
 
     /// The machine this row runs on, or `nil` when it runs here — or when the
-    /// workspace *is* that machine, since its name is already in the toolbar band
-    /// and its colour already in the footer. Marking every row of a machine's own
-    /// workspace repeats one fact down the whole column, which is noise, not a cue.
+    /// workspace *is* that machine, since its name is already in the toolbar band.
+    /// Marking every row of a machine's own workspace repeats one fact down the
+    /// whole column, which is noise, not a cue.
     private var remoteDevice: KnownDevice? {
         guard marksDevice else { return nil }
         return .running(session)
@@ -1531,8 +1521,6 @@ struct SidebarRowHighlight: View {
     }
 }
 
-/// A small coloured dot mirroring the menu-bar pulse: hidden when idle, amber
-/// when the session wants attention, blue while working.
 /// The resting "your turn" status, drawn as a ring *around* the leading brand mark: green when the
 /// agent just finished, orange when it's blocked on you. Working is the leading spinner and idle is
 /// nothing, so only those two states light the ring. Sized well past the 16pt icon column so it
@@ -1553,9 +1541,6 @@ private struct StatusRing: View {
     }
 }
 
-/// The "agent is working" mark: a 3×3 grid of dots with a bright comet that orbits
-/// the eight perimeter cells, so the small nine-square grid reads as rotating. Sits
-/// in place of the session's brand icon while a turn is in flight (see `SessionRow`).
 extension Color {
     /// Pure ink for the sidebar's working spinner: `labelColor` keeps ~15%
     /// transparency and the sidebar's vibrancy lightens it again, which left even

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -2,91 +2,6 @@ import AppKit
 import SwiftUI
 import TermioShared
 
-/// One source of truth for moving between workspaces, so the header menu, the
-/// footer dots, and the trackpad swipe can never disagree about the order or
-/// about which scope is current.
-@MainActor
-enum WorkspaceSpaces {
-    /// The workspaces a user can move between, in the order every surface shows
-    /// them: the ones they made first, then the machine fallbacks. A fallback is
-    /// where sessions land that nobody filed, so it sits after the filing.
-    static func ordered(in store: TermioStore) -> [Workspace] {
-        store.workspaces.filter { !$0.isDeviceFallback } + store.workspaces.filter(\.isDeviceFallback)
-    }
-
-    /// The workspace `step` places away from the current one, or `nil` at either
-    /// end. Deliberately not wrapping: a swipe that runs off the end should feel
-    /// like a wall, not teleport to the far side of the list.
-    static func neighbor(step: Int, in store: TermioStore) -> Workspace? {
-        let spaces = ordered(in: store)
-        guard let current = spaces.firstIndex(where: { $0.id == store.currentWorkspaceID })
-        else { return nil }
-        let target = current + step
-        guard spaces.indices.contains(target) else { return nil }
-        return spaces[target]
-    }
-
-    /// Every switcher goes through here, which is also what makes the switch
-    /// measurable in one place: the span covers the whole synchronous cost of
-    /// changing scope — the selection move, the device context, the sidebar
-    /// rebuild each one publishes — so a switch that feels slow has a number
-    /// next to it rather than an adjective.
-    static func select(_ workspace: Workspace, in store: TermioStore) {
-        Trace.workspace.measure("workspace switch", "to=\(workspace.name)") {
-            store.switchToWorkspace(workspace.id)
-        }
-    }
-
-}
-
-/// The rows every workspace switcher shows, wherever it is mounted. The sidebar's
-/// toolbar control is the only opening today; the rows live here rather than in
-/// it because there is one current workspace, and it would be a bug for two
-/// controls to disagree about which one it is.
-struct WorkspaceSwitcherMenuContent: View {
-    @EnvironmentObject var store: TermioStore
-
-    var body: some View {
-        let spaces = WorkspaceSpaces.ordered(in: store)
-        // An inline Picker is what draws the checkmark on the current workspace; a
-        // row of Buttons would leave the switcher unable to say which one is showing.
-        Picker("", selection: selection) {
-            ForEach(spaces) { workspace in
-                Text(workspace.name).tag(workspace.id)
-            }
-        }
-        .pickerStyle(.inline)
-        .labelsHidden()
-        Divider()
-        Button(localized("New Workspace…")) { store.presentNewWorkspacePanel() }
-        Button(localized("Rename Workspace…")) {
-            store.presentRenameWorkspacePanel(store.currentWorkspaceID)
-        }
-        // The last workspace has nowhere to send its sessions, and the sidebar has
-        // to have a scope to show, so the verb is absent rather than disabled.
-        if store.hasMultipleWorkspaces {
-            Button(localized("Remove Workspace")) {
-                store.confirmRemoveWorkspace(store.currentWorkspaceID)
-            }
-        }
-        // No device verb here, deliberately. A machine you can *go to* is the
-        // mode this scope replaced: it made the sidebar answer "which computer"
-        // when the question is "which work". A device is a place a new thing is
-        // put — New Terminal on it, Clone to it, File ▸ Connect to… for a box
-        // never reached — never a place the window travels to.
-    }
-
-    private var selection: Binding<Workspace.ID> {
-        Binding(
-            get: { store.currentWorkspaceID },
-            set: { id in
-                guard let workspace = store.workspaces.first(where: { $0.id == id }) else { return }
-                WorkspaceSpaces.select(workspace, in: store)
-            }
-        )
-    }
-}
-
 /// The workspace switcher, in the sidebar's own toolbar region: which scope you
 /// are in, and the control that changes it. It sits in the strip above the list
 /// rather than in a row of its own, next to the navigator toggle and the
@@ -100,7 +15,6 @@ struct WorkspaceSwitcherToolbarView: View {
     @EnvironmentObject var store: TermioStore
     @EnvironmentObject var settings: AppSettings
     @Environment(\.controlActiveState) private var controlActive
-    @Environment(\.colorScheme) private var colorScheme
 
     /// Long names truncate rather than push the sort and `+` buttons toward
     /// NSToolbar's `»` overflow: the sidebar region has only the room the
@@ -114,7 +28,7 @@ struct WorkspaceSwitcherToolbarView: View {
         if store.hasMultipleWorkspaces {
             let current = store.currentWorkspace
             Menu {
-                WorkspaceSwitcherMenuContent()
+                menuRows
             } label: {
                 HStack(spacing: 5) {
                     // Sized against the toolbar's own glyphs (the navigator toggle, the
@@ -142,6 +56,42 @@ struct WorkspaceSwitcherToolbarView: View {
             .fixedSize()
             .help(localized("The sidebar shows this workspace"))
         }
+    }
+
+    @ViewBuilder
+    private var menuRows: some View {
+        // An inline Picker is what draws the checkmark on the current workspace; a
+        // row of Buttons would leave the switcher unable to say which one is showing.
+        Picker("", selection: selection) {
+            ForEach(store.orderedWorkspaces) { workspace in
+                Text(workspace.name).tag(workspace.id)
+            }
+        }
+        .pickerStyle(.inline)
+        .labelsHidden()
+        Divider()
+        Button(localized("New Workspace…")) { store.presentNewWorkspacePanel() }
+        Button(localized("Rename Workspace…")) {
+            store.presentRenameWorkspacePanel(store.currentWorkspaceID)
+        }
+        // Removing the last workspace is refused in the store — the sidebar has to
+        // have a scope to show — and this menu only opens while there is more than
+        // one, so the row is always live where it is drawn.
+        Button(localized("Remove Workspace")) {
+            store.confirmRemoveWorkspace(store.currentWorkspaceID)
+        }
+        // No device verb here, deliberately. A machine you can *go to* is the
+        // mode this scope replaced: it made the sidebar answer "which computer"
+        // when the question is "which work". A device is a place a new thing is
+        // put — New Terminal on it, Clone to it, File ▸ Connect to… for a box
+        // never reached — never a place the window travels to.
+    }
+
+    private var selection: Binding<Workspace.ID> {
+        Binding(
+            get: { store.currentWorkspaceID },
+            set: { store.switchToWorkspace($0) }
+        )
     }
 
     // Matched to the sidebar toolbar's native glyphs (the `+` new-terminal item, the

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -462,18 +462,6 @@ extension TermioStore {
         }
     }
 
-    /// How a session's termiod counterpart died, if it did. `nil` for a session
-    /// that is running, that never ran, or whose tombstone has aged out of the
-    /// daemon's capped graveyard.
-    ///
-    /// The reason is the host's word (`exited` · `killed` · `daemon_lost`);
-    /// turning it into something a person reads is the caller's job, because the
-    /// host describes state and never decides presentation.
-    func termiodEndReason(for id: Session.ID) -> Termiod.SessionTombstone? {
-        guard let session = session(id) else { return nil }
-        return termiodTombstones[daemonSessionName(for: session)]
-    }
-
     // MARK: - Adopting a session the device already had
 
     /// Takes a session the **device** reports but this app has no row for, and

--- a/Sources/termio/TermioStore/DeviceContext.swift
+++ b/Sources/termio/TermioStore/DeviceContext.swift
@@ -73,42 +73,6 @@ enum DeviceSessionsState {
     }
 }
 
-/// One row of the current device's world.
-///
-/// The order of the cases is the order of authority. `running` comes from the
-/// device's `list` reply and is the only case that can assert a process exists;
-/// the other two describe rows this viewer authored whose process the device does
-/// not report, which is a different claim and is drawn differently.
-enum DeviceWorldRow: Identifiable {
-    /// A process the device says is running. The `Session` is this viewer's own
-    /// record of it — a title, a pin, an agent — and is `nil` for a session
-    /// started by the CLI or another client, which is exactly the case that
-    /// proves the list is not a local array.
-    case running(Termiod.SessionInformation, Session?)
-    /// A row this viewer authored that the device has no process for. Remote
-    /// sessions spawn on first attach (`create_if_missing`), so a session created
-    /// but never opened lives only here until it is clicked.
-    case notStarted(Session)
-    /// A row whose process the device buried, with the reason it gave.
-    case ended(Session, Termiod.SessionTombstone)
-
-    var id: String {
-        switch self {
-        case .running(let information, _): return "live:\(information.id)"
-        case .notStarted(let session): return "idle:\(session.id.uuidString)"
-        case .ended(let session, _): return "dead:\(session.id.uuidString)"
-        }
-    }
-
-    /// This viewer's record of the row, when it has one.
-    var session: Session? {
-        switch self {
-        case .running(_, let session): return session
-        case .notStarted(let session), .ended(let session, _): return session
-        }
-    }
-}
-
 extension TermioStore {
     /// The device the app is currently looking at. Every panel takes its data
     /// from here: switching is not a filter over one list, it is a different
@@ -157,35 +121,21 @@ extension TermioStore {
         refreshDeviceSessions()
     }
 
-    /// The current device's rows: what the device reports, then the rows this
-    /// viewer holds that it did not.
+    /// What the current device says is running that this app has no row for —
+    /// a session started from the `termiod` CLI on that machine, or by another
+    /// client. Every session this app authored already draws in its own
+    /// workspace, so anything with a record here would be a duplicate.
     ///
-    /// Running sessions lead and keep the device's own ordering — the device is
-    /// the authority for that list, so its order is the list's order. Everything
-    /// after is this app's own bookkeeping about rows the device did not mention.
-    func deviceWorld() -> [DeviceWorldRow] {
-        let device = currentDevice
-        let mine = sessions(authoredFor: device)
-        var rows: [DeviceWorldRow] = []
-        var claimed: Set<Session.ID> = []
-
-        for information in deviceSessions.sessions?.live ?? [] where information.alive {
-            let session = mine.first { daemonSessionName(for: $0) == information.name }
-            if let session { claimed.insert(session.id) }
-            rows.append(.running(information, session))
+    /// The device's own ordering is kept: it is the authority for this list, so
+    /// its order is the list's order. Its existence is also the proof the list is
+    /// the device's and not this Mac's — no amount of filtering a local array can
+    /// produce a row for a session this app never created.
+    func deviceOnlySessions() -> [Termiod.SessionInformation] {
+        let mine = sessions(authoredFor: currentDevice)
+        return (deviceSessions.sessions?.live ?? []).filter { information in
+            information.alive
+                && !mine.contains { daemonSessionName(for: $0) == information.name }
         }
-
-        // A session the device did not list is not automatically gone: it may
-        // never have been started. The tombstone is what tells the two apart, so
-        // it decides which row gets drawn.
-        for session in mine where !claimed.contains(session.id) {
-            if let tombstone = termiodEndReason(for: session) {
-                rows.append(.ended(session, tombstone))
-            } else {
-                rows.append(.notStarted(session))
-            }
-        }
-        return rows
     }
 
     /// The sessions this viewer authored **for** a device: its own records, which
@@ -224,6 +174,13 @@ extension TermioStore {
         session.termiodSessionName ?? session.id.uuidString
     }
 
+    /// How a session's termiod counterpart died, if it did. `nil` for a session
+    /// that is running, that never ran, or whose tombstone has aged out of the
+    /// daemon's capped graveyard.
+    ///
+    /// The reason is the host's word (`exited` · `killed` · `daemon_lost`);
+    /// turning it into something a person reads is the caller's job, because the
+    /// host describes state and never decides presentation.
     func termiodEndReason(for session: Session) -> Termiod.SessionTombstone? {
         termiodTombstones[daemonSessionName(for: session)]
     }

--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -178,13 +178,6 @@ extension TermioStore {
         return false
     }
 
-    /// Whether the session is one of a workspace's loose agent sessions — the
-    /// rows the Chats section draws.
-    func isLooseChat(_ id: Session.ID) -> Bool {
-        if case .chats? = locate(id) { return true }
-        return false
-    }
-
     /// The workspace a session belongs to: the one that owns it directly for a
     /// loose session, its project's owner otherwise.
     func workspace(for sessionID: Session.ID) -> Workspace? {
@@ -209,31 +202,39 @@ extension TermioStore {
     }
 
     /// Whether the switcher has anything to switch between. With one workspace it
-    /// stays out of sight — the same rule the device control follows: a control
-    /// that always reads the same thing is a label for a decision nobody took.
+    /// stays out of sight: a control that always reads the same thing is a label
+    /// for a decision nobody took.
     var hasMultipleWorkspaces: Bool { workspaces.count > 1 }
+
+    /// The workspaces a user can move between, in the order every surface shows
+    /// them: the ones they made first, then the machine fallbacks. A fallback is
+    /// where sessions land that nobody filed, so it sits after the filing.
+    var orderedWorkspaces: [Workspace] {
+        workspaces.filter { !$0.isDeviceFallback } + workspaces.filter(\.isDeviceFallback)
+    }
 
     /// Shows a different workspace. The selection moves with it, because a
     /// terminal from the scope you just left is precisely the thing the scope
     /// exists to stop showing — and the panes (files, git, issues) follow the
     /// selected session, so leaving it behind would leave them on the old repo.
     func switchToWorkspace(_ id: Workspace.ID) {
-        guard workspaces.contains(where: { $0.id == id }) else { return }
-        guard currentWorkspaceID != id else { return }
+        guard let target = workspaces.first(where: { $0.id == id }),
+              currentWorkspaceID != id
+        else { return }
         // The switch itself, and nothing else: the column is the answer to
         // "which workspace", and it can be drawn knowing only this. Timed
         // separately from the settle below, because the two are what the user
         // means by "the switch" and by "everything after it" — reporting them
         // as one number is how a fast switch reads as a slow one.
         let span = Trace.workspace.begin("workspace switch")
-        defer { Trace.workspace.end(span) }
+        defer { Trace.workspace.end(span, "to=\(target.name)") }
         // Explicitly un-animated. The column's rows are replaced wholesale by a
         // switch — nothing moves from one place to another — so there is no
-        // motion for an animation to describe, and an ambient one (the footer
-        // capsule's, a section's collapse) would still catch this change and
-        // drag the whole hosted tree through an animated relayout. A profile of
-        // the switch is mostly `NSHostingView.layout()` inside
-        // `NSAnimationContext.runAnimationGroup`; this is what takes it out.
+        // motion for an animation to describe, and an ambient one (a section's
+        // collapse) would still catch this change and drag the whole hosted tree
+        // through an animated relayout. A profile of the switch is mostly
+        // `NSHostingView.layout()` inside `NSAnimationContext.runAnimationGroup`;
+        // this is what takes it out.
         var instant = Transaction()
         instant.disablesAnimations = true
         withTransaction(instant) {
@@ -266,9 +267,9 @@ extension TermioStore {
     }
 
     /// The half of a workspace switch that is about the session, run a turn after
-    /// the column is drawn. Guarded by `workspaceArrival`, so a user who keeps
-    /// swiping only ever settles the workspace they stopped on — the intermediate
-    /// ones never open a file or ask a machine anything.
+    /// the column is drawn. Guarded by `workspaceArrival`, so a user stepping
+    /// through scopes (⌃⌥⌘1…9) only ever settles the one they stop on — the
+    /// intermediate ones never open a file or ask a machine anything.
     private func finishArriving(in id: Workspace.ID) {
         let span = Trace.workspace.begin("workspace settle")
         defer { Trace.workspace.end(span) }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -47,8 +47,9 @@ final class TermioStore: ObservableObject {
     }
 
     /// Counts arrivals in a workspace, so the work a switch defers can tell
-    /// whether it is still wanted. A user mid-swipe passes through scopes they
-    /// never stop on; only the last arrival settles (see `finishArriving`).
+    /// whether it is still wanted. A user stepping through scopes passes through
+    /// ones they never stop on; only the last arrival settles (see
+    /// `finishArriving`).
     var workspaceArrival: UInt64 = 0
 
     /// Which workspace the sidebar is showing. Live state, like the selection —
@@ -99,10 +100,10 @@ final class TermioStore: ObservableObject {
                 if let pid = project(for: id)?.id { noteProjectActivity(pid, force: true) }
             }
             // Debounced, not inline: moving the selection is the most frequent
-            // edit in the app — every row click, every ⌘⇧], every step of a
-            // workspace swipe — and a synchronous encode-and-write of the whole
-            // tree on each one is a hitch the user feels as the switch being
-            // slow. The quit path flushes whatever is still pending.
+            // edit in the app — every row click, every ⌘⇧], every workspace
+            // switch — and a synchronous encode-and-write of the whole tree on
+            // each one is a hitch the user feels as the switch being slow. The
+            // quit path flushes whatever is still pending.
             persistSoon()
         }
     }
@@ -1345,12 +1346,6 @@ final class TermioStore: ObservableObject {
         runtimes[sessionID]?.workingDirectory
     }
 
-    /// Acknowledge a resting "your turn" cue: a finished (`.done`) or blocked
-    /// (`.needsAttention`) session the user has now engaged with drops back to
-    /// `.idle`, clearing its sidebar/tray dot. A mid-turn `.working` is left
-    /// alone — its spinner isn't a cue to dismiss. Idempotent, and unlike the
-    /// `selectedSessionID` didSet it doesn't require the selection to *change*, so
-    /// re-clicking the session you're already on still clears the dot.
     /// Whether the user is plausibly looking at this session right now: termio is
     /// the active app and the session is selected. The status paths use it to pick
     /// between a quiet in-place settle and a "your turn" cue — with termio in the
@@ -1360,6 +1355,12 @@ final class TermioStore: ObservableObject {
         NSApp.isActive && selectedSessionID == id
     }
 
+    /// Acknowledge a resting "your turn" cue: a finished (`.done`) or blocked
+    /// (`.needsAttention`) session the user has now engaged with drops back to
+    /// `.idle`, clearing its sidebar/tray dot. A mid-turn `.working` is left
+    /// alone — its spinner isn't a cue to dismiss. Idempotent, and unlike the
+    /// `selectedSessionID` didSet it doesn't require the selection to *change*, so
+    /// re-clicking the session you're already on still clears the dot.
     func markSeen(_ id: Session.ID) {
         // Engaging with the session makes any delivered banner stale too.
         TaskNotificationCenter.shared.withdraw(for: id)

--- a/Tests/termioTests/TermiodStatusTests.swift
+++ b/Tests/termioTests/TermiodStatusTests.swift
@@ -140,7 +140,7 @@ final class TermiodStatusTests: XCTestCase {
     }
 
     /// The reason a row's session died is addressable from the row.
-    func testAnEndReasonIsFoundBySessionID() throws {
+    func testAnEndReasonIsFoundFromItsSession() throws {
         let session = Session(title: "agent", agent: .terminal)
         let store = makeStore(with: session)
         let name = session.id.uuidString
@@ -148,7 +148,7 @@ final class TermiodStatusTests: XCTestCase {
         store.recordTombstones(
             [try tombstone(name: name, reason: "daemon_lost")], live: [], persisted: [name])
 
-        XCTAssertEqual(store.termiodEndReason(for: session.id)?.reason, "daemon_lost")
+        XCTAssertEqual(store.termiodEndReason(for: session)?.reason, "daemon_lost")
     }
 
     /// A name that comes back alive buries its own grave. Tombstones merge rather
@@ -161,10 +161,10 @@ final class TermiodStatusTests: XCTestCase {
 
         store.recordTombstones(
             [try tombstone(name: name, reason: "daemon_lost")], live: [], persisted: [name])
-        XCTAssertNotNil(store.termiodEndReason(for: session.id))
+        XCTAssertNotNil(store.termiodEndReason(for: session))
 
         store.recordTombstones([], live: [try live(name: name)], persisted: [name])
-        XCTAssertNil(store.termiodEndReason(for: session.id))
+        XCTAssertNil(store.termiodEndReason(for: session))
     }
 
     /// Another client's sessions share the daemon but not the sidebar. Keeping
@@ -178,6 +178,6 @@ final class TermiodStatusTests: XCTestCase {
             live: [], persisted: [session.id.uuidString])
 
         XCTAssertTrue(store.termiodTombstones.isEmpty)
-        XCTAssertNil(store.termiodEndReason(for: session.id))
+        XCTAssertNil(store.termiodEndReason(for: session))
     }
 }


### PR DESCRIPTION
Pure subtraction. The workspace refactor built two surfaces and then removed them — the trackpad swipe and the footer dots — and moved a third, the device roster's ended and not-started rows, into the tree. The code that served them stayed behind.

**Gone because nothing calls it:** `WorkspaceSpaces.neighbor(step:in:)` (the swipe's only reader), `isLooseChat(_:)`, `DeviceRoster.current(_:known:)`, `FileTreeCache.forget(_:)` and `removeAll()`, and the `Session.ID` overload of `termiodEndReason` — its only callers were its own tests, which now ask with the session, the way the sidebar does.

**Folded in:** `WorkspaceSpaces` had two members left and both were the store's own work. The ordering becomes `TermioStore.orderedWorkspaces`, beside `orderedProjects`. `WorkspaceSwitcherMenuContent` folds into the one control that mounts it.

**One real bug:** `WorkspaceSpaces.select` wrapped `switchToWorkspace` in a second Trace span named the same as the one inside it, so every switch reported itself twice. The name now rides the surviving span. The five spans the latency doc cites — switch, column, settle, selection, device — are otherwise untouched.

**Narrowed:** `deviceWorld()` built three kinds of row for a caller that keeps one. It now returns what that caller asks for, and `DeviceWorldRow` goes with it.

The rest is comments: a swipe, footer dots and a footer capsule that no longer exist, a device switcher that is a workspace switcher now, and two doc comments stranded above the wrong declaration.

116 insertions, 256 deletions.

## Verified

`swift build`, `swift test` (405 tests, 0 failures), `./scripts/check-strings.sh` — run on the rebased branch, not just before the rebase.

No behaviour change, so there is nothing new to look at. The visual items still awaiting human eyes are the ones #345 listed, unchanged by this.

Release Notes:
No user-facing change.