### PR TITLE
Make the workspace verbs reachable with one workspace

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -963,6 +963,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.presentNewWorkspacePanel()
     }
 
+    /// The submenu's "Rename Workspace…" row. It acts on the workspace the window
+    /// is in, which is the one the rows above show checked.
+    @objc func renameWorkspace(_ sender: Any?) {
+        store.presentRenameWorkspacePanel(store.currentWorkspaceID)
+    }
+
+    /// The submenu's "Remove Workspace" row, acting on the current workspace like
+    /// the rename above. Disabled at one workspace (see `validateMenuItem`).
+    @objc func removeWorkspace(_ sender: Any?) {
+        store.confirmRemoveWorkspace(store.currentWorkspaceID)
+    }
+
     /// A row of the Connect to… submenu — first contact with a machine from
     /// `~/.ssh/config`. Opening a terminal on it is the connection: `termiod` is
     /// installed there if missing, the handshake records which device the alias
@@ -1536,7 +1548,6 @@ enum DeviceMenuTag {
     static let newTerminal = 7301
     static let newTerminalAtHome = 7302
     static let connectTo = 7303
-    static let workspace = 7304
     static let openProject = 7305
 }
 
@@ -1545,12 +1556,12 @@ enum DeviceMenuTag {
 /// this one exists because a key equivalent only fires from the main menu, and because
 /// a chord nobody can find is a chord nobody presses.
 ///
-/// Hidden while there is only one workspace (see `refreshDeviceItems`), so the menu
-/// grows the row at the same moment the toolbar grows the control.
+/// Always shown, including with a single workspace: the toolbar switcher collapses
+/// then — with one scope there is nothing to switch — so this is where creating,
+/// renaming and removing a workspace has to stay reachable.
 @MainActor
 private func makeWorkspaceItem() -> NSMenuItem {
     let item = NSMenuItem(title: localized("Workspace"), action: nil, keyEquivalent: "")
-    item.tag = DeviceMenuTag.workspace
     let submenu = NSMenu(title: localized("Workspace"))
     submenu.delegate = NSApp.delegate as? AppDelegate
     item.submenu = submenu
@@ -1633,8 +1644,6 @@ extension AppDelegate: NSMenuDelegate {
                 refreshNewTerminalItem(item, known: known, atHome: true, command: nil)
             case DeviceMenuTag.connectTo:
                 item.isHidden = DeviceRoster.unusedAliases(known: known).isEmpty
-            case DeviceMenuTag.workspace:
-                item.isHidden = !store.hasMultipleWorkspaces
             case DeviceMenuTag.openProject:
                 refreshOpenProjectItem(item, known: known)
             default:
@@ -1923,6 +1932,12 @@ extension AppDelegate: NSMenuDelegate {
         let new = menu.addItem(withTitle: localized("New Workspace…"),
                                action: #selector(newWorkspace(_:)), keyEquivalent: "")
         new.target = self
+        let rename = menu.addItem(withTitle: localized("Rename Workspace…"),
+                                  action: #selector(renameWorkspace(_:)), keyEquivalent: "")
+        rename.target = self
+        let remove = menu.addItem(withTitle: localized("Remove Workspace"),
+                                  action: #selector(removeWorkspace(_:)), keyEquivalent: "")
+        remove.target = self
     }
 
     private func fillConnectToMenu(_ menu: NSMenu) {
@@ -1950,6 +1965,11 @@ extension AppDelegate: NSMenuItemValidation {
             return !store.sidebarSessionGroups.isEmpty
         case #selector(newWorktree(_:)), #selector(newPullRequest(_:)):
             return currentBranchProject != nil
+        // The store refuses to remove the last workspace — the sidebar has to have
+        // a scope to show — so the row dims rather than answering a click with
+        // nothing.
+        case #selector(removeWorkspace(_:)):
+            return store.hasMultipleWorkspaces
         default:
             return true
         }

--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -396,9 +396,32 @@ extension TermioStore {
             title: localized("New Workspace"),
             message: localized("Name the workspace. It starts empty; sessions and projects you open from now on are filed under it."),
             confirm: localized("Create"),
-            defaultName: ""
+            defaultName: nextFreeWorkspaceName
         ) else { return }
         addWorkspace(named: name)
+    }
+
+    /// What the new-workspace field opens with: "Workspace", bumped past the names
+    /// already taken, the way `uniqueWorktreeDirName` bumps a worktree folder.
+    ///
+    /// The default is what makes the panel work at all. `promptForWorkspaceName`
+    /// treats an empty field as a cancel, so opening empty meant Return created
+    /// nothing and said nothing — a dead end at the first keystroke. Prefilled and
+    /// selected, Return creates and typing over it renames, which is what a new
+    /// item does everywhere else on macOS.
+    private var nextFreeWorkspaceName: String {
+        Self.nextFreeWorkspaceName(base: localized("Workspace"),
+                                   taken: Set(workspaces.map(\.name)))
+    }
+
+    /// The counter rule on its own, so it can be tested without standing up a
+    /// store: `base`, then `base 2`, `base 3`, skipping every name in use.
+    /// `nonisolated` because it reads nothing but its arguments.
+    nonisolated static func nextFreeWorkspaceName(base: String, taken: Set<String>) -> String {
+        guard taken.contains(base) else { return base }
+        var counter = 2
+        while taken.contains("\(base) \(counter)") { counter += 1 }
+        return "\(base) \(counter)"
     }
 
     /// Renames a workspace in place. A machine's fallback can be renamed like any

--- a/Tests/termioTests/WorkspaceMigrationTests.swift
+++ b/Tests/termioTests/WorkspaceMigrationTests.swift
@@ -261,3 +261,38 @@ final class WorkspaceMigrationTests: XCTestCase {
         XCTAssertEqual(reconciled.projects, once.projects)
     }
 }
+
+/// The default name the New Workspace panel opens with. The panel treats an empty
+/// field as a cancel, so this default is what makes Return create a workspace at
+/// all — an off-by-one here hands the user a name that is already taken.
+final class WorkspaceDefaultNameTests: XCTestCase {
+    func testFirstWorkspaceTakesTheBareName() {
+        XCTAssertEqual(
+            TermioStore.nextFreeWorkspaceName(base: "Workspace", taken: []), "Workspace")
+        XCTAssertEqual(
+            TermioStore.nextFreeWorkspaceName(base: "Workspace", taken: ["Sessions"]), "Workspace")
+    }
+
+    func testTheCounterStartsAtTwoAndSkipsWhatIsTaken() {
+        XCTAssertEqual(
+            TermioStore.nextFreeWorkspaceName(base: "Workspace", taken: ["Workspace"]),
+            "Workspace 2")
+        XCTAssertEqual(
+            TermioStore.nextFreeWorkspaceName(
+                base: "Workspace", taken: ["Workspace", "Workspace 2"]),
+            "Workspace 3")
+        // A gap is not filled: the next free number wins, not the lowest missing
+        // one, so the name never collides with a workspace further down the list.
+        XCTAssertEqual(
+            TermioStore.nextFreeWorkspaceName(
+                base: "Workspace", taken: ["Workspace", "Workspace 3"]),
+            "Workspace 2")
+    }
+
+    /// The base is `localized("Workspace")`, so the rule has to hold for a
+    /// translated base too — zh-Hans ships 工作区.
+    func testTheRuleHoldsForALocalizedBase() {
+        XCTAssertEqual(
+            TermioStore.nextFreeWorkspaceName(base: "工作区", taken: ["工作区"]), "工作区 2")
+    }
+}


### PR DESCRIPTION
New Workspace…, Rename Workspace… and Remove Workspace lived only in the toolbar switcher and in `File ▸ Workspace`, and both were hidden while there was one workspace. So a user with one workspace could never create a second, rename the one they had, or remove anything — the whole verb set was unreachable from the state every new install starts in.

It escaped notice because connecting to any machine auto-creates a fallback workspace and pushes you past the gate.

The switcher's collapse is correct and stays: with one scope there is nothing to switch. Its mistake was owning the only copy of verbs that are not switching. `File ▸ Workspace` is now always present and carries all three, with Remove dimmed at one workspace so the store's existing refusal is visible before the click.

Also fixes the panel opening empty: it treats an empty field as a cancel, so Return created nothing and said nothing. It now opens with the next free name, selected.

Release Notes:
New Workspace…, Rename Workspace… and Remove Workspace are always available under File ▸ Workspace, including when you have only one workspace. The New Workspace panel now opens with a name filled in.