### PR TITLE
Title the window by a loose terminal's own directory

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -248,8 +248,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         updateWindowTitle()
         // Keep the native title/subtitle in step with the selected session and its live branch.
         // The title reads only the selected session's working-directory/project path (see
-        // `updateWindowTitle`), both of which live on the structural store, so plain
-        // `objectWillChange` covers it — no per-session runtime ping needed here.
+        // `updateWindowTitle`). A loose terminal's cwd also reaches the structural store —
+        // `noteWorkingDirectory` persists it on the session — so plain `objectWillChange`
+        // covers every source, and no per-session runtime ping is needed here.
         titleObserver = store.objectWillChange
             .receive(on: RunLoop.main)
             .sink { [weak self] in
@@ -582,12 +583,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// session's real working directory, so a worktree session shows where it actually runs.
     private func updateWindowTitle() {
         guard let window else { return }
-        guard let id = store.selectedSessionID, let project = store.project(for: id) else {
+        guard let id = store.selectedSessionID,
+              let folder = store.titleFolder(for: id) else {
             window.title = "Termio"
             window.subtitle = ""
             return
         }
-        let folder = store.session(id)?.worktreePath ?? project.path
         window.title = abbreviatingHome(folder)
         // Deliberately no machine here. `subtitle` renders beside the title in
         // the titlebar, so naming the device put it in two places at once — the
@@ -2337,19 +2338,20 @@ private struct BranchPickerToolbarView: View {
     static let titleWidthFloor: CGFloat = 80
     static let titleWidthCeiling: CGFloat = 460
 
-    /// The selected session's working directory: its worktree if it has one, else its project
-    /// folder. `nil` when nothing is selected.
+    /// The selected session's working directory: its worktree, its project folder, or — for a
+    /// loose terminal, which owns its path — its live cwd. `nil` when nothing is selected.
     private var folder: String? {
-        guard let id = store.selectedSessionID, let project = store.project(for: id) else { return nil }
-        return store.session(id)?.worktreePath ?? project.path
+        store.selectedSessionID.flatMap(store.titleFolder)
     }
 
     private var title: String {
         // An SSH terminal is titled by its host, not the local cwd it happens to have
         // launched from ($HOME) — matching how the sidebar labels the same row.
         if let host = store.selectedSessionID.flatMap(store.session)?.sshHost { return host }
+        // Only a session with nowhere to name — a loose chat in its scratch directory —
+        // falls back to the app's own name.
         guard let folder else { return "Termio" }
-        return URL(fileURLWithPath: folder).lastPathComponent
+        return TermioStore.terminalLabel(forPath: folder)
     }
 
     private var branch: String? {
@@ -2389,8 +2391,11 @@ private struct BranchPickerToolbarView: View {
         // Keep short names at the established 80pt toolbar width and propose the same hard ceiling
         // that AppKit applies to the hosting view. Do not use negative padding here: it shrinks the
         // measured view without shrinking or moving the Text glyphs, allowing them to paint past the
-        // toolbar item's trailing edge. Default centering preserves the existing short-title position.
-        .frame(minWidth: Self.titleWidthFloor, maxWidth: Self.titleWidthCeiling)
+        // toolbar item's trailing edge. Leading, not centered: a name shorter than the 80pt floor
+        // would otherwise be centered inside it and a longer one drawn flush left, so the title's
+        // left edge moved with every session switch. Pinned, it starts where the terminal text
+        // below it does and only ever grows to the right.
+        .frame(minWidth: Self.titleWidthFloor, maxWidth: Self.titleWidthCeiling, alignment: .leading)
     }
 }
 

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1393,6 +1393,29 @@ final class TermioStore: ObservableObject {
         runtimes[sessionID]?.workingDirectory
     }
 
+    /// The folder the window chrome names for a session: a project session's worktree
+    /// if it has one, else its project folder. A loose terminal belongs to no project
+    /// but owns its path, so it names its live cwd — the same place the sidebar row and
+    /// the inspector already follow (see `inspectorCheckout`). `nil` for a loose chat,
+    /// whose scoped scratch directory is not a place worth naming, and for an unknown id.
+    ///
+    /// The loose ladder walks down to `$HOME` rather than stopping at the reported cwd:
+    /// a shell reports nothing until its first prompt, so a fresh terminal would
+    /// otherwise show the app's own name for a beat and then swap to a path. These are
+    /// the rungs `surface(for:in:)` spawns the shell down, so the title names where the
+    /// shell is about to land, not where it has confirmed it is.
+    func titleFolder(for sessionID: Session.ID) -> String? {
+        guard let session = session(sessionID) else { return nil }
+        if let project = project(for: sessionID) {
+            return session.worktreePath ?? project.path
+        }
+        guard isLooseTerminal(sessionID) else { return nil }
+        return workingDirectory(for: sessionID)
+            ?? session.lastWorkingDirectory
+            ?? session.spawnDirectory
+            ?? Self.looseTerminalRoot
+    }
+
     /// Whether the user is plausibly looking at this session right now: termio is
     /// the active app and the session is selected. The status paths use it to pick
     /// between a quiet in-place settle and a "your turn" cue — with termio in the
@@ -1495,8 +1518,9 @@ final class TermioStore: ObservableObject {
     }
 
     /// A loose terminal's display label for a working directory: `~` at the home
-    /// directory, otherwise the folder's basename.
-    private static func terminalLabel(forPath path: String) -> String {
+    /// directory, otherwise the folder's basename. Shared with the toolbar title so
+    /// the row and the chrome above it name the same place the same way.
+    static func terminalLabel(forPath path: String) -> String {
         let standardized = (path as NSString).standardizingPath
         if standardized == FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path {
             return "~"


### PR DESCRIPTION
A loose terminal belongs to no project, so the toolbar title and the native window title — both resolved through `project(for:)` — fell through to the app's own name. A shell sitting in `~` had "Termio" written above it.

Both now go through one resolver, `TermioStore.titleFolder(for:)`, which gives a loose terminal its live cwd: the place its sidebar row and the inspector already follow. The ladder continues past the reported cwd to the spawn directory and `$HOME`, because a shell reports nothing until its first prompt — without those rungs a new terminal showed the app name for a beat and then swapped to a path. A loose chat, whose scratch directory is not a place worth naming, keeps the fallback.

The title is leading-aligned now. A name shorter than the 80pt width floor was centered inside it while a longer one sat flush left, so the title's left edge moved on every session switch.

Verified on a dev build by sampling the window title right after opening a loose terminal: `Termio Termio … ~` before, `~` from the first sample after. `swift test` passes (455 tests).

Release Notes:

- A terminal that isn't in a project now shows its own folder in the window title, following it as you `cd`, instead of showing the app's name.