### PR TITLE
Open a project on the machine its workspace is on

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -910,22 +910,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    /// File ▸ Open Project… — presents the folder picker that opens a directory as a new
-    /// project. Reached via the responder chain (the menu item targets `nil`),
-    /// the same nil-target routing the Settings item uses.
+    /// File ▸ Open Project… — opens a project on the machine the current workspace
+    /// belongs to: the folder picker here, a path on that box in a workspace that
+    /// is a box's (see `presentOpenProjectPanel`). Reached via the responder chain
+    /// (the menu item targets `nil`), the same nil-target routing the Settings
+    /// item uses.
     @objc func openProject(_ sender: Any?) {
         store.presentOpenProjectPanel()
-    }
-
-    /// A device row of the Open Project submenu — the machine's alias rides in
-    /// `representedObject`. Termio can't browse that box, so the panel asks for a
-    /// repository to clone onto it or a path already there.
-    @objc func openProjectOnDevice(_ sender: NSMenuItem) {
-        guard let alias = sender.representedObject as? String else { return }
-        store.presentRemoteProjectPanel(
-            on: KnownDevice(
-                alias: alias,
-                deviceID: TermiodDeviceRegistry.shared.deviceID(for: TermiodRoute(sshAlias: alias))))
     }
 
     /// File ▸ New Terminal (⌘T) — a shell in the focused session's directory, beside
@@ -1623,7 +1614,6 @@ enum DeviceMenuTag {
     static let newTerminal = 7301
     static let newTerminalAtHome = 7302
     static let connectTo = 7303
-    static let openProject = 7305
     static let newWorkspace = 7306
 }
 
@@ -1695,8 +1685,6 @@ extension AppDelegate: NSMenuDelegate {
             fillNewSSHMenu(menu)
         case localized("Connect to…"):
             fillConnectToMenu(menu)
-        case localized("Open Project"):
-            fillOpenProjectMenu(menu)
         case localized("New Workspace"):
             fillNewWorkspaceMenu(menu)
         case localized("Workspace"):
@@ -1714,9 +1702,9 @@ extension AppDelegate: NSMenuDelegate {
         // the roster is read once per pass rather than once per item — reading
         // `~/.ssh/config` for "Connect to…" is the expensive half.
         let known = DeviceRoster.known(in: store)
-        // The other machines are read once per pass for the same reason: both the
-        // Open Project and the New Workspace rows collapse on the same list, and it
-        // parses `~/.ssh/config` to build it.
+        // The other machines are read once per pass for the same reason: the New
+        // Workspace row collapses on this list, and building it parses
+        // `~/.ssh/config`.
         let others = otherDevices(known: known)
         for item in menu.items {
             switch item.tag {
@@ -1726,8 +1714,6 @@ extension AppDelegate: NSMenuDelegate {
                 refreshNewTerminalItem(item, known: known, atHome: true, command: nil)
             case DeviceMenuTag.connectTo:
                 item.isHidden = DeviceRoster.unusedAliases(known: known).isEmpty
-            case DeviceMenuTag.openProject:
-                refreshOpenProjectItem(item, others: others)
             case DeviceMenuTag.newWorkspace:
                 refreshNewWorkspaceItem(item, others: others)
             default:
@@ -1769,62 +1755,13 @@ extension AppDelegate: NSMenuDelegate {
         if let command { item.applyShortcut(for: command) }
     }
 
-    /// The same single-device collapse applied to "Open Project…": a plain verb
-    /// while this Mac is the only machine, a device submenu once there is anywhere
-    /// else to put a project.
-    ///
-    /// Unlike New Terminal, this one *does* grow the submenu, because a project is
-    /// filed rather than entered: the workspace the row lands in has no device of
-    /// its own to inherit, so where the checkout lives is a choice only this menu
-    /// can carry. Picking This Mac is today's folder picker, unchanged.
-    ///
-    /// The shortcut travels to the This Mac row so ⌘O still opens a local folder
-    /// (AppKit's key-equivalent sweep descends submenus, the same behaviour the
-    /// New Chat menu relies on).
-    private func refreshOpenProjectItem(_ item: NSMenuItem, others: [KnownDevice]) {
-        guard !others.isEmpty else {
-            item.title = localized("Open Project…")
-            item.submenu = nil
-            item.action = #selector(openProject(_:))
-            item.target = self
-            item.applyShortcut(for: .openProject)
-            return
-        }
-        // The ellipsis moves to the rows: it is each of those that opens a panel,
-        // and a parent that only reveals a submenu never carries one. A submenu
-        // item's own key equivalent never fires, so ⌘O travels to the This Mac row
-        // (see `fillOpenProjectMenu`).
-        item.title = localized("Open Project")
-        item.keyEquivalent = ""
-        item.keyEquivalentModifierMask = []
-        // Attached once and filled by the delegate on open, like the other device
-        // submenus. Replacing the menu object on every pass would swap it out from
-        // under AppKit's key-equivalent sweep, which is what finds ⌘O in there.
-        //
-        // Everything below runs on the *first* reshape only. Once a submenu is
-        // attached AppKit owns both the action and the target — it installs its
-        // own `submenuAction:` aimed at the menu — and re-clearing them on a later
-        // pass strips that and leaves a submenu parent with no action, which dims
-        // the row permanently. This menu is refreshed on every open, so "later
-        // pass" means the second time the user pulls it down.
-        guard item.submenu?.title != localized("Open Project") else { return }
-        // Cleared together, and before the submenu is attached: AppKit adopts the
-        // menu as the item's target only when nothing else already claims it, and
-        // a leftover AppDelegate cannot perform `submenuAction:`.
-        item.action = nil
-        item.target = nil
-        let submenu = NSMenu(title: localized("Open Project"))
-        submenu.delegate = self
-        item.submenu = submenu
-    }
-
     /// The machines other than this Mac something can be put on: one worked on
-    /// before, plus one from `~/.ssh/config` never reached. Putting a project or a
-    /// workspace on a box is itself a first contact — `ensureRemoteReady` installs
-    /// termiod on the way — so the list is the same one `Clone to <device>…` offers.
+    /// before, plus one from `~/.ssh/config` never reached. Putting a workspace on
+    /// a box is itself a first contact — `ensureRemoteReady` installs termiod on
+    /// the way — so the list is the same one `Clone to <device>…` offers.
     ///
-    /// Empty is the single-machine install, which is what both device submenus
-    /// collapse on.
+    /// Empty is the single-machine install, which is what the New Workspace submenu
+    /// collapses on.
     private func otherDevices(known: [KnownDevice]) -> [KnownDevice] {
         known.filter { !$0.isLocal }
             + DeviceRoster.unusedAliases(known: known).map { KnownDevice(alias: $0, deviceID: nil) }
@@ -1853,10 +1790,15 @@ extension AppDelegate: NSMenuDelegate {
         // The ellipsis moves to the rows: each of those opens the name panel, and a
         // parent that only reveals a submenu never carries one.
         item.title = localized("New Workspace")
-        // Attached once and filled by the delegate on open, like the other device
-        // submenus — the File menu's copy is rebuilt per open, but the toolbar `+`
-        // keeps its item across refreshes. The action and target are cleared on the
-        // first reshape only, for the reason spelled out in `refreshOpenProjectItem`.
+        // Attached once and filled by the delegate on open — the File menu's copy is
+        // rebuilt per open, but the toolbar `+` keeps its item across refreshes.
+        //
+        // Everything below runs on the *first* reshape only. Once a submenu is
+        // attached AppKit owns both the action and the target — it installs its own
+        // `submenuAction:` aimed at the menu — and re-clearing them on a later pass
+        // strips that and leaves a submenu parent with no action, which dims the row
+        // permanently. This menu is refreshed on every open, so "later pass" means
+        // the second time the user pulls it down.
         guard item.submenu?.title != localized("New Workspace") else { return }
         item.action = nil
         item.target = nil
@@ -1876,24 +1818,6 @@ extension AppDelegate: NSMenuDelegate {
             let row = menu.addItem(
                 withTitle: "\(device.name)…",
                 action: #selector(newWorkspaceOnDevice(_:)),
-                keyEquivalent: "")
-            row.target = self
-            row.representedObject = device.alias
-        }
-    }
-
-    private func fillOpenProjectMenu(_ menu: NSMenu) {
-        let local = menu.addItem(
-            withTitle: localized("This Mac…"), action: #selector(openProject(_:)), keyEquivalent: "")
-        local.target = self
-        local.applyShortcut(for: .openProject)
-        menu.addItem(.separator())
-        for device in otherDevices(known: DeviceRoster.known(in: store)) {
-            // The machine's own name, so nothing here is translated — it is the
-            // alias out of the user's `~/.ssh/config`.
-            let row = menu.addItem(
-                withTitle: "\(device.name)…",
-                action: #selector(openProjectOnDevice(_:)),
                 keyEquivalent: "")
             row.target = self
             row.representedObject = device.alias
@@ -2253,14 +2177,13 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
         menu.addItem(terminal)
         menu.addItem(makeNewChatItem())
         menu.addItem(makeNewSSHItem())
-        // Targets the AppDelegate, like the terminal row above, so the delegate can
-        // reshape it into a device submenu on open (`refreshOpenProjectItem`) —
-        // both this and the File menu's row then go through one builder.
+        // A plain verb on every install, like the terminal row above: a project
+        // takes its machine from the workspace it is filed in, so the scope on
+        // screen has already made that choice (see `presentOpenProjectPanel`).
         let folder = NSMenuItem(title: localized("Open Project…"),
                                 action: #selector(AppDelegate.openProject(_:)),
                                 keyEquivalent: "")
         folder.target = NSApp.delegate as? AppDelegate
-        folder.tag = DeviceMenuTag.openProject
         menu.addItem(folder)
         // The one container verb that belongs in a context-free menu: a new
         // workspace reads no selection and no focus. It sits last, after a
@@ -2429,11 +2352,15 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             let item = NSToolbarItem(itemIdentifier: .inspectorTabs)
             item.label = localized("Inspector")
             item.toolTip = localized("Switch between project files, search, changes, and info")
-            let host = NSHostingView(rootView: InspectorTabsToolbar()
-                .environmentObject(store)
-                .environmentObject(store.settings))
-            host.sizingOptions = [.intrinsicContentSize]
-            item.view = host
+            // The switch's host also carries the terminal ‖ inspector seam, which the opaque
+            // fullscreen title bar would otherwise cover (see `InspectorTabsItemView`). It rides
+            // this item because this item is the one the tracking separator pins to the divider,
+            // and because a seam item of its own would push the switch off that divider.
+            item.view = InspectorTabsItemView(
+                content: AnyView(InspectorTabsToolbar()
+                    .environmentObject(store)
+                    .environmentObject(store.settings)),
+                splitView: splitViewController?.splitView)
             item.isBordered = false
             // First to overflow: the switch is incompressible, so when its section (the inspector
             // pane) gets too narrow it must yield to the `»` menu rather than slide over the divider
@@ -2501,6 +2428,132 @@ private extension NSToolbarItem.Identifier {
     static let toggleInspector = NSToolbarItem.Identifier("TermioToggleInspector")
     static let inspectorTrackingSeparator = NSToolbarItem.Identifier("TermioInspectorTrackingSeparator")
     static let branchPicker = NSToolbarItem.Identifier("TermioBranchPicker")
+}
+
+/// The inspector pane switch, plus the terminal ‖ inspector seam that an opaque title bar covers.
+///
+/// Windowed, nothing draws that seam: `.fullSizeContentView` runs the split view — dividers
+/// included — up behind the chrome, and `titlebarAppearsTransparent` lets divider 1 read straight
+/// through the toolbar band, so the line the user sees there *is* the content's own divider.
+/// Fullscreen drops that transparency (macOS 26's fullscreen title-bar host composites a light
+/// Liquid Glass band over a dark terminal otherwise — see `applyWindowTransparency`), and the
+/// opaque band it falls back to paints over the divider: the seam stops at the toolbar's floor
+/// while the content below still shows it.
+///
+/// A toolbar item is the only thing drawing *above* that band, so the hairline is hosted here
+/// rather than added as an item of its own — a separate item would push the switch off the
+/// divider by its own width plus the toolbar's inter-item spacing. It is a plain sublayer,
+/// positioned from the split view's live geometry, so it can sit outside this view's bounds and
+/// land on divider 1 at the band's full height. Auto Layout never sees it.
+private final class InspectorTabsItemView: NSView {
+    private let hosting: NSHostingView<AnyView>
+    private let seam = CALayer()
+    private weak var splitView: NSSplitView?
+
+    init(content: AnyView, splitView: NSSplitView?) {
+        self.hosting = NSHostingView(rootView: content)
+        self.splitView = splitView
+        super.init(frame: .zero)
+        wantsLayer = true
+        hosting.sizingOptions = [.intrinsicContentSize]
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(hosting)
+        // Pin on all four edges so the switch's own intrinsic width still drives the item's size —
+        // the Issues segment comes and goes, and the toolbar has to re-measure when it does.
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        layer?.addSublayer(seam)
+        seam.isHidden = true
+        // The window resizes on both fullscreen transitions, which relayouts this view — but the
+        // title bar's opacity is what the seam keys off, and that is flipped separately (before the
+        // enter animation, after the exit one). Re-place the line once each transition settles.
+        // Target/selector rather than a block: the center keeps a zeroing weak reference to an
+        // observer registered this way, so there is no token to tear down from a nonisolated deinit.
+        for name in [NSWindow.didEnterFullScreenNotification, NSWindow.didExitFullScreenNotification] {
+            NotificationCenter.default.addObserver(
+                self, selector: #selector(titleBarChromeDidChange), name: name, object: nil)
+        }
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    @objc private func titleBarChromeDidChange() {
+        needsLayout = true
+    }
+
+    /// A divider drag, a window resize and a fullscreen transition all reach this view as a frame
+    /// change, and `layout()` alone only follows the size half of that.
+    override func setFrameOrigin(_ newOrigin: NSPoint) {
+        super.setFrameOrigin(newOrigin)
+        needsLayout = true
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        needsLayout = true
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        needsLayout = true
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        positionSeam()
+    }
+
+    /// Places the hairline on divider 1, spanning the title-bar band, in this view's coordinates —
+    /// which puts it outside its own bounds, on the leading side, over the tracking separator's
+    /// empty slot.
+    private func positionSeam() {
+        // No implicit fade as the line moves with the divider or blinks out on collapse.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        defer { CATransaction.commit() }
+        guard let seamRect = seamRectInContentView(), let contentView = window?.contentView else {
+            seam.isHidden = true
+            return
+        }
+        seam.frame = convert(seamRect, from: contentView)
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            seam.backgroundColor = NSColor.separatorColor.cgColor
+        }
+        seam.isHidden = false
+    }
+
+    /// The seam's rectangle in the content view's coordinates, or nil when there is nothing to
+    /// draw: no inspector beside the terminal, or a title bar the divider already reads through.
+    private func seamRectInContentView() -> NSRect? {
+        guard let splitView, let window, let contentView = window.contentView,
+              splitView.arrangedSubviews.count > 2 else { return nil }
+        // Exactly when the band is opaque. Keying off transparency rather than off fullscreen keeps
+        // this in step with `applyWindowTransparency`, and stops the line doubling the divider that
+        // already shows through a transparent bar.
+        guard !window.titlebarAppearsTransparent else { return nil }
+        let inspector = splitView.arrangedSubviews[2]
+        guard !inspector.isHidden, inspector.frame.width > 0 else { return nil }
+        // The band is whatever `.fullSizeContentView` leaves above the layout rect. Zero means the
+        // chrome is hidden (a fullscreen toolbar the pointer hasn't summoned), and the divider is
+        // already visible for its whole height.
+        let bandBottom = window.contentLayoutRect.maxY
+        let bandHeight = contentView.bounds.maxY - bandBottom
+        guard bandHeight > 0 else { return nil }
+        let thickness = max(1, splitView.dividerThickness)
+        let dividerX = splitView.convert(
+            NSPoint(x: inspector.frame.minX - thickness, y: 0), to: contentView
+        ).x
+        return NSRect(x: dividerX, y: bandBottom, width: thickness, height: bandHeight)
+    }
 }
 
 /// The custom title item: the selected session's folder name over its live git branch, drawn as
@@ -2741,13 +2794,13 @@ private func buildMainMenu() -> NSMenu {
     // decides what the sidebar lists and which repo the panes read.
     fileMenu.addItem(makeWorkspaceItem())
     fileMenu.addItem(.separator())
-    // Tagged so the delegate can grow it into a device submenu when there is
-    // somewhere other than this Mac to put a project (see `refreshOpenProjectItem`).
+    // ⌘O opens a project on the machine the current workspace is on, so it stays a
+    // plain verb however many machines are known (see `presentOpenProjectPanel`).
     fileMenu.addItem(
         withTitle: localized("Open Project…"),
         action: #selector(AppDelegate.openProject(_:)),
         command: .openProject
-    ).tag = DeviceMenuTag.openProject
+    )
     fileMenu.addItem(.separator())
     // The two branch verbs that fit termio's read-only git surface, with
     // GitHub Desktop's Branch-menu bindings: creating a worktree (termio's

--- a/Sources/termio/FileBrowser/RemoteFolderPicker.swift
+++ b/Sources/termio/FileBrowser/RemoteFolderPicker.swift
@@ -1,0 +1,541 @@
+import AppKit
+
+/// One directory on another machine, as `NSBrowser` holds it.
+///
+/// A reference type because the browser keeps the items it is handed and asks
+/// about them again later by identity, and because the machine's answer for a
+/// directory arrives after the column that asked for it has already been drawn —
+/// the node is where that answer lands.
+private final class RemoteFolderNode {
+    let path: String
+    let name: String
+    /// The column this node's children are drawn in. The root's children are
+    /// column 0, so every child sits one deeper than its parent.
+    let childColumn: Int
+    /// `nil` until the machine has answered for this directory. Empty is a
+    /// different thing and a real one — it answered, and there is nothing inside —
+    /// which is why this is not simply an array that starts out empty.
+    var children: [RemoteFolderNode]?
+    var isLoading = false
+
+    init(path: String, name: String, childColumn: Int) {
+        self.path = path
+        self.name = name
+        self.childColumn = childColumn
+    }
+}
+
+/// Picks a folder on another machine — the panel `NSOpenPanel` cannot be, because
+/// the directory being chosen is not on a file system this Mac can mount, and no
+/// amount of configuring the system panel makes it ask a daemon over SSH.
+///
+/// Columns rather than a path field, which is what stood here before: a field
+/// completes what you type, so it helps only once you already know the name you
+/// are reaching for. Seeing what is on the machine is the whole difference, and it
+/// is the reason this is worth its own panel.
+///
+/// It costs what the completion cost. Every column is one `fs_list` round trip on
+/// a control channel held open for the life of the panel (§C.12, capability
+/// `files`) — nothing walks a tree, so a machine holding a huge checkout answers
+/// as fast as an empty one, and a column nobody opens is never asked for.
+///
+/// Directories only. A project root is a directory, and drawing the files beside
+/// it would fill every column with rows that cannot be chosen.
+@MainActor
+final class RemoteFolderPicker: NSObject {
+    /// What the panel was dismissed with. `clone` is the third button: cloning a
+    /// repository onto the machine names a folder that does not exist yet, so it
+    /// cannot be browsed to and is a different panel rather than a mode of this one.
+    enum Choice {
+        case folder(String)
+        case clone
+        case cancelled
+    }
+
+    private let alias: String
+    private let lister: TermiodDirectoryLister
+    private let browser = NSBrowser()
+    private let field = NSTextField()
+    private let status = NSTextField(labelWithString: "")
+    private var window: NSWindow?
+    private var completion: ((Choice) -> Void)?
+    /// The picker holds itself while the sheet is up — see `present(over:)`.
+    private var retained: RemoteFolderPicker?
+
+    private let root = RemoteFolderNode(path: "/", name: "/", childColumn: 0)
+    /// Every node made so far, by path. The listing reply carries a path rather
+    /// than the node it belongs to — a node cannot cross to the lister's queue and
+    /// back — so this is what turns the answer back into the row that asked.
+    private var nodes: [String: RemoteFolderNode] = [:]
+
+    /// Where the machine says this account lives. `/` until the handshake answers,
+    /// so a typed path is usable before the connection is.
+    private var home = "/"
+    /// The components of the directory to reveal once its ancestors have loaded,
+    /// consumed one column at a time. Opening on `/` and making the user walk down
+    /// to their own home is a panel that starts in the wrong place.
+    private var pendingSelection: [String] = []
+
+    /// The last directory listed for the *field*, and what was in it. One entry,
+    /// not a cache of many: a path field only ever completes inside the directory
+    /// the cursor is in, and holding older ones would serve stale names.
+    private var listedDirectory: String?
+    private var listedNames: [String] = []
+    /// Guards the re-entrant `controlTextDidChange` that accepting a completion
+    /// fires, which would otherwise ask for completions of the text just inserted.
+    private var isCompleting = false
+
+    init(alias: String) {
+        self.alias = alias
+        lister = TermiodDirectoryLister(route: .ssh(alias))
+        super.init()
+        nodes[root.path] = root
+    }
+
+    /// Presents the picker as a sheet on `parent` and reports what the user chose.
+    ///
+    /// A sheet, not an alert: an alert leads with the app icon, stacks its buttons
+    /// down the middle once there are three, and means "something happened".
+    /// Choosing a folder is a document verb, and `NSOpenPanel` is a sheet — this is
+    /// the panel it would have been if the folder were on this Mac.
+    ///
+    /// The listing channel is the panel's, so it closes with it — including on
+    /// Cancel, which would otherwise leak an SSH connection per dismissal.
+    func present(over parent: NSWindow?, completion: @escaping (Choice) -> Void) {
+        self.completion = completion
+        // Nothing else holds the picker once this returns: the window's target is
+        // unowned and the caller is done. Released in `finish`.
+        retained = self
+        let window = buildWindow()
+        self.window = window
+        connect()
+        guard let parent else {
+            window.center()
+            window.makeKeyAndOrderFront(nil)
+            return
+        }
+        parent.beginSheet(window)
+    }
+
+    private func buildWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 680, height: 520),
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false)
+        window.contentView = buildContent()
+        window.initialFirstResponder = browser
+        // The sheet can also end without either button: the window it hangs on
+        // closes, or the app quits. Without this the picker holds itself and its
+        // SSH channel forever, and the caller is never told anything happened.
+        window.delegate = self
+        // Below this the columns are too narrow to read a folder name in and the
+        // buttons start to crowd; a picker that can be dragged into uselessness is
+        // worse than one that stops.
+        window.minSize = NSSize(width: 520, height: 400)
+        return window
+    }
+
+    private func buildContent() -> NSView {
+        let content = NSView()
+
+        // One plain line, the way the system's own Open panel opens — not a bold
+        // headline over secondary text, which is an *alert's* grammar and says
+        // "something happened" about a panel that is only asking where to look.
+        let message = NSTextField(labelWithString: localized(
+            "Choose a project folder on \(alias)."))
+        message.lineBreakMode = .byTruncatingTail
+
+        browser.delegate = self
+        browser.pathSeparator = "/"
+        browser.allowsMultipleSelection = false
+        browser.allowsEmptySelection = true
+        browser.hasHorizontalScroller = true
+        browser.isTitled = false
+        browser.minColumnWidth = 170
+        // Sized to the icon rather than left at the default, which spaced bare text
+        // out far enough that a column read as a list of unrelated words.
+        browser.rowHeight = 20
+        // Copied per row, which is what puts the folder icon on every one of them.
+        browser.cellPrototype = RemoteFolderCell(textCell: "")
+        // The content band, a shade back from the panel's own chrome — the same
+        // separation the system panel draws between its columns and its toolbar.
+        browser.backgroundColor = .textBackgroundColor
+        browser.target = self
+        browser.action = #selector(browserClicked)
+        browser.doubleAction = #selector(browserDoubleClicked)
+
+        field.delegate = self
+        field.placeholderString = "/srv/api"
+
+        status.textColor = .secondaryLabelColor
+        status.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        status.lineBreakMode = .byTruncatingTail
+
+        let open = NSButton(
+            title: localized("Open"), target: self, action: #selector(openClicked))
+        open.keyEquivalent = "\r"
+        let cancel = NSButton(
+            title: localized("Cancel"), target: self, action: #selector(cancelClicked))
+        cancel.keyEquivalent = "\u{1b}"
+        // Bottom-leading, where the Save panel keeps New Folder: an auxiliary verb
+        // that leaves for another panel rather than answering this one's question.
+        let clone = NSButton(
+            title: localized("Clone a Repository…"), target: self, action: #selector(cloneClicked))
+        for button in [open, cancel, clone] { button.bezelStyle = .rounded }
+
+        // The columns are bounded top and bottom by a hairline, the way the system
+        // panel bounds its own: with a recessed background between them, the panel
+        // reads as header · content · footer instead of as one loose stack, and the
+        // column separators land on a band that is plainly the content.
+        let topDivider = NSBox()
+        topDivider.boxType = .separator
+        let bottomDivider = NSBox()
+        bottomDivider.boxType = .separator
+
+        let views =
+            [message, field, topDivider, browser, bottomDivider, status, open, cancel, clone]
+            as [NSView]
+        for view in views {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            content.addSubview(view)
+        }
+
+        let margin: CGFloat = 20
+        NSLayoutConstraint.activate([
+            message.topAnchor.constraint(equalTo: content.topAnchor, constant: margin),
+            message.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: margin),
+            message.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -margin),
+
+            // Above the columns, where the system panel keeps its location control.
+            // It says where you are and is how you get somewhere the columns would
+            // take a dozen clicks to reach; below them it read as a form field.
+            field.topAnchor.constraint(equalTo: message.bottomAnchor, constant: 10),
+            field.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: margin),
+            field.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -margin),
+
+            topDivider.topAnchor.constraint(equalTo: field.bottomAnchor, constant: 14),
+            topDivider.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            topDivider.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+
+            // Edge to edge. The system's columns run into the panel's sides, and
+            // that is most of what makes them read as a browser rather than as a
+            // control sitting inside a form.
+            browser.topAnchor.constraint(equalTo: topDivider.bottomAnchor),
+            browser.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            browser.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+
+            bottomDivider.topAnchor.constraint(equalTo: browser.bottomAnchor),
+            bottomDivider.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            bottomDivider.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            bottomDivider.bottomAnchor.constraint(equalTo: open.topAnchor, constant: -16),
+
+            open.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -margin),
+            open.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -margin),
+            open.widthAnchor.constraint(greaterThanOrEqualToConstant: 92),
+
+            cancel.trailingAnchor.constraint(equalTo: open.leadingAnchor, constant: -12),
+            cancel.firstBaselineAnchor.constraint(equalTo: open.firstBaselineAnchor),
+            cancel.widthAnchor.constraint(greaterThanOrEqualToConstant: 92),
+
+            clone.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: margin),
+            clone.firstBaselineAnchor.constraint(equalTo: open.firstBaselineAnchor),
+
+            // In the footer's empty middle, which is free until something goes
+            // wrong — a reserved line under the field would leave a permanent gap
+            // for a message that is almost never there.
+            status.leadingAnchor.constraint(equalTo: clone.trailingAnchor, constant: 12),
+            status.trailingAnchor.constraint(
+                lessThanOrEqualTo: cancel.leadingAnchor, constant: -12),
+            status.centerYAnchor.constraint(equalTo: open.centerYAnchor),
+        ])
+        // The browser is the only thing that should grow when the sheet is
+        // resized; everything else keeps the height it asks for.
+        browser.setContentHuggingPriority(.defaultLow, for: .vertical)
+        for view in [message, field, status] {
+            view.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        }
+        return content
+    }
+
+    @objc private func openClicked() {
+        let typed = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let path = RemotePathEntry.expandingTilde(typed, home: home)
+        finish(path.isEmpty ? .cancelled : .folder(path))
+    }
+
+    @objc private func cancelClicked() { finish(.cancelled) }
+
+    @objc private func cloneClicked() { finish(.clone) }
+
+    private func finish(_ choice: Choice) {
+        // Re-entrant by design: closing the window is one of the ways this is
+        // reached, and closing it again from in here would be the second.
+        guard completion != nil else { return }
+        lister.close()
+        if let window {
+            if let parent = window.sheetParent {
+                parent.endSheet(window)
+            } else {
+                window.close()
+            }
+        }
+        window = nil
+        let completion = self.completion
+        self.completion = nil
+        retained = nil
+        completion?(choice)
+    }
+
+    /// Opens the listing channel in the background. The panel is already up by
+    /// then — a modal that blocked on an SSH handshake before showing anything
+    /// would read as a hang on exactly the machine that is slowest to reach.
+    private func connect() {
+        lister.connect { [weak self] result in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                switch result {
+                case .success(let home):
+                    self.home = home
+                    if self.field.stringValue.isEmpty { self.field.stringValue = home }
+                    self.pendingSelection = home.split(separator: "/").map(String.init)
+                    self.load(self.root.path)
+                case .failure(let error):
+                    // Named rather than left as an empty browser: an empty column
+                    // and an unreachable machine look identical, and only one of
+                    // them is worth waiting through.
+                    self.status.stringValue = self.message(for: error)
+                }
+            }
+        }
+    }
+
+    /// Asks the machine for one directory, once. A column already answered for is
+    /// never re-asked; nothing here refreshes, because the panel is modal and a
+    /// directory does not change under a user who is looking at it.
+    private func load(_ path: String) {
+        guard let node = nodes[path], node.children == nil, !node.isLoading else { return }
+        node.isLoading = true
+        lister.list(path) { [weak self] result in
+            Task { @MainActor [weak self] in
+                guard let self, let node = self.nodes[path] else { return }
+                node.isLoading = false
+                switch result {
+                case .success(let entries):
+                    node.children = entries.map { entry in
+                        let child = RemoteFolderNode(
+                            path: Self.joining(path, entry.name),
+                            name: entry.name,
+                            childColumn: node.childColumn + 1)
+                        self.nodes[child.path] = child
+                        return child
+                    }
+                    if node.childColumn <= self.browser.lastColumn {
+                        self.browser.reloadColumn(node.childColumn)
+                    }
+                    self.revealPendingSelection()
+                case .failure(let error):
+                    // Answered, and the answer is "you may not look in here" —
+                    // recorded as an empty directory so the column stops asking.
+                    node.children = []
+                    self.status.stringValue = self.message(for: error)
+                }
+            }
+        }
+    }
+
+    /// Walks down the machine's home directory as its columns arrive, selecting one
+    /// component per pass. Selecting a row is what makes the browser ask for the
+    /// next column, so this is a chain rather than a loop over a tree nobody has.
+    private func revealPendingSelection() {
+        guard !pendingSelection.isEmpty else { return }
+        var node = root
+        for component in pendingSelection {
+            guard let children = node.children else {
+                load(node.path)
+                return
+            }
+            guard let row = children.firstIndex(where: { $0.name == component }) else {
+                // The home the machine reported has a component this account cannot
+                // list. Stop where the walk got to rather than starting over at `/`.
+                pendingSelection = []
+                return
+            }
+            browser.selectRow(row, inColumn: node.childColumn)
+            node = children[row]
+        }
+        pendingSelection = []
+        // The home directory itself is now selected, so its own contents are the
+        // last column to fill.
+        load(node.path)
+    }
+
+    private static func joining(_ directory: String, _ name: String) -> String {
+        directory.hasSuffix("/") ? directory + name : directory + "/" + name
+    }
+
+    /// The machine's own words where it has any: a refused listing carries the
+    /// daemon's message verbatim, and everything else is a `LocalizedError` that
+    /// already describes itself.
+    private func message(for error: Error) -> String {
+        if case TermiodDirectoryLister.Failure.refused(let message) = error { return message }
+        return error.localizedDescription
+    }
+
+    private func selectedNode() -> RemoteFolderNode? {
+        let column = browser.selectedColumn
+        guard column >= 0 else { return nil }
+        let row = browser.selectedRow(inColumn: column)
+        guard row >= 0 else { return nil }
+        return browser.item(atRow: row, inColumn: column) as? RemoteFolderNode
+    }
+
+    /// The browser writes into the field, and never the other way round: the field
+    /// is what Open reads, so a typed path always wins over what the columns
+    /// happen to be showing. Someone who knows the path types it; someone who does
+    /// not clicks to it and watches the field fill in.
+    @objc private func browserClicked() {
+        guard let node = selectedNode() else { return }
+        field.stringValue = node.path
+        status.stringValue = ""
+    }
+
+    @objc private func browserDoubleClicked() {
+        browserClicked()
+        openClicked()
+    }
+}
+
+extension RemoteFolderPicker: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        finish(.cancelled)
+    }
+}
+
+extension RemoteFolderPicker: NSBrowserDelegate {
+    func rootItem(for browser: NSBrowser) -> Any? { root }
+
+    func browser(_ browser: NSBrowser, numberOfChildrenOfItem item: Any?) -> Int {
+        let node = (item as? RemoteFolderNode) ?? root
+        guard let children = node.children else {
+            // The column is drawn empty and filled when the machine answers. There
+            // is nothing else honest to return: the delegate is synchronous and the
+            // directory is on the far end of an SSH connection.
+            load(node.path)
+            return 0
+        }
+        return children.count
+    }
+
+    func browser(_ browser: NSBrowser, child index: Int, ofItem item: Any?) -> Any {
+        let node = (item as? RemoteFolderNode) ?? root
+        guard let children = node.children, children.indices.contains(index) else { return root }
+        return children[index]
+    }
+
+    /// Nothing is a leaf: every row is a directory, so every row can be descended
+    /// into — including an empty one, which draws an empty column exactly as the
+    /// Finder does.
+    func browser(_ browser: NSBrowser, isLeafItem item: Any?) -> Bool { false }
+
+    func browser(_ browser: NSBrowser, objectValueForItem item: Any?) -> Any? {
+        (item as? RemoteFolderNode)?.name
+    }
+
+}
+
+/// The browser's row, carrying the folder icon every row shares.
+///
+/// Through the prototype rather than `browser(_:willDisplayCell:atRow:column:)`,
+/// which the item-based API never sends — it belongs to the older matrix-based
+/// delegate, so an image assigned there is set on nothing and never appears.
+///
+/// The icon is what makes a column read as folders instead of as a list of words,
+/// and it is the one thing a browser over another machine has to supply itself:
+/// the system resolves an icon from a URL, and none of these paths exist here.
+/// Every row is a directory, so every row wears the same one — it is the system's
+/// own folder, so the panel matches the local picker rather than approximating it.
+private final class RemoteFolderCell: NSBrowserCell {
+    static let folderIcon: NSImage = {
+        let icon = NSWorkspace.shared.icon(for: .folder)
+        icon.size = NSSize(width: 16, height: 16)
+        return icon
+    }()
+
+    override init(textCell string: String) {
+        super.init(textCell: string)
+        apply()
+    }
+
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+        apply()
+    }
+
+    private func apply() {
+        image = Self.folderIcon
+        font = .systemFont(ofSize: NSFont.systemFontSize)
+    }
+}
+
+extension RemoteFolderPicker: NSTextFieldDelegate {
+    func controlTextDidChange(_ notification: Notification) {
+        guard !isCompleting else { return }
+        refreshCompletions()
+    }
+
+    /// Splits what is typed at the last `/` into the directory to list and the
+    /// partial name to match inside it, then lists that directory if it is not the
+    /// one already held. Typing further into the same directory re-filters what is
+    /// in hand and never touches the network.
+    private func refreshCompletions() {
+        let typed = RemotePathEntry.expandingTilde(
+            field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines), home: home)
+        let (directory, _) = RemotePathEntry.split(typed)
+        guard directory != listedDirectory else {
+            showCompletions()
+            return
+        }
+        lister.list(directory) { [weak self] result in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                // The user may have typed on while this was in flight; a reply for
+                // a directory they have already left is dropped rather than shown
+                // against the wrong path.
+                let current = RemotePathEntry.expandingTilde(
+                    self.field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines),
+                    home: self.home)
+                guard RemotePathEntry.split(current).directory == directory else { return }
+                self.listedDirectory = directory
+                // An unreadable or missing directory completes to nothing. It is not
+                // an error to report: the user is mid-path, and a half-typed
+                // directory name is unreadable by definition.
+                self.listedNames = (try? result.get())?.map(\.name) ?? []
+                self.showCompletions()
+            }
+        }
+    }
+
+    private func showCompletions() {
+        guard !listedNames.isEmpty, let editor = field.currentEditor() as? NSTextView else { return }
+        isCompleting = true
+        editor.complete(nil)
+        isCompleting = false
+    }
+
+    func control(
+        _ control: NSControl,
+        textView: NSTextView,
+        completions words: [String],
+        forPartialWordRange charRange: NSRange,
+        indexOfSelectedItem index: UnsafeMutablePointer<Int>
+    ) -> [String] {
+        let typed = RemotePathEntry.expandingTilde(
+            field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines), home: home)
+        let (_, partial) = RemotePathEntry.split(typed)
+        guard !partial.isEmpty else { return listedNames }
+        return listedNames.filter {
+            $0.range(of: partial, options: [.caseInsensitive, .anchored]) != nil
+        }
+    }
+}

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -321,6 +321,36 @@
         }
       }
     },
+    "Clone": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆"
+          }
+        }
+      }
+    },
+    "Clone a Repository onto %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆一个仓库到 %@"
+          }
+        }
+      }
+    },
+    "Clone a Repository…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆仓库…"
+          }
+        }
+      }
+    },
     "Open a Folder": {
       "localizations": {
         "zh-Hans": {
@@ -1227,6 +1257,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "选取要在 Termio 中打开的项目文件夹。"
+          }
+        }
+      }
+    },
+    "Choose a project folder on %@.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选取 %@ 上的项目文件夹。"
           }
         }
       }
@@ -5601,6 +5641,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "克隆到"
+          }
+        }
+      }
+    },
+    "The clone runs on %@ and opens as a project there.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆在 %@ 上执行，并作为那台机器上的项目打开。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -180,6 +180,8 @@
 	<string>Choose a different name.</string>
 	<key>Choose a name for this workspace.</key>
 	<string>Choose a name for this workspace.</string>
+	<key>Choose a project folder on %@.</key>
+	<string>Choose a project folder on %@.</string>
 	<key>Choose a project folder to open in Termio.</key>
 	<string>Choose a project folder to open in Termio.</string>
 	<key>Choose another branch to compare with.</key>
@@ -192,8 +194,14 @@
 	<string>Choose…</string>
 	<key>Clear</key>
 	<string>Clear</string>
+	<key>Clone</key>
+	<string>Clone</string>
 	<key>Clone a Repository</key>
 	<string>Clone a Repository</string>
+	<key>Clone a Repository onto %@</key>
+	<string>Clone a Repository onto %@</string>
+	<key>Clone a Repository…</key>
+	<string>Clone a Repository…</string>
 	<key>Clone a repository onto %@, or open a folder that’s already there — the path completes as you type.</key>
 	<string>Clone a repository onto %@, or open a folder that’s already there — the path completes as you type.</string>
 	<key>Clone to</key>
@@ -1008,6 +1016,8 @@
 	<string>The agent New Chat (⌘N) starts. “Last used” follows whichever agent you most recently chatted with.</string>
 	<key>The base branch has commits this branch doesn’t have, as of the last fetch.</key>
 	<string>The base branch has commits this branch doesn’t have, as of the last fetch.</string>
+	<key>The clone runs on %@ and opens as a project there.</key>
+	<string>The clone runs on %@ and opens as a project there.</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>The coding agents offered when you start a session</string>
 	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -180,6 +180,8 @@
 	<string>请选取其他名称。</string>
 	<key>Choose a name for this workspace.</key>
 	<string>为这个工作区取个名字。</string>
+	<key>Choose a project folder on %@.</key>
+	<string>选取 %@ 上的项目文件夹。</string>
 	<key>Choose a project folder to open in Termio.</key>
 	<string>选取要在 Termio 中打开的项目文件夹。</string>
 	<key>Choose another branch to compare with.</key>
@@ -192,8 +194,14 @@
 	<string>选取…</string>
 	<key>Clear</key>
 	<string>清除</string>
+	<key>Clone</key>
+	<string>克隆</string>
 	<key>Clone a Repository</key>
 	<string>克隆仓库</string>
+	<key>Clone a Repository onto %@</key>
+	<string>克隆一个仓库到 %@</string>
+	<key>Clone a Repository…</key>
+	<string>克隆仓库…</string>
 	<key>Clone a repository onto %@, or open a folder that’s already there — the path completes as you type.</key>
 	<string>把一个仓库克隆到 %@，或者打开一个已经在那里的文件夹——路径会边输入边补全。</string>
 	<key>Clone to</key>
@@ -1008,6 +1016,8 @@
 	<string>新建聊天（⌘N）启动的 Agent。“上次使用”跟随你最近一次聊天所用的 Agent。</string>
 	<key>The base branch has commits this branch doesn’t have, as of the last fetch.</key>
 	<string>截至上次 fetch，基础分支上有当前分支还没有的提交。</string>
+	<key>The clone runs on %@ and opens as a project there.</key>
+	<string>克隆在 %@ 上执行，并作为那台机器上的项目打开。</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>新建会话时可以选用的编程 Agent</string>
 	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>

--- a/Sources/termio/Terminal/Termiod/TermiodTransfer.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodTransfer.swift
@@ -223,7 +223,11 @@ final class TermiodImagePaste: NSObject {
 
         let route = TermiodRoute(sshAlias: host)
         let name = image.scratchFileName
-        let target = session.id.uuidString
+        // The name the *daemon* knows this session by, which is the app's own uuid
+        // only for a session the app created. One adopted off the machine's roster
+        // keeps the name it already had over there, so addressing the upload by
+        // `session.id` asked ukvps about a session that has never existed on it.
+        let target = store.daemonSessionName(for: session)
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             let result = Result {
                 try Termiod.uploadToSessionScratch(

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -525,8 +525,33 @@ extension TermioStore {
         }
     }
 
-    /// Presents a folder picker that opens the chosen directory as a new project.
+    /// Opens a project on the machine the current workspace belongs to.
+    ///
+    /// The device is inherited, never asked for. A checkout takes its machine from
+    /// the workspace that owns it, so the scope on screen has already answered
+    /// "which machine" — the same reason `New Terminal` opens on the device you
+    /// are looking at instead of growing a picker. Asking again turns one decision
+    /// into two, and it is what used to pin ⌘O to this Mac while the window was
+    /// showing a box: the folder landed in a workspace the user was not in, and
+    /// selecting it threw them out of the one they were.
+    ///
+    /// Opening a project on a *different* machine is therefore two steps now —
+    /// switch workspace, then open — which is what the hierarchy says anyway: you
+    /// switch workspaces, never machines. The single step was never one either;
+    /// `addRemoteProject` ends in `switchToWorkspace`, so the scope moved regardless
+    /// of which menu row was clicked.
     func presentOpenProjectPanel() {
+        switch currentWorkspace.device {
+        case .thisMac:
+            presentLocalProjectPanel()
+        case .ssh(let alias):
+            presentRemoteProjectPanel(
+                on: KnownDevice(alias: alias, deviceID: currentWorkspace.deviceID))
+        }
+    }
+
+    /// Presents a folder picker that opens the chosen directory as a new project.
+    private func presentLocalProjectPanel() {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
@@ -571,42 +596,57 @@ extension TermioStore {
 
     // MARK: - A project on another machine
 
-    /// Opens a project that lives on `device`, which Termio cannot browse.
+    /// Opens a project that lives on `device`, browsed the way a folder on this Mac
+    /// is: a column picker over the machine's own directories
+    /// (`RemoteFolderPicker`), because a path you cannot see is a path you have to
+    /// already know.
     ///
-    /// There is no remote file picker, and this deliberately does not fake one:
-    /// `fs.list` is unbuilt on the client, and a panel that guesses at a directory
-    /// list would be a worse lie than a text field. So the two honest ways to name
-    /// a folder over there are to clone a repository onto the machine — which
-    /// creates the directory, so its path is known afterwards — or to type a path
-    /// that is already on it.
+    /// Cloning a repository onto the machine leaves through the picker's third
+    /// button. It names a folder that does not exist yet, so there is nothing to
+    /// browse to — a different question, and now a different panel.
     func presentRemoteProjectPanel(on device: KnownDevice) {
+        // Straight to the picker rather than back through `presentOpenProjectPanel`,
+        // which dispatches on the current workspace: this one has already been told
+        // which machine, and routing through the dispatcher would send a `.thisMac`
+        // caller back here whenever the scope on screen is a box's.
         guard let alias = device.alias else {
-            presentOpenProjectPanel()
+            presentLocalProjectPanel()
             return
         }
+        RemoteFolderPicker(alias: alias).present(over: NSApp.mainWindow) { [weak self] choice in
+            guard let self else { return }
+            switch choice {
+            case .cancelled:
+                return
+            case .folder(let path):
+                openRemoteProject(at: path, on: alias)
+            case .clone:
+                presentRemoteClonePanel(on: alias)
+            }
+        }
+    }
+
+    /// Asks for a repository to clone onto `alias`. One field, because the
+    /// destination is not the user's to name: the clone lands in the machine's home
+    /// directory and reports back the absolute path it created (`performRemoteClone`).
+    private func presentRemoteClonePanel(on alias: String) {
         let alert = NSAlert()
-        alert.messageText = localized("Open a Project on \(alias)")
+        alert.messageText = localized("Clone a Repository onto \(alias)")
         alert.informativeText = localized(
-            "Clone a repository onto \(alias), or open a folder that’s already there — the path completes as you type.")
-        alert.addButton(withTitle: localized("Open"))
+            "The clone runs on \(alias) and opens as a project there.")
+        alert.addButton(withTitle: localized("Clone"))
         alert.addButton(withTitle: localized("Cancel"))
 
-        let fields = RemoteProjectFields(alias: alias)
-        alert.accessoryView = fields.view
-        alert.window.initialFirstResponder = fields.field
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
+        // Not localized: a repository URL reads the same in every language.
+        field.placeholderString = "https://github.com/owner/repo.git"
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
 
-        let response = alert.runModal()
-        // The listing channel is the panel's, so it goes when the panel does —
-        // including on Cancel, which would otherwise leak an SSH connection per
-        // dismissal.
-        fields.stop()
-        guard response == .alertFirstButtonReturn else { return }
-        let entry = fields.entry
-        if fields.isCloning {
-            cloneProject(from: entry, on: alias)
-        } else {
-            openRemoteProject(at: entry, on: alias)
-        }
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let origin = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !origin.isEmpty else { return }
+        cloneProject(from: origin, on: alias)
     }
 
     /// Clones `originURL` onto `alias` and files the result as a project in a
@@ -988,169 +1028,5 @@ enum RemotePathEntry {
         guard path.hasPrefix("~/") else { return path }
         let tail = path.dropFirst(2)
         return home.hasSuffix("/") ? home + tail : home + "/" + tail
-    }
-}
-
-/// The two ways to name a directory on another machine, as the accessory view of
-/// `presentRemoteProjectPanel`: clone a repository onto it, or open a folder
-/// already there.
-///
-/// The folder field completes as it is typed. Each `/` asks the machine for one
-/// directory — never a tree — and the answer is cached under the directory it
-/// describes, so moving the cursor around inside a path costs nothing. That is
-/// the whole of the "remote file browser": `fs.list`, one directory deep, at the
-/// moment the user names a new one.
-///
-/// A class rather than a few locals because the controls need a target that
-/// outlives the call that builds it — the alert runs modally and both the switch
-/// and the field have to keep answering while it is up.
-@MainActor
-private final class RemoteProjectFields: NSObject, NSTextFieldDelegate {
-    let view = NSStackView()
-    let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
-    private let mode = NSSegmentedControl(
-        labels: [localized("Clone a Repository"), localized("Open a Folder")],
-        trackingMode: .selectOne, target: nil, action: nil)
-
-    private let alias: String
-    private let lister: TermiodDirectoryLister
-    /// Where the machine says this account lives. `/` until the handshake
-    /// answers, so the field is usable before the connection is.
-    private var home = "/"
-    /// The last directory listed, and what was in it. One entry, not a cache of
-    /// many: a path field only ever completes inside the directory the cursor is
-    /// in, and holding older ones would just serve stale names after a rename.
-    private var listedDirectory: String?
-    private var listedNames: [String] = []
-    /// Guards the re-entrant `controlTextDidChange` that accepting a completion
-    /// fires, which would otherwise ask for completions of the text completion
-    /// just inserted.
-    private var isCompleting = false
-
-    /// Whether the entry is a repository to clone rather than a folder to open.
-    var isCloning: Bool { mode.selectedSegment == 0 }
-
-    /// What the user named, with a leading `~` expanded against the machine's own
-    /// home. termiod spawns the shell with a raw `chdir` and expands nothing, so
-    /// this has to happen here — and it can, because the handshake already said
-    /// where home is.
-    var entry: String {
-        let typed = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !isCloning else { return typed }
-        return RemotePathEntry.expandingTilde(typed, home: home)
-    }
-
-    init(alias: String) {
-        self.alias = alias
-        lister = TermiodDirectoryLister(route: .ssh(alias))
-        super.init()
-        mode.selectedSegment = 0
-        mode.target = self
-        mode.action = #selector(modeChanged)
-        field.delegate = self
-        view.orientation = .vertical
-        view.alignment = .leading
-        view.spacing = 8
-        view.addArrangedSubview(mode)
-        view.addArrangedSubview(field)
-        field.widthAnchor.constraint(equalToConstant: 320).isActive = true
-        mode.widthAnchor.constraint(equalToConstant: 320).isActive = true
-        // NSAlert lays its accessory out by frame, so the stack has to carry its
-        // own measured height rather than a number guessed here — a control that
-        // grows with the user's text size would otherwise be clipped.
-        view.frame = NSRect(origin: .zero, size: view.fittingSize)
-        modeChanged()
-        connect()
-    }
-
-    /// Opens the listing channel in the background. The panel is already up by
-    /// then — a modal that blocked on an SSH handshake before showing anything
-    /// would read as a hang on exactly the machine that is slowest to reach.
-    private func connect() {
-        lister.connect { [weak self] result in
-            guard case .success(let home) = result else { return }
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.home = home
-                // Only seeds an untouched field: someone who started typing
-                // during the handshake keeps what they wrote.
-                if !self.isCloning, self.field.stringValue.isEmpty {
-                    self.field.stringValue = home.hasSuffix("/") ? home : home + "/"
-                    self.refreshCompletions()
-                }
-            }
-        }
-    }
-
-    func stop() {
-        lister.close()
-    }
-
-    /// The placeholder is the only thing that changes: one field either way, so
-    /// switching never loses what was typed into the other one. Neither example is
-    /// localized — a URL and an absolute path read the same in every language.
-    @objc private func modeChanged() {
-        field.placeholderString = isCloning ? "https://github.com/owner/repo.git" : "/srv/api"
-    }
-
-    func controlTextDidChange(_ notification: Notification) {
-        guard !isCompleting, !isCloning else { return }
-        refreshCompletions()
-    }
-
-    /// Splits what is typed at the last `/` into the directory to list and the
-    /// partial name to match inside it, then lists that directory if it is not
-    /// the one already held. Typing further into the same directory re-filters
-    /// what is in hand and never touches the network.
-    private func refreshCompletions() {
-        let (directory, _) = RemotePathEntry.split(entry)
-        guard directory != listedDirectory else {
-            showCompletions()
-            return
-        }
-        lister.list(directory) { [weak self] result in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                // The user may have typed on while this was in flight; a reply
-                // for a directory they have already left is dropped rather than
-                // shown against the wrong path.
-                guard RemotePathEntry.split(self.entry).directory == directory else { return }
-                switch result {
-                case .success(let entries):
-                    self.listedDirectory = directory
-                    self.listedNames = entries.map(\.name)
-                    self.showCompletions()
-                case .failure:
-                    // An unreadable or missing directory completes to nothing.
-                    // It is not an error to report: the user is mid-path, and a
-                    // half-typed directory name is unreadable by definition.
-                    self.listedDirectory = directory
-                    self.listedNames = []
-                }
-            }
-        }
-    }
-
-    private func showCompletions() {
-        guard !listedNames.isEmpty, let editor = field.currentEditor() as? NSTextView else {
-            return
-        }
-        isCompleting = true
-        editor.complete(nil)
-        isCompleting = false
-    }
-
-    func control(
-        _ control: NSControl,
-        textView: NSTextView,
-        completions words: [String],
-        forPartialWordRange charRange: NSRange,
-        indexOfSelectedItem index: UnsafeMutablePointer<Int>
-    ) -> [String] {
-        let (_, partial) = RemotePathEntry.split(entry)
-        guard !partial.isEmpty else { return listedNames }
-        return listedNames.filter {
-            $0.range(of: partial, options: [.caseInsensitive, .anchored]) != nil
-        }
     }
 }

--- a/Tests/termioTests/SubmenuParentEnablementTests.swift
+++ b/Tests/termioTests/SubmenuParentEnablementTests.swift
@@ -1,11 +1,12 @@
 import AppKit
 import XCTest
 
-/// The AppKit rule that dimmed ＋ ▸ Open Project and ＋ ▸ New Workspace.
+/// The AppKit rule that dimmed ＋ ▸ New Workspace (and ＋ ▸ Open Project, back
+/// when it grew a device submenu too).
 ///
-/// Both rows are built as ordinary action items with an explicit `target`, then
-/// reshaped into submenu parents once a second machine exists
-/// (`refreshOpenProjectItem` / `refreshNewWorkspaceItem`). Nulling the action is
+/// The row is built as an ordinary action item with an explicit `target`, then
+/// reshaped into a submenu parent once a second machine exists
+/// (`refreshNewWorkspaceItem`). Nulling the action is
 /// not enough: assigning `submenu` makes AppKit install its own `submenuAction:`,
 /// and it only adopts the submenu as the item's target when the target is already
 /// nil. A leftover target keeps the selector pointed at the AppDelegate, which
@@ -71,7 +72,7 @@ final class SubmenuParentEnablementTests: XCTestCase {
     /// launch: it worked once, then never again.
     ///
     /// Spelled out as two shapes rather than by calling the delegate:
-    /// `refreshOpenProjectItem` is private to the AppDelegate and needs a store and
+    /// `refreshNewWorkspaceItem` is private to the AppDelegate and needs a store and
     /// a window, so what is pinned here is the AppKit rule that makes its guard
     /// necessary, not the guard itself.
     func testClearingTheActionOnASecondRefreshDimsTheRow() {

--- a/docs/design/20260819-device-workspace-project.md
+++ b/docs/design/20260819-device-workspace-project.md
@@ -3,7 +3,7 @@ title: Device → Workspace → Project
 status: draft
 type: design
 created: 2026-08-19
-updated: 2026-08-19
+updated: 2026-08-22
 related:
   - 20260805-termiod-device-architecture.md
   - 20260819-workspace-switch-latency.md
@@ -218,10 +218,8 @@ collapse is correct again: with one scope there is nothing to switch.
 
 ### 8.2 The device comes from the menu, not the panel
 
-`New Workspace…` takes the same shape as `New Terminal` and `Open Project…`,
-which already grow a device submenu on a second machine and collapse to a plain
-verb without one (`refreshNewTerminalItem`, `refreshOpenProjectItem`,
-`DeviceMenuTag`):
+`New Workspace…` grows a device submenu on a second machine and collapses to a
+plain verb without one (`refreshNewWorkspaceItem`, `DeviceMenuTag`):
 
 ```
 One machine:     New Workspace…              → name panel
@@ -237,6 +235,16 @@ is a control for a decision they never took.
 
 The panel keeps #347's copy shape — **"New Workspace on ukvps"** beside
 **"Open a Project on ukvps"**.
+
+**`New Workspace` is the only device submenu this shape applies to**, and the
+rule that decides it is short: *a verb that creates the owner of a device must
+ask for one; a verb that creates something which inherits one must not.* A
+workspace is the owner, and a new one is not the one on screen, so there is
+nothing for it to inherit — the menu is the only place that choice can live.
+
+Everything below the workspace inherits, so `New Terminal` and `Open Project…`
+are plain verbs on every install (§9.1). `New SSH Connection ▸ <host>` keeps its
+list because the host is that verb's payload, not a device picker.
 
 ### 8.3 The panel opens with a usable default
 
@@ -298,11 +306,22 @@ mechanical one. **Stage 1 of the implementation deliberately does none of them.*
 
 - **`DeviceContext.swift:47` documents the opposite of §2** — *"one workspace
   holds checkouts on several devices"*. It must be corrected when Stage 2 lands.
-- **`Open Project ▸ <device>` loses its stated reason.** `App.swift:1685` says
-  the menu carries the device *because* "the workspace the row lands in has no
-  device of its own to inherit". Under §2 it inherits one, and the menu becomes
-  either redundant or a workspace-switching verb. §8.2 designs only the
-  `New Workspace` shape and should be extended to cover this.
+- **`Open Project ▸ <device>` lost its stated reason, and is gone.** The menu
+  carried the device *because* "the workspace the row lands in has no device of
+  its own to inherit". Under §2 it inherits one, which left the submenu either
+  redundant or a workspace-switching verb in a filing verb's clothes — and it was
+  already the latter, since `addRemoteProject` ends in `switchToWorkspace`.
+  `Open Project…` is now a plain verb on every install and
+  `presentOpenProjectPanel` dispatches on `currentWorkspace.device`: the folder
+  picker on this Mac, the remote path panel in a workspace that is a box's.
+
+  This also fixed the live half of it. ⌘O rode on the This Mac row, so pressing
+  it inside a workspace on a box opened a *local* picker, filed the folder into
+  `workspaceForThisMac`, and threw the user out of the scope they were in.
+
+  Opening a project on another machine is two steps now — switch workspace, then
+  ⌘O — which §2 already required of everything else. §8.2 records the rule that
+  decides which verbs keep a device submenu.
 - **Every workspace switch starts paying an SSH roster round trip.**
   `finishArriving` calls `switchToDevice` only when the workspace has an alias
   (`TermioStore+Workspaces.swift:284`); making that unconditional costs the


### PR DESCRIPTION
A workspace belongs to exactly one machine and a checkout takes its machine from the workspace that owns it — so `Open Project` had nothing left to ask. Its own comment said the submenu carried a device *because* "the workspace the row lands in has no device of its own to inherit", which stopped being true when every workspace got one. `New Terminal` had already made the opposite call, for the reason that now applies here: the switcher chose the machine, and asking again turns one decision into two.

The live half was ⌘O. It rode on the submenu's This Mac row, so pressing it inside a workspace on a box opened a *local* folder picker, filed the folder under this Mac, and threw the user out of the scope they were in.

`presentOpenProjectPanel` now dispatches on `currentWorkspace.device`, and every entry point — File menu, the sidebar `+`, the command palette, the welcome page — inherits that one decision.

## The picker

A workspace on a box needed something better than a text field to dispatch *to*. `NSOpenPanel` cannot browse a machine this Mac cannot mount, so this is a column browser over that machine's own directories, shaped after the system's own Open panel: one plain message line, columns edge to edge between hairlines, folder icons from `NSWorkspace`, `Cancel` / `Open` trailing with the auxiliary verb leading, where the Save panel keeps New Folder.

It costs what the path completion already cost: one `fs_list` per column on a control channel held open for the life of the panel. Nothing walks a tree, so a machine holding a huge checkout answers as fast as an empty one. The path field stays, above the columns where the system keeps its location control — typing is the fast path for someone who knows where they are going, and the browser is for everyone else.

Cloning leaves through the picker's own button rather than living in it as a mode: it names a folder that does not exist yet, so there is nothing to browse to.

## Also here

`daemonSessionName(for:)` for the image-paste upload. It named the session by the app's own uuid, which is what the daemon knows it by only for a session the app created — so pasting an image into a session adopted off a machine's roster failed with `no such session: <uuid>`.

## Verified

`swift build`, `swift test` (512 tests, 0 failures). The panel and the menu were driven by hand on a dev build against a real remote workspace.

Release Notes:
- Opening a project now happens on the machine the current workspace belongs to, with a folder browser for a workspace on another machine. ⌘O no longer drops a local folder into a different workspace.
- Fixed pasting an image into a remote session that Termio adopted rather than started.