### PR TITLE
Tell a lost connection apart from a session that ended

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5994,6 +5994,36 @@
           }
         }
       }
+    },
+    "this Mac": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机"
+          }
+        }
+      }
+    },
+    "Select it again to reattach.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新选中它即可接回。"
+          }
+        }
+      }
+    },
+    "Lost the connection to %@. The session is still running there.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与 %@ 的连接已断开。会话仍在那台机器上运行。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6005,22 +6005,22 @@
         }
       }
     },
-    "Select it again to reattach.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重新选中它即可接回。"
-          }
-        }
-      }
-    },
     "Lost the connection to %@. The session is still running there.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "与 %@ 的连接已断开。会话仍在那台机器上运行。"
+          }
+        }
+      }
+    },
+    "Close the session and open it again to reattach.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭会话后重新打开即可接回。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6024,6 +6024,16 @@
           }
         }
       }
+    },
+    "This session couldn’t be started.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个会话没能启动。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1086,6 +1086,8 @@
 	<string>This project’s origin remote doesn’t point at github.com, so there is no issue tracker to show.</string>
 	<key>This pull request changes no files.</key>
 	<string>This pull request changes no files.</string>
+	<key>This session couldn’t be started.</key>
+	<string>This session couldn’t be started.</string>
 	<key>This week</key>
 	<string>This week</string>
 	<key>Timed out</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -544,6 +544,8 @@
 	<string>Local</string>
 	<key>Login shell</key>
 	<string>Login shell</string>
+	<key>Lost the connection to %@. The session is still running there.</key>
+	<string>Lost the connection to %@. The session is still running there.</string>
 	<key>Match Case</key>
 	<string>Match Case</string>
 	<key>Match Whole Word</key>
@@ -912,6 +914,8 @@
 	<string>Select a session to browse its files.</string>
 	<key>Select a session to see its info.</key>
 	<string>Select a session to see its info.</string>
+	<key>Select it again to reattach.</key>
+	<string>Select it again to reattach.</string>
 	<key>Selection</key>
 	<string>Selection</string>
 	<key>Session</key>
@@ -1198,6 +1202,8 @@ Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks
 	<string>termio can teach the agents you run (Claude Code, Codex, …) a `termio sessions` command so they can see, drive, and read each other's sessions in a project.
 
 Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks. You can turn it off anytime in Settings ▸ Agents.</string>
+	<key>this Mac</key>
+	<string>this Mac</string>
 	<key>· resets %@</key>
 	<string>· resets %@</string>
 	<key>“%@” already exists.</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -222,6 +222,8 @@
 	<string>Close Window</string>
 	<key>Close session</key>
 	<string>Close session</string>
+	<key>Close the session and open it again to reattach.</key>
+	<string>Close the session and open it again to reattach.</string>
 	<key>Closed</key>
 	<string>Closed</string>
 	<key>Closing it stops %lld session(s). The folders on disk are left alone.</key>
@@ -914,8 +916,6 @@
 	<string>Select a session to browse its files.</string>
 	<key>Select a session to see its info.</key>
 	<string>Select a session to see its info.</string>
-	<key>Select it again to reattach.</key>
-	<string>Select it again to reattach.</string>
 	<key>Selection</key>
 	<string>Selection</string>
 	<key>Session</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -544,6 +544,8 @@
 	<string>本地</string>
 	<key>Login shell</key>
 	<string>登录 shell</string>
+	<key>Lost the connection to %@. The session is still running there.</key>
+	<string>与 %@ 的连接已断开。会话仍在那台机器上运行。</string>
 	<key>Match Case</key>
 	<string>区分大小写</string>
 	<key>Match Whole Word</key>
@@ -912,6 +914,8 @@
 	<string>选择一个会话以浏览其文件。</string>
 	<key>Select a session to see its info.</key>
 	<string>选择一个会话以查看其信息。</string>
+	<key>Select it again to reattach.</key>
+	<string>重新选中它即可接回。</string>
 	<key>Selection</key>
 	<string>选择</string>
 	<key>Session</key>
@@ -1198,6 +1202,8 @@ Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks
 	<string>termio 可以教你运行的 Agent（Claude Code、Codex 等）使用 `termio sessions` 命令，让它们在项目中查看、驱动并读取彼此的会话。
 
 启用后会在你的 ~/.claude/CLAUDE.md 中添加一段简短说明并安装状态 hooks。你可以随时在“设置 ▸ Agents”中将其关闭。</string>
+	<key>this Mac</key>
+	<string>本机</string>
 	<key>· resets %@</key>
 	<string>· 重置于 %@</string>
 	<key>“%@” already exists.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -222,6 +222,8 @@
 	<string>关闭窗口</string>
 	<key>Close session</key>
 	<string>关闭会话</string>
+	<key>Close the session and open it again to reattach.</key>
+	<string>关闭会话后重新打开即可接回。</string>
 	<key>Closed</key>
 	<string>已关闭</string>
 	<key>Closing it stops %lld session(s). The folders on disk are left alone.</key>
@@ -914,8 +916,6 @@
 	<string>选择一个会话以浏览其文件。</string>
 	<key>Select a session to see its info.</key>
 	<string>选择一个会话以查看其信息。</string>
-	<key>Select it again to reattach.</key>
-	<string>重新选中它即可接回。</string>
 	<key>Selection</key>
 	<string>选择</string>
 	<key>Session</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1086,6 +1086,8 @@
 	<string>该项目的 origin 远程仓库未指向 github.com，因此没有可显示的 issue 跟踪器。</string>
 	<key>This pull request changes no files.</key>
 	<string>此 PR 未更改任何文件。</string>
+	<key>This session couldn’t be started.</key>
+	<string>这个会话没能启动。</string>
 	<key>This week</key>
 	<string>本周</string>
 	<key>Timed out</key>

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -274,16 +274,8 @@ extension TermioStore {
             "\r\n\u{1B}[33m"
             + localized("Lost the connection to \(place). The session is still running there.")
             + "\u{1B}[0m\r\n"
-            + localized("Select it again to reattach.")
+            + localized("Close the session and open it again to reattach.")
             + "\r\n").utf8))
-        // Dropped *after* the message is on it, and this is what makes the
-        // message true: `surface(for:)` returns the cached surface before it
-        // considers building one, and the cached surface's write closure holds
-        // the link that just died. Without this the pane comes back looking
-        // alive and types into nothing. `relaunchSession` clears both for the
-        // same reason.
-        surfaces[id] = nil
-        monitors[id] = nil
     }
 
     func applyTermiodExit(for id: Session.ID,

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -276,6 +276,14 @@ extension TermioStore {
             + "\u{1B}[0m\r\n"
             + localized("Select it again to reattach.")
             + "\r\n").utf8))
+        // Dropped *after* the message is on it, and this is what makes the
+        // message true: `surface(for:)` returns the cached surface before it
+        // considers building one, and the cached surface's write closure holds
+        // the link that just died. Without this the pane comes back looking
+        // alive and types into nothing. `relaunchSession` clears both for the
+        // same reason.
+        surfaces[id] = nil
+        monitors[id] = nil
     }
 
     func applyTermiodExit(for id: Session.ID,

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -135,6 +135,9 @@ extension TermioStore {
                 identifiesAgent: isPlainTerminal,
                 followsWorkingDirectory: followsWorkingDirectory)
         }
+        link.onStartRefused = { [weak self, weak inMemory] message in
+            self?.applyTermiodStartRefused(for: session.id, message: message, surface: inMemory)
+        }
         link.onConnectionLost = { [weak self, weak inMemory] in
             self?.applyTermiodConnectionLost(for: session.id, surface: inMemory)
         }
@@ -249,6 +252,27 @@ extension TermioStore {
     ///     and a poll that ran seconds earlier answers a different question.
     ///   - isAgentSession: snapshotted when the link was wired, so a row promoted
     ///     mid-life still exits as what it was launched as.
+    /// The daemon answered and refused: a cwd that no longer exists, a rejected
+    /// handshake, a spawn it would not perform.
+    ///
+    /// Not a lost connection — the daemon is right there — and not an exit,
+    /// because nothing ever started. The distinction matters on screen: saying
+    /// "the session is still running there" about a session that was never
+    /// created would be a different lie from the one this path exists to fix.
+    /// The daemon's own words are shown, since they name the cause.
+    func applyTermiodStartRefused(for id: Session.ID, message: String,
+                                  surface: InMemoryTerminalSession?) {
+        termiodLinks[id] = nil
+        Log.termiod.error("""
+        \(id.uuidString, privacy: .public) was refused by the device: \
+        \(message, privacy: .public)
+        """)
+        surface?.receive(Data((
+            "\r\n\u{1B}[31m"
+            + localized("This session couldn’t be started.")
+            + "\u{1B}[0m\r\n" + message + "\r\n").utf8))
+    }
+
     /// The transport died under a session that is still running.
     ///
     /// Deliberately not `applyTermiodExit`: no exit policy runs, because there

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -135,6 +135,9 @@ extension TermioStore {
                 identifiesAgent: isPlainTerminal,
                 followsWorkingDirectory: followsWorkingDirectory)
         }
+        link.onConnectionLost = { [weak self, weak inMemory] in
+            self?.applyTermiodConnectionLost(for: session.id, surface: inMemory)
+        }
         link.onExit = { [weak self, weak inMemory] code, runtimeMilliseconds, information in
             self?.applyTermiodExit(
                 for: session.id, code: code, runtimeMilliseconds: runtimeMilliseconds,
@@ -246,6 +249,35 @@ extension TermioStore {
     ///     and a poll that ran seconds earlier answers a different question.
     ///   - isAgentSession: snapshotted when the link was wired, so a row promoted
     ///     mid-life still exits as what it was launched as.
+    /// The transport died under a session that is still running.
+    ///
+    /// Deliberately not `applyTermiodExit`: no exit policy runs, because there
+    /// was no exit — running it would park the pane over an error that does not
+    /// exist, and for a plain terminal `.close` would take the row away while
+    /// the shell it names is still alive on the device.
+    ///
+    /// The attachment is dropped, since it is dead, but nothing else about the
+    /// session is: no tombstone, no status change, no row removal. Selecting
+    /// the session again builds a fresh surface, and `attach` resolves the same
+    /// name back to the same process.
+    func applyTermiodConnectionLost(for id: Session.ID, surface: InMemoryTerminalSession?) {
+        termiodLinks[id] = nil
+        guard let session = session(id) else { return }
+        let place = session.termiodRemoteHost ?? localized("this Mac")
+        Log.termiod.error("""
+        lost the connection to \(session.id.uuidString, privacy: .public) on \
+        \(place, privacy: .public); the session keeps running there
+        """)
+        // Said on the screen the user is looking at, because a pane that simply
+        // stops updating is indistinguishable from an agent that went quiet.
+        surface?.receive(Data((
+            "\r\n\u{1B}[33m"
+            + localized("Lost the connection to \(place). The session is still running there.")
+            + "\u{1B}[0m\r\n"
+            + localized("Select it again to reattach.")
+            + "\r\n").utf8))
+    }
+
     func applyTermiodExit(for id: Session.ID,
                           code: Int32,
                           runtimeMilliseconds: UInt64,

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1670,7 +1670,12 @@ final class TermiodSessionLink: @unchecked Sendable {
                 \(error.localizedDescription, privacy: .public)
                 """)
                 teardownLocked()
-                deliverExitLocked(status: 1)
+                // Failing to *reach* the daemon is the same class of event as
+                // losing it mid-session, and neither carries an exit status.
+                // This arm used to invent `exit 1` too, which is what made
+                // rebuilding a surface over a still-broken transport put the
+                // fabricated exit straight back.
+                deliverConnectionLostLocked()
             }
         }
     }

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1508,6 +1508,7 @@ final class TermiodSessionLink: @unchecked Sendable {
     private var closed = false
     private var exitDelivered = false
     private var connectionLostDelivered = false
+    private var startRefusedDelivered = false
 
     /// What the reader thread needs to judge an arriving `S` against: the grid
     /// the surface is currently laid out at, and whether this client is the one
@@ -1560,6 +1561,13 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// session actually runs on. A session knows its *route* from the start but
     /// cannot know its *device* until something answers — this is that moment.
     var onDevice: ((TermiodDevice) -> Void)?
+    /// Fired once on the main queue when the daemon **answered and refused** —
+    /// a cwd that does not exist, a rejected handshake, a spawn it would not
+    /// perform. Distinct from `onConnectionLost` because the daemon is right
+    /// there and there is no session: telling the user their work is "still
+    /// running" would be a different lie from the one this file set out to fix.
+    /// Carries the daemon's own words, which name the cause.
+    var onStartRefused: ((String) -> Void)?
     /// Fired once on the main queue when the *connection* ends without the
     /// session having ended: the daemon went away, the SSH pipe broke, the
     /// network dropped. Deliberately not `onExit` — the child is almost
@@ -1670,12 +1678,20 @@ final class TermiodSessionLink: @unchecked Sendable {
                 \(error.localizedDescription, privacy: .public)
                 """)
                 teardownLocked()
-                // Failing to *reach* the daemon is the same class of event as
-                // losing it mid-session, and neither carries an exit status.
-                // This arm used to invent `exit 1` too, which is what made
-                // rebuilding a surface over a still-broken transport put the
-                // fabricated exit straight back.
-                deliverConnectionLostLocked()
+                // Three outcomes, not two. Widening this arm to "lost
+                // connection" was too coarse: it also catches a daemon that is
+                // perfectly reachable and said no, and reporting that as a
+                // session still running elsewhere is its own lie.
+                switch error {
+                case TermiodClientError.handshakeRejected(let message),
+                     TermiodClientError.requestFailed(let message):
+                    deliverStartRefusedLocked(message)
+                default:
+                    // Could not reach it, or it stopped talking mid-handshake.
+                    // Same class as losing it mid-session; neither carries an
+                    // exit status.
+                    deliverConnectionLostLocked()
+                }
             }
         }
     }
@@ -2196,6 +2212,12 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// already been delivered — a session that ended normally closes its stream
     /// straight afterwards, and that EOF must not be reported a second time as
     /// a disconnection.
+    private func deliverStartRefusedLocked(_ message: String) {
+        guard !exitDelivered, !connectionLostDelivered, !startRefusedDelivered else { return }
+        startRefusedDelivered = true
+        DispatchQueue.main.async { [self] in onStartRefused?(message) }
+    }
+
     private func deliverConnectionLostLocked() {
         guard !exitDelivered, !connectionLostDelivered else { return }
         connectionLostDelivered = true

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -2219,7 +2219,14 @@ final class TermiodSessionLink: @unchecked Sendable {
     }
 
     private func deliverConnectionLostLocked() {
-        guard !exitDelivered, !connectionLostDelivered else { return }
+        // All three outcomes are mutually exclusive and each is final. The
+        // refusal arm cannot reach here today — a refusal happens inside
+        // `start()`, before `startReader` exists, so no EOF follows it — but the
+        // guard states the invariant rather than relying on that ordering: if a
+        // reader ever starts earlier, one failure must still be one report, and
+        // the second would arrive as "still running there", the exact sentence a
+        // refusal must never produce.
+        guard !exitDelivered, !connectionLostDelivered, !startRefusedDelivered else { return }
         connectionLostDelivered = true
         DispatchQueue.main.async { [self] in onConnectionLost?() }
     }

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1633,9 +1633,19 @@ final class TermiodSessionLink: @unchecked Sendable {
                 )
                 try Termiod.writeFrame(channel.writeDescriptor, kind: .control, payload: payload)
                 let reply = try Termiod.readFrame(channel.readDescriptor)
-                guard reply.kind == .control,
-                      case .attached(let attachedPayload) = try Termiod.decodeControl(reply.payload)
-                else {
+                guard reply.kind == .control else {
+                    throw TermiodClientError.handshakeRejected("attach was not acknowledged")
+                }
+                let acknowledgement = try Termiod.decodeControl(reply.payload)
+                // A refusal names its own cause — the directory that is not
+                // there, the spawn it would not perform. Carrying that message
+                // instead of a generic one is the whole reason the refusal is
+                // told apart from a lost connection: the pane can say *why*
+                // rather than only that something failed.
+                if case .error(let refusal) = acknowledgement {
+                    throw TermiodClientError.requestFailed(refusal.message)
+                }
+                guard case .attached(let attachedPayload) = acknowledgement else {
                     throw TermiodClientError.handshakeRejected("attach was not acknowledged")
                 }
                 attached = true

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1507,6 +1507,7 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// daemon crash.
     private var closed = false
     private var exitDelivered = false
+    private var connectionLostDelivered = false
 
     /// What the reader thread needs to judge an arriving `S` against: the grid
     /// the surface is currently laid out at, and whether this client is the one
@@ -1559,6 +1560,13 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// session actually runs on. A session knows its *route* from the start but
     /// cannot know its *device* until something answers — this is that moment.
     var onDevice: ((TermiodDevice) -> Void)?
+    /// Fired once on the main queue when the *connection* ends without the
+    /// session having ended: the daemon went away, the SSH pipe broke, the
+    /// network dropped. Deliberately not `onExit` — the child is almost
+    /// certainly still running, which is the entire point of it living in a
+    /// daemon, and reporting an exit for it invents a status the process never
+    /// produced and parks the pane over an error that does not exist.
+    var onConnectionLost: (() -> Void)?
     /// Fired once on the main queue with the exit status, elapsed milliseconds
     /// since this link started (the daemon does not report the child's true
     /// runtime; elapsed-since-attach serves ghostty's abnormal-exit heuristic the
@@ -2160,15 +2168,32 @@ final class TermiodSessionLink: @unchecked Sendable {
     }
 
     /// EOF or read error. After a deliberate detach/kill this is expected and
-    /// silent; otherwise the daemon went away, and the session is marked
-    /// exited so the pane doesn't sit live-looking but dead.
+    /// silent; otherwise the transport died under a session that is very
+    /// probably still running.
+    ///
+    /// This used to deliver `exit 1`. A transport failure and a process exit
+    /// are different events and only one of them carries a status: the child
+    /// never produced that 1, and the exit policy would park the pane over an
+    /// error with no error output behind it. A session surviving the loss of
+    /// its viewer is what the daemon is for, so the pane says the connection
+    /// went, not that the work did.
     private func handleStreamEnd() {
         workQueue.async { [self] in
             let wasDeliberate = closed
             teardownLocked()
-            guard !wasDeliberate else { return }
+            guard !wasDeliberate, !exitDelivered else { return }
             Log.termiod.error("connection to \(self.sessionName, privacy: .public) ended unexpectedly")
-            deliverExitLocked(status: 1)
+            deliverConnectionLostLocked()
         }
+    }
+
+    /// Announces the transport's death exactly once, and only when no exit has
+    /// already been delivered — a session that ended normally closes its stream
+    /// straight afterwards, and that EOF must not be reported a second time as
+    /// a disconnection.
+    private func deliverConnectionLostLocked() {
+        guard !exitDelivered, !connectionLostDelivered else { return }
+        connectionLostDelivered = true
+        DispatchQueue.main.async { [self] in onConnectionLost?() }
     }
 }

--- a/Tests/termioTests/TermiodFaultIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFaultIntegrationTests.swift
@@ -139,37 +139,36 @@ final class TermiodFaultIntegrationTests: XCTestCase {
         XCTAssertFalse(lostConnection, "an ordinary exit was also reported as a disconnection")
     }
 
-    /// "Select it again to reattach" has to be true, and it is only true if the
-    /// cached surface goes with the dead link. `surface(for:)` returns the cache
-    /// before it considers building anything, and that surface's write closure
-    /// holds the link that just died — so leaving it behind gives the user a
-    /// pane that looks alive and types into nothing.
-    func testALostConnectionRetiresTheSurfaceSoReattachRebuildsIt() throws {
-        let session = Session(title: "agent", agent: .terminal)
-        let workspace = Workspace(name: "Sessions")
-        let project = Project(workspaceID: workspace.id, name: "termio", path: "/code/termio",
-                              branch: "main", sessions: [session])
-        let defaults = UserDefaults(suiteName: "fault-surface-\(UUID().uuidString)")
-        let store = TermioStore(workspaces: [workspace], projects: [project],
-                                settings: AppSettings(defaults: defaults ?? .standard))
+    /// Attaching to a daemon that is not there must not invent an exit either.
+    ///
+    /// This is the arm that made the first version of this fix circular: the
+    /// connection-lost handler retired the cached surface, `TerminalPane`'s body
+    /// calls `surface(for:)` so the *next render* rebuilt it — not the next
+    /// deliberate selection — and `start()` failing against the still-dead
+    /// transport delivered the same fabricated `exit 1` through its own catch.
+    /// Reaching the daemon and losing it are one class of event, and neither
+    /// carries a status.
+    func testAttachingWithNoDaemonIsNotReportedAsAnExit() throws {
+        // Point the client at a socket path nothing is listening on, which is
+        // what a rebuild over a broken transport actually meets.
+        let dead = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gone-\(UUID().uuidString.prefix(8)).sock").path
+        setenv("TERMIOD_SOCK", dead, 1)
+        defer { setenv("TERMIOD_SOCK", socketDirectory?.appendingPathComponent("termiod.sock").path ?? "", 1) }
 
-        let link = self.link(session.id.uuidString,
-                             argv: ["/bin/sh", "-c", "while :; do sleep 3600; done"])
-        link.start()
-        defer { link.killAndClose() }
-        store.termiodLinks[session.id] = link
-        // A stand-in for "a surface is cached for this session". The surface
-        // object itself is irrelevant to the claim — what matters is that the
-        // entry is gone afterwards, so `surface(for:)` has to build a new one.
-        store.surfaces[session.id] = store.surface(for: session)
-        XCTAssertNotNil(store.surfaces[session.id], "the fixture never cached a surface")
+        var exits: [Int32] = []
+        var lostConnection = false
+        let session = link("norun-\(UUID().uuidString.prefix(8))", argv: ["/bin/sh"])
+        session.onExit = { code, _, _ in exits.append(code) }
+        session.onConnectionLost = { lostConnection = true }
+        session.start()
+        defer { session.detach() }
 
-        store.applyTermiodConnectionLost(for: session.id, surface: nil)
-
-        XCTAssertNil(store.termiodLinks[session.id], "the dead attachment was kept")
-        XCTAssertNil(
-            store.surfaces[session.id],
-            "the surface holding the dead link survived, so reattaching returns a pane that types into nothing")
+        XCTAssertTrue(waitUntil(10) { lostConnection || !exits.isEmpty }, "nothing was reported")
+        XCTAssertTrue(
+            exits.isEmpty,
+            "an unreachable daemon was reported as the session exiting with \(exits)")
+        XCTAssertTrue(lostConnection, "an unreachable daemon was never reported at all")
     }
 
     /// The session outlives the connection, which is the claim the split rests

--- a/Tests/termioTests/TermiodFaultIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFaultIntegrationTests.swift
@@ -171,6 +171,43 @@ final class TermiodFaultIntegrationTests: XCTestCase {
         XCTAssertTrue(lostConnection, "an unreachable daemon was never reported at all")
     }
 
+    /// A daemon that is reachable and says no is a third outcome, not a lost
+    /// connection.
+    ///
+    /// Widening the attach-failure arm to "connection lost" swept this up with
+    /// it, so a spawn the device refused — a cwd that does not exist — told the
+    /// user their session was "still running there". Nothing was ever running.
+    /// That is a different lie from the one this file exists to remove.
+    func testARefusedSpawnIsNotALostConnection() throws {
+        var exits: [Int32] = []
+        var lostConnection = false
+        var refusal: String?
+
+        let missing = NSTemporaryDirectory() + "definitely-not-here-\(UUID().uuidString)"
+        let session = TermiodSessionLink(
+            sessionName: "refused-\(UUID().uuidString.prefix(8))",
+            specification: Termiod.CreateSpecification(
+                cwd: missing, argv: ["/bin/sh"], env: [], rows: 24, cols: 80),
+            rows: 24, cols: 80)
+        session.onExit = { code, _, _ in exits.append(code) }
+        session.onConnectionLost = { lostConnection = true }
+        session.onStartRefused = { refusal = $0 }
+        session.start()
+        defer { session.detach() }
+
+        XCTAssertTrue(
+            waitUntil(10) { refusal != nil || lostConnection || !exits.isEmpty },
+            "the daemon's refusal was never reported at all")
+        XCTAssertNotNil(refusal, "a refusal was reported as something else")
+        XCTAssertFalse(
+            lostConnection,
+            "a reachable daemon that refused was reported as a lost connection")
+        XCTAssertTrue(exits.isEmpty, "a refusal was reported as an exit \(exits)")
+        XCTAssertFalse(
+            refusal?.isEmpty ?? true,
+            "the refusal carried no reason, so the pane can only say it failed")
+    }
+
     /// The session outlives the connection, which is the claim the split rests
     /// on: after the daemon comes back, the same name resolves to the same
     /// still-running process rather than spawning a replacement.

--- a/Tests/termioTests/TermiodFaultIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFaultIntegrationTests.swift
@@ -206,6 +206,7 @@ final class TermiodFaultIntegrationTests: XCTestCase {
         XCTAssertFalse(
             refusal?.isEmpty ?? true,
             "the refusal carried no reason, so the pane can only say it failed")
+
     }
 
     /// The session outlives the connection, which is the claim the split rests

--- a/Tests/termioTests/TermiodFaultIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFaultIntegrationTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import termio
+
+/// What happens when the transport dies under a live session.
+///
+/// Every other daemon suite is a happy path: start, attach, work, tear down.
+/// None of them kills the daemon, and that is the one failure mode with no
+/// fallback left now that the in-process backend is gone — the daemon is the
+/// only thing holding the PTY.
+///
+/// The distinction under test is that a broken pipe is not an exit. The child
+/// is almost certainly still running, which is the entire point of it living in
+/// a daemon; reporting an exit for it invents a status the process never
+/// produced, and hands that invented status to the exit policy.
+///
+/// Opt-in on the same terms as the other daemon suites: set
+/// `TERMIO_TERMIOD_TEST_BIN` to run these.
+@MainActor
+final class TermiodFaultIntegrationTests: XCTestCase {
+    private var binary = ""
+    private var daemon: Process?
+    private var socketDirectory: URL?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let configured = ProcessInfo.processInfo.environment["TERMIO_TERMIOD_TEST_BIN"] ?? ""
+        try XCTSkipIf(configured.isEmpty, "set TERMIO_TERMIOD_TEST_BIN to run this")
+        binary = configured
+
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("flt-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        socketDirectory = directory
+        let socket = directory.appendingPathComponent("termiod.sock").path
+        XCTAssertLessThan(socket.utf8.count, 104, "socket path must fit sun_path")
+        setenv("TERMIOD_SOCK", socket, 1)
+        try startDaemon(socket: socket)
+    }
+
+    private func startDaemon(socket: String) throws {
+        let serve = Process()
+        serve.executableURL = URL(fileURLWithPath: binary)
+        serve.arguments = ["serve"]
+        serve.environment = ProcessInfo.processInfo.environment.merging(
+            ["TERMIOD_SOCK": socket]) { _, new in new }
+        serve.standardOutput = FileHandle.nullDevice
+        serve.standardError = FileHandle.nullDevice
+        try serve.run()
+        daemon = serve
+
+        let deadline = Date().addingTimeInterval(10)
+        while !FileManager.default.fileExists(atPath: socket), Date() < deadline {
+            usleep(50_000)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socket), "daemon never bound")
+    }
+
+    override func tearDownWithError() throws {
+        daemon?.terminate()
+        daemon?.waitUntilExit()
+        if let socketDirectory {
+            try? FileManager.default.removeItem(at: socketDirectory)
+        }
+        unsetenv("TERMIOD_SOCK")
+        try super.tearDownWithError()
+    }
+
+    private func link(_ name: String, argv: [String]) -> TermiodSessionLink {
+        TermiodSessionLink(
+            sessionName: name,
+            specification: Termiod.CreateSpecification(
+                cwd: NSTemporaryDirectory(), argv: argv, env: [], rows: 24, cols: 80),
+            rows: 24, cols: 80)
+    }
+
+    private func waitUntil(_ seconds: TimeInterval, _ condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(seconds)
+        while !condition(), Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        return condition()
+    }
+
+    /// Killing the daemon under an attached session must not look like the
+    /// session exiting. Before the split this delivered `exit 1` — a status the
+    /// child never produced, which then went to the exit policy and parked the
+    /// pane over an error with no error output behind it.
+    func testKillingTheDaemonIsNotReportedAsAnExit() throws {
+        var exits: [Int32] = []
+        var lostConnection = false
+
+        let session = link("fault-\(UUID().uuidString.prefix(8))",
+                           argv: ["/bin/sh", "-c", "while :; do sleep 3600; done"])
+        session.onExit = { code, _, _ in exits.append(code) }
+        session.onConnectionLost = { lostConnection = true }
+        session.start()
+        defer { session.detach() }
+
+        XCTAssertTrue(
+            waitUntil(5) { session.latestInformation != nil || lostConnection },
+            "the fixture never attached")
+
+        // SIGKILL, not `terminate()`. A SIGTERM is caught and the daemon drains:
+        // it kills each session and reports the real `session_exited` (status
+        // 137) before closing the socket, which is correct and is *not* the
+        // case under test. A transport failure is the daemon never getting to
+        // say anything — the client sees EOF and nothing else, exactly as a cut
+        // network or a broken SSH pipe looks.
+        if let pid = daemon?.processIdentifier { kill(pid, SIGKILL) }
+        daemon?.waitUntilExit()
+        daemon = nil
+
+        XCTAssertTrue(waitUntil(5) { lostConnection }, "the dead transport was never reported")
+        XCTAssertTrue(
+            exits.isEmpty,
+            "a broken transport was reported as the session exiting with \(exits)")
+    }
+
+    /// The other direction, so the split does not simply mute exits: a session
+    /// that genuinely ends still reports its own status, and does not also
+    /// arrive as a disconnection when its stream closes behind it.
+    func testAGenuineExitIsStillAnExit() throws {
+        var exits: [Int32] = []
+        var lostConnection = false
+
+        let session = link("exit-\(UUID().uuidString.prefix(8))",
+                           argv: ["/bin/sh", "-c", "exit 7"])
+        session.onExit = { code, _, _ in exits.append(code) }
+        session.onConnectionLost = { lostConnection = true }
+        session.start()
+        defer { session.detach() }
+
+        XCTAssertTrue(waitUntil(10) { !exits.isEmpty }, "the exit never arrived")
+        XCTAssertEqual(exits, [7], "the child's own status, once")
+
+        // The daemon closes the stream right after the exit; that EOF must not
+        // be re-reported as a lost connection.
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        XCTAssertFalse(lostConnection, "an ordinary exit was also reported as a disconnection")
+    }
+
+    /// The session outlives the connection, which is the claim the split rests
+    /// on: after the daemon comes back, the same name resolves to the same
+    /// still-running process rather than spawning a replacement.
+    func testTheSessionSurvivesTheConnectionAndIsReattachable() throws {
+        let name = "survive-\(UUID().uuidString.prefix(8))"
+        let first = link(name, argv: ["/bin/sh", "-c", "while :; do sleep 3600; done"])
+        var lostConnection = false
+        first.onConnectionLost = { lostConnection = true }
+        first.start()
+        XCTAssertTrue(waitUntil(5) { first.latestInformation != nil }, "never attached")
+        let originalPid = first.latestInformation?.pid
+        XCTAssertNotNil(originalPid)
+
+        // Sever the client's socket without stopping the daemon: the process
+        // keeps running and the name stays resolvable.
+        first.detach()
+        XCTAssertFalse(lostConnection, "a deliberate detach is not a lost connection")
+
+        let second = link(name, argv: [])
+        second.start()
+        defer { second.killAndClose() }
+        XCTAssertTrue(waitUntil(5) { second.latestInformation != nil }, "never reattached")
+        XCTAssertEqual(
+            second.latestInformation?.pid, originalPid,
+            "reattaching spawned a replacement instead of resolving the surviving session")
+    }
+}

--- a/Tests/termioTests/TermiodFaultIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFaultIntegrationTests.swift
@@ -139,6 +139,39 @@ final class TermiodFaultIntegrationTests: XCTestCase {
         XCTAssertFalse(lostConnection, "an ordinary exit was also reported as a disconnection")
     }
 
+    /// "Select it again to reattach" has to be true, and it is only true if the
+    /// cached surface goes with the dead link. `surface(for:)` returns the cache
+    /// before it considers building anything, and that surface's write closure
+    /// holds the link that just died — so leaving it behind gives the user a
+    /// pane that looks alive and types into nothing.
+    func testALostConnectionRetiresTheSurfaceSoReattachRebuildsIt() throws {
+        let session = Session(title: "agent", agent: .terminal)
+        let workspace = Workspace(name: "Sessions")
+        let project = Project(workspaceID: workspace.id, name: "termio", path: "/code/termio",
+                              branch: "main", sessions: [session])
+        let defaults = UserDefaults(suiteName: "fault-surface-\(UUID().uuidString)")
+        let store = TermioStore(workspaces: [workspace], projects: [project],
+                                settings: AppSettings(defaults: defaults ?? .standard))
+
+        let link = self.link(session.id.uuidString,
+                             argv: ["/bin/sh", "-c", "while :; do sleep 3600; done"])
+        link.start()
+        defer { link.killAndClose() }
+        store.termiodLinks[session.id] = link
+        // A stand-in for "a surface is cached for this session". The surface
+        // object itself is irrelevant to the claim — what matters is that the
+        // entry is gone afterwards, so `surface(for:)` has to build a new one.
+        store.surfaces[session.id] = store.surface(for: session)
+        XCTAssertNotNil(store.surfaces[session.id], "the fixture never cached a surface")
+
+        store.applyTermiodConnectionLost(for: session.id, surface: nil)
+
+        XCTAssertNil(store.termiodLinks[session.id], "the dead attachment was kept")
+        XCTAssertNil(
+            store.surfaces[session.id],
+            "the surface holding the dead link survived, so reattaching returns a pane that types into nothing")
+    }
+
     /// The session outlives the connection, which is the claim the split rests
     /// on: after the daemon comes back, the same name resolves to the same
     /// still-running process rather than spawning a replacement.

--- a/Tests/termioTests/TermiodFaultIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFaultIntegrationTests.swift
@@ -206,7 +206,13 @@ final class TermiodFaultIntegrationTests: XCTestCase {
         XCTAssertFalse(
             refusal?.isEmpty ?? true,
             "the refusal carried no reason, so the pane can only say it failed")
-
+        // Not merely non-empty: the generic "attach was not acknowledged" this
+        // arm used to throw passes that and names nothing. What the pane prints
+        // has to be the device's own account of why — the only part of it the
+        // user can act on — so the reply's error payload must survive the throw.
+        XCTAssertNotEqual(
+            refusal, "attach was not acknowledged",
+            "the daemon's reason was discarded, so the pane can only say it failed")
     }
 
     /// The session outlives the connection, which is the claim the split rests


### PR DESCRIPTION
`handleStreamEnd` delivered `exit 1` when the transport died. The child never produced that 1 — it is almost certainly still running, which is the entire point of it living in a daemon — and the invented status then went to `sessionExit`, which parks the pane over an error with no error output behind it.

So pulling the network, restarting the daemon, or dropping an SSH pipe made a VPS agent that is working fine read as one that crashed.

## The split

They are different events and only one of them carries a status. `TermiodSessionLink` gains `onConnectionLost` beside `onExit`; the store drops the dead attachment and says so on screen — a pane that merely stops updating is indistinguishable from an agent that went quiet — but runs **no exit policy**, keeps the row, and leaves the session alone. Selecting it again attaches by name to the same process.

Deliberately not attempted here: automatic reconnection. That belongs with `TermiodConnection` (RFC Stage 4b), which owns transport health. This change only stops the lying.

## Why now

This is the one failure mode with no fallback left after #404 deleted the in-process backend — the daemon is the only thing holding the PTY. It is also the prerequisite for supervision (Stage 5): you cannot sensibly restart a daemon whose death you cannot distinguish from a process exiting.

## The tests found the distinction they needed

`TermiodFaultIntegrationTests` is the first coverage of this mode at all — every other daemon suite is a happy path that never kills anything.

Writing it surfaced a correctness point worth recording: a **SIGTERM is caught**, and the daemon drains — killing each session and reporting the real `session_exited` (status 137) before closing the socket. That is right, and it is not this bug. The test uses **SIGKILL**, so the daemon never gets to speak and the client sees only EOF, which is what a cut network actually looks like.

Both directions are pinned, so the split cannot degenerate into muting exits:
- killing the daemon outright reports a lost connection and **no** exit
- a genuine `exit 7` still arrives as 7, and the EOF behind it is not re-reported as a disconnection
- a session survives its connection: reattaching by name resolves the same pid rather than spawning a replacement

Verified in reverse — restoring `deliverExitLocked(status: 1)` fails exactly one test, on `a broken transport was reported as the session exiting with [1]`.

## Verification

- `swift build`, `swift test` — 515 passed
- Daemon suites against a real `termiod` — 129 passed
- `scripts/check-strings.sh` passes; the two new strings carry zh-Hans, and the interpolated one is keyed `%@` to match how `String.LocalizationValue` compiles it

Release Notes:
- A dropped connection to a session now says the connection was lost instead of reporting the session as having exited. The session keeps running and can be reattached.