### PR TITLE
Gate notifications on Termio's own bundle

### DIFF
--- a/Sources/termio/App/TaskNotifications.swift
+++ b/Sources/termio/App/TaskNotifications.swift
@@ -60,7 +60,7 @@ final class TaskNotificationCenter: NSObject {
     /// any notification is clicked — including one whose click launches the app.
     func activate(store: TermioStore) {
         self.store = store
-        guard AppChannel.isBundledApp else { return }
+        guard AppChannel.isTermioAppBundle else { return }
         UNUserNotificationCenter.current().delegate = self
         // Ask for authorization eagerly, at launch, when the feature is on.
         // The lazy per-settle request (below) only ever fires while termio is
@@ -104,7 +104,7 @@ final class TaskNotificationCenter: NSObject {
     func sessionDidSettle(_ id: Session.ID, status: SessionStatus) {
         let turn = states[id]
         states[id]?.workingSince = nil
-        guard AppChannel.isBundledApp, let store, store.settings.notifyOnTaskCompletion else { return }
+        guard AppChannel.isTermioAppBundle, let store, store.settings.notifyOnTaskCompletion else { return }
         guard let session = store.session(id) else { return }
         let agent = store.effectiveAgent(for: session)
         // Only real agent turns notify; a plain terminal's bell/OSC noise doesn't.
@@ -164,7 +164,7 @@ final class TaskNotificationCenter: NSObject {
     /// gated on `notifyOnTaskCompletion`: that switch governs the *automatic*
     /// banners, whereas this is a direct, opt-in call.
     func postManual(title: String, body: String, project: Project?, session: Session?) {
-        guard AppChannel.isBundledApp else { return }
+        guard AppChannel.isTermioAppBundle else { return }
         let content = UNMutableNotificationContent()
         content.title = title
         if let project { content.subtitle = project.name }
@@ -240,7 +240,7 @@ final class TaskNotificationCenter: NSObject {
     /// `withdrawAll`, and removing an absent identifier is a no-op.
     func withdraw(for id: Session.ID) {
         states[id, default: TurnState()].generation += 1
-        guard AppChannel.isBundledApp else { return }
+        guard AppChannel.isTermioAppBundle else { return }
         UNUserNotificationCenter.current()
             .removeDeliveredNotifications(withIdentifiers: [Self.identifier(for: id)])
     }
@@ -256,14 +256,15 @@ final class TaskNotificationCenter: NSObject {
     /// Quit takes the sessions with it, so any banners left behind would point
     /// at nothing.
     func withdrawAll() {
-        guard AppChannel.isBundledApp else { return }
+        guard AppChannel.isTermioAppBundle else { return }
         UNUserNotificationCenter.current().removeAllDeliveredNotifications()
     }
 
     /// The macOS-side authorization for termio's notifications, for the Settings
-    /// row. `nil` outside a bundled app (the framework can't be touched there).
+    /// row. `nil` outside termio's own app bundle (the framework can't be touched
+    /// there).
     static func authorizationStatus() async -> UNAuthorizationStatus? {
-        guard AppChannel.isBundledApp else { return nil }
+        guard AppChannel.isTermioAppBundle else { return nil }
         return await UNUserNotificationCenter.current().notificationSettings()
             .authorizationStatus
     }
@@ -272,7 +273,7 @@ final class TaskNotificationCenter: NSObject {
     /// the first notification makes, just user-initiated. Returns whether the
     /// user granted it.
     static func requestPermission() async -> Bool {
-        guard AppChannel.isBundledApp else { return false }
+        guard AppChannel.isTermioAppBundle else { return false }
         return (try? await UNUserNotificationCenter.current()
             .requestAuthorization(options: [.alert, .sound])) ?? false
     }

--- a/Sources/termio/Companion/AppChannel.swift
+++ b/Sources/termio/Companion/AppChannel.swift
@@ -45,11 +45,25 @@ enum AppChannel {
     /// Registered in Info.plist; `build-app.sh` rewrites it for the dev bundle.
     static var urlScheme: String { "termio" + suffix }
 
-    /// True when running from a real `.app` bundle (either channel). A bare SwiftPM
-    /// binary (`swift run`, the test runner) has no bundle identifier, and
-    /// bundle-dependent frameworks — `UNUserNotificationCenter` aborts with
-    /// "bundleProxyForCurrentProcess is nil" — must not be touched without one.
-    static let isBundledApp = Bundle.main.bundleIdentifier != nil
+    /// The identifier a shipped termio carries. `build-app.sh` stamps this one for
+    /// the release channel and appends `.dev` for the side-by-side dev build, and
+    /// it refuses to build any other channel — so these two are the complete set.
+    private static let releaseBundleIdentifier = "sh.termio.app"
+
+    /// True when this process *is* one of termio's own `.app` bundles. It gates the
+    /// bundle-dependent frameworks: `UNUserNotificationCenter` aborts the process
+    /// with "bundleProxyForCurrentProcess is nil" unless the running bundle is one
+    /// LaunchServices knows.
+    ///
+    /// Asking the weaker question — "is there *a* bundle identifier?" — passed under
+    /// `swift test`, whose `xctest` host is bundled as Xcode's own tool and so
+    /// carries an identifier that buys the framework nothing. Every test that moved
+    /// the store's selection died on `SIGABRT` inside `markSeen`.
+    static let isTermioAppBundle: Bool = {
+        guard let identifier = Bundle.main.bundleIdentifier else { return false }
+        return identifier == releaseBundleIdentifier
+            || identifier == releaseBundleIdentifier + ".dev"
+    }()
 
     /// Internal state — control/status sockets, `state.json`, custom themes, and
     /// downloaded tunnel binaries: `~/Library/Application Support/termio[-dev]`.

--- a/Tests/termioTests/TermioStoreSelectionTests.swift
+++ b/Tests/termioTests/TermioStoreSelectionTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import termio
+
+/// Selecting a session is the store's busiest write: every sidebar click, every
+/// deep link and every ⌘⇧] lands in `selectedSessionID`'s `didSet`, which then
+/// acknowledges the arriving session's "your turn" cue. These cover that
+/// acknowledgement — the half of it a window isn't needed to see.
+///
+/// The path was untestable until `AppChannel.isTermioAppBundle` learned to tell
+/// termio's own bundle from any bundle at all: under `xctest` the old predicate
+/// said yes, `markSeen` reached `UNUserNotificationCenter`, and the whole run
+/// died on `SIGABRT`.
+@MainActor
+final class TermioStoreSelectionTests: XCTestCase {
+    private var directory: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("store-selection-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        suiteName = "store-selection-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        defaults.removePersistentDomain(forName: suiteName)
+        try await super.tearDown()
+    }
+
+    /// Both settings layers are handed scratch storage: a test must not rewrite
+    /// the settings file or the defaults domain of the termio the user is running.
+    private func makeStore(sessions: [Session]) -> TermioStore {
+        var workspace = Workspace(name: "Default")
+        workspace.terminals = sessions
+        let settings = AppSettings(
+            defaults: defaults,
+            settingsStore: SettingsStore(
+                defaults: defaults,
+                fileURL: directory.appendingPathComponent("settings.json"),
+                domainName: suiteName))
+        return TermioStore(workspaces: [workspace], settings: settings)
+    }
+
+    /// A finished agent's dot is dismissed by looking at it: "ready for you" has
+    /// been read the moment its session is on screen.
+    func testSelectingAFinishedSessionClearsItsCue() {
+        let watched = Session(title: "Terminal 1", agent: .terminal)
+        let finished = Session(title: "Terminal 2", agent: .claudeCode)
+        let store = makeStore(sessions: [watched, finished])
+        store.setStatus(.done, for: finished.id)
+
+        store.selectedSessionID = finished.id
+
+        XCTAssertEqual(store.status(for: finished.id), .idle)
+    }
+
+    /// A blocked agent's dot is not: reading a permission prompt is not answering
+    /// it, so only the agent proceeding clears one.
+    func testSelectingABlockedSessionKeepsItsCue() {
+        let watched = Session(title: "Terminal 1", agent: .terminal)
+        let blocked = Session(title: "Terminal 2", agent: .claudeCode)
+        let store = makeStore(sessions: [watched, blocked])
+        store.setStatus(.needsAttention, for: blocked.id)
+        store.blockingAttention.insert(blocked.id)
+
+        store.selectedSessionID = blocked.id
+
+        XCTAssertEqual(store.status(for: blocked.id), .needsAttention)
+    }
+}


### PR DESCRIPTION
`AppChannel.isBundledApp` asked whether `Bundle.main` had an identifier at all. Under `xctest` it does, so the guard meant to keep UserNotifications away from an unbundled process let the test host straight through — and any test touching the store's selection path died with `SIGABRT` rather than failing an assertion. A whole area of the store was untestable and the reason looked like a crash.

Replaced with a positive identity check against Termio's own bundle ids, which is the question the guard was always asking.

Release Notes:
None — internal.