### PR TITLE
Give a maximized detail the whole window

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,0 +1,233 @@
+---
+title: Markdown in Termio
+status: demo
+type: reference
+updated: 2026-08-22
+---
+
+# Markdown in Termio
+
+Everything on this page renders in Termio's Preview: open any `.md` file from the
+inspector, and the reader draws it in iA Writer Quattro on a capped measure, with
+code in your terminal font so Preview and Edit read as one document.
+
+This file exists to show that surface in one screen. Flip to **Edit** at any point
+to see the source behind what you are reading, then flip back.
+
+## Headings and rhythm
+
+### A third-level heading
+
+#### A fourth-level heading
+
+Hierarchy is carried by weight and space rather than rules — headings sit at 700,
+inline **bold** at 600, so emphasis inside a paragraph never shouts at heading
+weight. Paragraphs hard-wrapped at 80 columns in the source reflow to whatever
+width the pane has.
+
+## Inline text
+
+Text can be **bold**, *italic*, ***both at once***, ~~struck through~~, or set as
+`inline code`. Press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd> to open the command
+palette. You can <mark>highlight a phrase</mark>, write H<sub>2</sub>O and
+E = mc<sup>2</sup>, and abbreviate a <abbr title="pseudo-terminal">PTY</abbr>
+inline.
+
+Links come in three kinds: a [web link](https://termio.sh), a
+[relative link to a file in this repo](AGENTS.md), and an
+[in-page anchor](#tables) that jumps to a heading below. A bare URL such as
+https://github.com/termio-sh/termio autolinks on its own. Shortcodes become
+emoji: :rocket: :sparkles: :white_check_mark: :warning:
+
+Footnotes work too — the session lives on the box, not in the connection.[^1]
+
+## Lists
+
+- A terminal-first agentic development environment
+- Sessions that survive a closed laptop
+  - `termiod` hosts the PTY on the machine itself
+  - Detaching is not killing
+    - Reattach restores the exact screen
+- The user's machines, never a hosted control plane
+
+1. Spawn the session
+2. Attach from the Mac
+3. Attach from the phone at the same time
+4. Close the laptop; the agent keeps working
+
+- [x] One protocol, versioned and transport-agnostic
+- [x] Snapshots at boundaries, never per frame
+- [ ] QUIC transport
+- [ ] Grid diffs as an opt-in degrade
+
+## Quotes and alerts
+
+> Elegance is a small surface area. No grand architecture, no cut-rate MVP.
+>
+> > A nested quote, for a reply inside a reply.
+
+> [!NOTE]
+> Byte delivery never blocks on a host-side VT parse. The authoritative VT is a
+> sidecar for snapshots.
+
+> [!TIP]
+> `TERMIO_CHANNEL=dev` gets you a fully separate app — its own bundle id, state
+> directory, companion port and CLI — so a dev build can never disturb the release
+> one.
+
+> [!IMPORTANT]
+> The user's `~/.ssh/config` is authoritative. Read it, never override it.
+
+> [!WARNING]
+> A blocking PTY write under the surface lock beachballs the whole app.
+
+> [!CAUTION]
+> Never add an SPM dependency that ships resources: the generated `Bundle.module`
+> accessor resolves against a build-machine path and crashes in a shipped `.app`.
+
+## Code
+
+Fenced code is highlighted by the same highlight.js the editor uses, so a block
+here matches the source you flipped from.
+
+```swift
+/// One PTY per session; panes and layout are client concerns.
+func attach(to session: SessionID) async throws -> Snapshot {
+    let stream = try await transport.open(.attach(session))
+    for try await frame in stream {
+        guard case .snapshot(let grid) = frame else { continue }
+        return grid
+    }
+    throw AttachError.streamEndedBeforeSnapshot
+}
+```
+
+```rust
+// termiod: the durable session host. One code path for laptop, VPS and devbox.
+pub async fn spawn(cmd: Command, size: WinSize) -> Result<Session> {
+    let pty = Pty::open(size)?;
+    let child = pty.spawn(cmd)?;
+    Ok(Session::new(child, pty))
+}
+```
+
+```bash
+swift build                                # resolve + compile
+swift test                                 # run the unit tests
+TERMIO_CHANNEL=dev ./scripts/build-app.sh  # side-by-side dev app
+```
+
+```json
+{
+  "session": "termio://session/9E2C1F04-6B7A-4E5D-9C31-5A0D7B18E2F1",
+  "status": "needs-you",
+  "device": "devbox",
+  "attached": ["mac", "iphone"]
+}
+```
+
+```diff
+- let maximized = NSHostingView(rootView: AnyView(InspectorDetailContent()))
++ let maximized = NSHostingView(rootView: AnyView(MaximizedDetailContent()))
+```
+
+An unlabelled fence stays plain:
+
+```
+$ termio agent report --status done
+ok
+```
+
+## Diagrams
+
+A ```` ```mermaid ```` fence is drawn as a real diagram, not a code block.
+
+```mermaid
+flowchart LR
+    Mac[Mac app] -- framed protocol --> D((termiod))
+    Phone[iPhone] -- companion WS --> Mac
+    D --> PTY[PTY session]
+    PTY --> Agent[Coding agent]
+    Agent -. status .-> D
+```
+
+```mermaid
+sequenceDiagram
+    participant P as iPhone
+    participant M as Mac
+    participant D as termiod
+    P->>M: attach(session)
+    M->>D: attach
+    D-->>M: snapshot
+    M-->>P: mirror surface
+    Note over P,D: detach ≠ kill
+```
+
+## Tables
+
+| Channel | Bundle id | State directory | Companion port |
+| --- | --- | --- | --- |
+| release | `sh.termio.app` | `~/.termio` | 8787 |
+| dev | `sh.termio.app.dev` | `~/.termio-dev` | 8788 |
+
+Alignment is honored per column:
+
+| Left | Center | Right |
+| :--- | :----: | ----: |
+| snapshot | attach | 1 |
+| grid diff | resize | 24 |
+| raw bytes | always | 1440 |
+
+## Math
+
+Inline math sits in a sentence: the anti-100× invariant says parse cost stays off
+the delivery path, so throughput is $O(n)$ in bytes written, never $O(n \cdot m)$
+in cells parsed.
+
+$$
+\text{latency} = t_{\text{pty}} + t_{\text{pipe}} + t_{\text{draw}}
+$$
+
+## Images
+
+Relative image paths resolve against the file's own folder:
+
+![The Termio app icon](packaging/AppIcon.png)
+
+## Collapsed detail
+
+<details>
+<summary>Why the terminal is the interface</summary>
+
+Coding agents live in terminals. A chat lens over the same session has been built
+and fully reverted twice — the transcript is already the record, and rendering it
+as a second, lossier surface only adds a place for the two to disagree.
+
+</details>
+
+## Definitions
+
+<dl>
+  <dt>Attach</dt>
+  <dd>Bind a viewer to a running session and receive a snapshot.</dd>
+  <dt>Detach</dt>
+  <dd>Drop the viewer. The session keeps running on the host.</dd>
+  <dt>Observer</dt>
+  <dd>A reader that never claims the write token.</dd>
+</dl>
+
+## 中文排版
+
+同一份阅读器也照顾中文：整篇文档是中文时行距会放宽，标点会做压缩处理，所以「引号」、
+（括号）和逗号之间不会留出突兀的空白。中英混排时——比如提到 `termiod` 或 PTY——西文
+仍然保持原本的字距。
+
+---
+
+That is the whole surface: frontmatter, headings, inline styles, links, footnotes,
+lists, alerts, code, diagrams, tables, math, images, collapsible sections and
+tables of terms. Press <kbd>Esc</kbd> to close the reader and land back in the
+terminal.
+
+[^1]: An agent keeps working while the laptop is shut; reattaching restores the
+    exact screen it left behind.

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -103,6 +103,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // The full-window host that shows the active inspector detail blown up to cover everything
     // while `store.inspectorMaximized`; nil when the detail is docked in the inspector.
     private var maximizedDetailHost: NSHostingView<AnyView>?
+    // Whether maximizing is what collapsed the navigator, so restoring re-opens only a sidebar
+    // this mode closed — never one the user had already put away.
+    private var sidebarCollapsedForMaximize = false
     // Coalesces the per-frame `windowDidResize` stream into a single settle so the inspector's
     // max thickness (and the tracking-separator re-bind it forces) is recomputed once the drag
     // stops, not on every intermediate frame.
@@ -209,6 +212,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         applyWindowTransparency()
         applyChromeAppearance()
         updateInspectorMaxThickness()
+        // The autosaved frame can restore straight into fullscreen, so seed the mirror rather
+        // than waiting for a transition that already happened.
+        store.windowIsFullScreen = window.styleMask.contains(.fullScreen)
         installToolbar()
         // Empty the sidebar's toolbar region (sort + new-terminal) whenever the navigator collapses
         // and restore it when it reopens — the sidebar's own buttons ride with the sidebar, the way
@@ -216,7 +222,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // divider drag). No `.initial`: the launch-time sync below runs after the autosave restore.
         sidebarCollapseObserver = sidebarSplitItem?.observe(\.isCollapsed, options: [.new]) { [weak self] item, _ in
             let collapsed = item.isCollapsed
-            MainActor.assumeIsolated { self?.setNavigatorItemsVisible(!collapsed) }
+            MainActor.assumeIsolated {
+                self?.setNavigatorItemsVisible(!collapsed)
+                // A maximized detail reaches the window's leading edge only while the sidebar is
+                // collapsed; that's when its header has to clear the traffic lights — and when the
+                // toolbar has nothing left to carry.
+                self?.store.sidebarVisible = !collapsed
+                self?.syncMaximizedChrome()
+            }
         }
         // Mirror the inspector's live collapse state onto the store, so panes it hosts
         // can idle while hidden (a collapsed item keeps its view hierarchy alive — the
@@ -692,6 +705,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// `windowDidEnterFullScreen` corrects it.
     func windowWillEnterFullScreen(_ notification: Notification) {
         window?.titlebarAppearsTransparent = false
+        // Flip before the animation, so a maximized detail's header drops its traffic-light gap
+        // as the window grows rather than snapping inward once it lands.
+        store.windowIsFullScreen = true
+    }
+
+    /// The twin of `windowWillEnterFullScreen` for the maximized detail's header: the buttons come
+    /// back with the window, so the gap that clears them is restored before the animation ends.
+    func windowWillExitFullScreen(_ notification: Notification) {
+        store.windowIsFullScreen = false
     }
 
     /// Re-assert the terminal-colored chrome when crossing the fullscreen boundary. macOS rebuilds
@@ -701,12 +723,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func windowDidEnterFullScreen(_ notification: Notification) {
         applyChromeAppearance()
         applyWindowTransparency()
+        store.windowIsFullScreen = true
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
         applyChromeAppearance()
         applyWindowTransparency()
         updateInspectorMaxThickness()
+        store.windowIsFullScreen = false
     }
 
     /// View ▸ Toggle Full Screen (⌃⌘F).
@@ -1112,6 +1136,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func syncNavigatorItems() {
         guard let item = sidebarSplitItem else { return }
         setNavigatorItemsVisible(!item.isCollapsed)
+        store.sidebarVisible = !item.isCollapsed
     }
 
     /// Inserts or removes the sidebar's own toolbar actions (the sort pull-down and the `+`
@@ -1194,19 +1219,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     /// Mounts (or removes) the full-window host that shows the active inspector detail blown up to
-    /// cover the content area (the terminal + inspector region, *not* the project sidebar) — an
-    /// in-window maximize, *not* native macOS fullscreen: the window stays put in its Space, the
-    /// menu bar stays visible. The sidebar stays reachable, and toggling it slides the maximized
-    /// detail with it (see the leading constraint below).
+    /// cover the content area — an in-window maximize, *not* native macOS fullscreen: the window
+    /// stays put in its Space and the menu bar stays visible. The navigator collapses with it, so
+    /// "fill the window" means the window rather than the window minus a column of chrome; re-open
+    /// it (View menu) and the host slides with it, since its leading edge tracks the split.
     /// `InspectorDetailContent` is the same view the inspector docks; while it is up the inspector
-    /// hides its own copy (see `InspectorRoot`), so the detail renders once. The toolbar stays above
-    /// it, so its maximize button restores and Esc still closes.
+    /// hides its own copy (see `InspectorRoot`), so the detail renders once. The toolbar goes with
+    /// the sidebar (see `syncMaximizedChrome`); restore and close ride the detail's own header, and
+    /// Esc still closes.
     private func setDetailMaximized(_ on: Bool) {
         guard let container = splitViewController?.view else { return }
         if on {
             guard maximizedDetailHost == nil else { return }
+            // Measure the traffic lights rather than assuming their layout: the header runs up into
+            // the titlebar, and where the buttons end (plus a gap) is where its title may start.
+            let buttonsEnd = window?.standardWindowButton(.zoomButton)?.frame.maxX ?? 70
             let host = NSHostingView(rootView: AnyView(
-                InspectorDetailContent()
+                // The header's own leading padding supplies the gap after the buttons.
+                MaximizedDetailContent(trafficLightsInset: buttonsEnd)
                     .environmentObject(store)
                     .environmentObject(settings)
             ))
@@ -1234,13 +1264,58 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 host.bottomAnchor.constraint(equalTo: container.bottomAnchor),
             ])
             maximizedDetailHost = host
+            // "Fill the window" means the whole window: the navigator steps aside with the toolbar
+            // and comes back on restore. Leaving it up would keep a column of chrome beside a
+            // detail the user just asked to blow up — and its own controls (workspace, sort, `+`)
+            // live in the toolbar band that maximizing takes away.
+            if sidebarSplitItem?.isCollapsed == false {
+                sidebarCollapsedForMaximize = true
+                sidebarSplitItem?.isCollapsed = true
+            }
+            syncMaximizedChrome()
         } else {
             maximizedDetailHost?.removeFromSuperview()
             maximizedDetailHost = nil
+            // Only re-open what maximizing closed. A sidebar the user collapsed themselves — before
+            // maximizing, or while the detail was up — stays collapsed.
+            if sidebarCollapsedForMaximize {
+                sidebarCollapsedForMaximize = false
+                sidebarSplitItem?.isCollapsed = false
+            }
+            syncMaximizedChrome()
             // Removing the host re-exposes the terminal, but a tickless surface won't repaint
             // itself — nudge it so a switch out of a maximized detail can't leave a blank.
             store.repaintSelectedSurface()
         }
+    }
+
+    /// Drops the toolbar only when a maximized detail owns the *whole* window — which is to say
+    /// while the navigator is collapsed. Then the band carries nothing but the branch title and the
+    /// inspector toggle, both meaningless over a full-window detail, and the detail's own header
+    /// (name, Edit/Preview, restore, close) reads as a second bar under an empty one; hiding it
+    /// leaves the bare titlebar strip the traffic lights live in, and the detail's header becomes
+    /// the window's top bar. With the sidebar up the band is not spare chrome: the sidebar's own
+    /// workspace / sort / `+` controls live in its region, and taking the toolbar would strip the
+    /// sidebar of them for a mode that has nothing to do with it.
+    ///
+    /// Called on both the maximize transition and every sidebar collapse, so toggling the navigator
+    /// under a maximized detail lands in the right state. Idempotent — it returns when the toolbar
+    /// already matches, because re-asserting visibility churns the tracking separators.
+    private func syncMaximizedChrome() {
+        guard let window, let toolbar = window.toolbar else { return }
+        let hidesToolbar = maximizedDetailHost != nil && sidebarSplitItem?.isCollapsed == true
+        guard toolbar.isVisible == hidesToolbar else { return }
+        toolbar.isVisible = !hidesToolbar
+        // A hidden toolbar stops laying out, so its custom views come back measured against stale
+        // bounds — the branch picker's two-line project/branch title drew clipped at the top.
+        if !hidesToolbar {
+            DispatchQueue.main.async { [weak self] in self?.toolbarDelegate?.relayoutBranchPicker() }
+        }
+        // Without the toolbar the detail's header occupies the strip the window was dragged by, and
+        // a SwiftUI view swallows the mouse-down a titlebar drag needs. Dragging the background
+        // restores it: only views that *don't* handle the event start the drag, so the header's
+        // empty run moves the window while the document's own text keeps its selection drags.
+        window.isMovableByWindowBackground = hidesToolbar
     }
 
     /// Termio ▸ Check for Updates… — hands off to Sparkle's standard update flow.
@@ -2081,6 +2156,16 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
     private var terminalPaneView: NSView? {
         guard let items = splitViewController?.splitViewItems, items.count > 1 else { return nil }
         return items[1].viewController.view
+    }
+
+    /// Re-measures the branch picker's custom view. A hidden toolbar stops laying out, so the
+    /// hosting view's intrinsic size is stale when the band comes back (restoring from a maximized
+    /// detail) and the two-line project/branch title draws against the wrong height — clipped at the
+    /// top. Same three calls the pane-width observer makes; only the trigger differs.
+    func relayoutBranchPicker() {
+        branchPickerWidthConstraint?.constant = branchPickerWidthLimit()
+        branchPickerHostingView?.invalidateIntrinsicContentSize()
+        branchPickerHostingView?.superview?.needsLayout = true
     }
 
     private func branchPickerWidthLimit() -> CGFloat {

--- a/Sources/termio/Browser/FilePreview.swift
+++ b/Sources/termio/Browser/FilePreview.swift
@@ -74,6 +74,7 @@ struct FilePreviewView: View {
         }
         .padding(.horizontal, 12)
         .frame(height: GitChangesView.topBarHeight)
+        .modifier(DetailHeaderTitlebarInset())
         .background(Color(nsColor: settings.terminalBackgroundColor))
     }
 

--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -313,6 +313,7 @@ struct FileEditorView: View {
         // One explicit height for every file type: the mode pill is taller than the text row, so
         // without the clamp a markdown header outgrows plain files'.
         .frame(height: Self.headerHeight)
+        .modifier(DetailHeaderTitlebarInset())
         .background(Color(nsColor: settings.terminalBackgroundColor))
         .animation(.easeOut(duration: 0.15), value: isDirty)
     }

--- a/Sources/termio/FileBrowser/InspectorDetailHost.swift
+++ b/Sources/termio/FileBrowser/InspectorDetailHost.swift
@@ -110,6 +110,61 @@ struct InspectorRoot: View {
     }
 }
 
+/// The maximized detail's root view. It is the same content the inspector docks, run up under the
+/// titlebar: with the toolbar hidden for the duration (see `setDetailMaximized`) there is no band
+/// above it, so the detail's own header *is* the window's top bar rather than a second one beneath
+/// an empty strip. When the sidebar is collapsed the host reaches the window's leading edge and the
+/// traffic lights land on that header, so it takes an inset that clears them; with the sidebar open
+/// they sit over the sidebar and the header starts flush.
+struct MaximizedDetailContent: View {
+    @EnvironmentObject var store: TermioStore
+    /// Leading room the traffic lights need, measured from the live window by the app delegate —
+    /// the buttons' geometry is the system's to change, so it is never hardcoded here.
+    let trafficLightsInset: CGFloat
+
+    var body: some View {
+        InspectorDetailContent()
+            .environment(\.detailHeaderLeadingInset, needsTrafficLightsRoom ? trafficLightsInset : 0)
+            // Up into the titlebar only when the toolbar has stepped aside for this detail, which
+            // is exactly when the sidebar is collapsed (see `syncMaximizedChrome`). With the
+            // sidebar up the toolbar keeps the sidebar's controls, so the header stays below it
+            // rather than sliding under a band that is still drawing.
+            .ignoresSafeArea(.container, edges: store.sidebarVisible ? [] : .top)
+    }
+
+    /// Only when the buttons are actually sitting on this header. With the sidebar open they land
+    /// on the sidebar, and in fullscreen they are hidden until the pointer summons the titlebar —
+    /// which then slides in *over* the content, so holding a gap for them all along only pushes the
+    /// title inward for nothing.
+    private var needsTrafficLightsRoom: Bool {
+        !store.sidebarVisible && !store.windowIsFullScreen
+    }
+}
+
+/// Extra leading room a detail's header takes so its title clears the window's traffic lights.
+/// Non-zero only while the detail is maximized with the sidebar collapsed; docked in the inspector
+/// the header is nowhere near them.
+private struct DetailHeaderLeadingInsetKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    var detailHeaderLeadingInset: CGFloat {
+        get { self[DetailHeaderLeadingInsetKey.self] }
+        set { self[DetailHeaderLeadingInsetKey.self] = newValue }
+    }
+}
+
+/// Carried by every detail header bar, so each one clears the traffic lights when it rides the
+/// titlebar. Applied outside the header's own padding, which keeps its docked spacing untouched.
+struct DetailHeaderTitlebarInset: ViewModifier {
+    @Environment(\.detailHeaderLeadingInset) private var inset
+
+    func body(content: Content) -> some View {
+        content.padding(.leading, inset)
+    }
+}
+
 /// The detail's own window controls, drawn at the trailing edge of each detail's header. All three
 /// act on the content area, so they live
 /// *in* it rather than in the window toolbar — which also sidesteps the flaky

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -184,6 +184,7 @@ struct GitDiffView: View {
         // Fixed height + inset hairline shared with the git pane's mode switch, so this
         // bar and the inspector's `Changes | History` bar line up across the split.
         .frame(height: GitChangesView.topBarHeight)
+        .modifier(DetailHeaderTitlebarInset())
         .background(Color(nsColor: settings.terminalBackgroundColor))
         .overlay(alignment: .bottom) {
             Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 1)

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -684,6 +684,7 @@ struct IssueDetailView: View {
         }
         .padding(.horizontal, 8)
         .frame(height: GitChangesView.topBarHeight)
+        .modifier(DetailHeaderTitlebarInset())
         .overlay(alignment: .bottom) {
             Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 1)
         }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -531,6 +531,16 @@ final class TermioStore: ObservableObject {
     /// spawning `git status` for a pane nobody could see.
     @Published var inspectorVisible = false
 
+    /// Whether the leading project sidebar is expanded. Mirrored from its AppKit split item the
+    /// same way `inspectorVisible` is. A maximized detail reads it to know whether the traffic
+    /// lights land on its own header (sidebar collapsed) or on the sidebar (sidebar open).
+    @Published var sidebarVisible = true
+
+    /// Whether the window is in native macOS fullscreen. Mirrored from the window's own
+    /// enter/exit transitions. Fullscreen hides the traffic lights until the pointer summons the
+    /// titlebar, so a maximized detail stops reserving room for them there.
+    @Published var windowIsFullScreen = false
+
     /// A per-session snapshot of the inspector's *content* — which tab is showing, which
     /// detail (file / diff / PR-issue) is open, and how that detail splits the
     /// panel between its list and itself. Switching terminal tabs restores each session's


### PR DESCRIPTION
Maximizing a detail stacked two bars at the top of the window: the toolbar band — carrying only the branch title and the inspector toggle, both meaningless over a full-window detail — and the detail's own header directly beneath it.

Maximizing now collapses the navigator and hides the toolbar, so the detail's header *is* the window's top bar. Restoring brings both back, and only a sidebar this mode closed gets re-opened. Re-opening the navigator by hand while maximized brings the toolbar with it, since the sidebar's workspace / sort / new controls live in its region and shouldn't disappear for a mode on the other side of the window.

The header clears the traffic lights only when they actually sit on it — sidebar collapsed and not in native fullscreen, where the buttons stay hidden until the pointer summons the titlebar over the content anyway. The inset is measured off the live zoom button rather than assumed, and all four detail headers (editor, preview, diff, issue) carry it.

Two consequences of a hidden toolbar are handled: the window loses the strip it was dragged by, so it becomes movable by its background for the duration; and a hidden band stops laying out, which left the branch picker's two-line project/branch title clipped on the way back, so the picker is re-measured when the toolbar returns.

Also adds `EXAMPLE.md`, one document that exercises every construct the Markdown reader draws, so Preview can be checked or recorded in a single pass.

Verified with `swift build` and `swift test` (455 tests, 0 failures), plus a rendering check of `EXAMPLE.md` through `MarkdownReaderRenderer`, and the dev app rebuilt and driven through maximize / restore / fullscreen by hand.

Release Notes:
- A maximized file, diff or issue now fills the whole window: the toolbar and sidebar step aside, and the detail's own header becomes the window's top bar.