### PR TITLE
Grow the built-in theme list to 60

### DIFF
--- a/Shared/Sources/TermioShared/BuiltInThemes.swift
+++ b/Shared/Sources/TermioShared/BuiltInThemes.swift
@@ -1,4 +1,4 @@
-/// The built-in themes: 50 well-known Ghostty scheme names, in display order — 35
+/// The built-in themes: 60 well-known Ghostty scheme names, in display order — 45
 /// dark, then 15 light, by each theme's own background luminance.
 ///
 /// Shared because the Mac's theme picker and the iPhone's offer the same set, and
@@ -49,6 +49,16 @@ public enum BuiltInThemes {
         "Matte Black",
         "Carbonfox",
         "Sonokai",
+        "Shades Of Purple",
+        "Zenburn",
+        "Blue Matrix",
+        "Homebrew",
+        "IR Black",
+        "Ocean",
+        "Espresso",
+        "traffic",
+        "Miasma",
+        "Arthur",
         "Catppuccin Latte",
         "GitHub Light Default",
         "Rose Pine Dawn",

--- a/Sources/termio/CommandPalette/CommandPalette.swift
+++ b/Sources/termio/CommandPalette/CommandPalette.swift
@@ -423,7 +423,7 @@ struct CommandPaletteView: View {
     // MARK: - Themes
 
     /// The theme selector's rows: a "Terminal default" reset plus every theme
-    /// matching the slot's brightness — the user's own files and the built-in 50 —
+    /// matching the slot's brightness — the user's own files and the built-in 60 —
     /// so the palette can never apply one that renders the wrong way.
     private var themeItems: [PaletteItem] {
         let dark = slotIsDark

--- a/Sources/termio/Settings/ThemePickerField.swift
+++ b/Sources/termio/Settings/ThemePickerField.swift
@@ -3,7 +3,7 @@ import GhosttyTheme
 
 /// A searchable theme picker with live color swatches.
 ///
-/// The list is termio's default, the user's own theme files, and the 50 built-in
+/// The list is termio's default, the user's own theme files, and the 60 built-in
 /// schemes — everything the slot can actually paint, in one place. There is
 /// nothing to install first, so a row and a working theme are the same thing.
 ///

--- a/Sources/termio/Theme/ThemeLibrary.swift
+++ b/Sources/termio/Theme/ThemeLibrary.swift
@@ -2,10 +2,10 @@ import Foundation
 import GhosttyTheme
 import TermioShared
 
-/// termio's terminal-theme library: 50 built-in schemes, plus whatever the user
+/// termio's terminal-theme library: 60 built-in schemes, plus whatever the user
 /// has put in termio's `Themes` folder.
 ///
-/// The built-ins are the curated 50 (`BuiltInThemes`), resolved live out of the
+/// The built-ins are the curated 60 (`BuiltInThemes`), resolved live out of the
 /// `GhosttyTheme` product rather than copied onto disk. Nothing to install,
 /// nothing that goes stale when the pinned package updates a palette, and no way
 /// for a selected name to resolve to nothing.
@@ -17,7 +17,7 @@ import TermioShared
 /// their computer. A file wins over a built-in of the same name, so dropping in
 /// your own `Nord` overrides ours instead of fighting it.
 ///
-/// `theme(named:)` resolves past the 50 into the full bundled catalog, because a
+/// `theme(named:)` resolves past the 60 into the full bundled catalog, because a
 /// Ghostty config's `theme = X` may name any of them and has to keep painting.
 /// Such a name is listed too — see `selectableNames(dark:selection:)`.
 ///
@@ -33,14 +33,14 @@ enum ThemeLibrary {
 
     // MARK: - Built-ins
 
-    /// The curated 50, filtered to the names the pinned catalog resolves so a
+    /// The curated 60, filtered to the names the pinned catalog resolves so a
     /// package rename drops a stale entry instead of showing a dead one. The names
     /// are shared with the iPhone's picker (see `BuiltInThemes`), which offers the
     /// same set.
     static let builtInThemes: [GhosttyThemeDefinition] =
         BuiltInThemes.names.compactMap { GhosttyThemeCatalog.theme(named: $0) }
 
-    /// Built-in names of one brightness, sorted — one slot's worth of the 50.
+    /// Built-in names of one brightness, sorted — one slot's worth of the 60.
     static func builtInNames(dark: Bool) -> [String] {
         builtInThemes.filter { $0.isDark == dark }.map(\.name).sorted { $0.lowercased() < $1.lowercased() }
     }
@@ -81,7 +81,7 @@ enum ThemeLibrary {
     // MARK: - Resolution
 
     /// Resolves a theme by name: the user's own file first, then the bundled
-    /// catalog. Resolving past the built-in 50 into the full catalog is what lets a
+    /// catalog. Resolving past the built-in 60 into the full catalog is what lets a
     /// Ghostty config's `theme = Aardvark Blue` keep painting without termio
     /// copying a file to disk on its behalf.
     static func theme(named name: String) -> GhosttyThemeDefinition? {
@@ -121,7 +121,7 @@ enum ThemeLibrary {
     }
 
     /// Writes a theme's definition into the `Themes` folder so the user has a file
-    /// of their own to edit — this is how you fork one of the 50. The first copy
+    /// of their own to edit — this is how you fork one of the 60. The first copy
     /// takes the theme's own name and so shadows it; a second becomes `Nord 2` and
     /// stands beside it rather than overwriting the edits in the first.
     ///

--- a/Tests/termioTests/ThemeLibraryTests.swift
+++ b/Tests/termioTests/ThemeLibraryTests.swift
@@ -83,10 +83,10 @@ final class ThemeLibraryTests: XCTestCase {
 
     /// Derived from each theme's own background luminance, never a hand-kept
     /// per-name assignment — that is the whole point of `isDark` deciding the slot.
-    func testBuiltInsSplitThirtyFiveDarkAndFifteenLight() {
+    func testBuiltInsSplitFortyFiveDarkAndFifteenLight() {
         let definitions = ThemeLibrary.builtInThemes
-        XCTAssertEqual(definitions.count, 50)
-        XCTAssertEqual(definitions.filter(\.isDark).count, 35)
+        XCTAssertEqual(definitions.count, 60)
+        XCTAssertEqual(definitions.filter(\.isDark).count, 45)
         XCTAssertEqual(definitions.filter { !$0.isDark }.count, 15)
     }
 
@@ -126,7 +126,7 @@ final class ThemeLibraryTests: XCTestCase {
     }
 
     /// A Ghostty config may name any of the bundled schemes, not just the curated
-    /// 50, and termio writes that name straight into a slot. Resolution has to
+    /// 60, and termio writes that name straight into a slot. Resolution has to
     /// reach it — otherwise the window paints the default while the setting says
     /// otherwise.
     func testResolutionReachesPastTheBuiltInsIntoTheCatalog() throws {

--- a/web/landing/content/docs/appearance.mdx
+++ b/web/landing/content/docs/appearance.mdx
@@ -28,7 +28,7 @@ theme you chose there.
 
 ## Getting more themes
 
-**Browse Themes…** opens a store of 50 well-known schemes — Dracula, Catppuccin,
+**Browse Themes…** opens a store of 60 well-known schemes — Dracula, Catppuccin,
 Gruvbox, Rose Pine, Solarized, and the rest — one variant per family, each one
 picked to stay readable through a working day. **Install** writes that theme into
 your Themes folder and selects it in the light or dark slot it belongs to.

--- a/web/landing/content/docs/appearance.zh-CN.mdx
+++ b/web/landing/content/docs/appearance.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 外观
 description: 设置终端主题与字体、调整光标和窗口，并找到 Termio 其余的设置项——全都在一个熟悉的 macOS 设置窗口里。
 x-i18n:
   source_path: appearance.mdx
-  source_hash: 23a5863094895c0f387f35eeb232219da6227771895d21e8f5a7161738c4c8aa
-  generated_at: 2026-08-18
+  source_hash: 1456e808576609e97cc62fbb16730b87cfa0cd3515f6f792db1994d8362b8d91
+  generated_at: 2026-08-21
 ---
 
 用 `⌘,` 打开 **设置**。这是一个标准的 macOS 设置窗口，左侧一列标签页；**外观** 就是
@@ -30,7 +30,7 @@ Termio 使用 Ghostty 格式的主题，所以 Ghostty 主题生态里的东西�
 
 ## 获取更多主题 [#getting-more-themes]
 
-**浏览主题…** 会打开一个收录 50 款知名配色的商店——Dracula、Catppuccin、Gruvbox、
+**浏览主题…** 会打开一个收录 60 款知名配色的商店——Dracula、Catppuccin、Gruvbox、
 Rose Pine、Solarized 等等——每个系列只留一个变体，每一款都挑得住一整天的阅读。
 **安装** 会把那款主题写进你的主题文件夹，并放进它该在的浅色或深色槽位。全程不联网：
 这些配色本来就在 Termio 里面。


### PR DESCRIPTION
Ten more built-in schemes, each chosen to hold a background the list did not already have.

- **From OpenCode's set** — Shades Of Purple (`#1e1d40`, the only purple ground), Zenburn (`#3f3f3f`, the only neutral mid-grey), Blue Matrix (`#101116`, neon).
- **iTerm2 classics** — Homebrew (`#000000`, Terminal.app's green-on-black), IR Black (`#000000`, the 2007 original), Ocean (`#224fbc`, the only saturated blue ground).
- **The grey ladder Zenburn opens** — Espresso (`#323232`), traffic (`#272c30`, the most muted palette in the catalog), Miasma (`#222222`), Arthur (`#1c1c1c`).

The curation rule is unchanged and still enforced by `testNoTwoBuiltInsInASlotReadAsTheSameTheme`: every new entry clears ΔE 12 against every other theme in its slot, worst case 14.1 for Espresso against Nord.

Candidates that failed are left out rather than waved through. Ghostty's Matrix is the most distinct dark theme in the catalog at ΔE 37, but its body text reads at 2.7:1. Catppuccin Frappe, Catppuccin Macchiato, Cursor Dark, Tomorrow Night, Spacegray and Snazzy all measure below the floor against themes already on the list.

The dark slot goes 35 to 45. The light slot stays at 15: the catalog holds 86 light themes, but the largest set whose backgrounds are all ΔE 5 apart is fifteen, so a sixteenth would necessarily repeat a background.

Release Notes: Ten more built-in terminal themes — Homebrew, IR Black, Ocean, Zenburn, Espresso, Miasma, Arthur, traffic, Shades Of Purple and Blue Matrix.