### PR TITLE
Move workspace renaming and removing into a settings pane

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -897,6 +897,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         settingsWindow?.contentView = NSHostingView(rootView: SettingsView(
             settings: settings,
             usage: usageMonitor,
+            store: store,
             initialTab: initialTab,
             onSSHConnect: { [weak self] host in
                 guard let self else { return }
@@ -986,16 +987,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.presentNewWorkspacePanel(on: .ssh(alias: alias))
     }
 
-    /// The submenu's "Rename Workspace…" row. It acts on the workspace the window
-    /// is in, which is the one the rows above show checked.
-    @objc func renameWorkspace(_ sender: Any?) {
-        store.presentRenameWorkspacePanel(store.currentWorkspaceID)
-    }
-
-    /// The submenu's "Remove Workspace" row, acting on the current workspace like
-    /// the rename above. Disabled at one workspace (see `validateMenuItem`).
-    @objc func removeWorkspace(_ sender: Any?) {
-        store.confirmRemoveWorkspace(store.currentWorkspaceID)
+    /// "Workspace Settings…", from File ▸ Workspace and the sidebar switcher — the
+    /// one pane that shows every workspace at once, which is where renaming and
+    /// removing one live.
+    @objc func openWorkspaceSettings(_ sender: Any?) {
+        openSettings(initialTab: .workspaces)
     }
 
     /// A row of the Connect to… submenu — first contact with a machine from
@@ -2001,12 +1997,14 @@ extension AppDelegate: NSMenuDelegate {
                                action: #selector(newWorkspace(_:)), keyEquivalent: "")
         new.target = self
         refreshNewWorkspaceItem(new, others: otherDevices(known: DeviceRoster.known(in: store)))
-        let rename = menu.addItem(withTitle: localized("Rename Workspace…"),
-                                  action: #selector(renameWorkspace(_:)), keyEquivalent: "")
-        rename.target = self
-        let remove = menu.addItem(withTitle: localized("Remove Workspace"),
-                                  action: #selector(removeWorkspace(_:)), keyEquivalent: "")
-        remove.target = self
+        menu.addItem(.separator())
+        // Renaming and removing are in Settings ▸ Workspaces rather than here.
+        // Both act on a workspace the user has to pick, and a menu that shows the
+        // list one checked row at a time can only offer them for the current one —
+        // which is why they read as "Rename Workspace" with no name in them.
+        let settingsItem = menu.addItem(withTitle: localized("Workspace Settings…"),
+                                        action: #selector(openWorkspaceSettings(_:)), keyEquivalent: "")
+        settingsItem.target = self
     }
 
     private func fillConnectToMenu(_ menu: NSMenu) {
@@ -2034,11 +2032,6 @@ extension AppDelegate: NSMenuItemValidation {
             return !store.sidebarSessionGroups.isEmpty
         case #selector(newWorktree(_:)), #selector(newPullRequest(_:)):
             return currentBranchProject != nil
-        // The store refuses to remove the last workspace — the sidebar has to have
-        // a scope to show — so the row dims rather than answering a click with
-        // nothing.
-        case #selector(removeWorkspace(_:)):
-            return store.hasMultipleWorkspaces
         default:
             return true
         }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5885,16 +5885,6 @@
         }
       }
     },
-    "Rename Workspace…": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重命名工作区…"
-          }
-        }
-      }
-    },
     "Runs on %@": {
       "localizations": {
         "zh-Hans": {
@@ -6071,6 +6061,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "这个会话没能启动。"
+          }
+        }
+      }
+    },
+    "Workspaces": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区"
+          }
+        }
+      }
+    },
+    "The workspaces your projects and sessions are filed under": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的项目和会话归入的工作区"
+          }
+        }
+      }
+    },
+    "A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区把侧栏限定在归入它的项目和会话上，都在它所属的那台机器上。"
+          }
+        }
+      }
+    },
+    "Workspace Settings…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区设置…"
+          }
+        }
+      }
+    },
+    "Workspace actions": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区操作"
+          }
+        }
+      }
+    },
+    "Current workspace": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前工作区"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -62,6 +62,8 @@
 	<string>1 result</string>
 	<key>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</key>
 	<string>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</string>
+	<key>A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to.</key>
+	<string>A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to.</string>
 	<key>Activity</key>
 	<string>Activity</string>
 	<key>Add</key>
@@ -330,6 +332,8 @@
 	<string>Couldn’t write ~/.ssh/config: %@</string>
 	<key>Create</key>
 	<string>Create</string>
+	<key>Current workspace</key>
+	<string>Current workspace</string>
 	<key>Cursor</key>
 	<string>Cursor</string>
 	<key>Custom</key>
@@ -858,8 +862,6 @@
 	<string>Rename Session</string>
 	<key>Rename Workspace</key>
 	<string>Rename Workspace</string>
-	<key>Rename Workspace…</key>
-	<string>Rename Workspace…</string>
 	<key>Rename “%@”</key>
 	<string>Rename “%@”</string>
 	<key>Rename…</key>
@@ -1056,6 +1058,8 @@
 	<string>The working tree is clean.</string>
 	<key>The workspace is empty. Projects and sessions you open later go to another workspace.</key>
 	<string>The workspace is empty. Projects and sessions you open later go to another workspace.</string>
+	<key>The workspaces your projects and sessions are filed under</key>
+	<string>The workspaces your projects and sessions are filed under</string>
 	<key>Theme</key>
 	<string>Theme</string>
 	<key>Theme, fonts, cursor, and window</key>
@@ -1162,6 +1166,12 @@
 	<string>Working Directory</string>
 	<key>Workspace</key>
 	<string>Workspace</string>
+	<key>Workspace Settings…</key>
+	<string>Workspace Settings…</string>
+	<key>Workspace actions</key>
+	<string>Workspace actions</string>
+	<key>Workspaces</key>
+	<string>Workspaces</string>
 	<key>Worktree has changes</key>
 	<string>Worktree has changes</string>
 	<key>Worktree removed</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -62,6 +62,8 @@
 	<string>1 个结果</string>
 	<key>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</key>
 	<string>另一个 `%@` 已存在于 %@。请先移除，Termio 不会覆盖并非自己创建的文件。</string>
+	<key>A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to.</key>
+	<string>工作区把侧栏限定在归入它的项目和会话上，都在它所属的那台机器上。</string>
 	<key>Activity</key>
 	<string>活动</string>
 	<key>Add</key>
@@ -330,6 +332,8 @@
 	<string>无法写入 ~/.ssh/config：%@</string>
 	<key>Create</key>
 	<string>创建</string>
+	<key>Current workspace</key>
+	<string>当前工作区</string>
 	<key>Cursor</key>
 	<string>光标</string>
 	<key>Custom</key>
@@ -858,8 +862,6 @@
 	<string>重命名会话</string>
 	<key>Rename Workspace</key>
 	<string>重命名工作区</string>
-	<key>Rename Workspace…</key>
-	<string>重命名工作区…</string>
 	<key>Rename “%@”</key>
 	<string>重命名“%@”</string>
 	<key>Rename…</key>
@@ -1056,6 +1058,8 @@
 	<string>工作树中没有任何更改。</string>
 	<key>The workspace is empty. Projects and sessions you open later go to another workspace.</key>
 	<string>这个工作区是空的。之后打开的项目和会话会归入别的工作区。</string>
+	<key>The workspaces your projects and sessions are filed under</key>
+	<string>你的项目和会话归入的工作区</string>
 	<key>Theme</key>
 	<string>主题</string>
 	<key>Theme, fonts, cursor, and window</key>
@@ -1161,6 +1165,12 @@
 	<key>Working Directory</key>
 	<string>工作目录</string>
 	<key>Workspace</key>
+	<string>工作区</string>
+	<key>Workspace Settings…</key>
+	<string>工作区设置…</string>
+	<key>Workspace actions</key>
+	<string>工作区操作</string>
+	<key>Workspaces</key>
 	<string>工作区</string>
 	<key>Worktree has changes</key>
 	<string>Worktree 存在更改</string>

--- a/Sources/termio/Settings/SettingsTab.swift
+++ b/Sources/termio/Settings/SettingsTab.swift
@@ -7,6 +7,10 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case appearance
     case terminal
+    /// Sits above Devices because that is the containment order the app itself
+    /// uses: a workspace belongs to a device, and everything filed in it lives on
+    /// that machine.
+    case workspaces
     /// A **device** is a machine identified by its `host_id` and reached by one
     /// or more `~/.ssh/config` aliases — the term the session protocol, the
     /// daemon and `TermiodDevice` all already use. This tab was called
@@ -34,6 +38,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return localized("General")
         case .appearance: return localized("Appearance")
         case .terminal: return localized("Terminal")
+        case .workspaces: return localized("Workspaces")
         case .devices: return localized("Devices")
         case .keyboard: return localized("Keyboard")
         case .agents: return localized("Agents")
@@ -50,6 +55,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return .settings
         case .appearance: return .paintBoard
         case .terminal: return .terminal
+        case .workspaces: return .copy
         case .devices: return .serverStack
         case .keyboard: return .keyboard
         case .agents: return .bot
@@ -66,6 +72,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return localized("The termio command-line tool, agent skill, and notifications")
         case .appearance: return localized("Theme, fonts, cursor, and window")
         case .terminal: return localized("Scrollback history and text selection")
+        case .workspaces: return localized("The workspaces your projects and sessions are filed under")
         case .devices: return localized("The devices in your ~/.ssh/config, and the keys that reach them")
         case .keyboard: return localized("Keyboard shortcuts for every command")
         case .agents: return localized("The coding agents offered when you start a session")

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -12,20 +12,27 @@ import SwiftUI
 struct SettingsView: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var usage: UsageMonitor
+    /// The Workspaces tab's subject. Actions elsewhere are injected as closures so
+    /// a pane can't reach past its own concern, but that tab *is* a live view of
+    /// the workspace list — a closure would have to hand over a copy that stops
+    /// tracking the moment one is added.
+    @ObservedObject var store: TermioStore
     /// Opens an SSH terminal to a `~/.ssh/config` alias in the main window — the
-    /// Devices tab's Connect action, injected by the app delegate so the settings
-    /// window doesn't hold the store.
+    /// Devices tab's Connect action, injected by the app delegate because
+    /// connecting is a main-window launch, not something this window does.
     let onSSHConnect: (String) -> Void
     @State private var selection: SettingsTab
 
     init(
         settings: AppSettings,
         usage: UsageMonitor,
+        store: TermioStore,
         initialTab: SettingsTab = .general,
         onSSHConnect: @escaping (String) -> Void
     ) {
         self.settings = settings
         self.usage = usage
+        self.store = store
         self.onSSHConnect = onSSHConnect
         _selection = State(initialValue: initialTab)
     }
@@ -74,6 +81,7 @@ struct SettingsView: View {
         case .general: GeneralSettingsTab(settings: settings)
         case .appearance: AppearanceSettingsTab(settings: settings)
         case .terminal: TerminalSettingsTab(settings: settings)
+        case .workspaces: WorkspaceSettingsTab(store: store)
         case .devices: DevicesSettingsTab(settings: settings, onConnect: onSSHConnect)
         case .keyboard: KeybindingsSettingsTab()
         case .agents: AgentSettingsTab(settings: settings)

--- a/Sources/termio/Settings/WorkspaceSettingsTab.swift
+++ b/Sources/termio/Settings/WorkspaceSettingsTab.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+/// Settings ▸ Workspaces: the whole set at once, where renaming and removing one
+/// live. The switcher in the sidebar band only switches — the same line Settings ▸
+/// Devices already draws between connecting to a host and configuring one. A verb
+/// that reshapes the list belongs where the list is visible, not in a menu that
+/// shows one row of it at a time.
+///
+/// Creating stays in the menus as well as here: New Workspace… is how a second
+/// workspace comes to exist, and the switcher is hidden until there are two, so a
+/// create verb reachable only from this pane would be reachable only by someone
+/// who already knew to look for it.
+struct WorkspaceSettingsTab: View {
+    @ObservedObject var store: TermioStore
+
+    var body: some View {
+        Form {
+            Section {
+                ForEach(store.orderedWorkspaces) { workspace in
+                    WorkspaceSettingsRow(
+                        workspace: workspace,
+                        isCurrent: workspace.id == store.currentWorkspaceID,
+                        sessionCount: store.sessions(inWorkspace: workspace.id).count,
+                        canRemove: store.hasMultipleWorkspaces,
+                        rename: { store.presentRenameWorkspacePanel(workspace.id) },
+                        remove: { store.confirmRemoveWorkspace(workspace.id) }
+                    )
+                }
+                newWorkspaceControl
+            } header: {
+                SectionHeaderLabel(title: localized("Workspaces"))
+            } footer: {
+                // One sentence, saying what the thing is. What removing one costs is
+                // the confirmation alert's job, and it already says it.
+                Text(localized("A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    /// A plain verb on one machine, a device pull-down once there is a second box
+    /// to put a workspace on — the same collapse the menus make
+    /// (`refreshNewWorkspaceItem`). A workspace belongs to exactly one machine, so
+    /// the choice has to be made somewhere; making it here keeps the device level
+    /// invisible to someone who owns one machine.
+    @ViewBuilder
+    private var newWorkspaceControl: some View {
+        let others = DeviceRoster.cloneTargets(in: store)
+        if others.isEmpty {
+            Button {
+                store.presentNewWorkspacePanel(on: .thisMac)
+            } label: {
+                Label(localized("New Workspace"), systemImage: "plus")
+            }
+        } else {
+            Menu {
+                Button(localized("This Mac")) {
+                    store.presentNewWorkspacePanel(on: .thisMac)
+                }
+                ForEach(others) { device in
+                    Button(device.name) {
+                        store.presentNewWorkspacePanel(on: WorkspaceDevice(alias: device.alias))
+                    }
+                }
+            } label: {
+                Label(localized("New Workspace"), systemImage: "plus")
+            }
+            // Borderless so the two branches of this control look alike: with one
+            // machine it is a plain row (the `Button` above, matching Devices' "Add
+            // Host"), and the bordered pull-down default would turn the same verb
+            // into the only filled slab on the pane the moment a second machine
+            // exists. The bezel comes back on hover, the way every row-level
+            // control in System Settings behaves.
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+        }
+    }
+}
+
+/// One workspace: its name, the machine and session count under it, and the two
+/// verbs that reshape it behind a trailing menu.
+///
+/// The row carries exactly one control, at the trailing edge, and says everything
+/// else in type — the shape every list row in System Settings has. An earlier
+/// version put the name in a bordered text field and Remove in a bordered button
+/// on every row, which stacked two control chromes inside a grouped row that
+/// already draws its own background: three rows of boxes inside boxes, with the
+/// name's baseline pushed off the caption's leading edge by the field's insets.
+private struct WorkspaceSettingsRow: View {
+    let workspace: Workspace
+    let isCurrent: Bool
+    let sessionCount: Int
+    let canRemove: Bool
+    let rename: () -> Void
+    let remove: () -> Void
+
+    /// The machine the workspace is on, and what removing it would cost. Zero
+    /// sessions say so by omission rather than reading "0 sessions".
+    private var subtitle: String {
+        let device = workspace.device.displayName
+        guard sessionCount > 0 else { return device }
+        return localized("\(device) · \(sessionCount) session(s)")
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            // The same mark the switcher menu puts beside the workspace on screen,
+            // holding its width on every row so the names share one leading edge.
+            Image(systemName: "checkmark")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(isCurrent ? Color.secondary : Color.clear)
+                .frame(width: 12)
+                .accessibilityHidden(!isCurrent)
+                .accessibilityLabel(localized("Current workspace"))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(workspace.name)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 8)
+            actions
+        }
+        .contentShape(Rectangle())
+        .contextMenu { actionButtons }
+    }
+
+    /// The trailing overflow menu. Borderless and unindicated so the row reads as
+    /// type with one affordance in it, rather than as a row of buttons.
+    private var actions: some View {
+        Menu {
+            actionButtons
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .accessibilityLabel(localized("Workspace actions"))
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        Button(localized("Rename…"), action: rename)
+        // The store refuses to remove the last workspace — the sidebar has to have
+        // a scope to show — so the row dims rather than answering a click with
+        // nothing.
+        Button(localized("Remove"), role: .destructive, action: remove)
+            .disabled(!canRemove)
+    }
+}

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -134,6 +134,7 @@ struct WorkspaceSwitcherToolbarView: View {
             // a point the name truncates at.
             Text(current.name)
                 .font(nameFont)
+                .fontWeight(.medium)
                 .foregroundStyle(color)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -148,12 +149,14 @@ struct WorkspaceSwitcherToolbarView: View {
         }
     }
 
-    /// A step above the sidebar's own row text: this names the whole column, so it
-    /// reads as that column's title rather than as one more row of it. Derived from
-    /// the interface size rather than fixed, so it still follows the density
-    /// preference the rows below it follow.
+    /// The sidebar's own row size, so the band and the column below it share an
+    /// x-height and read as one thing — this names that column, and a size step
+    /// would separate it from what it names. The rank comes from weight instead:
+    /// a label larger than the 13pt window title beside it is what makes a titlebar
+    /// look mis-scaled. Derived from the interface size rather than fixed, so it
+    /// still follows the density preference the rows below it follow.
     private var nameFont: Font {
-        let size = settings.interfaceFontSize + 2
+        let size = settings.interfaceFontSize
         return settings.interfaceFontFamily.isEmpty
             ? .system(size: size)
             : .custom(settings.interfaceFontFamily, size: size)
@@ -234,17 +237,17 @@ private final class WorkspaceMenuHost: NSView {
         for row in WorkspaceMenu.rows(in: store, target: self, action: #selector(switchToWorkspace(_:))) {
             menu.addItem(row)
         }
-        menu.addItem(.separator())
         // This Mac, without asking: the device submenu belongs to the menus that
         // already carry one (File ▸ Workspace and the sidebar `+`), and growing a
         // third here would put a machine list in the switcher, which is the "go to
         // a computer" mode the workspace replaced.
         addAction(localized("New Workspace…"), to: menu, #selector(newWorkspace))
-        addAction(localized("Rename Workspace…"), to: menu, #selector(renameWorkspace))
-        // Removing the last workspace is refused in the store — the sidebar has to
-        // have a scope to show — and this menu only opens while there is more than
-        // one, so the row is always live where it is drawn.
-        addAction(localized("Remove Workspace"), to: menu, #selector(removeWorkspace))
+        menu.addItem(.separator())
+        // Renaming and removing are in Settings ▸ Workspaces. Creating stays here
+        // because it is the one verb that does not need the user to pick which
+        // workspace it acts on — the other two do, and this menu can only ever
+        // offer them for the row it already shows checked.
+        addAction(localized("Workspace Settings…"), to: menu, #selector(openWorkspaceSettings))
         // No device verb here, deliberately. A machine you can *go to* is the
         // mode this scope replaced: it made the sidebar answer "which computer"
         // when the question is "which work". A device is a place a new thing is
@@ -271,13 +274,7 @@ private final class WorkspaceMenuHost: NSView {
         store?.presentNewWorkspacePanel(on: .thisMac)
     }
 
-    @objc private func renameWorkspace() {
-        guard let store else { return }
-        store.presentRenameWorkspacePanel(store.currentWorkspaceID)
-    }
-
-    @objc private func removeWorkspace() {
-        guard let store else { return }
-        store.confirmRemoveWorkspace(store.currentWorkspaceID)
+    @objc private func openWorkspaceSettings() {
+        NSApp.sendAction(#selector(AppDelegate.openWorkspaceSettings(_:)), to: nil, from: nil)
     }
 }


### PR DESCRIPTION
The switcher menu carried all three workspace verbs. Two of them had no business there: rename and remove act on a workspace someone has to pick, and a menu that shows the list one checked row at a time can only offer them for the current one — which is why they read as "Rename Workspace" with no name in them.

They move to **Settings ▸ Workspaces**, where every workspace is on screen and the verb can name its subject. That is the line Settings ▸ Devices already draws: connecting to a host is a launch and lives in the menus, configuring one lives in the pane.

Creating stays in both. The switcher is hidden until a second workspace exists, so a create verb reachable only from the pane would be reachable only by someone who already knew to look for it.

The switcher and File ▸ Workspace now read: the workspace rows, New Workspace…, a separator, Workspace Settings…

Rows carry one control at the trailing edge and say the rest in type — `.headline` over `.caption`, matching the Devices tab's grid.

Release Notes:
- Renaming and removing a workspace moved to Settings ▸ Workspaces, which lists every workspace at once. The sidebar switcher and File ▸ Workspace now open it with Workspace Settings…