### PR TITLE
Report and consume termiod session facts

### DIFF
--- a/.github/workflows/termiod.yml
+++ b/.github/workflows/termiod.yml
@@ -15,12 +15,14 @@ on:
       - ".github/workflows/termiod.yml"
       - "Sources/termio/Terminal/Termiod/**"
       - "Tests/termioTests/TermiodFilesIntegrationTests.swift"
+      - "Tests/termioTests/TermiodWireOrderIntegrationTests.swift"
   pull_request:
     paths:
       - "termiod/**"
       - ".github/workflows/termiod.yml"
       - "Sources/termio/Terminal/Termiod/**"
       - "Tests/termioTests/TermiodFilesIntegrationTests.swift"
+      - "Tests/termioTests/TermiodWireOrderIntegrationTests.swift"
 
 concurrency:
   group: termiod-${{ github.ref }}
@@ -136,7 +138,8 @@ jobs:
           TERMIO_TERMIOD_TEST_BIN: ${{ github.workspace }}/termiod/target/debug/termiod
         run: |
           pkill -9 -f "target/debug/[t]ermiod|deps/[t]ermiod-" || true
-          swift test --filter TermiodFilesIntegrationTests
+          swift test --filter TermiodFilesIntegrationTests \
+                     --filter TermiodWireOrderIntegrationTests
 
       - name: Cross-compile the Linux release binary
         run: |

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -2024,7 +2024,7 @@ extension AppDelegate: NSMenuDelegate {
     }
 
     /// Fills a New SSH Connection submenu with one row per `~/.ssh/config` host —
-    /// the same aliases Settings ▸ Machines lists — each connecting directly, plus a
+    /// the same aliases Settings ▸ Devices lists — each connecting directly, plus a
     /// trailing "Add Host…" opening the same form as Settings' Add Host button
     /// and connecting to the machine it adds (see `addSSHHost`). With an empty
     /// config only "Add Host…" remains — the first-run path.

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -3582,12 +3582,12 @@
         }
       }
     },
-    "Machines": {
+    "Devices": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "机器"
+            "value": "设备"
           }
         }
       }
@@ -3662,12 +3662,12 @@
         }
       }
     },
-    "The machines in your ~/.ssh/config, and the keys that reach them": {
+    "The devices in your ~/.ssh/config, and the keys that reach them": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "~/.ssh/config 里的机器，以及连上它们的密钥"
+            "value": "~/.ssh/config 里的设备，以及连上它们的密钥"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -346,6 +346,8 @@
 	<string>Delete…</string>
 	<key>Detached at %@</key>
 	<string>Detached at %@</string>
+	<key>Devices</key>
+	<string>Devices</string>
 	<key>Discard %lld Files…</key>
 	<string>Discard %lld Files…</string>
 	<key>Discard Changes</key>
@@ -534,8 +536,6 @@
 	<string>Local</string>
 	<key>Login shell</key>
 	<string>Login shell</string>
-	<key>Machines</key>
-	<string>Machines</string>
 	<key>Match Case</key>
 	<string>Match Case</string>
 	<key>Match Whole Word</key>
@@ -1010,6 +1010,8 @@
 	<string>The base branch has commits this branch doesn’t have, as of the last fetch.</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>The coding agents offered when you start a session</string>
+	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>
+	<string>The devices in your ~/.ssh/config, and the keys that reach them</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
 	<string>The folder was removed, but git couldn’t prune its stale worktree metadata.</string>
 	<key>The ignore rule couldn’t be added.</key>
@@ -1018,8 +1020,6 @@
 	<string>The listing failed.</string>
 	<key>The machine answered with no listing for that folder.</key>
 	<string>The machine answered with no listing for that folder.</string>
-	<key>The machines in your ~/.ssh/config, and the keys that reach them</key>
-	<string>The machines in your ~/.ssh/config, and the keys that reach them</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>The project and session list. Kept separate from the terminal font, and need not be monospaced.</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -346,6 +346,8 @@
 	<string>删除…</string>
 	<key>Detached at %@</key>
 	<string>已分离于 %@</string>
+	<key>Devices</key>
+	<string>设备</string>
 	<key>Discard %lld Files…</key>
 	<string>放弃 %lld 个文件的更改…</string>
 	<key>Discard Changes</key>
@@ -534,8 +536,6 @@
 	<string>本地</string>
 	<key>Login shell</key>
 	<string>登录 shell</string>
-	<key>Machines</key>
-	<string>机器</string>
 	<key>Match Case</key>
 	<string>区分大小写</string>
 	<key>Match Whole Word</key>
@@ -1010,6 +1010,8 @@
 	<string>截至上次 fetch，基础分支上有当前分支还没有的提交。</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>新建会话时可以选用的编程 Agent</string>
+	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>
+	<string>~/.ssh/config 里的设备，以及连上它们的密钥</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
 	<string>文件夹已移除，但 git 无法清理其残留的 worktree 元数据。</string>
 	<key>The ignore rule couldn’t be added.</key>
@@ -1018,8 +1020,6 @@
 	<string>读取目录失败。</string>
 	<key>The machine answered with no listing for that folder.</key>
 	<string>这台机器没有返回该文件夹的内容。</string>
-	<key>The machines in your ~/.ssh/config, and the keys that reach them</key>
-	<string>~/.ssh/config 里的机器，以及连上它们的密钥</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>项目与会话列表。与终端字体分开设置，无需等宽字体。</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -1,11 +1,11 @@
 import AppKit
 import SwiftUI
 
-/// Settings ▸ Machines: the connectable hosts from `~/.ssh/config`, each one click
+/// Settings ▸ Devices: the connectable hosts from `~/.ssh/config`, each one click
 /// away from a terminal. The config file stays the single source of truth —
 /// termio reads the same hosts `ssh` itself resolves and writes nothing behind
 /// the user's back: Add Host appends a plain block, Edit opens the raw file.
-struct MachinesSettingsTab: View {
+struct DevicesSettingsTab: View {
     @ObservedObject var settings: AppSettings
     /// Opens an SSH terminal to the alias in the main window (wired to
     /// `TermioStore.addSSHSession` by the app delegate).
@@ -276,7 +276,7 @@ private extension SSHProbeResult {
 
 /// The Add Host sheet: the four fields a `Host` block actually needs, appended
 /// to `~/.ssh/config` as a block indistinguishable from a hand-written one.
-/// Shared by Settings ▸ Machines' Add Host button and the New SSH Connection ▸
+/// Shared by Settings ▸ Devices' Add Host button and the New SSH Connection ▸
 /// Add Host… menu row (which connects to the host right after adding it).
 struct AddSSHHostSheet: View {
     let existingAliases: Set<String>

--- a/Sources/termio/Settings/SettingsTab.swift
+++ b/Sources/termio/Settings/SettingsTab.swift
@@ -7,10 +7,16 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case appearance
     case terminal
+    /// A **device** is a machine identified by its `host_id` and reached by one
+    /// or more `~/.ssh/config` aliases — the term the session protocol, the
+    /// daemon and `TermiodDevice` all already use. This tab was called
+    /// "Machines" while the app had no other name for the far end.
+    ///
     /// The raw value stays `ssh` because it is the value persisted under
     /// `lastOpenKey`; changing it would reopen Settings on another tab for
-    /// everyone who left this one showing.
-    case machines = "ssh"
+    /// everyone who left this one showing. It has now survived two renamings,
+    /// which is the point of it.
+    case devices = "ssh"
     case keyboard
     case agents
     case usage
@@ -28,7 +34,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return localized("General")
         case .appearance: return localized("Appearance")
         case .terminal: return localized("Terminal")
-        case .machines: return localized("Machines")
+        case .devices: return localized("Devices")
         case .keyboard: return localized("Keyboard")
         case .agents: return localized("Agents")
         case .usage: return localized("Usage")
@@ -44,7 +50,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return .settings
         case .appearance: return .paintBoard
         case .terminal: return .terminal
-        case .machines: return .serverStack
+        case .devices: return .serverStack
         case .keyboard: return .keyboard
         case .agents: return .bot
         case .usage: return .chartColumn
@@ -60,7 +66,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return localized("The termio command-line tool, agent skill, and notifications")
         case .appearance: return localized("Theme, fonts, cursor, and window")
         case .terminal: return localized("Scrollback history and text selection")
-        case .machines: return localized("The machines in your ~/.ssh/config, and the keys that reach them")
+        case .devices: return localized("The devices in your ~/.ssh/config, and the keys that reach them")
         case .keyboard: return localized("Keyboard shortcuts for every command")
         case .agents: return localized("The coding agents offered when you start a session")
         case .usage: return localized("Token usage for your connected agents")

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -13,7 +13,7 @@ struct SettingsView: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var usage: UsageMonitor
     /// Opens an SSH terminal to a `~/.ssh/config` alias in the main window — the
-    /// Machines tab's Connect action, injected by the app delegate so the settings
+    /// Devices tab's Connect action, injected by the app delegate so the settings
     /// window doesn't hold the store.
     let onSSHConnect: (String) -> Void
     @State private var selection: SettingsTab
@@ -74,7 +74,7 @@ struct SettingsView: View {
         case .general: GeneralSettingsTab(settings: settings)
         case .appearance: AppearanceSettingsTab(settings: settings)
         case .terminal: TerminalSettingsTab(settings: settings)
-        case .machines: MachinesSettingsTab(settings: settings, onConnect: onSSHConnect)
+        case .devices: DevicesSettingsTab(settings: settings, onConnect: onSSHConnect)
         case .keyboard: KeybindingsSettingsTab()
         case .agents: AgentSettingsTab(settings: settings)
         case .usage: UsageSettingsTab(settings: settings, usage: usage)

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -1203,7 +1203,7 @@ private struct SessionRow: View {
             Group {
                 if session.isSSH, status != .working {
                     // An SSH terminal is a machine, so it carries the same server
-                    // glyph as its host row in Settings ▸ Machines (a globe reads as
+                    // glyph as its host row in Settings ▸ Devices (a globe reads as
                     // "web", not "that box") — except while a detected remote
                     // agent is working, when it falls through to the spinner below.
                     // Size 15 like the folder and agent marks sharing this

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -124,24 +124,20 @@ extension TermioStore {
             \(writer ? "the writer" : "an observer", privacy: .public)
             """)
         }
-        // What the device knows about the process, routed to the same consumers
-        // the in-process PTY's kernel poll feeds — and gated exactly where that
-        // poll is gated, because the two are one feature with two producers.
-        //
-        // The poll is installed only on a row that *started* as a plain terminal
-        // (a declared agent's foreground is its own subprocess, and reading a `rg`
-        // it spawned as "no agent here" would demote the row mid-turn), and inside
-        // that, it reads the cwd only for a loose terminal — a project session's
-        // place is its project, not wherever its shell wandered.
-        let isShellBackedSession = session.agent == .terminal
-        let followsWorkingDirectory = isShellBackedSession && isLooseTerminal(session.id)
+        // What the device knows about the process, gated exactly where the
+        // in-process PTY's own kernel poll is gated: that poll is installed only
+        // on a row declared `.terminal` (a declared agent's foreground is its own
+        // subprocess, and reading a `rg` it spawned as "no agent here" would
+        // demote the row mid-turn), and follows the cwd only for a loose terminal,
+        // whose place is wherever it wandered rather than a project root.
+        let isPlainTerminal = session.agent == .terminal
+        let followsWorkingDirectory = isPlainTerminal && isLooseTerminal(session.id)
         link.onInformation = { [weak self] information in
             self?.applyTermiodInformation(
                 information, for: session.id,
-                identifiesAgent: isShellBackedSession,
+                identifiesAgent: isPlainTerminal,
                 followsWorkingDirectory: followsWorkingDirectory)
         }
-        let isPlainTerminal = session.agent == .terminal
         link.onExit = { [weak self, weak inMemory] code, runtimeMilliseconds, information in
             self?.applyTermiodExit(
                 for: session.id, code: code, runtimeMilliseconds: runtimeMilliseconds,
@@ -210,31 +206,19 @@ extension TermioStore {
 
     /// Lands a roster push on the session's row.
     ///
-    /// The host answers *what the process is* — the foreground group's argv, the
-    /// child's directory, whether a job is running in front of the shell — and
-    /// nothing about what those mean. Every interpretation stays here, in the
-    /// consumers the in-process PTY's own kernel poll already feeds, so a session
-    /// behaves the same whether the syscalls ran in this process or on a VPS:
-    /// argv becomes an agent through the *user's* `AgentCatalog`, the child's cwd
-    /// becomes the followed working directory, and the foreground job answers the
-    /// close confirmation (read at close time from `latestInformation`, not
-    /// pushed anywhere).
+    /// The host reports what the process *is*; what that means is decided here, by
+    /// the same consumers the in-process PTY's kernel poll feeds, so a session
+    /// behaves the same whether the syscalls ran in this process or on a VPS.
     ///
-    /// Every field is optional and every absence stands down. That is the skew
-    /// rule, and it is load-bearing in one direction only: a daemon too old to
-    /// sample, or a process the kernel would not answer for, must leave the row
-    /// exactly as the screen-derived signals left it — never demote an agent,
-    /// never move a directory — because "the device did not say" is not evidence.
+    /// Every absence stands down — "the device did not say" is not evidence, so a
+    /// daemon too old to sample, or a process the kernel refused, must leave the
+    /// row exactly as the screen-derived signals left it.
     /// - Parameters:
-    ///   - identifiesAgent: whether this row's identity follows its foreground —
-    ///     true for a session that started as a plain shell, false for a declared
-    ///     agent whose foreground is its own subprocess.
-    ///   - followsWorkingDirectory: whether this row owns its cwd — true for a
-    ///     loose terminal, false for a project session, whose place is its project
-    ///     rather than wherever its shell wandered. A separate flag rather than a
-    ///     consequence of the first: the local producer gates the two separately,
-    ///     and collapsing them here would start following a project session's cwd
-    ///     on the daemon path and nowhere else.
+    ///   - identifiesAgent: whether this row's identity follows its foreground.
+    ///     False for a declared agent, whose foreground is its own subprocess.
+    ///   - followsWorkingDirectory: whether this row owns its cwd. A separate flag
+    ///     rather than a consequence of the first, because the local producer gates
+    ///     the two separately.
     func applyTermiodInformation(_ information: Termiod.SessionInformation,
                                  for id: Session.ID,
                                  identifiesAgent: Bool,
@@ -263,9 +247,8 @@ extension TermioStore {
     ///   - information: the device's final word, from the exit event. Never a
     ///     roster row — `childExecutableReplaced` is computed on the exit path,
     ///     and a poll that ran seconds earlier answers a different question.
-    ///   - isAgentSession: snapshotted when the link was wired, like the
-    ///     in-process path's own capture, so a row promoted mid-life still exits
-    ///     as what it was launched as.
+    ///   - isAgentSession: snapshotted when the link was wired, so a row promoted
+    ///     mid-life still exits as what it was launched as.
     func applyTermiodExit(for id: Session.ID,
                           code: Int32,
                           runtimeMilliseconds: UInt64,

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -124,23 +124,29 @@ extension TermioStore {
             \(writer ? "the writer" : "an observer", privacy: .public)
             """)
         }
-        link.onExit = { [weak self, weak inMemory] code, runtimeMilliseconds in
-            self?.termiodLinks[session.id] = nil
-            self?.lastScreenActivity[session.id] = nil
-            // Mirrors the PTYProcess exit policy, minus the self-update
-            // binary-replaced check (the daemon owns the process, so the app
-            // cannot pin its executable): a clean agent quit hands the pane
-            // back to a shell; everything else parks on the exit prompt, and
-            // a clean plain-terminal exit closes the pane.
-            if isAgentSession, code == 0 {
-                self?.revertSessionToShell(session.id)
-                return
-            }
-            inMemory?.finish(exitCode: UInt32(bitPattern: code),
-                             runtimeMilliseconds: runtimeMilliseconds)
-            if session.agent == .terminal, code == 0 {
-                self?.closeSession(session.id)
-            }
+        // What the device knows about the process, routed to the same consumers
+        // the in-process PTY's kernel poll feeds — and gated exactly where that
+        // poll is gated, because the two are one feature with two producers.
+        //
+        // The poll is installed only on a row that *started* as a plain terminal
+        // (a declared agent's foreground is its own subprocess, and reading a `rg`
+        // it spawned as "no agent here" would demote the row mid-turn), and inside
+        // that, it reads the cwd only for a loose terminal — a project session's
+        // place is its project, not wherever its shell wandered.
+        let isShellBackedSession = session.agent == .terminal
+        let followsWorkingDirectory = isShellBackedSession && isLooseTerminal(session.id)
+        link.onInformation = { [weak self] information in
+            self?.applyTermiodInformation(
+                information, for: session.id,
+                identifiesAgent: isShellBackedSession,
+                followsWorkingDirectory: followsWorkingDirectory)
+        }
+        let isPlainTerminal = session.agent == .terminal
+        link.onExit = { [weak self, weak inMemory] code, runtimeMilliseconds, information in
+            self?.applyTermiodExit(
+                for: session.id, code: code, runtimeMilliseconds: runtimeMilliseconds,
+                information: information, isAgentSession: isAgentSession,
+                isPlainTerminal: isPlainTerminal, surface: inMemory)
         }
         termiodLinks[session.id] = link
         link.start()
@@ -197,6 +203,101 @@ extension TermioStore {
             // reported on. Writing it would overwrite what the local signals
             // worked out, so it is left alone.
             break
+        }
+    }
+
+    // MARK: - Host-reported process facts
+
+    /// Lands a roster push on the session's row.
+    ///
+    /// The host answers *what the process is* — the foreground group's argv, the
+    /// child's directory, whether a job is running in front of the shell — and
+    /// nothing about what those mean. Every interpretation stays here, in the
+    /// consumers the in-process PTY's own kernel poll already feeds, so a session
+    /// behaves the same whether the syscalls ran in this process or on a VPS:
+    /// argv becomes an agent through the *user's* `AgentCatalog`, the child's cwd
+    /// becomes the followed working directory, and the foreground job answers the
+    /// close confirmation (read at close time from `latestInformation`, not
+    /// pushed anywhere).
+    ///
+    /// Every field is optional and every absence stands down. That is the skew
+    /// rule, and it is load-bearing in one direction only: a daemon too old to
+    /// sample, or a process the kernel would not answer for, must leave the row
+    /// exactly as the screen-derived signals left it — never demote an agent,
+    /// never move a directory — because "the device did not say" is not evidence.
+    /// - Parameters:
+    ///   - identifiesAgent: whether this row's identity follows its foreground —
+    ///     true for a session that started as a plain shell, false for a declared
+    ///     agent whose foreground is its own subprocess.
+    ///   - followsWorkingDirectory: whether this row owns its cwd — true for a
+    ///     loose terminal, false for a project session, whose place is its project
+    ///     rather than wherever its shell wandered. A separate flag rather than a
+    ///     consequence of the first: the local producer gates the two separately,
+    ///     and collapsing them here would start following a project session's cwd
+    ///     on the daemon path and nowhere else.
+    func applyTermiodInformation(_ information: Termiod.SessionInformation,
+                                 for id: Session.ID,
+                                 identifiesAgent: Bool,
+                                 followsWorkingDirectory: Bool) {
+        guard session(id) != nil else { return }
+        // `nil` argv is *unanswered*, so it never reaches `noteForegroundAgent` —
+        // which reads its own `nil` as "a shell is in front now" and demotes.
+        // An answered argv that matches nothing is that demotion, correctly.
+        if identifiesAgent, let argv = information.foregroundArgv {
+            noteForegroundAgent(AgentCatalog.shared.agent(forForegroundArguments: argv), for: id)
+        }
+        // The daemon's equivalent of the local kernel poll, landing in the same
+        // place it does. (The shell's own OSC 7 reaches `noteWorkingDirectory`
+        // ungated, from the surface — that channel is the program volunteering
+        // where it is, which is a different thing from termio going and looking.)
+        if followsWorkingDirectory, let cwd = information.childCwd, !cwd.isEmpty {
+            noteWorkingDirectory(cwd, for: id)
+        }
+    }
+
+    /// A daemon-hosted session's process is gone. Named rather than inlined in the
+    /// link callback so the wiring from "the device said the binary moved" to "the
+    /// pane relaunches" is reachable without a daemon.
+    ///
+    /// - Parameters:
+    ///   - information: the device's final word, from the exit event. Never a
+    ///     roster row — `childExecutableReplaced` is computed on the exit path,
+    ///     and a poll that ran seconds earlier answers a different question.
+    ///   - isAgentSession: snapshotted when the link was wired, like the
+    ///     in-process path's own capture, so a row promoted mid-life still exits
+    ///     as what it was launched as.
+    func applyTermiodExit(for id: Session.ID,
+                          code: Int32,
+                          runtimeMilliseconds: UInt64,
+                          information: Termiod.SessionInformation?,
+                          isAgentSession: Bool,
+                          isPlainTerminal: Bool,
+                          surface: InMemoryTerminalSession?) {
+        termiodLinks[id] = nil
+        lastScreenActivity[id] = nil
+        // The same policy the in-process PTY runs, on the same three inputs. The
+        // self-update check is no longer missing here: the app cannot pin a
+        // process it does not own, but the daemon that owns it can, and the exit
+        // event carries its answer.
+        let outcome = TermioStore.sessionExit(
+            code: code,
+            isAgentSession: isAgentSession,
+            isPlainTerminal: isPlainTerminal,
+            executableReplaced: information?.childExecutableReplaced == true)
+        switch outcome {
+        case .relaunch:
+            relaunchSession(id)
+            return
+        case .revertToShell:
+            revertSessionToShell(id)
+            return
+        case .close, .park:
+            break
+        }
+        surface?.finish(exitCode: UInt32(bitPattern: code),
+                        runtimeMilliseconds: runtimeMilliseconds)
+        if outcome == .close {
+            closeSession(id)
         }
     }
 

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -798,10 +798,54 @@ enum Termiod {
         /// this app has no row for means someone else is watching it.
         let attachedClients: Int
 
+        /// The pid the **device** picked to represent the group holding the tty's
+        /// foreground. Not the process group id: a group is not one process, and
+        /// which of its members answers for it is the host's call. Today's macOS
+        /// host answers with the group leader (whose pid is the pgid), but a host
+        /// that must skip a leader already reaped — `foo | bar` after `foo` exits,
+        /// where reading the leader would report *no* foreground command while
+        /// `bar` still runs — answers with the live member it found instead. This
+        /// side reads it as "the process to ask about", never as a group id.
+        ///
+        /// `nil` on a daemon too old to sample, and on one that sampled and found
+        /// nothing (a session whose child has gone).
+        let foregroundPid: Int32?
+        /// The selected live member's argv. **The host reports argv; this client decides
+        /// which agent it is** — mapping a program to an agent needs the user's own
+        /// manifests, which live here, so a box that has never heard of a
+        /// user-defined agent still reports enough for it to be recognised.
+        ///
+        /// `nil` means *not answered*, never "nothing is running": an old daemon
+        /// and an unreadable process look the same from here, and both must leave
+        /// the session's identity alone rather than demote it.
+        let foregroundArgv: [String]?
+        /// Whether something other than the session's own child holds the
+        /// foreground — a command is running rather than a shell idling at its
+        /// prompt.
+        ///
+        /// `nil` is *not reported*: the daemon omits the field when it is false,
+        /// so an idle prompt on a current daemon is indistinguishable from a
+        /// daemon that never sampled. Both mean the same thing to every consumer
+        /// (`remote-to-device.decisions.md` §2 — an absent field preserves
+        /// today's no-confirm behaviour, and must never be read as "unknown, so
+        /// confirm"), so the ambiguity costs nothing.
+        let foregroundJob: Bool?
+        /// The child's *current* directory — what `cd` moves, as opposed to `cwd`,
+        /// which is where the session was created. A path on the **device**.
+        let childCwd: String?
+        /// The binary the child is running, as the device's kernel resolved it.
+        let childExecutable: String?
+        /// Whether that binary has been replaced on disk since the session pinned
+        /// it — an agent that updated itself and quit, told apart from one that
+        /// just quit. Omitted when false, so `nil` reads as "not replaced".
+        let childExecutableReplaced: Bool?
+
         private enum CodingKeys: String, CodingKey {
             case id, name, pid, alive, cwd, command, status, title, createdUnix
             case agentID = "agentId"
             case attachedClients
+            case foregroundPid, foregroundArgv, foregroundJob
+            case childCwd, childExecutable, childExecutableReplaced
         }
 
         init(from decoder: Decoder) throws {
@@ -817,6 +861,17 @@ enum Termiod {
             title = try container.decodeIfPresent(String.self, forKey: .title)
             createdUnix = try container.decodeIfPresent(UInt64.self, forKey: .createdUnix) ?? 0
             attachedClients = try container.decodeIfPresent(Int.self, forKey: .attachedClients) ?? 0
+            // Every one of these stays optional rather than defaulting: a default
+            // would erase the difference between "the device says no" and "the
+            // device did not say", and each consumer below stands down on the
+            // second. This is the skew rule the whole additive contract rests on.
+            foregroundPid = try container.decodeIfPresent(Int32.self, forKey: .foregroundPid)
+            foregroundArgv = try container.decodeIfPresent([String].self, forKey: .foregroundArgv)
+            foregroundJob = try container.decodeIfPresent(Bool.self, forKey: .foregroundJob)
+            childCwd = try container.decodeIfPresent(String.self, forKey: .childCwd)
+            childExecutable = try container.decodeIfPresent(String.self, forKey: .childExecutable)
+            childExecutableReplaced = try container.decodeIfPresent(
+                Bool.self, forKey: .childExecutableReplaced)
         }
 
         /// What to call this session on screen. The name is the daemon's handle,
@@ -927,9 +982,30 @@ enum Termiod {
         let title: String?
     }
 
+    /// The device revising what it knows about a session — pushed on change, on
+    /// its own slow timer, never from the byte path (§A). `action` is the
+    /// daemon's word for what moved (`updated`, …) and stays a string so a newer
+    /// one does not fail the decode; `info` is the whole row, so a client never
+    /// merges deltas.
+    ///
+    /// `info` is optional because a delta that only announces a session's
+    /// arrival or departure has no row to carry — a client with nothing to
+    /// update simply ignores it.
+    struct RosterPayload: Decodable, Sendable {
+        let session: String
+        let action: String
+        let info: SessionInformation?
+    }
+
+    /// A session's process is gone. `info` is the device's final word on it —
+    /// `alive: false`, and a `childExecutableReplaced` computed on the exit path
+    /// rather than cached from the last poll, which is the whole reason the exit
+    /// carries a row at all: a binary swapped in the seconds before the agent
+    /// quit is exactly the case it answers. Absent on a daemon that predates it.
     struct SessionExitedPayload: Decodable, Sendable {
         let session: String
         let status: Int32
+        let info: SessionInformation?
     }
 
     /// Decoded `E` frames. Unknown events become `.unknown` and are ignored,
@@ -939,6 +1015,7 @@ enum Termiod {
         case status(StatusPayload)
         case writerChanged(WriterChangedPayload)
         case resized(ResizedPayload)
+        case roster(RosterPayload)
         case sessionExited(SessionExitedPayload)
         case unknown(String)
     }
@@ -1068,6 +1145,8 @@ enum Termiod {
             return .writerChanged(try decoder.decode(WriterChangedPayload.self, from: payload))
         case "resized":
             return .resized(try decoder.decode(ResizedPayload.self, from: payload))
+        case "roster":
+            return .roster(try decoder.decode(RosterPayload.self, from: payload))
         case "session_exited":
             return .sessionExited(try decoder.decode(SessionExitedPayload.self, from: payload))
         default:
@@ -1359,6 +1438,34 @@ final class TermiodSessionLink: @unchecked Sendable {
         return lastInputAtLocked
     }
 
+    /// The device's own description of this session while it is **running**, from
+    /// the last roster event it pushed. Its own lock rather than the work queue
+    /// because the one caller that cannot wait — the close confirmation, asked on
+    /// the main thread the instant the user clicks — must read it without a hop.
+    ///
+        /// This is a *cache of a push*, so it is as fresh as the daemon's sampling
+        /// cadence and no fresher. Every consumer treats it as a bounded sample;
+        /// `closeConfirmationReason` documents both directions in which it can be
+        /// stale and why asking `list` would not produce a fresher answer.
+    private let informationLock = NSLock()
+    private var latestInformationLocked: Termiod.SessionInformation?
+    /// The device's final word, from the exit event. Kept **apart** from the live
+    /// cache rather than overwriting it: the exit row describes a session that has
+    /// ended (`alive: false`, no foreground), it is recorded on the reader thread
+    /// while the link is still registered, and the close confirmation reads the
+    /// live cache from the main thread — so merging the two puts a dead session's
+    /// blank sample in front of a question about a running one. Two fields, no
+    /// window.
+    private var finalInformationLocked: Termiod.SessionInformation?
+
+    /// What the device last said about this session while it was running. `nil`
+    /// once nothing has pushed a roster row — never the exit row.
+    var latestInformation: Termiod.SessionInformation? {
+        informationLock.lock()
+        defer { informationLock.unlock() }
+        return latestInformationLocked
+    }
+
     /// Raw PTY bytes from the daemon — fed to the surface exactly where
     /// `PTYProcess`'s read pump delivers on the in-process path. Called on the
     /// reader thread; the consumer (`InMemoryTerminalSession.receive`) is
@@ -1368,11 +1475,17 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// session actually runs on. A session knows its *route* from the start but
     /// cannot know its *device* until something answers — this is that moment.
     var onDevice: ((TermiodDevice) -> Void)?
-    /// Fired once on the main queue with the exit status and elapsed
-    /// milliseconds since this link started (the daemon does not report the
-    /// child's true runtime; elapsed-since-attach serves ghostty's
-    /// abnormal-exit heuristic the same way).
-    var onExit: ((Int32, UInt64) -> Void)?
+    /// Fired once on the main queue with the exit status, elapsed milliseconds
+    /// since this link started (the daemon does not report the child's true
+    /// runtime; elapsed-since-attach serves ghostty's abnormal-exit heuristic the
+    /// same way), and the device's final word on the session when it sent one.
+    var onExit: ((Int32, UInt64, Termiod.SessionInformation?) -> Void)?
+    /// The device's revised description of this session, on the main queue,
+    /// every time the daemon pushes one. What the host reports is *facts about
+    /// the process* — foreground argv, the child's cwd, whether a job is running
+    /// — and what they mean is decided on this side, by the same consumers the
+    /// in-process PTY's own kernel poll feeds.
+    var onInformation: ((Termiod.SessionInformation) -> Void)?
     /// The session's workstream status as the host reports it (`working`,
     /// `needs_you`, …) with the workstream title when one rides along. Fired on
     /// the main queue for every `E status`.
@@ -1609,13 +1722,45 @@ final class TermiodSessionLink: @unchecked Sendable {
     }
 
     /// Must run on `workQueue` — `exitDelivered` is queue-confined state.
+    ///
+    /// The final row is read from its own field rather than passed in, so both
+    /// arrivals answer the same thing: the daemon emits `E session_exited` before
+    /// the `exited` control frame and this reader is serial, so the exit's own row
+    /// is already recorded by the time either lands. `nil` on a daemon too old to
+    /// carry one — which the exit policy reads as "the device did not say", never
+    /// as a fact about the process. The live roster cache is deliberately *not* a
+    /// fallback: a row sampled seconds before the exit answers a different
+    /// question, and the one field that matters here is computed on the exit path.
     private func deliverExitLocked(status: Int32) {
         guard !exitDelivered else { return }
         exitDelivered = true
         let runtimeMilliseconds = UInt64(max(0, Date().timeIntervalSince(startedAt) * 1000))
+        informationLock.lock()
+        let information = finalInformationLocked
+        informationLock.unlock()
         DispatchQueue.main.async { [self] in
-            onExit?(status, runtimeMilliseconds)
+            onExit?(status, runtimeMilliseconds, information)
         }
+    }
+
+    /// Records a roster push — the device revising what it knows about a session
+    /// that is still running — and publishes it. Called from the reader thread.
+    private func recordRosterInformation(_ information: Termiod.SessionInformation) {
+        informationLock.lock()
+        latestInformationLocked = information
+        informationLock.unlock()
+        DispatchQueue.main.async { [self] in onInformation?(information) }
+    }
+
+    /// Records the row riding the exit. It never reaches the live cache or the
+    /// live consumers: it describes a session that has *ended*, so handing it to
+    /// them would answer "is a command running in here" with a dead process's
+    /// blank sample, and would demote an agent row a beat before the exit path
+    /// decides what the pane becomes. `onExit` is its only reader.
+    private func recordFinalInformation(_ information: Termiod.SessionInformation) {
+        informationLock.lock()
+        finalInformationLocked = information
+        informationLock.unlock()
     }
 
     /// Dedicated blocking-read thread (the frame stream has no natural
@@ -1724,9 +1869,13 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// Unlocked by the `events` capability, and each arm is why it is offered:
     /// `status` is the product's core signal (an agent on a VPS has no other way
     /// to reach this Mac), `writer_changed` keeps write gating honest as the
-    /// token moves, and `resized` carries the authoritative dimensions §C.5
-    /// requires every client to know.
-    private func handleEvent(_ payload: Data) -> Bool {
+    /// token moves, `resized` carries the authoritative dimensions §C.5 requires
+    /// every client to know, and `roster` is what the device says the process is.
+    ///
+    /// Not private so the routing can be driven with real frames — which of the
+    /// two information caches an arriving frame lands in is the kind of thing
+    /// that goes wrong silently.
+    func handleEvent(_ payload: Data) -> Bool {
         let event: Termiod.IncomingEvent
         do {
             event = try Termiod.decodeEvent(payload)
@@ -1744,10 +1893,20 @@ final class TermiodSessionLink: @unchecked Sendable {
             applyWriter(change.writer)
         case .resized(let size):
             applyAuthoritativeGrid(TerminalGrid(rows: size.rows, cols: size.cols))
+        case .roster(let update):
+            // Not filtered by name: events are fanned per session, so everything
+            // arriving on this channel is about the session it was opened for.
+            // A delta with no row is an arrival/departure notice with nothing to
+            // update — the roster fetch is what answers those.
+            if let information = update.info { recordRosterInformation(information) }
         case .sessionExited(let exit):
+            // Recorded before the exit is delivered, and *before* the `exited`
+            // control frame the daemon sends next: this is the device's last word
+            // on the process, and the exit policy reads it.
+            if let information = exit.info { recordFinalInformation(information) }
             // The `exited` control frame says the same thing and normally lands
-            // first; both funnel into the same idempotent delivery, so whichever
-            // arrives is enough and neither can double-report.
+            // right after; both funnel into the same idempotent delivery, so
+            // whichever arrives is enough and neither can double-report.
             workQueue.async { [self] in
                 teardownLocked()
                 deliverExitLocked(status: exit.status)

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -798,37 +798,29 @@ enum Termiod {
         /// this app has no row for means someone else is watching it.
         let attachedClients: Int
 
-        /// The pid the **device** picked to represent the group holding the tty's
-        /// foreground. Not the process group id: a group is not one process, and
-        /// which of its members answers for it is the host's call. Today's macOS
-        /// host answers with the group leader (whose pid is the pgid), but a host
-        /// that must skip a leader already reaped — `foo | bar` after `foo` exits,
-        /// where reading the leader would report *no* foreground command while
-        /// `bar` still runs — answers with the live member it found instead. This
-        /// side reads it as "the process to ask about", never as a group id.
+        /// The process the **device** picked to answer for the group holding the
+        /// tty's foreground — a pid, never the group id. Which member answers is
+        /// the host's call: it skips a leader already reaped, as in `foo | bar`
+        /// once `foo` exits and only `bar` still holds the terminal.
         ///
-        /// `nil` on a daemon too old to sample, and on one that sampled and found
-        /// nothing (a session whose child has gone).
+        /// `nil` on a daemon too old to sample, and on one that found nobody.
         let foregroundPid: Int32?
-        /// The selected live member's argv. **The host reports argv; this client decides
-        /// which agent it is** — mapping a program to an agent needs the user's own
-        /// manifests, which live here, so a box that has never heard of a
-        /// user-defined agent still reports enough for it to be recognised.
+        /// That process's argv. The host reports it; **this** side decides which
+        /// agent it is, because the mapping needs the user's own manifests, which
+        /// live here — so a box that never heard of a user-defined agent still
+        /// reports enough for it to be recognised.
         ///
         /// `nil` means *not answered*, never "nothing is running": an old daemon
-        /// and an unreadable process look the same from here, and both must leave
-        /// the session's identity alone rather than demote it.
+        /// and an unreadable process look the same from here, and neither may
+        /// demote the row.
         let foregroundArgv: [String]?
         /// Whether something other than the session's own child holds the
         /// foreground — a command is running rather than a shell idling at its
         /// prompt.
         ///
-        /// `nil` is *not reported*: the daemon omits the field when it is false,
-        /// so an idle prompt on a current daemon is indistinguishable from a
-        /// daemon that never sampled. Both mean the same thing to every consumer
-        /// (`remote-to-device.decisions.md` §2 — an absent field preserves
-        /// today's no-confirm behaviour, and must never be read as "unknown, so
-        /// confirm"), so the ambiguity costs nothing.
+        /// Omitted when false, so `nil` conflates "idle" with "never sampled".
+        /// Harmless: both must read as today's no-confirm behaviour, never as
+        /// "unknown, so confirm" (`remote-to-device.decisions.md` §2).
         let foregroundJob: Bool?
         /// The child's *current* directory — what `cd` moves, as opposed to `cwd`,
         /// which is where the session was created. A path on the **device**.
@@ -983,25 +975,21 @@ enum Termiod {
     }
 
     /// The device revising what it knows about a session — pushed on change, on
-    /// its own slow timer, never from the byte path (§A). `action` is the
-    /// daemon's word for what moved (`updated`, …) and stays a string so a newer
-    /// one does not fail the decode; `info` is the whole row, so a client never
-    /// merges deltas.
-    ///
-    /// `info` is optional because a delta that only announces a session's
-    /// arrival or departure has no row to carry — a client with nothing to
-    /// update simply ignores it.
+    /// its own slow timer, never from the byte path (§A). `action` stays a string
+    /// so a newer one does not fail the decode; `info` is the whole row, so a
+    /// client never merges deltas, and is absent on a delta that only announces
+    /// an arrival or departure.
     struct RosterPayload: Decodable, Sendable {
         let session: String
         let action: String
         let info: SessionInformation?
     }
 
-    /// A session's process is gone. `info` is the device's final word on it —
-    /// `alive: false`, and a `childExecutableReplaced` computed on the exit path
-    /// rather than cached from the last poll, which is the whole reason the exit
-    /// carries a row at all: a binary swapped in the seconds before the agent
-    /// quit is exactly the case it answers. Absent on a daemon that predates it.
+    /// A session's process is gone. `info` is the device's final word on it, and
+    /// the reason the exit carries a row at all: `childExecutableReplaced` is
+    /// computed on the exit path, so a binary swapped in the seconds before the
+    /// agent quit — the self-update case — is answered here and nowhere else.
+    /// Absent on a daemon that predates it.
     struct SessionExitedPayload: Decodable, Sendable {
         let session: String
         let status: Int32
@@ -1438,24 +1426,18 @@ final class TermiodSessionLink: @unchecked Sendable {
         return lastInputAtLocked
     }
 
-    /// The device's own description of this session while it is **running**, from
-    /// the last roster event it pushed. Its own lock rather than the work queue
-    /// because the one caller that cannot wait — the close confirmation, asked on
-    /// the main thread the instant the user clicks — must read it without a hop.
-    ///
-        /// This is a *cache of a push*, so it is as fresh as the daemon's sampling
-        /// cadence and no fresher. Every consumer treats it as a bounded sample;
-        /// `closeConfirmationReason` documents both directions in which it can be
-        /// stale and why asking `list` would not produce a fresher answer.
+    /// The device's description of this session while it is **running**, from the
+    /// last roster push — a cache of a push, so no fresher than the daemon's
+    /// sampling cadence (`closeConfirmationReason` holds why that is acceptable).
+    /// Its own lock rather than the work queue because the one caller that cannot
+    /// wait — the close confirmation, asked on the main thread the instant the
+    /// user clicks — must read it without a hop.
     private let informationLock = NSLock()
     private var latestInformationLocked: Termiod.SessionInformation?
     /// The device's final word, from the exit event. Kept **apart** from the live
-    /// cache rather than overwriting it: the exit row describes a session that has
-    /// ended (`alive: false`, no foreground), it is recorded on the reader thread
-    /// while the link is still registered, and the close confirmation reads the
-    /// live cache from the main thread — so merging the two puts a dead session's
-    /// blank sample in front of a question about a running one. Two fields, no
-    /// window.
+    /// cache rather than overwriting it: it is recorded on the reader thread while
+    /// the link is still registered, so merging the two would put a dead session's
+    /// blank sample in front of a close confirmation about a running one.
     private var finalInformationLocked: Termiod.SessionInformation?
 
     /// What the device last said about this session while it was running. `nil`
@@ -1480,11 +1462,9 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// runtime; elapsed-since-attach serves ghostty's abnormal-exit heuristic the
     /// same way), and the device's final word on the session when it sent one.
     var onExit: ((Int32, UInt64, Termiod.SessionInformation?) -> Void)?
-    /// The device's revised description of this session, on the main queue,
-    /// every time the daemon pushes one. What the host reports is *facts about
-    /// the process* — foreground argv, the child's cwd, whether a job is running
-    /// — and what they mean is decided on this side, by the same consumers the
-    /// in-process PTY's own kernel poll feeds.
+    /// The device's revised description of this session, on the main queue, every
+    /// time the daemon pushes one: foreground argv, the child's cwd, whether a job
+    /// is running. Facts only — what they mean is decided on this side.
     var onInformation: ((Termiod.SessionInformation) -> Void)?
     /// The session's workstream status as the host reports it (`working`,
     /// `needs_you`, …) with the workstream title when one rides along. Fired on
@@ -1725,12 +1705,10 @@ final class TermiodSessionLink: @unchecked Sendable {
     ///
     /// The final row is read from its own field rather than passed in, so both
     /// arrivals answer the same thing: the daemon emits `E session_exited` before
-    /// the `exited` control frame and this reader is serial, so the exit's own row
-    /// is already recorded by the time either lands. `nil` on a daemon too old to
-    /// carry one — which the exit policy reads as "the device did not say", never
-    /// as a fact about the process. The live roster cache is deliberately *not* a
-    /// fallback: a row sampled seconds before the exit answers a different
-    /// question, and the one field that matters here is computed on the exit path.
+    /// the `exited` control frame and this reader is serial, so the row is already
+    /// recorded by the time either lands. The live roster cache is deliberately
+    /// *not* a fallback — a row sampled seconds before the exit answers a
+    /// different question — so `nil` here means the daemon never sent one.
     private func deliverExitLocked(status: Int32) {
         guard !exitDelivered else { return }
         exitDelivered = true
@@ -1752,11 +1730,11 @@ final class TermiodSessionLink: @unchecked Sendable {
         DispatchQueue.main.async { [self] in onInformation?(information) }
     }
 
-    /// Records the row riding the exit. It never reaches the live cache or the
-    /// live consumers: it describes a session that has *ended*, so handing it to
-    /// them would answer "is a command running in here" with a dead process's
-    /// blank sample, and would demote an agent row a beat before the exit path
-    /// decides what the pane becomes. `onExit` is its only reader.
+    /// Records the row riding the exit. `onExit` is its only reader: it describes
+    /// a session that has *ended*, so letting it reach the live consumers would
+    /// answer "is a command running in here" with a dead process's blank sample,
+    /// and demote an agent row a beat before the exit path decides what the pane
+    /// becomes.
     private func recordFinalInformation(_ information: Termiod.SessionInformation) {
         informationLock.lock()
         finalInformationLocked = information

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -875,7 +875,24 @@ enum Termiod {
         var displayLabel: String {
             if let title, !title.isEmpty { return title }
             if let agentID, !agentID.isEmpty { return agentID }
+            // What the device's kernel says is actually running, before the
+            // string rules that guess at it. A roster-only row — a session this
+            // app has never attached to — has no surface to read a title off,
+            // so this is the only place its label can come from that is not a
+            // guess. `nil` means the daemon did not answer, which is why the
+            // guess stays as the fallback rather than being replaced.
+            if let program = Self.programName(inArgv: foregroundArgv) { return program }
             return Self.programName(in: command) ?? name
+        }
+
+        /// The foreground program the device reported, named the way a person
+        /// would name it. Interpreters are the case that matters: `python
+        /// train.py` read as "python" tells you less than the script does, but
+        /// only the host knows the argv, so the choice of *which* word to show
+        /// belongs here rather than on the device.
+        private static func programName(inArgv argv: [String]?) -> String? {
+            guard let argv, let executable = argv.first, !executable.isEmpty else { return nil }
+            return URL(fileURLWithPath: executable).lastPathComponent
         }
 
         /// The program behind the login-shell wrapper Termio spawns through
@@ -925,11 +942,21 @@ enum Termiod {
         /// The workstream status the session last reported. A session that died
         /// while `needs_you` is a different story from one that died `idle`.
         let status: String
+        /// Whether the session's binary was replaced on disk while it ran — an
+        /// agent that updated itself and quit, told apart from one that just
+        /// quit. The exit *event* carries this too, but only to clients that
+        /// were attached when it happened; for anyone who reconnects afterwards
+        /// the tombstone is the only route.
+        ///
+        /// Absent on a `daemon_lost` grave and on a daemon too old to record
+        /// it — in both cases nobody measured, which is not the same as
+        /// measuring "not replaced", so it must never be shown as a self-update.
+        let childExecutableReplaced: Bool
 
         private enum CodingKeys: String, CodingKey {
             case id, name, cwd, command, reason, exitStatus, createdUnix, endedUnix
             case agentID = "agentId"
-            case title, status
+            case title, status, childExecutableReplaced
         }
 
         init(from decoder: Decoder) throws {
@@ -945,6 +972,8 @@ enum Termiod {
             agentID = try container.decodeIfPresent(String.self, forKey: .agentID)
             title = try container.decodeIfPresent(String.self, forKey: .title)
             status = try container.decodeIfPresent(String.self, forKey: .status) ?? "unknown"
+            childExecutableReplaced = try container.decodeIfPresent(
+                Bool.self, forKey: .childExecutableReplaced) ?? false
         }
     }
 

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -886,13 +886,19 @@ enum Termiod {
         }
 
         /// The foreground program the device reported, named the way a person
-        /// would name it. Interpreters are the case that matters: `python
-        /// train.py` read as "python" tells you less than the script does, but
-        /// only the host knows the argv, so the choice of *which* word to show
-        /// belongs here rather than on the device.
+        /// would name it: the last path component of `argv[0]`, minus the login
+        /// marker.
+        ///
+        /// That marker is not an edge case — it is the *idle* row. A login shell
+        /// is spawned with `argv[0] = "-zsh"` (`termiod/src/pty.rs`, and every
+        /// terminal before it), and a session sitting at its prompt reports its
+        /// own shell as the foreground, so passing the dash through would label
+        /// the most common roster row `-zsh`.
         private static func programName(inArgv argv: [String]?) -> String? {
             guard let argv, let executable = argv.first, !executable.isEmpty else { return nil }
-            return URL(fileURLWithPath: executable).lastPathComponent
+            let name = URL(fileURLWithPath: executable).lastPathComponent
+            let program = name.hasPrefix("-") ? String(name.dropFirst()) : name
+            return program.isEmpty ? nil : program
         }
 
         /// The program behind the login-shell wrapper Termio spawns through

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -804,22 +804,15 @@ extension TermioStore {
     /// PTY is alive for the whole life of the session, so confirming on a live PTY
     /// taxed *every* close to protect a conversation the agent can resume anyway.
     ///
-    /// A daemon-hosted session answers from the last roster push, which is a sample
-    /// up to one host poll old, and **asking again would not help**: `list` returns
-    /// the same `SessionInfo` built from the same cached sample, so a synchronous
-    /// round trip buys no freshness while costing 216–292 ms on the main thread over
-    /// SSH. So the staleness is accepted, and it is bounded in both directions:
-    ///
-    /// - **False positive** — the sampled job finished within the last poll, and the
-    ///   user is asked about a command that has already ended. Cost: one dialog they
-    ///   dismiss. This is the direction that is safe to be wrong in.
-    /// - **False negative** — a job started within the last poll, and the close goes
-    ///   through unasked. Cost: the same as the shipped no-confirm rule, which is
-    ///   what an absent field already means (`remote-to-device.decisions.md` §2 — an
-    ///   absent field must never be read as "unknown, so confirm", or every close on
-    ///   the sessions the rule deliberately exempts pays the tax).
-    ///
-    /// Which is why only an explicit `true` confirms.
+    /// A daemon-hosted session answers from the last roster push — a sample up to
+    /// one host poll old — and **asking again would not help**: `list` rebuilds its
+    /// answer from that same cached sample, so a synchronous round trip buys no
+    /// freshness while costing 216–292 ms on the main thread over SSH. The
+    /// staleness is bounded either way: a job that ended within the poll costs one
+    /// dialog the user dismisses, and one that started within it closes unasked —
+    /// which is exactly the shipped no-confirm rule. So only an explicit `true`
+    /// confirms; an absent field must never read as "unknown, so confirm"
+    /// (`remote-to-device.decisions.md` §2).
     func closeConfirmationReason(for session: Session) -> String? {
         guard session.agent.isShell else { return nil }
         let running = Self.foregroundJob(

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -784,14 +784,48 @@ extension TermioStore {
         closeSession(id)
     }
 
+    /// Whether a command is running in front of the session's shell, given what
+    /// each possible producer says. The one that **owns the process** answers:
+    /// an in-process PTY is asked `tcgetpgrp` at the instant of the question, so
+    /// its answer wins outright — including its `false`, which is a fresher no
+    /// than any cached yes. Only a session this app does not host falls through
+    /// to the device's last roster push. `nil` is nobody answering.
+    ///
+    /// Split out from `closeConfirmationReason` because the precedence is the
+    /// part worth pinning: the two producers disagree only while a link and a PTY
+    /// both exist for one row, and picking the wrong one there is silent.
+    static func foregroundJob(reportedLocally: Bool?, reportedByDevice: Bool?) -> Bool? {
+        reportedLocally ?? reportedByDevice
+    }
+
     /// Why closing this session needs confirming, or `nil` when it doesn't. The only
     /// case left is a plain shell with a command in front of it: that command exists
     /// nowhere else, so closing loses it outright. Agent sessions never ask — their
     /// PTY is alive for the whole life of the session, so confirming on a live PTY
     /// taxed *every* close to protect a conversation the agent can resume anyway.
-    private func closeConfirmationReason(for session: Session) -> String? {
+    ///
+    /// A daemon-hosted session answers from the last roster push, which is a sample
+    /// up to one host poll old, and **asking again would not help**: `list` returns
+    /// the same `SessionInfo` built from the same cached sample, so a synchronous
+    /// round trip buys no freshness while costing 216–292 ms on the main thread over
+    /// SSH. So the staleness is accepted, and it is bounded in both directions:
+    ///
+    /// - **False positive** — the sampled job finished within the last poll, and the
+    ///   user is asked about a command that has already ended. Cost: one dialog they
+    ///   dismiss. This is the direction that is safe to be wrong in.
+    /// - **False negative** — a job started within the last poll, and the close goes
+    ///   through unasked. Cost: the same as the shipped no-confirm rule, which is
+    ///   what an absent field already means (`remote-to-device.decisions.md` §2 — an
+    ///   absent field must never be read as "unknown, so confirm", or every close on
+    ///   the sessions the rule deliberately exempts pays the tax).
+    ///
+    /// Which is why only an explicit `true` confirms.
+    func closeConfirmationReason(for session: Session) -> String? {
         guard session.agent.isShell else { return nil }
-        guard let pty = ptyProcesses[session.id], pty.hasForegroundJob else { return nil }
+        let running = Self.foregroundJob(
+            reportedLocally: ptyProcesses[session.id]?.hasForegroundJob,
+            reportedByDevice: termiodLinks[session.id]?.latestInformation?.foregroundJob)
+        guard running == true else { return nil }
         return "A command is still running in this session. Closing it stops the command."
     }
 

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -114,6 +114,48 @@ enum PiSession {
 }
 
 extension TermioStore {
+    /// What a session's process exiting means for its pane.
+    enum SessionExit: Equatable {
+        /// The agent replaced its own binary and quit asking to be restarted
+        /// (codex's in-pane upgrade ends with "Please restart Codex."). Respawn it
+        /// in place with its resume arguments — the restart, done for the user.
+        case relaunch
+        /// A clean `/quit`: hand the pane back to a shell in the same directory,
+        /// exactly where a hand-started agent leaves you.
+        case revertToShell
+        /// A plain terminal that exited cleanly. The pane goes away with no extra
+        /// keypress, like a native terminal tab.
+        case close
+        /// Leave the exit on screen, on ghostty's "Press any key to close"
+        /// prompt, so a failure's output stays readable.
+        case park
+    }
+
+    /// The exit policy, as a decision with no side effects, so the in-process PTY
+    /// and the daemon link run the *same* one rather than two that drift.
+    ///
+    /// Both backends know the same three things at exit: the code, what the row
+    /// is, and whether the launch binary was replaced underneath the running
+    /// process. Only the last differs in how it is *learned* — the local PTY pins
+    /// the executable itself, the daemon owns the process and reports it — which
+    /// is a producer difference, not a policy one.
+    ///
+    /// - Parameters:
+    ///   - isAgentSession: a declared agent, not a plain terminal and not `ssh`.
+    ///   - isPlainTerminal: the row's declared agent is `.terminal` (an SSH
+    ///     terminal is one of these, which is why the two flags are separate
+    ///     rather than one being the negation of the other).
+    ///   - executableReplaced: `false` when nothing knows — an absent answer must
+    ///     never respawn a process the user quit.
+    static func sessionExit(code: Int32, isAgentSession: Bool, isPlainTerminal: Bool,
+                            executableReplaced: Bool) -> SessionExit {
+        // A non-zero exit always parks: its error output is the only record of
+        // what went wrong, and closing or respawning over it loses that.
+        guard code == 0 else { return .park }
+        if isAgentSession { return executableReplaced ? .relaunch : .revertToShell }
+        return isPlainTerminal ? .close : .park
+    }
+
     /// `path` when it still names a real directory, else `nil`. A recorded cwd outlives
     /// the folder it points at, and a shell spawned in a deleted directory lands at `/`.
     static func existingDirectory(_ path: String?) -> String? {
@@ -345,28 +387,26 @@ extension TermioStore {
             pty.onExit = { [weak self, weak inMemory, weak pty] code, runtimeMs in
                 self?.ptyProcesses[session.id] = nil
                 self?.lastScreenActivity[session.id] = nil
-                // A clean agent exit never parks the pane on the dead-end
-                // "Press any key to close" prompt (whose keypress deleted the
-                // session outright). Two flavors, told apart by the launch
-                // binary on disk:
-                //  - replaced (codex's in-pane upgrade ends with "Please restart
-                //    Codex." and quits — Homebrew purged the old version): do the
-                //    restart for the user, respawning the agent in place with its
-                //    resume arguments. Can't loop — the respawn pins the new
-                //    binary as its own baseline.
-                //  - untouched (a plain `/quit`): hand the pane back to a shell
-                //    in the same directory — exactly where a hand-started agent
-                //    leaves you — demoting the session to a plain terminal (the
-                //    identity mirror of `noteForegroundAgent`'s promotion).
-                // A non-zero exit still parks on the prompt: its error output
-                // must stay readable.
-                if isAgentSession, code == 0 {
-                    if pty?.childExecutableWasReplaced() == true {
-                        self?.relaunchSession(session.id)
-                    } else {
-                        self?.revertSessionToShell(session.id)
-                    }
+                // `sessionExit` holds the policy; what is local here is only how
+                // the replacement answer is *got* — this process spawned the
+                // child, so it pinned the launch binary itself and can compare it
+                // (the daemon path reads the same answer off the exit event).
+                // The respawn re-pins the new binary as its own baseline, so a
+                // relaunch cannot loop.
+                let outcome = Self.sessionExit(
+                    code: code,
+                    isAgentSession: isAgentSession,
+                    isPlainTerminal: session.agent == .terminal,
+                    executableReplaced: pty?.childExecutableWasReplaced() == true)
+                switch outcome {
+                case .relaunch:
+                    self?.relaunchSession(session.id)
                     return
+                case .revertToShell:
+                    self?.revertSessionToShell(session.id)
+                    return
+                case .close, .park:
+                    break
                 }
                 // Report the *real* runtime, not 0. On macOS ghostty ignores the
                 // exit code and shows its "failed to launch the requested command"
@@ -377,14 +417,11 @@ extension TermioStore {
                 // "process exited" message, reserving the scary banner for genuine
                 // sub-threshold launch failures (binary not found, bad argv).
                 inMemory?.finish(exitCode: UInt32(bitPattern: code), runtimeMilliseconds: runtimeMs)
-                // A plain terminal that exits *cleanly* closes its tab like a
-                // native terminal (Terminal.app / iTerm2 / Ghostty all do this) —
-                // you typed `exit`, so the pane goes away with no extra keypress.
-                // A non-zero exit (terminal or agent — clean agent exits were
-                // handled above) is left on screen so its error output stays
-                // readable rather than silently vanishing. ghostty can't read
-                // the exit code reliably on macOS, but our `waitpid` here can.
-                if session.agent == .terminal, code == 0 {
+                // ghostty can't read the exit code reliably on macOS, but our
+                // `waitpid` here can — which is what lets a clean plain-terminal
+                // exit close its tab like a native terminal while a failure stays
+                // on screen.
+                if outcome == .close {
                     self?.closeSession(session.id)
                 }
             }

--- a/Tests/termioTests/TermiodEventTests.swift
+++ b/Tests/termioTests/TermiodEventTests.swift
@@ -287,6 +287,82 @@ final class TermiodEventTests: XCTestCase {
         XCTAssertEqual(grave.agentID, "claude")
     }
 
+    /// A grave carries the self-update verdict. The exit *event* carries it too,
+    /// but only to clients that were attached when it fired — for a Mac that was
+    /// asleep when the agent replaced itself and quit, this is the only route.
+    func testATombstoneCarriesTheSelfUpdateVerdict() throws {
+        guard case .sessions(let payload) = try control("""
+        {"op":"sessions","sessions":[],"tombstones":[
+          {"id":"s_9","name":"9F1C-…","cwd":"/code","command":"claude",
+           "reason":"exited","exit_status":0,"created_unix":1786880000,
+           "ended_unix":1786886075,"status":"done","child_executable_replaced":true}]}
+        """) else { return XCTFail("expected a sessions reply") }
+        let grave = try XCTUnwrap(payload.tombstones.first)
+        XCTAssertTrue(grave.childExecutableReplaced)
+    }
+
+    /// `daemon_lost` cannot testify either way — the daemon that would have
+    /// re-read the inode is the thing that died. An absent field must read as
+    /// "nobody measured", never as a positive "not replaced" the UI could show.
+    func testALostGraveDoesNotClaimTheBinarySurvived() throws {
+        guard case .sessions(let payload) = try control("""
+        {"op":"sessions","sessions":[],"tombstones":[
+          {"id":"s_9","name":"9F1C-…","cwd":"/code","command":"claude",
+           "reason":"daemon_lost","created_unix":1786880000,"ended_unix":1786886075,
+           "status":"working"}]}
+        """) else { return XCTFail("expected a sessions reply") }
+        let grave = try XCTUnwrap(payload.tombstones.first)
+        XCTAssertFalse(grave.childExecutableReplaced)
+    }
+
+    // MARK: - What a roster-only row is called
+
+    private func information(_ json: String) throws -> Termiod.SessionInformation {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(Termiod.SessionInformation.self, from: Data(json.utf8))
+    }
+
+    /// The row this whole field exists for: a session on another machine that
+    /// this app has never attached to. There is no surface to read a title off,
+    /// and `command` is the login-shell wrapper Termio spawns through — so the
+    /// only non-guess is what the device's kernel reported.
+    func testARosterOnlyRowIsNamedByTheKernelNotTheCommandString() throws {
+        let info = try information("""
+        {"id":"s_1","name":"9F1C-…","pid":4242,"alive":true,"cwd":"/code",
+         "command":"/bin/zsh -ilc exec claude --resume","status":"working",
+         "created_unix":1786880000,"attached_clients":0,
+         "foreground_pid":4310,"foreground_argv":["/opt/homebrew/bin/npm","run","build"],
+         "foreground_job":true}
+        """)
+        XCTAssertEqual(info.displayLabel, "npm",
+                       "the kernel said npm; the command string would have guessed claude")
+    }
+
+    /// A daemon that did not answer must leave the label alone rather than blank
+    /// it — the string rules stay as the fallback, so an older host reads exactly
+    /// as it did before the field existed.
+    func testAnUnansweredForegroundFallsBackToTheCommandString() throws {
+        let info = try information("""
+        {"id":"s_1","name":"9F1C-…","pid":4242,"alive":true,"cwd":"/code",
+         "command":"/bin/zsh -ilc exec claude --resume","status":"working",
+         "created_unix":1786880000,"attached_clients":0}
+        """)
+        XCTAssertEqual(info.displayLabel, "claude")
+    }
+
+    /// An agent that reported a title outranks both. The title is what the agent
+    /// says it is *doing*; the argv is only what it is running.
+    func testAReportedTitleStillOutranksTheForegroundArgv() throws {
+        let info = try information("""
+        {"id":"s_1","name":"9F1C-…","pid":4242,"alive":true,"cwd":"/code",
+         "command":"/bin/zsh -il","status":"working","title":"fix #164",
+         "created_unix":1786880000,"attached_clients":0,
+         "foreground_argv":["/usr/bin/git","rebase","-i"]}
+        """)
+        XCTAssertEqual(info.displayLabel, "fix #164")
+    }
+
     /// A daemon too old to bury anything answers without the field. The live
     /// list is still the answer to the question asked, so the reply must decode.
     func testSessionsReplyWithoutTombstonesDecodes() throws {

--- a/Tests/termioTests/TermiodEventTests.swift
+++ b/Tests/termioTests/TermiodEventTests.swift
@@ -363,6 +363,20 @@ final class TermiodEventTests: XCTestCase {
         XCTAssertEqual(info.displayLabel, "fix #164")
     }
 
+    /// The idle row, which is most of them: a session sitting at its prompt
+    /// reports its own login shell as the foreground, and a login shell's
+    /// `argv[0]` carries the `-` marker (`termiod/src/pty.rs` sets it). Passing
+    /// that through would name the commonest roster row `-zsh`.
+    func testALoginShellIsNamedWithoutItsLoginMarker() throws {
+        let info = try information("""
+        {"id":"s_1","name":"9F1C-…","pid":4242,"alive":true,"cwd":"/code",
+         "command":"/bin/zsh -il","status":"idle",
+         "created_unix":1786880000,"attached_clients":0,
+         "foreground_pid":4242,"foreground_argv":["-zsh"]}
+        """)
+        XCTAssertEqual(info.displayLabel, "zsh")
+    }
+
     /// A daemon too old to bury anything answers without the field. The live
     /// list is still the answer to the question asked, so the reply must decode.
     func testSessionsReplyWithoutTombstonesDecodes() throws {

--- a/Tests/termioTests/TermiodEventTests.swift
+++ b/Tests/termioTests/TermiodEventTests.swift
@@ -70,6 +70,185 @@ final class TermiodEventTests: XCTestCase {
             #"{"ev":"session_exited","session":"s_1","status":137}"#)
         else { return XCTFail("expected a session_exited event") }
         XCTAssertEqual(exit.status, 137)
+        // A daemon that predates the exit row. The exit is still the answer to
+        // the question asked, so it decodes — with nothing claimed about the
+        // process.
+        XCTAssertNil(exit.info)
+    }
+
+    // MARK: - What the device says the process is
+
+    /// The push this whole plane exists for: the host reports the foreground
+    /// group's argv, the child's live directory, and whether a job is running —
+    /// facts, with no opinion about which agent that is.
+    func testRosterCarriesTheProcessFacts() throws {
+        guard case .roster(let update) = try event("""
+        {"ev":"roster","session":"s_1","action":"updated","info":
+          {"id":"s_1","name":"demo","cwd":"/code/termio","command":"/bin/zsh -il","pid":4242,
+           "rows":40,"cols":120,"clients":1,"created_unix":1786880000,"alive":true,
+           "status":"working","attached_clients":1,
+           "foreground_pid":4310,"foreground_argv":["claude","--resume"],"foreground_job":true,
+           "child_cwd":"/code/termio/web","child_executable":"/opt/homebrew/bin/claude",
+           "child_executable_replaced":true}}
+        """) else { return XCTFail("expected a roster event") }
+        XCTAssertEqual(update.action, "updated")
+        let info = try XCTUnwrap(update.info)
+        XCTAssertEqual(info.foregroundPid, 4310)
+        XCTAssertEqual(info.foregroundArgv, ["claude", "--resume"])
+        XCTAssertEqual(info.foregroundJob, true)
+        XCTAssertEqual(info.childCwd, "/code/termio/web")
+        XCTAssertEqual(info.childExecutable, "/opt/homebrew/bin/claude")
+        XCTAssertEqual(info.childExecutableReplaced, true)
+    }
+
+    /// A delta that only announces a session's arrival or departure carries no
+    /// row. There is nothing to update, and that must not fail the decode.
+    func testARosterDeltaWithoutARowDecodes() throws {
+        guard case .roster(let update) = try event(
+            #"{"ev":"roster","session":"s_1","action":"removed"}"#)
+        else { return XCTFail("expected a roster event") }
+        XCTAssertNil(update.info)
+    }
+
+    /// A daemon too old to sample the child answers with none of these fields.
+    /// Each must decode to `nil` — *unanswered* — rather than to a default that
+    /// would read as the device asserting something about the process.
+    func testAnOldDaemonsRowClaimsNothingAboutTheProcess() throws {
+        guard case .sessions(let payload) = try control("""
+        {"op":"sessions","sessions":[
+          {"id":"s_1","name":"demo","pid":4242,"alive":true,"cwd":"/code","command":"/bin/zsh -il",
+           "status":"unknown","created_unix":1786880000,"attached_clients":1}]}
+        """) else { return XCTFail("expected a sessions reply") }
+        let info = try XCTUnwrap(payload.sessions.first)
+        XCTAssertNil(info.foregroundPid)
+        XCTAssertNil(info.foregroundArgv)
+        XCTAssertNil(info.foregroundJob)
+        XCTAssertNil(info.childCwd)
+        XCTAssertNil(info.childExecutable)
+        XCTAssertNil(info.childExecutableReplaced)
+    }
+
+    /// The daemon omits `foreground_job` when it is false, so a shell idling at
+    /// its prompt on a *current* daemon carries no more of that field than an old
+    /// daemon does. Both mean "do not confirm this close", which is why nothing
+    /// has to tell them apart — but the sampled fields that *do* arrive show the
+    /// row was sampled, so the absence is a real `false` and not a blind spot.
+    func testAnIdlePromptOmitsTheForegroundJobRatherThanDenyingIt() throws {
+        guard case .roster(let update) = try event("""
+        {"ev":"roster","session":"s_1","action":"updated","info":
+          {"id":"s_1","name":"demo","cwd":"/code","command":"/bin/zsh -il","pid":4242,
+           "rows":40,"cols":120,"clients":1,"created_unix":1786880000,"alive":true,
+           "status":"unknown","attached_clients":1,
+           "foreground_pid":4242,"foreground_argv":["-zsh"],"child_cwd":"/code"}}
+        """) else { return XCTFail("expected a roster event") }
+        let info = try XCTUnwrap(update.info)
+        XCTAssertNil(info.foregroundJob)
+        XCTAssertEqual(info.foregroundPid, 4242)
+        XCTAssertEqual(info.foregroundArgv, ["-zsh"])
+    }
+
+    /// The exit's own row, which is the point of carrying one: the replacement
+    /// check is made on the exit path, not read from a poll that ran seconds
+    /// before the agent quit.
+    func testSessionExitedCarriesTheDevicesFinalWord() throws {
+        guard case .sessionExited(let exit) = try event("""
+        {"ev":"session_exited","session":"s_1","status":0,"info":
+          {"id":"s_1","name":"demo","cwd":"/code","command":"codex","pid":4242,
+           "rows":40,"cols":120,"clients":0,"created_unix":1786880000,"alive":false,
+           "status":"done","attached_clients":0,
+           "child_executable":"/opt/homebrew/bin/codex","child_executable_replaced":true}}
+        """) else { return XCTFail("expected a session_exited event") }
+        let info = try XCTUnwrap(exit.info)
+        XCTAssertFalse(info.alive)
+        XCTAssertEqual(info.childExecutableReplaced, true)
+    }
+
+    // MARK: - Where an arriving row lands
+
+    private func link() -> TermiodSessionLink {
+        TermiodSessionLink(
+            sessionName: "demo",
+            specification: Termiod.CreateSpecification(
+                cwd: "/code", argv: [], env: [], rows: 40, cols: 120),
+            rows: 40, cols: 120)
+    }
+
+    private static let liveRoster = """
+    {"ev":"roster","session":"s_1","action":"updated","info":
+      {"id":"s_1","name":"demo","cwd":"/code","command":"/bin/zsh -il","pid":4242,
+       "rows":40,"cols":120,"clients":1,"created_unix":1786880000,"alive":true,
+       "status":"working","attached_clients":1,
+       "foreground_pid":4310,"foreground_argv":["npm","run","build"],"foreground_job":true}}
+    """
+
+    private static let exitRow = """
+    {"ev":"session_exited","session":"s_1","status":0,"info":
+      {"id":"s_1","name":"demo","cwd":"/code","command":"codex","pid":4242,
+       "rows":40,"cols":120,"clients":0,"created_unix":1786880000,"alive":false,
+       "status":"done","attached_clients":0,"child_executable_replaced":true}}
+    """
+
+    /// A roster push is what the close confirmation reads, so it lands in the
+    /// live cache.
+    func testARosterPushLandsInTheLiveCache() {
+        let link = self.link()
+        _ = link.handleEvent(Data(Self.liveRoster.utf8))
+        XCTAssertEqual(link.latestInformation?.foregroundJob, true)
+    }
+
+    /// The exit row must never reach that cache. It describes a session that has
+    /// **ended** — `alive: false`, nothing in the foreground — and it is recorded
+    /// on the reader thread while the link is still registered, so overwriting
+    /// the live row here would let a close asked in that window be answered by a
+    /// dead process's blank sample.
+    func testTheExitRowNeverOverwritesTheLiveCache() {
+        let link = self.link()
+        _ = link.handleEvent(Data(Self.liveRoster.utf8))
+        _ = link.handleEvent(Data(Self.exitRow.utf8))
+
+        let cached = link.latestInformation
+        XCTAssertEqual(cached?.foregroundJob, true, "the live row must still be the live row")
+        XCTAssertEqual(cached?.alive, true)
+        XCTAssertNil(cached?.childExecutableReplaced)
+    }
+
+    /// And the exit still gets the device's final word, which is the only place
+    /// the replacement check is made on the exit path rather than read off a poll.
+    func testTheExitCarriesTheDevicesFinalReplacementAnswer() {
+        let link = self.link()
+        let delivered = expectation(description: "exit delivered")
+        var reported: Termiod.SessionInformation?
+        link.onExit = { _, _, information in
+            reported = information
+            delivered.fulfill()
+        }
+        _ = link.handleEvent(Data(Self.liveRoster.utf8))
+        _ = link.handleEvent(Data(Self.exitRow.utf8))
+
+        wait(for: [delivered], timeout: 2)
+        XCTAssertEqual(reported?.childExecutableReplaced, true)
+        XCTAssertEqual(reported?.alive, false)
+    }
+
+    /// A daemon too old to carry an exit row leaves the exit with nothing to read
+    /// — and the live cache is deliberately not a fallback: a row sampled seconds
+    /// before the exit answers a different question.
+    func testAnExitWithNoRowReportsNothingRatherThanTheLastPoll() {
+        let link = self.link()
+        let delivered = expectation(description: "exit delivered")
+        var reported: Termiod.SessionInformation?
+        var sawExit = false
+        link.onExit = { _, _, information in
+            reported = information
+            sawExit = true
+            delivered.fulfill()
+        }
+        _ = link.handleEvent(Data(Self.liveRoster.utf8))
+        _ = link.handleEvent(Data(#"{"ev":"session_exited","session":"s_1","status":0}"#.utf8))
+
+        wait(for: [delivered], timeout: 2)
+        XCTAssertTrue(sawExit)
+        XCTAssertNil(reported)
     }
 
     /// Additive evolution: an event from a newer daemon is ignored by name, not

--- a/Tests/termioTests/TermiodStatusTests.swift
+++ b/Tests/termioTests/TermiodStatusTests.swift
@@ -116,6 +116,293 @@ final class TermiodStatusTests: XCTestCase {
         XCTAssertNil(store.runtimes[stranger])
     }
 
+    // MARK: - Host-reported process facts
+
+    /// Builds one roster row from the daemon's own JSON, with only the sampled
+    /// fields the test cares about present — which is also how the wire looks,
+    /// since the host omits what it could not answer.
+    private func information(_ sampled: String, alive: Bool = true) throws
+        -> Termiod.SessionInformation {
+        let json = """
+        {"id":"s_1","name":"demo","cwd":"/code/termio","command":"/bin/zsh -il","pid":4242,
+         "rows":40,"cols":120,"clients":1,"created_unix":1786880000,"alive":\(alive),
+         "status":"unknown","attached_clients":1\(sampled.isEmpty ? "" : ",\(sampled)")}
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(Termiod.SessionInformation.self, from: Data(json.utf8))
+    }
+
+    /// A session that answers to no folder — the only kind whose cwd is its own.
+    private func makeLooseStore(with session: Session) -> TermioStore {
+        var workspace = Workspace(name: "Sessions")
+        workspace.terminals = [session]
+        let defaults = UserDefaults(suiteName: "termiod-status-\(UUID().uuidString)")
+        return TermioStore(workspaces: [workspace], projects: [],
+                           settings: AppSettings(defaults: defaults ?? .standard))
+    }
+
+    /// A loose terminal owns its cwd, so the device's answer lands where the
+    /// in-process kernel poll's answer lands.
+    func testTheChildsDirectoryIsFollowedForALooseTerminal() throws {
+        let session = Session(title: "ukvps", agent: .terminal)
+        let store = makeLooseStore(with: session)
+
+        store.applyTermiodInformation(
+            try information(#""child_cwd":"/code/termio/web""#),
+            for: session.id, identifiesAgent: true, followsWorkingDirectory: true)
+
+        XCTAssertEqual(store.workingDirectory(for: session.id), "/code/termio/web")
+    }
+
+    /// A project session's place is its project, not wherever its shell wandered.
+    /// The in-process poll reads no cwd for one of these at all, and the daemon
+    /// path must not quietly start following one just because the host offers it.
+    func testAProjectSessionsDirectoryIsNotFollowed() throws {
+        let session = Session(title: "shell", agent: .terminal)
+        let store = makeStore(with: session)
+
+        store.applyTermiodInformation(
+            try information(#""child_cwd":"/tmp/somewhere-else""#),
+            for: session.id, identifiesAgent: true, followsWorkingDirectory: false)
+
+        XCTAssertNil(store.workingDirectory(for: session.id))
+    }
+
+    /// A daemon that did not answer must not move the row. An absent directory
+    /// is not "the shell is at `/`" — it is silence, and silence leaves the last
+    /// known place alone.
+    func testAnUnansweredDirectoryLeavesTheRowWhereItWas() throws {
+        let session = Session(title: "ukvps", agent: .terminal)
+        let store = makeLooseStore(with: session)
+        store.noteWorkingDirectory("/code/termio", for: session.id)
+
+        store.applyTermiodInformation(
+            try information(#""foreground_pid":4242"#),
+            for: session.id, identifiesAgent: true, followsWorkingDirectory: true)
+
+        XCTAssertEqual(store.workingDirectory(for: session.id), "/code/termio")
+    }
+
+    /// An answered argv that matches no agent is the shell resurfacing: the
+    /// hand-started agent exited, so the row stops being that agent.
+    func testAShellResurfacingDemotesAPromotedRow() throws {
+        var session = Session(title: "Claude Code", agent: .terminal)
+        session.agent = AgentCatalog.shared.definition(for: "claude")
+        let store = makeStore(with: session)
+
+        store.applyTermiodInformation(
+            try information(#""foreground_pid":4242,"foreground_argv":["-zsh"]"#),
+            for: session.id, identifiesAgent: true, followsWorkingDirectory: false)
+
+        XCTAssertEqual(store.session(session.id)?.agent, .terminal)
+    }
+
+    /// An *unanswered* argv is not a shell. An old daemon, or a process the
+    /// kernel would not answer for, must never be read as "the agent is gone".
+    func testAnUnansweredArgvNeverDemotesARow() throws {
+        var session = Session(title: "Claude Code", agent: .terminal)
+        session.agent = AgentCatalog.shared.definition(for: "claude")
+        let store = makeStore(with: session)
+
+        store.applyTermiodInformation(
+            try information(#""child_cwd":"/code/termio""#),
+            for: session.id, identifiesAgent: true, followsWorkingDirectory: false)
+
+        XCTAssertEqual(store.session(session.id)?.agent.id, "claude")
+    }
+
+    /// A declared agent session never takes the identity half. Its foreground is
+    /// whatever the agent spawned — a `rg`, a `git` — and reading that as "no
+    /// agent here" would demote the row mid-turn. Mirrors where the in-process
+    /// poll is installed: shell-backed rows only.
+    func testADeclaredAgentSessionIsNotIdentifiedFromItsForeground() throws {
+        var session = Session(title: "Claude Code", agent: .terminal)
+        session.agent = AgentCatalog.shared.definition(for: "claude")
+        let store = makeStore(with: session)
+
+        store.applyTermiodInformation(
+            try information(#""foreground_pid":9001,"foreground_argv":["rg","--json","TODO"]"#),
+            for: session.id, identifiesAgent: false, followsWorkingDirectory: false)
+
+        XCTAssertEqual(store.session(session.id)?.agent.id, "claude")
+    }
+
+    /// A row this app does not have is not this app's story — the push must not
+    /// mint a runtime for it.
+    func testAPushForAnUnknownSessionIsDropped() throws {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(with: session)
+        let stranger = UUID()
+
+        store.applyTermiodInformation(
+            try information(#""child_cwd":"/code""#),
+            for: stranger, identifiesAgent: true, followsWorkingDirectory: true)
+
+        XCTAssertNil(store.runtimes[stranger])
+    }
+
+    // MARK: - Which producer answers "is a command running"
+
+    /// The producer that owns the process wins, including when it says no: an
+    /// in-process PTY is asked at the instant of the question, so its fresh
+    /// `false` outranks a roster push sampled up to a poll ago.
+    func testTheLocalPtyOutranksTheDevicesSample() {
+        XCTAssertEqual(
+            TermioStore.foregroundJob(reportedLocally: false, reportedByDevice: true), false)
+        XCTAssertEqual(
+            TermioStore.foregroundJob(reportedLocally: true, reportedByDevice: false), true)
+    }
+
+    /// A session this app does not host has only the device to ask.
+    func testADaemonHostedSessionIsAnsweredByTheDevice() {
+        XCTAssertEqual(
+            TermioStore.foregroundJob(reportedLocally: nil, reportedByDevice: true), true)
+        XCTAssertEqual(
+            TermioStore.foregroundJob(reportedLocally: nil, reportedByDevice: false), false)
+    }
+
+    /// Nobody answering is not `false` — it is the absence the skew rule turns
+    /// into today's no-confirm behaviour, one layer up.
+    func testNobodyAnsweringStaysUnanswered() {
+        XCTAssertNil(TermioStore.foregroundJob(reportedLocally: nil, reportedByDevice: nil))
+    }
+
+    /// Only an explicit `true` confirms. A shell with no producer at all — no PTY
+    /// here, no link, which is every restored row before it is surfaced — closes
+    /// without a dialog, and so does an agent row whichever way it answers.
+    func testOnlyAnAnsweredJobEverConfirmsAClose() {
+        let shell = Session(title: "shell", agent: .terminal)
+        var agent = Session(title: "Claude Code", agent: .terminal)
+        agent.agent = AgentCatalog.shared.definition(for: "claude")
+        let store = makeStore(with: shell)
+
+        XCTAssertNil(store.closeConfirmationReason(for: shell))
+        XCTAssertNil(store.closeConfirmationReason(for: agent))
+    }
+
+    // MARK: - The exit policy both backends run
+
+    /// A clean agent quit hands the pane back to a shell, and the same quit
+    /// after the binary was replaced underneath it restarts the agent instead.
+    /// One policy, whichever machine the PTY was on.
+    func testACleanAgentQuitRevertsUnlessItsBinaryWasReplaced() {
+        XCTAssertEqual(
+            TermioStore.sessionExit(code: 0, isAgentSession: true, isPlainTerminal: false,
+                                    executableReplaced: false),
+            .revertToShell)
+        XCTAssertEqual(
+            TermioStore.sessionExit(code: 0, isAgentSession: true, isPlainTerminal: false,
+                                    executableReplaced: true),
+            .relaunch)
+    }
+
+    /// A plain terminal that exits cleanly closes its pane like a native terminal
+    /// tab; an SSH terminal is one of those too, which is why the flags are
+    /// separate rather than one being the negation of the other.
+    func testACleanTerminalExitClosesThePane() {
+        XCTAssertEqual(
+            TermioStore.sessionExit(code: 0, isAgentSession: false, isPlainTerminal: true,
+                                    executableReplaced: false),
+            .close)
+    }
+
+    /// Anything non-zero stays on screen: its output is the only record of what
+    /// went wrong, and closing or respawning over it loses that.
+    func testANonZeroExitAlwaysParks() {
+        for agent in [true, false] {
+            for terminal in [true, false] {
+                XCTAssertEqual(
+                    TermioStore.sessionExit(code: 1, isAgentSession: agent,
+                                            isPlainTerminal: terminal,
+                                            executableReplaced: true),
+                    .park)
+            }
+        }
+    }
+
+    // MARK: - The exit, wired
+
+    private func agentSession() -> Session {
+        var session = Session(title: "Claude Code", agent: .terminal)
+        session.agent = AgentCatalog.shared.definition(for: "claude")
+        return session
+    }
+
+    /// The wiring the whole exit row exists for: the device says the agent's
+    /// binary was replaced under it, so the quit becomes the restart it asked
+    /// for — the row keeps its identity and its process is respawned, rather than
+    /// being handed back to a shell.
+    func testAReplacedBinaryRelaunchesTheAgentInPlace() throws {
+        let session = agentSession()
+        let store = makeStore(with: session)
+        store.setStatus(.working, for: session.id)
+
+        store.applyTermiodExit(
+            for: session.id, code: 0, runtimeMilliseconds: 90_000,
+            information: try information(#""child_executable_replaced":true"#, alive: false),
+            isAgentSession: true, isPlainTerminal: false, surface: nil)
+
+        XCTAssertEqual(store.session(session.id)?.agent.id, "claude")
+        XCTAssertEqual(store.status(for: session.id), .idle)
+    }
+
+    /// The same clean quit with the binary untouched is a plain `/quit`: the pane
+    /// goes back to being a shell.
+    func testAnUntouchedBinaryHandsThePaneBackToAShell() throws {
+        let session = agentSession()
+        let store = makeStore(with: session)
+
+        store.applyTermiodExit(
+            for: session.id, code: 0, runtimeMilliseconds: 90_000,
+            information: try information("", alive: false),
+            isAgentSession: true, isPlainTerminal: false, surface: nil)
+
+        XCTAssertEqual(store.session(session.id)?.agent, .terminal)
+    }
+
+    /// A daemon too old to carry an exit row says nothing, and nothing must never
+    /// respawn a process the user quit.
+    func testAnExitWithNoRowFromTheDeviceRevertsRatherThanRelaunching() {
+        let session = agentSession()
+        let store = makeStore(with: session)
+
+        store.applyTermiodExit(
+            for: session.id, code: 0, runtimeMilliseconds: 90_000, information: nil,
+            isAgentSession: true, isPlainTerminal: false, surface: nil)
+
+        XCTAssertEqual(store.session(session.id)?.agent, .terminal)
+    }
+
+    /// A clean plain-terminal exit takes the pane with it, and the link goes with
+    /// the row.
+    func testACleanTerminalExitRemovesTheRow() throws {
+        let session = Session(title: "shell", agent: .terminal)
+        let store = makeStore(with: session)
+
+        store.applyTermiodExit(
+            for: session.id, code: 0, runtimeMilliseconds: 5_000,
+            information: try information("", alive: false),
+            isAgentSession: false, isPlainTerminal: true, surface: nil)
+
+        XCTAssertNil(store.session(session.id))
+    }
+
+    /// A failure parks: the row stays exactly as it was, so its output is still
+    /// on screen to read. Even with the replacement flag set — a non-zero exit is
+    /// not the restart the agent asked for.
+    func testAFailedExitLeavesTheRowStanding() throws {
+        let session = agentSession()
+        let store = makeStore(with: session)
+
+        store.applyTermiodExit(
+            for: session.id, code: 1, runtimeMilliseconds: 90_000,
+            information: try information(#""child_executable_replaced":true"#, alive: false),
+            isAgentSession: true, isPlainTerminal: false, surface: nil)
+
+        XCTAssertEqual(store.session(session.id)?.agent.id, "claude")
+    }
+
     // MARK: - Tombstones
 
     private func tombstone(name: String, reason: String) throws -> Termiod.SessionTombstone {

--- a/Tests/termioTests/TermiodWireOrderIntegrationTests.swift
+++ b/Tests/termioTests/TermiodWireOrderIntegrationTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import termio
+
+/// Roster-then-exit ordering, against a real daemon and this app's real client.
+///
+/// The two halves of session-fact reporting are each tested against their own
+/// fixtures — Rust encodes what it says it encodes, Swift decodes what it says
+/// it decodes — and that pair of green suites still says nothing about the one
+/// thing a user sees: a live row that updates while a session runs and then
+/// settles onto its final state, in that order. A decode test cannot catch a
+/// field the daemon never actually sends, an ordering the fan-out does not
+/// preserve, or an exit row that overwrites the live cache on the way past.
+///
+/// Opt-in on the same terms as `TermiodFilesIntegrationTests`: point
+/// `TERMIO_TERMIOD_TEST_BIN` at a built `termiod` and it runs, otherwise it
+/// skips, so `swift test` never grows a cargo dependency.
+final class TermiodWireOrderIntegrationTests: XCTestCase {
+    private var binary = ""
+    private var daemon: Process?
+    private var socketDirectory: URL?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let configured = ProcessInfo.processInfo.environment["TERMIO_TERMIOD_TEST_BIN"] ?? ""
+        try XCTSkipIf(configured.isEmpty, "set TERMIO_TERMIOD_TEST_BIN to run this")
+        binary = configured
+
+        // Short socket directory name: `sun_path` is capped at 104 bytes and the
+        // per-user temp directory already spends half of it.
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("two-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        socketDirectory = directory
+        let socket = directory.appendingPathComponent("termiod.sock").path
+        XCTAssertLessThan(socket.utf8.count, 104, "socket path must fit sun_path")
+        setenv("TERMIOD_SOCK", socket, 1)
+
+        let serve = Process()
+        serve.executableURL = URL(fileURLWithPath: binary)
+        serve.arguments = ["serve"]
+        serve.environment = ProcessInfo.processInfo.environment.merging(
+            ["TERMIOD_SOCK": socket]) { _, new in new }
+        serve.standardOutput = FileHandle.nullDevice
+        serve.standardError = FileHandle.nullDevice
+        try serve.run()
+        daemon = serve
+
+        let deadline = Date().addingTimeInterval(10)
+        while !FileManager.default.fileExists(atPath: socket), Date() < deadline {
+            usleep(50_000)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socket), "daemon never bound")
+    }
+
+    override func tearDownWithError() throws {
+        daemon?.terminate()
+        daemon?.waitUntilExit()
+        if let socketDirectory {
+            try? FileManager.default.removeItem(at: socketDirectory)
+        }
+        unsetenv("TERMIOD_SOCK")
+        try super.tearDownWithError()
+    }
+
+    /// What arrived, in the order it arrived. Recorded rather than asserted
+    /// inline because the claim under test *is* the sequence.
+    private enum Arrival {
+        case information(Termiod.SessionInformation)
+        case exit(Int32, Termiod.SessionInformation?)
+    }
+
+    /// A session that outlives one foreground poll (2 s, `session.rs`
+    /// `FOREGROUND_POLL`) and then exits with a status worth telling apart from
+    /// zero, so the run covers a live update *and* a distinctive ending.
+    func testALiveRowArrivesBeforeTheExitAndTheExitCarriesTheFinalWord() throws {
+        let link = TermiodSessionLink(
+            sessionName: "wire-order-\(UUID().uuidString.prefix(8))",
+            specification: Termiod.CreateSpecification(
+                cwd: NSTemporaryDirectory(),
+                argv: ["/bin/sh", "-c", "sleep 3; exit 7"],
+                env: [], rows: 24, cols: 80),
+            rows: 24, cols: 80)
+
+        var arrivals: [Arrival] = []
+        let ended = expectation(description: "session exits")
+        link.onInformation = { information in
+            arrivals.append(.information(information))
+        }
+        link.onExit = { status, _, information in
+            arrivals.append(.exit(status, information))
+            ended.fulfill()
+        }
+        link.start()
+        defer { link.detach() }
+
+        wait(for: [ended], timeout: 30)
+
+        guard let last = arrivals.last, case .exit(let status, let final) = last else {
+            return XCTFail("the exit must be the last thing this client hears")
+        }
+        XCTAssertEqual(status, 7, "the child's own status, not a generic failure")
+
+        let liveRows = arrivals.compactMap { arrival -> Termiod.SessionInformation? in
+            if case .information(let information) = arrival { return information }
+            return nil
+        }
+        XCTAssertFalse(liveRows.isEmpty,
+                       "a session that outlives a foreground poll must push at least one row")
+        XCTAssertTrue(liveRows.allSatisfy(\.alive),
+                      "every row before the exit describes a living session")
+
+        // §2.3(b): the replacement check is made on the exit path, so the exit
+        // must carry a row of its own rather than leaving the client to reuse
+        // the last live one.
+        let information = try XCTUnwrap(final, "the exit must carry the device's final row")
+        XCTAssertFalse(information.alive, "the final row describes a session that has ended")
+    }
+
+    /// The exit row must not land in the live cache on its way past. It
+    /// describes a session that has **ended**, and a close confirmation that
+    /// read it would ask about a job on a dead session.
+    func testTheExitRowNeverBecomesTheLiveRow() throws {
+        let link = TermiodSessionLink(
+            sessionName: "exit-cache-\(UUID().uuidString.prefix(8))",
+            specification: Termiod.CreateSpecification(
+                cwd: NSTemporaryDirectory(),
+                argv: ["/bin/sh", "-c", "sleep 3; exit 0"],
+                env: [], rows: 24, cols: 80),
+            rows: 24, cols: 80)
+
+        let ended = expectation(description: "session exits")
+        link.onExit = { _, _, _ in ended.fulfill() }
+        link.start()
+        defer { link.detach() }
+
+        wait(for: [ended], timeout: 30)
+
+        // Settle: the exit row and the live cache are written on the same queue,
+        // so read after the callback rather than inside it.
+        let drained = expectation(description: "callbacks settle")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 5)
+
+        // Asserted non-nil rather than checked with `if let`: a session that ran
+        // for three seconds outlives a foreground poll, so an empty cache here
+        // would mean no roster ever arrived — which must fail this test, not
+        // pass it by skipping the claim.
+        let cached = try XCTUnwrap(
+            link.latestInformation,
+            "a session that outlived a foreground poll must have left a live row")
+        XCTAssertTrue(cached.alive,
+                      "the live cache holds the last *living* row, never the exit's")
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ from the real front matter).
 | active | design | [Sessions CLI v2 — reliability & command design](design/20260724-sessions-cli-v2.md) |
 | active | research | ["Reading list: PTYs, SSH, and detachable remote terminals"](READING.md) |
 | active | rfc | [Push-to-talk voice dictation — hold the space bar (iOS shipped, OpenAI)](rfcs/push-to-talk-voice-dictation.md) |
+| active | rfc | [Unify the server plane in Rust, reduce the Mac app to a viewer](rfcs/unify-server-plane.md) |
 | approved | design | [会话历史 · 搜索 · 恢复（Session History / Search / Resume）](design/20260628-session-history-search-resume.md) |
 | approved | design | [Agent Resume Identity — keeping the resume pin on the live conversation](design/20260716-agent-resume-identity.md) |
 | approved | design | [Git worktree creation & lifecycle (Codex-aligned)](design/20260706-worktree-creation-lifecycle.md) |
@@ -114,7 +115,6 @@ from the real front matter).
 | draft | rfc | [Remote git — the pane's verbs run on the device](rfcs/remote-git-plane.md) |
 | draft | rfc | [Review — One path, local sessions run through termiod too](rfcs/one-path-local-through-termiod.review-claude.md) |
 | draft | rfc | [Termiod web client on official Ghostty WASM (Linux first)](design/20260818-termiod-web-client-ghostty-wasm.md) |
-| draft | rfc | [Unify the server plane in Rust, reduce the Mac app to a viewer](rfcs/unify-server-plane.md) |
 | fixed | bug | [New terminal opens unfocused (hollow cursor, beeps until clicked)](bug/terminal-focus-loss-on-new-session-mount.md) |
 | fixed | bug | [Terminal loses focus after window deactivation](bug/terminal-focus-loss-on-window-key.md) |
 | fixed | bug | [Terminal loses focus while the window stays key — sibling-render trigger](bug/terminal-focus-loss-on-sibling-render.md) |

--- a/docs/rfcs/unify-server-plane.md
+++ b/docs/rfcs/unify-server-plane.md
@@ -20,7 +20,7 @@ related:
 > One server — `termiod` — owns every answer two people on two machines would
 > expect to match. Swift renders and nothing else. This is the **execution
 > spine**: the single ordered list of what happens next, restamped against the
-> tree at `90b3711`.
+> tree at `c69c022`.
 
 ---
 
@@ -84,7 +84,7 @@ inherited; none is new here.
 
 ---
 
-## 2. Ground truth — measured 2026-08-22 at `90b3711`
+## 2. Ground truth — measured 2026-08-22 at `c69c022`
 
 The first revision of this document was cut at `7fedc72`. Thirteen commits have
 landed under `termiod/` since, and they move three of its eight stages. What
@@ -127,10 +127,11 @@ tree. Stage 1 is closed.
 ### 2.3 The three gaps this restamp exists to record
 
 Stages 5 and 6 of the last revision were **half-landed in Rust and unreached from
-Swift**. All three gaps below now have an implementation, **written and reviewed
-but uncommitted and unmerged** (§2.4) — they are recorded here as the problem
-statement Stage 2 is answering, not as open work. Where an answer is only
-partial, the gate that remains is named in Stage 2.
+Swift**. All three gaps below now have an implementation, **written, reviewed,
+and committed together on `feat/termiod-session-facts`, but unmerged** (§2.4) —
+they are recorded here as the problem statement Stage 2 is answering, not as
+open work. Where an answer is only partial, the gate that remains is named in
+Stage 2.
 
 **(a) Swift never decodes the foreground fields.**
 `Termiod.SessionInformation` (`TermiodClient.swift:780-819`) decodes eleven keys
@@ -191,14 +192,14 @@ Linux path has still never been compiled or run — that is a Stage 2 gate.
 | --- | --- | --- |
 | `feat/termiod-remote-install` (`a497c00`) | 7 files, +732/−3 | **Answers open question 2 of the last revision.** Settings ▸ Machines reports what a box has and installs the slice this app carries; freshness is a digest, not a version string; the upload lands on a temp name and is moved only after `chmod`. Ships `TermiodInstaller.swift` (335) + 155 lines of tests, a `release.yml` artifact step, and `web/landing/public/install.sh`. Folded into Stage 5 |
 | `feat/termiod-wss` (5 commits) | 69 files, +18,791/−4 | A third client and a transport. Adds **zero** protocol verbs and touches **zero** Swift. **Its merge risk is no longer near zero** — `git log --oneline main --not feat/termiod-wss -- termiod/` is now **13 commits**, including `d38f50c`, `c4934c2` and `1746593`, so it needs a rebase across `protocol.rs`, `daemon.rs`, `git.rs` and `session.rs` rather than the byte-identical merge the last stamp described. Deferred, §8 |
-| `feat/stage5-rust-completion` | 0 commits · **+977/−62** uncommitted | **Stage 2's host half, implemented and reviewed.** `proc.rs` +595, `session.rs` +320, `protocol.rs` +117, `daemon.rs` +7. **99 tests pass.** |
-| `feat/stage5-swift-completion` | 0 commits · **+856/−59** uncommitted | **Stage 2's client half, implemented and reviewed.** `TermiodClient.swift` +181, `TermioStore+Termiod.swift` +135, `TermioStore+TerminalSurface.swift` +95, `TermioStore+ProjectActions.swift` +38, and 28 new cases across `TermiodEventTests` (+179) and `TermiodStatusTests` (+287). **483 tests pass.** |
+| `feat/termiod-session-facts` (`f4d8903`, `4f0e7da`) | 4 files · **+985/−62** | **Stage 2's host half, implemented and reviewed.** `proc.rs` +595, `session.rs` +328, `protocol.rs` +117, `daemon.rs` +7. The second commit adapts the new tests to `c69c022`'s graceful-shutdown API. **101 tests pass.** |
+| `feat/termiod-session-facts` (`96c73ad`) | 6 files · **+856/−59** | **Stage 2's client half, implemented and reviewed.** `TermiodClient.swift` +181, `TermioStore+Termiod.swift` +135, `TermioStore+TerminalSurface.swift` +95, `TermioStore+ProjectActions.swift` +38, and 28 new cases across `TermiodEventTests` (+179) and `TermiodStatusTests` (+287). **483 tests pass.** |
 | `feat/foreground-parity` | 0 commits · +42 uncommitted, plus an untracked `TermioStore+SessionFacts.swift` | **An earlier, superseded attempt at the same client half.** It decodes `foregroundJob` as a non-optional `Bool` with `?? false`, which erases "the device did not answer" from the type — the distinction the skew rule rests on — and it carries no tests. **Do not merge it alongside the pair above**; harvest `SessionFacts`'s single-answer framing if anything, and drop the rest. |
 
-**All three point at `main`'s tip and are zero commits ahead.** The last
-revision's §1.5 warned that a survey against a stale `main` reports merged work
-as abandoned; the mirror trap is here — `git log main..<branch>` empty does
-**not** mean the branch is empty. Check `git status` in its worktree too.
+The two completion worktrees were committed separately, then cherry-picked onto
+`feat/termiod-session-facts` at `c69c022` with this RFC. That integration branch
+is the only branch to review or merge for Stage 2. `feat/foreground-parity`
+remains a superseded, uncommitted worktree and must not be combined with it.
 
 ---
 

--- a/docs/rfcs/unify-server-plane.md
+++ b/docs/rfcs/unify-server-plane.md
@@ -1,9 +1,9 @@
 ---
 title: Unify the server plane in Rust, reduce the Mac app to a viewer
-status: draft
+status: active
 type: rfc
 created: 2026-08-19
-updated: 2026-08-19
+updated: 2026-08-22
 related:
   - one-path-local-through-termiod.md
   - one-path-local-through-termiod.review-claude.md
@@ -11,33 +11,50 @@ related:
   - one-workspace-source.review-codex.md
   - remote-git-plane.md
   - 20260805-termiod-device-architecture.md
+  - 20260819-device-workspace-project.md
   - 20260818-termiod-web-client-ghostty-wasm.md
 ---
 
 # Unify the server plane in Rust, reduce the Mac app to a viewer
 
 > One server — `termiod` — owns every answer two people on two machines would
-> expect to match. Swift renders and nothing else. This is the execution plan
-> across the four RFCs that already argued the pieces, corrected against the
-> tree as it stands on `main` at `7fedc72`.
+> expect to match. Swift renders and nothing else. This is the **execution
+> spine**: the single ordered list of what happens next, restamped against the
+> tree at `90b3711`.
 
 ---
 
 ## 0. What this document is, and is not
 
-It is **not** a re-argument. `one-path-local-through-termiod.md` made the case
-and inventoried the split; `one-workspace-source.md` and its codex review
-settled the workspace reference; `remote-git-plane.md` staged git. This document
-does three things those four cannot do individually:
+It is not a re-argument. Four documents already made the case and are still the
+place to read *why*:
 
-1. **Accounts for what is already built**, including on unmerged branches, so
-   the next person does not rebuild it (§1).
+| Document | What it is authoritative for |
+| --- | --- |
+| `20260805-termiod-device-architecture.md` | **The normative invariants.** §4 the presentation boundary, §4.1 what each side owns, §5 the four planes and one connection, §5.1 the connection as an object |
+| `20260819-device-workspace-project.md` | The vocabulary: Device → Workspace → Project → Session, and which of those a device owns |
+| `one-path-local-through-termiod.md` | The Swift-side inventory, the daemon-lifecycle blockers, the CLI verb-by-verb split |
+| `remote-git-plane.md` | The git tiers, and the askpass mechanism |
+
+This document does the three things none of them can do individually:
+
+1. **Restamps them against the tree**, so nobody rebuilds what has landed or
+   reads a solved problem as current (§2).
 2. **Draws the boundary as a file-by-file table** — stays Swift, moves to Rust,
-   deleted — with real line counts measured today (§2).
-3. **Orders the stages against the blocker**, and fixes the citations the source
-   RFCs have drifted on (§3, §4).
+   deleted (§4).
+3. **Orders the work into one list with gates that run** (§6), and says where it
+   disagrees with a source RFC (§7).
 
-Where it disagrees with an existing RFC it says so and shows the code (§5).
+**Two ordering claims are normative here and supersede their sources:**
+
+- **This RFC supersedes device architecture §8's migration ordering.** §8 was
+  written before the daemon shipped in the bundle, before `Checkout`, and before
+  the git read tier; its steps 5–12 no longer describe a runnable sequence. §8's
+  *invariants* stand; its *order* does not. Where §8 numbers a step, §6 cites it
+  and says where it now sits. The one piece of §8's numbering worth keeping is
+  its 4a/4b/4c split of the connection work, which §6 Stage 4 adopts verbatim.
+- **This RFC supersedes `one-workspace-source.md` §5's stage order**, for the
+  reason its own codex review gave (§7.3).
 
 The deciding rule is unchanged, from device architecture §4.1: *would two people
 watching this session from two different machines expect the same answer?* Yes →
@@ -45,133 +62,196 @@ Rust. No → Swift.
 
 ---
 
-## 1. What is already done
+## 1. The invariants this plan runs under
 
-Measured on 2026-08-19. Branch diffs are `git diff --stat main...<branch>` from
-the main checkout; `main` is `7fedc72`.
+Restated only so a stage cannot be read as licence to break one. All are
+inherited; none is new here.
 
-### 1.1 Landed on `main`
-
-Five things the source RFCs list as missing or as future stages are **already on
-`main`**, and three of them carry stale citations that would send an
-implementer down a dead path.
-
-| Item | Where | Which RFC still calls it open |
-| --- | --- | --- |
-| **The `(device, root)` workspace reference exists.** `Checkout` — `device: KnownDevice`, `root: String?`, plus `localRoot`, `isOnAnotherDevice`, `deviceIdentity`, and identity-based `==`/`hash` keyed on `host_id` before alias | `Sources/termio/TermioStore/DeviceContext.swift:56-101`, built by `TermioStore.checkout(for:in:localRoot:routeDeviceID:)` at `TermioStore.swift:513-526` | `one-workspace-source.md` §2 proposes `ProjectLocation`; `remote-git-plane.md` §8.1 says the decision "is unresolved … **This RFC is blocked on that decision**". Both are stale — `grep -rn ProjectLocation Sources/ Shared/` → **0**, and `Checkout` is the shipped answer under a different name |
-| **The panes stopped asking a session how it was opened.** `grep -rn 'sshHost' Sources/termio/FileBrowser/` → **0** | commit `58dc85e`, on `main` | `one-workspace-source.md` §5 marks Stage 0 "implemented" but attributes it to a branch and names a test class (`InspectorWorkspaceTests`) that does not exist. The real suite is `Tests/termioTests/InspectorCheckoutTests.swift`, 6 tests |
-| **SSH ControlMaster multiplexing on the app's own `ssh`.** `multiplexingArguments(host:)` probes `ssh -G`, refuses to override a user's `ControlMaster no`, caps `ControlPath` at 100 bytes, and is applied in `Transport.ssh` | `TermiodClient.swift:208-236`, applied at `:381` | `one-path-local-through-termiod.md` Stage 2 item `4a` asks for exactly this. It is done. Only `BatchMode`/`ConnectTimeout` are absent |
-| **The daemon ships inside the `.app`, universal and signed.** commit `2199f35 feat(termiod): ship the daemon inside the app`. `build-app.sh:201-281` builds one Rust slice per architecture, `lipo`s them, and **fails the build if a required slice is missing** — the same check the app binary already had; `release.yml:90-99` installs the pinned Zig for the VT engine; the daemon is signed before the outer seal (observed: `Contents/Resources/termiod: replacing existing signature`, then the app). `daemonBinaryPath()` resolves `TERMIO_TERMIOD_BIN` → `Bundle.main` → a checkout walk anchored at the *binary*, not `currentDirectoryPath` (`TermiodClient.swift:94-146`) | `one-path-local-through-termiod.md` §5.2 item 1 and `one-binary-and-a-daemon-that-ships.md` §1 both lead with the cwd bug **and** with "the daemon does not ship". Both are fixed. Stage 4 below is what is *left* of that item, not the whole of it |
-| **Tombstones are decoded and cleared client-side.** | `TermioStore+Termiod.swift`, `DeviceSessions.tombstones` at `DeviceContext.swift:113-120` | closed by PR #324, correctly recorded in the one-path RFC's own revision |
-
-### 1.2 `feat/termiod-wss` — 5 commits, 69 files, +18,791/−4
-
-The largest body of unmerged work, and it is **not** the CompanionServer
-migration. It is a third client and a transport, and it adds **zero protocol
-verbs**.
-
-| Commit | What it adds |
-| --- | --- |
-| `2010fa4` | WSS handshake gating — `termiod/src/wss.rs` (1,075 lines, new): loopback-only bind, Origin allowlist, 24-byte `/dev/urandom` token presented as the `termiod.token.<t>` subprotocol, `termiod pair` to mint/rotate, rotation watched with `notify` and closing live splices with `CloseCode::Policy` |
-| `abcda40` | `docs/design/20260818-termiod-web-client-ghostty-wasm.md`, 1,039 lines |
-| `0ff80f0` | The session protocol over a WebSocket. `splice()` opens a fresh `UnixStream` to `paths::socket_path()` and copies bytes verbatim in 64 KiB chunks; WebSocket message boundaries are deliberately not frame boundaries. `termiod/tests/wss_bridge.rs`, 803 lines, 10 tests |
-| `8ca91ae` | `scripts/check-ghostty-pin.sh` + `.github/workflows/ghostty-pin.yml` — holds libghostty-swift, libghostty-rs and the browser's wasm to one ghostty sha |
-| `418dfec` | `web/client/` — 51 files, React 19 + Vite, an unforked prebuilt `ghostty-vt.wasm` pinned by sha256, canvas2d renderer, 219 vitest cases |
-
-Three facts that matter for planning:
-
-- **`termiod/src/protocol.rs` is untouched.** `git diff --name-only
-  main...feat/termiod-wss -- termiod/src/protocol.rs` is empty. The browser is a
-  *subset* re-implementation in TypeScript, advertising
-  `["events","snapshot","scrollback"]` and no `files`/`git`/`upload`.
-- **No Swift is touched.** `git diff --name-only main...feat/termiod-wss | grep
-  -E '^(Sources|Shared|Tests)/'` → nothing. It does not move CompanionServer and
-  does not intend to; the design doc's non-goals name "Replacing the Mac or iOS
-  apps," and the default attach mode is `observe` so a browser cannot steal the
-  write token.
-- **Merge risk is near zero.** `git log --oneline main --not feat/termiod-wss --
-  termiod/` is empty: `main` has not moved under `termiod/` since the branch
-  point `615f49c`. `termiod/ARCHITECTURE.md` is byte-identical on both.
-
-Two gaps the branch carries: nothing in CI runs `vitest`/`tsc`/`vite build` for
-`web/client/`, and `termiod/ARCHITECTURE.md` still describes termiod as
-Unix-socket + `termiod stdio` only.
-
-**Accounting:** this branch is worth merging on its own terms — it proves the
-protocol is transport-agnostic (invariant #4) with a byte-identical splice, and
-it is 100% additive. It is **not** progress on the Swift→Rust boundary, and this
-plan does not depend on it.
-
-### 1.3 `feat/one-workspace-source` — 1 commit, 1 file, +5/−1
-
-`7fc1481 style(sidebar): match the device name to the toolbar glyph color`,
-touching `Sources/termio/Sidebar/DeviceSwitcher.swift` only. **The Stage 0 work
-is on `main`, not on this branch.** The branch is a cosmetic leftover; nothing
-of the ProjectLocation model exists in code anywhere.
-
-### 1.4 `wip/one-binary-rfc` — 1 commit, 2 docs, +884
-
-`docs/rfcs/one-binary-and-a-daemon-that-ships.md` (214 lines) proposed shipping
-`termiod` inside the `.app` **and** merging the two binaries — `termiod` becomes
-a mode of `termio`. The review (670 lines) refused it on six blockers. The two
-that must not be re-proposed:
-
-- **B1** — a daemon named `termio` copied to Application Support lands at
-  `…/Application Support/termio[-dev]/bin/termio`, byte-for-byte the path
-  `CommandLineTool.supportCopyURL` owns (`SessionControl.swift:798,803,829`) and
-  every installed hook command names absolutely. The hook ends `2>/dev/null ||
-  true` (`HookListener.swift:307`), so status reporting would die silently.
-- **B2** — the rename's headline reason is not real. Hooks invoke an absolute
-  path plus five flags and a dialect-dependent stdout contract
-  (`HookListener.swift:289,303-315`), not a binary name. And one-path §7.5 makes
-  `scripts/termio` a *router* to `termiod`: a router named `termio` cannot
-  dispatch to a binary named `termio`.
-
-Salvaged and folded into this plan: ship the daemon in the bundle (§4 Stage 4),
-the launchd-job repair, and the observation that version negotiation is mostly
-already built (`daemon.rs:480-486`).
-
-### 1.5 Already merged upstream
-
-`refactor/workspace-device`, `refactor/workspace-stage2`, `docs/workspace-model`,
-`feat/remote-project-picker` look empty against a *stale* local `main` — and the
-first draft of this document read that as abandonment. They are not abandoned:
-all four merged into `origin/main` as PRs #354–#359, along with
-`chore/machines-tab` and `fix/workspace-menu-reachable`. The branches can be
-deleted; the work they carried is upstream and this plan is rebased onto it.
-
-What landed there and bears directly on this plan:
-
-| Commit | What it changes for us |
-| --- | --- |
-| `16bbf5b` | `refactor(workspaces): give every workspace one device` — the workspace/device pairing this plan assumed it would have to introduce |
-| `f078aef` | `docs(design): settle the device, workspace and project hierarchy` — the hierarchy §3 treats as open is settled here |
-| `315d7a5` | `feat(projects): complete the path when opening a project on another machine` — ships `TermiodDirectoryLister.swift`, a second `fs.list` caller (§4 Stage 1) |
-| `a720448` | `fix(app): gate notifications on Termio's own bundle, not any bundle` |
-
-The lesson is procedural and worth keeping: **a branch survey run against an
-unfetched `main` reports merged work as abandoned.** Fetch first.
-
-### 1.6 The daemon's side of the workspace plane, verified
-
-Not a branch — shipped in `termiod/` on `main`, and unreached from Swift.
-
-| Verb | Handler | Stateful? |
-| --- | --- | --- |
-| `fs.list` | `daemon.rs:1021-1056` → `files::list` (`files.rs:71`) | **No.** Canonicalises the root, confines each path (rejects `..` and symlink escape, `files.rs:49-68`), pages at 2,000 entries, stubs `.git`/`.hg`/`.svn` as `unloaded_dir`, and fails one path in a batch alone |
-| `fs.read` | `daemon.rs:1058-1109` → `files::read` (`files.rs:181`) | **No.** Absolute path, 1 MiB soft cap, replies `fs_file` then `F` chunks |
-| `fs.match` | `daemon.rs:1110-…` | **Yes** — needs a `subscribe_resource` to have built the name index; without one it honestly answers `coverage: 0.0` |
-| `fs.search` | streams `search_results` events, then `fs_searched`; cancellable | **No**, but streaming |
-| `git:` resource, `git.diff` | `resource.rs`, `git.rs` (501 lines: `run_status` + `run_diff` and nothing else) | resource **yes**, `git.diff` no |
-
-Swift reaches none of them: `grep -rn '"fs\.' Sources/ Shared/` → **0**;
-`grep -rn '"git\.' Sources/ Shared/` → **0**.
+1. **Anti-100×** — byte delivery never blocks on a host-side VT parse. The
+   foreground sampler is a two-second poll on the session actor for exactly this
+   reason (`session.rs:1501-1509`), not a read per frame.
+2. **State sync at boundaries only** — snapshots on attach, resize and resync.
+   `grid_diff` stays opt-in.
+3. **Never embed SSH or crypto.** System OpenSSH, the user's `~/.ssh/config`.
+4. **One protocol, versioned and transport-agnostic.** A second protocol for the
+   phone is a violation, which is why the companion wire is a debt (§8) and not
+   a design.
+5. **No nested window manager in the host.** One PTY per session.
+6. **Single writer, many readers.**
+7. **The host describes state; it never decides how that state looks**
+   (device arch §4). The `grid_diff` refusal at `TermiodClient.swift:27` and the
+   `S`-payload `palette: false` fix are the same rule twice.
 
 ---
 
-## 2. The boundary
+## 2. Ground truth — measured 2026-08-22 at `90b3711`
 
-### 2.1 Stays Swift — the viewer, and the stopping line
+The first revision of this document was cut at `7fedc72`. Thirteen commits have
+landed under `termiod/` since, and they move three of its eight stages. What
+follows replaces §1 of that revision wholesale.
+
+### 2.1 Landed since the last stamp
+
+| Commit | What it changes for this plan |
+| --- | --- |
+| `d38f50c feat(termiod): serve the git read tier from the device` | `git.log`, `git.show`, `git.branches` beside `git.diff`. `git.rs` 501 → **1,271 lines** (`run_log:374`, `run_show:426`, `run_branches:503`); `protocol.rs:611-642` carries the requests, `:770-811` the replies. Every verb runs the box's own git with `--no-optional-locks`. **This is remote-git-plane §5 Stage 1, minus `git.blame`** |
+| `ab104f3 test(termiod): cover the git read tier over the wire` | the read tier is tested at the protocol boundary, not only in-process |
+| `26a5dcb` + `c4934c2` (`feat/rust-foreground`, PR #366) | `foreground_pid`, `foreground_argv`, `foreground_job`, `child_cwd`, `child_executable`, `child_executable_replaced` on `SessionInfo` (`protocol.rs:1020-1045`), fed by a new `termiod/src/proc.rs` (416 lines, cfg-gated: `KERN_PROCARGS2` on macOS, `/proc/<pid>/{cmdline,cwd,exe}` on Linux) and `tcgetpgrp` on the PTY **master** (`pty.rs:252-260`). **First time a Linux host can name the agent in a session at all** |
+| `1746593 fix(termiod): scope the daemon socket and launchd job by channel` | **Stage 4 items 1 and 2 of the last revision, both done.** `Termiod.socketPath(channelSuffix:environment:)` (`TermiodClient.swift:62-85`) mirrors `paths::channel_suffix()` (`paths.rs:23`); `service::label()` (`service.rs:36-40`) suffixes the launchd label, which is also the plist filename and the `gui/$UID` target |
+| `ff53d19 perf(files): score the name index with frizbee's SIMD matcher` | `fs.match`'s scorer (`files.rs:348-381`), `frizbee 0.13` in `termiod/Cargo.toml` |
+| `2ed6ff6 ci(termiod): run the Swift files client against a real daemon` | `.github/workflows/termiod.yml:139` runs `swift test --filter TermiodFilesIntegrationTests` against a daemon CI just built. The opt-in integration suite is no longer opt-in-and-never-run |
+| `96dc2df fix(termiod): give daemon-hosted sessions the same status tap as local ones` | agent status no longer degrades when a session moves to the daemon |
+| `3ded234 fix(termiod): strip the launcher's identity from spawned sessions` | `CLAUDE_CODE_*`, `TMUX`, `TERM_PROGRAM` no longer leak from whoever started the daemon into every session it spawns |
+
+Still true from the previous stamp, re-verified today: `Checkout` is the shipped
+`(device, root)` reference (`DeviceContext.swift:56-101`); the panes no longer
+ask a session how it was opened; `multiplexingArguments(host:)` ships
+(`TermiodClient.swift:233`, applied at `:406`); the daemon builds universal,
+`lipo`s with a failing arch check, signs inside the outer seal, and resolves out
+of `Bundle.main` (`daemonBinaryPath()`, `:119`).
+
+### 2.2 Stage-1 gates, re-run today
+
+```
+grep -rn 'SFTPClient\|SSHFileSystemProvider\|SSHMux\|SSHProviderError\|sftpAlias' Sources/ Tests/ | wc -l   → 0
+grep -rc 'op = "fs_list"' Sources/                                                                          → 1
+grep -rn 'PTYProcess(' Sources/ | wc -l                                                                     → 1
+grep -rn 'TermiodConnection' Sources/ | wc -l                                                               → 0
+```
+
+`FileBrowserView.swift:77-84` now has exactly two branches plus an honest empty
+state: `RemoteFileTreeView` for any checkout with a root on another device, the
+`unavailable(pane:on:)` state when the device has no root to give, and the local
+tree. Stage 1 is closed.
+
+### 2.3 The three gaps this restamp exists to record
+
+Stages 5 and 6 of the last revision were **half-landed in Rust and unreached from
+Swift**. All three gaps below now have an implementation, **written and reviewed
+but uncommitted and unmerged** (§2.4) — they are recorded here as the problem
+statement Stage 2 is answering, not as open work. Where an answer is only
+partial, the gate that remains is named in Stage 2.
+
+**(a) Swift never decodes the foreground fields.**
+`Termiod.SessionInformation` (`TermiodClient.swift:780-819`) decodes eleven keys
+— `id, name, pid, alive, cwd, command, status, agentId, title, createdUnix,
+attachedClients` — and **none** of the six the daemon now sends. The consequence
+is visible: `displayLabel` still falls back to `programName(in: command)`
+(`:838-849`), which splits the login-shell wrapper apart with string rules to
+guess what is running. That heuristic is precisely what a kernel read exists to
+replace, and it is still what the sidebar shows.
+
+**Mostly answered.** The decode is built — all six fields, every one optional so
+"the device said no" stays distinct from "the device did not say". `displayLabel`
+is **not** rewired and still reaches the command-string guess for a roster-only
+row, which is a Stage 2 gate.
+
+**(b) `child_executable_replaced` is computed at exit and then dropped.**
+`Session::info()` deliberately re-checks the pinned inode rather than caching it,
+with a comment saying why: *"the record that matters most is the one built on the
+exit path"* (`session.rs:366-379`). The exit path does call it — `session.rs:1587`
+builds an `info` with `alive: false` for the tombstone. But:
+
+- `Event::SessionExited` carries `{ session, status }` and nothing else
+  (`protocol.rs:924-927`), so an attached client learns the session ended and
+  never learns why the binary moved.
+- `Tombstone::from_info` copies eleven fields and not this one
+  (`tombstone.rs:96-108`), so the durable record drops it too.
+
+"The agent updated itself and quit" is therefore computed correctly at the one
+moment it matters and cannot reach any client by either route. This is a
+delivery gap, not a mechanism gap — `proc::ExecutableIdentity::was_replaced()`
+is right and tested (`proc.rs:44-58`, `notices_a_replaced_executable`).
+
+**Half answered.** The event route is built (Stage 2); the tombstone route is
+not. `Tombstone::from_info` still drops the field, so a client that was not
+attached when the session died still cannot learn it. That remains a Stage 2
+gate.
+
+**(c) Linux has no live-process-group-member scan.**
+`sample_foreground` reads argv straight off the pgid
+(`session.rs:389-410`), resting on the comment *"the foreground group leader's
+pid **is** the pgid"*. That holds while the leader is alive. It stops holding in
+the ordinary pipeline case — `foo | bar` puts both in a group named after `foo`,
+and when `foo` exits first the group still owns the tty. `/proc/<pgid>/cmdline`
+is then gone, `process_arguments` returns `None`, and the session reports
+`foreground_job: true` with no argv: the client knows a job is running and
+cannot name it. `grep -rn 'pgrp' termiod/src/` finds only `tcgetpgrp` — nothing
+scans `/proc/*/stat` field 5 for a live member of the group, and nothing calls
+libproc's `proc_listpgrppids` on macOS, though both mechanisms exist. The fix is
+per-platform and belongs with the rest of `proc.rs`'s cfg-gating.
+
+**Answered on both targets** (Stage 2), with the macOS path additionally
+re-checking `pbi_pgid` per candidate so a recycled pid cannot be reported. The
+Linux path has still never been compiled or run — that is a Stage 2 gate.
+
+### 2.4 Unmerged branches that bear on this plan
+
+| Branch | Size | Standing |
+| --- | --- | --- |
+| `feat/termiod-remote-install` (`a497c00`) | 7 files, +732/−3 | **Answers open question 2 of the last revision.** Settings ▸ Machines reports what a box has and installs the slice this app carries; freshness is a digest, not a version string; the upload lands on a temp name and is moved only after `chmod`. Ships `TermiodInstaller.swift` (335) + 155 lines of tests, a `release.yml` artifact step, and `web/landing/public/install.sh`. Folded into Stage 5 |
+| `feat/termiod-wss` (5 commits) | 69 files, +18,791/−4 | A third client and a transport. Adds **zero** protocol verbs and touches **zero** Swift. **Its merge risk is no longer near zero** — `git log --oneline main --not feat/termiod-wss -- termiod/` is now **13 commits**, including `d38f50c`, `c4934c2` and `1746593`, so it needs a rebase across `protocol.rs`, `daemon.rs`, `git.rs` and `session.rs` rather than the byte-identical merge the last stamp described. Deferred, §8 |
+| `feat/stage5-rust-completion` | 0 commits · **+977/−62** uncommitted | **Stage 2's host half, implemented and reviewed.** `proc.rs` +595, `session.rs` +320, `protocol.rs` +117, `daemon.rs` +7. **99 tests pass.** |
+| `feat/stage5-swift-completion` | 0 commits · **+856/−59** uncommitted | **Stage 2's client half, implemented and reviewed.** `TermiodClient.swift` +181, `TermioStore+Termiod.swift` +135, `TermioStore+TerminalSurface.swift` +95, `TermioStore+ProjectActions.swift` +38, and 28 new cases across `TermiodEventTests` (+179) and `TermiodStatusTests` (+287). **483 tests pass.** |
+| `feat/foreground-parity` | 0 commits · +42 uncommitted, plus an untracked `TermioStore+SessionFacts.swift` | **An earlier, superseded attempt at the same client half.** It decodes `foregroundJob` as a non-optional `Bool` with `?? false`, which erases "the device did not answer" from the type — the distinction the skew rule rests on — and it carries no tests. **Do not merge it alongside the pair above**; harvest `SessionFacts`'s single-answer framing if anything, and drop the rest. |
+
+**All three point at `main`'s tip and are zero commits ahead.** The last
+revision's §1.5 warned that a survey against a stale `main` reports merged work
+as abandoned; the mirror trap is here — `git log main..<branch>` empty does
+**not** mean the branch is empty. Check `git status` in its worktree too.
+
+---
+
+## 3. Vocabulary — Workspace is not Project, and only one of them is the device's
+
+The word "workspace" named three different objects across these documents, and
+every argument about *where workspaces live* was an argument between the
+definitions. `20260819-device-workspace-project.md` settled it, and this plan
+uses the settled terms exclusively:
+
+```
+Device        a machine, identified by host_id, reached by ≥1 ~/.ssh/config alias
+  └ Workspace a named scope in the sidebar; holds projects and loose sessions
+      └ Project    a checkout: a directory root on that device
+          └ Session a PTY in that device's termiod
+```
+
+Two ownership claims, and they point in different directions on purpose:
+
+- **Workspace is a client concern, and stays viewer-owned for now.** It is the
+  user's arrangement of their own work — the same class of thing as split
+  layout and session naming, which §4.1 already keeps in Swift. It lives in the
+  Mac's `state.json`, and #345 removed machine-scoped navigation deliberately:
+  you switch workspaces, never machines. Every workspace *names* a device
+  (`20260819` §2), which is a hierarchy claim, not a storage one.
+- **Project and Checkout are device-owned facts, and the registry that
+  enumerates them is device work.** A directory root either exists on that box
+  or does not; two viewers must agree. `Checkout` (`DeviceContext.swift:56-101`)
+  is already the client-side spelling of `(device, root)` with `host_id`-first
+  identity. What is missing is the device's own answer to *what projects are
+  here* — device arch §8.11's registry.
+
+The gap is one field wide and worth stating precisely, because it looks larger
+than it is: `WorkstreamSpec` already carries `project` (`protocol.rs:390`), the
+daemon stores it (`session.rs:306`), and `Session::info()` reads back only
+`agent_id` (`:358`). **A client can write a session's project and can never read
+it.** Closing that is the first inch of the registry, not a new plane.
+
+Deliberately deferred, per `20260819` §5: moving workspace *authority* to the
+device. That decision belongs with direct-attach (§8), because its whole
+justification is a phone talking to a Linux box with no Mac in the path.
+Adopting the hierarchy now costs nothing later — every workspace already names
+its device.
+
+Retired vocabulary, do not reintroduce: "workspace" meaning a directory root;
+"workspace fallback" / `isDeviceFallback`; "local project" versus "remote
+project".
+
+---
+
+## 4. The boundary
+
+### 4.1 Stays Swift — the viewer, and the stopping line
 
 These fail the two-observers test outright, or are macOS-coupled. Nothing in
 this plan touches them, and a future stage that proposes to must argue against
@@ -179,342 +259,620 @@ this list rather than around it.
 
 | Area | Lines | Why it stays |
 | --- | --- | --- |
-| libghostty surface, `TerminalPane`, `SplitTree`, every `*View` | `Sources/termio/Terminal/` 6,218 · `Sidebar/` 1,971 · `Info/` 5,813 | Rendering, layout and panes are client concerns — invariant #5 |
-| `OSCProgressScanner` (`Sources/termio/Agents/`) | — | A byte-stream scan. Every client receives the same bytes; a host opinion of "working" on the wire is the host deciding presentation |
+| libghostty surface, `TerminalPane`, `SplitTree`, every `*View` | `Terminal/` 6,218 · `Sidebar/` 1,971 · `Info/` 5,813 | Rendering, layout and panes are client concerns — invariant #5 |
+| `OSCProgressScanner` (`Agents/`) | — | A byte-stream scan. Every client receives the same bytes; a host opinion of "working" is the host deciding presentation |
 | `AgentStatusRules` — screen-rule agent status | `TermioStore+TerminalSurface.swift:356-366` | Reads the *rendered viewport*, which every client already holds |
 | Theme, palette, fonts, keybindings | `Theme/` 527 · `Keybindings/` 628 | The `grid_diff` refusal (`TermiodClient.swift:27`) is the same rule: the host must never resolve a colour |
-| `TaskNotifications`, `MenuBarController`, keychain reads, `NSWorkspace`, Quick Look | across `App/` 4,320 · `Companion/Usage/` | This Mac's Notification Center is this Mac's |
-| Encoding a human keypress | `Terminal/Ghostty/` | Needs an `NSEvent` and ghostty's key encoder. Rust must not grow a model of one — invariant #5 wearing a keyboard |
-| Session grouping, naming, `termio://session/<uuid>` links | `TermioStore/` | The project tree is the user's arrangement, not the device's |
+| `TaskNotifications`, `MenuBarController`, keychain reads, `NSWorkspace`, Quick Look | `App/` 4,320 · `Companion/Usage/` | This Mac's Notification Center is this Mac's |
+| Encoding a human keypress | `Terminal/Ghostty/` | Needs an `NSEvent` and ghostty's key encoder — invariant #5 wearing a keyboard |
+| **Workspace grouping**, session naming, `termio://session/<uuid>` links | `TermioStore/` | §3. The arrangement is the user's, not the device's |
 | `focus`, `notify` CLI verbs | `TermioStore+SessionControl.swift:44-53` | Name *this* window and *this* Mac |
+| argv → agent mapping | client-side | The daemon reports argv; which glyph that becomes is presentation |
 
-### 2.2 Moves to Rust
+### 4.2 Moves to Rust
 
-Ordered by how ready the daemon already is.
+Ordered by how ready the daemon already is. "Daemon state" is measured today.
 
 | Responsibility | Swift today | Daemon state | Stage |
 | --- | --- | --- | --- |
-| Directory listing, file read | `SSHFileSystemProvider.swift` 531 + `SFTPClient.swift` 878 (SFTP over `ssh -s host sftp`); local `FileManager` | **Shipped**, stateless | **1** |
-| Content search | `ContentSearch.swift` 144 (`git grep` via `Process`) | **Shipped**, streamed + cancellable | 2 |
-| Filename fuzzy finder | local walk | **Shipped**, needs a subscription for coverage | 3 (blocked) |
-| Filesystem change notification | `FileTreeWatcher.swift` 139 (FSEvents), no remote equivalent | **Shipped** as the `fs:` resource | 3 (blocked) |
-| Git status | `GitService.swift:958-984` → `/usr/bin/git` | **Shipped** as the `git:` resource | 3 (blocked) |
-| Git diff for one path | `GitService.diffText` | **Shipped** (`git.diff`) | 2 |
-| Git history, commit contents, branch compare, discard, `.gitignore`, remote/PR URLs, clone info, stall fingerprint | `GitService.swift` 985 total, 12 verbs | **Absent** — `git.rs` is `run_status` + `run_diff` | 6, per `remote-git-plane.md` §5 |
-| Worktree enumeration | `WorktreeService.swift` | **Absent** | 6 |
-| Foreground job / argv / cwd | `PTYProcess.swift:807,868,925` | **Absent** — no `tcgetpgrp` in `termiod/src` | 5 |
-| Session roster, `read`, `send`, `watch`, `spawn`, `close` | `TermioStore+SessionControl.swift` 1,040 | Verbs exist; the CLI talks to the Swift socket | 7 |
-| Agent hook sink | `HookListener.swift` 944, `agent-status.sock` on this Mac | `set_status` exists; nothing routes a hook into it | 7 |
+| Directory listing, file read | — (deleted) | **Shipped and consumed** | **1 — done** |
+| Foreground job / argv / cwd / executable identity | `PTYProcess.swift:864-930` | **Shipped** (`proc.rs`, `pty.rs:258`); group-member resolution and the client decode written but **unmerged** (§2.4) | **2** |
+| Content search | `ContentSearch.swift` 144 (`git grep` via `Process`) | **Shipped**, streamed + cancellable | 3 |
+| Git diff for one path | `GitService.diffText` | **Shipped** (`git.diff`) | 3 |
+| Filename fuzzy finder | local walk | **Shipped** (`fs.match`, frizbee scorer); needs a subscription for coverage | 9 (gated on 4b) |
+| Filesystem change notification | `FileTreeWatcher.swift` 139 (FSEvents), no remote equivalent | **Shipped** as the `fs:` resource | 9 (gated on 4b) |
+| Git status | `GitService.changes` → `/usr/bin/git` | **Shipped** as the `git:` resource | 9 (gated on 4b) |
+| Git history, commit contents, branch list | `GitService.log/commitChanges/branchCompare` | **Shipped** (`git.log`, `git.show`, `git.branches`) | 9 |
+| Blame | absent both sides | **Absent** | 9 (or never — §9.5) |
+| Worktree enumeration | `WorktreeService.swift` 72 | **Absent** | 9 |
+| `.gitignore`, remote/PR URLs, clone info, stall fingerprint | `GitService.swift:565-984` | **Absent** | 9 |
+| Discard, stage, commit, stash, branch ops | `GitService.discard` + absent | **Absent** — new scope | 11 |
+| Fetch / pull / push, askpass | absent | **Absent** — new scope | 11 |
+| Session roster, `read`, `send`, `watch`, `spawn`, `close` | `TermioStore+SessionControl.swift` 1,040 | Verbs exist; the CLI talks to the Swift socket | 10 |
+| Agent hook sink | `HookListener.swift` 944, `agent-status.sock` on this Mac | `set_status` exists; nothing routes a hook into it | 10 |
 | PTY ownership | `PTYProcess.swift` 996 | **Shipped** (`pty.rs`) | 8 |
 
-### 2.3 Deleted outright
+### 4.3 Deleted outright
 
-| File | Lines | When | Gate |
+| File | Lines | Stage | Gate |
 | --- | --- | --- | --- |
-| `Sources/termio/FileBrowser/SFTPClient.swift` | 878 | Stage 1 | the symbol gate below |
-| `Sources/termio/FileBrowser/SSHFileSystemProvider.swift` | 531 | Stage 1 | same |
-| `Tests/termioTests/SSHFileSystemProviderTests.swift` | 508 | Stage 1 | same |
-| `Checkout.sftpAlias` + its branch in `FileBrowserView.swift:77-80` | ~12 | Stage 1 | same |
-| `SSHMux` and the `ControlMaster` options injected into a plain `ssh` session's argv (`sshCommand(host:)`) | ~110 | Stage 1 | same — the master existed only so the SFTP tree could ride it |
-| `Termiod.isEnabled` and every branch on it | `TermiodClient.swift:46` | Stage 8 | `grep -rn 'TERMIO_TERMIOD\b' Sources/ \| wc -l` → 0 |
-| `PTYProcess(` construction | `TermioStore+TerminalSurface.swift:228-231` | Stage 8 | `grep -rn 'PTYProcess(' Sources/ \| wc -l` → 0 |
+| `SFTPClient.swift`, `SSHFileSystemProvider.swift`, `SSHFileSystemProviderTests.swift`, `Checkout.sftpAlias`, `SSHMux` | 1,409 + ~120 | 1 | **done** — the symbol grep in §2.2 is 0 |
+| `PTYBridge`'s dependence on `PTYProcess` | — | 6 | `grep -rn 'PTYProcess' Sources/termio/Companion/` → 0 |
+| `Termiod.isEnabled` (`TermiodClient.swift:46`) and every branch on it | — | 8 | `grep -rn 'TERMIO_TERMIOD\b' Sources/ \| wc -l` → 0 |
+| `PTYProcess(` construction (`TermioStore+TerminalSurface.swift:253`) and `PTYProcess.swift` | 996 | 8 | `grep -rn 'PTYProcess(' Sources/ \| wc -l` → 0 |
+| `ContentSearch.swift`, `FileTreeWatcher.swift` | 283 | 9 | their symbol grep → 0 |
 
-**`RemoteFileTree.swift` (507 lines) is NOT deleted, and that is a deliberate
-change from the brief.** It is three things: `RemotePreviewStorage`/`Lease` (the
-0700 `mkdtemp` staging for read-only previews, referenced from
-`App.swift:497` and `TermioStore.swift:246,1609`), `RemoteFileNode` +
-`RemoteFileBrowserModel` (the lazy `List(children:)` tree), and
-`RemoteFileTreeView`/`RemoteFileRow` (the presentation). Only the **provider it
-calls** is SFTP-shaped, and that surface is four methods —
-`root()`, `list(_:)`, `read(_:limit:)`, `disconnect()`
-(`SSHFileSystemProvider.swift:160-186`). Swapping the provider deletes the same
-1,409 lines of SFTP the brief targeted while adding ~250 instead of ~700, and it
-keeps a tree whose lazy-load re-entrancy, expansion-state identity and
-preview-race guards are already correct. Rewriting the view to delete it would
-be new code where the deletion target is the transport.
+`RemoteFileTree.swift` (507 lines) is **not** deleted — settled in the last
+revision and unchanged. Only the provider behind it was SFTP-shaped, and it was
+four methods wide. The tree's lazy-load re-entrancy, expansion-state identity
+and preview-race guards are correct; rewriting the view would be new code where
+the deletion target was the transport.
 
 ---
 
-## 3. The blocker, narrowed
+## 5. The blocker, narrowed
 
-`one-workspace-source.md` §7.1 and `remote-git-plane.md` §8.2 both state it:
+`withControlChannel` (`TermiodClient.swift:1155`) is one-shot: it opens a
+`Transport`, `defer`s its close, and nothing can outlive the closure. Re-verified
+today; `grep -rn 'TermiodConnection' Sources/` → 0.
 
-> **Connection ownership.** The review requires a durable per-device connection
-> before resource subscriptions, while `withControlChannel`
-> (`TermiodClient.swift:1025-1042`) is one-shot. Stage 3 depends on this; Stages
-> 1-2 do not, since `fs.list` is a request/response.
+**What it does and does not gate:**
 
-Verified: the citation has **not** drifted — `withControlChannel` is at
-`TermiodClient.swift:1033-1042` with its doc comment from `:1025`, and the body
-is `let transport = try Transport.open(route)` + `defer { transport.close() }`.
-Nothing can outlive the closure.
-
-`remote-git-plane.md` §8.1 also claims a second prerequisite — the workspace
-reference — and that one **is** resolved: `Checkout` (§1.1). §8.1 should be
-struck.
-
-**What the blocker does and does not gate:**
-
-- **Not gated:** `fs.list`, `fs.read`, `git.diff`, `fs.search`. Each is one
-  request and its replies on one channel. `fs.search` streams, but the stream
-  ends with `fs_searched` inside the same call.
-- **Gated:** `subscribe_resource` for `fs:` and `git:`, and therefore live file
-  watching, the git changes pane, and `fs.match` coverage. A subscription's
+- **Not gated** — `fs.list`, `fs.read`, `fs.search`, `git.diff`, `git.log`,
+  `git.show`, `git.branches`. Each is one request and its replies on one
+  channel. `fs.search` streams, but the stream ends with `fs_searched` inside
+  the same call.
+- **Gated** — `subscribe_resource` for `fs:` and `git:`, and therefore live file
+  watching, the git Changes pane, and `fs.match` coverage. A subscription's
   whole value is that it outlives the request.
+- **Gated** — the companion's exit fan-out (§6 Stage 6). `TermiodSessionLink.onExit`
+  is one closure held by `attachTermiodLink` (`TermioStore+Termiod.swift:119`);
+  the observer registry belongs on a connection, not on a transport.
 
-So the ordering constraint is: **no `fs:`/`git:` subscription work before a
-`TermiodConnection` object exists.** That is Stage 3's prerequisite, and Stage 3
-is the fourth thing this plan does, not the first.
+The cost the blocker does not name: each one-shot call over SSH is a full connect
+plus hello. Locally 0.2 ms; remotely 26–33 ms with a warm ControlMaster and
+230–300 ms without. A tree that expands one directory per click is inside that
+budget; a search that re-issues per keystroke is not. Stage 3's gate measures it.
 
-One cost the blocker does not name and this plan must: each one-shot call over
-SSH is a full connect + hello. Locally that is 0.2 ms; remotely it is 26–33 ms
-with a warm ControlMaster (which §1.1 confirms now exists) and 230–300 ms
-without. A file tree that expands one directory per click is inside that budget;
-a tree that re-lists on every keystroke is not. Stage 1's criterion measures it.
+`remote-git-plane.md` §8.1 names a *second* prerequisite — the workspace
+reference — and that one is resolved (`Checkout`). §8.1 should be struck; §8.2
+and §8.3 stand.
 
 ---
 
-## 4. Stages
+## 6. Stages
 
-Each is independently shippable and carries a gate that runs.
+Each is independently shippable and carries a gate that runs. **This list
+supersedes device architecture §8's ordering** (§0).
+
+The shape of the reorder, against the previous revision: foreground parity moves
+from 5 to **2** because Rust already shipped its half — and the rest of it is now
+written, reviewed and waiting on four gates (§2.4, Stage 2); supervision moves from 4
+to **5** and absorbs the remote-install branch; and **companion decoupling, the
+default-on soak, and deleting the local PTY fork (6, 7, 8) now come before the
+CLI move and before any git expansion.** The reason is one-path §5's own
+rollback note: Stage 8 is the only step that is hard to revert, its mitigation is
+sequencing rather than a switch, and every stage that runs *after* the flag is
+deleted is a stage that would otherwise have to be built twice — once for each
+side of the fork. Moving the CLI while two session backends exist is exactly that
+double build.
 
 ### Stage 1 — the Files pane reads a device through `fs.*`; SFTP is deleted — **done**
 
-**The single best deletion-to-new-code ratio in this plan**, and it needs
-nothing from the blocker. Landed as `68f5006` (the client, +7 integration tests)
-and `8e106ea` (the tree, the deletions): **+513 / −2,030** across 14 files, of
-which 141 of the additions are the new integration tests.
+Landed as `68f5006` + `8e106ea`: **+513 / −2,030** across 14 files, of which 141
+additions are integration tests. Gates re-run in §2.2 and all clean. CI now runs
+the Swift client against a real daemon (`termiod.yml:139`), which closes the
+"opt-in and therefore never run" gap the original stage carried.
 
-Today the Files pane has three behaviours (`FileBrowserView.swift:76-88`): the
-SFTP tree for a `sftpAlias`, a dead `unavailable(pane:on:)` placeholder for a
-checkout on another *device* (the termiod case — the actual bug), and the local
-`FileManager` tree. After this stage there are two: local, and `fs.*`.
+One verification remains open and is recorded as open, not claimed: the device
+branch of the pane has not been seen on screen against a second machine running
+`termiod`.
 
-1. Add `Termiod.listDirectories(route:root:paths:)` and
-   `Termiod.readFile(route:path:limit:)` in a new
-   `Sources/termio/Terminal/Termiod/TermiodFiles.swift`, built on
-   `withControlChannel(caps: ["files"])`, mirroring `TermiodTransfer.swift`'s
-   request/`readReply` shape and decoding the `F` chunk header
-   (`re:u64be, offset:u64be, last:u8`, `protocol.rs:953-967`).
-2. Add `FsFilePayload` to `IncomingControl` (`TermiodClient.swift`) — additive,
-   `.unknown` stays the default. `FsListedPayload` is **not** added: `315d7a5`
-   already put it there for the path picker (§1.5), and this stage reuses it
-   rather than declaring a second copy.
-3. **One `fs.list` client, not two.** `TermiodDirectoryLister.swift` (upstream,
-   for the path picker) and `TermiodFiles.swift` (this stage, for the tree) each
-   arrived with their own `FsListOperation`, `PathListingPayload` and
-   `FsListedPayload`. The call sites stay separate — the picker's round trip is
-   blocking and holds a channel for as long as a field is being typed in, the
-   tree's is async and per-pane — but the wire types are shared, and the picker's
-   private encoder is deleted in favour of the seq-stamped one. Upstream's
-   `PathListingPayload` wins: its `init(from:)` defaults a missing `entries` to
-   `[]`, where the version written here made it optional at every call site.
-   *Gate:* `grep -rc 'op = "fs_list"' Sources/` → exactly 1.
-3. Re-point `RemoteFileBrowserModel` at the new provider. It takes a `Checkout`
-   instead of a `host: String`; `root()` becomes `checkout.root`.
-4. `FileBrowserView` renders the tree for **any** `isOnAnotherDevice` checkout;
-   the `sftpAlias` branch and the property go.
-5. Delete `SFTPClient.swift`, `SSHFileSystemProvider.swift`, and
-   `SSHFileSystemProviderTests.swift`. Keep `SSHMux` only if something else
-   needs it (it does not — `grep` shows no consumer outside these files).
-6. A plain-`ssh` session whose host has no daemon gets the honest empty state
-   naming the host, not a blank pane. Offering to install is Stage 4's job,
-   because `remote deploy` cannot run from a shipped app today (see §5).
+### Stage 2 — foreground parity: the client half
 
-**Gates:**
-- `swift build` clean; `swift test` green.
-- `grep -rn 'SFTPClient\|SSHFileSystemProvider\|SSHMux\|SSHProviderError\|sftpAlias' Sources/ Tests/ | wc -l` → 0.
-  Not `grep -rn 'SFTP'`, which `one-workspace-source.md` §5 Stage 5 asks for:
-  two comments deliberately record what the files plane replaced, and a gate
-  that forbids naming the thing you deleted forbids explaining why.
-- A new `TermiodFilesIntegrationTests`, on the opt-in
-  `TERMIO_TERMIOD_TEST_BIN` pattern `TermiodTransferIntegrationTests.swift`
-  already establishes: spawn a real daemon on a private socket, list a temp
-  tree, read a file back byte-for-byte, and assert the confinement refusal for
-  `../escape`. Runs under `swift test` when the env var is set, skips otherwise.
-- **Not yet verified on screen.** The dev bundle builds and the app launches with
-  a window, but the device branch of the pane cannot be exercised without a
-  second machine running `termiod`, and `screencapture` is unavailable in the
-  environment this was built in (no Screen Recording permission — every capture
-  answers `could not create image from display`). The tree's rendering on a real
-  device session is an open verification, not a claim.
+Rust's first half shipped in `c4934c2`. The rest — the client decode, the two
+delivery gaps in §2.3, and the group-member scan — is **implemented across two
+worktrees, reviewed and approved, and neither committed nor merged** (§2.4):
+99 Rust tests and 483 Swift tests pass locally. **This stage has not landed**,
+and the gates at the end of this section are what stands between the two.
 
-### Stage 2 — Search and the diff view read a device
+Nothing below is a proposal. It is the shape the implementation settled on,
+recorded because two of the decisions contradict what `one-path-local-through-termiod.md`
+§3.2 specified, and a later reader comparing the two needs to know which won.
+
+#### The wire, as built
+
+Both changes are additive within `proto:1` and both reuse events that already
+existed. **No `foreground_changed` event exists, and none is needed** — see §7.9.
+
+```
+E { ev: "roster", session, action: "updated", info: SessionInfo }   # whole row, on change
+E { ev: "session_exited", session, status, info: SessionInfo? }     # + final row
+```
+
+- **`E roster` carries whole `SessionInfo` updates.** `emit_roster()` already
+  sent `{session, action, info}` with the complete row; the foreground poll now
+  calls it on change. A client never merges deltas, so there is no partial-update
+  ordering problem to get wrong, and no second event shape to version.
+- **`E session_exited` gains an optional final `info`** (`Option<Box<SessionInfo>>`).
+  It is sampled once, after the reap, and the *same* record feeds both the event
+  and the tombstone — deliberately not sampled twice, because
+  `child_executable_replaced` is a fresh disk read every time it is asked and an
+  agent that replaced its binary between two reads is precisely the case both
+  consumers exist for. Absent from an old daemon; a client that finds it absent
+  keeps what it last read from `list`, which is today's behaviour. Round-trip and
+  old-payload-decodes tests both exist.
+
+#### Close confirmation reads the cached push, on purpose
+
+`closeConfirmationReason` answers from the last roster push —
+a sample up to one `FOREGROUND_POLL` (**2 s**) old — and **does not** ask `list`.
+This inverts one-path §3.2's instruction (§7.10). The reason is mechanical:
+`Session::info()` reads the `self.foreground` cache, so a `list` round trip
+returns the same sample built from the same poll. **It is not fresher.** It
+would cost 216–292 ms on the main thread over SSH to learn nothing.
+
+An in-process PTY still wins outright when one exists — it is asked `tcgetpgrp`
+at the instant of the question, so its `false` is a genuinely fresher no
+(`TermioStore.foregroundJob(reportedLocally:reportedByDevice:)`). Only a session
+this app does not host falls through to the device's cache.
+
+The staleness is accepted because it is bounded in both directions, and the two
+directions cost differently:
+
+- **False positive** — the job finished within the last poll and the user is
+  asked about a command that already ended. Cost: one dismissed dialog. This is
+  the safe direction to be wrong in.
+- **False negative** — a job started within the last poll and the close goes
+  through unasked. Cost: exactly the shipped no-confirm rule, which is what an
+  absent field already means.
+
+Which is why only an explicit `true` confirms. `nil` is nobody answering and
+must never be read as "unknown, so confirm" — that would tax every close on the
+sessions the shipped rule deliberately exempts (`remote-to-device.decisions.md` §2).
+
+#### Resolving the group, per platform
+
+`tcgetpgrp` names a *group*; every argv lookup wants a *pid*. The two agree while
+the leader lives, and part in a pipeline the moment it does not — `find . | grep foo`
+after `find` finishes leaves `grep` holding the terminal with a zero-length
+`/proc/<pgid>/cmdline`. tmux scans for a live member (`osdep-linux.c`); so does
+this, behind one `proc::foreground_member(pgid)` with a per-target body.
+
+- **macOS** — `proc_listpgrppids` enumerates the group, then each candidate is
+  read back through `proc_pidinfo(PROC_PIDTBSDINFO)` for its state **and a
+  re-check that `pbi_pgid` still matches the group we were asked about**. That
+  recheck is not redundant with having enumerated the group: between `tcgetpgrp`
+  naming it and this running, a pid can be recycled into something else, and a
+  member whose group no longer matches is a different process wearing the same
+  number.
+- **Linux** — `/proc/<pgid>/stat` first, which answers on nearly every sample for
+  one `stat` read and no walk. Only when the leader cannot answer does it walk
+  `/proc`, reading one `stat` per process and **no `cmdline` at all**; argv is
+  resolved afterwards, in preference order, stopping at the first process that
+  answers.
+- **Selection is leader-first, then ascending pid** — arbitrary but *stable*, so
+  a wide pipeline does not flap between two survivors and push a roster event
+  every poll for no new information. Zombies and dead states are filtered.
+- **`foreground_job` is derived from the group, not from the resolved pid.** A
+  pipeline whose leader exited is still a running job; keying it on a member that
+  could not be read would say the opposite at the worst moment.
+
+#### The expensive half is off the session actor
+
+The poll now splits along what it costs to learn. `tcgetpgrp` and the job flag
+stay on the actor — cheap, and the close confirmation needs them current. Argv,
+cwd, the executable pin and the group walk are dispatched to
+`spawn_blocking` and applied later, because that actor also runs the PTY read
+and the fan-out, and a process-table walk there is time the byte path spends
+waiting. **The anti-100× invariant is about more than the VT parse.**
+
+Two guards make the split safe:
+
+- **One resolution in flight per session** (`foreground_pending`). The poll is
+  slower than the work; queueing would only pile up answers about groups that
+  have already lost the terminal.
+- **Stale-pgid rejection.** A resolution carries the `pgid` it describes, and
+  `apply_foreground` drops it if the foreground moved while it was in flight.
+  That is not a stale version of the truth — it is the answer to a different
+  question. When the group changes, the cached pid and argv are cleared rather
+  than carried, so the gap is honest until the next resolution fills it.
+
+#### Remaining gates — all four are open
+
+- **Linux `cfg` compilation and runtime.** The `/proc` path has never been
+  compiled or run; it waits on `termiod.yml`'s ubuntu-24.04-arm job. Behaviourally:
+  run `sleep 60 | cat` in a session, and after the leader exits `foreground_job`
+  is true **and** `foreground_argv` is non-empty.
+- **Combined wire-order integration coverage is absent.** Each half is tested
+  against its own fixtures; nothing exercises a real daemon pushing a roster
+  update and then an exit event to a real Swift client, in order. The
+  `TermiodFilesIntegrationTests` pattern (`termiod.yml:139`) is the place for it.
+- **`child_executable_replaced` is still not on `Tombstone`.** The exit *event*
+  carries it; `Tombstone::from_info` (`tombstone.rs:96-108`) does not, so a
+  client that was not attached when the session died cannot learn it. §2.3(b).
+- **`displayLabel` still falls back to `programName(in: command)`** for
+  roster-only rows the app has never attached to — which is exactly the row that
+  has no other source of truth. The decode is in place; the consumer is not
+  rewired.
+
+Non-blocking, and explicitly **not** a gate: Linux reads argv twice on the walk
+path — once as the `has_argv` predicate that selects the member, once again in
+`process_arguments`. Returning the argv from the probe would halve it. That is an
+optimization on the rare branch, not a correctness issue, and it should not hold
+the stage.
+
+### Stage 3 — Search and the diff view read a device
 
 `fs.search` (streamed, cancellable) behind `FileSearchView`/`ContentSearch`, and
-`git.diff` behind the diff overlay. Still one channel per request; still not
-blocked.
+`git.diff` behind the TextKit diff overlay. Still one channel per request; still
+not blocked.
 
-**Gates:** ⇧⌘F on a VPS session returns hits with correct paths and line
-numbers; cancelling mid-stream produces `fs_searched {canceled: true}`; a diff
-for a device path renders in the existing TextKit overlay.
+**Gates:** ⇧⌘F on a VPS session returns hits with correct paths and line numbers;
+cancelling mid-stream produces `fs_searched {canceled: true}`; a diff for a
+device path renders in the existing overlay. **Cold-expand latency over a warm
+ControlMaster is recorded** — this is the measurement open question 1 of the last
+revision asked for, and it decides nothing else in this list, so take it here.
 
-### Stage 3 — the connection is an object (unblocks subscriptions)
+### Stage 4 — the connection is an object
 
-`TermiodConnection` per device owning transport, health and reconnect;
-`TermiodSessionLink` becomes a client of it; `withControlChannel` becomes a
-channel on it rather than a process. `handleStreamEnd` stops calling
-`deliverExitLocked` (`TermiodClient.swift:1557-1563`) — a transport failure is
-not a process exit.
+Device architecture §8.4's split, adopted verbatim because the sub-steps have
+genuinely different shapes and only one of them is hard.
 
-Then, and only then: `fs:` and `git:` subscriptions, live tree updates, the git
-changes pane, `fs.match` coverage.
+**4a — the argument list.** `multiplexingArguments(host:)` already ships
+`ControlMaster`, `ControlPersist` and a length-capped `ControlPath`, and refuses
+to override a user's `ControlMaster no` (`TermiodClient.swift:233-236`, applied
+at `:406`). What is missing is `BatchMode` and `ConnectTimeout`, which every
+other ssh call site in the app sets and this one does not — so an unloaded key
+prompts onto an unread stderr and the attach hangs with no error. **A one-line
+change with a real failure behind it.**
 
-**Gates:**
+*Gate:* attach to a host with a passphrase-protected key and no agent: a named
+error inside `ConnectTimeout`, never a hang.
+
+**4b — `TermiodConnection`.** One per device, owning the transport, its health
+and reconnect. `TermiodSessionLink` becomes a client of it rather than a
+transport owner; `withControlChannel` becomes a channel *on* it rather than a
+process. `handleStreamEnd` (`TermiodClient.swift:1867-1873`) stops calling
+`deliverExitLocked` — **a transport failure is not a process exit**, and today
+they are the same code path. The exit observer registry Stage 6 needs lands here.
+
+*Gates:*
 - Three panes on one SSH device: `pgrep -lf 'ssh .*<alias>'` shows **one** ssh.
 - `launchctl kickstart -k` the daemon with three local panes open: each pane
   shows a state named `daemon_lost`, distinct from `exited`, and `termiod
   tombstones` lists all three with no invented exit status. **Not** "history
   intact" — sessions do not survive a daemon restart and by decision never will
-  (`tombstone.rs:184`, burial loop `:194-201`).
-- `touch` a file on the VPS; the tree updates without a manual refresh.
-- Replay inside the watcher's 300-second linger (`resource.rs:51`) is exact;
-  past it, `gap: true` forces a full rescan.
+  (`tombstone.rs`, burial loop).
+- Pull the network on an attached device: panes degrade, and nothing reports an
+  exit status the child never produced.
 
-### Stage 4 — the daemon is supervised, and the two channels stop sharing one
+**4c — channel ids in the framing.** An additive `proto` bump so the four planes
+genuinely share one pipe rather than one pipe each. Sequenced last of the three
+because 4b keeps the durability promise on its own; 4c is what makes the promise
+cheap.
 
-`one-path-local-through-termiod.md` Stage 1 items 1 and 2 are **done** (§1.1):
-the daemon is built universal, `lipo`'d with a failing arch check, signed inside
-the outer seal, and resolved out of `Bundle.main`. Four items are left, and each
-is a release blocker on its own:
+*Gate:* a session attachment, an `fs:` subscription and an upload run
+concurrently over one transport, and the upload's chunking does not stall the
+byte path.
 
-1. **Per-channel `TERMIOD_SOCK`.** `socketPath()` (`TermiodClient.swift:55-68`)
-   has no channel term, while every other per-machine artifact this app owns is
-   scoped off one bundle-id read (`AppChannel.swift`). `termio-dev` and `termio`
-   are one device today. Note the observed dev-build defect that lands nearby: a
-   failed `TERMIO_CHANNEL=dev ./scripts/build-app.sh` leaves a `.dev`-suffixed
-   `CFBundleIdentifier` in the assembled bundle, and the next run suffixes it
-   again — `sh.termio.app.dev.dev`. The suffix must be applied idempotently.
-2. **A per-channel launchd label.** `service.rs:26` has exactly one `LABEL`,
-   which is also the plist filename and the `gui/$UID` target, and `install()`
-   can only plist `std::env::current_exe()` (`:101-107`). Both need arguments.
-3. **The app installs or repairs the job on launch.** Nothing calls
-   `launchctl` — `grep -n 'launchctl' Sources/termio/Terminal/Termiod/*.swift`
-   → 0. Until it does, `KeepAlive` is a mitigation that does not exist and
-   `spawnDaemon` is the only path.
-4. **A systemd `--user` unit + `enable-linger`**, and a decision on what a
-   Sparkle update does to a running daemon (`one-path-local-through-termiod.md`
-   §5.2 item 9 — the recommendation there is a compatibility window).
+### Stage 5 — the daemon is supervised, on both platforms
 
-**Gates:** that RFC's Stage 1 criteria, minus the ones items 1 and 2 already
-satisfy. `lipo -archs termio.app/Contents/Resources/termiod` prints both slices
-today; the two-plists and `kill -9`-respawn checks are what remains, and the
-notarization checks are CI-only.
+Items 1 and 2 of the last revision landed in `1746593`. Three remain, and each is
+a release blocker on its own.
 
-### Stage 5 — foreground parity
+1. **The app installs or repairs the launchd job on launch.** Nothing calls
+   `launchctl` — `grep -rn 'launchctl' Sources/` → **0**. Until it does,
+   `KeepAlive` is a mitigation that does not exist and `spawnDaemon` is the only
+   path. `service::install()` (`service.rs:175-201`) already writes the
+   channel-scoped plist and boots the label out first; it can only plist
+   `std::env::current_exe()`, so the app must invoke the bundled daemon's own
+   `service install` rather than reimplement it in Swift.
+2. **Linux: a systemd `--user` unit plus `loginctl enable-linger`.**
+   `service.rs:161-165` currently *refuses* on Linux with an error telling the
+   user to do it by hand. That refusal is honest and is not shippable as the
+   answer.
+3. **Merge `feat/termiod-remote-install`** (§2.4), which is what makes 1 and 2
+   reachable for a box the user has not touched: Settings ▸ Machines probes with
+   `--version` rather than `test -x` (executing the binary is what proves it
+   matches the CPU and links against a libc that exists), compares a digest
+   rather than a crate version, and moves the upload into place only after
+   `chmod`. This is open question 2 of the last revision, answered.
 
-`foreground_job: bool?` on `SessionInfo`, `foreground_changed` as a debounced
-push event, `tcgetpgrp` on the master with a per-platform argv/cwd lookup, argv →
-agent mapping staying on the client. Additive within `proto:1`.
+Plus the standing decision from one-path §5.2 item 9: what a Sparkle update does
+to a running daemon. The recommendation there is a compatibility window; take it
+or replace it, but do not ship Stage 7 without an answer.
 
-**Gates:** `one-path-local-through-termiod.md` Stage 3's four criteria, run in
-`termiod`'s CI on both macOS and Linux.
+**Gates:** two plists, one per channel, both `RunAtLoad` + `KeepAlive`;
+`kill -9` the daemon and it respawns; `lipo -archs` on the shipped binary prints
+both slices (true today); a fresh Linux box reachable by alias goes from nothing
+installed to an open session without a terminal, and survives a logout.
 
-### Stage 6 — git history on the device
+### Stage 6 — the companion stops depending on `PTYProcess`
 
-`remote-git-plane.md` §5 Stages 1–4 in its own order. §8.1's prerequisite is
-already satisfied (§3); §8.2's is satisfied by Stage 3 here.
+one-path §5 Stage 4, and the biggest single stage here. **Not** "extract a
+protocol both types satisfy": `PTYBridge` uses thirteen `PTYProcess` members
+(`CompanionServer.swift:985-1080`), and the ones without a daemon counterpart are
+each a decision:
 
-### Stage 7 — the CLI moves, verb by verb
+- **`modeResyncPreamble()` / `isAlternateScreenActive`.** `alt_screen` *is* on
+  the wire (`protocol.rs:174`, carried in both the `S` snapshot and the `G`
+  grid), so the alt-screen test has a counterpart. The mode **preamble** — mouse
+  reporting, the modes a skipped replay never carries — does not. The `S`
+  snapshot is the natural home; say so before writing it.
+- **Byte-capped replay.** The phone needs at most 128 KiB of the ring, because
+  the whole ring reflowed at a narrow grid is the allocator-panic trigger
+  recorded at `CompanionServer.swift:1007-1010`. Either the wire grows a replay
+  bound on `attach`, or the client truncates what it receives. The second wastes
+  bandwidth on exactly the link that has least to spare. **Decide it here, not
+  in code review.**
+- **`jiggleResize()`.** A resize to identical dimensions is a daemon no-op, so
+  "make the child redraw" has no verb. The honest options are a client-side wipe
+  plus a snapshot request, or accepting a stale frame until the next output. Do
+  **not** invent a host-side redraw op without arguing it — the host does not
+  decide presentation (invariant #7).
+- **Ownership.** `claimCompanionOwnership` / `claimHostOwnership` are an explicit
+  claim; the daemon's writer token is newest-interactive-wins
+  (`recompute_writer`, `session.rs`). Reconciling them is the piece most likely
+  to change phone behaviour visibly.
 
-`one-path-local-through-termiod.md` §7 and Stage 6, unchanged, plus §4's hook
-routing. `scripts/termio` becomes a router; `focus` and `notify` stay.
+Exit fan-out is inherited from 4b rather than solved here.
 
-### Stage 8 — the companion, then delete the fork
+**Gates:** one-path §5 Stage 4's criteria, unchanged, plus
+`grep -rn 'PTYProcess' Sources/termio/Companion/` → 0. Verified on a real device,
+not the simulator.
 
-`one-path-local-through-termiod.md` Stages 4 and 5. Deliberately last: §1.5 of
-that RFC establishes that `PTYBridge` uses twelve `PTYProcess` members and three
-have no daemon counterpart at all, so this is a rebuild of the mirror, not a
-conformance exercise.
+### Stage 7 — default on, for one full release
+
+Ship with `Termiod.isEnabled` defaulting to **true** and `TERMIO_TERMIOD=0`
+able to force it off. Then run one release and change nothing else in this list.
+
+This is not a formality. Stages 1–6 each removed a reason the flag existed;
+Stage 8 removes the alternative, and its rollback is a release rollback rather
+than a runtime switch. The soak is the only thing standing between that and a
+user with no way back. **Task notifications never fire from a dev build**, so the
+notification path in particular has to be exercised on the release channel here
+or it is not exercised at all.
+
+**Gate:** one shipped release on the release channel with the daemon backend on
+by default and no rollback. Concretely: local sessions survive an app quit and
+relaunch reattaching to the same pid; the companion, agent status, and task
+notifications behave as they did with the flag off.
+
+### Stage 8 — delete the local PTY fork
+
+Only now. Remove `Termiod.isEnabled` and every branch on it, the in-process
+`PTYProcess` construction (`TermioStore+TerminalSurface.swift:253`), the flag-off
+alerts (`TermioStore+Termiod.swift:861-865`, `TermioStore+TerminalSurface.swift:572`),
+the `ptyProcesses` half of `terminateAllSessions`, and `PTYProcess.swift` itself.
+
+**Gates:** one-path §5 Stage 5's criteria verbatim —
+`grep -rn 'TERMIO_TERMIOD\b' Sources/ | wc -l` → 0 (correctly excluding
+`TERMIO_TERMIOD_BIN`); `grep -rn 'PTYProcess(' Sources/ | wc -l` → 0; `sleep 300`
+in a local pane survives a quit and relaunch at the same pid; `swift test` green;
+a screen-recorded pass of new terminal, new agent session, group, close with a
+running job, close idle, agent self-quit.
+
+**Rollback: a release rollback.** That is what Stage 7 buys.
+
+### Stage 9 — the git and file panes read the device
+
+**This stage migrates capabilities the app already has. It adds no verb the
+product does not already ship**, and that boundary is what separates it from
+Stage 11.
+
+Gated on 4b for everything subscription-shaped:
+
+- `fs:` subscription → live tree updates; delete `FileTreeWatcher.swift`.
+- `git:` subscription → the Changes pane on a device.
+- `fs.match` coverage → Open Quickly against a device.
+- `git.log` / `git.show` / `git.branches`, already shipped in Rust and consumed
+  by nobody (`grep -rn '"git\.' Sources/` → **0**) → History and Compare.
+- The verbs the daemon does **not** have yet but the app does, all read-only:
+  worktree enumeration (`WorktreeService.swift`), `.gitignore` pattern reads,
+  remote/PR URL derivation, clone info, the stall fingerprint.
+
+`GitService.discard` is the one mutation in today's app. It moves in **Stage 11**
+with the rest of the mutation tier, not here — a discard that runs on the wrong
+machine destroys work.
+
+**Gates:** History, Compare and Changes render for a device checkout with the
+same views they use locally, and every unsupported control is **hidden rather
+than inert**. `touch` a file on the VPS and the tree updates without a manual
+refresh. Replay inside the watcher's 300-second linger (`resource.rs:51`) is
+exact; past it, `gap: true` forces a full rescan. **The watcher's budget is
+bounded before this ships** — a recursive watch plus a full BFS name-index walk
+over `$HOME` or a large monorepo, alive five minutes past the last subscriber, is
+not obviously authorized by "the user let us read this machine" (open question 3).
+
+### Stage 10 — the CLI moves, verb by verb
+
+one-path §7 and its Stage 6, unchanged in content and in internal order: `read`,
+`send`/`answer`, `watch`, `list`, `spawn`/`run`/`close`, then
+`agent report` → `set-status` plus hook installation on the device.
+`scripts/termio` becomes a router; `focus` and `notify` stay in Swift (§4.1).
+
+Now cheap, because there is one session backend to route to rather than two.
+
+**Gates:** one-path Stage 6's criteria verbatim, including the old-shape check on
+**values** — `termio sessions list --json` matched against the pre-move build for
+a session that has `cd`'d out of its spawn directory, which is the case that
+passes a field-identical check while `cwd` silently rots.
+
+### Stage 11 — remote git's new scope: mutation, askpass, network
+
+`remote-git-plane.md` §5 Stages 2–4, in its order, and **only** these — the read
+tier (its Stage 1) landed in `d38f50c` and is consumed in Stage 9 above.
+
+- **Local mutation tier**: staging, commit, discard, stash, branch ops, ignore
+  writes. No network, no credentials. Commit runs the box's hooks, which is the
+  point — hook output and hook failure must reach the pane rather than be
+  swallowed into a generic error.
+- **The askpass channel, built and tested alone**, before any verb depends on
+  it: a prompt raised on the box, answered on the Mac, plus cancel and timeout.
+- **Network tier**: `git.fetch`, `git.pull`, `git.push`, cancellable, with
+  progress.
+
+The prompt-answered-from-the-phone property is a *consequence* of the askpass
+prompt being a typed protocol object, not extra work, and it must not be built
+into the askpass stage.
+
+**Gates:** remote-git-plane §5's per-stage gates verbatim — a failing
+`pre-commit` hook shows its own output; `index.lock` contention is reported as
+contention; a passphrase-protected clone completes after answering on the Mac and
+a cancel produces a named error rather than a hang.
+
+`git.blame` (remote-git-plane §5 Stage 1) is **not** scheduled: it is
+editor-adjacent and termio's editor is a preview (§9.5).
 
 ---
 
-## 5. Where this disagrees with an existing RFC
+## 7. Where this disagrees with an existing RFC
 
-1. **`remote-git-plane.md` §8.1 is stale.** It says the workspace reference
-   "is unresolved in `one-workspace-source.md` and its review" and that the RFC
-   "should not be implemented before it". `Checkout`
-   (`DeviceContext.swift:56-101`) resolves it, with `host_id`-first identity —
-   which is what the codex review asked for and what `ProjectLocation` did not
-   give. Strike §8.1; §8.2 and §8.3 stand.
+1. **Device architecture §8's ordering is superseded** (§0). Its invariants and
+   its 4a/4b/4c split stand; steps 5–12 do not describe a runnable sequence any
+   more. In particular §8's step 9 ("request plane, then file tree and git move")
+   sits at Stage 9 here and needs no request plane — `fs.*` and `git.*` are their
+   own verbs and shipped that way.
 
-2. **`one-workspace-source.md` §2's `ProjectLocation` should not be built.** It
-   is a two-case enum keyed on `deviceID`; `KnownDevice` + `Checkout` are the
-   same information already in the tree, already tested
+2. **`remote-git-plane.md` §8.1 is stale.** It says the workspace reference "is
+   unresolved" and that the RFC "should not be implemented before it". `Checkout`
+   (`DeviceContext.swift:56-101`) resolves it, with the `host_id`-first identity
+   the codex review asked for. Strike §8.1; §8.2 and §8.3 stand. Its §5 Stage 1
+   is done in Rust, which §8.1 would have forbidden starting.
+
+3. **`one-workspace-source.md` §2's `ProjectLocation` should not be built.** A
+   two-case enum keyed on `deviceID` is a second spelling of `KnownDevice` +
+   `Checkout`, which is already in the tree, already tested
    (`InspectorCheckoutTests`, 6 tests), and already consumed by every inspector
-   pane. Adding a second spelling of the same idea is the fork this plan exists
-   to remove. The codex review anticipated exactly this: it proposed
-   `WorkspaceReference { deviceID; root }` over the enum, and `Checkout` *is*
-   that struct.
+   pane. `grep -rn ProjectLocation Sources/ Shared/` → 0, and should stay 0. The
+   codex review anticipated this: it proposed `WorkspaceReference { deviceID;
+   root }`, and `Checkout` *is* that struct.
 
-3. **`one-workspace-source.md` §5's stage order is inverted.** It puts "delete
-   SFTP" last, at Stage 5, behind editing and mutations. Its own review
-   disagreed — "SFTP is read-only. A static `fs.list`/`fs.read` tree plus the
-   settled plain-SSH install affordance can replace it" — and the review is
-   right. Deleting 1,409 lines of the least-tested transport in the app is the
-   cheapest correctness win available and it gates nothing.
+4. **`one-workspace-source.md` §5's stage order is inverted**, and this document
+   supersedes it. It put "delete SFTP" last, behind editing and mutations; its
+   own review disagreed and was right. That deletion shipped first and removed
+   1,409 lines.
 
-4. **The brief's "delete `RemoteFileTree.swift`" is wrong.** See §2.3. The SFTP
-   plane is 1,409 lines; the tree that renders it is not part of it.
+5. **The brief's "delete `RemoteFileTree.swift`" is wrong.** §4.3.
 
-5. **`one-path-local-through-termiod.md` §5.2 item 1 and
-   `one-binary-and-a-daemon-that-ships.md` §1 both lead with a problem that is
-   solved.** "A released build today cannot start a daemon at all" was true when
-   written and is not now: commit `2199f35` builds, `lipo`s, arch-checks and
-   signs `termiod` into `Contents/Resources`, and `daemonBinaryPath()` resolves
-   it. Verified by building the bundle here. What is left is supervision and
-   channel scoping — Stage 4, and a much smaller item than either RFC prices it
-   at. Both should be edited rather than read as current.
+6. **`one-path-local-through-termiod.md` §5.2 item 1 and
+   `one-binary-and-a-daemon-that-ships.md` §1 both lead with a solved problem.**
+   "A released build cannot start a daemon at all" was true when written:
+   `2199f35` builds, `lipo`s, arch-checks and signs `termiod` into
+   `Contents/Resources`, and `daemonBinaryPath()` resolves it. What is left is
+   Stage 5, a much smaller item than either RFC prices it at.
 
-6. **`one-path-local-through-termiod.md` Stage 2 item `4a` is done.**
-   `multiplexingArguments` ships (`TermiodClient.swift:208-236`, applied at
-   `:381`). Stage 3 here inherits only `4b`.
+7. **`one-path-local-through-termiod.md` Stage 2 item `4a` is partly done, not
+   done.** The last revision of this document said "done"; that overstated it.
+   `multiplexingArguments` ships, `BatchMode`/`ConnectTimeout` do not, and the
+   missing pair is the difference between a named error and a hang. Corrected in
+   Stage 4a.
 
-7. **`one-binary-and-a-daemon-that-ships.md` §2.3 stays dead.** Two binaries,
-   two names. Reason: B1 and B2 in §1.4. Do not re-propose.
+8. **`one-binary-and-a-daemon-that-ships.md` §2.3 stays dead.** Two binaries, two
+   names. A daemon named `termio` copied to Application Support lands byte-for-
+   byte on the path `CommandLineTool.supportCopyURL` owns and that every
+   installed hook names absolutely; the hook ends `2>/dev/null || true`, so
+   status reporting would die silently. And a router named `termio` cannot
+   dispatch to a binary named `termio`. **Do not re-propose.**
+
+9. **`one-path-local-through-termiod.md` §3.2's `foreground_changed` event does
+   not exist and should not be built.** That section specifies
+   `E { ev: "foreground_changed", session, pid, argv, cwd? }` as a debounced
+   push. The implementation instead reuses `E roster`, which already carried
+   `{session, action, info}` with the **whole** `SessionInfo`, and adds an
+   optional final `info` to `E session_exited`. Every property §3.2 argued for is
+   kept — it is a push and not a poll, it never touches `fan_out`, and the host
+   reports argv while the client maps it to an agent — and one problem is
+   removed: a whole-row event has no partial-update ordering to get wrong and
+   needs no second shape to version. **Strike the `foreground_changed` line from
+   §3.2; its three rules stand.**
+
+10. **`one-path-local-through-termiod.md` §3.2's last sentence is inverted by the
+    mechanism.** It reads: *"`foreground_job` rides `list` rather than an event
+    because its consumer asks once, at close time, and a stale push is worse than
+    a fresh question."* The premise does not hold. `Session::info()` reads the
+    `self.foreground` cache, so a `list` reply is built from **the same 2-second
+    sample** the push carried — the question is not fresher, it is the same
+    answer fetched again at 216–292 ms of main-thread SSH latency. The close
+    confirmation therefore reads the cached push deliberately, with an
+    in-process PTY overriding it whenever one exists, and both stale directions
+    bounded (Stage 2). **Strike that sentence.** The skew rule it sits beside —
+    an absent field preserves today's no-confirm behaviour and must never be read
+    as "unknown, so confirm" — is unchanged and is load-bearing.
 
 ---
 
-## 6. Non-goals
+## 8. Explicitly deferred
 
-- **QUIC, discovery, `grid_diff` by default, the workspace registry (device
-  arch §8.11).** Out, as in the source RFCs.
+Not "out of scope forever" — sequenced after this plan, with the reason recorded
+so nobody reads the absence as an oversight.
+
+- **Merging `feat/termiod-wss`.** Worth doing on its own terms: it proves the
+  protocol is transport-agnostic (invariant #4) with a byte-identical splice, it
+  is 100% additive, and it adds zero protocol verbs. It is **not** progress on
+  the Swift→Rust boundary and nothing here depends on it. Two conditions before
+  it lands: it needs a rebase across the thirteen `termiod/` commits it is now
+  behind (§2.4), and nothing in CI runs `vitest`/`tsc`/`vite build` for
+  `web/client/`. `termiod/ARCHITECTURE.md` still describes termiod as
+  Unix-socket + `termiod stdio` only.
+- **iOS attaching directly to a device.** Device arch §8.12. The topology is
+  decided; the transport is not, and it is gated on §9.6 — how a phone reaches a
+  device without embedding SSH (invariant #3). Until that is answered, the phone
+  stays a client of the Mac.
+- **Deleting the companion wire.** It is the one place the repo contradicts
+  invariant #4, and it is *not* deletable before the line above: deleting it
+  first leaves the phone with nothing to speak. §5 of
+  `20260819-device-workspace-project.md` establishes the cost is low when the
+  time comes — `WireProtocol.swift` contains the word "workspace" zero times, and
+  the whole artifact is a display prefix plus a routing id.
+- **Moving workspace authority to the device.** §3. Belongs with direct-attach,
+  for the same reason.
+- **QUIC, discovery, `grid_diff` by default.**
 - **Session survival across a daemon restart.** Decided against
   (`one-path-local-through-termiod.md` §5.2 item 7): a holder process or an
-  `exec`-preserving re-exec is a supervisor design, and it would reintroduce the
+  `exec`-preserving re-exec is a supervisor design, and it reintroduces the
   failure mode the daemon exists to remove — two processes disagreeing about who
   owns a PTY. Make restarts rare and honest instead.
-- **Merging `termio` and `termiod` into one binary.** §1.4.
-- **Moving `OSCProgressScanner` or `AgentStatusRules` to the host.** §2.1.
-- **A chat/structured-event lens.** Built and reverted three times; the design
+- **Merging `termio` and `termiod` into one binary.** §7.8.
+- **Moving `OSCProgressScanner` or `AgentStatusRules` to the host.** §4.1.
+- **A chat / structured-event lens.** Built and reverted three times; the design
   docs record why.
-- **Windows.** ConPTY has no controlling terminal and no `tcgetpgrp`. The field
-  would be absent, which is the same shape as an old daemon that does not send
-  it. One degrade path serves both.
-- **Merging `feat/termiod-wss`.** Worth doing, independent of this plan, and not
-  sequenced here.
+- **Windows.** ConPTY has no controlling terminal and no `tcgetpgrp`. The
+  foreground fields would be absent, which is the same shape as an old daemon
+  that does not send them — one degrade path serves both.
 
 ---
 
-## 7. Open questions
+## 9. Open questions
 
-1. **Does the one-shot channel cost show up in the Files pane over SSH?** Stage
-   1's criterion measures cold expansion. If a warm ControlMaster does not hold
-   it under ~50 ms per expand, Stage 3 moves ahead of Stage 2.
-2. **What does a plain-`ssh` session's Files pane say, exactly?** Stage 1 ships
-   the honest empty state; the install affordance needs Stage 4, because
-   `remote deploy` cross-compiles with `env!("CARGO_MANIFEST_DIR")` and `cargo`
-   on the user's Mac (`remote.rs:254-268`) and cannot run from a shipped app.
-   Nothing publishes a Linux `termiod` artifact today.
-3. **Does the watcher's budget need a bound before Stage 3?** The codex review
-   raised it: a recursive watch plus a full BFS name-index walk over `$HOME` or
-   a large monorepo, alive 5 minutes past the last subscriber
-   (`resource.rs:51`). Reaching a machine authorizes reads; it does not
-   obviously authorize that.
+1. **Does the one-shot channel cost show up over SSH?** Stage 3 measures cold
+   expansion over a warm ControlMaster. If it does not hold under ~50 ms, Stage 4
+   moves ahead of Stage 3. *(Carried from the last revision; Stage 1 shipped
+   without measuring it because the tree expands one directory per click and
+   search does not.)*
+2. ~~**What does a plain-`ssh` session's Files pane say, and who installs the
+   daemon?**~~ **Answered** by `feat/termiod-remote-install` (§2.4), folded into
+   Stage 5. The pane's honest empty state names the host; Settings ▸ Machines is
+   the affordance.
+3. **Does the watcher's budget need a bound before Stage 9?** Raised by the codex
+   review: a recursive watch plus a full BFS name-index walk over `$HOME` or a
+   large monorepo, alive five minutes past the last subscriber
+   (`resource.rs:51`). Reaching a machine authorizes reads; it does not obviously
+   authorize that. Stage 9's gate says yes; the shape of the bound is open.
 4. **File identity for the editor and the diff overlay.** `openFileURL`,
    `GitDiffRequest` and `IssuesPanelModel.repoRoot` all store local paths. They
-   need `(Checkout, relative path)` before Stage 6. Not before Stage 1 —
+   need `(Checkout, relative path)` before Stage 9. Not before Stage 3 —
    previews stage to a local temp file and already work that way.
-5. **Where does `Termiod.isEnabled` stop gating?** Every stage here is inert
-   with the flag off. Flipping the default is Stage 8's precondition and needs
-   one full release cycle behind it.
+5. **Does blame belong at all?** remote-git-plane §5 Stage 1 lists it and its own
+   §9.5 doubts it, on the grounds that blame is editor-adjacent and termio's
+   editor is a preview. It did not ship with the rest of the read tier
+   (`grep -rn blame termiod/src/` → 0). Decide when there is a real editor
+   surface, not before.
+6. **What does a Sparkle update do to a running daemon?** one-path §5.2 item 9
+   recommends a compatibility window. Stage 7 cannot ship without an answer,
+   because the soak is the release where it would first bite.
+7. **Where does the device's project registry start?** §3 shows the first inch is
+   one field — `Session::info()` reading back `workstream.project`. Whether the
+   registry grows past that before direct-attach is the same question as
+   workspace authority, and should be answered with it.

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -306,9 +306,10 @@ impl Manager {
                     }) if session == session_id && until.iter().any(|wanted| wanted == &status) => {
                         return Ok((status, None));
                     }
-                    Ok(Event::SessionExited { session, status })
-                        if session == session_id
-                            && until.iter().any(|wanted| wanted == "exited") =>
+                    Ok(Event::SessionExited {
+                        session, status, ..
+                    }) if session == session_id
+                        && until.iter().any(|wanted| wanted == "exited") =>
                     {
                         return Ok(("exited".to_string(), Some(status)));
                     }

--- a/termiod/src/proc.rs
+++ b/termiod/src/proc.rs
@@ -184,16 +184,15 @@ mod imp {
     /// `proc_listpgrppids` answers with pids alone, so each one is read back
     /// through `PROC_PIDTBSDINFO` for its state and — the part that matters —
     /// its *own* idea of which group it is in. That second check is what keeps
-    /// a recycled pid out of the answer: a pid that has been reused since
-    /// `tcgetpgrp` named this group reports a different `pbi_pgid`, and the
-    /// shared rule drops it.
-    /// Two things about `proc_listpgrppids` are worth writing down, because
-    /// both were established against the kernel rather than read in a header:
-    /// it answers with a **count of pids**, not a byte length, and its
-    /// `NULL`-buffer sizing call ignores the group filter entirely — it reports
-    /// every pid on the machine. So there is no sizing call to make. Allocate,
-    /// and grow only when the answer exactly filled the buffer, which is the
-    /// one case a truncation cannot be told from a fit.
+    /// a recycled pid out of the answer: a pid reused since `tcgetpgrp` named
+    /// this group reports a different `pbi_pgid`, and the shared rule drops it.
+    ///
+    /// Two things about `proc_listpgrppids` were established against the kernel
+    /// rather than read in a header: it answers with a **count of pids**, not a
+    /// byte length, and its `NULL`-buffer sizing call ignores the group filter
+    /// entirely — it reports every pid on the machine. So there is no sizing
+    /// call to make. Allocate, and grow only when the answer exactly filled the
+    /// buffer, the one case a truncation cannot be told from a fit.
     fn group_members(pgid: i32) -> Vec<super::GroupMember> {
         if pgid <= 0 {
             return Vec::new();
@@ -243,10 +242,15 @@ mod imp {
         }
         Some(super::GroupMember {
             pid,
-            // Reduced to the one state the shared rule cares about. A process
-            // still being created (`SIDL`) has no argv yet and is filtered by
-            // the argv probe rather than by its state.
-            state: if info.pbi_status == SZOMB { 'Z' } else { 'R' },
+            // A zombie is the one state that disqualifies a member outright. A
+            // process still being created (`SIDL`) has no argv yet and is
+            // filtered by the argv probe instead, which costs nothing extra
+            // because that probe has to run for every candidate anyway.
+            liveness: if info.pbi_status == SZOMB {
+                super::Liveness::Dead
+            } else {
+                super::Liveness::Live
+            },
             process_group: info.pbi_pgid as i32,
         })
     }
@@ -349,10 +353,10 @@ mod imp {
     /// candidate is simply not a candidate.
     fn read_member(pid: i32) -> Option<super::GroupMember> {
         let raw = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-        let (state, process_group) = super::parse_process_stat(&raw)?;
+        let (liveness, process_group) = super::parse_process_stat(&raw)?;
         Some(super::GroupMember {
             pid,
-            state,
+            liveness,
             process_group,
         })
     }
@@ -394,10 +398,24 @@ mod imp {
 
 pub use imp::{executable_identity, foreground_member, process_arguments, working_directory};
 
-/// A process considered as a member of the foreground group, reduced to the
-/// three facts both hosts can enumerate cheaply: `/proc/<pid>/stat` on Linux,
-/// one `KERN_PROC_PGRP` sysctl on macOS. Argv is deliberately *not* here — it
-/// is the expensive read on both, and the selection resolves it lazily.
+/// Whether a candidate can still answer, or is on its way out. The hosts spell
+/// process state differently — a letter in `/proc/<pid>/stat`, a `p_stat` in
+/// `proc_bsdinfo` — and this is all of it the selection needs, so each host maps
+/// its own spelling on the way in rather than the rule learning both.
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "linux", test)),
+    allow(dead_code)
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Liveness {
+    Live,
+    Dead,
+}
+
+/// A process considered as a member of the foreground group, reduced to what
+/// both hosts can enumerate cheaply: one `/proc/<pid>/stat` read on Linux, one
+/// `PROC_PIDTBSDINFO` call on macOS. Argv is deliberately *not* here — it is the
+/// expensive read on both, and the selection resolves it lazily.
 #[cfg_attr(
     not(any(target_os = "macos", target_os = "linux", test)),
     allow(dead_code)
@@ -405,9 +423,7 @@ pub use imp::{executable_identity, foreground_member, process_arguments, working
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct GroupMember {
     pid: i32,
-    /// Single-letter process state, in Linux's spelling. macOS maps `SZOMB`
-    /// onto `Z` so one rule serves both.
-    state: char,
+    liveness: Liveness,
     process_group: i32,
 }
 
@@ -417,14 +433,14 @@ struct GroupMember {
 /// The group check is not redundant with having enumerated the group. It is
 /// what stops a recycled pid being reported: between `tcgetpgrp` naming a group
 /// and this running, that pid can belong to something else entirely, and a pid
-/// whose `e_pgid` / `pgrp` no longer matches is not the process we were asked
+/// whose own process group no longer matches is not the process we were asked
 /// about no matter what its number is.
 #[cfg_attr(
     not(any(target_os = "macos", target_os = "linux", test)),
     allow(dead_code)
 )]
 fn member_is_live(member: &GroupMember, pgid: i32) -> bool {
-    member.process_group == pgid && !matches!(member.state, 'Z' | 'X' | 'x')
+    member.process_group == pgid && member.liveness == Liveness::Live
 }
 
 /// The Linux decision, with both `/proc` reads handed in so the shape of the
@@ -487,8 +503,9 @@ fn select_foreground_member(
         .collect();
     candidates.sort_unstable();
     candidates.dedup();
-    let leader = candidates.iter().copied().find(|pid| *pid == pgid);
-    leader
+    candidates
+        .contains(&pgid)
+        .then_some(pgid)
         .into_iter()
         .chain(candidates.iter().copied().filter(|pid| *pid != pgid))
         .find(|pid| has_argv(*pid))
@@ -499,14 +516,21 @@ fn select_foreground_member(
 /// because field 2 is the executable name in parentheses and a program is free
 /// to be called `sleep 1) 0 (evil`. The kernel writes the name verbatim, so the
 /// only reliable anchor is the *last* `)` in the line.
+///
+/// `Z`, `X` and `x` are the states a process cannot come back from; everything
+/// else — sleeping, stopped, traced — is a process that still answers.
 #[cfg(any(target_os = "linux", test))]
-fn parse_process_stat(raw: &str) -> Option<(char, i32)> {
+fn parse_process_stat(raw: &str) -> Option<(Liveness, i32)> {
     let tail = &raw[raw.rfind(')')? + 1..];
     let mut fields = tail.split_whitespace();
     let state = fields.next()?.chars().next()?;
     // state, ppid, then pgrp.
     let process_group = fields.nth(1)?.parse().ok()?;
-    Some((state, process_group))
+    let liveness = match state {
+        'Z' | 'X' | 'x' => Liveness::Dead,
+        _ => Liveness::Live,
+    };
+    Some((liveness, process_group))
 }
 
 #[cfg(any(target_os = "macos", test))]
@@ -713,22 +737,29 @@ mod tests {
         assert!(split_procargs2(&(-1i32).to_ne_bytes()).is_none());
     }
 
-    fn member(pid: i32, state: char) -> GroupMember {
+    fn live(pid: i32) -> GroupMember {
         GroupMember {
             pid,
-            state,
+            liveness: Liveness::Live,
             process_group: 100,
+        }
+    }
+
+    fn dead(pid: i32) -> GroupMember {
+        GroupMember {
+            liveness: Liveness::Dead,
+            ..live(pid)
         }
     }
 
     /// Stand-in for the per-host argv read, which also records the order the
     /// selection probed in — the cost this closure exists to bound.
-    fn argv_of(live: &[i32]) -> (impl FnMut(i32) -> bool + '_, Rc<RefCell<Vec<i32>>>) {
+    fn argv_of(answering: &[i32]) -> (impl FnMut(i32) -> bool + '_, Rc<RefCell<Vec<i32>>>) {
         let probed = Rc::new(RefCell::new(Vec::new()));
         let seen = Rc::clone(&probed);
         let has_argv = move |pid: i32| {
             seen.borrow_mut().push(pid);
-            live.contains(&pid)
+            answering.contains(&pid)
         };
         (has_argv, probed)
     }
@@ -738,7 +769,7 @@ mod tests {
     #[test]
     fn prefers_the_group_leader_while_it_is_usable() {
         let (has_argv, probed) = argv_of(&[100, 101]);
-        let members = [member(100, 'S'), member(101, 'R')];
+        let members = [live(100), live(101)];
         assert_eq!(select_foreground_member(100, &members, has_argv), Some(100));
         assert_eq!(*probed.borrow(), vec![100]);
     }
@@ -750,13 +781,13 @@ mod tests {
     #[test]
     fn falls_back_to_a_live_member_when_the_leader_is_gone() {
         let (has_argv, _) = argv_of(&[103]);
-        let zombie = [member(100, 'Z'), member(103, 'R')];
+        let zombie = [dead(100), live(103)];
         assert_eq!(select_foreground_member(100, &zombie, has_argv), Some(103));
 
         // Reaped outright: the leader is not enumerable at all, so it is not
         // even a candidate.
         let (has_argv, probed) = argv_of(&[103]);
-        let reaped = [member(103, 'R')];
+        let reaped = [live(103)];
         assert_eq!(select_foreground_member(100, &reaped, has_argv), Some(103));
         assert_eq!(
             *probed.borrow(),
@@ -770,7 +801,7 @@ mod tests {
     #[test]
     fn skips_a_live_leader_with_no_argv() {
         let (has_argv, probed) = argv_of(&[104]);
-        let members = [member(100, 'R'), member(104, 'S')];
+        let members = [live(100), live(104)];
         assert_eq!(select_foreground_member(100, &members, has_argv), Some(104));
         assert_eq!(
             *probed.borrow(),
@@ -784,13 +815,13 @@ mod tests {
     #[test]
     fn picks_the_same_survivor_every_time() {
         let (has_argv, _) = argv_of(&[105, 107]);
-        let ascending = [member(107, 'S'), member(105, 'R')];
+        let ascending = [live(107), live(105)];
         assert_eq!(
             select_foreground_member(100, &ascending, has_argv),
             Some(105)
         );
         let (has_argv, _) = argv_of(&[105, 107]);
-        let descending = [member(105, 'R'), member(107, 'S')];
+        let descending = [live(105), live(107)];
         assert_eq!(
             select_foreground_member(100, &descending, has_argv),
             Some(105)
@@ -802,7 +833,7 @@ mod tests {
         let (has_argv, _) = argv_of(&[]);
         assert_eq!(select_foreground_member(100, &[], has_argv), None);
         let (has_argv, probed) = argv_of(&[100, 103]);
-        let all_dead = [member(100, 'Z'), member(103, 'X')];
+        let all_dead = [dead(100), dead(103)];
         assert_eq!(select_foreground_member(100, &all_dead, has_argv), None);
         assert!(
             probed.borrow().is_empty(),
@@ -816,7 +847,7 @@ mod tests {
     #[test]
     fn ignores_processes_from_another_group() {
         let (has_argv, probed) = argv_of(&[100]);
-        let mut stranger = member(100, 'R');
+        let mut stranger = live(100);
         stranger.process_group = 200;
         assert_eq!(select_foreground_member(100, &[stranger], has_argv), None);
         assert!(probed.borrow().is_empty());
@@ -829,10 +860,10 @@ mod tests {
     #[test]
     fn parses_the_proc_stat_layout() {
         let plain = "4242 (grep) R 4200 4100 4100 34816 4242 0 0 0 0 0 0 0 20 0";
-        assert_eq!(parse_process_stat(plain), Some(('R', 4100)));
+        assert_eq!(parse_process_stat(plain), Some((Liveness::Live, 4100)));
 
         let awkward = "4242 (a (b) c) Z 4200 4100 4100 34816 0 0 0 0 0 0 0 0 20 0";
-        assert_eq!(parse_process_stat(awkward), Some(('Z', 4100)));
+        assert_eq!(parse_process_stat(awkward), Some((Liveness::Dead, 4100)));
     }
 
     #[test]
@@ -868,7 +899,7 @@ mod tests {
     #[test]
     fn a_reaped_leader_falls_through_to_the_scan() {
         let (has_argv, _) = argv_of(&[103]);
-        let survivors = vec![member(103, 'R')];
+        let survivors = vec![live(103)];
         assert_eq!(
             resolve_foreground_member(100, None, || survivors.clone(), has_argv),
             Some(103)
@@ -880,13 +911,13 @@ mod tests {
     /// is an honest "no answer", not a fabricated pid.
     #[test]
     fn an_unusable_leader_falls_through_to_the_scan() {
-        let zombie = member(100, 'Z');
+        let zombie = dead(100);
         let (has_argv, _) = argv_of(&[104]);
         assert_eq!(
             resolve_foreground_member(
                 100,
                 Some(zombie.clone()),
-                || vec![zombie.clone(), member(104, 'S')],
+                || vec![zombie.clone(), live(104)],
                 has_argv
             ),
             Some(104)
@@ -906,7 +937,7 @@ mod tests {
         let (has_argv, _) = argv_of(&[100]);
         let answer = resolve_foreground_member(
             100,
-            Some(member(100, 'S')),
+            Some(live(100)),
             || panic!("the leader answered; nothing should have scanned /proc"),
             has_argv,
         );

--- a/termiod/src/proc.rs
+++ b/termiod/src/proc.rs
@@ -8,17 +8,27 @@
 //!
 //! termio's macOS app reads this with `KERN_PROCARGS2` + `proc_pidinfo`
 //! (`Sources/termio/Terminal/Ghostty/PTYProcess.swift`), which is why it has
-//! never worked for a Linux host. The same three questions have plain answers
-//! under `/proc`, so this module asks them behind one interface and lets the
-//! target pick the mechanism.
+//! never worked for a Linux host. The same questions have plain answers under
+//! `/proc`, so this module asks them behind one interface and lets the target
+//! pick the mechanism.
 //!
-//! Every function here is a syscall against a pid, so two rules hold at every
+//! What is *not* per-target is the shape of the answer. `tcgetpgrp` names a
+//! process group and every argv lookup wants a pid, and the two only agree
+//! while the group leader is alive. Both hosts therefore enumerate the group
+//! and pick a live member — `proc_listpgrppids` on macOS, a `/proc` walk on
+//! Linux — through one selection rule below.
+//!
+//! Every function here is a syscall against a pid, so three rules hold at every
 //! call site:
 //!
 //! 1. **Never on the byte path.** Sampling is a poll, bounded and infrequent;
-//!    PTY delivery must not wait on it (the anti-100× invariant).
+//!    PTY delivery must not wait on it (the anti-100× invariant). The session
+//!    actor dispatches this work to a blocking thread for exactly that reason.
 //! 2. **Never after the child is reaped.** A recycled pid answers confidently
 //!    about a process that is not ours.
+//! 3. **Never trust a pid without its group.** Every candidate is checked
+//!    against the group it was asked about, because rule 2's recycled pid is
+//!    reachable through a stale group id too.
 //!
 //! Failure is always `None`. A refusal by the kernel, a process that exited
 //! mid-read, a short buffer — none of them are worth an error type, because
@@ -147,6 +157,103 @@ mod imp {
         let path = executable_path(pid)?;
         Some(super::identity_for(path))
     }
+
+    /// Turn the tty's foreground process *group* into a process that can
+    /// actually answer for it.
+    ///
+    /// The Swift app passed the pgid straight to `KERN_PROCARGS2` and this
+    /// module copied it, on the assumption that a zombie leader still reports
+    /// its argv. **It does not.** `KERN_PROCARGS2` fails outright for a zombie
+    /// and for a reaped pid, so `find . | grep foo` loses its argv the instant
+    /// `find` finishes — while `grep` is still the program holding the
+    /// terminal. macOS needs the same live-member search Linux does; only the
+    /// enumeration mechanism differs.
+    ///
+    /// `proc_listpgrppids` is that mechanism — libproc's own process-group
+    /// enumeration, one call for the whole group rather than a directory walk,
+    /// so there is no cheaper leader-only probe worth trying first. The shared
+    /// selection prefers the leader from the enumerated set instead.
+    pub fn foreground_member(pgid: i32) -> Option<i32> {
+        super::select_foreground_member(pgid, &group_members(pgid), |pid| {
+            process_arguments(pid).is_some()
+        })
+    }
+
+    /// Every process the kernel currently counts in `pgid`.
+    ///
+    /// `proc_listpgrppids` answers with pids alone, so each one is read back
+    /// through `PROC_PIDTBSDINFO` for its state and — the part that matters —
+    /// its *own* idea of which group it is in. That second check is what keeps
+    /// a recycled pid out of the answer: a pid that has been reused since
+    /// `tcgetpgrp` named this group reports a different `pbi_pgid`, and the
+    /// shared rule drops it.
+    /// Two things about `proc_listpgrppids` are worth writing down, because
+    /// both were established against the kernel rather than read in a header:
+    /// it answers with a **count of pids**, not a byte length, and its
+    /// `NULL`-buffer sizing call ignores the group filter entirely — it reports
+    /// every pid on the machine. So there is no sizing call to make. Allocate,
+    /// and grow only when the answer exactly filled the buffer, which is the
+    /// one case a truncation cannot be told from a fit.
+    fn group_members(pgid: i32) -> Vec<super::GroupMember> {
+        if pgid <= 0 {
+            return Vec::new();
+        }
+        let mut capacity = 64usize;
+        loop {
+            let mut pids = vec![0i32; capacity];
+            let count = unsafe {
+                libc::proc_listpgrppids(
+                    pgid,
+                    pids.as_mut_ptr() as *mut libc::c_void,
+                    (capacity * std::mem::size_of::<i32>()) as libc::c_int,
+                )
+            };
+            if count <= 0 {
+                return Vec::new();
+            }
+            let count = (count as usize).min(capacity);
+            // A pipeline wide enough to fill 4096 slots is not a shape this has
+            // to serve exactly; taking the first 4096 members beats looping.
+            if count < capacity || capacity >= 4096 {
+                pids.truncate(count);
+                return pids.into_iter().filter_map(read_member).collect();
+            }
+            capacity *= 4;
+        }
+    }
+
+    /// One candidate's state and process group. A pid that vanished between the
+    /// enumeration and this read is simply not a candidate.
+    fn read_member(pid: i32) -> Option<super::GroupMember> {
+        if pid <= 0 {
+            return None;
+        }
+        let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+        let size = unsafe {
+            libc::proc_pidinfo(
+                pid,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                &mut info as *mut _ as *mut libc::c_void,
+                std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int,
+            )
+        };
+        if size as usize != std::mem::size_of::<libc::proc_bsdinfo>() {
+            return None;
+        }
+        Some(super::GroupMember {
+            pid,
+            // Reduced to the one state the shared rule cares about. A process
+            // still being created (`SIDL`) has no argv yet and is filtered by
+            // the argv probe rather than by its state.
+            state: if info.pbi_status == SZOMB { 'Z' } else { 'R' },
+            process_group: info.pbi_pgid as i32,
+        })
+    }
+
+    /// `SZOMB` from `<sys/proc.h>`. Spelled out because the libc crate does not
+    /// re-export the `p_stat` constants on this target.
+    const SZOMB: u32 = 5;
 }
 
 #[cfg(target_os = "linux")]
@@ -188,6 +295,73 @@ mod imp {
         let path = executable_path(pid)?;
         Some(super::identity_for(path))
     }
+
+    /// Turn the tty's foreground process *group* into a process that can
+    /// actually answer for it.
+    ///
+    /// `tcgetpgrp` names a group, and every argv lookup wants a pid. Reading
+    /// `/proc/<pgid>/cmdline` gets away with the confusion right up until the
+    /// group leader is gone: in `find . | grep foo` the leader is `find`, and
+    /// the moment it finishes, its `cmdline` is a zero-length file while `grep`
+    /// is still the program holding the terminal. Reported straight through,
+    /// the pane would claim nothing is running — the sidebar icon reverts, the
+    /// close confirmation half-disagrees with itself — while the user watches
+    /// output arrive. tmux scans for a live member instead (`osdep-linux.c`),
+    /// and so does this.
+    ///
+    /// The leader is preferred whenever it is usable, which is every simple
+    /// command and therefore nearly every sample: that path is one `stat` read
+    /// and no directory walk. The walk is the exception, not the cadence.
+    pub fn foreground_member(pgid: i32) -> Option<i32> {
+        super::resolve_foreground_member(pgid, read_member(pgid), || group_members(pgid), has_argv)
+    }
+
+    /// Every process currently in `pgid`, by walking `/proc`. Only reached when
+    /// the leader could not answer, so the walk's cost is paid on the rare
+    /// sample rather than on the cadence — and even then it reads one `stat`
+    /// per process and no `cmdline` at all. Argv is the expensive half and it
+    /// is resolved afterwards, for candidates that already passed this filter,
+    /// in preference order until one answers.
+    fn group_members(pgid: i32) -> Vec<super::GroupMember> {
+        let Ok(entries) = std::fs::read_dir("/proc") else {
+            return Vec::new();
+        };
+        let mut members = Vec::new();
+        for entry in entries.flatten() {
+            let Some(pid) = entry
+                .file_name()
+                .to_str()
+                .and_then(|name| name.parse::<i32>().ok())
+            else {
+                continue;
+            };
+            if let Some(member) = read_member(pid) {
+                if member.process_group == pgid {
+                    members.push(member);
+                }
+            }
+        }
+        members
+    }
+
+    /// One candidate's state and process group, from `/proc/<pid>/stat` alone.
+    /// The read can lose the race with the process exiting, and a vanished
+    /// candidate is simply not a candidate.
+    fn read_member(pid: i32) -> Option<super::GroupMember> {
+        let raw = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        let (state, process_group) = super::parse_process_stat(&raw)?;
+        Some(super::GroupMember {
+            pid,
+            state,
+            process_group,
+        })
+    }
+
+    /// A zombie or a process caught mid-exec answers with a zero-length
+    /// `cmdline`, which is the whole failure the member search routes around.
+    fn has_argv(pid: i32) -> bool {
+        std::fs::read(format!("/proc/{pid}/cmdline")).is_ok_and(|raw| raw.iter().any(|b| *b != 0))
+    }
 }
 
 /// Anything that is neither macOS nor Linux compiles and answers "unknown"
@@ -208,9 +382,132 @@ mod imp {
     pub fn executable_identity(_pid: i32) -> Option<ExecutableIdentity> {
         None
     }
+
+    /// No enumeration mechanism means no answer. Returning the pgid instead
+    /// would name a pid this host cannot read an argv for anyway, and a pid
+    /// with no argv behind it is worse than an absent field — the skew rule
+    /// already gives an absent field a defined meaning.
+    pub fn foreground_member(_pgid: i32) -> Option<i32> {
+        None
+    }
 }
 
-pub use imp::{executable_identity, process_arguments, working_directory};
+pub use imp::{executable_identity, foreground_member, process_arguments, working_directory};
+
+/// A process considered as a member of the foreground group, reduced to the
+/// three facts both hosts can enumerate cheaply: `/proc/<pid>/stat` on Linux,
+/// one `KERN_PROC_PGRP` sysctl on macOS. Argv is deliberately *not* here — it
+/// is the expensive read on both, and the selection resolves it lazily.
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "linux", test)),
+    allow(dead_code)
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GroupMember {
+    pid: i32,
+    /// Single-letter process state, in Linux's spelling. macOS maps `SZOMB`
+    /// onto `Z` so one rule serves both.
+    state: char,
+    process_group: i32,
+}
+
+/// Whether this member is still a candidate: the kernel counts it in the group
+/// we asked about, and has not marked it dead.
+///
+/// The group check is not redundant with having enumerated the group. It is
+/// what stops a recycled pid being reported: between `tcgetpgrp` naming a group
+/// and this running, that pid can belong to something else entirely, and a pid
+/// whose `e_pgid` / `pgrp` no longer matches is not the process we were asked
+/// about no matter what its number is.
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "linux", test)),
+    allow(dead_code)
+)]
+fn member_is_live(member: &GroupMember, pgid: i32) -> bool {
+    member.process_group == pgid && !matches!(member.state, 'Z' | 'X' | 'x')
+}
+
+/// The Linux decision, with both `/proc` reads handed in so the shape of the
+/// answer can be tested on a host that has no `/proc` to read.
+///
+/// `leader` is `None` in two different situations that must not be told apart
+/// here: a group whose leader has been reaped outright — it is not in `/proc`
+/// at all — and a read that lost the race with it exiting. Neither is a reason
+/// to stop, and treating a missing leader as the end of the answer would erase
+/// the argv of a pipeline that is still running, which is the case the fallback
+/// is for.
+///
+/// `scan` is lazy because the leader answers on nearly every sample, and a
+/// `/proc` walk per poll per session is not a cost worth paying by default.
+/// macOS has no equivalent shortcut — one sysctl already returns the whole
+/// group — so it calls [`select_foreground_member`] directly.
+#[cfg(any(target_os = "linux", test))]
+fn resolve_foreground_member(
+    pgid: i32,
+    leader: Option<GroupMember>,
+    scan: impl FnOnce() -> Vec<GroupMember>,
+    mut has_argv: impl FnMut(i32) -> bool,
+) -> Option<i32> {
+    if pgid <= 0 {
+        return None;
+    }
+    if leader.is_some_and(|member| member_is_live(&member, pgid)) && has_argv(pgid) {
+        return Some(pgid);
+    }
+    select_foreground_member(pgid, &scan(), has_argv)
+}
+
+/// Pick the process whose argv describes the foreground group.
+///
+/// The leader is tried first, so a session's reported foreground does not drift
+/// to some later stage of a pipeline while the stage that names it is still
+/// running. The rest are tried in ascending pid order — arbitrary, but
+/// *stable*, and a choice that flapped between two survivors would push a
+/// roster event every poll for no new information.
+///
+/// `has_argv` is a closure and the search stops at the first process that
+/// answers, because reading argv is a sysctl on macOS and a file read on Linux
+/// and a wide pipeline should not pay for one per member.
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "linux", test)),
+    allow(dead_code)
+)]
+fn select_foreground_member(
+    pgid: i32,
+    members: &[GroupMember],
+    mut has_argv: impl FnMut(i32) -> bool,
+) -> Option<i32> {
+    if pgid <= 0 {
+        return None;
+    }
+    let mut candidates: Vec<i32> = members
+        .iter()
+        .filter(|member| member_is_live(member, pgid))
+        .map(|member| member.pid)
+        .collect();
+    candidates.sort_unstable();
+    candidates.dedup();
+    let leader = candidates.iter().copied().find(|pid| *pid == pgid);
+    leader
+        .into_iter()
+        .chain(candidates.iter().copied().filter(|pid| *pid != pgid))
+        .find(|pid| has_argv(*pid))
+}
+
+/// The two fields of `/proc/<pid>/stat` that matter here: state and process
+/// group. Everything before them has to be skipped past rather than split on,
+/// because field 2 is the executable name in parentheses and a program is free
+/// to be called `sleep 1) 0 (evil`. The kernel writes the name verbatim, so the
+/// only reliable anchor is the *last* `)` in the line.
+#[cfg(any(target_os = "linux", test))]
+fn parse_process_stat(raw: &str) -> Option<(char, i32)> {
+    let tail = &raw[raw.rfind(')')? + 1..];
+    let mut fields = tail.split_whitespace();
+    let state = fields.next()?.chars().next()?;
+    // state, ppid, then pgrp.
+    let process_group = fields.nth(1)?.parse().ok()?;
+    Some((state, process_group))
+}
 
 #[cfg(any(target_os = "macos", test))]
 fn split_procargs2(buffer: &[u8]) -> Option<Vec<String>> {
@@ -268,7 +565,9 @@ fn identity_for(path: String) -> ExecutableIdentity {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
     use std::process::{Command, Stdio};
+    use std::rc::Rc;
     use std::time::{Duration, Instant};
 
     /// Spawn a real child and wait until the kernel agrees it has exec'd — the
@@ -412,5 +711,289 @@ mod tests {
         assert!(split_procargs2(&[]).is_none());
         assert!(split_procargs2(&0i32.to_ne_bytes()).is_none());
         assert!(split_procargs2(&(-1i32).to_ne_bytes()).is_none());
+    }
+
+    fn member(pid: i32, state: char) -> GroupMember {
+        GroupMember {
+            pid,
+            state,
+            process_group: 100,
+        }
+    }
+
+    /// Stand-in for the per-host argv read, which also records the order the
+    /// selection probed in — the cost this closure exists to bound.
+    fn argv_of(live: &[i32]) -> (impl FnMut(i32) -> bool + '_, Rc<RefCell<Vec<i32>>>) {
+        let probed = Rc::new(RefCell::new(Vec::new()));
+        let seen = Rc::clone(&probed);
+        let has_argv = move |pid: i32| {
+            seen.borrow_mut().push(pid);
+            live.contains(&pid)
+        };
+        (has_argv, probed)
+    }
+
+    /// The ordinary case, and the one the Linux fast path short-circuits on: a
+    /// single command, alive, named after itself. Nothing else is even probed.
+    #[test]
+    fn prefers_the_group_leader_while_it_is_usable() {
+        let (has_argv, probed) = argv_of(&[100, 101]);
+        let members = [member(100, 'S'), member(101, 'R')];
+        assert_eq!(select_foreground_member(100, &members, has_argv), Some(100));
+        assert_eq!(*probed.borrow(), vec![100]);
+    }
+
+    /// `find . | grep foo`: `find` finishes first and sits reaped or zombied
+    /// while `grep` is still the program the user is talking to. Reporting the
+    /// leader's empty argv here is how the pane would claim nothing is running
+    /// mid-pipeline.
+    #[test]
+    fn falls_back_to_a_live_member_when_the_leader_is_gone() {
+        let (has_argv, _) = argv_of(&[103]);
+        let zombie = [member(100, 'Z'), member(103, 'R')];
+        assert_eq!(select_foreground_member(100, &zombie, has_argv), Some(103));
+
+        // Reaped outright: the leader is not enumerable at all, so it is not
+        // even a candidate.
+        let (has_argv, probed) = argv_of(&[103]);
+        let reaped = [member(103, 'R')];
+        assert_eq!(select_foreground_member(100, &reaped, has_argv), Some(103));
+        assert_eq!(
+            *probed.borrow(),
+            vec![103],
+            "a dead leader must not cost an argv read"
+        );
+    }
+
+    /// A leader that is alive but caught between fork and exec has no argv yet.
+    /// Preferring it would report nothing while a sibling can answer.
+    #[test]
+    fn skips_a_live_leader_with_no_argv() {
+        let (has_argv, probed) = argv_of(&[104]);
+        let members = [member(100, 'R'), member(104, 'S')];
+        assert_eq!(select_foreground_member(100, &members, has_argv), Some(104));
+        assert_eq!(
+            *probed.borrow(),
+            vec![100, 104],
+            "the leader is tried first, then the rest in order"
+        );
+    }
+
+    /// Stable, not merely correct: two survivors must not take turns being the
+    /// answer, or every poll would push a roster event that says nothing new.
+    #[test]
+    fn picks_the_same_survivor_every_time() {
+        let (has_argv, _) = argv_of(&[105, 107]);
+        let ascending = [member(107, 'S'), member(105, 'R')];
+        assert_eq!(
+            select_foreground_member(100, &ascending, has_argv),
+            Some(105)
+        );
+        let (has_argv, _) = argv_of(&[105, 107]);
+        let descending = [member(105, 'R'), member(107, 'S')];
+        assert_eq!(
+            select_foreground_member(100, &descending, has_argv),
+            Some(105)
+        );
+    }
+
+    #[test]
+    fn refuses_a_group_with_nobody_left_in_it() {
+        let (has_argv, _) = argv_of(&[]);
+        assert_eq!(select_foreground_member(100, &[], has_argv), None);
+        let (has_argv, probed) = argv_of(&[100, 103]);
+        let all_dead = [member(100, 'Z'), member(103, 'X')];
+        assert_eq!(select_foreground_member(100, &all_dead, has_argv), None);
+        assert!(
+            probed.borrow().is_empty(),
+            "a dead group must not cost an argv read"
+        );
+    }
+
+    /// The membership check is what keeps a recycled pid out of the answer: a
+    /// pid that has since been moved into another group is not the process we
+    /// were asked about, whatever its number is.
+    #[test]
+    fn ignores_processes_from_another_group() {
+        let (has_argv, probed) = argv_of(&[100]);
+        let mut stranger = member(100, 'R');
+        stranger.process_group = 200;
+        assert_eq!(select_foreground_member(100, &[stranger], has_argv), None);
+        assert!(probed.borrow().is_empty());
+    }
+
+    /// `/proc/<pid>/stat` puts the executable name in parentheses as field 2,
+    /// unescaped. A parser that splits on whitespace, or that finds the *first*
+    /// `)`, reads the wrong process group for anything whose name contains a
+    /// space or a bracket — which a user is free to arrange.
+    #[test]
+    fn parses_the_proc_stat_layout() {
+        let plain = "4242 (grep) R 4200 4100 4100 34816 4242 0 0 0 0 0 0 0 20 0";
+        assert_eq!(parse_process_stat(plain), Some(('R', 4100)));
+
+        let awkward = "4242 (a (b) c) Z 4200 4100 4100 34816 0 0 0 0 0 0 0 0 20 0";
+        assert_eq!(parse_process_stat(awkward), Some(('Z', 4100)));
+    }
+
+    #[test]
+    fn rejects_an_unparseable_proc_stat() {
+        assert_eq!(parse_process_stat(""), None);
+        assert_eq!(parse_process_stat("4242 (grep"), None);
+        assert_eq!(parse_process_stat("4242 (grep) R"), None);
+        assert_eq!(parse_process_stat("4242 (grep) R 4200 nonsense"), None);
+    }
+
+    /// A group id is never a pid, and 0 is not a group this daemon can be
+    /// looking at.
+    #[test]
+    fn refuses_a_nonsense_process_group() {
+        assert_eq!(foreground_member(0), None);
+        assert_eq!(foreground_member(-1), None);
+        let (has_argv, _) = argv_of(&[]);
+        assert_eq!(
+            resolve_foreground_member(
+                0,
+                None,
+                || panic!("must not walk /proc for pgid 0"),
+                has_argv
+            ),
+            None
+        );
+    }
+
+    /// The Linux entry point's regression. A reaped leader is absent from
+    /// `/proc` entirely, so the leader read hands back `None` — and an entry
+    /// point that propagated that would answer "nothing is running" while the
+    /// rest of the pipeline still holds the terminal.
+    #[test]
+    fn a_reaped_leader_falls_through_to_the_scan() {
+        let (has_argv, _) = argv_of(&[103]);
+        let survivors = vec![member(103, 'R')];
+        assert_eq!(
+            resolve_foreground_member(100, None, || survivors.clone(), has_argv),
+            Some(103)
+        );
+    }
+
+    /// Same fall-through when the leader is present but past answering, and it
+    /// still ends at `None` when the scan finds nobody either — an empty group
+    /// is an honest "no answer", not a fabricated pid.
+    #[test]
+    fn an_unusable_leader_falls_through_to_the_scan() {
+        let zombie = member(100, 'Z');
+        let (has_argv, _) = argv_of(&[104]);
+        assert_eq!(
+            resolve_foreground_member(
+                100,
+                Some(zombie.clone()),
+                || vec![zombie.clone(), member(104, 'S')],
+                has_argv
+            ),
+            Some(104)
+        );
+        let (has_argv, _) = argv_of(&[]);
+        assert_eq!(
+            resolve_foreground_member(100, Some(zombie), Vec::new, has_argv),
+            None
+        );
+    }
+
+    /// The cadence argument, asserted rather than asserted-in-a-comment: a
+    /// usable leader must answer without walking `/proc`, because this feeds
+    /// the poll for every session on the host.
+    #[test]
+    fn a_usable_leader_never_walks_proc() {
+        let (has_argv, _) = argv_of(&[100]);
+        let answer = resolve_foreground_member(
+            100,
+            Some(member(100, 'S')),
+            || panic!("the leader answered; nothing should have scanned /proc"),
+            has_argv,
+        );
+        assert_eq!(answer, Some(100));
+    }
+
+    /// Two real processes in one real group, against the real kernel — the test
+    /// that would have caught the macOS identity mapping.
+    ///
+    /// `leader` is spawned into its own process group and `member` joins it, so
+    /// this reproduces `leader | member` without a shell arbitrating. Killing
+    /// and reaping the leader leaves a group whose id names a pid that no
+    /// longer exists, which is precisely the state `find . | grep foo` reaches
+    /// the moment `find` finishes.
+    #[test]
+    fn a_reaped_group_leader_does_not_erase_the_group() {
+        use std::os::unix::process::CommandExt;
+
+        let mut leader = Command::new(sleep_binary())
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0)
+            .spawn()
+            .expect("spawning the group leader");
+        let pgid = leader.id() as i32;
+
+        let follower = Command::new(sleep_binary())
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(pgid)
+            .spawn()
+            .expect("spawning a second member of that group");
+        let follower = Sleeper(follower);
+        // Both must have exec'd before the group means anything.
+        wait_for(|| {
+            process_arguments(pgid).is_some() && process_arguments(follower.pid()).is_some()
+        });
+
+        assert_eq!(
+            foreground_member(pgid),
+            Some(pgid),
+            "a live leader answers for its own group"
+        );
+
+        let _ = leader.kill();
+        let _ = leader.wait();
+        wait_for(|| process_arguments(pgid).is_none());
+
+        // The probe that settles it: the leader's argv is unreadable once it is
+        // reaped, on both hosts. Reporting the pgid straight through here is
+        // what produced an empty foreground for a live pipeline.
+        assert!(
+            process_arguments(pgid).is_none(),
+            "a reaped leader must not still answer for argv"
+        );
+        assert_eq!(
+            foreground_member(pgid),
+            Some(follower.pid()),
+            "the surviving member answers for the group"
+        );
+        let argv = process_arguments(follower.pid()).expect("argv for the survivor");
+        assert!(argv[0].ends_with("sleep"), "argv was {argv:?}");
+    }
+
+    /// A group with nothing left in it has no answer, and the enumeration must
+    /// say so rather than handing back the group id as if it were a pid.
+    #[test]
+    fn an_empty_group_has_no_foreground_member() {
+        let child = Sleeper::spawn("/");
+        let pid = child.pid();
+        drop(child);
+        wait_for(|| process_arguments(pid).is_none());
+        assert_eq!(foreground_member(pid), None);
+    }
+
+    fn wait_for(mut ready: impl FnMut() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if ready() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("the kernel never reached the expected process state");
     }
 }

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -924,6 +924,19 @@ pub enum Event {
     SessionExited {
         session: String,
         status: i32,
+        /// The session's last `SessionInfo`, sampled after the child was reaped
+        /// and carried on the event so the answer travels with the news. Nobody
+        /// can ask for it afterwards: the session actor stops the moment this is
+        /// sent, and `list` no longer has a row. It always reports
+        /// `alive: false`, and `child_executable_replaced` is evaluated at exit
+        /// time — the whole reason the record has to be built here rather than
+        /// reconstructed from an earlier poll.
+        ///
+        /// Optional because an old daemon does not send it. A client that finds
+        /// it absent keeps whatever it last read from `list`, which is exactly
+        /// today's behaviour.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        info: Option<Box<SessionInfo>>,
     },
     /// This attachment's stream was cut and restarted at a fresh boundary. It
     /// arrives after the `S`/`ready` pair that re-establishes JOIN, and it means
@@ -1017,18 +1030,27 @@ pub struct SessionInfo {
     pub attached_clients: usize,
     #[serde(default)]
     pub writer_client_id: Option<String>,
-    /// The process group that owns the tty's foreground right now. This is the
-    /// program the user is talking to, which after the first minute of a
-    /// session is rarely the one in `command`.
+    /// The live process inside the tty's foreground process group whose argv is
+    /// reported below. This is the program the user is talking to, which after
+    /// the first minute of a session is rarely the one in `command`.
+    ///
+    /// A pid, not the process group id. The two agree whenever the group leader
+    /// is still running, which is every simple command; they part in a pipeline
+    /// whose leader has exited while a later stage still runs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub foreground_pid: Option<i32>,
-    /// Argv of that process group's leader — the agent's identity, read from
-    /// the kernel rather than scraped off the screen.
+    /// Argv of that process — the agent's identity, read from the kernel rather
+    /// than scraped off the screen.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub foreground_argv: Option<Vec<String>>,
     /// Whether something other than the session's own child holds the
     /// foreground, i.e. a command is running rather than a shell idling at its
     /// prompt. This is the signal a client keys "closing this loses work" off.
+    ///
+    /// Derived from the foreground *process group*, not from `foreground_pid`:
+    /// a pipeline whose leader has already exited is still a running job, and
+    /// comparing the surviving member's pid against the shell would say so
+    /// twice over — but comparing a *missing* one would say the opposite.
     #[serde(default, skip_serializing_if = "is_false")]
     pub foreground_job: bool,
     /// The child's *current* directory, which `cd` moves and `cwd` (the
@@ -1624,7 +1646,8 @@ mod tests {
         decode_cells, decode_file_chunk, decode_grid_payload, decode_history_payload,
         decode_snapshot_payload, decode_upload_chunk, encode_cells, encode_file_chunk,
         encode_grid_payload, encode_history_payload, encode_snapshot_payload, encode_upload_chunk,
-        Control, FileChunk, GridDiff, GridRow, HistoryChunk, Snapshot, UploadChunk, WireCell,
+        Control, Event, FileChunk, GridDiff, GridRow, HistoryChunk, SessionInfo, Snapshot,
+        UploadChunk, WireCell,
         WireColor, COLOR_TAG_RGB, SNAPSHOT_CELL_SIZE, FILE_CHUNK_HEADER_SIZE,
         MAX_FILE_FRAME_SIZE, MAX_UPLOAD_FRAME_SIZE,
     };
@@ -1852,5 +1875,87 @@ mod tests {
 
         let encoded = encode_grid_payload(&grid).unwrap();
         assert_eq!(decode_grid_payload(&encoded).unwrap(), grid);
+    }
+
+    fn ended_session() -> SessionInfo {
+        SessionInfo {
+            id: "s_1".to_string(),
+            name: "demo".to_string(),
+            cwd: "/work".to_string(),
+            command: "claude".to_string(),
+            pid: 4242,
+            rows: 48,
+            cols: 180,
+            clients: 0,
+            created_unix: 1_700_000_000,
+            alive: false,
+            status: "done".to_string(),
+            agent_id: Some("claude".to_string()),
+            title: None,
+            attached_clients: 0,
+            writer_client_id: None,
+            foreground_pid: None,
+            foreground_argv: None,
+            foreground_job: false,
+            child_cwd: Some("/work/sub".to_string()),
+            child_executable: Some("/usr/local/bin/claude".to_string()),
+            child_executable_replaced: true,
+        }
+    }
+
+    /// The exit event is the last thing said about a session, so the record it
+    /// carries has to survive the wire intact — `alive` and
+    /// `child_executable_replaced` in particular, since the client's whole
+    /// relaunch decision reads them.
+    #[test]
+    fn exit_event_carries_the_final_record() {
+        let event = Event::SessionExited {
+            session: "s_1".to_string(),
+            status: 0,
+            info: Some(Box::new(ended_session())),
+        };
+        let encoded = serde_json::to_value(&event).unwrap();
+        assert_eq!(encoded["info"]["alive"], false);
+        assert_eq!(encoded["info"]["child_executable_replaced"], true);
+        assert_eq!(encoded["info"]["child_executable"], "/usr/local/bin/claude");
+
+        match serde_json::from_value::<Event>(encoded).unwrap() {
+            Event::SessionExited { info, status, .. } => {
+                let info = info.expect("the record round-trips");
+                assert_eq!(status, 0);
+                assert!(!info.alive);
+                assert!(info.child_executable_replaced);
+                assert_eq!(info.pid, 4242);
+            }
+            other => panic!("decoded as the wrong event: {other:?}"),
+        }
+    }
+
+    /// Additive in both directions: an old daemon sends no `info`, and a new
+    /// daemon that has none to send omits the key rather than writing `null`,
+    /// so an old client's payload is byte-identical to what it saw before.
+    #[test]
+    fn exit_event_info_is_additive() {
+        let old_host = br#"{"ev":"session_exited","session":"s_1","status":137}"#;
+        match serde_json::from_slice::<Event>(old_host).unwrap() {
+            Event::SessionExited {
+                session,
+                status,
+                info,
+            } => {
+                assert_eq!(session, "s_1");
+                assert_eq!(status, 137);
+                assert!(info.is_none(), "an absent record must not be invented");
+            }
+            other => panic!("old exit payload decoded as the wrong event: {other:?}"),
+        }
+
+        let without = serde_json::to_value(Event::SessionExited {
+            session: "s_1".to_string(),
+            status: 0,
+            info: None,
+        })
+        .unwrap();
+        assert!(without.get("info").is_none());
     }
 }

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -346,9 +346,13 @@ struct Session {
     /// answer a snapshot again — attach and resync fall back to ring replay.
     vt_stale: Option<String>,
     /// Last sample of who is in the tty's foreground and where the child is.
-    /// Refreshed by the poll tick only; `info()` reads the cache so a roster
-    /// request never turns into a burst of syscalls.
+    /// `info()` reads this cache so a roster request never turns into a burst
+    /// of syscalls.
     foreground: ForegroundSample,
+    /// A resolution is in flight on a blocking thread. One at a time: the poll
+    /// is slower than the work, and piling up would only queue answers about
+    /// groups that have already lost the terminal.
+    foreground_pending: bool,
     /// The binary the child is running, pinned on the first sample that finds
     /// it. One-shot on purpose: this is the *launch* baseline that
     /// `was_replaced()` compares against, and resampling would paper over the
@@ -356,14 +360,46 @@ struct Session {
     child_executable: Option<crate::proc::ExecutableIdentity>,
 }
 
-/// What one foreground poll found. Compared whole so a tick that learns nothing
-/// new costs nothing beyond the syscalls.
+/// What the session believes about its foreground right now.
+///
+/// Split deliberately along what it costs to learn. `pgid` and `job` come from
+/// one `tcgetpgrp` and are refreshed on the actor; everything below them is a
+/// process-table walk and arrives later, from [`ForegroundResolution`].
 #[derive(Default, Clone, PartialEq, Eq)]
 struct ForegroundSample {
+    /// The foreground process *group*, exactly as `tcgetpgrp` reported it.
+    /// Kept even when no member of it could be read, because "is a job
+    /// running?" is answered by comparing this against the session's own child
+    /// and must not turn into "no" the moment a pipeline's leader exits.
     pgid: Option<i32>,
+    /// The member of that group whose argv is reported below. Equal to `pgid`
+    /// whenever the group leader is still usable, which is the common case.
+    pid: Option<i32>,
     argv: Option<Vec<String>>,
     job: bool,
     cwd: Option<String>,
+}
+
+/// The expensive half of a foreground sample, computed on a blocking thread and
+/// handed back to the actor.
+///
+/// Reading argv means a `KERN_PROCARGS2` sysctl on macOS and a file read on
+/// Linux, and finding *which* pid to read it for can mean walking every process
+/// on the box when a pipeline's leader has exited. None of that may happen on
+/// the session actor: that task also runs the PTY read and the fan-out, so a
+/// process-table walk there is time the byte path spends waiting — the
+/// anti-100× invariant, which is about more than the VT parse.
+struct ForegroundResolution {
+    /// The group this answer describes. The foreground can move while the
+    /// resolution is in flight, and an answer about a group that has since lost
+    /// the terminal is not a stale version of the truth — it is the answer to a
+    /// different question, and gets dropped.
+    pgid: Option<i32>,
+    pid: Option<i32>,
+    argv: Option<Vec<String>>,
+    cwd: Option<String>,
+    /// Only set when the session had not pinned its binary yet.
+    executable: Option<crate::proc::ExecutableIdentity>,
 }
 
 impl Session {
@@ -384,7 +420,7 @@ impl Session {
             title: self.title.clone(),
             attached_clients: self.clients.len(),
             writer_client_id: self.writer.clone(),
-            foreground_pid: self.foreground.pgid,
+            foreground_pid: self.foreground.pid,
             foreground_argv: self.foreground.argv.clone(),
             foreground_job: self.foreground.job,
             child_cwd: self.foreground.cwd.clone(),
@@ -403,35 +439,101 @@ impl Session {
         }
     }
 
-    /// Ask the kernel who holds the tty's foreground and where the child is
-    /// standing. Returns whether anything moved, so a quiet session emits no
-    /// roster traffic.
+    /// The cheap half of the poll, and the only half that runs here: one
+    /// `tcgetpgrp` on the master. Returns whether anything moved, so a quiet
+    /// session emits no roster traffic.
     ///
-    /// Called from the poll tick only. These are a handful of cheap syscalls,
-    /// but they are still syscalls on the session actor's thread, and the
-    /// anti-100× invariant means byte delivery must never be the thing paying
-    /// for them — hence a fixed, slow cadence rather than a sample per frame.
-    fn sample_foreground(&mut self) -> bool {
+    /// The expensive half is dispatched to a blocking thread and applied later
+    /// by [`Session::apply_foreground`]. Both halves have to exist because they
+    /// answer different questions on different deadlines: "is a job running?"
+    /// is read at close time and must be current, and it is answerable from the
+    /// group id alone; "what is that job?" drives an icon and can be a beat
+    /// late.
+    fn sample_foreground(
+        &mut self,
+        resolved: &mpsc::UnboundedSender<ForegroundResolution>,
+    ) -> bool {
         if self.pid <= 0 {
             return false;
         }
         let pgid = self.pty.foreground_pgid();
-        let sample = ForegroundSample {
-            pgid,
-            // The foreground group leader's pid *is* the pgid: the shell puts
-            // each job in a group named after its leader.
-            argv: pgid.and_then(crate::proc::process_arguments),
-            job: pgid.is_some_and(|pgid| pgid != self.pid),
-            cwd: crate::proc::working_directory(self.pid),
-        };
-        if self.child_executable.is_none() {
-            self.child_executable = crate::proc::executable_identity(self.pid);
+        // Compared against the *group*: a foreground group that is not the
+        // child's own is a running job whether or not any member of it could
+        // be read.
+        let job = pgid.is_some_and(|pgid| pgid != self.pid);
+        let mut changed = false;
+        if self.foreground.pgid != pgid {
+            self.foreground.pgid = pgid;
+            // The cached identity described a group that no longer holds the
+            // terminal. Dropping it is an honest gap the resolution below
+            // fills; keeping it would name a program that has already exited.
+            self.foreground.pid = None;
+            self.foreground.argv = None;
+            changed = true;
         }
-        if sample == self.foreground {
+        if self.foreground.job != job {
+            self.foreground.job = job;
+            changed = true;
+        }
+        self.request_foreground(pgid, resolved);
+        changed
+    }
+
+    /// Hand the process-table work to a blocking thread.
+    fn request_foreground(
+        &mut self,
+        pgid: Option<i32>,
+        resolved: &mpsc::UnboundedSender<ForegroundResolution>,
+    ) {
+        if self.foreground_pending {
+            return;
+        }
+        self.foreground_pending = true;
+        let child = self.pid;
+        let pin_executable = self.child_executable.is_none();
+        let resolved = resolved.clone();
+        tokio::task::spawn_blocking(move || {
+            // A group id is not a pid. The shell names each job's group after
+            // its leader, so the two agree for as long as that leader is alive
+            // — and stop agreeing in a pipeline the moment it is not, which is
+            // why the pid comes from the host rather than from that assumption.
+            let pid = pgid.and_then(crate::proc::foreground_member);
+            let _ = resolved.send(ForegroundResolution {
+                pgid,
+                pid,
+                argv: pid.and_then(crate::proc::process_arguments),
+                cwd: crate::proc::working_directory(child),
+                executable: pin_executable
+                    .then(|| crate::proc::executable_identity(child))
+                    .flatten(),
+            });
+        });
+    }
+
+    /// Take a resolution the blocking thread finished, unless the foreground
+    /// moved while it was in flight. Returns whether anything moved.
+    fn apply_foreground(&mut self, resolution: ForegroundResolution) -> bool {
+        self.foreground_pending = false;
+        if resolution.pgid != self.foreground.pgid {
             return false;
         }
-        self.foreground = sample;
-        true
+        if self.child_executable.is_none() {
+            self.child_executable = resolution.executable;
+        }
+        let mut changed = false;
+        if self.foreground.pid != resolution.pid {
+            self.foreground.pid = resolution.pid;
+            changed = true;
+        }
+        if self.foreground.argv != resolution.argv {
+            self.foreground.argv = resolution.argv;
+            changed = true;
+        }
+        if self.foreground.cwd != resolution.cwd {
+            self.foreground.cwd = resolution.cwd;
+            changed = true;
+        }
+        changed
     }
 
     fn recompute_writer(&mut self) {
@@ -1323,6 +1425,7 @@ pub fn spawn(
         sidecar_queue: sidecar.queue,
         vt_stale: None,
         foreground: ForegroundSample::default(),
+        foreground_pending: false,
         child_executable: None,
     };
 
@@ -1533,11 +1636,20 @@ async fn run(
     // sample once when it catches up, not replay a backlog of polls.
     let mut foreground_poll = tokio::time::interval(FOREGROUND_POLL);
     foreground_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // The process-table half of each poll runs on a blocking thread and comes
+    // back here. Held for the life of the loop so the branch below never sees a
+    // closed channel while the session is alive.
+    let (foreground_tx, mut foreground_rx) = mpsc::unbounded_channel::<ForegroundResolution>();
 
     loop {
         tokio::select! {
             _ = foreground_poll.tick() => {
-                if session.sample_foreground() {
+                if session.sample_foreground(&foreground_tx) {
+                    session.emit_roster();
+                }
+            }
+            Some(resolution) = foreground_rx.recv() => {
+                if session.apply_foreground(resolution) {
                     session.emit_roster();
                 }
             }
@@ -1608,9 +1720,20 @@ async fn run(
         Some(w) => w.await.unwrap_or(-1),
         None => -1,
     };
+    // One final record, built after the reap and used for everything that
+    // outlives the session: the exit event clients hear, and the tombstone the
+    // manager buries. Sampling it twice would let the two disagree — the
+    // interesting field, `child_executable_replaced`, is a fresh disk read every
+    // time it is asked, and an agent that replaced its binary between the two
+    // reads is exactly the case both consumers are for.
+    //
+    // `alive: false` — this record only ever describes a session that has ended.
+    let mut info = session.info();
+    info.alive = false;
     let exit_event = Event::SessionExited {
         session: session.id.clone(),
         status: code,
+        info: Some(Box::new(info.clone())),
     };
     let _ = session.events.send(exit_event.clone());
     for entry in session.clients.values() {
@@ -1618,10 +1741,6 @@ async fn run(
         let _ = entry.out.send(ClientEvent::Exited(code));
     }
     let _ = tokio::task::spawn_blocking(move || sidecar_thread.join()).await;
-    // `alive: false` — this record only ever describes a session that has ended,
-    // and a tombstone built from it must not claim otherwise.
-    let mut info = session.info();
-    info.alive = false;
     let _ = on_exit.send(SessionEnded {
         info,
         status: code,
@@ -1970,6 +2089,7 @@ mod tests {
                 sidecar_queue,
                 vt_stale: None,
                 foreground: super::ForegroundSample::default(),
+                foreground_pending: false,
                 child_executable: None,
             },
             event_rx,
@@ -2329,6 +2449,7 @@ mod tests {
             sidecar_queue: Arc::new(SidecarQueue::new()),
             vt_stale: None,
             foreground: super::ForegroundSample::default(),
+            foreground_pending: false,
             child_executable: None,
         };
 
@@ -2468,15 +2589,18 @@ mod tests {
         );
 
         // Learning who is in there is a roster change, so clients hear about it
-        // without polling.
-        let roster = loop {
-            match events_rx.try_recv() {
-                Ok(Event::Roster { info, .. }) => break info,
-                Ok(_) => continue,
-                Err(error) => panic!("no roster event for the first foreground sample: {error:?}"),
-            }
-        };
-        assert!(roster.is_some_and(|info| info.foreground_pid.is_some()));
+        // without polling. It takes two events, not one: the poll publishes the
+        // process group as soon as `tcgetpgrp` answers, and the identity behind
+        // it lands when the off-actor resolution comes back. Scanning for the
+        // second is the point — taking the first would assert against the half
+        // that is deliberately cheap.
+        let identified = std::iter::from_fn(|| events_rx.try_recv().ok()).any(|event| {
+            matches!(event, Event::Roster { info: Some(info), .. } if info.foreground_pid.is_some())
+        });
+        assert!(
+            identified,
+            "no roster event ever carried the resolved foreground pid"
+        );
 
         handle.send(SessionMsg::Kill {
             reason: EndReason::Killed,
@@ -2502,19 +2626,121 @@ mod tests {
             data: b"sleep 30\n".to_vec(),
         });
 
-        let busy = settled_info(&handle, |info| info.foreground_job).await;
-        assert_ne!(busy.foreground_pid, Some(busy.pid));
-        assert!(
-            busy.foreground_argv
+        // Settled on the argv, not on `foreground_job`. The two now land in
+        // separate ticks by design — the group id is read on the actor and the
+        // identity behind it arrives from a blocking thread — so waiting on the
+        // cheap half and asserting the expensive one is a race.
+        let busy = settled_info(&handle, |info| {
+            info.foreground_argv
                 .as_ref()
                 .and_then(|argv| argv.first())
-                .is_some_and(|arg| arg.ends_with("sleep")),
-            "foreground argv was {:?}",
-            busy.foreground_argv
+                .is_some_and(|arg| arg.ends_with("sleep"))
+        })
+        .await;
+        assert!(busy.foreground_job, "a running command is a job");
+        assert_ne!(busy.foreground_pid, Some(busy.pid));
+
+        handle.send(SessionMsg::Kill);
+    }
+
+    /// The pipeline case, end to end against a real shell and a real tty: the
+    /// group leader exits while a later stage keeps running.
+    ///
+    /// `true | sleep 30` makes a job whose leader is `true`, which finishes
+    /// immediately and is left a zombie or reaped outright while `sleep` still
+    /// holds the terminal. Reading argv from the process *group* id — what both
+    /// hosts did before this — answers nothing here, so the pane would claim
+    /// nothing is running while the user watches a command run. The assertion
+    /// is deliberately on argv being present and naming `sleep`: that is the
+    /// user-visible property, and it is what regressed.
+    #[tokio::test]
+    async fn a_pipeline_keeps_its_argv_after_the_group_leader_exits() {
+        let shell = ["/bin/sh", "/usr/bin/sh"]
+            .into_iter()
+            .find(|path| std::path::Path::new(path).exists())
+            .expect("no sh binary on this host");
+        let (handle, _events_rx, _on_exit) =
+            start_session(vec![shell.to_string(), "-i".to_string()], "/");
+
+        settled_info(&handle, |info| info.foreground_pid == Some(info.pid)).await;
+
+        handle.send(SessionMsg::Inject {
+            data: b"true | sleep 30\n".to_vec(),
+        });
+
+        let piped = settled_info(&handle, |info| {
+            info.foreground_job && info.foreground_argv.is_some()
+        })
+        .await;
+
+        let argv = piped
+            .foreground_argv
+            .as_ref()
+            .expect("a live pipeline must report an argv");
+        assert!(
+            argv.first().is_some_and(|arg| arg.ends_with("sleep")),
+            "the surviving stage should name itself; argv was {argv:?}"
+        );
+        assert_ne!(
+            piped.foreground_pid,
+            Some(piped.pid),
+            "the pipeline is not the session's own shell"
         );
 
         handle.send(SessionMsg::Kill {
             reason: EndReason::Killed,
         });
+    }
+
+    /// The session actor is the last thing that can answer for a session, and
+    /// once it has gone the only descriptions left are the ones it sent on its
+    /// way out. Both of them — the event clients hear and the record the
+    /// manager buries — have to be the *same* record, or a client and a
+    /// tombstone can disagree about a session neither can re-read.
+    #[tokio::test]
+    async fn the_exit_event_carries_the_record_the_tombstone_is_built_from() {
+        let cat = ["/bin/cat", "/usr/bin/cat"]
+            .into_iter()
+            .find(|path| std::path::Path::new(path).exists())
+            .expect("no cat binary on this host");
+        let (handle, mut events_rx, mut on_exit_rx) = start_session(vec![cat.to_string()], "/");
+
+        // Wait for the first foreground sample, so the record under test is the
+        // fully populated one rather than a session caught before its first
+        // poll tick.
+        let live = settled_info(&handle, |info| info.child_executable.is_some()).await;
+        assert!(live.alive, "a running session says so");
+
+        handle.send(SessionMsg::Kill);
+
+        let exited = loop {
+            match events_rx.recv().await {
+                Ok(Event::SessionExited { session, info, .. }) => break (session, info),
+                Ok(_) => continue,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(error) => panic!("the exit event never arrived: {error:?}"),
+            }
+        };
+        let (session_id, event_info) = exited;
+        assert_eq!(session_id, "foreground-session");
+        let event_info = event_info.expect("the exit event carries the final record");
+        assert!(
+            !event_info.alive,
+            "a record built on the exit path must not claim the session is alive"
+        );
+        assert_eq!(event_info.pid, live.pid);
+        assert_eq!(event_info.child_executable, live.child_executable);
+
+        let ended = on_exit_rx
+            .recv()
+            .await
+            .expect("the manager is told the session ended");
+        assert!(ended.killed, "a client asked for this end");
+        assert!(!ended.info.alive);
+        assert_eq!(
+            serde_json::to_value(&*event_info).unwrap(),
+            serde_json::to_value(&ended.info).unwrap(),
+            "the event and the tombstone must be one record, not two samples"
+        );
     }
 }

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -2640,7 +2640,9 @@ mod tests {
         assert!(busy.foreground_job, "a running command is a job");
         assert_ne!(busy.foreground_pid, Some(busy.pid));
 
-        handle.send(SessionMsg::Kill);
+        handle.send(SessionMsg::Kill {
+            reason: EndReason::Killed,
+        });
     }
 
     /// The pipeline case, end to end against a real shell and a real tty: the
@@ -2711,7 +2713,9 @@ mod tests {
         let live = settled_info(&handle, |info| info.child_executable.is_some()).await;
         assert!(live.alive, "a running session says so");
 
-        handle.send(SessionMsg::Kill);
+        handle.send(SessionMsg::Kill {
+            reason: EndReason::Killed,
+        });
 
         let exited = loop {
             match events_rx.recv().await {
@@ -2735,7 +2739,11 @@ mod tests {
             .recv()
             .await
             .expect("the manager is told the session ended");
-        assert!(ended.killed, "a client asked for this end");
+        assert_eq!(
+            ended.reason,
+            EndReason::Killed,
+            "a client asked for this end"
+        );
         assert!(!ended.info.alive);
         assert_eq!(
             serde_json::to_value(&*event_info).unwrap(),

--- a/termiod/src/tombstone.rs
+++ b/termiod/src/tombstone.rs
@@ -88,6 +88,13 @@ pub struct Tombstone {
     /// that died `idle`, and that difference is exactly what the user lost.
     #[serde(default)]
     pub status: String,
+    /// The session's binary was replaced on disk while it ran — "the agent
+    /// updated itself and quit" rather than "the agent crashed". Computed on
+    /// the exit path, where the inode read is still meaningful, and carried
+    /// here because a client that was not attached when the session died has
+    /// no other route to it: `Event::SessionExited` reaches only the attached.
+    #[serde(default)]
+    pub child_executable_replaced: bool,
 }
 
 fn now_unix() -> u64 {
@@ -111,6 +118,7 @@ impl Tombstone {
             agent_id: info.agent_id.clone(),
             title: info.title.clone(),
             status: info.status.clone(),
+            child_executable_replaced: info.child_executable_replaced,
         }
     }
 }
@@ -160,6 +168,12 @@ impl RosterEntry {
             agent_id: self.agent_id,
             title: self.title,
             status: self.status,
+            // Both roads here — a daemon that died under the session, and one
+            // that stopped before the ordinary reaper reached it — skip the exit
+            // path, so the pinned inode was never re-read. `false` means "nobody
+            // looked", the same shape of ignorance as `exit_status: None` above,
+            // and neither grave can testify to a self-update either way.
+            child_executable_replaced: false,
         }
     }
 }
@@ -384,6 +398,52 @@ mod tests {
         assert_eq!(graves[0].exit_status, Some(0));
         assert_eq!(graves[0].status, "working");
         assert_eq!(graves[0].title.as_deref(), Some("fixing the parser"));
+    }
+
+    /// "The agent updated itself and quit" survives to a client that was not
+    /// watching. `Event::SessionExited` reaches only attached clients, so the
+    /// durable record is the sole route for anyone who reconnects afterwards —
+    /// and the field it needs is computed exactly once, on the exit path.
+    #[test]
+    fn a_replaced_executable_survives_in_the_durable_record() {
+        let dir = temp_dir("replaced");
+        let graveyard = Graveyard::open(&dir).unwrap();
+        let mut dying = info("a");
+        dying.alive = false;
+        dying.child_executable_replaced = true;
+        graveyard.note_live(&info("a"));
+        graveyard.bury(&dying, EndReason::Exited, Some(0));
+        drop(graveyard);
+
+        // Reopened, so this reads the field back off disk rather than out of
+        // the in-memory copy that bury() just wrote.
+        let graves = Graveyard::open(&dir).unwrap().all();
+        assert_eq!(graves.len(), 1);
+        assert!(
+            graves[0].child_executable_replaced,
+            "a self-update is why the session ended, and the record must say so"
+        );
+    }
+
+    /// Graveyards written before the field existed must still load. It is the
+    /// one file in the daemon that outlives its own binary by design, so a
+    /// missing key is an ordinary older-daemon read, not corruption.
+    #[test]
+    fn a_grave_written_without_the_field_still_loads() {
+        let dir = temp_dir("legacy");
+        std::fs::write(
+            dir.join("tombstones.json"),
+            r#"[{"id":"a","name":"a","cwd":"/tmp","command":"sh","reason":"exited",
+                 "exit_status":0,"created_unix":1000,"ended_unix":2000,"status":"idle"}]"#,
+        )
+        .unwrap();
+
+        let graves = Graveyard::open(&dir).unwrap().all();
+        assert_eq!(graves.len(), 1);
+        assert!(
+            !graves[0].child_executable_replaced,
+            "absent means the older daemon never measured it, which is not a replacement"
+        );
     }
 
     /// The case the whole file exists for: a session still on the roster when a


### PR DESCRIPTION
## What changes

`termiod` now resolves a live member of the terminal's foreground process group, keeps the expensive lookup off the session actor, and sends the final `SessionInfo` with `session_exited`. `child_executable_replaced` is carried onto the tombstone as well as the exit event, so a Mac that was asleep when an agent replaced itself and quit can still tell that apart from a crash.

The Mac client decodes full roster and exit records, routes daemon facts through agent detection, working-directory following, close confirmation, and the shared exit policy, and keeps the in-process PTY result authoritative. A roster-only row is now named by the kernel's foreground argv rather than by string rules guessing at the login-shell wrapper. The local PTY implementation remains unchanged: this is the Shape B boundary.

Settings ▸ Machines becomes Settings ▸ Devices, matching the vocabulary the protocol, the daemon and `TermiodDevice` already use. The persisted `rawValue` stays `ssh`, so nobody's Settings reopens on a different tab.

The server-plane RFC is now the active execution spine. It records the settled wire shape, the superseded `foreground_changed` proposal, and the remaining Stage 2 gates.

## Verification

- `swift build`
- `swift test` — 491 tests passed, 11 skipped
- `cargo test` — 101 tests passed on macOS and, via the `linux` job, on `ubuntu-24.04-arm`, which is where the `/proc` path compiles and runs
- `TermiodWireOrderIntegrationTests` runs against a real daemon in the `termiod` workflow
- Combined Rust and Swift review approved with no blocking findings

## Still open

- Give the in-process PTY the same live-member search: `PTYProcess.foregroundProcessArguments()` still passes the pgid to `KERN_PROCARGS2`, which reports nothing once a pipeline's leader is reaped

Release Notes:
- Improve foreground job detection and session-exit handling for termiod-backed terminals.
- Settings ▸ Machines is now Settings ▸ Devices.
