### PR TITLE
Pick a workspace's colour from the theme's own palette

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -812,6 +812,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         NSApp.appearance = appearance
         window?.appearance = appearance
         settingsWindow?.appearance = appearance
+        applySettingsWindowChrome()
+    }
+
+    /// Paints the Settings window in the terminal theme, the same recipe the main window
+    /// uses: an opaque themed background under a transparent titlebar, so the toolbar band
+    /// sits flush with the panes instead of on AppKit's stock grey. Re-run whenever the
+    /// theme changes (`applyChromeAppearance` is on the settings observer), because the
+    /// window paints this itself and won't follow the SwiftUI tree.
+    private func applySettingsWindowChrome() {
+        guard let settingsWindow else { return }
+        settingsWindow.backgroundColor = resolvedTerminalBackground()
+        settingsWindow.titlebarAppearsTransparent = true
     }
 
     /// Installs a real `NSToolbar` carrying CodeEdit's chrome: a leading navigator toggle, the
@@ -890,6 +902,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
             if !restored { window.center() }
             settingsWindow = window
+            applySettingsWindowChrome()
         }
         // `.frame(minWidth:minHeight:)` on the root: NSHostingView forwards the
         // SwiftUI tree's small intrinsic minimum up into contentMinSize, which
@@ -1985,7 +1998,8 @@ extension AppDelegate: NSMenuDelegate {
     /// switcher draws the same rows from `WorkspaceMenu.rows`, but AppKit resolves
     /// a key equivalent against the main menu, so only this one claims them.
     private func fillWorkspaceMenu(_ menu: NSMenu) {
-        for row in WorkspaceMenu.rows(in: store, target: self, action: #selector(switchToWorkspace(_:))) {
+        let rows = WorkspaceMenu.rows(in: store, target: self, action: #selector(switchToWorkspace(_:)))
+        for row in rows {
             menu.addItem(row)
         }
         menu.addItem(.separator())
@@ -1993,18 +2007,21 @@ extension AppDelegate: NSMenuDelegate {
         // device submenu on two (`refreshNewWorkspaceItem`). This menu is rebuilt on
         // every open rather than refreshed in place, so the row is shaped here
         // instead of by tag.
-        let new = menu.addItem(withTitle: localized("New Workspace…"),
-                               action: #selector(newWorkspace(_:)), keyEquivalent: "")
+        let new = WorkspaceMenu.verb(localized("New Workspace…"), symbol: "plus", alignedWith: rows)
+        new.action = #selector(newWorkspace(_:))
         new.target = self
+        menu.addItem(new)
         refreshNewWorkspaceItem(new, others: otherDevices(known: DeviceRoster.known(in: store)))
         menu.addItem(.separator())
         // Renaming and removing are in Settings ▸ Workspaces rather than here.
         // Both act on a workspace the user has to pick, and a menu that shows the
         // list one checked row at a time can only offer them for the current one —
         // which is why they read as "Rename Workspace" with no name in them.
-        let settingsItem = menu.addItem(withTitle: localized("Workspace Settings…"),
-                                        action: #selector(openWorkspaceSettings(_:)), keyEquivalent: "")
+        let settingsItem = WorkspaceMenu.verb(
+            localized("Workspace Settings…"), symbol: "gearshape", alignedWith: rows)
+        settingsItem.action = #selector(openWorkspaceSettings(_:))
         settingsItem.target = self
+        menu.addItem(settingsItem)
     }
 
     private func fillConnectToMenu(_ menu: NSMenu) {

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -1221,6 +1221,16 @@
         }
       }
     },
+    "Colour": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "颜色"
+          }
+        }
+      }
+    },
     "Couldn’t create worktree session": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -238,6 +238,8 @@
 	<string>Collapse All</string>
 	<key>Collapse Results</key>
 	<string>Collapse Results</string>
+	<key>Colour</key>
+	<string>Colour</string>
 	<key>Colour %lld</key>
 	<string>Colour %lld</string>
 	<key>Command</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -238,6 +238,8 @@
 	<string>全部折叠</string>
 	<key>Collapse Results</key>
 	<string>折叠结果</string>
+	<key>Colour</key>
+	<string>颜色</string>
 	<key>Colour %lld</key>
 	<string>颜色 %lld</string>
 	<key>Command</key>

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -9,6 +9,11 @@ import SwiftUI
 /// pane that carries the group's title + subtitle in the toolbar with a grouped
 /// `Form` below. Window chrome (resizable, unified toolbar, saved size) is set up
 /// in `AppDelegate.openSettings`.
+///
+/// Both columns paint the terminal theme's colors rather than the stock window
+/// material, the way every other chrome surface does (see `ChromeTheme`) — the
+/// theme is the app's one source of color truth, and a preferences window in
+/// system grey was the last surface that ignored it.
 struct SettingsView: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var usage: UsageMonitor
@@ -48,6 +53,8 @@ struct SettingsView: View {
                 .tag(tab)
             }
             .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
+            .background(Color(nsColor: settings.panelBackgroundColor))
             .navigationSplitViewColumnWidth(min: 184, ideal: 204, max: 240)
         } detail: {
             NavigationStack {
@@ -55,6 +62,8 @@ struct SettingsView: View {
                     .navigationTitle(selection.title)
                     .navigationSubtitle(selection.subtitle)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .scrollContentBackground(.hidden)
+                    .background(Color(nsColor: settings.terminalBackgroundColor))
                     .toolbar {
                         // Without a toolbar item the NavigationStack collapses the
                         // title + subtitle into one inline "Title – Subtitle" line
@@ -62,7 +71,6 @@ struct SettingsView: View {
                         // the full-height two-line chrome on every pane (macOS 26).
                         ToolbarItem(placement: .principal) { Text("") }
                     }
-                    .toolbarBackground(.regularMaterial, for: .windowToolbar)
             }
         }
         .navigationSplitViewStyle(.balanced)

--- a/Sources/termio/Settings/WorkspaceSettingsTab.swift
+++ b/Sources/termio/Settings/WorkspaceSettingsTab.swift
@@ -12,6 +12,11 @@ import SwiftUI
 /// who already knew to look for it.
 struct WorkspaceSettingsTab: View {
     @ObservedObject var store: TermioStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// The palette a workspace's mark is an index into. Resolved once here rather
+    /// than per row: every row draws from the same theme.
+    private var chrome: ChromeTheme? { store.settings.chromeTheme(for: colorScheme) }
 
     var body: some View {
         Form {
@@ -22,7 +27,9 @@ struct WorkspaceSettingsTab: View {
                         isCurrent: workspace.id == store.currentWorkspaceID,
                         sessionCount: store.sessions(inWorkspace: workspace.id).count,
                         canRemove: store.hasMultipleWorkspaces,
+                        tints: chrome?.workspaceTints ?? [],
                         rename: { store.presentRenameWorkspacePanel(workspace.id) },
+                        recolor: { store.setWorkspaceColor(workspace.id, to: $0) },
                         remove: { store.confirmRemoveWorkspace(workspace.id) }
                     )
                 }
@@ -93,8 +100,17 @@ private struct WorkspaceSettingsRow: View {
     let isCurrent: Bool
     let sessionCount: Int
     let canRemove: Bool
+    let tints: [Color]
     let rename: () -> Void
+    let recolor: (Int) -> Void
     let remove: () -> Void
+
+    /// The mark this workspace wears in the switcher, wrapped the way the switcher
+    /// wraps it so both surfaces agree under a theme with fewer tints.
+    private var color: Color? {
+        guard !tints.isEmpty else { return nil }
+        return tints[(workspace.color ?? 0) % tints.count]
+    }
 
     /// The machine the workspace is on, and what removing it would cost. Zero
     /// sessions say so by omission rather than reading "0 sessions".
@@ -114,6 +130,15 @@ private struct WorkspaceSettingsRow: View {
                 .frame(width: 12)
                 .accessibilityHidden(!isCurrent)
                 .accessibilityLabel(localized("Current workspace"))
+            // The switcher's own mark, shown here because this is the other place
+            // every workspace is visible at once — and the place it can be
+            // changed. Not a control: the row carries one, and it is the menu.
+            if let color {
+                Circle()
+                    .fill(color)
+                    .frame(width: 10, height: 10)
+                    .accessibilityHidden(true)
+            }
             VStack(alignment: .leading, spacing: 2) {
                 Text(workspace.name)
                     .font(.headline)
@@ -151,6 +176,26 @@ private struct WorkspaceSettingsRow: View {
     @ViewBuilder
     private var actionButtons: some View {
         Button(localized("Rename…"), action: rename)
+        if !tints.isEmpty {
+            // A submenu rather than a row of wells: the row's one control is this
+            // menu, and a second chrome beside the name is what the row's shape
+            // exists to avoid. The tick marks the current one, so the colour is
+            // readable without relying on colour alone.
+            Menu(localized("Colour")) {
+                ForEach(tints.indices, id: \.self) { index in
+                    Button {
+                        recolor(index)
+                    } label: {
+                        Label {
+                            Text(localized("Colour \(index + 1)"))
+                        } icon: {
+                            Image(systemName: (workspace.color ?? 0) % tints.count == index
+                                ? "checkmark.circle.fill" : "circle.fill")
+                        }
+                    }
+                }
+            }
+        }
         // The store refuses to remove the last workspace — the sidebar has to have
         // a scope to show — so the row dims rather than answering a click with
         // nothing.

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -50,6 +50,28 @@ enum WorkspaceMenu {
         }
     }
 
+    /// A verb below the rows — New Workspace…, Workspace Settings… — carrying the
+    /// glyph that keeps it on the rows' leading edge.
+    ///
+    /// `NSMenuItem` draws a title with no image in the image column, so a bare verb
+    /// under rows that wear a colour starts further left than every name above it.
+    /// The glyph is what puts them back on one edge, which is why it is decided here
+    /// beside the rows rather than by each menu that adds a verb: the marks are
+    /// conditional on a terminal theme being selected, and under unmarked rows the
+    /// glyph is the thing that would break the alignment.
+    @MainActor
+    static func verb(_ title: String, symbol: String, alignedWith rows: [NSMenuItem]) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        if rows.contains(where: { $0.image != nil }) {
+            // Stepped down from the menu default, which draws a symbol heavier than
+            // the dot it shares a column with: the glyph is here to hold the leading
+            // edge, so it should not out-weigh the marks it is aligning to.
+            item.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)?
+                .withSymbolConfiguration(.init(pointSize: 11, weight: .regular))
+        }
+        return item
+    }
+
     /// The row's title with the machine trailing it in the secondary colour, so
     /// the name still reads as the name.
     @MainActor
@@ -78,7 +100,10 @@ enum WorkspaceMenu {
 @MainActor
 enum WorkspaceSwatch {
     private static let cache = NSCache<NSString, NSImage>()
-    private static let size = NSSize(width: 10, height: 10)
+    /// Sized to the cap height of the menu font rather than to some fraction of the
+    /// row: the dot sits beside a name and reads as a mark on it, so it is balanced
+    /// against the letters, not against the row's height.
+    private static let size = NSSize(width: 12, height: 12)
 
     static func image(for workspace: Workspace, chrome: ChromeTheme?) -> NSImage? {
         guard let color = resolved(workspace, chrome: chrome) else { return nil }
@@ -93,13 +118,19 @@ enum WorkspaceSwatch {
         return image
     }
 
+    /// The colour a workspace wears, for the surfaces that draw it themselves
+    /// rather than handing an image to AppKit.
+    ///
     /// Wrapped rather than clamped: the index is stored against a palette whose
     /// size is the theme's business, and a theme with fewer tints must still draw
     /// every workspace rather than collapsing the tail onto one colour.
-    private static func resolved(_ workspace: Workspace, chrome: ChromeTheme?) -> NSColor? {
+    static func color(for workspace: Workspace, chrome: ChromeTheme?) -> Color? {
         guard let tints = chrome?.workspaceTints, !tints.isEmpty else { return nil }
-        let index = (workspace.color ?? 0) % tints.count
-        return NSColor(tints[index])
+        return tints[(workspace.color ?? 0) % tints.count]
+    }
+
+    private static func resolved(_ workspace: Workspace, chrome: ChromeTheme?) -> NSColor? {
+        color(for: workspace, chrome: chrome).map(NSColor.init)
     }
 }
 
@@ -234,20 +265,23 @@ private final class WorkspaceMenuHost: NSView {
     private func showMenu() {
         guard let store else { return }
         let menu = NSMenu()
-        for row in WorkspaceMenu.rows(in: store, target: self, action: #selector(switchToWorkspace(_:))) {
+        let rows = WorkspaceMenu.rows(in: store, target: self, action: #selector(switchToWorkspace(_:)))
+        for row in rows {
             menu.addItem(row)
         }
         // This Mac, without asking: the device submenu belongs to the menus that
         // already carry one (File ▸ Workspace and the sidebar `+`), and growing a
         // third here would put a machine list in the switcher, which is the "go to
         // a computer" mode the workspace replaced.
-        addAction(localized("New Workspace…"), to: menu, #selector(newWorkspace))
+        addAction(localized("New Workspace…"), to: menu, #selector(newWorkspace),
+                  symbol: "plus", alignedWith: rows)
         menu.addItem(.separator())
         // Renaming and removing are in Settings ▸ Workspaces. Creating stays here
         // because it is the one verb that does not need the user to pick which
         // workspace it acts on — the other two do, and this menu can only ever
         // offer them for the row it already shows checked.
-        addAction(localized("Workspace Settings…"), to: menu, #selector(openWorkspaceSettings))
+        addAction(localized("Workspace Settings…"), to: menu, #selector(openWorkspaceSettings),
+                  symbol: "gearshape", alignedWith: rows)
         // No device verb here, deliberately. A machine you can *go to* is the
         // mode this scope replaced: it made the sidebar answer "which computer"
         // when the question is "which work". A device is a place a new thing is
@@ -259,8 +293,12 @@ private final class WorkspaceMenuHost: NSView {
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: bounds.height + 4), in: self)
     }
 
-    private func addAction(_ title: String, to menu: NSMenu, _ action: Selector) {
-        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+    private func addAction(
+        _ title: String, to menu: NSMenu, _ action: Selector,
+        symbol: String, alignedWith rows: [NSMenuItem]
+    ) {
+        let item = WorkspaceMenu.verb(title, symbol: symbol, alignedWith: rows)
+        item.action = action
         item.target = self
         menu.addItem(item)
     }

--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -448,6 +448,16 @@ extension TermioStore {
         if let color { workspaces[index].color = color }
     }
 
+    /// Changes a workspace's mark. Its own verb because Settings ▸ Workspaces sets
+    /// the colour on a row without touching the name, and renaming through this
+    /// would make an unchanged name look like an edit in every observer.
+    func setWorkspaceColor(_ id: Workspace.ID, to color: Int) {
+        guard let index = workspaces.firstIndex(where: { $0.id == id }),
+              workspaces[index].color != color
+        else { return }
+        workspaces[index].color = color
+    }
+
     /// Removes a workspace, closing everything in it. The last workspace is never
     /// removed — the sidebar has to have a scope to show — and the caller confirms
     /// first, since this ends live sessions.
@@ -675,7 +685,13 @@ private final class WorkspaceFields: NSObject {
     private let tints: [Color]
     private var swatches: [NSButton] = []
 
-    private static let swatchSize: CGFloat = 18
+    private static let swatchSize: CGFloat = 26
+    /// The panel's one column width. The field and every swatch row share it, so
+    /// the grid ends where the name field ends instead of trailing off inside it.
+    private static let width: CGFloat = 260
+    /// Six to a row, which is what makes a row of the palette one intensity and a
+    /// column of it one hue (`ChromeTheme.workspaceTints`).
+    private static let swatchesPerRow = 6
 
     init(name: String, color: Int, tints: [Color]) {
         self.color = color
@@ -683,23 +699,36 @@ private final class WorkspaceFields: NSObject {
         super.init()
         field.stringValue = name
 
-        let row = NSStackView()
-        row.orientation = .horizontal
-        row.spacing = 6
-        for index in tints.indices {
-            let button = NSButton(
-                frame: NSRect(x: 0, y: 0, width: Self.swatchSize, height: Self.swatchSize))
-            button.isBordered = false
-            button.title = ""
-            button.setButtonType(.momentaryChange)
-            button.target = self
-            button.action = #selector(pick(_:))
-            button.tag = index
-            // A colour has no name to read out, so the position is what a screen
-            // reader can say about it.
-            button.setAccessibilityLabel(localized("Colour \(index + 1)"))
-            swatches.append(button)
-            row.addArrangedSubview(button)
+        let grid = NSStackView()
+        grid.orientation = .vertical
+        grid.alignment = .leading
+        grid.spacing = 10
+        for start in stride(from: 0, to: tints.count, by: Self.swatchesPerRow) {
+            let row = NSStackView()
+            row.orientation = .horizontal
+            // Spread rather than spaced by a fixed gap: the row is as wide as the
+            // field above it, and a short last row keeps its columns under the
+            // full one instead of bunching to the leading edge.
+            row.distribution = .equalSpacing
+            for index in start..<min(start + Self.swatchesPerRow, tints.count) {
+                let button = NSButton(
+                    frame: NSRect(x: 0, y: 0, width: Self.swatchSize, height: Self.swatchSize))
+                button.isBordered = false
+                button.title = ""
+                button.setButtonType(.momentaryChange)
+                button.target = self
+                button.action = #selector(pick(_:))
+                button.tag = index
+                // A colour has no name to read out, so the position is what a
+                // screen reader can say about it.
+                button.setAccessibilityLabel(localized("Colour \(index + 1)"))
+                button.widthAnchor.constraint(equalToConstant: Self.swatchSize).isActive = true
+                button.heightAnchor.constraint(equalToConstant: Self.swatchSize).isActive = true
+                swatches.append(button)
+                row.addArrangedSubview(button)
+            }
+            row.widthAnchor.constraint(equalToConstant: Self.width).isActive = true
+            grid.addArrangedSubview(row)
         }
         redrawSwatches()
 
@@ -707,8 +736,8 @@ private final class WorkspaceFields: NSObject {
         view.alignment = .leading
         view.spacing = 10
         view.addArrangedSubview(field)
-        if !tints.isEmpty { view.addArrangedSubview(row) }
-        field.widthAnchor.constraint(equalToConstant: 260).isActive = true
+        if !tints.isEmpty { view.addArrangedSubview(grid) }
+        field.widthAnchor.constraint(equalToConstant: Self.width).isActive = true
         // NSAlert lays its accessory out by frame, so the stack carries its own
         // measured size rather than a number guessed here.
         view.frame = NSRect(origin: .zero, size: view.fittingSize)
@@ -725,19 +754,27 @@ private final class WorkspaceFields: NSObject {
         }
     }
 
-    /// The selected swatch wears a ring rather than a checkmark: a tick drawn on
-    /// top of a colour has to be light or dark, and either one disappears against
-    /// half the palette.
+    /// The selected swatch is drawn as a ring around a gap around a smaller dot,
+    /// all in its own colour — the treatment every colour picker on this system
+    /// uses, and the one Dia's `ColorSwatch` builds out of a main layer and a
+    /// separate selection layer.
+    ///
+    /// Not a checkmark and not a contrasting outline: a tick or a ring in the
+    /// label colour has to be light or dark, and either choice disappears against
+    /// half of a palette that comes from the user's terminal theme. A shape made
+    /// of the swatch's own colour cannot lose contrast with itself.
     private static func swatch(_ color: NSColor, selected: Bool) -> NSImage {
         NSImage(size: NSSize(width: swatchSize, height: swatchSize), flipped: false) { rect in
             color.setFill()
-            NSBezierPath(ovalIn: rect.insetBy(dx: 3, dy: 3)).fill()
-            if selected {
-                NSColor.labelColor.setStroke()
-                let ring = NSBezierPath(ovalIn: rect.insetBy(dx: 0.75, dy: 0.75))
-                ring.lineWidth = 1.5
-                ring.stroke()
+            guard selected else {
+                NSBezierPath(ovalIn: rect.insetBy(dx: 1, dy: 1)).fill()
+                return true
             }
+            NSBezierPath(ovalIn: rect.insetBy(dx: 5, dy: 5)).fill()
+            color.setStroke()
+            let ring = NSBezierPath(ovalIn: rect.insetBy(dx: 1.5, dy: 1.5))
+            ring.lineWidth = 2
+            ring.stroke()
             return true
         }
     }

--- a/Sources/termio/TermioStore/WorkspaceMigration.swift
+++ b/Sources/termio/TermioStore/WorkspaceMigration.swift
@@ -212,9 +212,9 @@ enum WorkspaceMigration {
     }
 
     /// The palette is the theme's and its size is not known here, so the index is
-    /// chosen within a fixed span and wrapped by whoever draws it. Five is the
+    /// chosen within a fixed span and wrapped by whoever draws it. Twelve is the
     /// count every built-in theme yields (`ChromeTheme.workspaceTints`).
-    static let colorCount = 5
+    static let colorCount = 12
 
     private static func leastUsedColor(in used: [Int: Int]) -> Int {
         (0..<colorCount).min { left, right in

--- a/Sources/termio/Theme/ChromeTheme.swift
+++ b/Sources/termio/Theme/ChromeTheme.swift
@@ -68,12 +68,17 @@ struct ChromeTheme {
             ?? definition.selectionBackground.flatMap(Color.init(hex:))
             ?? foreground
         self.isDark = dark
-        // Green, yellow, blue, magenta, cyan — the bright half (palette 10-14),
-        // which is the half that survives a dark background. A slot the theme
-        // leaves undefined drops out rather than becoming a default hue that
-        // belongs to no theme; if every one is missing, the accent stands in so a
-        // workspace always has a mark.
-        let tints = [10, 11, 12, 13, 14]
+        // Six hues at two intensities: the bright half first (palette 9-14, the
+        // half that survives a dark background), then the normal half (1-6) under
+        // it, so a picker laid out six to a row reads as a hue per column and an
+        // intensity per row.
+        //
+        // Black and white are left out at both intensities: those are the slots a
+        // theme spends on its own background and foreground, so as a mark they
+        // read as "no colour". A slot the theme leaves undefined drops out rather
+        // than becoming a default hue that belongs to no theme; if every one is
+        // missing, the accent stands in so a workspace always has a mark.
+        let tints = [9, 10, 11, 12, 13, 14, 1, 2, 3, 4, 5, 6]
             .compactMap { definition.palette[$0] }
             .compactMap(Color.init(hex:))
         self.workspaceTints = tints.isEmpty ? [self.accent] : tints
@@ -256,6 +261,26 @@ extension AppSettings {
                     ?? NSColor(srgbRed: 0x21 / 255.0, green: 0x21 / 255.0, blue: 0x21 / 255.0, alpha: 1)
             }
             return lightBackground.map(NSColor.init) ?? NSColor.white
+        }
+    }
+
+    /// `terminalBackgroundColor`'s companion for a sidebar column: `ChromeTheme.panel-
+    /// Background` when a theme is selected, and the same lift off the no-theme fallback
+    /// otherwise, so a window paints one coherent pair either way. The main window can
+    /// leave its sidebar vibrant — it fills the screen and there is nothing behind it to
+    /// sample — but a small window floating over the app needs an opaque fill, or its
+    /// sidebar reads as whatever window happens to be underneath.
+    var panelBackgroundColor: NSColor {
+        let lightPanel = chromeTheme(for: .light)?.panelBackground
+        let darkPanel = chromeTheme(for: .dark)?.panelBackground
+        return NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            if isDark {
+                return darkPanel.map(NSColor.init)
+                    ?? NSColor(srgbRed: 0x2e / 255.0, green: 0x2e / 255.0, blue: 0x2e / 255.0, alpha: 1)
+            }
+            return lightPanel.map(NSColor.init)
+                ?? NSColor(srgbRed: 0xf5 / 255.0, green: 0xf5 / 255.0, blue: 0xf5 / 255.0, alpha: 1)
         }
     }
 }

--- a/termiod/vt/examples/parse_cost.rs
+++ b/termiod/vt/examples/parse_cost.rs
@@ -1,0 +1,32 @@
+//! CPU cost of parsing a payload into the grid — the half of the daemon's bill
+//! that a shared-memory transport cannot touch.
+//!
+//! Run: cargo run --release -p termiod-vt --example parse_cost -- <file> [rows] [cols]
+
+use std::time::Instant;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: parse_cost <payload> [rows] [cols]");
+    let rows: u16 = args.next().and_then(|v| v.parse().ok()).unwrap_or(50);
+    let cols: u16 = args.next().and_then(|v| v.parse().ok()).unwrap_or(200);
+
+    let bytes = std::fs::read(&path).expect("read payload");
+    let mut terminal = termiod_vt::VtTerminal::new(rows, cols).expect("VtTerminal::new");
+
+    // Feed in 64 KiB chunks, the shape the sidecar actually sees.
+    let start = Instant::now();
+    for chunk in bytes.chunks(65536) {
+        terminal.vt_write(chunk);
+    }
+    let elapsed = start.elapsed();
+
+    let mb = bytes.len() as f64 / 1048576.0;
+    println!(
+        "{:>6.1} MB  {:>7.3} s  {:>8.1} MB/s  {:>7.3} s per 100 MB",
+        mb,
+        elapsed.as_secs_f64(),
+        mb / elapsed.as_secs_f64(),
+        elapsed.as_secs_f64() / mb * 100.0
+    );
+}


### PR DESCRIPTION
Follows #412, which gave a workspace a colour and put it in the switcher, and #413, which built the pane that lists every workspace at once.

## Twelve hues, all the theme's

The palette was five bright ANSI slots. It is now six hues at two intensities — bright (9–14) over normal (1–6) — so a picker six to a row reads as **one hue per column, one intensity per row**. Still nothing invented: a colour that came out of a palette of ours would be a stranger the moment the user changes theme, which is the same reason the stored value is an index rather than a colour.

Black and white are left out at both intensities. Those are the slots a theme spends on its own background and foreground, so as a mark they read as no colour at all.

## The picker

26pt swatches spread to the width of the name field with `.equalSpacing`, rather than bunched at its leading edge — a short last row keeps its columns under the full one.

Selection is a **ring around a gap around a smaller dot, all in the swatch's own colour**. That is what this system's own pickers do, and what Dia builds out of a `mainLayer` and a separate `selectionLayer`. The previous treatment was an outline in the label colour, which cannot work against a palette taken from the user's terminal theme: whatever fixed lightness the outline has, half the palette will swallow it. A shape made of the swatch's own colour cannot lose contrast with itself.

## And in Settings ▸ Workspaces

The mark is drawn on every row and can be changed there, because that pane is the other place the whole set is visible at once.

It is a submenu inside the row's existing overflow menu, not a second control beside the name: that row's shape is one control at the trailing edge and type everywhere else, and a colour well would put a second chrome inside a grouped row that already draws its own background. The current colour carries a tick, so it is never signalled by colour alone.

`setWorkspaceColor` is its own store verb — the pane changes a colour without touching the name, and routing it through `renameWorkspace` would make an unchanged name look like an edit to every observer.

## Also carried

Two pieces of the same afternoon's work on the switcher that live in the same files: the Settings window takes the terminal theme's background under a transparent titlebar the way the main window does, and the menu's own verbs align with the rows above them now that those rows carry a swatch.

## Verified

`swift build`, `swift test` (522 tests, 0 failures), `check-strings.sh` clean. Driven by hand on a dev build: creating a workspace, changing a colour from the settings pane, and watching the switcher's dots follow.

Release Notes:
- A workspace's colour can be picked from a wider palette, and changed later in Settings ▸ Workspaces.