### PR TITLE
Restore agent status when a session runs under termiod

### DIFF
--- a/Sources/termio/Agents/HookListener.swift
+++ b/Sources/termio/Agents/HookListener.swift
@@ -98,6 +98,12 @@ final class HookListener {
     private let queue = DispatchQueue(label: "com.termio.hook-listener")
     private var source: DispatchSourceRead?
     private var listenDescriptor: Int32 = -1
+    /// Watches the socket *file* we bound, so an instance that loses the path to
+    /// someone else's `unlink` finds out (see `LocalSocket.watchForReplacement`).
+    private var pathWatch: DispatchSourceFileSystemObject?
+    /// Runs only while another instance holds the path, and takes it back when
+    /// that one goes away (see `LocalSocket.retryWhenFree`).
+    private var reclaim: DispatchSourceTimer?
 
     init(onReport: @escaping @MainActor (StatusReport) -> Void) {
         self.onReport = onReport
@@ -115,27 +121,43 @@ final class HookListener {
         try? FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         let path = url.path
-        // A stale socket file from a previous run would make bind() fail with
-        // EADDRINUSE, so clear it first. (Errors here are fine — it may not exist.)
+        // Only clear a socket file nothing is listening on — the same guard session
+        // control uses, and for a worse failure. Unlinking whatever is there lets a
+        // second instance steal the channel: the running app keeps its now-unnamed
+        // socket, every hook connects to the new file, and once the thief exits the
+        // file it leaves behind refuses every connection. Hooks fire constantly, so
+        // the command they run ends in `2>/dev/null || true` and cannot say a word
+        // about it — the status plane just goes quiet, permanently, with agents
+        // still working and every row calm.
+        if LocalSocket.isLive(path) {
+            Self.log("""
+                another termio already answers at \(path) — leaving agent status to it \
+                (relaunch this process with TERMIO_CHANNEL=dev for a channel of its own; \
+                that steers this run, not how a bundle was built)
+                """)
+            // Standing down is not a decision for the rest of the run: the other
+            // instance is usually a short-lived `swift run`, and when it goes the
+            // path is ours to take.
+            if reclaim == nil {
+                reclaim = LocalSocket.retryWhenFree(path: path, on: queue) { [weak self] in
+                    self?.bindAndListen()
+                }
+            }
+            return
+        }
+        reclaim?.cancel()
+        reclaim = nil
+        // Nothing answers, so any file here is a leftover: clearing it is what
+        // keeps bind() from failing with EADDRINUSE.
         unlink(path)
 
         let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
         guard descriptor >= 0 else { Self.log("socket() failed: \(errno)"); return }
 
-        var address = sockaddr_un()
-        address.sun_family = sa_family_t(AF_UNIX)
-        let capacity = MemoryLayout.size(ofValue: address.sun_path)
-        let bytes = Array(path.utf8)
-        guard bytes.count < capacity else {
-            Self.log("socket path too long (\(bytes.count) ≥ \(capacity)): \(path)")
+        guard var address = LocalSocket.address(for: path) else {
+            Self.log("socket path too long: \(path)")
             close(descriptor)
             return
-        }
-        withUnsafeMutablePointer(to: &address.sun_path) {
-            $0.withMemoryRebound(to: UInt8.self, capacity: capacity) { destination in
-                for (index, byte) in bytes.enumerated() { destination[index] = byte }
-                destination[bytes.count] = 0
-            }
         }
         let size = socklen_t(MemoryLayout<sockaddr_un>.size)
         let bound = withUnsafePointer(to: &address) {
@@ -155,6 +177,16 @@ final class HookListener {
         listenDescriptor = descriptor
         self.source = source
         source.resume()
+        pathWatch = LocalSocket.watchForReplacement(of: path, on: queue) { [weak self] in
+            guard let self else { return }
+            Self.log("agent status socket was replaced — rebinding")
+            self.pathWatch?.cancel()
+            self.pathWatch = nil
+            self.source?.cancel()
+            self.source = nil
+            self.listenDescriptor = -1
+            self.bindAndListen()
+        }
     }
 
     private func acceptPending() {

--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -1,6 +1,117 @@
 import Darwin
 import Foundation
 
+/// The bind-time defenses every local socket termio serves needs, in one place.
+/// Both listeners in this folder answer on an `AF_UNIX` path under the channel's
+/// Application Support directory, and both fail the same way without these: an
+/// unconditional `unlink` before `bind` lets a second instance take the *name*
+/// from a healthy first one, which then keeps listening on an inode nothing can
+/// address and never finds out. The usual thief is a bare SwiftPM binary — no
+/// bundle id means `AppChannel.suffix` is empty, so `swift run` during
+/// development lands on the *release* channel.
+enum LocalSocket {
+    /// Fills a `sockaddr_un` for `path`, or nil when the path doesn't fit
+    /// `sun_path`. Shared by the listeners and the liveness probe so all of them
+    /// agree on exactly which address they mean.
+    static func address(for path: String) -> sockaddr_un? {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        let bytes = Array(path.utf8)
+        guard bytes.count < capacity else { return nil }
+        withUnsafeMutablePointer(to: &address.sun_path) {
+            $0.withMemoryRebound(to: UInt8.self, capacity: capacity) { destination in
+                for (index, byte) in bytes.enumerated() { destination[index] = byte }
+                destination[bytes.count] = 0
+            }
+        }
+        return address
+    }
+
+    /// True when something is already accepting connections at `path`. A refused
+    /// connection — or no file at all — means the socket is stale and safe to
+    /// replace; a connect that lands means a live owner we must not evict.
+    static func isLive(_ path: String) -> Bool {
+        guard FileManager.default.fileExists(atPath: path),
+              var address = address(for: path)
+        else { return false }
+        let probe = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard probe >= 0 else { return false }
+        defer { close(probe) }
+        let size = socklen_t(MemoryLayout<sockaddr_un>.size)
+        return withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(probe, $0, size) }
+        } == 0
+    }
+
+    /// The inode behind `path`, or nil when nothing is there — the identity check
+    /// that tells "still our socket" from "someone rebound this name".
+    static func inode(of path: String) -> UInt64? {
+        var status = stat()
+        guard lstat(path, &status) == 0 else { return nil }
+        return UInt64(status.st_ino)
+    }
+
+    /// How often a listener that stood down re-probes the path it gave up.
+    static let reclaimInterval: TimeInterval = 30
+
+    /// Calls `onFree` once nothing answers at `path` any more. This is the other
+    /// half of standing down: the instance that took the path can exit *without*
+    /// unlinking, which leaves a file that refuses every connection and an inode
+    /// that never changes — so the replacement watch cannot see it and the socket
+    /// stays dead until someone relaunches the app. Only a periodic probe
+    /// distinguishes "still serving" from "gone, and its leftovers are in the way".
+    ///
+    /// Returns the resumed timer to retain; cancel it once the path is bound.
+    static func retryWhenFree(
+        path: String, on queue: DispatchQueue, onFree: @escaping () -> Void
+    ) -> DispatchSourceTimer {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + reclaimInterval, repeating: reclaimInterval)
+        timer.setEventHandler {
+            guard !isLive(path) else { return }
+            onFree()
+        }
+        timer.resume()
+        return timer
+    }
+
+    /// Watches for another instance's `unlink` taking a bound socket file away and
+    /// calls `onReplaced` when it happens. Without this, losing the path is
+    /// permanent and silent: the listener stays bound to an inode with no name,
+    /// every client gets ECONNREFUSED, and only a relaunch recovers. The caller's
+    /// handler re-runs its bind, which probes again — so a live replacement makes
+    /// it stand down, a bare `rm` gets the path back.
+    ///
+    /// The socket file itself can't be the watch target: `open(2)` on an AF_UNIX
+    /// socket fails with ENXIO, so a file-level vnode source never arms. We watch
+    /// the enclosing directory and re-check the entry when it changes.
+    ///
+    /// Returns the resumed source to retain, or nil when the watch can't be armed.
+    static func watchForReplacement(
+        of path: String, on queue: DispatchQueue, onReplaced: @escaping () -> Void
+    ) -> DispatchSourceFileSystemObject? {
+        let directory = (path as NSString).deletingLastPathComponent
+        let descriptor = open(directory, O_EVTONLY)
+        guard descriptor >= 0, let bound = inode(of: path) else {
+            if descriptor >= 0 { close(descriptor) }
+            return nil
+        }
+        let watch = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor, eventMask: [.write, .delete, .rename], queue: queue)
+        watch.setEventHandler {
+            // Every write anywhere in the support directory lands here (state.json
+            // above all), so the cheap identity check comes first: only a vanished
+            // entry or a different inode means the socket was replaced.
+            guard inode(of: path) != bound else { return }
+            onReplaced()
+        }
+        watch.setCancelHandler { close(descriptor) }
+        watch.resume()
+        return watch
+    }
+}
+
 /// One request from the `termio sessions …` CLI, sent as a single JSON object
 /// over `SessionControlListener`'s local socket. This is the write/drive
 /// counterpart to `HookListener`'s read-only status stream: where a hook reports
@@ -162,6 +273,9 @@ final class SessionControlListener: @unchecked Sendable {
     /// Watches the socket *file* we bound, so an instance that loses the path to
     /// someone else's `unlink` finds out (see `watchForReplacement`).
     private var pathWatch: DispatchSourceFileSystemObject?
+    /// Runs only while another instance holds the path, and takes it back when
+    /// that one goes away (see `LocalSocket.retryWhenFree`).
+    private var reclaim: DispatchSourceTimer?
 
     init(onRequest: @escaping @MainActor (ControlRequest) async -> Data,
          onWatch: @escaping @MainActor (ControlRequest) -> (UUID?, Data?, [SessionWatchEvent])) {
@@ -186,7 +300,7 @@ final class SessionControlListener: @unchecked Sendable {
         // with ECONNREFUSED while the app looks perfectly fine. The usual thief is
         // a bare SwiftPM binary — no bundle id means `AppChannel.suffix` is empty,
         // so `swift run` during development lands on the *release* channel.
-        if Self.isLive(path) {
+        if LocalSocket.isLive(path) {
             // Name `dev`, not `<name>`: a placeholder reads as "any name works",
             // and the reader's next move is usually TERMIO_CHANNEL=<name>
             // ./scripts/build-app.sh — which builds no such channel.
@@ -195,14 +309,24 @@ final class SessionControlListener: @unchecked Sendable {
                 to it (relaunch this process with TERMIO_CHANNEL=dev for a channel of \
                 its own; that steers this run, not how a bundle was built)
                 """)
+            // The instance we defer to is usually a short-lived `swift run`, and it
+            // can exit without unlinking — a dead file the replacement watch cannot
+            // see, because its inode never changes. Probing is the only way back.
+            if reclaim == nil {
+                reclaim = LocalSocket.retryWhenFree(path: path, on: queue) { [weak self] in
+                    self?.bindAndListen()
+                }
+            }
             return
         }
+        reclaim?.cancel()
+        reclaim = nil
         unlink(path)
 
         let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
         guard descriptor >= 0 else { Self.log("socket() failed: \(errno)"); return }
 
-        guard var address = Self.address(for: path) else {
+        guard var address = LocalSocket.address(for: path) else {
             Self.log("socket path too long: \(path)")
             close(descriptor)
             return
@@ -227,65 +351,9 @@ final class SessionControlListener: @unchecked Sendable {
         watchForReplacement(path)
     }
 
-    /// Fills a `sockaddr_un` for `path`, or nil when the path doesn't fit
-    /// `sun_path`. Shared by the listener and the liveness probe so both agree on
-    /// exactly which address they mean.
-    private static func address(for path: String) -> sockaddr_un? {
-        var address = sockaddr_un()
-        address.sun_family = sa_family_t(AF_UNIX)
-        let capacity = MemoryLayout.size(ofValue: address.sun_path)
-        let bytes = Array(path.utf8)
-        guard bytes.count < capacity else { return nil }
-        withUnsafeMutablePointer(to: &address.sun_path) {
-            $0.withMemoryRebound(to: UInt8.self, capacity: capacity) { destination in
-                for (index, byte) in bytes.enumerated() { destination[index] = byte }
-                destination[bytes.count] = 0
-            }
-        }
-        return address
-    }
-
-    /// True when something is already accepting connections at `path`. A refused
-    /// connection — or no file at all — means the socket is stale and safe to
-    /// replace; a connect that lands means a live owner we must not evict.
-    private static func isLive(_ path: String) -> Bool {
-        guard FileManager.default.fileExists(atPath: path),
-              var address = address(for: path)
-        else { return false }
-        let probe = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard probe >= 0 else { return false }
-        defer { close(probe) }
-        let size = socklen_t(MemoryLayout<sockaddr_un>.size)
-        return withUnsafePointer(to: &address) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(probe, $0, size) }
-        } == 0
-    }
-
-    /// Watches for another instance's `unlink` taking our socket file away.
-    /// Without this, losing the path is permanent and silent: the listener stays
-    /// bound to an inode with no name, every client gets ECONNREFUSED, and only a
-    /// relaunch recovers. On a change we re-run `bindAndListen`, which probes
-    /// again — so a live replacement makes us stand down, a bare `rm` gets the
-    /// path back.
-    ///
-    /// The socket file itself can't be the watch target: `open(2)` on an AF_UNIX
-    /// socket fails with ENXIO, so a file-level vnode source never arms. We watch
-    /// the enclosing directory and re-check our own entry when it changes.
     private func watchForReplacement(_ path: String) {
-        let directory = (path as NSString).deletingLastPathComponent
-        let descriptor = open(directory, O_EVTONLY)
-        guard descriptor >= 0, let bound = Self.inode(of: path) else {
-            if descriptor >= 0 { close(descriptor) }
-            return
-        }
-        let watch = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: descriptor, eventMask: [.write, .delete, .rename], queue: queue)
-        watch.setEventHandler { [weak self] in
+        pathWatch = LocalSocket.watchForReplacement(of: path, on: queue) { [weak self] in
             guard let self else { return }
-            // Every write anywhere in the support directory lands here (state.json
-            // above all), so the cheap identity check comes first: only a vanished
-            // entry or a different inode means our socket was replaced.
-            guard Self.inode(of: path) != bound else { return }
             Self.log("session control socket was replaced — rebinding")
             self.pathWatch?.cancel()
             self.pathWatch = nil
@@ -294,17 +362,6 @@ final class SessionControlListener: @unchecked Sendable {
             self.listenDescriptor = -1
             self.bindAndListen()
         }
-        watch.setCancelHandler { close(descriptor) }
-        pathWatch = watch
-        watch.resume()
-    }
-
-    /// The inode behind `path`, or nil when nothing is there — the identity check
-    /// that tells "still our socket" from "someone rebound this name".
-    private static func inode(of path: String) -> UInt64? {
-        var status = stat()
-        guard lstat(path, &status) == 0 else { return nil }
-        return UInt64(status.st_ino)
     }
 
     private func acceptPending() {

--- a/Sources/termio/Resources/agents/claude.json
+++ b/Sources/termio/Resources/agents/claude.json
@@ -15,7 +15,7 @@
   "install": "https://claude.com/claude-code",
   "skills": { "dir": "~/.claude/skills" },
   "titleStatus": {
-    "working": ["^[⠀-⣿] "]
+    "working": ["^[⠀-⣿◐-◓] "]
   },
   "hooks": {
     "type": "json",

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -82,7 +82,18 @@ extension TermioStore {
                            to inMemory: InMemoryTerminalSession,
                            for session: Session) {
         let isAgentSession = session.agent != .terminal && !session.isSSH
-        link.onOutput = { [weak inMemory] data in inMemory?.receive(data) }
+        // The same status tap the in-process PTY installs on its output. The daemon
+        // owning the PTY changes where the bytes come from, not what they say about
+        // the agent — and the channels this restores (screen liveness, declared
+        // screen rules, `OSC 9;4`) are what keep a spinner truthful when the host's
+        // own `E status` is silent and a hook report went missing.
+        let statusTap = makeStatusTap(
+            for: session, surface: inMemory, backend: link,
+            lastInputAt: { [weak link] in link?.lastInputAt })
+        link.onOutput = { [weak inMemory] data in
+            inMemory?.receive(data)
+            statusTap(data)
+        }
         // The attach handshake is the cheapest device discovery there is — it was
         // going to happen anyway — so every surfaced session teaches the app which
         // machine it is on, with no extra round trip.

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1259,6 +1259,17 @@ final class TermiodSessionLink: @unchecked Sendable {
     private var closed = false
     private var exitDelivered = false
 
+    /// The last instant something was written toward the session's stdin. Its own
+    /// lock, not the work queue, so the status tap can read it from the reader
+    /// thread without a hop.
+    private let inputLock = NSLock()
+    private var lastInputAtLocked = Date.distantPast
+    var lastInputAt: Date {
+        inputLock.lock()
+        defer { inputLock.unlock() }
+        return lastInputAtLocked
+    }
+
     /// Raw PTY bytes from the daemon — fed to the surface exactly where
     /// `PTYProcess`'s read pump delivers on the in-process path. Called on the
     /// reader thread; the consumer (`InMemoryTerminalSession.receive`) is
@@ -1365,6 +1376,13 @@ final class TermiodSessionLink: @unchecked Sendable {
 
     func send(_ data: Data) {
         guard !data.isEmpty else { return }
+        // Stamped here rather than on the work queue: this is the choke point every
+        // input path crosses (Mac keystrokes, the phone bridge, `sessions send`),
+        // and the status tap reads it to tell input echo apart from agent-driven
+        // output. Same contract as `PTYProcess.lastInputAt`.
+        inputLock.lock()
+        lastInputAtLocked = Date()
+        inputLock.unlock()
         workQueue.async { [self] in
             guard !closed else { return }
             guard attached else {

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -367,6 +367,15 @@ extension TermioStore {
     /// can keep spinning), and a title-idle only ends a turn — an arbitrary title
     /// (which classifies idle by no-match) must not clear hook-set states.
     func applyTitleActivity(_ activity: AgentStatusRules.Activity, for id: Session.ID) {
+        // Liveness first, before the transition guard — every frame of a ticking
+        // title spinner is evidence the turn is still running, not just the first
+        // one. Claude reprints a new braille frame several times a second and they
+        // all collapse to a no-op here; refreshing only on the transition let
+        // `sweepStaleWorking` clear the spinner 12s into a live turn, and because
+        // the latch below still read `.working`, no later frame could raise it
+        // again — the turn finished with a calm row. This mirrors what
+        // `applyScreenDetectedActivity` already does with its own signal.
+        if activity == .working { lastWorkingAt[id] = Date() }
         guard lastTitleActivity[id] != activity else { return }
         let previous = lastTitleActivity[id]
         lastTitleActivity[id] = activity
@@ -376,7 +385,6 @@ extension TermioStore {
             guard let session = session(id), effectiveAgent(for: session) != .terminal
             else { return }
             setStatus(.working, for: id)
-            lastWorkingAt[id] = Date()
         case .attention:
             clearWorking(id)
             flagBlockingAttention(for: id)
@@ -407,6 +415,10 @@ extension TermioStore {
         // or resolves to an agent that doesn't emit progress, so it can't repopulate a
         // cleared entry or move a replacement process's dot.
         guard let session = session(id), effectiveAgent(for: session).emitsProgressStatus else { return }
+        // Repeated busy reports are liveness, same as a ticking title (see
+        // `applyTitleActivity`): refresh before the transition guard so a turn the
+        // agent keeps asserting can't be swept out from under it.
+        if activity == .working { lastWorkingAt[id] = Date() }
         guard lastProgressActivity[id] != activity else { return }
         let previous = lastProgressActivity[id]
         lastProgressActivity[id] = activity
@@ -414,7 +426,6 @@ extension TermioStore {
         case .working:
             guard status(for: id) != .needsAttention else { return }
             setStatus(.working, for: id)
-            lastWorkingAt[id] = Date()
         case .attention:
             clearWorking(id)
             flagBlockingAttention(for: id)

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -280,121 +280,16 @@ extension TermioStore {
         }
         if let pty {
             pty.addSink { [weak inMemory] data in inMemory?.receive(data) }
-            // Tap the same stream as a working-status signal (see
-            // `noteOutputActivity` for the full model): a *changing* rendered
-            // screen keeps a working session's `lastWorkingAt` fresh — and, when
-            // hooks have gone quiet, can promote an idle session back to working —
-            // while a static screen lets the stale sweep clear the spinner. The
-            // screen, not raw bytes, is the primary key: an agent parked at an
-            // idle prompt still dribbles output (a redraw, a blinking cursor) that
-            // the byte stream alone reads as activity, which is what pins a
-            // finished agent's spinner on forever. The per-tick byte count rides
-            // along as a secondary liveness signal for a viewport the user
-            // scrolled away from the live tail. `readViewportText` is thread-safe
-            // (its own lock), so the compare runs on the read pump; only the
-            // changed-flag and byte count hop to the main actor. Throttled to once
-            // a second. The read pump calls sinks serially, so the captured
-            // `lastPoke` / `lastScreenSignature` / `pendingBytes` need no lock.
-            // A user agent may declare `status` regex rules in its `agent.json`; the
-            // same viewport read that feeds the liveness sweep is classified against
-            // them to drive working / needs-attention / done for agents that ship no
-            // hook system (see `AgentStatusRules`). Built-ins carry no rules (they use
-            // hooks), so this is `nil` for them and the classify step is skipped.
-            //
-            // Caveat: `readViewportText` returns the *displayed* viewport, which follows
-            // the user's scrollback — so scrolling an inline agent's pane up feeds stale
-            // rows to the classifier until it snaps back to the bottom (self-healing;
-            // the byte-count signal covers working-liveness meanwhile). herdr avoids
-            // this by reading the live bottom (active) buffer; the clean fix
-            // here needs a `readActiveText()` on the libghostty wrapper (its blessed read
-            // serializes against the PTY write under a private lock we can't hold, and a
-            // raw unsynchronized `GHOSTTY_POINT_ACTIVE` read from this pump thread would
-            // race `inMemory.receive` — the exact libghostty threading hazard termio has
-            // been bitten by). Tracked as an upstream ask, not worked around unsafely.
-            let statusRules = session.agent.statusRules
-            let agentID = session.agent.id
             let isAgentSession = session.agent != .terminal && !session.isSSH
-            let statusTrace = ProcessInfo.processInfo.environment["TERMIO_STATUS_TRACE"] != nil
-            // Reads this session's ConEmu `OSC 9;4` progress out of the raw stream as
-            // a busy/idle signal (Grok emits it natively). Scanned on every chunk
-            // *before* the 1 s status throttle below — an agent's turn boundary is an
-            // edge, not something to sample once a second. The scan runs for every
-            // session (a plain terminal can be promoted to a hand-started Grok, whose
-            // sink was built while the row was still a shell); whether a transition is
-            // *acted on* is gated in `applyProgressActivity` by the session's live
-            // agent, so an unrelated shell's `wget`/`npm` progress bar can't move a dot.
-            var progressScanner = OSCProgressScanner()
-            var lastPoke = Date.distantPast
-            var lastScreenSignature: Int?
-            // Bytes seen since the last poke, so the throttled tick can report the
-            // stream's volume alongside the screen compare — the scroll-frozen-
-            // viewport liveness signal (see `noteOutputActivity`).
-            var pendingBytes = 0
-            pty.addSink { [weak self, weak inMemory, weak pty] data in
-                pendingBytes += data.count
-                for progress in progressScanner.scan(data) {
-                    if statusTrace {
-                        AgentStatusRules.trace(
-                            agent: "\(agentID).progress", session: session.id,
-                            activity: progress, matched: "OSC 9;4")
-                    }
-                    // Tie the event to the PTY that produced it. Unlike the title
-                    // channel — whose Combine subscription is torn down with the view
-                    // state on relaunch — this sink is only session-id-keyed, so a
-                    // same-agent relaunch could otherwise let a dead PTY's queued
-                    // `working` mark the replacement process. Applying only while this
-                    // PTY is still the session's live one drops that stale event.
-                    DispatchQueue.main.async { [weak pty] in
-                        guard let self, let pty, self.ptyProcesses[session.id] === pty else { return }
-                        self.applyProgressActivity(progress, for: session.id)
-                    }
-                }
-                let now = Date()
-                guard now.timeIntervalSince(lastPoke) >= 1 else { return }
-                lastPoke = now
-                let bytes = pendingBytes
-                pendingBytes = 0
+            pty.addSink(makeStatusTap(
+                for: session, surface: inMemory, backend: pty,
+                lastInputAt: { [weak pty] in pty?.lastInputAt },
                 // Pin the agent's launch binary (once, post-exec) as the baseline
                 // for the self-update relaunch check in `onExit` below. Agent
                 // sessions only — a terminal's exit policy never consults it.
-                if isAgentSession { pty?.recordChildExecutable() }
-                // The PTY timestamps every stdin write (Mac keystrokes, phone
-                // input over the companion bridge, synthetic `sessions send`
-                // text), so sampling it here — instead of tapping only the Mac
-                // surface's write callback — keeps promotion quiet after input
-                // from any device. Input echo repaints the screen just like
-                // agent output does.
-                let inputAt = pty?.lastInputAt
-                let text = inMemory?.readViewportText()
-                let screenChanged: Bool
-                if let text {
-                    let signature = text.hashValue
-                    screenChanged = signature != lastScreenSignature
-                    lastScreenSignature = signature
-                } else {
-                    // No surface to read (e.g. detached) — fall back to treating
-                    // output as activity rather than risk clearing a live turn.
-                    screenChanged = true
-                }
-                let detected: AgentStatusRules.Activity?
-                if let statusRules {
-                    let (activity, matched) = statusRules.explain(text ?? "")
-                    detected = activity
-                    if statusTrace {
-                        AgentStatusRules.trace(
-                            agent: agentID, session: session.id, activity: activity, matched: matched)
-                    }
-                } else {
-                    detected = nil
-                }
-                DispatchQueue.main.async {
-                    if let inputAt { self?.noteUserInput(session.id, at: inputAt) }
-                    self?.noteOutputActivity(session.id, screenChanged: screenChanged, bytes: bytes)
-                    if let detected {
-                        self?.applyScreenDetectedActivity(detected, for: session.id)
-                    }
-                }
-            }
+                // The daemon path has no equivalent: it owns the process, so the
+                // app cannot pin its executable.
+                onPoke: { [weak pty] in if isAgentSession { pty?.recordChildExecutable() } }))
             // A plain terminal's kernel-sampled introspection, after output settles:
             // which agent (if any) is running in its foreground, and — for a loose
             // terminal — the shell's cwd. Both are read from the child's own process
@@ -513,6 +408,150 @@ extension TermioStore {
         // writing them here is fine; only the `projects` write must be deferred.)
         DispatchQueue.main.async { [self] in recordLaunch(session.id, resumeID: launch.resumeID) }
         return state
+    }
+
+    /// Builds the status half of a session's byte stream — the tap both backends
+    /// install on their output, so a session behaves identically whether its PTY is
+    /// in this process or inside `termiod`. It was written for the in-process PTY
+    /// and lived inside that branch, which quietly meant a daemon-hosted session had
+    /// no screen liveness, no screen-rule classification and no `OSC 9;4` scan at
+    /// all: its only surviving channel was the title, and one channel is not enough
+    /// to keep a spinner honest.
+    ///
+    /// What the tap reads (see `noteOutputActivity` for the full model): a *changing*
+    /// rendered screen keeps a working session's `lastWorkingAt` fresh — and, when
+    /// hooks have gone quiet, can promote an idle session back to working — while a
+    /// static screen lets the stale sweep clear the spinner. The screen, not raw
+    /// bytes, is the primary key: an agent parked at an idle prompt still dribbles
+    /// output (a redraw, a blinking cursor) that the byte stream alone reads as
+    /// activity, which is what pins a finished agent's spinner on forever. The
+    /// per-tick byte count rides along as a secondary liveness signal for a viewport
+    /// the user scrolled away from the live tail. `readViewportText` is thread-safe
+    /// (its own lock), so the compare runs on the delivering thread; only the
+    /// changed-flag and byte count hop to the main actor. Throttled to once a second.
+    /// Both backends deliver serially, so the captured `lastPoke` /
+    /// `lastScreenSignature` / `pendingBytes` need no lock.
+    ///
+    /// A user agent may declare `status` regex rules in its `agent.json`; the same
+    /// viewport read that feeds the liveness sweep is classified against them to
+    /// drive working / needs-attention / done for agents that ship no hook system
+    /// (see `AgentStatusRules`). Built-ins carry no rules (they use hooks), so this
+    /// is `nil` for them and the classify step is skipped.
+    ///
+    /// Caveat: `readViewportText` returns the *displayed* viewport, which follows the
+    /// user's scrollback — so scrolling an inline agent's pane up feeds stale rows to
+    /// the classifier until it snaps back to the bottom (self-healing; the byte-count
+    /// signal covers working-liveness meanwhile). herdr avoids this by reading the
+    /// live bottom (active) buffer; the clean fix here needs a `readActiveText()` on
+    /// the libghostty wrapper (its blessed read serializes against the PTY write
+    /// under a private lock we can't hold, and a raw unsynchronized
+    /// `GHOSTTY_POINT_ACTIVE` read from this pump thread would race
+    /// `inMemory.receive` — the exact libghostty threading hazard termio has been
+    /// bitten by). Tracked as an upstream ask, not worked around unsafely.
+    ///
+    /// - Parameters:
+    ///   - backend: the object delivering the bytes (the `PTYProcess` or the
+    ///     `TermiodSessionLink`), held weakly and used to drop events a dead
+    ///     backend queued for a session that has since relaunched.
+    ///   - lastInputAt: when something was last written toward the session's stdin,
+    ///     from whichever backend owns the write path.
+    ///   - onPoke: backend-specific work for the throttled tick.
+    func makeStatusTap(
+        for session: Session,
+        surface inMemory: InMemoryTerminalSession,
+        backend: AnyObject,
+        lastInputAt: @escaping () -> Date?,
+        onPoke: @escaping () -> Void = {}
+    ) -> (Data) -> Void {
+        let statusRules = session.agent.statusRules
+        let agentID = session.agent.id
+        let statusTrace = ProcessInfo.processInfo.environment["TERMIO_STATUS_TRACE"] != nil
+        // Reads this session's ConEmu `OSC 9;4` progress out of the raw stream as
+        // a busy/idle signal (Grok emits it natively). Scanned on every chunk
+        // *before* the 1 s status throttle below — an agent's turn boundary is an
+        // edge, not something to sample once a second. The scan runs for every
+        // session (a plain terminal can be promoted to a hand-started Grok, whose
+        // sink was built while the row was still a shell); whether a transition is
+        // *acted on* is gated in `applyProgressActivity` by the session's live
+        // agent, so an unrelated shell's `wget`/`npm` progress bar can't move a dot.
+        var progressScanner = OSCProgressScanner()
+        var lastPoke = Date.distantPast
+        var lastScreenSignature: Int?
+        // Bytes seen since the last poke, so the throttled tick can report the
+        // stream's volume alongside the screen compare — the scroll-frozen-
+        // viewport liveness signal (see `noteOutputActivity`).
+        var pendingBytes = 0
+        return { [weak self, weak inMemory, weak backend] data in
+            pendingBytes += data.count
+            for progress in progressScanner.scan(data) {
+                if statusTrace {
+                    AgentStatusRules.trace(
+                        agent: "\(agentID).progress", session: session.id,
+                        activity: progress, matched: "OSC 9;4")
+                }
+                // Tie the event to the backend that produced it. Unlike the title
+                // channel — whose Combine subscription is torn down with the view
+                // state on relaunch — this tap is only session-id-keyed, so a
+                // same-agent relaunch could otherwise let a dead PTY's queued
+                // `working` mark the replacement process. Applying only while this
+                // backend is still the session's live one drops that stale event.
+                DispatchQueue.main.async { [weak backend] in
+                    guard let self, let backend,
+                          self.isLiveBackend(backend, for: session.id) else { return }
+                    self.applyProgressActivity(progress, for: session.id)
+                }
+            }
+            let now = Date()
+            guard now.timeIntervalSince(lastPoke) >= 1 else { return }
+            lastPoke = now
+            let bytes = pendingBytes
+            pendingBytes = 0
+            onPoke()
+            // The backend timestamps every stdin write (Mac keystrokes, phone
+            // input over the companion bridge, synthetic `sessions send` text), so
+            // sampling it here — instead of tapping only the Mac surface's write
+            // callback — keeps promotion quiet after input from any device. Input
+            // echo repaints the screen just like agent output does.
+            let inputAt = lastInputAt()
+            let text = inMemory?.readViewportText()
+            let screenChanged: Bool
+            if let text {
+                let signature = text.hashValue
+                screenChanged = signature != lastScreenSignature
+                lastScreenSignature = signature
+            } else {
+                // No surface to read (e.g. detached) — fall back to treating
+                // output as activity rather than risk clearing a live turn.
+                screenChanged = true
+            }
+            let detected: AgentStatusRules.Activity?
+            if let statusRules {
+                let (activity, matched) = statusRules.explain(text ?? "")
+                detected = activity
+                if statusTrace {
+                    AgentStatusRules.trace(
+                        agent: agentID, session: session.id, activity: activity, matched: matched)
+                }
+            } else {
+                detected = nil
+            }
+            DispatchQueue.main.async {
+                if let inputAt { self?.noteUserInput(session.id, at: inputAt) }
+                self?.noteOutputActivity(session.id, screenChanged: screenChanged, bytes: bytes)
+                if let detected {
+                    self?.applyScreenDetectedActivity(detected, for: session.id)
+                }
+            }
+        }
+    }
+
+    /// Whether this object is still the thing running the session — the in-process
+    /// PTY or the daemon link the store currently holds for it. A tap that outlived
+    /// its backend answers `false` and its queued events are dropped.
+    func isLiveBackend(_ backend: AnyObject, for id: Session.ID) -> Bool {
+        if let pty = ptyProcesses[id] { return pty === backend }
+        if let link = termiodLinks[id] { return link === backend }
+        return false
     }
 
     /// Stands in for the shell that would otherwise spawn locally. It carries no PTY

--- a/Tests/termioTests/AgentTitleStatusTests.swift
+++ b/Tests/termioTests/AgentTitleStatusTests.swift
@@ -1,0 +1,72 @@
+import AppKit
+import XCTest
+@testable import termio
+
+/// The `OSC 0/2` title as a status channel. It is the only signal that survives
+/// when hooks are silent and the host reports nothing, so what it must not do is
+/// go quiet on its own while the agent is still working.
+@MainActor
+final class AgentTitleStatusTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // The attention arms ask whether the user is looking, which reads `NSApp`.
+        _ = NSApplication.shared
+    }
+
+    private func makeStore(with session: Session) -> TermioStore {
+        let workspace = Workspace(name: "Sessions")
+        let project = Project(workspaceID: workspace.id, name: "termio", path: "/code/termio",
+                              branch: "main", sessions: [session])
+        let defaults = UserDefaults(suiteName: "agent-title-status-\(UUID().uuidString)")
+        return TermioStore(workspaces: [workspace], projects: [project],
+                           settings: AppSettings(defaults: defaults ?? .standard))
+    }
+
+    /// Every frame of a ticking title spinner is evidence the turn is still
+    /// running. They collapse to a no-op at the transition guard, so if only the
+    /// first one refreshed the liveness clock, `sweepStaleWorking` cleared the
+    /// spinner 12s into a live turn — and the latch then stopped any later frame
+    /// from raising it again, so the row stayed calm until the agent finished.
+    func testEveryWorkingTitleFrameRefreshesLiveness() {
+        let session = Session(title: "agent", agent: .claudeCode)
+        let store = makeStore(with: session)
+
+        store.applyTitleActivity(.working, for: session.id)
+        XCTAssertEqual(store.status(for: session.id), .working)
+
+        // Stand in for a turn that has been running long enough for the sweep to
+        // be interested, then let the agent tick its spinner once more.
+        let stale = Date(timeIntervalSinceNow: -60)
+        store.lastWorkingAt[session.id] = stale
+        store.applyTitleActivity(.working, for: session.id)
+
+        let refreshed = try? XCTUnwrap(store.lastWorkingAt[session.id])
+        XCTAssertGreaterThan(refreshed ?? stale, stale)
+    }
+
+    /// The other direction still has to work: a title that calms is how a turn
+    /// ends without a `Stop` hook.
+    func testACalmTitleEndsTheTurn() {
+        let session = Session(title: "agent", agent: .claudeCode)
+        let store = makeStore(with: session)
+
+        store.applyTitleActivity(.working, for: session.id)
+        store.applyTitleActivity(.idle, for: session.id)
+
+        XCTAssertNotEqual(store.status(for: session.id), .working)
+        XCTAssertNil(store.lastWorkingAt[session.id])
+    }
+
+    /// Claude Code ships two spinner alphabets: braille through 2.1.227, and the
+    /// half-circles it switched to in 2.1.228. Matching only the first meant the
+    /// title channel went silent the day a user updated.
+    func testClaudeTitleRulesReadBothSpinnerAlphabets() throws {
+        let rules = try XCTUnwrap(AgentDefinition.claudeCode.titleRules)
+
+        for frame in ["⠋", "⠙", "⠹", "◐", "◑", "◒", "◓"] {
+            XCTAssertEqual(rules.explain("\(frame) Fix the resize bug").activity, .working,
+                           "\(frame) should read as working")
+        }
+        XCTAssertEqual(rules.explain("✳ Fix the resize bug").activity, .idle)
+    }
+}


### PR DESCRIPTION
An agent could work for a full turn with its sidebar row sitting calm. Three
independent failures stacked up, and every one of them was silent.

**The hook socket could be stolen.** `SessionControl` probes the path before
unlinking it; `HookListener` did not, so any bare SwiftPM binary — `swift run`,
`swift test`, a worktree build launched without `TERMIO_CHANNEL` — took the name
from the running app. The app kept listening on an inode nothing could address,
and once the thief exited, its leftover file refused every connection. The hook
command ends in `2>/dev/null || true`, so nothing could report it. Both
listeners now share one implementation, and neither gives up the path for good:
an instance that takes it can exit *without* unlinking, leaving a dead file whose
inode never changes, so a periodic probe is the only way back.

**A ticking title aged out its own turn.** `applyTitleActivity` refreshed
`lastWorkingAt` inside the transition branch, so only the first spinner frame
counted as liveness. Claude reprints a frame several times a second and they all
collapse to a no-op at the guard, which let the 12s stale sweep clear the spinner
mid-turn — and because the latch still read `.working`, no later frame could
raise it again. `applyProgressActivity` had the same shape.

**Daemon-hosted sessions had no status tap at all.** The tap lived inside the
in-process PTY branch, so a session running under termiod got no screen liveness,
no declared screen rules, no `OSC 9;4` scan and no input timestamps — leaving the
title as its only channel.

Also: Claude Code ships two spinner alphabets (braille through 2.1.227,
half-circles from 2.1.228) and the title rule only read the first.

## Verification

`swift build` clean, 446 tests pass including three new ones pinning the title
channel. The daemon path was checked on a real run: an isolated runtime channel
(`TERMIO_CHANNEL=probe`, own state and sockets, hook fan-out not reaching it at
all), with a daemon-hosted Claude session holding `working` for 45s across the
stale sweep and settling to `done` when the turn ended. The same configuration
dropped to `idle` at ~16s before this change.

## Known gaps, not addressed here

- Hand-started agent detection still doesn't work on termiod sessions:
  `noteForegroundAgent` and the cwd poll read the child's pid through
  `KERN_PROCARGS2` / `PROC_PIDVNODEPATHINFO`, which the app cannot do for a
  process the daemon owns. That needs a protocol addition.
- Claude still declares no screen rules. Adding them would take status authority
  away from hooks — `noteOutputActivity` stands down for agents that declare
  rules — so it is a design change rather than a fix.

Release Notes:
- Fixed an agent's spinner going quiet mid-turn, and agent status stopping
  entirely after another build of termio had been launched.