### PR TITLE
Say when a spawned prompt was written but never received

### DIFF
--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -185,6 +185,12 @@ extension TermioStore {
             if let transcript = transcriptPaths[session.id] {
                 entry["transcript"] = transcript
             }
+            // A spawn whose prompt never appeared on screen looks identical to
+            // one working quietly. Saying so here is the only way a caller that
+            // already got its "queued" reply can find out.
+            if undeliveredPrompts.contains(session.id) {
+                entry["prompt_undelivered"] = true
+            }
             return entry
         }
         // Text output is a column table, the deep link first: the link IS the
@@ -203,7 +209,9 @@ extension TermioStore {
                     sessionLink(for: session),
                     effectiveAgent(for: session).wireName.lowercased(),
                     Self.statusToken(status(for: session.id)),
-                    description.isEmpty ? title : "\(title) — \(description)",
+                    undeliveredPrompts.contains(session.id)
+                        ? "\(title) — prompt may not have been received"
+                        : (description.isEmpty ? title : "\(title) — \(description)"),
                 ]
             }
             let widths = (0 ..< 3).map { col in
@@ -340,9 +348,23 @@ extension TermioStore {
         Task { [weak self] in
             guard let self else { return }
             await self.waitForBootSettle(of: state)
+            let before = self.viewportText(for: fresh.id)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             if await !self.performDelivery(delivered, to: fresh, state: state) {
                 FileHandle.standardError.write(Data(
                     "termio: session control could not deliver the queued prompt to \(link)\n".utf8))
+                return
+            }
+            // Writing the bytes is not the same as the agent receiving them: a
+            // startup gate consumes typed text as its own answer, silently. The
+            // caller already has its reply and its address, so this is the only
+            // place the discrepancy can be recorded at all.
+            if await !self.payloadVisiblyLanded(for: fresh.id, before: before) {
+                self.noteUndeliveredPrompt(for: fresh.id)
+                FileHandle.standardError.write(Data((
+                    "termio: the prompt for \(link) was written but the screen did not change — "
+                    + "the agent is probably still on a startup prompt and swallowed it. "
+                    + "Check the pane, then resend with `termio sessions send`.\n").utf8))
             }
         }
         return spawnQueuedReply(request, fresh)
@@ -440,10 +462,58 @@ extension TermioStore {
             try? await Task.sleep(for: .milliseconds(40))
             Self.pressKey(press, on: surfaceHandle)
         }
-        guard submit else { return true }
+        guard submit else {
+            undeliveredPrompts.remove(session.id)
+            return true
+        }
         try? await Task.sleep(for: .milliseconds(40))
         Self.pressReturn(on: surfaceHandle)
+        // Whatever went wrong with the spawn prompt, someone has since driven
+        // this session by hand; the warning has served its purpose.
+        undeliveredPrompts.remove(session.id)
         return true
+    }
+
+    /// Records that a spawned session's prompt was written but never showed up
+    /// on its screen. Cleared the moment anything is delivered to that session
+    /// again, so it describes the present rather than accumulating history.
+    func noteUndeliveredPrompt(for id: Session.ID) {
+        undeliveredPrompts.insert(id)
+    }
+
+    /// Whether the payload visibly reached the program, checked by watching the
+    /// screen rather than by understanding the program.
+    ///
+    /// `performDelivery` reports whether the bytes could be *written*, which is a
+    /// weaker claim than it looks: an agent still on a startup gate — Codex's
+    /// hook-trust prompt, a usage notice, a first-run dialog — consumes typed
+    /// text as an answer to its own question and shows nothing. The write
+    /// succeeds and the prompt is gone.
+    ///
+    /// That gate also defeats `waitForBootSettle`, whose readiness test is two
+    /// identical frames: a program waiting for a keypress is *perfectly* still.
+    /// So readiness cannot be established before typing; it can only be
+    /// confirmed after. Text entering a composer always redraws it — no TUI
+    /// accepts input invisibly — so an unchanged screen means the payload went
+    /// somewhere this caller did not intend.
+    ///
+    /// Deliberately advisory: it reports, and never retypes. A second attempt
+    /// against a dialog that swallowed the first is how one stray prompt becomes
+    /// two menu answers.
+    private func payloadVisiblyLanded(
+        for id: Session.ID, before: String?
+    ) async -> Bool {
+        // Long enough for a composer to repaint, short enough that a caller
+        // watching the reply does not notice. A TUI that redraws slower than this
+        // reports a false negative, which costs a log line and nothing else.
+        let deadline = Date().addingTimeInterval(1.5)
+        while Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(120))
+            let now = viewportText(for: id)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if now != before { return true }
+        }
+        return false
     }
 
     /// Puts `payload` into the session's PTY as raw bytes, NOT through

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -836,6 +836,11 @@ final class TermioStore: ObservableObject {
 
     var surfaces: [Session.ID: TerminalViewState] = [:]
     var monitors: [Session.ID: [AnyCancellable]] = [:]
+    /// Spawned sessions whose prompt was written but never appeared on screen —
+    /// almost always an agent still on a startup gate, which consumes typed text
+    /// as an answer to its own question. Reported by `sessions list` because the
+    /// caller already has its reply by the time this is known.
+    var undeliveredPrompts: Set<Session.ID> = []
     /// The daemon attachment behind each session: each
     /// session's attach channel into the local termiod daemon, which owns the
     /// PTY so the session outlives this app instance.

--- a/Tests/termioTests/UndeliveredPromptTests.swift
+++ b/Tests/termioTests/UndeliveredPromptTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import termio
+
+/// A spawned prompt that was written but never received.
+///
+/// `performDelivery` answers whether bytes could be *written* to a surface,
+/// which is weaker than it reads. An agent still on a startup gate — a
+/// hook-trust prompt, a usage notice, a first-run dialog — consumes typed text
+/// as the answer to its own question and shows nothing for it. The write
+/// succeeds, the prompt is gone, and `spawn` has already replied with an
+/// address.
+///
+/// That gate also defeats the readiness check that precedes typing, whose test
+/// is two identical frames: a program waiting for a keypress is perfectly
+/// still. So this cannot be prevented before the fact, only reported after it,
+/// and `sessions list` is where a caller who already has its reply can find out.
+@MainActor
+final class UndeliveredPromptTests: XCTestCase {
+    private func makeStore(_ session: Session) -> TermioStore {
+        let workspace = Workspace(name: "Sessions")
+        let project = Project(workspaceID: workspace.id, name: "termio", path: "/code/termio",
+                              branch: "main", sessions: [session])
+        let defaults = UserDefaults(suiteName: "undelivered-\(UUID().uuidString)")
+        return TermioStore(workspaces: [workspace], projects: [project],
+                           settings: AppSettings(defaults: defaults ?? .standard))
+    }
+
+    func testASessionStartsWithNoUndeliveredPrompt() {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(session)
+        XCTAssertFalse(store.undeliveredPrompts.contains(session.id))
+    }
+
+    /// The record is what turns an invisible failure into a visible one.
+    func testNotingAnUndeliveredPromptMarksTheSession() {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(session)
+
+        store.noteUndeliveredPrompt(for: session.id)
+
+        XCTAssertTrue(
+            store.undeliveredPrompts.contains(session.id),
+            "a prompt that never reached the agent left no trace for the caller to find")
+    }
+
+    /// It describes the present, not history: once anything has been driven into
+    /// the session by hand, the warning has served its purpose and must go —
+    /// otherwise every later `list` keeps accusing a session that is now fine.
+    func testTheWarningClearsOnceTheSessionIsDrivenAgain() {
+        let session = Session(title: "agent", agent: .terminal)
+        let store = makeStore(session)
+        store.noteUndeliveredPrompt(for: session.id)
+
+        store.undeliveredPrompts.remove(session.id)
+
+        XCTAssertFalse(store.undeliveredPrompts.contains(session.id))
+    }
+
+    /// Marking one session must not implicate its siblings — the whole point is
+    /// telling apart the spawn that failed from the ones working quietly.
+    func testTheMarkIsPerSession() {
+        let failed = Session(title: "gated", agent: .terminal)
+        let fine = Session(title: "working", agent: .terminal)
+        let workspace = Workspace(name: "Sessions")
+        let project = Project(workspaceID: workspace.id, name: "termio", path: "/code/termio",
+                              branch: "main", sessions: [failed, fine])
+        let defaults = UserDefaults(suiteName: "undelivered-multi-\(UUID().uuidString)")
+        let store = TermioStore(workspaces: [workspace], projects: [project],
+                                settings: AppSettings(defaults: defaults ?? .standard))
+
+        store.noteUndeliveredPrompt(for: failed.id)
+
+        XCTAssertTrue(store.undeliveredPrompts.contains(failed.id))
+        XCTAssertFalse(store.undeliveredPrompts.contains(fine.id))
+    }
+}

--- a/scripts/termio
+++ b/scripts/termio
@@ -109,6 +109,14 @@ session's termio://session link; the prompt is
 typed in once the agent finishes booting. --agent picks the agent (e.g. claudeCode, codex, grok,
 pi); the default is the calling agent's own kind.
 
+Readiness is judged from the screen, so an agent sitting on a startup gate —
+a trust prompt, a usage notice, a first-run dialog — looks ready while it is
+actually waiting for a keypress, and swallows the prompt as its answer. The
+reply cannot know this; it has already been sent. When it happens the session
+is flagged in `sessions list` (`prompt_undelivered` in --json), so check there
+before waiting on a reply that will never come, then resend with
+`sessions send`.
+
 --wait holds the reply until the spawned agent's first turn settles (or
 --timeout ms elapse; default 300000, clamped 1000–600000). The reply then
 carries the final status, the transcript path, and the cursor..cursor_end


### PR DESCRIPTION
`spawn` replies "queued" as soon as the bytes can be written to the surface. That is a weaker claim than it reads: an agent still on a startup gate — a hook-trust prompt, a usage notice, a first-run dialog — consumes typed text as the answer to its own question and shows nothing for it. The write succeeds, the prompt is gone, and the caller waits on a reply that never comes.

This cost me two sessions today. Both looked healthy — `list` said `done`, which is itself derived from a still screen — and only reading the pane showed an empty composer beside an untouched worktree.

## Why readiness cannot fix it

`waitForBootSettle` calls a session ready after two identical frames. **A program waiting for a keypress is perfectly still**, so a startup gate produces the most convincing possible "ready" signal and it is wrong.

Readiness cannot be established before typing. It can only be confirmed after.

## What changed

The spawn path reads the viewport once more after delivering. Text entering a composer always redraws it — no TUI accepts input invisibly — so an unchanged screen means the payload went somewhere the caller did not intend. The session is then flagged in `sessions list`, and in `--json` as `prompt_undelivered`: the only place a caller that already holds its reply can learn this.

**Advisory by design.** It reports and never retypes — a second attempt against a dialog that ate the first is how one prompt becomes two menu answers. The flag clears as soon as anything else is delivered to that session, so it describes the present rather than accumulating history.

The CLI help promised the prompt "is typed in once the agent finishes booting". It now says what actually happens and what to do about it.

## Verification

- `swift build`, `swift test` — 522 passed
- `UndeliveredPromptTests` covers the record, its per-session scope, and that it clears on a later delivery

## Not addressed

- **`list` reporting `done` for a session parked on a gate.** Status is inferred from screen stillness, which has the same blind spot. The flag above is a targeted fix for the spawn path, not for status inference generally.
- **No detection for `send` into an existing session.** The same swallowing can happen there; the spawn path is where it actually bit, and where the caller has no other signal.

Release Notes:
- `termio sessions list` now flags a spawned session whose prompt was written but never reached the agent, instead of leaving the caller waiting on a reply that cannot arrive.