### PR TITLE
Drop the workspace colour

### DIFF
--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -129,20 +129,6 @@ struct Workspace: Identifiable, Hashable, Codable {
     /// unknown stays safe.
     var isAutoCreated: Bool?
 
-    /// Which of the theme's workspace tints marks this scope in the switcher, as
-    /// an index rather than a colour.
-    ///
-    /// An index because the palette is the terminal theme's, not ours
-    /// (`ChromeTheme.workspaceTints`): storing the resolved colour would freeze a
-    /// scope into the theme it was made under, and a workspace should re-skin
-    /// with everything else. It is also what makes the choice survivable — a hex
-    /// picked out of one palette is a stranger in the next one.
-    ///
-    /// `nil` only until `WorkspaceMigration.reconcile` fills it, which it does on
-    /// every load, so nothing downstream has to invent a colour for a workspace
-    /// written before this existed.
-    var color: Int?
-
     /// Every session the workspace owns directly. Its projects' sessions are not
     /// here — they belong to the project.
     var looseSessions: [Session] { terminals + chats }
@@ -169,7 +155,7 @@ struct Workspace: Identifiable, Hashable, Codable {
 
 extension Workspace {
     private enum CodingKeys: String, CodingKey {
-        case id, name, terminals, chats, deviceAlias, deviceID, isAutoCreated, color
+        case id, name, terminals, chats, deviceAlias, deviceID, isAutoCreated
     }
 
     /// Missing collections take their empty defaults so a workspace written by an
@@ -185,7 +171,6 @@ extension Workspace {
         deviceAlias = try c.decodeIfPresent(String.self, forKey: .deviceAlias)
         deviceID = try c.decodeIfPresent(String.self, forKey: .deviceID)
         isAutoCreated = try c.decodeIfPresent(Bool.self, forKey: .isAutoCreated)
-        color = try c.decodeIfPresent(Int.self, forKey: .color)
     }
 
     /// First-run state for a fresh install: one workspace holding one shell, so a

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -1211,16 +1211,6 @@
         }
       }
     },
-    "Colour %lld": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "颜色 %lld"
-          }
-        }
-      }
-    },
     "Couldn’t create worktree session": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -238,8 +238,6 @@
 	<string>Collapse All</string>
 	<key>Collapse Results</key>
 	<string>Collapse Results</string>
-	<key>Colour %lld</key>
-	<string>Colour %lld</string>
 	<key>Command</key>
 	<string>Command</string>
 	<key>Command Palette…</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -238,8 +238,6 @@
 	<string>全部折叠</string>
 	<key>Collapse Results</key>
 	<string>折叠结果</string>
-	<key>Colour %lld</key>
-	<string>颜色 %lld</string>
 	<key>Command</key>
 	<string>命令</string>
 	<key>Command Palette…</key>

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -19,10 +19,6 @@ enum WorkspaceMenu {
     @MainActor
     static func rows(in store: TermioStore, target: AnyObject, action: Selector) -> [NSMenuItem] {
         let shortcuts = KeybindingStore.workspaceShortcuts
-        // The menu is AppKit and has no SwiftUI environment to read the
-        // appearance from, so it asks the window that is showing it.
-        let dark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let chrome = store.settings.chromeTheme(for: dark ? .dark : .light)
         return store.orderedWorkspaces.enumerated().map { index, workspace in
             let item = NSMenuItem(title: workspace.name, action: action, keyEquivalent: "")
             if index < shortcuts.count {
@@ -32,16 +28,10 @@ enum WorkspaceMenu {
             item.target = target
             item.representedObject = workspace.id.uuidString
             item.state = workspace.id == store.currentWorkspaceID ? .on : .off
-            // The scope's own colour. This is the one place every workspace is
-            // visible at once, which is the only place a colour can be read
-            // without having been memorised — the menu is its own legend. Drawn
-            // nowhere else: inside a workspace every row belongs to it, so the
-            // same hue repeated down the sidebar would say nothing.
-            item.image = WorkspaceSwatch.image(for: workspace, chrome: chrome)
             // Which machine, in words, and only when the name does not already
             // say it — an auto-created workspace *is* named after its alias.
-            // Words rather than a second mark: the row has one image slot and the
-            // colour has it, and a machine's name is the thing a person types.
+            // In words rather than as a mark: a machine's name is the thing a
+            // person types, and the row has the room for it.
             if let alias = workspace.deviceAlias,
                !workspace.name.localizedCaseInsensitiveContains(alias) {
                 item.attributedTitle = titled(workspace.name, on: alias)
@@ -64,42 +54,6 @@ enum WorkspaceMenu {
                 .foregroundColor: NSColor.secondaryLabelColor,
             ]))
         return title
-    }
-}
-
-/// The dot a workspace wears in the switcher, rendered once per colour and kept.
-///
-/// Menus are rebuilt on every open (`menuNeedsUpdate`), so a swatch drawn per row
-/// per open is the same handful of images made over and over. The cache is keyed
-/// by the colour it drew, not by the workspace, because two scopes sharing a hue
-/// share the picture — and because a key that *is* the colour needs no
-/// invalidation when the theme changes: the same index resolves to a different
-/// colour, which is a different key.
-@MainActor
-enum WorkspaceSwatch {
-    private static let cache = NSCache<NSString, NSImage>()
-    private static let size = NSSize(width: 10, height: 10)
-
-    static func image(for workspace: Workspace, chrome: ChromeTheme?) -> NSImage? {
-        guard let color = resolved(workspace, chrome: chrome) else { return nil }
-        let key = NSString(string: color.description)
-        if let cached = cache.object(forKey: key) { return cached }
-        let image = NSImage(size: size, flipped: false) { rect in
-            color.setFill()
-            NSBezierPath(ovalIn: rect.insetBy(dx: 1, dy: 1)).fill()
-            return true
-        }
-        cache.setObject(image, forKey: key)
-        return image
-    }
-
-    /// Wrapped rather than clamped: the index is stored against a palette whose
-    /// size is the theme's business, and a theme with fewer tints must still draw
-    /// every workspace rather than collapsing the tail onto one colour.
-    private static func resolved(_ workspace: Workspace, chrome: ChromeTheme?) -> NSColor? {
-        guard let tints = chrome?.workspaceTints, !tints.isEmpty else { return nil }
-        let index = (workspace.color ?? 0) % tints.count
-        return NSColor(tints[index])
     }
 }
 

--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -416,9 +416,7 @@ extension TermioStore {
     /// it is what authorises sweeping an empty one away. A workspace someone asked
     /// for is theirs even while it holds nothing.
     @discardableResult
-    func addWorkspace(named name: String, on device: WorkspaceDevice, color: Int? = nil)
-        -> Workspace.ID
-    {
+    func addWorkspace(named name: String, on device: WorkspaceDevice) -> Workspace.ID {
         let workspace = Workspace(
             name: name,
             deviceAlias: device.alias,
@@ -428,8 +426,7 @@ extension TermioStore {
             deviceID: device.alias.flatMap {
                 TermiodDeviceRegistry.shared.deviceID(for: TermiodRoute(sshAlias: $0))
             },
-            isAutoCreated: false,
-            color: color)
+            isAutoCreated: false)
         workspaces.append(workspace)
         currentWorkspaceID = workspace.id
         settings.currentWorkspaceID = workspace.id
@@ -439,13 +436,10 @@ extension TermioStore {
         return workspace.id
     }
 
-    func renameWorkspace(_ id: Workspace.ID, to name: String, color: Int? = nil) {
+    func renameWorkspace(_ id: Workspace.ID, to name: String) {
         let name = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty, let index = workspaces.firstIndex(where: { $0.id == id }) else { return }
         workspaces[index].name = name
-        // The same panel carries both, so renaming is also where a scope's colour
-        // is changed — there is no second dialog for one control.
-        if let color { workspaces[index].color = color }
     }
 
     /// Removes a workspace, closing everything in it. The last workspace is never
@@ -519,13 +513,13 @@ extension TermioStore {
             title = localized("New Workspace")
             message = localized("Name the workspace. It starts empty; sessions and projects you open on this Mac from now on are filed under it.")
         }
-        guard let chosen = promptForWorkspaceName(
+        guard let name = promptForWorkspaceName(
             title: title,
             message: message,
             confirm: localized("Create"),
             defaultName: nextFreeWorkspaceName
         ) else { return }
-        addWorkspace(named: chosen.name, on: device, color: chosen.color)
+        addWorkspace(named: name, on: device)
     }
 
     /// What the new-workspace field opens with: "Workspace", bumped past the names
@@ -555,14 +549,13 @@ extension TermioStore {
     /// other — the alias is what identifies it, not the label.
     func presentRenameWorkspacePanel(_ id: Workspace.ID) {
         guard let workspace = workspaces.first(where: { $0.id == id }) else { return }
-        guard let chosen = promptForWorkspaceName(
+        guard let name = promptForWorkspaceName(
             title: localized("Rename Workspace"),
             message: localized("Choose a name for this workspace."),
             confirm: localized("Rename"),
-            defaultName: workspace.name,
-            color: workspace.color
+            defaultName: workspace.name
         ) else { return }
-        renameWorkspace(id, to: chosen.name, color: chosen.color)
+        renameWorkspace(id, to: name)
     }
 
     /// Confirms before removing a workspace, because it closes every session in
@@ -589,34 +582,21 @@ extension TermioStore {
     /// A one-field name prompt, the same `NSAlert` shape the worktree and rename
     /// prompts use. Returns the trimmed entry, or `nil` if cancelled or emptied.
     private func promptForWorkspaceName(
-        title: String, message: String, confirm: String, defaultName: String,
-        color: Int? = nil
-    ) -> (name: String, color: Int)? {
+        title: String, message: String, confirm: String, defaultName: String
+    ) -> String? {
         let alert = NSAlert()
         alert.messageText = title
         alert.informativeText = message
         alert.addButton(withTitle: confirm)
         alert.addButton(withTitle: localized("Cancel"))
-
-        // The colour arrives already chosen — the least-used one, the same rule
-        // that fills it in for every workspace written before there were colours.
-        // So this is a decision the user may change, never one they must make:
-        // the panel opens with the name selected and Return still creates.
-        let fields = WorkspaceFields(
-            name: defaultName,
-            color: color ?? WorkspaceMigration.assigningColors(workspaces + [Workspace(name: "")])
-                .last?.color ?? 0,
-            tints: settings.chromeTheme(for: appearanceIsDark ? .dark : .light)?.workspaceTints ?? [])
-        alert.accessoryView = fields.view
-        alert.window.initialFirstResponder = fields.field
-        fields.field.selectText(nil)
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 24))
+        field.stringValue = defaultName
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+        field.selectText(nil)
         guard alert.runModal() == .alertFirstButtonReturn else { return nil }
-        let name = fields.field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        return name.isEmpty ? nil : (name, fields.color)
-    }
-
-    private var appearanceIsDark: Bool {
-        NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let name = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
     }
 
     // MARK: - The machine fallback
@@ -654,91 +634,5 @@ extension TermioStore {
             name: alias, deviceAlias: alias, deviceID: deviceID, isAutoCreated: true)
         workspaces.append(workspace)
         return workspace.id
-    }
-}
-
-/// The new-workspace panel's accessory: the name, and the colour the scope wears
-/// in the switcher.
-///
-/// The colour is a row of swatches rather than a pop-up because there are five of
-/// them and they are the thing being chosen — a menu would hide the choice behind
-/// a click and show a word for a colour. One arrives already selected, so the
-/// panel is still a name field that Return commits.
-///
-/// A class rather than a few locals because the alert runs modally and the
-/// swatches have to keep answering clicks while it is up.
-@MainActor
-private final class WorkspaceFields: NSObject {
-    let view = NSStackView()
-    let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 24))
-    private(set) var color: Int
-    private let tints: [Color]
-    private var swatches: [NSButton] = []
-
-    private static let swatchSize: CGFloat = 18
-
-    init(name: String, color: Int, tints: [Color]) {
-        self.color = color
-        self.tints = tints
-        super.init()
-        field.stringValue = name
-
-        let row = NSStackView()
-        row.orientation = .horizontal
-        row.spacing = 6
-        for index in tints.indices {
-            let button = NSButton(
-                frame: NSRect(x: 0, y: 0, width: Self.swatchSize, height: Self.swatchSize))
-            button.isBordered = false
-            button.title = ""
-            button.setButtonType(.momentaryChange)
-            button.target = self
-            button.action = #selector(pick(_:))
-            button.tag = index
-            // A colour has no name to read out, so the position is what a screen
-            // reader can say about it.
-            button.setAccessibilityLabel(localized("Colour \(index + 1)"))
-            swatches.append(button)
-            row.addArrangedSubview(button)
-        }
-        redrawSwatches()
-
-        view.orientation = .vertical
-        view.alignment = .leading
-        view.spacing = 10
-        view.addArrangedSubview(field)
-        if !tints.isEmpty { view.addArrangedSubview(row) }
-        field.widthAnchor.constraint(equalToConstant: 260).isActive = true
-        // NSAlert lays its accessory out by frame, so the stack carries its own
-        // measured size rather than a number guessed here.
-        view.frame = NSRect(origin: .zero, size: view.fittingSize)
-    }
-
-    @objc private func pick(_ sender: NSButton) {
-        color = sender.tag
-        redrawSwatches()
-    }
-
-    private func redrawSwatches() {
-        for (index, button) in zip(tints.indices, swatches) {
-            button.image = Self.swatch(NSColor(tints[index]), selected: index == color)
-        }
-    }
-
-    /// The selected swatch wears a ring rather than a checkmark: a tick drawn on
-    /// top of a colour has to be light or dark, and either one disappears against
-    /// half the palette.
-    private static func swatch(_ color: NSColor, selected: Bool) -> NSImage {
-        NSImage(size: NSSize(width: swatchSize, height: swatchSize), flipped: false) { rect in
-            color.setFill()
-            NSBezierPath(ovalIn: rect.insetBy(dx: 3, dy: 3)).fill()
-            if selected {
-                NSColor.labelColor.setStroke()
-                let ring = NSBezierPath(ovalIn: rect.insetBy(dx: 0.75, dy: 0.75))
-                ring.lineWidth = 1.5
-                ring.stroke()
-            }
-            return true
-        }
     }
 }

--- a/Sources/termio/TermioStore/WorkspaceMigration.swift
+++ b/Sources/termio/TermioStore/WorkspaceMigration.swift
@@ -177,52 +177,7 @@ enum WorkspaceMigration {
             project.workspaceID = fallbackID
             return project
         }
-        // A colour for every workspace, including the ones written before there
-        // were any and the halves the split below has just minted. Assigned
-        // rather than derived from the id: a hash repeats often enough to notice
-        // with a palette this small, and the point of the mark is that two rows
-        // differ.
-        //
-        // After the split, not before — that is the whole of the idempotence.
-        // Colouring first left a fresh half with none, so the *next* load filled
-        // it in and the tree came back changed; `reconcile` runs on every launch,
-        // and a pass that keeps finding work is a sidebar that reshuffles itself.
-        let settled = stampingDevices(workspaces: workspaces, projects: filed)
-        return (assigningColors(settled.workspaces), settled.projects)
-    }
-
-    /// Fills in a tint for every workspace that has none, choosing the one the
-    /// fewest others already carry so a small palette spreads before it repeats.
-    ///
-    /// Order-independent: the workspaces that already chose are counted first, so
-    /// the answer does not depend on which end of the list is walked.
-    static func assigningColors(_ workspaces: [Workspace]) -> [Workspace] {
-        var used: [Int: Int] = [:]
-        for workspace in workspaces {
-            if let color = workspace.color { used[color, default: 0] += 1 }
-        }
-        return workspaces.map { workspace in
-            guard workspace.color == nil else { return workspace }
-            var workspace = workspace
-            let color = leastUsedColor(in: used)
-            used[color, default: 0] += 1
-            workspace.color = color
-            return workspace
-        }
-    }
-
-    /// The palette is the theme's and its size is not known here, so the index is
-    /// chosen within a fixed span and wrapped by whoever draws it. Five is the
-    /// count every built-in theme yields (`ChromeTheme.workspaceTints`).
-    static let colorCount = 5
-
-    private static func leastUsedColor(in used: [Int: Int]) -> Int {
-        (0..<colorCount).min { left, right in
-            let leftCount = used[left] ?? 0
-            let rightCount = used[right] ?? 0
-            if leftCount != rightCount { return leftCount < rightCount }
-            return left < right
-        } ?? 0
+        return stampingDevices(workspaces: workspaces, projects: filed)
     }
 
     /// Leaves every workspace belonging to exactly one machine — the rule the whole

--- a/Sources/termio/Theme/ChromeTheme.swift
+++ b/Sources/termio/Theme/ChromeTheme.swift
@@ -23,9 +23,6 @@ struct ChromeTheme {
     let accent: Color
     /// Whether the theme reads as dark, so the window can match its system
     /// appearance (traffic lights, scrollbars) to the theme.
-    /// Hues a workspace can be marked with in the switcher, in a fixed order
-    /// (see `Workspace.color`).
-    let workspaceTints: [Color]
     let isDark: Bool
 
     /// Ink guaranteed to contrast a background: dimmed white over dark, dimmed black over light.
@@ -68,15 +65,6 @@ struct ChromeTheme {
             ?? definition.selectionBackground.flatMap(Color.init(hex:))
             ?? foreground
         self.isDark = dark
-        // Green, yellow, blue, magenta, cyan — the bright half (palette 10-14),
-        // which is the half that survives a dark background. A slot the theme
-        // leaves undefined drops out rather than becoming a default hue that
-        // belongs to no theme; if every one is missing, the accent stands in so a
-        // workspace always has a mark.
-        let tints = [10, 11, 12, 13, 14]
-            .compactMap { definition.palette[$0] }
-            .compactMap(Color.init(hex:))
-        self.workspaceTints = tints.isEmpty ? [self.accent] : tints
     }
 
     /// WCAG contrast ratio between two opaque colors (1…21). Colors that can't be

--- a/Tests/termioTests/WorkspaceMigrationTests.swift
+++ b/Tests/termioTests/WorkspaceMigrationTests.swift
@@ -260,7 +260,7 @@ final class WorkspaceMigrationTests: XCTestCase {
         // on, and could then claim a workspace the user named.
         var settled = home
         settled.isAutoCreated = false
-        XCTAssertEqual(ignoringColors(workspaces), ignoringColors([settled]))
+        XCTAssertEqual(workspaces, [settled])
         XCTAssertEqual(projects, [filed])
 
         // And it is a fixed point from there — the property the churn would break.
@@ -296,7 +296,7 @@ final class WorkspaceMigrationTests: XCTestCase {
 
         var settled = scope
         settled.isAutoCreated = false
-        XCTAssertEqual(ignoringColors(workspaces), ignoringColors([settled]))
+        XCTAssertEqual(workspaces, [settled])
         XCTAssertEqual(workspaces.first?.device, .thisMac)
         XCTAssertNil(workspaces.first?.deviceAlias, "no alias is written, so the file keeps its shape")
     }
@@ -436,51 +436,6 @@ final class WorkspaceMigrationTests: XCTestCase {
         XCTAssertEqual(twice.projects, once.projects)
     }
 
-    /// Every workspace ends a load with a colour, including one written before
-    /// colours existed — the switcher draws from this and has no second answer.
-    func testEveryWorkspaceLeavesReconcileWithAColor() {
-        let (workspaces, _) = WorkspaceMigration.reconcile(
-            workspaces: [Workspace(name: "Work"), Workspace(name: "Servers")], projects: [])
-
-        XCTAssertTrue(workspaces.allSatisfy { $0.color != nil })
-    }
-
-    /// A palette this small has to spread before it repeats: two scopes that came
-    /// in blank must not come out the same colour.
-    func testColorsSpreadBeforeTheyRepeat() {
-        let blank = (0..<WorkspaceMigration.colorCount).map { Workspace(name: "Scope \($0)") }
-
-        let (workspaces, _) = WorkspaceMigration.reconcile(workspaces: blank, projects: [])
-
-        XCTAssertEqual(Set(workspaces.compactMap(\.color)).count, WorkspaceMigration.colorCount)
-    }
-
-    /// A colour the user picked is theirs. The fill only ever answers for a
-    /// workspace that has none.
-    func testAChosenColorSurvivesReconcile() {
-        var chosen = Workspace(name: "Work")
-        chosen.color = 3
-
-        let (workspaces, _) = WorkspaceMigration.reconcile(
-            workspaces: [chosen, Workspace(name: "Servers")], projects: [])
-
-        XCTAssertEqual(workspaces.first { $0.id == chosen.id }?.color, 3)
-    }
-
-    /// The half a split mints is coloured in the same pass that made it. Missing
-    /// this is what broke idempotence: the next load filled it in, so a tree came
-    /// back changed from a pass that runs on every launch.
-    func testASplitHalfIsColoredInThePassThatCreatedIt() {
-        let spanning = Workspace(name: "Work")
-        let (workspaces, _) = WorkspaceMigration.reconcile(
-            workspaces: [spanning],
-            projects: [checkout("api", in: spanning, on: "ukvps"),
-                       checkout("web", in: spanning, on: "devbox")])
-
-        XCTAssertGreaterThan(workspaces.count, 1, "the span is what makes it split")
-        XCTAssertTrue(workspaces.allSatisfy { $0.color != nil })
-    }
-
     /// The upgrade runs once. A state file that already carries workspaces is
     /// never handed to `migrate`, and re-running it over its own output would be a
     /// sign the snapshot decode had gone wrong — so pin that the fold is stable.
@@ -537,16 +492,5 @@ final class WorkspaceDefaultNameTests: XCTestCase {
     func testTheRuleHoldsForALocalizedBase() {
         XCTAssertEqual(
             TermioStore.nextFreeWorkspaceName(base: "工作区", taken: ["工作区"]), "工作区 2")
-    }
-}
-
-/// Colours are filled in by `reconcile` for every workspace that has none, which
-/// is a different question from the one these tests ask. Compared without them so
-/// an ownership assertion keeps saying what it says.
-func ignoringColors(_ workspaces: [Workspace]) -> [Workspace] {
-    workspaces.map { workspace in
-        var workspace = workspace
-        workspace.color = nil
-        return workspace
     }
 }

--- a/Tests/termioTests/WorkspaceProjectFilingTests.swift
+++ b/Tests/termioTests/WorkspaceProjectFilingTests.swift
@@ -139,7 +139,7 @@ final class WorkspaceProjectFilingTests: XCTestCase {
         let relaunched = WorkspaceMigration.reconcile(
             workspaces: upgraded.workspaces, projects: saved)
 
-        XCTAssertEqual(ignoringColors(relaunched.workspaces), ignoringColors(upgraded.workspaces))
+        XCTAssertEqual(relaunched.workspaces, upgraded.workspaces)
         XCTAssertEqual(relaunched.projects.map(\.workspaceID), saved.map(\.workspaceID))
     }
 }


### PR DESCRIPTION
Removes the colour added in #412, and with it the palette, the picker, the stored field and the backfill. The device mark from the same PR stays — that half is a fact and fixes a real silence.

## Why a browser has it, and why we do not

Chrome tints a profile because two of its windows are pixel-identical, the profile is not named anywhere persistent, and picking the wrong one posts to the wrong account or shares the wrong screen. The cue therefore has to be **ambient, peripheral and window-level** — which is why Chrome paints the whole frame and Arc the whole sidebar, and why the dot in their menus is the by-product rather than the point.

None of those premises hold here:

| Browser | Termio |
| --- | --- |
| Several windows that look alike | One window |
| Profile not named on screen | Named in the toolbar; the sidebar lists only that scope; the title says it too |
| Wrong choice crosses identities | Wrong choice opens a terminal in the wrong place, undone by closing it |
| Picked from the Dock by colour | One Dock icon |

The one expensive confusion in Termio is *which machine* a session runs on, and that is a fact rather than a preference — the device mark carries it, and a colour never could, since nothing stops two workspaces on the same box wearing different ones.

The earlier reasoning ("the switcher menu is the one place every workspace is visible at once, so the colour goes there") argued about *where* to put it and never about *whether* — and in a menu that prints every name, a hue adds nothing the name does not already say.

## What it cost

A stored field, a backfill on every load, a palette derived from the theme, a picker in the create panel and another in Settings, and an idempotence bug in `reconcile` — colouring before the device split left a freshly minted half blank, so the next launch filled it in and the tree came back changed. The machinery it took to make the colour *work* is the clearest evidence it was not carrying its weight.

A later measurement made the same point from the other end: across the built-in themes, 47% of the second-intensity hues were indistinguishable from their bright twin, so twelve swatches were often six colours drawn twice. Fixing that needed adaptive contrast stepping and a per-colour direction choice — a lot of mechanism underneath a decoration.

## Kept

The alias beside a workspace's name in the switcher. That says which machine a scope is on, in the words a person would type, and it was the half of the original commit doing real work.

## Verified

`swift build`, `swift test` (518 tests, 0 failures), `check-strings.sh` clean. Nothing references `workspaceTints`, `WorkspaceSwatch` or `Workspace.color` any more.

Release Notes:
- Workspaces no longer carry a colour.