### PR TITLE
Group the phone's projects by workspace

### DIFF
--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -8,15 +8,19 @@ import Foundation
 /// History:
 ///   0: pre-versioning. No `wire` field on the wire; any peer that omits it.
 ///   1: 2026-08-07: `wire` declared on `.auth` and `CompanionRoster`.
+///   2: 2026-08-22: `RosterProject` names its workspace and that workspace's
+///      device, and its `branch`/`kind` became required. A v1 peer can't read a
+///      v2 roster, so both minimums move with it: the mismatch has to say
+///      "update the other end" rather than draw an empty project list.
 public enum Wire {
     /// A peer that predates the field entirely. Absent decodes to this.
     public static let legacy = 0
     /// This build's revision.
-    public static let current = 1
+    public static let current = 2
     /// Oldest Mac this phone will talk to.
-    public static let minimumServer = 0
+    public static let minimumServer = 2
     /// Oldest phone this Mac will serve.
-    public static let minimumClient = 0
+    public static let minimumClient = 2
 }
 
 /// The companion wire protocol, shared by the Mac companion server and the iOS
@@ -608,40 +612,66 @@ private func decodeLossyArray<Element: Decodable, Key: CodingKey>(
     return elements
 }
 
+/// One container of sessions as the phone lists it — a project checkout, or a
+/// workspace's loose Terminals or Chats section.
+///
+/// Every container names the workspace it is filed under and the machine that
+/// workspace belongs to, because the Mac's tree is Device → Workspace → Project
+/// → Session and a flat list drops the middle two: a checkout on a Linux VPS and
+/// one on the Mac arrive looking identical. `workspaceID` groups them and
+/// `deviceAlias` says which box the group is on.
 public struct RosterProject: Codable, Sendable, Equatable {
     public let id: String
     public let name: String
     public let path: String
-    /// Current git branch of the checkout, nil for non-repos. Optional so
-    /// older peers that don't send it still decode.
-    public let branch: String?
+    /// The workspace this container is filed under, by the Mac's stable id, so
+    /// the phone groups its list the way the sidebar's scope does.
+    public let workspaceID: String
+    /// That workspace's name, as the Mac's switcher shows it.
+    public let workspaceName: String
+    /// The `~/.ssh/config` alias of the machine the workspace belongs to, and
+    /// nil for the Mac that is serving this roster. One claim, matching
+    /// `Workspace.deviceAlias`: which machine, never "did the user name it".
+    public let deviceAlias: String?
+    /// Current git branch of the checkout, empty for non-repos and for the
+    /// loose sections.
+    public let branch: String
     /// What this container *is* on the Mac — `ProjectKind` on the wire:
     /// "folder" (a real project), "terminals" (loose shells), "chats" (loose
-    /// agent sessions). nil from an older Mac; treat as "folder".
-    public let kind: String?
+    /// agent sessions).
+    public let kind: String
     public let sessions: [RosterSession]
 
     public init(
-        id: String, name: String, path: String, branch: String? = nil,
-        kind: String? = nil, sessions: [RosterSession]
+        id: String, name: String, path: String,
+        workspaceID: String, workspaceName: String, deviceAlias: String? = nil,
+        branch: String = "", kind: String, sessions: [RosterSession]
     ) {
         self.id = id
         self.name = name
         self.path = path
+        self.workspaceID = workspaceID
+        self.workspaceName = workspaceName
+        self.deviceAlias = deviceAlias
         self.branch = branch
         self.kind = kind
         self.sessions = sessions
     }
 
-    private enum CodingKeys: String, CodingKey { case id, name, path, branch, kind, sessions }
+    private enum CodingKeys: String, CodingKey {
+        case id, name, path, workspaceID, workspaceName, deviceAlias, branch, kind, sessions
+    }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(String.self, forKey: .id)
         name = try c.decode(String.self, forKey: .name)
         path = try c.decode(String.self, forKey: .path)
-        branch = try c.decodeIfPresent(String.self, forKey: .branch)
-        kind = try c.decodeIfPresent(String.self, forKey: .kind)
+        workspaceID = try c.decode(String.self, forKey: .workspaceID)
+        workspaceName = try c.decode(String.self, forKey: .workspaceName)
+        deviceAlias = try c.decodeIfPresent(String.self, forKey: .deviceAlias)
+        branch = try c.decode(String.self, forKey: .branch)
+        kind = try c.decode(String.self, forKey: .kind)
         sessions = decodeLossyArray(c, CodingKeys.sessions)
     }
 }

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -1275,40 +1275,52 @@ extension TermioStore {
     /// Snapshot the current projects/sessions as a wire roster, mirroring what
     /// the sidebar renders (display titles, live agent status).
     func companionRoster() -> CompanionRoster {
-        // The phone still sees containers, one per section, because its roster is
-        // a flat list of cards and always has been. A workspace's Terminals and
-        // Chats each ride as one, tagged with the kind the phone already keys off
-        // (`RosterProject.kind`); telling the phone about workspaces themselves is
-        // an additive protocol change and belongs to its own RFC.
+        // The roster stays one flat list of containers, but each one names the
+        // workspace it belongs to and the machine that workspace is on, so the
+        // phone can group by workspace instead of pouring every machine's
+        // checkouts into a single column. Containers are emitted workspace by
+        // workspace, in sidebar order, so the pushed order is already the
+        // grouping order.
         var projects: [RosterProject] = []
         for workspace in workspaces {
-            let name = hasMultipleWorkspaces ? workspace.name : ""
+            let alias = workspace.deviceAlias
             if !workspace.terminals.isEmpty {
                 projects.append(RosterProject(
                     id: Self.looseWireID(workspace: workspace, chats: false),
-                    name: name.isEmpty ? "Terminals" : "\(name) — Terminals",
+                    name: "Terminals",
                     path: Self.looseTerminalRoot,
+                    workspaceID: workspace.id.uuidString,
+                    workspaceName: workspace.name,
+                    deviceAlias: alias,
                     kind: "terminals",
                     sessions: workspace.terminals.map(rosterSession)))
             }
             if !workspace.chats.isEmpty {
                 projects.append(RosterProject(
                     id: Self.looseWireID(workspace: workspace, chats: true),
-                    name: name.isEmpty ? "Chats" : "\(name) — Chats",
+                    name: "Chats",
                     path: Self.looseChatRoot,
+                    workspaceID: workspace.id.uuidString,
+                    workspaceName: workspace.name,
+                    deviceAlias: alias,
                     kind: "chats",
                     sessions: workspace.chats.map(rosterSession)))
             }
-        }
-        projects += self.projects.map { project in
-            RosterProject(
-                id: project.id.uuidString,
-                name: project.name,
-                path: project.path,
-                branch: branchModel.branch(for: project.path) ?? project.branch,
-                kind: "folder",
-                sessions: project.sessions.map(rosterSession)
-            )
+            projects += self.projects(inWorkspace: workspace.id).map { project in
+                RosterProject(
+                    id: project.id.uuidString,
+                    name: project.name,
+                    path: project.path,
+                    workspaceID: workspace.id.uuidString,
+                    workspaceName: workspace.name,
+                    deviceAlias: alias,
+                    // "—" is the desktop's own no-branch placeholder; the wire
+                    // says empty so the phone has one thing to test.
+                    branch: Self.wireBranch(branchModel.branch(for: project.path) ?? project.branch),
+                    kind: "folder",
+                    sessions: project.sessions.map(rosterSession)
+                )
+            }
         }
         // The phone's new-session menu mirrors the desktop's enabled agents,
         // in preset order — the same filter the sidebar's quick-add row uses.
@@ -1329,6 +1341,13 @@ extension TermioStore {
 
     private static func wireAgent(_ agent: AgentPreset) -> String {
         agent.wireName
+    }
+
+    /// A checkout's branch as the wire says it: the name, or empty for a folder
+    /// that is not a repo. "—" is a glyph the sidebar draws in an empty column,
+    /// not a branch, and it has no business crossing to another app.
+    private static func wireBranch(_ branch: String) -> String {
+        branch == "—" ? "" : branch
     }
 
     private static func wireStatus(_ status: SessionStatus) -> String {

--- a/Tests/termioTests/CompanionRosterWorkspaceTests.swift
+++ b/Tests/termioTests/CompanionRosterWorkspaceTests.swift
@@ -1,0 +1,76 @@
+import TermioShared
+import XCTest
+@testable import termio
+
+/// What the phone is told about where a checkout lives.
+///
+/// The roster used to be every workspace's projects poured into one list, so a
+/// checkout on a Linux box and one on this Mac reached the phone looking
+/// identical. Each container now names its workspace and that workspace's
+/// machine — the middle two levels of Device → Workspace → Project → Session,
+/// which the flat list had been dropping.
+@MainActor
+final class CompanionRosterWorkspaceTests: XCTestCase {
+    private func makeStore(workspaces: [Workspace], projects: [Project]) -> TermioStore {
+        let defaults = UserDefaults(suiteName: "companion-roster-\(UUID().uuidString)")
+            ?? UserDefaults.standard
+        return TermioStore(
+            workspaces: workspaces, projects: projects,
+            settings: AppSettings(defaults: defaults))
+    }
+
+    private func project(_ name: String, in workspace: Workspace) -> Project {
+        Project(
+            workspaceID: workspace.id, name: name, path: "/tmp/\(name)",
+            branch: "main", sessions: [])
+    }
+
+    func testEveryContainerNamesItsWorkspaceAndMachine() {
+        let home = Workspace(name: "Sessions", terminals: [Session(title: "Terminal 1")])
+        let box = Workspace(name: "ukvps", deviceAlias: "ukvps")
+        let store = makeStore(
+            workspaces: [home, box],
+            projects: [project("termio", in: home), project("api", in: box)])
+
+        let roster = store.companionRoster()
+
+        XCTAssertEqual(
+            roster.projects.map { [$0.name, $0.workspaceName, $0.deviceAlias ?? "—"] },
+            [
+                ["Terminals", "Sessions", "—"],
+                ["termio", "Sessions", "—"],
+                ["api", "ukvps", "ukvps"],
+            ],
+            "containers ride in workspace order, each naming its scope and machine"
+        )
+        XCTAssertEqual(
+            roster.projects.map(\.workspaceID),
+            [home.id.uuidString, home.id.uuidString, box.id.uuidString])
+    }
+
+    /// The loose sections used to have their workspace spliced into the name
+    /// ("Work — Terminals") because there was nowhere else to put it. With the
+    /// workspace on the wire that is the same job done twice.
+    func testLooseSectionsAreNotNamedAfterTheirWorkspace() {
+        let work = Workspace(
+            name: "Work", terminals: [Session(title: "Terminal 1")],
+            chats: [Session(title: "Chat 1")])
+        let store = makeStore(workspaces: [work, Workspace(name: "Personal")], projects: [])
+
+        let roster = store.companionRoster()
+
+        XCTAssertEqual(roster.projects.map(\.name), ["Terminals", "Chats"])
+        XCTAssertEqual(roster.projects.map(\.workspaceName), ["Work", "Work"])
+    }
+
+    /// A folder that is not a repo has no branch, and the sidebar's "—" is a glyph
+    /// it draws in an empty column — never a branch name to hand another app.
+    func testANonRepoReportsNoBranch() {
+        let home = Workspace(name: "Sessions")
+        var folder = project("notes", in: home)
+        folder.branch = "—"
+        let store = makeStore(workspaces: [home], projects: [folder])
+
+        XCTAssertEqual(store.companionRoster().projects.first?.branch, "")
+    }
+}

--- a/Tests/termioTests/WireProtocolTests.swift
+++ b/Tests/termioTests/WireProtocolTests.swift
@@ -3,6 +3,25 @@ import TermioShared
 import XCTest
 
 final class WireProtocolTests: XCTestCase {
+    /// The keys every wire-2 project carries, spliced into the fixtures below so
+    /// each test is about the one tolerance it names rather than about these.
+    private static let workspaceFields =
+        #""workspaceID":"w1","workspaceName":"Sessions","branch":"","kind":"folder""#
+
+    /// The wire-2 break, stated as a test: a project from a v1 Mac names no
+    /// workspace, so it is unreadable rather than half-read. The version gate is
+    /// what turns that into "update the other end"; this only pins that the
+    /// decoder does not quietly invent a workspace for it.
+    func testProjectWithoutAWorkspaceIsUnreadable() throws {
+        let json = #"""
+        {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio","sessions":[]}]}
+        """#
+
+        let decoded = try XCTUnwrap(CompanionRoster.decode(json))
+
+        XCTAssertEqual(decoded.projects, [])
+    }
+
     func testAuthRoundTripCarriesCurrentWireVersion() {
         let auth = CompanionControl.auth(token: "pairing-token", wire: Wire.current)
 
@@ -37,7 +56,8 @@ final class WireProtocolTests: XCTestCase {
     /// empty app.
     func testRosterDropsOnlyTheUnreadableSession() throws {
         let json = """
-        {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio","sessions":[\
+        {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio",\
+        \(Self.workspaceFields),"sessions":[\
         {"id":"s1","title":"Good","agent":"claude","status":"idle"},\
         {"id":"s2","title":"Missing agent and status"},\
         {"id":"s3","title":"Also good","agent":"codex","status":"working"}]}]}
@@ -52,9 +72,9 @@ final class WireProtocolTests: XCTestCase {
     func testRosterDropsOnlyTheUnreadableProject() throws {
         let json = """
         {"t":"roster","projects":[\
-        {"id":"p1","name":"termio","path":"/tmp/termio","sessions":[]},\
-        {"name":"no id","path":"/tmp/broken","sessions":[]},\
-        {"id":"p3","name":"other","path":"/tmp/other","sessions":[]}]}
+        {"id":"p1","name":"termio","path":"/tmp/termio",\(Self.workspaceFields),"sessions":[]},\
+        {"name":"no id","path":"/tmp/broken",\(Self.workspaceFields),"sessions":[]},\
+        {"id":"p3","name":"other","path":"/tmp/other",\(Self.workspaceFields),"sessions":[]}]}
         """
 
         let decoded = try XCTUnwrap(CompanionRoster.decode(json))
@@ -66,7 +86,8 @@ final class WireProtocolTests: XCTestCase {
     /// still decodes — unknown keys are ignored, not fatal.
     func testRosterKeepsSessionWithUnknownFields() throws {
         let json = """
-        {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio","sessions":[\
+        {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio",\
+        \(Self.workspaceFields),"sessions":[\
         {"id":"s1","title":"Good","agent":"claude","status":"idle","somethingNewer":{"a":1}}]}]}
         """
 
@@ -94,7 +115,8 @@ final class WireProtocolTests: XCTestCase {
     func testRosterSkipsNonObjectSessionEntries() throws {
         for bad in ["null", "42", #""a string""#, "[1,2]", "[]", "true"] {
             let json = """
-            {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio","sessions":[\
+            {"t":"roster","projects":[{"id":"p1","name":"termio","path":"/tmp/termio",\
+            \(Self.workspaceFields),"sessions":[\
             {"id":"s1","title":"Good","agent":"claude","status":"idle"},\
             \(bad),\
             {"id":"s3","title":"Also good","agent":"codex","status":"working"}]}]}
@@ -130,6 +152,7 @@ final class WireProtocolTests: XCTestCase {
             projects: [
                 RosterProject(
                     id: "p1", name: "termio", path: "/tmp/termio",
+                    workspaceID: "w1", workspaceName: "ukvps", deviceAlias: "ukvps",
                     branch: "fix/wire-tolerance", kind: "folder",
                     sessions: [
                         RosterSession(

--- a/ios/Sources/Localizable.xcstrings
+++ b/ios/Sources/Localizable.xcstrings
@@ -1481,6 +1481,16 @@
         }
       }
     },
+    "on %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 %@ 上"
+          }
+        }
+      }
+    },
     "plain text": {
       "localizations": {
         "zh-Hans": {

--- a/ios/Sources/Models.swift
+++ b/ios/Sources/Models.swift
@@ -52,8 +52,17 @@ struct MockProject: Identifiable {
     /// Current git branch of the checkout (nil for non-repos / mock data).
     var branch: String?
     /// The Mac's `ProjectKind` raw value ("folder" / "terminals" / "chats");
-    /// nil from an older Mac or mock data — treat as a plain folder project.
+    /// nil for mock data — treat as a plain folder project.
     var kind: String?
+    /// The workspace this project is filed under on the Mac, and that
+    /// workspace's name — the list groups by the id and heads each group with
+    /// the name. Empty for the bundled mock, which has no workspace to speak of.
+    var workspaceID: String = ""
+    var workspaceName: String = ""
+    /// The `~/.ssh/config` alias of the machine the workspace is on, nil when
+    /// that machine is the Mac we're paired with. A checkout on a VPS and one on
+    /// the Mac are otherwise indistinguishable here.
+    var deviceAlias: String?
     let sessions: [MockSession]
 
     /// A stand-in for the Mac's loose-terminals container before it has opened
@@ -150,8 +159,8 @@ extension SessionStatus {
 
 extension MockSession {
     init(roster: RosterSession, project: RosterProject, agentsByID: [String: RosterAgent]) {
+        let projectBranch = project.branch.isEmpty ? nil : project.branch
         // "—" is the desktop's placeholder for "no branch"; drop it here.
-        let projectBranch = project.branch.flatMap { $0 == "—" || $0.isEmpty ? nil : $0 }
         let worktreeBranch = roster.branch.flatMap { $0 == "—" || $0.isEmpty ? nil : $0 }
         self.init(
             title: roster.title,
@@ -177,8 +186,11 @@ extension MockProject {
             name: roster.name,
             path: roster.path,
             rosterID: roster.id,
-            branch: roster.branch.flatMap { $0 == "—" || $0.isEmpty ? nil : $0 },
+            branch: roster.branch.isEmpty ? nil : roster.branch,
             kind: roster.kind,
+            workspaceID: roster.workspaceID,
+            workspaceName: roster.workspaceName,
+            deviceAlias: roster.deviceAlias,
             sessions: roster.sessions.map {
                 MockSession(roster: $0, project: roster, agentsByID: agentsByID)
             }

--- a/ios/Sources/ProjectListViewController.swift
+++ b/ios/Sources/ProjectListViewController.swift
@@ -12,14 +12,45 @@ import UIKit
 final class ProjectListViewController: UIViewController {
     private let store: RosterStore
 
-    private enum Section { case needsYou, projects }
+    /// One workspace's projects — the group the table draws as a section. The
+    /// Mac's tree is Device → Workspace → Project → Session, and the phone was
+    /// showing only the last two: every machine's checkouts poured into one
+    /// column, a VPS clone indistinguishable from a local one. The workspace is
+    /// the group; `deviceAlias` is the machine it is on, named in the header the
+    /// way the Mac names it, and never a level you navigate.
+    private struct WorkspaceGroup {
+        let id: String
+        let name: String
+        let deviceAlias: String?
+        var projects: [MockProject]
+
+        /// The machine to put after the workspace name, and nil when there is
+        /// nothing to add: this Mac carries no mark — being on the machine you
+        /// paired with is the absence of one — and neither does a workspace
+        /// already named after its box, where the header says it once. Both
+        /// rules are the desktop sidebar's.
+        var machineLabel: String? {
+            guard let deviceAlias,
+                  deviceAlias.caseInsensitiveCompare(name) != .orderedSame
+            else { return nil }
+            return deviceAlias
+        }
+    }
+
+    private enum Section {
+        case needsYou
+        /// An index into `groups`.
+        case workspace(Int)
+    }
+
     /// The sections currently on screen, rebuilt on every roster change.
     private var sections: [Section] = []
     /// Cross-project attention sessions (the strip's rows).
     private var attention: [MockSession] = []
-    /// The store's projects in the chosen order — what the table shows.
-    /// Chats-kind containers are excluded: they have their own tab.
-    private var visible: [MockProject] = []
+    /// The store's projects, grouped by workspace in roster order — what the
+    /// table shows. Chats- and Terminals-kind containers are excluded: they have
+    /// their own tabs.
+    private var groups: [WorkspaceGroup] = []
 
     /// Mirrors the Mac sidebar's sort pull-down. The roster arrives in the
     /// Mac's recent-activity order, so "Recent Activity" means "as pushed";
@@ -189,19 +220,59 @@ final class ProjectListViewController: UIViewController {
     }
 
     /// Rebuild the section list from the store: the attention strip (only when
-    /// non-empty), then the projects in the chosen order. The loose funnels
-    /// (Chats, Terminals) belong to their own tabs, so they're kept out of the
-    /// folder list — their attention sessions still surface in the strip here,
-    /// the cross-cutting shortcut.
+    /// non-empty), then one section per workspace. The loose funnels (Chats,
+    /// Terminals) belong to their own tabs, so they're kept out of the folder
+    /// list — their attention sessions still surface in the strip here, the
+    /// cross-cutting shortcut.
     private func refilter() {
         attention = store.attentionSessions
-        let ordered = sortByName
-            ? store.projects.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-            : store.projects
-        visible = ordered.filter { $0.kind != "chats" && $0.kind != "terminals" }
-        sections = (attention.isEmpty ? [] : [.needsYou]) + [.projects]
+        let folders = store.projects.filter { $0.kind != "chats" && $0.kind != "terminals" }
+        groups = Self.grouped(folders, sortedByName: sortByName)
+        sections = (attention.isEmpty ? [] : [.needsYou]) + groups.indices.map(Section.workspace)
         tableView.reloadData()
         updateEmptyState()
+    }
+
+    /// Projects into workspace groups. Workspaces keep the order the Mac pushed
+    /// them in — the sidebar's own order — and only the projects inside a group
+    /// re-sort when the user picks Name, so switching sort never reshuffles the
+    /// machines out from under them.
+    private static func grouped(_ projects: [MockProject], sortedByName: Bool) -> [WorkspaceGroup] {
+        var groups: [WorkspaceGroup] = []
+        var indexByWorkspace: [String: Int] = [:]
+        for project in projects {
+            if let index = indexByWorkspace[project.workspaceID] {
+                groups[index].projects.append(project)
+                continue
+            }
+            indexByWorkspace[project.workspaceID] = groups.count
+            groups.append(WorkspaceGroup(
+                id: project.workspaceID,
+                name: project.workspaceName,
+                deviceAlias: project.deviceAlias,
+                projects: [project]
+            ))
+        }
+        guard sortedByName else { return groups }
+        return groups.map { group in
+            var sorted = group
+            sorted.projects.sort {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+            return sorted
+        }
+    }
+
+    /// Every project on screen, in section order.
+    private var visible: [MockProject] { groups.flatMap(\.projects) }
+
+    /// Whether the sections are headed by their workspace. One unnamed local
+    /// workspace is the case almost everyone is in, and the Mac hides its own
+    /// workspace switcher there too — the page title already says "Projects".
+    /// A second workspace, or one that names a machine, is what makes the
+    /// grouping worth a header.
+    private var showsWorkspaceHeaders: Bool {
+        groups.count > 1 || groups.contains { $0.deviceAlias != nil && !$0.name.isEmpty }
     }
 
     // MARK: - Empty state
@@ -332,23 +403,36 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch sections[section] {
         case .needsYou: attention.count
-        case .projects: visible.count
+        case .workspace(let index): groups[index].projects.count
         }
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        // Headers only when the strip splits the page in two; a plain project
-        // list under the "Projects" page title needs no second label.
-        guard sections.count > 1 else { return nil }
+        guard showsHeaders else { return nil }
         guard let header = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: SectionCapView.reuseID
         ) as? SectionCapView else { return nil }
-        header.configure(title: sections[section] == .needsYou ? localized("Needs You") : localized("Projects"))
+        switch sections[section] {
+        case .needsYou:
+            header.configure(title: localized("Needs You"))
+        case .workspace(let index):
+            let group = groups[index]
+            header.configure(
+                title: showsWorkspaceHeaders ? group.name : localized("Projects"),
+                detail: showsWorkspaceHeaders ? group.machineLabel : nil
+            )
+        }
         return header
     }
 
+    /// Headers appear when the strip splits the page in two, or when the
+    /// workspaces themselves need naming.
+    private var showsHeaders: Bool {
+        sections.count > 1 || showsWorkspaceHeaders
+    }
+
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        sections.count > 1 ? 28 : 0
+        showsHeaders ? 28 : 0
     }
 
     /// A whitespace gap below each group — the divider-free separator,
@@ -379,11 +463,12 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
             }
             .margins(.horizontal, 12)
             .margins(.vertical, 0)
-        case .projects:
+        case .workspace(let index):
+            let projects = groups[index].projects
             cell.contentConfiguration = UIHostingConfiguration {
                 ProjectRow(
-                    project: visible[indexPath.row],
-                    showsSeparator: indexPath.row < visible.count - 1
+                    project: projects[indexPath.row],
+                    showsSeparator: indexPath.row < projects.count - 1
                 )
             }
             .margins(.horizontal, 12)
@@ -398,9 +483,9 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
             // Straight to the terminal — the strip exists so the blocked
             // session is one tap away, never behind its project page.
             store.openSession(attention[indexPath.row])
-        case .projects:
+        case .workspace(let index):
             navigationController?.pushViewController(
-                ProjectDetailViewController(store: store, project: visible[indexPath.row]),
+                ProjectDetailViewController(store: store, project: groups[index].projects[indexPath.row]),
                 animated: true
             )
         }
@@ -411,7 +496,7 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
         _ tableView: UITableView,
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
-        guard sections[indexPath.section] == .needsYou,
+        guard case .needsYou = sections[indexPath.section],
               store.companionURL != nil,
               let sessionID = attention[indexPath.row].rosterID
         else { return nil }
@@ -430,8 +515,8 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
         contextMenuConfigurationForRowAt indexPath: IndexPath,
         point: CGPoint
     ) -> UIContextMenuConfiguration? {
-        guard sections[indexPath.section] == .projects else { return nil }
-        let project = visible[indexPath.row]
+        guard case .workspace(let index) = sections[indexPath.section] else { return nil }
+        let project = groups[index].projects[indexPath.row]
         guard store.companionURL != nil, project.rosterID != nil else { return nil }
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             UIMenu(title: project.name, children: self?.store.newSessionActions(in: project) ?? [])
@@ -507,29 +592,54 @@ private struct ProjectRow: View {
 
 // MARK: - Section header
 
-/// A small gray caps label capping a group — only used when the attention
-/// strip splits the root page into two groups.
+/// A small gray caps label capping a group, with room for one trailing detail —
+/// the machine a workspace is on. Mail and Files head their groups the same way:
+/// the account or location names the section, and the rows underneath say
+/// nothing more about where they live.
+///
+/// The detail keeps its own case. It is an `~/.ssh/config` alias, a literal the
+/// user typed, and uppercasing it would make it something they can't find again.
 private final class SectionCapView: UITableViewHeaderFooterView {
     static let reuseID = "sectionCap"
 
     private let label = UILabel()
+    private let detailLabel = UILabel()
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
         label.font = .systemFont(ofSize: 13, weight: .semibold)
         label.textColor = .secondaryLabel
         label.translatesAutoresizingMaskIntoConstraints = false
+        detailLabel.font = .systemFont(ofSize: 13, weight: .regular)
+        detailLabel.textColor = .tertiaryLabel
+        detailLabel.textAlignment = .right
+        // The workspace name is the section's identity; the machine gives way
+        // when there isn't room for both.
+        detailLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        detailLabel.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(label)
+        contentView.addSubview(detailLabel)
         NSLayoutConstraint.activate([
             label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 22),
-            label.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -16),
             label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -6),
+            detailLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: label.trailingAnchor, constant: 8),
+            detailLabel.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor, constant: -22),
+            detailLabel.firstBaselineAnchor.constraint(equalTo: label.firstBaselineAnchor),
         ])
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    func configure(title: String) {
+    func configure(title: String, detail: String? = nil) {
         label.text = title.uppercased()
+        detailLabel.text = detail
+        detailLabel.isHidden = detail == nil
+        isAccessibilityElement = true
+        accessibilityTraits = .header
+        // VoiceOver reads the group once, so the machine belongs in the same
+        // breath as the name rather than as a second, orphaned element.
+        accessibilityLabel = detail.map { "\(title), \(localized("on \($0)"))" } ?? title
     }
 }


### PR DESCRIPTION
The phone listed every workspace's checkouts in one flat column. A repo on a Linux VPS and one on this Mac arrived indistinguishable — same row, same folder mark, nothing saying where either lives. The Mac's tree is Device → Workspace → Project → Session; the companion wire was carrying only the last two.

## What changes for the user

The Projects page draws one section per workspace, headed by the workspace name with the machine it is on trailing — the `~/.ssh/config` alias, as it reads in their config. A workspace on the paired Mac carries nothing after its name, and one already named after its box doesn't repeat it: both rules are the desktop sidebar's.

Nothing is filtered. A session living on a VPS while the phone watches it is the point; what was missing was belonging, not a filter.

The common case is untouched: one local workspace still renders as the plain list under the "Projects" title, with no header until the Needs You strip splits the page.

Device does not become a level you navigate. #345 removed machine-scoped navigation on the Mac — you switch workspaces, never machines — and a machine switcher on the phone would fork the two models. `PairedMac` keeps its own job (which Mac is feeding this phone).

## How

- `RosterProject` gains `workspaceID`, `workspaceName` and `deviceAlias`.
- `TermioStore.companionRoster()` emits containers workspace by workspace in sidebar order, so the pushed order is already the grouping order. The hand-spliced `"Work — Terminals"` name retires — with workspaces on the wire it was the same job done twice.
- `ProjectListViewController` groups by workspace id, keeping the Mac's order for the groups and re-sorting only inside one when the user picks Name, so changing the sort never reshuffles the machines.

## Compatibility: this is a deliberate break

`branch` and `kind` lose the optionals that existed only for peers predating them, and a v1 project names no workspace, so **a v1 peer cannot read a v2 roster**. Both wire minimums move to 2 with it: an old phone against this Mac gets "Update Termio on your phone to connect to this Mac", and this phone against a released Mac gets the mirror of that, instead of a silently empty project list. TestFlight users need the next build.

## Verified

- `swift build`, `swift test` — 503 tests, 0 failures. New `CompanionRosterWorkspaceTests` covers the grouping, the retired name splice, and `"—"` never crossing as a branch name; `WireProtocolTests` pins the break itself.
- iOS built for the simulator and driven against a real `CompanionServer` on a spare port, serving a store with a local workspace and one on `ukvps`. Read back from screenshots: the two groups, the `ukvps` label, the alias suppressed where the workspace already carries the name, and the single-local-workspace page unchanged from before.
- **Not run:** the phone → Mac → ssh → remote `termiod` leg. Both companion ports were held by running apps (the release app on 8787, PR #404's build on 8788), so the roster was served from a harness rather than a live Mac app. This PR changes what a container is labelled, not how a remote session attaches, but that link is still worth exercising once #404 lands.

Release Notes:
- The iPhone app groups projects by workspace, with the machine each workspace lives on named in its header. Requires an updated Mac app — this build and older ones can't read each other's roster.