### PR TITLE
Stop Also Running from listing another Termio's sessions

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -831,6 +831,16 @@
         }
       }
     },
+    "Close All": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部关闭"
+          }
+        }
+      }
+    },
     "Close All Terminals": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -202,6 +202,8 @@
 	<string>Close</string>
 	<key>Close (Esc)</key>
 	<string>Close (Esc)</string>
+	<key>Close All</key>
+	<string>Close All</string>
 	<key>Close All Chats</key>
 	<string>Close All Chats</string>
 	<key>Close All Terminals</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -202,6 +202,8 @@
 	<string>关闭</string>
 	<key>Close (Esc)</key>
 	<string>关闭（Esc）</string>
+	<key>Close All</key>
+	<string>全部关闭</string>
 	<key>Close All Chats</key>
 	<string>关闭所有聊天</string>
 	<key>Close All Terminals</key>

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -384,6 +384,8 @@ struct SidebarView: View {
             items.append(.separator)
         }
         items.append(.action(localized("Refresh")) { store.refreshDeviceSessions() })
+        items.append(.separator)
+        items.append(.action(localized("Close All")) { store.requestCloseAllDeviceSessions() })
         return items
     }
 
@@ -1415,10 +1417,7 @@ private struct DeviceOnlySessionRow: View {
     let chrome: ChromeTheme?
     @State private var isHovering = false
 
-    private var title: String {
-        if let title = information.title, !title.isEmpty { return title }
-        return information.name
-    }
+    private var title: String { information.displayLabel }
 
     /// What the device says the row is doing, in the fewest words that stay true:
     /// the command, and the directory it runs in on that machine.
@@ -1449,10 +1448,11 @@ private struct DeviceOnlySessionRow: View {
                 }
             }
             Spacer(minLength: 4)
-            if information.attachedClients > 0 {
-                // Someone else is watching this session. Worth saying out loud —
-                // the write token is single-holder, so opening it may not hand
-                // over the keyboard.
+            // Someone else is watching this session. Worth saying out loud — the
+            // write token is single-holder, so opening it may not hand over the
+            // keyboard. It yields the trailing edge to the close button on hover,
+            // which is where every other row in the sidebar puts that action.
+            if information.attachedClients > 0, !isHovering {
                 HugeIconView(icon: .view, size: 13, color: .secondary)
             }
         }
@@ -1462,10 +1462,35 @@ private struct DeviceOnlySessionRow: View {
         .help(information.cwd.isEmpty
               ? localized("Opened outside Termio on this device")
               : localized("Opened outside Termio, in \(information.cwd)"))
-        .onHover { isHovering = $0 }
         .simultaneousGesture(TapGesture().onEnded { store.adoptDeviceSession(information) })
+        // The same hover-reveal close as a session row. Without it the only way
+        // to end one of these was to adopt it into the sidebar first and close
+        // it there — backwards for the rows this section mostly holds, which are
+        // sessions no Termio on this Mac has a record of any more.
+        //
+        // Layered *outside* the row's tap, or the click that closes a session
+        // would also adopt it: a simultaneous gesture fires for every tap its
+        // own subtree receives, button or not. Hover is read outside both, so
+        // moving onto the button doesn't count as leaving the row and blink it
+        // back out from under the cursor.
+        .overlay(alignment: .trailing) {
+            SessionRowActionButton(
+                systemImage: "xmark.circle.fill",
+                help: localized("Close session"),
+                chrome: chrome
+            ) {
+                store.requestCloseDeviceSession(information)
+            }
+            .opacity(isHovering ? 1 : 0)
+            .allowsHitTesting(isHovering)
+        }
+        .onHover { isHovering = $0 }
         .background(SidebarRowContextMenu(items: {
-            [.action(localized("Open")) { store.adoptDeviceSession(information) }]
+            [
+                .action(localized("Open")) { store.adoptDeviceSession(information) },
+                .separator,
+                .action(localized("Close Session")) { store.requestCloseDeviceSession(information) },
+            ]
         }))
         .listRowBackground(
             SidebarRowHighlight(isSelected: false, isHovering: isHovering, chrome: chrome)

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -493,7 +493,7 @@ extension TermioStore {
             return
         }
         let device = currentDevice
-        var session = Session(title: information.title ?? information.name, agent: .terminal)
+        var session = Session(title: information.displayLabel, agent: .terminal)
         session.termiodSessionName = information.name.isEmpty ? information.id : information.name
         session.termiodRemoteHost = device.alias
         session.deviceID = device.deviceID
@@ -512,6 +512,81 @@ extension TermioStore {
         }
         workspaces[index].terminals.append(session)
         selectedSessionID = session.id
+    }
+
+    /// Ends a session the **device** reports and this app has no row for.
+    ///
+    /// Adoption alone left the roster one-way: the only route to a stranger row
+    /// was to take it into the sidebar first, which is backwards for the case
+    /// that produces most of them — a Termio whose state file was reset or
+    /// replaced, leaving its PTYs alive under names nothing here will ever
+    /// claim. Closing one is a device operation, so nothing local is touched:
+    /// there is no record, no surface and no link to tear down.
+    ///
+    /// It asks first, every time, and not on `requestCloseSession`'s terms —
+    /// that one can look at the PTY to see whether the close loses anything,
+    /// and this one cannot, because the process belongs to something that isn't
+    /// this app. Unknown is not the same as harmless.
+    func requestCloseDeviceSession(_ information: Termiod.SessionInformation) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Close “\(information.displayLabel)”?"
+        alert.informativeText = information.attachedClients > 0
+            ? "Another client is attached to this session. Closing it stops the "
+                + "process running on \(deviceDescription)."
+            : "This session isn't open in Termio. Closing it stops the process "
+                + "running on \(deviceDescription)."
+        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: "Close Session")
+        alert.buttons.last?.hasDestructiveAction = true
+        guard alert.runModal() == .alertSecondButtonReturn else { return }
+        closeDeviceSessions([information])
+    }
+
+    /// The whole stranger list at once. One question for the lot: a state-file
+    /// reset leaves them by the dozen, and answering the same alert twenty times
+    /// is not a safeguard.
+    func requestCloseAllDeviceSessions() {
+        let rows = deviceOnlySessions()
+        guard !rows.isEmpty else { return }
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Close \(rows.count) session\(rows.count == 1 ? "" : "s")?"
+        alert.informativeText = "These sessions aren't open in Termio. Closing them "
+            + "stops every one of their processes on \(deviceDescription)."
+        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: "Close Sessions")
+        alert.buttons.last?.hasDestructiveAction = true
+        guard alert.runModal() == .alertSecondButtonReturn else { return }
+        closeDeviceSessions(rows)
+    }
+
+    private func closeDeviceSessions(_ rows: [Termiod.SessionInformation]) {
+        let route = currentDevice.route
+        // The roster is asked once, after the last kill has been answered:
+        // re-asking mid-sweep would only fetch the rows that haven't died yet.
+        let kills = DispatchGroup()
+        for information in rows {
+            kills.enter()
+            Termiod.killSession(target: information.name.isEmpty ? information.id : information.name,
+                                route: route) { kills.leave() }
+        }
+        kills.notify(queue: .main) { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                // The kills changed the answer, so a reply that settled moments
+                // ago is stale by construction — clearing the coalescing window
+                // is what keeps `refreshDeviceSessions` from standing down and
+                // leaving the closed rows on screen.
+                self.rosterFetches[route.description]?.settledAt = nil
+                self.refreshDeviceSessions()
+            }
+        }
+    }
+
+    /// How to name the machine in a sentence a person reads.
+    private var deviceDescription: String {
+        currentDevice.alias ?? "this Mac"
     }
 
     // MARK: - Remote terminals (per-session SSH host)

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -783,6 +783,35 @@ enum Termiod {
             createdUnix = try container.decodeIfPresent(UInt64.self, forKey: .createdUnix) ?? 0
             attachedClients = try container.decodeIfPresent(Int.self, forKey: .attachedClients) ?? 0
         }
+
+        /// What to call this session on screen. The name is the daemon's handle,
+        /// not a label: a session Termio created is named with the app's session
+        /// uuid, so a roster row for one this app has no record of would read as
+        /// a line of hex. In order of how much it tells a person: the reported
+        /// title, the agent, the program actually running, and — only when the
+        /// command says nothing — the name itself.
+        var displayLabel: String {
+            if let title, !title.isEmpty { return title }
+            if let agentID, !agentID.isEmpty { return agentID }
+            return Self.programName(in: command) ?? name
+        }
+
+        /// The program behind the login-shell wrapper Termio spawns through
+        /// (`/bin/zsh -ilc exec claude …`): the shell, its flags and `exec` are
+        /// scaffolding, and the first word after them is the thing running. A
+        /// bare `/bin/zsh -il` has nothing behind the scaffolding because the
+        /// shell *is* the session, so it names itself.
+        private static func programName(in command: String) -> String? {
+            var words = command.split(whereSeparator: \.isWhitespace).map(String.init)
+            guard let executable = words.first, !executable.isEmpty else { return nil }
+            let shell = URL(fileURLWithPath: executable).lastPathComponent
+            guard shell.hasSuffix("sh") else { return shell }
+            words.removeFirst()
+            while let flag = words.first, flag.hasPrefix("-") { words.removeFirst() }
+            if words.first == "exec" { words.removeFirst() }
+            guard let program = words.first, !program.isEmpty else { return shell }
+            return URL(fileURLWithPath: program).lastPathComponent
+        }
     }
 
     /// A dead session, as the daemon buried it (termiod/src/tombstone.rs). This
@@ -1136,8 +1165,21 @@ enum Termiod {
     /// Ends a session for real — the explicit user-facing destroy verb, never
     /// part of quit/detach. The target may be a termiod id or name (the app
     /// uses the session UUID it named the session with).
-    static func killSession(target: String, route: TermiodRoute = .local) {
+    ///
+    /// `completion` runs on the main queue once the daemon has answered, however
+    /// it answered. A caller that shows the device's own roster needs it: asking
+    /// for the roster before the kill lands would put the row straight back.
+    static func killSession(
+        target: String,
+        route: TermiodRoute = .local,
+        completion: (@Sendable @MainActor () -> Void)? = nil
+    ) {
         DispatchQueue.global(qos: .utility).async {
+            defer {
+                if let completion {
+                    DispatchQueue.main.async { MainActor.assumeIsolated(completion) }
+                }
+            }
             do {
                 try withControlChannel(route: route) { transport, _ in
                     try writeFrame(transport.writeDescriptor, kind: .control,

--- a/Sources/termio/TermioStore/DeviceContext.swift
+++ b/Sources/termio/TermioStore/DeviceContext.swift
@@ -192,9 +192,24 @@ extension TermioStore {
     /// produce a row for a session this app never created.
     func deviceOnlySessions() -> [Termiod.SessionInformation] {
         let mine = sessions(authoredFor: currentDevice)
+        let isLocal = currentDevice.isLocal
         return (deviceSessions.sessions?.live ?? []).filter { information in
-            information.alive
-                && !mine.contains { daemonSessionName(for: $0) == information.name }
+            guard information.alive else { return false }
+            guard !mine.contains(where: { daemonSessionName(for: $0) == information.name })
+            else { return false }
+            // On this Mac, a session someone is already attached to belongs to
+            // another Termio. The daemon socket is per user, not per app, so a
+            // second copy on the same login — a dev build beside the release
+            // one — is handed the first one's entire roster, and every row of
+            // it arrives here looking like a session nothing accounts for.
+            // They are neither lost nor takeable (single writer), so they are
+            // not this list's business.
+            //
+            // Only on this Mac. On another device the roster *is* the sidebar,
+            // and a session the phone has open is still one of that machine's
+            // sessions — dropping it there would hide the box's own work.
+            if isLocal, information.attachedClients > 0 { return false }
+            return true
         }
     }
 

--- a/web/landing/src/data/changelog.ts
+++ b/web/landing/src/data/changelog.ts
@@ -17,6 +17,22 @@ export type ChangelogEntry = {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: "0.40.2",
+    date: "2026-08-22",
+    title: "Also Running lists only what nothing is watching",
+    changes: {
+      new: [
+        "Sessions under Also Running can be closed from the sidebar. Hover a row for its close button, or close the whole list from the section header — ending one used to mean opening it first.",
+      ],
+      improved: [
+        "Rows under Also Running are named after the program they're running, instead of the identifier the session was created with.",
+      ],
+      fixed: [
+        "Sessions belonging to another copy of termio on the same Mac no longer appear under Also Running. Both share one session host, so the second one to open was handed the first one's whole list and showed every row of it as a session nothing accounted for.",
+      ],
+    },
+  },
+  {
     version: "0.40.1",
     date: "2026-08-22",
     title: "The spinner stays on for the whole turn",


### PR DESCRIPTION
The termiod socket is per user, not per app, so a second copy of Termio on the same login — a dev build beside the release one — is handed the first one's entire roster. Every row of it reached the sidebar as a session nothing accounts for: twenty rows of another window's live work, listed under Also Running as strangers to adopt.

The attached-client count already knew. On this Mac a session someone is holding belongs to another Termio, and single writer means it isn't takeable anyway, so it's filtered out. Only on this Mac — on another device that roster *is* the sidebar, and a session the phone has open is still that machine's work.

The rows that remain are ones nothing is attached to, and they can now be closed. Before this they offered one action, Open, so ending one meant adopting it into the sidebar first and closing it there. They get the same hover-reveal close as a session row, plus Close Session and a Close All on the section header, and each kill asks first: `requestCloseSession` can read the PTY to see whether anything is lost, and this can't, because the process belongs to something that isn't this app.

They also stop reading as hex. A session Termio created is named with its uuid, so the label now falls back through the reported title, the agent, and the program running behind the login-shell wrapper before settling for the name.

Release Notes:
- Sessions belonging to another copy of Termio on the same Mac no longer appear under Also Running.
- Sessions listed under Also Running can be closed from the sidebar, and read as the program they're running instead of an identifier.