### PR TITLE
Show the file when syntax highlighting cannot start

### DIFF
--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -49,10 +49,14 @@ struct HighlightedTextView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSScrollView {
         let storage = context.coordinator.textStorage
-        _ = storage.highlightr.setTheme(to: theme)
-        storage.highlightr.theme.setCodeFont(font)
-        storage.highlightr.theme.codeParagraphStyle = Self.paragraphStyle(font: font, lineSpacing: lineSpacing)
-        storage.highlightr.theme.codeBaselineOffset = Self.baselineOffset(lineSpacing: lineSpacing)
+        // No highlighter means highlighting could not be set up at all; the editor still
+        // shows the file, just uncolored.
+        if let highlightr = storage.highlightr {
+            _ = highlightr.setTheme(to: theme)
+            highlightr.theme.setCodeFont(font)
+            highlightr.theme.codeParagraphStyle = Self.paragraphStyle(font: font, lineSpacing: lineSpacing)
+            highlightr.theme.codeBaselineOffset = Self.baselineOffset(lineSpacing: lineSpacing)
+        }
         storage.language = language
         context.coordinator.appliedTheme = theme
         context.coordinator.appliedFont = font
@@ -157,7 +161,7 @@ struct HighlightedTextView: NSViewRepresentable {
         // large files; the text storage already re-highlights edited ranges incrementally on its own.
         var needsRehighlight = false
         if coordinator.appliedTheme != theme {
-            _ = storage.highlightr.setTheme(to: theme)
+            _ = storage.highlightr?.setTheme(to: theme)
             coordinator.appliedTheme = theme
             needsRehighlight = true
         }
@@ -178,9 +182,11 @@ struct HighlightedTextView: NSViewRepresentable {
         // `setTheme` above replaces the whole `Theme` instance (dropping its font and line metrics),
         // so the font, line height, and baseline lift are reasserted as one package first.
         if needsRehighlight {
-            storage.highlightr.theme.setCodeFont(font)
-            storage.highlightr.theme.codeParagraphStyle = Self.paragraphStyle(font: font, lineSpacing: lineSpacing)
-            storage.highlightr.theme.codeBaselineOffset = Self.baselineOffset(lineSpacing: lineSpacing)
+            if let highlightr = storage.highlightr {
+                highlightr.theme.setCodeFont(font)
+                highlightr.theme.codeParagraphStyle = Self.paragraphStyle(font: font, lineSpacing: lineSpacing)
+                highlightr.theme.codeBaselineOffset = Self.baselineOffset(lineSpacing: lineSpacing)
+            }
             storage.language = language
         }
 

--- a/Sources/termio/Editor/Highlightr/CodeAttributedString.swift
+++ b/Sources/termio/Editor/Highlightr/CodeAttributedString.swift
@@ -52,8 +52,16 @@ open class CodeAttributedString : NSTextStorage
     let stringStorage = NSTextStorage()
 
     /// Highlightr instace used internally for highlighting. Use this for configuring the theme.
-    public let highlightr: Highlightr
-    
+    ///
+    /// Optional, unlike upstream, which force-unwraps `Highlightr()` in every initializer.
+    /// That constructor fails whenever syntax highlighting cannot be set up — a missing
+    /// resource, a `JSContext` that would not allocate — and none of those are worth killing
+    /// the app over: the editor's job is to show the file, and uncolored text does that.
+    /// The trap fired for real, from a sheet's layout pass (#348 follow-up), and it had
+    /// already shipped once as the v0.2.4 release crash this file was vendored to fix.
+    /// `nil` here means "no highlighting"; the storage behaves as plain text.
+    public let highlightr: Highlightr?
+
     /// This object will be notified before and after the highlighting.
     open var highlightDelegate : HighlightDelegate?
 
@@ -63,7 +71,7 @@ open class CodeAttributedString : NSTextStorage
      - parameter highlightr: The highlightr instance to use. Defaults to `Highlightr()`.
 
      */
-    public init(highlightr: Highlightr = Highlightr()!)
+    public init(highlightr: Highlightr? = Highlightr())
     {
         self.highlightr = highlightr
         super.init()
@@ -72,24 +80,24 @@ open class CodeAttributedString : NSTextStorage
 
     /// Initialize the CodeAttributedString
     public override init() {
-        self.highlightr = Highlightr()!
+        self.highlightr = Highlightr()
         super.init()
         setupListeners()
     }
-    
+
     /// Initialize the CodeAttributedString
     required public init?(coder aDecoder: NSCoder)
     {
-        self.highlightr = Highlightr()!
+        self.highlightr = Highlightr()
         super.init(coder: aDecoder)
         setupListeners()
     }
-    
+
     #if os(OSX)
     /// Initialize the CodeAttributedString
     required public init?(pasteboardPropertyList propertyList: Any, ofType type: NSPasteboard.PasteboardType)
     {
-        self.highlightr = Highlightr()!
+        self.highlightr = Highlightr()
         super.init(pasteboardPropertyList: propertyList, ofType: type)
         setupListeners()
     }
@@ -166,11 +174,12 @@ open class CodeAttributedString : NSTextStorage
 
     func highlight(_ range: NSRange)
     {
-        if(language == nil)
+        // No highlighter (see `highlightr`) or no language means the text stays as typed.
+        guard highlightr != nil, let language else
         {
             return;
         }
-        
+
         if let highlightDelegate = highlightDelegate
         {
             let shouldHighlight : Bool? = highlightDelegate.shouldHighlight?(range)
@@ -185,7 +194,9 @@ open class CodeAttributedString : NSTextStorage
         let line = string.substring(with: range)
         DispatchQueue.global().async
         {
-            let tmpStrg = self.highlightr.highlight(line, as: self.language!)
+            // Read back off `self`, as upstream does: capturing the highlighter directly
+            // would carry a non-Sendable value into this `@Sendable` closure.
+            let tmpStrg = self.highlightr?.highlight(line, as: language)
             let finish = UncheckedSendableClosure(run: {
                 //Checks to see if this highlighting is still valid.
                 if((range.location + range.length) > self.stringStorage.length)

--- a/Sources/termio/Editor/Highlightr/Highlightr.swift
+++ b/Sources/termio/Editor/Highlightr/Highlightr.swift
@@ -66,27 +66,46 @@ open class Highlightr
      */
     public init?(highlightPath: String? = nil)
     {
-        guard let jsContext = JSContext() else { return nil }
+        // Each `return nil` says which guard failed. Callers degrade to unhighlighted
+        // text rather than trapping, so without this a failure is invisible until
+        // someone notices their code is not colored.
+        guard let jsContext = JSContext() else
+        {
+            Log.app.error("highlightr: JSContext() returned nil")
+            return nil
+        }
         _ = JSValue(newObjectIn: jsContext)
 
         let bundle = Bundle.termioResources
         self.bundle = bundle
         guard let hgPath = highlightPath ?? bundle.path(forResource: "highlight.min", ofType: "js") else
         {
+            Log.app.error(
+                "highlightr: highlight.min.js missing from \(bundle.bundleURL.path, privacy: .public)")
             return nil
         }
-        
-        guard let hgJs = try? String.init(contentsOfFile: hgPath) else { return nil }
+
+        guard let hgJs = try? String.init(contentsOfFile: hgPath) else
+        {
+            Log.app.error("highlightr: could not read \(hgPath, privacy: .public)")
+            return nil
+        }
         _ = jsContext.evaluateScript(hgJs)
-        guard let hljs = jsContext.objectForKeyedSubscript("hljs") else { return nil }
+        guard let hljs = jsContext.objectForKeyedSubscript("hljs") else
+        {
+            Log.app.error("highlightr: highlight.min.js defined no hljs global")
+            return nil
+        }
 
         self.hljs = hljs
-        
+
         guard setTheme(to: "xcode") else
         {
+            Log.app.error(
+                "highlightr: xcode.min.css missing from \(bundle.bundleURL.path, privacy: .public)")
             return nil
         }
-        
+
     }
     
     /**

--- a/Tests/termioTests/CodeAttributedStringTests.swift
+++ b/Tests/termioTests/CodeAttributedStringTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import termio
+
+/// `Highlightr()` fails whenever syntax highlighting cannot be set up — a resource it
+/// cannot read, a `JSContext` that will not allocate. Every initializer used to
+/// force-unwrap it, so that condition killed the app the moment a file editor was built.
+/// The contract now is that the editor still shows the file, just uncolored.
+final class CodeAttributedStringTests: XCTestCase {
+    func testWithoutAHighlighterTheTextIsStillStored() {
+        let storage = CodeAttributedString(highlightr: nil)
+        storage.language = "swift"
+
+        storage.append(NSAttributedString(string: "let answer = 42\n"))
+        storage.append(NSAttributedString(string: "print(answer)\n"))
+
+        XCTAssertNil(storage.highlightr)
+        XCTAssertEqual(storage.string, "let answer = 42\nprint(answer)\n")
+    }
+
+    /// Editing is what drives `highlight(_:)`, which is where the nil highlighter is read.
+    func testEditingWithoutAHighlighterLeavesTheTextIntact() {
+        let storage = CodeAttributedString(highlightr: nil)
+        storage.language = "swift"
+        storage.append(NSAttributedString(string: "struct Box {}"))
+
+        storage.replaceCharacters(in: NSRange(location: 7, length: 3), with: "Crate")
+
+        XCTAssertEqual(storage.string, "struct Crate {}")
+    }
+
+    /// A language of nil already meant "no highlighting"; it must stay that way.
+    func testNoLanguageIsStillAccepted() {
+        let storage = CodeAttributedString(highlightr: nil)
+        storage.append(NSAttributedString(string: "plain text"))
+
+        XCTAssertNil(storage.language)
+        XCTAssertEqual(storage.string, "plain text")
+    }
+}


### PR DESCRIPTION
Opening a file editor could kill the app outright. The crash landed during a sheet's layout pass, before the editor had drawn anything:

```
0  CodeAttributedString.init() + 168     brk 1
1  @objc CodeAttributedString.init()
2  HighlightedTextView.Coordinator.init(text:)
3  makeCoordinator() … SheetContentRoot.sizeThatFits
```

`Coordinator` holds a `CodeAttributedString`, and every initializer in that vendored file did `self.highlightr = Highlightr()!`. Confirmed in the release binary rather than inferred: `Highlightr.init(highlightPath:)` is the only optional-returning call in the function, and it is followed by a `cbz x0` into `"Unexpectedly found nil while unwrapping an Optional value" / CodeAttributedString.swift`.

`Highlightr.init?` returns nil from five guards — `JSContext()`, the `highlight.min.js` lookup, reading it, the `hljs` global, and the theme stylesheet. Every one of them means the same thing: syntax highlighting is unavailable. None of them is a reason to lose the buffer. The file header already records this class shipping once before, as the v0.2.4 release crash the vendoring was done to fix; vendoring corrected the resource lookup but left the trap in place.

The highlighter is now optional, and nil means the editor shows the file as plain text. That also retires the `self.language!` unwrap that sat on the same line. Each guard logs which one failed, so a recurrence names its cause instead of leaving only a trap — which matters here, because the crash report alone was not enough to pin down which guard fired.

No new warnings (6 in that file before and after, checked by stashing and rebuilding). 445 tests pass, including three new ones covering the nil-highlighter path.

Release Notes:
- Fixed a crash when opening a file in the editor on machines where syntax highlighting could not start. The file now opens as plain text instead.