### PR TITLE
Give every workspace one device

### DIFF
--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -11,6 +11,50 @@ struct RecentProject: Identifiable, Hashable, Codable {
     var id: String { path }
 }
 
+/// The machine a workspace belongs to, said outright.
+///
+/// `Workspace.deviceAlias` is one optional carrying two different claims: `nil`
+/// means both "this Mac" and "a workspace the user made", and code that tests
+/// `deviceAlias != nil` gets an answer to whichever question it happened to be
+/// asking. Naming the machine on its own separates them — this says only which
+/// device owns the scope, and says it for every workspace, including the ones
+/// nobody ever named a device for.
+///
+/// Derived, never stored: `deviceAlias` remains the persisted field and `nil` on
+/// disk still decodes to this Mac, so no state file changes shape. A snapshot
+/// that fails to decode is swallowed into a fresh first-run tree (`StateFile`),
+/// which would replace the user's whole sidebar — the invariant is therefore
+/// established at load time by `WorkspaceMigration.reconcile`, never by a stricter
+/// decoder.
+///
+/// Distinct from `KnownDevice`, which pairs the alias with the `host_id` a
+/// handshake revealed. This is the filing key: what the workspace *claims*, known
+/// before anything has connected.
+enum WorkspaceDevice: Hashable {
+    case thisMac
+    case ssh(alias: String)
+
+    init(alias: String?) {
+        self = alias.map(WorkspaceDevice.ssh) ?? .thisMac
+    }
+
+    /// The `~/.ssh/config` alias this machine is reached by, `nil` for this Mac —
+    /// the shape the stored fields and every existing call site already speak.
+    var alias: String? {
+        switch self {
+        case .thisMac: nil
+        case .ssh(let alias): alias
+        }
+    }
+
+    var isThisMac: Bool { alias == nil }
+
+    /// What a workspace named after this machine is called. This Mac has no alias
+    /// to show and the host never supplies a display name, so the client picks one
+    /// (the same name `KnownDevice` shows in every device menu).
+    var displayName: String { alias ?? localized("This Mac") }
+}
+
 /// The scope the sidebar shows: one Pinned working set, one Terminals section,
 /// one Chats section, and the projects filed under it. Everything the sidebar
 /// drew before is here; what changed is that a workspace bounds it, where a
@@ -41,34 +85,77 @@ struct Workspace: Identifiable, Hashable, Codable {
     /// `~/.ssh` and everything beside it.
     var chats: [Session] = []
 
-    /// The machine whose unfiled sessions land here — the `~/.ssh/config` alias
-    /// this fallback workspace was born from — or `nil` for one the user made.
+    /// The machine this workspace belongs to — the `~/.ssh/config` alias it is
+    /// reached by — or `nil` for one on this Mac.
     ///
-    /// A session the `termiod` CLI or a phone started on a box has no project and
-    /// no workspace the user chose for it, and it must still be reachable. It
-    /// gathers here, in a workspace named for that machine. This is the alias, the
+    /// Every workspace has a machine, and everything filed under it is on that
+    /// machine: its projects' checkouts and the loose sessions that the `termiod`
+    /// CLI or a phone started with nowhere else to be. This is the alias, the
     /// *bootstrap* identity: it exists before anything has connected, which is when
     /// the workspace has to exist (device architecture §9.5).
     var deviceAlias: String?
 
     /// The `host_id` the alias turned out to reach, filled in by the first
-    /// `hello_ok` and `nil` until then. Two fallback workspaces sharing one of
-    /// these are two names for the same machine.
+    /// `hello_ok` and `nil` until then. Two workspaces sharing one of these are
+    /// two names for the same machine.
     var deviceID: String?
 
-    /// Whether this workspace is a machine's fallback rather than one the user
-    /// made. Only these are named after a device, and only these are dropped when
-    /// they empty out.
-    var isDeviceFallback: Bool { deviceAlias != nil }
+    /// The machine this workspace belongs to. Every workspace has one, and
+    /// `WorkspaceMigration.reconcile` guarantees it agrees with the projects filed
+    /// under it — so a caller asks the workspace which machine it is on instead of
+    /// re-deriving that from whichever field is nearest.
+    var device: WorkspaceDevice { WorkspaceDevice(alias: deviceAlias) }
+
+    /// Whether Termio created this workspace on the user's behalf, rather than the
+    /// user asking for it. Only these may be swept when they empty out.
+    ///
+    /// Declared at creation, never inferred. It used to be read off `deviceAlias`
+    /// — "named after a machine" standing in for "made automatically" — and the
+    /// device stamping in `WorkspaceMigration.reconcile` broke that proxy: a
+    /// workspace the user named and filled with checkouts on one box now carries
+    /// that box's alias too, and would have become sweepable. A workspace someone
+    /// named is theirs whichever machine it turned out to be on.
+    ///
+    /// Optional on purpose: **absent** means "written before this field existed,
+    /// so it is not yet known", and `false` means "asked and answered — this one
+    /// is the user's". Collapsing the two to `false` is what made an earlier
+    /// version of this wrong: `reconcile` recovers the answer for absent values,
+    /// so a stored `false` that decoded as absent would be re-derived on every
+    /// launch, and a workspace the user named after the box its checkouts sit on
+    /// would be claimed the second time the app opened. Recovery runs once and
+    /// then records what it decided.
+    ///
+    /// A missing value is never swept — `isAutoCreated == true` is the test, so
+    /// unknown stays safe.
+    var isAutoCreated: Bool?
 
     /// Every session the workspace owns directly. Its projects' sessions are not
     /// here — they belong to the project.
     var looseSessions: [Session] { terminals + chats }
+
+    /// The same machine as `device`, in the form the menus and row marks name it —
+    /// the alias paired with the `host_id` a handshake revealed — and `nil` for
+    /// this Mac, which is the machine nothing needs to be told about.
+    var knownDevice: KnownDevice? {
+        deviceAlias.map { KnownDevice(alias: $0, deviceID: deviceID) }
+    }
+
+    /// Whether `alias` reaches this workspace's machine.
+    ///
+    /// Matched by device identity once both ends know it, so a box reached by a
+    /// LAN name and a tailnet name is still one machine, and by alias until the
+    /// first handshake resolves one — the bootstrap/stable split `KnownDevice`
+    /// carries. This Mac matches no alias: it is not reached by one.
+    func isOn(alias: String, device deviceID: String?) -> Bool {
+        guard let mine = deviceAlias else { return false }
+        if let deviceID, let known = self.deviceID { return deviceID == known }
+        return mine == alias
+    }
 }
 
 extension Workspace {
     private enum CodingKeys: String, CodingKey {
-        case id, name, terminals, chats, deviceAlias, deviceID
+        case id, name, terminals, chats, deviceAlias, deviceID, isAutoCreated
     }
 
     /// Missing collections take their empty defaults so a workspace written by an
@@ -83,6 +170,7 @@ extension Workspace {
         chats = try c.decodeIfPresent([Session].self, forKey: .chats) ?? []
         deviceAlias = try c.decodeIfPresent(String.self, forKey: .deviceAlias)
         deviceID = try c.decodeIfPresent(String.self, forKey: .deviceID)
+        isAutoCreated = try c.decodeIfPresent(Bool.self, forKey: .isAutoCreated)
     }
 
     /// First-run state for a fresh install: one workspace holding one shell, so a
@@ -170,39 +258,27 @@ struct Project: Identifiable, Hashable, Codable {
     /// resolves to a device.
     var remoteCheckouts: [String: String] = [:]
 
-    /// The machine this project's checkout lives on — the `~/.ssh/config` alias —
-    /// or `nil` for a folder on this Mac.
+    /// The machine a state file written **before** the hierarchy recorded on the
+    /// checkout itself, and `nil` on every project this build writes.
     ///
-    /// A project used to be a folder on this Mac by definition, so `path` was
-    /// always this Mac's to read. It no longer is: `Open Project ▸ <device>` files
-    /// a repo that exists only on another box, and `path` then names a directory
-    /// over there. Everything that reads local disk — the branch probe, Reveal in
-    /// Finder, worktrees, the recents list — is gated on this being `nil`.
+    /// A checkout inherits its machine from the workspace that owns it — a
+    /// workspace belongs to exactly one — so the app asks the store
+    /// (`TermioStore.device(of:)`) and this field is not part of that answer.
+    /// It survives for `WorkspaceMigration`, the one place the two shapes meet:
+    /// a workspace whose checkouts turn out to span machines can only be
+    /// recognised from what the old file recorded per checkout.
     ///
-    /// The alias is the *bootstrap* identity, the one that exists before anything
-    /// has connected (device architecture §9.5); `deviceID` is what it turns out
-    /// to be.
-    var deviceAlias: String?
-
-    /// The `host_id` the alias turned out to reach, learned by the first
-    /// handshake and `nil` until then.
-    var deviceID: String?
+    /// Decoded, never encoded. Writing it back would make every later load read
+    /// the tree as the old shape again, and a project that records no machine
+    /// would go on meaning "this Mac" instead of "whichever machine my workspace
+    /// is on" — which is a remote checkout torn off its workspace on next launch.
+    var legacyDevice: KnownDevice?
 }
 
 extension Project {
     private enum CodingKeys: String, CodingKey {
         case id, workspaceID, name, path, branch, sessions, worktrees, pinned, remoteCheckouts
         case deviceAlias, deviceID
-    }
-
-    /// Whether this project's checkout is on another machine, so nothing here may
-    /// read `path` off local disk.
-    var isOnAnotherDevice: Bool { deviceAlias != nil }
-
-    /// The machine the checkout lives on, or `nil` for this Mac — what the row's
-    /// mark and the empty states name.
-    var device: KnownDevice? {
-        deviceAlias.map { KnownDevice(alias: $0, deviceID: deviceID) }
     }
 
     /// Missing collection and flag keys take their pre-feature defaults so older
@@ -226,8 +302,29 @@ extension Project {
         pinned = try container.decodeIfPresent(Bool.self, forKey: .pinned) ?? false
         remoteCheckouts =
             try container.decodeIfPresent([String: String].self, forKey: .remoteCheckouts) ?? [:]
-        deviceAlias = try container.decodeIfPresent(String.self, forKey: .deviceAlias)
-        deviceID = try container.decodeIfPresent(String.self, forKey: .deviceID)
+        // Kept in the decoder after the live fields went: a file written before
+        // the hierarchy is the only thing that still says which machine each
+        // checkout is on, and dropping the keys here would lose the split that
+        // `WorkspaceMigration` needs them for.
+        let recordedAlias = try container.decodeIfPresent(String.self, forKey: .deviceAlias)
+        let recordedDeviceID = try container.decodeIfPresent(String.self, forKey: .deviceID)
+        legacyDevice = recordedAlias.map { KnownDevice(alias: $0, deviceID: recordedDeviceID) }
+    }
+
+    /// Written out by hand so `legacyDevice` does not round-trip — see the field.
+    /// Every other property is listed here, so a new one has to be added to this
+    /// and to `CodingKeys` to be persisted.
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(workspaceID, forKey: .workspaceID)
+        try container.encode(name, forKey: .name)
+        try container.encode(path, forKey: .path)
+        try container.encode(branch, forKey: .branch)
+        try container.encode(sessions, forKey: .sessions)
+        try container.encode(worktrees, forKey: .worktrees)
+        try container.encode(pinned, forKey: .pinned)
+        try container.encode(remoteCheckouts, forKey: .remoteCheckouts)
     }
 
     /// The recorded checkout for one machine, addressed by device where the app
@@ -241,18 +338,6 @@ extension Project {
     func remoteCheckout(device deviceID: String?, alias: String) -> String? {
         if let deviceID, let path = remoteCheckouts[deviceID] { return path }
         return remoteCheckouts[alias]
-    }
-
-    /// Whether this project *is* the directory `path` on that machine — the test
-    /// behind "opening the same folder twice reopens the row you already have".
-    ///
-    /// Matched by device identity once both ends know it, so a box reached by a
-    /// second alias doesn't open a duplicate row for the same checkout, and by
-    /// alias until the first handshake resolves one.
-    func isCheckout(at path: String, on alias: String, device deviceID: String?) -> Bool {
-        guard isOnAnotherDevice, self.path == path else { return false }
-        if let deviceID, let mine = self.deviceID { return deviceID == mine }
-        return deviceAlias == alias
     }
 }
 

--- a/Sources/termio/Sidebar/DeviceSwitcher.swift
+++ b/Sources/termio/Sidebar/DeviceSwitcher.swift
@@ -166,12 +166,20 @@ func newTerminalMenuItem(
     })
 }
 
-/// "Move to Workspace ▸": files a project under a different scope. `nil` with one
-/// workspace — there is nowhere to move to, and a submenu naming only the
-/// workspace the project is already in is a dead click.
+/// "Move to Workspace ▸": files a project under a different scope on the same
+/// machine. `nil` when nothing is left to offer — a submenu naming only the
+/// workspace the project is already in is a dead click, and one naming a
+/// workspace the move would refuse is worse.
+///
+/// Same machine only, because `moveProject` refuses the rest: a checkout is a
+/// directory on one box, and the move would not move the directory. Putting the
+/// repo on another machine is a clone, which is `Clone to <device>…`.
 @MainActor
 func moveToWorkspaceMenuItem(store: TermioStore, project: Project) -> SidebarMenuItem? {
-    let targets = store.orderedWorkspaces.filter { $0.id != project.workspaceID }
+    guard let device = store.device(of: project) else { return nil }
+    let targets = store.orderedWorkspaces.filter {
+        $0.id != project.workspaceID && $0.device == device
+    }
     guard !targets.isEmpty else { return nil }
     return .submenu(localized("Move to Workspace"), targets.map { workspace in
         .action(workspace.name) { store.moveProject(project.id, toWorkspace: workspace.id) }

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -180,11 +180,14 @@ struct SidebarView: View {
         // feature must not introduce. They carry their workspace's name as the
         // breadcrumb, so the row says where clicking will take you.
         let waitingElsewhere = elsewhereNeedingYou(currentWorkspace: workspace.id)
-        // Whether any row in this column wears a machine mark. A machine's own
-        // workspace already says which machine it is, in the toolbar band above
-        // the column, so marking each of its rows repeats one fact down the whole
-        // column. Decided here, once, and handed to the rows.
-        let marksDevice = !workspace.isDeviceFallback
+        // Whether any row in this column wears a machine mark. Suppressed only
+        // where the band above the column already answers it: a workspace Termio
+        // named after a box repeats that one fact down every row. A workspace the
+        // *user* named keeps its marks however remote it is — "Ship auth" names no
+        // machine, so the rows are the only thing that can. Decided here, once,
+        // and handed to the rows.
+        let bandNamesTheMachine = workspace.isAutoCreated == true && !workspace.device.isThisMac
+        let marksDevice = !bandNamesTheMachine
         let hasPinned = !pinnedProjects.isEmpty || !pinnedWorktrees.isEmpty
             || !pinnedSessions.isEmpty || !waitingElsewhere.isEmpty
         let hasTerminals = !workspace.terminals.isEmpty
@@ -627,11 +630,15 @@ private struct ProjectHeader: View {
     }
 
     /// The machine this project's checkout lives on, when that is not this Mac.
-    /// `nil` inside a machine's own fallback workspace for the same reason a
-    /// session row's mark is: the workspace already *is* that machine.
+    /// It is the machine of the workspace the project is filed under — a checkout
+    /// records none of its own. `nil` in a workspace Termio named after a box, for
+    /// the same reason a session row's mark is: the name in the band above the
+    /// column already says it.
     private var remoteDevice: KnownDevice? {
-        guard !store.currentWorkspace.isDeviceFallback else { return nil }
-        return project.device
+        guard let workspace = store.workspace(owning: project),
+              workspace.isAutoCreated != true
+        else { return nil }
+        return workspace.knownDevice
     }
 
     /// Adding a session to a project on another machine means adding it *there*.
@@ -639,7 +646,7 @@ private struct ProjectHeader: View {
     /// the remote empty argv), so the terminal is the only verb this row offers —
     /// see `headerPresets`, which is why no agent preset reaches this.
     private func addSession(_ preset: AgentPreset) {
-        if let alias = project.deviceAlias {
+        if let alias = store.device(of: project)?.alias {
             store.addRemoteTerminal(host: alias, project: project.id)
             return
         }
@@ -650,7 +657,7 @@ private struct ProjectHeader: View {
     /// machine offers a terminal only: Termio can't launch an agent over there,
     /// and a row of agent buttons that silently open shells would claim otherwise.
     private var headerPresets: [AgentPreset] {
-        project.isOnAnotherDevice ? [.terminal] : headerSessionPresets(settings)
+        store.isOnAnotherDevice(project) ? [.terminal] : headerSessionPresets(settings)
     }
 
     /// Width the trailing quick-add icons occupy (button frame 22 + 3 spacing each), so
@@ -673,7 +680,7 @@ private struct ProjectHeader: View {
         // verb names it outright instead of offering a device submenu whose rows
         // would all be wrong but one. The agents submenu is absent for the same
         // reason `headerPresets` drops them: nothing launches an agent over there.
-        if project.isOnAnotherDevice { return remoteMenuItems }
+        if store.isOnAnotherDevice(project) { return remoteMenuItems }
         var items: [SidebarMenuItem] = [
             newTerminalMenuItem(store: store, project: project) { addSession(.terminal) },
             .submenu(localized("New Agent Session"), enabledAgentPresets(settings)

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -34,10 +34,10 @@ struct WorkspaceSwitcherToolbarView: View {
                     // Sized against the toolbar's own glyphs (the navigator toggle, the
                     // sort pull-down) rather than shrunk to fit beside them, and set in
                     // the sidebar's interface font — this control belongs to that column.
-                    // A machine's fallback is a machine, and says so with the same
-                    // server mark its rows carry; a workspace the user made is a
-                    // place they put things, so it takes the folder mark.
-                    HugeIconView(icon: current.isDeviceFallback ? .serverStack : .folderOpen,
+                    // A workspace on another machine says so with the same server
+                    // mark its rows carry; one on this Mac is a place you put
+                    // things, so it takes the folder mark.
+                    HugeIconView(icon: current.device.isThisMac ? .folderOpen : .serverStack,
                                  size: 15, color: color)
                     Text(current.name)
                         .font(settings.interfaceFont)

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -218,11 +218,9 @@ extension TermioStore {
                 projects[index].remoteCheckouts[device.id] = legacy
                 projects[index].remoteCheckouts[alias] = nil
             }
-            // And what a project *on* this machine turned out to be sitting on,
-            // so two aliases for one box stop reading as two places.
-            if projects[index].deviceAlias == alias, projects[index].deviceID != device.id {
-                projects[index].deviceID = device.id
-            }
+            // What the checkout itself is sitting on is not recorded here: a
+            // project takes its machine from the workspace that owns it, and the
+            // workspace loop below is where that is written down.
             for sessionIndex in projects[index].sessions.indices
             where projects[index].sessions[sessionIndex].termiodRemoteHost == alias
                 && projects[index].sessions[sessionIndex].deviceID != device.id {
@@ -807,8 +805,11 @@ extension TermioStore {
         /// A project already in the tree: the clone is recorded as its checkout on
         /// that machine.
         case existing(Project.ID)
-        /// A project made from the clone itself, filed under `workspace`.
-        case new(name: String, workspace: Workspace.ID)
+        /// A project made from the clone itself. It is filed by `addRemoteProject`,
+        /// in a workspace on the machine the clone landed on — a checkout takes its
+        /// machine from its workspace, so the destination is not the caller's to
+        /// name.
+        case new(name: String)
     }
 
     /// Clones a project's `origin` **onto** `host` (git clone runs on the remote,
@@ -944,13 +945,12 @@ extension TermioStore {
             else { return id }
             projects[index].remoteCheckouts[deviceID] = path
             return id
-        case .new(let name, let workspace):
+        case .new(let name):
             // No path means the clone landed somewhere we couldn't read back, and
             // a project row whose directory is a guess is worse than no row: the
             // terminal still opens on the machine, just without one.
             guard let path = clonedPath else { return nil }
-            return addRemoteProject(
-                name: name, at: path, on: alias, device: deviceID, workspace: workspace)
+            return addRemoteProject(name: name, at: path, on: alias, device: deviceID)
         }
     }
 }

--- a/Sources/termio/TermioStore/DeviceContext.swift
+++ b/Sources/termio/TermioStore/DeviceContext.swift
@@ -45,8 +45,9 @@ struct KnownDevice: Identifiable, Hashable {
 /// status, search results, and issues with nothing on screen saying so.
 ///
 /// A checkout is a repo on a machine — the pair the panes need. It is not the
-/// sidebar's `Workspace`, which is the scope the user chooses and can span
-/// machines; one workspace holds checkouts on several devices.
+/// sidebar's `Workspace`, which is the scope the user chooses: a workspace
+/// belongs to one machine and holds many checkouts on it, and the checkout is
+/// where the root comes from.
 ///
 /// Identity is the device, not the alias it was reached by. The same machine
 /// answering to a LAN name, a WAN name, and a tailnet name is one checkout, not

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -381,13 +381,11 @@ extension TermioStore {
     /// loose shell opens its sibling at the same cwd. Agents ignore it: being
     /// confined to the scoped directory is the point.
     func addScratchSession(agent: AgentPreset = .terminal, spawnDirectory: String? = nil) {
-        // A machine's fallback workspace holds what runs on *that* machine, and this
-        // session runs here — filing it there would make the workspace say something
-        // untrue. It lands in the first workspace the user made instead, and the
+        // A workspace on another machine holds what runs over there, and this
+        // session runs here — filing it there would make the workspace say
+        // something untrue. It lands in a workspace on this Mac instead, and the
         // selection carries the scope over with it.
-        let home = currentWorkspace.isDeviceFallback
-            ? workspaces.first { !$0.isDeviceFallback } ?? currentWorkspace
-            : currentWorkspace
+        let home = workspaceForThisMac
         guard let index = workspaces.firstIndex(where: { $0.id == home.id }) else { return }
         // Remember the agent behind a bare "New Chat", so the single ⌘N / `+` / menu
         // action relaunches whatever you actually use (see `defaultChatAgent`).
@@ -548,13 +546,19 @@ extension TermioStore {
         settings.noteRecentProject(name: url.lastPathComponent, path: path)
         // Matched among this Mac's projects only: a checkout on another machine
         // can carry the same path string and is not the same folder.
-        if let existing = projects.first(where: { !$0.isOnAnotherDevice && $0.path == path }) {
+        if let existing = projects.first(where: { !isOnAnotherDevice($0) && $0.path == path }) {
             selectedSessionID = existing.sessions.first?.id
             return
         }
         let session = Session(title: "Terminal 1")
+        // The folder is on this Mac, so it is filed under a workspace on this Mac —
+        // ⌘O and the welcome page reach here with any workspace current, a box's
+        // included, and a local checkout in a workspace on a box is a row nothing
+        // over there can account for. Redirected rather than refused: the user
+        // picked a real folder, and a picker that closes having done nothing reads
+        // as a bug.
         let project = Project(
-            workspaceID: currentWorkspace.id,
+            workspaceID: workspaceForThisMac.id,
             name: url.lastPathComponent,
             path: path,
             branch: "—",
@@ -608,8 +612,8 @@ extension TermioStore {
         }
     }
 
-    /// Clones `originURL` onto `alias` and files the result as a project in the
-    /// current workspace. Reuses the same clone `Clone to <device>…` runs — deploy
+    /// Clones `originURL` onto `alias` and files the result as a project in a
+    /// workspace on `alias`. Reuses the same clone `Clone to <device>…` runs — deploy
     /// gate, HUD, verbatim remote stderr — rather than a second path that would
     /// drift from it.
     private func cloneProject(from originURL: String, on alias: String) {
@@ -618,9 +622,7 @@ extension TermioStore {
         // *is* the origin, so there is no local branch that could be ahead of it.
         let info = GitService.CloneInfo(
             originURL: originURL, repositoryName: name, unpushedCommits: nil)
-        cloneOnRemote(
-            host: alias, info: info,
-            into: .new(name: name, workspace: currentWorkspace.id))
+        cloneOnRemote(host: alias, info: info, into: .new(name: name))
     }
 
     /// Files a directory that is already on `alias` as a project, then opens its
@@ -647,28 +649,32 @@ extension TermioStore {
             name: name.isEmpty ? alias : name,
             at: path,
             on: alias,
-            device: TermiodDeviceRegistry.shared.deviceID(for: TermiodRoute(sshAlias: alias)),
-            workspace: currentWorkspace.id)
+            device: TermiodDeviceRegistry.shared.deviceID(for: TermiodRoute(sshAlias: alias)))
         addRemoteTerminal(host: alias, project: id)
     }
 
-    /// Adds a project whose checkout is on another machine, in `workspace` — a
-    /// normal project row, marked with its device. Reopening the same directory on
-    /// the same machine selects the row that is already there.
+    /// Adds a project whose checkout is on another machine — a normal project row,
+    /// filed in a workspace on that machine. Reopening the same directory on the
+    /// same machine selects the row that is already there.
+    ///
+    /// The workspace is not the caller's to choose: a checkout takes its machine
+    /// from the workspace that owns it, so one on `alias` goes to a workspace on
+    /// `alias` — the current one when it is already that machine's, and that
+    /// machine's own otherwise. The mirror of `addProject`, which redirects a local
+    /// folder to `workspaceForThisMac`.
     ///
     /// No branch probe and no recents entry: both read this Mac's disk, and this
     /// project's folder is not on it.
     @discardableResult
     func addRemoteProject(
-        name: String, at path: String, on alias: String, device deviceID: String?,
-        workspace: Workspace.ID
+        name: String, at path: String, on alias: String, device deviceID: String?
     ) -> Project.ID {
-        if let existing = projects.first(where: { $0.isCheckout(at: path, on: alias, device: deviceID) }) {
+        if let existing = checkout(at: path, on: alias, device: deviceID) {
             selectedSessionID = existing.sessions.first?.id
             return existing.id
         }
         var project = Project(
-            workspaceID: workspace,
+            workspaceID: workspace(forDevice: alias, deviceID: deviceID),
             name: name,
             path: path,
             // No local git to ask, and the daemon reports no branch yet. The em
@@ -677,14 +683,18 @@ extension TermioStore {
             branch: "—",
             sessions: []
         )
-        project.deviceAlias = alias
-        project.deviceID = deviceID
         // The checkout `New Terminal` reads. Keyed by device once a handshake has
         // said which one this alias reaches, by alias until then —
         // `remoteCheckout(device:alias:)` answers from either, and `adoptDevice`
         // promotes the alias key when the machine finally identifies itself.
         project.remoteCheckouts[deviceID ?? alias] = path
         projects.append(project)
+        // The row is filed on its machine, which need not be the workspace on
+        // screen, so the scope follows it there. Done here rather than left to the
+        // terminal that opens next: that terminal can fail — an unreachable box, a
+        // refused deploy — and a project the user just asked for must not land in a
+        // scope they are not looking at.
+        switchToWorkspace(project.workspaceID)
         return project.id
     }
 
@@ -821,13 +831,19 @@ extension TermioStore {
         pruneEmptyDeviceWorkspaces()
     }
 
-    /// Drops any machine fallback workspace left holding nothing, except the one
-    /// the sidebar is currently showing — pulling the scope out from under the
-    /// user as they close the last row on a box is a jump they did not ask for.
+    /// Drops any workspace Termio made itself that is left holding nothing, except
+    /// the one the sidebar is currently showing — pulling the scope out from under
+    /// the user as they close the last row on a box is a jump they did not ask for.
+    ///
+    /// Gated on `isAutoCreated`, not on the workspace naming a machine. Those were
+    /// the same set until `reconcile` began stamping a device onto every workspace;
+    /// after it, a workspace the user named and filled with checkouts on one box
+    /// also names that box, and sweeping it would delete something they made. A
+    /// name someone chose is not Termio's to reclaim.
     private func pruneEmptyDeviceWorkspaces() {
         let occupied = Set(projects.map(\.workspaceID))
         workspaces.removeAll { workspace in
-            workspace.isDeviceFallback
+            workspace.isAutoCreated == true
                 && workspace.looseSessions.isEmpty
                 && !occupied.contains(workspace.id)
                 && workspace.id != currentWorkspaceID

--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -206,11 +206,86 @@ extension TermioStore {
     /// for a decision nobody took.
     var hasMultipleWorkspaces: Bool { workspaces.count > 1 }
 
+    /// Where something that runs on **this Mac** is filed: the current workspace
+    /// when it belongs to this Mac, and the first one that does otherwise.
+    ///
+    /// A workspace belongs to one machine, so a local shell or a local folder put
+    /// into a workspace on a box would make that workspace say something untrue —
+    /// and the sidebar would draw a row nothing on that machine can account for.
+    /// The selection carries the scope across with it, so the user still lands on
+    /// what they just created.
+    var workspaceForThisMac: Workspace {
+        let current = currentWorkspace
+        guard !current.device.isThisMac else { return current }
+        return workspaces.first { $0.device.isThisMac } ?? current
+    }
+
     /// The workspaces a user can move between, in the order every surface shows
-    /// them: the ones they made first, then the machine fallbacks. A fallback is
-    /// where sessions land that nobody filed, so it sits after the filing.
+    /// them: the ones the user made first, then the ones Termio made for them. A
+    /// workspace nobody asked for is where sessions land that nobody filed, so it
+    /// sits after the filing.
+    ///
+    /// Ordered by who made it, not by which machine it is on. Every workspace
+    /// names a machine now, so sorting by the device would push a workspace the
+    /// user named and filled with checkouts on one box to the bottom of their own
+    /// list.
     var orderedWorkspaces: [Workspace] {
-        workspaces.filter { !$0.isDeviceFallback } + workspaces.filter(\.isDeviceFallback)
+        workspaces.filter { $0.isAutoCreated != true } + workspaces.filter { $0.isAutoCreated == true }
+    }
+
+    // MARK: - The machine a project is on
+
+    /// The workspace a project is filed under, or `nil` for a project whose owner
+    /// is gone. `WorkspaceMigration.reconcile` files every orphan under a real
+    /// workspace on load, so this answers for everything in the tree.
+    func workspace(owning project: Project) -> Workspace? {
+        workspaces.first { $0.id == project.workspaceID }
+    }
+
+    /// The machine a project's checkout lives on: the machine of the workspace
+    /// that owns it. A checkout records none of its own — a workspace belongs to
+    /// exactly one machine and everything filed under it is on that machine — so
+    /// this is the only reading of the question.
+    ///
+    /// `nil` means the owning workspace is missing and the machine is genuinely
+    /// unknown. Do not read that as this Mac: this is the gate on touching local
+    /// disk, and answering "here" for a checkout that may be on a box is how the
+    /// wrong machine's files get read.
+    func device(of project: Project) -> WorkspaceDevice? {
+        workspace(owning: project)?.device
+    }
+
+    /// Whether a project's checkout is on another machine, so nothing may read its
+    /// `path` off this Mac's disk. An unknown machine counts as another one, which
+    /// is the safe direction for a gate.
+    func isOnAnotherDevice(_ project: Project) -> Bool {
+        device(of: project) != .thisMac
+    }
+
+    /// The project that already *is* the directory `path` on that machine — what
+    /// "opening the same folder twice reopens the row you have" asks.
+    ///
+    /// The machine comes from the owning workspace, which is also what makes the
+    /// match by device identity work: a box reached by a second alias tomorrow
+    /// still resolves to the row that is already there.
+    func checkout(at path: String, on alias: String, device deviceID: String?) -> Project? {
+        projects.first { project in
+            project.path == path
+                && workspace(owning: project)?.isOn(alias: alias, device: deviceID) == true
+        }
+    }
+
+    /// Where a checkout on `alias` is filed: the current workspace when it is
+    /// already that machine's, and the machine's own workspace otherwise, created
+    /// on first use.
+    ///
+    /// The mirror of `workspaceForThisMac`, for the same reason — a checkout takes
+    /// its machine from its workspace, so filing one that lives on a box into a
+    /// workspace on this Mac would make the row claim to be here and let the panes
+    /// read this Mac's disk for a directory that is over there.
+    func workspace(forDevice alias: String, deviceID: String? = nil) -> Workspace.ID {
+        if currentWorkspace.device == .ssh(alias: alias) { return currentWorkspace.id }
+        return deviceWorkspace(for: alias, deviceID: deviceID)
     }
 
     /// Shows a different workspace. The selection moves with it, because a
@@ -380,9 +455,16 @@ extension TermioStore {
     /// Files a project under another workspace. The project's sessions travel with
     /// it — they are the project's, not the workspace's.
     func moveProject(_ projectID: Project.ID, toWorkspace workspaceID: Workspace.ID) {
-        guard workspaces.contains(where: { $0.id == workspaceID }),
+        guard let target = workspaces.first(where: { $0.id == workspaceID }),
               let index = projects.firstIndex(where: { $0.id == projectID }),
-              projects[index].workspaceID != workspaceID
+              projects[index].workspaceID != workspaceID,
+              // Refused across machines. A checkout is a directory on one box; the
+              // move would not move the directory, so the row would come to rest in
+              // a workspace whose machine has never had that path. Putting the repo
+              // on the other machine is a clone — a different verb, with a cost.
+              // `moveToWorkspaceMenuItem` offers only same-machine targets, so this
+              // is the backstop rather than the place the user learns it.
+              device(of: projects[index]) == target.device
         else { return }
         projects[index].workspaceID = workspaceID
     }
@@ -472,8 +554,11 @@ extension TermioStore {
             if let deviceID, workspaces[index].deviceID == nil { workspaces[index].deviceID = deviceID }
             return workspaces[index].id
         }
+        // Marked as Termio's own the moment it is made, which is the only place
+        // that fact is known for certain. Nobody asked for this workspace; a
+        // session arrived on a machine with nowhere to be filed.
         let workspace = Workspace(
-            name: alias, deviceAlias: alias, deviceID: deviceID)
+            name: alias, deviceAlias: alias, deviceID: deviceID, isAutoCreated: true)
         workspaces.append(workspace)
         return workspace.id
     }

--- a/Sources/termio/TermioStore/WorkspaceMigration.swift
+++ b/Sources/termio/TermioStore/WorkspaceMigration.swift
@@ -106,7 +106,8 @@ enum WorkspaceMigration {
                     name: container.sshHost ?? container.name,
                     terminals: container.sessions,
                     deviceAlias: container.sshHost ?? container.name,
-                    deviceID: container.deviceID
+                    deviceID: container.deviceID,
+                    isAutoCreated: true
                 ))
             case .folder:
                 projects.append(Project(
@@ -127,25 +128,216 @@ enum WorkspaceMigration {
 
     /// Files any project whose owner no longer exists — a workspace deleted while
     /// the app was closed, or a project written before workspaces — under the
-    /// first workspace, and guarantees there is a first workspace to file it
-    /// under. Runs on every load, not just the upgrade: losing the sidebar to a
-    /// dangling id is the failure this rules out.
+    /// first workspace, guarantees there is a first workspace to file it under,
+    /// and leaves every workspace naming exactly one machine. Runs on every load,
+    /// not just the upgrade: losing the sidebar to a dangling id is the failure
+    /// this rules out, and a workspace that spans two machines is the one this
+    /// stage adds.
+    ///
+    /// This is where the device invariant is established, rather than in the
+    /// decoder, because a throwing decode is swallowed (`StateFile.load`) and
+    /// comes back as a first-run tree — a stricter `Workspace` decoder would
+    /// silently replace the user's whole sidebar. Nothing here changes the on-disk
+    /// shape: `deviceAlias` is still the stored field and `nil` is still this Mac.
     static func reconcile(
         workspaces: [Workspace], projects: [Project]
     ) -> (workspaces: [Workspace], projects: [Project]) {
         var workspaces = workspaces
         if workspaces.isEmpty { workspaces = [Workspace(name: Workspace.defaultName)] }
-        // A user workspace, not a machine's fallback: an orphan is the user's
-        // work, and burying it under a box they may never open again hides it.
-        let fallbackID = (workspaces.first { !$0.isDeviceFallback } ?? workspaces[0]).id
+        // Recover "Termio made this" for files written before the flag existed,
+        // and do it *before* the device pass below, which is the only moment the
+        // answer is still knowable: until then a named machine can only have come
+        // from `deviceWorkspace(for:)` or the pre-workspace migration, both of
+        // which create a workspace nobody asked for. Afterwards every workspace
+        // names a machine and the two are indistinguishable.
+        //
+        // Idempotent: a workspace already carrying the flag keeps it, and one the
+        // user renamed away from its alias is left alone — renaming it is how they
+        // claimed it.
+        for index in workspaces.indices where workspaces[index].isAutoCreated == nil {
+            // Only a workspace that names a machine *and* holds nothing can be one
+            // `deviceWorkspace(for:)` minted: it files loose sessions and is created
+            // empty, whereas a workspace the user filled is theirs however it was
+            // named. Recording the answer — including `false` — is what stops this
+            // running again next launch against a device this pass is about to
+            // stamp on.
+            let workspace = workspaces[index]
+            let unclaimed = workspace.deviceAlias.map { $0 == workspace.name } ?? false
+            workspaces[index].isAutoCreated =
+                unclaimed && projects.allSatisfy { $0.workspaceID != workspace.id }
+        }
+        // A workspace on this Mac: an orphan is the user's work, and burying it
+        // under a box they may never open again hides it. An orphan that turns out
+        // to be a checkout over there is moved on by the device pass below.
+        let fallbackID = (workspaces.first { $0.device.isThisMac } ?? workspaces[0]).id
         let known = Set(workspaces.map(\.id))
-        let projects = projects.map { project -> Project in
+        let filed = projects.map { project -> Project in
             guard !known.contains(project.workspaceID) else { return project }
             var project = project
             project.workspaceID = fallbackID
             return project
         }
-        return (workspaces, projects)
+        return stampingDevices(workspaces: workspaces, projects: filed)
+    }
+
+    /// Leaves every workspace belonging to exactly one machine — the rule the whole
+    /// Device → Workspace → Project hierarchy rests on.
+    ///
+    /// Three cases, and only the last one is lossy:
+    ///
+    /// - Every project on one machine: the workspace adopts it. A workspace holding
+    ///   nothing but checkouts on a box *is* that box's, whoever made it.
+    /// - No projects and no device: this Mac, which is what `nil` already meant.
+    /// - Projects on two machines: the workspace **splits**, one per machine. This
+    ///   is reachable in shipped state files — `addRemoteProject` used to file a
+    ///   checkout on a box into whatever workspace was current, and `addProject` a
+    ///   local folder into it just the same, including when that workspace was a
+    ///   box's. Both now file by machine, so the split is an upgrade path.
+    ///
+    /// Idempotent: run over its own output, every workspace already names one
+    /// machine and nothing moves.
+    private static func stampingDevices(
+        workspaces: [Workspace], projects: [Project]
+    ) -> (workspaces: [Workspace], projects: [Project]) {
+        var projects = projects
+        var result: [Workspace] = []
+        // What a checkout that names no machine means, which is not the same thing
+        // in the two shapes a state file comes in. Before the hierarchy every
+        // checkout recorded its own machine, so silence there meant this Mac; now a
+        // checkout inherits its workspace's machine, and silence means exactly
+        // that — a remote checkout in a box's workspace records nothing at all. One
+        // file is written whole by one build, so a single project still carrying a
+        // record dates the tree it came from.
+        //
+        // Reading it the other way is what would break: taking silence for this Mac
+        // in a file this build wrote would tear every remote checkout off its
+        // workspace on the next launch, and taking it for inheritance in an older
+        // file would let a workspace holding local *and* remote checkouts adopt the
+        // box and carry the local ones with it.
+        let recordsCheckoutDevices = projects.contains { $0.legacyDevice != nil }
+        func claimedDevice(_ project: Project) -> WorkspaceDevice? {
+            if let alias = project.legacyDevice?.alias { return .ssh(alias: alias) }
+            return recordsCheckoutDevices ? .thisMac : nil
+        }
+        // Where a project split off a workspace goes when the tree already has a
+        // home for its machine: one workspace per alias is what `deviceWorkspace(for:)`
+        // assumes, so a split must not mint a second one. Aliases are safe to read
+        // ahead — this pass only ever adds one to a workspace that had none, so a
+        // workspace that already names a machine still names it at the end.
+        var deviceHomes: [String: Workspace.ID] = [:]
+        for workspace in workspaces {
+            guard let alias = workspace.deviceAlias, deviceHomes[alias] == nil else { continue }
+            deviceHomes[alias] = workspace.id
+        }
+
+        for workspace in workspaces {
+            let owned = projects.filter { $0.workspaceID == workspace.id }
+            let claims = owned.compactMap(claimedDevice)
+            // A device the workspace already names counts as a claim in its own
+            // right: its loose sessions were filed there because they run there,
+            // and nothing else records that.
+            var devices = Set(claims)
+            // A loose shell records its own machine and nothing else does, so it
+            // is a claim exactly like a checkout's. Leaving it out let a workspace
+            // holding local shells and one remote checkout adopt the remote box —
+            // and on a one-workspace tree that left nowhere on this Mac for local
+            // work to go, which is the violation this pass exists to prevent.
+            for session in workspace.looseSessions {
+                devices.insert(WorkspaceDevice(alias: session.termiodRemoteHost ?? session.sshHost))
+            }
+            if !workspace.device.isThisMac { devices.insert(workspace.device) }
+
+            guard devices.count > 1 else {
+                var workspace = workspace
+                // Adoption only ever writes an alias onto a workspace that had
+                // none. This Mac stays `nil`, so the file keeps its shape.
+                if let only = devices.first, workspace.deviceAlias == nil {
+                    workspace.deviceAlias = only.alias
+                    workspace.deviceID = owned.first {
+                        claimedDevice($0) == only
+                    }?.legacyDevice?.deviceID
+                }
+                if let alias = workspace.deviceAlias, deviceHomes[alias] == nil {
+                    deviceHomes[alias] = workspace.id
+                }
+                result.append(workspace)
+                continue
+            }
+
+            // The half that keeps the workspace's id, and with it the name and the
+            // loose sessions. Wire ids embed this uuid — `looseWireID` builds
+            // `<uuid>-terminals` for the phone to start a session by, and
+            // `ControlScope.id` keys the CLI's watch streams — so it has to survive
+            // on one half rather than being reissued on both.
+            //
+            // A workspace that already named a machine keeps that half: its loose
+            // sessions run over there, and `deviceWorkspace(for:)` finds it by
+            // alias. Otherwise this Mac's half keeps it, and failing that the half
+            // holding the most projects (ties by alias, so the result is stable).
+            let keeper = keptDevice(of: workspace, among: devices, claims: claims)
+            var kept = workspace
+            kept.deviceAlias = keeper.alias
+            if kept.deviceID == nil {
+                kept.deviceID = owned.first {
+                    claimedDevice($0) == keeper
+                }?.legacyDevice?.deviceID
+            }
+            if let alias = kept.deviceAlias, deviceHomes[alias] == nil {
+                deviceHomes[alias] = kept.id
+            }
+            result.append(kept)
+
+            for device in devices.subtracting([keeper]).sorted(by: { ($0.alias ?? "") < ($1.alias ?? "") }) {
+                let home: Workspace.ID
+                if let alias = device.alias, let existing = deviceHomes[alias] {
+                    home = existing
+                } else if device.isThisMac, let existing = result.first(where: \.device.isThisMac) {
+                    // Only a workspace this pass has already settled: one still
+                    // ahead of us may yet adopt a machine, and filing a local
+                    // checkout into it would re-break what we are here to fix.
+                    home = existing.id
+                } else {
+                    // Named after the machine, which is the only thing this half is
+                    // known to have in common.
+                    // Termio's own: nobody asked for this half, it exists because
+                    // the workspace it came from held checkouts on two machines.
+                    // Set here rather than recovered later, so a second `reconcile`
+                    // over this output changes nothing.
+                    var half = Workspace(
+                        name: device.displayName, deviceAlias: device.alias,
+                        isAutoCreated: true)
+                    half.deviceID = owned.first {
+                        claimedDevice($0) == device
+                    }?.legacyDevice?.deviceID
+                    if let alias = device.alias { deviceHomes[alias] = half.id }
+                    result.append(half)
+                    home = half.id
+                }
+                for index in projects.indices
+                where projects[index].workspaceID == workspace.id
+                    && claimedDevice(projects[index]) == device {
+                    projects[index].workspaceID = home
+                }
+            }
+        }
+        return (result, projects)
+    }
+
+    /// Which machine's half keeps the original workspace — see the call site for
+    /// why that matters. `claims` is one entry per checkout that names a machine,
+    /// so the tie-break counts checkouts, the way it did when every checkout
+    /// carried its own device.
+    private static func keptDevice(
+        of workspace: Workspace, among devices: Set<WorkspaceDevice>, claims: [WorkspaceDevice]
+    ) -> WorkspaceDevice {
+        if !workspace.device.isThisMac { return workspace.device }
+        if devices.contains(.thisMac) { return .thisMac }
+        func count(_ device: WorkspaceDevice) -> Int {
+            claims.filter { $0 == device }.count
+        }
+        return devices.sorted {
+            count($0) == count($1) ? ($0.alias ?? "") < ($1.alias ?? "") : count($0) > count($1)
+        }.first ?? .thisMac
     }
 
     // MARK: - The container migrations that came before

--- a/Sources/termio/Welcome/WelcomeView.swift
+++ b/Sources/termio/Welcome/WelcomeView.swift
@@ -111,7 +111,7 @@ struct WelcomeView: View {
         // has no local folder to reopen, and the path would land as a local
         // project pointing at a directory that isn't here.
         for project in store.orderedProjects
-        where !project.isOnAnotherDevice && seen.insert(project.path).inserted {
+        where !store.isOnAnotherDevice(project) && seen.insert(project.path).inserted {
             out.append(RecentProject(name: project.name, path: project.path))
         }
         for recent in settings.recentProjects where seen.insert(recent.path).inserted {

--- a/Tests/termioTests/RemoteProjectTests.swift
+++ b/Tests/termioTests/RemoteProjectTests.swift
@@ -3,83 +3,139 @@ import XCTest
 
 /// A project whose checkout is on another machine.
 ///
-/// The identity question is the one worth pinning: a box commonly answers to a
-/// LAN name, a WAN name, and a tailnet name, so matching a checkout by the alias
-/// it was reached through would open a second row for the same directory the day
-/// the user changes networks.
+/// The machine is the workspace's now — a checkout inherits it from the scope it
+/// is filed under — so these ask the store rather than the project. The identity
+/// question is the one worth pinning: a box commonly answers to a LAN name, a WAN
+/// name, and a tailnet name, so matching a checkout by the alias it was reached
+/// through would open a second row for the same directory the day the user
+/// changes networks.
 @MainActor
 final class RemoteProjectTests: XCTestCase {
-    private func remote(_ path: String, alias: String, device: String? = nil) -> Project {
+    private func makeStore(workspace: Workspace, projects: [Project]) -> TermioStore {
+        let defaults = UserDefaults(suiteName: "remote-project-\(UUID().uuidString)")
+            ?? UserDefaults.standard
+        return TermioStore(
+            workspaces: [workspace], projects: projects,
+            settings: AppSettings(defaults: defaults))
+    }
+
+    private func checkout(_ path: String, in workspace: Workspace) -> Project {
         var project = Project(
-            workspaceID: UUID(), name: "api", path: path, branch: "—", sessions: [])
-        project.deviceAlias = alias
-        project.deviceID = device
-        project.remoteCheckouts[device ?? alias] = path
+            workspaceID: workspace.id, name: "api", path: path, branch: "—", sessions: [])
+        project.remoteCheckouts[workspace.deviceID ?? workspace.deviceAlias ?? ""] = path
         return project
     }
 
     func testSameDirectoryOnTheSameDeviceIsTheSameCheckout() {
-        let project = remote("/srv/api", alias: "vps-lan", device: "device-a")
+        let vps = Workspace(name: "vps-lan", deviceAlias: "vps-lan", deviceID: "device-a")
+        let project = checkout("/srv/api", in: vps)
+        let store = makeStore(workspace: vps, projects: [project])
 
-        XCTAssertTrue(project.isCheckout(at: "/srv/api", on: "vps-lan", device: "device-a"))
-        XCTAssertTrue(project.isCheckout(at: "/srv/api", on: "vps-tailnet", device: "device-a"),
-                      "one machine reached by a second alias is still one checkout")
-        XCTAssertFalse(project.isCheckout(at: "/srv/web", on: "vps-lan", device: "device-a"),
-                       "a different directory on the same machine is a different checkout")
-        XCTAssertFalse(project.isCheckout(at: "/srv/api", on: "other", device: "device-b"))
+        XCTAssertEqual(store.checkout(at: "/srv/api", on: "vps-lan", device: "device-a")?.id,
+                       project.id)
+        XCTAssertEqual(store.checkout(at: "/srv/api", on: "vps-tailnet", device: "device-a")?.id,
+                       project.id, "one machine reached by a second alias is still one checkout")
+        XCTAssertNil(store.checkout(at: "/srv/web", on: "vps-lan", device: "device-a"),
+                     "a different directory on the same machine is a different checkout")
+        XCTAssertNil(store.checkout(at: "/srv/api", on: "other", device: "device-b"))
     }
 
     /// Until a handshake resolves a `host_id` the alias is all there is — the same
     /// bootstrap/stable split `KnownDevice` carries.
     func testAliasMatchesUntilADeviceResolvesIt() {
-        let project = remote("/srv/api", alias: "vps-lan")
+        let vps = Workspace(name: "vps-lan", deviceAlias: "vps-lan")
+        let project = checkout("/srv/api", in: vps)
+        let store = makeStore(workspace: vps, projects: [project])
 
-        XCTAssertTrue(project.isCheckout(at: "/srv/api", on: "vps-lan", device: nil))
-        XCTAssertTrue(project.isCheckout(at: "/srv/api", on: "vps-lan", device: "device-a"),
-                      "a device this row hasn’t learned yet can’t disprove the alias")
-        XCTAssertFalse(project.isCheckout(at: "/srv/api", on: "vps-wan", device: nil))
+        XCTAssertEqual(store.checkout(at: "/srv/api", on: "vps-lan", device: nil)?.id, project.id)
+        XCTAssertEqual(store.checkout(at: "/srv/api", on: "vps-lan", device: "device-a")?.id,
+                       project.id,
+                       "a device this workspace hasn’t learned yet can’t disprove the alias")
+        XCTAssertNil(store.checkout(at: "/srv/api", on: "vps-wan", device: nil))
     }
 
     /// A folder on this Mac is never a remote checkout, however the paths line up —
     /// the local project row and a same-named directory on a VPS are two places.
     func testALocalProjectIsNeverARemoteCheckout() {
-        let local = Project(
-            workspaceID: UUID(), name: "api", path: "/srv/api", branch: "main", sessions: [])
+        let home = Workspace(name: "Sessions")
+        let project = Project(
+            workspaceID: home.id, name: "api", path: "/srv/api", branch: "main", sessions: [])
+        let store = makeStore(workspace: home, projects: [project])
 
-        XCTAssertFalse(local.isOnAnotherDevice)
-        XCTAssertNil(local.device)
-        XCTAssertFalse(local.isCheckout(at: "/srv/api", on: "vps-lan", device: "device-a"))
+        XCTAssertEqual(store.device(of: project), .thisMac)
+        XCTAssertFalse(store.isOnAnotherDevice(project))
+        XCTAssertNil(store.checkout(at: "/srv/api", on: "vps-lan", device: "device-a"))
+    }
+
+    /// The local-disk gate is the store's answer, not the project's: a checkout
+    /// filed in a workspace on a box is over there, and nothing may read its path
+    /// off this Mac.
+    func testACheckoutInAMachinesWorkspaceIsOnThatMachine() {
+        let vps = Workspace(name: "ukvps", deviceAlias: "ukvps")
+        let project = checkout("/srv/api", in: vps)
+        let store = makeStore(workspace: vps, projects: [project])
+
+        XCTAssertEqual(store.device(of: project), .ssh(alias: "ukvps"))
+        XCTAssertTrue(store.isOnAnotherDevice(project))
+    }
+
+    /// A project whose workspace is gone: the machine is unknown, and unknown must
+    /// not read as this Mac — the gate would open on a directory that may be on a
+    /// box. Unreachable through the tree, since `reconcile` files every orphan on
+    /// load, which is why the gate is what has to be safe.
+    func testAProjectWithNoWorkspaceIsNotTreatedAsLocal() {
+        let home = Workspace(name: "Sessions")
+        let orphan = Project(
+            workspaceID: UUID(), name: "api", path: "/srv/api", branch: "—", sessions: [])
+        let store = makeStore(workspace: home, projects: [])
+
+        XCTAssertNil(store.device(of: orphan))
+        XCTAssertTrue(store.isOnAnotherDevice(orphan))
     }
 
     /// The checkout a remote terminal opens in resolves through the device key when
     /// one is known and the alias key until then, so the row works before and after
     /// the machine identifies itself.
     func testTheSeededCheckoutResolvesBothWays() {
-        let known = remote("/srv/api", alias: "vps-lan", device: "device-a")
+        var known = Project(
+            workspaceID: UUID(), name: "api", path: "/srv/api", branch: "—", sessions: [])
+        known.remoteCheckouts["device-a"] = "/srv/api"
         XCTAssertEqual(known.remoteCheckout(device: "device-a", alias: "vps-lan"), "/srv/api")
 
-        let unresolved = remote("/srv/api", alias: "vps-lan")
+        var unresolved = known
+        unresolved.remoteCheckouts = ["vps-lan": "/srv/api"]
         XCTAssertEqual(unresolved.remoteCheckout(device: nil, alias: "vps-lan"), "/srv/api")
         XCTAssertEqual(unresolved.remoteCheckout(device: "device-a", alias: "vps-lan"), "/srv/api",
                        "a device key that isn’t recorded yet falls back to the alias")
     }
 
-    /// The device fields survive a round trip, and a project written before them
-    /// still decodes as a folder on this Mac.
-    func testDeviceSurvivesEncodingAndOlderStateFilesStayLocal() throws {
-        let project = remote("/srv/api", alias: "vps-lan", device: "device-a")
-        let decoded = try JSONDecoder().decode(
-            Project.self, from: try JSONEncoder().encode(project))
+    /// A state file written before the hierarchy recorded the machine on each
+    /// checkout. Those keys are still read, because they are the only thing that
+    /// says a workspace's checkouts span two machines — and they are not written
+    /// back, so the load after the upgrade reads a tree that inherits instead.
+    func testOlderStateFilesStillCarryTheirCheckoutsMachine() throws {
+        let older = """
+        {"id":"\(UUID().uuidString)","name":"api","path":"/srv/api","branch":"—",
+         "sessions":[],"deviceAlias":"vps-lan","deviceID":"device-a"}
+        """
+        let legacy = try JSONDecoder().decode(Project.self, from: Data(older.utf8))
+        XCTAssertEqual(legacy.legacyDevice?.alias, "vps-lan")
+        XCTAssertEqual(legacy.legacyDevice?.deviceID, "device-a")
 
-        XCTAssertEqual(decoded.deviceAlias, "vps-lan")
-        XCTAssertEqual(decoded.deviceID, "device-a")
-        XCTAssertTrue(decoded.isOnAnotherDevice)
+        let rewritten = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(legacy)) as? [String: Any]
+        XCTAssertNil(rewritten?["deviceAlias"], "the machine is the workspace's to record")
+        XCTAssertNil(rewritten?["deviceID"])
+    }
 
+    /// A project written before either key existed decodes to one that inherits,
+    /// which is what every project this build writes does.
+    func testAProjectThatNamesNoMachineInheritsOne() throws {
         let older = """
         {"id":"\(UUID().uuidString)","name":"api","path":"/Users/me/api",
          "branch":"main","sessions":[]}
         """
         let legacy = try JSONDecoder().decode(Project.self, from: Data(older.utf8))
-        XCTAssertFalse(legacy.isOnAnotherDevice)
+        XCTAssertNil(legacy.legacyDevice)
     }
 }

--- a/Tests/termioTests/TermiodDeviceAdoptionTests.swift
+++ b/Tests/termioTests/TermiodDeviceAdoptionTests.swift
@@ -94,7 +94,7 @@ final class TermiodDeviceAdoptionTests: XCTestCase {
         XCTAssertEqual(store.workspaces[0].deviceID, "h_aaaa")
         XCTAssertEqual(store.workspaces[0].deviceAlias, "vps",
                        "the alias stays the bootstrap identity")
-        XCTAssertTrue(store.workspaces[0].isDeviceFallback)
+        XCTAssertEqual(store.workspaces[0].device, .ssh(alias: "vps"))
     }
 
     /// Two aliases for one machine are recorded as one device but are **not**

--- a/Tests/termioTests/WorkspaceDeviceTests.swift
+++ b/Tests/termioTests/WorkspaceDeviceTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import termio
+
+/// Where work that runs on **this Mac** is filed once a workspace belongs to
+/// exactly one machine.
+///
+/// The rule already existed for loose sessions, phrased as "not a machine's
+/// fallback"; it is restated here as a claim about the machine, and it now covers
+/// `Open Project…` too — that path filed a local folder into whatever workspace
+/// was current, a box's included. Both callers read `workspaceForThisMac`, which
+/// is the decision; appending the row is not.
+@MainActor
+final class WorkspaceDeviceTests: XCTestCase {
+    private func makeStore(workspaces: [Workspace], current: Workspace) -> TermioStore {
+        let defaults = UserDefaults(suiteName: "workspace-device-\(UUID().uuidString)")
+            ?? UserDefaults.standard
+        let store = TermioStore(workspaces: workspaces, settings: AppSettings(defaults: defaults))
+        store.currentWorkspaceID = current.id
+        return store
+    }
+
+    /// A workspace states its machine outright, so an absent alias stops having to
+    /// mean both "this Mac" and "the user made it". Nothing is stored differently —
+    /// this reads the field that was always there.
+    func testAWorkspaceNamesItsMachine() {
+        XCTAssertEqual(Workspace(name: "Sessions").device, .thisMac)
+        XCTAssertEqual(Workspace(name: "ukvps", deviceAlias: "ukvps").device,
+                       .ssh(alias: "ukvps"))
+        XCTAssertNil(WorkspaceDevice.thisMac.alias, "this Mac has no alias to reach it by")
+    }
+
+    /// A local shell or a local folder opened while a box's workspace is current
+    /// lands on this Mac, not over there — the workspace would otherwise claim work
+    /// that machine knows nothing about.
+    func testLocalWorkGoesToAWorkspaceOnThisMac() {
+        let home = Workspace(name: "Sessions")
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps")
+        let store = makeStore(workspaces: [home, ukvps], current: ukvps)
+
+        XCTAssertEqual(store.workspaceForThisMac.id, home.id)
+    }
+
+    /// A workspace already on this Mac keeps it: the redirect exists to correct a
+    /// machine mismatch, not to overrule which scope the user is working in.
+    func testTheCurrentWorkspaceIsKeptWhenItIsAlreadyOnThisMac() {
+        let home = Workspace(name: "Sessions")
+        let other = Workspace(name: "Side")
+        let store = makeStore(workspaces: [home, other], current: other)
+
+        XCTAssertEqual(store.workspaceForThisMac.id, other.id)
+    }
+
+    /// With no workspace on this Mac at all, the current one still takes it: a row
+    /// the user cannot see is worse than a workspace whose machine is briefly
+    /// wrong, and the next load's `reconcile` splits it back apart.
+    func testWithNoLocalWorkspaceTheCurrentOneStillTakesIt() {
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps")
+        let store = makeStore(workspaces: [ukvps], current: ukvps)
+
+        XCTAssertEqual(store.workspaceForThisMac.id, ukvps.id)
+    }
+}
+
+/// Which workspaces Termio may sweep when they empty out.
+///
+/// The flag exists because the device pass made the old test unsafe: once every
+/// workspace names a machine, "named after a machine" no longer distinguishes one
+/// Termio invented from one the user made and filled with checkouts on that box.
+final class WorkspaceAutoCreatedTests: XCTestCase {
+    /// `autoCreated` defaults to **nil**, not `false`: nil is what a state file
+    /// written before the flag decodes to, which is the input the recovery pass
+    /// exists for. Defaulting it to `false` made these tests assert against a
+    /// value that had already been answered.
+    private func workspace(
+        _ name: String, alias: String? = nil, autoCreated: Bool? = nil
+    ) -> Workspace {
+        Workspace(name: name, deviceAlias: alias, isAutoCreated: autoCreated)
+    }
+
+    /// A file written before the flag: a fallback still looks exactly as
+    /// `deviceWorkspace(for:)` made it, so it is reclaimed as Termio's.
+    func testAnUntouchedFallbackIsRecoveredAsAutoCreated() {
+        let (result, _) = WorkspaceMigration.reconcile(
+            workspaces: [workspace("ukvps", alias: "ukvps")], projects: [])
+        XCTAssertEqual(result[0].isAutoCreated, true)
+    }
+
+    /// Renaming a fallback is how a user claims it, so the name no longer matching
+    /// the alias means it is theirs and must never be swept.
+    func testARenamedFallbackIsTheUsers() {
+        let (result, _) = WorkspaceMigration.reconcile(
+            workspaces: [workspace("Ship auth", alias: "ukvps")], projects: [])
+        XCTAssertEqual(result[0].isAutoCreated, false)
+    }
+
+    /// The regression this flag exists to stop: a workspace the user named, whose
+    /// projects all live on one box, adopts that box's alias in the device pass —
+    /// and must not become sweepable because of it.
+    func testAUserWorkspaceAdoptingADeviceStaysTheUsers() {
+        let named = workspace("Ship auth")
+        var checkout = Project(
+            workspaceID: named.id, name: "api", path: "/srv/api", branch: "—", sessions: [])
+        checkout.legacyDevice = KnownDevice(alias: "ukvps", deviceID: nil)
+        let (result, _) = WorkspaceMigration.reconcile(
+            workspaces: [named], projects: [checkout])
+
+        let adopted = result.first { $0.id == named.id }
+        XCTAssertEqual(adopted?.deviceAlias, "ukvps", "the device pass should still stamp it")
+        XCTAssertEqual(adopted?.isAutoCreated, false, "but it is still the user's workspace")
+    }
+
+    /// `reconcile` runs on every load, so the recovery must not change its answer
+    /// on the second pass — by then every workspace names a machine.
+    func testRecoveryIsIdempotent() {
+        let once = WorkspaceMigration.reconcile(
+            workspaces: [workspace("Ship auth"), workspace("ukvps", alias: "ukvps")],
+            projects: [])
+        let twice = WorkspaceMigration.reconcile(
+            workspaces: once.workspaces, projects: once.projects)
+        XCTAssertEqual(once.workspaces.map(\.isAutoCreated), twice.workspaces.map(\.isAutoCreated))
+        XCTAssertEqual(twice.workspaces.first { $0.name == "Ship auth" }?.isAutoCreated, false)
+    }
+}
+
+/// The two failures an adversarial review found in the first cut of the device
+/// pass. Both are launch-2 or loose-session shaped, which is why the original
+/// tests missed them.
+final class WorkspaceDeviceRegressionTests: XCTestCase {
+    private func checkout(_ name: String, in workspace: Workspace, on alias: String?) -> Project {
+        var project = Project(
+            workspaceID: workspace.id, name: name, path: "/srv/\(name)",
+            branch: "—", sessions: [])
+        project.legacyDevice = alias.map { KnownDevice(alias: $0, deviceID: nil) }
+        return project
+    }
+
+    /// A user names a workspace after the box its checkouts live on. Launch 1
+    /// stamps the alias; launch 2 must not then read that stamp back as "Termio
+    /// made this" and make the workspace sweepable.
+    func testAUserWorkspaceNamedAfterItsMachineSurvivesASecondLaunch() {
+        let named = Workspace(name: "ukvps")
+        let first = WorkspaceMigration.reconcile(
+            workspaces: [named], projects: [checkout("api", in: named, on: "ukvps")])
+        XCTAssertEqual(first.workspaces[0].deviceAlias, "ukvps", "launch 1 stamps the device")
+        XCTAssertEqual(first.workspaces[0].isAutoCreated, false, "and records that it is the user's")
+
+        let second = WorkspaceMigration.reconcile(
+            workspaces: first.workspaces, projects: first.projects)
+        XCTAssertEqual(
+            second.workspaces[0].isAutoCreated, false,
+            "launch 2 must not claim a workspace the user named")
+        XCTAssertEqual(second.workspaces, first.workspaces, "and must change nothing at all")
+    }
+
+    /// A workspace holding local shells and one remote checkout used to adopt the
+    /// remote box, because only projects were consulted — leaving a one-workspace
+    /// tree with nowhere on this Mac for local work to go.
+    func testLocalLooseShellsKeepAWorkspaceOffARemoteBox() {
+        let scope = Workspace(name: "Sessions", terminals: [Session(title: "Terminal 1")])
+        let (workspaces, _) = WorkspaceMigration.reconcile(
+            workspaces: [scope], projects: [checkout("api", in: scope, on: "ukvps")])
+
+        XCTAssertNotNil(
+            workspaces.first { $0.device.isThisMac },
+            "a local shell is a claim on this Mac, so somewhere must still be local")
+        let kept = workspaces.first { $0.id == scope.id }
+        XCTAssertEqual(kept?.device, .thisMac, "the shells' own workspace stays local")
+        XCTAssertEqual(kept?.terminals.count, 1, "and keeps them")
+    }
+
+    /// The same, for a loose shell that runs on a box: it claims that box, so a
+    /// workspace holding only those does not end up on this Mac by default.
+    func testARemoteLooseShellClaimsItsMachine() {
+        var shell = Session(title: "Terminal 1")
+        shell.termiodRemoteHost = "ukvps"
+        let scope = Workspace(name: "Sessions", terminals: [shell])
+
+        let (workspaces, _) = WorkspaceMigration.reconcile(workspaces: [scope], projects: [])
+        XCTAssertEqual(workspaces.first { $0.id == scope.id }?.device, .ssh(alias: "ukvps"))
+    }
+}

--- a/Tests/termioTests/WorkspaceMigrationTests.swift
+++ b/Tests/termioTests/WorkspaceMigrationTests.swift
@@ -33,6 +33,18 @@ final class WorkspaceMigrationTests: XCTestCase {
         Legacy(name: name, path: "/code/\(name)", branch: "main", sessions: sessions)
     }
 
+    /// A checkout as an older state file wrote it: the machine recorded on the
+    /// checkout itself, which is what `reconcile` reads to give the workspace one.
+    /// No alias is that file's way of saying this Mac.
+    private func checkout(
+        _ name: String, in workspace: Workspace, on alias: String? = nil, device: String? = nil
+    ) -> Project {
+        var project = Project(workspaceID: workspace.id, name: name, path: "/code/\(name)",
+                              branch: "main", sessions: [])
+        project.legacyDevice = alias.map { KnownDevice(alias: $0, deviceID: device) }
+        return project
+    }
+
     /// The whole point of the upgrade: the user opens to the column they closed.
     /// Terminals, Chats and every folder project land in one workspace, so the
     /// switcher stays out of sight for someone who never asked for a second scope.
@@ -64,7 +76,7 @@ final class WorkspaceMigrationTests: XCTestCase {
 
         XCTAssertTrue(projects.isEmpty, "a machine is not a folder")
         XCTAssertEqual(workspaces.count, 2)
-        let fallback = workspaces.first { $0.isDeviceFallback }
+        let fallback = workspaces.first { !$0.device.isThisMac }
         XCTAssertEqual(fallback?.name, "ukvps")
         XCTAssertEqual(fallback?.deviceAlias, "ukvps")
         XCTAssertEqual(fallback?.deviceID, "h_aaaa", "the machine it resolved to is kept")
@@ -242,8 +254,156 @@ final class WorkspaceMigrationTests: XCTestCase {
         let (workspaces, projects) = WorkspaceMigration.reconcile(
             workspaces: [home], projects: [filed])
 
-        XCTAssertEqual(workspaces, [home])
+        // Everything but the ownership answer is untouched. That answer is
+        // recorded rather than left absent on purpose: an unrecorded one would be
+        // re-derived next launch, against a device this pass may have just stamped
+        // on, and could then claim a workspace the user named.
+        var settled = home
+        settled.isAutoCreated = false
+        XCTAssertEqual(workspaces, [settled])
         XCTAssertEqual(projects, [filed])
+
+        // And it is a fixed point from there — the property the churn would break.
+        let again = WorkspaceMigration.reconcile(workspaces: workspaces, projects: projects)
+        XCTAssertEqual(again.workspaces, workspaces)
+    }
+
+    // MARK: - Every workspace belongs to one machine
+
+    /// A workspace holding nothing but checkouts on one box *is* that box's,
+    /// whoever made it — so it says so, and the device it resolved to rides along.
+    func testAWorkspaceAdoptsTheMachineItsProjectsAreOn() {
+        let scope = Workspace(name: "Servers")
+        let (workspaces, projects) = WorkspaceMigration.reconcile(
+            workspaces: [scope],
+            projects: [checkout("api", in: scope, on: "ukvps", device: "h_aaaa"),
+                       checkout("web", in: scope, on: "ukvps")])
+
+        XCTAssertEqual(workspaces.count, 1, "one machine, so nothing to split")
+        XCTAssertEqual(workspaces.first?.device, .ssh(alias: "ukvps"))
+        XCTAssertEqual(workspaces.first?.deviceID, "h_aaaa")
+        XCTAssertEqual(workspaces.first?.id, scope.id, "adoption is not a new workspace")
+        XCTAssertEqual(Set(projects.map(\.workspaceID)), [scope.id])
+    }
+
+    /// Nothing filed under it and no machine named: this Mac, which is what an
+    /// absent alias already meant. Nothing is written, so the state file keeps its
+    /// shape.
+    func testAWorkspaceWithNoProjectsStaysOnThisMac() {
+        let scope = Workspace(name: "Sessions", terminals: [session("Terminal 1")])
+
+        let (workspaces, _) = WorkspaceMigration.reconcile(workspaces: [scope], projects: [])
+
+        var settled = scope
+        settled.isAutoCreated = false
+        XCTAssertEqual(workspaces, [settled])
+        XCTAssertEqual(workspaces.first?.device, .thisMac)
+        XCTAssertNil(workspaces.first?.deviceAlias, "no alias is written, so the file keeps its shape")
+    }
+
+    /// The lossy case, and a reachable one: `addProject` files a local folder into
+    /// whatever workspace is current and `addRemoteProject` files a checkout on a
+    /// box into the same place. A workspace cannot mean two machines, so it splits.
+    func testAWorkspaceWhoseProjectsSpanMachinesSplits() throws {
+        let scope = Workspace(name: "Work", terminals: [session("Terminal 1")])
+        let local = checkout("termio", in: scope)
+        let remote = checkout("api", in: scope, on: "ukvps")
+
+        let (workspaces, projects) = WorkspaceMigration.reconcile(
+            workspaces: [scope], projects: [local, remote])
+
+        XCTAssertEqual(workspaces.count, 2)
+        let here = try XCTUnwrap(workspaces.first { $0.device == .thisMac })
+        let there = try XCTUnwrap(workspaces.first { $0.device == .ssh(alias: "ukvps") })
+        XCTAssertEqual(there.name, "ukvps", "the new half is named after its machine")
+        XCTAssertEqual(projects.first { $0.id == local.id }?.workspaceID, here.id)
+        XCTAssertEqual(projects.first { $0.id == remote.id }?.workspaceID, there.id)
+    }
+
+    /// The original uuid survives the split, and on the half the user is still
+    /// looking at. Wire ids embed it — `looseWireID` builds `<uuid>-terminals` for
+    /// the phone to start a session by, and `ControlScope.id` keys the CLI's watch
+    /// streams — so reissuing it on both halves would break both.
+    func testTheOriginalWorkspaceKeepsItsIdAndItsLooseSessions() {
+        let scope = Workspace(name: "Work", terminals: [session("Terminal 1")],
+                              chats: [session("Claude Code", agent: .claudeCode)])
+
+        let (workspaces, _) = WorkspaceMigration.reconcile(
+            workspaces: [scope],
+            projects: [checkout("termio", in: scope), checkout("api", in: scope, on: "ukvps")])
+
+        let kept = workspaces.first { $0.id == scope.id }
+        XCTAssertEqual(kept?.device, .thisMac, "this Mac's half keeps the id")
+        XCTAssertEqual(kept?.name, "Work", "and the name the user gave it")
+        XCTAssertEqual(kept?.looseSessions.map(\.id), scope.looseSessions.map(\.id),
+                       "a loose session has no project to place it by")
+    }
+
+    /// A machine's own workspace keeps the id when it is the one that splits: its
+    /// loose sessions run on that box, and `deviceWorkspace(for:)` finds it by
+    /// alias. The stray local checkout is what moves.
+    func testAMachinesWorkspaceKeepsItsIdAndSheddsTheLocalCheckout() {
+        let ukvps = Workspace(name: "ukvps", terminals: [remote("Terminal 1", host: "ukvps")],
+                              deviceAlias: "ukvps")
+        let strayLocal = checkout("termio", in: ukvps)
+
+        let (workspaces, projects) = WorkspaceMigration.reconcile(
+            workspaces: [ukvps],
+            projects: [strayLocal, checkout("api", in: ukvps, on: "ukvps")])
+
+        let kept = workspaces.first { $0.id == ukvps.id }
+        XCTAssertEqual(kept?.device, .ssh(alias: "ukvps"))
+        XCTAssertEqual(kept?.terminals.count, 1, "the remote shells stay on their machine")
+        XCTAssertEqual(workspaces.count, 2)
+        let here = workspaces.first { $0.device == .thisMac }
+        XCTAssertEqual(projects.first { $0.id == strayLocal.id }?.workspaceID, here?.id)
+    }
+
+    /// A split files its checkouts into the workspace that machine already has,
+    /// rather than minting a second one for the same alias — `deviceWorkspace(for:)`
+    /// matches by alias and expects to find one.
+    func testASplitReusesTheMachinesExistingWorkspace() {
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps")
+        let scope = Workspace(name: "Work")
+        let remote = checkout("api", in: scope, on: "ukvps")
+
+        let (workspaces, projects) = WorkspaceMigration.reconcile(
+            workspaces: [scope, ukvps], projects: [checkout("termio", in: scope), remote])
+
+        XCTAssertEqual(workspaces.count, 2, "no second workspace for a machine that has one")
+        XCTAssertEqual(projects.first { $0.id == remote.id }?.workspaceID, ukvps.id)
+    }
+
+    /// A local checkout shed by a machine's workspace goes to the workspace this
+    /// Mac already has, rather than adding a scope for a machine the user is
+    /// sitting in front of.
+    func testALocalCheckoutShedByASplitGoesToTheWorkspaceThisMacHas() {
+        let home = Workspace(name: "Sessions")
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps")
+        let stray = checkout("termio", in: ukvps)
+
+        let (workspaces, projects) = WorkspaceMigration.reconcile(
+            workspaces: [home, ukvps], projects: [stray, checkout("api", in: ukvps, on: "ukvps")])
+
+        XCTAssertEqual(workspaces.count, 2)
+        XCTAssertEqual(projects.first { $0.id == stray.id }?.workspaceID, home.id)
+    }
+
+    /// `reconcile` runs on every load, so a tree it produced must come back
+    /// unchanged — otherwise the sidebar reshuffles itself on every launch.
+    func testReconcileIsIdempotentOverItsOwnOutput() {
+        let scope = Workspace(name: "Work", terminals: [session("Terminal 1")])
+        let once = WorkspaceMigration.reconcile(
+            workspaces: [scope, Workspace(name: "Servers")],
+            projects: [checkout("termio", in: scope),
+                       checkout("api", in: scope, on: "ukvps"),
+                       checkout("web", in: scope, on: "devbox")])
+
+        let twice = WorkspaceMigration.reconcile(
+            workspaces: once.workspaces, projects: once.projects)
+
+        XCTAssertEqual(twice.workspaces, once.workspaces)
+        XCTAssertEqual(twice.projects, once.projects)
     }
 
     /// The upgrade runs once. A state file that already carries workspaces is
@@ -257,7 +417,15 @@ final class WorkspaceMigrationTests: XCTestCase {
         let reconciled = WorkspaceMigration.reconcile(
             workspaces: once.workspaces, projects: once.projects)
 
-        XCTAssertEqual(reconciled.workspaces, once.workspaces)
+        // `migrate` does not answer the ownership question for the home workspace
+        // it mints, so the first `reconcile` records it; nothing else moves.
+        XCTAssertEqual(reconciled.workspaces.map(\.id), once.workspaces.map(\.id))
+        XCTAssertEqual(reconciled.workspaces.map(\.name), once.workspaces.map(\.name))
+        XCTAssertEqual(reconciled.workspaces.map(\.deviceAlias), once.workspaces.map(\.deviceAlias))
         XCTAssertEqual(reconciled.projects, once.projects)
+
+        let again = WorkspaceMigration.reconcile(
+            workspaces: reconciled.workspaces, projects: reconciled.projects)
+        XCTAssertEqual(again.workspaces, reconciled.workspaces)
     }
 }

--- a/Tests/termioTests/WorkspaceProjectFilingTests.swift
+++ b/Tests/termioTests/WorkspaceProjectFilingTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import termio
+
+/// Where a project may be filed, now that the workspace is what says which
+/// machine it is on.
+///
+/// Two consequences the hierarchy has and the flat model did not: a project
+/// cannot be moved to a workspace on another machine, because the move would not
+/// move the directory; and a checkout that records no machine of its own is on
+/// its workspace's, which is what every project written from here on looks like.
+@MainActor
+final class WorkspaceProjectFilingTests: XCTestCase {
+    private func makeStore(workspaces: [Workspace], projects: [Project]) -> TermioStore {
+        let defaults = UserDefaults(suiteName: "workspace-filing-\(UUID().uuidString)")
+            ?? UserDefaults.standard
+        return TermioStore(
+            workspaces: workspaces, projects: projects,
+            settings: AppSettings(defaults: defaults))
+    }
+
+    private func project(_ name: String, in workspace: Workspace) -> Project {
+        Project(workspaceID: workspace.id, name: name, path: "/code/\(name)",
+                branch: "main", sessions: [])
+    }
+
+    /// The rows a submenu offers, so a test can read the menu the way a user does.
+    private func rows(of item: SidebarMenuItem?) -> [String] {
+        guard case .submenu(_, let rows) = item else { return [] }
+        return rows.compactMap { row in
+            if case .action(let label, _) = row { return label }
+            return nil
+        }
+    }
+
+    // MARK: - Moving between workspaces
+
+    func testAProjectMovesToAnotherWorkspaceOnItsOwnMachine() {
+        let work = Workspace(name: "Work", isAutoCreated: false)
+        let side = Workspace(name: "Side", isAutoCreated: false)
+        let api = project("api", in: work)
+        let store = makeStore(workspaces: [work, side], projects: [api])
+
+        store.moveProject(api.id, toWorkspace: side.id)
+
+        XCTAssertEqual(store.projects.first?.workspaceID, side.id)
+    }
+
+    /// A checkout is a directory on one box. Moving its row to a workspace on
+    /// another machine would leave the row naming a path that machine has never
+    /// had — putting the repo over there is a clone, a different verb.
+    func testAProjectIsNotMovedToAWorkspaceOnAnotherMachine() {
+        let work = Workspace(name: "Work", isAutoCreated: false)
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps", isAutoCreated: true)
+        let api = project("api", in: work)
+        let store = makeStore(workspaces: [work, ukvps], projects: [api])
+
+        store.moveProject(api.id, toWorkspace: ukvps.id)
+
+        XCTAssertEqual(store.projects.first?.workspaceID, work.id, "the row stays where it is")
+    }
+
+    /// The menu offers only what the move would accept: a row that is refused on
+    /// click is worse than no row.
+    func testTheMoveMenuOffersOnlyWorkspacesOnTheSameMachine() {
+        let work = Workspace(name: "Work", isAutoCreated: false)
+        let side = Workspace(name: "Side", isAutoCreated: false)
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps", isAutoCreated: true)
+        let api = project("api", in: work)
+        let store = makeStore(workspaces: [work, side, ukvps], projects: [api])
+
+        let menu = moveToWorkspaceMenuItem(store: store, project: api)
+
+        XCTAssertEqual(rows(of: menu), ["Side"])
+    }
+
+    /// And disappears when the only other workspaces are on other machines.
+    func testTheMoveMenuIsAbsentWithNoTargetOnTheSameMachine() {
+        let work = Workspace(name: "Work", isAutoCreated: false)
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps", isAutoCreated: true)
+        let api = project("api", in: work)
+        let store = makeStore(workspaces: [work, ukvps], projects: [api])
+
+        XCTAssertNil(moveToWorkspaceMenuItem(store: store, project: api))
+    }
+
+    // MARK: - The order the switcher shows
+
+    /// Ordered by who made it, not by which machine it is on: every workspace
+    /// names a machine now, so ordering by the device would push a workspace the
+    /// user named and filled with checkouts on one box to the bottom of their own
+    /// list.
+    func testTermiosOwnWorkspacesSortAfterTheOnesTheUserMade() {
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps", isAutoCreated: true)
+        let onABox = Workspace(name: "Ship auth", deviceAlias: "devbox", isAutoCreated: false)
+        let work = Workspace(name: "Work", isAutoCreated: false)
+        let store = makeStore(workspaces: [ukvps, onABox, work], projects: [])
+
+        XCTAssertEqual(store.orderedWorkspaces.map(\.name), ["Ship auth", "Work", "ukvps"])
+    }
+
+    // MARK: - What a checkout that names no machine means
+
+    /// A checkout filed in a box's workspace and recording no machine of its own
+    /// is on that box. Reading its silence as "this Mac" — which is what it meant
+    /// in a file written before the hierarchy — would tear every remote checkout
+    /// off its workspace.
+    func testACheckoutThatRecordsNoMachineIsOnItsWorkspacesMachine() {
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps", isAutoCreated: true)
+        let api = project("api", in: ukvps)
+
+        let (workspaces, projects) = WorkspaceMigration.reconcile(
+            workspaces: [ukvps], projects: [api])
+
+        XCTAssertEqual(workspaces.count, 1, "nothing to split: the checkout claims nothing")
+        XCTAssertEqual(workspaces.first?.device, .ssh(alias: "ukvps"))
+        XCTAssertEqual(projects.first?.workspaceID, ukvps.id)
+    }
+
+    /// The launch after the upgrade. The first `reconcile` reads the machine each
+    /// checkout recorded and files the tree by it; the save that follows drops
+    /// those keys, because the workspace is where the machine lives now. The
+    /// second launch must then leave the same tree alone — the round trip is what
+    /// makes this a different input from the first pass.
+    func testTheLaunchAfterAnUpgradeChangesNothing() throws {
+        let scope = Workspace(name: "Work", terminals: [Session(title: "Terminal 1")])
+        var remote = project("api", in: scope)
+        remote.legacyDevice = KnownDevice(alias: "ukvps", deviceID: "h_aaaa")
+
+        let upgraded = WorkspaceMigration.reconcile(
+            workspaces: [scope], projects: [project("termio", in: scope), remote])
+        XCTAssertEqual(upgraded.workspaces.count, 2, "the mixed workspace splits on the upgrade")
+
+        // What the state file holds afterwards: `legacyDevice` is decoded, never
+        // written, so the next launch decodes projects that name no machine.
+        let saved = try JSONDecoder().decode(
+            [Project].self, from: try JSONEncoder().encode(upgraded.projects))
+        XCTAssertTrue(saved.allSatisfy { $0.legacyDevice == nil })
+
+        let relaunched = WorkspaceMigration.reconcile(
+            workspaces: upgraded.workspaces, projects: saved)
+
+        XCTAssertEqual(relaunched.workspaces, upgraded.workspaces)
+        XCTAssertEqual(relaunched.projects.map(\.workspaceID), saved.map(\.workspaceID))
+    }
+}


### PR DESCRIPTION
A workspace belonged to a machine only when Termio had invented it. The same type behaved two ways — `isDeviceFallback` sorted it last, drew a server glyph and made it sweepable — and the device was recorded three times over, on the workspace, on every project and on every session.

Every workspace now names its device; projects and sessions inherit it. `Project.deviceAlias`/`deviceID` leave the live model and survive as decode-only `legacyDevice`, because old state files still carry them and migration is the only thing allowed to read them.

**The invariant is established at load time, never in a decoder.** A throwing `Snapshot` decode is swallowed by `try?` and comes back as a fresh first-run tree — a stricter `Workspace` decoder would silently replace the user's entire sidebar. So the on-disk format is unchanged and `reconcile` does the work on every load, splitting a workspace whose projects span machines and keeping the original UUID on one half (wire ids embed it: `looseWireID` and `ControlScope.id`).

Reviewed adversarially, which found four bugs, all fixed here with regression tests:

- The ownership flag was re-derived every launch and claimed a workspace the user had named after the box its checkouts sit on. It is now tri-state — absent means "not yet determined", `false` means "asked and answered".
- Loose sessions did not count as device claims, so a workspace holding local shells and one remote checkout adopted the remote box, leaving nowhere on this Mac for local work to go.

**Behaviour change worth calling out:** `Open Project ▸ <machine>` now files the project into that machine's workspace rather than the current one. #347 shipped this morning promising the opposite, and its release note is now wrong. The invariant forbids a remote checkout in a this-Mac workspace, so the choice was refuse or file by machine.

Two lesser findings are deliberately left for a follow-up: adoption can mint a second workspace for one alias, and the shed-local-checkout home is array-order dependent.

Verified: `swift build` clean, `swift test` 445 tests 0 failures, `check-strings.sh` clean. **Not verified on screen** — Screen Recording is unavailable on the machine this was built on, so no UI claim here rests on having seen it.

Release Notes:
Workspaces now belong to a machine. A project opened on another machine is filed under that machine's workspace, and a workspace holding work from two machines is split in two on first launch.