### PR TITLE
Add the 0.38.0 changelog entry

### DIFF
--- a/web/landing/src/data/changelog.ts
+++ b/web/landing/src/data/changelog.ts
@@ -17,6 +17,20 @@ export type ChangelogEntry = {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: "0.38.0",
+    date: "2026-08-21",
+    title: "Workspace shortcuts",
+    changes: {
+      new: [
+        "⌘1 through ⌘9 switch workspaces. Each shortcut sits beside its workspace in the sidebar's workspace menu, so you can read it rather than remember it.",
+      ],
+      improved: [
+        "The workspace name in the toolbar stands on its own, larger and without an icon or chevron crowding it.",
+        "The sidebar and inspector buttons match each other. The sidebar button no longer carries a background of its own.",
+      ],
+    },
+  },
+  {
     version: "0.37.0",
     date: "2026-08-21",
     title: "Workspaces",


### PR DESCRIPTION
Release prep for 0.38.0. `pnpm docs:check` passes locally: `changelog: newest entry 0.38.0 covers v0.37.0`.

Covers the two user-facing changes since v0.37.0 — ⌘1…9 workspace switching, and the toolbar's workspace name and pane toggles. The two `fix` commits on main are deliberately not listed: they repair regressions introduced and corrected between releases, so no shipped build ever carried them.

## Release Notes

- Documentation only.