### PR TITLE
Declare the Termio requirement in the skill's compatibility field

### DIFF
--- a/Sources/termio/Resources/skills/termio/SKILL.md
+++ b/Sources/termio/Resources/skills/termio/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: termio
 description: See and drive the sibling agent sessions running alongside you in this Termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside Termio (TERMIO_SESSION set).
+compatibility: Requires Termio (TERMIO_SESSION set in the environment)
 ---
 
 # Driving sibling sessions (Termio)

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: termio
 description: See and drive the sibling agent sessions running alongside you in this Termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside Termio (TERMIO_SESSION set).
+compatibility: Requires Termio (TERMIO_SESSION set in the environment)
 ---
 
 # Driving sibling sessions (Termio)

--- a/web/landing/public/skill.md
+++ b/web/landing/public/skill.md
@@ -1,6 +1,7 @@
 ---
 name: termio
 description: See and drive the sibling agent sessions running alongside you in this Termio project via the `termio sessions` CLI — list and watch their status, spawn new agent or plain-terminal sessions, send a prompt or an answer into a session, and read an agent's reply from its transcript. Use when delegating work to another session, checking on or supervising what other sessions are doing, or starting a command the user should see in its own visible pane. Do not use merely because a task could run in parallel. Requires running inside Termio (TERMIO_SESSION set).
+compatibility: Requires Termio (TERMIO_SESSION set in the environment)
 ---
 
 # Driving sibling sessions (Termio)


### PR DESCRIPTION
The `termio` skill only works inside Termio, and said so in prose at the end of its `description`. The [Agent Skills spec](https://agentskills.io/specification) defines `compatibility` for exactly this — environment requirements, max 500 characters — so the requirement is now stated where a client can read it, not only where a model can.

It is added rather than moved. `description` is the part loaded at startup for routing, and `compatibility` support varies between agent implementations; dropping the sentence would trade a signal that works everywhere for one that might not be read at all.

All three mirrors — the bundle resource, `skills/termio/`, and `web/landing/public/skill.md` — stay byte-identical, so `SessionSkillInstallerTests` still passes. `swift build` and `swift test` are green (441 tests, 0 failures).

Release Notes: None