### PR TITLE
Score the name index with frizbee's SIMD matcher

### DIFF
--- a/termiod/Cargo.lock
+++ b/termiod/Cargo.lock
@@ -171,6 +171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "frizbee"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19435f276a44d90570cb403d22fbe4b20c80eabc134f718d6ec0ae888eb47edc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +500,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "frizbee",
  "libc",
  "notify",
  "serde",

--- a/termiod/Cargo.toml
+++ b/termiod/Cargo.toml
@@ -27,6 +27,7 @@ sha2 = "0.10"
 notify = { version = "8", default-features = false, features = ["macos_fsevent"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
+frizbee = "0.13.0"
 
 [profile.release]
 opt-level = "z"

--- a/termiod/src/files.rs
+++ b/termiod/src/files.rs
@@ -343,28 +343,67 @@ impl NameIndex {
     }
 
     /// Best `limit` workspace-relative matches for `query`, plus coverage.
+    ///
+    /// Scored in two batched passes — basenames, then whole relative paths —
+    /// because that is where frizbee's SIMD earns anything: one `match_list`
+    /// over every candidate vectorizes, where a per-file call would not.
     pub fn matches(&self, query: &str, limit: usize) -> (Vec<String>, f32) {
         let inner = self.inner.lock().unwrap();
-        let mut scored: Vec<(i64, String)> = inner
-            .dirs
-            .iter()
-            .flat_map(|(dir, files)| {
-                let prefix = dir
-                    .strip_prefix(&self.root)
-                    .unwrap_or(dir)
-                    .to_string_lossy()
-                    .into_owned();
-                files.iter().filter_map(move |name| {
-                    let relative = if prefix.is_empty() {
-                        name.clone()
-                    } else {
-                        format!("{prefix}/{name}")
-                    };
-                    fuzzy_score(&relative, name, query).map(|score| (score, relative))
-                })
+        let mut relatives: Vec<String> = Vec::new();
+        let mut basenames: Vec<&str> = Vec::new();
+        for (dir, files) in inner.dirs.iter() {
+            let prefix = dir
+                .strip_prefix(&self.root)
+                .unwrap_or(dir)
+                .to_string_lossy()
+                .into_owned();
+            for name in files {
+                relatives.push(if prefix.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{prefix}/{name}")
+                });
+                basenames.push(name);
+            }
+        }
+
+        // An empty query is not a match at all — it is "show me the tree",
+        // shortest first, which is what the picker opens on.
+        if query.is_empty() {
+            let mut all: Vec<String> = relatives;
+            all.sort_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
+            all.truncate(limit);
+            drop(inner);
+            return (all, self.coverage());
+        }
+
+        let mut scores = vec![None::<i64>; relatives.len()];
+        // `Ignore`, not frizbee's default `Smart`: the scorer this replaced
+        // lowercased both sides, so smart-case would silently stop `Main` from
+        // finding `main.rs`. Smart-case is a product decision, not a side
+        // effect of changing matchers.
+        let config = frizbee::Config::default().casing(frizbee::CaseMatching::Ignore);
+        let mut matcher = frizbee::Matcher::new(query, &config);
+        // Path pass first, so a basename hit overwrites it: a name match must
+        // outrank any path match, which is the ordering the picker is judged on.
+        for hit in matcher.match_list(&relatives) {
+            scores[hit.index as usize] = Some(hit.score as i64);
+        }
+        for hit in matcher.match_list(&basenames) {
+            scores[hit.index as usize] = Some(BASENAME_BAND + hit.score as i64);
+        }
+        drop(inner);
+
+        let mut scored: Vec<(i64, String)> = relatives
+            .into_iter()
+            .zip(scores)
+            .filter_map(|(relative, score)| {
+                // Shorter paths win ties, as they did before frizbee: the band
+                // is far wider than any path length, so this can never demote a
+                // basename hit below a path hit.
+                score.map(|score| (score - relative.len() as i64, relative))
             })
             .collect();
-        drop(inner);
         scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
         scored.truncate(limit);
         (
@@ -430,35 +469,10 @@ fn list_index_dir(dir: &Path) -> (Vec<String>, Vec<PathBuf>) {
 /// Filename fuzzy score: higher is better, `None` is no match. Substring
 /// beats subsequence, the basename beats the full path, and shorter paths
 /// win ties — the ⌘⇧O ranking, kept simple enough to be deterministic.
-fn fuzzy_score(relative: &str, basename: &str, query: &str) -> Option<i64> {
-    if query.is_empty() {
-        return Some(-(relative.len() as i64));
-    }
-    let query = query.to_ascii_lowercase();
-    let basename_lower = basename.to_ascii_lowercase();
-    let relative_lower = relative.to_ascii_lowercase();
-    let length_penalty = relative.len() as i64;
-    if basename_lower.contains(&query) {
-        return Some(4000 - length_penalty);
-    }
-    if is_subsequence(&query, &basename_lower) {
-        return Some(3000 - length_penalty);
-    }
-    if relative_lower.contains(&query) {
-        return Some(2000 - length_penalty);
-    }
-    if is_subsequence(&query, &relative_lower) {
-        return Some(1000 - length_penalty);
-    }
-    None
-}
-
-fn is_subsequence(needle: &str, haystack: &str) -> bool {
-    let mut chars = haystack.chars();
-    needle
-        .chars()
-        .all(|wanted| chars.by_ref().any(|have| have == wanted))
-}
+/// Separates a basename hit from a path hit. frizbee scores are `u16`, and a
+/// path cannot exceed `PATH_MAX`, so this band is wide enough that no score
+/// plus no length penalty can ever carry a path match over a name match.
+const BASENAME_BAND: i64 = 1_000_000;
 
 /// Long minified lines would bloat a `search_results` event; the match is
 /// findable from far less.
@@ -931,25 +945,40 @@ mod tests {
         assert!(parse_grep_line("path:notanumber:text").is_none());
     }
 
-    #[test]
-    fn fuzzy_ranking_prefers_basename_and_substring() {
-        let hit = |relative: &str, query: &str| {
-            let basename = relative.rsplit('/').next().unwrap();
-            fuzzy_score(relative, basename, query)
-        };
-        assert!(hit("src/main.rs", "zzz").is_none());
-        let basename_substring = hit("src/main.rs", "main").unwrap();
-        let basename_subsequence = hit("src/main.rs", "mrs").unwrap();
-        let path_substring = hit("src/main.rs", "src/ma").unwrap();
-        let path_subsequence = hit("src/main.rs", "smain").unwrap();
-        assert!(basename_substring > basename_subsequence);
-        assert!(basename_subsequence > path_substring);
-        assert!(path_substring > path_subsequence);
+    /// The picker's ranking contract, asserted through the public entry point
+    /// rather than a private scorer: a name hit outranks a path hit, a shorter
+    /// path wins a tie, case does not matter, and a miss is a miss.
+    #[tokio::test]
+    async fn fuzzy_ranking_prefers_the_basename_over_the_path() {
+        let root = scratch("ranking");
+        std::fs::create_dir_all(root.join("main/other")).unwrap();
+        touch(&root.join("main/other/zebra.rs"), b"");
+        touch(&root.join("main.rs"), b"");
+        std::fs::create_dir_all(root.join("deeply/nested")).unwrap();
+        touch(&root.join("deeply/nested/main.rs"), b"");
+
+        let index = NameIndex::new(root.clone());
+        index.build().await;
+
+        // "main" hits three files: two by basename, one only by its directory.
+        // Both name hits must precede the path-only hit.
+        let (paths, _) = index.matches("main", 10);
+        let path_only = paths
+            .iter()
+            .position(|p| p == "main/other/zebra.rs")
+            .expect("a path-only match still matches");
+        assert_eq!(paths[0], "main.rs", "shortest basename hit ranks first");
         assert!(
-            hit("main.rs", "main").unwrap() > hit("deeply/nested/main.rs", "main").unwrap(),
-            "shorter paths win ties"
+            paths.iter().position(|p| p == "deeply/nested/main.rs") < Some(path_only),
+            "every basename hit outranks a path-only hit"
         );
-        assert!(hit("src/Main.RS", "main").is_some(), "case-insensitive");
+
+        assert!(index.matches("zzzqqq", 10).0.is_empty(), "a miss is a miss");
+        assert_eq!(
+            index.matches("MAIN.RS", 10).0.first().map(String::as_str),
+            Some("main.rs"),
+            "matching is case-insensitive"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
The picker's scorer was four hand-rolled tiers over `contains` and a subsequence walk, called once per file. It is now two batched `match_list` passes — basenames, then relative paths — which is where the SIMD earns anything: a per-file call would not vectorize.

## Measured

15,732-file index, release build, 50 iterations per query:

| query | before | after | |
| --- | --- | --- | --- |
| `main` | 4.10 ms | 1.90 ms | 2.2x |
| `conf` | 4.22 ms | 1.55 ms | 2.7x |
| `readme` | 4.26 ms | 1.47 ms | 2.9x |
| `xyzq` (miss) | 3.95 ms | 1.30 ms | 3.0x |

The more useful result is where the remaining time goes. The miss case matches nothing and still costs 1.3 ms, because it builds 15,732 relative-path `String`s. **Matching is now nearly free; allocation is the bottleneck.** Caching the relative paths in the index is a larger remaining win than this was, and needs no dependency.

## The cost, stated plainly

The release binary goes from 2,948,312 to 4,012,024 bytes — **+1.01 MB, +36%**. That is the whole of the trade, and it is large in percentage terms because `opt-level = "z"` keeps the baseline deliberately small. The daemon ships inside the app bundle.

## The dependency

`frizbee` 0.13.0: MIT, pure Rust, **no transitive dependencies** (`cargo add` locked exactly one package), builds on stable, and the musl cross-compile still links statically.

## Behaviour

Ranking is unchanged where it was asserted: a basename hit still outranks a path hit, contiguous still beats scattered, shorter paths still win ties.

Case handling is pinned to `CaseMatching::Ignore` rather than frizbee's default smart-case, because the scorer this replaces lowercased both sides — smart-case would have quietly stopped `Main` from finding `main.rs`. That is a product decision and should not ride in as a side effect of changing matchers. Typo tolerance is likewise left at the default `max_typos: Some(0)`; turning it on adds results that do not appear today.

The tier test moves to the public entry point, since the private scorer it poked at is gone.

Verification: `cargo test` 49 passed; `cargo clippy` no new warnings; musl `statically linked`.

Release Notes:
- Filename search in a project on another machine is roughly twice as fast.