### PR TITLE
Complete the path when opening a project on another machine

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -281,12 +281,32 @@
         }
       }
     },
-    "Termio can’t browse another machine’s files. Clone a repository onto %@, or enter a folder that’s already there.": {
+    "Clone a repository onto %@, or open a folder that’s already there — the path completes as you type.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Termio 无法浏览另一台机器上的文件。把一个仓库克隆到 %@，或者输入一个已经在那里的文件夹。"
+            "value": "把一个仓库克隆到 %@，或者打开一个已经在那里的文件夹——路径会边输入边补全。"
+          }
+        }
+      }
+    },
+    "This machine’s termiod is too old to list folders.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这台机器上的 termiod 版本太旧，列不出文件夹。"
+          }
+        }
+      }
+    },
+    "The machine answered with no listing for that folder.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这台机器没有返回该文件夹的内容。"
           }
         }
       }
@@ -321,12 +341,12 @@
         }
       }
     },
-    "Termio opens the folder on %@ exactly as typed, so the path has to start with “/”. “~” isn’t expanded.": {
+    "Enter a path that starts with “/”. “~/” works too, once %@ has said where home is.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Termio 会按你输入的原样打开 %@ 上的文件夹，所以路径必须以“/”开头，“~”不会展开。"
+            "value": "请输入以“/”开头的路径。等 %@ 报出主目录之后，“~/”也可以用。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -196,6 +196,8 @@
 	<string>Clear</string>
 	<key>Clone a Repository</key>
 	<string>Clone a Repository</string>
+	<key>Clone a repository onto %@, or open a folder that’s already there — the path completes as you type.</key>
+	<string>Clone a repository onto %@, or open a folder that’s already there — the path completes as you type.</string>
 	<key>Clone to</key>
 	<string>Clone to</string>
 	<key>Close</key>
@@ -388,6 +390,8 @@
 	<string>Enter Code on GitHub</string>
 	<key>Enter a host from your ~/.ssh/config, or a user@host to connect to.</key>
 	<string>Enter a host from your ~/.ssh/config, or a user@host to connect to.</string>
+	<key>Enter a path that starts with “/”. “~/” works too, once %@ has said where home is.</key>
+	<string>Enter a path that starts with “/”. “~/” works too, once %@ has said where home is.</string>
 	<key>Enter an absolute path</key>
 	<string>Enter an absolute path</string>
 	<key>Every paired iPhone is signed out and must re-scan the new QR to reconnect.</key>
@@ -992,16 +996,12 @@
 	<string>Termio can show %@'s token usage and plan limits by reading its local session logs and its `credentials/kimi-code.json` sign-in. Nothing is read until you allow it.</string>
 	<key>Termio can show %@'s token usage and plan limits by reading its local session logs and its sign-in from your login Keychain. Nothing is read until you allow it; macOS will ask once about the Keychain.</key>
 	<string>Termio can show %@'s token usage and plan limits by reading its local session logs and its sign-in from your login Keychain. Nothing is read until you allow it; macOS will ask once about the Keychain.</string>
-	<key>Termio can’t browse another machine’s files. Clone a repository onto %@, or enter a folder that’s already there.</key>
-	<string>Termio can’t browse another machine’s files. Clone a repository onto %@, or enter a folder that’s already there.</string>
 	<key>Termio could not append to the repository’s .gitignore. Check its permissions and try again.</key>
 	<string>Termio could not append to the repository’s .gitignore. Check its permissions and try again.</string>
 	<key>Termio for iPhone is in beta</key>
 	<string>Termio for iPhone is in beta</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio is open source — star the repo, report bugs, and request features.</string>
-	<key>Termio opens the folder on %@ exactly as typed, so the path has to start with “/”. “~” isn’t expanded.</key>
-	<string>Termio opens the folder on %@ exactly as typed, so the path has to start with “/”. “~” isn’t expanded.</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</string>
 	<key>Test</key>
@@ -1022,6 +1022,8 @@
 	<string>The folder was removed, but git couldn’t prune its stale worktree metadata.</string>
 	<key>The ignore rule couldn’t be added.</key>
 	<string>The ignore rule couldn’t be added.</string>
+	<key>The machine answered with no listing for that folder.</key>
+	<string>The machine answered with no listing for that folder.</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>The project and session list. Kept separate from the terminal font, and need not be monospaced.</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
@@ -1064,6 +1066,8 @@
 	<string>This folder has no git “origin” remote to clone.</string>
 	<key>This host sent a name the file tree can’t show.</key>
 	<string>This host sent a name the file tree can’t show.</string>
+	<key>This machine’s termiod is too old to list folders.</key>
+	<string>This machine’s termiod is too old to list folders.</string>
 	<key>This month</key>
 	<string>This month</string>
 	<key>This project’s origin remote doesn’t point at github.com, so there is no issue tracker to show.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -196,6 +196,8 @@
 	<string>清除</string>
 	<key>Clone a Repository</key>
 	<string>克隆仓库</string>
+	<key>Clone a repository onto %@, or open a folder that’s already there — the path completes as you type.</key>
+	<string>把一个仓库克隆到 %@，或者打开一个已经在那里的文件夹——路径会边输入边补全。</string>
 	<key>Clone to</key>
 	<string>克隆到</string>
 	<key>Close</key>
@@ -388,6 +390,8 @@
 	<string>在 GitHub 上输入代码</string>
 	<key>Enter a host from your ~/.ssh/config, or a user@host to connect to.</key>
 	<string>输入 ~/.ssh/config 中的主机，或要连接的 user@host。</string>
+	<key>Enter a path that starts with “/”. “~/” works too, once %@ has said where home is.</key>
+	<string>请输入以“/”开头的路径。等 %@ 报出主目录之后，“~/”也可以用。</string>
 	<key>Enter an absolute path</key>
 	<string>请输入绝对路径</string>
 	<key>Every paired iPhone is signed out and must re-scan the new QR to reconnect.</key>
@@ -992,16 +996,12 @@
 	<string>Termio 可通过读取 %@ 的本地会话日志及其 `credentials/kimi-code.json` 登录信息，显示其 token 用量和套餐限额。在你允许之前不会读取任何内容。</string>
 	<key>Termio can show %@'s token usage and plan limits by reading its local session logs and its sign-in from your login Keychain. Nothing is read until you allow it; macOS will ask once about the Keychain.</key>
 	<string>Termio 可通过读取 %@ 的本地会话日志及登录钥匙串中的登录信息，显示其 token 用量和套餐限额。在你允许之前不会读取任何内容；macOS 会就钥匙串询问一次。</string>
-	<key>Termio can’t browse another machine’s files. Clone a repository onto %@, or enter a folder that’s already there.</key>
-	<string>Termio 无法浏览另一台机器上的文件。把一个仓库克隆到 %@，或者输入一个已经在那里的文件夹。</string>
 	<key>Termio could not append to the repository’s .gitignore. Check its permissions and try again.</key>
 	<string>Termio 无法将内容追加到该仓库的 .gitignore。请检查其权限后重试。</string>
 	<key>Termio for iPhone is in beta</key>
 	<string>Termio for iPhone 正在测试中</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio 是开源软件：欢迎给仓库加星标、报告 bug 和提出功能请求。</string>
-	<key>Termio opens the folder on %@ exactly as typed, so the path has to start with “/”. “~” isn’t expanded.</key>
-	<string>Termio 会按你输入的原样打开 %@ 上的文件夹，所以路径必须以“/”开头，“~”不会展开。</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Browse Themes installs one of 50 curated schemes, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio 会随 macOS 外观变化在两者间切换；将槽位留在默认值即可使用 Termio 自带的画布。“浏览主题”可以从 50 个精选配色中安装一个，你放进主题文件夹的 Ghostty 格式文件也会出现在这里。</string>
 	<key>Test</key>
@@ -1022,6 +1022,8 @@
 	<string>文件夹已移除，但 git 无法清理其残留的 worktree 元数据。</string>
 	<key>The ignore rule couldn’t be added.</key>
 	<string>无法添加忽略规则。</string>
+	<key>The machine answered with no listing for that folder.</key>
+	<string>这台机器没有返回该文件夹的内容。</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>项目与会话列表。与终端字体分开设置，无需等宽字体。</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
@@ -1064,6 +1066,8 @@
 	<string>这个文件夹没有 git “origin” 远程，无法克隆。</string>
 	<key>This host sent a name the file tree can’t show.</key>
 	<string>该主机返回了文件树无法显示的名称。</string>
+	<key>This machine’s termiod is too old to list folders.</key>
+	<string>这台机器上的 termiod 版本太旧，列不出文件夹。</string>
 	<key>This month</key>
 	<string>本月</string>
 	<key>This project’s origin remote doesn’t point at github.com, so there is no issue tracker to show.</key>

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -641,9 +641,13 @@ enum Termiod {
         /// Capabilities the daemon accepted. Absent on an older daemon, so it
         /// defaults rather than failing the handshake — negotiate, never lockstep.
         let caps: [String]
+        /// The account's home directory over there, for the pickers that have to
+        /// name a path on that machine. Empty on a daemon too old to send it, and
+        /// on one that could not read `HOME`; callers fall back to `/`.
+        let home: String
 
         private enum CodingKeys: String, CodingKey {
-            case hostId, host, clientId, caps
+            case hostId, host, clientId, caps, home
         }
 
         init(from decoder: Decoder) throws {
@@ -652,7 +656,46 @@ enum Termiod {
             host = try container.decode(String.self, forKey: .host)
             clientId = try container.decode(String.self, forKey: .clientId)
             caps = try container.decodeIfPresent([String].self, forKey: .caps) ?? []
+            home = try container.decodeIfPresent(String.self, forKey: .home) ?? ""
         }
+    }
+
+    /// One row of an `fs_listed` page (§C.12). `kind` is left as the daemon's
+    /// own word rather than an enum: a kind this build has never heard of must
+    /// decode and sort as "not a directory", not fail the whole listing.
+    struct DirEntryPayload: Decodable {
+        let name: String
+        let kind: String
+
+        /// Whether this entry can be descended into. `unloaded_dir` counts —
+        /// it is a directory the host declines to *walk* (VCS internals), not
+        /// one it refuses to list when asked directly. Compared against the
+        /// daemon's snake_case wire value: `convertFromSnakeCase` rewrites
+        /// keys, never values.
+        var isDirectory: Bool { kind == "dir" || kind == "unloaded_dir" }
+    }
+
+    /// One requested path's listing. A path that vanished or escaped the root
+    /// carries `error` and fails alone, so a batch never sinks whole.
+    struct PathListingPayload: Decodable {
+        let path: String
+        let entries: [DirEntryPayload]
+        let error: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case path, entries, error
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            path = try container.decode(String.self, forKey: .path)
+            entries = try container.decodeIfPresent([DirEntryPayload].self, forKey: .entries) ?? []
+            error = try container.decodeIfPresent(String.self, forKey: .error)
+        }
+    }
+
+    struct FsListedPayload: Decodable {
+        let listings: [PathListingPayload]
     }
 
     struct AttachedPayload: Decodable {
@@ -891,6 +934,7 @@ enum Termiod {
         case uploadOpened(UploadOpenedPayload)
         case uploadAck(UploadAckPayload)
         case uploadCommitted(UploadCommittedPayload)
+        case fsListed(FsListedPayload)
         /// The addressed half of `writer_changed`: sent to one client to tell it
         /// who owns size now (§C.5). Same payload shape, so it feeds the same
         /// handler — a client that only listened to the broadcast would still be
@@ -927,6 +971,8 @@ enum Termiod {
             return .uploadAck(try decoder.decode(UploadAckPayload.self, from: payload))
         case "upload_committed":
             return .uploadCommitted(try decoder.decode(UploadCommittedPayload.self, from: payload))
+        case "fs_listed":
+            return .fsListed(try decoder.decode(FsListedPayload.self, from: payload))
         case "resize_claim":
             return .resizeClaim(try decoder.decode(WriterChangedPayload.self, from: payload))
         case "error":
@@ -974,6 +1020,10 @@ enum Termiod {
         /// offered, and empty on a daemon too old to answer. Check it before
         /// waiting on a frame the host may never send.
         let capabilities: Set<String>
+        /// The account's home directory on that machine, or `/` when the daemon
+        /// did not say — old enough not to send it, or unable to read `HOME`.
+        /// Never empty, so a picker always has somewhere to start.
+        let home: String
     }
 
     /// Sends `hello` and waits for `hello_ok`. Callers pass the capabilities
@@ -1012,7 +1062,8 @@ enum Termiod {
                 """)
             }
             return Handshake(
-                device: device, clientID: payload.clientId, capabilities: Set(payload.caps))
+                device: device, clientID: payload.clientId, capabilities: Set(payload.caps),
+                home: payload.home.hasPrefix("/") ? payload.home : "/")
         case .helloError(let message):
             throw TermiodClientError.handshakeRejected(message)
         case .error(let payload):

--- a/Sources/termio/Terminal/Termiod/TermiodDirectoryLister.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodDirectoryLister.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+extension Termiod {
+    private struct FsListOperation: Encodable {
+        let op = "fs_list"
+        let root: String
+        let paths: [String]
+    }
+
+    /// One `fs_list` round trip for a single directory. Blocking; the lister
+    /// serialises the calls so a reply always belongs to the request in flight.
+    ///
+    /// Frames that are not this reply are skipped rather than treated as an
+    /// error: a control channel may carry anything the daemon chooses to say,
+    /// and a listing must not fail because something else arrived first.
+    static func requestListing(_ transport: Transport, root: String) throws -> PathListingPayload {
+        let operation = FsListOperation(root: root, paths: [root])
+        try writeFrame(
+            transport.writeDescriptor, kind: .control, payload: encodeControl(operation))
+        while true {
+            let frame = try readFrame(transport.readDescriptor)
+            guard frame.kind == .control else { continue }
+            switch try decodeControl(frame.payload) {
+            case .fsListed(let payload):
+                guard let listing = payload.listings.first else {
+                    throw TermiodClientError.requestFailed(
+                        localized("The machine answered with no listing for that folder."))
+                }
+                return listing
+            case .error(let failure):
+                throw TermiodClientError.requestFailed(failure.message)
+            default:
+                continue
+            }
+        }
+    }
+}
+
+/// Lists directories on another machine, one directory at a time, over a
+/// control channel it holds open for as long as a picker needs it.
+///
+/// This is the request plane's read half (§C.12, capability `files`) and it is
+/// deliberately *not* a file browser: a path field asks for the directory the
+/// user is currently typing inside, and the answer is one `fs.list`. Nothing
+/// walks a tree, so a machine with a huge checkout costs the same as an empty
+/// one.
+///
+/// The channel is held rather than reopened per keystroke because opening one
+/// means `ssh <host> termiod stdio` — a whole SSH round trip, which would land
+/// on every `/` the user types. It rides its own channel and never a session's
+/// attachment, for the same reason transfers do: byte delivery must not queue
+/// behind a directory listing (anti-100× invariant).
+final class TermiodDirectoryLister: @unchecked Sendable {
+    /// A directory that can be descended into, which is all a project picker
+    /// offers — a file is never a project root.
+    struct Entry: Sendable, Equatable {
+        let name: String
+    }
+
+    enum Failure: Error {
+        /// The daemon answered, but refused this path — gone, unreadable, or
+        /// outside the root. Carries the daemon's own words.
+        case refused(String)
+    }
+
+    private let route: TermiodRoute
+    /// Serialises the blocking frame reads: one request is in flight at a time,
+    /// so a reply can never be claimed by the wrong caller.
+    private let queue = DispatchQueue(label: "sh.termio.termiod.directory-lister")
+    private var transport: Termiod.Transport?
+    private var handshake: Termiod.Handshake?
+
+    init(route: TermiodRoute) {
+        self.route = route
+    }
+
+    /// Connects and reports the home directory to start from. Called once, off
+    /// the main thread; every later `list` reuses the channel it opened.
+    func connect(completion: @escaping @Sendable (Result<String, Error>) -> Void) {
+        queue.async { [self] in
+            do {
+                let transport = try Termiod.Transport.open(route)
+                let handshake = try Termiod.performHello(
+                    transport, role: "control", caps: ["files"])
+                guard handshake.capabilities.contains("files") else {
+                    transport.close()
+                    // An older daemon that never learned the file plane. The
+                    // picker still opens; it just cannot complete a path.
+                    throw Failure.refused(
+                        localized("This machine’s termiod is too old to list folders."))
+                }
+                self.transport = transport
+                self.handshake = handshake
+                completion(.success(handshake.home))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// The directories directly inside `path`, sorted the way a picker reads:
+    /// case-insensitively, with dot-directories last so `~/.cache` never sits
+    /// above `~/code`.
+    ///
+    /// `root` is `path` itself. Confinement is anchored at the directory being
+    /// listed rather than at some remembered ancestor, because the field lets
+    /// the user retype the whole path at any moment — anchoring anywhere else
+    /// would refuse a sibling directory the user can plainly `cd` to.
+    func list(_ path: String, completion: @escaping @Sendable (Result<[Entry], Error>) -> Void) {
+        queue.async { [self] in
+            guard let transport else {
+                completion(.failure(TermiodClientError.connectionClosed))
+                return
+            }
+            do {
+                let listing = try Termiod.requestListing(transport, root: path)
+                if let message = listing.error {
+                    completion(.failure(Failure.refused(message)))
+                    return
+                }
+                let directories = listing.entries
+                    .filter(\.isDirectory)
+                    .map { Entry(name: $0.name) }
+                    .sorted { left, right in
+                        let leftHidden = left.name.hasPrefix(".")
+                        let rightHidden = right.name.hasPrefix(".")
+                        if leftHidden != rightHidden { return rightHidden }
+                        return left.name.localizedStandardCompare(right.name) == .orderedAscending
+                    }
+                completion(.success(directories))
+            } catch {
+                // A lost pipe must not leave a dead transport behind answering
+                // every later keystroke with the same corpse.
+                if case TermiodClientError.connectionClosed = error { close() }
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Drops the channel. Safe to call more than once, and from any thread.
+    func close() {
+        queue.async { [self] in
+            transport?.close()
+            transport = nil
+            handshake = nil
+        }
+    }
+}

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -590,17 +590,21 @@ extension TermioStore {
         let alert = NSAlert()
         alert.messageText = localized("Open a Project on \(alias)")
         alert.informativeText = localized(
-            "Termio can’t browse another machine’s files. Clone a repository onto \(alias), or enter a folder that’s already there.")
+            "Clone a repository onto \(alias), or open a folder that’s already there — the path completes as you type.")
         alert.addButton(withTitle: localized("Open"))
         alert.addButton(withTitle: localized("Cancel"))
 
-        let fields = RemoteProjectFields()
+        let fields = RemoteProjectFields(alias: alias)
         alert.accessoryView = fields.view
         alert.window.initialFirstResponder = fields.field
 
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
-        let entry = fields.field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !entry.isEmpty else { return }
+        let response = alert.runModal()
+        // The listing channel is the panel's, so it goes when the panel does —
+        // including on Cancel, which would otherwise leak an SSH connection per
+        // dismissal.
+        fields.stop()
+        guard response == .alertFirstButtonReturn else { return }
+        let entry = fields.entry
         if fields.isCloning {
             cloneProject(from: entry, on: alias)
         } else {
@@ -628,13 +632,14 @@ extension TermioStore {
     /// if the path isn't there, rather than the row quietly pointing at nothing.
     private func openRemoteProject(at entry: String, on alias: String) {
         // termiod spawns the shell with a raw `chdir` and expands neither `~` nor a
-        // relative path (termiod/src/session.rs `Pty::spawn`), so anything else
-        // would start the shell somewhere the user did not name.
+        // relative path (termiod/src/session.rs `Pty::spawn`). The panel has already
+        // expanded `~` against the home the handshake reported, so anything still
+        // not absolute here is a path no machine could resolve.
         guard entry.hasPrefix("/") else {
             let alert = NSAlert()
             alert.messageText = localized("Enter an absolute path")
             alert.informativeText = localized(
-                "Termio opens the folder on \(alias) exactly as typed, so the path has to start with “/”. “~” isn’t expanded.")
+                "Enter a path that starts with “/”. “~/” works too, once \(alias) has said where home is.")
             alert.alertStyle = .informational
             alert.addButton(withTitle: localized("OK"))
             alert.runModal()
@@ -928,28 +933,87 @@ extension TermioStore {
     }
 }
 
-/// The two ways to name a directory on a machine Termio cannot browse, as the
-/// accessory view of `presentRemoteProjectPanel`.
+/// The two string rules the remote path field runs on, apart from the field so
+/// they can be tested without a window.
+enum RemotePathEntry {
+    /// `/srv/ap` → (`/srv/`, `ap`). The directory keeps its trailing slash: it is
+    /// what gets sent to `fs.list`, and a listing of `/srv` and of `/srv/` are the
+    /// same request. A path with no `/` at all names no directory, which is right —
+    /// it is not yet a place on that machine.
+    static func split(_ path: String) -> (directory: String, partial: String) {
+        guard let slash = path.lastIndex(of: "/") else { return ("", path) }
+        return (String(path[...slash]), String(path[path.index(after: slash)...]))
+    }
+
+    /// Expands a leading `~` against the machine's own home, which the handshake
+    /// reported. Only a leading one, and only when it stands alone or is followed
+    /// by `/`: `~user` names *another* account's home, which this cannot resolve
+    /// and must not silently rewrite into this one's.
+    static func expandingTilde(_ path: String, home: String) -> String {
+        if path == "~" { return home }
+        guard path.hasPrefix("~/") else { return path }
+        let tail = path.dropFirst(2)
+        return home.hasSuffix("/") ? home + tail : home + "/" + tail
+    }
+}
+
+/// The two ways to name a directory on another machine, as the accessory view of
+/// `presentRemoteProjectPanel`: clone a repository onto it, or open a folder
+/// already there.
 ///
-/// A class rather than a few locals because the segmented control needs a target
-/// that outlives the call that builds it — the alert runs modally and the switch
-/// has to keep answering while it is up.
+/// The folder field completes as it is typed. Each `/` asks the machine for one
+/// directory — never a tree — and the answer is cached under the directory it
+/// describes, so moving the cursor around inside a path costs nothing. That is
+/// the whole of the "remote file browser": `fs.list`, one directory deep, at the
+/// moment the user names a new one.
+///
+/// A class rather than a few locals because the controls need a target that
+/// outlives the call that builds it — the alert runs modally and both the switch
+/// and the field have to keep answering while it is up.
 @MainActor
-private final class RemoteProjectFields: NSObject {
+private final class RemoteProjectFields: NSObject, NSTextFieldDelegate {
     let view = NSStackView()
     let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
     private let mode = NSSegmentedControl(
         labels: [localized("Clone a Repository"), localized("Open a Folder")],
         trackingMode: .selectOne, target: nil, action: nil)
 
+    private let alias: String
+    private let lister: TermiodDirectoryLister
+    /// Where the machine says this account lives. `/` until the handshake
+    /// answers, so the field is usable before the connection is.
+    private var home = "/"
+    /// The last directory listed, and what was in it. One entry, not a cache of
+    /// many: a path field only ever completes inside the directory the cursor is
+    /// in, and holding older ones would just serve stale names after a rename.
+    private var listedDirectory: String?
+    private var listedNames: [String] = []
+    /// Guards the re-entrant `controlTextDidChange` that accepting a completion
+    /// fires, which would otherwise ask for completions of the text completion
+    /// just inserted.
+    private var isCompleting = false
+
     /// Whether the entry is a repository to clone rather than a folder to open.
     var isCloning: Bool { mode.selectedSegment == 0 }
 
-    override init() {
+    /// What the user named, with a leading `~` expanded against the machine's own
+    /// home. termiod spawns the shell with a raw `chdir` and expands nothing, so
+    /// this has to happen here — and it can, because the handshake already said
+    /// where home is.
+    var entry: String {
+        let typed = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !isCloning else { return typed }
+        return RemotePathEntry.expandingTilde(typed, home: home)
+    }
+
+    init(alias: String) {
+        self.alias = alias
+        lister = TermiodDirectoryLister(route: .ssh(alias))
         super.init()
         mode.selectedSegment = 0
         mode.target = self
         mode.action = #selector(modeChanged)
+        field.delegate = self
         view.orientation = .vertical
         view.alignment = .leading
         view.spacing = 8
@@ -962,6 +1026,30 @@ private final class RemoteProjectFields: NSObject {
         // grows with the user's text size would otherwise be clipped.
         view.frame = NSRect(origin: .zero, size: view.fittingSize)
         modeChanged()
+        connect()
+    }
+
+    /// Opens the listing channel in the background. The panel is already up by
+    /// then — a modal that blocked on an SSH handshake before showing anything
+    /// would read as a hang on exactly the machine that is slowest to reach.
+    private func connect() {
+        lister.connect { [weak self] result in
+            guard case .success(let home) = result else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.home = home
+                // Only seeds an untouched field: someone who started typing
+                // during the handshake keeps what they wrote.
+                if !self.isCloning, self.field.stringValue.isEmpty {
+                    self.field.stringValue = home.hasSuffix("/") ? home : home + "/"
+                    self.refreshCompletions()
+                }
+            }
+        }
+    }
+
+    func stop() {
+        lister.close()
     }
 
     /// The placeholder is the only thing that changes: one field either way, so
@@ -969,5 +1057,66 @@ private final class RemoteProjectFields: NSObject {
     /// localized — a URL and an absolute path read the same in every language.
     @objc private func modeChanged() {
         field.placeholderString = isCloning ? "https://github.com/owner/repo.git" : "/srv/api"
+    }
+
+    func controlTextDidChange(_ notification: Notification) {
+        guard !isCompleting, !isCloning else { return }
+        refreshCompletions()
+    }
+
+    /// Splits what is typed at the last `/` into the directory to list and the
+    /// partial name to match inside it, then lists that directory if it is not
+    /// the one already held. Typing further into the same directory re-filters
+    /// what is in hand and never touches the network.
+    private func refreshCompletions() {
+        let (directory, _) = RemotePathEntry.split(entry)
+        guard directory != listedDirectory else {
+            showCompletions()
+            return
+        }
+        lister.list(directory) { [weak self] result in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                // The user may have typed on while this was in flight; a reply
+                // for a directory they have already left is dropped rather than
+                // shown against the wrong path.
+                guard RemotePathEntry.split(self.entry).directory == directory else { return }
+                switch result {
+                case .success(let entries):
+                    self.listedDirectory = directory
+                    self.listedNames = entries.map(\.name)
+                    self.showCompletions()
+                case .failure:
+                    // An unreadable or missing directory completes to nothing.
+                    // It is not an error to report: the user is mid-path, and a
+                    // half-typed directory name is unreadable by definition.
+                    self.listedDirectory = directory
+                    self.listedNames = []
+                }
+            }
+        }
+    }
+
+    private func showCompletions() {
+        guard !listedNames.isEmpty, let editor = field.currentEditor() as? NSTextView else {
+            return
+        }
+        isCompleting = true
+        editor.complete(nil)
+        isCompleting = false
+    }
+
+    func control(
+        _ control: NSControl,
+        textView: NSTextView,
+        completions words: [String],
+        forPartialWordRange charRange: NSRange,
+        indexOfSelectedItem index: UnsafeMutablePointer<Int>
+    ) -> [String] {
+        let (_, partial) = RemotePathEntry.split(entry)
+        guard !partial.isEmpty else { return listedNames }
+        return listedNames.filter {
+            $0.range(of: partial, options: [.caseInsensitive, .anchored]) != nil
+        }
     }
 }

--- a/Tests/termioTests/RemoteProjectTests.swift
+++ b/Tests/termioTests/RemoteProjectTests.swift
@@ -82,4 +82,45 @@ final class RemoteProjectTests: XCTestCase {
         let legacy = try JSONDecoder().decode(Project.self, from: Data(older.utf8))
         XCTAssertFalse(legacy.isOnAnotherDevice)
     }
+
+    // MARK: - The path field's two rules
+
+    /// What the field asks the machine for, and what it matches locally. The
+    /// directory keeps its trailing slash so re-listing the same directory is
+    /// recognised as the same request no matter how the user got there.
+    func testSplitNamesTheDirectoryToListAndTheNameToMatch() {
+        XCTAssertEqual(RemotePathEntry.split("/srv/ap").directory, "/srv/")
+        XCTAssertEqual(RemotePathEntry.split("/srv/ap").partial, "ap")
+
+        // Sitting on a slash lists that directory and matches everything in it.
+        XCTAssertEqual(RemotePathEntry.split("/srv/").directory, "/srv/")
+        XCTAssertEqual(RemotePathEntry.split("/srv/").partial, "")
+
+        // The root is a directory like any other.
+        XCTAssertEqual(RemotePathEntry.split("/").directory, "/")
+        XCTAssertEqual(RemotePathEntry.split("/").partial, "")
+
+        // No slash yet: nothing on that machine has been named, so nothing is
+        // listed — the empty directory is what stops a request going out.
+        XCTAssertEqual(RemotePathEntry.split("srv").directory, "")
+        XCTAssertEqual(RemotePathEntry.split("srv").partial, "srv")
+    }
+
+    /// `~` is expanded here because termiod expands nothing: it spawns the shell
+    /// with a raw `chdir`. A double slash would be harmless but reads as a typo
+    /// in the field, so the two shapes of `home` produce the same path.
+    func testTildeExpandsAgainstTheMachinesOwnHome() {
+        XCTAssertEqual(
+            RemotePathEntry.expandingTilde("~/code/api", home: "/home/me"), "/home/me/code/api")
+        XCTAssertEqual(
+            RemotePathEntry.expandingTilde("~/code/api", home: "/home/me/"), "/home/me/code/api")
+        XCTAssertEqual(RemotePathEntry.expandingTilde("~", home: "/home/me"), "/home/me")
+
+        // An absolute path is already an answer.
+        XCTAssertEqual(RemotePathEntry.expandingTilde("/srv/api", home: "/home/me"), "/srv/api")
+
+        // `~user` is *another* account's home. Termio cannot resolve it and must
+        // not quietly rewrite it into this one's.
+        XCTAssertEqual(RemotePathEntry.expandingTilde("~root/api", home: "/home/me"), "~root/api")
+    }
 }

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -515,6 +515,7 @@ async fn handle_conn(stream: UnixStream, manager: Manager) -> Result<()> {
                         std::env::consts::ARCH
                     ),
                     client_id: client_id.clone(),
+                    home: std::env::var("HOME").unwrap_or_default(),
                 },
             )
             .await?;

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -400,6 +400,14 @@ pub enum Control {
         host_id: String,
         host: String,
         client_id: String,
+        /// This account's home directory on the device, so a client that has
+        /// to name a path over here — a project picker, a `~`-prefixed entry —
+        /// starts where the user's work is instead of at `/`. Sent at the
+        /// handshake rather than fetched, because expanding `~` client-side
+        /// costs no round trip while someone is typing. Empty when the home
+        /// directory cannot be determined; clients fall back to `/`.
+        #[serde(default)]
+        home: String,
     },
     HelloErr {
         code: ErrorCode,


### PR DESCRIPTION
Opening a project on another machine asked for a folder on a machine Termio refused to look at, so the honest affordance was a text field you had to already know the answer for.

termiod has served `fs.list` since §C.12 — batched, paged, confined to a root, with 30 unit and 62 smoke tests. Only the Swift half was missing. Each `/` you type lists exactly one directory and the answer is cached under it, so nothing walks a tree and a machine with a huge checkout costs the same as an empty one. The listing rides its own control channel, never a session's attachment.

`hello_ok` gained a `home` field so the field starts where the user's work is and `~` expands client-side without a round trip per keystroke. Old daemons omit it and fall back to `/`.

Verified against a live daemon: `hello_ok` reports the account's home and `fs_list` rooted there returns real directories. Not yet exercised against a remote box running an older termiod, which degrades to plain text entry.

Release Notes:
Opening a project on another machine now completes the folder path as you type, starting from your home directory on that machine.