### PR TITLE
Stop the daemon without pretending it crashed

### DIFF
--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -21,13 +21,15 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot, Notify};
 
 const EVENT_BUFFER: usize = 1024;
+const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct ManagerInner {
     sessions: HashMap<String, SessionHandle>,
     id_counter: u32,
+    draining: bool,
 }
 
 #[derive(Clone)]
@@ -47,6 +49,7 @@ pub struct Manager {
     /// death has to leave evidence — an empty session list otherwise reads as
     /// "nothing was running" rather than "everything was lost".
     graveyard: Arc<Graveyard>,
+    session_removed: Arc<Notify>,
 }
 
 impl Manager {
@@ -60,6 +63,7 @@ impl Manager {
             inner: Arc::new(Mutex::new(ManagerInner {
                 sessions: HashMap::new(),
                 id_counter: 0,
+                draining: false,
             })),
             next_client_id: Arc::new(AtomicU64::new(1)),
             on_exit,
@@ -68,6 +72,7 @@ impl Manager {
             resources: Registry::new(),
             uploads: crate::files::Uploads::new(),
             graveyard,
+            session_removed: Arc::new(Notify::new()),
         }
     }
 
@@ -76,18 +81,20 @@ impl Manager {
         format!("c_{id:x}")
     }
 
-    fn new_session_id(&self) -> String {
+    fn create(&self, spec: crate::protocol::CreateSpec) -> Result<String> {
+        // The lock makes the transition to draining an exact boundary: a
+        // create either installs its handle before the shutdown snapshot or
+        // observes `draining` and never spawns a child.
+        let mut guard = self.inner.lock().unwrap();
+        if guard.draining {
+            anyhow::bail!("daemon is draining");
+        }
         let seed = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.subsec_nanos())
             .unwrap_or(0);
-        let mut guard = self.inner.lock().unwrap();
         guard.id_counter = guard.id_counter.wrapping_add(1);
-        format!("{:08x}", seed ^ guard.id_counter.wrapping_mul(2654435761))
-    }
-
-    fn create(&self, spec: crate::protocol::CreateSpec) -> Result<String> {
-        let id = self.new_session_id();
+        let id = format!("{:08x}", seed ^ guard.id_counter.wrapping_mul(2654435761));
         let name = spec.name.clone().unwrap_or_else(|| id.clone());
         let cwd = spec.cwd.clone().unwrap_or_default();
         let command = if spec.argv.is_empty() {
@@ -112,11 +119,7 @@ impl Manager {
             self.events.clone(),
         )
         .context("spawning session")?;
-        self.inner
-            .lock()
-            .unwrap()
-            .sessions
-            .insert(id.clone(), handle);
+        guard.sessions.insert(id.clone(), handle);
         Ok(id)
     }
 
@@ -135,7 +138,51 @@ impl Manager {
     }
 
     fn remove(&self, id: &str) -> bool {
-        self.inner.lock().unwrap().sessions.remove(id).is_some()
+        let removed = self.inner.lock().unwrap().sessions.remove(id).is_some();
+        if removed {
+            self.session_removed.notify_one();
+        }
+        removed
+    }
+
+    fn begin_draining(&self, reason: EndReason) {
+        let mut guard = self.inner.lock().unwrap();
+        guard.draining = true;
+        for handle in guard.sessions.values() {
+            handle.send(SessionMsg::Kill { reason });
+        }
+    }
+
+    async fn wait_until_empty(&self) {
+        loop {
+            let removed = self.session_removed.notified();
+            if self.inner.lock().unwrap().sessions.is_empty() {
+                return;
+            }
+            removed.await;
+        }
+    }
+
+    async fn finish_draining(&self, reason: EndReason) -> Result<()> {
+        if tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, self.wait_until_empty())
+            .await
+            .is_ok()
+        {
+            return self.graveyard.bury_remaining(reason);
+        }
+
+        eprintln!(
+            "termiod: shutdown drain exceeded {} seconds; forcing remaining sessions",
+            SHUTDOWN_DRAIN_TIMEOUT.as_secs()
+        );
+        // Mark the surviving roster entries before the direct kill. If their
+        // actors wake and reap concurrently, the graveyard's runtime dedupe
+        // preserves this deliberate-stop reason.
+        let persisted = self.graveyard.bury_remaining(reason);
+        for handle in self.handles() {
+            handle.force_kill();
+        }
+        persisted
     }
 
     fn publish(&self, event: Event) {
@@ -344,11 +391,13 @@ pub async fn serve() -> Result<()> {
         tokio::spawn(async move {
             while let Some(ended) = on_exit_rx.recv().await {
                 let id = ended.info.id.clone();
-                let reason = if ended.killed {
-                    EndReason::Killed
-                } else {
-                    EndReason::Exited
-                };
+                // A termination request can win after PTY EOF but before this
+                // task receives the actor's end record. The handle retains the
+                // first requested reason until burial completes.
+                let reason = manager
+                    .find(&id)
+                    .and_then(|handle| handle.termination_reason())
+                    .unwrap_or(ended.reason);
                 manager
                     .graveyard
                     .bury(&ended.info, reason, Some(ended.status));
@@ -367,29 +416,47 @@ pub async fn serve() -> Result<()> {
 
     eprintln!("termiod listening on {}", sock_path.display());
 
-    {
-        let sock_path = sock_path.clone();
-        tokio::spawn(async move {
-            let mut term =
-                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
-            tokio::select! {
-                _ = tokio::signal::ctrl_c() => {}
-                _ = term.recv() => {}
-            }
-            let _ = std::fs::remove_file(&sock_path);
-            std::process::exit(0);
-        });
-    }
+    let mut terminate =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .context("installing SIGTERM handler")?;
+    let shutdown_signal = async move {
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => result.context("waiting for SIGINT"),
+            _ = terminate.recv() => Ok(()),
+        }
+    };
+    tokio::pin!(shutdown_signal);
 
     loop {
-        let (stream, _addr) = listener.accept().await?;
-        let manager = manager.clone();
-        tokio::spawn(async move {
-            if let Err(e) = handle_conn(stream, manager).await {
-                eprintln!("termiod: connection error: {e:#}");
+        tokio::select! {
+            biased;
+            result = &mut shutdown_signal => {
+                result?;
+                break;
             }
-        });
+            accepted = listener.accept() => {
+                let (stream, _addr) = accepted?;
+                let manager = manager.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = handle_conn(stream, manager).await {
+                        eprintln!("termiod: connection error: {e:#}");
+                    }
+                });
+            }
+        }
     }
+
+    manager.begin_draining(EndReason::DaemonStopped);
+    let drained = manager.finish_draining(EndReason::DaemonStopped).await;
+    // Keeping the bound listener through the drain prevents an autostarting
+    // client from placing a replacement daemon over state still being buried.
+    drop(listener);
+    match std::fs::remove_file(&sock_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => eprintln!("termiod: could not remove socket during shutdown: {error}"),
+    }
+    drained
 }
 
 #[derive(Clone)]
@@ -789,10 +856,9 @@ async fn process_control(
         Control::Kill { id, seq } => {
             let response = match manager.resolve(&id).await {
                 Some(handle) => {
-                    handle.send(SessionMsg::Kill);
-                    if manager.remove(&handle.id) {
-                        manager.publish_removed(&handle.id);
-                    }
+                    handle.send(SessionMsg::Kill {
+                        reason: EndReason::Killed,
+                    });
                     Control::Ok { re: seq }
                 }
                 None => error(

--- a/termiod/src/service.rs
+++ b/termiod/src/service.rs
@@ -206,7 +206,9 @@ fn install() -> Result<()> {
 fn uninstall() -> Result<()> {
     let path = plist_path()?;
     let label = label();
-    let _ = launchctl(&["bootout", &format!("{}/{label}", domain_target())]);
+    let booted_out = launchctl(&["bootout", &format!("{}/{label}", domain_target())])
+        .map(|output| output.status.success())
+        .unwrap_or(false);
     match std::fs::remove_file(&path) {
         Ok(()) => println!("removed {}", path.display()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -214,9 +216,15 @@ fn uninstall() -> Result<()> {
         }
         Err(error) => return Err(error).with_context(|| format!("removing {}", path.display())),
     }
-    // Sessions are not killed here: uninstalling supervision is not a request to
-    // destroy what is running. The daemon keeps going until it exits on its own.
-    println!("running sessions are untouched; the daemon will not restart once it exits.");
+    // Booting out the job stops the daemon launchd owns, which ends its
+    // sessions — the old message claimed the opposite. But a daemon some client
+    // autostarted is not launchd's to stop, and it keeps running, so the claim
+    // is only true when there was a loaded job to boot out.
+    if booted_out {
+        println!("the daemon and its running sessions were stopped; it will not restart.");
+    } else {
+        println!("no supervised daemon was loaded; anything already running is untouched.");
+    }
     Ok(())
 }
 

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -8,12 +8,13 @@ use crate::protocol::{
     MAX_HISTORY_FRAME_SIZE, SNAPSHOT_CELL_SIZE,
 };
 use crate::pty::Pty;
+use crate::tombstone::EndReason;
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc as std_mpsc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -201,7 +202,9 @@ pub enum SessionMsg {
     Info {
         reply: oneshot::Sender<SessionInfo>,
     },
-    Kill,
+    Kill {
+        reason: EndReason,
+    },
 }
 
 /// What the manager needs to bury a session (§6). The session actor is the last
@@ -211,20 +214,42 @@ pub enum SessionMsg {
 pub struct SessionEnded {
     pub info: SessionInfo,
     pub status: i32,
-    /// A client asked for this end (`kill`), rather than the process choosing it.
-    pub killed: bool,
+    pub reason: EndReason,
 }
 
 /// Cheap, cloneable reference to a session task.
 #[derive(Clone)]
 pub struct SessionHandle {
     pub id: String,
+    pid: i32,
     tx: mpsc::UnboundedSender<SessionMsg>,
+    /// PTY EOF can become ready in the same scheduler turn as `Kill`; keeping
+    /// the first requested reason outside the queue makes that race deterministic.
+    termination_reason: Arc<Mutex<Option<EndReason>>>,
 }
 
 impl SessionHandle {
     pub fn send(&self, msg: SessionMsg) -> bool {
+        if let SessionMsg::Kill { reason } = &msg {
+            let mut requested = self.termination_reason.lock().unwrap();
+            if requested.is_none() {
+                *requested = Some(*reason);
+            }
+        }
         self.tx.send(msg).is_ok()
+    }
+
+    pub fn termination_reason(&self) -> Option<EndReason> {
+        *self.termination_reason.lock().unwrap()
+    }
+
+    /// A session actor normally owns termination and reports the exact reason.
+    /// This is only for the shutdown deadline: killing the process releases the
+    /// blocking child waiter even if the actor itself stopped making progress.
+    pub fn force_kill(&self) {
+        unsafe {
+            libc::kill(-self.pid, libc::SIGKILL);
+        }
     }
 }
 
@@ -1272,6 +1297,7 @@ pub fn spawn(
     let sidecar = spawn_sidecar(rows, cols)?;
 
     let (tx, rx) = mpsc::unbounded_channel();
+    let termination_reason = Arc::new(Mutex::new(None));
     let session = Session {
         id: id.clone(),
         name,
@@ -1318,8 +1344,14 @@ pub fn spawn(
         on_exit,
         sidecar.results,
         sidecar.thread,
+        termination_reason.clone(),
     ));
-    Ok(SessionHandle { id, tx })
+    Ok(SessionHandle {
+        id,
+        pid,
+        tx,
+        termination_reason,
+    })
 }
 
 struct Sidecar {
@@ -1488,12 +1520,13 @@ async fn run(
     on_exit: mpsc::UnboundedSender<SessionEnded>,
     mut sidecar_results: mpsc::UnboundedReceiver<SidecarResult>,
     sidecar_thread: JoinHandle<()>,
+    termination_reason: Arc<Mutex<Option<EndReason>>>,
 ) {
     let mut buf = vec![0u8; READ_CHUNK];
     let mut waiter = Some(waiter);
     let mut sidecar_results_open = true;
     let mut history_stages = VecDeque::<ClientId>::new();
-    let mut killed = false;
+    let mut end_reason = EndReason::Exited;
     // The first tick is immediate, so a session answers "what is running in
     // there" from its first roster request rather than after a cold two
     // seconds. Missed ticks are skipped instead of queued: a busy actor should
@@ -1518,10 +1551,8 @@ async fn run(
             }
             msg = rx.recv() => {
                 let Some(msg) = msg else { break };
-                if handle_msg(&mut session, msg) {
-                    // `handle_msg` only asks to stop for `Kill`, so this is the
-                    // one end a client chose — the distinction a tombstone keeps.
-                    killed = true;
+                if let Some(reason) = handle_msg(&mut session, msg) {
+                    end_reason = reason;
                     break;
                 }
             }
@@ -1564,6 +1595,11 @@ async fn run(
     }
 
     session.fallback_all_pending("session ended before the VT snapshot completed");
+    if end_reason == EndReason::Exited {
+        if let Some(requested) = *termination_reason.lock().unwrap() {
+            end_reason = requested;
+        }
+    }
     if let Some(sidecar_tx) = session.sidecar_tx.take() {
         let _ = sidecar_tx.send(SidecarCommand::Shutdown);
     }
@@ -1589,12 +1625,11 @@ async fn run(
     let _ = on_exit.send(SessionEnded {
         info,
         status: code,
-        killed,
+        reason: end_reason,
     });
 }
 
-/// Returns true if the session should terminate (`kill`).
-fn handle_msg(session: &mut Session, msg: SessionMsg) -> bool {
+fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
     match msg {
         SessionMsg::AddClient {
             id,
@@ -1696,11 +1731,11 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> bool {
                 // client named. The child would see no SIGWINCH from this
                 // ioctl either, so nothing downstream is waiting on it.
                 if rows == session.rows && cols == session.cols {
-                    return false;
+                    return None;
                 }
                 if let Err(error) = session.pty.resize(rows, cols) {
                     session.reject_resize(&id, &error);
-                    return false;
+                    return None;
                 }
                 session.rows = rows;
                 session.cols = cols;
@@ -1737,15 +1772,15 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> bool {
         SessionMsg::Info { reply } => {
             let _ = reply.send(session.info());
         }
-        SessionMsg::Kill => {
+        SessionMsg::Kill { reason } => {
             // The child is a session leader, so pgid == pid.
             unsafe {
                 libc::kill(-session.pid, libc::SIGKILL);
             }
-            return true;
+            return Some(reason);
         }
     }
-    false
+    None
 }
 
 #[cfg(test)]
@@ -1758,6 +1793,7 @@ mod tests {
     };
     use crate::protocol::{Control, ErrorCode, Event, SessionInfo};
     use crate::pty::Pty;
+    use crate::tombstone::EndReason;
     use bytes::Bytes;
     use std::collections::{HashMap, VecDeque};
     use std::sync::{mpsc as std_mpsc, Arc};
@@ -2296,14 +2332,15 @@ mod tests {
             child_executable: None,
         };
 
-        assert!(!handle_msg(
+        assert!(handle_msg(
             &mut session,
             SessionMsg::Resize {
                 id: "writer".to_string(),
                 rows: 40,
                 cols: 120,
             },
-        ));
+        )
+        .is_none());
 
         assert_eq!((session.rows, session.cols), (24, 80));
         assert!(matches!(
@@ -2441,7 +2478,9 @@ mod tests {
         };
         assert!(roster.is_some_and(|info| info.foreground_pid.is_some()));
 
-        handle.send(SessionMsg::Kill);
+        handle.send(SessionMsg::Kill {
+            reason: EndReason::Killed,
+        });
     }
 
     /// A command started *inside* the session takes the tty's foreground away
@@ -2474,6 +2513,8 @@ mod tests {
             busy.foreground_argv
         );
 
-        handle.send(SessionMsg::Kill);
+        handle.send(SessionMsg::Kill {
+            reason: EndReason::Killed,
+        });
     }
 }

--- a/termiod/src/tombstone.rs
+++ b/termiod/src/tombstone.rs
@@ -22,7 +22,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -41,6 +41,8 @@ pub enum EndReason {
     Exited,
     /// A client asked for it (`kill`). The user meant this.
     Killed,
+    /// The daemon was deliberately stopped and drained its sessions first.
+    DaemonStopped,
     /// The daemon went away while the session was running. Nobody chose this,
     /// and it is the reason tombstones exist at all.
     DaemonLost,
@@ -51,6 +53,7 @@ impl EndReason {
         match self {
             EndReason::Exited => "exited",
             EndReason::Killed => "killed",
+            EndReason::DaemonStopped => "daemon_stopped",
             EndReason::DaemonLost => "daemon_lost",
         }
     }
@@ -68,7 +71,7 @@ pub struct Tombstone {
     pub name: String,
     pub cwd: String,
     pub command: String,
-    /// `exited` · `killed` · `daemon_lost`.
+    /// `exited` · `killed` · `daemon_stopped` · `daemon_lost`.
     pub reason: String,
     /// The process's exit code. `None` for `daemon_lost` — the daemon that
     /// would have reaped the child died first, so no honest answer exists.
@@ -144,13 +147,13 @@ impl RosterEntry {
         }
     }
 
-    fn into_tombstone(self) -> Tombstone {
+    fn into_tombstone(self, reason: EndReason) -> Tombstone {
         Tombstone {
             id: self.id,
             name: self.name,
             cwd: self.cwd,
             command: self.command,
-            reason: EndReason::DaemonLost.as_str().to_string(),
+            reason: reason.as_str().to_string(),
             exit_status: None,
             created_unix: self.created_unix,
             ended_unix: now_unix(),
@@ -164,6 +167,10 @@ impl RosterEntry {
 struct State {
     graves: Vec<Tombstone>,
     roster: HashMap<String, RosterEntry>,
+    /// Prevents the bounded shutdown fallback and a late session reaper from
+    /// recording the same end twice. IDs can eventually be reused, so creation
+    /// time remains part of the identity.
+    buried: HashSet<(String, u64)>,
 }
 
 /// The on-disk record of what died. One per daemon, living beside the socket so
@@ -188,6 +195,7 @@ impl Graveyard {
             state: Mutex::new(State {
                 graves: Vec::new(),
                 roster: HashMap::new(),
+                buried: HashSet::new(),
             }),
         };
 
@@ -196,7 +204,7 @@ impl Graveyard {
         // Newest first, so the cap drops the oldest history rather than the
         // sessions that just died.
         for orphan in orphans.into_iter().rev() {
-            graves.insert(0, orphan.into_tombstone());
+            graves.insert(0, orphan.into_tombstone(EndReason::DaemonLost));
         }
         graves.truncate(MAX_GRAVES);
 
@@ -218,6 +226,12 @@ impl Graveyard {
     pub fn note_live(&self, info: &SessionInfo) {
         {
             let mut state = self.state.lock().unwrap();
+            if state
+                .buried
+                .contains(&(info.id.clone(), info.created_unix))
+            {
+                return;
+            }
             state
                 .roster
                 .insert(info.id.clone(), RosterEntry::from_info(info));
@@ -232,6 +246,12 @@ impl Graveyard {
     pub fn bury(&self, info: &SessionInfo, reason: EndReason, exit_status: Option<i32>) {
         {
             let mut state = self.state.lock().unwrap();
+            if !state
+                .buried
+                .insert((info.id.clone(), info.created_unix))
+            {
+                return;
+            }
             state.roster.remove(&info.id);
             state.graves.insert(0, Tombstone::from_info(info, reason, exit_status));
             state.graves.truncate(MAX_GRAVES);
@@ -239,6 +259,33 @@ impl Graveyard {
         if let Err(error) = self.persist_roster().and_then(|_| self.persist_graves()) {
             eprintln!("termiod: could not record session end: {error:#}");
         }
+    }
+
+    /// Converts anything that did not reach the ordinary reaper before the
+    /// shutdown deadline. The shared `buried` set makes this atomic with
+    /// `bury`, so a late reaper cannot replace or duplicate the stop reason.
+    pub fn bury_remaining(&self, reason: EndReason) -> Result<()> {
+        {
+            let mut state = self.state.lock().unwrap();
+            let mut remaining: Vec<RosterEntry> =
+                state.roster.drain().map(|(_, entry)| entry).collect();
+            remaining.sort_by_key(|entry| entry.created_unix);
+            for entry in remaining {
+                if state
+                    .buried
+                    .insert((entry.id.clone(), entry.created_unix))
+                {
+                    state.graves.insert(0, entry.into_tombstone(reason));
+                }
+            }
+            state.graves.truncate(MAX_GRAVES);
+        }
+
+        // The grave must reach disk before its roster entry disappears. If the
+        // process dies between these writes, the next daemon may show a
+        // duplicate explanation, but it cannot silently lose the session.
+        self.persist_graves()?;
+        self.persist_roster()
     }
 
     /// Every tombstone, newest first.
@@ -372,6 +419,24 @@ mod tests {
         let graves = Graveyard::open(&dir).unwrap().all();
         assert_eq!(graves.len(), 1);
         assert_eq!(graves[0].reason, "killed");
+    }
+
+    /// The deadline fallback and the actor reaper can finish in either order.
+    /// Whichever arrives late must not duplicate the grave or change its reason.
+    #[test]
+    fn a_late_reaper_does_not_replace_the_shutdown_reason() {
+        let dir = temp_dir("shutdown-race");
+        let graveyard = Graveyard::open(&dir).unwrap();
+        graveyard.note_live(&info("a"));
+        graveyard
+            .bury_remaining(EndReason::DaemonStopped)
+            .unwrap();
+        graveyard.bury(&info("a"), EndReason::Exited, Some(137));
+
+        let graves = graveyard.all();
+        assert_eq!(graves.len(), 1);
+        assert_eq!(graves[0].reason, "daemon_stopped");
+        assert_eq!(graves[0].exit_status, None);
     }
 
     /// Restarting repeatedly must not keep re-burying the same dead session.

--- a/termiod/tests/graceful_shutdown.rs
+++ b/termiod/tests/graceful_shutdown.rs
@@ -1,0 +1,178 @@
+use serde_json::Value;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const BIN: &str = env!("CARGO_BIN_EXE_termiod");
+
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new() -> TestDir {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before epoch")
+            .as_nanos();
+        // Unix-domain socket paths are short on macOS; the per-user temporary
+        // directory can consume most of that limit before the test adds a name.
+        let path = PathBuf::from(format!("/tmp/tgs-{}-{nonce:x}", std::process::id()));
+        std::fs::create_dir(&path).expect("create isolated daemon state directory");
+        TestDir(path)
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct Daemon {
+    child: Child,
+    socket: PathBuf,
+}
+
+impl Daemon {
+    fn start(socket: &Path) -> Daemon {
+        let mut child = Command::new(BIN)
+            .arg("serve")
+            .env("TERMIOD_SOCK", socket)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn isolated daemon");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !socket.exists() {
+            if let Some(status) = child.try_wait().expect("poll daemon startup") {
+                let mut stderr = String::new();
+                if let Some(mut stream) = child.stderr.take() {
+                    let _ = stream.read_to_string(&mut stderr);
+                }
+                panic!("daemon exited {status} before binding its socket: {stderr}");
+            }
+            assert!(Instant::now() < deadline, "daemon never bound its socket");
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        Daemon {
+            child,
+            socket: socket.to_path_buf(),
+        }
+    }
+
+    fn terminate(&mut self) -> ExitStatus {
+        let result = unsafe { libc::kill(self.child.id() as i32, libc::SIGTERM) };
+        assert_eq!(result, 0, "send SIGTERM to isolated daemon");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match self.child.try_wait().expect("poll isolated daemon") {
+                Some(status) => return status,
+                None if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                None => {
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    let mut stderr = String::new();
+                    if let Some(mut stream) = self.child.stderr.take() {
+                        let _ = stream.read_to_string(&mut stderr);
+                    }
+                    panic!("daemon did not finish its shutdown drain: {stderr}");
+                }
+            }
+        }
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+        let _ = std::fs::remove_file(&self.socket);
+    }
+}
+
+fn read_array(path: &Path) -> Vec<Value> {
+    let bytes = std::fs::read(path).unwrap_or_else(|error| {
+        panic!("read {}: {error}", path.display());
+    });
+    serde_json::from_slice(&bytes).unwrap_or_else(|error| {
+        panic!("parse {}: {error}", path.display());
+    })
+}
+
+#[test]
+fn sigterm_buries_sessions_as_deliberately_stopped_before_the_next_daemon_starts() {
+    let state = TestDir::new();
+    let socket = state.0.join("termiod.sock");
+    let roster = state.0.join("roster.json");
+    let graves = state.0.join("tombstones.json");
+    let mut first = Daemon::start(&socket);
+
+    let created = Command::new(BIN)
+        .args([
+            "create",
+            "--name",
+            "shutdown-proof",
+            "--",
+            "/bin/sh",
+            "-c",
+            "sleep 30",
+        ])
+        .env("TERMIOD_SOCK", &socket)
+        .output()
+        .expect("create session through isolated daemon");
+    assert!(
+        created.status.success(),
+        "create failed: {}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    let id = String::from_utf8(created.stdout)
+        .expect("session id is UTF-8")
+        .trim()
+        .to_string();
+    assert!(!id.is_empty(), "create returned no session id");
+    assert_eq!(read_array(&roster).len(), 1, "session was not rostered");
+
+    let first_status = first.terminate();
+    assert!(first_status.success(), "first daemon exited {first_status}");
+    assert!(!socket.exists(), "shutdown left the socket behind");
+
+    let stopped = read_array(&graves);
+    assert_eq!(stopped.len(), 1, "expected one grave after shutdown");
+    assert_eq!(stopped[0]["id"], id);
+    assert_eq!(stopped[0]["reason"], "daemon_stopped");
+    assert!(
+        read_array(&roster).is_empty(),
+        "shutdown left a live roster"
+    );
+
+    let mut second = Daemon::start(&socket);
+    let ready = Command::new(BIN)
+        .args(["list", "--json"])
+        .env("TERMIOD_SOCK", &socket)
+        .output()
+        .expect("query replacement daemon");
+    assert!(
+        ready.status.success(),
+        "replacement daemon was not ready: {}",
+        String::from_utf8_lossy(&ready.stderr)
+    );
+    let adopted = read_array(&graves);
+    assert_eq!(adopted.len(), 1, "the next daemon added another grave");
+    assert_eq!(adopted[0]["id"], id);
+    assert_eq!(adopted[0]["reason"], "daemon_stopped");
+    assert!(
+        adopted.iter().all(|grave| grave["reason"] != "daemon_lost"),
+        "the next daemon relabeled a deliberate stop as a crash"
+    );
+
+    let second_status = second.terminate();
+    assert!(
+        second_status.success(),
+        "second daemon exited {second_status}"
+    );
+}


### PR DESCRIPTION
A daemon told to stop removed its socket and called `process::exit(0)` (`daemon.rs`), so nothing was buried. The next daemon found those sessions still on the roster, inferred the previous one had died under them, and adopted them as `daemon_lost` — a crash label for something the user chose. `termiod service uninstall` compounded it: `launchctl bootout` stops the daemon launchd owns, and the command then printed *"running sessions are untouched"*.

**Shutdown is now a drain.** The manager flips to draining under the same lock that installs a new session, so a create either lands before the snapshot or is refused rather than spawning into a dying daemon. Every session is asked to stop, the reaper gets a bounded five seconds to bury each one properly, and anything left is marked and force-killed. The listener stays bound throughout, so an autostarting client cannot drop a replacement daemon on top of state still being written.

**Carrying the reason required a real one.** `SessionMsg::Kill` and `SessionEnded` now name an `EndReason` instead of a Boolean, and the handle records the requested reason *before* the message is queued — without that, a PTY EOF winning the select ends the session as `exited` and the deliberate stop is lost. The graveyard keys burials by id and creation time, so the deadline path and a late reaper can neither double-record nor disagree.

**The uninstall message branches on whether a job was actually booted out.** A daemon some client autostarted is not launchd's to stop, and it keeps running.

`termiod/tests/graceful_shutdown.rs` is black-box: it SIGTERMs an isolated daemon, then starts a replacement on the same socket and asserts the graves say `daemon_stopped` and that the replacement adopts nothing. Confirmed it fails without the change (`expected one grave after shutdown, left: 0`). Full suite: 83 passing.

This is the foundation for an in-app "Restart Host…" — a host that cannot stop honestly cannot be operated honestly — but it stands on its own.

Release Notes:
- Stopping the session host no longer reports its sessions as lost to a crash.