### PR TITLE
Put the download link in the release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,14 +266,16 @@ jobs:
 
       # Record the release on GitHub for the tag + auto-generated changelog.
       # Artifacts live on R2 (the private repo's own assets aren't public), so the
-      # download link goes in the title's trailing note rather than as an asset.
+      # download link leads the body — GitHub renders release titles as plain text,
+      # so a URL there is unclickable.
       - name: Record GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.meta.outputs.version }}"
           gh release create "v${VERSION}" \
-            --title "${APP_NAME} v${VERSION} — $DOWNLOAD_BASE_URL/v${VERSION}/${APP_NAME}.dmg" \
+            --title "${APP_NAME} v${VERSION}" \
+            --notes "[Download ${APP_NAME} ${VERSION} for macOS]($DOWNLOAD_BASE_URL/v${VERSION}/${APP_NAME}.dmg)" \
             --generate-notes
 
       # Point the Homebrew tap (termio-sh/homebrew-tap) at this release so


### PR DESCRIPTION
GitHub renders release titles as plain text, so the DMG URL parked in every release title was unclickable — a reader had to select it by hand and paste it into a browser, while the body held nothing but the generated changelog. The title is now just `termio vX.Y.Z`, and the download link leads the body ahead of the changelog.

The 70 existing releases have already been backfilled the same way: retitled, with the link prepended to their existing notes.

Release Notes:
- Release pages now carry a clickable download link in the body instead of a bare URL in the title.