### PR TITLE
Stop a second attachment resizing the PTY behind the first

### DIFF
--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -467,8 +467,9 @@ final class CompanionServer {
             }
         case .resize(let cols, let rows):
             // The phone reports its grid on attach, foreground, and layout —
-            // each report claims the size (tmux's newest-client rule; one PTY
-            // has one winsize, per-client grids don't exist at this layer).
+            // each report claims the write token and with it the size (tmux's
+            // newest-client rule; one PTY has one winsize, per-client grids
+            // don't exist at this layer).
             bridges[id]?.applyClientResize(cols: cols, rows: rows)
         case .listFiles(let projectID, let path):
             handleListFiles(projectID: projectID, path: path, on: connection)
@@ -1038,10 +1039,20 @@ final class SessionBridge: @unchecked Sendable {
         onInput?()
     }
 
-    /// A resize control from this client. Sizing is the writer's to set, and
-    /// the phone becomes the writer by attaching or by typing — so this is the
-    /// grid the daemon adopts, and it answers with a keyframe rendered for it.
+    /// A resize control from this client. Sizing is the writer's to set, and on
+    /// this path the grid report *is* the claim: the phone sends one when it
+    /// opens a session, comes back to that screen, or rotates — every one of
+    /// them the user arriving at this session on this device. Attaching used to
+    /// take the token by itself, which read the same for a phone opening one
+    /// session and for a Mac window quietly holding fifteen, and let the phone
+    /// pull the shared PTY down to its width behind the Mac's back.
+    ///
+    /// The claim lands first and the grid follows it: `resize` records the size
+    /// whether or not this attachment can send it yet, and the grant re-asserts
+    /// it. So the daemon adopts this grid and answers with a keyframe rendered
+    /// for it — but only once the user has actually shown up here.
     func applyClientResize(cols: Int, rows: Int) {
+        link.claimWriter()
         link.resize(rows: rows, cols: cols)
     }
 

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1739,10 +1739,10 @@ final class TermiodSessionLink: @unchecked Sendable {
                 // Typing is what claims the token, the same rule
                 // `PTYProcess.claimHostOwnership` follows on the in-process
                 // path: the size and the write follow the device whose user is
-                // actually at the keyboard. Without this a second attachment —
-                // a phone looking at the same session — would silently mute
-                // this one for as long as it stayed attached, because the
-                // daemon hands the token to whoever attached last.
+                // actually at the keyboard. Typing is the *only* thing that
+                // moves the token — attaching does not, or a phone merely
+                // looking at this session would mute this window and pull the
+                // PTY down to its own width.
                 //
                 // Ordering is safe: frames on one connection are processed in
                 // order, so the claim is resolved before the input behind it is
@@ -1752,6 +1752,32 @@ final class TermiodSessionLink: @unchecked Sendable {
             } catch {
                 Log.termiod.error("""
                 input write to \(self.sessionName, privacy: .public) failed: \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            }
+        }
+    }
+
+    /// Takes the write token for this attachment because its user is now here.
+    ///
+    /// Typing claims it implicitly (`send`), which covers the Mac: a window is
+    /// attached to every session it has a pane for, so nothing short of the
+    /// keyboard distinguishes the session being *used* from the fifteen sitting
+    /// behind it. A phone is the other shape — it attaches to the one session
+    /// its user just opened — and needs to say so out loud, because until it
+    /// holds the token its screen is painted for somebody else's grid.
+    ///
+    /// The grant arrives as `writer_changed`, and `applyWriter` re-asserts this
+    /// client's grid on the way through; there is nothing to send here beyond
+    /// the claim itself.
+    func claimWriter() {
+        workQueue.async { [self] in
+            guard !closed, attached, !isWriter else { return }
+            do {
+                try claimWriterLocked()
+            } catch {
+                Log.termiod.error("""
+                claiming the write token on \(self.sessionName, privacy: .public) failed: \
                 \(error.localizedDescription, privacy: .public)
                 """)
             }
@@ -2196,8 +2222,16 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// size the PTY already has never costs a barrier repaint, and the check
     /// below — the PTY only diverges from what this client asked for when
     /// another client owns the token, and that is the §C.5 case where this
-    /// window is wrapping bytes at the wrong width. Letterboxing the viewport
-    /// against it is the client-side step this foundation leaves open.
+    /// window is wrapping bytes at the wrong width.
+    ///
+    /// A writer answers that divergence instead of only noting it. It has to:
+    /// the surface reports a grid only when it *changes*
+    /// (`InMemoryTerminalSession.dispatchResize` drops an unchanged viewport),
+    /// so a PTY moved out from under a still window has no second chance to be
+    /// noticed — the screen stays formatted for someone else's grid until the
+    /// user drags the window edge. Letterboxing an *observer's* viewport, which
+    /// cannot resize anything, is the client-side step this foundation still
+    /// leaves open.
     private func applyAuthoritativeGrid(_ grid: TerminalGrid) {
         workQueue.async { [self] in
             guard authoritativeGrid != grid else { return }
@@ -2209,6 +2243,15 @@ final class TermiodSessionLink: @unchecked Sendable {
             this client renders \
             \(self.desiredGrid.rows, privacy: .public)x\(self.desiredGrid.cols, privacy: .public)
             """)
+            guard isWriter else { return }
+            do {
+                try sendResizeLocked(desiredGrid)
+            } catch {
+                Log.termiod.error("""
+                restoring the grid on \(self.sessionName, privacy: .public) failed: \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            }
         }
     }
 

--- a/Tests/termioTests/TermiodWriteTokenIntegrationTests.swift
+++ b/Tests/termioTests/TermiodWriteTokenIntegrationTests.swift
@@ -3,12 +3,11 @@ import XCTest
 
 /// Two attachments on one session, against a real daemon.
 ///
-/// The daemon hands the write token to whoever attached last, which is right
-/// for a single client and wrong the moment a second device looks at the same
-/// session: a phone opening a session would mute the Mac until it detached,
-/// and the Mac had no way to answer short of tearing its attachment down.
-/// `claim_writer` is what lets the token follow the device being *used*, and
-/// this is the only test that exercises both halves of that against a real
+/// The daemon hands the write token to the first attachment and to nobody
+/// after it: a second device *looking* at a session must not mute the first,
+/// and must not drag the one shared PTY to its own width behind that client's
+/// back. `claim_writer` is what lets the token follow the device being *used*,
+/// and this is the only test that exercises both halves of that against a real
 /// daemon rather than against fixtures.
 ///
 /// Opt-in on the same terms as the other daemon suites: set
@@ -82,41 +81,80 @@ final class TermiodWriteTokenIntegrationTests: XCTestCase {
         XCTAssertEqual(holder.isWriter, expected, what, file: file, line: line)
     }
 
+    /// Asserts a writer state *holds* through a settling window.
+    ///
+    /// `waitForWriter` cannot express "nothing happened": it is satisfied by the
+    /// state the watcher already starts in, so it returns before the event that
+    /// would have contradicted it has had time to arrive. Asserting that a
+    /// second attachment did *not* take the token with a wait is therefore a
+    /// test that passes against the exact behaviour it exists to catch — which
+    /// is what the first draft of this file did.
+    private func assertWriterHolds(
+        _ holder: WriterWatcher, _ expected: Bool, _ what: String,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(1.5)
+        while Date() < deadline {
+            XCTAssertEqual(holder.isWriter, expected, what, file: file, line: line)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+    }
+
+    /// Waits for the link to say anything at all about its writer state. Every
+    /// attachment announces its initial standing, so this is what tells "has not
+    /// reported yet" apart from "reported that it is a reader".
+    private func waitForFirstReport(
+        _ holder: WriterWatcher, file: StaticString = #filePath, line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(5)
+        while holder.reports == 0, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertGreaterThan(holder.reports, 0, "the attachment never reported", file: file, line: line)
+    }
+
     /// `onWriter` fires on the main queue; the tests read it from there too.
     private final class WriterWatcher {
         var isWriter = false
+        var reports = 0
     }
 
-    func testTypingTakesTheWriteTokenBackFromTheDeviceThatAttachedLast() throws {
+    func testTheWriteTokenFollowsTypingRatherThanAttaching() throws {
         let name = "write-token-\(UUID().uuidString.prefix(8))"
 
         let mac = link(name)
         let macWriter = WriterWatcher()
-        mac.onWriter = { macWriter.isWriter = $0 }
+        mac.onWriter = { macWriter.isWriter = $0; macWriter.reports += 1 }
         mac.start()
         defer { mac.detach() }
         waitForWriter(macWriter, true, "the first attachment holds the token")
 
-        // A phone opens the same session. Attaching still takes the token —
-        // that is what makes a fresh client usable without a round trip.
+        // A phone opens the same session. Looking is not taking.
         let phone = link(name)
         let phoneWriter = WriterWatcher()
-        phone.onWriter = { phoneWriter.isWriter = $0 }
+        phone.onWriter = { phoneWriter.isWriter = $0; phoneWriter.reports += 1 }
         phone.start()
         defer { phone.detach() }
-        waitForWriter(phoneWriter, true, "the newer attachment takes the token")
-        waitForWriter(macWriter, false, "and the older one is told it lost it")
+        waitForFirstReport(phoneWriter)
+        assertWriterHolds(phoneWriter, false, "a second attachment arrives as a reader")
+        assertWriterHolds(macWriter, true, "and leaves the first one writing")
 
-        // The Mac's user types. Before `claim_writer` this input was simply
-        // refused by the daemon and the Mac stayed mute.
-        mac.send(Data("echo\n".utf8))
-        waitForWriter(macWriter, true, "typing on the Mac takes the token back")
-        waitForWriter(phoneWriter, false, "and the phone is told it lost it")
+        // The phone's user types. Before `claim_writer` this input was simply
+        // refused by the daemon and the phone stayed mute.
+        phone.send(Data("echo\n".utf8))
+        waitForWriter(phoneWriter, true, "typing on the phone takes the token")
+        waitForWriter(macWriter, false, "and the Mac is told it lost it")
 
         // And back again, so the token is genuinely mobile rather than
         // one-directional.
-        phone.send(Data("echo\n".utf8))
-        waitForWriter(phoneWriter, true, "typing on the phone takes it back")
-        waitForWriter(macWriter, false, "the Mac yields in turn")
+        mac.send(Data("echo\n".utf8))
+        waitForWriter(macWriter, true, "typing on the Mac takes it back")
+        waitForWriter(phoneWriter, false, "the phone yields in turn")
+
+        // The other half of the same rule: a deliberate claim moves the token
+        // without a keystroke, which is what a phone opening a session sends.
+        phone.claimWriter()
+        waitForWriter(phoneWriter, true, "an explicit claim takes the token")
+        waitForWriter(macWriter, false, "and the Mac is told it lost it")
     }
 }

--- a/docs/design/20260730-termiod-session-mux.md
+++ b/docs/design/20260730-termiod-session-mux.md
@@ -3,7 +3,7 @@ title: termiod — Agent-native session mux
 status: draft
 type: design
 created: 2026-07-30
-updated: 2026-07-31
+updated: 2026-08-24
 related:
   - 20260708-session-daemon-architecture.md
   - 20260724-sidebar-scroll-performance.md
@@ -246,7 +246,7 @@ Align with [session-daemon-architecture](20260708-session-daemon-architecture.md
 | **v1.1** | Dirty-row / grid diffs at frame cap | Bandwidth + fidelity |
 | **always** | list/create/kill/attach, resize claim, **agent status**, roster deltas | ADE |
 
-**Rules:** detach ≠ kill · resize newest-client (v1) · multi-viewer observe yes · default **single writer** until §8 · capability negotiation on `hello`.
+**Rules:** detach ≠ kill · resize follows the write token, which an attach takes only when nobody holds it and `claim_writer` moves after that · multi-viewer observe yes · default **single writer** until §8 · capability negotiation on `hello`.
 
 **Input replication, not state sync (the anti-100× core).** The host keeps
 viewers consistent by shipping the **log** (raw PTY bytes, each client replays

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -3,7 +3,7 @@ title: termiod Session Protocol
 status: draft
 type: design
 created: 2026-07-30
-updated: 2026-08-22
+updated: 2026-08-24
 related:
   - 20260730-termiod-session-mux.md
   - 20260708-session-daemon-architecture.md
@@ -319,12 +319,20 @@ ignores `Resized`/`WriterChanged` (`client.rs`) — acceptable for a single
 same-size CLI, incorrect the moment a second differently-sized viewer
 attaches.)*
 
-**Writer policy — single writer, newest claim, observable.** Any
-`mode:"interact"` attach takes the write token; the previous writer stays
-attached but demoted, and *everyone* on the session gets
-`E {ev:"writer_changed", writer:"c_41"}`. Observers' `D`/`R` frames are
-answered with `error {code:"not_writer"}` rather than dropped. This is the
-POC behavior formalized plus notification. CRDT/multi-caret input is
+**Writer policy — single writer, follows the device being used, observable.**
+A `mode:"interact"` attach takes the write token only when nobody holds it;
+after that the token moves on `claim_writer` alone, which every client sends
+when its user actually shows up (typing, or opening the session on a phone).
+The previous writer stays attached but demoted, and *everyone* on the session
+gets `E {ev:"writer_changed", writer:"c_41"}`. Observers' `D`/`R` frames are
+answered with `error {code:"not_writer"}` rather than dropped.
+
+Attach originally took the token unconditionally, which reads identically for a
+phone opening one session and a Mac window quietly holding fifteen: the phone's
+grid then travelled to the shared PTY through the attach resize, and the
+desktop — whose `R` frames are gated on the token it had just lost — was left
+rendering a screen formatted for a grid it does not have, with no event able to
+correct it. Promotion has to be a verb, not a side effect of arriving. CRDT/multi-caret input is
 explicitly rejected (§H); the write token is also the natural place a future
 share ACL plugs in without new message shapes.
 

--- a/docs/design/20260805-termiod-hot-path-and-client-classes.md
+++ b/docs/design/20260805-termiod-hot-path-and-client-classes.md
@@ -3,7 +3,7 @@ title: Hot path, attach join point, and client classes
 status: draft
 type: design
 created: 2026-08-05
-updated: 2026-08-16
+updated: 2026-08-24
 related:
   - 20260730-termiod-session-protocol.md
   - 20260805-termiod-device-architecture.md
@@ -139,7 +139,14 @@ the current rule does not have:
 **Rejected as a default policy. Accepted as an explicit, stateless modifier**
 (D5): `attach {mode:"interact", claim:"polite"}` fails with `busy` when a live
 writer exists, instead of silently demoting them. No lease, no TTL, no clock —
-the caller decides, and the default stays newest-claim-wins.
+the caller decides.
+
+*Superseded in implementation.* Attaching no longer demotes anyone at all — it
+takes the token only when nobody holds it — so `polite` is now the behaviour of
+every attach and the modifier has nothing left to modify. Newest-claim-wins
+survives only for `claim_writer`, the verb a client sends when its user shows
+up. See the [session protocol](20260730-termiod-session-protocol.md) writer
+policy.
 
 ### C.4 Compat sink in v1 (part of Grok #2)
 
@@ -363,7 +370,7 @@ tag degrades to `Default` rather than failing the frame.
 | **D2** | §C.6 | The `S` payload **includes its own prologue** and must be state-independent on apply. Clients MUST NOT prepend their own reset. Frame order after `attached` is fixed: `S` → `ready` → `H`* interleavable with `D` | **Landed 2026-08-13** (prologue in `format_vt`; the reference client and the Mac client apply raw) |
 | **D3** | §C.6 | Replace the stage table's "who parses VT" column with the **client-class profiles** of §D.3. Stages describe the host's capability; classes describe what a client negotiates | Doc restructure |
 | **D4** | §F #10 | Mark risk #10 **closed** (4 MiB `CLIENT_BACKLOG_CAP`, shipped) and both residuals closed too: (a) the degrade is **forced resync** — `S` + `ready` + `E{ev:"resynced", reason}`, dropping only on a second strike; (b) the sidecar command queue carries a 16 MiB budget whose only legal degrade is `E{ev:"vt_stale", reason}` (refuse snapshots, fall back to ring replay), never dropping bytes to the VT and never dropping a byte owed to a client | **Landed 2026-08-16** |
-| **D5** | §C.4, §C.5 | `attach` gains `claim:"newest"|"polite"` (default `newest`, i.e. today's behaviour). `polite` returns `error{code:"busy"}` when a live writer exists. Supersedes the sticky-writer idea | Additive control field |
+| **D5** | §C.4, §C.5 | `attach` gains `claim:"newest"|"polite"`. `polite` returns `error{code:"busy"}` when a live writer exists. Supersedes the sticky-writer idea | **Overtaken 2026-08-24** — attach takes the token only when nobody holds it, so every attach is `polite` and the field was never added; newest-claim-wins survives on `claim_writer` |
 | **D6** | §C.6 | Normative: `grid_diff` MUST NOT be selected by transport class; legal selection signals enumerated (§D.4). Lead with the capability argument, cite the 8.6× second | Wording, normative |
 | **D7** | §C.10 + §C.6 | State the shared mechanism once — *durable object + monotonic cursor + bounded ring + explicit gap signal* — and keep the two words distinct: **`gap`** = your baseline is unusable, resync; **tombstone** = this session is dead and here is why (`tombstone.rs`). The terminal plane adopts `gap`, not the word "tombstone" | Vocabulary |
 | **D8** | §C.5 | Delete the stale "POC gap: `Attached` omits `rows`/`cols`" note; move the requirement into a **client conformance list** (parse at authoritative dims; honour `Resized`; honour `WriterChanged`) | Doc correction |

--- a/docs/design/20260818-session-guests.md
+++ b/docs/design/20260818-session-guests.md
@@ -3,7 +3,7 @@ title: Session guests — three deltas, not a sharing subsystem
 status: draft
 type: design
 created: 2026-08-18
-updated: 2026-08-18
+updated: 2026-08-24
 related:
   - 20260818-termiod-web-client-ghostty-wasm.md
   - 20260730-termiod-session-protocol.md
@@ -130,7 +130,7 @@ Two gates, and the first one is the deliberate act. `may_type` is off at mint, i
 
 That yields three properties worth stating, because they are what makes typing safe enough to consider at all:
 
-- **The owner is never locked out.** Taking input back is another `interact` attach; newest wins, so the owner's click always beats the guest's earlier claim.
+- **The owner is never locked out.** Taking input back is a `claim_writer` from the owner's pane — typing sends one — and the newest claim wins, so the owner always beats the guest's earlier claim. (Attaching is not a claim: a guest merely *opening* the session cannot take the token, or the owner's window would go read-only at a stranger's grid without anyone typing.)
 - **Handover is visible to everyone.** `writer_changed` is a fan-out event, so the guest's page and the owner's pane header show the same fact from both sides.
 - **Nothing new is invented.** Take input / Release is already specified in the web-client RFC as "close the observe socket, open an interact one."
 

--- a/docs/design/20260818-termiod-web-client-ghostty-wasm.md
+++ b/docs/design/20260818-termiod-web-client-ghostty-wasm.md
@@ -3,7 +3,7 @@ title: Termiod web client on official Ghostty WASM (Linux first)
 status: draft
 type: rfc
 created: 2026-08-18
-updated: 2026-08-18
+updated: 2026-08-24
 related:
   - 20260730-termiod-session-protocol.md
   - 20260805-termiod-hot-path-and-client-classes.md
@@ -293,7 +293,7 @@ Control-channel sequence (existing ops, no new verbs):
 
 Steady state on the attach socket is raw `D` in both directions. The host's sidecar VT (`termiod/vt`) is consulted only to build `S` / `H`. The browser's Wasm VT parses the same bytes. Two state machines, one log. That is the anti-100× invariant applied to a third client, not a new architecture.
 
-Default attach mode is **`observe`**. Opening the page while a Mac holds the write token must not steal it (`recompute_writer` promotes the newest `AttachMode::Interact`). A **Take input** control closes the observe attachment and opens a new attach WebSocket with `mode: interact` (there is no promote verb; `Control::Attach` sets mode once per channel). **Release** does the reverse: detach the interact socket and reattach as observe. `claim: "polite"` is specified in the hot-path doc and is **not** on `Control::Attach`; the web client does not invent it.
+Default attach mode is **`observe`**. Opening the page while a Mac holds the write token must not steal it — and since an `interact` attach now takes the token only when nobody holds it, neither mode steals. Eligibility is still fixed at attach: only an `AttachMode::Interact` client may claim, and no control operation turns an observer into one. So the **first** *Take input* is still a reattach — detach the observe socket, open one with `mode: interact` — and every handover after that is a bare `Control::ClaimWriter` on the channel already open, because promotion is now a verb. **Release** remains a reattach as observe, since giving the token *back* has no verb. `claim: "polite"` is specified in the hot-path doc and is **not** on `Control::Attach`; the web client does not invent it.
 
 ### VT source
 
@@ -482,7 +482,7 @@ The test is device architecture §4's: feed one `S` to a light page and a dark p
 
 Client-side KeyEncoder against the official `key/encoder.h` + `key/event.h`. Structured `KeyboardEvent` → escape bytes, including DECCKM / kitty flags the Wasm is already tracking. The host accepts raw PTY bytes on the attach write path (`SessionMsg::Input` in `run_attach`). There is no structured-key verb to invent.
 
-The **write token** is `AttachMode`, not the pairing secret. `mode: interact` claims it (newest-claim-wins, `recompute_writer`). `mode: observe` never claims. Observer `D` / `R` is answered `error { code: "not_writer" }`. No CRDT.
+The **write token** is `Control::ClaimWriter`, not the pairing secret and not `AttachMode`. `mode: interact` makes a client *eligible* to claim, and takes the token on attach only when nobody holds it; `mode: observe` is never eligible. Observer `D` / `R` is answered `error { code: "not_writer" }`. No CRDT.
 
 ### Resize
 
@@ -967,7 +967,7 @@ Sharing ACLs, phone-direct-over-WSS as a replacement for the companion wire, and
 12. **`H` never enters the Wasm.** Decoded `WireColor` rows are the seam's row shape; the renderer paints history above the viewport in the viewer's palette.
 13. **Linux first, one hop to the device.** The browser attaches to the box's `termiod`. The Mac is not a gateway. Channel-id multiplexing is not a prerequisite.
 14. **Clipboard and extra data channels are out of v1.** Do not invent Superlogical's unpublished protocol.
-15. **Pairing token authenticates the pipe. `mode: interact` claims the write token** (newest wins, `recompute_writer`). `mode: observe` never claims. The page defaults to observe and may attach either way. No CRDT.
+15. **Pairing token authenticates the pipe. `Control::ClaimWriter` takes the write token**; `mode: interact` only makes a client eligible to send it, and takes the token on attach when nobody holds it. `mode: observe` is never eligible. The page defaults to observe and may attach either way. No CRDT.
 
 ---
 

--- a/docs/rfcs/one-path-local-through-termiod.md
+++ b/docs/rfcs/one-path-local-through-termiod.md
@@ -3,7 +3,7 @@ title: One path — local sessions run through termiod too
 status: in-review
 type: rfc
 created: 2026-08-17
-updated: 2026-08-17
+updated: 2026-08-24
 related:
   - one-path-local-through-termiod.review-claude.md
   - 20260805-termiod-device-architecture.md
@@ -84,7 +84,7 @@ in §2 that this whole RFC is for.
 | --- | --- | --- |
 | Own the PTY, spawn with `login_tty` | `PTYProcess.swift:144-231` (`forkpty`) | **Has it** — `pty.rs:67-167`, same shape, deliberately |
 | Non-blocking writes, write backlog | `PTYProcess.swift:478-624` | **Has it** — `pty.rs:208-226` + per-client budget `session.rs:25` |
-| Resize / `TIOCSWINSZ`, host-vs-companion ownership | `PTYProcess.swift:626-742` | **Different policy, not missing** — resize yes (`pty.rs:183`); the daemon arbitrates by newest interactive attach with a `writer_changed` fan-out (smoke checks 42–44), where the companion arbitrates by explicit claim. Reconciling the two is Stage 4's design work |
+| Resize / `TIOCSWINSZ`, host-vs-companion ownership | `PTYProcess.swift:626-742` | **Reconciled** — resize yes (`pty.rs:183`); the daemon used to arbitrate by newest interactive attach with a `writer_changed` fan-out (smoke checks 42–44) where the companion arbitrated by explicit claim. Both now arbitrate by explicit claim: an attach takes the token only when nobody holds it, and `claim_writer` moves it after that |
 | Reap the child, report exit code + true runtime | `PTYProcess.swift:211-224` | **Has it** — `session_exited`, but the daemon reports no runtime; the client substitutes elapsed-since-attach and says so (`TermiodClient.swift:1150-1152`) |
 | **Timestamp of the last input from any device** | `PTYProcess.swift:522` (`lastInputAt`), read at `TermioStore+TerminalSurface.swift:344` | **Missing** — the link never timestamps writes. This is the choke that keeps agent promotion quiet after a keystroke from the Mac, the phone, or `sessions send`; the comment at `:337-343` says it taps the PTY precisely so *every* device counts |
 | **Foreground process argv** (agent identity) | `PTYProcess.swift:866-874` — `tcgetpgrp` + `KERN_PROCARGS2` | **Missing** — no `tcgetpgrp` anywhere in `termiod/src` |

--- a/termiod/ARCHITECTURE.md
+++ b/termiod/ARCHITECTURE.md
@@ -70,8 +70,10 @@ client ──► pipe ──► termiod ──► PTY ──► agent
 - Hot path: raw PTY bytes over the pipe.  
 - Every negotiated channel starts with `hello`; a no-`hello` v0 control frame
   enters legacy mode with no capabilities.
-- One interactive attachment owns the write/resize token. A newer interactive
-  claim demotes (but does not detach) the prior writer; observers never claim.
+- One interactive attachment owns the write/resize token. Attaching takes it
+  only when nobody holds it; after that the token follows the device being
+  *used* — a `claim_writer` demotes (but does not detach) the prior writer.
+  Observers never claim.
 - `E` frames fan out status, writer, resize, exit, and roster deltas. A
   control channel can subscribe without attaching to a PTY.
 - VT / libghostty snapshot: **later** (host-side sidecar for resync), not in the critical path for every keystroke.

--- a/termiod/smoke_test.py
+++ b/termiod/smoke_test.py
@@ -377,6 +377,17 @@ def session_pid(name):
     return None
 
 
+def wait_for_size(name, expected, timeout=4.0):
+    """The size a claim carries arrives a round trip after the keystroke that
+    claimed it, so sampling `list` immediately would race the barrier."""
+    end = time.time() + timeout
+    while time.time() < end:
+        if session_size(name) == expected:
+            return True
+        time.sleep(0.1)
+    return session_size(name) == expected
+
+
 def session_size(name):
     for s in json.loads(cli_out("list", "--json")):
         if s["name"] == name or s["id"] == name:
@@ -425,7 +436,8 @@ def main():
     time.sleep(0.3)
     check("detach ≠ kill: session still listed", session_pid("demo") is not None)
 
-    # Reattach: different window size (newest-client claim), same process.
+    # Reattach: different window size. The session has no writer left, so this
+    # attach takes the token and its grid applies.
     p2, m2 = spawn_attach(["demo"], rows=40, cols=100)
     read_until(m2, "attached to demo")
     replay = drain(m2, 0.4)
@@ -433,7 +445,7 @@ def main():
     os.write(m2, b"echo MARKER_TWO\r")
     check("reattach: input works", b"MARKER_TWO" in read_until(m2, "MARKER_TWO"))
     check("reattach: same process (pid unchanged)", session_pid("demo") == pid_before)
-    check("reattach: newest-client resize (40x100)", session_size("demo") == (40, 100))
+    check("reattach: an unheld session takes the new grid (40x100)", session_size("demo") == (40, 100))
     os.write(m2, b"\x1c")
     p2.wait(timeout=5)
     cli("kill", "demo")
@@ -441,7 +453,7 @@ def main():
     print("\n# 2. multi-client fan-out + single-writer input")
     a1p, a1 = spawn_attach(["fan", "--", "cat"], rows=26, cols=90)
     read_until(a1, "attached to fan")
-    a2p, a2 = spawn_attach(["fan"], rows=34, cols=110)  # newest ⇒ writer
+    a2p, a2 = spawn_attach(["fan"], rows=34, cols=110)  # a reader until it types
     read_until(a2, "attached to fan")
 
     # Inject via `send` (always applied); cat echoes to *both* clients.
@@ -449,13 +461,17 @@ def main():
     check("fan-out: client 1 sees injected output", b"PINGPONG" in read_until(a1, "PINGPONG"))
     check("fan-out: client 2 sees injected output", b"PINGPONG" in read_until(a2, "PINGPONG"))
 
-    # Single writer = newest (a2). Input from a1 (not writer) is ignored.
+    # Single writer = whoever is being used. a1 attached first and still holds
+    # the token; a2 arriving did not take it, and — the regression this pins —
+    # did not drag the one PTY down to a2's grid behind a1's back.
+    check("attaching does not take the winsize", session_size("fan") == (26, 90))
     os.write(a1, b"FROM_A1\r")
-    time.sleep(0.4)
-    leaked = drain(a2, 0.4)
-    check("single-writer: non-writer input ignored", b"FROM_A1" not in leaked)
+    check("single-writer: writer input applied", b"FROM_A1" in read_until(a2, "FROM_A1"))
+
+    # Typing is what moves the token, and the size travels with it.
     os.write(a2, b"FROM_A2\r")
-    check("single-writer: writer input applied", b"FROM_A2" in read_until(a2, "FROM_A2"))
+    check("single-writer: typing takes the token", b"FROM_A2" in read_until(a1, "FROM_A2"))
+    check("the winsize follows the token", wait_for_size("fan", (34, 110)))
 
     os.write(a2, b"\x1c")
     a2p.wait(timeout=5)
@@ -1030,17 +1046,24 @@ def main():
     attached2, _ = w2.recv_matching(
         lambda kind, msg: kind == "C" and msg.get("op") == "attached"
     )
+    check(
+        "writer policy: attaching does not take the token from a live writer",
+        attached1 is not None
+        and attached2 is not None
+        and attached1[1]["writer"] is True
+        and attached2[1]["writer"] is False,
+    )
+    # Promotion is a verb. A client sends it when its user shows up — typing on
+    # the Mac, opening the session on a phone — and never merely by arriving.
+    w2.send_control({"op": "claim_writer", "seq": 3})
     changed, _ = w1.recv_matching(
         lambda kind, msg: kind == "E"
         and msg.get("ev") == "writer_changed"
         and msg.get("writer") == w2.hello["client_id"]
     )
     check(
-        "writer policy: newest interactive attach wins and emits writer_changed",
-        attached1 is not None
-        and attached2 is not None
-        and attached2[1]["writer"] is True
-        and changed is not None,
+        "writer policy: claim_writer moves the token and emits writer_changed",
+        changed is not None,
     )
     w1.send_data(b"REJECT_ME\r")
     rejected, _ = w1.recv_matching(

--- a/termiod/src/client.rs
+++ b/termiod/src/client.rs
@@ -8,7 +8,7 @@ use crate::protocol::{
 };
 use anyhow::{bail, Context, Result};
 use std::os::fd::AsRawFd;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
@@ -511,9 +511,13 @@ pub async fn attach(
     )
     .await?;
 
+    // Attaching no longer takes the token off whoever holds it, so this
+    // attachment types its way in like any other device (`Control::ClaimWriter`).
+    let holds_token = Arc::new(AtomicBool::new(false));
     let id = match read_frame(&mut rd).await? {
-        Some(Frame::Control(Control::Attached { id, name, .. })) => {
+        Some(Frame::Control(Control::Attached { id, name, writer, .. })) => {
             eprintln!("[attached to {name} ({id}) — detach with Ctrl-\\ ]\r");
+            holds_token.store(writer, Ordering::Relaxed);
             id
         }
         Some(Frame::Control(Control::Error { message, .. })) => bail!(message),
@@ -528,6 +532,14 @@ pub async fn attach(
     let (resize_claim_tx, mut resize_claim_rx) = tokio::sync::mpsc::unbounded_channel();
     let scrollback_rows = Arc::new(AtomicUsize::new(0));
     let reader_scrollback_rows = scrollback_rows.clone();
+    let reader_holds_token = holds_token.clone();
+    let reader_client_id = negotiated_client_id.clone();
+    // Shared with the input loop rather than kept local to it, so the answer to
+    // a claim clears the latch from wherever it arrives — including a refusal,
+    // which carries no `writer_changed` and would otherwise leave this
+    // attachment silently unable to ever ask again.
+    let claiming = Arc::new(AtomicBool::new(false));
+    let reader_claiming = claiming.clone();
     let reader = tokio::spawn(async move {
         let mut stdout = tokio::io::stdout();
         let mut status = None;
@@ -566,6 +578,14 @@ pub async fn attach(
                     ..
                 }))) if negotiated_client_id.as_deref() == Some(writer.as_str()) => {
                     let _ = resize_claim_tx.send(());
+                }
+                Ok(Some(Frame::Event(Event::WriterChanged { writer, .. }))) => {
+                    let mine = matches!((&writer, &reader_client_id), (Some(w), Some(id)) if w == id);
+                    reader_holds_token.store(mine, Ordering::Relaxed);
+                    reader_claiming.store(false, Ordering::Relaxed);
+                }
+                Ok(Some(Frame::Control(Control::Error { .. }))) => {
+                    reader_claiming.store(false, Ordering::Relaxed);
                 }
                 Ok(Some(Frame::Control(Control::Exited { status: s, .. }))) => {
                     status = Some(s);
@@ -607,6 +627,30 @@ pub async fn attach(
                             }
                             detached = true;
                             break;
+                        }
+                        // Typing is what takes the token; attaching no longer
+                        // does. Sent at most once per lost token — the answer
+                        // clears the latch — so a burst of keystrokes on a muted
+                        // attachment is not a burst of claims. Latched only on a
+                        // claim that actually reached the wire: a write that
+                        // failed draws no answer at all, and latching it anyway
+                        // would mute this attachment for good.
+                        if !holds_token.load(Ordering::Relaxed)
+                            && !claiming.load(Ordering::Relaxed)
+                        {
+                            // Latched *before* the write is awaited. The answer
+                            // can land during that await, and a latch written
+                            // afterwards would overwrite the reader's clear —
+                            // leaving this attachment unable to claim again the
+                            // next time it loses the token. Only a write that
+                            // never reached the wire unlatches, because nothing
+                            // is coming back to do it.
+                            claiming.store(true, Ordering::Relaxed);
+                            if write_control(
+                                &mut wr, &Control::ClaimWriter { seq: None }).await.is_err()
+                            {
+                                claiming.store(false, Ordering::Relaxed);
+                            }
                         }
                         if write_data(&mut wr, &buf[..n]).await.is_err() {
                             break;

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -527,11 +527,13 @@ pub enum Control {
     },
     /// Client asks for the write token, without re-attaching to get it.
     ///
-    /// Attaching interactively already takes the token, which is right for the
-    /// first client and wrong for every one after it: two devices on one
-    /// session — a Mac and a phone showing the same agent — would otherwise
-    /// have to tear down and rebuild an attachment every time the user's hands
-    /// moved, and whichever attached last would silently mute the other.
+    /// Attaching interactively takes the token only when nobody holds it, which
+    /// is right for the first client and would be wrong for every one after it:
+    /// two devices on one session — a Mac and a phone showing the same agent —
+    /// would otherwise have to tear down and rebuild an attachment every time
+    /// the user's hands moved, whichever attached last would silently mute the
+    /// other, and the newcomer's grid would drag the one shared PTY to its own
+    /// width behind the muted client's back.
     ///
     /// So the token follows the device being *used*: a client claims it when
     /// its user actually types. Observers are refused (§A: observers never

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -1811,7 +1811,15 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
             // Enabling precedes this client's in-band Snapshot request, so
             // later Writes can only produce G results after its S boundary.
             session.sync_grid_diff_interest();
-            if interactive {
+            // Attaching is a viewer arriving, not a device taking over. Taking
+            // the token here meant a phone merely *looking* at a session pulled
+            // the one shared PTY down to phone width through `run_attach`'s
+            // resize, and the Mac had no answer: its own resizes are gated on
+            // holding the token, so the window sat there rendering a screen
+            // formatted for a grid it does not have. The token travels by
+            // typing — both ends claim on input — so the only attach that takes
+            // it is the one that finds nobody holding it.
+            if interactive && session.writer.is_none() {
                 session.writer = Some(id.clone());
             }
             let is_writer = session.writer.as_deref() == Some(id.as_str());
@@ -2241,7 +2249,7 @@ mod tests {
     /// Attaching is what took the token before this verb existed, so the phone
     /// permanently muted the Mac the moment it looked at a session, and the Mac
     /// could only answer by tearing its attachment down and rebuilding it. The
-    /// token has to be able to travel without that.
+    /// token travels by typing instead.
     #[tokio::test]
     async fn the_write_token_follows_the_device_being_used() {
         let Sidecar {
@@ -2255,16 +2263,49 @@ mod tests {
         let _mac = attach_interactive_client(&mut session, "mac");
         assert_eq!(session.writer.as_deref(), Some("mac"), "first in, writer");
 
-        // Attaching still takes the token: that is what makes a fresh client
-        // usable without a round trip.
+        // Looking is not taking: the phone arrives as a reader, and the Mac —
+        // whose window is the one sized for this PTY — keeps writing.
         let _phone = attach_interactive_client(&mut session, "phone");
+        assert_eq!(session.writer.as_deref(), Some("mac"));
+
+        assert!(claim_writer(&mut session, "phone"), "the phone's user typed");
         assert_eq!(session.writer.as_deref(), Some("phone"));
 
         assert!(claim_writer(&mut session, "mac"), "the Mac's user typed");
         assert_eq!(session.writer.as_deref(), Some("mac"));
 
-        assert!(claim_writer(&mut session, "phone"), "the phone's user typed");
-        assert_eq!(session.writer.as_deref(), Some("phone"));
+        let _ = session.sidecar_tx.take();
+        let _ = thread.join();
+    }
+
+    /// The other half of that rule. A session nobody is holding hands the token
+    /// to whoever attaches next, because that attach is the reattach path: the
+    /// window coming back to a detached session is what resizes the PTY to fit
+    /// it, and refusing the token here would strand the session at the size the
+    /// last viewer happened to leave.
+    #[tokio::test]
+    async fn a_session_nobody_holds_gives_the_token_to_the_next_attach() {
+        let Sidecar {
+            commands,
+            results: _results,
+            queue,
+            thread,
+        } = spawn_sidecar(24, 80).unwrap();
+        let (mut session, _events) = test_session(commands, queue);
+
+        let _mac = attach_interactive_client(&mut session, "mac");
+        assert_eq!(session.writer.as_deref(), Some("mac"));
+
+        handle_msg(
+            &mut session,
+            SessionMsg::RemoveClient {
+                id: "mac".to_string(),
+            },
+        );
+        assert_eq!(session.writer.as_deref(), None, "nobody is left to write");
+
+        let _reattached = attach_interactive_client(&mut session, "mac-again");
+        assert_eq!(session.writer.as_deref(), Some("mac-again"));
 
         let _ = session.sidecar_tx.take();
         let _ = thread.join();


### PR DESCRIPTION
A TUI would sometimes draw its whole frame at a fraction of the pane's width — a narrow wrapped block in a wide, otherwise empty pane — and only dragging the window edge put it right.

Attaching interactively took the write token unconditionally, and `run_attach` then resized the session to the newcomer's grid. That reads identically for a phone opening one session and for a Mac window quietly holding fifteen. So a phone merely *looking* at a session pulled the one shared PTY down to its width, and the desktop — whose own `R` frames are gated on the token it had just lost — was left rendering a screen formatted for a grid it does not have. Nothing could correct it: the surface reports a grid only when it *changes*, so a window that had not moved never spoke again.

Reproduced with two ptys against a real daemon: a 24x40 client attaching dragged a 47x118 session down to 24x80, and the first client never recovered.

The token now follows the device being used, which is what the protocol already said it did:

- An attach takes it only when nobody holds it; `claim_writer` moves it after that. Typing already sends one, so the Mac is unaffected.
- The phone sends one when it opens a session, returns to that screen, or rotates — the deliberate act that used to hide inside the attach. Its own `reassertGrid` was documented as "coming back to the app is still a claim" but only ever sent a resize, which is not a claim.
- The CLI never claimed at all, having relied on the steal, and would otherwise have gone silently read-only.
- A writer that sees the PTY move under it re-asserts its grid instead of only logging the disagreement.

Verified: attaching at 24x40 no longer moves a 47x118 session, and that client typing still takes both token and size. The integration test covering this policy is opt-in (`TERMIO_TERMIOD_TEST_BIN`) and was asserting the old behavior; it is rewritten, and confirmed to fail against the old rule and pass against the new one. `cargo test` 109 passed, `swift test` 525 passed with the daemon suites enabled.

Release Notes: Fixed a terminal sometimes drawing at the wrong width — squeezed into a narrow column of a wide pane — after another device looked at the same session. The write token, and with it the terminal's size, now follows the device you are actually using rather than the one that attached most recently.