### PR TITLE
Let a remote session row follow its agent's title like a local one

### DIFF
--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -432,6 +432,27 @@ enum SessionStatus: Hashable {
 struct Session: Identifiable, Hashable, Codable {
     var id = UUID()
     var title: String
+
+    /// The name this session was *given* — by the user renaming it, by a person on
+    /// the far box (`termiod new -n build`), or by Termio naming the row for what it
+    /// is with nothing better behind it (`SSH Shell`). It wins over every label the
+    /// app can derive, and `nil` (the common case) means nobody has named this row.
+    ///
+    /// It is a field of its own rather than a flag beside `title` because the two
+    /// have different owners. `title` is the placeholder the app composes and freely
+    /// rewrites — `Terminal 3`, `Claude Code`, a migration renumbering an old state
+    /// file — while this is set only by the act of naming. Keeping them apart is
+    /// what makes them impossible to contradict: a flag has to be updated at every
+    /// site that touches `title`, and the sites that forget leave a row insisting on
+    /// a name nobody gave it.
+    ///
+    /// The distinction used to be recovered by pattern-matching `title` — anything
+    /// that wasn't `Terminal N` or the agent's own name was read as the user's. That
+    /// is why a remote row stayed frozen at `boxlit · ukvps` while its local twin
+    /// followed the agent's topic: the label Termio composed for it was
+    /// indistinguishable from one the user typed.
+    var givenTitle: String?
+
     /// Which agent (or plain shell) this session runs.
     var agent: AgentPreset
     var createdAt: Date
@@ -577,7 +598,30 @@ struct Session: Identifiable, Hashable, Codable {
     private enum CodingKeys: String, CodingKey {
         case id, title, agent, createdAt, worktreePath, resumeID, launched, launchedAt,
              liveTitle, promptTitle, lastWorkingDirectory, spawnDirectory, sshHost, pinned,
-             termiodRemoteHost, termiodRemoteCwd, deviceID, termiodSessionName
+             termiodRemoteHost, termiodRemoteCwd, deviceID, termiodSessionName,
+             givenTitle
+    }
+
+    /// The name to recover from a state file written before `givenTitle` existed,
+    /// back when `title` held both kinds of label. The old code told them apart by
+    /// pattern-matching, so this has to as well: anything that wasn't one of the
+    /// labels Termio composed was, by the only definition that existed then, a name
+    /// someone gave.
+    ///
+    /// `<name> · <host>` and a bare host are named here because they are the
+    /// composed labels that test got wrong — `addRemoteTerminal` wrote them into
+    /// `title`, and every gate downstream then read them as chosen. A session the
+    /// user really did rename to something ending in its own host's alias reads as
+    /// composed and starts following its agent; renaming it again settles it.
+    static func recoveredGivenTitle(
+        _ title: String, agent: AgentPreset, remoteHost: String?
+    ) -> String? {
+        if TermioStore.isAutoTerminalName(title) { return nil }
+        if title == agent.displayName { return nil }
+        if let remoteHost, title == remoteHost || title.hasSuffix(" · \(remoteHost)") {
+            return nil
+        }
+        return title
     }
 
     /// Custom decoding so state files written before the resume fields existed still
@@ -605,6 +649,8 @@ struct Session: Identifiable, Hashable, Codable {
         deviceID = try container.decodeIfPresent(String.self, forKey: .deviceID)
         termiodSessionName = try container.decodeIfPresent(
             String.self, forKey: .termiodSessionName)
+        givenTitle = try container.decodeIfPresent(String.self, forKey: .givenTitle)
+            ?? Self.recoveredGivenTitle(title, agent: agent, remoteHost: termiodRemoteHost)
     }
 }
 

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -622,6 +622,7 @@ extension TermioStore {
     func adoptDeviceSession(_ information: Termiod.SessionInformation) {
         let device = currentDevice
         var session = Session(title: information.displayLabel, agent: .terminal)
+        session.givenTitle = information.givenName
         session.termiodSessionName = information.name.isEmpty ? information.id : information.name
         session.termiodRemoteHost = device.alias
         session.deviceID = device.deviceID
@@ -733,8 +734,10 @@ extension TermioStore {
     /// sit dead.
     ///
     /// `cwd` (used by "Clone to <device>…") is the remote directory the shell spawns
-    /// in; `title` overrides the sidebar label (the host alias by default, or a
-    /// repo name for a clone).
+    /// in; `title` overrides the sidebar label (the host alias by default, or a repo
+    /// name for a clone) for a session that lands in a machine's own workspace. A
+    /// session that lands under a project takes that project's own naming instead —
+    /// see `createRemoteTerminalSession`.
     func addRemoteTerminal(
         host: String,
         cwd: String? = nil,
@@ -756,7 +759,6 @@ extension TermioStore {
                 self.presentRemoteSetupFailure(host: host, message: error.message)
             case .success(let device):
                 var cwd = cwd
-                var title = title
                 // Opened from a project row: the user means "this repo, on that
                 // machine". The local path doesn't exist over there, so the only
                 // honest answer is the checkout `Clone to <device>…` recorded.
@@ -771,7 +773,6 @@ extension TermioStore {
                         return
                     }
                     cwd = checkout
-                    title = title ?? "\(project.name) · \(host)"
                 }
                 self.createRemoteTerminalSession(
                     host: host, device: device.id, cwd: cwd, title: title, project: projectID
@@ -820,6 +821,15 @@ extension TermioStore {
         // to the machine's own fallback workspace, so a remote session is never
         // filed among the loose local shells.
         if let projectID, let index = projects.firstIndex(where: { $0.id == projectID }) {
+            // Named exactly like a local project's terminals (`addSession`), because
+            // the header above the row already names the repo and the row's device
+            // mark already names the machine — repeating both back as the label
+            // (`boxlit · ukvps`) said nothing the row wasn't saying, and it pinned
+            // the label: a composed name that isn't the auto convention reads as one
+            // the user chose, so the row could never become `Claude Code` and then
+            // follow the agent's own title the way its local twin does.
+            let count = projects[index].sessions.filter { $0.agent == .terminal }.count
+            session.title = "Terminal \(count + 1)"
             projects[index].sessions.append(session)
             selectedSessionID = session.id
             return

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -929,6 +929,20 @@ enum Termiod {
         /// a line of hex. In order of how much it tells a person: the reported
         /// title, the agent, the program actually running, and — only when the
         /// command says nothing — the name itself.
+        /// The rungs of `displayLabel` that are a *name* rather than a guess at one:
+        /// a title typed on the box, the daemon's own session name, the program the
+        /// session is running. A viewer keeps these — they are the only thing naming
+        /// the row over there.
+        ///
+        /// `nil` when the label is only the agent's id, which the client's own
+        /// promotion improves on: that row becomes `Claude Code`, and then whatever
+        /// the agent's live title says it is working on.
+        var givenName: String? {
+            if let title, !title.isEmpty { return title }
+            if let agentID, !agentID.isEmpty { return nil }
+            return displayLabel
+        }
+
         var displayLabel: String {
             if let title, !title.isEmpty { return title }
             if let agentID, !agentID.isEmpty { return agentID }

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -187,7 +187,7 @@ extension TermioStore {
         guard let session = session(id),
               session.promptTitle == nil,
               session.agent != .terminal,
-              session.title == session.agent.displayName,
+              session.givenTitle == nil,
               let title = AgentPromptTitle.normalized(raw)
         else { return }
         updateSession(id) { $0.promptTitle = title }
@@ -456,10 +456,10 @@ extension TermioStore {
             // promoted row is the agent's own subprocess, not a new identity.
             guard session.agent == .terminal, detected != .terminal else { return }
             // Adopt the declared-session title convention (`addSession`) so the row
-            // reads `Claude Code` — but never overwrite a name the user chose.
-            if Self.isAutoTerminalName(session.title) {
-                session.title = detected.displayName
-            }
+            // reads `Claude Code`. Unconditional: a name the user chose lives in
+            // `givenTitle` and outranks this at display time, so there is nothing
+            // here to protect it from.
+            session.title = detected.displayName
             session.agent = detected
             self[home] = session
         } else if session.agent != .terminal {
@@ -478,13 +478,12 @@ extension TermioStore {
         guard let home = locate(id) else { return }
         var session = self[home]
         guard session.agent != .terminal else { return }
-        // Un-renamed rows fall back to the auto `Terminal N` convention (numbered
-        // like `addSession`, counting this row itself), so display naming — cwd
-        // basename for loose terminals — takes over again.
-        if session.title == session.agent.displayName {
-            let terminalCount = roster(at: home).filter { $0.agent == .terminal }.count
-            session.title = "Terminal \(terminalCount + 1)"
-        }
+        // Back to the auto `Terminal N` convention (numbered like `addSession`,
+        // counting this row itself), so display naming — cwd basename for loose
+        // terminals — takes over again. A name the user chose is untouched by this:
+        // it lives in `givenTitle` and still outranks the placeholder.
+        let terminalCount = roster(at: home).filter { $0.agent == .terminal }.count
+        session.title = "Terminal \(terminalCount + 1)"
         session.agent = .terminal
         session.liveTitle = nil
         session.promptTitle = nil

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -417,6 +417,11 @@ extension TermioStore {
         // machine. The distinction matters beside the numbered rows: an "SSH Shell"
         // dies with the connection, while a durable termiod session survives a detach.
         var session = Session(title: "SSH Shell", agent: .terminal)
+        // A name, not a placeholder: it is what makes an `ssh` shell legible next to
+        // the durable rows, and nothing better is waiting behind it — the cwd a
+        // loose terminal falls back to reports a directory on the far box, which is
+        // how this row would end up called `ubuntu`.
+        session.givenTitle = session.title
         session.sshHost = host
 
         let workspaceID = deviceWorkspace(for: host)
@@ -793,7 +798,17 @@ extension TermioStore {
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         let name = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty else { return }
-        updateSession(id) { $0.title = name }
+        // Typing one of Termio's own conventions back into the field is how a row is
+        // handed to automatic naming again: the agent's plain name returns an agent
+        // session to its live terminal title, `Terminal N` returns a shell to its
+        // numbering. Anything else is a name, and names are kept verbatim.
+        //
+        // `title` is deliberately not written: it is the app's own placeholder, and
+        // leaving it alone is what lets a row that is later un-named fall back to a
+        // sensible label instead of to whatever it was once called.
+        let composed = name == effectiveAgent(for: session).displayName
+            || Self.isAutoTerminalName(name)
+        updateSession(id) { $0.givenTitle = composed ? nil : name }
     }
 
     /// The user-facing "Close Session": the same teardown as `closeSession`, but it

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1487,25 +1487,26 @@ final class TermioStore: ObservableObject {
     /// once it reports something meaningful — that is how a `Claude Code` row
     /// becomes `Explore e2b.dev infra`, keeping two sessions of the same agent
     /// distinguishable. Agents whose OSC title names only the project can instead
-    /// fall back to a compact first-prompt title supplied by their hook. A name the
-    /// user set themselves wins, followed by a meaningful native title, then the
-    /// prompt-derived fallback.
+    /// fall back to a compact first-prompt title supplied by their hook. A
+    /// `givenTitle` wins over both, then a meaningful native title, then the
+    /// prompt-derived fallback, then the composed placeholder.
     ///
     /// Plain terminals never adopt a live title (their shell would just report
-    /// `user@host`/cwd noise); instead the auto-named ones (`Terminal N`) all show
-    /// a bare `Terminal` label. The stored title is left untouched (it seeds the
-    /// worktree branch slug, which must stay stable and unique); only the displayed
+    /// `user@host`/cwd noise); instead the ones Termio named itself all show a bare
+    /// `Terminal` label. `title` is left untouched throughout — only the displayed
     /// value is derived here.
+    ///
+    /// The name a row was given is a field (`Session.givenTitle`), never a string
+    /// test over `title`: a session running on another machine is born with a label
+    /// Termio composed for it, and reading that label as chosen is what used to
+    /// freeze a remote row at `<project> · <host>` for the rest of its life.
     func displayTitle(for session: Session) -> String {
+        if let given = session.givenTitle { return given }
         if session.agent != .terminal {
-            return AgentSessionTitle.resolved(
-                stored: session.title,
-                agentName: session.agent.displayName,
+            return AgentSessionTitle.automatic(
                 native: runtimes[session.id]?.liveTitle ?? session.liveTitle,
-                promptFallback: session.promptTitle)
-        }
-        guard Self.isAutoTerminalName(session.title) else {
-            return session.title
+                promptFallback: session.promptTitle,
+                placeholder: session.title)
         }
         // A loose terminal is labeled by its live cwd's basename (`~` at home):
         // the session owns its path, so `cd ~/code/foo` renames the row to `foo`
@@ -1534,7 +1535,9 @@ final class TermioStore: ObservableObject {
 
     /// Whether `title` is an auto-generated `Terminal N` label (as opposed to a
     /// name the user chose), which is what makes it eligible for live re-indexing.
-    static func isAutoTerminalName(_ title: String) -> Bool {
+    /// A pure test over the string, so `Session` can reach it while decoding off
+    /// the main actor.
+    nonisolated static func isAutoTerminalName(_ title: String) -> Bool {
         let suffix = title.dropFirst("Terminal ".count)
         return title.hasPrefix("Terminal ") && !suffix.isEmpty
             && suffix.allSatisfy(\.isNumber)
@@ -1659,12 +1662,12 @@ final class TermioStore: ObservableObject {
 /// The order the sidebar names an agent session in, kept out of `TermioStore` so a
 /// test can pin the precedence without standing up a window.
 enum AgentSessionTitle {
-    /// A name the user set wins outright. Otherwise the agent's own native title
-    /// speaks, and only when it says nothing does the first prompt stand in.
-    static func resolved(
-        stored: String, agentName: String, native: String?, promptFallback: String?
+    /// What an agent row calls itself when nobody has named it: the agent's own
+    /// native title speaks first, the first prompt stands in when it says nothing,
+    /// and the composed placeholder shows only when neither has anything to say.
+    static func automatic(
+        native: String?, promptFallback: String?, placeholder: String
     ) -> String {
-        guard stored == agentName else { return stored }
-        return native ?? promptFallback ?? stored
+        native ?? promptFallback ?? placeholder
     }
 }

--- a/Tests/termioTests/LiveTerminalTitleTests.swift
+++ b/Tests/termioTests/LiveTerminalTitleTests.swift
@@ -54,24 +54,43 @@ final class LiveTerminalTitleTests: XCTestCase {
 
     func testAgentTitlePrecedence() {
         XCTAssertEqual(
-            AgentSessionTitle.resolved(
-                stored: "Codex", agentName: "Codex", native: "Native title",
-                promptFallback: "Prompt title"),
+            AgentSessionTitle.automatic(
+                native: "Native title", promptFallback: "Prompt title",
+                placeholder: "Codex"),
             "Native title")
         XCTAssertEqual(
-            AgentSessionTitle.resolved(
-                stored: "Codex", agentName: "Codex", native: nil,
-                promptFallback: "Prompt title"),
+            AgentSessionTitle.automatic(
+                native: nil, promptFallback: "Prompt title", placeholder: "Codex"),
             "Prompt title")
         XCTAssertEqual(
-            AgentSessionTitle.resolved(
-                stored: "My name", agentName: "Codex", native: "Native title",
-                promptFallback: "Prompt title"),
-            "My name")
-        XCTAssertEqual(
-            AgentSessionTitle.resolved(
-                stored: "Codex", agentName: "Codex", native: nil, promptFallback: nil),
+            AgentSessionTitle.automatic(
+                native: nil, promptFallback: nil, placeholder: "Codex"),
             "Codex")
+    }
+
+    /// The remote regression: a label Termio composed for a row on another machine
+    /// is a placeholder, so the agent's live title still speaks through it. Reading
+    /// it as a chosen name is what froze a VPS row at `boxlit · ukvps` while its
+    /// local twin followed the conversation.
+    func testComposedRemoteLabelStillYieldsToTheLiveTitle() {
+        XCTAssertEqual(
+            AgentSessionTitle.automatic(
+                native: "Wire up the relay", promptFallback: nil,
+                placeholder: "boxlit · ukvps"),
+            "Wire up the relay")
+    }
+
+    /// The invariant the field shape buys: rewriting the placeholder — a promotion,
+    /// a demotion, a state-file migration renumbering old rows — can never disturb
+    /// the name someone gave. A flag beside `title` had to be updated at every one
+    /// of those sites, and the ones that forgot pinned the row to a name nobody gave.
+    func testRewritingThePlaceholderLeavesAGivenNameAlone() {
+        var session = Session(title: "Terminal 3", agent: .terminal)
+        session.givenTitle = "Deploy watch"
+
+        session.title = "Claude Code"
+
+        XCTAssertEqual(session.givenTitle, "Deploy watch")
     }
 
     func testCodexHookForwardsToolAndPromptFields() {
@@ -88,5 +107,38 @@ final class LiveTerminalTitleTests: XCTestCase {
         let decoded = try JSONDecoder().decode(Session.self, from: data)
 
         XCTAssertEqual(decoded.promptTitle, "Refactor Codex titles")
+    }
+
+    func testGivenTitlePersistsWithSession() throws {
+        var session = Session(title: "Codex", agent: .codex)
+        session.givenTitle = "Deploy watch"
+
+        let data = try JSONEncoder().encode(session)
+        let decoded = try JSONDecoder().decode(Session.self, from: data)
+
+        XCTAssertEqual(decoded.givenTitle, "Deploy watch")
+    }
+
+    /// A state file written before `givenTitle` existed has to be read back into the
+    /// same meaning: Termio's own conventions are placeholders, a real name is kept —
+    /// and the `<project> · <host>` label the old remote path wrote is recovered as
+    /// the placeholder it always was, so an already-frozen row unfreezes on upgrade.
+    func testGivenTitleIsRecoveredFromStateFilesWithoutIt() {
+        XCTAssertNil(
+            Session.recoveredGivenTitle("Terminal 3", agent: .terminal, remoteHost: nil))
+        XCTAssertNil(
+            Session.recoveredGivenTitle("Claude Code", agent: .claudeCode, remoteHost: nil))
+        XCTAssertNil(
+            Session.recoveredGivenTitle("boxlit · ukvps", agent: .claudeCode, remoteHost: "ukvps"))
+        XCTAssertNil(
+            Session.recoveredGivenTitle("ukvps", agent: .terminal, remoteHost: "ukvps"))
+        XCTAssertEqual(
+            Session.recoveredGivenTitle("Deploy watch", agent: .claudeCode, remoteHost: "ukvps"),
+            "Deploy watch")
+        // The same composed shape on a *local* session was never written by Termio,
+        // so it can only be a name someone typed.
+        XCTAssertEqual(
+            Session.recoveredGivenTitle("boxlit · ukvps", agent: .terminal, remoteHost: nil),
+            "boxlit · ukvps")
     }
 }


### PR DESCRIPTION
A session opened on another machine was born with a label Termio composed for it — `<project> · <host>` — stored in the same field a name the user types goes in. Every gate downstream told the two apart by pattern-matching that string, so the composed label read as chosen: the row could never be renamed to `Claude Code` when a shell turned into an agent, and never adopted the agent's live terminal title.

A VPS row sat frozen at `boxlit · ukvps` while its local twin followed the conversation — with the title it should have been showing already saved on the session.

## What changed

`title` and the name a row was given are now separate fields with different owners. `title` is the placeholder the app composes and freely rewrites; `givenTitle` is set only by the act of naming — a rename, a title typed on the far box, or a row Termio names for what it is with nothing better behind it (`SSH Shell`).

They cannot contradict each other because nothing has to keep them in step. A flag beside `title` would have needed updating at every site that writes a title, including the state migrations that renumber old rows — which would have re-pinned exactly the rows those migrations exist to unstick.

With the name in its own field the gates disappear rather than move. Promotion and demotion write the placeholder unconditionally, and `displayTitle` is a precedence chain: given name, live title, first-prompt title, placeholder.

Remote sessions opened from a project row now number themselves like a local project's terminals — the header already names the repo and the row's device mark already names the machine.

## Upgrade

State files written before `givenTitle` recover it on decode, so a row already frozen unfreezes on upgrade instead of needing a manual rename.

## Verification

`swift build` clean, 525 tests pass. Added coverage for the precedence chain, the recovery on decode, and the invariant that rewriting the placeholder leaves a given name alone.

Not yet verified on screen — `screencapture` is blocked on this machine, so the sidebar rows have not been looked at in a running build.

Release Notes:
- Sessions running on another machine now show what their agent is working on, the way local sessions do, instead of a fixed `project · host` label.