### PR TITLE
Link the iPhone section to the TestFlight beta

### DIFF
--- a/web/landing/src/components/section-label.tsx
+++ b/web/landing/src/components/section-label.tsx
@@ -52,6 +52,22 @@ export function AppleMark({ className }: { className?: string }) {
   );
 }
 
+// TestFlight's two-tone paper plane, drawn in the current text color so it sits
+// in a pill the same way the Apple mark does.
+export function TestFlightMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={cn("h-[1.05em] w-[1.05em]", className)}
+      fill="currentColor"
+    >
+      <path d="M21.6 2.4 2.9 8.8 10.9 13.1Z" />
+      <path d="M21.6 2.4 10.9 13.1 15.2 21.1Z" opacity="0.55" />
+    </svg>
+  );
+}
+
 // GitHub's octocat glyph — the open-source cue, shared by the nav pill and the
 // hero's star button.
 export function GitHubMark({ className }: { className?: string }) {

--- a/web/landing/src/components/sections/companion.tsx
+++ b/web/landing/src/components/sections/companion.tsx
@@ -4,7 +4,10 @@ import Image from "next/image";
 import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Reveal } from "@/components/reveal";
+import { buttonVariants } from "@/components/ui/button";
+import { TestFlightMark } from "@/components/section-label";
 import { useInView } from "@/lib/use-in-view";
+import { testflightUrl } from "@/lib/site";
 
 const CYCLE_MS = 3200;
 
@@ -91,6 +94,18 @@ export function Companion() {
                 </div>
               ))}
             </dl>
+
+            <a
+              href={testflightUrl}
+              className={cn(
+                buttonVariants(),
+                "mt-9 h-12 gap-2 rounded-full px-7 text-base",
+                "shadow-[0_12px_32px_rgba(20,23,28,0.18),0_0_0_1px_rgba(0,211,199,0.14)]",
+              )}
+            >
+              <TestFlightMark />
+              Get the iOS beta
+            </a>
           </Reveal>
 
           <Reveal delayMs={120}>


### PR DESCRIPTION
The companion section on the landing page describes the iPhone app but never offered a way to install it — the only paths to the beta were the footer link and the closing CTA band. This adds the primary pill under the three points, using the same `testflightUrl` the footer and CTA band already share.

The pill carries a new `TestFlightMark`: TestFlight's two-tone paper plane, drawn in `currentColor` so it inherits the button's text color the way `AppleMark` does. Apple publishes no monochrome TestFlight glyph, so this is an approximation of the icon's plane rather than official artwork.

Release Notes:
- The iPhone section of the landing page now links straight to the TestFlight beta.