### PR TITLE
Fix the toolbar toggles' overflow rows and the workspace switcher's accessibility

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -2270,6 +2270,10 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             host.sizingOptions = [.intrinsicContentSize]
             item.view = host
             item.isBordered = false
+            // The view takes the click; the action is what AppKit reads to synthesize this
+            // item's row in the `»` overflow menu and to validate it. A view-based item with
+            // neither an action nor a `menuFormRepresentation` overflows into a dead row.
+            item.action = #selector(NSSplitViewController.toggleSidebar(_:))
             return item
         case .workspaceSwitcher:
             // The workspace the sidebar is scoped to, at the head of the sidebar's own toolbar
@@ -2293,7 +2297,9 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             // A pull-down that sets how the sidebar orders projects (Recent Activity /
             // Name). Sits just left of the `+`, at the trailing edge of the sidebar's
             // toolbar region. Native `NSMenuToolbarItem` so it carries the standard
-            // menu chevron and free Liquid Glass bordered look, matching the toggles.
+            // menu chevron and free Liquid Glass bordered look. It keeps that border
+            // unconditionally where the pane toggles don't: this opens a menu, and a
+            // menu is always available — their capsule says whether a pane is open.
             let item = NSMenuToolbarItem(itemIdentifier: .sortProjects)
             item.label = localized("Sort")
             item.toolTip = localized("Choose how projects are ordered")
@@ -2362,6 +2368,8 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             host.sizingOptions = [.intrinsicContentSize]
             item.view = host
             item.isBordered = false
+            // Kept for the overflow menu and validation, as on the navigator toggle above.
+            item.action = #selector(AppDelegate.toggleFilesInspector(_:))
             return item
         case .branchPicker:
             let item = NSToolbarItem(itemIdentifier: .branchPicker)

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -69,12 +69,12 @@ struct WorkspaceSwitcherToolbarView: View {
                 .truncationMode(.middle)
                 .frame(maxWidth: Self.nameWidthCeiling)
                 .fixedSize()
+                // The overlay owns the press, the tooltip, and the accessibility of
+                // this control — it is the view under the pointer, so a `.help()` here
+                // would be shadowed by it and a SwiftUI accessibility element here would
+                // hide it. See `WorkspaceMenuHost`.
                 .overlay(WorkspaceMenuPopper(store: store))
-                .help(localized("The sidebar shows this workspace"))
-                .accessibilityElement()
-                .accessibilityLabel(localized("Workspace"))
-                .accessibilityValue(current.name)
-                .accessibilityAddTraits(.isButton)
+                .accessibilityHidden(true)
         }
     }
 
@@ -113,6 +113,7 @@ private struct WorkspaceMenuPopper: NSViewRepresentable {
     func makeNSView(context: Context) -> WorkspaceMenuHost {
         let view = WorkspaceMenuHost()
         view.store = store
+        view.toolTip = localized("The sidebar shows this workspace")
         return view
     }
 
@@ -136,6 +137,28 @@ private final class WorkspaceMenuHost: NSView {
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func mouseDown(with event: NSEvent) {
+        showMenu()
+    }
+
+    // MARK: - Accessibility
+    //
+    // The element is this view rather than the `Text` beneath it. A SwiftUI
+    // `.accessibilityAddTraits(.isButton)` only sets a trait — nothing there answers
+    // a press — so the control announced itself as a button and then did nothing,
+    // which the `Menu` it replaced did not do. Answering here gives the press a real
+    // implementation and one description that cannot disagree with the label drawn.
+
+    override func isAccessibilityElement() -> Bool { true }
+    override func accessibilityRole() -> NSAccessibility.Role? { .popUpButton }
+    override func accessibilityLabel() -> String? { localized("Workspace") }
+    override func accessibilityValue() -> Any? { store?.currentWorkspace.name }
+
+    override func accessibilityPerformPress() -> Bool {
+        showMenu()
+        return true
+    }
+
+    private func showMenu() {
         guard let store else { return }
         let menu = NSMenu()
         for row in WorkspaceMenu.rows(in: store, target: self, action: #selector(switchToWorkspace(_:))) {
@@ -146,14 +169,12 @@ private final class WorkspaceMenuHost: NSView {
         // already carry one (File ▸ Workspace and the sidebar `+`), and growing a
         // third here would put a machine list in the switcher, which is the "go to
         // a computer" mode the workspace replaced.
-        addAction(localized("New Workspace…"), to: menu) { $0.presentNewWorkspacePanel(on: .thisMac) }
-        addAction(localized("Rename Workspace…"), to: menu) {
-            $0.presentRenameWorkspacePanel($0.currentWorkspaceID)
-        }
+        addAction(localized("New Workspace…"), to: menu, #selector(newWorkspace))
+        addAction(localized("Rename Workspace…"), to: menu, #selector(renameWorkspace))
         // Removing the last workspace is refused in the store — the sidebar has to
         // have a scope to show — and this menu only opens while there is more than
         // one, so the row is always live where it is drawn.
-        addAction(localized("Remove Workspace"), to: menu) { $0.confirmRemoveWorkspace($0.currentWorkspaceID) }
+        addAction(localized("Remove Workspace"), to: menu, #selector(removeWorkspace))
         // No device verb here, deliberately. A machine you can *go to* is the
         // mode this scope replaced: it made the sidebar answer "which computer"
         // when the question is "which work". A device is a place a new thing is
@@ -165,10 +186,9 @@ private final class WorkspaceMenuHost: NSView {
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: bounds.height + 4), in: self)
     }
 
-    private func addAction(_ title: String, to menu: NSMenu, run: @escaping (TermioStore) -> Void) {
-        let item = NSMenuItem(title: title, action: #selector(invoke(_:)), keyEquivalent: "")
+    private func addAction(_ title: String, to menu: NSMenu, _ action: Selector) {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
-        item.representedObject = Handler(run)
         menu.addItem(item)
     }
 
@@ -177,15 +197,17 @@ private final class WorkspaceMenuHost: NSView {
         store?.switchToWorkspace(id)
     }
 
-    @objc private func invoke(_ sender: NSMenuItem) {
-        guard let store, let handler = sender.representedObject as? Handler else { return }
-        handler.run(store)
+    @objc private func newWorkspace() {
+        store?.presentNewWorkspacePanel(on: .thisMac)
     }
 
-    /// Boxes a menu-item closure so it can ride along on `representedObject`, the
-    /// only payload an `NSMenuItem` carries.
-    private final class Handler {
-        let run: (TermioStore) -> Void
-        init(_ run: @escaping (TermioStore) -> Void) { self.run = run }
+    @objc private func renameWorkspace() {
+        guard let store else { return }
+        store.presentRenameWorkspacePanel(store.currentWorkspaceID)
+    }
+
+    @objc private func removeWorkspace() {
+        guard let store else { return }
+        store.confirmRemoveWorkspace(store.currentWorkspaceID)
     }
 }

--- a/Tests/termioTests/KeybindingSurfaceTests.swift
+++ b/Tests/termioTests/KeybindingSurfaceTests.swift
@@ -53,8 +53,23 @@ final class KeybindingSurfaceTests: XCTestCase {
         }
     }
 
-    /// The collisions that were live when #203 was filed, pinned so they cannot
-    /// come back one at a time.
+    /// No two claimants may share a shortcut. `conflict(for:excluding:)` guards the
+    /// recorder at runtime, but nothing guarded the shipped table — and a catalog
+    /// default landing on, say, ⌘3 would go unnoticed: it would win the menu bar,
+    /// ⌘3 would stop reaching the third workspace, and the unbind test above would
+    /// still pass, because both claimants unbind the same trigger.
+    func testNoTwoClaimantsShareAShortcut() {
+        let claimed = KeyCommandCatalog.all.compactMap { KeybindingStore.shared.shortcut(for: $0.id) }
+            + KeybindingStore.hostReserved.map(\.shortcut)
+        let duplicates = claimed.filter { shortcut in claimed.filter { $0 == shortcut }.count > 1 }
+        XCTAssertTrue(
+            duplicates.isEmpty,
+            "two commands claim: \(Set(duplicates.map(\.display)).sorted().joined(separator: ", "))"
+        )
+    }
+
+    /// The collisions that were live when #203 was filed, plus ghostty's `goto_tab`
+    /// on the digits, pinned so they cannot come back one at a time.
     func testKnownGhosttyCollisionsAreUnbound() {
         let triggers = Set(KeybindingStore.shared.surfaceUnbindTriggers)
         for trigger in [

--- a/docs/design/20260819-device-workspace-project.md
+++ b/docs/design/20260819-device-workspace-project.md
@@ -310,8 +310,8 @@ mechanical one. **Stage 1 of the implementation deliberately does none of them.*
   `20260819-workspace-switch-latency.md` was written when user-made workspaces
   never paid this.
 - **⌘1…9 reshuffle once.** `orderedWorkspaces` is also the shortcut order
-  (`App.swift:1911`); dropping the fallback-last rule moves them. The comment at
-  `:1904` already accepts positional instability.
+  (`WorkspaceMenu.rows`); dropping the fallback-last rule moves them. The comment
+  on `KeybindingStore.workspaceShortcuts` already accepts positional instability.
 - **`Session.deviceID` is the small half.** Every "which machine is this
   session on" read is `session.termiodRemoteHost ?? session.sshHost`
   (`DeviceContext.swift:181`, `TermioStore.swift:494`, and four more).


### PR DESCRIPTION
Follow-ups from a review of #381. Both are regressions that PR introduced.

**The pane toggles lost their overflow rows.** Moving both toggles to a hosted view dropped their `action`. Clicking still works — the SwiftUI button handles that — but `NSToolbarItem.action` is also what AppKit reads to synthesize an item's row in the `»` overflow menu, so with no action and no `menuFormRepresentation` those rows were present and inert. Both toggles are in `defaultIdentifiers`, and `.inspectorTabs` already sets `menuFormRepresentation` for the same reason.

**The switcher announced itself as a button and did nothing when pressed.** `.accessibilityAddTraits(.isButton)` sets a trait but supplies no press action, and `.accessibilityElement()` ignores children, so the AppKit view that could have answered was hidden from the tree. The `Menu` it replaced was operable, so this was a regression. The element is now the view that already owns the click: it reports the pop-up role, carries the current workspace as its value, and implements the press by opening the same menu the mouse opens.

Also in here: the tooltip moves onto the view that actually hit-tests (a `.help()` beneath the overlay was shadowed), the boxed-closure `Handler` gives way to three plain selectors, a stale comment on the sort item is corrected, and the design doc's line citations are retargeted — they had come to point at unrelated code.

**New test.** `hostReserved` went from 3 entries to 12 in #381 and nothing guarded the shipped table against two claimants sharing a shortcut. A future catalog default on a digit would have gone unnoticed: it would win the menu bar, ⌘3 would quietly stop reaching the third workspace, and `testEveryHostShortcutIsUnbound` would still pass, because both claimants unbind the same trigger.

## Verification

`swift build` clean, 441 tests pass.

Driven through the accessibility API on a dev build:

- Pressing the switcher opens the menu, rows read back as `Work, Personal, ukvps, —, New Workspace…, Rename Workspace…, Remove Workspace`. This exercises `accessibilityPerformPress` → `showMenu()`, the same path the mouse takes.
- The navigator toggle still collapses and reopens the sidebar after its action was restored (toolbar item count 6 → 3 → 6).

## Release Notes

- Fixed the sidebar and inspector buttons doing nothing when the toolbar was too narrow to show them and they moved into the overflow menu.
- The workspace switcher can now be opened with VoiceOver.