### PR TITLE
Report the missing directory when a session can't start

### DIFF
--- a/Sources/termio/Companion/AppChannel.swift
+++ b/Sources/termio/Companion/AppChannel.swift
@@ -65,10 +65,31 @@ enum AppChannel {
             || identifier == releaseBundleIdentifier + ".dev"
     }()
 
+    /// True when this process is a test binary rather than either termio.
+    ///
+    /// `swift test` has no bundle id ending in `.dev` and no `TERMIO_CHANNEL`, so
+    /// without this it lands on the **release** channel — and `TermioStore`
+    /// persists on every `projects` mutation, so a test that builds a store over
+    /// fixture projects overwrites the installed app's session tree. That is not a
+    /// hypothetical: it has replaced a real user's projects with `/code/termio`.
+    /// The channel suffix is deliberately left alone; only the directories that
+    /// get written move, since the ports and URL scheme are never claimed here.
+    static let isRunningTests: Bool = NSClassFromString("XCTestCase") != nil
+
+    /// A scratch home for a test run, thrown away with the rest of the temp
+    /// directory. Keyed by pid so two concurrent runs can't read each other's
+    /// writes.
+    private static let testDirectory: URL = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+            "termio-tests-\(ProcessInfo.processInfo.processIdentifier)", isDirectory: true)
+
     /// Internal state — control/status sockets, `state.json`, custom themes, and
     /// downloaded tunnel binaries: `~/Library/Application Support/termio[-dev]`.
     /// Falls back to a home dotfolder if Application Support can't be resolved.
     static var supportDirectory: URL {
+        if isRunningTests {
+            return testDirectory.appendingPathComponent("support", isDirectory: true)
+        }
         let name = "termio" + suffix
         if let base = FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
@@ -81,7 +102,10 @@ enum AppChannel {
     /// User-facing config the user drops files into (agent definitions, worktrees):
     /// `~/.termio[-dev]`.
     static var homeConfigDirectory: URL {
-        FileManager.default.homeDirectoryForCurrentUser
+        if isRunningTests {
+            return testDirectory.appendingPathComponent("home", isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".termio" + suffix, isDirectory: true)
     }
 

--- a/Tests/termioTests/StateFileIsolationTests.swift
+++ b/Tests/termioTests/StateFileIsolationTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import termio
+
+/// The test suite must never write to a channel a real termio reads.
+///
+/// `TermioStore.projects` persists in its `didSet`, so *any* test that builds a
+/// store over fixture projects writes a complete `state.json`. Under `swift test`
+/// there is no `TERMIO_CHANNEL` and no `.dev` bundle id, so the channel resolved
+/// to **release** — and a full run left the installed app owning one project at
+/// `/code/termio`, wiping the user's real session tree. The whole tree, because
+/// `persist` writes a snapshot rather than a patch.
+@MainActor
+final class StateFileIsolationTests: XCTestCase {
+    func testTheChannelKnowsItIsUnderTest() {
+        XCTAssertTrue(AppChannel.isRunningTests)
+    }
+
+    /// The directories that get *written* are the ones that have to move. Both,
+    /// not just the state file: sockets, themes, downloaded binaries and agent
+    /// definitions all hang off these two.
+    func testWrittenDirectoriesLeaveEveryRealChannelAlone() {
+        let temporary = FileManager.default.temporaryDirectory.standardizedFileURL.path
+        for directory in [AppChannel.supportDirectory, AppChannel.homeConfigDirectory] {
+            let path = directory.standardizedFileURL.path
+            XCTAssertTrue(path.hasPrefix(temporary), "\(path) is not under the temp directory")
+            XCTAssertFalse(path.contains("Application Support"), path)
+        }
+    }
+
+    /// The end-to-end version of the same claim, stated the way the bug was
+    /// found: mutate a store's projects, then look for the fixture on disk
+    /// anywhere a shipped termio would read it.
+    func testAStoreMutationCannotReachAnInstalledTermioSStateFile() throws {
+        let defaults = UserDefaults(suiteName: "isolation-\(UUID().uuidString)")
+            ?? UserDefaults.standard
+        let workspace = Workspace(name: "Sessions")
+        let store = TermioStore(workspaces: [workspace], projects: [],
+                                settings: AppSettings(defaults: defaults))
+
+        let marker = "/code/termio-isolation-\(UUID().uuidString)"
+        store.projects = [Project(workspaceID: workspace.id, name: "termio", path: marker,
+                                  branch: "main", sessions: [])]
+
+        // Decoded, not string-matched: `JSONEncoder` escapes `/` as `\/`, so a
+        // `contains("/code/…")` over the raw file never matches — it would report
+        // every channel clean, including a clobbered one.
+        func persistedPaths(at url: URL) -> [String] {
+            guard let data = try? Data(contentsOf: url),
+                  let snapshot = try? JSONDecoder().decode(StateFile.Snapshot.self, from: data)
+            else { return [] }
+            return snapshot.projects.map(\.path)
+        }
+
+        let support = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        for channel in ["termio", "termio-dev"] {
+            guard let stateURL = support?
+                .appendingPathComponent(channel, isDirectory: true)
+                .appendingPathComponent("state.json") else { continue }
+            XCTAssertFalse(persistedPaths(at: stateURL).contains(marker),
+                           "a test wrote a fixture project into \(stateURL.path)")
+        }
+
+        let isolated = AppChannel.supportDirectory.appendingPathComponent("state.json")
+        XCTAssertTrue(
+            persistedPaths(at: isolated).contains(marker),
+            "the store did persist — to the isolated channel, which is the point")
+    }
+}

--- a/termiod/src/pty.rs
+++ b/termiod/src/pty.rs
@@ -331,14 +331,34 @@ impl Pty {
             });
         }
 
-        let child = cmd
-            .spawn()
-            .with_context(|| format!("spawning session program '{program}'"))?;
+        let spawned = cmd.spawn();
 
-        // Parent no longer needs the slave.
+        // Parent no longer needs the slave, on the failing path as much as the
+        // succeeding one: a session whose directory is gone gets retried every
+        // time the user clicks it, and a leaked slave per attempt runs the
+        // daemon out of descriptors.
         unsafe {
             libc::close(slave_raw);
         }
+
+        let child = match spawned {
+            Ok(child) => child,
+            Err(error) => {
+                // A missing program and a missing working directory both come
+                // back as ENOENT, and the kernel doesn't say which one it meant.
+                // Name the one that is actually gone — a checkout deleted or
+                // sitting on an unmounted volume is far likelier than a missing
+                // shell, and blaming the shell sends the user hunting the wrong
+                // thing.
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    if let Some(dir) = cwd.filter(|dir| !std::path::Path::new(dir).is_dir()) {
+                        bail!("session directory '{dir}' no longer exists");
+                    }
+                }
+                return Err(error)
+                    .with_context(|| format!("spawning session program '{program}'"));
+            }
+        };
 
         let pid = child.id() as i32;
         let master = AsyncFd::new(master)?;
@@ -482,6 +502,46 @@ mod tests {
         assert!(!dumped.contains("CLAUDE_CODE_CHILD_SESSION="));
         assert!(dumped.contains("TERM_PROGRAM=termio"));
         assert!(!dumped.contains("TERM_PROGRAM=Apple_Terminal"));
+    }
+
+    /// A checkout that was deleted or is sitting on an unmounted volume fails the
+    /// spawn with the same ENOENT a missing program does. The message has to name
+    /// the directory: blaming `/bin/zsh` for a missing folder sent a user hunting
+    /// a shell that was never broken.
+    #[tokio::test]
+    async fn a_missing_working_directory_is_not_reported_as_a_missing_program() {
+        let missing = std::env::temp_dir().join(format!("termiod-gone-{}", std::process::id()));
+        let missing = missing.to_string_lossy().to_string();
+
+        let Err(error) = Pty::spawn(&["/bin/sh".to_string()], Some(&missing), &[], 24, 80) else {
+            panic!("a spawn into a directory that does not exist must fail");
+        };
+        let message = format!("{error:#}");
+
+        assert!(message.contains(&missing), "{message}");
+        assert!(!message.contains("/bin/sh"), "{message}");
+    }
+
+    /// The other half: a program that really is missing still says so, so naming
+    /// the directory has not just moved the misattribution the other way.
+    #[tokio::test]
+    async fn a_missing_program_is_still_reported_as_a_missing_program() {
+        let here = std::env::temp_dir().to_string_lossy().to_string();
+
+        let Err(error) = Pty::spawn(
+            &["/nonexistent/termiod-not-a-program".to_string()],
+            Some(&here),
+            &[],
+            24,
+            80,
+        ) else {
+            panic!("a spawn of a program that does not exist must fail");
+        };
+
+        assert!(
+            format!("{error:#}").contains("/nonexistent/termiod-not-a-program"),
+            "{error:#}"
+        );
     }
 
     /// `LC_ALL` outranks both, then `LC_CTYPE`, then `LANG` — and an exported

--- a/web/landing/src/data/changelog.ts
+++ b/web/landing/src/data/changelog.ts
@@ -17,6 +17,17 @@ export type ChangelogEntry = {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: "0.41.2",
+    date: "2026-08-23",
+    title: "A session that can't start says why",
+    changes: {
+      fixed: [
+        "A session whose folder has been deleted, moved, or left on an unmounted drive now names the folder. It used to report that your shell didn't exist — the same error code covers both, and termio picked the wrong one to blame.",
+        "Running the test suite from a checkout no longer overwrites the installed app's projects and sessions. This one only ever reached people who build termio themselves.",
+      ],
+    },
+  },
+  {
     version: "0.41.1",
     date: "2026-08-23",
     title: "The workspace name holds still",


### PR DESCRIPTION
A session whose working directory no longer exists failed with `spawning session program '/bin/zsh': No such file or directory`. `/bin/zsh` was fine — a missing program and a missing `current_dir` both surface as ENOENT, and the context line named the program. The daemon also leaked the PTY slave on that path, once per retry.

The second commit is how the directory went missing in the first place. `TermioStore.projects`'s `didSet` calls `persist()`, which writes a whole snapshot. Under `swift test` there is no `TERMIO_CHANNEL` and the xctest host's bundle id doesn't end in `.dev`, so `AppChannel` resolved to the **release** channel: any test building a store over fixture projects overwrote the installed app's session tree. A full suite run left `state.json` owning a single project at `/code/termio` — a fixture path from `TermiodDeviceAdoptionTests` — and every session under it then failed to spawn.

Verified by running the full suite against the default channel: the fixtures land in a per-pid temp directory and both `~/Library/Application Support/termio` and `termio-dev` come through untouched. `AppChannel.swift` already warned about this hazard for `swift run`; tests were never covered by it.

Release Notes:
- A session whose folder has been deleted, moved, or left on an unmounted drive now names the folder instead of reporting that your shell doesn't exist.
- Running the test suite from a checkout no longer overwrites the installed app's projects and sessions.