### PR TITLE
Drop the toolbar display-mode context menu

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -827,6 +827,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         toolbar.displayMode = .iconOnly
         toolbar.allowsUserCustomization = false
         toolbar.showsBaselineSeparator = false
+        // The chrome is fixed, so the right-click menu had nothing to offer but a
+        // labelled variant of icons the window is laid out around.
+        if #available(macOS 15, *) {
+            toolbar.allowsDisplayModeCustomization = false
+        }
         if #available(macOS 26, *) {
             window.toolbarStyle = .automatic
         } else {


### PR DESCRIPTION
Right-clicking the window toolbar opened AppKit's stock customization menu — "Icon and Text" / "Icon Only" over a disabled "Remove Item". The toolbar is fixed chrome (`allowsUserCustomization = false`), so the menu only offered a labelled variant of icons the window is laid out around.

Setting `allowsDisplayModeCustomization = false` (macOS 15+) removes it.

Release Notes:
- Right-clicking the toolbar no longer opens a menu for switching its icons to labelled buttons.