### PR TITLE
Draw the app on the landing page instead of screenshotting it

### DIFF
--- a/web/landing/src/app/globals.css
+++ b/web/landing/src/app/globals.css
@@ -575,28 +575,6 @@ html[data-docs-theme="dark"]:has(.docs-surface) {
     }
   }
 
-  /* Orchestration demo: a short dash travels the full beam path once per
-     pulse. The path is normalized with pathLength=100; the 200 gap keeps a
-     single dash visible, and the offset sweep walks it from before the start
-     (30) to past the end (-105). React re-keys the path per pulse to restart. */
-  @keyframes beam-pulse {
-    from {
-      stroke-dashoffset: 30;
-      opacity: 1;
-    }
-    85% {
-      opacity: 1;
-    }
-    to {
-      stroke-dashoffset: -105;
-      opacity: 0;
-    }
-  }
-  .beam-pulse {
-    stroke-dasharray: 30 200;
-    stroke-linecap: round;
-    animation: beam-pulse 1s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-  }
   @keyframes demo-cursor-blink {
     50% {
       opacity: 0;
@@ -605,13 +583,38 @@ html[data-docs-theme="dark"]:has(.docs-surface) {
   .demo-cursor {
     animation: demo-cursor-blink 1s step-end infinite;
   }
-  @keyframes dot-pulse {
-    50% {
-      opacity: 0.35;
+  /* The sidebar's "agent is working" mark, ported from the app's
+     WorkingIndicator: a comet runs the eight perimeter cells of a 3×3 dot grid,
+     carried by a brightness wave and a size swell so the tail can stay at half
+     ink and the grid keeps real weight. Every dot plays the same ramp — its
+     place on the ring is a negative animation-delay. Timings match the Swift
+     original: 1.1s a lap, opacity max(0.5, 1 - distance/4), scale
+     1 + 0.2·max(0, 1 - distance/2). */
+  @keyframes working-comet {
+    0% {
+      opacity: 1;
+      transform: scale(1.2);
+    }
+    12.5% {
+      opacity: 0.75;
+      transform: scale(1.1);
+    }
+    25%,
+    75% {
+      opacity: 0.5;
+      transform: scale(1);
+    }
+    87.5% {
+      opacity: 0.75;
+      transform: scale(1.1);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1.2);
     }
   }
-  .dot-working {
-    animation: dot-pulse 1.6s ease-in-out infinite;
+  .working-dot {
+    animation: working-comet 1.1s linear infinite;
   }
   /* Output lines land all at once (not typed) but fade + rise in gently, so a
      result "arriving" reads as a soft reveal rather than an abrupt pop. */
@@ -628,12 +631,260 @@ html[data-docs-theme="dark"]:has(.docs-surface) {
   .line-in {
     animation: line-in 0.32s var(--ease-apple) both;
   }
+  /* The content area splitting in two: the new column wipes open from the
+     divider outward, the way dragging a split open reveals it. */
+  @keyframes split-in {
+    from {
+      opacity: 0;
+      clip-path: inset(0 100% 0 0);
+    }
+    to {
+      opacity: 1;
+      clip-path: inset(0 0 0 0);
+    }
+  }
+  .split-in {
+    animation: split-in 0.44s var(--ease-apple) both;
+  }
+  /* A pane opening inside that column: the divider above it is already there,
+     so the content wipes down from it rather than sliding in from nowhere. */
+  @keyframes pane-in {
+    from {
+      opacity: 0;
+      clip-path: inset(0 0 100% 0);
+      transform: translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      clip-path: inset(0 0 0 0);
+      transform: none;
+    }
+  }
+  .pane-in {
+    animation: pane-in 0.42s var(--ease-apple) both;
+  }
   @media (prefers-reduced-motion: reduce) {
-    .beam-pulse,
     .demo-cursor,
-    .dot-working,
-    .line-in {
+    .working-dot,
+    .line-in,
+    .pane-in,
+    .split-in {
       animation: none;
+    }
+  }
+
+  /* ── Feature-grid mocks ────────────────────────────────────────────────
+     Six small app mocks loop forever beside the orchestration demo, so every
+     one of these is compositor-only (opacity / transform / color) and none of
+     them touches layout. Loops share a 6s bar so cards drifting against each
+     other still read as one system; per-element `animation-delay` places each
+     row in that bar. */
+
+  /* A two-state cross-fade — source ⇄ rendered, probing ⇄ reachable. `-a` holds
+     first, `-b` takes over, and both rest before the swap back. */
+  @keyframes mock-fade-a {
+    0%,
+    38% {
+      opacity: 1;
+    }
+    46%,
+    88% {
+      opacity: 0;
+    }
+    96%,
+    100% {
+      opacity: 1;
+    }
+  }
+  @keyframes mock-fade-b {
+    0%,
+    38% {
+      opacity: 0;
+    }
+    46%,
+    88% {
+      opacity: 1;
+    }
+    96%,
+    100% {
+      opacity: 0;
+    }
+  }
+  .mock-fade-a {
+    animation: mock-fade-a 6s var(--ease-apple) infinite both;
+  }
+  .mock-fade-b {
+    animation: mock-fade-b 6s var(--ease-apple) infinite both;
+  }
+
+  /* A row lighting up as the selection walks a list. */
+  @keyframes mock-option {
+    0%,
+    0.1% {
+      background-color: rgba(255, 255, 255, 0);
+    }
+    4%,
+    22% {
+      background-color: rgba(255, 255, 255, 0.09);
+    }
+    28%,
+    100% {
+      background-color: rgba(255, 255, 255, 0);
+    }
+  }
+  .mock-option {
+    animation: mock-option 4.8s var(--ease-apple) infinite both;
+  }
+
+  /* The palette query typing itself. Width, not content, so there is one
+     animated property and no reflow of anything around it. */
+  @keyframes mock-type {
+    0% {
+      max-width: 0ch;
+    }
+    18%,
+    88% {
+      max-width: 6ch;
+    }
+    100% {
+      max-width: 0ch;
+    }
+  }
+  .mock-type {
+    animation: mock-type 4.8s steps(6, end) infinite both;
+  }
+
+  /* The palette's live theme preview: the session behind it repaints as each
+     theme in the list is highlighted. */
+  @keyframes mock-theme {
+    0%,
+    28% {
+      background-color: #1b1b21;
+    }
+    38%,
+    62% {
+      background-color: #1e1c2b;
+    }
+    72%,
+    100% {
+      background-color: #231a24;
+    }
+  }
+  @keyframes mock-theme-ink {
+    0%,
+    28% {
+      color: #7dd3fc;
+    }
+    38%,
+    62% {
+      color: #cba6f7;
+    }
+    72%,
+    100% {
+      color: #ebbcba;
+    }
+  }
+  .mock-theme {
+    animation: mock-theme 4.8s var(--ease-apple) infinite both;
+  }
+  .mock-theme-ink {
+    animation: mock-theme-ink 4.8s var(--ease-apple) infinite both;
+  }
+
+  /* A session row cycling the app's three states: working (spinner), done
+     (green ring), needs-you (orange ring). The mark and the spinner are both
+     mounted and cross-faded, so the swap costs no layout. */
+  @keyframes mock-status-spinner {
+    0%,
+    28% {
+      opacity: 1;
+    }
+    33%,
+    100% {
+      opacity: 0;
+    }
+  }
+  @keyframes mock-status-mark {
+    0%,
+    28% {
+      opacity: 0;
+    }
+    33%,
+    100% {
+      opacity: 1;
+    }
+  }
+  /* Lit only after the spinner is fully out: in the app, working IS the
+     spinner, so a ring around one would be a state that cannot happen. */
+  @keyframes mock-status-ring {
+    0%,
+    36% {
+      border-color: transparent;
+    }
+    42%,
+    62% {
+      border-color: #27c93f;
+    }
+    68%,
+    92% {
+      border-color: #ffb764;
+    }
+    97%,
+    100% {
+      border-color: transparent;
+    }
+  }
+  .mock-status-spinner {
+    animation: mock-status-spinner 6s var(--ease-apple) infinite both;
+  }
+  .mock-status-mark {
+    animation: mock-status-mark 6s var(--ease-apple) infinite both;
+  }
+  .mock-status-ring {
+    animation: mock-status-ring 6s var(--ease-apple) infinite both;
+  }
+
+  /* A worktree's session revealed under its branch, one after another. */
+  @keyframes mock-open {
+    0%,
+    2% {
+      opacity: 0;
+      transform: translateY(-3px);
+    }
+    12%,
+    92% {
+      opacity: 1;
+      transform: none;
+    }
+    100% {
+      opacity: 0;
+      transform: translateY(-3px);
+    }
+  }
+  .mock-open {
+    animation: mock-open 6s var(--ease-apple) infinite both;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mock-fade-a,
+    .mock-fade-b,
+    .mock-option,
+    .mock-type,
+    .mock-theme,
+    .mock-theme-ink,
+    .mock-status-spinner,
+    .mock-status-mark,
+    .mock-status-ring,
+    .mock-open {
+      animation: none;
+    }
+    /* Without the loop the `-b` layer would sit on top of `-a`; hold the
+       rendered/settled state, which is the one worth showing still. */
+    .mock-fade-a {
+      opacity: 0;
+    }
+    .mock-status-spinner {
+      opacity: 0;
     }
   }
 

--- a/web/landing/src/components/agent-icons.tsx
+++ b/web/landing/src/components/agent-icons.tsx
@@ -20,8 +20,11 @@ import { cn } from "@/lib/utils";
 // default so the logos stay legible on the near-black canvas), and `.Color` is
 // the full brand-color mark. Pass `color` to opt into `.Color`; brands with no
 // color variant (e.g. Grok — xAI's mark is monochrome by design) fall back to
-// the mono mark, which is already their brand look. Pi has no brand icon in the
-// set, so it falls back to a glyph.
+// the mono mark, which is already their brand look.
+//
+// Two agents have no icon in the set, and rather than draw a logo for someone
+// else's product they get the character each already prints for itself: Pi's π,
+// and the diagonal hatch Crush rules its banner with.
 type GlyphProps = { size?: number };
 type BrandIcon = React.ComponentType<GlyphProps> & {
   Color?: React.ComponentType<GlyphProps>;
@@ -40,14 +43,19 @@ const brandByAgent: Record<string, BrandIcon> = {
   DeepSeek: DeepSeek,
 };
 
-function PiGlyph({ size = 20 }: GlyphProps) {
+const glyphByAgent: Record<string, string> = {
+  Pi: "π",
+  Crush: "╱╱",
+};
+
+function TextGlyph({ size = 20, text }: GlyphProps & { text: string }) {
   return (
     <span
       aria-hidden="true"
       className="inline-flex items-center justify-center font-mono font-semibold leading-none"
       style={{ width: size, height: size, fontSize: size * 0.95 }}
     >
-      π
+      {text}
     </span>
   );
 }
@@ -65,10 +73,14 @@ export function AgentIcon({
   color?: boolean;
 }) {
   const Brand = brandByAgent[name];
-  const Glyph = Brand ? (color ? (Brand.Color ?? Brand) : Brand) : PiGlyph;
+  const Glyph = Brand && (color ? (Brand.Color ?? Brand) : Brand);
   return (
     <span className={cn("inline-flex shrink-0", className)} aria-hidden="true">
-      <Glyph size={size} />
+      {Glyph ? (
+        <Glyph size={size} />
+      ) : (
+        <TextGlyph size={size} text={glyphByAgent[name] ?? name.slice(0, 1)} />
+      )}
     </span>
   );
 }

--- a/web/landing/src/components/app-chrome.tsx
+++ b/web/landing/src/components/app-chrome.tsx
@@ -1,0 +1,185 @@
+import { cn } from "@/lib/utils";
+
+// The pieces of Termio's own chrome, drawn in DOM so the marketing mocks stay
+// crisp at any size and can animate. Shared by the orchestration demo and the
+// feature grid's mocks, so a detail only has to be right once.
+//
+// Everything here is ported from the app rather than invented: the status
+// language from Sidebar/SidebarView.swift, the working mark's geometry from
+// Shared/TermioShared/SessionStatus.swift.
+
+export type Status = "idle" | "working" | "needs-you" | "done";
+
+// Green done / orange needs-you is the sidebar's only color channel — the app
+// deliberately keeps per-agent brand tints out of it, so the mocks do too.
+export const DONE = "#27c93f"; // brand-green — matches StatusRing's .green
+export const NEEDS_YOU = "#ffb764"; // brand-amber — matches StatusRing's .orange
+
+export function TrafficLights({ size = 11 }: { size?: number }) {
+  return (
+    <div
+      className="flex shrink-0 items-center"
+      style={{ gap: Math.round(size * 0.55) }}
+    >
+      {["bg-brand-red", "bg-brand-amber", "bg-brand-green"].map((tone) => (
+        <span
+          key={tone}
+          className={cn("rounded-full", tone)}
+          style={{ width: size, height: size }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// The resting "your turn" status, drawn as a ring *around* a session's leading
+// mark — green when the agent just finished, orange when it is blocked on you.
+// Working is the spinner and idle is nothing, so only those two light the ring.
+// An overlay, so it never shifts the row it sits in.
+export function StatusRing({
+  status,
+  size = 20,
+}: {
+  status: Status;
+  size?: number;
+}) {
+  return (
+    <span
+      className="pointer-events-none absolute rounded-full border-[1.5px] transition-colors duration-300"
+      style={{
+        width: size,
+        height: size,
+        borderColor:
+          status === "done"
+            ? DONE
+            : status === "needs-you"
+              ? NEEDS_YOU
+              : "transparent",
+      }}
+    />
+  );
+}
+
+// The eight perimeter cells of a 3×3 grid in clockwise order, as (column, row)
+// with the center at (1,1) — the ring the comet travels.
+const RING: readonly (readonly [number, number])[] = [
+  [0, 0],
+  [1, 0],
+  [2, 0],
+  [2, 1],
+  [2, 2],
+  [1, 2],
+  [0, 2],
+  [0, 1],
+];
+const PERIOD = 1.1; // seconds a lap, as in the Swift original
+
+// The app's "agent is working" mark: a comet runs the eight perimeter cells of
+// a 3×3 dot grid over a steady half-ink center. Geometry scales off `size` from
+// the app's 13pt/2.5pt/3.6pt trio; the brightness and swell ramps live in the
+// `working-comet` keyframes, and each dot's place on the ring is a negative
+// animation delay.
+export function WorkingIndicator({ size = 13 }: { size?: number }) {
+  const dot = (size / 13) * 2.5;
+  const pitch = (size / 13) * 3.6;
+  return (
+    <span
+      className="relative block shrink-0 text-foreground"
+      style={{ width: size, height: size }}
+    >
+      {[[1, 1] as const, ...RING].map(([column, row], i) => (
+        <span
+          key={`${column}-${row}`}
+          className={cn(
+            "absolute rounded-full bg-current",
+            // The center dot is the steady anchor; only the ring animates.
+            i === 0 ? "opacity-50" : "working-dot",
+          )}
+          style={{
+            width: dot,
+            height: dot,
+            left: `calc(50% + ${(column - 1) * pitch - dot / 2}px)`,
+            top: `calc(50% + ${(row - 1) * pitch - dot / 2}px)`,
+            animationDelay: i === 0 ? undefined : `${-((i - 1) / 8) * PERIOD}s`,
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+export function FolderGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinejoin="round"
+      className={cn("shrink-0", className)}
+    >
+      <path d="M3 7.5A1.5 1.5 0 0 1 4.5 6h4l2 2.5h7A1.5 1.5 0 0 1 19 10v7a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 3 17z" />
+    </svg>
+  );
+}
+
+export function BranchGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      className={cn("shrink-0", className)}
+    >
+      <line x1="6" y1="3" x2="6" y2="15" />
+      <circle cx="18" cy="6" r="3" />
+      <circle cx="6" cy="18" r="3" />
+      <path d="M18 9a9 9 0 0 1-9 9" />
+    </svg>
+  );
+}
+
+// Settings ▸ SSH gives a remote host this glyph, and so does a session running
+// on one — a globe would read as "web", not "that box".
+export function ServerGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinejoin="round"
+      className={cn("shrink-0", className)}
+    >
+      <rect x="3" y="4" width="18" height="7" rx="2" />
+      <rect x="3" y="13" width="18" height="7" rx="2" />
+      <path d="M7 7.5h.01M7 16.5h.01" />
+    </svg>
+  );
+}
+
+// The window a mock lives in: the app's rounded frame, with the sidebar tone a
+// step above the terminal's near-black and the inset top hairline plus cast
+// shadow that make it read as a real macOS window rather than a flat panel.
+export function MockWindow({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "flex overflow-hidden rounded-xl border border-white/10 bg-[#1b1b21]",
+        "shadow-[inset_0_1px_0_0_rgba(255,255,255,0.07),0_16px_32px_-18px_rgba(0,0,0,0.8)]",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web/landing/src/components/sections/agent-showcase.tsx
+++ b/web/landing/src/components/sections/agent-showcase.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { useCallback, useEffect, useRef, useState } from "react";
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
@@ -9,7 +8,9 @@ import Autoplay from "embla-carousel-autoplay";
 import { WheelGesturesPlugin } from "embla-carousel-wheel-gestures";
 import { Reveal } from "@/components/reveal";
 import { AgentIcon } from "@/components/agent-icons";
+import { AgentTui } from "@/components/sections/agent-tui";
 import { cn } from "@/lib/utils";
+import type { SupportedAgent } from "@/lib/site";
 import { useInView } from "@/lib/use-in-view";
 
 // The carousel API, named off the hook so the core package stays a transitive
@@ -62,40 +63,46 @@ function cylinderTransform(
   )}px)`;
 }
 
-// One entry per agent capture in public/agent/ (all 1280×1236 @2x).
+// One entry per agent that has a panel. The panel beside a name is drawn, not
+// captured — see agent-tui.tsx. `satisfies` ties every name back to
+// `supportedAgents`, so a name here that the marquee doesn't claim is a build
+// error rather than a discrepancy nobody notices.
 const agents = [
   {
     name: "Claude Code",
     blurb:
-      "Anthropic's agentic coding CLI. Session status flows into the sidebar as it works.",
-    src: "/agent/claude.png",
+      "Anthropic's agentic coding CLI. Termio ships it a skill, so it can list, spawn, and answer the sessions running beside it — the panel here is that skill running.",
   },
   {
     name: "Codex",
-    blurb: "OpenAI's coding agent, with your plan usage tracked in Settings.",
-    src: "/agent/codex.png",
+    blurb: "OpenAI's coding agent. Slash commands and pickers draw in a real PTY, so `/model` behaves exactly as it does anywhere else — and your plan usage shows in Settings.",
   },
   {
     name: "OpenCode",
-    blurb: "The open-source terminal agent — full TUI, rendered natively.",
-    src: "/agent/opencode.png",
+    blurb: "The open-source terminal agent. Its whole TUI renders natively, MCP servers and status bar included — nothing is re-implemented.",
   },
   {
     name: "Amp",
     blurb: "Sourcegraph's agent for big, multi-file changes.",
-    src: "/agent/amp.png",
   },
   {
     name: "Kimi",
     blurb: "Moonshot AI's Kimi CLI, launched in one tap.",
-    src: "/agent/kimi.png",
   },
   {
     name: "Pi",
-    blurb: "Pi Agent — tracked in the sidebar like everything else.",
-    src: "/agent/pi.png",
+    blurb: "Pi Agent, loading its own skills and extensions at launch and reporting status back like everything else.",
   },
-] as const;
+  {
+    name: "Crush",
+    blurb:
+      "Charm's terminal agent, which lists the LSPs, MCP servers and skills it loaded for the repo.",
+  },
+  {
+    name: "Grok",
+    blurb: "xAI's CLI, with its own worktree and session resume on launch.",
+  },
+] as const satisfies readonly { name: SupportedAgent; blurb: string }[];
 
 // Agent showcase: the sentence sits on its own line, and under it a drum of
 // agent names rolls on where the sentence left off — the focused name sharp,
@@ -111,9 +118,9 @@ export function AgentShowcase() {
   const [paused, setPaused] = useState(false);
   const [rolling, setRolling] = useState(false);
   const reducedMotion = useRef(false);
-  // The screenshot for each agent, positioned frame by frame from the same
+  // Each agent's terminal UI, positioned frame by frame from the same
   // measurement that drives the names.
-  const frames = useRef<(HTMLImageElement | null)[]>([]);
+  const frames = useRef<(HTMLDivElement | null)[]>([]);
   const { ref: viewRef, inView } = useInView<HTMLDivElement>();
 
   const [emblaRef, emblaApi] = useEmblaCarousel(
@@ -358,41 +365,36 @@ export function AgentShowcase() {
                 </div>
               </div>
 
-              {/* Right: the filmstrip. Every capture is mounted and stacked in
-                  the same window; `applyFalloff` puts each one a full frame
-                  from the last, so the strip runs past the window as the drum
-                  turns. The @container wrapper lets the corner radius scale
-                  with the rendered image width (cqw), like the hero carousel. */}
+              {/* Right: the filmstrip. Every agent's terminal UI is mounted and
+                  stacked in the same window; `applyFalloff` puts each one a
+                  full frame from the last, so the strip runs past the window as
+                  the drum turns. The @container wrapper is what the panels size
+                  themselves against — they scale in `cqw`, so a drawn TUI keeps
+                  a screenshot's one virtue of scaling as a single piece. */}
               <div className="@container">
                 <div
                   role="region"
                   aria-roledescription="carousel"
-                  aria-label="Agent screenshots"
+                  aria-label="Agent terminal UIs"
                   className={cn(
-                    "relative overflow-hidden rounded-[clamp(6px,1cqw,12px)] transition-opacity duration-500",
+                    "relative overflow-hidden rounded-[clamp(10px,2.2cqw,22px)] transition-opacity duration-500",
                     rolling ? "opacity-100" : "opacity-0",
                   )}
                   style={{ aspectRatio: "1280 / 1236" }}
                 >
                   {agents.map((agent, i) => (
-                    <Image
-                      key={agent.src}
+                    <div
+                      key={agent.name}
                       ref={(node) => {
                         frames.current[i] = node;
                       }}
-                      src={agent.src}
-                      width={1280}
-                      height={1236}
-                      alt={`${agent.name} running in Termio`}
-                      loading="lazy"
-                      // The captures are 1280px wide but render in the ~32rem
-                      // right column of the card; without `sizes` the browser
-                      // downloads the 3840px rendition.
-                      sizes="(min-width: 64rem) 32rem, calc(100vw - 5.5rem)"
-                      draggable={false}
+                      role="img"
+                      aria-label={`${agent.name} running in Termio`}
                       aria-hidden={i !== active}
-                      className="pointer-events-none absolute inset-0 h-full w-full object-cover will-change-[opacity,filter,transform] motion-reduce:transition-opacity motion-reduce:duration-300"
-                    />
+                      className="pointer-events-none absolute inset-0 h-full w-full will-change-[opacity,filter,transform] motion-reduce:transition-opacity motion-reduce:duration-300"
+                    >
+                      <AgentTui name={agent.name} />
+                    </div>
                   ))}
                 </div>
               </div>

--- a/web/landing/src/components/sections/agent-tui.tsx
+++ b/web/landing/src/components/sections/agent-tui.tsx
@@ -1,0 +1,753 @@
+import { cn } from "@/lib/utils";
+
+// Each supported agent's terminal UI, drawn in DOM instead of screenshotted.
+//
+// Every layout here was taken from a real capture of that CLI running inside
+// Termio (the files these replaced, public/agent/*.png): the banner blocks, the
+// key/value headers, the hint rows and the status lines are what each agent
+// actually prints on launch — the same reason the orchestration demo draws the
+// app's chrome rather than photographing it.
+//
+// Two things are deliberately not verbatim. Paths and session ids are
+// genericised (a capture carries the author's home directory), and dated
+// promos are dropped — a banner announcing a model launch is stale the week
+// after it ships, and these panels are permanent.
+//
+// Sizing: the whole panel scales off the container's width in `cqw`, with every
+// child in `em`. The showcase renders these at anything from a phone column to
+// half a desktop card, and a screenshot's one virtue — scaling as one piece —
+// had to survive the port.
+
+const PATH = "~/Documents/GitHub/termio";
+
+// OpenCode's launch wordmark, transcribed character for character from the
+// running CLI. The lone `▄` on the first row is the `d`'s ascender.
+const OPENCODE_MARK = [
+  "                                 ▄",
+  "█▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█",
+  "█  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀",
+  "▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀",
+];
+
+/* ---------------------------------------------------------------- shell --- */
+
+// Termio's own window around the agent, matching the captures: traffic lights,
+// the sidebar toggle, the folder-over-branch title block, the inspector toggle.
+function AgentWindow({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-[clamp(10px,2.2cqw,22px)] bg-[#1c1c1e] font-mono text-[#e6e6ea]",
+        className,
+      )}
+      style={{ fontSize: "2.35cqw", lineHeight: 1.55 }}
+    >
+      <div className="flex shrink-0 items-center gap-[1em] px-[1.1em] py-[0.9em]">
+        <div className="flex shrink-0 items-center gap-[0.5em]">
+          <span className="size-[0.85em] rounded-full bg-brand-red" />
+          <span className="size-[0.85em] rounded-full bg-brand-amber" />
+          <span className="size-[0.85em] rounded-full bg-brand-green" />
+        </div>
+        <PaneGlyph className="ml-[0.4em] w-[1.5em] text-white/45" />
+        <div className="ml-[0.6em] min-w-0 leading-tight">
+          <p className="truncate text-[0.95em] font-semibold text-white">
+            termio
+          </p>
+          <p className="truncate text-[0.8em] text-white/45">main</p>
+        </div>
+        <PaneGlyph className="ml-auto w-[1.5em] shrink-0 text-white/45" />
+      </div>
+      <div className="min-h-0 flex-1 px-[1.4em] pb-[1em]">{children}</div>
+    </div>
+  );
+}
+
+function PaneGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      className={cn("shrink-0", className)}
+      style={{ aspectRatio: "1 / 1" }}
+    >
+      <rect x="3" y="5" width="18" height="14" rx="3" />
+      <path d="M10 5v14" />
+    </svg>
+  );
+}
+
+// The rule-bounded input row most of these CLIs draw at the bottom.
+function RuledInput({
+  char = "❯",
+  rule = "rgba(255,255,255,0.22)",
+}: {
+  char?: string;
+  rule?: string;
+}) {
+  return (
+    <div
+      className="mt-auto border-y py-[0.5em]"
+      style={{ borderColor: rule }}
+    >
+      <p className="flex items-center gap-[0.6em] text-white/70">
+        <span>{char}</span>
+        <span className="inline-block h-[1.05em] w-[0.6em] bg-white/80" />
+      </p>
+    </div>
+  );
+}
+
+// A boxed input, for the agents that draw a border around theirs.
+function BoxedInput({
+  char,
+  placeholder,
+  border = "rgba(255,255,255,0.22)",
+  children,
+}: {
+  char?: string;
+  placeholder?: string;
+  border?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      className="rounded-[0.35em] border px-[0.8em] py-[0.55em]"
+      style={{ borderColor: border }}
+    >
+      {children ?? (
+        <p className="flex items-center gap-[0.6em] text-white/55">
+          {char && <span>{char}</span>}
+          {placeholder ? (
+            <span>{placeholder}</span>
+          ) : (
+            <span className="inline-block h-[1.05em] w-[0.6em] bg-white/70" />
+          )}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// Terminal art — block letters, braille — laid out a cell at a time rather than
+// as lines of text. A `<pre>` would hold together only where the mono face
+// covers those blocks itself; where it falls back, the substituted glyphs carry
+// their own advance width and the picture shears. A fixed grid can't.
+function CharGrid({
+  lines,
+  cell = 0.6,
+  className,
+}: {
+  lines: readonly string[];
+  /**
+   * Cell width in `em`, against the mono face's own ~0.6em advance. The row
+   * height and the glyph scale off it together, so a larger cell draws larger
+   * art rather than the same art spaced further apart.
+   */
+  cell?: number;
+  className?: string;
+}) {
+  const columns = Math.max(...lines.map((line) => [...line].length));
+  return (
+    <span
+      aria-hidden
+      className={cn("grid", className)}
+      style={{
+        // Sized in the grid's own `em`, so the cell stays one mono advance
+        // wide and one terminal row tall whatever scale it is drawn at.
+        fontSize: `${cell / 0.6}em`,
+        gridTemplateColumns: `repeat(${columns}, 0.6em)`,
+        gridAutoRows: "1.02em",
+        lineHeight: 1,
+      }}
+    >
+      {lines.flatMap((line, y) =>
+        [...line].map((char, x) => <span key={`${x}-${y}`}>{char}</span>),
+      )}
+    </span>
+  );
+}
+
+/* ----------------------------------------------------------------- claude --- */
+
+// Claude Code leads with its pixel mark beside a three-line header, and closes
+// on the permission-mode footer.
+function ClaudeTui() {
+  return (
+    <AgentWindow>
+      <div className="flex h-full flex-col">
+        <div className="flex items-start gap-[1.1em] pt-[0.4em]">
+          <pre className="shrink-0 text-[0.95em] leading-[1.15] text-[#c37b62]">
+            {"▐▛███▜▌\n▝▜█████▛▘\n  ▘▘ ▝▝"}
+          </pre>
+          <div className="min-w-0">
+            <p>
+              <span className="font-semibold text-white">Claude Code</span>{" "}
+              <span className="text-white/40">v2.1.220</span>
+            </p>
+            <p className="truncate text-white/55">Opus 5 · Claude Max</p>
+            <p className="truncate text-white/40">{PATH}</p>
+          </div>
+        </div>
+
+        <p className="mt-[1em] truncate">
+          <span className="text-white/45">❯ </span>
+          <span className="text-white/85">/termio list the sibling sessions</span>
+        </p>
+        <p className="mt-[0.7em] truncate text-white/70">
+          <span className="text-[#c37b62]">⏺</span> Running 1 shell command…
+        </p>
+        <p className="truncate pl-[1.2em] text-white/40">
+          ⎿ $ termio sessions list --json
+        </p>
+        <p className="mt-[0.6em] text-white/55">Idle (3)</p>
+        {[
+          ["7c1f2a4e…", "codex", "implement PLAN.md"],
+          ["5a77c0e2…", "deepseek", "review the diff"],
+          ["d4e6b209…", "grok", "security scan"],
+        ].map(([id, agent, title]) => (
+          <p key={id} className="truncate text-white/45">
+            <span className="text-white/30">- </span>
+            {id} <span className="text-white/60">{agent}</span> — {title}
+          </p>
+        ))}
+        <p className="mt-[0.6em] truncate text-white/50">
+          <span className="text-[#c37b62]">✻</span> Cooked for 11s
+        </p>
+
+        <RuledInput />
+        <p className="pt-[0.5em] text-[0.95em] text-white/35">
+          ⏸ manual mode on · ? for shortcuts · ← for agents
+        </p>
+      </div>
+    </AgentWindow>
+  );
+}
+
+/* ------------------------------------------------------------------ codex --- */
+
+// Codex opens with a bordered header box, a tip, a usage note, and the
+// highlighted composer over its model/cwd status line.
+function CodexTui() {
+  const MODELS = [
+    ["1.", "gpt-5.6-sol (current)", "Latest frontier agentic coding model."],
+    ["2.", "gpt-5.6-terra", "Balanced model for everyday work."],
+    ["3.", "gpt-5.6-luna", "Fast and affordable coding model."],
+    ["4.", "gpt-5.5", "Frontier model for complex work."],
+  ];
+  return (
+    <AgentWindow>
+      <div className="flex h-full flex-col pt-[0.5em]">
+        <div className="rounded-[0.3em] border border-white/[0.18] px-[0.9em] py-[0.7em]">
+          <p className="truncate">
+            <span className="text-white/60">{">_"}</span>{" "}
+            <span className="font-semibold text-white">OpenAI Codex</span>{" "}
+            <span className="text-white/40">(v0.147.0)</span>
+          </p>
+          <p className="mt-[0.5em] flex gap-[0.6em] truncate">
+            <span className="w-[5.2em] shrink-0 text-white/40">model:</span>
+            <span className="truncate">
+              <span className="text-white">gpt-5.6-sol xhigh</span>{" "}
+              <span className="text-[#7ec9a6]">/model</span>{" "}
+              <span className="text-white/40">to change</span>
+            </span>
+          </p>
+        </div>
+
+        <p className="mt-[1em] text-white/85">Select Model and Effort</p>
+        <div className="mt-[0.5em]">
+          {MODELS.map(([n, name, desc], i) => (
+            <p key={n} className="truncate">
+              <span className={i === 0 ? "text-[#7ec9a6]" : "text-transparent"}>
+                ›{" "}
+              </span>
+              <span className={i === 0 ? "text-white" : "text-white/70"}>
+                {n} {name}
+              </span>{" "}
+              <span className="text-white/35">{desc}</span>
+            </p>
+          ))}
+        </div>
+        <p className="mt-[0.7em] truncate text-white/35">
+          Press enter to confirm or esc to go back
+        </p>
+
+        <p className="mt-auto truncate text-[0.92em] text-[#7ec9a6]">
+          gpt-5.6-sol xhigh fast{" "}
+          <span className="text-[#7ec9a6]/60">· {PATH}</span>
+        </p>
+      </div>
+    </AgentWindow>
+  );
+}
+
+/* --------------------------------------------------------------- opencode --- */
+
+// OpenCode centres its block wordmark over a teal-edged composer, with the
+// hint row and status bar it draws underneath.
+function OpenCodeTui() {
+  return (
+    <AgentWindow>
+      <div className="flex h-full flex-col">
+        <div className="flex flex-1 items-center justify-center">
+          {/* The wordmark is block characters, not type — this is the exact art
+              OpenCode prints, down to the ascender floating over the `d`. Each
+              row is split at the halfway letter because the CLI draws `open`
+              dim and `code` bright. */}
+          <pre
+            className="leading-[1.05]"
+            style={{ fontSize: "0.86em" }}
+            aria-hidden
+          >
+            {OPENCODE_MARK.map((row, i) => (
+              <div key={i}>
+                <span className="text-white/40">{row.slice(0, 19)}</span>
+                <span className="text-white/90">{row.slice(19)}</span>
+              </div>
+            ))}
+          </pre>
+        </div>
+        <div className="border-l-[0.18em] border-[#4fd6c9] bg-white/[0.06] px-[0.9em] py-[0.7em]">
+          <p className="truncate text-white/45">
+            Ask anything… <span className="text-white/60">&quot;Fix broken tests&quot;</span>
+          </p>
+          <p className="mt-[0.6em] truncate">
+            <span className="text-[#4fd6c9]">Sisyphus</span>
+            <span className="text-white/50"> - </span>
+            <span className="text-[#8b9cf7]">Ultraworker</span>
+            <span className="text-white/35"> · </span>
+            <span className="text-white/85">GPT-5.5</span>{" "}
+            <span className="text-white/40">OpenAI</span>
+            <span className="text-white/35"> · </span>
+            <span className="text-[#e0a458]">medium</span>
+          </p>
+        </div>
+        <p className="mt-[0.5em] truncate text-right text-[0.92em]">
+          <span className="text-white/85">tab</span>{" "}
+          <span className="text-white/40">agents</span>{" "}
+          <span className="ml-[0.6em] text-white/85">ctrl+p</span>{" "}
+          <span className="text-white/40">commands</span>
+        </p>
+        <p className="mt-auto truncate text-[0.92em] text-white/40">
+          <span className="text-[#e0a458]">•</span>{" "}
+          <span className="text-[#e0a458]">Tip</span> Add .md files to
+          .opencode/commands/ for reusable prompts
+        </p>
+        <p className="mt-[0.6em] flex items-center gap-[0.6em] truncate text-[0.9em] text-white/35">
+          <span className="truncate">{PATH}:main</span>
+          <span className="text-[#5fb47f]">⊙ 4 MCP</span>
+          <span className="ml-auto shrink-0">1.17.20</span>
+        </p>
+      </div>
+    </AgentWindow>
+  );
+}
+
+/* -------------------------------------------------------------------- amp --- */
+
+// Amp fills the pane with a dot-matrix sphere over a boxed composer that
+// carries its reasoning level and cwd on the border.
+function AmpTui() {
+  return (
+    <AgentWindow>
+      <div className="flex h-full flex-col">
+        <p className="pt-[0.6em] text-center text-[#b5c96a]">Welcome to Amp</p>
+        <div className="flex flex-1 items-center justify-center gap-[2em] overflow-hidden">
+          <AmpSphere />
+          {/* Amp lists its two entry points beside the mark on launch. */}
+          <div className="shrink-0 text-white/45">
+            <p>
+              <span className="text-white/75">ctrl+o</span> for commands
+            </p>
+            <p>
+              <span className="text-white/75">?</span> for shortcuts
+            </p>
+          </div>
+        </div>
+        <div className="relative mt-[0.8em]">
+          <div className="h-[3.2em] rounded-[0.25em] border border-white/25" />
+          <span className="absolute -top-[0.75em] right-[0.8em] bg-[#1c1c1e] px-[0.4em] text-[0.92em] text-[#6fcf97]">
+            medium
+          </span>
+          <span className="absolute -bottom-[0.75em] right-[0.8em] max-w-[90%] truncate bg-[#1c1c1e] px-[0.4em] text-[0.92em] text-white/45">
+            {PATH} (main)
+          </span>
+        </div>
+      </div>
+    </AgentWindow>
+  );
+}
+
+// The sphere, laid out deterministically: a dot per grid cell, sized and
+// dimmed by its distance from the centre so the matrix reads as a lit ball.
+// Deterministic on purpose — a random pattern would differ between the server
+// render and the client one.
+function AmpSphere() {
+  const COLUMNS = 34;
+  const ROWS = 19;
+  const cells = [];
+  for (let y = 0; y < ROWS; y++) {
+    for (let x = 0; x < COLUMNS; x++) {
+      const nx = (x - (COLUMNS - 1) / 2) / (COLUMNS / 2);
+      const ny = (y - (ROWS - 1) / 2) / (ROWS / 2);
+      const r = Math.sqrt(nx * nx + ny * ny);
+      if (r > 1) {
+        cells.push(<span key={`${x}-${y}`} />);
+        continue;
+      }
+      // Light falls from the upper left, so dots grow and brighten toward it.
+      const lit = Math.max(0, 1 - Math.hypot(nx + 0.45, ny + 0.5) / 1.5);
+      const size = 0.14 + lit * 0.24;
+      cells.push(
+        <span
+          key={`${x}-${y}`}
+          className="place-self-center rounded-full bg-[#b5c96a]"
+          style={{
+            width: `${size}em`,
+            height: `${size}em`,
+            opacity: 0.25 + lit * 0.75,
+          }}
+        />,
+      );
+    }
+  }
+  return (
+    <span
+      aria-hidden
+      className="grid"
+      style={{
+        gridTemplateColumns: `repeat(${COLUMNS}, 0.66em)`,
+        gridAutoRows: "0.66em",
+      }}
+    >
+      {cells}
+    </span>
+  );
+}
+
+/* ------------------------------------------------------------------- kimi --- */
+
+// Kimi Code draws a blue-bordered welcome card with a key/value block, then a
+// highlight line, its boxed composer, and a git-aware status line.
+function KimiTui() {
+  const ROWS = [
+    ["Directory:", PATH],
+    ["Session:", "session_723638cd-b2bf-4156"],
+    ["Model:", "kimi-for-coding"],
+    ["Version:", "0.23.4"],
+  ] as const;
+  return (
+    <AgentWindow>
+      <div className="flex h-full flex-col pt-[0.4em]">
+        <div className="rounded-[0.35em] border border-[#3b6fd4] px-[1em] py-[0.8em]">
+          <div className="flex items-center gap-[0.9em]">
+            <span
+              className="relative grid shrink-0 place-items-center rounded-[0.12em] bg-[#2d64d8]"
+              style={{ width: "2.2em", height: "1.6em" }}
+              aria-hidden
+            >
+              <span className="flex gap-[0.35em]">
+                <span className="block h-[0.42em] w-[0.2em] bg-white" />
+                <span className="block h-[0.42em] w-[0.2em] bg-white" />
+              </span>
+            </span>
+            <div className="min-w-0">
+              <p className="font-semibold text-[#5b8def]">
+                Welcome to Kimi Code!
+              </p>
+              <p className="truncate text-white/40">
+                Run <span className="text-white/60">/login</span> to get started.
+              </p>
+            </div>
+          </div>
+          <div className="mt-[0.7em] space-y-[0.05em]">
+            {ROWS.map(([key, value]) => (
+              <p key={key} className="flex gap-[0.6em] truncate">
+                <span className="w-[5.6em] shrink-0 text-white/40">{key}</span>
+                <span className="truncate text-white/80">{value}</span>
+              </p>
+            ))}
+          </div>
+        </div>
+        <p className="mt-[0.9em] text-white/85">Select platform</p>
+        <div className="mt-[0.4em]">
+          <p className="truncate">
+            <span className="text-[#5b8def]">❯ </span>
+            <span className="text-white">1. Moonshot</span>{" "}
+            <span className="text-white/35">kimi-for-coding</span>
+          </p>
+          <p className="truncate text-white/60">
+            <span className="text-transparent">❯ </span>2. [ Add New Platform ]
+          </p>
+        </div>
+
+        <div className="mt-auto">
+          <BoxedInput char=">" />
+          <p className="mt-[0.5em] flex gap-[0.7em] truncate text-[0.9em] text-white/35">
+            <span className="shrink-0 text-white/55">K2.7 Coding</span>
+            <span className="truncate">…/GitHub/termio main [+1060 -401]</span>
+          </p>
+          <p className="truncate text-right text-[0.9em] text-white/30">
+            context: 0.0% (0/262.1k)
+          </p>
+        </div>
+      </div>
+    </AgentWindow>
+  );
+}
+
+/* --------------------------------------------------------------------- pi --- */
+
+// Pi prints a dense startup block — key bindings, then the skills and
+// extensions it loaded — over a purple-ruled composer and a cost/model line.
+function PiTui() {
+  return (
+    <AgentWindow>
+      <div className="flex h-full flex-col pt-[0.5em]">
+        <p>
+          <span className="font-semibold text-[#5fc9c3]">pi</span>{" "}
+          <span className="text-white/40">v0.80.6</span>
+        </p>
+        <p className="text-white/40">
+          escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash
+        </p>
+        <p className="mt-[0.7em] text-white/55">
+          Pi can explain its own features and look up its docs.
+        </p>
+        <p className="mt-[0.7em] text-[#e0a458]">[Skills]</p>
+        <p className="truncate pl-[0.8em] text-white/60">
+          get-design-md, pdf, prompt-coach
+        </p>
+        <p className="mt-[0.5em] text-[#e0a458]">[Extensions]</p>
+        <p className="truncate pl-[0.8em] text-white/60">
+          pi-agent, muxy-notify.ts, pi-kimi-coder
+        </p>
+        <div className="mt-auto">
+          <RuledInput char="" rule="rgba(150,130,220,0.5)" />
+          <p className="mt-[0.4em] truncate text-[0.92em] text-white/45">
+            {PATH} (main)
+          </p>
+          <p className="flex gap-[0.8em] truncate text-[0.92em] text-white/35">
+            <span>↑8.3k ↓13 $0.042 (sub) 3.1%/272k</span>
+            <span className="ml-auto shrink-0 truncate">
+              (openai-codex) gpt-5.5 · high
+            </span>
+          </p>
+        </div>
+      </div>
+    </AgentWindow>
+  );
+}
+
+/* ------------------------------------------------------------------ crush --- */
+
+// Crush opens on Charm's hatched banner over a block wordmark, then the model
+// line and the three-column inventory of what it loaded for this repo — LSPs,
+// MCP servers, skills — above its composer and key hints.
+function CrushTui() {
+  // This repo's own skills, which is what Crush picks up from `skills/` here.
+  const SKILLS = [
+    "animation-vocabulary",
+    "app-screenshot-debug",
+    "apple-design",
+    "asc",
+    "bump-version",
+    "check-ghostty-update",
+    "conventional-commit",
+    "dia-source-analysis",
+  ];
+  return (
+    <AgentWindow>
+      <div className="flex h-full flex-col pt-[0.3em]">
+        <CrushBanner />
+        <p className="mt-[0.9em] truncate text-white/50">{PATH}</p>
+        <p className="mt-[0.9em] truncate">
+          <span className="text-white/35">◇ </span>
+          <span className="text-white/90">Claude Opus 5</span>{" "}
+          <span className="text-white/50">via AWS Bedrock US</span>
+        </p>
+        <p className="pl-[1.2em] text-white/35">Reasoning High</p>
+        {/* Crush gives the three columns equal thirds; the skill names are the
+            only ones long enough to care, so they get the slack. */}
+        <div className="mt-[1em] grid grid-cols-[1fr_1fr_1.45fr] gap-[0.6em]">
+          <p className="text-white/35">LSPs</p>
+          <p className="text-white/35">MCPs</p>
+          <p className="text-white/35">Skills</p>
+        </div>
+        <div className="mt-[0.9em] grid grid-cols-[1fr_1fr_1.45fr] gap-[0.6em]">
+          <p className="text-white/35">None</p>
+          <p className="text-white/35">None</p>
+          <div className="min-w-0">
+            {SKILLS.map((skill) => (
+              <p key={skill} className="truncate">
+                <span className="text-[#12c78f]">● </span>
+                <span className="text-white/50">{skill}</span>
+              </p>
+            ))}
+          </div>
+        </div>
+        <div className="mt-auto pt-[0.8em]">
+          <p className="truncate">
+            <span className="text-[#68ffd6]">&gt; </span>
+            <span className="text-white/35">Ready for instructions</span>
+          </p>
+          <p className="text-[#12c78f]">:::</p>
+          <p className="text-[#12c78f]">:::</p>
+          <p className="mt-[0.8em] truncate text-[0.92em]">
+            <span className="text-white/50">/ or ctrl+p</span>{" "}
+            <span className="text-white/35">commands</span>{" "}
+            <span className="text-white/20">•</span>{" "}
+            <span className="text-white/50">ctrl+m</span>{" "}
+            <span className="text-white/35">models</span>{" "}
+            <span className="text-white/20">•</span>{" "}
+            <span className="text-white/50">shift+enter</span>{" "}
+            <span className="text-white/35">newline</span>
+          </p>
+        </div>
+      </div>
+    </AgentWindow>
+  );
+}
+
+// The banner is three columns that share four rows: a fixed hatch block, the
+// wordmark, and a hatch fill that runs off the right edge. Crush stretches one
+// letter of the wordmark to whatever width it is given; these are the letter
+// forms at their natural five cells.
+const CRUSH_WORDMARK = [
+  "▄▀▀▀▀ █▀▀▀▄ █   █ ▄▀▀▀▀ █   █",
+  "█     █▀▀▀▄ █   █ ▀▀▀▀█ █▀▀▀█",
+  " ▀▀▀▀ ▀   ▀  ▀▀▀  ▀▀▀▀  ▀   ▀",
+];
+
+function CrushBanner() {
+  const hatch = "╱".repeat(6);
+  const fill = "╱".repeat(48);
+  return (
+    <div className="flex gap-[0.6em] overflow-hidden" style={{ lineHeight: 1 }}>
+      <div className="shrink-0 text-[#6b50ff]">
+        {[0, 1, 2, 3].map((row) => (
+          <p key={row} style={{ height: "1.02em" }}>
+            {hatch}
+          </p>
+        ))}
+      </div>
+      <div className="shrink-0">
+        <p
+          className="flex justify-between gap-[1.5em]"
+          style={{ height: "1.02em" }}
+        >
+          <span className="text-[#ff60ff]">Charm™</span>
+          <span className="text-[#6b50ff]">v0.89.0</span>
+        </p>
+        {/* One gradient across the whole wordmark, clipped to the glyphs, the
+            way Crush ramps magenta to violet from the C to the H. */}
+        <CharGrid
+          lines={CRUSH_WORDMARK}
+          className="bg-gradient-to-r from-[#ff60ff] to-[#6b50ff] bg-clip-text text-transparent"
+        />
+      </div>
+      <div className="min-w-0 flex-1 overflow-hidden text-[#6b50ff]">
+        {[0, 1, 2, 3].map((row) => (
+          <p
+            key={row}
+            className="whitespace-nowrap"
+            style={{ height: "1.02em" }}
+          >
+            {fill}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------- grok --- */
+
+// Grok's launch screen: the branch and directory it opened in, its braille
+// mark, the four things it can do before a prompt, a rotating tip, and a boxed
+// composer carrying the model and approval mode on its lower border.
+const GROK_MARK = [
+  "⠀⠀⠀⠀⠀⠀⣀⣀⡀⠀⠀⠀⢀⠄",
+  "⠀⠀⠀⣠⣾⠿⠛⠛⠛⠛⢀⡴⠁⠀",
+  "⠀⠀⣼⡟⠁⠀⠀⠀⢀⡴⠻⣿⡀⠀",
+  "⠀⠀⣿⡇⠀⠀⠀⠔⠁⠀⠀⣿⡇⠀",
+  "⠀⠀⢹⣷⠀⠀⠀⠀⠀⢀⣴⡿⠀⠀",
+  "⠀⢀⠞⠁⠠⢶⣶⣶⣶⠿⠋⠀⠀⠀",
+  "⠐⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀",
+];
+
+const GROK_MENU = [
+  ["New worktree", "ctrl+w"],
+  ["Resume session", "ctrl+s"],
+  ["Changelog", ""],
+  ["Quit", "ctrl+q"],
+] as const;
+
+function GrokTui() {
+  return (
+    <AgentWindow>
+      <div className="flex h-full flex-col pt-[0.4em]">
+        <p className="flex gap-[1.2em] truncate">
+          <span className="shrink-0 text-white/85">main</span>
+          <span className="truncate text-white/35">{PATH}</span>
+        </p>
+        <div className="mt-[1.2em] flex justify-center text-white/45">
+          <CharGrid lines={GROK_MARK} cell={0.74} />
+        </div>
+        <div className="mt-[1.4em] px-[1.4em]">
+          {GROK_MENU.map(([label, key]) => (
+            <p key={label} className="flex gap-[1em] truncate">
+              <span className="truncate text-white/85">{label}</span>
+              <span className="ml-auto shrink-0 text-white/40">{key}</span>
+            </p>
+          ))}
+        </div>
+        {/* Grok leaves the middle of the screen empty and stacks the tip on
+            top of the composer, so the whole block hangs off the bottom. */}
+        <div className="mt-auto">
+          <p className="text-pretty text-white/40">
+            <span className="font-semibold">Tip:</span> Run{" "}
+            <span className="text-white/70">/compact [context]</span> when chat
+            gets long.
+          </p>
+          <div className="relative mt-[1.4em]">
+            <BoxedInput char="❯" />
+            <span className="absolute -bottom-[0.75em] right-[0.9em] max-w-[90%] truncate bg-[#1c1c1e] px-[0.4em] text-[0.92em] text-white/45">
+              Grok 4.6 (high){" "}
+              <span className="text-white/30">·</span> always-approve
+            </span>
+          </div>
+          <p className="mt-[1.6em] truncate text-right">
+            <span className="text-white/70">Grok Build</span>{" "}
+            <span className="text-white/35">1.0.5 [stable]</span>
+          </p>
+        </div>
+      </div>
+    </AgentWindow>
+  );
+}
+
+/* ------------------------------------------------------------------------ */
+
+const BY_AGENT: Record<string, () => React.ReactElement> = {
+  "Claude Code": ClaudeTui,
+  Codex: CodexTui,
+  OpenCode: OpenCodeTui,
+  Amp: AmpTui,
+  Kimi: KimiTui,
+  Pi: PiTui,
+  Crush: CrushTui,
+  Grok: GrokTui,
+};
+
+export function AgentTui({ name }: { name: string }) {
+  const Tui = BY_AGENT[name];
+  return Tui ? <Tui /> : null;
+}

--- a/web/landing/src/components/sections/feature-grid.tsx
+++ b/web/landing/src/components/sections/feature-grid.tsx
@@ -1,45 +1,54 @@
-import Image from "next/image";
 import { Reveal } from "@/components/reveal";
 import { SectionLabel } from "@/components/section-label";
+import {
+  InspectorMock,
+  MarkdownMock,
+  PaletteMock,
+  RemoteMock,
+  SidebarMock,
+  WorktreeMock,
+} from "@/components/sections/feature-mocks";
 
-// One entry per capture in public/feature/ (native dimensions vary, so each
-// card carries its own intrinsic size and the row stretches to the taller one).
+// Six cards, each carrying a small animated mock of the surface it describes
+// (see feature-mocks.tsx) rather than a screenshot — the same DOM-drawn app
+// chrome the orchestration demo uses, so the whole page reads as one product
+// rather than a page about one.
 const features = [
   {
-    title: "Knows when an agent needs you",
+    title: "A fleet you can read",
     blurb:
-      "Session dots show working, idle, or needs-you, aggregated into a menu-bar tray — calm while agents work, ringing the moment one is blocked on you.",
-    src: "/feature/tray.png",
-    alt: "The Termio menu-bar tray listing sessions grouped by project",
-    width: 870,
-    height: 700,
+      "Every session reports a live status — working, finished, or blocked on you — and the same three states aggregate into the menu-bar tray.",
+    Mock: SidebarMock,
   },
   {
     title: "Command palette",
     blurb:
-      "Jump to any session, project, or action from one search box — themes too, previewed live as you browse, Enter to keep or Esc to revert.",
-    src: "/feature/pallette.png",
-    alt: "The Termio command palette over a terminal session",
-    width: 1120,
-    height: 800,
+      "⇧⌘P runs any action, and Open Quickly jumps to any session, project, or file. Themes preview live as you browse them — Enter keeps, Esc puts it back.",
+    Mock: PaletteMock,
   },
   {
-    title: "Usage at a glance",
+    title: "Files beside the terminal",
     blurb:
-      "Your Claude and Codex plan limits in Settings, read locally from your own credentials — no proxy, no account.",
-    src: "/feature/usage.png",
-    alt: "Claude and Codex usage meters in Termio's settings",
-    width: 1150,
-    height: 918,
+      "Browse the project, open files in a syntax-highlighted editor, read the git diff, search contents — a side panel that never pulls you out of the terminal.",
+    Mock: InspectorMock,
   },
   {
-    title: "Native appearance",
+    title: "Markdown you can actually read",
     blurb:
-      "Light, dark, and a glass look that follows the system, with hundreds of built-in terminal themes or your own. A real Mac app, down to the chrome.",
-    src: "/feature/appearance.png",
-    alt: "Termio's appearance settings with light, dark, and glass modes",
-    width: 1160,
-    height: 926,
+      "Open a README or a plan and Termio renders it — GFM tables, task lists, math, Mermaid diagrams — in your terminal theme, beside the agent writing it.",
+    Mock: MarkdownMock,
+  },
+  {
+    title: "Your other machines",
+    blurb:
+      "Termio runs sessions on the hosts in your own ~/.ssh/config, each wearing its machine's mark. System OpenSSH does the connecting — no embedded client, no relay.",
+    Mock: RemoteMock,
+  },
+  {
+    title: "A worktree per agent",
+    blurb:
+      "Worktrees are read straight from git and nested under the project, so two agents can work the same repo without ever touching each other's files.",
+    Mock: WorktreeMock,
   },
 ] as const;
 
@@ -51,7 +60,7 @@ export function FeatureGrid() {
         <Reveal className="flex flex-col items-center text-center">
           <SectionLabel accent="muted">What&apos;s inside</SectionLabel>
           <h2 className="mt-4 text-balance text-3xl font-medium leading-[1.1] tracking-tight text-foreground sm:text-[44px]">
-            Built for watching agents work
+            Built for agentic coding
           </h2>
           <p className="mt-5 max-w-lg text-balance text-base leading-relaxed text-muted-foreground">
             Several agents going at once, most of them fine without you, one of
@@ -59,33 +68,22 @@ export function FeatureGrid() {
           </p>
         </Reveal>
 
-        <div className="mt-12 grid gap-5 sm:grid-cols-2 sm:gap-6">
+        <div className="mt-12 grid gap-5 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
           {features.map((feature, i) => (
             <Reveal
-              key={feature.src}
+              key={feature.title}
               as="article"
-              delayMs={(i % 2) * 80}
-              className="flex flex-col rounded-3xl bg-card p-6 sm:p-8"
+              delayMs={(i % 3) * 80}
+              className="flex flex-col rounded-3xl bg-card p-6"
             >
-              <h3 className="text-xl font-medium tracking-tight text-foreground">
+              <h3 className="text-lg font-medium tracking-tight text-foreground">
                 {feature.title}
               </h3>
-              <p className="mt-2 max-w-md text-pretty text-sm leading-relaxed text-muted-foreground">
+              <p className="mt-2 text-pretty text-sm leading-relaxed text-muted-foreground">
                 {feature.blurb}
               </p>
               <div className="mt-auto pt-6">
-                <Image
-                  src={feature.src}
-                  width={feature.width}
-                  height={feature.height}
-                  alt={feature.alt}
-                  loading="lazy"
-                  // The captures render inside a ~32rem card column; without
-                  // `sizes` the browser downloads the full-width rendition.
-                  sizes="(min-width: 40rem) 32rem, calc(100vw - 5.5rem)"
-                  draggable={false}
-                  className="w-full rounded-xl"
-                />
+                <feature.Mock />
               </div>
             </Reveal>
           ))}
@@ -93,9 +91,9 @@ export function FeatureGrid() {
 
         <Reveal delayMs={80}>
           <p className="mx-auto mt-10 max-w-3xl text-balance text-center text-sm leading-relaxed text-muted-foreground">
-            Also in the box: git worktrees nested under each project, a
-            read-only git pane with unified diffs, a click-to-edit file editor,
-            and Ghostty-style split panes.
+            Also in the box: your Claude and Codex plan limits read from your own
+            credentials, hundreds of terminal themes with light, dark, and glass
+            window looks, and Ghostty-style split panes.
           </p>
         </Reveal>
       </div>

--- a/web/landing/src/components/sections/feature-mocks.tsx
+++ b/web/landing/src/components/sections/feature-mocks.tsx
@@ -1,0 +1,391 @@
+import { AgentIcon } from "@/components/agent-icons";
+import {
+  BranchGlyph,
+  DONE,
+  FolderGlyph,
+  MockWindow,
+  NEEDS_YOU,
+  ServerGlyph,
+  TrafficLights,
+  WorkingIndicator,
+} from "@/components/app-chrome";
+import { cn } from "@/lib/utils";
+
+// One small animated mock per feature card. Each is the real surface drawn in
+// DOM — the sidebar, the palette, the inspector, the Markdown reader, the SSH
+// host list, the worktree tree — not a screenshot and not a diagram.
+//
+// The motion is pure CSS (see the `mock-*` keyframes in globals.css): no timers,
+// no React state, nothing re-rendering per frame, and every loop is compositor
+// work (opacity / transform / color). Six of these share a page with the
+// orchestration demo, so none of them may cost a render.
+
+const ROW = "flex items-center gap-1.5 rounded-md px-1.5 py-1 text-[10px]";
+
+/* ------------------------------------------------------------ 1. sidebar --- */
+
+// Every session's status in one column. The three states cycle on staggered
+// delays so the card shows the whole language — spinner, green ring, orange
+// ring — without anything having to happen on a timer.
+const FLEET = [
+  { agent: "Claude Code", title: "ship v0.22.0", phase: 0 },
+  { agent: "Codex", title: "implement PLAN.md", phase: 1 },
+  { agent: "DeepSeek", title: "review the diff", phase: 2 },
+  { agent: "Grok", title: "security scan", phase: 3 },
+] as const;
+
+export function SidebarMock() {
+  return (
+    <MockWindow className="h-[9.5rem] flex-col">
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        <TrafficLights size={7} />
+      </div>
+      <div className="px-2">
+        <div className="flex items-center gap-1.5 px-1.5 py-1 text-[10px] text-foreground/80">
+          <FolderGlyph className="size-3 text-muted-foreground" />
+          <span>termio</span>
+        </div>
+        <ul className="flex flex-col">
+          {FLEET.map((session, i) => (
+            <li
+              key={session.title}
+              className={cn(ROW, "pl-5", i === 1 && "bg-white/[0.08]")}
+            >
+              <span className="relative grid size-3.5 shrink-0 place-items-center">
+                {/* Both marks are always mounted and cross-faded by the cycle,
+                    so a row swapping to the spinner costs no layout. */}
+                <span
+                  className="mock-status-spinner absolute"
+                  style={{ animationDelay: `${session.phase * -1.5}s` }}
+                >
+                  <WorkingIndicator size={11} />
+                </span>
+                <span
+                  className="mock-status-mark"
+                  style={{ animationDelay: `${session.phase * -1.5}s` }}
+                >
+                  <AgentIcon name={session.agent} size={11} color />
+                </span>
+                <span
+                  className="mock-status-ring pointer-events-none absolute size-[17px] rounded-full border-[1.5px]"
+                  style={{ animationDelay: `${session.phase * -1.5}s` }}
+                />
+              </span>
+              <span className="truncate text-foreground/80">
+                {session.title}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </MockWindow>
+  );
+}
+
+/* ---------------------------------------------------- 2. command palette --- */
+
+// ⇧⌘P over a running session. The query types itself, the selection walks the
+// results, and the terminal behind it repaints as each theme is highlighted —
+// the palette's live preview, which is the part that is hard to photograph.
+const THEMES = ["Tokyo Night", "Catppuccin Mocha", "Rosé Pine"] as const;
+
+export function PaletteMock() {
+  return (
+    <MockWindow className="mock-theme relative h-[9.5rem] flex-col">
+      {/* The session underneath, tinted by whichever theme is highlighted. */}
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        <TrafficLights size={7} />
+      </div>
+      <div className="px-3 font-mono text-[9px] leading-[1.7]">
+        <p className="mock-theme-ink">$ swift build</p>
+        <p className="mock-theme-ink opacity-70">Compiling termio…</p>
+      </div>
+
+      {/* The palette itself, floating over the session. */}
+      <div className="absolute inset-x-3 top-11 rounded-lg border border-white/[0.14] bg-[#16161b]/95 shadow-[0_12px_28px_-12px_rgba(0,0,0,0.9)] backdrop-blur-md">
+        <div className="flex items-center gap-1.5 border-b border-white/[0.08] px-2 py-1.5">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            className="size-2.5 shrink-0 text-muted-foreground"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
+          <span className="mock-type overflow-hidden whitespace-nowrap text-[10px] text-foreground/90">
+            theme
+          </span>
+          <span className="demo-cursor -ml-1 text-[10px] text-foreground/60">
+            ▏
+          </span>
+        </div>
+        <ul className="p-1">
+          {THEMES.map((theme, i) => (
+            <li
+              key={theme}
+              className={cn(ROW, "mock-option gap-2 py-[3px]")}
+              style={{ animationDelay: `${i * 1.6}s` }}
+            >
+              <span className="size-2 shrink-0 rounded-[3px] bg-current opacity-70" />
+              <span className="truncate text-foreground/85">{theme}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </MockWindow>
+  );
+}
+
+/* ---------------------------------------------------------- 3. inspector --- */
+
+// Files beside the terminal: the tree on the left, the file open on the right.
+// The selection walks the tree and the editor repaints with it.
+const TREE: readonly { name: string; folder?: boolean }[] = [
+  { name: "Sources", folder: true },
+  { name: "TokenStore.swift" },
+  { name: "Models.swift" },
+  { name: "PLAN.md" },
+];
+
+export function InspectorMock() {
+  return (
+    <MockWindow className="h-[9.5rem]">
+      <div className="flex w-[47%] shrink-0 flex-col border-r border-white/[0.07]">
+        <div className="flex items-center gap-2 px-2.5 py-2">
+          <TrafficLights size={7} />
+        </div>
+        <ul className="px-1.5">
+          {TREE.map((entry, i) => (
+            <li
+              key={entry.name}
+              className={cn(
+                ROW,
+                "gap-1.5 text-[9px]",
+                !entry.folder && "mock-option pl-4",
+              )}
+              style={
+                entry.folder ? undefined : { animationDelay: `${(i - 1) * 1.6}s` }
+              }
+            >
+              {entry.folder ? (
+                <FolderGlyph className="size-3 text-muted-foreground" />
+              ) : (
+                <span className="size-3 shrink-0" />
+              )}
+              <span className="truncate text-foreground/75">{entry.name}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      {/* The file open beside it, syntax-highlighted. */}
+      <div className="min-w-0 flex-1 px-2.5 py-2 font-mono text-[9px] leading-[1.75]">
+        <p className="truncate">
+          <span className="text-[#c792ea]">struct</span>{" "}
+          <span className="text-[#82aaff]">TokenStore</span>
+          <span className="text-slate-400"> {"{"}</span>
+        </p>
+        <p className="truncate pl-2">
+          <span className="text-[#c792ea]">let</span>{" "}
+          <span className="text-slate-300">keychain</span>
+          <span className="text-slate-400">:</span>{" "}
+          <span className="text-[#82aaff]">Keychain</span>
+        </p>
+        <p className="truncate pl-2">
+          <span className="text-[#c792ea]">func</span>{" "}
+          <span className="text-[#82aaff]">refresh</span>
+          <span className="text-slate-400">() {"{"}</span>
+        </p>
+        <p className="truncate pl-4 text-slate-500">// …</p>
+        <p className="truncate pl-2 text-slate-400">{"}"}</p>
+        <p className="truncate text-slate-400">{"}"}</p>
+      </div>
+    </MockWindow>
+  );
+}
+
+/* ------------------------------------------------------------ 4. markdown --- */
+
+// A README opened in the reader. The pane cross-fades between the source and
+// what Termio renders from it — GFM tables and task lists included.
+export function MarkdownMock() {
+  return (
+    <MockWindow className="relative h-[9.5rem] flex-col">
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        <TrafficLights size={7} />
+        <span className="truncate text-[9px] text-muted-foreground">
+          PLAN.md
+        </span>
+      </div>
+
+      {/* Source. */}
+      <div className="mock-fade-a absolute inset-x-0 bottom-0 top-7 px-3 font-mono text-[9px] leading-[1.8]">
+        <p className="text-[#82aaff]"># Auth refactor</p>
+        <p className="text-slate-400">Move token storage into the keychain.</p>
+        <p className="mt-1 text-slate-300">
+          <span className="text-[#c792ea]">- [x]</span> audit call sites
+        </p>
+        <p className="text-slate-300">
+          <span className="text-[#c792ea]">- [ ]</span> migrate `TokenStore`
+        </p>
+        <p className="text-slate-300">
+          <span className="text-[#c792ea]">- [ ]</span> drop the shim
+        </p>
+      </div>
+
+      {/* Rendered. */}
+      <div className="mock-fade-b absolute inset-x-0 bottom-0 top-7 px-3 text-[10px] leading-[1.7]">
+        <p className="border-b border-white/[0.1] pb-0.5 text-[12px] font-semibold text-foreground">
+          Auth refactor
+        </p>
+        <p className="mt-1 text-[9px] text-muted-foreground">
+          Move token storage into the keychain.
+        </p>
+        <ul className="mt-1 space-y-[3px] text-[9px] text-foreground/85">
+          {[true, false, false].map((checked, i) => (
+            <li key={i} className="flex items-center gap-1.5">
+              <span
+                className={cn(
+                  "grid size-2.5 shrink-0 place-items-center rounded-[3px] border",
+                  checked
+                    ? "border-transparent text-[#08080a]"
+                    : "border-white/25",
+                )}
+                style={checked ? { backgroundColor: DONE } : undefined}
+              >
+                {checked && (
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={4}
+                    className="size-1.5"
+                  >
+                    <path d="m5 13 5 5L20 7" />
+                  </svg>
+                )}
+              </span>
+              <span className={cn(checked && "text-muted-foreground")}>
+                {["audit call sites", "migrate TokenStore", "drop the shim"][i]}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </MockWindow>
+  );
+}
+
+/* --------------------------------------------------------------- 5. remote --- */
+
+// Settings ▸ SSH, reading the hosts out of your own `~/.ssh/config`. The probe
+// runs down the list and each host comes back reachable.
+const HOSTS = [
+  { name: "devbox", tint: "#5ac8fa" },
+  { name: "vps-fra", tint: "#bf5af2" },
+  { name: "mac-mini", tint: "#ffd60a" },
+] as const;
+
+export function RemoteMock() {
+  return (
+    <MockWindow className="h-[9.5rem] flex-col">
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        <TrafficLights size={7} />
+        <span className="truncate text-[9px] text-muted-foreground">
+          ~/.ssh/config
+        </span>
+      </div>
+      <ul className="px-2">
+        {HOSTS.map((host, i) => (
+          <li key={host.name} className={cn(ROW, "gap-2 py-[5px]")}>
+            <ServerGlyph className="size-3 text-muted-foreground" />
+            <span className="truncate text-foreground/80">{host.name}</span>
+            <span
+              className="ml-auto size-1.5 shrink-0 rounded-full"
+              style={{ backgroundColor: host.tint }}
+            />
+            {/* The Test Connection probe: dots, then reachable. */}
+            <span className="relative grid w-11 shrink-0 place-items-center">
+              <span
+                className="mock-fade-a absolute text-[9px] text-muted-foreground"
+                style={{ animationDelay: `${i * 0.5}s` }}
+              >
+                ···
+              </span>
+              <span
+                className="mock-fade-b absolute whitespace-nowrap text-[9px]"
+                style={{ animationDelay: `${i * 0.5}s`, color: DONE }}
+              >
+                ✓ 24ms
+              </span>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </MockWindow>
+  );
+}
+
+/* ------------------------------------------------------------ 6. worktrees --- */
+
+// Worktrees read straight from git, nested under the project as branch folders
+// with their own sessions. Each one opens in turn.
+const WORKTREES: readonly {
+  branch: string;
+  session?: string;
+  status?: "working" | "done" | "needs-you";
+}[] = [
+  { branch: "feat/auth-refactor", session: "implement PLAN.md", status: "working" },
+  { branch: "fix/session-title", session: "reproduce the bug", status: "needs-you" },
+];
+
+export function WorktreeMock() {
+  return (
+    <MockWindow className="h-[9.5rem] flex-col">
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        <TrafficLights size={7} />
+      </div>
+      <div className="px-2">
+        <div className="flex items-center gap-1.5 px-1.5 py-1 text-[10px] text-foreground/80">
+          <FolderGlyph className="size-3 text-muted-foreground" />
+          <span>termio</span>
+        </div>
+        <ul className="flex flex-col">
+          {WORKTREES.map((tree, i) => (
+            <li key={tree.branch}>
+              <div className={cn(ROW, "gap-1.5 pl-4 text-muted-foreground")}>
+                <BranchGlyph className="size-2.5 opacity-70" />
+                <span className="truncate">{tree.branch}</span>
+              </div>
+              {/* The session living in that worktree, revealed in turn. */}
+              {tree.session && (
+              <div
+                className={cn(ROW, "mock-open gap-1.5 pl-8")}
+                style={{ animationDelay: `${i * 1.5}s` }}
+              >
+                <span className="relative grid size-3 shrink-0 place-items-center">
+                  {tree.status === "working" ? (
+                    <WorkingIndicator size={10} />
+                  ) : (
+                    <span
+                      className="size-1.5 rounded-full"
+                      style={{
+                        backgroundColor:
+                          tree.status === "done" ? DONE : NEEDS_YOU,
+                      }}
+                    />
+                  )}
+                </span>
+                <span className="truncate text-foreground/70">
+                  {tree.session}
+                </span>
+              </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </MockWindow>
+  );
+}

--- a/web/landing/src/components/sections/orchestration-demo.tsx
+++ b/web/landing/src/components/sections/orchestration-demo.tsx
@@ -3,23 +3,41 @@
 import { useEffect, useRef, useState } from "react";
 import { useInView } from "@/lib/use-in-view";
 import { AgentIcon } from "@/components/agent-icons";
+import { cn } from "@/lib/utils";
 
-// The orchestration section's animated demo: a hub-and-spoke graph (claude
-// supervising five worker sessions) synced beat-for-beat to a terminal that
-// types itself. One state machine drives both — as each worker becomes active
-// the LEFT graph lights that node and pulses its beam, while the RIGHT terminal
-// types that worker's command and prints its result. Together they narrate one
-// ship-a-feature pipeline: plan → build → review → secure-tag → feedback. Falls
-// back to a static done-state summary for SSR, screen readers, and reduced
-// motion.
+// The orchestration section's demo is the app itself rather than a diagram of
+// it: a Termio window whose left pane is the real sidebar, and whose content
+// area is the layout the app actually gets used in (see the hero captures) —
+// the driver session's shell holding the left column, and a stack of the
+// agents it spawned filling the right one.
+//
+// One state machine runs all of it. The first `termio sessions spawn` splits
+// the content area in two; every spawn after that adds a pane to the right
+// column, so the fleet builds up on screen as the driver types. Each spawn
+// also lands a session row in the sidebar, and the row and its pane then carry
+// the same status (the app's rotating nine-dot working mark, a green ring when
+// the turn finishes, an orange ring when the agent stops to ask) until the
+// result prints back into the transcript.
+//
+// Chrome is the app's: traffic lights over the sidebar, the window's title
+// block (folder over branch) left-aligned atop the content, status on a row's
+// leading mark rather than a trailing dot (Sidebar/SidebarView.swift).
+//
+// One deliberate liberty: `termio sessions spawn` starts a session, it does not
+// group it into a split — grouping is a user action ("Group with"). The demo
+// shows them grouped because the whole point is watching an agent work while
+// another drives it.
+//
+// Falls back to a static done-state window for SSR, screen readers, and
+// reduced motion.
 
 type TranscriptLine = {
   text?: string;
   prompt?: boolean;
-  // Output color semantics: plain (undefined) = neutral status text,
-  // "done" = completion sky, matching the done dot on the left. needs-you
-  // moments stay neutral in the transcript — only the left status dot goes
-  // amber (colored text read as noise in the code pane).
+  // Output color semantics: plain (undefined) = neutral status text, "done" =
+  // the same green the sidebar's done ring uses, so one state reads the same
+  // everywhere. needs-you moments stay neutral in the transcript — only the
+  // ring and the agent pane go orange (colored text read as noise here).
   tone?: "done";
   blank?: boolean;
   id?: number; // stable key so a freshly-pushed line animates in exactly once
@@ -27,129 +45,163 @@ type TranscriptLine = {
 
 type Status = "idle" | "working" | "needs-you" | "done";
 
-type Pulse = {
-  id: number;
-  dir: "out" | "back";
-  color: string;
-  y: number;
-};
-
 type Frame = {
   lines: TranscriptLine[];
   typing: string | null;
-  statuses: Status[]; // index-aligned with WORKERS
-  pulse: Pulse | null;
+  statuses: Status[]; // index-aligned with SESSIONS
+  // The session whose pane is focused — the one just spawned. null before the
+  // first spawn, when the content area is a single, unsplit shell.
+  active: number | null;
 };
 
-// Section palette — three hue families and nothing else: slate for neutrals
-// (window ink, idle/working), sky for "done", amber for "needs-you"; the pill
-// bases are aurora-tinted blue-greys (#d8e4ee/#c8d7e5) so they sit between the
-// dark pane and the slate-900 labels. Each status hue has two steps: a bright
-// one for the dark pane (beam pulses, transcript text) and a solid -500 for
-// the dots on the light pills. No green anywhere.
-const ACTIVE = "#e2e8f0"; // slate-200 — packet traveling the beam
-const AMBER = "#fbbf24"; // amber-400 — needs-you on dark (beam)
-const SKY = "#7dd3fc"; // sky-300 — done on dark (beam + transcript text)
+// Status colors are the app's, not the section's: green done / orange needs-you
+// are the sidebar's only color channel, and this is that sidebar.
+const DONE = "#27c93f"; // brand-green — matches StatusRing's .green
+const NEEDS_YOU = "#ffb764"; // brand-amber — matches StatusRing's .orange
 
-// The five workers, in pipeline order (index = story order = top-to-bottom in
-// the graph). Each drives one stage of shipping a change; the middle worker
-// (y=170) gets the straight beam. `name` keys the real brand logo.
-// Sessions are addressed by termio://session/<uuid> links since 8b38709 (the
-// <agent>@<id> handle is gone); `id` is the first uuid segment of each demo
-// session's link — bare ids are valid CLI targets, and short enough that the
-// longest transcript line stays under ~70 chars (the right pane clips longer).
-type Worker = { name: string; id: string; y: number };
+// The driving session: the one whose shell holds the left column. It stays
+// working for the whole run — it is the thing typing.
+const DRIVER = { agent: "Claude Code", title: "ship v0.22.0" };
 
-const WORKERS: readonly Worker[] = [
-  { name: "Claude Code", id: "9b3e11d0", y: 40 },
-  { name: "Codex", id: "7c1f2a4e", y: 105 },
-  { name: "DeepSeek", id: "5a77c0e2", y: 170 },
-  { name: "Grok", id: "d4e6b209", y: 235 },
-  { name: "Kimi", id: "3f8a2c11", y: 300 },
-];
+// The four sessions it spawns, in pipeline order — top-to-bottom in both the
+// sidebar and the right column. A row's title is the prompt the CLI spawned it with, which is what
+// the app shows as a session's title, and `tools` is what that agent's own
+// pane shows itself doing. Output lines use the sessions-watch text shape:
+// link  [status]  detail; sessions are addressed by termio://session/<uuid>
+// since 8b38709 (the <agent>@<id> handle is gone). `interaction` (codex only)
+// shows a needs-you round trip: the agent asks, the driver answers, it resumes.
+type Tool = { verb: string; target: string; result: string };
 
-// One story beat per worker. `interaction` (codex only) shows a needs-you round
-// trip: the agent asks, claude answers, the agent resumes.
-type Beat = {
-  worker: number;
+type Session = {
+  agent: string;
+  /** The agent as you'd name it on the command line, shown in its own pane. */
+  cli: string;
+  title: string;
   cmd: string;
   started: string;
-  interaction?: { needsYou: string; answer: string; sent: string };
+  /** Present-tense verb for the agent pane's working line. */
+  activity: string;
+  elapsed: string;
+  tools: readonly Tool[];
+  /** Tool-call glyphs. Claude Code prints a filled bullet over a `⌊` result
+   *  line; the rest of the fleet uses the common `•` / `└` pair. */
+  bullet: string;
+  sub: string;
+  interaction?: {
+    needsYou: string;
+    answer: string;
+    sent: string;
+    /** The question as the agent's own pane puts it. */
+    question: string;
+    reply: string;
+  };
   done: string;
+  /** The agent pane's closing line once the turn settles. */
+  outcome: string;
 };
 
-// Output lines use the sessions-watch text shape: link  [status]  detail.
-const BEATS: readonly Beat[] = [
+const SESSIONS: readonly Session[] = [
   {
-    worker: 0,
+    agent: "Claude Code",
+    cli: "claude",
+    title: "plan the auth refactor",
     cmd: 'termio sessions spawn "plan the auth refactor" --agent claude',
     started: "termio://session/9b3e11d0  [working]  planning",
+    activity: "Planning",
+    elapsed: "0m 41s",
+    tools: [
+      { verb: "Read", target: "Auth/TokenStore.swift", result: "412 lines" },
+      { verb: "Grep", target: '"refreshToken"', result: "29 matches" },
+    ],
+    bullet: "●",
+    sub: "⌊",
     done: "termio://session/9b3e11d0  [done]  7 steps -> PLAN.md",
+    outcome: "7 steps -> PLAN.md",
   },
   {
-    worker: 1,
+    agent: "Codex",
+    cli: "codex",
+    title: "implement PLAN.md",
     cmd: 'termio sessions spawn "implement PLAN.md" --agent codex',
     started: "termio://session/7c1f2a4e  [working]  building",
+    activity: "Building",
+    elapsed: "1m 06s",
+    tools: [
+      { verb: "Edit", target: "TokenStore.swift", result: "+180 -52" },
+      { verb: "Shell", target: "swift build", result: "succeeded" },
+    ],
+    bullet: "•",
+    sub: "└",
     interaction: {
-      needsYou: "termio://session/7c1f2a4e  [needs-you]  Run pnpm test? (y/n)",
+      needsYou: "termio://session/7c1f2a4e  [needs-you]  Run swift test? (y/n)",
       answer: 'termio sessions send 7c1f2a4e "y"',
       sent: "sent to termio://session/7c1f2a4e",
+      question: "Run swift test? (y/n)",
+      reply: "y",
     },
     done: "termio://session/7c1f2a4e  [done]  +412 -128, tests pass",
+    outcome: "+412 -128, tests pass",
   },
   {
-    worker: 2,
+    agent: "DeepSeek",
+    cli: "deepseek",
+    title: "review the diff",
     cmd: 'termio sessions spawn "review the diff" --agent deepseek',
     started: "termio://session/5a77c0e2  [working]  reviewing",
+    activity: "Reviewing",
+    elapsed: "0m 28s",
+    tools: [
+      { verb: "Read", target: "PLAN.md", result: "7 steps" },
+      { verb: "Diff", target: "Sources/Auth", result: "12 files" },
+    ],
+    bullet: "•",
+    sub: "└",
     done: "termio://session/5a77c0e2  [done]  2 nits, 0 blockers",
+    outcome: "2 nits, 0 blockers",
   },
   {
-    worker: 3,
+    agent: "Grok",
+    cli: "grok",
+    title: "security scan, then tag v0.22.0",
     cmd: 'termio sessions spawn "security scan, then tag v0.22.0" --agent grok',
     started: "termio://session/d4e6b209  [working]  scanning",
+    activity: "Scanning",
+    elapsed: "0m 52s",
+    tools: [
+      { verb: "Scan", target: "Sources", result: "0 findings" },
+      { verb: "Shell", target: "git tag v0.22.0", result: "tagged" },
+    ],
+    bullet: "•",
+    sub: "└",
     done: "termio://session/d4e6b209  [done]  clean, tagged v0.22.0",
-  },
-  {
-    worker: 4,
-    cmd: 'termio sessions spawn "summarize the week\'s feedback" --agent kimi',
-    started: "termio://session/3f8a2c11  [working]  gathering",
-    done: "termio://session/3f8a2c11  [done]  5 themes -> FEEDBACK.md",
+    outcome: "clean, tagged v0.22.0",
   },
 ];
 
+// The project's worktrees, shown the way the sidebar shows them: quiet folder
+// rows under the session list, no status of their own.
+const WORKTREES = [
+  "feat/auth-refactor",
+  "fix/session-title",
+  "feat/remote-tree",
+  "chore/deps",
+] as const;
+
 // Static fallback / screen-reader copy: the whole pipeline in its done state.
-const DONE_SUMMARY: readonly TranscriptLine[] = BEATS.map((b) => ({
+const DONE_SUMMARY: readonly TranscriptLine[] = SESSIONS.map((s) => ({
   tone: "done" as const,
-  text: b.done,
+  text: s.done,
 }));
 
 const STATIC_FRAME: Frame = {
-  lines: [...DONE_SUMMARY],
+  lines: DONE_SUMMARY.slice(-3),
   typing: null,
-  statuses: WORKERS.map(() => "done"),
-  pulse: null,
+  statuses: SESSIONS.map(() => "done"),
+  active: SESSIONS.length - 1,
 };
 
-// Beam from the hub's right edge (104,170) to a worker's left edge (184,y), and
-// the reverse. The middle worker (y=170) gets a straight line.
-const beamPath = (y: number) =>
-  y === 170 ? "M104 170 L 184 170" : `M104 170 C 142 170, 142 ${y}, 184 ${y}`;
-const beamPathBack = (y: number) =>
-  y === 170 ? "M184 170 L 104 170" : `M184 ${y} C 142 ${y}, 142 170, 104 170`;
-
-// Per-status pill styling for the worker nodes.
-// Borderless light pills: status reads through a small colored dot inside the
-// pill (plus the idle dimming) — the same status language as Termio's own
-// sidebar. Glows/box-shadows around foreignObject content clip into hard
-// blocks in some browsers, so no halo at all.
-const STATUS_DOT: Record<Status, string> = {
-  idle: "#cbd5e1", // slate-300
-  working: "#64748b", // slate-500
-  "needs-you": "#f59e0b", // amber-500
-  done: "#0ea5e9", // sky-500
-};
-
-const MAX_LINES = 8; // rolling transcript window (fits the reserved height)
+// Rolling transcript window, sized to the shell's column at its tallest.
+const MAX_LINES = 8;
 
 function sleep(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -158,7 +210,6 @@ function sleep(ms: number) {
 export function OrchestrationDemo() {
   const { ref, inView } = useInView<HTMLDivElement>("80px");
   const [frame, setFrame] = useState<Frame>(STATIC_FRAME);
-  const pulseId = useRef(0);
 
   useEffect(() => {
     if (!inView) return;
@@ -167,8 +218,6 @@ export function OrchestrationDemo() {
     let cancelled = false;
     const patch = (p: Partial<Frame>) =>
       setFrame((f) => (cancelled ? f : { ...f, ...p }));
-    const pulse = (dir: Pulse["dir"], color: string, y: number) =>
-      patch({ pulse: { id: ++pulseId.current, dir, color, y } });
 
     const buf: TranscriptLine[] = [];
     let lineSeq = 0;
@@ -196,57 +245,51 @@ export function OrchestrationDemo() {
     const play = async () => {
       while (!cancelled) {
         buf.length = 0;
-        const statuses: Status[] = WORKERS.map(() => "idle");
-        patch({ lines: [], typing: null, statuses: [...statuses], pulse: null });
+        const statuses: Status[] = SESSIONS.map(() => "idle");
+        patch({ lines: [], typing: null, statuses: [...statuses], active: null });
         await sleep(700);
         if (cancelled) return;
 
-        for (let b = 0; b < BEATS.length; b++) {
-          const beat = BEATS[b];
-          const w = WORKERS[beat.worker];
-          const last = b === BEATS.length - 1;
+        for (let i = 0; i < SESSIONS.length; i++) {
+          const session = SESSIONS[i];
+          const last = i === SESSIONS.length - 1;
 
-          // The worker comes alive: left node lights, beam pulses hub → worker,
-          // right terminal types its command.
-          statuses[beat.worker] = "working";
-          patch({ statuses: [...statuses] });
-          pulse("out", ACTIVE, w.y);
-          await type(beat.cmd);
+          // Command first, then the session exists: its sidebar row arrives and
+          // its pane opens under the shell, both already working.
+          await type(session.cmd);
           if (cancelled) return;
+          statuses[i] = "working";
+          patch({ statuses: [...statuses], active: i });
           // The result arrives all at once (a whole line), after a short beat.
-          await sleep(360);
-          push({ text: beat.started });
-          await sleep(beat.interaction ? 850 : 1500);
+          await sleep(420);
+          push({ text: session.started });
+          await sleep(session.interaction ? 1400 : 2100);
           if (cancelled) return;
 
-          if (beat.interaction) {
-            push({ text: beat.interaction.needsYou });
-            statuses[beat.worker] = "needs-you";
+          if (session.interaction) {
+            push({ text: session.interaction.needsYou });
+            statuses[i] = "needs-you";
             patch({ statuses: [...statuses] });
-            pulse("back", AMBER, w.y);
-            await sleep(1600);
+            await sleep(1800);
             if (cancelled) return;
             // Blank separator so the answer command starts a fresh block, like
             // every other typed command.
             push({ blank: true });
-            await type(beat.interaction.answer);
+            await type(session.interaction.answer);
             if (cancelled) return;
             await sleep(320);
-            push({ text: beat.interaction.sent });
-            statuses[beat.worker] = "working";
+            push({ text: session.interaction.sent });
+            statuses[i] = "working";
             patch({ statuses: [...statuses] });
-            pulse("out", ACTIVE, w.y);
-            await sleep(1500);
+            await sleep(1700);
             if (cancelled) return;
           }
 
-          // Result streams back: node settles to done, beam pulses worker → hub.
-          push({ tone: "done", text: beat.done });
-          statuses[beat.worker] = "done";
+          push({ tone: "done", text: session.done });
+          statuses[i] = "done";
           patch({ statuses: [...statuses] });
-          pulse("back", SKY, w.y);
           push({ blank: true });
-          await sleep(last ? 4200 : 1250);
+          await sleep(last ? 4200 : 1600);
         }
       }
     };
@@ -257,167 +300,457 @@ export function OrchestrationDemo() {
     };
   }, [inView]);
 
-  const pulsePath = frame.pulse
-    ? frame.pulse.dir === "back"
-      ? beamPathBack(frame.pulse.y)
-      : beamPath(frame.pulse.y)
-    : null;
+  // Every session that exists yet, in spawn order — the right column's panes.
+  const spawned = SESSIONS.map((session, index) => ({ session, index })).filter(
+    ({ index }) => frame.statuses[index] !== "idle",
+  );
+  const split = spawned.length > 0;
 
   return (
-    // One surface with the section around it: the session graph (left) and the
-    // live CLI transcript (right) sit directly on the parent's bg-card, with
-    // only hairline dividers separating the panes.
-    <div ref={ref} className="relative overflow-hidden">
-      <div className="relative">
-        {/* minmax(0,…) everywhere: a plain implicit column would take the
-            transcript pre's min-content width (its longest unbreakable line),
-            blowing the column wider than the card on phones — the graph pane
-            then centers in that oversized column and clips at the card edge. */}
-        <div className="relative grid grid-cols-[minmax(0,1fr)] lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)]">
-          {/* Left: the live session graph — claude code driving five workers,
-              each a real brand logo. The active node lights and its beam pulses
-              in sync with the command running on the right. */}
-          <div
-            aria-hidden="true"
-            className="relative flex items-center justify-center overflow-hidden border-b border-white/[0.12] p-5 sm:p-6 lg:border-b-0 lg:border-r"
-          >
-            <svg viewBox="0 0 340 340" className="relative w-full max-w-[380px]" fill="none">
-              {/* Static edges from the hub to each worker. */}
-              {WORKERS.map((w) => (
-                <path
-                  key={`edge-${w.id}`}
-                  d={beamPath(w.y)}
-                  stroke="rgba(255,255,255,0.18)"
-                  strokeWidth="1.5"
-                />
-              ))}
-              {frame.pulse && pulsePath && (
-                <path
-                  key={frame.pulse.id}
-                  d={pulsePath}
-                  pathLength={100}
-                  stroke={frame.pulse.color}
-                  strokeWidth="2"
-                  className="beam-pulse"
-                />
-              )}
-
-              {/* Hub: the supervising claude-code session (real logo). */}
-              <foreignObject x="0" y="148" width="120" height="44">
-                {/* Pill bases are blue-grey (not paper white) so they read as
-                    lit by the aurora rather than pasted over it; hub one step
-                    brighter than the workers. */}
-                <div className="flex h-11 items-center gap-2.5 rounded-full bg-[#d8e4ee] px-3.5">
-                  {/* Mono-only marks (Grok, Kimi) draw in currentColor, so the
-                      light pill needs a dark color context. */}
-                  <AgentIcon name="Claude Code" size={24} color className="text-slate-900" />
-                  <span className="font-sans text-[15px] font-medium text-slate-900">
-                    claude
-                  </span>
-                </div>
-              </foreignObject>
-
-              {/* Worker sessions: real color logos, status shown by border/glow
-                  as each lights up through the pipeline. */}
-              {WORKERS.map((w, i) => {
-                const status = frame.statuses[i] ?? "idle";
-                return (
-                  <foreignObject
-                    key={w.id}
-                    x="176"
-                    y={w.y - 20}
-                    width="164"
-                    height="40"
-                    style={{
-                      opacity: status === "idle" ? 0.72 : 1,
-                      transition: "opacity 0.5s ease",
-                    }}
-                  >
-                    <div className="flex h-10 items-center gap-2 rounded-full bg-[#c8d7e5] px-3">
-                      {/* Kimi's color mark is blue-on-white and washes out on
-                          the light pill, so it uses the mono (currentColor)
-                          variant instead. */}
-                      <AgentIcon
-                        name={w.name}
-                        size={20}
-                        color={w.name !== "Kimi"}
-                        className="text-slate-900"
-                      />
-                      <span className="truncate font-sans text-[12px] font-medium text-slate-900">
-                        {w.id}
-                      </span>
-                      <span
-                        className="ml-auto h-2 w-2 shrink-0 rounded-full"
-                        style={{
-                          backgroundColor: STATUS_DOT[status],
-                          transition: "background-color 0.4s ease",
-                        }}
-                      />
-                    </div>
-                  </foreignObject>
-                );
-              })}
-            </svg>
+    <div ref={ref} className="relative">
+      {/* The window. Sidebar tone sits a step above the terminal's near-black,
+          the way the app's source list sits above its surfaces; the inset top
+          hairline plus the cast shadow are what make it read as a real macOS
+          window rather than a flat panel. */}
+      <div className="flex h-[25rem] overflow-hidden rounded-2xl border border-white/10 bg-[#1b1b21] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.08),0_28px_60px_-24px_rgba(0,0,0,0.8)] md:h-[27rem] lg:h-[28rem]">
+        {/* The sidebar only opens once the window is wide enough for the
+            terminal beside it to hold a full command line unwrapped — below
+            that it folds away, which is the app's own collapsed-source-list
+            state rather than a web-only compromise. */}
+        <aside
+          aria-hidden="true"
+          className="hidden w-[34%] max-w-[16.5rem] shrink-0 flex-col lg:flex"
+        >
+          <div className="flex items-center gap-2 px-3.5 py-3">
+            <TrafficLights />
+            <SidebarToggleGlyph className="ml-1.5" />
+            <PlusGlyph className="ml-auto" />
           </div>
 
-          {/* Right: the CLI transcript, floating directly on the glow. */}
-          <div>
-            {/* Screen-reader copy of the pipeline's outcome; the animated pane
-                re-renders too often to be useful aloud. */}
-            <pre className="sr-only">
-              {DONE_SUMMARY.map((l) => `${l.text}\n`).join("")}
-            </pre>
+          <div className="min-h-0 flex-1 overflow-hidden px-2 pt-1">
+            <ProjectRow name="termio" />
+            <ul className="flex flex-col">
+              <SessionRow
+                agent={DRIVER.agent}
+                title={DRIVER.title}
+                status="working"
+              />
+              {SESSIONS.map((session, i) => {
+                const status = frame.statuses[i] ?? "idle";
+                if (status === "idle") return null;
+                return (
+                  <SessionRow
+                    key={session.title}
+                    agent={session.agent}
+                    title={session.title}
+                    status={status}
+                    // Selection follows the pane below: the app highlights the
+                    // session you are looking at, and that is the one whose
+                    // terminal just opened.
+                    selected={i === frame.active}
+                    // Rows arrive as the driver spawns them, so each one fades
+                    // in once — the same reveal the transcript lines use.
+                    className="line-in"
+                  />
+                );
+              })}
+            </ul>
+            <ul className="mt-1 flex flex-col">
+              {WORKTREES.map((branch) => (
+                <WorktreeRow key={branch} branch={branch} />
+              ))}
+            </ul>
+          </div>
+        </aside>
 
-            {/* min-height reserves the rolling window's space so the window does
-                not grow line by line while typing. Phones hard-wrap at the pane
-                edge exactly like a real terminal (the JSON lines have no soft
-                break points); from sm up lines stay unwrapped and can scroll. */}
-            <pre
-              aria-hidden="true"
-              className="min-h-[340px] whitespace-pre-wrap break-all p-5 font-mono text-[13px] leading-relaxed sm:min-h-[320px] sm:whitespace-pre sm:break-normal sm:overflow-x-auto sm:p-6 sm:text-[14px]"
+        {/* The content area: the driver session's shell on the left, and — once
+            something has been spawned — the split holding the agents' own
+            terminals on the right. The window's title block (the session's
+            folder over its branch) sits at the top, the way the app titles a
+            window. */}
+        <div className="flex min-w-0 flex-1 flex-col border-white/[0.07] bg-[#0b0b0d] lg:border-l">
+          <div className="flex items-start gap-3 px-4 pb-2 pt-3 sm:px-5">
+            <div className="flex lg:hidden">
+              <TrafficLights />
+            </div>
+            <div className="min-w-0 leading-tight">
+              <p className="truncate text-[12px] font-medium text-foreground/85">
+                termio
+              </p>
+              <p className="truncate text-[10.5px] text-muted-foreground">main</p>
+            </div>
+            <InspectorGlyph className="ml-auto shrink-0" />
+          </div>
+
+          {/* Screen-reader copy of the pipeline's outcome; the animated panes
+              re-render too often to be useful aloud. */}
+          <pre className="sr-only">
+            {DONE_SUMMARY.map((l) => `${l.text}\n`).join("")}
+          </pre>
+
+          <div
+            aria-hidden="true"
+            className="flex min-h-0 flex-1 px-4 pb-4 sm:px-5 sm:pb-5"
+          >
+            {/* The driver's shell. It keeps the left column once the split
+                opens, so it wraps its longer commands there exactly like a real
+                terminal in a narrow pane — the link lines have no soft break
+                points to fall on. */}
+            <div
+              className={cn(
+                "min-w-0",
+                split ? "w-full md:w-[55%] md:shrink-0" : "flex-1",
+              )}
             >
-              {frame.lines.map((line, i) =>
-                line.blank ? (
-                  <span key={line.id ?? i}>{"\n"}</span>
-                ) : (
-                  <span
-                    key={line.id ?? i}
-                    className={
-                      // Output lines fade in on arrival; typed prompt lines
-                      // are already animated by the typewriter, so they don't.
-                      // Whitespace behavior inherits from the pre (wrap on
-                      // phones, pre from sm up).
-                      line.prompt ? "block" : "line-in block"
-                    }
-                  >
-                    {line.prompt ? (
-                      <>
-                        <span className="select-none text-slate-400">$ </span>
-                        <span className="text-slate-50">{line.text}</span>
-                      </>
-                    ) : (
-                      <span
-                        className={
-                          line.tone === "done" ? "text-sky-300" : "text-slate-300"
-                        }
-                      >
-                        {line.text}
-                      </span>
-                    )}
+              <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[1.6] md:text-[11.5px] xl:text-[12px] xl:leading-[1.65]">
+                {frame.lines.map((line, i) =>
+                  line.blank ? (
+                    <span key={line.id ?? i}>{"\n"}</span>
+                  ) : (
+                    <span
+                      key={line.id ?? i}
+                      className={
+                        // Output lines fade in on arrival; typed prompt lines
+                        // are already animated by the typewriter, so they don't.
+                        line.prompt ? "block" : "line-in block"
+                      }
+                    >
+                      {line.prompt ? (
+                        <>
+                          <span className="select-none text-slate-400">$ </span>
+                          <span className="text-slate-50">{line.text}</span>
+                        </>
+                      ) : (
+                        <span
+                          style={
+                            line.tone === "done" ? { color: DONE } : undefined
+                          }
+                          className={line.tone === "done" ? "" : "text-slate-300"}
+                        >
+                          {line.text}
+                        </span>
+                      )}
+                    </span>
+                  ),
+                )}
+                {frame.typing !== null && (
+                  <span className="block">
+                    <span className="select-none text-slate-400">$ </span>
+                    <span className="text-slate-50">{frame.typing}</span>
+                    <span className="demo-cursor text-slate-50/80">▋</span>
                   </span>
-                ),
-              )}
-              {frame.typing !== null && (
-                <span className="block">
-                  <span className="select-none text-slate-400">$ </span>
-                  <span className="text-slate-50">{frame.typing}</span>
-                  <span className="demo-cursor text-slate-50/80">▋</span>
-                </span>
-              )}
-            </pre>
+                )}
+              </pre>
+            </div>
+
+            {/* The right column. It wipes open on the first spawn, then each
+                later spawn adds a pane under the last — the same beat as the
+                row arriving in the sidebar, and the layout the app is actually
+                used in. Every pane is keyed by its agent, so it mounts once and
+                plays its own open. Below md the window is too narrow to hold
+                two columns of terminal text, so the split waits for the room. */}
+            {split && (
+              <div className="split-in ml-3 hidden min-w-0 flex-1 flex-col border-l border-white/[0.07] pl-3 md:flex">
+                {spawned.map(({ session, index }, position) => (
+                  <div
+                    key={session.cli}
+                    className={cn(
+                      "pane-in min-h-0 flex-1",
+                      position > 0 && "mt-2 border-t border-white/[0.07] pt-2",
+                    )}
+                  >
+                    <AgentPane
+                      session={session}
+                      status={frame.statuses[index] ?? "idle"}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>
     </div>
+  );
+}
+
+/* ----------------------------------------------------------- agent pane --- */
+
+// One spawned agent working in its own pane. The shape is a stylized agent-CLI
+// session rather than any one vendor's exact chrome: who it is and what it was
+// asked, the tool calls it is making, and a closing line — held to four rows,
+// because four of these share the right column and each one still has to read.
+// The closing line carries the same working / needs-you / done language as the
+// sidebar row beside it.
+function AgentPane({
+  session,
+  status,
+}: {
+  session: Session;
+  status: Status;
+}) {
+  return (
+    <div className="min-h-0 font-mono text-[10px] leading-[1.6] lg:text-[10.5px]">
+      <p className="flex items-center gap-1.5 truncate">
+        <AgentIcon
+          name={session.agent}
+          size={11}
+          color={session.agent !== "Kimi"}
+          className="text-foreground/80"
+        />
+        <span className="shrink-0 text-foreground/80">{session.cli}</span>
+        <span className="truncate text-muted-foreground/70">
+          {session.title}
+        </span>
+      </p>
+      {/* Result inline after the call rather than on its own `└` row: at four
+          panes to a column there is no height to spend on a line each. */}
+      {session.tools.map((tool) => (
+        <p key={tool.verb + tool.target} className="truncate">
+          <span className="select-none text-slate-500">{session.bullet} </span>
+          <span className="text-slate-200">{tool.verb} </span>
+          <span className="text-slate-400">{tool.target}</span>
+          <span className="text-slate-500">
+            {" "}
+            {session.sub} {tool.result}
+          </span>
+        </p>
+      ))}
+
+      {status === "needs-you" && session.interaction && (
+        <p className="truncate" style={{ color: NEEDS_YOU }}>
+          <span className="select-none">? </span>
+          {session.interaction.question}
+          <span className="demo-cursor"> ▋</span>
+        </p>
+      )}
+      {status === "working" && (
+        <p className="flex items-center gap-1.5 truncate">
+          <WorkingIndicator />
+          <span className="text-slate-300">{session.activity}</span>
+          <span className="truncate text-slate-500">
+            ({session.elapsed} · esc to interrupt)
+          </span>
+        </p>
+      )}
+      {status === "done" && (
+        <p className="truncate" style={{ color: DONE }}>
+          <span className="select-none">✓ </span>
+          {session.outcome}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/* --------------------------------------------------------------- chrome --- */
+
+function TrafficLights() {
+  return (
+    <div className="flex shrink-0 items-center gap-[6px]">
+      <span className="size-[11px] rounded-full bg-brand-red" />
+      <span className="size-[11px] rounded-full bg-brand-amber" />
+      <span className="size-[11px] rounded-full bg-brand-green" />
+    </div>
+  );
+}
+
+function SidebarToggleGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      className={cn("size-[15px] text-muted-foreground", className)}
+    >
+      <rect x="3" y="4" width="18" height="16" rx="3" />
+      <path d="M9.5 4v16" />
+    </svg>
+  );
+}
+
+function PlusGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.9}
+      strokeLinecap="round"
+      className={cn("size-[15px] text-muted-foreground", className)}
+    >
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}
+
+function InspectorGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      className={cn("size-[15px] text-muted-foreground", className)}
+    >
+      <rect x="3" y="4" width="18" height="16" rx="3" />
+      <path d="M14.5 4v16" />
+    </svg>
+  );
+}
+
+/* -------------------------------------------------------------- sidebar --- */
+
+function FolderGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinejoin="round"
+      className={cn("shrink-0", className)}
+    >
+      <path d="M3 7.5A1.5 1.5 0 0 1 4.5 6h4l2 2.5h7A1.5 1.5 0 0 1 19 10v7a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 3 17z" />
+    </svg>
+  );
+}
+
+function ProjectRow({ name }: { name: string }) {
+  return (
+    <div className="flex items-center gap-2 px-2 py-[5px] text-[12.5px] text-foreground/85">
+      <FolderGlyph className="size-[15px] text-muted-foreground" />
+      <span className="truncate">{name}</span>
+    </div>
+  );
+}
+
+function SessionRow({
+  agent,
+  title,
+  status,
+  selected = false,
+  className,
+}: {
+  agent: string;
+  title: string;
+  status: Status;
+  selected?: boolean;
+  className?: string;
+}) {
+  return (
+    <li
+      className={cn(
+        // Sessions indent under their project header, and selection is a soft
+        // full-width fill — no outline (SidebarRowHighlight).
+        "flex items-center gap-1.5 rounded-[7px] py-[5px] pl-6 pr-2",
+        selected && "bg-white/[0.09]",
+        className,
+      )}
+    >
+      <span className="relative grid size-4 shrink-0 place-items-center">
+        {status === "working" ? (
+          <WorkingIndicator />
+        ) : (
+          // Kimi's color mark is blue-on-white and washes out on the dark
+          // sidebar, so it uses the mono (currentColor) variant instead.
+          <AgentIcon
+            name={agent}
+            size={12}
+            color={agent !== "Kimi"}
+            className="text-foreground/80"
+          />
+        )}
+        {/* The resting status is a ring around the leading mark — green when the
+            turn just finished, orange when the agent is blocked on you — never a
+            trailing dot. Sized well past the icon so it reads as a halo rather
+            than an outline on the mark, and an overlay so it never shifts the
+            row. */}
+        <span
+          className="pointer-events-none absolute size-5 rounded-full border-[1.5px] transition-colors duration-300"
+          style={{
+            borderColor:
+              status === "done"
+                ? DONE
+                : status === "needs-you"
+                  ? NEEDS_YOU
+                  : "transparent",
+          }}
+        />
+      </span>
+      <span
+        className={cn(
+          "truncate text-[12.5px]",
+          selected ? "text-foreground" : "text-foreground/80",
+        )}
+      >
+        {title}
+      </span>
+    </li>
+  );
+}
+
+function WorktreeRow({ branch }: { branch: string }) {
+  return (
+    <li className="flex items-center gap-1.5 py-[5px] pl-6 pr-2 text-[12.5px] text-muted-foreground">
+      <FolderGlyph className="size-4" />
+      <span className="truncate">{branch}</span>
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        className="ml-auto size-3 shrink-0 opacity-60"
+      >
+        <line x1="6" y1="3" x2="6" y2="15" />
+        <circle cx="18" cy="6" r="3" />
+        <circle cx="6" cy="18" r="3" />
+        <path d="M18 9a9 9 0 0 1-9 9" />
+      </svg>
+    </li>
+  );
+}
+
+// The eight perimeter cells of a 3×3 grid in clockwise order, as (column, row)
+// with the center at (1,1) — the ring the comet travels, matching the app's
+// WorkingIndicator (Shared/TermioShared/SessionStatus.swift). Geometry is the
+// app's too: 2.5pt dots on a 3.6pt pitch, over a steady half-ink center.
+const RING: readonly (readonly [number, number])[] = [
+  [0, 0],
+  [1, 0],
+  [2, 0],
+  [2, 1],
+  [2, 2],
+  [1, 2],
+  [0, 2],
+  [0, 1],
+];
+const DOT = 2.5;
+const PITCH = 3.6;
+const PERIOD = 1.1;
+
+function WorkingIndicator() {
+  return (
+    <span className="relative block size-[13px] shrink-0 text-foreground">
+      {[[1, 1] as const, ...RING].map(([column, row], i) => (
+        <span
+          key={`${column}-${row}`}
+          className={cn(
+            "absolute rounded-full bg-current",
+            // The center dot is the steady anchor; only the ring animates.
+            i === 0 ? "opacity-50" : "working-dot",
+          )}
+          style={{
+            width: DOT,
+            height: DOT,
+            left: `calc(50% + ${(column - 1) * PITCH - DOT / 2}px)`,
+            top: `calc(50% + ${(row - 1) * PITCH - DOT / 2}px)`,
+            animationDelay: i === 0 ? undefined : `${-((i - 1) / 8) * PERIOD}s`,
+          }}
+        />
+      ))}
+    </span>
   );
 }

--- a/web/landing/src/lib/site.ts
+++ b/web/landing/src/lib/site.ts
@@ -1,16 +1,28 @@
 // Shared site constants. Termio is free to use and ships with Sparkle
 // auto-updates — no account, no license keys, no payment backend.
 
+// The agents Termio ships a manifest for, in the order the app itself lists
+// them (`Sources/termio/Resources/agents/*.json`, the `order` field). The hero
+// marquee and the FAQ answer read this list; the agent showcase draws a panel
+// for the subset of it we have a capture of, and its names are checked against
+// this type so the two can't drift apart again. The app bundles a few more
+// manifests than this — an agent joins the list once it has a brand mark and
+// someone has run it.
 export const supportedAgents = [
   "Claude Code",
   "Codex",
-  "Antigravity",
-  "Amp",
-  "Pi",
   "OpenCode",
-  "Copilot",
+  "Pi",
+  "Amp",
   "Cursor",
+  "Copilot",
+  "Kimi",
+  "Antigravity",
+  "Crush",
+  "Grok",
 ] as const;
+
+export type SupportedAgent = (typeof supportedAgents)[number];
 
 export const navLinks = [
   { label: "Docs", href: "/docs" },


### PR DESCRIPTION
The orchestration demo, the feature grid and the agent showcase all ran on captures. This draws those surfaces in DOM instead, so they stay crisp at any size, can animate, and get corrected against the app rather than re-shot.

**Orchestration** — the hub-and-spoke graph is gone. The demo is a Termio window: the real sidebar on the left, and a content area that splits on the first `termio sessions spawn` and stacks each spawned agent's pane in the right column. Status is ported from `SidebarView.swift` and `SessionStatus.swift` — the nine-dot working mark, a green ring when a turn finishes, an orange ring when the agent stops to ask.

One deliberate liberty, recorded in the file header: `spawn` starts a session, it does not group it into a split. Grouping is a user action.

**Feature grid** — six cards on a 3×2, each with a small animated mock of the surface it describes. Motion is pure CSS, since six loops share a page with the orchestration demo and none may cost a render. All off under `prefers-reduced-motion`.

**Agent showcase** — eight agents, each TUI transcribed from a real run of that CLI inside Termio. Claude Code and Codex show a concrete scenario (a skill invocation, the `/model` picker); the rest show what they print on launch. Transcribing caught two hint rows that had been guessed wrong: Crush binds `ctrl+m` for models and `shift+enter` for a newline, and Grok's tip is about `/compact`.

`supportedAgents` and the showcase list are tied together by a `satisfies` clause so the two cannot drift apart again.

Agents with no CLI on hand — Antigravity, Copilot, Cursor — are deliberately left out rather than drawn from guesswork.

Verified: `pnpm docs:check`, `tsc --noEmit` and `next build` all clean; every panel and card screenshotted and read back at 1440 / 1100 / 900 / 768 / 640.

Note: `public/agent/*.png` and `public/feature/*.png` are now unreferenced. Left on disk in this PR.

Release Notes:
- Site only — no app-facing change.