### PR TITLE
Pick a new workspace's machine from the menu

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -950,9 +950,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.switchToWorkspace(id)
     }
 
-    /// The submenu's trailing "New Workspace…" row.
+    /// "New Workspace…" wherever it stands as a plain verb — the Workspace
+    /// submenu's row, the toolbar `+`'s last row — and the This Mac row of the
+    /// device submenu those grow on a second machine.
     @objc func newWorkspace(_ sender: Any?) {
-        store.presentNewWorkspacePanel()
+        store.presentNewWorkspacePanel(on: .thisMac)
+    }
+
+    /// A device row of the New Workspace submenu (File ▸ Workspace and the toolbar
+    /// `+` share it — see `refreshNewWorkspaceItem`). Nothing is reached here: a
+    /// workspace is a filing scope, so it exists on that machine before anything
+    /// has connected to it.
+    @objc func newWorkspaceOnDevice(_ sender: NSMenuItem) {
+        guard let alias = sender.representedObject as? String else { return }
+        store.presentNewWorkspacePanel(on: .ssh(alias: alias))
     }
 
     /// The submenu's "Rename Workspace…" row. It acts on the workspace the window
@@ -1541,6 +1552,7 @@ enum DeviceMenuTag {
     static let newTerminalAtHome = 7302
     static let connectTo = 7303
     static let openProject = 7305
+    static let newWorkspace = 7306
 }
 
 /// The "Workspace ▸" item — the scopes, with the current one checked, and where the
@@ -1613,6 +1625,8 @@ extension AppDelegate: NSMenuDelegate {
             fillConnectToMenu(menu)
         case localized("Open Project"):
             fillOpenProjectMenu(menu)
+        case localized("New Workspace"):
+            fillNewWorkspaceMenu(menu)
         case localized("Workspace"):
             fillWorkspaceMenu(menu)
         default:
@@ -1628,6 +1642,10 @@ extension AppDelegate: NSMenuDelegate {
         // the roster is read once per pass rather than once per item — reading
         // `~/.ssh/config` for "Connect to…" is the expensive half.
         let known = DeviceRoster.known(in: store)
+        // The other machines are read once per pass for the same reason: both the
+        // Open Project and the New Workspace rows collapse on the same list, and it
+        // parses `~/.ssh/config` to build it.
+        let others = otherDevices(known: known)
         for item in menu.items {
             switch item.tag {
             case DeviceMenuTag.newTerminal:
@@ -1637,7 +1655,9 @@ extension AppDelegate: NSMenuDelegate {
             case DeviceMenuTag.connectTo:
                 item.isHidden = DeviceRoster.unusedAliases(known: known).isEmpty
             case DeviceMenuTag.openProject:
-                refreshOpenProjectItem(item, known: known)
+                refreshOpenProjectItem(item, others: others)
+            case DeviceMenuTag.newWorkspace:
+                refreshNewWorkspaceItem(item, others: others)
             default:
                 continue
             }
@@ -1689,8 +1709,8 @@ extension AppDelegate: NSMenuDelegate {
     /// The shortcut travels to the This Mac row so ⌘O still opens a local folder
     /// (AppKit's key-equivalent sweep descends submenus, the same behaviour the
     /// New Chat menu relies on).
-    private func refreshOpenProjectItem(_ item: NSMenuItem, known: [KnownDevice]) {
-        guard !openProjectDevices(known: known).isEmpty else {
+    private func refreshOpenProjectItem(_ item: NSMenuItem, others: [KnownDevice]) {
+        guard !others.isEmpty else {
             item.title = localized("Open Project…")
             item.submenu = nil
             item.action = #selector(openProject(_:))
@@ -1715,13 +1735,66 @@ extension AppDelegate: NSMenuDelegate {
         item.submenu = submenu
     }
 
-    /// The machines a project can be opened on: one worked on before, plus one from
-    /// `~/.ssh/config` never reached. Opening a project on a box is itself a first
-    /// contact — `ensureRemoteReady` installs termiod on the way — so the list is
-    /// the same one `Clone to <device>…` offers.
-    private func openProjectDevices(known: [KnownDevice]) -> [KnownDevice] {
+    /// The machines other than this Mac something can be put on: one worked on
+    /// before, plus one from `~/.ssh/config` never reached. Putting a project or a
+    /// workspace on a box is itself a first contact — `ensureRemoteReady` installs
+    /// termiod on the way — so the list is the same one `Clone to <device>…` offers.
+    ///
+    /// Empty is the single-machine install, which is what both device submenus
+    /// collapse on.
+    private func otherDevices(known: [KnownDevice]) -> [KnownDevice] {
         known.filter { !$0.isLocal }
             + DeviceRoster.unusedAliases(known: known).map { KnownDevice(alias: $0, deviceID: nil) }
+    }
+
+    /// The same single-device collapse applied to "New Workspace…": a plain verb
+    /// while this Mac is the only machine, a device submenu once there is a second
+    /// box to put a workspace on.
+    ///
+    /// A workspace belongs to exactly one machine, so the choice has to be made
+    /// somewhere. Making it here rather than in the name panel is what keeps the
+    /// device level invisible to someone who owns one machine — a pop-up inside the
+    /// panel would show every local-only user a one-item menu reading "This Mac",
+    /// which is a control for a decision they never took.
+    ///
+    /// No key equivalent travels with the shape: creating a workspace has no
+    /// shortcut, so unlike ⌘O there is nothing to move onto the This Mac row.
+    private func refreshNewWorkspaceItem(_ item: NSMenuItem, others: [KnownDevice]) {
+        guard !others.isEmpty else {
+            item.title = localized("New Workspace…")
+            item.submenu = nil
+            item.action = #selector(newWorkspace(_:))
+            item.target = self
+            return
+        }
+        // The ellipsis moves to the rows: each of those opens the name panel, and a
+        // parent that only reveals a submenu never carries one.
+        item.title = localized("New Workspace")
+        item.action = nil
+        // Attached once and filled by the delegate on open, like the other device
+        // submenus — the File menu's copy is rebuilt per open, but the toolbar `+`
+        // keeps its item across refreshes.
+        guard item.submenu?.title != localized("New Workspace") else { return }
+        let submenu = NSMenu(title: localized("New Workspace"))
+        submenu.delegate = self
+        item.submenu = submenu
+    }
+
+    private func fillNewWorkspaceMenu(_ menu: NSMenu) {
+        let local = menu.addItem(
+            withTitle: localized("This Mac…"), action: #selector(newWorkspace(_:)), keyEquivalent: "")
+        local.target = self
+        menu.addItem(.separator())
+        for device in otherDevices(known: DeviceRoster.known(in: store)) {
+            // The machine's own name, so nothing here is translated — it is the
+            // alias out of the user's `~/.ssh/config`.
+            let row = menu.addItem(
+                withTitle: "\(device.name)…",
+                action: #selector(newWorkspaceOnDevice(_:)),
+                keyEquivalent: "")
+            row.target = self
+            row.representedObject = device.alias
+        }
     }
 
     private func fillOpenProjectMenu(_ menu: NSMenu) {
@@ -1730,7 +1803,7 @@ extension AppDelegate: NSMenuDelegate {
         local.target = self
         local.applyShortcut(for: .openProject)
         menu.addItem(.separator())
-        for device in openProjectDevices(known: DeviceRoster.known(in: store)) {
+        for device in otherDevices(known: DeviceRoster.known(in: store)) {
             // The machine's own name, so nothing here is translated — it is the
             // alias out of the user's `~/.ssh/config`.
             let row = menu.addItem(
@@ -1921,9 +1994,14 @@ extension AppDelegate: NSMenuDelegate {
             item.state = workspace.id == store.currentWorkspaceID ? .on : .off
         }
         menu.addItem(.separator())
+        // The same row the toolbar `+` carries: a plain verb on one machine, a
+        // device submenu on two (`refreshNewWorkspaceItem`). This menu is rebuilt on
+        // every open rather than refreshed in place, so the row is shaped here
+        // instead of by tag.
         let new = menu.addItem(withTitle: localized("New Workspace…"),
                                action: #selector(newWorkspace(_:)), keyEquivalent: "")
         new.target = self
+        refreshNewWorkspaceItem(new, others: otherDevices(known: DeviceRoster.known(in: store)))
         let rename = menu.addItem(withTitle: localized("Rename Workspace…"),
                                   action: #selector(renameWorkspace(_:)), keyEquivalent: "")
         rename.target = self
@@ -2099,6 +2177,18 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
         folder.target = NSApp.delegate as? AppDelegate
         folder.tag = DeviceMenuTag.openProject
         menu.addItem(folder)
+        // The one container verb that belongs in a context-free menu: a new
+        // workspace reads no selection and no focus. It sits last, after a
+        // separator, because starting a scope is rarer than starting a session —
+        // and it is reshaped into a device submenu on open like the rows above
+        // (`refreshNewWorkspaceItem`), since a workspace is on one machine.
+        menu.addItem(.separator())
+        let workspace = NSMenuItem(title: localized("New Workspace…"),
+                                   action: #selector(AppDelegate.newWorkspace(_:)),
+                                   keyEquivalent: "")
+        workspace.target = NSApp.delegate as? AppDelegate
+        workspace.tag = DeviceMenuTag.newWorkspace
+        menu.addItem(workspace)
         return menu
     }
 

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5725,12 +5725,22 @@
         }
       }
     },
-    "Name the workspace. It starts empty; sessions and projects you open from now on are filed under it.": {
+    "Name the workspace. It starts empty; sessions and projects you open on %@ from now on are filed under it.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "为工作区取个名字。它一开始是空的，此后你打开的会话和项目都归入其中。"
+            "value": "为工作区取个名字。它一开始是空的，此后你在 %@ 上打开的会话和项目都归入其中。"
+          }
+        }
+      }
+    },
+    "Name the workspace. It starts empty; sessions and projects you open on this Mac from now on are filed under it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "为工作区取个名字。它一开始是空的，此后你在这台 Mac 上打开的会话和项目都归入其中。"
           }
         }
       }
@@ -5741,6 +5751,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "新建工作区"
+          }
+        }
+      }
+    },
+    "New Workspace on %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 %@ 上新建工作区"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -556,8 +556,10 @@
 	<string>My Agent</string>
 	<key>Name</key>
 	<string>Name</string>
-	<key>Name the workspace. It starts empty; sessions and projects you open from now on are filed under it.</key>
-	<string>Name the workspace. It starts empty; sessions and projects you open from now on are filed under it.</string>
+	<key>Name the workspace. It starts empty; sessions and projects you open on %@ from now on are filed under it.</key>
+	<string>Name the workspace. It starts empty; sessions and projects you open on %@ from now on are filed under it.</string>
+	<key>Name the workspace. It starts empty; sessions and projects you open on this Mac from now on are filed under it.</key>
+	<string>Name the workspace. It starts empty; sessions and projects you open on this Mac from now on are filed under it.</string>
 	<key>Name the worktree. A new branch of this name is created from HEAD and nested under this project.</key>
 	<string>Name the worktree. A new branch of this name is created from HEAD and nested under this project.</string>
 	<key>Navigation</key>
@@ -594,6 +596,8 @@
 	<string>New Terminal at Home</string>
 	<key>New Workspace</key>
 	<string>New Workspace</string>
+	<key>New Workspace on %@</key>
+	<string>New Workspace on %@</string>
 	<key>New Workspace…</key>
 	<string>New Workspace…</string>
 	<key>New Worktree</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -556,8 +556,10 @@
 	<string>我的 Agent</string>
 	<key>Name</key>
 	<string>名称</string>
-	<key>Name the workspace. It starts empty; sessions and projects you open from now on are filed under it.</key>
-	<string>为工作区取个名字。它一开始是空的，此后你打开的会话和项目都归入其中。</string>
+	<key>Name the workspace. It starts empty; sessions and projects you open on %@ from now on are filed under it.</key>
+	<string>为工作区取个名字。它一开始是空的，此后你在 %@ 上打开的会话和项目都归入其中。</string>
+	<key>Name the workspace. It starts empty; sessions and projects you open on this Mac from now on are filed under it.</key>
+	<string>为工作区取个名字。它一开始是空的，此后你在这台 Mac 上打开的会话和项目都归入其中。</string>
 	<key>Name the worktree. A new branch of this name is created from HEAD and nested under this project.</key>
 	<string>为 worktree 命名。将从 HEAD 创建一个同名新分支，并嵌套在此项目下。</string>
 	<key>Navigation</key>
@@ -594,6 +596,8 @@
 	<string>在个人文件夹新建终端</string>
 	<key>New Workspace</key>
 	<string>新建工作区</string>
+	<key>New Workspace on %@</key>
+	<string>在 %@ 上新建工作区</string>
 	<key>New Workspace…</key>
 	<string>新建工作区…</string>
 	<key>New Worktree</key>

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -70,7 +70,11 @@ struct WorkspaceSwitcherToolbarView: View {
         .pickerStyle(.inline)
         .labelsHidden()
         Divider()
-        Button(localized("New Workspace…")) { store.presentNewWorkspacePanel() }
+        // This Mac, without asking: the device submenu belongs to the menus that
+        // already carry one (File ▸ Workspace and the sidebar `+`), and growing a
+        // third here would put a machine list in the switcher, which is the "go to
+        // a computer" mode the workspace replaced.
+        Button(localized("New Workspace…")) { store.presentNewWorkspacePanel(on: .thisMac) }
         Button(localized("Rename Workspace…")) {
             store.presentRenameWorkspacePanel(store.currentWorkspaceID)
         }

--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -405,11 +405,28 @@ extension TermioStore {
 
     // MARK: - Editing the set of workspaces
 
-    /// Creates a workspace and moves into it. Named by the user, so the prompt is
-    /// the caller's job; this is the state change.
+    /// Creates a workspace on `device` and moves into it. Named by the user, so
+    /// the prompt is the caller's job; this is the state change.
+    ///
+    /// The machine is the caller's too: every workspace is on one, and which one
+    /// is a decision the menu carries (`refreshNewWorkspaceItem`), so nothing is
+    /// guessed here from what the user happens to be looking at.
+    ///
+    /// Never `isAutoCreated`: that flag means Termio invented the workspace, and
+    /// it is what authorises sweeping an empty one away. A workspace someone asked
+    /// for is theirs even while it holds nothing.
     @discardableResult
-    func addWorkspace(named name: String) -> Workspace.ID {
-        let workspace = Workspace(name: name)
+    func addWorkspace(named name: String, on device: WorkspaceDevice) -> Workspace.ID {
+        let workspace = Workspace(
+            name: name,
+            deviceAlias: device.alias,
+            // Usually filled in by the first `hello_ok`, but if the alias has been
+            // reached before the answer is known now — and a workspace carrying it
+            // matches checkouts on that box without waiting for a connection.
+            deviceID: device.alias.flatMap {
+                TermiodDeviceRegistry.shared.deviceID(for: TermiodRoute(sshAlias: $0))
+            },
+            isAutoCreated: false)
         workspaces.append(workspace)
         currentWorkspaceID = workspace.id
         settings.currentWorkspaceID = workspace.id
@@ -471,16 +488,38 @@ extension TermioStore {
 
     // MARK: - Prompts
 
-    /// Asks for a name, then creates the workspace and moves into it. Bailing out
-    /// leaves the tree untouched.
-    func presentNewWorkspacePanel() {
+    /// Asks for a name, then creates the workspace on `device` and moves into it.
+    /// Bailing out leaves the tree untouched.
+    ///
+    /// The machine arrives already chosen, from the row that opened this panel, so
+    /// the panel names it rather than asking again — "New Workspace on ukvps"
+    /// beside "Open a Project on ukvps". Someone with one machine sees neither the
+    /// choice nor the name of it.
+    func presentNewWorkspacePanel(on device: WorkspaceDevice) {
+        // The machine is named in the body as well as the title, because the body
+        // is the line that makes the promise: what gets filed here will live on
+        // that box. "this Mac", said over a workspace being created on ukvps, is
+        // not vague — it is wrong about the one fact the sentence is for.
+        //
+        // Two whole sentences rather than one with the machine interpolated: this
+        // Mac has no alias to drop in, and "this Mac" as a fragment key is not
+        // something a translator can place inside a sentence they can't see.
+        let title: String
+        let message: String
+        if let alias = device.alias {
+            title = localized("New Workspace on \(alias)")
+            message = localized("Name the workspace. It starts empty; sessions and projects you open on \(alias) from now on are filed under it.")
+        } else {
+            title = localized("New Workspace")
+            message = localized("Name the workspace. It starts empty; sessions and projects you open on this Mac from now on are filed under it.")
+        }
         guard let name = promptForWorkspaceName(
-            title: localized("New Workspace"),
-            message: localized("Name the workspace. It starts empty; sessions and projects you open from now on are filed under it."),
+            title: title,
+            message: message,
             confirm: localized("Create"),
             defaultName: nextFreeWorkspaceName
         ) else { return }
-        addWorkspace(named: name)
+        addWorkspace(named: name, on: device)
     }
 
     /// What the new-workspace field opens with: "Workspace", bumped past the names

--- a/Tests/termioTests/WorkspaceCreationTests.swift
+++ b/Tests/termioTests/WorkspaceCreationTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+
+@testable import termio
+
+/// Creating a workspace from the menu. Two facts are worth a test because both
+/// are silent when wrong: the machine the workspace lands on comes from the row
+/// that was clicked, and a workspace someone asked for is never marked as
+/// Termio's own — `pruneEmptyDeviceWorkspaces` deletes an empty
+/// `isAutoCreated` workspace, so getting that flag wrong makes a user's brand
+/// new, still-empty workspace disappear.
+@MainActor
+final class WorkspaceCreationTests: XCTestCase {
+    private var directory: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("workspace-creation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        suiteName = "workspace-creation-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        defaults.removePersistentDomain(forName: suiteName)
+        try await super.tearDown()
+    }
+
+    /// Scratch storage for both settings layers: a test must not rewrite the
+    /// settings file or the defaults domain of the termio the user is running.
+    private func makeStore() -> TermioStore {
+        let settings = AppSettings(
+            defaults: defaults,
+            settingsStore: SettingsStore(
+                defaults: defaults,
+                fileURL: directory.appendingPathComponent("settings.json"),
+                domainName: suiteName))
+        return TermioStore(workspaces: [Workspace(name: "Default")], settings: settings)
+    }
+
+    private func workspace(_ id: Workspace.ID, in store: TermioStore) -> Workspace? {
+        store.workspaces.first { $0.id == id }
+    }
+
+    func testWorkspaceCreatedOnThisMacHasNoAlias() {
+        let store = makeStore()
+
+        let id = store.addWorkspace(named: "Ship auth", on: .thisMac)
+
+        XCTAssertEqual(workspace(id, in: store)?.device, .thisMac)
+        XCTAssertNil(workspace(id, in: store)?.deviceAlias, "this Mac is the machine with no alias")
+    }
+
+    /// The row that was clicked decides the machine, so the alias has to survive
+    /// the trip into the tree — a workspace filed on this Mac instead would take
+    /// every checkout opened in it with it.
+    func testWorkspaceCreatedOnADeviceCarriesItsAlias() {
+        let store = makeStore()
+
+        let id = store.addWorkspace(named: "Ship auth", on: .ssh(alias: "ukvps"))
+
+        XCTAssertEqual(workspace(id, in: store)?.device, .ssh(alias: "ukvps"))
+        XCTAssertEqual(workspace(id, in: store)?.deviceAlias, "ukvps")
+    }
+
+    /// `isAutoCreated` authorises deletion. It must be a recorded `false`, not a
+    /// missing value: absent means "written before the field existed", which
+    /// `WorkspaceMigration.reconcile` is free to re-derive.
+    func testUserCreatedWorkspaceIsNotMarkedAutoCreated() {
+        let store = makeStore()
+
+        let local = store.addWorkspace(named: "Ship auth", on: .thisMac)
+        let remote = store.addWorkspace(named: "Ship auth on the box", on: .ssh(alias: "ukvps"))
+
+        XCTAssertEqual(workspace(local, in: store)?.isAutoCreated, false)
+        XCTAssertEqual(workspace(remote, in: store)?.isAutoCreated, false,
+                       "naming a machine is not the same as being made by Termio")
+    }
+
+    /// A machine's fallback is the other half of the contrast: nobody asked for
+    /// it, so it is Termio's to sweep.
+    func testTheMachineFallbackIsMarkedAutoCreated() {
+        let store = makeStore()
+
+        let id = store.deviceWorkspace(for: "ukvps")
+
+        XCTAssertEqual(workspace(id, in: store)?.isAutoCreated, true)
+    }
+
+    /// Creating a workspace moves into it, and an empty scope has nothing to keep
+    /// selected.
+    func testCreatingAWorkspaceMovesIntoIt() {
+        let store = makeStore()
+
+        let id = store.addWorkspace(named: "Ship auth", on: .thisMac)
+
+        XCTAssertEqual(store.currentWorkspaceID, id)
+        XCTAssertNil(store.selectedSessionID)
+    }
+}


### PR DESCRIPTION
Every workspace belongs to exactly one machine since #359, but `addWorkspace(named:)` still made one without saying which — so a workspace created from any of the three New Workspace verbs landed on this Mac by default, and was marked with whatever `isAutoCreated` defaulted to.

Implements §8 of `docs/design/20260819-device-workspace-project.md`.

## The machine comes from the menu, not the panel

`New Workspace…` now takes the shape `New Terminal` and `Open Project…` already have — a plain verb on a one-machine install, a device submenu once there is a second:

```
One machine:     New Workspace…              → name panel
Two or more:     New Workspace ▸ This Mac…   → name panel
                                ──────────
                                ukvps…       → name panel
```

A device pop-up inside the panel cannot do this: it would show every local-only user a one-item menu reading "This Mac", which is a control for a decision they never took. Both the File menu's row and the sidebar `+`'s go through one builder via `refreshDeviceItems`.

The panel names the machine in its title *and* its body — "New Workspace on ukvps" beside "Open a Project on ukvps" — because the body is the line that promises where the things filed here will live. `docs/remote-project-filing` is editing that same sentence; this takes it over so it names the machine instead of hard-coding "this Mac".

## Not auto-created

`isAutoCreated` authorises sweeping an empty workspace away. A workspace the user asked for records a real `false`, never an absent value — absent means "written before the field existed", which `reconcile` is free to re-derive.

## Also here

- The sidebar `+` gains `New Workspace…` as its last row after a separator: it reads no selection and no focus, so it meets that menu's bar, and a container verb is rarer than New Terminal or New Chat.
- `openProjectDevices` became `otherDevices` and is read once per refresh pass rather than once per item — both device submenus collapse on the same list, and building it parses `~/.ssh/config`.

## Not in this PR

- The device context does not follow. Creating a workspace on `ukvps` makes it current without calling `switchToDevice`, so New Terminal there still opens on this Mac until a session is selected. That is session filing, and it belongs with the rest of it.
- Nothing in `WorkspaceMigration`.
- §9's open questions — whether the workspace registry moves to `termiod`, and whether `moveProject` refuses or clones across devices — stay open. §9 answers this one explicitly: no viewer knows what a workspace is today, so the hierarchy can be adopted without settling where the registry lives.

## Verification

```
swift build                 → Build complete
swift test                  → 438 tests, 9 skipped, 0 failures (5 new)
./scripts/check-strings.sh  → no missing keys; the 7 pre-existing unused-key notes
```

New `WorkspaceCreationTests` covers the machine a new workspace lands on, that it is not marked auto-created (against a machine fallback, which is), and that creating moves into the new scope.

**The menu shape has not been seen on screen.** Screen Recording is off on the machine this was built on, so the submenu, its single-machine collapse, and the panel title are unverified visually — worth a look before merge.

## Release Notes:

- New Workspace now asks which machine to create it on when you have more than one, and is reachable from the sidebar's `+` menu.