### PR TITLE
Offer all four Catppuccin flavors

### DIFF
--- a/Shared/Sources/TermioShared/BuiltInThemes.swift
+++ b/Shared/Sources/TermioShared/BuiltInThemes.swift
@@ -1,5 +1,7 @@
-/// The built-in themes: 69 well-known Ghostty scheme names, in display order — 47
-/// dark, then 22 light, by each theme's own background luminance.
+/// The built-in themes: well-known Ghostty scheme names, in display order — the
+/// dark ones, then the light ones, split by each theme's own background
+/// luminance. `ThemeLibraryTests` is where the tally lives; restating it here
+/// only creates a second number to forget.
 ///
 /// Shared because the Mac's theme picker and the iPhone's offer the same set, and
 /// two hand-kept copies would drift. Names only: both ends resolve them against

--- a/Shared/Sources/TermioShared/BuiltInThemes.swift
+++ b/Shared/Sources/TermioShared/BuiltInThemes.swift
@@ -1,4 +1,4 @@
-/// The built-in themes: 67 well-known Ghostty scheme names, in display order — 45
+/// The built-in themes: 69 well-known Ghostty scheme names, in display order — 47
 /// dark, then 22 light, by each theme's own background luminance.
 ///
 /// Shared because the Mac's theme picker and the iPhone's offer the same set, and
@@ -6,16 +6,23 @@
 /// `GhosttyThemeCatalog` to render, and that meaning does not belong in this
 /// package.
 ///
-/// Curated, not exhaustive. No two entries read as the same theme — measured as
-/// weighted mean CIE Lab distance over background, foreground, and ANSI 1–6, with
-/// every pair clearing ΔE 12, which is what keeps near-duplicate families
-/// (TokyoNight Night/Storm, Catppuccin Mocha/Macchiato, Rose Pine/Moon) down to
-/// one row each. `ThemeLibraryTests` enforces the resolve, the brightness split,
-/// and the distance rule.
+/// Curated, not exhaustive. No two *unrelated* entries read as the same theme —
+/// measured as weighted mean CIE Lab distance over background, foreground, and
+/// ANSI 1–6, with every cross-family pair clearing ΔE 11, which is what keeps a
+/// scheme from arriving twice under two names (TokyoNight Night vs Storm 2.6).
+/// The list's own tightest pair is Catppuccin Frappé against Nord at 11.3.
+///
+/// Flavors of one family are exempt because listing them is a deliberate act, not
+/// an oversight: Catppuccin's three dark flavors sit at 4.3–8.6 of each other and
+/// are still all here, since the flavor name is exactly what its users pick
+/// between. `ThemeLibraryTests` enforces the resolve, the brightness split, and
+/// the distance rule.
 public enum BuiltInThemes {
     public static let names: [String] = [
         "Dracula",
         "Catppuccin Mocha",
+        "Catppuccin Macchiato",
+        "Catppuccin Frappe",
         "TokyoNight Night",
         "Nord",
         "Gruvbox Dark",

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -452,24 +452,9 @@ final class AppSettings: ObservableObject {
         didSet { store.set(notificationSoundEnabled, forKey: Key.notificationSound) }
     }
 
-    /// Resolves a Ghostty theme name against the bundled catalog, tolerating the naming drift
-    /// between Ghostty's theme list and the catalog's iTerm2-Color-Schemes names
-    /// ("catppuccin-latte" vs "Catppuccin Latte", "Tokyo Night" vs "tokyonight"): exact match
-    /// first, then a case/separator-insensitive one. (termio's custom user themes are
-    /// deliberately not consulted — a Ghostty config can only mean Ghostty's own theme names.)
-    private static func resolveGhosttyTheme(_ name: String) -> GhosttyThemeDefinition? {
-        if let exact = GhosttyThemeCatalog.theme(named: name) { return exact }
-        let normalized = normalizeThemeName(name)
-        return GhosttyThemeCatalog.allThemes.first { normalizeThemeName($0.name) == normalized }
-    }
-
-    private static func normalizeThemeName(_ name: String) -> String {
-        name.lowercased().filter { $0.isLetter || $0.isNumber }
-    }
-
     /// The Ghostty config's contribution to the registration defaults — the middle layer of
     /// termio setting > Ghostty config > built-in default. Only names the bundled catalog
-    /// resolves inherit; Ghostty also accepts custom theme files termio has no way to render.
+    /// resolves inherit; see `ThemeLibrary.catalogTheme(matching:)` for which those are.
     private static func ghosttyRegistrationOverrides(from ghostty: GhosttyUserConfig) -> [String: Any] {
         var overrides: [String: Any] = [:]
         if let family = ghostty.fontFamilies.first { overrides[Key.fontFamily] = family }
@@ -480,14 +465,14 @@ final class AppSettings: ObservableObject {
             // terminal in light/dark *chrome* — a dark theme inherited into the light slot
             // makes a half-dark window (light sidebar, dark canvas). A bare theme lands only
             // in the appearance it belongs to; the other slot keeps termio's own canvas.
-            if let definition = resolveGhosttyTheme(name) {
+            if let definition = ThemeLibrary.catalogTheme(matching: name) {
                 overrides[definition.isDark ? Key.darkThemeName : Key.lightThemeName] = definition.name
             }
         case .split(let light, let dark):
-            if let light, let definition = resolveGhosttyTheme(light) {
+            if let light, let definition = ThemeLibrary.catalogTheme(matching: light) {
                 overrides[Key.lightThemeName] = definition.name
             }
-            if let dark, let definition = resolveGhosttyTheme(dark) {
+            if let dark, let definition = ThemeLibrary.catalogTheme(matching: dark) {
                 overrides[Key.darkThemeName] = definition.name
             }
         case nil:

--- a/Sources/termio/Settings/ThemePickerField.swift
+++ b/Sources/termio/Settings/ThemePickerField.swift
@@ -3,7 +3,7 @@ import GhosttyTheme
 
 /// A searchable theme picker with live color swatches.
 ///
-/// The list is termio's default, the user's own theme files, and the 69 built-in
+/// The list is termio's default, the user's own theme files, and the built-in
 /// schemes — everything the slot can actually paint, in one place. There is
 /// nothing to install first, so a row and a working theme are the same thing.
 ///

--- a/Sources/termio/Settings/ThemePickerField.swift
+++ b/Sources/termio/Settings/ThemePickerField.swift
@@ -3,7 +3,7 @@ import GhosttyTheme
 
 /// A searchable theme picker with live color swatches.
 ///
-/// The list is termio's default, the user's own theme files, and the 67 built-in
+/// The list is termio's default, the user's own theme files, and the 69 built-in
 /// schemes — everything the slot can actually paint, in one place. There is
 /// nothing to install first, so a row and a working theme are the same thing.
 ///

--- a/Sources/termio/Theme/ThemeLibrary.swift
+++ b/Sources/termio/Theme/ThemeLibrary.swift
@@ -2,10 +2,10 @@ import Foundation
 import GhosttyTheme
 import TermioShared
 
-/// termio's terminal-theme library: 69 built-in schemes, plus whatever the user
+/// termio's terminal-theme library: the built-in schemes, plus whatever the user
 /// has put in termio's `Themes` folder.
 ///
-/// The built-ins are the curated 69 (`BuiltInThemes`), resolved live out of the
+/// The built-ins are the curated list (`BuiltInThemes`), resolved live out of the
 /// `GhosttyTheme` product rather than copied onto disk. Nothing to install,
 /// nothing that goes stale when the pinned package updates a palette, and no way
 /// for a selected name to resolve to nothing.
@@ -17,9 +17,9 @@ import TermioShared
 /// their computer. A file wins over a built-in of the same name, so dropping in
 /// your own `Nord` overrides ours instead of fighting it.
 ///
-/// `theme(named:)` resolves past the 69 into the full bundled catalog, because a
-/// Ghostty config's `theme = X` may name any of them and has to keep painting.
-/// Such a name is listed too — see `selectableNames(dark:selection:)`.
+/// `theme(named:)` resolves past the curated list into the full bundled catalog,
+/// because a Ghostty config's `theme = X` may name any of them and has to keep
+/// painting. Such a name is listed too — see `selectableNames(dark:selection:)`.
 ///
 /// Loading is lenient: a malformed file is skipped rather than failing the whole
 /// load.
@@ -33,14 +33,14 @@ enum ThemeLibrary {
 
     // MARK: - Built-ins
 
-    /// The curated 69, filtered to the names the pinned catalog resolves so a
+    /// The curated list, filtered to the names the pinned catalog resolves so a
     /// package rename drops a stale entry instead of showing a dead one. The names
     /// are shared with the iPhone's picker (see `BuiltInThemes`), which offers the
     /// same set.
     static let builtInThemes: [GhosttyThemeDefinition] =
         BuiltInThemes.names.compactMap { GhosttyThemeCatalog.theme(named: $0) }
 
-    /// Built-in names of one brightness, sorted — one slot's worth of the 69.
+    /// Built-in names of one brightness, sorted — one slot's worth of the list.
     static func builtInNames(dark: Bool) -> [String] {
         builtInThemes.filter { $0.isDark == dark }.map(\.name).sorted { $0.lowercased() < $1.lowercased() }
     }
@@ -81,12 +81,34 @@ enum ThemeLibrary {
     // MARK: - Resolution
 
     /// Resolves a theme by name: the user's own file first, then the bundled
-    /// catalog. Resolving past the built-in 69 into the full catalog is what lets a
+    /// catalog. Resolving past the built-ins into the full catalog is what lets a
     /// Ghostty config's `theme = Aardvark Blue` keep painting without termio
     /// copying a file to disk on its behalf.
     static func theme(named name: String) -> GhosttyThemeDefinition? {
         if let own = userThemes.first(where: { $0.name == name }) { return own }
         return GhosttyThemeCatalog.theme(named: name)
+    }
+
+    /// Resolves a name Ghostty wrote rather than one picked in termio, tolerating
+    /// the spelling drift between Ghostty's theme list and the catalog's
+    /// iTerm2-Color-Schemes names ("catppuccin-latte" vs "Catppuccin Latte",
+    /// "Tokyo Night" vs "tokyonight"): exact match first, then one that ignores
+    /// case and separators.
+    ///
+    /// User theme files are deliberately not consulted, which is the whole reason
+    /// this is not `theme(named:)`. A Ghostty config can only mean Ghostty's own
+    /// themes, so a same-named file in termio's folder must not quietly redirect
+    /// it. Names the catalog cannot resolve are left to termio's own default —
+    /// Ghostty also accepts theme files termio has no way to render.
+    static func catalogTheme(matching name: String) -> GhosttyThemeDefinition? {
+        if let exact = GhosttyThemeCatalog.theme(named: name) { return exact }
+        let target = comparableName(name)
+        return GhosttyThemeCatalog.allThemes.first { comparableName($0.name) == target }
+    }
+
+    /// A theme name reduced to what every spelling of it agrees on.
+    private static func comparableName(_ name: String) -> String {
+        name.lowercased().filter { $0.isLetter || $0.isNumber }
     }
 
     /// The names one slot may offer, filtered by each theme's own `isDark`
@@ -121,7 +143,7 @@ enum ThemeLibrary {
     }
 
     /// Writes a theme's definition into the `Themes` folder so the user has a file
-    /// of their own to edit — this is how you fork one of the 69. The first copy
+    /// of their own to edit — this is how you fork a built-in. The first copy
     /// takes the theme's own name and so shadows it; a second becomes `Nord 2` and
     /// stands beside it rather than overwriting the edits in the first.
     ///

--- a/Sources/termio/Theme/ThemeLibrary.swift
+++ b/Sources/termio/Theme/ThemeLibrary.swift
@@ -2,10 +2,10 @@ import Foundation
 import GhosttyTheme
 import TermioShared
 
-/// termio's terminal-theme library: 67 built-in schemes, plus whatever the user
+/// termio's terminal-theme library: 69 built-in schemes, plus whatever the user
 /// has put in termio's `Themes` folder.
 ///
-/// The built-ins are the curated 67 (`BuiltInThemes`), resolved live out of the
+/// The built-ins are the curated 69 (`BuiltInThemes`), resolved live out of the
 /// `GhosttyTheme` product rather than copied onto disk. Nothing to install,
 /// nothing that goes stale when the pinned package updates a palette, and no way
 /// for a selected name to resolve to nothing.
@@ -17,7 +17,7 @@ import TermioShared
 /// their computer. A file wins over a built-in of the same name, so dropping in
 /// your own `Nord` overrides ours instead of fighting it.
 ///
-/// `theme(named:)` resolves past the 67 into the full bundled catalog, because a
+/// `theme(named:)` resolves past the 69 into the full bundled catalog, because a
 /// Ghostty config's `theme = X` may name any of them and has to keep painting.
 /// Such a name is listed too — see `selectableNames(dark:selection:)`.
 ///
@@ -33,14 +33,14 @@ enum ThemeLibrary {
 
     // MARK: - Built-ins
 
-    /// The curated 67, filtered to the names the pinned catalog resolves so a
+    /// The curated 69, filtered to the names the pinned catalog resolves so a
     /// package rename drops a stale entry instead of showing a dead one. The names
     /// are shared with the iPhone's picker (see `BuiltInThemes`), which offers the
     /// same set.
     static let builtInThemes: [GhosttyThemeDefinition] =
         BuiltInThemes.names.compactMap { GhosttyThemeCatalog.theme(named: $0) }
 
-    /// Built-in names of one brightness, sorted — one slot's worth of the 67.
+    /// Built-in names of one brightness, sorted — one slot's worth of the 69.
     static func builtInNames(dark: Bool) -> [String] {
         builtInThemes.filter { $0.isDark == dark }.map(\.name).sorted { $0.lowercased() < $1.lowercased() }
     }
@@ -81,7 +81,7 @@ enum ThemeLibrary {
     // MARK: - Resolution
 
     /// Resolves a theme by name: the user's own file first, then the bundled
-    /// catalog. Resolving past the built-in 67 into the full catalog is what lets a
+    /// catalog. Resolving past the built-in 69 into the full catalog is what lets a
     /// Ghostty config's `theme = Aardvark Blue` keep painting without termio
     /// copying a file to disk on its behalf.
     static func theme(named name: String) -> GhosttyThemeDefinition? {
@@ -121,7 +121,7 @@ enum ThemeLibrary {
     }
 
     /// Writes a theme's definition into the `Themes` folder so the user has a file
-    /// of their own to edit — this is how you fork one of the 67. The first copy
+    /// of their own to edit — this is how you fork one of the 69. The first copy
     /// takes the theme's own name and so shadows it; a second becomes `Nord 2` and
     /// stands beside it rather than overwriting the edits in the first.
     ///

--- a/Tests/termioTests/ThemeLibraryTests.swift
+++ b/Tests/termioTests/ThemeLibraryTests.swift
@@ -83,7 +83,10 @@ final class ThemeLibraryTests: XCTestCase {
 
     /// Derived from each theme's own background luminance, never a hand-kept
     /// per-name assignment — that is the whole point of `isDark` deciding the slot.
-    func testBuiltInsSplitFortySevenDarkAndTwentyTwoLight() {
+    /// The tally lives here and nowhere else, so growing the list is one number to
+    /// update rather than a sweep through prose. It is a tripwire, not a target:
+    /// what it catches is a name added or lost without anyone meaning to.
+    func testBuiltInsSplitByBackgroundLuminance() {
         let definitions = ThemeLibrary.builtInThemes
         XCTAssertEqual(definitions.count, 69)
         XCTAssertEqual(definitions.filter(\.isDark).count, 47)
@@ -159,7 +162,7 @@ final class ThemeLibraryTests: XCTestCase {
     }
 
     /// A Ghostty config may name any of the bundled schemes, not just the curated
-    /// 69, and termio writes that name straight into a slot. Resolution has to
+    /// ones, and termio writes that name straight into a slot. Resolution has to
     /// reach it — otherwise the window paints the default while the setting says
     /// otherwise.
     func testResolutionReachesPastTheBuiltInsIntoTheCatalog() throws {
@@ -187,6 +190,19 @@ final class ThemeLibraryTests: XCTestCase {
         XCTAssertFalse(
             ThemeLibrary.selectableNames(dark: true, selection: inherited.name)
                 .contains(inherited.name))
+    }
+
+    /// A Ghostty config spells theme names its own way, and the slot it feeds is
+    /// written from the catalog's spelling — so `theme = catppuccin-frappe` has to
+    /// land on `Catppuccin Frappe` rather than on termio's default. An unknown
+    /// name resolves to nothing, which is what leaves that slot at the default
+    /// instead of guessing at a theme file termio cannot render.
+    func testAGhosttySpellingResolvesToTheCatalogName() {
+        for spelling in ["catppuccin-frappe", "Catppuccin Frappe", "CATPPUCCIN FRAPPE", "catppuccinfrappe"] {
+            XCTAssertEqual(
+                ThemeLibrary.catalogTheme(matching: spelling)?.name, "Catppuccin Frappe", spelling)
+        }
+        XCTAssertNil(ThemeLibrary.catalogTheme(matching: "a theme nobody shipped"))
     }
 
     private func firstCatalogThemeOutsideTheBuiltIns(dark: Bool) -> GhosttyThemeDefinition? {

--- a/Tests/termioTests/ThemeLibraryTests.swift
+++ b/Tests/termioTests/ThemeLibraryTests.swift
@@ -83,29 +83,62 @@ final class ThemeLibraryTests: XCTestCase {
 
     /// Derived from each theme's own background luminance, never a hand-kept
     /// per-name assignment — that is the whole point of `isDark` deciding the slot.
-    func testBuiltInsSplitFortyFiveDarkAndTwentyTwoLight() {
+    func testBuiltInsSplitFortySevenDarkAndTwentyTwoLight() {
         let definitions = ThemeLibrary.builtInThemes
-        XCTAssertEqual(definitions.count, 67)
-        XCTAssertEqual(definitions.filter(\.isDark).count, 45)
+        XCTAssertEqual(definitions.count, 69)
+        XCTAssertEqual(definitions.filter(\.isDark).count, 47)
         XCTAssertEqual(definitions.filter { !$0.isDark }.count, 22)
     }
 
     /// The curation rule that keeps the list free of near-duplicates: within a
-    /// slot, no two themes sit closer than ΔE 12 on the weighted Lab metric the
-    /// list was built with. Rejected pairs measure far below it (TokyoNight
-    /// Night vs Storm 2.6, Catppuccin Mocha vs Macchiato 4.3), so a family that
-    /// sneaks a second variant onto the list fails here.
+    /// slot, no two themes of different families sit closer than ΔE 11 on the
+    /// weighted Lab metric the list was built with. Rejected pairs measure far
+    /// below it (TokyoNight Night vs Storm 2.6), so a scheme arriving a second
+    /// time under another name fails here.
+    ///
+    /// The floor was 12 until Catppuccin Frappé joined: it sits 11.3 from Nord —
+    /// two blue-greys, `303446` against `2e3440` — and is now the list's tightest
+    /// pair, under the 12.1 of Kanagawa Dragon vs Melange Dark that set the old
+    /// line. Admitting a flavor someone came looking for is worth 0.7 of ΔE; a
+    /// third theme in that neighbourhood would not be.
+    ///
+    /// Flavors of one family are compared only for the split and the resolve.
+    /// Putting `Catppuccin Frappe` beside `Catppuccin Mocha` is a decision someone
+    /// made on purpose, and no ΔE would have told them otherwise.
     func testNoTwoBuiltInsInASlotReadAsTheSameTheme() throws {
         for dark in [true, false] {
             let definitions = ThemeLibrary.builtInThemes.filter { $0.isDark == dark }
             for first in 0..<definitions.count {
                 for second in (first + 1)..<definitions.count {
+                    guard !sameFamily(definitions[first].name, definitions[second].name) else { continue }
                     let distance = try weightedDistance(definitions[first], definitions[second])
                     XCTAssertGreaterThanOrEqual(
-                        distance, 12,
+                        distance, 11,
                         "\(definitions[first].name) and \(definitions[second].name) read as one theme")
                 }
             }
+        }
+    }
+
+    /// Themes of one scheme family, which every catalog spells as a shared first
+    /// word: Catppuccin Mocha/Macchiato/Frappe, Kanagawa Wave/Dragon.
+    private func sameFamily(_ first: String, _ second: String) -> Bool {
+        first.split(separator: " ").first == second.split(separator: " ").first
+    }
+
+    // MARK: - Chrome
+
+    /// Adding a theme to the list also puts it behind the sidebar and the window,
+    /// so every built-in has to derive chrome — a name that paints the terminal
+    /// but drops the chrome back to the system appearance is a half-applied theme,
+    /// which is what a missing background or foreground would produce.
+    func testEveryBuiltInDerivesChrome() throws {
+        for definition in ThemeLibrary.builtInThemes {
+            let chrome = try XCTUnwrap(ChromeTheme(definition), definition.name)
+            XCTAssertEqual(chrome.isDark, definition.isDark, definition.name)
+            // The device marks come from the theme's own bright ANSI slots, so a
+            // theme that defines none of them still has to yield a usable mark.
+            XCTAssertFalse(chrome.deviceTints.isEmpty, definition.name)
         }
     }
 
@@ -126,7 +159,7 @@ final class ThemeLibraryTests: XCTestCase {
     }
 
     /// A Ghostty config may name any of the bundled schemes, not just the curated
-    /// 67, and termio writes that name straight into a slot. Resolution has to
+    /// 69, and termio writes that name straight into a slot. Resolution has to
     /// reach it — otherwise the window paints the default while the setting says
     /// otherwise.
     func testResolutionReachesPastTheBuiltInsIntoTheCatalog() throws {


### PR DESCRIPTION
Frappé and Macchiato join Latte and Mocha, so the flavor name a Catppuccin user picks by is the name they find in the picker. The same list feeds the Mac's theme picker and the iPhone's, so both slots get all four.

Chrome needs no per-theme work — `ChromeTheme` derives panel, muted ink, accent, and device tints from any definition. A test now holds that for every built-in rather than leaving it assumed.

Two judgment calls worth knowing about:

- **The distance rule now exempts flavors of one family**, derived from the shared first word rather than a hand-kept pair list. Listing Frappé beside Mocha is a decision someone made on purpose, and no ΔE was going to talk them out of it.
- **The cross-family floor drops from ΔE 12 to 11.** Frappé sits 11.3 from Nord — two blue-greys, `303446` against `2e3440` — under the 12.1 of Kanagawa Dragon vs Melange Dark that set the old line. That 0.7 buys a flavor people come looking for; a third theme in that neighbourhood would not be worth it.

A cleanup rides along, in its own commit: the list's size was restated in seven doc comments across three files (the last three theme commits each had to sweep them), and `Settings` kept a second theme-name resolver. The count now lives only in the test that asserts the split, and name resolution has one home in `ThemeLibrary`.

Release Notes: Catppuccin Frappé and Macchiato join Latte and Mocha in the theme picker.