### PR TITLE
Hand the detail to the maximize host without flashing the file tree

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -95,6 +95,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // Manages the maximize host as a detail opens/closes (see the `store.objectWillChange`
     // sink in `applicationDidFinishLaunching`).
     private var overlayObserver: AnyCancellable?
+    // Drives the same host straight off the maximize flag, synchronously (see
+    // `store.inspectorMaximizedDidChange`), so the handoff to and from the full-window
+    // host lands in the frame the docked detail leaves in.
+    private var maximizeObserver: AnyCancellable?
     // Un-collapses the inspector when the user opens a detail (see `store.detailDidOpen`).
     private var detailOpenObserver: AnyCancellable?
     // Previous maximize state, so the observer re-binds the tracking separator on the restore
@@ -286,33 +290,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 }
             }
 
+        // The maximize button itself: applied synchronously, in the same turn the flag flips, so
+        // the full-window host is already up when SwiftUI drops the inspector's docked copy. Going
+        // through `objectWillChange` below instead would land a runloop late, and the inspector's
+        // always-mounted file tree — normally covered by the detail — showed through the gap.
+        maximizeObserver = store.inspectorMaximizedDidChange
+            .sink { [weak self] maximized in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    self.applyDetailMaximized(maximized && self.store.isDetailPresented)
+                }
+            }
+
         // A detail (file editor, diff, PR/issue) opens in the right inspector, beside the
         // terminal. Its own window controls (hide list / maximize / close) live *in* the detail's
         // header now (see `InspectorDetailChromeButtons`), not the toolbar — so this observer only
-        // mounts and tears down the full-window maximize host.
+        // mounts and tears down the full-window maximize host. It catches the presentation half of
+        // the state (a detail closing out from under a maximized host); the flag's own half is the
+        // synchronous observer above.
         // `objectWillChange` fires before the value lands, so read the settled state next runloop.
         overlayObserver = store.objectWillChange
             .receive(on: RunLoop.main)
             .sink { [weak self] in
                 MainActor.assumeIsolated {
                     guard let self else { return }
-                    let presented = self.store.isDetailPresented
-                    let maximized = self.store.inspectorMaximized && presented
-                    let restored = self.detailWasMaximized && !maximized
-                    self.detailWasMaximized = maximized
-                    // Blow the detail up into a full-window host when maximized; tear it down otherwise.
-                    self.setDetailMaximized(maximized)
-                    // The pane switch (Files/Search/Changes/Issues/Info) re-aims the inspector's list
-                    // column, which the full-window detail now covers — so while maximized the tabs
-                    // would act on something off-screen. Pull them from the toolbar for the duration
-                    // and restore them on the way back down (the inspector is still open behind the host).
-                    self.syncInspectorTabsVisibility()
-                    // Tearing down the maximize host relayouts around divider 1, which can leave the
-                    // tracking separator inert (the centered-tabs / missing-divider glitch). Re-bind
-                    // once layout settles.
-                    if restored {
-                        DispatchQueue.main.async { [weak self] in self?.reassertInspectorSeparator() }
-                    }
+                    self.applyDetailMaximized(self.store.inspectorMaximized && self.store.isDetailPresented)
                 }
             }
 
@@ -1054,9 +1056,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// would act on something off-screen — pull them while maximized, restore them on the way back
     /// down. Idempotent (`setInspectorSwitchVisible` no-ops when already in the target state), so the
     /// overlay observer can call it on every store change.
-    func syncInspectorTabsVisibility() {
+    func syncInspectorTabsVisibility(maximized: Bool) {
         guard let item = filesInspectorItem else { return }
-        let maximized = store.inspectorMaximized && store.isDetailPresented
         setInspectorSwitchVisible(!item.isCollapsed && !maximized)
     }
 
@@ -1203,6 +1204,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         if item.isCollapsed {
             item.isCollapsed = false
             setInspectorSwitchVisible(true)
+        }
+    }
+
+    /// Brings the window into or out of the maximized-detail mode. Idempotent, and reached from two
+    /// clocks: synchronously as the maximize flag flips (so the host swaps with the docked detail in
+    /// one frame) and from the deferred store observer (which catches the detail closing out from
+    /// under a host that is already up).
+    private func applyDetailMaximized(_ maximized: Bool) {
+        let restored = detailWasMaximized && !maximized
+        detailWasMaximized = maximized
+        setDetailMaximized(maximized)
+        // The pane switch (Files/Search/Changes/Issues/Info) re-aims the inspector's list column,
+        // which the full-window detail now covers — so while maximized the tabs would act on
+        // something off-screen. Pull them from the toolbar for the duration and restore them on the
+        // way back down (the inspector is still open behind the host).
+        syncInspectorTabsVisibility(maximized: maximized)
+        // Tearing down the maximize host relayouts around divider 1, which can leave the tracking
+        // separator inert (the centered-tabs / missing-divider glitch). Re-bind once layout settles.
+        if restored {
+            DispatchQueue.main.async { [weak self] in self?.reassertInspectorSeparator() }
         }
     }
 

--- a/Sources/termio/FileBrowser/InspectorDetailHost.swift
+++ b/Sources/termio/FileBrowser/InspectorDetailHost.swift
@@ -82,7 +82,11 @@ struct InspectorRoot: View {
             }
             .frame(width: geo.size.width, height: geo.size.height)
             .coordinateSpace(.named(Self.dragSpace))
-            .animation(.easeOut(duration: 0.12), value: showDetail)
+            // Keyed to the *presentation*, not to `showDetail`: opening and closing a detail
+            // should cross-fade over the list, but maximizing only hands the same detail off to
+            // the full-window host. Fading there would spend 120ms dissolving the docked copy —
+            // uncovering the file tree it sits on — for a swap the user must not see at all.
+            .animation(.easeOut(duration: 0.12), value: store.isDetailPresented)
             .animation(.easeOut(duration: 0.12), value: twoColumn)
         }
     }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -305,7 +305,20 @@ final class TermioStore: ObservableObject {
     /// hosts the detail beside the terminal by default; the detail's maximize button flips this
     /// to cover everything (see the app delegate's full-window host), and it resets to `false`
     /// automatically whenever the last detail closes.
-    @Published var inspectorMaximized = false
+    @Published var inspectorMaximized = false {
+        didSet {
+            guard inspectorMaximized != oldValue else { return }
+            inspectorMaximizedDidChange.send(inspectorMaximized)
+        }
+    }
+
+    /// Fires once `inspectorMaximized` has actually landed, which `objectWillChange` cannot do.
+    /// The two halves of the maximize handoff live in different frameworks — SwiftUI drops the
+    /// docked detail, the app delegate mounts the full-window host — and a delegate driven off
+    /// `objectWillChange` has to defer a runloop to read the settled value, by which time SwiftUI
+    /// has already uncovered the inspector's file tree. Publishing from `didSet` lets the host go
+    /// up in the same turn the flag flips, so the swap never shows what is underneath.
+    let inspectorMaximizedDidChange = PassthroughSubject<Bool, Never>()
 
     /// Whether the list column is collapsed so the detail fills the whole inspector (terminal still
     /// visible), one step short of `inspectorMaximized`. Flipped by the detail chrome's list toggle;


### PR DESCRIPTION
Maximizing an inspector detail showed the file tree for a beat before the full-window detail appeared.

The maximize button flips one flag that two frameworks answer on two different clocks. SwiftUI's `InspectorRoot` drops the docked detail, and the app delegate mounts the AppKit full-window host — but the delegate ran off `objectWillChange`, which fires *before* the value lands, so it had to defer a runloop to read the settled state. By then SwiftUI had already uncovered the file tree that is always mounted full-width beneath the detail (deliberately, so `List(children:)` keeps its disclosure state). The docked copy also faded out over 120ms via a transition keyed to `showDetail`, holding that tree on screen for the whole dissolve — and symmetrically on the way back down.

- `inspectorMaximized` now publishes from `didSet` through `inspectorMaximizedDidChange`, so the host can go up in the same turn the flag flips.
- The delegate's shared body moves into `applyDetailMaximized(_:)`, called both synchronously from that subject and from the existing deferred observer, which is now only responsible for a detail closing out from under a live host.
- The inspector's fade is keyed to `isDetailPresented` instead of `showDetail`: opening and closing a detail still cross-fades over the list, but maximizing is an instant swap, since it changes only where the same content is hosted.

Release Notes:

- Maximizing a file preview, diff, or issue no longer flashes the file tree on the way in or out.