### PR TITLE
Stop a resize from mangling an agent's input box

### DIFF
--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1327,6 +1327,9 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// The last grid actually written as an `R` frame, so a redundant resize
     /// isn't re-sent while the daemon is still applying the first one.
     private var sentGrid: TerminalGrid?
+    /// Bumped by every `resize`; only the newest scheduled send may write its
+    /// frame. See `scheduleResizeLocked`.
+    private var resizeGeneration: UInt64 = 0
     /// The PTY's real size, from `attached` and then every `E resized`. This is
     /// the authority — §C.5: a client that parses at its own window size instead
     /// of this one wraps the same bytes differently and diverges from the host.
@@ -1335,6 +1338,15 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// daemon crash.
     private var closed = false
     private var exitDelivered = false
+
+    /// What the reader thread needs to judge an arriving `S` against: the grid
+    /// the surface is currently laid out at, and whether this client is the one
+    /// moving the PTY toward it. Its own lock rather than the work queue because
+    /// a snapshot is rendered inline on the reader thread — hopping would break
+    /// the S-before-D ordering that path exists to preserve.
+    private let renderLock = NSLock()
+    private var renderTargetLocked: TerminalGrid
+    private var renderWriterLocked = false
 
     /// The last instant something was written toward the session's stdin. Its own
     /// lock, not the work queue, so the status tap can read it from the reader
@@ -1384,7 +1396,9 @@ final class TermiodSessionLink: @unchecked Sendable {
         self.sessionName = sessionName
         self.specification = specification
         self.route = route
-        desiredGrid = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
+        let grid = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
+        desiredGrid = grid
+        renderTargetLocked = grid
     }
 
     /// Kicks off connect → hello → attach in the background. The caller wires
@@ -1415,6 +1429,7 @@ final class TermiodSessionLink: @unchecked Sendable {
                 }
                 attached = true
                 isWriter = attachedPayload.writer
+                publishRenderWriter(attachedPayload.writer)
                 // `attached` reports the session's size *before* this attach is
                 // applied; the daemon then resizes to what a writer asked for and
                 // announces it as `E resized`. Seeding from the reply means an
@@ -1479,6 +1494,11 @@ final class TermiodSessionLink: @unchecked Sendable {
 
     func resize(rows: Int, cols: Int) {
         let size = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
+        // Recorded before the hop: this is what the surface is laid out at right
+        // now, and the reader thread judges every arriving keyframe against it.
+        renderLock.lock()
+        renderTargetLocked = size
+        renderLock.unlock()
         workQueue.async { [self] in
             guard !closed else { return }
             desiredGrid = size
@@ -1486,8 +1506,32 @@ final class TermiodSessionLink: @unchecked Sendable {
             // Observers must not resize the shared PTY out from under the
             // writer; the daemon would reject the frame anyway.
             guard isWriter else { return }
+            scheduleResizeLocked()
+        }
+    }
+
+    /// How long the grid must hold still before the size goes to the daemon.
+    /// The same 50ms `PTYProcess.resizeFromHost` coalesces on, and for a
+    /// sharper reason here: on the in-process path an intermediate size costs a
+    /// SIGWINCH, while on this one every distinct size is a host-side
+    /// **barrier** — the session quiesces, resizes, and pushes a fresh keyframe
+    /// to every attachment. A live drag or a settling split emits a burst of
+    /// them, and each keyframe is a full repaint racing the child's own redraw.
+    private static let resizeCoalescingInterval = DispatchTimeInterval.milliseconds(50)
+
+    /// Sends `desiredGrid` once the surface stops moving. Generation-stamped
+    /// rather than debounced with a cancellable work item because the size is
+    /// re-read at fire time: the last scheduled send is the only one that
+    /// writes, and it writes whatever the grid settled at.
+    ///
+    /// Must run on `workQueue`.
+    private func scheduleResizeLocked() {
+        resizeGeneration &+= 1
+        let generation = resizeGeneration
+        workQueue.asyncAfter(deadline: .now() + Self.resizeCoalescingInterval) { [self] in
+            guard !closed, attached, isWriter, generation == resizeGeneration else { return }
             do {
-                try sendResizeLocked(size)
+                try sendResizeLocked(desiredGrid)
             } catch {
                 Log.termiod.error("""
                 resize of \(self.sessionName, privacy: .public) failed: \
@@ -1602,15 +1646,19 @@ final class TermiodSessionLink: @unchecked Sendable {
                     // pulls the first live `D` — preserves S-before-D through
                     // the same `onOutput` seam, with no hold-back buffer needed.
                     // A mid-session `S` (the resize barrier's fresh keyframe)
-                    // takes the same path and repaints idempotently.
-                    if let repaint = TermiodSnapshot.decode(frame.payload)
-                        .map(TermiodSnapshot.render) {
-                        self.onOutput?(repaint)
-                    } else {
+                    // takes the same path and repaints idempotently — but only
+                    // one taken at the grid this surface is actually laid out
+                    // at (see `snapshotIsStale`).
+                    guard let keyframe = TermiodSnapshot.decode(frame.payload) else {
                         Log.termiod.error("""
                         undecodable snapshot frame on \(self.sessionName, privacy: .public)
                         """)
+                        break
                     }
+                    guard !self.snapshotIsStale(rows: keyframe.rows, cols: keyframe.cols) else {
+                        break
+                    }
+                    self.onOutput?(TermiodSnapshot.render(keyframe))
                 case .control:
                     if self.handleControl(frame.payload) { return }
                 case .event:
@@ -1729,6 +1777,7 @@ final class TermiodSessionLink: @unchecked Sendable {
             let mine = writer != nil && writer == clientID
             guard mine != isWriter else { return }
             isWriter = mine
+            publishRenderWriter(mine)
             Log.termiod.info("""
             write token on \(self.sessionName, privacy: .public) \
             \(mine ? "claimed" : "lost", privacy: .public)
@@ -1745,6 +1794,51 @@ final class TermiodSessionLink: @unchecked Sendable {
             }
             DispatchQueue.main.async { [self] in onWriter?(mine) }
         }
+    }
+
+    private func publishRenderWriter(_ mine: Bool) {
+        renderLock.lock()
+        renderWriterLocked = mine
+        renderLock.unlock()
+    }
+
+    /// Whether an arriving keyframe describes a screen this surface can't paint.
+    ///
+    /// The payload is a formatted repaint, wrapped rows and all, laid out for
+    /// the grid the host VT held when it was taken. Painted into a surface of a
+    /// different width every wrapped row shifts, which is a mangled screen — and
+    /// the TUIs that redraw incrementally (an agent's composer box) never repaint
+    /// it back, so the damage sits there until the next keystroke.
+    ///
+    /// Only a **writer** may drop one, and that is what makes dropping safe
+    /// rather than a blank pane: this client is then the one moving the PTY, so
+    /// a mismatch means its own resize is still in flight and the barrier at the
+    /// far end of it will push a keyframe at the right size. An observer has no
+    /// such promise — nothing it does will produce another `S` — so it paints
+    /// what it was given and lives with §C.5 divergence.
+    static func snapshotIsStale(payload: TerminalGrid,
+                                target: TerminalGrid,
+                                isWriter: Bool) -> Bool {
+        isWriter && payload != target
+    }
+
+    /// Reader-thread half of `snapshotIsStale`, reading the surface's grid and
+    /// the write token under `renderLock`.
+    private func snapshotIsStale(rows: Int, cols: Int) -> Bool {
+        let payload = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
+        renderLock.lock()
+        let target = renderTargetLocked
+        let writer = renderWriterLocked
+        renderLock.unlock()
+        guard Self.snapshotIsStale(payload: payload, target: target, isWriter: writer) else {
+            return false
+        }
+        Log.termiod.info("""
+        skipping \(payload.rows, privacy: .public)x\(payload.cols, privacy: .public) keyframe on \
+        \(self.sessionName, privacy: .public); this surface is \
+        \(target.rows, privacy: .public)x\(target.cols, privacy: .public)
+        """)
+        return true
     }
 
     /// Records the PTY's real size. Two things read it: `sendResizeLocked`, so a

--- a/Tests/termioTests/TermiodKeyframeGridTests.swift
+++ b/Tests/termioTests/TermiodKeyframeGridTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import termio
+
+/// Which keyframes a termiod attachment is allowed to paint.
+///
+/// The daemon's `S` payload is a formatted repaint — wrapped rows and all — laid
+/// out for the grid the host VT held when it was taken. Painting one into a
+/// surface of a different width shifts every wrapped row, and an incrementally
+/// redrawing TUI never repairs it, so the damage sits on screen until the next
+/// keystroke. The rule has two halves and both have a real failure mode: a
+/// writer drops the mismatch because its own resize will produce a correct one,
+/// and an observer must paint it anyway because nothing it does will produce
+/// another.
+final class TermiodKeyframeGridTests: XCTestCase {
+    private let surface = TerminalGrid(rows: 40, cols: 100)
+
+    func testWriterSkipsAKeyframeTakenAtAnotherGrid() {
+        XCTAssertTrue(TermiodSessionLink.snapshotIsStale(
+            payload: TerminalGrid(rows: 37, cols: 54),
+            target: surface,
+            isWriter: true))
+    }
+
+    func testWriterPaintsAKeyframeThatMatchesTheSurface() {
+        XCTAssertFalse(TermiodSessionLink.snapshotIsStale(
+            payload: surface,
+            target: surface,
+            isWriter: true))
+    }
+
+    /// A single column apart is the case that matters: it is invisible in a log
+    /// line and it wraps every full-width row one cell early.
+    func testOneColumnOfDriftIsStale() {
+        XCTAssertTrue(TermiodSessionLink.snapshotIsStale(
+            payload: TerminalGrid(rows: 40, cols: 99),
+            target: surface,
+            isWriter: true))
+    }
+
+    func testObserverPaintsAMismatchedKeyframe() {
+        XCTAssertFalse(TermiodSessionLink.snapshotIsStale(
+            payload: TerminalGrid(rows: 37, cols: 54),
+            target: surface,
+            isWriter: false))
+    }
+}

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1688,6 +1688,16 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> bool {
         }
         SessionMsg::Resize { id, rows, cols } => {
             if session.writer.as_ref() == Some(&id) {
+                // A resize is a barrier: the session quiesces and every
+                // attachment is handed a fresh keyframe to repaint from. Doing
+                // that for a size the PTY already has buys nothing and costs
+                // each viewer a full repaint — and one arrives on every attach,
+                // because `run_attach` asks unconditionally for the size the
+                // client named. The child would see no SIGWINCH from this
+                // ioctl either, so nothing downstream is waiting on it.
+                if rows == session.rows && cols == session.cols {
+                    return false;
+                }
                 if let Err(error) = session.pty.resize(rows, cols) {
                     session.reject_resize(&id, &error);
                     return false;

--- a/termiod/tests/attach_barrier.rs
+++ b/termiod/tests/attach_barrier.rs
@@ -1,0 +1,186 @@
+//! A resize that changes nothing must not repaint anybody.
+//!
+//! A resize is a barrier (§C.5): the session quiesces, resizes, and hands a
+//! fresh keyframe to *every* snapshot-capable attachment, not just the client
+//! that asked. `run_attach` asks for the client's size on every attach, so
+//! without a no-op guard each attach repaints every other viewer of that
+//! session — a phone mirroring it, a second window, the split beside it — for a
+//! size change that never happened. A keyframe landing mid-frame is exactly
+//! what mangles an incrementally redrawing TUI's composer box, and an idle TUI
+//! never repairs it.
+//!
+//! The session runs `cat`, so nothing but the protocol writes to the screen and
+//! a keyframe can only come from an attach or a resize.
+
+use std::io::{Read, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const BIN: &str = env!("CARGO_BIN_EXE_termiod");
+/// Long enough for a barrier to cross the sidecar and come back; every drain
+/// ends on this timeout, so it is also most of the test's runtime.
+const QUIET: Duration = Duration::from_millis(600);
+
+fn write_frame(w: &mut impl Write, kind: u8, payload: &[u8]) {
+    let mut header = [0u8; 5];
+    header[0] = kind;
+    header[1..5].copy_from_slice(&(payload.len() as u32).to_be_bytes());
+    w.write_all(&header).unwrap();
+    w.write_all(payload).unwrap();
+    w.flush().unwrap();
+}
+
+fn read_frame(r: &mut impl Read) -> Option<(u8, Vec<u8>)> {
+    let mut header = [0u8; 5];
+    r.read_exact(&mut header).ok()?;
+    let len = u32::from_be_bytes([header[1], header[2], header[3], header[4]]) as usize;
+    let mut payload = vec![0u8; len];
+    r.read_exact(&mut payload).ok()?;
+    Some((header[0], payload))
+}
+
+struct Daemon {
+    child: Child,
+    socket: String,
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = std::fs::remove_file(&self.socket);
+    }
+}
+
+fn start_daemon(tag: &str) -> Daemon {
+    let socket = format!("/tmp/termiod-attach-barrier-{tag}.sock");
+    let _ = std::fs::remove_file(&socket);
+    let child = Command::new(BIN)
+        .arg("serve")
+        .env("TERMIOD_SOCK", &socket)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn serve");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !std::path::Path::new(&socket).exists() {
+        assert!(Instant::now() < deadline, "daemon never bound the socket");
+        std::thread::sleep(Duration::from_millis(30));
+    }
+    Daemon { child, socket }
+}
+
+/// One attached client, held open so later barriers can be observed on it.
+struct Client {
+    bridge: Child,
+    _stdin: std::process::ChildStdin,
+    frames: mpsc::Receiver<(u8, Vec<u8>)>,
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        let _ = self.bridge.kill();
+        let _ = self.bridge.wait();
+    }
+}
+
+/// Attaches as an interactive, snapshot-capable client at `rows`x`cols`.
+fn attach(socket: &str, session: &str, rows: u16, cols: u16) -> Client {
+    let mut bridge = Command::new(BIN)
+        .arg("stdio")
+        .env("TERMIOD_SOCK", socket)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn stdio bridge");
+    let mut to_bridge = bridge.stdin.take().expect("bridge stdin");
+    let mut from_bridge = bridge.stdout.take().expect("bridge stdout");
+
+    let hello = r#"{"op":"hello","proto":1,"min_proto":1,"role":"attach","caps":["snapshot","events"],"client":"attach-barrier"}"#;
+    write_frame(&mut to_bridge, b'C', hello.as_bytes());
+    let (kind, payload) = read_frame(&mut from_bridge).expect("hello reply");
+    assert_eq!(kind, b'C');
+    assert!(
+        String::from_utf8_lossy(&payload).contains("\"op\":\"hello_ok\""),
+        "expected hello_ok, got {}",
+        String::from_utf8_lossy(&payload)
+    );
+
+    let attach = format!(
+        r#"{{"op":"attach","target":"{session}","rows":{rows},"cols":{cols},"mode":"interact"}}"#
+    );
+    write_frame(&mut to_bridge, b'C', attach.as_bytes());
+
+    let (frames, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        while let Some(frame) = read_frame(&mut from_bridge) {
+            if frames.send(frame).is_err() {
+                return;
+            }
+        }
+    });
+
+    Client {
+        bridge,
+        _stdin: to_bridge,
+        frames: receiver,
+    }
+}
+
+/// The grid of every keyframe that arrives before this client's stream goes
+/// quiet.
+fn keyframe_grids(client: &Client) -> Vec<(u16, u16)> {
+    let mut grids = Vec::new();
+    while let Ok((kind, payload)) = client.frames.recv_timeout(QUIET) {
+        if kind != b'S' {
+            continue;
+        }
+        assert!(payload.len() >= 5, "malformed snapshot header");
+        grids.push((
+            u16::from_be_bytes([payload[1], payload[2]]),
+            u16::from_be_bytes([payload[3], payload[4]]),
+        ));
+    }
+    grids
+}
+
+#[test]
+fn attaching_at_the_session_size_repaints_nobody() {
+    let daemon = start_daemon("sizes");
+    let created = Command::new(BIN)
+        .arg("create")
+        .arg("--name")
+        .arg("barrier")
+        .arg("--")
+        .arg("/bin/cat")
+        .env("TERMIOD_SOCK", &daemon.socket)
+        .output()
+        .expect("create session");
+    assert!(created.status.success(), "create failed: {created:?}");
+
+    // A size the session does not have, so this attach really does resize it.
+    // One keyframe, and it describes the size asked for — the pending attach
+    // capture is superseded by the barrier rather than delivered alongside it.
+    let watcher = attach(&daemon.socket, "barrier", 30, 100);
+    assert_eq!(
+        keyframe_grids(&watcher),
+        vec![(30, 100)],
+        "an attach that resizes the session owes exactly one keyframe, at the new size"
+    );
+
+    // A second window onto the same session, at the size it already is. It gets
+    // its own attach keyframe...
+    let second = attach(&daemon.socket, "barrier", 30, 100);
+    assert_eq!(
+        keyframe_grids(&second),
+        vec![(30, 100)],
+        "an attaching client is always owed its own keyframe"
+    );
+
+    // ...and the client already watching is owed nothing: the size did not move.
+    assert!(
+        keyframe_grids(&watcher).is_empty(),
+        "a no-op resize repainted an unrelated viewer"
+    );
+}


### PR DESCRIPTION
A daemon-hosted session could end up with its composer box drawn at the wrong width, and it stayed that way until the next keystroke. Three things behind it, all of them new with the move of the PTY into termiod.

**A no-op resize repainted every viewer.** A resize is a barrier: the session quiesces and every snapshot-capable attachment is handed a fresh keyframe. `run_attach` asks for the client's size on every attach, so attaching a second window to a session already at that size repainted the phone mirroring it and the split beside it, for a size change that never happened. Guarded in `handle_msg`.

**Resizes were not coalesced.** `PTYProcess.resizeFromHost` folds a layout burst into one SIGWINCH; the daemon link sent one `R` frame per layout tick, and each one is a barrier with a repaint attached. Now on the same 50ms window.

**Keyframes were painted blind.** The payload is a formatted repaint laid out for the grid the host VT held when it was taken, wrapped rows and all — into a surface of a different width, every wrapped row shifts. A writer now skips a mismatch, because it is the one moving the PTY and a correctly sized keyframe is already on its way. An observer still paints what it was given; nothing it does would produce another one.

`termiod/tests/attach_barrier.rs` covers the barrier end to end — it fails with the guard removed (`a no-op resize repainted an unrelated viewer`). `TermiodKeyframeGridTests` covers both halves of the keyframe rule.

Release Notes:
- Fixed an agent's input box being drawn wrong after a window or split resize.