### PR TITLE
Name the SSH settings tab Machines

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1873,7 +1873,7 @@ extension AppDelegate: NSMenuDelegate {
     }
 
     /// Fills a New SSH Connection submenu with one row per `~/.ssh/config` host —
-    /// the same aliases Settings ▸ SSH lists — each connecting directly, plus a
+    /// the same aliases Settings ▸ Machines lists — each connecting directly, plus a
     /// trailing "Add Host…" opening the same form as Settings' Add Host button
     /// and connecting to the machine it adds (see `addSSHHost`). With an empty
     /// config only "Add Host…" remains — the first-run path.

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -3562,12 +3562,12 @@
         }
       }
     },
-    "SSH": {
+    "Machines": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "SSH"
+            "value": "机器"
           }
         }
       }
@@ -3642,12 +3642,12 @@
         }
       }
     },
-    "Your ~/.ssh/config hosts, one click away": {
+    "The machines in your ~/.ssh/config, and the keys that reach them": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "一键连接 ~/.ssh/config 中的主机"
+            "value": "~/.ssh/config 里的机器，以及连上它们的密钥"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -532,6 +532,8 @@
 	<string>Local</string>
 	<key>Login shell</key>
 	<string>Login shell</string>
+	<key>Machines</key>
+	<string>Machines</string>
 	<key>Match Case</key>
 	<string>Match Case</string>
 	<key>Match Whole Word</key>
@@ -872,8 +874,6 @@
 	<string>Runs with `%@`. The agent won’t ask before editing files or running commands.</string>
 	<key>SF Symbol name</key>
 	<string>SF Symbol name</string>
-	<key>SSH</key>
-	<string>SSH</string>
 	<key>Save</key>
 	<string>Save</string>
 	<key>Save failed: %@</key>
@@ -1022,6 +1022,8 @@
 	<string>The folder was removed, but git couldn’t prune its stale worktree metadata.</string>
 	<key>The ignore rule couldn’t be added.</key>
 	<string>The ignore rule couldn’t be added.</string>
+	<key>The machines in your ~/.ssh/config, and the keys that reach them</key>
+	<string>The machines in your ~/.ssh/config, and the keys that reach them</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>The project and session list. Kept separate from the terminal font, and need not be monospaced.</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
@@ -1148,8 +1150,6 @@
 	<string>You can restore it from the Trash.</string>
 	<key>Your Host entries from ~/.ssh/config — the same aliases `ssh` resolves. Right-click a host to connect.</key>
 	<string>Your Host entries from ~/.ssh/config — the same aliases `ssh` resolves. Right-click a host to connect.</string>
-	<key>Your ~/.ssh/config hosts, one click away</key>
-	<string>Your ~/.ssh/config hosts, one click away</string>
 	<key>Zoom</key>
 	<string>Zoom</string>
 	<key>Zoom Split</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -532,6 +532,8 @@
 	<string>本地</string>
 	<key>Login shell</key>
 	<string>登录 shell</string>
+	<key>Machines</key>
+	<string>机器</string>
 	<key>Match Case</key>
 	<string>区分大小写</string>
 	<key>Match Whole Word</key>
@@ -872,8 +874,6 @@
 	<string>以 `%@` 运行。Agent 在编辑文件或运行命令前将不再询问。</string>
 	<key>SF Symbol name</key>
 	<string>SF Symbol 名称</string>
-	<key>SSH</key>
-	<string>SSH</string>
 	<key>Save</key>
 	<string>存储</string>
 	<key>Save failed: %@</key>
@@ -1022,6 +1022,8 @@
 	<string>文件夹已移除，但 git 无法清理其残留的 worktree 元数据。</string>
 	<key>The ignore rule couldn’t be added.</key>
 	<string>无法添加忽略规则。</string>
+	<key>The machines in your ~/.ssh/config, and the keys that reach them</key>
+	<string>~/.ssh/config 里的机器，以及连上它们的密钥</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>项目与会话列表。与终端字体分开设置，无需等宽字体。</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
@@ -1148,8 +1150,6 @@
 	<string>可以从废纸篓恢复它。</string>
 	<key>Your Host entries from ~/.ssh/config — the same aliases `ssh` resolves. Right-click a host to connect.</key>
 	<string>来自 ~/.ssh/config 的 Host 条目，与 `ssh` 解析的别名一致。右键点按主机即可连接。</string>
-	<key>Your ~/.ssh/config hosts, one click away</key>
-	<string>一键连接 ~/.ssh/config 中的主机</string>
 	<key>Zoom</key>
 	<string>缩放</string>
 	<key>Zoom Split</key>

--- a/Sources/termio/Settings/MachinesSettingsTab.swift
+++ b/Sources/termio/Settings/MachinesSettingsTab.swift
@@ -1,11 +1,11 @@
 import AppKit
 import SwiftUI
 
-/// Settings ▸ SSH: the connectable hosts from `~/.ssh/config`, each one click
+/// Settings ▸ Machines: the connectable hosts from `~/.ssh/config`, each one click
 /// away from a terminal. The config file stays the single source of truth —
 /// termio reads the same hosts `ssh` itself resolves and writes nothing behind
 /// the user's back: Add Host appends a plain block, Edit opens the raw file.
-struct SSHSettingsTab: View {
+struct MachinesSettingsTab: View {
     @ObservedObject var settings: AppSettings
     /// Opens an SSH terminal to the alias in the main window (wired to
     /// `TermioStore.addSSHSession` by the app delegate).
@@ -276,7 +276,7 @@ private extension SSHProbeResult {
 
 /// The Add Host sheet: the four fields a `Host` block actually needs, appended
 /// to `~/.ssh/config` as a block indistinguishable from a hand-written one.
-/// Shared by Settings ▸ SSH's Add Host button and the New SSH Connection ▸
+/// Shared by Settings ▸ Machines' Add Host button and the New SSH Connection ▸
 /// Add Host… menu row (which connects to the host right after adding it).
 struct AddSSHHostSheet: View {
     let existingAliases: Set<String>

--- a/Sources/termio/Settings/SettingsTab.swift
+++ b/Sources/termio/Settings/SettingsTab.swift
@@ -7,7 +7,10 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case appearance
     case terminal
-    case ssh
+    /// The raw value stays `ssh` because it is the value persisted under
+    /// `lastOpenKey`; changing it would reopen Settings on another tab for
+    /// everyone who left this one showing.
+    case machines = "ssh"
     case keyboard
     case agents
     case usage
@@ -25,7 +28,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return localized("General")
         case .appearance: return localized("Appearance")
         case .terminal: return localized("Terminal")
-        case .ssh: return localized("SSH")
+        case .machines: return localized("Machines")
         case .keyboard: return localized("Keyboard")
         case .agents: return localized("Agents")
         case .usage: return localized("Usage")
@@ -41,7 +44,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return .settings
         case .appearance: return .paintBoard
         case .terminal: return .terminal
-        case .ssh: return .serverStack
+        case .machines: return .serverStack
         case .keyboard: return .keyboard
         case .agents: return .bot
         case .usage: return .chartColumn
@@ -57,7 +60,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return localized("The termio command-line tool, agent skill, and notifications")
         case .appearance: return localized("Theme, fonts, cursor, and window")
         case .terminal: return localized("Scrollback history and text selection")
-        case .ssh: return localized("Your ~/.ssh/config hosts, one click away")
+        case .machines: return localized("The machines in your ~/.ssh/config, and the keys that reach them")
         case .keyboard: return localized("Keyboard shortcuts for every command")
         case .agents: return localized("The coding agents offered when you start a session")
         case .usage: return localized("Token usage for your connected agents")

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -13,7 +13,7 @@ struct SettingsView: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var usage: UsageMonitor
     /// Opens an SSH terminal to a `~/.ssh/config` alias in the main window — the
-    /// SSH tab's Connect action, injected by the app delegate so the settings
+    /// Machines tab's Connect action, injected by the app delegate so the settings
     /// window doesn't hold the store.
     let onSSHConnect: (String) -> Void
     @State private var selection: SettingsTab
@@ -80,7 +80,7 @@ struct SettingsView: View {
         case .general: GeneralSettingsTab(settings: settings)
         case .appearance: AppearanceSettingsTab(settings: settings, isBrowsingStore: $isBrowsingThemeStore)
         case .terminal: TerminalSettingsTab(settings: settings)
-        case .ssh: SSHSettingsTab(settings: settings, onConnect: onSSHConnect)
+        case .machines: MachinesSettingsTab(settings: settings, onConnect: onSSHConnect)
         case .keyboard: KeybindingsSettingsTab()
         case .agents: AgentSettingsTab(settings: settings)
         case .usage: UsageSettingsTab(settings: settings, usage: usage)

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -1194,7 +1194,7 @@ private struct SessionRow: View {
             Group {
                 if session.isSSH, status != .working {
                     // An SSH terminal is a machine, so it carries the same server
-                    // glyph as its host row in Settings ▸ SSH (a globe reads as
+                    // glyph as its host row in Settings ▸ Machines (a globe reads as
                     // "web", not "that box") — except while a detected remote
                     // agent is working, when it falls through to the spinner below.
                     // Size 15 like the folder and agent marks sharing this


### PR DESCRIPTION
Nobody opens Settings to configure SSH; they open it to add a server. `remote-to-device` §4.2 already specifies **Settings ▸ Machines** as the replacement, so this executes a decision rather than making one.

Only the tab is renamed. `SSHConfigFile`, `AddSSHHostSheet`, the public keys section and "New SSH Connection" keep their names — they parse `~/.ssh/config`, append `Host` blocks and open `ssh`, and renaming them would make the names lie. The enum's raw value stays `ssh` because it is the key Settings reopens on.

Release Notes:
Settings ▸ SSH is now Settings ▸ Machines.