### PR TITLE
Rebuild the docs typography and fix the mobile header

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,11 @@
 name: Docs
 
-# The docs site rots in two mechanical ways, so both are checked rather than
+# The docs site rots in mechanical ways, so each is checked rather than
 # remembered: the changelog falling behind the shipped releases (it once stopped
-# twelve releases back, which reads as an abandoned project), and a translation
-# drifting from the English page it was made from. The keyboard-shortcut table is
+# twelve releases back, which reads as an abandoned project), a translation
+# drifting from the English page it was made from, and an internal link or
+# `#anchor` pointing at a page or heading that has since been renamed — links are
+# just strings in MDX, so a build never notices. The keyboard-shortcut table is
 # generated from the app's own command catalog and checked here too — the docs
 # described a pane gesture for two releases after it was replaced.
 on:
@@ -48,6 +50,12 @@ jobs:
         working-directory: web/landing
         run: node scripts/sync-keybindings.mjs --check
 
-      - name: Check the changelog and the translations
+      - name: Check the changelog, the translations, and the internal links
         working-directory: web/landing
         run: node scripts/docs-check.mjs
+
+      # The link check is only as good as its slugifier: one that disagrees with
+      # the renderer rejects correct anchors, which teaches everyone to ignore it.
+      - name: Test the anchor rules
+        working-directory: web/landing
+        run: node --test "scripts/*.test.mjs"

--- a/web/landing/content/docs/agents.mdx
+++ b/web/landing/content/docs/agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Running multiple agents
-description: Keep a fleet of agents side by side, read their live status at a glance, and let Termio's hooks tell you the moment one needs you.
+description: Keep a fleet of agents side by side, read their live status at a glance, and let Termio’s hooks tell you the moment one needs you.
 ---
 
 Termio is built for running more than one agent at once. The sidebar is your
@@ -22,7 +22,7 @@ Termio recognizes the common coding agents out of the box:
 | Copilot | `copilot` |
 | Cursor | `cursor-agent` |
 
-Any of these that's installed on your `PATH` appears as a launch option. A plain
+Any of these that’s installed on your `PATH` appears as a launch option. A plain
 shell is always available too. Running something else? Any CLI can become a
 first-class agent — see [Custom agents](/docs/custom-agents).
 
@@ -37,8 +37,8 @@ first-class agent — see [Custom agents](/docs/custom-agents).
 
 Every session row carries a live status dot — **working**, **idle**, **done**, or
 **needs you**. Termio derives these from a mix of signals: the
-agent's own hooks where it exposes them, and the terminal's output otherwise, so
-the sidebar stays honest even for agents that don't emit structured events. The
+agent’s own hooks where it exposes them, and the terminal’s output otherwise, so
+the sidebar stays honest even for agents that don’t emit structured events. The
 [sidebar guide](/docs/sidebar#status) explains what each state means, and
 [Session control](/docs/session-control) covers the opt-in hooks that make them
 sharpest.
@@ -53,8 +53,8 @@ sharpest.
 ## Switching without losing your place
 
 Clicking a session brings it forward instantly; the others keep running in the
-background. Because each session is a real process, an agent doesn't pause when
-it's off-screen — you can kick off a long run in one, switch to another, and come
+background. Because each session is a real process, an agent doesn’t pause when
+it’s off-screen — you can kick off a long run in one, switch to another, and come
 back when the first raises its hand. When you have more than a handful of
 sessions, `⇧⌘O` jumps straight to any of them by name — see
 [Navigation](/docs/navigation).

--- a/web/landing/content/docs/agents.zh-CN.mdx
+++ b/web/landing/content/docs/agents.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 同时运行多个 Agent
 description: 让一支 Agent 队伍并排工作，一眼读出它们的实时状态，并让 Termio 的 hooks 在某一个需要你时立刻告诉你。
 x-i18n:
   source_path: agents.mdx
-  source_hash: d27bfb6603af316d63460e973bfab02241213c91741f38412cc3dbf671ddbc28
-  generated_at: 2026-08-16
+  source_hash: 8ac6848bfb17ca95af32fdaf57a358997e9e44ef61b49be23ea4e016b3152054
+  generated_at: 2026-08-18
 ---
 
 Termio 就是为同时运行多个 Agent 造的。侧栏是你的控制台：每个会话是一行，每一行都汇报

--- a/web/landing/content/docs/appearance.mdx
+++ b/web/landing/content/docs/appearance.mdx
@@ -1,10 +1,10 @@
 ---
 title: Appearance
-description: Set your terminal theme and font, tune the cursor and window, and find the rest of Termio's settings — all in a familiar macOS settings window.
+description: Set your terminal theme and font, tune the cursor and window, and find the rest of Termio’s settings — all in a familiar macOS settings window.
 ---
 
-Open **Settings** with `⌘,`. It's a standard macOS settings window with a sidebar
-of tabs; **Appearance** is where the terminal's look lives.
+Open **Settings** with `⌘,`. It’s a standard macOS settings window with a sidebar
+of tabs; **Appearance** is where the terminal’s look lives.
 
 ## Theme
 
@@ -12,7 +12,7 @@ Termio uses Ghostty-format themes, so anything from the wider Ghostty theme
 ecosystem works. Pick a light and a dark theme from **Settings ▸ Appearance** and
 Termio follows the system between them.
 
-The two slots list the themes you have — Termio's own canvas plus whatever is in
+The two slots list the themes you have — Termio’s own canvas plus whatever is in
 your Themes folder — not a catalog of hundreds you never chose.
 
 <DocsImage
@@ -22,7 +22,7 @@ your Themes folder — not a catalog of hundreds you never chose.
   height={1288}
 />
 
-If you already use Ghostty, there's nothing to pick on a fresh install: Termio
+If you already use Ghostty, there’s nothing to pick on a fresh install: Termio
 reads your `~/.config/ghostty/config` on first launch and starts with the font and
 theme you chose there.
 
@@ -50,7 +50,7 @@ back.
   height={1664}
 />
 
-To add a theme the store doesn't carry, drop a Ghostty-format theme file into:
+To add a theme the store doesn’t carry, drop a Ghostty-format theme file into:
 
 ```
 ~/Library/Application Support/termio/Themes/
@@ -69,8 +69,8 @@ while you work — `⌘=` to grow, `⌘-` to shrink, `⌘0` to reset.
 
 The same tab tunes the cursor (block, bar, or underline; steady or blinking) and
 the window itself — padding around the terminal, and background opacity and blur
-for a translucent window over your desktop. The app's own chrome lives here too:
-the sidebar's font and density.
+for a translucent window over your desktop. The app’s own chrome lives here too:
+the sidebar’s font and density.
 
 ## The rest of Settings
 
@@ -86,7 +86,7 @@ The other tabs cover the rest of the app:
 - **Agents** — add agents, enable them, and turn on [session
   control](/docs/session-control).
 - **Usage** — token usage for agents you sign in to (Claude Code, Codex). Termio
-  reuses each CLI's own credentials to show you where you stand against your
+  reuses each CLI’s own credentials to show you where you stand against your
   limits; it stores nothing of its own.
 - **Mobile** — pairing and remote access for the [iPhone
   companion](/docs/iphone).

--- a/web/landing/content/docs/appearance.zh-CN.mdx
+++ b/web/landing/content/docs/appearance.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 外观
 description: 设置终端主题与字体、调整光标和窗口，并找到 Termio 其余的设置项——全都在一个熟悉的 macOS 设置窗口里。
 x-i18n:
   source_path: appearance.mdx
-  source_hash: e8eb9019cf1010d0c4013610aa7653b3cfff28f4016b544cac295f70ff5cf40b
-  generated_at: 2026-08-16
+  source_hash: 23a5863094895c0f387f35eeb232219da6227771895d21e8f5a7161738c4c8aa
+  generated_at: 2026-08-18
 ---
 
 用 `⌘,` 打开 **设置**。这是一个标准的 macOS 设置窗口，左侧一列标签页；**外观** 就是

--- a/web/landing/content/docs/atp.mdx
+++ b/web/landing/content/docs/atp.mdx
@@ -1,17 +1,17 @@
 ---
 title: Agent Terminal Protocol
-description: ATP is how Termio hosts any agent CLI — one JSON manifest declaring how to launch it, how it reports status, and how to resume its exact conversation. The agent's own TUI stays in a real terminal.
+description: ATP is how Termio hosts any agent CLI — one JSON manifest declaring how to launch it, how it reports status, and how to resume its exact conversation. The agent’s own TUI stays in a real terminal.
 ---
 
 Editor protocols re-render your agent inside an editor pane. ATP takes the
-opposite bet: the agent's own TUI already is the interface, so it stays in a real
+opposite bet: the agent’s own TUI already is the interface, so it stays in a real
 terminal, and the protocol standardizes only the thin layer around it —
 **launch**, **live status**, and **exact resume**. Every agent Termio ships is
 defined by this same manifest; there is no privileged internal API.
 
 ## The manifest
 
-One JSON file per agent. This is Termio's bundled Grok manifest, verbatim:
+One JSON file per agent. This is Termio’s bundled Grok manifest, verbatim:
 
 ```json
 {
@@ -52,10 +52,10 @@ One JSON file per agent. This is Termio's bundled Grok manifest, verbatim:
 | --- | --- |
 | `id` | Stable identifier. Sessions persist it, so it never changes once shipped. |
 | `name` | Display name in the picker and sidebar. |
-| `command` | The CLI to launch, resolved on your login shell's `PATH`. |
-| `permissionBypassFlag` | The vendor's skip-permissions flag, wired to a one-click toggle. Optional. |
+| `command` | The CLI to launch, resolved on your login shell’s `PATH`. |
+| `permissionBypassFlag` | The vendor’s skip-permissions flag, wired to a one-click toggle. Optional. |
 | `icon` | `vector` (a built-in brand mark), `path` (your PNG/SVG file), or `symbol` (an SF Symbol), with an optional `tint`. |
-| `install` | The vendor's install page, offered when the command isn't found. Optional. |
+| `install` | The vendor’s install page, offered when the command isn’t found. Optional. |
 | `order` | Position in the agent picker. Optional; omitted manifests sort last. |
 
 ## Status
@@ -67,11 +67,11 @@ channels:
 
 | Channel | Role |
 | --- | --- |
-| `hooks` | The precise channel: Termio installs the agent's own hook configuration (JSON, TOML, or a plugin, per `dialect`) so the agent itself reports each `on → state` event. When hooks are declared they are the single source of truth. |
-| `titleStatus` | Regex rules over the agent's live terminal title (OSC 0/2) — the in-band signal some agents broadcast. Coexists with hooks and corrects a missed event the instant the title flips. |
+| `hooks` | The precise channel: Termio installs the agent’s own hook configuration (JSON, TOML, or a plugin, per `dialect`) so the agent itself reports each `on → state` event. When hooks are declared they are the single source of truth. |
+| `titleStatus` | Regex rules over the agent’s live terminal title (OSC 0/2) — the in-band signal some agents broadcast. Coexists with hooks and corrects a missed event the instant the title flips. |
 | `status` | Screen-classification regexes for agents with no hook system at all. Ignored when hooks are declared. |
 
-`hooks.conversation` names where the agent's own session id appears in its hook
+`hooks.conversation` names where the agent’s own session id appears in its hook
 payloads (a stdin JSON field for shell hooks, an event key path for plugins).
 With it, each status report also carries conversation *identity* — so when the
 agent rotates to a new conversation mid-session (`/new`, `/clear`), Termio
@@ -86,14 +86,15 @@ which fields are present:
 
 **Pinned id** — the CLI accepts a session id at launch. `create` starts a fresh
 conversation under a Termio-minted id and `resume` continues it; `storeRoot` +
-`storeMatch` describe the agent's on-disk session store so Termio can tell the
+`storeMatch` describe the agent’s on-disk session store so Termio can tell the
 two apart (creating a duplicate id errors, as does resuming a missing one).
 
 **Discovered id** — the agent mints the id itself. `discover` describes the
-mechanism, never an agent: where session records live, how a record is read
-(`jsonl` — the first line of a log that is itself the transcript, or `json` — a
-standalone metadata file), and key paths to the id and working directory.
-Termio recovers the id, binds it to the tab, and resumes exactly from then on.
+mechanism, never an agent: where session records live, how a record is read, and
+key paths to the id and working directory. A record is either `jsonl` (the first
+line of a log that is itself the transcript) or `json` (a standalone metadata
+file). Termio recovers the id, binds it to the tab, and resumes exactly from
+then on.
 
 ```json
 "resume": {

--- a/web/landing/content/docs/atp.zh-CN.mdx
+++ b/web/landing/content/docs/atp.zh-CN.mdx
@@ -3,8 +3,8 @@ title: Agent 终端协议
 description: ATP 是 Termio 托管任意 Agent 命令行工具的方式——一份 JSON 清单声明如何启动它、它如何汇报状态、如何精确恢复那段对话。Agent 自己的 TUI 始终留在真实终端里。
 x-i18n:
   source_path: atp.mdx
-  source_hash: cc00b0a0dda4c1c7626a24427f92833ae369bb83598583123ef554236d37d563
-  generated_at: 2026-08-10
+  source_hash: ddaac7ba90facb8742421a55ce91330612319489c8673ffd79a63eea794ad86c
+  generated_at: 2026-08-18
 ---
 
 编辑器类协议把你的 Agent 重新渲染进编辑器面板。ATP 押的是相反的注：Agent 自己的 TUI
@@ -88,9 +88,9 @@ API。
 两者（创建重复 id 会报错，恢复不存在的 id 也会）。
 
 **发现式 id** —— id 由 Agent 自己生成。`discover` 描述的是机制，而不是某个 Agent：会话记录
-存在哪里、一条记录怎么读（`jsonl` —— 日志的第一行，而这份日志本身就是对话记录；或 `json`
-—— 一个独立的元数据文件），以及指向 id 和工作目录的键路径。Termio 找回这个 id，把它绑定到
-标签上，从此精确恢复。
+存在哪里、一条记录怎么读，以及指向 id 和工作目录的键路径。一条记录要么是 `jsonl`（日志的
+第一行，而这份日志本身就是对话记录），要么是 `json`（一个独立的元数据文件）。Termio 找回
+这个 id，把它绑定到标签上，从此精确恢复。
 
 ```json
 "resume": {

--- a/web/landing/content/docs/concepts.mdx
+++ b/web/landing/content/docs/concepts.mdx
@@ -9,10 +9,10 @@ docs read quickly.
 
 ## Project
 
-A project is a folder on your Mac — usually a repository. It's the unit the
+A project is a folder on your Mac — usually a repository. It’s the unit the
 sidebar groups by, and the working directory every session inside it starts in.
 
-Opening a project doesn't copy or index anything. Termio remembers the path and
+Opening a project doesn’t copy or index anything. Termio remembers the path and
 reads git for the rest.
 
 ## Session
@@ -20,7 +20,7 @@ reads git for the rest.
 A session is one real terminal running one thing: an agent, a dev server, or a
 plain shell. Each session owns a PTY — the same kind of terminal `ssh` or
 Terminal.app gives a process — and Termio renders it with
-[libghostty](https://ghostty.org), Ghostty's terminal core.
+[libghostty](https://ghostty.org), Ghostty’s terminal core.
 
 Two properties matter:
 
@@ -36,18 +36,18 @@ Two properties matter:
   workspace — the session tree, which session was selected, the inspector layout
   — so relaunching restores the same list with fresh shells. Sessions that survive
   a quit (and a laptop lid) are what the `termiod` session host is being built
-  for; they are not what today's app does.
+  for; they are not what today’s app does.
 </Callout>
 
 ## Pane
 
-A pane is a session's slot on screen. One session normally fills the window, and
+A pane is a session’s slot on screen. One session normally fills the window, and
 splitting *groups* another session beside it — an agent on the left, a dev server
 and a shell on the right.
 
 Panes are a view concern, not a second kind of session: the thing in a pane is a
-full session with its own sidebar row and its own status. That's why the verbs are
-**Group with** and **Ungroup** rather than "split" and "close pane" — grouping
+full session with its own sidebar row and its own status. That’s why the verbs are
+**Group with** and **Ungroup** rather than “split” and “close pane” — grouping
 changes how sessions are arranged, not what they are.
 
 <DocsImage
@@ -62,7 +62,7 @@ See [Keyboard shortcuts](/docs/keyboard#panes) for the bindings.
 ## Worktree
 
 A git worktree is a second checkout of the same repository on its own branch. When
-two agents work one repo at once, worktrees are what keep them out of each other's
+two agents work one repo at once, worktrees are what keep them out of each other’s
 files.
 
 Termio reads them from git (`git worktree list`) rather than tracking its own copy,
@@ -72,34 +72,34 @@ is the source of truth. See [Git worktrees](/docs/worktrees).
 
 ## Status
 
-Every session reports what it's doing right now. There are four states, and the
+Every session reports what it’s doing right now. There are four states, and the
 distinction between the last two is the point of the whole model:
 
 | Status | Meaning | How it looks |
 | --- | --- | --- |
-| `idle` | Nothing pending, or you're already looking at it. | No mark |
-| `working` | The agent is processing a turn. | The comet replaces the session's icon |
+| `idle` | Nothing pending, or you’re already looking at it. | No mark |
+| `working` | The agent is processing a turn. | The comet replaces the session’s icon |
 | `done` | The agent finished while you were elsewhere. | A green dot — *ready for you* |
 | `needs-you` | The agent is blocked on you: a permission prompt, a question. | An orange ring — *waiting on you* |
 
 A finished turn is `done`, never `needs-you`. Conflating the two is what makes a
 fleet of agents feel like a pile of alarms: if everything demands attention,
-nothing does. Termio keeps "ready" calm and reserves the loud state for an agent
+nothing does. Termio keeps “ready” calm and reserves the loud state for an agent
 that genuinely cannot continue without you.
 
-These statuses roll up: a project's row summarizes its sessions, and the menu-bar
+These statuses roll up: a project’s row summarizes its sessions, and the menu-bar
 tray summarizes everything, so you can watch a fleet from another app.
 
 ### Where the signal comes from
 
-Termio doesn't guess from pixels where it doesn't have to. It reads, in order of
+Termio doesn’t guess from pixels where it doesn’t have to. It reads, in order of
 authority:
 
-1. **The agent's own hooks.** On first run Termio writes its status hooks into the
+1. **The agent’s own hooks.** On first run Termio writes its status hooks into the
    config of each agent that supports them, so the agent reports its own turns.
    Nothing for you to configure. See [Session control](/docs/session-control).
 2. **In-band terminal signals.** Progress and title sequences an agent already
-   emits (`OSC 9;4`, `OSC 777`) are read straight off the stream — that's how Grok
+   emits (`OSC 9;4`, `OSC 777`) are read straight off the stream — that’s how Grok
    reports busy and idle without hooks.
 3. **The screen, as a last resort.** For an agent with neither, Termio watches the
    pane for the shape of a prompt waiting on input, and promotes a status only

--- a/web/landing/content/docs/concepts.zh-CN.mdx
+++ b/web/landing/content/docs/concepts.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 核心概念
 description: Termio 由四个名词构成——项目、会话、窗格、worktree——再加上一套状态模型，告诉你哪个 Agent 需要你。
 x-i18n:
   source_path: concepts.mdx
-  source_hash: 79ea4374780c6376ba9d3b511d3d106a5f7b079102836325309fc3962cd4ffc2
-  generated_at: 2026-08-16
+  source_hash: 8c32ec93fa6031356ab16be072252663548fb048dc2ccf12336e003866e28b05
+  generated_at: 2026-08-18
 ---
 
 Termio 是一个用来同时运行多个编程 Agent 的终端。应用里的一切都由四个名词和一套状态

--- a/web/landing/content/docs/custom-agents.mdx
+++ b/web/landing/content/docs/custom-agents.mdx
@@ -10,14 +10,14 @@ Agents list, and the sidebar with its own name, icon, and live status — exactl
 like Claude Code or Codex.
 
 <Callout type="note">
-  You don't *need* a manifest to run an arbitrary CLI — you can always launch a
+  You don’t *need* a manifest to run an arbitrary CLI — you can always launch a
   plain shell and run it there. A manifest is what promotes it to a real agent
   with an icon and status detection.
 </Callout>
 
 ## Add an agent
 
-Drop a JSON file into your config folder, named after the agent's `id`:
+Drop a JSON file into your config folder, named after the agent’s `id`:
 
 ```
 ~/.termio/config/agents/<id>.json
@@ -45,7 +45,7 @@ reorder, or tweak its command from **Settings ▸ Agents** like any other.
 />
 
 <Callout type="tip">
-  Use a built-in's `id` (for example `claudeCode`) as your filename to **override**
+  Use a built-in’s `id` (for example `claudeCode`) as your filename to **override**
   it — handy for launching Claude Code through a wrapper script while keeping its
   icon and hooks.
 </Callout>
@@ -60,8 +60,8 @@ reorder, or tweak its command from **Settings ▸ Agents** like any other.
 | `icon` | | An icon — see below. Defaults to a generic glyph. |
 | `status` | | Screen-scrape rules for live status — see below. |
 | `resume` | | How a reopened session continues its exact conversation — an object of launch-argument templates and a session-store descriptor. See the [Agent Terminal Protocol](/docs/atp#resume). Omit it and every launch starts fresh. |
-| `permissionBypassFlag` | | A flag appended when you toggle "skip permission prompts" for this agent. |
-| `tint` | | A hex color (e.g. `"#14B8A6"`) used to tint the "working" spinner. |
+| `permissionBypassFlag` | | A flag appended when you toggle “skip permission prompts” for this agent. |
+| `tint` | | A hex color (e.g. `"#14B8A6"`) used to tint the “working” spinner. |
 
 ### Icon
 
@@ -79,9 +79,9 @@ For `path`, put the image file next to the `.json` in the same folder.
 
 ### Live status
 
-If your agent doesn't ship a hook system, Termio can still read its status by
+If your agent doesn’t ship a hook system, Termio can still read its status by
 matching regular expressions against the terminal screen. List patterns that mean
-"busy" under `working` and patterns that mean "waiting on you" under `attention`:
+“busy” under `working` and patterns that mean “waiting on you” under `attention`:
 
 ```json
 "status": {
@@ -91,7 +91,7 @@ matching regular expressions against the terminal screen. List patterns that mea
 ```
 
 A line matching `attention` flips the session to **needs you** (the key keeps the
-protocol's name; it wins over `working`, since a prompt can sit under a
+protocol’s name; it wins over `working`, since a prompt can sit under a
 still-spinning header); a line matching `working` marks it **working**. See the
 [sidebar status reference](/docs/sidebar#status) for what each state means.
 

--- a/web/landing/content/docs/custom-agents.zh-CN.mdx
+++ b/web/landing/content/docs/custom-agents.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 自定义 Agent
 description: 往 ~/.termio/config/agents 里放一个小小的 JSON 清单，就能让 Termio 认识任何命令行工具——给它名字、图标和实时状态识别，它就和内置 Agent 一样是一等公民。
 x-i18n:
   source_path: custom-agents.mdx
-  source_hash: 36b5baf646e8763d991681d0e60e28fea955d3e20afe03d506eb907f0faeef00
-  generated_at: 2026-08-16
+  source_hash: 0e87be1ce606e7b0f2a09299ab9ca2ab42f81068bf8a1fca8322413da7bbe9e9
+  generated_at: 2026-08-18
 ---
 
 Termio 内置了常见的编程 Agent，但这个目录是开放的：任何命令行工具都能成为一等 Agent。

--- a/web/landing/content/docs/first-session.mdx
+++ b/web/landing/content/docs/first-session.mdx
@@ -4,7 +4,7 @@ description: Open a project, launch an agent in a real terminal, and split the w
 ---
 
 A *session* in Termio is a real terminal running one thing — an agent, a dev
-server, or a plain shell. Here's the path from a fresh launch to a working setup.
+server, or a plain shell. Here’s the path from a fresh launch to a working setup.
 
 ## Open a project
 
@@ -24,12 +24,12 @@ just a working directory — the agents you launch inside it start there.
 With a project selected, start a new session and pick an agent — Claude Code,
 Codex, Gemini, or any other CLI you have installed. Termio opens it in a real
 terminal at the project root. You type into it exactly as you would in any
-terminal; the agent's TUI renders natively.
+terminal; the agent’s TUI renders natively.
 
-The sidebar shows the session's live status — **working**, **idle**, **done**, or
+The sidebar shows the session’s live status — **working**, **idle**, **done**, or
 **needs you**. [Concepts](/docs/concepts#status) explains all four; the one to
 watch for is **needs you**, which means the agent is blocked on a prompt or a
-permission and can't continue without you.
+permission and can’t continue without you.
 
 <Callout type="tip">
   Kick off a long run in one session, switch to another, and let the sidebar tell
@@ -50,8 +50,8 @@ Most real work wants more than one pane. Split the current pane to the right wit
 agent in one, your dev server in another, a shell in a third. Panes tile as a
 tree, so you can nest splits into any layout.
 
-To rearrange a layout, hover a pane's header and drag the grab handle that
-appears. A highlight previews where the pane will land: drop on another pane's
+To rearrange a layout, hover a pane’s header and drag the grab handle that
+appears. A highlight previews where the pane will land: drop on another pane’s
 left, right, top, or bottom half to place it on that side, or on the center to
 swap the two panes.
 
@@ -71,7 +71,7 @@ rebindable — see [Keyboard shortcuts](/docs/keyboard).
 Sessions are live processes, not saved transcripts. When you quit Termio, the
 shells and agents exit — reopening the app starts fresh. The read-only session
 trace (see the **Info** pane) keeps a rendered record of what happened, but the
-running process itself doesn't survive a quit.
+running process itself doesn’t survive a quit.
 
 <DocsImage
   src="/screenshots/docs/24-info-trace.png"
@@ -81,7 +81,7 @@ running process itself doesn't survive a quit.
 />
 
 <Callout type="warning">
-  Quitting Termio ends every running agent and shell. Long agent runs don't
+  Quitting Termio ends every running agent and shell. Long agent runs don’t
   survive an app restart — leave Termio open while they work.
 </Callout>
 

--- a/web/landing/content/docs/first-session.zh-CN.mdx
+++ b/web/landing/content/docs/first-session.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 你的第一个会话
 description: 打开项目，在真实终端里启动 Agent，再拆分窗口，让开发服务器和一个 shell 并排待在旁边。
 x-i18n:
   source_path: first-session.mdx
-  source_hash: 6cd0efa7d30a56014531d29d1a892b6c47072ed5ce1abae0ce486ee1a4702eb9
-  generated_at: 2026-08-16
+  source_hash: a816060566ecde7aeb04a9e2ebae669a16b466951270a45ed65ac8650b6426bc
+  generated_at: 2026-08-18
 ---
 
 Termio 里的*会话*就是一个真实终端，跑着一件事——一个 Agent、一个开发服务器，或者

--- a/web/landing/content/docs/index.mdx
+++ b/web/landing/content/docs/index.mdx
@@ -12,7 +12,7 @@ and stays on your own Mac.
 
 - **A real terminal per agent.** Claude Code, Codex, Gemini, Amp, Pi, OpenCode,
   Copilot and Cursor each run in a genuine PTY — not a re-rendered chat log.
-  What you'd see in iTerm is exactly what you see here.
+  What you’d see in iTerm is exactly what you see here.
 - **A sidebar of sessions.** Every agent and shell is one click away. Statuses
   update live, so you can see which agent is working, which is idle, and which
   needs your attention.
@@ -31,7 +31,7 @@ and stays on your own Mac.
 
 Termio has no account, no sign-in, and no telemetry. Your terminals, code and
 agent conversations never pass through servers of ours — there are none in the
-product's data path. The agents you run talk to their own providers under your
+product’s data path. The agents you run talk to their own providers under your
 own accounts, exactly as they would from a plain terminal.
 
 Termio is **free to use** — no account, no license keys, no payment backend.
@@ -46,7 +46,7 @@ Termio is **free to use** — no account, no license keys, no payment backend.
     Open a project, launch an agent in a real terminal, and split the window.
   </Card>
   <Card href="/docs/agents" title="Running multiple agents">
-    Keep a fleet side by side and read each one's live status at a glance.
+    Keep a fleet side by side and read each one’s live status at a glance.
   </Card>
   <Card href="/docs/session-control" title="Orchestration & the CLI">
     Let agents spawn, drive, and supervise each other with `termio sessions`.

--- a/web/landing/content/docs/index.zh-CN.mdx
+++ b/web/landing/content/docs/index.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 简介
 description: Termio 是一款原生 Mac 应用，为你的 AI 编程 Agent 提供工作台——Claude Code、Codex 以及其他 Agent 并排运行，各自待在真实终端里，所有数据都不离开你的机器。
 x-i18n:
   source_path: index.mdx
-  source_hash: 235aef706d21f5800c19b7656fda34bf060c0f899bb202651793a82eedaa4e6a
-  generated_at: 2026-08-10
+  source_hash: 80581a277bc958e750ad3061abf2f0bd6db7187428c3a33fc608440d933da3dc
+  generated_at: 2026-08-18
 ---
 
 Termio 是一款原生 Mac 应用，为你的 AI 编程 Agent 安了个家。你不必再在零散的终端

--- a/web/landing/content/docs/inspector.mdx
+++ b/web/landing/content/docs/inspector.mdx
@@ -3,7 +3,7 @@ title: The inspector
 description: Browse files, edit them with syntax highlighting, read the git diff, and search the project — a full side panel that never pulls you out of the terminal.
 ---
 
-The inspector is Termio's side panel for everything *around* the terminal:
+The inspector is Termio’s side panel for everything *around* the terminal:
 files, changes, and search. It sits beside your sessions so you can glance at
 code without switching apps.
 
@@ -11,7 +11,7 @@ code without switching apps.
 
 The file tree mirrors the working directory. Single-click a file to open it in a
 built-in editor with syntax highlighting, soft-wrap, and a live line/column
-readout. Edits auto-save — there's no save button. Images, PDFs, and HTML open
+readout. Edits auto-save — there’s no save button. Images, PDFs, and HTML open
 in a Quick Look preview instead.
 
 <DocsImage
@@ -53,14 +53,14 @@ The git pane has three read-only tabs:
   height={1664}
 />
 
-It's deliberately read-only: writing to git (commit, push, PR) stays in the
+It’s deliberately read-only: writing to git (commit, push, PR) stays in the
 terminal, where the agent and your own commands already live.
 
 ## Search
 
-The inspector's **Search** tab runs a content search across the project (backed
+The inspector’s **Search** tab runs a content search across the project (backed
 by `git grep`) and jumps you straight to the matching line in the editor — it
-searches inside files, not just filenames. This is the "find in files" you know
+searches inside files, not just filenames. This is the “find in files” you know
 from an editor.
 
 <DocsImage
@@ -70,12 +70,12 @@ from an editor.
   height={1664}
 />
 
-Looking for a file *by name* instead? That's [Open Quickly](/docs/navigation)
+Looking for a file *by name* instead? That’s [Open Quickly](/docs/navigation)
 (`⇧⌘O`), which also jumps between sessions and recent projects.
 
 ## Opening files from the terminal
 
-Cmd-click a file path in terminal output — even inside an agent's TUI — and
+Cmd-click a file path in terminal output — even inside an agent’s TUI — and
 Termio opens it in the editor. Cmd-click a URL to open it in your browser, or a
 `file://` link for a read-only preview overlay.
 

--- a/web/landing/content/docs/inspector.zh-CN.mdx
+++ b/web/landing/content/docs/inspector.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 检查器
 description: 浏览文件、带语法高亮地编辑、读 git 差异、搜索项目——一整块侧面板，永不把你从终端里拽出来。
 x-i18n:
   source_path: inspector.mdx
-  source_hash: b819a8f91967d9a35cbb611110137c5c886ccbd42c4fb62e67ecc4c0689fd1ad
-  generated_at: 2026-08-16
+  source_hash: e32ecf8a32ebc1c8efcb4bbda8a2cd876b8548a669abdf339d4e5e9539d8d730
+  generated_at: 2026-08-18
 ---
 
 检查器是 Termio 用来处理终端*周边*一切的侧面板：文件、更改和搜索。它就在会话旁边，

--- a/web/landing/content/docs/installation.mdx
+++ b/web/landing/content/docs/installation.mdx
@@ -4,11 +4,11 @@ description: Download Termio for macOS, drag it to Applications, and let Sparkle
 ---
 
 Termio runs on Apple silicon and Intel Macs from the same download. Installation is a normal drag-to-Applications
-— there's no account to create and no license key to enter.
+— there’s no account to create and no license key to enter.
 
 <Callout type="note" title="Before you begin">
   Termio needs macOS 14 or later, on Apple silicon or Intel. It hosts the agent
-  CLIs you already have installed — it doesn't bundle them.
+  CLIs you already have installed — it doesn’t bundle them.
 </Callout>
 
 ## Download and install
@@ -49,9 +49,9 @@ You can trigger a check any time from **Termio ▸ Check for Updates**.
 
 ## Bring your own agents
 
-Termio doesn't bundle the coding agents — it hosts the ones you already have on
+Termio doesn’t bundle the coding agents — it hosts the ones you already have on
 your Mac. Install whichever CLIs you use (for example `claude`, `codex`, or
-`gemini`) and make sure they're on your `PATH`. Termio launches each one in a
+`gemini`) and make sure they’re on your `PATH`. Termio launches each one in a
 login shell, so anything your shell profile sets up will be available.
 
 Once an agent is installed, it shows up as a launchable option when you start a
@@ -62,7 +62,7 @@ session.
 Termio ships a small command-line tool. Open **Settings ▸ General** and turn on
 **Command-line tool** to symlink `termio` onto your `PATH`. From then on
 `termio` in any directory opens it as a project, and `termio sessions …` lets your
-agents coordinate with each other. It's entirely optional — see
+agents coordinate with each other. It’s entirely optional — see
 [Session control & the CLI](/docs/session-control).
 
 ## Next steps

--- a/web/landing/content/docs/installation.zh-CN.mdx
+++ b/web/landing/content/docs/installation.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 安装
 description: 下载 macOS 版 Termio，拖进「应用程序」，之后交给 Sparkle 自动更新——无需账号，也没有许可证密钥。
 x-i18n:
   source_path: installation.mdx
-  source_hash: 50ca1991bff5daf950dc3fe6eed46f2765b1464163dd910e59d68252f430e62c
-  generated_at: 2026-08-16
+  source_hash: 97bf0afc2d426ddbb9e6cd8e2e45055667cf000b0fb973c0d8f1636cb735247b
+  generated_at: 2026-08-18
 ---
 
 Termio 用同一个下载包同时运行在 Apple 芯片和 Intel 的 Mac 上。安装就是普通的拖进「应用程序」——不用注册账号，

--- a/web/landing/content/docs/iphone.mdx
+++ b/web/landing/content/docs/iphone.mdx
@@ -5,7 +5,7 @@ description: Pair the Termio iOS app with your Mac over a QR code and check in o
 
 Termio for iPhone is a companion, not a separate service. It connects to exactly
 one place: the Termio app on your own Mac, over your local network or a tunnel
-you configure. There's no relay in between.
+you configure. There’s no relay in between.
 
 ## Pairing
 
@@ -13,7 +13,7 @@ you configure. There's no relay in between.
 2. In the iOS app, scan it. The camera is used only to read the code — scanning
    happens on-device and nothing is stored or transmitted.
 
-Once paired, the phone can reach your Mac's sessions whenever the two can see
+Once paired, the phone can reach your Mac’s sessions whenever the two can see
 each other on the network.
 
 <DocsImage
@@ -26,8 +26,8 @@ each other on the network.
 ## What you can do from the phone
 
 - **See your projects and sessions**, with the same live statuses as on the Mac,
-  plus a cross-project "Needs You" strip for the sessions waiting on input.
-- **Type straight into a session.** The phone drives the real terminal — you're
+  plus a cross-project “Needs You” strip for the sessions waiting on input.
+- **Type straight into a session.** The phone drives the real terminal — you’re
   typing into the agent exactly as on the desktop, with a key-bar for scrollback
   and jump keys, and hold-to-talk voice dictation if you enable it.
 - **Preview files** read-only over the same connection.
@@ -64,7 +64,7 @@ behind a tunnel you control (for example a named `cloudflared` tunnel) and pair
 against that address. Termio never routes your traffic through servers of ours.
 
 <Callout type="warning">
-  A Mac that's asleep can't answer the phone. For always-reachable access, keep
-  the Mac awake (Termio has a "keep reachable" toggle) or wake it with a
+  A Mac that’s asleep can’t answer the phone. For always-reachable access, keep
+  the Mac awake (Termio has a “keep reachable” toggle) or wake it with a
   second always-on device on your LAN.
 </Callout>

--- a/web/landing/content/docs/iphone.zh-CN.mdx
+++ b/web/landing/content/docs/iphone.zh-CN.mdx
@@ -3,8 +3,8 @@ title: iPhone 伴侣应用
 description: 用二维码把 Termio iOS 应用与你的 Mac 配对，随时用手机查看正在运行的 Agent——只连你自己的机器，不经过任何中继。
 x-i18n:
   source_path: iphone.mdx
-  source_hash: 1f5a89a0827ff042c20c37c007d0ae351de5a90969ddfc0612db0df7ec69eced
-  generated_at: 2026-08-16
+  source_hash: 098a7039697f81338ec7b1d91a8c82681ef73d9daa4baf958d06e233f5a14767
+  generated_at: 2026-08-18
 ---
 
 Termio for iPhone 是伴侣应用，不是另一个服务。它只连接一个地方：你自己 Mac 上的 Termio

--- a/web/landing/content/docs/keyboard.mdx
+++ b/web/landing/content/docs/keyboard.mdx
@@ -1,10 +1,10 @@
 ---
 title: Keyboard shortcuts
-description: Every shortcut Termio ships, read straight from the app's own command catalog — and how to rebind any of them under Settings ▸ Keyboard.
+description: Every shortcut Termio ships, read straight from the app’s own command catalog — and how to rebind any of them under Settings ▸ Keyboard.
 ---
 
 Termio is built to run from the keyboard. The tables below are generated from the
-app's command catalog, so they list exactly what this version ships. Every command
+app’s command catalog, so they list exactly what this version ships. Every command
 is rebindable — see [Customizing](#customizing).
 
 ## Sessions and projects
@@ -16,7 +16,7 @@ focused session — and puts the new session beside it, in the same project. New
 Terminal at Home always starts at `~`; it ships unbound, so bind it under
 [Customizing](#customizing) if that is the one you reach for.
 
-Cycling follows the sidebar's visual order, so `⇧⌘]` moves to the next session as
+Cycling follows the sidebar’s visual order, so `⇧⌘]` moves to the next session as
 you see it listed, not in the order the sessions were created.
 
 <Keybindings category="Session" />
@@ -36,20 +36,20 @@ jumps to *things* — sessions, projects, and files. See
 Split Left and Split Up ship unbound, the way Ghostty ships them: the two
 directions people reach for constantly get the keys, and the mirrored pair stays a
 menu verb until you bind it yourself. Both are always available from the Command
-Palette and the pane's context menu.
+Palette and the pane’s context menu.
 
 `⌘W` is **Ungroup** — it takes the focused pane out of the group and leaves the
 session running on its own. To end a session, use **Close Session** from the
-sidebar row's context menu.
+sidebar row’s context menu.
 
-Panes can also be rearranged with the mouse: hover a pane's header, grab the
+Panes can also be rearranged with the mouse: hover a pane’s header, grab the
 handle that appears, and drop the pane on a neighbour. A highlight previews the
 drop — an edge half places the pane on that side, the center swaps the two.
 
 ## Branches and worktrees
 
-Termio takes these two bindings from GitHub Desktop's Branch menu verbatim, where
-New Branch is `⇧⌘N`. Termio's branch-creation verb is the worktree.
+Termio takes these two bindings from GitHub Desktop’s Branch menu verbatim, where
+New Branch is `⇧⌘N`. Termio’s branch-creation verb is the worktree.
 
 <Keybindings category="Branch" />
 
@@ -61,7 +61,7 @@ New Branch is `⇧⌘N`. Termio's branch-creation verb is the worktree.
 
 <Keybindings category="Window" />
 
-The system shortcuts you'd expect work as usual — `⌘C` / `⌘V` to copy and paste,
+The system shortcuts you’d expect work as usual — `⌘C` / `⌘V` to copy and paste,
 `⌘A` to select all, `⌘,` for Settings, `⌘Q` to quit.
 
 ## Customizing
@@ -85,7 +85,7 @@ Only the shortcuts you change are written there — the defaults ship with the a
 so the file stays small and easy to read.
 
 A binding must include `⌘`. Without it, the chord would collide with what the
-terminal itself needs: an agent's TUI expects `⌃C`, `⌥←`, and the rest to reach it
+terminal itself needs: an agent’s TUI expects `⌃C`, `⌥←`, and the rest to reach it
 untouched.
 
 <Callout type="tip">

--- a/web/landing/content/docs/keyboard.zh-CN.mdx
+++ b/web/landing/content/docs/keyboard.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 键盘快捷键
 description: Termio 附带的每一个快捷键，直接读自应用自己的命令目录——以及如何在「设置 ▸ 键盘」里重新绑定它们。
 x-i18n:
   source_path: keyboard.mdx
-  source_hash: 442fd8a66085ee1c16c32e1ce3fe28571139230d9332eb9f5fe2923868ab9051
-  generated_at: 2026-08-16
+  source_hash: 769dc4db8f856dfd54d5e5907f709799bfca53b81fb4b1603d4df75addbff204
+  generated_at: 2026-08-18
 ---
 
 Termio 是为键盘操作而造的。下面的表格由应用的命令目录生成，因此列出的正是这个版本实际

--- a/web/landing/content/docs/navigation.mdx
+++ b/web/landing/content/docs/navigation.mdx
@@ -21,7 +21,7 @@ inspector, starting an agent, whatever the app can do.
 
 It doubles as a way to *learn* the shortcuts: every command lists its key
 equivalent right there, so the palette you reach for today teaches you the
-binding you'll reach for tomorrow.
+binding you’ll reach for tomorrow.
 
 <DocsImage
   src="/screenshots/docs/10-command-palette.png"
@@ -37,8 +37,8 @@ at once, grouped under headers:
 
 - **Sessions** — every running session, by title. The fastest way to switch when
   the sidebar is full.
-- **Recent** — projects and folders you've opened before, to reopen in a keystroke.
-- **Files** — once you start typing, the current project's files (from `git
+- **Recent** — projects and folders you’ve opened before, to reopen in a keystroke.
+- **Files** — once you start typing, the current project’s files (from `git
   ls-files`, so ignored paths stay out), opened straight into the editor.
 
 <DocsImage
@@ -48,8 +48,8 @@ at once, grouped under headers:
   height={1664}
 />
 
-It's the "jump to anything" companion to the Command Palette's "do anything." For
-searching *inside* files rather than by name, use the inspector's [Search
+It’s the “jump to anything” companion to the Command Palette’s “do anything.” For
+searching *inside* files rather than by name, use the inspector’s [Search
 tab](/docs/inspector#search).
 
 ## Everything is rebindable

--- a/web/landing/content/docs/navigation.zh-CN.mdx
+++ b/web/landing/content/docs/navigation.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 命令面板与快速打开
 description: 两个键盘面板让你不用鼠标也能驱动 Termio——命令面板执行任何操作，快速打开跳到任意会话、项目或文件。
 x-i18n:
   source_path: navigation.mdx
-  source_hash: 49790c84598d4f1534e5fdfb1b3afacb0ae19987e5065135734398519732a79a
-  generated_at: 2026-08-16
+  source_hash: 35281ff91c3d4d37698208ac157f3c86ad7b1482bed3f8b9bc27ca464ceed556
+  generated_at: 2026-08-18
 ---
 
 Termio 有两个覆盖面板，让你的手留在键盘上。一个执行*操作*，另一个跳到*东西*。两者都是

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -1,20 +1,20 @@
 ---
 title: Session control & the CLI
-description: Termio's orchestration API — status hooks that let agents report what they're doing, and the termio sessions CLI that lets you (or another agent) spawn, drive, and supervise sessions from the shell.
+description: Termio’s orchestration API — status hooks that let agents report what they’re doing, and the termio sessions CLI that lets you (or another agent) spawn, drive, and supervise sessions from the shell.
 ---
 
 Two related, opt-in features sit behind the live statuses you see in the sidebar:
-**status hooks** that let agents report what they're doing, and the **`termio`
+**status hooks** that let agents report what they’re doing, and the **`termio`
 command-line tool** that lets you — or another agent — drive sessions from the
 shell. Neither is required to use Termio; both make a fleet of agents easier to
 run.
 
 ## Live agent status
 
-Termio can install small **status hooks** into your agents' own config files
+Termio can install small **status hooks** into your agents’ own config files
 (Claude Code, Codex, Cursor, and the plugin-based agents). When an agent starts
 working, finishes, or stops to ask a question, the hook reports that to Termio, so
-the sidebar's [status dots](/docs/sidebar#status) reflect exactly what's happening
+the sidebar’s [status dots](/docs/sidebar#status) reflect exactly what’s happening
 instead of being guessed from output.
 
 Turn it on from **Settings ▸ General ▸ Live agent status** (Termio also offers it
@@ -25,7 +25,7 @@ you added yourself untouched.
 
 **Settings ▸ General ▸ Session control** turns on the `termio sessions`
 orchestration API below, and teaches your agents it exists by installing a
-`termio` **agent skill** into each agent's skills folder (`~/.claude/skills`,
+`termio` **agent skill** into each agent’s skills folder (`~/.claude/skills`,
 `~/.codex/skills`). The skill loads on demand — an agent carries only its
 one-line description until a task actually involves driving sibling sessions —
 and Termio re-asserts it on every launch, so app updates propagate and
@@ -38,7 +38,7 @@ hand-edits heal automatically. Toggling it off removes the skill again.
   height={1288}
 />
 
-Running an agent Termio doesn't auto-configure? The same skill is published at
+Running an agent Termio doesn’t auto-configure? The same skill is published at
 [termio.sh/skill.md](https://termio.sh/skill.md) and installable straight from
 the repo:
 
@@ -70,7 +70,7 @@ shell equivalent of **Open Project**.
 
 ### The orchestration model
 
-The `termio sessions` family is Termio's orchestration API: it lets one agent —
+The `termio sessions` family is Termio’s orchestration API: it lets one agent —
 or your own scripts — see and steer sibling sessions in the same project. Before
 the verb reference, the design rules everything below follows:
 
@@ -83,16 +83,16 @@ the verb reference, the design rules everything below follows:
   never its mutable contents, so a copied address survives the session
   promoting, demoting, or being renamed — and stays self-describing when
   pasted anywhere.
-- **Transcript as truth.** An agent's *result* is read from its own structured
+- **Transcript as truth.** An agent’s *result* is read from its own structured
   transcript (the path and line range the replies hand back), never scraped off
   the screen. The screen is the result channel only for plain `run` terminals,
   which have no transcript.
 - **Waiting is explicit.** No command blocks unless you pass `--wait`, and
-  `--wait` always means the same thing: wait for the turn's *outcome*, fail
+  `--wait` always means the same thing: wait for the turn’s *outcome*, fail
   fast when no outcome can come, and split the result across exit codes.
 - **Signal, never kill.** The supervision plane observes and reports — `watch`
   events, the `stalled` alarm — but never terminates or auto-answers a session.
-  Acting on a signal is always the supervisor's decision.
+  Acting on a signal is always the supervisor’s decision.
 
 ### Drive sessions
 
@@ -105,7 +105,7 @@ Add `--json` to any command for machine-readable output.
 | `termio sessions spawn "<prompt>"` | Start a new agent session on the prompt; replies immediately with its session link. |
 | `termio sessions run "<command>"` | Start a new plain terminal session typing that shell command — a dev server, a test run — in a visible pane, no LLM. |
 | `termio sessions send <link> "<text>"` | Type text into an existing session and submit it with a real Return keypress — a prompt to drive it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. |
-| `termio sessions read <link>` | Print the session's current screen without focusing it (`--lines N` keeps the tail) — the result channel for `run` sessions. |
+| `termio sessions read <link>` | Print the session’s current screen without focusing it (`--lines N` keeps the tail) — the result channel for `run` sessions. |
 | `termio sessions close <link>` | Close one or more session tabs. |
 | `termio sessions focus <link>` | Bring a session to the front in the app. |
 
@@ -129,16 +129,16 @@ focused help for any one verb.
 ### Spawning without waiting
 
 `spawn` returns the moment the session exists: the reply carries the new
-session's link, and the prompt itself is typed in once the agent finishes
+session’s link, and the prompt itself is typed in once the agent finishes
 booting. Add
 `--agent <id>` (e.g. `codex`, `grok`, `pi`) to choose the agent; it defaults to
-the caller's own kind.
+the caller’s own kind.
 
 ### Running plain commands
 
 Not everything in a fleet is an agent. `run` starts a *terminal* session on a
 shell command — a dev server, a test watcher, a build — in a visible pane you
-can watch and take over, and `read` prints any session's current screen
+can watch and take over, and `read` prints any session’s current screen
 without focusing it. A plain command has no transcript, so its screen is its
 result channel; agent results keep flowing through transcripts.
 
@@ -198,29 +198,29 @@ outcomes so scripts can branch without parsing: **0** settled, **1** error
 - **Stall alarm, opt-in.** `--state stalled` adds a watch-plane signal for the
   unattended runaway: a session still `working` that has made **no repo change
   and next-to-no transcript growth for 20+ minutes**. Sustained output — a long
-  build streaming logs — suppresses it. The event carries the detector's
+  build streaming logs — suppresses it. The event carries the detector’s
   reasoning in `evidence` (`"working 42m, no repo change, transcript +3
   lines"`), fires once per quiet stretch, and re-arms when progress resumes.
-  Termio only signals; it never kills — the session's real status stays
+  Termio only signals; it never kills — the session’s real status stays
   `working` and the sidebar is untouched. Not in the default filter.
 - **Actionable events.** A `needs-you` event carries the on-screen question in
-  `prompt`; a `done` event carries the session's `transcript` path and
+  `prompt`; a `done` event carries the session’s `transcript` path and
   `cursor_end` — enough to answer, or to read the result, without another
   round-trip.
 - **Heartbeat.** In `--json` mode the app writes `{"heartbeat":true}` after 30
   seconds of silence, so a quiet stream is distinguishable from a dead one.
 - **Exit codes.** `0` after Ctrl-C (the normal end of supervision), `2` when
-  the stream closed from the app side — "I chose to stop" and "Termio went
-  away" are different outcomes.
+  the stream closed from the app side — “I chose to stop” and “Termio went
+  away” are different outcomes.
 
 ### Spawned sessions know their caller
 
 When one Termio session spawns another, the delivered prompt opens with a short
-provenance envelope: it names the caller's link and allows exactly one
+provenance envelope: it names the caller’s link and allows exactly one
 back-channel — a mid-task question, or a one-line completion ping, via
 `termio sessions send <caller-link> …`. Nothing else travels that way: no
 conversation, no delegating tasks back. Results stay transcript-as-truth — the
-supervisor reads the worker's transcript, with `watch` as the backstop. A
+supervisor reads the worker’s transcript, with `watch` as the backstop. A
 `spawn` from a plain shell (outside any Termio session) gets no envelope.
 
 ### Fail loud
@@ -278,9 +278,9 @@ everywhere): the final `status`, and the transcript line range
 `cwd` is omitted until the shell reports one; `snapshot` marks the on-attach
 roster lines; `prompt` rides on `needs-you` events, `transcript` +
 `cursor_end` on `done` events (exactly as in wait replies), and `evidence` on
-`stalled` events — the stall detector's reasoning, e.g.
+`stalled` events — the stall detector’s reasoning, e.g.
 `"working 42m, no repo change, transcript +3 lines"`. `stalled` appears only
-on the watch stream, never as a session's `status` in `list` or wait replies.
+on the watch stream, never as a session’s `status` in `list` or wait replies.
 After 30 seconds of silence the app writes `{"heartbeat": true}`.
 
 <Callout type="tip">

--- a/web/landing/content/docs/session-control.zh-CN.mdx
+++ b/web/landing/content/docs/session-control.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 会话控制与命令行
 description: Termio 的编排 API——让 Agent 汇报自己在做什么的状态 hooks，以及让你（或另一个 Agent）从 shell 里派生、驱动和监督会话的 termio sessions 命令行。
 x-i18n:
   source_path: session-control.mdx
-  source_hash: 03434b91dddcb3121bcd9161e58d8d47b6447d40cd7f0f36c73b0f58407f376c
-  generated_at: 2026-08-16
+  source_hash: c51862ad7e768ef4905dc4f6e02dbd18c66d6e276bb00b2a82601a7c416a647e
+  generated_at: 2026-08-18
 ---
 
 你在侧栏看到的实时状态背后，是两个相关的可选功能：让 Agent 汇报自己在做什么的**状态

--- a/web/landing/content/docs/sidebar.mdx
+++ b/web/landing/content/docs/sidebar.mdx
@@ -1,10 +1,10 @@
 ---
 title: The sidebar
-description: The sidebar is Termio's control surface — Terminals, Chats, and Projects grouped in one list, each session reporting a live status so you always know which agent needs you.
+description: The sidebar is Termio’s control surface — Terminals, Chats, and Projects grouped in one list, each session reporting a live status so you always know which agent needs you.
 ---
 
-Everything you run in Termio lives in the sidebar on the left. It's one scrollable
-list, grouped into sections, where every row is a live session reporting what it's
+Everything you run in Termio lives in the sidebar on the left. It’s one scrollable
+list, grouped into sections, where every row is a live session reporting what it’s
 doing right now. Click a row to bring it forward; the rest keep running in the
 background.
 
@@ -15,12 +15,12 @@ The sidebar groups your sessions by what they are:
 - **Terminals** — standalone shells and agents you start with `⌘T`, not tied to a
   project. Your scratchpad.
 - **Chats** — throwaway agent sessions for quick questions (see below).
-- **Projects** — the folders you've opened. Each project expands to the sessions
-  running inside it, and any git worktrees nest one level deeper, giving a
-  three-level tree: project → worktree → session. See [Git
+- **Projects** — the folders you’ve opened. Each project expands to the sessions
+  running inside it, and any git worktrees nest one level deeper. The tree is
+  three levels: project → worktree → session. See [Git
   worktrees](/docs/worktrees).
 
-Empty sections stay hidden, so the list only shows what you're actually using.
+Empty sections stay hidden, so the list only shows what you’re actually using.
 
 <DocsImage
   src="/screenshots/docs/04-project-session-hierarchy.png"
@@ -36,12 +36,12 @@ Every session row carries a status dot that updates live. There are four states:
 | Status | Meaning |
 | --- | --- |
 | **working** | The agent is actively producing output. |
-| **idle** | Nothing pending, or you're already looking at it. |
-| **done** | Finished a task while you were on another session — a calm "ready" cue, so you notice a completed run without it shouting for attention. |
+| **idle** | Nothing pending, or you’re already looking at it. |
+| **done** | Finished a task while you were on another session — a calm “ready” cue, so you notice a completed run without it shouting for attention. |
 | **needs you** | Blocked on a question or a permission prompt. Go back. |
 
 The distinction between **needs you** and **done** is the point: *needs you* means
-an agent is stuck and can't proceed without you; *done* means it finished on its
+an agent is stuck and can’t proceed without you; *done* means it finished on its
 own and is just letting you know. [Concepts](/docs/concepts#status) covers the
 model and where each signal comes from.
 
@@ -56,13 +56,13 @@ model and where each signal comes from.
 The **Chats** section holds scratch agent sessions — for when you want to ask an
 agent something without opening a project. Press `⌘N` for a **New Chat** and it
 starts in a shared scratch directory (`~/.termio/chats`), never in whatever folder
-you happen to be in. Close them individually, or clear the lot from the section's
+you happen to be in. Close them individually, or clear the lot from the section’s
 menu. Treat them as disposable: quick questions, throwaway experiments, nothing
 you need to keep.
 
 ## Switching without losing your place
 
-Because each session is a real process, an agent doesn't pause when it's
+Because each session is a real process, an agent doesn’t pause when it’s
 off-screen. Click between rows freely, or — once you have more than a handful —
 jump straight to any session by name with `⇧⌘O`. See
 [Navigation](/docs/navigation).

--- a/web/landing/content/docs/sidebar.zh-CN.mdx
+++ b/web/landing/content/docs/sidebar.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 侧栏
 description: 侧栏是 Termio 的控制台——终端、聊天和项目归在同一个列表里，每个会话汇报实时状态，你总能知道哪个 Agent 需要你。
 x-i18n:
   source_path: sidebar.mdx
-  source_hash: 79da7c88ca706e4a58bab4b0199c56f6a037a72ca437e023bbdb547bf46f91c4
-  generated_at: 2026-08-16
+  source_hash: 72b4c70ea1cac21954d539651af01b86d65805eab2fe3f06e964bc114a95b735
+  generated_at: 2026-08-18
 ---
 
 你在 Termio 里跑的一切都住在左侧的侧栏里。它是一个可滚动的列表，按区块分组，每一行

--- a/web/landing/content/docs/worktrees.mdx
+++ b/web/landing/content/docs/worktrees.mdx
@@ -1,10 +1,10 @@
 ---
 title: Git worktrees
-description: Termio reads your repository's worktrees straight from git and shows them as a nested branch under the project, so parallel agent work stays isolated.
+description: Termio reads your repository’s worktrees straight from git and shows them as a nested branch under the project, so parallel agent work stays isolated.
 ---
 
-When you have several agents working a repository at once, you don't want them
-stepping on each other's files. Git worktrees give each line of work its own
+When you have several agents working a repository at once, you don’t want them
+stepping on each other’s files. Git worktrees give each line of work its own
 checkout on its own branch — and Termio surfaces them natively.
 
 ## How Termio sees worktrees
@@ -20,8 +20,8 @@ regains focus, and when the git directory changes.
 
 ## Working in a worktree
 
-Open a session inside a worktree and it starts in that worktree's directory on
-that worktree's branch. Point one agent at your `main` checkout and another at a
+Open a session inside a worktree and it starts in that worktree’s directory on
+that worktree’s branch. Point one agent at your `main` checkout and another at a
 `feat/…` worktree, and their edits never collide — each has its own working tree,
 its own index, its own branch.
 
@@ -37,7 +37,7 @@ An empty worktree still appears in the tree. Open its context menu and choose
 
 ## Reviewing the work
 
-The inspector's git pane is read-only by design: three tabs — **Changes**,
+The inspector’s git pane is read-only by design: three tabs — **Changes**,
 **Compare**, and **History** — let you read the diff, see what the branch would
 merge, and browse commits per worktree. Committing, pushing, and opening pull
 requests happen in the terminal, where you (or the agent) already are — see the

--- a/web/landing/content/docs/worktrees.zh-CN.mdx
+++ b/web/landing/content/docs/worktrees.zh-CN.mdx
@@ -3,8 +3,8 @@ title: Git worktree
 description: Termio 直接从 git 读取仓库的 worktree，并把它们显示为项目下嵌套的一层，让并行的 Agent 工作彼此隔离。
 x-i18n:
   source_path: worktrees.mdx
-  source_hash: 4dca84ce78e77f875b51272c4f7ce825896228d74ea66514cb6a8bfb763b5ddc
-  generated_at: 2026-08-16
+  source_hash: aa8d93ccf1bffdaa01332ba685ea6f0e33887808a35a709ee8ea5685a399299a
+  generated_at: 2026-08-18
 ---
 
 当好几个 Agent 同时在一个仓库里干活时，你不希望它们互相踩文件。git worktree 给每条工作线

--- a/web/landing/package.json
+++ b/web/landing/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "node --test \"scripts/*.test.mjs\"",
     "postinstall": "fumadocs-mdx",
     "keybindings:sync": "node scripts/sync-keybindings.mjs",
     "docs:stamp": "node scripts/docs-check.mjs --stamp",

--- a/web/landing/scripts/docs-check.mjs
+++ b/web/landing/scripts/docs-check.mjs
@@ -16,7 +16,7 @@ import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const landingRoot = resolve(scriptDir, "..");
@@ -144,6 +144,112 @@ function headingOutline(text) {
 function frontmatter(text) {
   const match = text.match(/^---\n([\s\S]*?)\n---/);
   return match ? match[1] : "";
+}
+
+// ---------------------------------------------------------------------- links
+
+/**
+ * The anchor id of a heading, the way the docs pipeline assigns it: an explicit
+ * `## 状态 [#status]` wins, otherwise the text is slugified. Inline markup is
+ * stripped first, so `## The \`termio\` command-line tool` and `## **Panes**`
+ * anchor on their words rather than their backticks and asterisks.
+ */
+function headingAnchor(heading) {
+  const explicit = heading.match(/\[#([^\]]+)\]\s*$/);
+  if (explicit) return explicit[1];
+  return (
+    heading
+      .replace(/`([^`]*)`/g, "$1")
+      .replace(/\*\*?([^*]*)\*\*?/g, "$1")
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+      .trim()
+      .toLowerCase()
+      .replace(/[^\p{Letter}\p{Number}\s-]/gu, "")
+      // One hyphen per space, not one per run. `## Command Palette — ⇧⌘P` loses
+      // the dash and the glyphs but keeps the spaces that flanked them, so the id
+      // the site renders is `command-palette--p` — with the double hyphen. A
+      // slugifier that collapses runs here rejects the correct anchor.
+      .replace(/\s/g, "-")
+  );
+}
+
+/** Every heading's anchor id on a page, ignoring fenced code. */
+function pageAnchors(text) {
+  const anchors = new Set();
+  let fenced = false;
+  for (const line of text.split("\n")) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+      fenced = !fenced;
+      continue;
+    }
+    if (fenced || !trimmed.startsWith("#")) continue;
+    const level = trimmed.match(/^#+/)[0].length;
+    if (level > 6 || trimmed[level] !== " ") continue;
+    anchors.add(headingAnchor(trimmed.slice(level + 1)));
+  }
+  return anchors;
+}
+
+/** The public URL a content file is served at. */
+function pageHref(name, defaultLanguage) {
+  const parts = name.replace(/\.mdx$/, "").split(".");
+  const slug = parts[0];
+  const locale = parts.length > 1 ? parts[1] : defaultLanguage;
+  const base = locale === defaultLanguage ? "/docs" : `/${locale}/docs`;
+  return slug === "index" ? base : `${base}/${slug}`;
+}
+
+/**
+ * Every internal link lands on a page that exists, and every `#anchor` on a
+ * heading that exists. Both rot silently: a renamed page leaves a 404 behind a
+ * link that still looks fine in the source, and a reworded heading breaks every
+ * anchor pointing at it — including the explicit `[#id]` a translation carries so
+ * its links survive. Neither shows up in a build, because MDX links are just
+ * strings until someone clicks one.
+ */
+function checkLinks() {
+  const { defaultLanguage } = configuredLocales();
+  const files = readdirSync(docsDir).filter((name) => name.endsWith(".mdx"));
+
+  const anchorsByHref = new Map();
+  for (const name of files) {
+    anchorsByHref.set(
+      pageHref(name, defaultLanguage),
+      pageAnchors(readFileSync(resolve(docsDir, name), "utf8")),
+    );
+  }
+
+  let checked = 0;
+  for (const name of files) {
+    const text = readFileSync(resolve(docsDir, name), "utf8");
+    const lines = text.split("\n");
+
+    for (const [index, line] of lines.entries()) {
+      // Markdown links and JSX `href` attributes, absolute paths only —
+      // external URLs are not this script's business.
+      const found = [
+        ...line.matchAll(/\]\((\/[^)\s]*)\)/g),
+        ...line.matchAll(/href="(\/[^"]*)"/g),
+      ];
+      for (const [, href] of found) {
+        checked += 1;
+        const [path, anchor] = href.split("#");
+        const target = path.replace(/\/$/, "") || "/docs";
+        if (!anchorsByHref.has(target)) {
+          fail(`links: ${name}:${index + 1} → ${href} (no such page)`);
+          continue;
+        }
+        if (anchor && !anchorsByHref.get(target).has(anchor)) {
+          fail(`links: ${name}:${index + 1} → ${href} (no heading anchors to #${anchor})`);
+        }
+      }
+    }
+  }
+
+  if (errors.length === 0) {
+    notes.push(`links: ${checked} internal links resolve to a page and an anchor`);
+  }
 }
 
 function sourceHash(text) {
@@ -298,27 +404,39 @@ function stampTranslations(dateISO) {
 
 // --------------------------------------------------------------------- main
 
-const only = process.argv.slice(2);
-const stampArg = only.find((arg) => arg === "--stamp" || arg.startsWith("--stamp="));
-const run = (flag) => only.length === 0 || only.includes(flag);
+// The anchor rules are exported so they can be tested directly: they encode how
+// the docs pipeline slugifies a heading, and a slugifier that disagrees with the
+// renderer rejects correct links. See docs-check.test.mjs.
+export { headingAnchor, pageAnchors };
 
-if (stampArg) {
-  // The date the translation was generated. Can be passed in rather than read from
-  // the clock so a re-run is reproducible: --stamp=2026-08-10.
-  const given = stampArg.startsWith("--stamp=")
-    ? stampArg.slice("--stamp=".length)
-    : undefined;
-  stampTranslations(given ?? new Date().toISOString().slice(0, 10));
+// The checks run only when this file is the command being executed. Importing it
+// from a test must not run them, or the test inherits its exit code.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const only = process.argv.slice(2);
+  const stampArg = only.find(
+    (arg) => arg === "--stamp" || arg.startsWith("--stamp="),
+  );
+  const run = (flag) => only.length === 0 || only.includes(flag);
+
+  if (stampArg) {
+    // The date the translation was generated. Can be passed in rather than read
+    // from the clock so a re-run is reproducible: --stamp=2026-08-10.
+    const given = stampArg.startsWith("--stamp=")
+      ? stampArg.slice("--stamp=".length)
+      : undefined;
+    stampTranslations(given ?? new Date().toISOString().slice(0, 10));
+  }
+
+  if (run("--changelog")) checkChangelog();
+  if (run("--i18n")) checkI18n();
+  if (run("--links")) checkLinks();
+
+  for (const note of notes) console.log(note);
+  if (errors.length > 0) {
+    console.error("");
+    for (const error of errors) console.error(`✗ ${error}`);
+    console.error(`\n${errors.length} problem(s) found.`);
+    process.exit(1);
+  }
+  console.log("docs-check: ok");
 }
-
-if (run("--changelog")) checkChangelog();
-if (run("--i18n")) checkI18n();
-
-for (const note of notes) console.log(note);
-if (errors.length > 0) {
-  console.error("");
-  for (const error of errors) console.error(`✗ ${error}`);
-  console.error(`\n${errors.length} problem(s) found.`);
-  process.exit(1);
-}
-console.log("docs-check: ok");

--- a/web/landing/scripts/docs-check.test.mjs
+++ b/web/landing/scripts/docs-check.test.mjs
@@ -1,0 +1,74 @@
+// The anchor rules, pinned. `headingAnchor` has to agree with the id the docs
+// pipeline actually renders, because a link is checked against what this function
+// returns — a slugifier that is merely close rejects correct anchors and passes
+// broken ones. The cases below are taken from real headings in content/docs, and
+// the expected values were read back off the rendered pages.
+//
+//   pnpm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { headingAnchor, pageAnchors } from "./docs-check.mjs";
+
+test("slugifies plain headings", () => {
+  assert.equal(headingAnchor("Status"), "status");
+  assert.equal(
+    headingAnchor("Where the signal comes from"),
+    "where-the-signal-comes-from",
+  );
+});
+
+test("an explicit [#id] wins over the text", () => {
+  assert.equal(headingAnchor("恢复 [#resume]"), "resume");
+  assert.equal(headingAnchor("状态 [#status]"), "status");
+});
+
+test("strips inline markup rather than slugifying it", () => {
+  assert.equal(
+    headingAnchor("The `termio` command-line tool"),
+    "the-termio-command-line-tool",
+  );
+  assert.equal(headingAnchor("**Panes**"), "panes");
+  assert.equal(headingAnchor("See [Concepts](/docs/concepts)"), "see-concepts");
+});
+
+// The bug this file exists for: dropped punctuation leaves its spaces behind, and
+// the renderer emits one hyphen per space instead of one per run. Collapsing the
+// run here produced `command-palette-p` for a heading the site serves at
+// `command-palette--p`.
+test("keeps one hyphen per space, so dropped glyphs leave their gap", () => {
+  assert.equal(
+    headingAnchor("Command Palette — `⇧⌘P`"),
+    "command-palette--p",
+  );
+  assert.equal(headingAnchor("Open Quickly — `⇧⌘O`"), "open-quickly--o");
+  assert.equal(headingAnchor("命令面板 —— `⇧⌘P`"), "命令面板--p");
+});
+
+test("keeps CJK headings addressable", () => {
+  assert.equal(headingAnchor("信号从哪里来"), "信号从哪里来");
+});
+
+test("pageAnchors collects every heading and ignores fenced code", () => {
+  const page = [
+    "---",
+    "title: Example",
+    "---",
+    "",
+    "Opening prose.",
+    "",
+    "## Real heading",
+    "",
+    "```sh",
+    "# not a heading, a shell comment",
+    "```",
+    "",
+    "### Nested one [#pinned]",
+    "",
+    "#not-a-heading-either",
+  ].join("\n");
+
+  assert.deepEqual(
+    [...pageAnchors(page)].sort(),
+    ["pinned", "real-heading"],
+  );
+});

--- a/web/landing/src/app/globals.css
+++ b/web/landing/src/app/globals.css
@@ -741,14 +741,226 @@ html[data-docs-theme="dark"]:has(.docs-surface) {
   [data-sidebar-panel] {
     display: none;
   }
+}
+
+/* The docs prose lives in `utilities`, not `components`, because that is where
+   fumadocs' typography plugin puts `.prose`. Layer order outranks specificity in
+   the cascade, so a `.docs-surface article .prose` rule one layer down loses to a bare
+   `.prose` — silently, and only for the properties the plugin happens to set. In
+   the same layer, specificity decides and these win. The same applies to the
+   library's chrome, which carries Tailwind utilities of its own. */
+@layer utilities {
+  /* ── Square corners, docs only ───────────────────────────────────────────
+     The docs are the one surface where the terminal aesthetic wins over the
+     Apple-HIG rounding the landing page uses: the reader is here to look at
+     code blocks and terminal screenshots, both of which are rectangles, and a
+     1rem radius on a 36px sidebar row rendered as a capsule — the shape macOS
+     reserves for a tag, not a list item.
+
+     Scoped to the docs *page* rather than the `.docs-surface` subtree: popovers
+     are portaled to `document.body`, so the language switcher and its rows sat
+     outside the subtree and kept their radius while everything around them went
+     square. The landing page never renders `.docs-surface`, so it is untouched —
+     the same `html:has()` test the scrollbar rule above uses. Two things opt out:
+     anything genuinely round (circles by nature, not rounded rectangles) and
+     inline code, whose small radius keeps a `code` chip legible as one object
+     inside a line of prose. */
+  html:has(.docs-surface) *:not([class*="rounded-full"]) {
+    border-radius: 0;
+  }
+  .docs-surface article .prose :not(pre) > code {
+    border-radius: 3px;
+  }
+
+  /* ── Docs prose typography ───────────────────────────────────────────────
+     fumadocs ships a Tailwind-typography `.prose` tuned for a column as wide as
+     the page. Here that was 836px of 16px text — about 104 characters a line,
+     where reading comfort tops out around 75. Everything below hangs off fixing
+     that: a reading measure, body copy a notch larger to suit it, and headings
+     that take their space from above rather than below.
+
+     Every rule is scoped through `article`, because `.prose` is not only the page
+     body — the library puts it on each table-of-contents link too, so that inline
+     code in a heading renders styled there. Matching `.prose` alone turned every
+     TOC entry into a flex column and sized it like body copy. */
+  .docs-surface article .prose {
+    --docs-measure: 40rem;
+    /* The gap between two elements of the same section. Space above a heading is
+       this plus the heading's own margin, because margins do not collapse in a
+       flex container — the two add, which is the point. */
+    --docs-prose-gap: 1.25rem;
+    font-size: 1.0625rem;
+    line-height: 1.7;
+
+    /* Vertical rhythm comes from one gap, not from margins meeting each other.
+       With margins, the space between two blocks is the larger of the pair, so
+       tightening the space under a heading meant reaching past it to style the
+       next sibling, and the first child needed its top margin reset by hand.
+       A flex column has neither problem: the gap is the gap, the first and last
+       children get no edge spacing, and a heading that wants more room above it
+       simply adds a margin on itself. */
+    display: flex;
+    flex-direction: column;
+    gap: var(--docs-prose-gap);
+  }
+  /* The plugin's own vertical margins would stack on top of the gap. */
+  .docs-surface article .prose > * {
+    margin-block: 0;
+  }
+
+  /* One measure for everything read as a sentence, expressed as a token rather
+     than an exception list: an element opts out by setting `--docs-measure` on
+     itself, and because custom properties inherit, a container can opt out its
+     whole subtree the same way. Three kinds of thing opt out here, and each is a
+     figure rather than prose — media (screenshots and video, which carry
+     `not-prose`), tables, whose width comes from their columns, and code blocks:
+     the longest line in these docs is 97 characters, so a block held to the text
+     measure would scroll horizontally on every CLI page. */
+  .docs-surface article .prose > * {
+    max-width: var(--docs-measure);
+  }
+  .docs-surface article .prose > :is(table, pre, figure, .not-prose),
+  .docs-surface article .prose > :has(> :is(table, pre)) {
+    --docs-measure: none;
+  }
+
+  /* A section head belongs to the text under it: the space above it is what
+     separates two sections, and it is several times the space below. */
+  .docs-surface article .prose :is(h2, h3, h4) {
+    letter-spacing: -0.018em;
+  }
+  .docs-surface article .prose h2 {
+    margin-top: 2.25rem;
+    line-height: 1.25;
+  }
+  .docs-surface article .prose h3 {
+    margin-top: 1.25rem;
+    line-height: 1.3;
+  }
+  .docs-surface article .prose h4 {
+    margin-top: 0.75rem;
+  }
+  /* A screenshot is a change of subject, not another paragraph, so it takes more
+     air than the prose rhythm gives it. */
+  .docs-surface article .prose > :is(figure, .not-prose) {
+    margin-block: 0.75rem;
+  }
+
+  /* The library's code block is a white card with a lift. This site already has a
+     token for the surface code sits on — `--code`, grey in light and near-black
+     in dark — and builds its panels from hairlines, so the card takes that colour
+     and drops the shadow. On a white page a white block reads as nothing at all. */
+  .docs-surface article .prose figure.shiki {
+    background: var(--code);
+    box-shadow: none;
+  }
+
+  /* Inline code sits inside a line of prose, so it is tuned against the sans
+     text around it rather than styled as its own object: the mono face runs
+     optically low next to SF, and `vertical-align` lifts it without changing the
+     line box the way a margin or a transform would. Long identifiers may break —
+     `termio://session/<uuid>` in a 40rem column would otherwise force the line
+     to overflow rather than wrap. */
+  .docs-surface article .prose :not(pre) > code {
+    vertical-align: 0.045em;
+    white-space: break-spaces;
+  }
+  /* In a heading, code is part of the heading: it takes its size and weight and
+     drops the chip, so `## The \`termio\` command-line tool` reads as one line of
+     type instead of a label with a badge in it. */
+  .docs-surface article .prose :is(h1, h2, h3, h4) code {
+    padding: 0;
+    border: none;
+    background: none;
+    font-size: inherit;
+    font-weight: inherit;
+    vertical-align: baseline;
+  }
+
+  /* The site's list mark: a hairline dash, as on the changelog and the legal
+     pages. Ordered lists keep their numerals — the contrast is the point on a
+     page that has both a set of things and a sequence of steps. */
+  .docs-surface article .prose ul {
+    list-style: none;
+    padding-inline-start: 0;
+  }
+  .docs-surface article .prose ul > li {
+    position: relative;
+    padding-inline-start: 1.375rem;
+  }
+  .docs-surface article .prose ul > li::before {
+    content: "";
+    position: absolute;
+    inset-inline-start: 0;
+    top: 0.85em;
+    width: 0.625rem;
+    height: 1px;
+    background: var(--muted-foreground);
+    opacity: 0.7;
+  }
+
+  /* Tables as hairline rows. The library's table is a rounded bordered card
+     with a filled header band and a rule between every cell; on a page built
+     from hairlines that reads as a spreadsheet pasted into the prose. These
+     tables are reference lists — the status model, the shortcut catalog — so
+     they get row rules only, and the mono uppercase column label the rest of
+     the site already uses for the same job. Selectors are deliberately
+     `table th` rather than `th`: the library's own rules are specific enough to
+     outrank the shorter form. */
+  .docs-surface article .prose table {
+    border: none;
+    border-radius: 0;
+    background: none;
+    border-collapse: collapse;
+    /* Content width, not full width. A two-column shortcut table stretched
+       across the page leaves the shortcut stranded a screen away from the
+       command it belongs to; tables with sentences in them still fill. */
+    width: auto;
+    max-width: 100%;
+    font-size: 0.9375rem;
+    line-height: 1.55;
+  }
+  .docs-surface article .prose table :is(th, td) {
+    border: none;
+    border-bottom: 1px solid var(--border);
+    background: none;
+    padding: 0.625rem 1.5rem 0.625rem 0;
+    text-align: start;
+    vertical-align: top;
+  }
+  .docs-surface article .prose table th {
+    font-family: var(--font-mono-stack);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+  }
+  .docs-surface article .prose table tbody tr:last-child td {
+    border-bottom: none;
+  }
+  /* A command or a shortcut is one token. Wrapped, `termio sessions spawn
+     "<prompt>"` reads as two. */
+  .docs-surface article .prose table code {
+    white-space: nowrap;
+  }
+
   /* CJK copy needs a little more air between lines than Latin at the same size,
      and Chinese punctuation shouldn't start a line. */
-  .docs-surface:lang(zh-CN) .prose,
-  .docs-surface:lang(zh-CN) .prose p,
-  .docs-surface:lang(zh-CN) .prose li {
+  .docs-surface:lang(zh-CN) article .prose,
+  .docs-surface:lang(zh-CN) article .prose p,
+  .docs-surface:lang(zh-CN) article .prose li {
     @apply leading-[1.85];
   }
-  .docs-surface:lang(zh-CN) .prose {
+  .docs-surface:lang(zh-CN) article .prose {
     line-break: strict;
+  }
+  /* The mono uppercase column label is a Latin device: `text-transform` does
+     nothing to Chinese, and 11px leaves a Han character unreadable. Translated
+     tables get the same quiet head at a legible size in the text face. */
+  .docs-surface:lang(zh-CN) article .prose table th {
+    font-family: inherit;
+    font-size: 0.8125rem;
+    letter-spacing: 0.02em;
   }
 }

--- a/web/landing/src/components/docs/doc-page.tsx
+++ b/web/landing/src/components/docs/doc-page.tsx
@@ -65,6 +65,14 @@ export async function DocPage({
   const MDX = page.data.body;
   const raw = await page.data.getText("raw");
 
+  // The library's prev/next pager and a hand-authored `<Cards>` block answer the
+  // same question, so a page carrying both offered the reader two stacked rows of
+  // destination cards — and on Concepts they collided outright: the pager's
+  // *previous* page was "Your first session", which the Cards block was offering
+  // as a next step. Four pages curate their own next steps; the other eleven rely
+  // on the pager. So a page does one or the other, decided by what it contains.
+  const curatesNextSteps = raw.includes("<Cards>");
+
   // Structured data. `TechArticle` is what a documentation page is, and stating it
   // lets a search engine treat the page as documentation rather than guessing from
   // the markup; `BreadcrumbList` is what produces the "Termio › Docs › …" trail
@@ -121,6 +129,7 @@ export async function DocPage({
       toc={page.data.toc}
       full={page.data.full}
       tableOfContent={{ style: "clerk" }}
+      footer={{ enabled: !curatesNextSteps }}
       editOnGithub={{
         owner: "termio-sh",
         repo: "termio",
@@ -132,10 +141,22 @@ export async function DocPage({
       {/* Actions sit on the title's row, hard right: they are page-level tools,
           not part of the prose, and below the description they read as the first
           thing to do rather than something available throughout. */}
-      <div className="flex items-start justify-between gap-6">
+      {/* One row only where there is room for one. On a phone the two actions eat
+          most of the width, which left the title colliding with them and the
+          description wrapping one or two words at a time. */}
+      <div className="mb-8 flex flex-col items-start gap-3 sm:mb-0 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+        {/* The library sizes a page title at 1.75em — the same 28px its own h2
+            headings get, so a title read as the first section rather than the
+            name of the page. It is set here rather than in CSS because these are
+            Tailwind utilities on the library's components, and `cn` replaces a
+            conflicting one; a stylesheet rule in a lower layer would not. */}
         <div className="min-w-0">
-          <DocsTitle>{page.data.title}</DocsTitle>
-          <DocsDescription>{page.data.description}</DocsDescription>
+          <DocsTitle className="text-[2.125rem] leading-[1.15] tracking-[-0.021em]">
+            {page.data.title}
+          </DocsTitle>
+          <DocsDescription className="mb-0 mt-3 max-w-[40rem] text-[1.1875rem] leading-[1.55] sm:mb-9">
+            {page.data.description}
+          </DocsDescription>
         </div>
         <div className="mt-1 flex shrink-0 items-center gap-1">
           <CopyMarkdownButton

--- a/web/landing/src/components/docs/docs-frame.tsx
+++ b/web/landing/src/components/docs/docs-frame.tsx
@@ -3,7 +3,7 @@ import { RootProvider } from "fumadocs-ui/provider/next";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { DocsHeader } from "@/components/docs/docs-header";
 import { source } from "@/lib/source";
-import { docsChrome } from "@/lib/docs-ui";
+import { docsChrome, docsLibraryChrome } from "@/lib/docs-ui";
 import { i18n, languageNames, type DocsLanguage } from "@/lib/i18n";
 import { githubUrl } from "@/lib/site";
 
@@ -45,6 +45,7 @@ export function DocsFrame({
             locale: language,
             name: languageNames[language] ?? language,
           })),
+          translations: docsLibraryChrome(lang),
         }}
       >
         <DocsHeader lang={lang} />

--- a/web/landing/src/components/docs/docs-header.tsx
+++ b/web/landing/src/components/docs/docs-header.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
+import { SearchTrigger } from "fumadocs-ui/layouts/shared/slots/search-trigger";
 import { Logo } from "@/components/logo";
 import { GitHubMark } from "@/components/section-label";
 import { ThemeSwitch } from "@/components/docs/theme-switch";
+import { source } from "@/lib/source";
 import { docsChrome } from "@/lib/docs-ui";
 import type { DocsLanguage } from "@/lib/i18n";
 import { githubUrl, downloadUrl } from "@/lib/site";
@@ -17,6 +19,7 @@ export function DocsHeader({ lang }: { lang: DocsLanguage }) {
   // `/zh-CN` is not a page — it 404s. The locale lives on the Docs link below.
   const home = "/";
   const docsHome = lang === "en" ? "/docs" : `/${lang}/docs`;
+  const tree = source.getPageTree(lang);
 
   return (
     // Opaque, and no backdrop-filter. A translucent blurred header has to
@@ -25,7 +28,10 @@ export function DocsHeader({ lang }: { lang: DocsLanguage }) {
     // scroll. The landing's pill can afford the effect because it floats over a
     // hero; here there is nothing behind the bar worth seeing through it.
     <header className="sticky top-0 z-50 border-b border-border bg-background">
-      <div className="mx-auto flex h-14 w-full max-w-7xl items-center gap-3 px-5 sm:px-8">
+      {/* 97rem is the docs grid's `--fd-layout-width`, and 1.5rem − 1px is the
+          sidebar's row inset: sharing both puts the wordmark on the same vertical
+          line as the sidebar links. */}
+      <div className="mx-auto flex h-14 w-full max-w-[97rem] items-center gap-3 px-5 md:pe-8 md:ps-[calc(1.5rem-1px)]">
         <Link
           href={home}
           className="group flex shrink-0 items-center rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
@@ -43,6 +49,16 @@ export function DocsHeader({ lang }: { lang: DocsLanguage }) {
         </Link>
 
         <div className="ml-auto flex items-center gap-2">
+          {/* Below `md` the sidebar is not rendered at all, and it is what holds
+              the search field — so on a phone there was no way to search. The
+              trigger opens the library's own dialog, which lives in `RootProvider`
+              above this header. (Its sidebar trigger cannot be used here: that one
+              reads a context published inside `DocsLayout`, which this bar sits
+              outside of. The page tree is handled by the menu below instead.) */}
+          <SearchTrigger
+            aria-label={chrome.searchTrigger}
+            className="md:hidden"
+          />
           <ThemeSwitch chrome={chrome} />
           <span
             className="hidden h-5 w-px bg-border sm:block"
@@ -65,6 +81,58 @@ export function DocsHeader({ lang }: { lang: DocsLanguage }) {
           </a>
         </div>
       </div>
+
+      {/* The page tree, for the widths where the sidebar does not exist. A plain
+          disclosure rather than a drawer: it needs no client JS, no context from
+          the layout below, and it closes itself on navigation because the page
+          reloads. Above `md` the sidebar carries this and the menu is hidden. */}
+      <details className="group border-t border-border md:hidden">
+        <summary className="flex cursor-pointer list-none items-center gap-2 px-5 py-2.5 text-[13px] text-muted-foreground [&::-webkit-details-marker]:hidden">
+          <MenuIcon className="h-4 w-4" />
+          {chrome.menu}
+          <ChevronIcon className="ml-auto h-4 w-4 transition-transform group-open:rotate-180" />
+        </summary>
+        <nav className="border-t border-border px-3 pb-3 pt-1">
+          {tree.children.map((node, index) => {
+            if (node.type === "separator") {
+              return (
+                <p
+                  key={`separator-${index}`}
+                  className="px-2 pb-1 pt-3 text-[12px] font-semibold text-foreground"
+                >
+                  {node.name}
+                </p>
+              );
+            }
+            if (node.type !== "page") return null;
+            return (
+              <Link
+                key={node.url}
+                href={node.url}
+                className="block px-2 py-1.5 text-[15px] text-muted-foreground no-underline transition-colors hover:text-foreground"
+              >
+                {node.name}
+              </Link>
+            );
+          })}
+        </nav>
+      </details>
     </header>
+  );
+}
+
+function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={className}>
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function MenuIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true" className={className}>
+      <path d="M4 7h16M4 12h16M4 17h16" />
+    </svg>
   );
 }

--- a/web/landing/src/components/docs/theme-switch.tsx
+++ b/web/landing/src/components/docs/theme-switch.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { cn } from "@/lib/utils";
 import type { DocsChrome } from "@/lib/docs-ui";
 
@@ -22,32 +22,37 @@ function apply(theme: DocsTheme) {
   }
 }
 
+// The `data-docs-theme` attribute on <html> is the state — not this component.
+// The shell renders one switch in the desktop sidebar and another inside the
+// mobile menu, and both have to agree, so they read the attribute rather than each
+// holding a copy. That makes it an external store: a subscribe, a snapshot, and no
+// local state to keep in sync.
+function subscribe(onChange: () => void) {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-docs-theme"],
+  });
+  return () => observer.disconnect();
+}
+
+function readTheme(): DocsTheme {
+  const current = document.documentElement.dataset.docsTheme;
+  return current === "light" || current === "dark" ? current : "system";
+}
+
+// The server cannot know what the reader picked, so it renders no selection and
+// the client fills one in. React calls this for the server pass and for the
+// hydration pass, which is what keeps the two from disagreeing.
+function readThemeOnServer(): undefined {
+  return undefined;
+}
+
 // The docs' appearance switch: System, Light, Dark. Only the docs have it — the
 // landing page is a dark object by design — so the choice is stored under its own
 // key and applied to a `data-docs-theme` attribute the docs styles scope on.
 export function ThemeSwitch({ chrome }: { chrome: DocsChrome }) {
-  // Undefined until mounted: the server has no way to know what the reader
-  // picked, and rendering a guess would flip a button under them on hydration.
-  const [theme, setTheme] = useState<DocsTheme | undefined>(undefined);
-
-  // The attribute on <html> is the state, not this component — the shell renders
-  // one switch for the desktop sidebar and one inside the mobile menu, and
-  // watching the attribute keeps both honest instead of letting the hidden one go
-  // stale until a resize reveals it.
-  useEffect(() => {
-    const root = document.documentElement;
-    const read = () => {
-      const current = root.dataset.docsTheme;
-      setTheme(current === "light" || current === "dark" ? current : "system");
-    };
-    read();
-    const observer = new MutationObserver(read);
-    observer.observe(root, {
-      attributes: true,
-      attributeFilter: ["data-docs-theme"],
-    });
-    return () => observer.disconnect();
-  }, []);
+  const theme = useSyncExternalStore(subscribe, readTheme, readThemeOnServer);
 
   const options: { value: DocsTheme; label: string; icon: React.ReactNode }[] = [
     { value: "system", label: chrome.themeSystem, icon: <SystemIcon /> },

--- a/web/landing/src/lib/docs-ui.ts
+++ b/web/landing/src/lib/docs-ui.ts
@@ -7,13 +7,10 @@ import type { DocsLanguage } from "@/lib/i18n";
 export type DocsChrome = {
   searchTrigger: string;
   searchPlaceholder: string;
-  searching: string;
-  searchUnavailable: string;
-  /** `{query}` is replaced with what the reader typed. A template, not a
-   * function: this object crosses into a client component, and functions can't. */
   noResults: string;
   menu: string;
   onThisPage: string;
+  noHeadings: string;
   previous: string;
   next: string;
   copyForLLM: string;
@@ -22,7 +19,6 @@ export type DocsChrome = {
   markdown: string;
   markdownAriaLabel: string;
   editPage: string;
-  skipToContent: string;
   language: string;
   docsLabel: string;
   download: string;
@@ -36,11 +32,10 @@ export type DocsChrome = {
 const en: DocsChrome = {
   searchTrigger: "Search docs",
   searchPlaceholder: "Search the docs…",
-  searching: "Searching…",
-  searchUnavailable: "Search isn’t available right now — try again in a moment.",
-  noResults: "No results for “{query}”.",
+  noResults: "No results.",
   menu: "Documentation menu",
   onThisPage: "On this page",
+  noHeadings: "No headings",
   previous: "Previous",
   next: "Next",
   copyForLLM: "Copy for LLM",
@@ -49,7 +44,6 @@ const en: DocsChrome = {
   markdown: "Markdown",
   markdownAriaLabel: "Open this page as raw Markdown",
   editPage: "Edit this page on GitHub",
-  skipToContent: "Skip to content",
   language: "Language",
   docsLabel: "Docs",
   download: "Download",
@@ -63,11 +57,10 @@ const en: DocsChrome = {
 const zhCN: DocsChrome = {
   searchTrigger: "搜索文档",
   searchPlaceholder: "搜索文档…",
-  searching: "搜索中…",
-  searchUnavailable: "搜索暂时不可用，请稍后再试。",
-  noResults: "没有与“{query}”匹配的结果。",
+  noResults: "没有匹配的结果。",
   menu: "文档目录",
   onThisPage: "本页内容",
+  noHeadings: "本页没有小标题",
   previous: "上一页",
   next: "下一页",
   copyForLLM: "拷贝给 LLM",
@@ -76,7 +69,6 @@ const zhCN: DocsChrome = {
   markdown: "Markdown",
   markdownAriaLabel: "以 Markdown 原文打开本页",
   editPage: "在 GitHub 上编辑本页",
-  skipToContent: "跳到正文",
   language: "语言",
   docsLabel: "文档",
   download: "下载",
@@ -91,4 +83,28 @@ const CHROME: Record<DocsLanguage, DocsChrome> = { en, "zh-CN": zhCN };
 
 export function docsChrome(lang: DocsLanguage): DocsChrome {
   return CHROME[lang] ?? en;
+}
+
+// The words fumadocs writes itself — the search field, the table of contents
+// heading, the pager, the edit link. Without this map the library falls back to
+// its English defaults, which is why a Chinese page carried an English "On this
+// page" above a Chinese outline. Its keys are the English string plus the context
+// it appears in; that is the library's own key format, not a convention of ours,
+// so they are quoted verbatim from `fumadocs-ui/dist/.translations`.
+export function docsLibraryChrome(lang: DocsLanguage): Record<string, string> {
+  const chrome = docsChrome(lang);
+  return {
+    "On this page(table of contents)": chrome.onThisPage,
+    "Table of Contents(inline table of contents)": chrome.onThisPage,
+    "No Headings(table of contents)": chrome.noHeadings,
+    "Search(search trigger)": chrome.searchTrigger,
+    "Search(search dialog)": chrome.searchPlaceholder,
+    "No results found(search dialog)": chrome.noResults,
+    "Previous Page(pagination)": chrome.previous,
+    "Next Page(pagination)": chrome.next,
+    "Edit on GitHub(edit page)": chrome.editPage,
+    "Toggle Menu(mobile menu)(aria-label)": chrome.menu,
+    "Choose a language(language switcher)": chrome.language,
+    "Choose a language(language switcher)(aria-label)": chrome.language,
+  };
 }

--- a/web/landing/src/mdx-components.tsx
+++ b/web/landing/src/mdx-components.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { ComponentProps, ReactNode } from "react";
 import type { MDXComponents } from "mdx/types";
+import defaultMdxComponents from "fumadocs-ui/mdx";
 import { Keybindings } from "@/components/docs/keybindings";
 import { cn } from "@/lib/utils";
 
@@ -194,11 +195,15 @@ function DocsLink({ href = "", ...props }: ComponentProps<"a">) {
   return <a href={href} target="_blank" rel="noreferrer" {...props} />;
 }
 
-// The component map handed to every compiled MDX page. Typography is carried by
-// fumadocs-ui's `DocsBody`; here we swap in behavior — smart
-// links — and register the custom components authors can use in MDX.
+// The component map handed to every compiled MDX page. It starts from the
+// library's defaults and overrides from there — replacing them outright meant a
+// fenced code block rendered as a bare <pre><code> with no `CodeBlock` around it,
+// so it had no surface of its own and the only thing painting it was the
+// inline-code chip repeating once per line. Ours win where we have a considered
+// version: smart links, and the Callout and Card set built for this site.
 export function getMDXComponents(extra?: MDXComponents): MDXComponents {
   return {
+    ...defaultMdxComponents,
     a: DocsLink as MDXComponents["a"],
     Callout,
     Cards,
@@ -208,7 +213,10 @@ export function getMDXComponents(extra?: MDXComponents): MDXComponents {
     DocsVideo,
     Keybindings,
     ...extra,
-  };
+    // `MDXComponents` declares every tag optional and also carries an index
+    // signature that rejects `undefined`, so spreading it into itself never
+    // satisfies its own type.
+  } as MDXComponents;
 }
 
 function InfoIcon({ className }: { className?: string }) {


### PR DESCRIPTION
The docs site ran on stock fumadocs typography and had never been checked on a phone. This measures what was wrong, fixes it, and adds the check that keeps one class of rot from coming back.

## What changes for a reader

- Body copy sits on a **40rem measure** instead of the full 836px column — 104 characters a line became 76. Body is 17px, and the heading scale is a hierarchy again (34 / 25.5 / 21.25) rather than four sizes within 4px of each other.
- **Code blocks render as code blocks.** The MDX component map was replacing the library's rather than extending it, so a fenced block had no surface of its own — what looked like one was the inline-code chip repeating per line. The copy button was missing entirely.
- **The docs work on a phone.** There was no navigation and no search below `md`, and the page title collided with the page actions.
- Tables are hairline rows at content width; lists take the dash the changelog already uses; the docs surface is square.
- Chinese pages read Chinese: the search field, table of contents, pager and edit link were English over a translated page.
- A page offers one set of next steps, not two.

## Notes for review

Three things were measured rather than eyeballed, and the numbers are in the commit bodies: the reading measure, the header/sidebar alignment (23px at 1440, 207px at 1920 — a fixed padding could only ever be right at one width), and horizontal overflow across 6 device sizes × 6 pages, which is zero.

Two scoping traps cost a debugging pass each and are worth knowing about:

- The prose rules must live in the `utilities` layer, because that is where the typography plugin puts `.prose`. Layer order outranks specificity, so a more specific rule one layer down loses silently — and only for the properties the plugin happens to set.
- `.prose` is not only the page body. The library puts it on every table-of-contents link, so unscoped rules turned each TOC entry into a flex column at body size.

`style(docs): use curly quotes` touches 30 files but is mechanical — prose punctuation only, with fenced blocks, code spans and JSX attributes left alone.

## Verification

`tsc` clean · 6/6 tests · `docs:check` ok (82 internal links and anchors resolve) · `pnpm build` 77 pages · rendered and read back in light, dark, zh-CN, at 1280/1440/1920 and on iPhone SE/15/15 Pro Max, Galaxy S, Pixel 7, iPad mini.

Release Notes: The documentation site gets a proper reading measure and type scale, working code blocks, and navigation and search on mobile.