### PR TITLE
Name the program running in a pipeline in local sessions

### DIFF
--- a/Sources/termio/Terminal/Ghostty/PTYProcess.swift
+++ b/Sources/termio/Terminal/Ghostty/PTYProcess.swift
@@ -858,13 +858,45 @@ final class PTYProcess: @unchecked Sendable {
         return info.st_ino != inode
     }
 
+    /// Whether a candidate can still answer for the group, or is on its way out.
+    /// `KERN_PROCARGS2` refuses a zombie, so a member the kernel has already
+    /// marked dead costs a sysctl to learn nothing.
+    enum MemberLiveness {
+        case live
+        case dead
+    }
+
+    /// A process considered as a member of the tty's foreground group, reduced to
+    /// what one `PROC_PIDTBSDINFO` call answers. Argv is deliberately not here —
+    /// it is the expensive read, and the selection resolves it lazily.
+    struct ForegroundGroupMember: Equatable {
+        let pid: pid_t
+        let liveness: MemberLiveness
+        let processGroup: pid_t
+    }
+
+    /// `SZOMB` from `<sys/proc.h>`. Spelled out because Darwin does not surface
+    /// the `p_stat` constants to Swift.
+    private static let zombieStatus: UInt32 = 5
+
     /// The argv of the process group currently in the *foreground* of this PTY —
     /// the program the user is actually interacting with: the login shell until it
     /// runs a command, then that command (a hand-started `claude`), then the shell
-    /// again once it exits. Read via `tcgetpgrp` + `KERN_PROCARGS2`, the pair iTerm2
-    /// and friends use to name a pane's running program (`tcgetpgrp` on a forkpty
-    /// master returns the tty's foreground group on macOS — verified). `nil` once the
-    /// child is reaped (a recycled pid must never be queried) or if the kernel refuses.
+    /// again once it exits. `tcgetpgrp` names the group — on a forkpty master it
+    /// returns the tty's foreground group on macOS, verified — and
+    /// `KERN_PROCARGS2` names a process: the pair iTerm2 and friends use to say
+    /// what is running in a pane.
+    ///
+    /// A group is not a process, though, and the two only agree while the leader
+    /// is alive. `sleep 60 | cat` runs both stages in one group named after
+    /// `sleep`; the moment `sleep` finishes, `KERN_PROCARGS2` on that pgid fails
+    /// outright while `cat` is still the program holding the terminal — so the
+    /// pane knew a job was running and had no name for it. termiod solved this in
+    /// `termiod/src/proc.rs`; this is the same search, and the two backends now
+    /// answer alike for the same pipeline.
+    ///
+    /// `nil` once the child is reaped (a recycled pid must never be queried), or
+    /// when nobody in the group can answer.
     func foregroundProcessArguments() -> [String]? {
         lock.lock()
         let exited = childExited
@@ -872,7 +904,89 @@ final class PTYProcess: @unchecked Sendable {
         guard !exited, pid > 0 else { return nil }
         let foreground = tcgetpgrp(masterFD)
         guard foreground > 0 else { return nil }
-        return Self.processArguments(pid: foreground)
+        return Self.foregroundArguments(
+            group: foreground,
+            members: Self.groupMembers(of: foreground),
+            read: { Self.processArguments(pid: $0) })
+    }
+
+    /// Pick the argv that describes the foreground group.
+    ///
+    /// The leader is tried first, so what a pane reports does not drift to some
+    /// later stage of a pipeline while the stage that names it is still running.
+    /// The rest are tried in ascending pid order — arbitrary, but *stable*: a
+    /// choice that flapped between two survivors would rename the row every poll
+    /// for no new information.
+    ///
+    /// A member whose own process group no longer matches the one we asked about
+    /// is dropped, and that check is not redundant with having enumerated the
+    /// group: between `tcgetpgrp` naming a group and this running, a pid can be
+    /// recycled into something else entirely, and its number alone is no evidence
+    /// it is the process we were asked about.
+    ///
+    /// `read` is a closure and the search stops at the first process that answers,
+    /// because each read is a sysctl and a wide pipeline should not pay for one
+    /// per member.
+    static func foregroundArguments(
+        group: pid_t, members: [ForegroundGroupMember], read: (pid_t) -> [String]?
+    ) -> [String]? {
+        guard group > 0 else { return nil }
+        let candidates = members
+            .filter { $0.processGroup == group && $0.liveness == .live }
+            .map(\.pid)
+            .sorted()
+        var ordered = candidates.contains(group) ? [group] : []
+        for pid in candidates where pid != group && !ordered.contains(pid) {
+            ordered.append(pid)
+        }
+        for pid in ordered {
+            if let arguments = read(pid) { return arguments }
+        }
+        return nil
+    }
+
+    /// Every process the kernel currently counts in `group`, each read back
+    /// through `PROC_PIDTBSDINFO` for its state and — the part that matters — its
+    /// *own* idea of which group it is in.
+    ///
+    /// Two things about `proc_listpgrppids` were established against the kernel
+    /// rather than read in a header: it answers with a **count of pids**, not a
+    /// byte length, and its `NULL`-buffer sizing call ignores the group filter
+    /// entirely, reporting every pid on the machine. So there is no sizing call to
+    /// make. Allocate, and grow only when the answer exactly filled the buffer —
+    /// the one case a truncation cannot be told from a fit. A pipeline wide enough
+    /// to fill 4096 slots is not a shape this has to serve exactly.
+    private static func groupMembers(of group: pid_t) -> [ForegroundGroupMember] {
+        guard group > 0 else { return [] }
+        var capacity = 64
+        while true {
+            var pids = [pid_t](repeating: 0, count: capacity)
+            let count = proc_listpgrppids(
+                group, &pids, Int32(capacity * MemoryLayout<pid_t>.size))
+            guard count > 0 else { return [] }
+            let found = min(Int(count), capacity)
+            if found < capacity || capacity >= 4096 {
+                return pids.prefix(found).compactMap(member(of:))
+            }
+            capacity *= 4
+        }
+    }
+
+    /// One candidate's state and process group. A pid that vanished between the
+    /// enumeration and this read is simply not a candidate.
+    private static func member(of pid: pid_t) -> ForegroundGroupMember? {
+        guard pid > 0 else { return nil }
+        var info = proc_bsdinfo()
+        let size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info,
+                                Int32(MemoryLayout<proc_bsdinfo>.size))
+        guard size == Int32(MemoryLayout<proc_bsdinfo>.size) else { return nil }
+        // A zombie is the one state that disqualifies a member outright. A process
+        // still being created has no argv yet and is filtered by the read instead,
+        // which costs nothing extra because that read has to run anyway.
+        return ForegroundGroupMember(
+            pid: pid,
+            liveness: info.pbi_status == zombieStatus ? .dead : .live,
+            processGroup: pid_t(info.pbi_pgid))
     }
 
     /// Reads a process's full argument vector from the kernel (`KERN_PROCARGS2`),

--- a/Tests/termioTests/PTYForegroundTests.swift
+++ b/Tests/termioTests/PTYForegroundTests.swift
@@ -1,0 +1,181 @@
+import Darwin
+import XCTest
+@testable import termio
+
+/// Naming the program in the foreground of a PTY, pinned at both levels: the
+/// selection rule on its own, and the real kernel case it exists for — a
+/// pipeline that outlives the process its group is named after.
+final class PTYForegroundTests: XCTestCase {
+    private func live(_ pid: pid_t, group: pid_t = 100) -> PTYProcess.ForegroundGroupMember {
+        PTYProcess.ForegroundGroupMember(pid: pid, liveness: .live, processGroup: group)
+    }
+
+    private func dead(_ pid: pid_t, group: pid_t = 100) -> PTYProcess.ForegroundGroupMember {
+        PTYProcess.ForegroundGroupMember(pid: pid, liveness: .dead, processGroup: group)
+    }
+
+    /// Stand-in for the argv sysctl that also records the order it was probed in —
+    /// the cost the closure exists to bound.
+    private func reader(answering: [pid_t]) -> (read: (pid_t) -> [String]?, probed: () -> [pid_t]) {
+        let probed = Probed()
+        return ({ pid in
+            probed.record(pid)
+            return answering.contains(pid) ? ["command-\(pid)"] : nil
+        }, { probed.pids })
+    }
+
+    private final class Probed {
+        private(set) var pids: [pid_t] = []
+        func record(_ pid: pid_t) { pids.append(pid) }
+    }
+
+    /// The ordinary case: one command, alive, named after itself. Nothing else is
+    /// even probed.
+    func testPrefersTheGroupLeaderWhileItIsUsable() {
+        let (read, probed) = reader(answering: [100, 101])
+        let arguments = PTYProcess.foregroundArguments(
+            group: 100, members: [live(100), live(101)], read: read)
+        XCTAssertEqual(arguments, ["command-100"])
+        XCTAssertEqual(probed(), [100])
+    }
+
+    /// `sleep 60 | cat`: the leader finishes first and sits zombied — or reaped
+    /// outright, in which case the kernel does not enumerate it at all — while the
+    /// later stage is still the program the user is talking to.
+    func testFallsBackToALiveMemberWhenTheLeaderIsGone() {
+        let (zombieRead, _) = reader(answering: [103])
+        XCTAssertEqual(
+            PTYProcess.foregroundArguments(
+                group: 100, members: [dead(100), live(103)], read: zombieRead),
+            ["command-103"])
+
+        let (reapedRead, probed) = reader(answering: [103])
+        XCTAssertEqual(
+            PTYProcess.foregroundArguments(group: 100, members: [live(103)], read: reapedRead),
+            ["command-103"])
+        XCTAssertEqual(probed(), [103], "a dead leader must not cost an argv read")
+    }
+
+    /// A leader that is alive but caught between fork and exec has no argv yet.
+    /// Preferring it would report nothing while a sibling can answer.
+    func testSkipsALiveLeaderWithNoArguments() {
+        let (read, probed) = reader(answering: [104])
+        XCTAssertEqual(
+            PTYProcess.foregroundArguments(
+                group: 100, members: [live(100), live(104)], read: read),
+            ["command-104"])
+        XCTAssertEqual(probed(), [100, 104], "the leader is tried first, then the rest in order")
+    }
+
+    /// Stable, not merely correct: two survivors must not take turns being the
+    /// answer, or the pane would rename itself on every poll for no new reason.
+    func testPicksTheSameSurvivorEveryTime() {
+        let (ascending, _) = reader(answering: [105, 107])
+        XCTAssertEqual(
+            PTYProcess.foregroundArguments(
+                group: 100, members: [live(107), live(105)], read: ascending),
+            ["command-105"])
+        let (descending, _) = reader(answering: [105, 107])
+        XCTAssertEqual(
+            PTYProcess.foregroundArguments(
+                group: 100, members: [live(105), live(107)], read: descending),
+            ["command-105"])
+    }
+
+    func testRefusesAGroupWithNobodyLeftInIt() {
+        let (empty, _) = reader(answering: [])
+        XCTAssertNil(PTYProcess.foregroundArguments(group: 100, members: [], read: empty))
+
+        let (allDead, probed) = reader(answering: [100, 103])
+        XCTAssertNil(
+            PTYProcess.foregroundArguments(
+                group: 100, members: [dead(100), dead(103)], read: allDead))
+        XCTAssertTrue(probed().isEmpty, "a dead group must not cost an argv read")
+    }
+
+    /// The membership check is what keeps a recycled pid out of the answer: a pid
+    /// that has since moved into another group is not the process we were asked
+    /// about, whatever its number is.
+    func testIgnoresProcessesFromAnotherGroup() {
+        let (read, probed) = reader(answering: [100])
+        XCTAssertNil(
+            PTYProcess.foregroundArguments(
+                group: 100, members: [live(100, group: 200)], read: read))
+        XCTAssertTrue(probed().isEmpty)
+    }
+
+    func testRefusesAGroupThatIsNotAGroup() {
+        let (read, _) = reader(answering: [0])
+        XCTAssertNil(PTYProcess.foregroundArguments(group: 0, members: [live(0)], read: read))
+        XCTAssertNil(PTYProcess.foregroundArguments(group: -1, members: [], read: read))
+    }
+
+    /// The case the search exists for, against the real kernel: an interactive
+    /// shell runs `sleep … | cat`, whose two stages share one process group named
+    /// after `sleep`. Reading the pgid directly names the pipeline while `sleep`
+    /// lives and goes silent the instant it exits — with `cat` still holding the
+    /// terminal.
+    func testNamesAPipelineWhoseLeaderHasExited() throws {
+        let shell = "/bin/zsh"
+        guard FileManager.default.isExecutableFile(atPath: shell) else {
+            throw XCTSkip("no \(shell) on this host")
+        }
+        // `-f` skips the user's startup files (a slow rc would race the poll);
+        // `-i` is what turns job control on, without which the pipeline would run
+        // in the shell's own group and never show the split.
+        guard let pty = PTYProcess(
+            argv: [shell, "-f", "-i"], cwd: "/",
+            env: ["TERM": "xterm-256color", "PS1": "$ "], cols: 80, rows: 24)
+        else {
+            XCTFail("could not spawn \(shell) on a PTY")
+            return
+        }
+        defer { pty.terminate() }
+
+        // `cat /dev/tty` rather than a bare `cat`: it is the same pipeline shape,
+        // but it reads the terminal instead of the pipe, so it stays put after the
+        // leader exits rather than following it out on EOF.
+        XCTAssertTrue(waitForPrompt(pty), "the shell never reached a prompt")
+        pty.write(Data("sleep 1 | cat /dev/tty\n".utf8))
+
+        let named = try XCTUnwrap(
+            waitForForeground(pty) { $0.first?.hasSuffix("sleep") == true },
+            "the pipeline was never named while its leader ran")
+        XCTAssertEqual(named, ["sleep", "1"])
+
+        let survivor = try XCTUnwrap(
+            waitForForeground(pty) { $0.first?.hasSuffix("cat") == true },
+            "the foreground job lost its name when the group leader exited")
+        XCTAssertEqual(survivor, ["cat", "/dev/tty"])
+        XCTAssertTrue(pty.hasForegroundJob, "the survivor still holds the terminal")
+    }
+
+    /// The shell has to have claimed the tty before a typed command can reach it;
+    /// until then `tcgetpgrp` still names the spawn.
+    private func waitForPrompt(_ pty: PTYProcess) -> Bool {
+        waitUntil(seconds: 5) { pty.foregroundProcessArguments()?.first?.hasSuffix("zsh") == true }
+    }
+
+    private func waitForForeground(
+        _ pty: PTYProcess, matching: ([String]) -> Bool
+    ) -> [String]? {
+        var seen: [String]?
+        _ = waitUntil(seconds: 5) {
+            guard let arguments = pty.foregroundProcessArguments(), matching(arguments) else {
+                return false
+            }
+            seen = arguments
+            return true
+        }
+        return seen
+    }
+
+    private func waitUntil(seconds: TimeInterval, _ condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if condition() { return true }
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        return false
+    }
+}


### PR DESCRIPTION
A terminal's foreground process group is named after its first process, and that process is not always the one still running. `sleep 60 | cat` puts both stages in one group named after `sleep`; when `sleep` finishes, `KERN_PROCARGS2` on that pgid fails outright while `cat` is still the program holding the terminal. The pane knew a job was running and had no name for it.

termiod already searched the group for a member that can answer. The in-process PTY did not, so the same command read one way in a termiod-backed session and another way in a local one — visible side by side, since the daemon ships behind `TERMIO_TERMIOD=1`.

`PTYProcess.foregroundProcessArguments()` now runs the daemon's search: enumerate the group with `proc_listpgrppids`, read each candidate back through `PROC_PIDTBSDINFO` for its state and its own process group, drop zombies and anything whose group no longer matches — that last check is what keeps a pid recycled since `tcgetpgrp` out of the answer. The leader is preferred so the name does not drift down a running pipeline, the rest are tried in ascending pid order so the choice is stable, and the search stops at the first process that answers. The daemon is untouched and the wire protocol is unchanged.

Cost is one extra `proc_pidinfo` per group member on a poll that already runs off the main thread, 350ms after output stops.

## Verified

Against a real interactive zsh on a forkpty PTY, running `sleep 1 | cat /dev/tty` (a bare `cat` follows its leader out on EOF, so it cannot hold the state long enough to sample):

- Before: while `sleep` ran, the foreground read `sleep 1`. The moment it exited the read went nil, with `hasForegroundJob` still true and `cat /dev/tty` still enumerable in the group.
- After: the same pipeline reads `sleep 1`, then `cat /dev/tty`.

`swift build` clean. `swift test`: 463 tests, 0 failures. `PTYForegroundTests` covers the selection rule as pure logic — leader preference, zombie and reaped leaders, a leader caught between fork and exec, stable choice between two survivors, the recycled-pid guard — plus the real-PTY case above, which fails on the old one-line read.

Release Notes:
- Fixed the running program not being named when it is part of a pipeline whose first stage has already finished.