### PR TITLE
Widen the light theme slot to 22

### DIFF
--- a/Shared/Sources/TermioShared/BuiltInThemes.swift
+++ b/Shared/Sources/TermioShared/BuiltInThemes.swift
@@ -1,5 +1,5 @@
-/// The built-in themes: 60 well-known Ghostty scheme names, in display order — 45
-/// dark, then 15 light, by each theme's own background luminance.
+/// The built-in themes: 67 well-known Ghostty scheme names, in display order — 45
+/// dark, then 22 light, by each theme's own background luminance.
 ///
 /// Shared because the Mac's theme picker and the iPhone's offer the same set, and
 /// two hand-kept copies would drift. Names only: both ends resolve them against
@@ -74,5 +74,12 @@ public enum BuiltInThemes {
         "One Half Light",
         "Modus Operandi",
         "Bluloco Light",
+        "Horizon Bright",
+        "Material",
+        "Neobones Light",
+        "Nvim Light",
+        "Coffee Theme",
+        "Novel",
+        "Belafonte Day",
     ]
 }

--- a/Sources/termio/CommandPalette/CommandPalette.swift
+++ b/Sources/termio/CommandPalette/CommandPalette.swift
@@ -423,7 +423,7 @@ struct CommandPaletteView: View {
     // MARK: - Themes
 
     /// The theme selector's rows: a "Terminal default" reset plus every theme
-    /// matching the slot's brightness — the user's own files and the built-in 60 —
+    /// matching the slot's brightness — the user's own files and the built-in 67 —
     /// so the palette can never apply one that renders the wrong way.
     private var themeItems: [PaletteItem] {
         let dark = slotIsDark

--- a/Sources/termio/Settings/ThemePickerField.swift
+++ b/Sources/termio/Settings/ThemePickerField.swift
@@ -3,7 +3,7 @@ import GhosttyTheme
 
 /// A searchable theme picker with live color swatches.
 ///
-/// The list is termio's default, the user's own theme files, and the 60 built-in
+/// The list is termio's default, the user's own theme files, and the 67 built-in
 /// schemes — everything the slot can actually paint, in one place. There is
 /// nothing to install first, so a row and a working theme are the same thing.
 ///

--- a/Sources/termio/Theme/ThemeLibrary.swift
+++ b/Sources/termio/Theme/ThemeLibrary.swift
@@ -2,10 +2,10 @@ import Foundation
 import GhosttyTheme
 import TermioShared
 
-/// termio's terminal-theme library: 60 built-in schemes, plus whatever the user
+/// termio's terminal-theme library: 67 built-in schemes, plus whatever the user
 /// has put in termio's `Themes` folder.
 ///
-/// The built-ins are the curated 60 (`BuiltInThemes`), resolved live out of the
+/// The built-ins are the curated 67 (`BuiltInThemes`), resolved live out of the
 /// `GhosttyTheme` product rather than copied onto disk. Nothing to install,
 /// nothing that goes stale when the pinned package updates a palette, and no way
 /// for a selected name to resolve to nothing.
@@ -17,7 +17,7 @@ import TermioShared
 /// their computer. A file wins over a built-in of the same name, so dropping in
 /// your own `Nord` overrides ours instead of fighting it.
 ///
-/// `theme(named:)` resolves past the 60 into the full bundled catalog, because a
+/// `theme(named:)` resolves past the 67 into the full bundled catalog, because a
 /// Ghostty config's `theme = X` may name any of them and has to keep painting.
 /// Such a name is listed too — see `selectableNames(dark:selection:)`.
 ///
@@ -33,14 +33,14 @@ enum ThemeLibrary {
 
     // MARK: - Built-ins
 
-    /// The curated 60, filtered to the names the pinned catalog resolves so a
+    /// The curated 67, filtered to the names the pinned catalog resolves so a
     /// package rename drops a stale entry instead of showing a dead one. The names
     /// are shared with the iPhone's picker (see `BuiltInThemes`), which offers the
     /// same set.
     static let builtInThemes: [GhosttyThemeDefinition] =
         BuiltInThemes.names.compactMap { GhosttyThemeCatalog.theme(named: $0) }
 
-    /// Built-in names of one brightness, sorted — one slot's worth of the 60.
+    /// Built-in names of one brightness, sorted — one slot's worth of the 67.
     static func builtInNames(dark: Bool) -> [String] {
         builtInThemes.filter { $0.isDark == dark }.map(\.name).sorted { $0.lowercased() < $1.lowercased() }
     }
@@ -81,7 +81,7 @@ enum ThemeLibrary {
     // MARK: - Resolution
 
     /// Resolves a theme by name: the user's own file first, then the bundled
-    /// catalog. Resolving past the built-in 60 into the full catalog is what lets a
+    /// catalog. Resolving past the built-in 67 into the full catalog is what lets a
     /// Ghostty config's `theme = Aardvark Blue` keep painting without termio
     /// copying a file to disk on its behalf.
     static func theme(named name: String) -> GhosttyThemeDefinition? {
@@ -121,7 +121,7 @@ enum ThemeLibrary {
     }
 
     /// Writes a theme's definition into the `Themes` folder so the user has a file
-    /// of their own to edit — this is how you fork one of the 60. The first copy
+    /// of their own to edit — this is how you fork one of the 67. The first copy
     /// takes the theme's own name and so shadows it; a second becomes `Nord 2` and
     /// stands beside it rather than overwriting the edits in the first.
     ///

--- a/Tests/termioTests/ThemeLibraryTests.swift
+++ b/Tests/termioTests/ThemeLibraryTests.swift
@@ -83,11 +83,11 @@ final class ThemeLibraryTests: XCTestCase {
 
     /// Derived from each theme's own background luminance, never a hand-kept
     /// per-name assignment — that is the whole point of `isDark` deciding the slot.
-    func testBuiltInsSplitFortyFiveDarkAndFifteenLight() {
+    func testBuiltInsSplitFortyFiveDarkAndTwentyTwoLight() {
         let definitions = ThemeLibrary.builtInThemes
-        XCTAssertEqual(definitions.count, 60)
+        XCTAssertEqual(definitions.count, 67)
         XCTAssertEqual(definitions.filter(\.isDark).count, 45)
-        XCTAssertEqual(definitions.filter { !$0.isDark }.count, 15)
+        XCTAssertEqual(definitions.filter { !$0.isDark }.count, 22)
     }
 
     /// The curation rule that keeps the list free of near-duplicates: within a
@@ -126,7 +126,7 @@ final class ThemeLibraryTests: XCTestCase {
     }
 
     /// A Ghostty config may name any of the bundled schemes, not just the curated
-    /// 60, and termio writes that name straight into a slot. Resolution has to
+    /// 67, and termio writes that name straight into a slot. Resolution has to
     /// reach it — otherwise the window paints the default while the setting says
     /// otherwise.
     func testResolutionReachesPastTheBuiltInsIntoTheCatalog() throws {

--- a/web/landing/content/docs/appearance.mdx
+++ b/web/landing/content/docs/appearance.mdx
@@ -28,7 +28,7 @@ theme you chose there.
 
 ## Getting more themes
 
-**Browse Themes…** opens a store of 60 well-known schemes — Dracula, Catppuccin,
+**Browse Themes…** opens a store of 67 well-known schemes — Dracula, Catppuccin,
 Gruvbox, Rose Pine, Solarized, and the rest — one variant per family, each one
 picked to stay readable through a working day. **Install** writes that theme into
 your Themes folder and selects it in the light or dark slot it belongs to.

--- a/web/landing/content/docs/appearance.zh-CN.mdx
+++ b/web/landing/content/docs/appearance.zh-CN.mdx
@@ -3,7 +3,7 @@ title: 外观
 description: 设置终端主题与字体、调整光标和窗口，并找到 Termio 其余的设置项——全都在一个熟悉的 macOS 设置窗口里。
 x-i18n:
   source_path: appearance.mdx
-  source_hash: 1456e808576609e97cc62fbb16730b87cfa0cd3515f6f792db1994d8362b8d91
+  source_hash: 46175c108616b94193a8b724123a7404affe3d557b5c9435421ea3d09e5ba738
   generated_at: 2026-08-21
 ---
 
@@ -30,7 +30,7 @@ Termio 使用 Ghostty 格式的主题，所以 Ghostty 主题生态里的东西�
 
 ## 获取更多主题 [#getting-more-themes]
 
-**浏览主题…** 会打开一个收录 60 款知名配色的商店——Dracula、Catppuccin、Gruvbox、
+**浏览主题…** 会打开一个收录 67 款知名配色的商店——Dracula、Catppuccin、Gruvbox、
 Rose Pine、Solarized 等等——每个系列只留一个变体，每一款都挑得住一整天的阅读。
 **安装** 会把那款主题写进你的主题文件夹，并放进它该在的浅色或深色槽位。全程不联网：
 这些配色本来就在 Termio 里面。


### PR DESCRIPTION
Seven more light schemes, each holding a background the slot did not have.

| Theme | Background | Body text | Fills |
| --- | --- | --- | --- |
| Horizon Bright | `#fdf0ed` | 16.2:1 | peach — nothing on the list leaned warm-pink |
| Material | `#eaeaea` | 13.1:1 | a deeper neutral grey |
| Neobones Light | `#e5ede6` | 12.0:1 | the only green-tinted light background that holds its contrast |
| Nvim Light | `#e0e2ea` | 14.0:1 | deep cool grey |
| Coffee Theme | `#f5deb3` | 16.0:1 | wheat |
| Novel | `#dfdbc3` | 10.4:1 | parchment |
| Belafonte Day | `#d5ccba` | 7.1:1 | tan — the least white light background in the catalog |

**Nothing is removed.** Six of the fifteen already on the list share a white or near-white background (`#ffffff` three times, `#f9f9f9` twice, `#fafafa` once). They stay: widening the range around them costs a user nothing, while dropping a theme takes away one someone may have selected.

Every new entry clears ΔE 12 against every other theme in the slot, enforced by `testNoTwoBuiltInsInASlotReadAsTheSameTheme`. Worst case is 15.0, Material against GitHub Light Default.

Two candidates were left out on readability rather than distinctness: TokyoNight Day (4.5:1) and Everforest Light Med (4.7:1) both have distinctive backgrounds but body text too faint to work through.

Release Notes: Seven more built-in light themes — Horizon Bright, Material, Neobones Light, Nvim Light, Coffee Theme, Novel and Belafonte Day.