### PR TITLE
Stop a remote attach hanging on an SSH passphrase prompt

### DIFF
--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -856,7 +856,8 @@ extension TermioStore {
         // mirrors `Termiod.remoteBinary()` (`$HOME/.local/bin/termiod`).
         let probe = runProcess(
             "/usr/bin/ssh",
-            ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host,
+            ["-o", "BatchMode=yes",
+             "-o", "ConnectTimeout=\(Termiod.connectTimeoutSeconds)", host,
              "test -x $HOME/.local/bin/termiod && echo yes || echo no"]
         )
         guard let probe else {

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -218,78 +218,131 @@ enum Termiod {
             ?? "$HOME/.local/bin/termiod"
     }
 
-    /// Options that make the SSH connection a resource this app holds rather
+    /// Every `-o` this app puts on its own `ssh`, resolved once per host. Two
+    /// concerns share one resolution because the `ssh -G` probe behind it forks
+    /// and this sits on the path that opens a session.
+    ///
+    /// **Multiplexing** makes the connection a resource this app holds rather
     /// than one it re-establishes per session. Without a master, every session
     /// and every reconnect pays a full TCP handshake plus SSH key exchange —
     /// measured at 230–300 ms against a VPS, against 26–33 ms once a master
     /// exists.
     ///
-    /// Nothing is injected when the user's own config already configures
-    /// multiplexing for this host. A command-line `-o` outranks
-    /// `~/.ssh/config`, so injecting unconditionally would override a
-    /// deliberate `ControlMaster no`, and the config is authoritative for how
-    /// to reach a host. Answers are cached per host because `ssh -G` forks and
-    /// this sits on the path that opens a session.
-    static func multiplexingArguments(host: String) -> [String] {
-        if let cached = multiplexingLock.withLock({ multiplexingCache[host] }) {
+    /// **`BatchMode` and `ConnectTimeout`** are what every other ssh call site
+    /// in the app already sets and this one did not. Nobody can answer a prompt
+    /// on this channel: the child's stdin is the framed protocol pipe, and ssh
+    /// asks for a key passphrase on `/dev/tty` — which is whatever terminal
+    /// launched the app and is not watching it, or nothing at all under Finder.
+    /// A passphrase-protected key with no agent loaded therefore either blocked
+    /// on that read with no timeout (still hung past 20 s on OpenSSH 10.2p1) or
+    /// failed for a reason the attach never saw. `BatchMode=yes` makes it exit
+    /// 255 with "Permission denied" in about a second, and `ConnectTimeout`
+    /// bounds the separate case of a host that swallows the connect and never
+    /// answers.
+    ///
+    /// A command-line `-o` outranks `~/.ssh/config`, so nothing is injected
+    /// where the user already answered the question: not multiplexing when they
+    /// configured either half of it, and not a timeout when they chose one for a
+    /// slow link. `BatchMode` is the exception and goes on unconditionally —
+    /// there is no reading of it under which a pipe nobody can type into should
+    /// wait for someone to.
+    static func sshArguments(host: String) -> [String] {
+        if let cached = sshArgumentsLock.withLock({ sshArgumentsCache[host] }) {
             return cached
         }
         // The probe runs outside the lock (never hold a lock across a fork); a
         // rare duplicate lookup just recomputes the same answer.
-        let resolved = resolveMultiplexingArguments(host: host)
-        multiplexingLock.withLock { multiplexingCache[host] = resolved }
+        let options = effectiveSSHConfig(host: host).map(EffectiveSSHOptions.init(dump:))
+        let resolved = sshArguments(options: options, controlPath: controlPath(for: host))
+        sshArgumentsLock.withLock { sshArgumentsCache[host] = resolved }
         return resolved
     }
 
-    private static let multiplexingLock = NSLock()
+    private static let sshArgumentsLock = NSLock()
     /// `nonisolated(unsafe)` because every access goes through
-    /// `multiplexingLock` above — the lock, not the actor, is what makes this
+    /// `sshArgumentsLock` above — the lock, not the actor, is what makes this
     /// safe, and the compiler cannot see that.
-    nonisolated(unsafe) private static var multiplexingCache: [String: [String]] = [:]
+    nonisolated(unsafe) private static var sshArgumentsCache: [String: [String]] = [:]
 
-    private static func resolveMultiplexingArguments(host: String) -> [String] {
-        guard userLeavesMultiplexingToUs(host: host),
-              let directory = controlSocketDirectory() else { return [] }
-        let path = directory.appendingPathComponent(controlSocketName(for: host)).path
-        // A Unix socket path is capped at 104 bytes, and an over-long
-        // ControlPath makes ssh fail outright rather than degrade. An unusually
-        // long temporary directory must cost multiplexing, never the session.
-        guard path.utf8.count < 100 else { return [] }
-        return ["-o", "ControlMaster=auto",
-                "-o", "ControlPath=\(path)",
-                "-o", "ControlPersist=10m"]
-    }
+    /// Matches the remote-readiness probe in `TermioStore+Termiod.swift`, so
+    /// both roads to a host give up on the same clock.
+    static let connectTimeoutSeconds = 10
 
-    /// `ssh -G <host>` prints the fully-resolved effective config. Multiplexing
-    /// is ours to set only when the user has configured neither half of it;
-    /// `false` and `none` are what OpenSSH prints for those defaults. A failed
-    /// probe answers "no", so a broken probe can never smuggle options past a
-    /// config it could not read.
-    private static func userLeavesMultiplexingToUs(host: String) -> Bool {
-        guard let config = effectiveSSHConfig(host: host) else { return false }
-        var master: String?
-        var path: String?
-        for line in config.split(separator: "\n") {
-            let fields = line.split(separator: " ", maxSplits: 1)
-            guard fields.count == 2 else { continue }
-            let value = fields[1].trimmingCharacters(in: .whitespaces).lowercased()
-            switch fields[0].lowercased() {
-            case "controlmaster": master = value
-            case "controlpath": path = value
-            default: continue
-            }
+    /// The argument list itself, taking what the probe found rather than
+    /// running it, so the decisions above are checkable without an ssh on the
+    /// machine. `options` is `nil` when `ssh -G` could not be read: only
+    /// `BatchMode` survives that, because the rest would be overriding a config
+    /// this process failed to read.
+    static func sshArguments(options: EffectiveSSHOptions?, controlPath: String?) -> [String] {
+        var arguments = ["-o", "BatchMode=yes"]
+        guard let options else { return arguments }
+        if !options.setsConnectTimeout {
+            arguments += ["-o", "ConnectTimeout=\(connectTimeoutSeconds)"]
         }
-        // A missing `controlmaster` line means an OpenSSH too old to be read
-        // this way, so leave its config alone.
-        guard let master, ["false", "no", "none"].contains(master) else { return false }
-        // OpenSSH omits `controlpath` entirely when it is unset (confirmed on
-        // 10.2p1) where older versions print `none`; both mean the user has
-        // chosen no path. Requiring the line to be present made this whole
-        // function answer "no" on a current macOS, which is a silent no-op —
-        // the exact failure this is meant to end.
-        return path == nil || path == "none"
+        if options.leavesMultiplexingToUs, let controlPath {
+            arguments += ["-o", "ControlMaster=auto",
+                          "-o", "ControlPath=\(controlPath)",
+                          "-o", "ControlPersist=10m"]
+        }
+        return arguments
     }
 
+    /// `nil` when multiplexing has to be skipped for this host. A Unix socket
+    /// path is capped at 104 bytes, and an over-long `ControlPath` makes ssh
+    /// fail outright rather than degrade. An unusually long temporary directory
+    /// must cost multiplexing, never the session.
+    private static func controlPath(for host: String) -> String? {
+        guard let directory = controlSocketDirectory() else { return nil }
+        let path = directory.appendingPathComponent(controlSocketName(for: host)).path
+        guard path.utf8.count < 100 else { return nil }
+        return path
+    }
+
+    /// The three lines of `ssh -G <host>`'s fully-resolved config that decide
+    /// whether an option is ours to set. Parsing is separate from the fork that
+    /// produces the dump so it can be tested against real OpenSSH output.
+    struct EffectiveSSHOptions {
+        /// The user configured neither half of multiplexing. `false` and `none`
+        /// are what OpenSSH prints for those defaults.
+        let leavesMultiplexingToUs: Bool
+        /// The user chose a connect timeout, whatever it is; OpenSSH prints
+        /// `connecttimeout none` when nobody has.
+        let setsConnectTimeout: Bool
+
+        init(dump: String) {
+            var master: String?
+            var path: String?
+            var timeout: String?
+            for line in dump.split(separator: "\n") {
+                let fields = line.split(separator: " ", maxSplits: 1)
+                guard fields.count == 2 else { continue }
+                let value = fields[1].trimmingCharacters(in: .whitespaces).lowercased()
+                switch fields[0].lowercased() {
+                case "controlmaster": master = value
+                case "controlpath": path = value
+                case "connecttimeout": timeout = value
+                default: continue
+                }
+            }
+            // A missing `controlmaster` line means an OpenSSH too old to be read
+            // this way, so leave its config alone. `connecttimeout` reads the
+            // same way: absent means unreadable, and unreadable keeps the
+            // decision with the config.
+            let masterIsOurs = master.map { ["false", "no", "none"].contains($0) } ?? false
+            // OpenSSH omits `controlpath` entirely when it is unset (confirmed on
+            // 10.2p1) where older versions print `none`; both mean the user has
+            // chosen no path. Requiring the line to be present made this whole
+            // check answer "no" on a current macOS, which is a silent no-op —
+            // the exact failure this is meant to end.
+            let pathIsOurs = path == nil || path == "none"
+            leavesMultiplexingToUs = masterIsOurs && pathIsOurs
+            setsConnectTimeout = timeout != "none"
+        }
+    }
+
+    /// `ssh -G <host>` prints the config every option resolves to for that host.
+    /// `nil` when it could not be run or exited non-zero, which is what stops a
+    /// broken probe from smuggling options past a config it could not read.
     private static func effectiveSSHConfig(host: String) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
@@ -403,7 +456,7 @@ enum Termiod {
 
             let command = "\(remoteBinary()) stdio"
             let arguments = ["ssh", "-o", "ServerAliveInterval=15"]
-                + multiplexingArguments(host: host)
+                + sshArguments(host: host)
                 + [host, command]
             let argv: [UnsafeMutablePointer<CChar>?] = arguments.map { strdup($0) } + [nil]
             defer { argv.forEach { free($0) } }

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -667,7 +667,7 @@ extension TermioStore {
     /// No `ControlMaster` options are injected. The session used to double as a
     /// master so the inspector's SFTP tree could ride it; the tree now reads the
     /// device's own daemon, which brings its own multiplexing
-    /// (`Termiod.multiplexingArguments`) and, unlike this, only after checking
+    /// (`Termiod.sshArguments`) and, unlike this, only after checking
     /// that the user's `~/.ssh/config` left the decision to us.
     static func sshCommand(host: String) -> String {
         "ssh -- \(shellQuoted(host))"

--- a/Tests/termioTests/TermiodSSHArgumentsTests.swift
+++ b/Tests/termioTests/TermiodSSHArgumentsTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import termio
+
+/// The `-o` list the app puts on its own `ssh`, and the `ssh -G` reading that
+/// decides which of them are ours to set. Two things are pinned here.
+///
+/// `BatchMode=yes` is unconditional. Nobody can answer a prompt on this
+/// channel — its stdin is the framed protocol pipe, and ssh asks for a key
+/// passphrase on a `/dev/tty` nobody is watching — so an unloaded key blocked
+/// the attach instead of failing it. That is the bug this list exists to end,
+/// and it comes back the moment the flag becomes conditional on anything.
+///
+/// Everything else defers to `~/.ssh/config`, because a command-line `-o`
+/// outranks it. A user who chose `ControlMaster auto`, a `ControlPath`, or a
+/// `ConnectTimeout` for a slow link keeps it.
+final class TermiodSSHArgumentsTests: XCTestCase {
+    /// Trimmed to the four lines that matter, in the spelling OpenSSH 10.2p1
+    /// prints them: `controlmaster false` and `connecttimeout none` for unset,
+    /// and no `controlpath` line at all.
+    private let defaultsDump = """
+        user alice
+        hostname vps.example
+        batchmode no
+        controlmaster false
+        connecttimeout none
+        serveraliveinterval 0
+        """
+
+    private let controlPath = "/tmp/termio-ssh/2f1c8a90b3d4e5f6"
+
+    func testUntouchedConfigGetsEveryOption() {
+        let arguments = Termiod.sshArguments(
+            options: Termiod.EffectiveSSHOptions(dump: defaultsDump),
+            controlPath: controlPath)
+        XCTAssertEqual(arguments, [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=\(Termiod.connectTimeoutSeconds)",
+            "-o", "ControlMaster=auto",
+            "-o", "ControlPath=\(controlPath)",
+            "-o", "ControlPersist=10m",
+        ])
+    }
+
+    func testUserMultiplexingIsNotOverridden() {
+        let dump = defaultsDump.replacingOccurrences(
+            of: "controlmaster false", with: "controlmaster auto")
+        let arguments = Termiod.sshArguments(
+            options: Termiod.EffectiveSSHOptions(dump: dump), controlPath: controlPath)
+        XCTAssertFalse(arguments.contains("ControlMaster=auto"))
+        XCTAssertTrue(arguments.contains("BatchMode=yes"))
+    }
+
+    func testUserControlPathIsNotOverridden() {
+        let dump = defaultsDump + "\ncontrolpath /Users/alice/.ssh/cm-%C"
+        let arguments = Termiod.sshArguments(
+            options: Termiod.EffectiveSSHOptions(dump: dump), controlPath: controlPath)
+        XCTAssertFalse(arguments.contains(where: { $0.hasPrefix("ControlPath=") }))
+    }
+
+    func testUserConnectTimeoutIsNotOverridden() {
+        let dump = defaultsDump.replacingOccurrences(
+            of: "connecttimeout none", with: "connecttimeout 60")
+        let arguments = Termiod.sshArguments(
+            options: Termiod.EffectiveSSHOptions(dump: dump), controlPath: controlPath)
+        XCTAssertFalse(arguments.contains(where: { $0.hasPrefix("ConnectTimeout=") }))
+        XCTAssertTrue(arguments.contains("ControlMaster=auto"))
+    }
+
+    /// An OpenSSH old enough not to print the line is unreadable, not permissive:
+    /// the same restraint `controlmaster`'s missing line already gets.
+    func testAbsentConnectTimeoutLineLeavesTheConfigAlone() {
+        let dump = defaultsDump.replacingOccurrences(of: "connecttimeout none\n", with: "")
+        let arguments = Termiod.sshArguments(
+            options: Termiod.EffectiveSSHOptions(dump: dump), controlPath: controlPath)
+        XCTAssertFalse(arguments.contains(where: { $0.hasPrefix("ConnectTimeout=") }))
+    }
+
+    /// An unreadable probe keeps only the flag that cannot override anything:
+    /// `BatchMode`'s default is `no`, and a pipe nobody can type into never
+    /// wants the other answer.
+    func testUnreadableProbeStillRefusesToPrompt() {
+        XCTAssertEqual(
+            Termiod.sshArguments(options: nil, controlPath: controlPath),
+            ["-o", "BatchMode=yes"])
+    }
+
+    /// A control socket path over the 104-byte cap makes ssh fail outright, so
+    /// it costs multiplexing — never the flags that keep the session honest.
+    func testMissingControlPathCostsOnlyMultiplexing() {
+        let arguments = Termiod.sshArguments(
+            options: Termiod.EffectiveSSHOptions(dump: defaultsDump), controlPath: nil)
+        XCTAssertEqual(arguments, [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=\(Termiod.connectTimeoutSeconds)",
+        ])
+    }
+}


### PR DESCRIPTION
`Transport.ssh` builds the app's own `ssh` argument list. It already carried `ServerAliveInterval`, `ControlMaster`, `ControlPersist` and a length-capped `ControlPath`. It never carried `BatchMode` or `ConnectTimeout`, which every other ssh call site in the app sets — `SSHConfig.testConnection`, `performRemoteReadyCheck`, and both Rust call sites in `termiod`.

Nobody can answer a prompt on that channel. Its stdin is the framed protocol pipe, and ssh asks for a key passphrase on `/dev/tty` — whatever terminal launched the app and is not watching it, or nothing at all under Finder. A passphrase-protected key with no agent loaded blocked there with no timeout.

Measured against a local sshd with an encrypted key and no agent, same argument shape as `Transport.ssh`:

| | today | with the flags |
| --- | --- | --- |
| controlling terminal present (`swift run`) | still running at 20 s, `Enter passphrase for key …` written where nothing reads it | exit 255 in ~1 s, `Permission denied (publickey,…)` |
| no controlling terminal (Finder-launched bundle) | exit 255 in ~1 s, key silently skipped | same, and the reason is on stderr |

Either way the attach now ends in `TermiodClientError` rather than waiting.

`BatchMode=yes` goes on unconditionally — its default is `no`, and there is no reading of it under which a pipe nobody can type into should wait for someone to. `ConnectTimeout` does not: a command-line `-o` outranks `~/.ssh/config`, and a user on a slow link may have chosen their own, so it is injected only when `ssh -G` prints `connecttimeout none`. That is the restraint multiplexing already had. Both now ride the one `ssh -G` probe instead of two, and its parsing moved into an `EffectiveSSHOptions` that `TermiodSSHArgumentsTests` checks against real OpenSSH 10.2p1 output — including that a user's `ControlMaster`, `ControlPath` or `ConnectTimeout` survives, and that an unreadable probe still refuses to prompt.

`unify-server-plane.md` §1.1 still says these two options are absent. Left alone deliberately: `docs/unify-server-plane-restamp` owns that file right now.

Release Notes:
- Fixed a remote session hanging instead of reporting an error when the SSH key needs a passphrase and no agent is loaded.