### PR TITLE
Keep the mermaid harness window out of the window server

### DIFF
--- a/Sources/termio/Info/MermaidRenderer.swift
+++ b/Sources/termio/Info/MermaidRenderer.swift
@@ -172,18 +172,23 @@ final class MermaidRenderer: NSObject {
         return webView
     }
 
-    /// The view lives in a borderless window parked far offscreen. WebKit does not lay out
-    /// a view that belongs to no window, and without layout `getBBox` returns zeroes and
-    /// every diagram collapses to a point.
+    /// The view lives in a borderless window. WebKit does not lay out a view that belongs
+    /// to no window, and without layout `getBBox` returns zeroes and every diagram
+    /// collapses to a point.
+    ///
+    /// The window is deliberately never ordered in. Belonging to a window is all WebKit
+    /// needs — it lays out and measures text in an unordered one exactly as it does in a
+    /// visible one. Ordering it front cost us a real window: borderless, unclosable, at
+    /// the normal level, and the window server does not honor an offscreen park position,
+    /// so it showed up as a white square in Mission Control that lived until the app quit
+    /// (#348).
     private func makeWebView() -> WKWebView {
         let frame = NSRect(x: 0, y: 0, width: 1400, height: 1400)
         let webView = WKWebView(frame: frame, configuration: WKWebViewConfiguration())
         webView.navigationDelegate = self
         let window = NSWindow(
-            contentRect: NSRect(x: -30000, y: -30000, width: frame.width, height: frame.height),
-            styleMask: [.borderless], backing: .buffered, defer: false)
+            contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
         window.contentView = webView
-        window.orderFront(nil)
         self.window = window
         return webView
     }


### PR DESCRIPTION
Previewing a Markdown file with a ```mermaid fence left a blank white window next to termio — no title bar, no close button, unselectable, and alive until the app quit. Reopening a preview brought it back.

Mermaid measures label text with `getBBox` before it can lay a diagram out, so it needs a real DOM. `MermaidRenderer` gives it one by parking a `WKWebView` in a borderless window, because WebKit does not lay out a view that belongs to no window. That window was also ordered front, which made it a genuine window: normal level, default collection behavior, no close affordance — a full participant in Mission Control, App Exposé, ⌘` cycling and the Window menu. The `-30000` park position did not save it either; the window server clamps it back toward the display.

Ordering it in was never necessary. Belonging to a window is all WebKit needs. Dropping `orderFront` leaves the window as an AppKit object WebKit can lay out in, while the window server never composites it.

Verified against the real `mermaid.min.js`: flowchart, sequence and state diagrams all render with byte-identical SVG and the same non-degenerate viewBoxes as before, both immediately after load and after a 45s idle (a non-visible window is not throttled). On the running app the harness window goes from `onscreen=true` to `onscreen=false`.

Fixes #348.

Release Notes:
- Fixed a blank white window that appeared alongside termio after previewing a Markdown file containing a mermaid diagram, and could not be closed without quitting.