### PR TITLE
Refuse to open a remote session when termiod is off

### DIFF
--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -131,6 +131,17 @@ extension TermioStore {
             return existing
         }
 
+        // With the daemon off there is nothing to attach to, and falling through
+        // would spawn a *local* login shell in this Mac's `$HOME` under the remote
+        // host's name. `addRemoteTerminal` refuses at creation; this is the same
+        // refusal on re-select and on restore. Keyed on `termiodRemoteHost`, not
+        // `sshHost` — a plain SSH terminal is a local PTY running `ssh <host>`.
+        if let remoteHost = session.termiodRemoteHost, !Termiod.isEnabled {
+            let placeholder = termiodDisabledPlaceholder(host: remoteHost)
+            surfaces[session.id] = placeholder
+            return placeholder
+        }
+
         // An isolated worktree (if one was created for this session) wins over the
         // project's own directory, so the agent edits the branch in place.
         // A loose terminal instead respawns at the cwd it last reported over OSC 7
@@ -501,6 +512,26 @@ extension TermioStore {
         // is harmless. (`surfaces`/`monitors` are plain, non-`@Published` caches, so
         // writing them here is fine; only the `projects` write must be deferred.)
         DispatchQueue.main.async { [self] in recordLaunch(session.id, resumeID: launch.resumeID) }
+        return state
+    }
+
+    /// Stands in for the shell that would otherwise spawn locally. It carries no PTY
+    /// and no daemon link, so nothing runs behind it and nothing can be typed in, and
+    /// nothing is recorded as launched. Rendering is pumped by hand because this
+    /// embedding paints only on a wakeup and no process will ever produce one here.
+    private func termiodDisabledPlaceholder(host: String) -> TerminalViewState {
+        let controller = TerminalController { [self] builder in
+            applyAppearance(to: &builder)
+        }
+        let state = TerminalViewState(controller: controller)
+        state.controller.setTheme(makeTheme())
+        let inMemory = InMemoryTerminalSession(write: { _ in }, resize: { _ in })
+        state.configuration = TerminalSurfaceOptions(backend: .inMemory(inMemory))
+        // The sentence `presentTermiodDisabledAlert` shows, so both doors agree.
+        inMemory.receive(
+            "\r\n  This session runs on \(host) through termiod.\r\n"
+                + "  Set TERMIO_TERMIOD=1 and relaunch termio to open it.\r\n")
+        warmUpRendering(state)
         return state
     }
 


### PR DESCRIPTION
A session pinned to a termiod device can only be reached through the opt-in daemon backend. With `TERMIO_TERMIOD` unset, `surface(for:)` fell through to the normal path and spawned a **local** login shell in this Mac's `$HOME` — a pane labelled with the remote host while showing the user's own machine. Every command typed into it would have run here.

`addRemoteTerminal` already refuses at creation time. This is the same refusal at the other door: a session re-selected from the sidebar, or restored from `state.json` on the next launch.

The pane returned in its place carries no PTY and no daemon link, so nothing runs behind it and nothing can be typed into it. Its message is the one `presentTermiodDisabledAlert` already shows, so a user who dismissed the alert and clicked the session twice reads the same sentence both times. Nothing is recorded as launched — the session never started.

The guard keys on `termiodRemoteHost`, not `sshHost`: a plain SSH terminal runs `ssh <host>` in a local PTY and needs no daemon at all, so it must keep working with the flag off.

Verified: `swift build` clean, `swift test` 455 tests 0 failures, swiftlint and `check-strings.sh` clean. **Not verified on screen** — Screen Recording is unavailable on the machine this was built on, so the placeholder pane has not been seen rendered; it uses the same `receive` seam and `warmUpRendering` call as live output.

Release Notes:
A session that lives on a remote device now says so when the termiod backend is off, instead of quietly opening a local shell in its place.