### PR TITLE
Give the termiod host's states and identities their own types

### DIFF
--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -9,9 +9,10 @@ use crate::protocol::{
     Event, FileChunk, Frame, SessionInfo, Snapshot, FILE_CHUNK_HEADER_SIZE, HOST_CAPABILITIES,
     MAX_FILE_FRAME_SIZE, PROTOCOL_VERSION, SUPPORTED_PROTOCOLS,
 };
+use crate::id::ClientId;
 use crate::resource::Registry;
 use crate::session::{
-    self, ClientBacklog, ClientEvent, ClientId, Metered, SessionEnded, SessionHandle, SessionMsg,
+    self, ClientBacklog, ClientEvent, Metered, SessionEnded, SessionHandle, SessionMsg,
 };
 use crate::tombstone::{EndReason, Graveyard};
 use anyhow::{Context, Result};
@@ -78,7 +79,7 @@ impl Manager {
 
     fn alloc_client_id(&self) -> ClientId {
         let id = self.next_client_id.fetch_add(1, Ordering::Relaxed);
-        format!("c_{id:x}")
+        ClientId::new(format!("c_{id:x}"))
     }
 
     fn create(&self, spec: crate::protocol::CreateSpec) -> Result<String> {
@@ -582,7 +583,7 @@ async fn handle_conn(stream: UnixStream, manager: Manager) -> Result<()> {
                         std::env::consts::OS,
                         std::env::consts::ARCH
                     ),
-                    client_id: client_id.clone(),
+                    client_id: client_id.to_string(),
                     home: std::env::var("HOME").unwrap_or_default(),
                 },
             )

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -9,7 +9,7 @@ use crate::protocol::{
     Event, FileChunk, Frame, SessionInfo, Snapshot, FILE_CHUNK_HEADER_SIZE, HOST_CAPABILITIES,
     MAX_FILE_FRAME_SIZE, PROTOCOL_VERSION, SUPPORTED_PROTOCOLS,
 };
-use crate::id::ClientId;
+use crate::id::{ClientId, SessionId};
 use crate::resource::Registry;
 use crate::session::{
     self, ClientBacklog, ClientEvent, Metered, SessionEnded, SessionHandle, SessionMsg,
@@ -28,7 +28,7 @@ const EVENT_BUFFER: usize = 1024;
 const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct ManagerInner {
-    sessions: HashMap<String, SessionHandle>,
+    sessions: HashMap<SessionId, SessionHandle>,
     id_counter: u32,
     draining: bool,
 }
@@ -82,7 +82,7 @@ impl Manager {
         ClientId::new(format!("c_{id:x}"))
     }
 
-    fn create(&self, spec: crate::protocol::CreateSpec) -> Result<String> {
+    fn create(&self, spec: crate::protocol::CreateSpec) -> Result<SessionId> {
         // The lock makes the transition to draining an exact boundary: a
         // create either installs its handle before the shutdown snapshot or
         // observes `draining` and never spawns a child.
@@ -95,8 +95,11 @@ impl Manager {
             .map(|d| d.subsec_nanos())
             .unwrap_or(0);
         guard.id_counter = guard.id_counter.wrapping_add(1);
-        let id = format!("{:08x}", seed ^ guard.id_counter.wrapping_mul(2654435761));
-        let name = spec.name.clone().unwrap_or_else(|| id.clone());
+        let id = SessionId::new(format!(
+            "{:08x}",
+            seed ^ guard.id_counter.wrapping_mul(2654435761)
+        ));
+        let name = spec.name.clone().unwrap_or_else(|| id.to_string());
         let cwd = spec.cwd.clone().unwrap_or_default();
         let command = if spec.argv.is_empty() {
             format!(
@@ -124,7 +127,7 @@ impl Manager {
         Ok(id)
     }
 
-    fn find(&self, id: &str) -> Option<SessionHandle> {
+    fn find(&self, id: &SessionId) -> Option<SessionHandle> {
         self.inner.lock().unwrap().sessions.get(id).cloned()
     }
 
@@ -138,7 +141,7 @@ impl Manager {
             .collect()
     }
 
-    fn remove(&self, id: &str) -> bool {
+    fn remove(&self, id: &SessionId) -> bool {
         let removed = self.inner.lock().unwrap().sessions.remove(id).is_some();
         if removed {
             self.session_removed.notify_one();
@@ -199,7 +202,7 @@ impl Manager {
         }
     }
 
-    async fn publish_created(&self, id: &str) {
+    async fn publish_created(&self, id: &SessionId) {
         let Some(handle) = self.find(id) else {
             return;
         };
@@ -216,7 +219,7 @@ impl Manager {
         });
     }
 
-    fn publish_removed(&self, id: &str) {
+    fn publish_removed(&self, id: &SessionId) {
         self.publish(Event::Roster {
             session: id.to_string(),
             action: "removed".to_string(),
@@ -236,9 +239,12 @@ impl Manager {
         infos
     }
 
-    /// Resolve a target that may be an id or a name.
+    /// Resolve a target that may be an id or a name. The only door into the
+    /// session table for a string that came off the wire: `find` takes a
+    /// `SessionId`, so nothing else can index the table with an unresolved
+    /// target.
     async fn resolve(&self, target: &str) -> Option<SessionHandle> {
-        if let Some(handle) = self.find(target) {
+        if let Some(handle) = self.find(&SessionId::new(target)) {
             return Some(handle);
         }
         for handle in self.handles() {
@@ -273,7 +279,7 @@ impl Manager {
         let Some(initial_info) = self.info(&handle).await else {
             return if until.iter().any(|wanted| wanted == "exited") {
                 Control::WaitResult {
-                    session: session_id,
+                    session: session_id.to_string(),
                     status: "exited".to_string(),
                     timed_out: false,
                     exit_status: None,
@@ -291,7 +297,7 @@ impl Manager {
         let initial = initial_info.status;
         if until.iter().any(|wanted| wanted == &initial) {
             return Control::WaitResult {
-                session: session_id,
+                session: session_id.to_string(),
                 status: initial,
                 timed_out: false,
                 exit_status: None,
@@ -304,12 +310,14 @@ impl Manager {
                 match events.recv().await {
                     Ok(Event::Status {
                         session, status, ..
-                    }) if session == session_id && until.iter().any(|wanted| wanted == &status) => {
+                    }) if session == session_id.as_str()
+                        && until.iter().any(|wanted| wanted == &status) =>
+                    {
                         return Ok((status, None));
                     }
                     Ok(Event::SessionExited {
                         session, status, ..
-                    }) if session == session_id
+                    }) if session == session_id.as_str()
                         && until.iter().any(|wanted| wanted == "exited") =>
                     {
                         return Ok(("exited".to_string(), Some(status)));
@@ -324,7 +332,7 @@ impl Manager {
 
         match tokio::time::timeout(Duration::from_millis(timeout_ms), wait).await {
             Ok(Ok((status, exit_status))) => Control::WaitResult {
-                session: session_id,
+                session: session_id.to_string(),
                 status,
                 timed_out: false,
                 exit_status,
@@ -335,7 +343,7 @@ impl Manager {
                 let current = self.info(&handle).await.map(|info| info.status);
                 if current.is_none() && until.iter().any(|wanted| wanted == "exited") {
                     return Control::WaitResult {
-                        session: session_id,
+                        session: session_id.to_string(),
                         status: "exited".to_string(),
                         timed_out: false,
                         exit_status: None,
@@ -343,7 +351,7 @@ impl Manager {
                     };
                 }
                 Control::WaitResult {
-                    session: session_id,
+                    session: session_id.to_string(),
                     status: current.unwrap_or_else(|| "exited".to_string()),
                     timed_out: true,
                     exit_status: None,
@@ -392,7 +400,9 @@ pub async fn serve() -> Result<()> {
         let manager = manager.clone();
         tokio::spawn(async move {
             while let Some(ended) = on_exit_rx.recv().await {
-                let id = ended.info.id.clone();
+                // The end record is a wire struct, so its id crosses back into
+                // the host's vocabulary here.
+                let id = SessionId::new(ended.info.id.clone());
                 // A termination request can win after PTY EOF but before this
                 // task receives the actor's end record. The handle retains the
                 // first requested reason until burial completes.
@@ -836,7 +846,10 @@ async fn process_control(
             let response = match manager.create(spec) {
                 Ok(id) => {
                     manager.publish_created(&id).await;
-                    Control::Created { id, re: seq }
+                    Control::Created {
+                        id: id.to_string(),
+                        re: seq,
+                    }
                 }
                 Err(e) => error(seq, ErrorCode::CreateFailed, format!("{e:#}"), false),
             };
@@ -1625,7 +1638,7 @@ async fn resolve_upload_dest(
     dest: &str,
     root: Option<&str>,
     session: Option<&str>,
-) -> std::result::Result<(crate::files::UploadDest, Option<String>), (ErrorCode, String)> {
+) -> std::result::Result<(crate::files::UploadDest, Option<SessionId>), (ErrorCode, String)> {
     if let Some(name) = dest.strip_prefix("temp:") {
         let Some(session) = session else {
             return Err((
@@ -1755,12 +1768,12 @@ async fn run_attach(
         handle.send(SessionMsg::Info { reply: tx });
         rx.await
             .map(|info| info.name)
-            .unwrap_or_else(|_| handle.id.clone())
+            .unwrap_or_else(|_| handle.id.to_string())
     };
     let _ = out.send(Outbound::Control(Control::Attached {
-        id: handle.id.clone(),
+        id: handle.id.to_string(),
         name,
-        session_id: handle.id.clone(),
+        session_id: handle.id.to_string(),
         writer: added.writer,
         rows: added.rows,
         cols: added.cols,
@@ -1781,7 +1794,7 @@ async fn run_attach(
     let supports_grid_diff = supports_snapshot && connection.capabilities.contains("grid_diff");
     let negotiated = connection.negotiated;
     let event_out = out.clone();
-    let session_id = handle.id.clone();
+    let session_id = handle.id.to_string();
     let bridge_backlog = backlog;
     let mut bridge = tokio::spawn(async move {
         while let Some(event) = client_events.recv().await {

--- a/termiod/src/files.rs
+++ b/termiod/src/files.rs
@@ -11,6 +11,7 @@
 //! nothing here can touch the terminal hot path by construction, because it
 //! only ever runs on control channels.
 
+use crate::id::SessionId;
 use crate::protocol::{DirEntry, EntryKind, PathListing};
 use anyhow::{anyhow, bail, Context, Result};
 use std::path::{Component, Path, PathBuf};
@@ -568,7 +569,7 @@ struct UploadState {
     size: u64,
     sha256: String,
     mode: Option<u32>,
-    session: Option<String>,
+    session: Option<SessionId>,
     received: u64,
     hasher: sha2::Sha256,
     file: std::fs::File,
@@ -610,7 +611,7 @@ impl Uploads {
         size: u64,
         sha256: &str,
         mode: Option<u32>,
-        session: Option<String>,
+        session: Option<SessionId>,
     ) -> Result<(String, u64)> {
         if sha256.len() != 64 || !sha256.bytes().all(|byte| byte.is_ascii_hexdigit()) {
             bail!("sha256 must be 64 hex characters");
@@ -775,12 +776,12 @@ impl Uploads {
 
     /// Drop every in-flight upload bound for a dead session's scratch dir.
     /// Called from the reaper before the dir itself is removed.
-    pub fn drop_session(&self, session_id: &str) {
+    pub fn drop_session(&self, session_id: &SessionId) {
         let mut inner = self.inner.lock().unwrap();
         let doomed: Vec<String> = inner
             .by_id
             .iter()
-            .filter(|(_, state)| state.session.as_deref() == Some(session_id))
+            .filter(|(_, state)| state.session.as_ref() == Some(session_id))
             .map(|(id, _)| id.clone())
             .collect();
         for id in doomed {
@@ -1204,7 +1205,7 @@ mod tests {
                 body.len() as u64,
                 &hex_sha256(&body),
                 Some(0o777),
-                Some("s_1".to_string()),
+                Some(SessionId::new("s_1")),
             )
             .unwrap();
         uploads.chunk(&id, 0, &body).unwrap();
@@ -1217,10 +1218,10 @@ mod tests {
         // dotfile behind.
         let dest = resolve_scratch_dest(&root, "paste-2.png").unwrap();
         let (id, _) = uploads
-            .open(dest, 4, &hex_sha256(b"gone"), None, Some("s_1".to_string()))
+            .open(dest, 4, &hex_sha256(b"gone"), None, Some(SessionId::new("s_1")))
             .unwrap();
         uploads.chunk(&id, 0, b"go").unwrap();
-        uploads.drop_session("s_1");
+        uploads.drop_session(&SessionId::new("s_1"));
         assert!(uploads.chunk(&id, 2, b"ne").is_err(), "upload is gone");
         let names: Vec<String> = std::fs::read_dir(&root)
             .unwrap()

--- a/termiod/src/id.rs
+++ b/termiod/src/id.rs
@@ -1,0 +1,44 @@
+//! The host's identities.
+//!
+//! A client id, a session id and a session name were all `String`, and they all
+//! flow through the same functions. Nothing but the type told them apart, so the
+//! type is what tells them apart.
+//!
+//! These are host-side only. The wire keeps bare JSON strings, because that is
+//! what a JSON string is: `SessionInfo.id` and `Control::HelloOk.client_id` stay
+//! `String`, and every crossing into or out of them is a visible `new` or
+//! `to_string`. Swift sees no difference.
+
+use std::fmt;
+
+/// One connection to this host. Allocated per accepted connection, never reused
+/// within a daemon's life, and the key of both a session's client roster and the
+/// resource registry's subscriber tables.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ClientId(String);
+
+impl ClientId {
+    /// Take a string the caller vouches for. Every call site is a boundary: the
+    /// daemon minting an id for a connection it just accepted.
+    pub fn new(id: impl Into<String>) -> ClientId {
+        ClientId(id.into())
+    }
+
+    /// A subscriber that is not a connection. The resource registry's `git:`
+    /// kind rides the `fs:` watcher by subscribing to it and needs a key for
+    /// that interest; naming the constructor keeps the fabrication visible
+    /// rather than leaving a `format!` that reads like a real client.
+    pub fn internal(id: impl Into<String>) -> ClientId {
+        ClientId(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ClientId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/termiod/src/id.rs
+++ b/termiod/src/id.rs
@@ -35,6 +35,9 @@ impl ClientId {
         ClientId(id.into())
     }
 
+    /// Only the assertions need this: everything in the host either keys a map
+    /// with a whole `ClientId` or renders one through `Display`.
+    #[cfg(test)]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/termiod/src/id.rs
+++ b/termiod/src/id.rs
@@ -1,8 +1,11 @@
 //! The host's identities.
 //!
 //! A client id, a session id and a session name were all `String`, and they all
-//! flow through the same functions. Nothing but the type told them apart, so the
-//! type is what tells them apart.
+//! flow through the same functions: a client id keys a session's roster, a
+//! session id keys the session table and the graveyard, and a user-supplied
+//! target — which may be an id *or* a name — arrives from the wire looking
+//! exactly like both. Nothing but the type told them apart, so the type is what
+//! tells them apart.
 //!
 //! These are host-side only. The wire keeps bare JSON strings, because that is
 //! what a JSON string is: `SessionInfo.id` and `Control::HelloOk.client_id` stay
@@ -38,6 +41,31 @@ impl ClientId {
 }
 
 impl fmt::Display for ClientId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// One session on this host. Distinct from the *name* a session carries, which
+/// a user picks; distinct again from the target a client sends, which is either
+/// of the two and must be resolved against the table before anything indexes
+/// with it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionId(String);
+
+impl SessionId {
+    /// Take a string the caller vouches for: an id the daemon minted, or one
+    /// read back out of a record the daemon wrote.
+    pub fn new(id: impl Into<String>) -> SessionId {
+        SessionId(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SessionId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -11,6 +11,7 @@ mod client;
 mod daemon;
 mod files;
 mod git;
+mod id;
 mod paths;
 mod proc;
 mod protocol;

--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -4,6 +4,7 @@
 //! logout). Fall back to a uid-scoped dir under the system temp dir. Either
 //! way the directory is created 0700 so no other user can connect.
 
+use crate::id::SessionId;
 use anyhow::{bail, Context, Result};
 use std::io::{Read, Write};
 use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
@@ -89,7 +90,7 @@ pub fn scratch_root() -> Result<PathBuf> {
 
 /// One session's scratch dir, created 0700 on first use and reaped with the
 /// session.
-pub fn session_scratch_dir(session_id: &str) -> Result<PathBuf> {
+pub fn session_scratch_dir(session_id: &SessionId) -> Result<PathBuf> {
     let dir = scratch_root()?.join(format!("session-{session_id}"));
     if !dir.exists() {
         std::fs::DirBuilder::new()

--- a/termiod/src/resource.rs
+++ b/termiod/src/resource.rs
@@ -23,7 +23,7 @@
 //!   FSEvents' `MustScanSubDirs`.
 
 use crate::protocol::Event;
-use crate::session::ClientId;
+use crate::id::ClientId;
 use anyhow::{anyhow, Context, Result};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::{HashMap, VecDeque};
@@ -414,7 +414,7 @@ impl Registry {
         let fs_entry = self.fs_entry_locked(watches, &fs_id, Path::new(root))?;
 
         let (signal_tx, signal_rx) = mpsc::unbounded_channel::<Event>();
-        let internal_client = format!("git-signal:{resource}");
+        let internal_client = ClientId::internal(format!("git-signal:{resource}"));
         {
             let mut guard = fs_entry.state.lock().unwrap();
             guard.subscribers.insert(internal_client.clone(), signal_tx);
@@ -441,10 +441,10 @@ impl Registry {
     /// subscribed. The watch keeps running for `LINGER` so the same client can
     /// come back and resume from its cursor — detach ≠ kill, applied to the
     /// resource plane.
-    pub fn unsubscribe(&self, resource: &str, client: &str) -> bool {
+    pub fn unsubscribe(&self, resource: &str, client: &ClientId) -> bool {
         fn drop_interest<B: ResourceBatch>(
             state: &Arc<Mutex<ResourceState<B>>>,
-            client: &str,
+            client: &ClientId,
         ) -> bool {
             let mut guard = state.lock().unwrap();
             let removed = guard.subscribers.remove(client).is_some();
@@ -462,7 +462,7 @@ impl Registry {
     }
 
     /// Drop every subscription held by a departing connection.
-    pub fn drop_client(&self, client: &str) {
+    pub fn drop_client(&self, client: &ClientId) {
         let resources: Vec<String> = self.watches.lock().unwrap().keys().cloned().collect();
         for resource in resources {
             self.unsubscribe(&resource, client);
@@ -515,7 +515,7 @@ async fn git_loop(
     entry: GitEntry,
     registry: Registry,
     fs_resource: String,
-    internal_client: String,
+    internal_client: ClientId,
 ) {
     refresh_git(&resource, &root, &entry).await;
     loop {
@@ -800,13 +800,13 @@ mod tests {
     fn changes_while_detached_are_recorded_and_replayed_on_return() {
         let mut state = headless();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        state.subscribers.insert("c_1".to_string(), tx);
+        state.subscribers.insert(ClientId::new("c_1"), tx);
 
         state.publish("fs:/repo", batch(&["/repo/attached"]));
         assert_eq!(rx.try_recv().map(|e| seqs(&[e])[0]).unwrap(), 1);
 
         // The client goes away; the agent keeps writing.
-        state.subscribers.remove("c_1");
+        state.subscribers.remove(&ClientId::new("c_1"));
         state.idle_since = Some(Instant::now());
         state.publish("fs:/repo", batch(&["/repo/while-gone-1"]));
         state.publish("fs:/repo", batch(&["/repo/while-gone-2"]));

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -7,7 +7,7 @@ use crate::protocol::{
     HistoryChunk, SessionInfo, Snapshot, WireCell, WireColor, WorkstreamSpec, HISTORY_HEADER_SIZE,
     MAX_HISTORY_FRAME_SIZE, SNAPSHOT_CELL_SIZE,
 };
-use crate::id::ClientId;
+use crate::id::{ClientId, SessionId};
 use crate::pty::Pty;
 use crate::tombstone::EndReason;
 use bytes::Bytes;
@@ -118,7 +118,7 @@ pub struct SessionEnded {
 /// Cheap, cloneable reference to a session task.
 #[derive(Clone)]
 pub struct SessionHandle {
-    pub id: String,
+    pub id: SessionId,
     pid: i32,
     tx: mpsc::UnboundedSender<SessionMsg>,
     /// PTY EOF can become ready in the same scheduler turn as `Kill`; keeping
@@ -180,7 +180,7 @@ enum ClientDelivery {
 }
 
 struct Session {
-    id: String,
+    id: SessionId,
     name: String,
     cwd: String,
     command: String,
@@ -267,7 +267,7 @@ struct ForegroundResolution {
 impl Session {
     fn info(&self) -> SessionInfo {
         SessionInfo {
-            id: self.id.clone(),
+            id: self.id.to_string(),
             name: self.name.clone(),
             cwd: self.cwd.clone(),
             command: self.command.clone(),
@@ -469,7 +469,7 @@ impl Session {
         self.send_sidecar(SidecarCommand::Shutdown);
         self.sidecar_tx.take();
         self.emit_event(Event::VtStale {
-            session: self.id.clone(),
+            session: self.id.to_string(),
             reason: reason.clone(),
         });
         self.disconnect_grid_clients(&reason);
@@ -561,7 +561,7 @@ impl Session {
     /// fresh boundary. No other client is touched.
     fn force_resync(&mut self, client_id: &ClientId, reason: &str) {
         let request_id = self.allocate_snapshot_request();
-        let session_id = self.id.clone();
+        let session_id = self.id.to_string();
         let Some(entry) = self.clients.get_mut(client_id) else {
             return;
         };
@@ -632,7 +632,7 @@ impl Session {
 
     fn emit_roster(&mut self) {
         self.emit_event(Event::Roster {
-            session: self.id.clone(),
+            session: self.id.to_string(),
             action: "updated".to_string(),
             info: Some(Box::new(self.info())),
         });
@@ -644,7 +644,7 @@ impl Session {
                 Self::queue_non_data(
                     entry,
                     ClientEvent::Control(Control::ResizeClaim {
-                        session: self.id.clone(),
+                        session: self.id.to_string(),
                         writer: self.writer.as_ref().map(ClientId::to_string),
                     }),
                 );
@@ -652,7 +652,7 @@ impl Session {
         }
         let writer = self.writer.as_ref().map(ClientId::to_string);
         self.emit_event(Event::WriterChanged {
-            session: self.id.clone(),
+            session: self.id.to_string(),
             writer,
         });
     }
@@ -782,7 +782,7 @@ impl Session {
     }
 
     fn queue_history_chunk(
-        session_id: &str,
+        session_id: &SessionId,
         client_id: &ClientId,
         entry: &mut ClientEntry,
     ) -> Result<bool, ()> {
@@ -917,7 +917,7 @@ impl Session {
             || entry
                 .out
                 .send(ClientEvent::Event(Event::Ready {
-                    session: self.id.clone(),
+                    session: self.id.to_string(),
                 }))
                 .is_err()
         {
@@ -991,7 +991,7 @@ impl Session {
                     || entry
                         .out
                         .send(ClientEvent::Event(Event::Ready {
-                            session: self.id.clone(),
+                            session: self.id.to_string(),
                         }))
                         .is_err())
                 .then(|| id.clone())
@@ -1221,7 +1221,7 @@ fn release_buffered(backlog: &ClientBacklog, data: VecDeque<Metered>) {
 /// manager so it can remove the handle from the table.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn(
-    id: String,
+    id: SessionId,
     name: String,
     cwd: String,
     command: String,
@@ -1591,7 +1591,7 @@ async fn run(
     let mut info = session.info();
     info.alive = false;
     let exit_event = Event::SessionExited {
-        session: session.id.clone(),
+        session: session.id.to_string(),
         status: code,
         info: Some(Box::new(info.clone())),
     };
@@ -1751,7 +1751,7 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
                 session.send_sidecar(SidecarCommand::Resize { rows, cols });
                 session.begin_snapshot_barrier();
                 session.emit_event(Event::Resized {
-                    session: session.id.clone(),
+                    session: session.id.to_string(),
                     rows,
                     cols,
                 });
@@ -1772,7 +1772,7 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
                 session.title = title;
             }
             session.emit_event(Event::Status {
-                session: session.id.clone(),
+                session: session.id.to_string(),
                 status: session.status.clone(),
                 title: session.title.clone(),
             });
@@ -1800,7 +1800,7 @@ mod tests {
         SidecarCommand, SidecarQueue, SidecarResult, SCROLLBACK_STAGE_MAX_BYTES,
         SNAPSHOT_CELL_SIZE,
     };
-    use crate::id::ClientId;
+    use crate::id::{ClientId, SessionId};
     use crate::protocol::{Control, ErrorCode, Event, SessionInfo};
     use crate::pty::Pty;
     use crate::tombstone::EndReason;
@@ -1902,7 +1902,7 @@ mod tests {
         let (events, event_rx) = broadcast::channel(64);
         (
             Session {
-                id: "session".to_string(),
+                id: SessionId::new("session"),
                 name: "test".to_string(),
                 cwd: String::new(),
                 command: "cat".to_string(),
@@ -2364,7 +2364,7 @@ mod tests {
         let backlog = Arc::new(ClientBacklog::new());
         let (sidecar_tx, sidecar_rx) = std_mpsc::channel();
         let mut session = Session {
-            id: "session".to_string(),
+            id: SessionId::new("session"),
             name: "test".to_string(),
             cwd: String::new(),
             command: "cat".to_string(),
@@ -2480,7 +2480,7 @@ mod tests {
         let (on_exit, on_exit_rx) = mpsc::unbounded_channel();
         let (events, events_rx) = broadcast::channel(64);
         let handle = super::spawn(
-            "foreground-session".to_string(),
+            SessionId::new("foreground-session"),
             "test".to_string(),
             cwd.to_string(),
             argv.join(" "),

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -34,7 +34,7 @@ pub(crate) use backlog::{ClientBacklog, Metered};
 
 mod sidecar;
 
-pub(crate) use sidecar::{SidecarCapture, SidecarCommand, SidecarQueue, SidecarResult};
+pub(crate) use sidecar::{SidecarCapture, SidecarCommand, SidecarQueue, SidecarResult, Vt};
 
 /// Pushed to an attached connection task.
 #[derive(Clone)]
@@ -330,12 +330,7 @@ struct Session {
     ring: VecDeque<Bytes>,
     ring_bytes: usize,
     events: broadcast::Sender<Event>,
-    sidecar_tx: Option<std_mpsc::Sender<SidecarCommand>>,
-    sidecar_queue: Arc<SidecarQueue>,
-    /// Set once the VT has been denied bytes it needed. The screen it holds no
-    /// longer describes any boundary in the output stream, so it can never
-    /// answer a snapshot again — attach and resync fall back to ring replay.
-    vt_stale: Option<String>,
+    vt: Vt,
     /// Last sample of who is in the tty's foreground and where the child is.
     /// `info()` reads this cache so a roster request never turns into a burst
     /// of syscalls.
@@ -567,11 +562,9 @@ impl Session {
     }
 
     fn send_sidecar(&mut self, command: SidecarCommand) -> bool {
-        let sent = self
-            .sidecar_tx
-            .as_ref()
-            .is_some_and(|sender| sender.send(command).is_ok());
-        if !sent && self.sidecar_tx.take().is_some() {
+        let was_live = self.vt.is_live();
+        let sent = self.vt.send(command);
+        if !sent && was_live {
             eprintln!("termiod: VT sidecar for session {} stopped", self.id);
         }
         sent
@@ -582,35 +575,35 @@ impl Session {
     /// silently would leave `S` describing a screen that never occurred, and
     /// blocking here would put the VT parse back on the fan-out path.
     fn write_sidecar(&mut self, chunk: Bytes) {
-        if self.vt_stale.is_some() || self.sidecar_tx.is_none() {
+        if !self.vt.is_live() {
             return;
         }
-        if !self.sidecar_queue.try_reserve(chunk.len()) {
+        let len = chunk.len();
+        if !self.vt.try_reserve(len) {
             self.mark_vt_stale(format!(
                 "VT sidecar fell more than {} behind the PTY",
                 sidecar::cap_description()
             ));
             return;
         }
-        let len = chunk.len();
         if !self.send_sidecar(SidecarCommand::Write(chunk)) {
-            self.sidecar_queue.release(len);
+            self.vt.release(len);
         }
     }
 
     fn mark_vt_stale(&mut self, reason: String) {
-        if self.vt_stale.is_some() {
+        if !self.vt.is_live() {
             return;
         }
         eprintln!(
             "termiod: VT sidecar for session {} is stale: {reason}; snapshots now fall back to ring replay",
             self.id
         );
-        self.vt_stale = Some(reason.clone());
         // Nothing more will reach the VT, so drain what is queued rather than
-        // let a wedged parse hold the memory.
+        // let a wedged parse hold the memory. The shutdown goes out while the
+        // sender is still there; the VT is down the moment it has.
         self.send_sidecar(SidecarCommand::Shutdown);
-        self.sidecar_tx.take();
+        self.vt = Vt::down(reason.clone());
         self.emit_event(Event::VtStale {
             session: self.id.to_string(),
             reason: reason.clone(),
@@ -622,11 +615,7 @@ impl Session {
     /// Ask the sidecar for one client's snapshot, or fail it straight into the
     /// ring-replay fallback when the VT can no longer answer.
     fn request_snapshot(&mut self, client_id: ClientId, request_id: u64, scrollback: bool) {
-        let refusal = self.vt_stale.clone().or_else(|| {
-            self.sidecar_tx
-                .is_none()
-                .then(|| "VT sidecar is unavailable".to_string())
-        });
+        let refusal = self.vt.refusal().map(str::to_string);
         if let Some(reason) = refusal {
             self.finish_snapshot(&client_id, request_id, Err(reason));
             return;
@@ -636,11 +625,7 @@ impl Session {
             request_id,
             scrollback,
         }) {
-            self.finish_snapshot(
-                &client_id,
-                request_id,
-                Err("VT sidecar is unavailable".to_string()),
-            );
+            self.finish_snapshot(&client_id, request_id, Err(sidecar::UNAVAILABLE.to_string()));
         }
     }
 
@@ -1390,9 +1375,7 @@ pub fn spawn(
         ring: VecDeque::new(),
         ring_bytes: 0,
         events,
-        sidecar_tx: Some(sidecar.commands),
-        sidecar_queue: sidecar.queue,
-        vt_stale: None,
+        vt: Vt::live(sidecar.commands, sidecar.queue),
         foreground: ForegroundSample::default(),
         foreground_pending: false,
         child_executable: None,
@@ -1650,7 +1633,10 @@ async fn run(
                     }
                     None => {
                         sidecar_results_open = false;
-                        session.sidecar_tx.take();
+                        // The VT is down for the reason any absent sidecar is —
+                        // it cannot be asked — while the clients that were
+                        // waiting on an answer are told what happened to them.
+                        session.vt = Vt::down(sidecar::UNAVAILABLE);
                         session.disconnect_grid_clients("VT sidecar response channel closed");
                         session.fallback_all_pending("VT sidecar response channel closed");
                     }
@@ -1681,9 +1667,7 @@ async fn run(
             end_reason = requested;
         }
     }
-    if let Some(sidecar_tx) = session.sidecar_tx.take() {
-        let _ = sidecar_tx.send(SidecarCommand::Shutdown);
-    }
+    session.vt.shut_down();
 
     let code = match waiter.take() {
         Some(w) => w.await.unwrap_or(-1),
@@ -1916,7 +1900,7 @@ mod tests {
     use super::{
         handle_msg, scrollback_row_limit, should_emit_keyframe, spawn_sidecar, ClientBacklog,
         ClientDelivery, ClientEntry, ClientEvent, ClientPlane, ClientRole, Session, SessionHandle,
-        SessionMsg, Sidecar, SidecarCommand, SidecarQueue, SidecarResult,
+        SessionMsg, Sidecar, SidecarCommand, SidecarQueue, SidecarResult, Vt,
         SCROLLBACK_STAGE_MAX_BYTES, SNAPSHOT_CELL_SIZE,
     };
     use crate::id::{ClientId, SessionId};
@@ -2041,9 +2025,7 @@ mod tests {
                 ring: VecDeque::new(),
                 ring_bytes: 0,
                 events,
-                sidecar_tx: Some(sidecar_tx),
-                sidecar_queue,
-                vt_stale: None,
+                vt: Vt::live(sidecar_tx, sidecar_queue),
                 foreground: super::ForegroundSample::default(),
                 foreground_pending: false,
                 child_executable: None,
@@ -2183,7 +2165,7 @@ mod tests {
         assert!(claim_writer(&mut session, "phone"), "the phone's user typed");
         assert_eq!(writer(&session), Some("phone"));
 
-        let _ = session.sidecar_tx.take();
+        session.vt.shut_down();
         let _ = thread.join();
     }
 
@@ -2209,7 +2191,7 @@ mod tests {
             "a refused claim must not disturb the writer it failed to displace"
         );
 
-        let _ = session.sidecar_tx.take();
+        session.vt.shut_down();
         let _ = thread.join();
     }
 
@@ -2229,7 +2211,7 @@ mod tests {
         assert!(!claim_writer(&mut session, "ghost"));
         assert_eq!(writer(&session), Some("mac"));
 
-        let _ = session.sidecar_tx.take();
+        session.vt.shut_down();
         let _ = thread.join();
     }
 
@@ -2319,7 +2301,7 @@ mod tests {
             "the snapshot boundary and the bytes buffered behind it did not line up"
         );
 
-        let _ = session.sidecar_tx.take();
+        session.vt.shut_down();
         let _ = tokio::task::spawn_blocking(move || thread.join()).await;
     }
 
@@ -2403,7 +2385,7 @@ mod tests {
         );
         assert!(backlog.is_dropped());
 
-        let _ = session.sidecar_tx.take();
+        session.vt.shut_down();
         let _ = tokio::task::spawn_blocking(move || thread.join()).await;
     }
 
@@ -2437,7 +2419,13 @@ mod tests {
         session.write_sidecar(chunk.clone());
         session.fan_out(chunk.clone());
 
-        assert!(session.vt_stale.is_some(), "the budget did not bite");
+        assert!(
+            session
+                .vt
+                .refusal()
+                .is_some_and(|reason| reason.contains("behind the PTY")),
+            "the budget did not bite"
+        );
         let mut announced = false;
         while let Ok(event) = events.try_recv() {
             announced |= matches!(event, Event::VtStale { .. });
@@ -2470,7 +2458,7 @@ mod tests {
         assert_eq!(snapshots, 0, "a stale VT still answered a snapshot");
         assert_eq!(replayed, chunk, "the ring-replay fallback did not run");
 
-        let _ = session.sidecar_tx.take();
+        session.vt.shut_down();
         let _ = tokio::task::spawn_blocking(move || thread.join()).await;
     }
 
@@ -2513,9 +2501,7 @@ mod tests {
             ring: VecDeque::new(),
             ring_bytes: 0,
             events,
-            sidecar_tx: Some(sidecar_tx),
-            sidecar_queue: Arc::new(SidecarQueue::new()),
-            vt_stale: None,
+            vt: Vt::live(sidecar_tx, Arc::new(SidecarQueue::new())),
             foreground: super::ForegroundSample::default(),
             foreground_pending: false,
             child_executable: None,

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -3,9 +3,7 @@
 //! connection — detach never kills it.
 
 use crate::protocol::{
-    encode_grid_payload, encode_history_payload, Control, ErrorCode, Event, GridDiff, GridRow,
-    HistoryChunk, SessionInfo, Snapshot, WireCell, WireColor, WorkstreamSpec, HISTORY_HEADER_SIZE,
-    MAX_HISTORY_FRAME_SIZE, SNAPSHOT_CELL_SIZE,
+    encode_grid_payload, Control, ErrorCode, Event, GridDiff, SessionInfo, Snapshot, WorkstreamSpec,
 };
 use crate::id::{ClientId, SessionId};
 use crate::pty::Pty;
@@ -21,13 +19,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 
 const RING_CAP: usize = 128 * 1024;
 const READ_CHUNK: usize = 64 * 1024;
-pub const SCROLLBACK_STAGE_MAX_BYTES: usize = 1024 * 1024;
 pub const KEYFRAME_EVERY_FRAMES: u32 = 256;
-/// How often the session asks the kernel what is running in its terminal.
-/// Slow on purpose: this answers "which agent is in there", a question whose
-/// answer changes when a human starts or stops a program, not per frame.
-const FOREGROUND_POLL: std::time::Duration = std::time::Duration::from_secs(2);
-
 mod backlog;
 
 pub(crate) use backlog::{ClientBacklog, Metered};
@@ -35,6 +27,17 @@ pub(crate) use backlog::{ClientBacklog, Metered};
 mod sidecar;
 
 pub(crate) use sidecar::{SidecarCapture, SidecarCommand, SidecarQueue, SidecarResult, Vt};
+
+mod foreground;
+
+use foreground::{Foreground, ForegroundResolution};
+
+mod wire;
+
+use wire::{
+    encode_scrollback_chunks, grid_from_damage, scrollback_row_limit, wire_cell,
+    SCROLLBACK_STAGE_MAX_BYTES,
+};
 
 /// Pushed to an attached connection task.
 #[derive(Clone)]
@@ -331,61 +334,10 @@ struct Session {
     ring_bytes: usize,
     events: broadcast::Sender<Event>,
     vt: Vt,
-    /// Last sample of who is in the tty's foreground and where the child is.
+    /// Who is in the tty's foreground and where the child is standing.
     /// `info()` reads this cache so a roster request never turns into a burst
     /// of syscalls.
-    foreground: ForegroundSample,
-    /// A resolution is in flight on a blocking thread. One at a time: the poll
-    /// is slower than the work, and piling up would only queue answers about
-    /// groups that have already lost the terminal.
-    foreground_pending: bool,
-    /// The binary the child is running, pinned on the first sample that finds
-    /// it. One-shot on purpose: this is the *launch* baseline that
-    /// `was_replaced()` compares against, and resampling would paper over the
-    /// in-place upgrade it exists to notice.
-    child_executable: Option<crate::proc::ExecutableIdentity>,
-}
-
-/// What the session believes about its foreground right now.
-///
-/// Split deliberately along what it costs to learn. `pgid` and `job` come from
-/// one `tcgetpgrp` and are refreshed on the actor; everything below them is a
-/// process-table walk and arrives later, from [`ForegroundResolution`].
-#[derive(Default, Clone, PartialEq, Eq)]
-struct ForegroundSample {
-    /// The foreground process *group*, exactly as `tcgetpgrp` reported it.
-    /// Kept even when no member of it could be read, because "is a job
-    /// running?" is answered by comparing this against the session's own child
-    /// and must not turn into "no" the moment a pipeline's leader exits.
-    pgid: Option<i32>,
-    /// The member of that group whose argv is reported below. Equal to `pgid`
-    /// whenever the group leader is still usable, which is the common case.
-    pid: Option<i32>,
-    argv: Option<Vec<String>>,
-    job: bool,
-    cwd: Option<String>,
-}
-
-/// The expensive half of a foreground sample, computed on a blocking thread and
-/// handed back to the actor.
-///
-/// Reading argv means a `KERN_PROCARGS2` sysctl on macOS and a file read on
-/// Linux, and finding *which* pid to read it for can mean walking every process
-/// on the box when a pipeline's leader has exited. None of that may happen on
-/// the session actor: that task also runs the PTY read and the fan-out, so a
-/// process-table walk there is time the byte path spends waiting — the
-/// anti-100× invariant, which is about more than the VT parse.
-struct ForegroundResolution {
-    /// The group this answer describes. The foreground can move while the
-    /// resolution is in flight, and an answer about a group that has since lost
-    /// the terminal is not a stale version of the truth — it is the answer to a
-    /// different question, and gets dropped.
-    pgid: Option<i32>,
-    pid: Option<i32>,
-    argv: Option<Vec<String>>,
-    cwd: Option<String>,
-    /// Only set when the session had not pinned its binary yet.
-    executable: Option<crate::proc::ExecutableIdentity>,
+    foreground: Foreground,
 }
 
 impl Session {
@@ -406,120 +358,13 @@ impl Session {
             title: self.title.clone(),
             attached_clients: self.clients.len(),
             writer_client_id: self.writer.as_ref().map(ClientId::to_string),
-            foreground_pid: self.foreground.pid,
-            foreground_argv: self.foreground.argv.clone(),
-            foreground_job: self.foreground.job,
-            child_cwd: self.foreground.cwd.clone(),
-            child_executable: self
-                .child_executable
-                .as_ref()
-                .map(|identity| identity.path.clone()),
-            // Checked here rather than cached from the last tick: the record
-            // that matters most is the one built on the exit path, and a binary
-            // swapped during the seconds before the child quit is exactly the
-            // case this answers.
-            child_executable_replaced: self
-                .child_executable
-                .as_ref()
-                .is_some_and(|identity| identity.was_replaced()),
+            foreground_pid: self.foreground.current().pid,
+            foreground_argv: self.foreground.current().argv.clone(),
+            foreground_job: self.foreground.current().job,
+            child_cwd: self.foreground.current().cwd.clone(),
+            child_executable: self.foreground.executable_path(),
+            child_executable_replaced: self.foreground.executable_replaced(),
         }
-    }
-
-    /// The cheap half of the poll, and the only half that runs here: one
-    /// `tcgetpgrp` on the master. Returns whether anything moved, so a quiet
-    /// session emits no roster traffic.
-    ///
-    /// The expensive half is dispatched to a blocking thread and applied later
-    /// by [`Session::apply_foreground`]. Both halves have to exist because they
-    /// answer different questions on different deadlines: "is a job running?"
-    /// is read at close time and must be current, and it is answerable from the
-    /// group id alone; "what is that job?" drives an icon and can be a beat
-    /// late.
-    fn sample_foreground(
-        &mut self,
-        resolved: &mpsc::UnboundedSender<ForegroundResolution>,
-    ) -> bool {
-        if self.pid <= 0 {
-            return false;
-        }
-        let pgid = self.pty.foreground_pgid();
-        // Compared against the *group*: a foreground group that is not the
-        // child's own is a running job whether or not any member of it could
-        // be read.
-        let job = pgid.is_some_and(|pgid| pgid != self.pid);
-        let mut changed = false;
-        if self.foreground.pgid != pgid {
-            self.foreground.pgid = pgid;
-            // The cached identity described a group that no longer holds the
-            // terminal. Dropping it is an honest gap the resolution below
-            // fills; keeping it would name a program that has already exited.
-            self.foreground.pid = None;
-            self.foreground.argv = None;
-            changed = true;
-        }
-        if self.foreground.job != job {
-            self.foreground.job = job;
-            changed = true;
-        }
-        self.request_foreground(pgid, resolved);
-        changed
-    }
-
-    /// Hand the process-table work to a blocking thread.
-    fn request_foreground(
-        &mut self,
-        pgid: Option<i32>,
-        resolved: &mpsc::UnboundedSender<ForegroundResolution>,
-    ) {
-        if self.foreground_pending {
-            return;
-        }
-        self.foreground_pending = true;
-        let child = self.pid;
-        let pin_executable = self.child_executable.is_none();
-        let resolved = resolved.clone();
-        tokio::task::spawn_blocking(move || {
-            // A group id is not a pid. The shell names each job's group after
-            // its leader, so the two agree for as long as that leader is alive
-            // — and stop agreeing in a pipeline the moment it is not, which is
-            // why the pid comes from the host rather than from that assumption.
-            let pid = pgid.and_then(crate::proc::foreground_member);
-            let _ = resolved.send(ForegroundResolution {
-                pgid,
-                pid,
-                argv: pid.and_then(crate::proc::process_arguments),
-                cwd: crate::proc::working_directory(child),
-                executable: pin_executable
-                    .then(|| crate::proc::executable_identity(child))
-                    .flatten(),
-            });
-        });
-    }
-
-    /// Take a resolution the blocking thread finished, unless the foreground
-    /// moved while it was in flight. Returns whether anything moved.
-    fn apply_foreground(&mut self, resolution: ForegroundResolution) -> bool {
-        self.foreground_pending = false;
-        if resolution.pgid != self.foreground.pgid {
-            return false;
-        }
-        if self.child_executable.is_none() {
-            self.child_executable = resolution.executable;
-        }
-        let mut changed = false;
-        if self.foreground.pid != resolution.pid {
-            self.foreground.pid = resolution.pid;
-            changed = true;
-        }
-        if self.foreground.argv != resolution.argv {
-            self.foreground.argv = resolution.argv;
-            changed = true;
-        }
-        if self.foreground.cwd != resolution.cwd {
-            self.foreground.cwd = resolution.cwd;
-            changed = true;
-        }
-        changed
     }
 
     fn recompute_writer(&mut self) {
@@ -1192,107 +1037,6 @@ impl Session {
     }
 }
 
-fn scrollback_row_limit(cols: u16) -> usize {
-    let row_bytes = usize::from(cols).saturating_mul(SNAPSHOT_CELL_SIZE);
-    SCROLLBACK_STAGE_MAX_BYTES
-        .checked_div(row_bytes)
-        .unwrap_or(0)
-}
-
-fn encode_scrollback_chunks(
-    cols: u16,
-    rows: Vec<Vec<termiod_vt::Cell>>,
-) -> Result<VecDeque<Bytes>, String> {
-    if rows.is_empty() {
-        return Ok(VecDeque::new());
-    }
-    let row_bytes = usize::from(cols)
-        .checked_mul(SNAPSHOT_CELL_SIZE)
-        .ok_or_else(|| "scrollback row length overflow".to_string())?;
-    let rows_per_chunk = MAX_HISTORY_FRAME_SIZE
-        .checked_sub(HISTORY_HEADER_SIZE)
-        .and_then(|available| available.checked_div(row_bytes))
-        .unwrap_or(0)
-        .min(usize::from(u16::MAX));
-    if rows_per_chunk == 0 {
-        return Err(format!(
-            "one {cols}-column row cannot fit in a {MAX_HISTORY_FRAME_SIZE}-byte H frame"
-        ));
-    }
-
-    let mut rows = rows.into_iter();
-    let mut chunks = VecDeque::new();
-    let mut first_offset = 1u32;
-    loop {
-        let mut cells = Vec::with_capacity(rows_per_chunk * usize::from(cols));
-        let mut row_count = 0u16;
-        for _ in 0..rows_per_chunk {
-            let Some(row) = rows.next() else {
-                break;
-            };
-            if row.len() != usize::from(cols) {
-                return Err(format!(
-                    "scrollback row has {} cells, expected {cols}",
-                    row.len()
-                ));
-            }
-            cells.extend(row.into_iter().map(wire_cell));
-            row_count += 1;
-        }
-        if row_count == 0 {
-            break;
-        }
-        let payload = encode_history_payload(&HistoryChunk {
-            cols,
-            first_offset,
-            row_count,
-            cells,
-        })
-        .map_err(|error| error.to_string())?;
-        chunks.push_back(Bytes::from(payload));
-        first_offset = first_offset
-            .checked_add(u32::from(row_count))
-            .ok_or_else(|| "scrollback offset overflow".to_string())?;
-    }
-    Ok(chunks)
-}
-
-fn wire_color(color: termiod_vt::Color) -> WireColor {
-    match color {
-        termiod_vt::Color::Default => WireColor::Default,
-        termiod_vt::Color::Palette(index) => WireColor::Palette(index),
-        termiod_vt::Color::Rgb(value) => WireColor::Rgb([value.r, value.g, value.b]),
-    }
-}
-
-fn wire_cell(cell: termiod_vt::Cell) -> WireCell {
-    WireCell {
-        codepoint: cell.codepoint,
-        foreground: wire_color(cell.foreground),
-        background: wire_color(cell.background),
-        attributes: cell.attributes,
-    }
-}
-
-fn grid_from_damage(frame_seq: u32, damage: termiod_vt::Damage) -> GridDiff {
-    GridDiff {
-        frame_seq,
-        rows: damage.rows,
-        cols: damage.cols,
-        cursor_x: damage.cursor_x,
-        cursor_y: damage.cursor_y,
-        alt_screen: damage.alt_screen,
-        dirty_rows: damage
-            .dirty_rows
-            .into_iter()
-            .map(|row| GridRow {
-                row_index: row.row_index,
-                cells: row.cells.into_iter().map(wire_cell).collect(),
-            })
-            .collect(),
-    }
-}
-
 fn keyframe_every_frames() -> u32 {
     std::env::var("TERMIOD_KEYFRAME_EVERY")
         .ok()
@@ -1376,9 +1120,7 @@ pub fn spawn(
         ring_bytes: 0,
         events,
         vt: Vt::live(sidecar.commands, sidecar.queue),
-        foreground: ForegroundSample::default(),
-        foreground_pending: false,
-        child_executable: None,
+        foreground: Foreground::default(),
     };
 
     let waiter = tokio::task::spawn_blocking(move || {
@@ -1586,7 +1328,7 @@ async fn run(
     // there" from its first roster request rather than after a cold two
     // seconds. Missed ticks are skipped instead of queued: a busy actor should
     // sample once when it catches up, not replay a backlog of polls.
-    let mut foreground_poll = tokio::time::interval(FOREGROUND_POLL);
+    let mut foreground_poll = tokio::time::interval(foreground::POLL_INTERVAL);
     foreground_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // The process-table half of each poll runs on a blocking thread and comes
     // back here. Held for the life of the loop so the branch below never sees a
@@ -1596,12 +1338,12 @@ async fn run(
     loop {
         tokio::select! {
             _ = foreground_poll.tick() => {
-                if session.sample_foreground(&foreground_tx) {
+                if session.foreground.poll(&session.pty, session.pid, &foreground_tx) {
                     session.emit_roster();
                 }
             }
             Some(resolution) = foreground_rx.recv() => {
-                if session.apply_foreground(resolution) {
+                if session.foreground.apply(resolution) {
                     session.emit_roster();
                 }
             }
@@ -1898,10 +1640,9 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
 #[cfg(test)]
 mod tests {
     use super::{
-        handle_msg, scrollback_row_limit, should_emit_keyframe, spawn_sidecar, ClientBacklog,
-        ClientDelivery, ClientEntry, ClientEvent, ClientPlane, ClientRole, Session, SessionHandle,
-        SessionMsg, Sidecar, SidecarCommand, SidecarQueue, SidecarResult, Vt,
-        SCROLLBACK_STAGE_MAX_BYTES, SNAPSHOT_CELL_SIZE,
+        handle_msg, should_emit_keyframe, spawn_sidecar, ClientBacklog, ClientDelivery, ClientEntry,
+        ClientEvent, ClientPlane, ClientRole, Session, SessionHandle, SessionMsg, Sidecar,
+        SidecarCommand, SidecarQueue, SidecarResult, Vt,
     };
     use crate::id::{ClientId, SessionId};
     use crate::protocol::{Control, ErrorCode, Event, SessionInfo};
@@ -1924,16 +1665,6 @@ mod tests {
 
 
 
-
-    #[test]
-    fn scrollback_stage_cap_is_measured_in_encoded_rows() {
-        let cols = 80u16;
-        let row_bytes = usize::from(cols) * SNAPSHOT_CELL_SIZE;
-        let rows = scrollback_row_limit(cols);
-
-        assert!(rows * row_bytes <= SCROLLBACK_STAGE_MAX_BYTES);
-        assert!((rows + 1) * row_bytes > SCROLLBACK_STAGE_MAX_BYTES);
-    }
 
     #[test]
     fn keyframe_cadence_replaces_every_nth_grid_flush() {
@@ -2026,9 +1757,7 @@ mod tests {
                 ring_bytes: 0,
                 events,
                 vt: Vt::live(sidecar_tx, sidecar_queue),
-                foreground: super::ForegroundSample::default(),
-                foreground_pending: false,
-                child_executable: None,
+                foreground: super::Foreground::default(),
             },
             event_rx,
         )
@@ -2502,9 +2231,7 @@ mod tests {
             ring_bytes: 0,
             events,
             vt: Vt::live(sidecar_tx, Arc::new(SidecarQueue::new())),
-            foreground: super::ForegroundSample::default(),
-            foreground_pending: false,
-            child_executable: None,
+            foreground: super::Foreground::default(),
         };
 
         assert!(handle_msg(

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -7,6 +7,7 @@ use crate::protocol::{
     HistoryChunk, SessionInfo, Snapshot, WireCell, WireColor, WorkstreamSpec, HISTORY_HEADER_SIZE,
     MAX_HISTORY_FRAME_SIZE, SNAPSHOT_CELL_SIZE,
 };
+use crate::id::ClientId;
 use crate::pty::Pty;
 use crate::tombstone::EndReason;
 use bytes::Bytes;
@@ -17,8 +18,6 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc, oneshot};
-
-pub type ClientId = String;
 
 const RING_CAP: usize = 128 * 1024;
 const READ_CHUNK: usize = 64 * 1024;
@@ -282,7 +281,7 @@ impl Session {
             agent_id: self.workstream.as_ref().map(|w| w.agent_id.clone()),
             title: self.title.clone(),
             attached_clients: self.clients.len(),
-            writer_client_id: self.writer.clone(),
+            writer_client_id: self.writer.as_ref().map(ClientId::to_string),
             foreground_pid: self.foreground.pid,
             foreground_argv: self.foreground.argv.clone(),
             foreground_job: self.foreground.job,
@@ -646,14 +645,15 @@ impl Session {
                     entry,
                     ClientEvent::Control(Control::ResizeClaim {
                         session: self.id.clone(),
-                        writer: self.writer.clone(),
+                        writer: self.writer.as_ref().map(ClientId::to_string),
                     }),
                 );
             }
         }
+        let writer = self.writer.as_ref().map(ClientId::to_string);
         self.emit_event(Event::WriterChanged {
             session: self.id.clone(),
-            writer: self.writer.clone(),
+            writer,
         });
     }
 
@@ -748,7 +748,7 @@ impl Session {
         self.remove_dead(dead);
     }
 
-    fn reject_not_writer(&mut self, id: &str) {
+    fn reject_not_writer(&mut self, id: &ClientId) {
         if let Some(entry) = self.clients.get_mut(id) {
             Self::queue_non_data(
                 entry,
@@ -762,7 +762,7 @@ impl Session {
         }
     }
 
-    fn reject_resize(&mut self, id: &str, error: &anyhow::Error) {
+    fn reject_resize(&mut self, id: &ClientId, error: &anyhow::Error) {
         let message = format!("resize failed: {error}");
         eprintln!(
             "termiod: resize failed for writer {id} in session {}: {error}",
@@ -783,7 +783,7 @@ impl Session {
 
     fn queue_history_chunk(
         session_id: &str,
-        client_id: &str,
+        client_id: &ClientId,
         entry: &mut ClientEntry,
     ) -> Result<bool, ()> {
         let Some(payload) = entry.staged_history.front() else {
@@ -809,7 +809,7 @@ impl Session {
         Ok(!entry.staged_history.is_empty())
     }
 
-    fn continue_history(&mut self, client_id: &str) -> bool {
+    fn continue_history(&mut self, client_id: &ClientId) -> bool {
         let result = self
             .clients
             .get_mut(client_id)
@@ -817,7 +817,7 @@ impl Session {
         match result {
             Some(Ok(more)) => more,
             Some(Err(())) => {
-                self.remove_dead(vec![client_id.to_string()]);
+                self.remove_dead(vec![client_id.clone()]);
                 false
             }
             None => false,
@@ -829,7 +829,7 @@ impl Session {
     /// after `ready`, with buffered live data allowed between staged chunks.
     fn finish_snapshot(
         &mut self,
-        client_id: &str,
+        client_id: &ClientId,
         request_id: u64,
         result: Result<SidecarCapture, String>,
     ) -> bool {
@@ -854,7 +854,7 @@ impl Session {
             ..
         } = std::mem::replace(&mut entry.delivery, ClientDelivery::Live)
         else {
-            self.clients.insert(client_id.to_string(), entry);
+            self.clients.insert(client_id.clone(), entry);
             return false;
         };
 
@@ -948,7 +948,7 @@ impl Session {
                 return false;
             }
         }
-        self.clients.insert(client_id.to_string(), entry);
+        self.clients.insert(client_id.clone(), entry);
         history_pending
     }
 
@@ -1037,7 +1037,7 @@ impl Session {
 
     fn fallback_snapshot(
         &mut self,
-        client_id: &str,
+        client_id: &ClientId,
         entry: ClientEntry,
         buffered: VecDeque<Metered>,
         deferred: VecDeque<ClientEvent>,
@@ -1067,12 +1067,12 @@ impl Session {
                 return;
             }
         }
-        self.clients.insert(client_id.to_string(), entry);
+        self.clients.insert(client_id.clone(), entry);
     }
 
-    fn remove_finished_client(&mut self, client_id: &str) {
+    fn remove_finished_client(&mut self, client_id: &ClientId) {
         let old_writer = self.writer.clone();
-        if old_writer.as_deref() == Some(client_id) {
+        if old_writer.as_ref() == Some(client_id) {
             self.recompute_writer();
         }
         self.sync_grid_diff_interest();
@@ -1665,7 +1665,7 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             if interactive {
                 session.writer = Some(id.clone());
             }
-            let is_writer = session.writer.as_deref() == Some(id.as_str());
+            let is_writer = session.writer.as_ref() == Some(&id);
             let _ = reply.send(AddClientReply {
                 writer: is_writer,
                 rows: session.rows,
@@ -1685,7 +1685,7 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             let old_writer = session.writer.clone();
             session.clients.remove(&id);
             session.sync_grid_diff_interest();
-            if old_writer.as_deref() == Some(id.as_str()) {
+            if old_writer.as_ref() == Some(&id) {
                 session.recompute_writer();
             }
             if session.writer != old_writer {
@@ -1800,6 +1800,7 @@ mod tests {
         SidecarCommand, SidecarQueue, SidecarResult, SCROLLBACK_STAGE_MAX_BYTES,
         SNAPSHOT_CELL_SIZE,
     };
+    use crate::id::ClientId;
     use crate::protocol::{Control, ErrorCode, Event, SessionInfo};
     use crate::pty::Pty;
     use crate::tombstone::EndReason;
@@ -1810,6 +1811,12 @@ mod tests {
 
     fn chunk(len: usize) -> Bytes {
         Bytes::from(vec![b'x'; len])
+    }
+
+    /// The write token as a plain str, so the assertions read as they did
+    /// when the roster was keyed by `String`.
+    fn writer(session: &Session) -> Option<&str> {
+        session.writer.as_ref().map(ClientId::as_str)
     }
 
 
@@ -1851,7 +1858,7 @@ mod tests {
             .unwrap();
         sidecar
             .send(SidecarCommand::Snapshot {
-                client_id: "client".to_string(),
+                client_id: ClientId::new("client"),
                 request_id: 1,
                 scrollback: false,
             })
@@ -1978,7 +1985,7 @@ mod tests {
         handle_msg(
             session,
             SessionMsg::AddClient {
-                id: id.to_string(),
+                id: ClientId::new(id),
                 interactive: true,
                 out: client_tx,
                 backlog: Arc::new(ClientBacklog::new()),
@@ -1996,7 +2003,7 @@ mod tests {
         handle_msg(
             session,
             SessionMsg::ClaimWriter {
-                id: id.to_string(),
+                id: ClientId::new(id),
                 reply,
             },
         );
@@ -2014,7 +2021,7 @@ mod tests {
         handle_msg(
             session,
             SessionMsg::AddClient {
-                id: id.to_string(),
+                id: ClientId::new(id),
                 interactive: false,
                 out: client_tx,
                 backlog: backlog.clone(),
@@ -2044,18 +2051,18 @@ mod tests {
         let (mut session, _events) = test_session(commands, queue);
 
         let _mac = attach_interactive_client(&mut session, "mac");
-        assert_eq!(session.writer.as_deref(), Some("mac"), "first in, writer");
+        assert_eq!(writer(&session), Some("mac"), "first in, writer");
 
         // Attaching still takes the token: that is what makes a fresh client
         // usable without a round trip.
         let _phone = attach_interactive_client(&mut session, "phone");
-        assert_eq!(session.writer.as_deref(), Some("phone"));
+        assert_eq!(writer(&session), Some("phone"));
 
         assert!(claim_writer(&mut session, "mac"), "the Mac's user typed");
-        assert_eq!(session.writer.as_deref(), Some("mac"));
+        assert_eq!(writer(&session), Some("mac"));
 
         assert!(claim_writer(&mut session, "phone"), "the phone's user typed");
-        assert_eq!(session.writer.as_deref(), Some("phone"));
+        assert_eq!(writer(&session), Some("phone"));
 
         let _ = session.sidecar_tx.take();
         let _ = thread.join();
@@ -2078,7 +2085,7 @@ mod tests {
 
         assert!(!claim_writer(&mut session, "watcher"));
         assert_eq!(
-            session.writer.as_deref(),
+            writer(&session),
             Some("mac"),
             "a refused claim must not disturb the writer it failed to displace"
         );
@@ -2101,7 +2108,7 @@ mod tests {
 
         let _mac = attach_interactive_client(&mut session, "mac");
         assert!(!claim_writer(&mut session, "ghost"));
-        assert_eq!(session.writer.as_deref(), Some("mac"));
+        assert_eq!(writer(&session), Some("mac"));
 
         let _ = session.sidecar_tx.take();
         let _ = thread.join();
@@ -2163,7 +2170,7 @@ mod tests {
         let (mut joining, _joining_backlog) = attach_client(&mut session, "joining", true);
         assert!(
             matches!(
-                session.clients["joining"].delivery,
+                session.clients[&ClientId::new("joining")].delivery,
                 ClientDelivery::SnapshotPending { .. }
             ),
             "the joining client is not behind a barrier, so this proves nothing"
@@ -2228,13 +2235,13 @@ mod tests {
             session.fan_out(mib.clone());
         }
         assert!(backlog.reserve(chunk(1)).is_none(), "budget is not full");
-        assert!(session.clients.contains_key("slow"));
+        assert!(session.clients.contains_key(&ClientId::new("slow")));
 
         // The overflow chunk. It is not delivered — it is what the snapshot
         // replaces — and the client survives it.
         session.fan_out(mib.clone());
         assert!(
-            session.clients.contains_key("slow"),
+            session.clients.contains_key(&ClientId::new("slow")),
             "the first overflow dropped the client instead of resyncing it"
         );
         assert!(
@@ -2272,7 +2279,7 @@ mod tests {
         }
         session.fan_out(mib.clone());
         assert!(
-            !session.clients.contains_key("slow"),
+            !session.clients.contains_key(&ClientId::new("slow")),
             "the second overflow did not drop the client"
         );
         assert!(backlog.is_dropped());
@@ -2371,7 +2378,7 @@ mod tests {
             pty,
             input_tx,
             clients: HashMap::from([(
-                "writer".to_string(),
+                ClientId::new("writer"),
                 ClientEntry {
                     out: client_tx,
                     backlog,
@@ -2384,7 +2391,7 @@ mod tests {
                     backlog_strikes: 0,
                 },
             )]),
-            writer: Some("writer".to_string()),
+            writer: Some(ClientId::new("writer")),
             next_seq: 2,
             next_snapshot_request: 1,
             ring: VecDeque::new(),
@@ -2401,7 +2408,7 @@ mod tests {
         assert!(handle_msg(
             &mut session,
             SessionMsg::Resize {
-                id: "writer".to_string(),
+                id: ClientId::new("writer"),
                 rows: 40,
                 cols: 120,
             },

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -12,7 +12,6 @@ use crate::tombstone::EndReason;
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -23,11 +22,6 @@ pub type ClientId = String;
 
 const RING_CAP: usize = 128 * 1024;
 const READ_CHUNK: usize = 64 * 1024;
-const CLIENT_BACKLOG_CAP: usize = 4 * 1024 * 1024;
-/// PTY bytes allowed to sit unparsed in the VT sidecar's command FIFO. The
-/// per-client budget stopped a slow socket from buying unbounded memory; this
-/// stops a slow *parse* from doing the same one hop upstream.
-const SIDECAR_QUEUE_CAP: usize = 16 * 1024 * 1024;
 pub const SCROLLBACK_STAGE_MAX_BYTES: usize = 1024 * 1024;
 pub const KEYFRAME_EVERY_FRAMES: u32 = 256;
 /// How often the session asks the kernel what is running in its terminal.
@@ -35,117 +29,13 @@ pub const KEYFRAME_EVERY_FRAMES: u32 = 256;
 /// answer changes when a human starts or stops a program, not per frame.
 const FOREGROUND_POLL: std::time::Duration = std::time::Duration::from_secs(2);
 
-/// A payload admitted against a client's backlog. The epoch pins it to the
-/// reservation that let it through, so a forced resync can discard everything
-/// already queued for that client without corrupting the count.
-#[derive(Clone)]
-pub struct Metered {
-    pub bytes: Bytes,
-    epoch: u64,
-}
+mod backlog;
 
-/// Counts PTY bytes queued anywhere between a session and its socket writer.
-pub(crate) struct ClientBacklog {
-    outstanding: AtomicUsize,
-    /// Bumped by a forced resync. Everything reserved under an older epoch is
-    /// stale: it precedes a snapshot that supersedes it, so it is dropped
-    /// undelivered and never released.
-    epoch: AtomicU64,
-    dropped: AtomicBool,
-}
+pub(crate) use backlog::{ClientBacklog, Metered};
 
-impl ClientBacklog {
-    pub(crate) fn new() -> Self {
-        Self {
-            outstanding: AtomicUsize::new(0),
-            epoch: AtomicU64::new(0),
-            dropped: AtomicBool::new(false),
-        }
-    }
+mod sidecar;
 
-    fn reserve(&self, bytes: Bytes) -> Option<Metered> {
-        self.outstanding
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
-                outstanding
-                    .checked_add(bytes.len())
-                    .filter(|total| *total <= CLIENT_BACKLOG_CAP)
-            })
-            .ok()?;
-        Some(Metered {
-            bytes,
-            epoch: self.epoch.load(Ordering::Acquire),
-        })
-    }
-
-    /// True once the client has consumed everything the session handed it.
-    #[cfg(test)]
-    fn is_drained(&self) -> bool {
-        self.outstanding.load(Ordering::Relaxed) == 0
-    }
-
-    /// Discard everything already queued for this client and start a new epoch.
-    /// The queued payloads are dropped where they sit rather than released, so
-    /// the counter is reset here instead of unwound.
-    fn begin_resync(&self) {
-        self.epoch.fetch_add(1, Ordering::AcqRel);
-        self.outstanding.store(0, Ordering::Release);
-    }
-
-    /// True while this payload still belongs to the client's current stream.
-    pub(crate) fn is_current(&self, payload: &Metered) -> bool {
-        payload.epoch == self.epoch.load(Ordering::Acquire)
-    }
-
-    pub(crate) fn release(&self, payload: &Metered) {
-        if !self.is_current(payload) {
-            return;
-        }
-        let _ =
-            self.outstanding
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
-                    Some(outstanding.saturating_sub(payload.bytes.len()))
-                });
-    }
-
-    fn mark_dropped(&self) {
-        self.dropped.store(true, Ordering::Release);
-    }
-
-    pub(crate) fn is_dropped(&self) -> bool {
-        self.dropped.load(Ordering::Acquire)
-    }
-}
-
-/// Counts PTY bytes queued for the VT sidecar but not yet parsed.
-struct SidecarQueue {
-    outstanding: AtomicUsize,
-}
-
-impl SidecarQueue {
-    fn new() -> Self {
-        Self {
-            outstanding: AtomicUsize::new(0),
-        }
-    }
-
-    fn try_reserve(&self, bytes: usize) -> bool {
-        self.outstanding
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
-                outstanding
-                    .checked_add(bytes)
-                    .filter(|total| *total <= SIDECAR_QUEUE_CAP)
-            })
-            .is_ok()
-    }
-
-    fn release(&self, bytes: usize) {
-        let _ =
-            self.outstanding
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
-                    Some(outstanding.saturating_sub(bytes))
-                });
-    }
-}
+pub(crate) use sidecar::{SidecarCapture, SidecarCommand, SidecarQueue, SidecarResult};
 
 /// Pushed to an attached connection task.
 #[derive(Clone)]
@@ -288,42 +178,6 @@ enum ClientDelivery {
         data: VecDeque<Metered>,
         deferred: VecDeque<ClientEvent>,
     },
-}
-
-enum SidecarCommand {
-    Write(Bytes),
-    Resize {
-        rows: u16,
-        cols: u16,
-    },
-    Snapshot {
-        client_id: ClientId,
-        request_id: u64,
-        scrollback: bool,
-    },
-    SetGridDiff(bool),
-    Shutdown,
-}
-
-/// Snapshot replies and live grid updates share this single FIFO channel.
-/// Separate channels could let a post-boundary G overtake its S and regress
-/// rows after the client applies the newer snapshot.
-enum SidecarResult {
-    Snapshot {
-        client_id: ClientId,
-        request_id: u64,
-        result: Result<SidecarCapture, String>,
-    },
-    Grid(GridDiff),
-    Keyframe(termiod_vt::Snapshot),
-}
-
-struct SidecarCapture {
-    snapshot: termiod_vt::Snapshot,
-    /// The same screen serialised back to VT sequences. `None` only if the
-    /// formatter failed, in which case delivery falls back to packed cells.
-    vt: Option<Vec<u8>>,
-    scrollback: Option<Result<termiod_vt::Scrollback, String>>,
 }
 
 struct Session {
@@ -591,8 +445,8 @@ impl Session {
         }
         if !self.sidecar_queue.try_reserve(chunk.len()) {
             self.mark_vt_stale(format!(
-                "VT sidecar fell more than {} MiB behind the PTY",
-                SIDECAR_QUEUE_CAP / (1024 * 1024)
+                "VT sidecar fell more than {} behind the PTY",
+                sidecar::cap_description()
             ));
             return;
         }
@@ -824,9 +678,9 @@ impl Session {
                     }
                     entry.backlog.mark_dropped();
                     eprintln!(
-                        "termiod: dropping slow client {id} from session {}: output backlog exceeded {} MiB again",
+                        "termiod: dropping slow client {id} from session {}: output backlog exceeded {} again",
                         self.id,
-                        CLIENT_BACKLOG_CAP / (1024 * 1024)
+                        backlog::cap_description()
                     );
                     return Some(id.clone());
                 };
@@ -848,10 +702,7 @@ impl Session {
         for client_id in resync {
             self.force_resync(
                 &client_id,
-                &format!(
-                    "output backlog exceeded {} MiB",
-                    CLIENT_BACKLOG_CAP / (1024 * 1024)
-                ),
+                &format!("output backlog exceeded {}", backlog::cap_description()),
             );
         }
     }
@@ -881,9 +732,9 @@ impl Session {
                 let Some(metered) = entry.backlog.reserve(payload.clone()) else {
                     entry.backlog.mark_dropped();
                     eprintln!(
-                        "termiod: dropping slow grid-diff client {id} from session {}: output backlog exceeded {} MiB",
+                        "termiod: dropping slow grid-diff client {id} from session {}: output backlog exceeded {}",
                         self.id,
-                        CLIENT_BACKLOG_CAP / (1024 * 1024)
+                        backlog::cap_description()
                     );
                     return Some(id.clone());
                 };
@@ -941,8 +792,8 @@ impl Session {
         let Some(metered) = entry.backlog.reserve(payload.clone()) else {
             entry.backlog.mark_dropped();
             eprintln!(
-                "termiod: dropping slow client {client_id} from session {session_id}: scrollback backlog exceeded {} MiB",
-                CLIENT_BACKLOG_CAP / (1024 * 1024)
+                "termiod: dropping slow client {client_id} from session {session_id}: scrollback backlog exceeded {}",
+                backlog::cap_description()
             );
             return Err(());
         };
@@ -1946,8 +1797,8 @@ mod tests {
     use super::{
         handle_msg, scrollback_row_limit, should_emit_keyframe, spawn_sidecar, ClientBacklog,
         ClientDelivery, ClientEntry, ClientEvent, Session, SessionHandle, SessionMsg, Sidecar,
-        SidecarCommand, SidecarQueue, SidecarResult, CLIENT_BACKLOG_CAP,
-        SCROLLBACK_STAGE_MAX_BYTES, SIDECAR_QUEUE_CAP, SNAPSHOT_CELL_SIZE,
+        SidecarCommand, SidecarQueue, SidecarResult, SCROLLBACK_STAGE_MAX_BYTES,
+        SNAPSHOT_CELL_SIZE,
     };
     use crate::protocol::{Control, ErrorCode, Event, SessionInfo};
     use crate::pty::Pty;
@@ -1961,65 +1812,8 @@ mod tests {
         Bytes::from(vec![b'x'; len])
     }
 
-    #[test]
-    fn client_backlog_enforces_byte_cap() {
-        let backlog = ClientBacklog::new();
 
-        let bulk = backlog
-            .reserve(chunk(CLIENT_BACKLOG_CAP - 1))
-            .expect("bulk reservation");
-        let last = backlog.reserve(chunk(1)).expect("last byte");
-        assert!(backlog.reserve(chunk(1)).is_none());
 
-        backlog.release(&bulk);
-        backlog.release(&last);
-        assert!(backlog.is_drained());
-        let after = backlog
-            .reserve(chunk(1))
-            .expect("reservation after release");
-        backlog.release(&after);
-    }
-
-    #[test]
-    fn resync_retires_queued_payloads_without_unwinding_the_count() {
-        let backlog = ClientBacklog::new();
-        let stale = backlog
-            .reserve(chunk(CLIENT_BACKLOG_CAP))
-            .expect("full reservation");
-        assert!(backlog.reserve(chunk(1)).is_none());
-
-        backlog.begin_resync();
-
-        // The queued payload is dropped where it sits, so the client starts the
-        // new epoch with the whole budget rather than waiting for a drain.
-        assert!(!backlog.is_current(&stale));
-        assert!(backlog.is_drained());
-        let fresh = backlog
-            .reserve(chunk(CLIENT_BACKLOG_CAP))
-            .expect("fresh reservation");
-
-        // A late release of a retired payload must not credit the new epoch.
-        backlog.release(&stale);
-        assert!(backlog.reserve(chunk(1)).is_none());
-        backlog.release(&fresh);
-        assert!(backlog.is_drained());
-    }
-
-    #[test]
-    fn sidecar_queue_stops_admitting_bytes_past_its_budget() {
-        let queue = SidecarQueue::new();
-
-        assert!(queue.try_reserve(SIDECAR_QUEUE_CAP));
-        assert!(!queue.try_reserve(1));
-
-        queue.release(SIDECAR_QUEUE_CAP);
-        assert!(queue.try_reserve(1));
-        queue.release(1);
-        // Releasing more than was reserved is a bug, not a panic: the VT thread
-        // and the session actor account independently.
-        queue.release(SIDECAR_QUEUE_CAP);
-        assert!(queue.try_reserve(SIDECAR_QUEUE_CAP));
-    }
 
     #[test]
     fn scrollback_stage_cap_is_measured_in_encoded_rows() {
@@ -2087,10 +1881,7 @@ mod tests {
         thread.join().unwrap();
         // Every byte the session charged to the queue is credited back once the
         // VT has parsed it, or the budget ratchets shut on a healthy session.
-        assert_eq!(
-            queue.outstanding.load(std::sync::atomic::Ordering::Relaxed),
-            0
-        );
+        assert!(queue.is_drained());
     }
 
     /// A session with no clients, a live sidecar, and a PTY that only has to
@@ -2433,7 +2224,7 @@ mod tests {
 
         // Nothing on the far end ever releases, so the budget fills for real.
         let mib = chunk(1024 * 1024);
-        for _ in 0..(CLIENT_BACKLOG_CAP / mib.len()) {
+        for _ in 0..(super::backlog::CAP_FOR_TESTS / mib.len()) {
             session.fan_out(mib.clone());
         }
         assert!(backlog.reserve(chunk(1)).is_none(), "budget is not full");
@@ -2476,7 +2267,7 @@ mod tests {
 
         // Second strike. The client starts from an empty budget and still
         // cannot drain, so this time it goes.
-        for _ in 0..(CLIENT_BACKLOG_CAP / mib.len()) {
+        for _ in 0..(super::backlog::CAP_FOR_TESTS / mib.len()) {
             session.fan_out(mib.clone());
         }
         session.fan_out(mib.clone());
@@ -2503,7 +2294,7 @@ mod tests {
         } = spawn_sidecar(24, 80).unwrap();
         // Park the whole budget so the next PTY chunk cannot be admitted. This
         // stands in for a VT parse that has stopped making progress.
-        assert!(queue.try_reserve(SIDECAR_QUEUE_CAP));
+        assert!(queue.try_reserve(super::sidecar::CAP_FOR_TESTS));
         let (mut session, mut events) = test_session(commands, queue);
         let (mut client, _backlog) = attach_snapshot_client(&mut session, "raw");
         pump_sidecar(&mut session, &mut results, 1).await;

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -154,12 +154,8 @@ impl SessionHandle {
 struct ClientEntry {
     out: mpsc::UnboundedSender<ClientEvent>,
     backlog: Arc<ClientBacklog>,
-    /// Interactive attach order. Highest sequence owns the write token.
-    seq: u64,
-    interactive: bool,
-    snapshot_capable: bool,
-    grid_diff: bool,
-    delivery: ClientDelivery,
+    role: ClientRole,
+    plane: ClientPlane,
     /// Attach-only history staging. Resize barriers discard any remainder and
     /// deliberately do not restage it; resize/reflow history is a later policy.
     staged_history: VecDeque<Bytes>,
@@ -168,6 +164,139 @@ struct ClientEntry {
     /// already zeroed the count of what the client owes, so a second overflow
     /// means it could not keep up even from a clean start.
     backlog_strikes: u32,
+}
+
+/// Whether this attachment can hold the write token.
+enum ClientRole {
+    /// Attached without a tty. §A: an observer never claims the token. One that
+    /// could would strand the session at whatever size the last real client
+    /// left, having no tty of its own to resize.
+    Observer,
+    /// Attached with a tty. `seq` is interactive attach order — the highest
+    /// takes the token back when the current holder leaves. Only interactive
+    /// attachments are numbered, because only they are ever compared.
+    Interactive { seq: u64 },
+}
+
+impl ClientRole {
+    fn is_interactive(&self) -> bool {
+        matches!(self, ClientRole::Interactive { .. })
+    }
+
+    /// The attach order to rank this client by, or `None` for an attachment
+    /// that is not in the running for the token at all.
+    fn attach_seq(&self) -> Option<u64> {
+        match self {
+            ClientRole::Observer => None,
+            ClientRole::Interactive { seq } => Some(*seq),
+        }
+    }
+}
+
+/// Which plane the attachment reads, and — for the two that have one — where it
+/// stands relative to its snapshot boundary.
+///
+/// This is the negotiated capability pair made exclusive. `grid_diff` without
+/// `snapshot` was never a state the host would run: the parsed plane bootstraps
+/// and recovers through `S`, so the daemon drops the capability at hello and
+/// `AddClient` dropped it again. There is now no fourth case to drop.
+enum ClientPlane {
+    /// Never negotiated `snapshot`: raw PTY bytes only, ring replay on attach.
+    /// No boundary to stand behind, so no barrier and nothing to resync to —
+    /// which is why this variant carries no delivery state at all.
+    Raw,
+    /// Negotiated `snapshot`: raw PTY bytes, punctuated by `S` boundaries on
+    /// attach, resize and resync.
+    Snapshot(ClientDelivery),
+    /// Negotiated `snapshot` + `grid_diff`: server-parsed cells and keyframes,
+    /// never downstream PTY bytes.
+    Grid(ClientDelivery),
+}
+
+impl ClientPlane {
+    fn snapshots(&self) -> bool {
+        !matches!(self, ClientPlane::Raw)
+    }
+
+    fn is_grid(&self) -> bool {
+        matches!(self, ClientPlane::Grid(_))
+    }
+
+    /// Where this attachment stands relative to its snapshot boundary. `None`
+    /// for a raw attachment, which has no boundary and is live by construction.
+    fn delivery(&self) -> Option<&ClientDelivery> {
+        match self {
+            ClientPlane::Raw => None,
+            ClientPlane::Snapshot(delivery) | ClientPlane::Grid(delivery) => Some(delivery),
+        }
+    }
+
+    fn delivery_mut(&mut self) -> Option<&mut ClientDelivery> {
+        match self {
+            ClientPlane::Raw => None,
+            ClientPlane::Snapshot(delivery) | ClientPlane::Grid(delivery) => Some(delivery),
+        }
+    }
+
+    /// The request this attachment is waiting on, if it is behind a barrier.
+    fn pending_request(&self) -> Option<u64> {
+        match self.delivery() {
+            Some(ClientDelivery::SnapshotPending { request_id, .. }) => Some(*request_id),
+            _ => None,
+        }
+    }
+
+    fn is_pending(&self) -> bool {
+        self.pending_request().is_some()
+    }
+
+    /// Open a snapshot barrier. Events already deferred behind an older barrier
+    /// carry over — they are still owed — while the data buffered behind it is
+    /// handed back, because the snapshot that is coming supersedes it and the
+    /// caller decides whether to credit those bytes or retire them.
+    ///
+    /// A raw attachment has no barrier to open; nothing calls this for one, and
+    /// it is a no-op if anything ever does.
+    fn begin_pending(&mut self, request_id: u64) -> VecDeque<Metered> {
+        let Some(delivery) = self.delivery_mut() else {
+            return VecDeque::new();
+        };
+        let (superseded, deferred) = match std::mem::replace(delivery, ClientDelivery::Live) {
+            ClientDelivery::Live => (VecDeque::new(), VecDeque::new()),
+            ClientDelivery::SnapshotPending { data, deferred, .. } => (data, deferred),
+        };
+        *delivery = ClientDelivery::SnapshotPending {
+            request_id,
+            data: VecDeque::new(),
+            deferred,
+        };
+        superseded
+    }
+
+    /// Queue an event behind this attachment's open barrier. `false` when there
+    /// is no barrier and the caller should send it straight out.
+    fn defer(&mut self, event: ClientEvent) -> bool {
+        match self.delivery_mut() {
+            Some(ClientDelivery::SnapshotPending { deferred, .. }) => {
+                deferred.push_back(event);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Close an open barrier, leaving the attachment live, and hand back what
+    /// was queued behind it: the buffered data and the deferred events, in that
+    /// order. Empty queues for an attachment that had no barrier open.
+    fn settle(&mut self) -> (VecDeque<Metered>, VecDeque<ClientEvent>) {
+        let Some(delivery) = self.delivery_mut() else {
+            return (VecDeque::new(), VecDeque::new());
+        };
+        match std::mem::replace(delivery, ClientDelivery::Live) {
+            ClientDelivery::SnapshotPending { data, deferred, .. } => (data, deferred),
+            ClientDelivery::Live => (VecDeque::new(), VecDeque::new()),
+        }
+    }
 }
 
 enum ClientDelivery {
@@ -402,9 +531,23 @@ impl Session {
         self.writer = self
             .clients
             .iter()
-            .filter(|(_, entry)| entry.interactive)
-            .max_by_key(|(_, entry)| entry.seq)
+            .filter_map(|(id, entry)| entry.role.attach_seq().map(|seq| (id, seq)))
+            .max_by_key(|(_, seq)| *seq)
             .map(|(id, _)| id.clone());
+    }
+
+    /// The write token only ever moves through here, and only ever onto a
+    /// client that attached with a tty. Returns whether the claim was allowed.
+    fn grant_writer(&mut self, id: &ClientId) -> bool {
+        if !self
+            .clients
+            .get(id)
+            .is_some_and(|entry| entry.role.is_interactive())
+        {
+            return false;
+        }
+        self.writer = Some(id.clone());
+        true
     }
 
     fn allocate_snapshot_request(&mut self) -> u64 {
@@ -502,7 +645,7 @@ impl Session {
     }
 
     fn wants_grid_diffs(&self) -> bool {
-        self.clients.values().any(|entry| entry.grid_diff)
+        self.clients.values().any(|entry| entry.plane.is_grid())
     }
 
     fn sync_grid_diff_interest(&mut self) {
@@ -513,7 +656,7 @@ impl Session {
         let snapshot_clients: Vec<ClientId> = self
             .clients
             .iter()
-            .filter(|(_, entry)| entry.snapshot_capable)
+            .filter(|(_, entry)| entry.plane.snapshots())
             .map(|(id, _)| id.clone())
             .collect();
         let mut requests = Vec::with_capacity(snapshot_clients.len());
@@ -528,21 +671,10 @@ impl Session {
             // resize cancels any unfinished stage and does not recapture it;
             // history reflow/restaging semantics are intentionally deferred.
             entry.staged_history.clear();
-            let previous = std::mem::replace(&mut entry.delivery, ClientDelivery::Live);
-            let deferred = match previous {
-                ClientDelivery::Live => VecDeque::new(),
-                ClientDelivery::SnapshotPending { data, deferred, .. } => {
-                    // The new snapshot includes every write queued before the
-                    // resize, so replaying older buffered data would overlap.
-                    release_buffered(&entry.backlog, data);
-                    deferred
-                }
-            };
-            entry.delivery = ClientDelivery::SnapshotPending {
-                request_id,
-                data: VecDeque::new(),
-                deferred,
-            };
+            // The new snapshot includes every write queued before the resize, so
+            // replaying older buffered data would overlap.
+            let superseded = entry.plane.begin_pending(request_id);
+            release_buffered(&entry.backlog, superseded);
             requests.push((client_id, request_id));
         }
 
@@ -568,22 +700,13 @@ impl Session {
         entry.backlog_strikes += 1;
         entry.staged_history.clear();
         entry.backlog.begin_resync();
-        let previous = std::mem::replace(&mut entry.delivery, ClientDelivery::Live);
-        let mut deferred = match previous {
-            ClientDelivery::Live => VecDeque::new(),
-            // The buffered data was reserved under the epoch just retired, so it
-            // is dropped with the rest rather than replayed past the new `S`.
-            ClientDelivery::SnapshotPending { deferred, .. } => deferred,
-        };
-        deferred.push_back(ClientEvent::Event(Event::Resynced {
+        // The buffered data was reserved under the epoch just retired, so it is
+        // dropped where it sits rather than replayed past the new `S`.
+        drop(entry.plane.begin_pending(request_id));
+        entry.plane.defer(ClientEvent::Event(Event::Resynced {
             session: session_id,
             reason: reason.to_string(),
         }));
-        entry.delivery = ClientDelivery::SnapshotPending {
-            request_id,
-            data: VecDeque::new(),
-            deferred,
-        };
         eprintln!(
             "termiod: resyncing client {client_id} on session {}: {reason}",
             self.id
@@ -592,12 +715,12 @@ impl Session {
     }
 
     fn queue_non_data(entry: &mut ClientEntry, event: ClientEvent) -> bool {
-        match &mut entry.delivery {
-            ClientDelivery::Live => entry.out.send(event).is_ok(),
-            ClientDelivery::SnapshotPending { deferred, .. } => {
+        match entry.plane.delivery_mut() {
+            Some(ClientDelivery::SnapshotPending { deferred, .. }) => {
                 deferred.push_back(event);
                 true
             }
+            _ => entry.out.send(event).is_ok(),
         }
     }
 
@@ -668,11 +791,11 @@ impl Session {
                 // The parsed plane is opt-in: G clients never reserve or
                 // receive downstream PTY bytes. Raw clients keep this exact
                 // byte-blind path regardless of sidecar lag.
-                if entry.grid_diff {
+                if entry.plane.is_grid() {
                     return None;
                 }
                 let Some(payload) = entry.backlog.reserve(data.clone()) else {
-                    if entry.backlog_strikes == 0 && entry.snapshot_capable {
+                    if entry.backlog_strikes == 0 && entry.plane.snapshots() {
                         resync.push(id.clone());
                         return None;
                     }
@@ -684,15 +807,16 @@ impl Session {
                     );
                     return Some(id.clone());
                 };
-                match &mut entry.delivery {
-                    ClientDelivery::Live => {
+                match entry.plane.delivery_mut() {
+                    Some(ClientDelivery::SnapshotPending { data: buffered, .. }) => {
+                        buffered.push_back(payload);
+                    }
+                    // Raw, or snapshot-capable and past its boundary.
+                    _ => {
                         if entry.out.send(ClientEvent::Data(payload.clone())).is_err() {
                             entry.backlog.release(&payload);
                             return Some(id.clone());
                         }
-                    }
-                    ClientDelivery::SnapshotPending { data: buffered, .. } => {
-                        buffered.push_back(payload);
                     }
                 }
                 None
@@ -722,9 +846,7 @@ impl Session {
             .clients
             .iter_mut()
             .filter_map(|(id, entry)| {
-                if !entry.grid_diff
-                    || matches!(entry.delivery, ClientDelivery::SnapshotPending { .. })
-                {
+                if !entry.plane.is_grid() || entry.plane.is_pending() {
                     // An ordered G observed while pending precedes this
                     // client's S boundary, so the S supersedes it.
                     return None;
@@ -833,35 +955,25 @@ impl Session {
         request_id: u64,
         result: Result<SidecarCapture, String>,
     ) -> bool {
-        let is_current = self.clients.get(client_id).is_some_and(|entry| {
-            matches!(
-                entry.delivery,
-                ClientDelivery::SnapshotPending {
-                    request_id: current,
-                    ..
-                } if current == request_id
-            )
-        });
+        // A reply for a request this attachment is no longer waiting on
+        // describes a boundary that a resize or a resync has already replaced.
+        let is_current = self
+            .clients
+            .get(client_id)
+            .and_then(|entry| entry.plane.pending_request())
+            == Some(request_id);
         if !is_current {
             return false;
         }
         let Some(mut entry) = self.clients.remove(client_id) else {
             return false;
         };
-        let ClientDelivery::SnapshotPending {
-            mut data,
-            mut deferred,
-            ..
-        } = std::mem::replace(&mut entry.delivery, ClientDelivery::Live)
-        else {
-            self.clients.insert(client_id.clone(), entry);
-            return false;
-        };
+        let (mut data, mut deferred) = entry.plane.settle();
 
         let capture = match result {
             Ok(capture) => capture,
             Err(error) => {
-                if entry.grid_diff {
+                if entry.plane.is_grid() {
                     eprintln!(
                         "termiod: grid-diff snapshot unavailable for client {client_id} in session {}: {error}; disconnecting client",
                         self.id
@@ -884,7 +996,7 @@ impl Session {
         // Raw-plane clients get VT sequences so their own libghostty decides
         // colour (their theme, their palette, full SGR). Grid-diff clients are
         // server-state by design and need packed cells to seed the grid.
-        let snapshot_vt = if entry.grid_diff { None } else { capture.vt };
+        let snapshot_vt = if entry.plane.is_grid() { None } else { capture.vt };
         if let Some(scrollback) = capture.scrollback {
             match scrollback {
                 Ok(scrollback) => {
@@ -979,9 +1091,7 @@ impl Session {
             .clients
             .iter_mut()
             .filter_map(|(id, entry)| {
-                if !entry.grid_diff
-                    || matches!(entry.delivery, ClientDelivery::SnapshotPending { .. })
-                {
+                if !entry.plane.is_grid() || entry.plane.is_pending() {
                     return None;
                 }
                 (entry
@@ -1004,7 +1114,7 @@ impl Session {
         let ids: Vec<ClientId> = self
             .clients
             .iter()
-            .filter(|(_, entry)| entry.grid_diff)
+            .filter(|(_, entry)| entry.plane.is_grid())
             .map(|(id, _)| id.clone())
             .collect();
         if ids.is_empty() {
@@ -1017,10 +1127,9 @@ impl Session {
         );
         let old_writer = self.writer.clone();
         for id in ids {
-            if let Some(entry) = self.clients.remove(&id) {
-                if let ClientDelivery::SnapshotPending { data, .. } = entry.delivery {
-                    release_buffered(&entry.backlog, data);
-                }
+            if let Some(mut entry) = self.clients.remove(&id) {
+                let (buffered, _deferred) = entry.plane.settle();
+                release_buffered(&entry.backlog, buffered);
                 let _ = entry.out.send(ClientEvent::Control(Control::Error {
                     re: None,
                     code: ErrorCode::Internal,
@@ -1085,11 +1194,11 @@ impl Session {
         let pending: Vec<(ClientId, u64)> = self
             .clients
             .iter()
-            .filter_map(|(id, entry)| match entry.delivery {
-                ClientDelivery::SnapshotPending { request_id, .. } => {
-                    Some((id.clone(), request_id))
-                }
-                ClientDelivery::Live => None,
+            .filter_map(|(id, entry)| {
+                entry
+                    .plane
+                    .pending_request()
+                    .map(|request_id| (id.clone(), request_id))
             })
             .collect();
         for (id, request_id) in pending {
@@ -1620,11 +1729,18 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             grid_diff,
             reply,
         } => {
-            let seq = session.next_seq;
-            session.next_seq += 1;
+            // Only interactive attachments are numbered: the sequence exists
+            // to rank claims on the write token, and an observer is never in
+            // that ranking.
+            let role = if interactive {
+                let seq = session.next_seq;
+                session.next_seq += 1;
+                ClientRole::Interactive { seq }
+            } else {
+                ClientRole::Observer
+            };
             let old_writer = session.writer.clone();
             let snapshot_request = snapshot.then(|| session.allocate_snapshot_request());
-            let grid_diff = grid_diff && snapshot;
 
             if !snapshot {
                 for replay in &session.ring {
@@ -1637,24 +1753,32 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
                     }
                 }
             }
+            // A client that did not negotiate snapshots gets the raw plane and
+            // no barrier; one that did starts behind the barrier its bootstrap
+            // `S` will open. Grid diffs ride on top of the snapshot plane and
+            // are unreachable without it.
+            let plane = match snapshot_request {
+                None => ClientPlane::Raw,
+                Some(request_id) => {
+                    let delivery = ClientDelivery::SnapshotPending {
+                        request_id,
+                        data: VecDeque::new(),
+                        deferred: VecDeque::new(),
+                    };
+                    if grid_diff {
+                        ClientPlane::Grid(delivery)
+                    } else {
+                        ClientPlane::Snapshot(delivery)
+                    }
+                }
+            };
             session.clients.insert(
                 id.clone(),
                 ClientEntry {
                     out,
                     backlog,
-                    seq,
-                    interactive,
-                    snapshot_capable: snapshot,
-                    grid_diff,
-                    delivery: if let Some(request_id) = snapshot_request {
-                        ClientDelivery::SnapshotPending {
-                            request_id,
-                            data: VecDeque::new(),
-                            deferred: VecDeque::new(),
-                        }
-                    } else {
-                        ClientDelivery::Live
-                    },
+                    role,
+                    plane,
                     staged_history: VecDeque::new(),
                     backlog_strikes: 0,
                 },
@@ -1663,7 +1787,7 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             // later Writes can only produce G results after its S boundary.
             session.sync_grid_diff_interest();
             if interactive {
-                session.writer = Some(id.clone());
+                session.grant_writer(&id);
             }
             let is_writer = session.writer.as_ref() == Some(&id);
             let _ = reply.send(AddClientReply {
@@ -1705,20 +1829,15 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
         SessionMsg::ClaimWriter { id, reply } => {
             // An observer is refused rather than promoted: it attached without
             // a tty and cannot resize, so handing it the token would strand the
-            // session at whatever size the last real client left.
-            let eligible = session
-                .clients
-                .get(&id)
-                .map(|entry| entry.interactive)
-                .unwrap_or(false);
+            // session at whatever size the last real client left. A stranger —
+            // a stale id, a racing reconnect — is refused for the same reason
+            // `grant_writer` will not install a writer nobody can reach.
+            let held = session.writer.as_ref() == Some(&id);
+            let eligible = session.grant_writer(&id);
             let _ = reply.send(eligible);
-            if !eligible {
+            if !eligible || held {
                 return None;
             }
-            if session.writer.as_ref() == Some(&id) {
-                return None;
-            }
-            session.writer = Some(id);
             // The client that just took the token is told its own size claim is
             // now the one that counts, the same shape `AddClient` uses.
             session.emit_writer_changed(session.writer.clone());
@@ -1796,9 +1915,9 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
 mod tests {
     use super::{
         handle_msg, scrollback_row_limit, should_emit_keyframe, spawn_sidecar, ClientBacklog,
-        ClientDelivery, ClientEntry, ClientEvent, Session, SessionHandle, SessionMsg, Sidecar,
-        SidecarCommand, SidecarQueue, SidecarResult, SCROLLBACK_STAGE_MAX_BYTES,
-        SNAPSHOT_CELL_SIZE,
+        ClientDelivery, ClientEntry, ClientEvent, ClientPlane, ClientRole, Session, SessionHandle,
+        SessionMsg, Sidecar, SidecarCommand, SidecarQueue, SidecarResult,
+        SCROLLBACK_STAGE_MAX_BYTES, SNAPSHOT_CELL_SIZE,
     };
     use crate::id::{ClientId, SessionId};
     use crate::protocol::{Control, ErrorCode, Event, SessionInfo};
@@ -2170,8 +2289,8 @@ mod tests {
         let (mut joining, _joining_backlog) = attach_client(&mut session, "joining", true);
         assert!(
             matches!(
-                session.clients[&ClientId::new("joining")].delivery,
-                ClientDelivery::SnapshotPending { .. }
+                session.clients[&ClientId::new("joining")].plane,
+                ClientPlane::Snapshot(ClientDelivery::SnapshotPending { .. })
             ),
             "the joining client is not behind a barrier, so this proves nothing"
         );
@@ -2382,11 +2501,8 @@ mod tests {
                 ClientEntry {
                     out: client_tx,
                     backlog,
-                    seq: 1,
-                    interactive: true,
-                    snapshot_capable: false,
-                    grid_diff: false,
-                    delivery: ClientDelivery::Live,
+                    role: ClientRole::Interactive { seq: 1 },
+                    plane: ClientPlane::Raw,
                     staged_history: VecDeque::new(),
                     backlog_strikes: 0,
                 },

--- a/termiod/src/session/backlog.rs
+++ b/termiod/src/session/backlog.rs
@@ -1,0 +1,160 @@
+//! What a client is allowed to have in flight, and what happens when it is not
+//! keeping up.
+//!
+//! Pure policy: no PTY, no VT, no runtime. A session hands bytes to this and is
+//! told whether they may be queued — the decision to drop a straggler and
+//! resync it is made here and nowhere else, which is what keeps a slow socket
+//! from buying unbounded memory on the host.
+
+use bytes::Bytes;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+
+/// How many bytes may sit queued for one client before it is dropped and
+/// resynced. Per client on purpose: one slow socket must not be able to spend
+/// the host's memory on everyone else's behalf.
+const CLIENT_BACKLOG_CAP: usize = 4 * 1024 * 1024;
+
+/// The limit in the words a log line or a refusal uses. Callers reporting *why*
+/// a client was dropped should ask rather than restate the constant, so the
+/// number and its explanation cannot drift apart.
+/// The cap itself, for tests that need to build a payload sized against it.
+#[cfg(test)]
+pub(crate) const CAP_FOR_TESTS: usize = CLIENT_BACKLOG_CAP;
+
+pub(crate) fn cap_description() -> String {
+    format!("{} MiB", CLIENT_BACKLOG_CAP / (1024 * 1024))
+}
+
+/// A payload admitted against a client's backlog. The epoch pins it to the
+/// reservation that let it through, so a forced resync can discard everything
+/// already queued for that client without corrupting the count.
+#[derive(Clone)]
+pub(crate) struct Metered {
+    pub(crate) bytes: Bytes,
+    epoch: u64,
+}
+
+/// Counts PTY bytes queued anywhere between a session and its socket writer.
+pub(crate) struct ClientBacklog {
+    outstanding: AtomicUsize,
+    /// Bumped by a forced resync. Everything reserved under an older epoch is
+    /// stale: it precedes a snapshot that supersedes it, so it is dropped
+    /// undelivered and never released.
+    epoch: AtomicU64,
+    dropped: AtomicBool,
+}
+
+impl ClientBacklog {
+    pub(crate) fn new() -> Self {
+        Self {
+            outstanding: AtomicUsize::new(0),
+            epoch: AtomicU64::new(0),
+            dropped: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn reserve(&self, bytes: Bytes) -> Option<Metered> {
+        self.outstanding
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
+                outstanding
+                    .checked_add(bytes.len())
+                    .filter(|total| *total <= CLIENT_BACKLOG_CAP)
+            })
+            .ok()?;
+        Some(Metered {
+            bytes,
+            epoch: self.epoch.load(Ordering::Acquire),
+        })
+    }
+
+    /// True once the client has consumed everything the session handed it.
+    #[cfg(test)]
+    pub(crate) fn is_drained(&self) -> bool {
+        self.outstanding.load(Ordering::Relaxed) == 0
+    }
+
+    /// Discard everything already queued for this client and start a new epoch.
+    /// The queued payloads are dropped where they sit rather than released, so
+    /// the counter is reset here instead of unwound.
+    pub(crate) fn begin_resync(&self) {
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        self.outstanding.store(0, Ordering::Release);
+    }
+
+    /// True while this payload still belongs to the client's current stream.
+    pub(crate) fn is_current(&self, payload: &Metered) -> bool {
+        payload.epoch == self.epoch.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn release(&self, payload: &Metered) {
+        if !self.is_current(payload) {
+            return;
+        }
+        let _ =
+            self.outstanding
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
+                    Some(outstanding.saturating_sub(payload.bytes.len()))
+                });
+    }
+
+    pub(crate) fn mark_dropped(&self) {
+        self.dropped.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn is_dropped(&self) -> bool {
+        self.dropped.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chunk(len: usize) -> Bytes {
+        Bytes::from(vec![b'x'; len])
+    }
+
+    #[test]
+    fn client_backlog_enforces_byte_cap() {
+        let backlog = ClientBacklog::new();
+
+        let bulk = backlog
+            .reserve(chunk(CLIENT_BACKLOG_CAP - 1))
+            .expect("bulk reservation");
+        let last = backlog.reserve(chunk(1)).expect("last byte");
+        assert!(backlog.reserve(chunk(1)).is_none());
+
+        backlog.release(&bulk);
+        backlog.release(&last);
+        assert!(backlog.is_drained());
+        let after = backlog
+            .reserve(chunk(1))
+            .expect("reservation after release");
+        backlog.release(&after);
+    }
+
+    #[test]
+    fn resync_retires_queued_payloads_without_unwinding_the_count() {
+        let backlog = ClientBacklog::new();
+        let stale = backlog
+            .reserve(chunk(CLIENT_BACKLOG_CAP))
+            .expect("full reservation");
+        assert!(backlog.reserve(chunk(1)).is_none());
+
+        backlog.begin_resync();
+
+        // The queued payload is dropped where it sits, so the client starts the
+        // new epoch with the whole budget rather than waiting for a drain.
+        assert!(!backlog.is_current(&stale));
+        assert!(backlog.is_drained());
+        let fresh = backlog
+            .reserve(chunk(CLIENT_BACKLOG_CAP))
+            .expect("fresh reservation");
+
+        // A late release of a retired payload must not credit the new epoch.
+        backlog.release(&stale);
+        assert!(backlog.reserve(chunk(1)).is_none());
+        backlog.release(&fresh);
+        assert!(backlog.is_drained());
+    }
+}

--- a/termiod/src/session/foreground.rs
+++ b/termiod/src/session/foreground.rs
@@ -1,0 +1,194 @@
+//! Who is running in the session's terminal, and where.
+//!
+//! This answers "which agent is in there" — a question whose answer changes
+//! when a human starts or stops a program, not per frame. It knows nothing
+//! about clients, snapshots or the protocol; it needs a tty and a child pid,
+//! and everything else it learns from the kernel.
+//!
+//! Split deliberately along what each half costs. `tcgetpgrp` is one syscall
+//! and runs on the session actor; reading argv is a `KERN_PROCARGS2` sysctl on
+//! macOS and a file read on Linux, and finding *which* pid to read it for can
+//! mean walking every process on the box when a pipeline's leader has exited.
+//! None of that may happen on the actor: that task also runs the PTY read and
+//! the fan-out, so a process-table walk there is time the byte path spends
+//! waiting — the anti-100× invariant, which is about more than the VT parse.
+
+use crate::proc::ExecutableIdentity;
+use crate::pty::Pty;
+use tokio::sync::mpsc;
+
+/// How often the session asks the kernel what is running in its terminal.
+/// Slow on purpose, for the reason in the module note above.
+pub(crate) const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// What the session believes about its foreground right now.
+#[derive(Default, Clone, PartialEq, Eq)]
+pub(crate) struct ForegroundSample {
+    /// The foreground process *group*, exactly as `tcgetpgrp` reported it.
+    /// Kept even when no member of it could be read, because "is a job
+    /// running?" is answered by comparing this against the session's own child
+    /// and must not turn into "no" the moment a pipeline's leader exits.
+    pgid: Option<i32>,
+    /// The member of that group whose argv is reported below. Equal to `pgid`
+    /// whenever the group leader is still usable, which is the common case.
+    pub(super) pid: Option<i32>,
+    pub(super) argv: Option<Vec<String>>,
+    pub(super) job: bool,
+    pub(super) cwd: Option<String>,
+}
+
+/// The expensive half of a foreground sample, computed on a blocking thread and
+/// handed back to the actor.
+pub(crate) struct ForegroundResolution {
+    /// The group this answer describes. The foreground can move while the
+    /// resolution is in flight, and an answer about a group that has since lost
+    /// the terminal is not a stale version of the truth — it is the answer to a
+    /// different question, and gets dropped.
+    pgid: Option<i32>,
+    pid: Option<i32>,
+    argv: Option<Vec<String>>,
+    cwd: Option<String>,
+    /// Only set when the session had not pinned its binary yet.
+    executable: Option<ExecutableIdentity>,
+}
+
+/// The session's foreground knowledge and the machinery that keeps it current.
+///
+/// The three pieces live together because they are only meaningful together:
+/// `pending` guards the dispatch that fills `sample`, and `executable` is
+/// pinned by the same resolution. They are not a state machine — a resolution
+/// in flight says nothing about what `sample` currently holds, which is exactly
+/// why [`Foreground::apply`] re-checks the group before believing an answer.
+#[derive(Default)]
+pub(crate) struct Foreground {
+    sample: ForegroundSample,
+    /// A resolution is in flight on a blocking thread. One at a time: the poll
+    /// is slower than the work, and piling up would only queue answers about
+    /// groups that have already lost the terminal.
+    pending: bool,
+    /// The binary the child is running, pinned on the first sample that finds
+    /// it. One-shot on purpose: this is the *launch* baseline that
+    /// `was_replaced()` compares against, and resampling would paper over the
+    /// in-place upgrade it exists to notice.
+    executable: Option<ExecutableIdentity>,
+}
+
+impl Foreground {
+    pub(super) fn current(&self) -> &ForegroundSample {
+        &self.sample
+    }
+
+    /// The path of the binary the session's child is running, as pinned at
+    /// launch.
+    pub(super) fn executable_path(&self) -> Option<String> {
+        self.executable.as_ref().map(|identity| identity.path.clone())
+    }
+
+    /// Whether that binary has since been replaced on disk. A fresh read every
+    /// time it is asked: the record that matters most is the one built on the
+    /// exit path, and a binary swapped during the seconds before the child quit
+    /// is exactly the case this answers.
+    pub(super) fn executable_replaced(&self) -> bool {
+        self.executable
+            .as_ref()
+            .is_some_and(|identity| identity.was_replaced())
+    }
+
+    /// The cheap half of the poll, and the only half that runs on the actor:
+    /// one `tcgetpgrp` on the master. Returns whether anything moved, so a
+    /// quiet session emits no roster traffic.
+    ///
+    /// The expensive half is dispatched to a blocking thread and applied later
+    /// by [`Foreground::apply`]. Both halves have to exist because they answer
+    /// different questions on different deadlines: "is a job running?" is read
+    /// at close time and must be current, and it is answerable from the group
+    /// id alone; "what is that job?" drives an icon and can be a beat late.
+    pub(super) fn poll(
+        &mut self,
+        pty: &Pty,
+        child: i32,
+        resolved: &mpsc::UnboundedSender<ForegroundResolution>,
+    ) -> bool {
+        if child <= 0 {
+            return false;
+        }
+        let pgid = pty.foreground_pgid();
+        // Compared against the *group*: a foreground group that is not the
+        // child's own is a running job whether or not any member of it could
+        // be read.
+        let job = pgid.is_some_and(|pgid| pgid != child);
+        let mut changed = false;
+        if self.sample.pgid != pgid {
+            self.sample.pgid = pgid;
+            // The cached identity described a group that no longer holds the
+            // terminal. Dropping it is an honest gap the resolution below
+            // fills; keeping it would name a program that has already exited.
+            self.sample.pid = None;
+            self.sample.argv = None;
+            changed = true;
+        }
+        if self.sample.job != job {
+            self.sample.job = job;
+            changed = true;
+        }
+        self.request(pgid, child, resolved);
+        changed
+    }
+
+    /// Hand the process-table work to a blocking thread.
+    fn request(
+        &mut self,
+        pgid: Option<i32>,
+        child: i32,
+        resolved: &mpsc::UnboundedSender<ForegroundResolution>,
+    ) {
+        if self.pending {
+            return;
+        }
+        self.pending = true;
+        let pin_executable = self.executable.is_none();
+        let resolved = resolved.clone();
+        tokio::task::spawn_blocking(move || {
+            // A group id is not a pid. The shell names each job's group after
+            // its leader, so the two agree for as long as that leader is alive
+            // — and stop agreeing in a pipeline the moment it is not, which is
+            // why the pid comes from the host rather than from that assumption.
+            let pid = pgid.and_then(crate::proc::foreground_member);
+            let _ = resolved.send(ForegroundResolution {
+                pgid,
+                pid,
+                argv: pid.and_then(crate::proc::process_arguments),
+                cwd: crate::proc::working_directory(child),
+                executable: pin_executable
+                    .then(|| crate::proc::executable_identity(child))
+                    .flatten(),
+            });
+        });
+    }
+
+    /// Take a resolution the blocking thread finished, unless the foreground
+    /// moved while it was in flight. Returns whether anything moved.
+    pub(super) fn apply(&mut self, resolution: ForegroundResolution) -> bool {
+        self.pending = false;
+        if resolution.pgid != self.sample.pgid {
+            return false;
+        }
+        if self.executable.is_none() {
+            self.executable = resolution.executable;
+        }
+        let mut changed = false;
+        if self.sample.pid != resolution.pid {
+            self.sample.pid = resolution.pid;
+            changed = true;
+        }
+        if self.sample.argv != resolution.argv {
+            self.sample.argv = resolution.argv;
+            changed = true;
+        }
+        if self.sample.cwd != resolution.cwd {
+            self.sample.cwd = resolution.cwd;
+            changed = true;
+        }
+        changed
+    }
+}

--- a/termiod/src/session/sidecar.rs
+++ b/termiod/src/session/sidecar.rs
@@ -8,6 +8,8 @@
 
 use bytes::Bytes;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc as std_mpsc;
+use std::sync::Arc;
 
 /// PTY bytes allowed to sit unparsed in the sidecar's command FIFO. The
 /// per-client budget stops a slow socket from buying unbounded memory; this
@@ -98,6 +100,96 @@ pub(crate) struct SidecarCapture {
     /// formatter failed, in which case delivery falls back to packed cells.
     pub(crate) vt: Option<Vec<u8>>,
     pub(crate) scrollback: Option<Result<termiod_vt::Scrollback, String>>,
+}
+
+/// What a snapshot request is refused with when the sidecar is simply not
+/// there — it never started, its sender is gone, or its answers stopped
+/// arriving. A VT that went *stale* refuses with the reason it went stale.
+pub(crate) const UNAVAILABLE: &str = "VT sidecar is unavailable";
+
+/// A session's VT, and whether it still has one.
+///
+/// These were three fields held in agreement by hand: a command sender, its
+/// byte budget, and a `vt_stale: Option<String>`. A stale reason alongside a
+/// live sender was not a state this host would run, and every question about
+/// the VT had to be asked twice to find out which kind of "no" it was.
+pub(crate) enum Vt {
+    /// The sidecar thread is parsing. `queue` is the budget that keeps it off
+    /// the byte path: the producer stops feeding the VT rather than blocking on
+    /// it or letting a slow parse buy unbounded memory.
+    Live {
+        commands: std_mpsc::Sender<SidecarCommand>,
+        queue: Arc<SidecarQueue>,
+    },
+    /// Nothing more will reach the VT. The screen it held no longer describes
+    /// any boundary in the output stream, so it can never answer a snapshot
+    /// again — attach and resync fall back to ring replay, and `reason` is what
+    /// they are told.
+    Down { reason: String },
+}
+
+impl Vt {
+    pub(crate) fn live(commands: std_mpsc::Sender<SidecarCommand>, queue: Arc<SidecarQueue>) -> Vt {
+        Vt::Live { commands, queue }
+    }
+
+    pub(crate) fn down(reason: impl Into<String>) -> Vt {
+        Vt::Down {
+            reason: reason.into(),
+        }
+    }
+
+    pub(crate) fn is_live(&self) -> bool {
+        matches!(self, Vt::Live { .. })
+    }
+
+    /// Why the VT cannot answer a snapshot, or `None` while it still can.
+    pub(crate) fn refusal(&self) -> Option<&str> {
+        match self {
+            Vt::Live { .. } => None,
+            Vt::Down { reason } => Some(reason),
+        }
+    }
+
+    /// Charge `bytes` of PTY output to the VT's budget. `false` means the parse
+    /// has fallen far enough behind that the only legal degrade is to stop
+    /// feeding it and say so.
+    pub(crate) fn try_reserve(&self, bytes: usize) -> bool {
+        match self {
+            Vt::Live { queue, .. } => queue.try_reserve(bytes),
+            Vt::Down { .. } => false,
+        }
+    }
+
+    /// Credit back bytes the VT will never parse.
+    pub(crate) fn release(&self, bytes: usize) {
+        if let Vt::Live { queue, .. } = self {
+            queue.release(bytes);
+        }
+    }
+
+    /// Hand the sidecar a command. `false` if it did not arrive, which also
+    /// takes the VT down: a sender that will not take a command has no thread
+    /// behind it, and the session is finding that out here.
+    pub(crate) fn send(&mut self, command: SidecarCommand) -> bool {
+        let Vt::Live { commands, .. } = self else {
+            return false;
+        };
+        if commands.send(command).is_ok() {
+            return true;
+        }
+        *self = Vt::down(UNAVAILABLE);
+        false
+    }
+
+    /// Ask the sidecar thread to stop and stop expecting answers from it.
+    /// Failure earns no word here: this runs on the way out.
+    pub(crate) fn shut_down(&mut self) {
+        if let Vt::Live { commands, .. } = self {
+            let _ = commands.send(SidecarCommand::Shutdown);
+        }
+        *self = Vt::down(UNAVAILABLE);
+    }
 }
 
 #[cfg(test)]

--- a/termiod/src/session/sidecar.rs
+++ b/termiod/src/session/sidecar.rs
@@ -25,7 +25,7 @@ pub(crate) fn cap_description() -> String {
 }
 
 use crate::protocol::GridDiff;
-use super::ClientId;
+use crate::id::ClientId;
 
 /// Counts PTY bytes queued for the VT sidecar but not yet parsed.
 pub(crate) struct SidecarQueue {

--- a/termiod/src/session/sidecar.rs
+++ b/termiod/src/session/sidecar.rs
@@ -1,0 +1,122 @@
+//! The VT sidecar's side of a session: what it is asked to do, what it hands
+//! back, and the budget that keeps a slow parse from costing unbounded memory.
+//!
+//! The sidecar is deliberately off the byte path — bytes reach clients whether
+//! or not it keeps up, which is the anti-100x invariant. This module owns the
+//! machinery that makes "whether or not" safe: a queue that refuses work rather
+//! than growing, so falling behind degrades the snapshot and never the stream.
+
+use bytes::Bytes;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// PTY bytes allowed to sit unparsed in the sidecar's command FIFO. The
+/// per-client budget stops a slow socket from buying unbounded memory; this
+/// stops a slow *parse* from doing the same one hop upstream.
+const SIDECAR_QUEUE_CAP: usize = 16 * 1024 * 1024;
+
+/// The budget in the words a staleness notice uses. Asked for rather than
+/// restated, so the number and the sentence explaining it cannot drift.
+/// The budget itself, for tests that need to fill it exactly.
+#[cfg(test)]
+pub(crate) const CAP_FOR_TESTS: usize = SIDECAR_QUEUE_CAP;
+
+pub(crate) fn cap_description() -> String {
+    format!("{} MiB", SIDECAR_QUEUE_CAP / (1024 * 1024))
+}
+
+use crate::protocol::GridDiff;
+use super::ClientId;
+
+/// Counts PTY bytes queued for the VT sidecar but not yet parsed.
+pub(crate) struct SidecarQueue {
+    outstanding: AtomicUsize,
+}
+
+impl SidecarQueue {
+    pub(crate) fn new() -> Self {
+        Self {
+            outstanding: AtomicUsize::new(0),
+        }
+    }
+
+    pub(crate) fn try_reserve(&self, bytes: usize) -> bool {
+        self.outstanding
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
+                outstanding
+                    .checked_add(bytes)
+                    .filter(|total| *total <= SIDECAR_QUEUE_CAP)
+            })
+            .is_ok()
+    }
+
+    /// Whether every byte charged to the queue has been credited back. A
+    /// healthy session ends here; anything else means the budget ratchets shut.
+    pub(crate) fn is_drained(&self) -> bool {
+        self.outstanding.load(Ordering::Relaxed) == 0
+    }
+
+    pub(crate) fn release(&self, bytes: usize) {
+        let _ =
+            self.outstanding
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |outstanding| {
+                    Some(outstanding.saturating_sub(bytes))
+                });
+    }
+}
+
+pub(crate) enum SidecarCommand {
+    Write(Bytes),
+    Resize {
+        rows: u16,
+        cols: u16,
+    },
+    Snapshot {
+        client_id: ClientId,
+        request_id: u64,
+        scrollback: bool,
+    },
+    SetGridDiff(bool),
+    Shutdown,
+}
+
+/// Snapshot replies and live grid updates share this single FIFO channel.
+/// Separate channels could let a post-boundary G overtake its S and regress
+/// rows after the client applies the newer snapshot.
+pub(crate) enum SidecarResult {
+    Snapshot {
+        client_id: ClientId,
+        request_id: u64,
+        result: Result<SidecarCapture, String>,
+    },
+    Grid(GridDiff),
+    Keyframe(termiod_vt::Snapshot),
+}
+
+pub(crate) struct SidecarCapture {
+    pub(crate) snapshot: termiod_vt::Snapshot,
+    /// The same screen serialised back to VT sequences. `None` only if the
+    /// formatter failed, in which case delivery falls back to packed cells.
+    pub(crate) vt: Option<Vec<u8>>,
+    pub(crate) scrollback: Option<Result<termiod_vt::Scrollback, String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidecar_queue_stops_admitting_bytes_past_its_budget() {
+        let queue = SidecarQueue::new();
+
+        assert!(queue.try_reserve(SIDECAR_QUEUE_CAP));
+        assert!(!queue.try_reserve(1));
+
+        queue.release(SIDECAR_QUEUE_CAP);
+        assert!(queue.try_reserve(1));
+        queue.release(1);
+        // Releasing more than was reserved is a bug, not a panic: the VT thread
+        // and the session actor account independently.
+        queue.release(SIDECAR_QUEUE_CAP);
+        assert!(queue.try_reserve(SIDECAR_QUEUE_CAP));
+    }
+}

--- a/termiod/src/session/wire.rs
+++ b/termiod/src/session/wire.rs
@@ -1,0 +1,138 @@
+//! Turning what the VT engine holds into what the protocol carries.
+//!
+//! Pure translation: no session, no client, no PTY. A cell becomes a `WireCell`,
+//! a damage set becomes a `G` payload, a scrollback capture becomes a run of `H`
+//! frames sized to fit the frame limit. Everything here is a function of its
+//! arguments, which is why it can be read — and tested — without a session.
+
+use crate::protocol::{
+    encode_history_payload, GridDiff, GridRow, HistoryChunk, WireCell, WireColor,
+    HISTORY_HEADER_SIZE, MAX_HISTORY_FRAME_SIZE, SNAPSHOT_CELL_SIZE,
+};
+use bytes::Bytes;
+use std::collections::VecDeque;
+
+/// How much encoded scrollback one attach may stage. The rows are held in
+/// memory until the client drains them, so this is a per-attachment cost.
+pub(crate) const SCROLLBACK_STAGE_MAX_BYTES: usize = 1024 * 1024;
+
+/// How many rows of `cols` columns fit in the staging budget.
+pub(crate) fn scrollback_row_limit(cols: u16) -> usize {
+    let row_bytes = usize::from(cols).saturating_mul(SNAPSHOT_CELL_SIZE);
+    SCROLLBACK_STAGE_MAX_BYTES
+        .checked_div(row_bytes)
+        .unwrap_or(0)
+}
+
+/// Pack captured scrollback into `H` payloads, each one whole rows and none of
+/// them over the frame limit. Offsets count back from the live screen, so the
+/// first chunk starts at 1.
+pub(crate) fn encode_scrollback_chunks(
+    cols: u16,
+    rows: Vec<Vec<termiod_vt::Cell>>,
+) -> Result<VecDeque<Bytes>, String> {
+    if rows.is_empty() {
+        return Ok(VecDeque::new());
+    }
+    let row_bytes = usize::from(cols)
+        .checked_mul(SNAPSHOT_CELL_SIZE)
+        .ok_or_else(|| "scrollback row length overflow".to_string())?;
+    let rows_per_chunk = MAX_HISTORY_FRAME_SIZE
+        .checked_sub(HISTORY_HEADER_SIZE)
+        .and_then(|available| available.checked_div(row_bytes))
+        .unwrap_or(0)
+        .min(usize::from(u16::MAX));
+    if rows_per_chunk == 0 {
+        return Err(format!(
+            "one {cols}-column row cannot fit in a {MAX_HISTORY_FRAME_SIZE}-byte H frame"
+        ));
+    }
+
+    let mut rows = rows.into_iter();
+    let mut chunks = VecDeque::new();
+    let mut first_offset = 1u32;
+    loop {
+        let mut cells = Vec::with_capacity(rows_per_chunk * usize::from(cols));
+        let mut row_count = 0u16;
+        for _ in 0..rows_per_chunk {
+            let Some(row) = rows.next() else {
+                break;
+            };
+            if row.len() != usize::from(cols) {
+                return Err(format!(
+                    "scrollback row has {} cells, expected {cols}",
+                    row.len()
+                ));
+            }
+            cells.extend(row.into_iter().map(wire_cell));
+            row_count += 1;
+        }
+        if row_count == 0 {
+            break;
+        }
+        let payload = encode_history_payload(&HistoryChunk {
+            cols,
+            first_offset,
+            row_count,
+            cells,
+        })
+        .map_err(|error| error.to_string())?;
+        chunks.push_back(Bytes::from(payload));
+        first_offset = first_offset
+            .checked_add(u32::from(row_count))
+            .ok_or_else(|| "scrollback offset overflow".to_string())?;
+    }
+    Ok(chunks)
+}
+
+fn wire_color(color: termiod_vt::Color) -> WireColor {
+    match color {
+        termiod_vt::Color::Default => WireColor::Default,
+        termiod_vt::Color::Palette(index) => WireColor::Palette(index),
+        termiod_vt::Color::Rgb(value) => WireColor::Rgb([value.r, value.g, value.b]),
+    }
+}
+
+pub(crate) fn wire_cell(cell: termiod_vt::Cell) -> WireCell {
+    WireCell {
+        codepoint: cell.codepoint,
+        foreground: wire_color(cell.foreground),
+        background: wire_color(cell.background),
+        attributes: cell.attributes,
+    }
+}
+
+pub(crate) fn grid_from_damage(frame_seq: u32, damage: termiod_vt::Damage) -> GridDiff {
+    GridDiff {
+        frame_seq,
+        rows: damage.rows,
+        cols: damage.cols,
+        cursor_x: damage.cursor_x,
+        cursor_y: damage.cursor_y,
+        alt_screen: damage.alt_screen,
+        dirty_rows: damage
+            .dirty_rows
+            .into_iter()
+            .map(|row| GridRow {
+                row_index: row.row_index,
+                cells: row.cells.into_iter().map(wire_cell).collect(),
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{scrollback_row_limit, SCROLLBACK_STAGE_MAX_BYTES};
+    use crate::protocol::SNAPSHOT_CELL_SIZE;
+
+    #[test]
+    fn scrollback_stage_cap_is_measured_in_encoded_rows() {
+        let cols = 80u16;
+        let row_bytes = usize::from(cols) * SNAPSHOT_CELL_SIZE;
+        let rows = scrollback_row_limit(cols);
+
+        assert!(rows * row_bytes <= SCROLLBACK_STAGE_MAX_BYTES);
+        assert!((rows + 1) * row_bytes > SCROLLBACK_STAGE_MAX_BYTES);
+    }
+}

--- a/termiod/src/tombstone.rs
+++ b/termiod/src/tombstone.rs
@@ -27,6 +27,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::id::SessionId;
 use crate::protocol::SessionInfo;
 
 /// How many tombstones are kept. Enough to explain a bad afternoon, bounded so
@@ -179,12 +180,38 @@ impl RosterEntry {
 }
 
 /// What identifies one session's end. The id alone is not enough: ids are short
-/// and can eventually be reused, so the creation time rides along.
-type GraveKey = (String, u64);
+/// and can eventually be reused, so the creation time rides along. Built only
+/// from a whole record, so the pair cannot be assembled half-right.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct GraveKey {
+    session: SessionId,
+    created_unix: u64,
+}
+
+impl GraveKey {
+    fn of(session: &str, created_unix: u64) -> GraveKey {
+        GraveKey {
+            session: SessionId::new(session),
+            created_unix,
+        }
+    }
+
+    fn from_info(info: &SessionInfo) -> GraveKey {
+        GraveKey::of(&info.id, info.created_unix)
+    }
+
+    fn from_grave(grave: &Tombstone) -> GraveKey {
+        GraveKey::of(&grave.id, grave.created_unix)
+    }
+
+    fn from_roster(entry: &RosterEntry) -> GraveKey {
+        GraveKey::of(&entry.id, entry.created_unix)
+    }
+}
 
 struct State {
     graves: Vec<Tombstone>,
-    roster: HashMap<String, RosterEntry>,
+    roster: HashMap<SessionId, RosterEntry>,
     /// An index of `graves`, keeping the "has this end already been recorded?"
     /// question O(1). It is what stops the bounded shutdown fallback and a late
     /// session reaper from recording the same end twice, and what stops a
@@ -199,7 +226,7 @@ impl State {
         if !self.buried.insert(key.clone()) {
             return false;
         }
-        self.roster.remove(&key.0);
+        self.roster.remove(&key.session);
         self.graves.insert(0, tombstone());
         true
     }
@@ -209,7 +236,7 @@ impl State {
     /// how it would grow without bound on a long-lived host.
     fn cap_graves(&mut self) {
         for dropped in self.graves.drain(MAX_GRAVES.min(self.graves.len())..) {
-            self.buried.remove(&(dropped.id, dropped.created_unix));
+            self.buried.remove(&GraveKey::from_grave(&dropped));
         }
     }
 }
@@ -254,11 +281,7 @@ impl Graveyard {
             state.graves = graves;
             // Index what was just loaded, so the invariant holds from the first
             // burial rather than from the first one this daemon happens to make.
-            state.buried = state
-                .graves
-                .iter()
-                .map(|grave| (grave.id.clone(), grave.created_unix))
-                .collect();
+            state.buried = state.graves.iter().map(GraveKey::from_grave).collect();
         }
         // The roster starts empty for this daemon: whatever the last one held is
         // now buried, and leaving the file behind would bury it twice on the
@@ -274,15 +297,12 @@ impl Graveyard {
     pub fn note_live(&self, info: &SessionInfo) {
         {
             let mut state = self.state.lock().unwrap();
-            if state
-                .buried
-                .contains(&(info.id.clone(), info.created_unix))
-            {
+            if state.buried.contains(&GraveKey::from_info(info)) {
                 return;
             }
             state
                 .roster
-                .insert(info.id.clone(), RosterEntry::from_info(info));
+                .insert(SessionId::new(info.id.clone()), RosterEntry::from_info(info));
         }
         if let Err(error) = self.persist_roster() {
             eprintln!("termiod: could not record live session: {error:#}");
@@ -294,7 +314,7 @@ impl Graveyard {
     pub fn bury(&self, info: &SessionInfo, reason: EndReason, exit_status: Option<i32>) {
         {
             let mut state = self.state.lock().unwrap();
-            let key = (info.id.clone(), info.created_unix);
+            let key = GraveKey::from_info(info);
             if !state.record(key, || Tombstone::from_info(info, reason, exit_status)) {
                 return;
             }
@@ -317,7 +337,7 @@ impl Graveyard {
             // come out newest-first, the order every other path leaves them in.
             remaining.sort_by_key(|entry| entry.created_unix);
             for entry in remaining {
-                let key = (entry.id.clone(), entry.created_unix);
+                let key = GraveKey::from_roster(&entry);
                 state.record(key, || entry.into_tombstone(reason));
             }
             state.cap_graves();


### PR DESCRIPTION
Type safety in the `termiod` host, not tidying. Every step compiles with the suite green, and `protocol.rs` and `Shared/` have zero diff — the wire format is untouched.

## Identities

`ClientId` was an alias for `String`, and a session id, a session name and a client id all flowed through the same functions. `ClientId` and `SessionId` are newtypes now, host-side only: the wire keeps bare JSON strings and every crossing is a visible `new` or `to_string`.

The payoff is at the doors. `Manager::find` takes a `SessionId`, which makes `resolve` the only route a string off the wire has into the session table — a name can no longer reach a lookup that wants an id. `GraveKey` becomes a struct built from a whole record, so the pair that identifies one session's end cannot be assembled half-right.

The `git:` resource kind subscribes to the `fs:` watcher under a fabricated subscriber id. It now goes through a named constructor instead of a `format!` that read like a real connection.

## Clients

`ClientEntry` described one attachment with four independent bools, several combinations of which were nonsense the code kept refuting.

`ClientPlane` is the negotiated capability pair made exclusive. `grid_diff` without `snapshot` was refused twice — once at hello, once in `AddClient` — and there is now no fourth case to refuse. `Raw` carries no delivery state at all, so an attachment with no snapshot boundary cannot be parked behind one.

`ClientRole` numbers only the attachments ranked for the write token, which is what `recompute_writer` always meant by `seq`; an observer's was dead weight the sort filtered back out. The token moves through one method that refuses a client without a tty, so §A is enforced where the token lives rather than at each of its three callers.

## The VT

A command sender, its byte budget and `vt_stale: Option<String>` were three fields held in agreement by hand. A stale reason beside a live sender was not a state this host would run, and `request_snapshot` had to ask twice to learn which kind of "no" it was answering.

`Vt` is `Live { commands, queue }` or `Down { reason }`. The anti-100x path is unchanged: `write_sidecar` still charges the budget and hands the chunk over without waiting, and the only legal degrade is still to stop feeding the VT and say so.

## Modules

`session::wire` and `session::foreground`, following the split already applied to `backlog` and `sidecar`. Neither depends on a session, and the scrollback-cap test moved with its subject.

`Session` goes from 26 fields to 22. `session.rs` loses about 260 lines.

## Behaviour

106 unit tests and every integration suite pass, with no assertion weakened. Two deliberate notes:

- After the VT goes down, a failed sidecar send no longer credits bytes back to `SidecarQueue`. Nothing reads that counter once the sidecar is gone and nothing reserves against it again.
- On the response-channel-closed path the VT keeps the generic `"VT sidecar is unavailable"` reason, so a later snapshot refusal reads exactly as it did before. The specific reason still reaches the clients that were actually waiting.

Release Notes: None — internal refactor of the `termiod` host with no user-facing or protocol change.
