### PR TITLE
Close the gap between the navigator toggle and the workspace name

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1139,14 +1139,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// when the sidebar is collapsed — matching Finder/Xcode, which drop their sidebar buttons with
     /// the sidebar, and freeing the horizontal room that otherwise forces NSToolbar's `»` overflow.
     /// The paired flexible space (which right-aligns the two against the sidebar divider) is inserted
-    /// and removed *with* them. When open the region reads `toggleNavigator, workspaceSwitcher, flex,
-    /// sortProjects, newTerminal | sidebarTrackingSeparator`. Mirrors `setInspectorSwitchVisible`.
+    /// and removed *with* them. When open the region reads `toggleNavigator, flex, sortProjects,
+    /// newTerminal | sidebarTrackingSeparator`. Mirrors `setInspectorSwitchVisible`.
     ///
-    /// The workspace switcher leaves with the sidebar it labels. It used to move across the tracking
-    /// separator instead, on the argument that a bare terminal looks the same in every scope and the
-    /// switcher is the only thing naming the current one. In practice it reads as a stray word beside
-    /// the window title — the sidebar's region empties with the sidebar, the way Finder's and Xcode's
-    /// do, and the workspace is still one click away through the sidebar or the Workspace menu.
+    /// The workspace name leaves with the sidebar it labels, but it is not managed here — it rides
+    /// inside the `toggleNavigator` item and hides itself on `store.sidebarVisible` (see
+    /// `NavigatorToggleToolbarView`). It used to move across the tracking separator instead, on the
+    /// argument that a bare terminal looks the same in every scope and the switcher is the only thing
+    /// naming the current one. In practice it reads as a stray word beside the window title — the
+    /// sidebar's region empties with the sidebar, the way Finder's and Xcode's do, and the workspace
+    /// is still one click away through the sidebar or the Workspace menu.
     private func setNavigatorItemsVisible(_ visible: Bool) {
         guard let toolbar = window?.toolbar else { return }
         func index(of id: NSToolbarItem.Identifier) -> Int? {
@@ -1159,23 +1161,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         defer { NSAnimationContext.endGrouping() }
         if visible {
             guard index(of: .sortProjects) == nil else { return }
-            // Drop any stray copy before re-inserting, so the item is never added twice and the
-            // separator's index — the anchor every insert below uses — stays valid.
-            if let existing = index(of: .workspaceSwitcher) { toolbar.removeItem(at: existing) }
             guard let sep = index(of: .sidebarTrackingSeparator) else { return }
-            // Insert in reverse at that one index so the final order is workspaceSwitcher, flex,
-            // sortProjects, newTerminal. Re-reading the separator's index between inserts would walk
-            // it past the items just added and land the switcher against the `+` instead.
+            // Insert in reverse at that one index so the final order is flex, sortProjects,
+            // newTerminal. Re-reading the separator's index between inserts would walk it past the
+            // items just added and land the space against the `+` instead.
             toolbar.insertItem(withItemIdentifier: .newTerminal, at: sep)
             toolbar.insertItem(withItemIdentifier: .sortProjects, at: sep)
             toolbar.insertItem(withItemIdentifier: .flexibleSpace, at: sep)
-            toolbar.insertItem(withItemIdentifier: .workspaceSwitcher, at: sep)
         } else {
-            // The switcher goes with the sidebar. Removed before the guard below, because at launch
-            // with the sidebar already collapsed there are no sidebar buttons to clean up and the
-            // switcher still has to leave. Idempotent, so the repeated collapse callbacks the KVO
-            // observer sends cost nothing.
-            if let existing = index(of: .workspaceSwitcher) { toolbar.removeItem(at: existing) }
             // Only clean up when the buttons are actually present (nothing to remove at launch with
             // the sidebar already collapsed). Re-find each id after every removal — indices shift.
             guard let sortIdx = index(of: .sortProjects) else { return }
@@ -2257,7 +2250,7 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         defaultIdentifiers + [
-            .workspaceSwitcher, .sortProjects, .newTerminal, .inspectorTrackingSeparator, .inspectorTabs,
+            .sortProjects, .newTerminal, .inspectorTrackingSeparator, .inspectorTabs,
         ]
     }
 
@@ -2275,7 +2268,9 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             let item = NSToolbarItem(itemIdentifier: .toggleNavigator)
             item.label = localized("Navigator")
             item.toolTip = localized("Hide or show the navigator")
-            let host = NSHostingView(rootView: NavigatorToggleToolbarView())
+            let host = NSHostingView(rootView: NavigatorToggleToolbarView()
+                .environmentObject(store)
+                .environmentObject(settings))
             host.sizingOptions = [.intrinsicContentSize]
             item.view = host
             item.isBordered = false
@@ -2283,24 +2278,6 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
             // item's row in the `»` overflow menu and to validate it. A view-based item with
             // neither an action nor a `menuFormRepresentation` overflows into a dead row.
             item.action = #selector(NSSplitViewController.toggleSidebar(_:))
-            return item
-        case .workspaceSwitcher:
-            // The workspace the sidebar is scoped to, at the head of the sidebar's own toolbar
-            // region — the band above the column it scopes. Borderless SwiftUI rather than an
-            // `NSMenuToolbarItem` so the control can name the workspace: this toolbar is
-            // `.iconOnly`, which drops item titles. Its menu is still AppKit, built from the same
-            // `WorkspaceMenu.rows` this file's `fillWorkspaceMenu` uses, so the two can't drift.
-            // It draws nothing while there is only one workspace, which is also when the sidebar
-            // region has the least room to spare.
-            let item = NSToolbarItem(itemIdentifier: .workspaceSwitcher)
-            item.label = localized("Workspace")
-            item.toolTip = localized("Choose which workspace the sidebar shows")
-            let host = NSHostingView(rootView: WorkspaceSwitcherToolbarView()
-                .environmentObject(store)
-                .environmentObject(settings))
-            host.sizingOptions = [.intrinsicContentSize]
-            item.view = host
-            item.isBordered = false
             return item
         case .sortProjects:
             // A pull-down that sets how the sidebar orders projects (Recent Activity /
@@ -2414,7 +2391,6 @@ private final class MainToolbarDelegate: NSObject, NSToolbarDelegate, NSMenuDele
 
 private extension NSToolbarItem.Identifier {
     static let toggleNavigator = NSToolbarItem.Identifier("TermioToggleNavigator")
-    static let workspaceSwitcher = NSToolbarItem.Identifier("TermioWorkspaceSwitcher")
     static let sortProjects = NSToolbarItem.Identifier("TermioSortProjects")
     static let newTerminal = NSToolbarItem.Identifier("TermioNewTerminal")
     static let inspectorTabs = NSToolbarItem.Identifier("TermioInspectorTabs")
@@ -2643,6 +2619,10 @@ private struct BranchPickerToolbarView: View {
 private struct PaneToggleToolbarView: View {
     let symbol: String
     let showsCapsule: Bool
+    /// Outer width. Defaults to the shared control height, which makes a capsuled button a circle.
+    /// A button that never draws a capsule has nothing to fill that square with, and the slack
+    /// only pushes whatever follows it further away — so the navigator toggle asks for less.
+    var width: CGFloat = InspectorTabsToolbar.controlHeight
     let help: String
     let label: String
     let toggle: () -> Void
@@ -2659,8 +2639,7 @@ private struct PaneToggleToolbarView: View {
                 .font(.system(size: 17))
                 .foregroundStyle(controlActive == .inactive
                                  ? Color(nsColor: .disabledControlTextColor) : .primary)
-                .frame(width: InspectorTabsToolbar.controlHeight,
-                       height: InspectorTabsToolbar.controlHeight)
+                .frame(width: width, height: InspectorTabsToolbar.controlHeight)
                 .background { if showsCapsule { capsuleBackground } }
                 .contentShape(.capsule)
         }
@@ -2680,8 +2659,35 @@ private struct PaneToggleToolbarView: View {
     }
 }
 
+/// The navigator toggle and, while the navigator is open, the name of the workspace the column
+/// below is scoped to.
+///
+/// One toolbar item carrying both, rather than the two adjacent items this used to be: NSToolbar
+/// spaces neighbouring items on its own terms, and between a button and the word naming the column
+/// under it that spacing read as a gap neither control asked for — the name looked detached from
+/// the button it sits beside. Hosted together, the distance is this view's to set.
+///
+/// The name draws only while the sidebar is open (it labels a column that has to be on screen) and
+/// only while there is more than one workspace to be in — `WorkspaceSwitcherToolbarView` owns that
+/// second rule, along with the menu the name pops.
 private struct NavigatorToggleToolbarView: View {
+    @EnvironmentObject var store: TermioStore
+
+    /// Close enough to read as one control band with the button, still clear of the glyph. The
+    /// toggle's own frame contributes a little more (it is wider than the symbol it draws), so the
+    /// gap on screen is a few points past this.
+    private static let nameSpacing: CGFloat = 6
+
     var body: some View {
+        HStack(spacing: Self.nameSpacing) {
+            toggle
+            if store.sidebarVisible {
+                WorkspaceSwitcherToolbarView()
+            }
+        }
+    }
+
+    private var toggle: some View {
         PaneToggleToolbarView(
             // Never capsuled, open or collapsed. This button lives in the sidebar's own toolbar
             // region, over the vibrant `.sidebar` material and beside the traffic lights — a
@@ -2690,6 +2696,10 @@ private struct NavigatorToggleToolbarView: View {
             // own image size and tint and would stop matching the trailing button's glyph.
             symbol: "sidebar.leading",
             showsCapsule: false,
+            // Tight to the glyph (19.5pt at this weight) rather than the capsuled button's square.
+            // With the navigator collapsed the title lands right after this item, and the square's
+            // trailing half was reading as a hole between the button and the name it belongs to.
+            width: 26,
             help: localized("Hide or show the navigator"),
             label: localized("Navigator")
         ) {

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5775,16 +5775,6 @@
         }
       }
     },
-    "Choose which workspace the sidebar shows": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择侧栏显示哪个工作区"
-          }
-        }
-      }
-    },
     "Closing it stops %lld session(s). The folders on disk are left alone.": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -194,8 +194,6 @@
 	<string>Choose another branch to compare with.</string>
 	<key>Choose how projects are ordered</key>
 	<string>Choose how projects are ordered</string>
-	<key>Choose which workspace the sidebar shows</key>
-	<string>Choose which workspace the sidebar shows</string>
 	<key>Choose…</key>
 	<string>Choose…</string>
 	<key>Clear</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -194,8 +194,6 @@
 	<string>请另选一个用于对比的分支。</string>
 	<key>Choose how projects are ordered</key>
 	<string>选取项目的排序方式</string>
-	<key>Choose which workspace the sidebar shows</key>
-	<string>选择侧栏显示哪个工作区</string>
 	<key>Choose…</key>
 	<string>选取…</string>
 	<key>Clear</key>

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -87,7 +87,13 @@ struct WorkspaceSwitcherToolbarView: View {
             // three glyphs wide, and every point this control spends on decoration is
             // a point the name truncates at.
             Text(current.name)
-                .font(nameFont)
+                // The very font the sidebar's rows and section headers use — not a copy of its
+                // definition, which is what this was and what let the two drift on paper. The band
+                // and the column below it share an x-height and read as one thing: this names that
+                // column, and a size step would separate it from what it names. Rank comes from
+                // weight instead — a label larger than the window title beside it is what makes a
+                // titlebar look mis-scaled.
+                .font(settings.interfaceFont)
                 .fontWeight(.medium)
                 .foregroundStyle(color)
                 .lineLimit(1)
@@ -101,19 +107,6 @@ struct WorkspaceSwitcherToolbarView: View {
                 .overlay(WorkspaceMenuPopper(store: store))
                 .accessibilityHidden(true)
         }
-    }
-
-    /// The sidebar's own row size, so the band and the column below it share an
-    /// x-height and read as one thing — this names that column, and a size step
-    /// would separate it from what it names. The rank comes from weight instead:
-    /// a label larger than the 13pt window title beside it is what makes a titlebar
-    /// look mis-scaled. Derived from the interface size rather than fixed, so it
-    /// still follows the density preference the rows below it follow.
-    private var nameFont: Font {
-        let size = settings.interfaceFontSize
-        return settings.interfaceFontFamily.isEmpty
-            ? .system(size: size)
-            : .custom(settings.interfaceFontFamily, size: size)
     }
 
     // Matched to the sidebar toolbar's native glyphs (the `+` new-terminal item, the


### PR DESCRIPTION
The navigator toggle and the workspace name were two adjacent toolbar items, so what sat between them was NSToolbar's inter-item spacing plus the toggle's own frame — about 22pt, roughly double what AppKit's own apps leave. Between a button and the word naming the column under it, that read as a gap neither control asked for.

Both now live in the `toggleNavigator` item, spaced by an HStack. The name hides itself on `store.sidebarVisible` instead of being inserted and removed by `setNavigatorItemsVisible`, so it still leaves with the sidebar it labels; its menu, tooltip, and accessibility are untouched. The toggle also drops the square frame it borrowed from the pane switch's height — it never draws a capsule, so that width was slack that only pushed the name further away.

The name's font now comes from `settings.interfaceFont` — the property the sidebar's rows and section headers already read — rather than a hand-copy of its definition that nothing kept in step. The sizes already matched; nothing enforced it.

Release Notes:

- Fixed the workspace name sitting too far from the sidebar toggle in the toolbar.