### PR TITLE
Set up a Mac the same way as a Linux box, and prove the DMG carries the daemons

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,40 @@ jobs:
 
           echo "DMG_PATH=$DMG_PATH" >> "$GITHUB_ENV"
 
+      # What a user receives is the app *inside the DMG*, not the one the build
+      # left in the checkout — signing, notarization and the DMG copy all sit
+      # between them. The daemons are the payload that makes a remote machine
+      # work at all and they are plain files in Resources, so nothing else would
+      # notice them going missing: the app would install, launch, and fail only
+      # when someone pointed it at a VPS.
+      - name: Verify the daemons survived into the DMG
+        run: |
+          mount_point="$RUNNER_TEMP/dmg-check"
+          mkdir -p "$mount_point"
+          hdiutil attach "$DMG_PATH" -mountpoint "$mount_point" -nobrowse -quiet
+          resources="$mount_point/${APP_NAME}.app/Contents/Resources"
+          status=0
+          for daemon in \
+            "termiod:Mach-O" \
+            "termiod-x86_64-unknown-linux-musl:ELF 64-bit" \
+            "termiod-aarch64-unknown-linux-musl:ELF 64-bit"; do
+            name="${daemon%%:*}"
+            want="${daemon#*:}"
+            if [ ! -f "$resources/$name" ]; then
+              echo "error: $name is missing from the shipped app" >&2
+              status=1
+              continue
+            fi
+            got="$(file -b "$resources/$name")"
+            echo "$name: $got"
+            case "$got" in
+              *"$want"*) ;;
+              *) echo "error: $name is not a $want binary" >&2; status=1 ;;
+            esac
+          done
+          hdiutil detach "$mount_point" -quiet
+          exit $status
+
       # Notarize + staple the DMG. The app inside is already Developer-ID-signed
       # with the hardened runtime and a secure timestamp, which notarization needs.
       - name: Notarize and staple DMG

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -249,13 +249,19 @@ fn deploy(host: &str, prebuilt: Option<&str>, target_override: Option<&str>) -> 
     Ok(())
 }
 
-/// A daemon for `target` shipped beside this executable, as `termiod-<target>`.
+/// A daemon for `target` shipped beside this executable.
 ///
 /// This is what makes deploying possible for someone who installed Termio rather
 /// than cloning it: `cross_compile` below needs cargo, the musl target, and this
 /// crate's source tree at the path baked into it, none of which a `.app` from the
 /// DMG has. `scripts/build-app.sh` puts both Linux binaries in `Contents/Resources`
 /// next to the daemon that reads this, so the common case is a copy.
+///
+/// A Mac takes the daemon that is *already* there — the one running this code. It
+/// is built universal for the same reason the app is, so one file serves both
+/// architectures and there is nothing per-target to ship. Sent as a plain copy:
+/// `scp` sets no quarantine attribute, so a Developer-ID-signed binary landing on
+/// another Mac runs without a Gatekeeper prompt.
 ///
 /// Found by the executable's own directory rather than by a bundle path or an
 /// environment variable: the daemon is run by absolute path out of whatever
@@ -264,25 +270,41 @@ fn deploy(host: &str, prebuilt: Option<&str>, target_override: Option<&str>) -> 
 /// path that proves the source tree actually cross-builds.
 fn shipped_binary(target: &str) -> Option<String> {
     let exe = std::env::current_exe().ok()?;
+    if target.contains("apple-darwin") {
+        return exe.to_str().map(str::to_owned);
+    }
     let candidate = exe.parent()?.join(format!("termiod-{target}"));
     candidate
         .is_file()
         .then(|| candidate.to_string_lossy().into_owned())
 }
 
-/// Ask the remote `uname` and map to a musl Rust target.
+/// Ask the remote `uname` and map it to a Rust target.
+///
+/// Macs are here because a device is a machine the user owns, and plenty of them
+/// are a Mac mini or a Studio on the same desk — "remote" describes the road, not
+/// the thing at the end of it. The daemon's own build already covers Darwin (it is
+/// what runs local sessions), so supporting it costs a branch here rather than a
+/// new artifact.
 fn detect_target(host: &str) -> Result<String> {
     let uname = ssh_capture(host, "uname -sm")?;
-    let uname = uname.trim();
-    if !uname.starts_with("Linux") {
-        bail!("remote host is not Linux (uname: '{uname}'); pass --target explicitly");
-    }
-    let target = if uname.contains("x86_64") || uname.contains("amd64") {
-        "x86_64-unknown-linux-musl"
-    } else if uname.contains("aarch64") || uname.contains("arm64") {
-        "aarch64-unknown-linux-musl"
-    } else {
-        bail!("unrecognized remote arch (uname: '{uname}'); pass --target explicitly");
+    target_for_uname(uname.trim())
+}
+
+/// The `uname -sm` half of `detect_target`, split out so the mapping can be
+/// checked without a machine to ask.
+fn target_for_uname(uname: &str) -> Result<String> {
+    let arm = uname.contains("aarch64") || uname.contains("arm64");
+    let intel = uname.contains("x86_64") || uname.contains("amd64");
+    let target = match (uname.split_whitespace().next(), arm, intel) {
+        (Some("Linux"), true, _) => "aarch64-unknown-linux-musl",
+        (Some("Linux"), _, true) => "x86_64-unknown-linux-musl",
+        (Some("Darwin"), true, _) => "aarch64-apple-darwin",
+        (Some("Darwin"), _, true) => "x86_64-apple-darwin",
+        (Some("Linux" | "Darwin"), _, _) => {
+            bail!("unrecognized remote arch (uname: '{uname}'); pass --target explicitly")
+        }
+        _ => bail!("remote host is neither Linux nor macOS (uname: '{uname}'); pass --target explicitly"),
     };
     Ok(target.to_string())
 }
@@ -395,4 +417,38 @@ fn shell_quote(s: &str) -> String {
         return s.to_string();
     }
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// What `uname -sm` actually prints on the machines Termio is pointed at.
+    #[test]
+    fn a_machine_is_recognized_from_its_own_uname() {
+        assert_eq!(target_for_uname("Linux x86_64").unwrap(), "x86_64-unknown-linux-musl");
+        assert_eq!(target_for_uname("Linux aarch64").unwrap(), "aarch64-unknown-linux-musl");
+        assert_eq!(target_for_uname("Darwin arm64").unwrap(), "aarch64-apple-darwin");
+        assert_eq!(target_for_uname("Darwin x86_64").unwrap(), "x86_64-apple-darwin");
+    }
+
+    /// A machine Termio has no daemon for says so, and says which of the two
+    /// things it could not recognise — the system or the architecture.
+    #[test]
+    fn an_unsupported_machine_names_what_was_not_recognized() {
+        let arch = target_for_uname("Linux riscv64").unwrap_err().to_string();
+        assert!(arch.contains("unrecognized remote arch"), "{arch}");
+
+        let system = target_for_uname("FreeBSD amd64").unwrap_err().to_string();
+        assert!(system.contains("neither Linux nor macOS"), "{system}");
+    }
+
+    /// The Mac case takes the daemon that is already running this code rather
+    /// than a per-target sibling, because it is built universal.
+    #[test]
+    fn a_mac_is_served_by_the_running_daemon_itself() {
+        let running = std::env::current_exe().ok().and_then(|p| p.to_str().map(str::to_owned));
+        assert_eq!(shipped_binary("aarch64-apple-darwin"), running);
+        assert_eq!(shipped_binary("x86_64-apple-darwin"), running);
+    }
 }


### PR DESCRIPTION
The two gaps left open by #408.

## A device can be a Mac

`detect_target` bailed on anything that was not Linux, so a Mac mini or a Studio on the same desk — the most ordinary second machine a developer owns — could not be set up at all. "Remote" describes the road, not the thing at the end of it, and the daemon has always run on macOS: that is what serves local sessions.

So Darwin costs a branch rather than a new artifact. The bundled daemon is already universal for the same reason the app is, so a Mac target sends the binary that is running the deploy — one file, both architectures, nothing per-target to build or ship. `scp` sets no quarantine attribute, so a Developer-ID-signed daemon landing on another Mac runs without a Gatekeeper prompt.

The `uname -sm` mapping moved into `target_for_uname`, which makes it checkable without a machine to ask, and it now names which half it did not recognise — the system or the architecture — instead of reporting both as "not Linux".

## The DMG is asserted, not assumed

`build-app.sh` checks what it copies. That proves nothing about what a user receives: signing, notarization and the DMG copy all sit between the two, and the daemons are plain files in `Resources` that nothing else would miss. A release that dropped them would install, launch, and look completely fine — until someone pointed it at a machine.

The release workflow now mounts the finished DMG and asserts all three daemons are present and are what they claim: a Mach-O for this Mac, an ELF per Linux architecture.

## Verified

`cargo test` — 106 passing, 3 of them new for the target mapping and the Mac payload. The DMG assertion's shell was run against a real bundle with the slices in place, including a deliberately missing entry to confirm it fails rather than passes quietly.

Not verified: an actual deploy to a second Mac (I have one machine here) and a real release run. The first release carrying this is where the DMG check earns its keep.

Release Notes:
- Termio can now set up another Mac as a device, not just a Linux box.