### PR TITLE
Make device filing deterministic and order-independent

### DIFF
--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -563,17 +563,28 @@ extension TermioStore {
     // MARK: - The machine fallback
 
     /// The fallback workspace for `alias`, created on first use — "the sessions on
-    /// that box that nothing else accounts for". One per machine, matched by alias
-    /// rather than by name, so two sessions on the same box always land together.
+    /// that box that nothing else accounts for". Matched by alias rather than by
+    /// name, so two sessions on the same box always land together.
     ///
     /// It is a workspace like any other: the switcher lists it, the sidebar draws
     /// it with the same four sections. What makes it a fallback is only that
     /// nobody chose it — the `termiod` CLI and the phone start sessions on a
     /// machine without saying where they belong, and those sessions have to be
     /// reachable somewhere.
+    ///
+    /// More than one workspace can name the same machine, so this picks rather than
+    /// assumes: `WorkspaceMigration.reconcile` lets a workspace the user named and
+    /// filled with checkouts on one box adopt that box, and the box may already
+    /// have a fallback of its own. Termio's own comes first — a session nobody
+    /// filed belongs in the workspace nobody asked for, not in the middle of the
+    /// user's own work. (Adoption is not the alternative: the workspace really is
+    /// on that machine, and moving its projects out to say so would empty a
+    /// workspace the user named.)
     @discardableResult
     func deviceWorkspace(for alias: String, deviceID: String? = nil) -> Workspace.ID {
-        if let index = workspaces.firstIndex(where: { $0.deviceAlias == alias }) {
+        let onThatMachine = workspaces.indices.filter { workspaces[$0].deviceAlias == alias }
+        if let index = onThatMachine.first(where: { workspaces[$0].isAutoCreated == true })
+            ?? onThatMachine.first {
             if let deviceID, workspaces[index].deviceID == nil { workspaces[index].deviceID = deviceID }
             return workspaces[index].id
         }

--- a/Sources/termio/TermioStore/WorkspaceMigration.swift
+++ b/Sources/termio/TermioStore/WorkspaceMigration.swift
@@ -219,33 +219,60 @@ enum WorkspaceMigration {
             if let alias = project.legacyDevice?.alias { return .ssh(alias: alias) }
             return recordsCheckoutDevices ? .thisMac : nil
         }
+        // Every machine a workspace has something on.
+        //
+        // A device the workspace already names counts as a claim in its own right:
+        // its loose sessions were filed there because they run there, and nothing
+        // else records that. A loose shell records its own machine and nothing else
+        // does, so it is a claim exactly like a checkout's. Leaving it out let a
+        // workspace holding local shells and one remote checkout adopt the remote
+        // box — and on a one-workspace tree that left nowhere on this Mac for local
+        // work to go, which is the violation this pass exists to prevent.
+        func devices(of workspace: Workspace, claims: [WorkspaceDevice]) -> Set<WorkspaceDevice> {
+            var devices = Set(claims)
+            for session in workspace.looseSessions {
+                devices.insert(WorkspaceDevice(alias: session.termiodRemoteHost ?? session.sshHost))
+            }
+            if !workspace.device.isThisMac { devices.insert(workspace.device) }
+            return devices
+        }
+        // The machine a workspace ends this pass on, decided from the workspace
+        // alone. It is the same three cases the loop below walks — adopt, stay,
+        // split — read for their answer rather than for their effect, which is what
+        // makes a home knowable before the pass has reached it.
+        func settledDevice(of workspace: Workspace) -> WorkspaceDevice {
+            let claims = projects.filter { $0.workspaceID == workspace.id }
+                .compactMap(claimedDevice)
+            let devices = devices(of: workspace, claims: claims)
+            if devices.count > 1 {
+                return keptDevice(of: workspace, among: devices, claims: claims)
+            }
+            guard let only = devices.first, workspace.deviceAlias == nil else {
+                return workspace.device
+            }
+            return only
+        }
         // Where a project split off a workspace goes when the tree already has a
-        // home for its machine: one workspace per alias is what `deviceWorkspace(for:)`
-        // assumes, so a split must not mint a second one. Aliases are safe to read
-        // ahead — this pass only ever adds one to a workspace that had none, so a
-        // workspace that already names a machine still names it at the end.
-        var deviceHomes: [String: Workspace.ID] = [:]
+        // home for its machine: an upgrade the user did not ask for must not also
+        // hand them a second scope for a box they already have one for.
+        //
+        // Computed over the whole input before anything moves, so the answer does
+        // not turn on the order `state.json` happens to list workspaces in.
+        // Reading it off the part already processed is what made this asymmetric:
+        // a machine's home was found wherever it sat, while this Mac's was found
+        // only when it came first — and a file listing the box's workspace ahead of
+        // the local one minted a second "This Mac" beside the perfectly good
+        // existing one.
+        var homes: [WorkspaceDevice: Workspace.ID] = [:]
         for workspace in workspaces {
-            guard let alias = workspace.deviceAlias, deviceHomes[alias] == nil else { continue }
-            deviceHomes[alias] = workspace.id
+            let device = settledDevice(of: workspace)
+            if homes[device] == nil { homes[device] = workspace.id }
         }
 
         for workspace in workspaces {
             let owned = projects.filter { $0.workspaceID == workspace.id }
             let claims = owned.compactMap(claimedDevice)
-            // A device the workspace already names counts as a claim in its own
-            // right: its loose sessions were filed there because they run there,
-            // and nothing else records that.
-            var devices = Set(claims)
-            // A loose shell records its own machine and nothing else does, so it
-            // is a claim exactly like a checkout's. Leaving it out let a workspace
-            // holding local shells and one remote checkout adopt the remote box —
-            // and on a one-workspace tree that left nowhere on this Mac for local
-            // work to go, which is the violation this pass exists to prevent.
-            for session in workspace.looseSessions {
-                devices.insert(WorkspaceDevice(alias: session.termiodRemoteHost ?? session.sshHost))
-            }
-            if !workspace.device.isThisMac { devices.insert(workspace.device) }
+            let devices = devices(of: workspace, claims: claims)
 
             guard devices.count > 1 else {
                 var workspace = workspace
@@ -256,9 +283,6 @@ enum WorkspaceMigration {
                     workspace.deviceID = owned.first {
                         claimedDevice($0) == only
                     }?.legacyDevice?.deviceID
-                }
-                if let alias = workspace.deviceAlias, deviceHomes[alias] == nil {
-                    deviceHomes[alias] = workspace.id
                 }
                 result.append(workspace)
                 continue
@@ -282,20 +306,12 @@ enum WorkspaceMigration {
                     claimedDevice($0) == keeper
                 }?.legacyDevice?.deviceID
             }
-            if let alias = kept.deviceAlias, deviceHomes[alias] == nil {
-                deviceHomes[alias] = kept.id
-            }
             result.append(kept)
 
             for device in devices.subtracting([keeper]).sorted(by: { ($0.alias ?? "") < ($1.alias ?? "") }) {
                 let home: Workspace.ID
-                if let alias = device.alias, let existing = deviceHomes[alias] {
+                if let existing = homes[device] {
                     home = existing
-                } else if device.isThisMac, let existing = result.first(where: \.device.isThisMac) {
-                    // Only a workspace this pass has already settled: one still
-                    // ahead of us may yet adopt a machine, and filing a local
-                    // checkout into it would re-break what we are here to fix.
-                    home = existing.id
                 } else {
                     // Named after the machine, which is the only thing this half is
                     // known to have in common.
@@ -309,7 +325,7 @@ enum WorkspaceMigration {
                     half.deviceID = owned.first {
                         claimedDevice($0) == device
                     }?.legacyDevice?.deviceID
-                    if let alias = device.alias { deviceHomes[alias] = half.id }
+                    homes[device] = half.id
                     result.append(half)
                     home = half.id
                 }

--- a/Tests/termioTests/WorkspaceDeviceTests.swift
+++ b/Tests/termioTests/WorkspaceDeviceTests.swift
@@ -59,6 +59,45 @@ final class WorkspaceDeviceTests: XCTestCase {
 
         XCTAssertEqual(store.workspaceForThisMac.id, ukvps.id)
     }
+
+    /// Two workspaces can name one machine, so the fallback lookup picks rather
+    /// than assuming the first match is the right one. The shape is reachable from
+    /// a shipped state file: a workspace the user named, holding a checkout on a
+    /// box that already has a fallback, adopts that box on the next load. A session
+    /// the `termiod` CLI or the phone then starts over there is one nobody filed,
+    /// so it belongs in the workspace nobody asked for — not in the middle of the
+    /// user's own work.
+    func testAMachinesFallbackIsPreferredOverAWorkspaceThatAdoptedIt() {
+        let named = Workspace(name: "Work")
+        let fallback = Workspace(name: "ukvps", deviceAlias: "ukvps")
+        var checkout = Project(
+            workspaceID: named.id, name: "api", path: "/srv/api", branch: "—", sessions: [])
+        checkout.legacyDevice = KnownDevice(alias: "ukvps", deviceID: nil)
+
+        let (workspaces, projects) = WorkspaceMigration.reconcile(
+            workspaces: [named, fallback], projects: [checkout])
+        XCTAssertEqual(workspaces.filter { $0.deviceAlias == "ukvps" }.count, 2,
+                       "both are on that box — adoption is what states the truth")
+        XCTAssertEqual(projects.first?.workspaceID, named.id,
+                       "and the user keeps the workspace they named, checkout and all")
+
+        let store = makeStore(workspaces: workspaces, current: named)
+
+        XCTAssertEqual(store.deviceWorkspace(for: "ukvps"), fallback.id)
+        XCTAssertEqual(store.workspaces.count, 2, "and nothing is minted for a machine that has one")
+    }
+
+    /// The preference is among the workspaces that exist, not a requirement that a
+    /// fallback does: a machine whose only workspace is the user's still resolves
+    /// to it rather than growing a second one beside it.
+    func testAMachinesOnlyWorkspaceAnswersEvenWhenItIsTheUsers() {
+        let home = Workspace(name: "Sessions", isAutoCreated: false)
+        let named = Workspace(name: "Work", deviceAlias: "ukvps", isAutoCreated: false)
+        let store = makeStore(workspaces: [home, named], current: home)
+
+        XCTAssertEqual(store.deviceWorkspace(for: "ukvps"), named.id)
+        XCTAssertEqual(store.workspaces.count, 2)
+    }
 }
 
 /// Which workspaces Termio may sweep when they empty out.

--- a/Tests/termioTests/WorkspaceMigrationTests.swift
+++ b/Tests/termioTests/WorkspaceMigrationTests.swift
@@ -377,16 +377,46 @@ final class WorkspaceMigrationTests: XCTestCase {
     /// A local checkout shed by a machine's workspace goes to the workspace this
     /// Mac already has, rather than adding a scope for a machine the user is
     /// sitting in front of.
+    ///
+    /// Asserted for both orderings: which workspace `state.json` lists first is an
+    /// accident of when the user made them, and the sidebar they get back must not
+    /// turn on it. Listing the box's workspace first used to mint a third workspace
+    /// named "This Mac" beside the perfectly good local one.
     func testALocalCheckoutShedByASplitGoesToTheWorkspaceThisMacHas() {
         let home = Workspace(name: "Sessions")
         let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps")
         let stray = checkout("termio", in: ukvps)
+        let filed = [stray, checkout("api", in: ukvps, on: "ukvps")]
+
+        for order in [[home, ukvps], [ukvps, home]] {
+            let (workspaces, projects) = WorkspaceMigration.reconcile(
+                workspaces: order, projects: filed)
+
+            XCTAssertEqual(workspaces.count, 2, "the Mac in front of the user already has one")
+            XCTAssertEqual(projects.first { $0.id == stray.id }?.workspaceID, home.id)
+        }
+    }
+
+    /// Naming no machine is not the same as being on this Mac, which is what makes
+    /// the local home worth deciding up front rather than reading off the workspaces
+    /// already processed: a workspace whose checkouts all sit on a box adopts that
+    /// box in this very pass. The shed local checkout gets a workspace of its own
+    /// rather than being filed into a scope that is on its way to another machine.
+    func testAShedLocalCheckoutSkipsAWorkspaceThatIsAboutToAdoptAMachine() throws {
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps")
+        let servers = Workspace(name: "Servers")
+        let stray = checkout("termio", in: ukvps)
 
         let (workspaces, projects) = WorkspaceMigration.reconcile(
-            workspaces: [home, ukvps], projects: [stray, checkout("api", in: ukvps, on: "ukvps")])
+            workspaces: [ukvps, servers],
+            projects: [stray, checkout("api", in: ukvps, on: "ukvps"),
+                       checkout("web", in: servers, on: "devbox")])
 
-        XCTAssertEqual(workspaces.count, 2)
-        XCTAssertEqual(projects.first { $0.id == stray.id }?.workspaceID, home.id)
+        XCTAssertEqual(workspaces.first { $0.id == servers.id }?.device, .ssh(alias: "devbox"),
+                       "it adopts the box its only checkout is on")
+        let here = try XCTUnwrap(workspaces.first { $0.device == .thisMac })
+        XCTAssertNotEqual(here.id, servers.id)
+        XCTAssertEqual(projects.first { $0.id == stray.id }?.workspaceID, here.id)
     }
 
     /// `reconcile` runs on every load, so a tree it produced must come back


### PR DESCRIPTION
Two findings from the adversarial review of #359's device pass. Neither is dangerous; both are visible churn on upgrade.

**Adoption could produce two workspaces for one alias.** `deviceWorkspace(for:)` looks a machine's workspace up with `firstIndex(where: { $0.deviceAlias == alias })`, so it assumed there was only one. The split honoured that; adoption did not — a workspace the user made, holding only checkouts on one box, adopts that box's alias too. A session then started by the `termiod` CLI or the phone landed in whichever came first, possibly the user's.

The lookup now prefers the machine's own auto-created workspace, falls back to one that merely adopted the alias, and mints only when neither exists. That makes the answer deterministic without forbidding the second workspace or merging anything.

**The split was array-order dependent.** Its alias branch consulted a map precomputed over the whole input; its this-Mac branch consulted only workspaces already processed. So the order workspaces happen to sit in `state.json` decided whether a spurious "This Mac" workspace was minted beside a perfectly good local one. Both branches now read one map built up front.

The test that covered the second case passed only because it listed its workspaces in the lucky order; it now asserts the same outcome for both orderings.

Deliberately unchanged: two workspaces reached by two aliases for one `host_id` still do not merge (`TermiodDeviceAdoptionTests.testDoesNotYetMergeTwoWorkspacesOnOneDevice`) — that is a separate decision, and its test still passes.

Verified: `swift build` clean, `swift test` 455 tests 0 failures, `check-strings.sh` clean.

Release Notes:
Fixed two upgrade-time quirks in how workspaces are matched to machines: a session started outside Termio could be filed under the wrong workspace, and an unnecessary "This Mac" workspace could appear.