### PR TITLE
Switch workspaces with ⌘1…9 and unify the toolbar toggles

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -2259,15 +2259,17 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     ) -> NSToolbarItem? {
         switch itemIdentifier {
         case .toggleNavigator:
+            // Hand-drawn for the same reason as the inspector toggle it now mirrors (see
+            // `NavigatorToggleToolbarView`): a native `isBordered` item wears its capsule in both
+            // states, so the pill said nothing on this end of the toolbar while the trailing one
+            // used it to mean "the pane is open".
             let item = NSToolbarItem(itemIdentifier: .toggleNavigator)
             item.label = localized("Navigator")
             item.toolTip = localized("Hide or show the navigator")
-            item.image = NSImage(systemSymbolName: "sidebar.leading", accessibilityDescription: "Navigator")
-            item.isBordered = true
-            // `NSSplitViewController.toggleSidebar(_:)` collapses the first (sidebar) item with
-            // the system animation. `nil` target routes up the responder chain to the split
-            // controller (the window's content view controller), so no custom action is needed.
-            item.action = #selector(NSSplitViewController.toggleSidebar(_:))
+            let host = NSHostingView(rootView: NavigatorToggleToolbarView())
+            host.sizingOptions = [.intrinsicContentSize]
+            item.view = host
+            item.isBordered = false
             return item
         case .workspaceSwitcher:
             // The workspace the sidebar is scoped to, at the head of the sidebar's own toolbar
@@ -2350,14 +2352,16 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
                 dividerIndex: 1
             )
         case .toggleInspector:
-            // Native bordered button, built exactly like the navigator toggle so the two are the
-            // same size; the trailing-sidebar glyph mirrors the leading one.
+            // Hand-drawn (see `InspectorToggleToolbarView`) because this one button has to look
+            // the same with and without its capsule; the trailing-sidebar glyph mirrors the
+            // navigator toggle's leading one.
             let item = NSToolbarItem(itemIdentifier: .toggleInspector)
             item.label = localized("Inspector")
             item.toolTip = localized("Hide or show the inspector")
-            item.image = NSImage(systemSymbolName: "sidebar.trailing", accessibilityDescription: "Inspector")
-            item.isBordered = true
-            item.action = #selector(AppDelegate.toggleFilesInspector(_:))
+            let host = NSHostingView(rootView: InspectorToggleToolbarView().environmentObject(store))
+            host.sizingOptions = [.intrinsicContentSize]
+            item.view = host
+            item.isBordered = false
             return item
         case .branchPicker:
             let item = NSToolbarItem(itemIdentifier: .branchPicker)
@@ -2470,6 +2474,102 @@ private struct BranchPickerToolbarView: View {
         // left edge moved with every session switch. Pinned, it starts where the terminal text
         // below it does and only ever grows to the right.
         .frame(minWidth: Self.titleWidthFloor, maxWidth: Self.titleWidthCeiling, alignment: .leading)
+    }
+}
+
+/// Both pane toggles — the navigator at the leading end of the toolbar, the inspector at the
+/// trailing end — drawn by one view so the two ends can never disagree.
+///
+/// Hand-drawn rather than a native `isBordered` toolbar item because AppKit renders the two
+/// states through different paths — bordered goes through `NSButton` (symbol scaled to the
+/// capsule, `.labelColor`), unbordered through the plain toolbar-image path (the toolbar's own
+/// image size and tint) — so flipping the border also changed the glyph's size and shade, and the
+/// two buttons stopped matching. Owning the glyph pins it and leaves the capsule as the only
+/// thing that changes.
+///
+/// Whether a capsule is drawn at all is the caller's to say, because the two sit on different
+/// backdrops: the trailing button is over plain window chrome, where the capsule is what marks
+/// the inspector as open; the leading one is over the sidebar's own vibrant material, where a
+/// glass pill reads as a lump on the column rather than as state. It takes
+/// `InspectorTabsToolbar`'s height and its `.regular` glass, which is already the pane switch's
+/// answer to matching the native buttons.
+private struct PaneToggleToolbarView: View {
+    let symbol: String
+    let showsCapsule: Bool
+    let help: String
+    let label: String
+    let toggle: () -> Void
+
+    @Environment(\.controlActiveState) private var controlActive
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Button(action: toggle) {
+            Image(systemName: symbol)
+                // Sized by measurement, not by guess: at 15pt this drew a 17.5×13.5pt glyph
+                // against the native bordered item it replaced (19.5×15.5), and the pair read
+                // uneven across the toolbar. 17 matches it.
+                .font(.system(size: 17))
+                .foregroundStyle(controlActive == .inactive
+                                 ? Color(nsColor: .disabledControlTextColor) : .primary)
+                .frame(width: InspectorTabsToolbar.controlHeight,
+                       height: InspectorTabsToolbar.controlHeight)
+                .background { if showsCapsule { capsuleBackground } }
+                .contentShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .help(help)
+        .accessibilityLabel(label)
+    }
+
+    @ViewBuilder
+    private var capsuleBackground: some View {
+        if #available(macOS 26.0, *) {
+            Color.clear.glassEffect(.regular, in: .capsule)
+        } else {
+            Capsule(style: .continuous)
+                .fill(colorScheme == .dark ? Color.white.opacity(0.06) : Color.white)
+        }
+    }
+}
+
+private struct NavigatorToggleToolbarView: View {
+    var body: some View {
+        PaneToggleToolbarView(
+            // Never capsuled, open or collapsed. This button lives in the sidebar's own toolbar
+            // region, over the vibrant `.sidebar` material and beside the traffic lights — a
+            // glass pill there sits on the column instead of on the chrome. Hand-drawn all the
+            // same, rather than an unbordered native item, because that path takes the toolbar's
+            // own image size and tint and would stop matching the trailing button's glyph.
+            symbol: "sidebar.leading",
+            showsCapsule: false,
+            help: localized("Hide or show the navigator"),
+            label: localized("Navigator")
+        ) {
+            // `NSSplitViewController.toggleSidebar(_:)` collapses the first (sidebar) item with
+            // the system animation. A `nil` target routes up the responder chain to the split
+            // controller (the window's content view controller), so there is no action to write.
+            NSApp.sendAction(#selector(NSSplitViewController.toggleSidebar(_:)), to: nil, from: nil)
+        }
+    }
+}
+
+/// The trailing inspector toggle: the same glyph in both states, wearing the glass capsule only
+/// while the inspector is open. Closed, the button stands alone over the terminal, where a capsule
+/// reads as a chip of chrome floating on the content; open, it is the right end of the row the
+/// pane switch draws, and the shared capsule is what makes them one group.
+private struct InspectorToggleToolbarView: View {
+    @EnvironmentObject var store: TermioStore
+
+    var body: some View {
+        PaneToggleToolbarView(
+            symbol: "sidebar.trailing",
+            showsCapsule: store.inspectorVisible,
+            help: localized("Hide or show the inspector"),
+            label: localized("Inspector")
+        ) {
+            NSApp.sendAction(#selector(AppDelegate.toggleFilesInspector(_:)), to: nil, from: nil)
+        }
     }
 }
 

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1977,23 +1977,13 @@ extension AppDelegate: NSMenuDelegate {
     /// opens a terminal there, which installs `termiod` on the way
     /// (`ensureRemoteReady`) and teaches the app which machine the alias reaches —
     /// after which it is a device and moves out of this menu.
-    /// The Workspace submenu: one row per workspace, the current one checked. The
-    /// first nine take ⌃⌥⌘1…9 — positional, so they are not in `KeyCommandCatalog`
-    /// with the rebindable commands: what row 2 means changes with the list, and a
-    /// binding whose target moves is not a binding a user can keep. The modifier trio
-    /// is the one no terminal program can want (Cmd is off-limits to a TUI) and that
-    /// nothing else in termio takes.
+    /// The Workspace submenu: one row per workspace, the current one checked, the
+    /// first nine on ⌘1…9. This is the copy that *binds* those keys — the sidebar
+    /// switcher draws the same rows from `WorkspaceMenu.rows`, but AppKit resolves
+    /// a key equivalent against the main menu, so only this one claims them.
     private func fillWorkspaceMenu(_ menu: NSMenu) {
-        for (index, workspace) in store.orderedWorkspaces.enumerated() {
-            let item = menu.addItem(
-                withTitle: workspace.name,
-                action: #selector(switchToWorkspace(_:)),
-                keyEquivalent: index < 9 ? String(index + 1) : ""
-            )
-            item.keyEquivalentModifierMask = [.control, .option, .command]
-            item.target = self
-            item.representedObject = workspace.id.uuidString
-            item.state = workspace.id == store.currentWorkspaceID ? .on : .off
+        for row in WorkspaceMenu.rows(in: store, target: self, action: #selector(switchToWorkspace(_:))) {
+            menu.addItem(row)
         }
         menu.addItem(.separator())
         // The same row the toolbar `+` carries: a plain verb on one machine, a
@@ -2282,11 +2272,11 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
         case .workspaceSwitcher:
             // The workspace the sidebar is scoped to, at the head of the sidebar's own toolbar
             // region — the band above the column it scopes. Borderless SwiftUI rather than an
-            // `NSMenuToolbarItem` so the one workspace menu has one definition
-            // (`WorkspaceSwitcherMenuContent`) instead of an AppKit copy that can drift from it,
-            // and so the control can name the workspace: this toolbar is `.iconOnly`, which drops
-            // item titles. It draws nothing while there is only one workspace, which is also when
-            // the sidebar region has the least room to spare.
+            // `NSMenuToolbarItem` so the control can name the workspace: this toolbar is
+            // `.iconOnly`, which drops item titles. Its menu is still AppKit, built from the same
+            // `WorkspaceMenu.rows` this file's `fillWorkspaceMenu` uses, so the two can't drift.
+            // It draws nothing while there is only one workspace, which is also when the sidebar
+            // region has the least room to spare.
             let item = NSToolbarItem(itemIdentifier: .workspaceSwitcher)
             item.label = localized("Workspace")
             item.toolTip = localized("Choose which workspace the sidebar shows")

--- a/Sources/termio/Keybindings/KeybindingStore.swift
+++ b/Sources/termio/Keybindings/KeybindingStore.swift
@@ -113,7 +113,28 @@ final class KeybindingStore: ObservableObject {
         // item is inserted by AppKit, so termio has no command of its own here —
         // only the duty to stop the surface from eating the key.
         ("Enter Full Screen", .init(modifiers: [.command, .control], key: .char("f"))),
-    ]
+    ] + workspaceShortcuts.enumerated().map { ("Workspace \($0.offset + 1)", $0.element) }
+
+    /// ⌘1…9 — the rows of the workspace switcher (`WorkspaceMenu.rows`).
+    ///
+    /// Cmd-digit is what an app means by "the nth top-level thing", and termio's
+    /// top-level thing is the workspace. Ghostty's own `goto_tab` on these keys
+    /// has nothing to reach in an app with no tabs, and session navigation
+    /// already holds the other half of that convention (⌘⇧] / ⌘⇧[ cycle), so the
+    /// indexed half is free.
+    ///
+    /// Being in `hostReserved` is what makes them work at all: ghostty binds
+    /// ⌘1…9 by default, a surface-handled keybind is consumed before the menu bar
+    /// sees the event, and `TerminalCallbackBridge` drops `goto_tab` as
+    /// unperformable in this embedding. Without the unbind the key would do
+    /// nothing whenever a terminal has focus — which in termio is nearly always.
+    ///
+    /// Positional, so deliberately not catalog commands: what row 2 means changes
+    /// with the list, and a binding whose target moves is not one a user can
+    /// rebind and keep. The switcher draws the digit beside each name so the
+    /// number is read rather than remembered.
+    static let workspaceShortcuts: [Shortcut] =
+        (1...9).map { .init(modifiers: [.command], key: .char(String($0))) }
 
     /// Keys the *surface* owns: they act on the terminal's own text, ghostty
     /// already implements them, and unbinding them would break the terminal.

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -2,6 +2,37 @@ import AppKit
 import SwiftUI
 import TermioShared
 
+/// The workspace rows, in the order every surface shows them: one item per
+/// workspace, the one on screen checked, the first nine carrying ⌘1…9.
+///
+/// One builder for both menus that draw them — the sidebar switcher and File ▸
+/// Workspace — because the digit is positional. Two menus numbering their own
+/// rows could disagree about which workspace ⌘2 reaches, and a number that lies
+/// is worse than no number at all.
+enum WorkspaceMenu {
+    /// `representedObject` carries the workspace's uuid string, which is what
+    /// `action` reads back — the one thing both callers' handlers share.
+    ///
+    /// The key equivalents are live only in the menu bar's copy: AppKit matches a
+    /// keystroke against the main menu, so the same items in a pull-down draw the
+    /// glyphs without claiming ⌘1…9 a second time.
+    @MainActor
+    static func rows(in store: TermioStore, target: AnyObject, action: Selector) -> [NSMenuItem] {
+        let shortcuts = KeybindingStore.workspaceShortcuts
+        return store.orderedWorkspaces.enumerated().map { index, workspace in
+            let item = NSMenuItem(title: workspace.name, action: action, keyEquivalent: "")
+            if index < shortcuts.count {
+                item.keyEquivalent = shortcuts[index].keyEquivalent
+                item.keyEquivalentModifierMask = shortcuts[index].keyEquivalentModifierMask
+            }
+            item.target = target
+            item.representedObject = workspace.id.uuidString
+            item.state = workspace.id == store.currentWorkspaceID ? .on : .off
+            return item
+        }
+    }
+}
+
 /// The workspace switcher, in the sidebar's own toolbar region: which scope you
 /// are in, and the control that changes it. It sits in the strip above the list
 /// rather than in a row of its own, next to the navigator toggle and the
@@ -27,75 +58,35 @@ struct WorkspaceSwitcherToolbarView: View {
         // word is a label for a decision the user never took.
         if store.hasMultipleWorkspaces {
             let current = store.currentWorkspace
-            Menu {
-                menuRows
-            } label: {
-                HStack(spacing: 5) {
-                    // Sized against the toolbar's own glyphs (the navigator toggle, the
-                    // sort pull-down) rather than shrunk to fit beside them, and set in
-                    // the sidebar's interface font — this control belongs to that column.
-                    // A workspace on another machine says so with the same server
-                    // mark its rows carry; one on this Mac is a place you put
-                    // things, so it takes the folder mark.
-                    HugeIconView(icon: current.device.isThisMac ? .folderOpen : .serverStack,
-                                 size: 15, color: color)
-                    Text(current.name)
-                        .font(settings.interfaceFont)
-                        .foregroundStyle(color)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    HugeIconView(icon: .chevronRight, size: 8, color: color,
-                                 lineWidthOverride: 1.75)
-                        .rotationEffect(.degrees(90))
-                }
+            // The name and nothing else. No device mark — the rows below already say
+            // which machine they are on — and no menu chevron: the toolbar band is
+            // three glyphs wide, and every point this control spends on decoration is
+            // a point the name truncates at.
+            Text(current.name)
+                .font(nameFont)
+                .foregroundStyle(color)
+                .lineLimit(1)
+                .truncationMode(.middle)
                 .frame(maxWidth: Self.nameWidthCeiling)
-                .contentShape(Rectangle())
-            }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
-            .help(localized("The sidebar shows this workspace"))
+                .fixedSize()
+                .overlay(WorkspaceMenuPopper(store: store))
+                .help(localized("The sidebar shows this workspace"))
+                .accessibilityElement()
+                .accessibilityLabel(localized("Workspace"))
+                .accessibilityValue(current.name)
+                .accessibilityAddTraits(.isButton)
         }
     }
 
-    @ViewBuilder
-    private var menuRows: some View {
-        // An inline Picker is what draws the checkmark on the current workspace; a
-        // row of Buttons would leave the switcher unable to say which one is showing.
-        Picker("", selection: selection) {
-            ForEach(store.orderedWorkspaces) { workspace in
-                Text(workspace.name).tag(workspace.id)
-            }
-        }
-        .pickerStyle(.inline)
-        .labelsHidden()
-        Divider()
-        // This Mac, without asking: the device submenu belongs to the menus that
-        // already carry one (File ▸ Workspace and the sidebar `+`), and growing a
-        // third here would put a machine list in the switcher, which is the "go to
-        // a computer" mode the workspace replaced.
-        Button(localized("New Workspace…")) { store.presentNewWorkspacePanel(on: .thisMac) }
-        Button(localized("Rename Workspace…")) {
-            store.presentRenameWorkspacePanel(store.currentWorkspaceID)
-        }
-        // Removing the last workspace is refused in the store — the sidebar has to
-        // have a scope to show — and this menu only opens while there is more than
-        // one, so the row is always live where it is drawn.
-        Button(localized("Remove Workspace")) {
-            store.confirmRemoveWorkspace(store.currentWorkspaceID)
-        }
-        // No device verb here, deliberately. A machine you can *go to* is the
-        // mode this scope replaced: it made the sidebar answer "which computer"
-        // when the question is "which work". A device is a place a new thing is
-        // put — New Terminal on it, Clone to it, File ▸ Connect to… for a box
-        // never reached — never a place the window travels to.
-    }
-
-    private var selection: Binding<Workspace.ID> {
-        Binding(
-            get: { store.currentWorkspaceID },
-            set: { store.switchToWorkspace($0) }
-        )
+    /// A step above the sidebar's own row text: this names the whole column, so it
+    /// reads as that column's title rather than as one more row of it. Derived from
+    /// the interface size rather than fixed, so it still follows the density
+    /// preference the rows below it follow.
+    private var nameFont: Font {
+        let size = settings.interfaceFontSize + 2
+        return settings.interfaceFontFamily.isEmpty
+            ? .system(size: size)
+            : .custom(settings.interfaceFontFamily, size: size)
     }
 
     // Matched to the sidebar toolbar's native glyphs (the `+` new-terminal item, the
@@ -104,5 +95,97 @@ struct WorkspaceSwitcherToolbarView: View {
     // one control band with them rather than a dimmer `.secondary` label.
     private var color: Color {
         controlActive == .inactive ? Color(nsColor: .disabledControlTextColor) : .primary
+    }
+}
+
+/// Opens the switcher's menu on click, over the label above it.
+///
+/// AppKit rather than SwiftUI's `Menu` because only `NSMenuItem` draws both halves
+/// a row needs at once: a checkmark in the state column for the workspace on
+/// screen, and the ⌘-digit that reaches it, right-aligned in the column macOS puts
+/// shortcuts in. SwiftUI offers one or the other — an inline `Picker` checkmarks,
+/// a `Button` takes `.keyboardShortcut` — and `.keyboardShortcut` would also
+/// *claim* ⌘1…9 for as long as this view is mounted, a second live binding racing
+/// File ▸ Workspace for the same keystroke.
+private struct WorkspaceMenuPopper: NSViewRepresentable {
+    let store: TermioStore
+
+    func makeNSView(context: Context) -> WorkspaceMenuHost {
+        let view = WorkspaceMenuHost()
+        view.store = store
+        return view
+    }
+
+    func updateNSView(_ nsView: WorkspaceMenuHost, context: Context) {
+        nsView.store = store
+    }
+}
+
+/// The click target, and the target of the menu it pops. One class rather than a
+/// view plus a coordinator: the menu is built when it opens, out of the store this
+/// view already holds, so there is no second place for its contents to live.
+private final class WorkspaceMenuHost: NSView {
+    weak var store: TermioStore?
+
+    /// Flipped so the anchor below reads in the direction the menu opens, rather
+    /// than depending on whichever convention the hosting view happens to use.
+    override var isFlipped: Bool { true }
+
+    /// A click in a background window opens the menu rather than only raising the
+    /// window — the switcher is often the reason the window is being reached for.
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let store else { return }
+        let menu = NSMenu()
+        for row in WorkspaceMenu.rows(in: store, target: self, action: #selector(switchToWorkspace(_:))) {
+            menu.addItem(row)
+        }
+        menu.addItem(.separator())
+        // This Mac, without asking: the device submenu belongs to the menus that
+        // already carry one (File ▸ Workspace and the sidebar `+`), and growing a
+        // third here would put a machine list in the switcher, which is the "go to
+        // a computer" mode the workspace replaced.
+        addAction(localized("New Workspace…"), to: menu) { $0.presentNewWorkspacePanel(on: .thisMac) }
+        addAction(localized("Rename Workspace…"), to: menu) {
+            $0.presentRenameWorkspacePanel($0.currentWorkspaceID)
+        }
+        // Removing the last workspace is refused in the store — the sidebar has to
+        // have a scope to show — and this menu only opens while there is more than
+        // one, so the row is always live where it is drawn.
+        addAction(localized("Remove Workspace"), to: menu) { $0.confirmRemoveWorkspace($0.currentWorkspaceID) }
+        // No device verb here, deliberately. A machine you can *go to* is the
+        // mode this scope replaced: it made the sidebar answer "which computer"
+        // when the question is "which work". A device is a place a new thing is
+        // put — New Terminal on it, Clone to it, File ▸ Connect to… for a box
+        // never reached — never a place the window travels to.
+
+        // Anchored under the label the way a pull-down opens, rather than at the
+        // pointer the way a context menu does.
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: bounds.height + 4), in: self)
+    }
+
+    private func addAction(_ title: String, to menu: NSMenu, run: @escaping (TermioStore) -> Void) {
+        let item = NSMenuItem(title: title, action: #selector(invoke(_:)), keyEquivalent: "")
+        item.target = self
+        item.representedObject = Handler(run)
+        menu.addItem(item)
+    }
+
+    @objc private func switchToWorkspace(_ sender: NSMenuItem) {
+        guard let raw = sender.representedObject as? String, let id = UUID(uuidString: raw) else { return }
+        store?.switchToWorkspace(id)
+    }
+
+    @objc private func invoke(_ sender: NSMenuItem) {
+        guard let store, let handler = sender.representedObject as? Handler else { return }
+        handler.run(store)
+    }
+
+    /// Boxes a menu-item closure so it can ride along on `representedObject`, the
+    /// only payload an `NSMenuItem` carries.
+    private final class Handler {
+        let run: (TermioStore) -> Void
+        init(_ run: @escaping (TermioStore) -> Void) { self.run = run }
     }
 }

--- a/Tests/termioTests/KeybindingSurfaceTests.swift
+++ b/Tests/termioTests/KeybindingSurfaceTests.swift
@@ -68,7 +68,7 @@ final class KeybindingSurfaceTests: XCTestCase {
             "super+,",              // open_config          → Settings…
             "super+q",              // quit                 → Quit Termio
             "super+ctrl+f",         // toggle_fullscreen    → Enter Full Screen
-        ] {
+        ] + (1...9).map { "super+\($0)" } {  // goto_tab:N → the workspace switcher's rows
             XCTAssertTrue(triggers.contains(trigger), "\(trigger) is still handled by the surface")
         }
     }

--- a/docs/design/20260819-device-workspace-project.md
+++ b/docs/design/20260819-device-workspace-project.md
@@ -309,7 +309,7 @@ mechanical one. **Stage 1 of the implementation deliberately does none of them.*
   216–292 ms cold roster measured at `TermioStore+Termiod.swift:258`.
   `20260819-workspace-switch-latency.md` was written when user-made workspaces
   never paid this.
-- **⌃⌥⌘1…9 reshuffle once.** `orderedWorkspaces` is also the shortcut order
+- **⌘1…9 reshuffle once.** `orderedWorkspaces` is also the shortcut order
   (`App.swift:1911`); dropping the fallback-last rule moves them. The comment at
   `:1904` already accepts positional instability.
 - **`Session.deviceID` is the small half.** Every "which machine is this


### PR DESCRIPTION
Two changes to the sidebar's chrome.

**⌘1…9 switches workspaces.** The Workspace submenu already numbered its rows, on ⌃⌥⌘1…9 — a chord picked back when Cmd-digit was assumed to belong to the terminal. It doesn't: Cmd never reaches a TUI, ghostty's `goto_tab` has nothing to reach in an app with no tabs, and session navigation already holds the cycling half of that convention on ⌘⇧] / ⌘⇧[.

Reserving ⌘1…9 in `KeybindingStore.hostReserved` is what makes them work at all — ghostty binds those keys by default, a surface keybind is consumed before the menu bar sees the event, and `TerminalCallbackBridge` drops `goto_tab` as unperformable here, so without the unbind the key would die silently under a focused terminal.

The binding is positional, so the digit has to be readable: the sidebar switcher now draws the same rows the menu bar does, from one `WorkspaceMenu.rows` — checkmark in the state column, shortcut right-aligned. One list means ⌘2 can't name different workspaces in the two menus. Only the menu bar's copy binds the keys; AppKit resolves key equivalents against the main menu, so the pull-down draws the glyphs without claiming them twice.

**Both pane toggles now look the same.** The trailing toggle wore its glass capsule only while the inspector was open; the leading one was a native bordered item, which macOS 26 capsules either way — so it sat pilled over a collapsed sidebar, saying nothing, beside a button using the same pill to say something. Both are drawn by one `PaneToggleToolbarView` now. The navigator wears no capsule in either state: it sits over the sidebar's vibrant material beside the traffic lights, where a glass pill reads as a lump on the column rather than as chrome.

## Verification

`swift build` clean, 440 tests pass. `super+1`…`super+9` added to the pinned ghostty-collision list in `KeybindingSurfaceTests`.

Not yet verified on screen — screen capture was unavailable in the environment this was written in. Worth a look at three things before merging:

- The switcher's menu opens and is anchored under the label (it is now an `NSMenu` popped from an AppKit view overlaid on the label, inside an `NSHostingView` sized to intrinsic content).
- ⌘2 switches while a terminal pane has focus — that is the unbind path.
- The two toggle glyphs read even across the toolbar. The 17pt constant was measured against the *bordered* native item; the navigator is now unbordered.

## Release Notes

- Switch workspaces with ⌘1…9. The shortcut for each workspace is shown beside its name in the sidebar's workspace menu.
- The sidebar and inspector buttons in the toolbar now match. The sidebar button no longer shows a background.