### PR TITLE
Drag a sidebar session into a pane to group it

### DIFF
--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -1340,6 +1340,10 @@ private struct SessionRow: View {
             // an editor, a text field — will accept it. Shipping the link means a
             // stray drop pastes something that works (`termio://session/<uuid>`,
             // what `termio sessions` takes) instead of leaking an internal id.
+            // A pane recognises one of these rows by parsing that link back off the
+            // drag pasteboard (see `PaneDropDelegate`), so plain text is the whole
+            // payload: SwiftUI rebuilds the item provider on the receiving side, and
+            // a private type registered here would not survive the trip.
             return NSItemProvider(object: store.sessionLink(for: session) as NSString)
         } preview: {
             // The drag preview is just the row's identity (icon + title), so the

--- a/Sources/termio/Terminal/PaneDragRearrange.swift
+++ b/Sources/termio/Terminal/PaneDragRearrange.swift
@@ -105,6 +105,7 @@ final class PaneDragRearrange {
         // interfere with a TUI's own mouse reporting.
         monitor(.mouseMoved) { [weak self] in
             self?.hovered($0)
+            self?.clearStrandedDropCue()
             return false
         }
         // A pointer that leaves for another app sends no further mouse-moved
@@ -127,6 +128,21 @@ final class PaneDragRearrange {
         else { return setHover(nil) }
         setHover(PaneHandleHover(pane: hit.id,
                                  overHandle: Self.handleRect(in: hit.size).contains(hit.point)))
+    }
+
+    /// Takes down a sidebar-drag cue that outlived its drag.
+    ///
+    /// The panes' drop delegate clears the cue on exit and on drop, but SwiftUI
+    /// gives a `DropDelegate` no "the session ended" hook, so a drag ending where
+    /// neither fires would strand the highlight. Mouse-moved events resume the
+    /// moment a drag session lets go of the pointer, and a drag cannot be in flight
+    /// with the button up — making this the first thing to run after any drag,
+    /// however it ended, for the cost of a comparison the rest of the time.
+    private func clearStrandedDropCue() {
+        guard let store, store.sessionDropTarget != nil,
+              NSEvent.pressedMouseButtons & 1 == 0 else { return }
+        store.sessionDropTarget = nil
+        store.draggingSessionID = nil
     }
 
     /// Republishing on every mouse-moved event would redraw the pane tree at

--- a/Sources/termio/Terminal/SplitTree.swift
+++ b/Sources/termio/Terminal/SplitTree.swift
@@ -47,10 +47,21 @@ enum PaneDropZone: Equatable {
         let relY = point.y / size.height
         let half = centerFraction / 2
         if abs(relX - 0.5) <= half, abs(relY - 0.5) <= half { return .center }
+        return edge(at: point, in: size)
+    }
+
+    /// The nearest edge, with no center box — the zoning a session dragged out of
+    /// the sidebar uses. That drag has exactly one meaning, "group in on this
+    /// side", so every part of the pane has to answer it: a middle that did
+    /// something else would be a dead zone you can only discover by missing.
+    static func edge(at point: CGPoint, in size: CGSize) -> PaneDropZone {
+        guard size.width > 0, size.height > 0 else { return .left }
+        let relX = point.x / size.width
+        let relY = point.y / size.height
         let edges: [(PaneDropZone, CGFloat)] = [
             (.left, relX), (.right, 1 - relX), (.top, relY), (.bottom, 1 - relY),
         ]
-        return edges.min { $0.1 < $1.1 }!.0
+        return edges.min { $0.1 < $1.1 }?.0 ?? .left
     }
 
     /// The part of the target pane to highlight while this zone is hovered:

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 import GhosttyTerminal
 
 extension Notification.Name {
@@ -44,10 +45,6 @@ struct TerminalPane: View {
     @EnvironmentObject var settings: AppSettings
     @State private var focusDriver = TerminalFocusDriver()
     @State private var activated: [Session.ID] = []
-    /// The pane the pointer is currently over during a drag. With splits, the drop
-    /// resolves to one pane, not the whole terminal group: the wash and the insert
-    /// both follow the pane under the pointer.
-    @State private var dropTargetPane: Session.ID?
 
     var body: some View {
         GeometryReader { geo in
@@ -170,19 +167,16 @@ struct TerminalPane: View {
                 // This must sit above `.position`, which grows the modified view to fill the
                 // whole terminal group: a drop destination applied after it would accept the
                 // drag anywhere, and the topmost pane in the stack would swallow every drop.
-                .dropDestination(for: URL.self) { urls, _ in
-                    guard isVisible else { return false }
-                    return sendPaths(urls, to: id)
-                } isTargeted: { targeted in
-                    guard isVisible else { return }
-                    // Moving between panes can report the new pane's `true` before the old
-                    // pane's `false`; only the pane that still owns the highlight clears it.
-                    if targeted {
-                        dropTargetPane = id
-                    } else if dropTargetPane == id {
-                        dropTargetPane = nil
-                    }
-                }
+                // One destination per pane, for every kind of drop. Two destinations over
+                // the same pane cannot be made to agree: whichever one loses the drop is
+                // never told the drag left, and its highlight stays on screen forever.
+                .onDrop(of: [.url, .fileURL, .text], delegate: PaneDropDelegate(
+                    pane: id,
+                    size: rect.size,
+                    isVisible: isVisible,
+                    store: store,
+                    send: { sendPaths($0, to: id) }
+                ))
                 .position(x: rect.midX, y: rect.midY)
                 .opacity(isVisible ? 1 : 0)
                 .allowsHitTesting(isVisible)
@@ -208,17 +202,48 @@ struct TerminalPane: View {
             if let drag = store.paneDrag, let layout, !zoomed {
                 PaneDragOverlay(drag: drag, layout: layout, preview: store.paneDragPreview)
             }
-            // Dragging a file or an issue in reads the same as dragging a pane around:
-            // the identical wash over the one pane the release would land in, sliding
-            // from pane to pane rather than blinking.
-            PaneDropWash(rect: dropTargetPane.map { id in
-                zoomed && store.selectedSessionID == id ? bounds : (paneFrames[id] ?? bounds)
-            } ?? .zero)
+            // Under the wash, so the pane you are carrying can still show a target
+            // on it — the two say different things and have to be able to coexist.
+            SessionDragLift(rect: draggedPaneRect(bounds: bounds, paneFrames: paneFrames, zoomed: zoomed))
+            // Dragging a file, an issue or a session in reads the same as dragging a
+            // pane around: the identical wash over what the release would land in,
+            // sliding as the pointer moves rather than blinking. A whole pane means
+            // the payload is typed at its prompt; a half means the layout changes.
+            PaneDropWash(rect: dropWashRect(bounds: bounds, paneFrames: paneFrames, zoomed: zoomed))
         }
         // Ghostty's own timing (`SurfaceDragSource`): the handle fades in and
         // brightens rather than blinking. The drag overlay animates its own
         // pieces — the highlight slides, the preview must not.
         .animation(.easeInOut(duration: 0.15), value: store.paneHandleHover)
+    }
+
+    /// What the in-flight drop would land on. A `.center` target highlights the
+    /// whole pane (the payload is typed at its prompt), an edge the half the layout
+    /// would give up — one piece of state for both cues, so they cannot disagree.
+    ///
+    /// The mouse-button test is what keeps the cue from being stranded. SwiftUI
+    /// gives a `DropDelegate` no "the session ended" callback, so a drag that ends
+    /// where neither `dropExited` nor `performDrop` fires would leave its highlight
+    /// on screen for good. A drag cannot exist with the button up.
+    private func dropWashRect(bounds: CGRect, paneFrames: [Session.ID: CGRect],
+                              zoomed: Bool) -> CGRect {
+        guard let target = store.sessionDropTarget, NSEvent.pressedMouseButtons & 1 != 0
+        else { return .zero }
+        let frame = zoomed && store.selectedSessionID == target.pane
+            ? bounds : (paneFrames[target.pane] ?? bounds)
+        return target.zone.highlightRect(in: frame)
+    }
+
+    /// The on-screen pane of the session being dragged out of the sidebar, or
+    /// `.zero` when it has none — the usual case, since you drag a session
+    /// precisely because it is not the one you are looking at. Guarded on the mouse
+    /// button for the same reason as the wash.
+    private func draggedPaneRect(bounds: CGRect, paneFrames: [Session.ID: CGRect],
+                                 zoomed: Bool) -> CGRect {
+        guard let dragged = store.draggingSessionID, NSEvent.pressedMouseButtons & 1 != 0,
+              store.visiblePaneIDs.contains(dragged) else { return .zero }
+        return zoomed && store.selectedSessionID == dragged
+            ? bounds : (paneFrames[dragged] ?? bounds)
     }
 
     /// A surface becoming first responder is the source of truth for split selection.
@@ -743,6 +768,147 @@ private struct PaneDropWash: View {
             .onChange(of: rect) { _, new in
                 if new != .zero { lastRect = new }
             }
+    }
+}
+
+/// Where a session dragged out of the sidebar would land: the pane under the
+/// pointer and the half it would take. The sidebar-drag twin of `PaneDragState`.
+struct SessionDropTarget: Equatable {
+    var pane: Session.ID
+    var zone: PaneDropZone
+}
+
+/// One drop destination per pane, for every kind of drop.
+///
+/// A file, a folder or an issue link is inserted at that pane's prompt. A session
+/// dragged out of the sidebar means one thing only — group it in beside this pane,
+/// on the side you released over — so every part of the pane is a live edge, and a
+/// pane it cannot join declines the drag instead of doing something else with it.
+///
+/// One destination covering every type, never a second layered over the first:
+/// SwiftUI's `URL` transferable imports from plain text, so both would see a
+/// session drag, only one would perform the drop, and the loser is never told the
+/// drag left — its highlight then stays on screen for good.
+///
+/// A `DropDelegate` rather than a `dropDestination` because only `dropUpdated`
+/// carries the pointer; `isTargeted:` is a Bool, which is all a whole-pane wash
+/// ever needed.
+private struct PaneDropDelegate: DropDelegate {
+    let pane: Session.ID
+    /// The pane's own size — the space `PaneDropZone` reads `info.location` in.
+    let size: CGSize
+    let isVisible: Bool
+    let store: TermioStore
+    let send: ([URL]) -> Bool
+
+    /// A session drag is refused by every pane it cannot join — its own pane,
+    /// another project, another worktree — so the pointer shows the no-drop cursor
+    /// rather than accepting a release that would do nothing. Anything that is not
+    /// one of our rows is a payload for the prompt, and always lands.
+    func validateDrop(info: DropInfo) -> Bool {
+        guard isVisible else { return false }
+        guard let moved = draggedSession else { return true }
+        return store.canGroup(moved, with: pane)
+    }
+
+    func dropEntered(info: DropInfo) { track(info) }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        track(info)
+        return DropProposal(operation: .copy)
+    }
+
+    /// Cleared unconditionally rather than only when the cue is this pane's.
+    /// Moving between panes can report the new pane's entry before the old pane's
+    /// exit, so this can wipe a cue that was just set — but the new pane's next
+    /// `dropUpdated` puts it straight back, a frame later at worst. A cue that
+    /// heals itself while the pointer moves beats one that can be left behind.
+    func dropExited(info: DropInfo) { store.sessionDropTarget = nil }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let moved = draggedSession
+        store.sessionDropTarget = nil
+        store.draggingSessionID = nil
+        guard let moved else { return insert(info) }
+        guard store.canGroup(moved, with: pane) else { return false }
+        store.dropSession(moved, onto: pane, zone: PaneDropZone.edge(at: info.location, in: size))
+        return true
+    }
+
+    /// Lights what the release would commit: the half this pane would give up to a
+    /// session being grouped in, or the whole pane for a payload being typed.
+    private func track(_ info: DropInfo) {
+        guard isVisible else { return }
+        let zone = draggedSession == nil ? .center : PaneDropZone.edge(at: info.location, in: size)
+        store.sessionDropTarget = SessionDropTarget(pane: pane, zone: zone)
+    }
+
+    /// The session a dragged sidebar row is carrying, parsed back out of the drag
+    /// pasteboard.
+    ///
+    /// `DropInfo`'s own item providers cannot answer this. SwiftUI rebuilds them on
+    /// the receiving side into `public.url` plus plain text, so a private type
+    /// registered at the source never survives the trip — and loading the text back
+    /// is async, while `dropUpdated` has to answer with the pointer still moving.
+    /// The drag pasteboard holds the same payload, synchronously.
+    private var draggedSession: Session.ID? {
+        guard let link = NSPasteboard(name: .drag).string(forType: .string) else { return nil }
+        return TermioStore.sessionID(fromLink: link.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Everything that ends up at the prompt: files and folders from the Finder or
+    /// the file tree, an issue's link from the Issues list.
+    private func insert(_ info: DropInfo) -> Bool {
+        let providers = info.itemProviders(for: [.url])
+        guard !providers.isEmpty else { return false }
+        Task { @MainActor in
+            var dropped: [URL] = []
+            for provider in providers {
+                if let url = await provider.droppedURL() { dropped.append(url) }
+            }
+            _ = send(dropped)
+        }
+        return true
+    }
+}
+
+/// Main-actor bound because the providers come off a `DropInfo` and never leave
+/// the drop: only the continuation crosses to whichever queue the load answers on.
+@MainActor
+private extension NSItemProvider {
+    /// The item as a URL, or nil when it carries none.
+    func droppedURL() async -> URL? {
+        await withCheckedContinuation { continuation in
+            _ = loadObject(ofClass: URL.self) { url, _ in
+                continuation.resume(returning: url)
+            }
+        }
+    }
+}
+
+/// The pane whose session is being dragged out of the sidebar, dimmed to say it is
+/// out of play: a session cannot be grouped with itself, so this is the one pane
+/// the release cannot land on. Without it, that refusal is indistinguishable from
+/// the drag being broken.
+///
+/// A neutral scrim rather than `PaneDropWash`'s blue-grey. The tint is what carries
+/// "a drop lands here", so spending it on the one pane that refuses the drop reads
+/// as the opposite of the truth — the pane lights up and the drag looks like it is
+/// offering a single, wrong option. Dimming says "not this one" in the vocabulary
+/// disabled controls already use.
+private struct SessionDragLift: View {
+    /// `.zero` when the dragged session has no pane on screen.
+    let rect: CGRect
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.black.opacity(colorScheme == .dark ? 0.28 : 0.12))
+            .frame(width: rect.width, height: rect.height)
+            .position(x: rect.midX, y: rect.midY)
+            .opacity(rect == .zero ? 0 : 1)
+            .allowsHitTesting(false)
+            .animation(.easeInOut(duration: 0.15), value: rect == .zero)
     }
 }
 

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -195,14 +195,51 @@ extension TermioStore {
     /// reordered so the group reads as an adjacent run, which is what lets
     /// `splitLinkMarks` draw its bracket over them.
     func groupSession(_ moved: Session.ID, with anchor: Session.ID) {
-        guard moved != anchor,
-              let anchorHome = locate(anchor), let movedHome = locate(moved),
-              anchorHome.sharesRoster(with: movedHome)
-        else { return }
+        guard canGroup(moved, with: anchor) else { return }
         // Already sharing the anchor's group — nothing to switch.
         if let anchorGroup = groupIndex(containing: anchor),
            groupIndex(containing: moved) == anchorGroup { return }
+        // No zone: the menu has no pointer to read a side off, so the axis
+        // alternates across the anchor's current one.
+        splice(moved, beside: anchor, direction: nil, slot: .second)
+    }
 
+    /// Whether `moved` may be grouped in beside `anchor`: same roster, and the
+    /// same working bucket (project root vs a given worktree). The bucket match
+    /// is what keeps a group's sidebar rows one adjacent run, so its ┌/└ bracket
+    /// draws — the same rule `groupableTargets` filters the menu with, exposed so
+    /// a drag can light its drop cue only where a release would actually land.
+    func canGroup(_ moved: Session.ID, with anchor: Session.ID) -> Bool {
+        guard moved != anchor,
+              let anchorHome = locate(anchor), let movedHome = locate(moved),
+              anchorHome.sharesRoster(with: movedHome)
+        else { return false }
+        return session(moved)?.worktreePath == session(anchor)?.worktreePath
+    }
+
+    /// Lands a session dragged out of the sidebar on the `zone` half of a visible
+    /// pane: the drag counterpart of "Group with", and the reason the pane area
+    /// accepts a row at all. A session already grouped with the target is only
+    /// being rearranged, so it takes `dropPane`'s path — one gesture, whichever
+    /// side of that line the dragged row happens to be on.
+    ///
+    /// Edge zones only: the pointer resolves a side through `PaneDropZone.edge`,
+    /// which has no center. `.center` still reaches here from a pane-rearrange
+    /// drag, where it means swap, so it is refused rather than guessed at.
+    func dropSession(_ moved: Session.ID, onto target: Session.ID, zone: PaneDropZone) {
+        guard let direction = zone.splitDirection, canGroup(moved, with: target) else { return }
+        let movedGroup = groupIndex(containing: moved)
+        if movedGroup != nil, movedGroup == groupIndex(containing: target) {
+            return dropPane(moved, onto: target, zone: zone)
+        }
+        splice(moved, beside: target, direction: direction, slot: zone.slot)
+    }
+
+    /// Moves `moved` in beside `anchor` as a new branch. `direction` nil
+    /// alternates the axis across the anchor's current one; a lone anchor (no
+    /// branch yet) opens side by side either way.
+    private func splice(_ moved: Session.ID, beside anchor: Session.ID,
+                        direction: SplitDirection?, slot: SplitSlot) {
         // 1. Detach `moved` from any prior group, keeping the "one leaf, one tree"
         //    invariant. This may dissolve that group and shift `splitGroups`
         //    indices, so the anchor's group is (re)resolved only afterwards.
@@ -210,39 +247,46 @@ extension TermioStore {
             setGroup(at: previous, to: splitGroups[previous].removing(leaf: moved))
         }
 
-        // 2. Splice beside the anchor, alternating the split axis across its
-        //    current one; a lone anchor (no branch yet) opens side by side.
+        // 2. Splice beside the anchor.
         let anchorGroup = groupIndex(containing: anchor)
-        let direction: SplitDirection
-        if let group = anchorGroup, let current = splitGroups[group].branchDirection(childLeaf: anchor) {
-            direction = current == .horizontal ? .vertical : .horizontal
+        let axis: SplitDirection
+        if let direction {
+            axis = direction
+        } else if let group = anchorGroup,
+                  let current = splitGroups[group].branchDirection(childLeaf: anchor) {
+            axis = current == .horizontal ? .vertical : .horizontal
         } else {
-            direction = .horizontal
+            axis = .horizontal
         }
         if let group = anchorGroup {
             splitGroups[group] = splitGroups[group]
-                .splitting(leaf: anchor, direction: direction, adding: moved)
+                .splitting(leaf: anchor, direction: axis, adding: moved, slot: slot)
         } else {
-            splitGroups.append(.split(SplitBranch(direction: direction, ratio: 0.5,
-                                                  first: .leaf(anchor), second: .leaf(moved))))
+            splitGroups.append(.split(SplitBranch(
+                direction: axis, ratio: 0.5,
+                first: .leaf(slot == .first ? moved : anchor),
+                second: .leaf(slot == .first ? anchor : moved))))
         }
 
-        // 3. Sit `moved`'s row right after the anchor's so the sidebar reads the
-        //    group as a contiguous run (see `splitLinkMarks`).
-        moveSessionRow(moved, besideAnchor: anchor)
+        // 3. Sit `moved`'s row beside the anchor's so the sidebar reads the group
+        //    as a contiguous run (see `splitLinkMarks`), on the side the pane
+        //    itself landed — the row order follows the layout.
+        moveSessionRow(moved, besideAnchor: anchor, slot: slot)
         selectedSessionID = moved
         isPaneZoomed = false
     }
 
-    /// Moves `moved`'s row to immediately follow the anchor's within their shared
-    /// roster, keeping a split group's sidebar rows adjacent. The anchor index is
-    /// read *after* the removal so it stays valid regardless of which row came first.
-    private func moveSessionRow(_ moved: Session.ID, besideAnchor anchor: Session.ID) {
+    /// Moves `moved`'s row next to the anchor's within their shared roster,
+    /// keeping a split group's sidebar rows adjacent — above the anchor for a
+    /// leading pane, below it otherwise. The anchor index is read *after* the
+    /// removal so it stays valid regardless of which row came first.
+    private func moveSessionRow(_ moved: Session.ID, besideAnchor anchor: Session.ID,
+                                slot: SplitSlot) {
         guard let home = locate(moved) else { return }
         var sessions = roster(at: home)
         let row = sessions.remove(at: home.sessionIndex)
         let anchorIndex = sessions.firstIndex { $0.id == anchor } ?? sessions.count - 1
-        sessions.insert(row, at: anchorIndex + 1)
+        sessions.insert(row, at: slot == .first ? anchorIndex : anchorIndex + 1)
         setRoster(sessions, at: home)
     }
 

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -183,12 +183,22 @@ final class TermioStore: ObservableObject {
         backgroundActivationIDs.append(id)
     }
 
-    /// The session currently being drag-reordered in the sidebar, recorded when a row
+    /// The session currently being dragged out of the sidebar, recorded when the row
     /// drag begins so a hovered row can ask `canReorder` whether it's a legal drop
     /// target (same project + worktree bucket) and light its background only then.
-    /// Transient drag bookkeeping — deliberately *not* `@Published`, since it's read
-    /// on drop-hover events, never rendered.
-    var draggingSessionID: Session.ID?
+    ///
+    /// `@Published` because the terminal area draws from it too: the pane you are
+    /// carrying is washed for the length of the drag, which is the only thing that
+    /// distinguishes "this pane is the session in your hand" from a drop that
+    /// silently did nothing.
+    @Published var draggingSessionID: Session.ID?
+
+    /// Where a sidebar row dragged over the terminal area would land: the pane
+    /// under the pointer and the half it would take. Written by the panes' drop
+    /// delegate, drawn by `TerminalPane` — the sidebar-drag twin of `paneDrag`,
+    /// and `@Published` for the same reason: the highlight is on screen, so it
+    /// has to redraw as the pointer crosses zones.
+    @Published var sessionDropTarget: SessionDropTarget?
 
     /// When each project was last active — the moment one of its agents last reported
     /// work, or the user last switched to one of its sessions. Drives the sidebar's

--- a/Tests/termioTests/SessionDropTests.swift
+++ b/Tests/termioTests/SessionDropTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+
+@testable import termio
+
+/// Dropping a sidebar row on a pane's edge (the drag form of "Group with"). The
+/// zone math has its own tests in `SplitTreeTests`; these cover what the store
+/// does with a zone once the pointer has resolved one — which side the pane takes,
+/// which side the *row* takes, and the drops that must not become layout changes.
+@MainActor
+final class SessionDropTests: XCTestCase {
+    private var directory: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("session-drop-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        suiteName = "session-drop-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        defaults.removePersistentDomain(forName: suiteName)
+        try await super.tearDown()
+    }
+
+    private func makeStore(sessions: [Session]) -> TermioStore {
+        var workspace = Workspace(name: "Default")
+        workspace.terminals = sessions
+        let settings = AppSettings(
+            defaults: defaults,
+            settingsStore: SettingsStore(
+                defaults: defaults,
+                fileURL: directory.appendingPathComponent("settings.json"),
+                domainName: suiteName))
+        return TermioStore(workspaces: [workspace], settings: settings)
+    }
+
+    private func rowOrder(_ store: TermioStore) -> [Session.ID] {
+        store.workspaces.first?.terminals.map(\.id) ?? []
+    }
+
+    /// The half you drop on is the half you get: releasing on the anchor's left
+    /// puts the dragged pane first, on a horizontal axis.
+    func testDroppingOnTheLeftEdgeTakesTheLeadingHalf() {
+        let anchor = Session(title: "Terminal 1")
+        let moved = Session(title: "Terminal 2")
+        let store = makeStore(sessions: [anchor, moved])
+
+        store.dropSession(moved.id, onto: anchor.id, zone: .left)
+
+        XCTAssertEqual(store.splitGroups.count, 1)
+        XCTAssertEqual(store.splitGroups.first?.leafIDs, [moved.id, anchor.id])
+        XCTAssertEqual(store.splitGroups.first?.branchDirection(childLeaf: anchor.id), .horizontal)
+        XCTAssertEqual(store.selectedSessionID, moved.id)
+    }
+
+    /// A bottom drop is the same gesture on the other axis, and lands second.
+    func testDroppingOnTheBottomEdgeStacksBelow() {
+        let anchor = Session(title: "Terminal 1")
+        let moved = Session(title: "Terminal 2")
+        let store = makeStore(sessions: [anchor, moved])
+
+        store.dropSession(moved.id, onto: anchor.id, zone: .bottom)
+
+        XCTAssertEqual(store.splitGroups.first?.leafIDs, [anchor.id, moved.id])
+        XCTAssertEqual(store.splitGroups.first?.branchDirection(childLeaf: anchor.id), .vertical)
+    }
+
+    /// The sidebar reads a group as one adjacent run, in the layout's order — so a
+    /// pane that landed on the leading side lists *above* its anchor, not below it.
+    func testTheRowFollowsTheSideThePaneLandedOn() {
+        let first = Session(title: "Terminal 1")
+        let anchor = Session(title: "Terminal 2")
+        let moved = Session(title: "Terminal 3")
+        let store = makeStore(sessions: [first, anchor, moved])
+
+        store.dropSession(moved.id, onto: anchor.id, zone: .top)
+
+        XCTAssertEqual(rowOrder(store), [first.id, moved.id, anchor.id])
+    }
+
+    /// A pane already grouped with the target is only being rearranged: it moves
+    /// within the tree instead of being spliced in a second time.
+    func testDroppingInsideTheSameGroupRearrangesRatherThanDuplicates() {
+        let anchor = Session(title: "Terminal 1")
+        let moved = Session(title: "Terminal 2")
+        let store = makeStore(sessions: [anchor, moved])
+        store.dropSession(moved.id, onto: anchor.id, zone: .right)
+
+        store.dropSession(moved.id, onto: anchor.id, zone: .left)
+
+        XCTAssertEqual(store.splitGroups.count, 1)
+        XCTAssertEqual(store.splitGroups.first?.leafIDs, [moved.id, anchor.id])
+    }
+
+    /// A session drag has no dead middle: releasing dead centre still picks a side,
+    /// because "group in beside this pane" is the only thing the gesture means.
+    func testEveryPointOfAPaneIsALiveEdge() {
+        let size = CGSize(width: 800, height: 600)
+        for point in [CGPoint(x: 400, y: 300), CGPoint(x: 401, y: 299), CGPoint(x: 0, y: 0)] {
+            XCTAssertNotNil(PaneDropZone.edge(at: point, in: size).splitDirection,
+                            "no edge at \(point)")
+        }
+        XCTAssertEqual(PaneDropZone.edge(at: CGPoint(x: 60, y: 300), in: size), .left)
+        XCTAssertEqual(PaneDropZone.edge(at: CGPoint(x: 400, y: 560), in: size), .bottom)
+    }
+
+    /// The center zone still exists for the pane-rearrange drag, where it means
+    /// swap — so `dropSession` keeps refusing it rather than guessing a side.
+    func testTheCenterIsNotALayoutChange() {
+        let anchor = Session(title: "Terminal 1")
+        let moved = Session(title: "Terminal 2")
+        let store = makeStore(sessions: [anchor, moved])
+
+        store.dropSession(moved.id, onto: anchor.id, zone: .center)
+
+        XCTAssertTrue(store.splitGroups.isEmpty)
+    }
+
+    /// Two sessions in different checkouts can't be grouped — their rows can't be
+    /// made adjacent without breaking the other bucket's run, which is what the
+    /// group bracket is drawn from.
+    func testSessionsInDifferentWorktreesDoNotGroup() {
+        var anchor = Session(title: "Terminal 1")
+        anchor.worktreePath = "/tmp/checkout-a"
+        var moved = Session(title: "Terminal 2")
+        moved.worktreePath = "/tmp/checkout-b"
+        let store = makeStore(sessions: [anchor, moved])
+
+        XCTAssertFalse(store.canGroup(moved.id, with: anchor.id))
+        store.dropSession(moved.id, onto: anchor.id, zone: .right)
+
+        XCTAssertTrue(store.splitGroups.isEmpty)
+    }
+
+    /// Dropping a row on its own pane is the degenerate case of the same gesture.
+    func testASessionCannotBeGroupedWithItself() {
+        let session = Session(title: "Terminal 1")
+        let store = makeStore(sessions: [session])
+
+        XCTAssertFalse(store.canGroup(session.id, with: session.id))
+        store.dropSession(session.id, onto: session.id, zone: .right)
+
+        XCTAssertTrue(store.splitGroups.isEmpty)
+    }
+}


### PR DESCRIPTION
Grouping two sessions was menu-only ("Group with"). Now a sidebar row can be dragged straight into the terminal area: release over a pane's edge and the session is grouped in on that side.

**Every part of a pane is a live edge.** `PaneDropZone.edge` drops the center box the pane-rearrange drag keeps for swap, so releasing anywhere picks a side. A center that meant something else was a dead zone you could only find by missing the split you were aiming for.

**A drop that cannot land says so.** A pane the session can't join — its own pane, another project, another worktree — declines the drag, and the pane holding the dragged session dims for the length of it. Without that, a refused drag is indistinguishable from a broken one.

**The pane's file drop became a `DropDelegate`.** It had to: only `dropUpdated` carries the pointer, and edge zones need it. It also covers every type in one destination, because two destinations over one pane cannot agree — SwiftUI's `URL` transferable imports from plain text, so both see a session drag, only one performs the drop, and the loser is never told the drag left, stranding its highlight on screen. For the same reason the highlight is drawn only while the mouse button is down: `DropDelegate` has no "session ended" callback, so no single hook is guaranteed to fire.

A dragged row is recognised by parsing its link back off the drag pasteboard. `DropInfo`'s item providers can't answer it — SwiftUI rebuilds them on the receiving side into `public.url` plus plain text, so a private type registered at the source never survives the trip, and loading the text back is async while `dropUpdated` has to answer mid-motion.

Dropping a session no longer types its `termio://session/<uuid>` link at a prompt. Copy Address already does that, and supporting both is what made the middle of every pane ambiguous. Arbitrary text dragged from another app no longer inserts either — that only ever worked through the same silent text-to-URL coercion.

## Testing

`swift build`, `swift test` (7 new store-level cases in `SessionDropTests`: which half the pane takes, which side the row takes, same-group rearrange, cross-worktree and self-drop refusal, and that no point in a pane fails to produce an edge). Drag, split, refusal and file-drop behaviour verified by hand in a dev build.

Release Notes:
- Drag a session from the sidebar onto a pane's edge to group the two side by side.