### PR TITLE
Read the tty's foreground process from the kernel, on Linux as well as macOS

### DIFF
--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -12,6 +12,7 @@ mod daemon;
 mod files;
 mod git;
 mod paths;
+mod proc;
 mod protocol;
 mod pty;
 mod remote;

--- a/termiod/src/proc.rs
+++ b/termiod/src/proc.rs
@@ -1,0 +1,416 @@
+//! Who is actually running in a session's terminal.
+//!
+//! A session's `command` is what it was *created* with. That answers nothing
+//! once a login shell has been sitting there for an hour: the program the user
+//! is talking to is whatever holds the tty's foreground process group, and the
+//! directory that matters is wherever the child `cd`'d to since. The kernel
+//! knows both; nothing in the byte stream does.
+//!
+//! termio's macOS app reads this with `KERN_PROCARGS2` + `proc_pidinfo`
+//! (`Sources/termio/Terminal/Ghostty/PTYProcess.swift`), which is why it has
+//! never worked for a Linux host. The same three questions have plain answers
+//! under `/proc`, so this module asks them behind one interface and lets the
+//! target pick the mechanism.
+//!
+//! Every function here is a syscall against a pid, so two rules hold at every
+//! call site:
+//!
+//! 1. **Never on the byte path.** Sampling is a poll, bounded and infrequent;
+//!    PTY delivery must not wait on it (the anti-100× invariant).
+//! 2. **Never after the child is reaped.** A recycled pid answers confidently
+//!    about a process that is not ours.
+//!
+//! Failure is always `None`. A refusal by the kernel, a process that exited
+//! mid-read, a short buffer — none of them are worth an error type, because
+//! every caller does the same thing with all of them: keep the last known
+//! answer and try again next tick.
+
+/// The binary a process is running, pinned tightly enough to notice it being
+/// swapped underneath. The inode is the discriminating half: an agent that
+/// updates itself in place keeps its path and changes its file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutableIdentity {
+    pub path: String,
+    /// `None` when the file was already gone at sampling time, which reads as
+    /// "replaced" for every later comparison.
+    pub inode: Option<u64>,
+}
+
+impl ExecutableIdentity {
+    /// Whether the recorded binary has since been replaced on disk: the file is
+    /// gone (a package manager purging the old versioned directory on upgrade)
+    /// or its inode changed (an in-place reinstall). This is how an exit that
+    /// means "the agent updated itself and quit" is told from a plain quit,
+    /// whose binary is untouched.
+    pub fn was_replaced(&self) -> bool {
+        let Some(inode) = self.inode else {
+            return true;
+        };
+        match std::fs::metadata(&self.path) {
+            Ok(metadata) => {
+                use std::os::unix::fs::MetadataExt;
+                metadata.ino() != inode
+            }
+            Err(_) => true,
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use super::ExecutableIdentity;
+
+    /// Reads a process's full argument vector from the kernel
+    /// (`KERN_PROCARGS2`), whose buffer is laid out
+    /// `[argc: i32][exec path]\0…\0[argv0]\0[argv1]\0…[env]`. Own-user
+    /// processes only, which is exactly the scope here: the session child and
+    /// its descendants.
+    pub fn process_arguments(pid: i32) -> Option<Vec<String>> {
+        let mut mib: [libc::c_int; 3] = [libc::CTL_KERN, libc::KERN_PROCARGS2, pid];
+        let mut size: libc::size_t = 0;
+        let probe = unsafe {
+            libc::sysctl(
+                mib.as_mut_ptr(),
+                mib.len() as libc::c_uint,
+                std::ptr::null_mut(),
+                &mut size,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if probe != 0 || size <= std::mem::size_of::<i32>() {
+            return None;
+        }
+        let mut buffer = vec![0u8; size];
+        let read = unsafe {
+            libc::sysctl(
+                mib.as_mut_ptr(),
+                mib.len() as libc::c_uint,
+                buffer.as_mut_ptr() as *mut libc::c_void,
+                &mut size,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if read != 0 {
+            return None;
+        }
+        buffer.truncate(size);
+        super::split_procargs2(&buffer)
+    }
+
+    /// The process's current working directory, read from the kernel
+    /// (`PROC_PIDVNODEPATHINFO`). This is the fallback every terminal without
+    /// shell integration relies on: macOS's stock zsh only emits OSC 7 under
+    /// `TERM_PROGRAM=Apple_Terminal`, and termiod injects no shell
+    /// integration — but the kernel always knows.
+    pub fn working_directory(pid: i32) -> Option<String> {
+        let mut info: libc::proc_vnodepathinfo = unsafe { std::mem::zeroed() };
+        let size = unsafe {
+            libc::proc_pidinfo(
+                pid,
+                libc::PROC_PIDVNODEPATHINFO,
+                0,
+                &mut info as *mut _ as *mut libc::c_void,
+                std::mem::size_of::<libc::proc_vnodepathinfo>() as libc::c_int,
+            )
+        };
+        if size <= 0 {
+            return None;
+        }
+        // `vip_path` is declared as nested arrays purely to sidestep a const
+        // generics limit in libc; the bytes are one flat NUL-terminated path.
+        let raw = &info.pvi_cdir.vip_path;
+        let flat = unsafe {
+            std::slice::from_raw_parts(raw.as_ptr() as *const u8, std::mem::size_of_val(raw))
+        };
+        super::string_until_nul(flat)
+    }
+
+    pub fn executable_path(pid: i32) -> Option<String> {
+        let mut buffer = vec![0u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+        let written = unsafe {
+            libc::proc_pidpath(
+                pid,
+                buffer.as_mut_ptr() as *mut libc::c_void,
+                buffer.len() as u32,
+            )
+        };
+        if written <= 0 {
+            return None;
+        }
+        buffer.truncate(written as usize);
+        super::string_until_nul(&buffer)
+    }
+
+    pub fn executable_identity(pid: i32) -> Option<ExecutableIdentity> {
+        let path = executable_path(pid)?;
+        Some(super::identity_for(path))
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use super::ExecutableIdentity;
+
+    /// `/proc/<pid>/cmdline` is argv verbatim, NUL-separated and NUL-
+    /// terminated. Kernel threads have an empty one; so does a process caught
+    /// mid-exec, and both are correctly "no answer yet".
+    pub fn process_arguments(pid: i32) -> Option<Vec<String>> {
+        let raw = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+        let arguments: Vec<String> = raw
+            .split(|byte| *byte == 0)
+            .filter(|part| !part.is_empty())
+            .map(|part| String::from_utf8_lossy(part).into_owned())
+            .collect();
+        (!arguments.is_empty()).then_some(arguments)
+    }
+
+    /// `/proc/<pid>/cwd` is a symlink the kernel resolves on read, so this is
+    /// the live directory rather than the one the process started in.
+    pub fn working_directory(pid: i32) -> Option<String> {
+        let path = std::fs::read_link(format!("/proc/{pid}/cwd")).ok()?;
+        let path = path.to_str()?.to_string();
+        (!path.is_empty()).then_some(path)
+    }
+
+    /// `/proc/<pid>/exe` gains a literal " (deleted)" suffix once the binary is
+    /// unlinked — an upgrade caught in the act. The suffix is stripped so the
+    /// path stays usable, and the missing inode carries the fact forward.
+    pub fn executable_path(pid: i32) -> Option<String> {
+        let path = std::fs::read_link(format!("/proc/{pid}/exe")).ok()?;
+        let path = path.to_str()?;
+        let path = path.strip_suffix(" (deleted)").unwrap_or(path).to_string();
+        (!path.is_empty()).then_some(path)
+    }
+
+    pub fn executable_identity(pid: i32) -> Option<ExecutableIdentity> {
+        let path = executable_path(pid)?;
+        Some(super::identity_for(path))
+    }
+}
+
+/// Anything that is neither macOS nor Linux compiles and answers "unknown"
+/// rather than failing the build. termiod has no third host today; when it does,
+/// this is the one place that needs a mechanism.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+mod imp {
+    use super::ExecutableIdentity;
+
+    pub fn process_arguments(_pid: i32) -> Option<Vec<String>> {
+        None
+    }
+
+    pub fn working_directory(_pid: i32) -> Option<String> {
+        None
+    }
+
+    pub fn executable_identity(_pid: i32) -> Option<ExecutableIdentity> {
+        None
+    }
+}
+
+pub use imp::{executable_identity, process_arguments, working_directory};
+
+#[cfg(any(target_os = "macos", test))]
+fn split_procargs2(buffer: &[u8]) -> Option<Vec<String>> {
+    let header = std::mem::size_of::<i32>();
+    if buffer.len() <= header {
+        return None;
+    }
+    let mut argc_bytes = [0u8; 4];
+    argc_bytes.copy_from_slice(&buffer[..header]);
+    let argc = i32::from_ne_bytes(argc_bytes);
+    if argc <= 0 {
+        return None;
+    }
+    let mut index = header;
+    // Skip the executable path that precedes argv[0], then the NUL padding
+    // between it and argv[0].
+    while index < buffer.len() && buffer[index] != 0 {
+        index += 1;
+    }
+    while index < buffer.len() && buffer[index] == 0 {
+        index += 1;
+    }
+    let mut arguments = Vec::new();
+    let mut current = Vec::new();
+    while index < buffer.len() && arguments.len() < argc as usize {
+        let byte = buffer[index];
+        index += 1;
+        if byte == 0 {
+            arguments.push(String::from_utf8_lossy(&current).into_owned());
+            current.clear();
+        } else {
+            current.push(byte);
+        }
+    }
+    (!arguments.is_empty()).then_some(arguments)
+}
+
+#[cfg(target_os = "macos")]
+fn string_until_nul(bytes: &[u8]) -> Option<String> {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    let text = String::from_utf8_lossy(&bytes[..end]).into_owned();
+    (!text.is_empty()).then_some(text)
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux", test))]
+fn identity_for(path: String) -> ExecutableIdentity {
+    use std::os::unix::fs::MetadataExt;
+    let inode = std::fs::metadata(&path).ok().map(|metadata| metadata.ino());
+    ExecutableIdentity { path, inode }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    /// Spawn a real child and wait until the kernel agrees it has exec'd — the
+    /// window between `fork` and `exec` is real, and a test that reads through
+    /// it asserts against the parent's argv instead of the child's.
+    struct Sleeper(std::process::Child);
+
+    fn sleep_binary() -> &'static str {
+        ["/bin/sleep", "/usr/bin/sleep"]
+            .into_iter()
+            .find(|path| std::path::Path::new(path).exists())
+            .expect("no sleep binary on this host")
+    }
+
+    impl Sleeper {
+        fn spawn(cwd: &str) -> Sleeper {
+            // Absolute on purpose: the test asserts on the executable path the
+            // kernel reports, and a PATH lookup would make that unpredictable.
+            let child = Command::new(sleep_binary())
+                .arg("30")
+                .current_dir(cwd)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawning /bin/sleep");
+            let sleeper = Sleeper(child);
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while Instant::now() < deadline {
+                if let Some(argv) = process_arguments(sleeper.pid()) {
+                    if argv.first().is_some_and(|arg| arg.ends_with("sleep")) {
+                        return sleeper;
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            panic!("child never showed up in the kernel's process table");
+        }
+
+        fn pid(&self) -> i32 {
+            self.0.id() as i32
+        }
+    }
+
+    impl Drop for Sleeper {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    #[test]
+    fn reads_a_live_child_argv() {
+        let child = Sleeper::spawn("/");
+        let argv = process_arguments(child.pid()).expect("argv for a live child");
+        assert_eq!(argv.len(), 2, "argv was {argv:?}");
+        assert!(argv[0].ends_with("sleep"), "argv[0] was {:?}", argv[0]);
+        assert_eq!(argv[1], "30");
+    }
+
+    #[test]
+    fn reads_a_live_child_working_directory() {
+        let temp = std::env::temp_dir().join(format!("termiod-proc-{}", std::process::id()));
+        std::fs::create_dir_all(&temp).expect("creating the test directory");
+        // The kernel answers with the resolved path; macOS's /tmp is a symlink,
+        // so the expectation has to be resolved too.
+        let expected = std::fs::canonicalize(&temp).expect("canonicalizing the test directory");
+        let child = Sleeper::spawn(temp.to_str().expect("utf-8 temp path"));
+
+        let cwd = working_directory(child.pid()).expect("cwd for a live child");
+        assert_eq!(std::path::Path::new(&cwd), expected);
+
+        drop(child);
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn pins_the_child_executable_and_sees_it_intact() {
+        let child = Sleeper::spawn("/");
+        let identity = executable_identity(child.pid()).expect("identity for a live child");
+        // Resolved, not spelled: on a busybox host /bin/sleep is a symlink and
+        // the kernel correctly names /bin/busybox as what is running. Asserting
+        // the literal path would encode one distro's layout as the contract.
+        let expected = std::fs::canonicalize(sleep_binary()).expect("canonical sleep binary");
+        assert_eq!(std::path::Path::new(&identity.path), expected);
+        assert!(identity.inode.is_some(), "no inode for an on-disk binary");
+        assert!(
+            !identity.was_replaced(),
+            "an untouched binary must not read as replaced"
+        );
+    }
+
+    /// The whole point of pinning the inode: a path that still exists but is a
+    /// different file is a replacement, and a path that is gone is one too.
+    #[test]
+    fn notices_a_replaced_executable() {
+        let dir = std::env::temp_dir().join(format!("termiod-exe-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("creating the test directory");
+        let path = dir.join("agent");
+        std::fs::write(&path, b"#!/bin/sh\n").expect("writing the fake binary");
+        let identity = identity_for(path.to_string_lossy().into_owned());
+        assert!(!identity.was_replaced());
+
+        // The upgrade shape, and deterministic about it: the replacement exists
+        // alongside the original before the rename, so the two inodes cannot
+        // collide. Deleting and rewriting in place can hand back the same inode
+        // number on some filesystems, which would prove nothing.
+        let upgrade = dir.join("agent.new");
+        std::fs::write(&upgrade, b"#!/bin/sh\n# v2\n").expect("writing the replacement");
+        std::fs::rename(&upgrade, &path).expect("swapping the replacement in");
+        assert!(identity.was_replaced(), "a new inode is a replacement");
+
+        std::fs::remove_file(&path).expect("removing the fake binary");
+        assert!(identity.was_replaced(), "a missing file is a replacement");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn refuses_a_pid_that_is_not_running() {
+        // pid 0 is never a queryable user process on either host.
+        assert!(process_arguments(0).is_none());
+        assert!(working_directory(0).is_none());
+        assert!(executable_identity(0).is_none());
+    }
+
+    /// The macOS buffer layout, asserted without the kernel: argc, the exec
+    /// path, NUL padding, then argv.
+    #[test]
+    fn parses_the_procargs2_layout() {
+        let mut buffer = Vec::new();
+        buffer.extend_from_slice(&2i32.to_ne_bytes());
+        buffer.extend_from_slice(b"/usr/local/bin/claude\0\0\0");
+        buffer.extend_from_slice(b"claude\0--resume\0");
+        buffer.extend_from_slice(b"PATH=/usr/bin\0");
+        let argv = split_procargs2(&buffer).expect("argv from a well-formed buffer");
+        assert_eq!(argv, vec!["claude".to_string(), "--resume".to_string()]);
+    }
+
+    #[test]
+    fn rejects_a_truncated_procargs2_buffer() {
+        assert!(split_procargs2(&[]).is_none());
+        assert!(split_procargs2(&0i32.to_ne_bytes()).is_none());
+        assert!(split_procargs2(&(-1i32).to_ne_bytes()).is_none());
+    }
+}

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -887,10 +887,39 @@ pub struct SessionInfo {
     pub attached_clients: usize,
     #[serde(default)]
     pub writer_client_id: Option<String>,
+    /// The process group that owns the tty's foreground right now. This is the
+    /// program the user is talking to, which after the first minute of a
+    /// session is rarely the one in `command`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreground_pid: Option<i32>,
+    /// Argv of that process group's leader — the agent's identity, read from
+    /// the kernel rather than scraped off the screen.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreground_argv: Option<Vec<String>>,
+    /// Whether something other than the session's own child holds the
+    /// foreground, i.e. a command is running rather than a shell idling at its
+    /// prompt. This is the signal a client keys "closing this loses work" off.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub foreground_job: bool,
+    /// The child's *current* directory, which `cd` moves and `cwd` (the
+    /// directory the session was created in) does not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_cwd: Option<String>,
+    /// The binary the child is running, as the kernel resolved it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_executable: Option<String>,
+    /// Whether that binary has been replaced on disk since it was pinned — an
+    /// agent that updated itself and quit, told apart from one that just quit.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub child_executable_replaced: bool,
 }
 
 fn default_status() -> String {
     "unknown".to_string()
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 pub async fn write_frame<W: AsyncWriteExt + Unpin>(

--- a/termiod/src/pty.rs
+++ b/termiod/src/pty.rs
@@ -178,6 +178,20 @@ impl Pty {
         })
     }
 
+    /// The process group that currently owns the tty's foreground — the program
+    /// the user is actually interacting with: the login shell until it runs a
+    /// command, then that command, then the shell again once it exits.
+    ///
+    /// `tcgetpgrp` on the *master* is deliberate and portable: both XNU and
+    /// Linux route TIOCGPGRP on a pty master to the slave's session, and the
+    /// master side is exempt from the "must be your controlling terminal" check
+    /// that would otherwise refuse the daemon. `None` when the slave has no
+    /// session (the child is gone, or has not exec'd yet).
+    pub fn foreground_pgid(&self) -> Option<i32> {
+        let pgid = unsafe { libc::tcgetpgrp(self.master.get_ref().as_raw_fd()) };
+        (pgid > 0).then_some(pgid)
+    }
+
     /// Push a new window size to the PTY (TIOCSWINSZ). The kernel delivers
     /// SIGWINCH to the foreground process group.
     pub fn resize(&self, rows: u16, cols: u16) -> Result<()> {

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -29,6 +29,10 @@ const CLIENT_BACKLOG_CAP: usize = 4 * 1024 * 1024;
 const SIDECAR_QUEUE_CAP: usize = 16 * 1024 * 1024;
 pub const SCROLLBACK_STAGE_MAX_BYTES: usize = 1024 * 1024;
 pub const KEYFRAME_EVERY_FRAMES: u32 = 256;
+/// How often the session asks the kernel what is running in its terminal.
+/// Slow on purpose: this answers "which agent is in there", a question whose
+/// answer changes when a human starts or stops a program, not per frame.
+const FOREGROUND_POLL: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// A payload admitted against a client's backlog. The epoch pins it to the
 /// reservation that let it through, so a forced resync can discard everything
@@ -316,6 +320,25 @@ struct Session {
     /// longer describes any boundary in the output stream, so it can never
     /// answer a snapshot again — attach and resync fall back to ring replay.
     vt_stale: Option<String>,
+    /// Last sample of who is in the tty's foreground and where the child is.
+    /// Refreshed by the poll tick only; `info()` reads the cache so a roster
+    /// request never turns into a burst of syscalls.
+    foreground: ForegroundSample,
+    /// The binary the child is running, pinned on the first sample that finds
+    /// it. One-shot on purpose: this is the *launch* baseline that
+    /// `was_replaced()` compares against, and resampling would paper over the
+    /// in-place upgrade it exists to notice.
+    child_executable: Option<crate::proc::ExecutableIdentity>,
+}
+
+/// What one foreground poll found. Compared whole so a tick that learns nothing
+/// new costs nothing beyond the syscalls.
+#[derive(Default, Clone, PartialEq, Eq)]
+struct ForegroundSample {
+    pgid: Option<i32>,
+    argv: Option<Vec<String>>,
+    job: bool,
+    cwd: Option<String>,
 }
 
 impl Session {
@@ -336,7 +359,54 @@ impl Session {
             title: self.title.clone(),
             attached_clients: self.clients.len(),
             writer_client_id: self.writer.clone(),
+            foreground_pid: self.foreground.pgid,
+            foreground_argv: self.foreground.argv.clone(),
+            foreground_job: self.foreground.job,
+            child_cwd: self.foreground.cwd.clone(),
+            child_executable: self
+                .child_executable
+                .as_ref()
+                .map(|identity| identity.path.clone()),
+            // Checked here rather than cached from the last tick: the record
+            // that matters most is the one built on the exit path, and a binary
+            // swapped during the seconds before the child quit is exactly the
+            // case this answers.
+            child_executable_replaced: self
+                .child_executable
+                .as_ref()
+                .is_some_and(|identity| identity.was_replaced()),
         }
+    }
+
+    /// Ask the kernel who holds the tty's foreground and where the child is
+    /// standing. Returns whether anything moved, so a quiet session emits no
+    /// roster traffic.
+    ///
+    /// Called from the poll tick only. These are a handful of cheap syscalls,
+    /// but they are still syscalls on the session actor's thread, and the
+    /// anti-100× invariant means byte delivery must never be the thing paying
+    /// for them — hence a fixed, slow cadence rather than a sample per frame.
+    fn sample_foreground(&mut self) -> bool {
+        if self.pid <= 0 {
+            return false;
+        }
+        let pgid = self.pty.foreground_pgid();
+        let sample = ForegroundSample {
+            pgid,
+            // The foreground group leader's pid *is* the pgid: the shell puts
+            // each job in a group named after its leader.
+            argv: pgid.and_then(crate::proc::process_arguments),
+            job: pgid.is_some_and(|pgid| pgid != self.pid),
+            cwd: crate::proc::working_directory(self.pid),
+        };
+        if self.child_executable.is_none() {
+            self.child_executable = crate::proc::executable_identity(self.pid);
+        }
+        if sample == self.foreground {
+            return false;
+        }
+        self.foreground = sample;
+        true
     }
 
     fn recompute_writer(&mut self) {
@@ -1226,6 +1296,8 @@ pub fn spawn(
         sidecar_tx: Some(sidecar.commands),
         sidecar_queue: sidecar.queue,
         vt_stale: None,
+        foreground: ForegroundSample::default(),
+        child_executable: None,
     };
 
     let waiter = tokio::task::spawn_blocking(move || {
@@ -1422,9 +1494,20 @@ async fn run(
     let mut sidecar_results_open = true;
     let mut history_stages = VecDeque::<ClientId>::new();
     let mut killed = false;
+    // The first tick is immediate, so a session answers "what is running in
+    // there" from its first roster request rather than after a cold two
+    // seconds. Missed ticks are skipped instead of queued: a busy actor should
+    // sample once when it catches up, not replay a backlog of polls.
+    let mut foreground_poll = tokio::time::interval(FOREGROUND_POLL);
+    foreground_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         tokio::select! {
+            _ = foreground_poll.tick() => {
+                if session.sample_foreground() {
+                    session.emit_roster();
+                }
+            }
             _ = tokio::task::yield_now(), if !history_stages.is_empty() => {
                 let client_id = history_stages
                     .pop_front()
@@ -1659,11 +1742,11 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> bool {
 mod tests {
     use super::{
         handle_msg, scrollback_row_limit, should_emit_keyframe, spawn_sidecar, ClientBacklog,
-        ClientDelivery, ClientEntry, ClientEvent, Session, SessionMsg, Sidecar, SidecarCommand,
-        SidecarQueue, SidecarResult, CLIENT_BACKLOG_CAP, SCROLLBACK_STAGE_MAX_BYTES,
-        SIDECAR_QUEUE_CAP, SNAPSHOT_CELL_SIZE,
+        ClientDelivery, ClientEntry, ClientEvent, Session, SessionHandle, SessionMsg, Sidecar,
+        SidecarCommand, SidecarQueue, SidecarResult, CLIENT_BACKLOG_CAP,
+        SCROLLBACK_STAGE_MAX_BYTES, SIDECAR_QUEUE_CAP, SNAPSHOT_CELL_SIZE,
     };
-    use crate::protocol::{Control, ErrorCode, Event};
+    use crate::protocol::{Control, ErrorCode, Event, SessionInfo};
     use crate::pty::Pty;
     use bytes::Bytes;
     use std::collections::{HashMap, VecDeque};
@@ -1840,6 +1923,8 @@ mod tests {
                 sidecar_tx: Some(sidecar_tx),
                 sidecar_queue,
                 vt_stale: None,
+                foreground: super::ForegroundSample::default(),
+                child_executable: None,
             },
             event_rx,
         )
@@ -2197,6 +2282,8 @@ mod tests {
             sidecar_tx: Some(sidecar_tx),
             sidecar_queue: Arc::new(SidecarQueue::new()),
             vt_stale: None,
+            foreground: super::ForegroundSample::default(),
+            child_executable: None,
         };
 
         assert!(!handle_msg(
@@ -2231,5 +2318,152 @@ mod tests {
             _ => panic!("failed resize did not return a typed control error"),
         }
         assert!(client_rx.try_recv().is_err());
+    }
+
+    /// Drive a real session until its sampled foreground satisfies `ready`, or
+    /// give up. The poll runs on a fixed cadence and the first tick can land
+    /// before the child has exec'd, so a test that reads once reads the wrong
+    /// process.
+    async fn settled_info(
+        handle: &SessionHandle,
+        ready: impl Fn(&SessionInfo) -> bool,
+    ) -> SessionInfo {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+        let mut last = None;
+        while tokio::time::Instant::now() < deadline {
+            let (tx, rx) = oneshot::channel();
+            if !handle.send(SessionMsg::Info { reply: tx }) {
+                break;
+            }
+            let Ok(info) = rx.await else { break };
+            if ready(&info) {
+                return info;
+            }
+            last = Some(info);
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("the session never reported the expected foreground: {last:?}");
+    }
+
+    /// Both receivers are handed back rather than dropped here: a broadcast
+    /// channel with no receiver discards every send, and the roster assertion
+    /// reads one of them.
+    #[allow(clippy::type_complexity)]
+    fn start_session(
+        argv: Vec<String>,
+        cwd: &str,
+    ) -> (
+        SessionHandle,
+        broadcast::Receiver<Event>,
+        mpsc::UnboundedReceiver<super::SessionEnded>,
+    ) {
+        let (on_exit, on_exit_rx) = mpsc::unbounded_channel();
+        let (events, events_rx) = broadcast::channel(64);
+        let handle = super::spawn(
+            "foreground-session".to_string(),
+            "test".to_string(),
+            cwd.to_string(),
+            argv.join(" "),
+            argv,
+            Vec::new(),
+            24,
+            80,
+            None,
+            on_exit,
+            events,
+        )
+        .expect("spawning a real session");
+        (handle, events_rx, on_exit_rx)
+    }
+
+    /// The whole point: a live session can name the program in its terminal,
+    /// say where that program is standing, and pin the binary behind it —
+    /// against a real child, not a fixture.
+    #[tokio::test]
+    async fn a_session_names_the_program_running_in_its_terminal() {
+        let cat = ["/bin/cat", "/usr/bin/cat"]
+            .into_iter()
+            .find(|path| std::path::Path::new(path).exists())
+            .expect("no cat binary on this host");
+        let dir = std::fs::canonicalize(std::env::temp_dir()).expect("canonical temp dir");
+        let dir = dir.to_string_lossy().into_owned();
+        let (handle, mut events_rx, _on_exit) = start_session(vec![cat.to_string()], &dir);
+
+        let info = settled_info(&handle, |info| {
+            info.foreground_argv
+                .as_ref()
+                .and_then(|argv| argv.first())
+                .is_some_and(|arg| arg.ends_with("cat"))
+        })
+        .await;
+
+        assert_eq!(info.foreground_argv.as_deref(), Some(&[cat.to_string()][..]));
+        assert_eq!(
+            info.foreground_pid,
+            Some(info.pid),
+            "the session's own child is the foreground group leader"
+        );
+        assert!(
+            !info.foreground_job,
+            "the session child itself is not a job running *inside* the session"
+        );
+        assert_eq!(info.child_cwd.as_deref(), Some(dir.as_str()));
+        // Resolved, not spelled: on a busybox host /bin/cat is a symlink and the
+        // kernel correctly names /bin/busybox as what is running.
+        let expected = std::fs::canonicalize(cat).expect("canonical cat binary");
+        assert_eq!(
+            info.child_executable.as_deref().map(std::path::Path::new),
+            Some(expected.as_path())
+        );
+        assert!(
+            !info.child_executable_replaced,
+            "an untouched binary must not read as replaced"
+        );
+
+        // Learning who is in there is a roster change, so clients hear about it
+        // without polling.
+        let roster = loop {
+            match events_rx.try_recv() {
+                Ok(Event::Roster { info, .. }) => break info,
+                Ok(_) => continue,
+                Err(error) => panic!("no roster event for the first foreground sample: {error:?}"),
+            }
+        };
+        assert!(roster.is_some_and(|info| info.foreground_pid.is_some()));
+
+        handle.send(SessionMsg::Kill);
+    }
+
+    /// A command started *inside* the session takes the tty's foreground away
+    /// from the shell. This is the distinction between "a shell is sitting at a
+    /// prompt" and "something is running in there".
+    #[tokio::test]
+    async fn a_command_started_in_the_session_takes_the_foreground() {
+        let shell = ["/bin/sh", "/usr/bin/sh"]
+            .into_iter()
+            .find(|path| std::path::Path::new(path).exists())
+            .expect("no sh binary on this host");
+        let (handle, _events_rx, _on_exit) =
+            start_session(vec![shell.to_string(), "-i".to_string()], "/");
+
+        let idle = settled_info(&handle, |info| info.foreground_pid == Some(info.pid)).await;
+        assert!(!idle.foreground_job, "a bare prompt is not a running job");
+
+        handle.send(SessionMsg::Inject {
+            data: b"sleep 30\n".to_vec(),
+        });
+
+        let busy = settled_info(&handle, |info| info.foreground_job).await;
+        assert_ne!(busy.foreground_pid, Some(busy.pid));
+        assert!(
+            busy.foreground_argv
+                .as_ref()
+                .and_then(|argv| argv.first())
+                .is_some_and(|arg| arg.ends_with("sleep")),
+            "foreground argv was {:?}",
+            busy.foreground_argv
+        );
+
+        handle.send(SessionMsg::Kill);
     }
 }

--- a/termiod/src/tombstone.rs
+++ b/termiod/src/tombstone.rs
@@ -307,6 +307,12 @@ mod tests {
             title: Some("fixing the parser".to_string()),
             attached_clients: 0,
             writer_client_id: None,
+            foreground_pid: None,
+            foreground_argv: None,
+            foreground_job: false,
+            child_cwd: None,
+            child_executable: None,
+            child_executable_replaced: false,
         }
     }
 


### PR DESCRIPTION
`PTYProcess.swift` answers four questions the daemon could not: what argv is running in the foreground, whether there is a foreground job at all, the child's *current* working directory, and the child's executable identity. `grep -rn tcgetpgrp termiod/src` returned nothing.

The visible consequence: the agent-status detector sits inside `if let pty` in `TermioStore+TerminalSurface.swift`, and on the termiod path `pty` is nil — so the agent icon never updated for a session hosted by a daemon.

## Why this belongs in Rust

Swift reads argv through `KERN_PROCARGS2`, which is macOS-only. termiod also runs on Linux, where none of this has ever worked. `src/proc.rs` implements both behind one interface — `sysctl`/`proc_pidinfo` on macOS, `/proc/<pid>/cmdline` and `/proc/<pid>/cwd` on Linux — so a Linux device reports its foreground program for the first time.

## Shape

- `src/proc.rs` (new): `process_arguments`, `working_directory`, `executable_identity`, cfg-gated per platform. No new crates; `libc` was already a dependency.
- Six additive fields on `SessionInfo`. No new control ops — unknown fields are ignored by design, so an older client is unaffected.
- Sampled on a 2s `tokio::time::interval` in the session actor with `MissedTickBehavior::Skip` and an immediate first tick, so a session can answer "what is running in there" on its first roster request rather than after a cold two seconds. A roster event is emitted only when the sample actually changes.
- `sample_foreground` is three bounded single-pid syscalls, so the byte path is not meaningfully delayed.

## Verification

- `cargo test` — 58 passed, 0 failed (was 49)
- `cargo clippy` — no new warnings
- `cargo build --release --target aarch64-unknown-linux-musl` — still `statically linked`
- `python3 smoke_test.py` — ALL CHECKS PASSED
- **The Linux path was executed, not just compiled**: the musl test binary was run under `alpine:3.20` on `linux/arm64` — 58/58, including `reads_a_live_child_argv` and `reads_a_live_child_working_directory` against a real spawned child.

No Swift changes. Nothing consumes these fields yet; wiring the agent detector to them is a separate change.

Release Notes:
- termiod now reports the program running in the foreground of a session, its working directory, and whether a job is running — on Linux hosts as well as macOS.