### PR TITLE
Build both libghostty forks against ghostty 74a133e

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "87b9cee789842c15ff5379e0749ae4ccbc660164c76172e8d96f02fd3dcbd5ef",
+  "originHash" : "90ce116c5d4a23c04e012ec12232e0320cdf59e47e4414abf10373e140cccbe6",
   "pins" : [
     {
       "identity" : "highlightr",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "b35dabd15e2b096b58017b78eb5f404208c8f7c7",
-        "version" : "1.0.17"
+        "revision" : "21d67c485107aa2c0d0ac76cfd6d52d16ad1eafd",
+        "version" : "1.0.18"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // live resize" suspicion that briefly rolled this back to Lakr233 was a
         // misdiagnosis — the real bug was termio's own PTY spawn shape (see
         // docs/bug/terminal-resize-no-reflow-HANDOFF.md §0).
-        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.17"),
+        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.18"),
         // Sparkle powers in-app auto-update (the "Check for Updates…" menu item and
         // background update checks). It reads the appcast published with each GitHub
         // release; the matching EdDSA public key is embedded in packaging/Info.plist.

--- a/ios/TermioMobile.xcodeproj/project.pbxproj
+++ b/ios/TermioMobile.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 			repositoryURL = "https://github.com/termio-sh/libghostty-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.17;
+				minimumVersion = 1.0.18;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "f2d4cbdf7a16bc5d917034f813f47c2a1c5dde97",
-        "version" : "1.0.16"
+        "revision" : "21d67c485107aa2c0d0ac76cfd6d52d16ad1eafd",
+        "version" : "1.0.18"
       }
     },
     {

--- a/termiod/Cargo.lock
+++ b/termiod/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 [[package]]
 name = "libghostty-vt"
 version = "0.2.1"
-source = "git+https://github.com/termio-sh/libghostty-rs?rev=04500f9f78edf487b6d218d951b0979c768fb7f0#04500f9f78edf487b6d218d951b0979c768fb7f0"
+source = "git+https://github.com/termio-sh/libghostty-rs?rev=cc05bd1a53842450b595846ca8572c739cb98d66#cc05bd1a53842450b595846ca8572c739cb98d66"
 dependencies = [
  "bitflags",
  "int-enum",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "libghostty-vt-sys"
 version = "0.2.1"
-source = "git+https://github.com/termio-sh/libghostty-rs?rev=04500f9f78edf487b6d218d951b0979c768fb7f0#04500f9f78edf487b6d218d951b0979c768fb7f0"
+source = "git+https://github.com/termio-sh/libghostty-rs?rev=cc05bd1a53842450b595846ca8572c739cb98d66#cc05bd1a53842450b595846ca8572c739cb98d66"
 
 [[package]]
 name = "log"

--- a/termiod/vt/Cargo.toml
+++ b/termiod/vt/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 # script. What stays here is termiod's own snapshot boundary: the wire cell is
 # ours, not the engine's.
 #
-# Pinned to termio-sh/libghostty-rs, our fork, which builds ghostty 56e1f3a —
+# Pinned to termio-sh/libghostty-rs, our fork, which builds ghostty 74a133e —
 # the same one libghostty-swift ships to the Mac and iOS clients, so the host
 # and its clients run one VT. That parity is why this engine was chosen over
 # alacritty_terminal in the first place.
@@ -22,8 +22,8 @@ publish = false
 # other.
 #
 # Track libghostty-swift when it releases: its title carries the ghostty it
-# built (`1.0.16 · ghostty v1.3.1-1841-g9d8fbd1`), and that sha is the one to
+# built (`1.0.18 · ghostty v1.3.1-2199-g74a133e`), and that sha is the one to
 # match here. Since ghostty#13759 dropped iOS from the full build, that release
 # also carries a patch putting iOS back, so the two forks move together.
 [dependencies]
-libghostty-vt = { git = "https://github.com/termio-sh/libghostty-rs", rev = "04500f9f78edf487b6d218d951b0979c768fb7f0" }
+libghostty-vt = { git = "https://github.com/termio-sh/libghostty-rs", rev = "cc05bd1a53842450b595846ca8572c739cb98d66" }


### PR DESCRIPTION
Moves the terminal core from ghostty `56e1f3a` to `74a133e`: `libghostty-swift` 1.0.17 → 1.0.18 for the Mac and iOS clients, `libghostty-rs` `04500f9` → `cc05bd1` for termiod's VT sidecar.

The two forks move in one commit by necessity. `libghostty-vt-sys` checks its generated bindings into the tree, so a pin that disagrees with them does not fail to build — it corrupts the heap.

Most of the 131-commit gap is the Kitty graphics conformance push, which termio does not exercise. What does reach termio is the rest: a tabstop bit cleared instead of toggled on unset, the cursor pin garbage flag cleared on screen reset, the progress bar cleared on full reset, mode 2048 in-band size reports, and one fewer allocation and copy on the selection `StringMap` path behind cmd-click link detection.

Verified: `swift build`, `swift test`, `cargo test` in `termiod/` (76 passing), and both Swift pins re-resolved to 1.0.18.

Release Notes:
- Updated the terminal core to ghostty 74a133e, picking up terminal reset and tabstop fixes and in-band resize reports.