### PR TITLE
Keep Open Project and New Workspace clickable in the sidebar menu

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1720,13 +1720,24 @@ extension AppDelegate: NSMenuDelegate {
         // item's own key equivalent never fires, so ⌘O travels to the This Mac row
         // (see `fillOpenProjectMenu`).
         item.title = localized("Open Project")
-        item.action = nil
         item.keyEquivalent = ""
         item.keyEquivalentModifierMask = []
         // Attached once and filled by the delegate on open, like the other device
         // submenus. Replacing the menu object on every pass would swap it out from
         // under AppKit's key-equivalent sweep, which is what finds ⌘O in there.
+        //
+        // Everything below runs on the *first* reshape only. Once a submenu is
+        // attached AppKit owns both the action and the target — it installs its
+        // own `submenuAction:` aimed at the menu — and re-clearing them on a later
+        // pass strips that and leaves a submenu parent with no action, which dims
+        // the row permanently. This menu is refreshed on every open, so "later
+        // pass" means the second time the user pulls it down.
         guard item.submenu?.title != localized("Open Project") else { return }
+        // Cleared together, and before the submenu is attached: AppKit adopts the
+        // menu as the item's target only when nothing else already claims it, and
+        // a leftover AppDelegate cannot perform `submenuAction:`.
+        item.action = nil
+        item.target = nil
         let submenu = NSMenu(title: localized("Open Project"))
         submenu.delegate = self
         item.submenu = submenu
@@ -1767,11 +1778,13 @@ extension AppDelegate: NSMenuDelegate {
         // The ellipsis moves to the rows: each of those opens the name panel, and a
         // parent that only reveals a submenu never carries one.
         item.title = localized("New Workspace")
-        item.action = nil
         // Attached once and filled by the delegate on open, like the other device
         // submenus — the File menu's copy is rebuilt per open, but the toolbar `+`
-        // keeps its item across refreshes.
+        // keeps its item across refreshes. The action and target are cleared on the
+        // first reshape only, for the reason spelled out in `refreshOpenProjectItem`.
         guard item.submenu?.title != localized("New Workspace") else { return }
+        item.action = nil
+        item.target = nil
         let submenu = NSMenu(title: localized("New Workspace"))
         submenu.delegate = self
         item.submenu = submenu

--- a/Tests/termioTests/SubmenuParentEnablementTests.swift
+++ b/Tests/termioTests/SubmenuParentEnablementTests.swift
@@ -1,0 +1,106 @@
+import AppKit
+import XCTest
+
+/// The AppKit rule that dimmed ＋ ▸ Open Project and ＋ ▸ New Workspace.
+///
+/// Both rows are built as ordinary action items with an explicit `target`, then
+/// reshaped into submenu parents once a second machine exists
+/// (`refreshOpenProjectItem` / `refreshNewWorkspaceItem`). Nulling the action is
+/// not enough: assigning `submenu` makes AppKit install its own `submenuAction:`,
+/// and it only adopts the submenu as the item's target when the target is already
+/// nil. A leftover target keeps the selector pointed at the AppDelegate, which
+/// cannot perform it, so the row dims — while still drawing its arrow, which is
+/// what made the symptom read as a broken submenu rather than a wrong target.
+///
+/// Two things are pinned separately, because `NSMenu.update()` on a detached menu
+/// reports them differently. A stripped action does dim the item here, so that one
+/// is asserted directly. A wrong *target* does not — the live app is where that
+/// showed, with the reshaped row logging `action=submenuAction: target=set` and
+/// drawing grey — so the target case is pinned as wiring rather than as state.
+final class SubmenuParentEnablementTests: XCTestCase {
+    /// Stands in for the AppDelegate: a plausible menu target that, like it, does
+    /// not implement `submenuAction:`.
+    private final class Target: NSObject {
+        @objc func openProject(_ sender: Any?) {}
+    }
+
+    private static let submenuAction = Selector(("submenuAction:"))
+
+    /// `NSMenuItem.target` is weak, so the stand-in delegate is held by the test
+    /// for as long as the item is — the app holds its AppDelegate the same way.
+    private let delegate = Target()
+
+    private func reshaped(clearingTarget: Bool) -> NSMenuItem {
+        let item = NSMenuItem(
+            title: "Open Project", action: #selector(Target.openProject(_:)), keyEquivalent: "")
+        item.target = delegate
+        // Exactly the reshape the delegate performs.
+        item.action = nil
+        if clearingTarget { item.target = nil }
+        item.submenu = NSMenu(title: "Open Project")
+        return item
+    }
+
+    /// The trap: AppKit owns a submenu parent's action, so nulling it is not what
+    /// decides anything — the target is.
+    func testAttachingASubmenuInstallsAppKitsOwnAction() {
+        let item = reshaped(clearingTarget: true)
+        XCTAssertEqual(item.action.map(NSStringFromSelector), NSStringFromSelector(Self.submenuAction))
+    }
+
+    /// The bug: AppKit does not replace a target that is already set, so
+    /// `submenuAction:` stays aimed at the AppDelegate, which never implements it.
+    func testALeftoverTargetKeepsTheRowAimedAtTheDelegate() {
+        XCTAssertTrue(
+            reshaped(clearingTarget: false).target is Target,
+            "the delegate is still what AppKit will ask to open the submenu")
+    }
+
+    /// The fix: cleared before the submenu is attached, AppKit takes ownership of
+    /// the target — which is what `makeNewChatItem` gets for free by never setting
+    /// one.
+    func testClearingTheTargetLetsAppKitOwnIt() {
+        XCTAssertTrue(
+            reshaped(clearingTarget: true).target is NSMenu,
+            "AppKit adopts the menu itself once nothing else claims the item")
+    }
+
+    /// This menu is refreshed on every open, so the reshape runs again on an item
+    /// that is already a submenu parent. What the delegate used to do then — clear
+    /// the action unconditionally — is what dimmed the row for the rest of the
+    /// launch: it worked once, then never again.
+    ///
+    /// Spelled out as two shapes rather than by calling the delegate:
+    /// `refreshOpenProjectItem` is private to the AppDelegate and needs a store and
+    /// a window, so what is pinned here is the AppKit rule that makes its guard
+    /// necessary, not the guard itself.
+    func testClearingTheActionOnASecondRefreshDimsTheRow() {
+        let menu = NSMenu(title: "New Session")
+        let item = reshaped(clearingTarget: true)
+        menu.addItem(item)
+        menu.update()
+        XCTAssertTrue(item.isEnabled, "the first pull-down was always fine")
+
+        // The old second pass, verbatim.
+        item.action = nil
+        item.target = nil
+        menu.update()
+        XCTAssertFalse(
+            item.isEnabled,
+            "stripping AppKit's submenuAction: leaves a submenu parent with no action")
+    }
+
+    /// The fixed second pass: the refresh returns before touching either, and the
+    /// row survives every subsequent open.
+    func testLeavingAppKitsActionAloneKeepsTheRowLive() {
+        let menu = NSMenu(title: "New Session")
+        let item = reshaped(clearingTarget: true)
+        menu.addItem(item)
+        menu.update()
+        menu.update()
+        XCTAssertTrue(item.isEnabled)
+        XCTAssertEqual(
+            item.action.map(NSStringFromSelector), NSStringFromSelector(Self.submenuAction),
+            "AppKit's action survives a refresh that leaves it alone")
+    }
+}


### PR DESCRIPTION
Both rows dim in the sidebar `+` menu as soon as a second machine exists — which is exactly when their device submenu is the only way to reach another box. The first pull-down works; every one after it is grey.

## Cause

They are the only items built as ordinary action rows and later reshaped into submenu parents, and the reshape runs on every open.

Once a submenu is attached AppKit owns the item's action: it installs its own `submenuAction:` aimed at the menu. Clearing the action again on the next pass strips that and leaves a submenu parent with no action, which validation dims — while the arrow keeps drawing, which is why this read as a broken submenu rather than a stripped selector.

Measured on a bare `NSMenu`:

```
pass 1 → action=submenuAction: target=NSMenu enabled=true
pass 2 → action=nil           target=nil    enabled=false
```

A second, smaller trap sits underneath it: AppKit adopts the menu as the item's target only when nothing else already claims it, and a leftover AppDelegate cannot perform `submenuAction:`.

## Fix

The action and target are cleared on the first reshape only, and together. New Chat and New SSH Connection were never affected because they are born as submenu parents and never name a target.

`SubmenuParentEnablementTests` pins both traps, including a second `menu.update()` — the pass the earlier attempt at this missed.

Release Notes:
- Fixed Open Project and New Workspace dimming in the sidebar `+` menu once a second machine was known.