### PR TITLE
Add the 0.41.3 changelog entry

### DIFF
--- a/web/landing/src/data/changelog.ts
+++ b/web/landing/src/data/changelog.ts
@@ -17,6 +17,17 @@ export type ChangelogEntry = {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: "0.41.3",
+    date: "2026-08-23",
+    title: "A session on another machine says what it's working on",
+    changes: {
+      fixed: [
+        "A session running on another machine now follows what its agent is doing, the way a local one does — the row becomes the agent's name, then the topic it's working on. It used to sit on a fixed \"project · host\" label forever: the name termio composed for the row was kept in the same place a name you type goes, so nothing was ever allowed to replace it.",
+        "Maximizing a file no longer flashes the file tree on the way there.",
+      ],
+    },
+  },
+  {
     version: "0.41.2",
     date: "2026-08-23",
     title: "A session that can't start says why",


### PR DESCRIPTION
Covers what landed since v0.41.2: the remote session titles fix (#423) and the inspector maximize flash (#422). Required before the tag — the Docs workflow fails once a tag exists without an entry covering it.

`pnpm docs:check` passes locally.

Release Notes:
- None. Landing-site content only.