### PR TITLE
Equalize split runs and let spawns state direction and ratio

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -160,9 +160,17 @@ struct ControlRequest: Decodable {
     /// produce them, and hand-writing them into `text` is right by luck at best.
     /// See `SessionKeyPress`.
     let keys: [String]?
+    /// `spawn`/`run` placement: where the new pane lands relative to the
+    /// caller's — `right` or `down` (herdr's split vocabulary). Absent means
+    /// the automatic opposite-stack rule.
+    let direction: String?
+    /// `spawn`/`run` placement: the new pane's fraction of the split. Stating
+    /// one pins the divider so later spawns don't redistribute it away.
+    let ratio: Double?
 
     private enum CodingKeys: String, CodingKey {
         case op, format, target, text, lines, agent, snapshot, wait, title, enter, keys
+        case direction, ratio
         case callerSession = "caller_session"
         case callerCwd = "caller_cwd"
         case timeoutMs = "timeout_ms"

--- a/Sources/termio/Resources/skills/termio/SKILL.md
+++ b/Sources/termio/Resources/skills/termio/SKILL.md
@@ -32,12 +32,19 @@ id-prefix works too).
   detectable. Exits 0 on your Ctrl-C, 2 if Termio itself went away.
 - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
   prompt (`--agent codex` picks the agent; default: your own kind). Replies
-  immediately with the new session's link — use it for every follow-up;
-  the prompt itself is typed in once the agent finishes booting.
+  immediately with the new session's link (`target` in `--json`) — use it
+  for every follow-up; the prompt itself is typed in once the agent
+  finishes booting.
 - `termio sessions run "<command>"` — start a NEW plain terminal session
   typing that shell command (a dev server, a test run) into a visible pane —
   no LLM. Use it instead of your own background shell when the user should
   be able to see and take over the process.
+- `--direction right|down` and `--ratio <0..1>` on `spawn`/`run` — place the
+  new pane beside or below YOUR pane (every spawn anchors to the caller),
+  and give it that share of the split: `--direction down --ratio 0.25` is a
+  log strip under you. Omit both for the default placement. Panes without a
+  stated ratio share their run evenly, and a stated one holds against later
+  spawns — so only state a ratio when the content needs it.
 - `termio sessions send <link> "<text>"` — type text into that existing
   sibling and submit it with a real Return keypress. Send a prompt to drive
   it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. A

--- a/Sources/termio/Terminal/SplitTree.swift
+++ b/Sources/termio/Terminal/SplitTree.swift
@@ -108,6 +108,11 @@ struct SplitBranch: Codable, Hashable {
     var id = UUID()
     var direction: SplitDirection
     var ratio: Double
+    /// Whether this divider's ratio was set deliberately — a user drag, or a
+    /// spawn that asked for a specific share. `equalized()` leaves pinned
+    /// dividers alone, so stated intent survives later inserts and removals;
+    /// everything unpinned is app-chosen and free to redistribute.
+    var pinned: Bool
     var first: SplitNode
     var second: SplitNode
 
@@ -115,6 +120,47 @@ struct SplitBranch: Codable, Hashable {
     /// panes need to stay readable; applied on every ratio write so a persisted
     /// tree can never restore into a degenerate layout either.
     static let ratioRange: ClosedRange<Double> = 0.15...0.85
+
+    static func clampedRatio(_ ratio: Double) -> Double {
+        min(max(ratio, ratioRange.lowerBound), ratioRange.upperBound)
+    }
+
+    init(direction: SplitDirection, ratio: Double, pinned: Bool = false,
+         first: SplitNode, second: SplitNode) {
+        self.direction = direction
+        self.ratio = ratio
+        self.pinned = pinned
+        self.first = first
+        self.second = second
+    }
+
+    /// The branch an insert produces: `newPane` takes `slot`, with `share` of
+    /// the span when the caller stated one (a spawn's `--ratio`) — a stated
+    /// share pins the divider so `equalized()` keeps it. No share splits at
+    /// half, unpinned, free to redistribute. Keeping this arithmetic in one
+    /// place is what guarantees every insert path pins on exactly the same
+    /// condition.
+    init(direction: SplitDirection, adding newPane: SplitNode, at slot: SplitSlot,
+         share: Double?, to existing: SplitNode) {
+        let clamped = share.map(Self.clampedRatio)
+        self.init(direction: direction,
+                  ratio: clamped.map { slot == .first ? $0 : 1 - $0 } ?? 0.5,
+                  pinned: clamped != nil,
+                  first: slot == .first ? newPane : existing,
+                  second: slot == .first ? existing : newPane)
+    }
+
+    /// `pinned` arrived after trees were already persisted, so it decodes as
+    /// absent-means-false rather than failing on an older state file.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        direction = try container.decode(SplitDirection.self, forKey: .direction)
+        ratio = try container.decode(Double.self, forKey: .ratio)
+        pinned = try container.decodeIfPresent(Bool.self, forKey: .pinned) ?? false
+        first = try container.decode(SplitNode.self, forKey: .first)
+        second = try container.decode(SplitNode.self, forKey: .second)
+    }
 }
 
 /// The split layout of the terminal area: a binary tree whose leaves are
@@ -165,21 +211,23 @@ indirect enum SplitNode: Codable, Hashable {
     /// Replaces the `target` leaf with a split of it and `newLeaf`. The default
     /// slot puts the new pane second/trailing, matching "Split Right"/"Split
     /// Down"; a drag-drop passes `.first` to land it on the leading side.
-    /// A miss returns the tree unchanged.
+    /// `newShare` is the fraction the *new* pane takes; naming one pins the
+    /// divider (see `SplitBranch.pinned`), leaving it unnamed splits at half
+    /// and lets `equalized()` redistribute. A miss returns the tree unchanged.
     func splitting(leaf target: Session.ID, direction: SplitDirection,
-                   adding newLeaf: Session.ID, slot: SplitSlot = .second) -> SplitNode {
+                   adding newLeaf: Session.ID, slot: SplitSlot = .second,
+                   newShare: Double? = nil) -> SplitNode {
         switch self {
         case .leaf(let id) where id == target:
-            return .split(SplitBranch(direction: direction, ratio: 0.5,
-                                      first: slot == .first ? .leaf(newLeaf) : .leaf(id),
-                                      second: slot == .first ? .leaf(id) : .leaf(newLeaf)))
+            return .split(SplitBranch(direction: direction, adding: .leaf(newLeaf), at: slot,
+                                      share: newShare, to: .leaf(id)))
         case .leaf:
             return self
         case .split(var branch):
             branch.first = branch.first.splitting(leaf: target, direction: direction,
-                                                  adding: newLeaf, slot: slot)
+                                                  adding: newLeaf, slot: slot, newShare: newShare)
             branch.second = branch.second.splitting(leaf: target, direction: direction,
-                                                    adding: newLeaf, slot: slot)
+                                                    adding: newLeaf, slot: slot, newShare: newShare)
             return .split(branch)
         }
     }
@@ -190,21 +238,24 @@ indirect enum SplitNode: Codable, Hashable {
     /// spawn placement rule — an agent that keeps spawning companions stays
     /// full-height while the companions stack up opposite it. A miss returns
     /// the tree unchanged.
-    func splitting(oppositeLeaf target: Session.ID, adding newLeaf: Session.ID) -> SplitNode {
+    func splitting(oppositeLeaf target: Session.ID, adding newLeaf: Session.ID,
+                   newShare: Double? = nil) -> SplitNode {
         switch self {
         case .leaf:
             return self
         case .split(var branch):
             let cross: SplitDirection = branch.direction == .horizontal ? .vertical : .horizontal
             if branch.first == .leaf(target) {
-                branch.second = .split(SplitBranch(direction: cross, ratio: 0.5,
-                                                   first: branch.second, second: .leaf(newLeaf)))
+                branch.second = .split(SplitBranch(direction: cross, adding: .leaf(newLeaf),
+                                                   at: .second, share: newShare, to: branch.second))
             } else if branch.second == .leaf(target) {
-                branch.first = .split(SplitBranch(direction: cross, ratio: 0.5,
-                                                  first: branch.first, second: .leaf(newLeaf)))
+                branch.first = .split(SplitBranch(direction: cross, adding: .leaf(newLeaf),
+                                                  at: .second, share: newShare, to: branch.first))
             } else {
-                branch.first = branch.first.splitting(oppositeLeaf: target, adding: newLeaf)
-                branch.second = branch.second.splitting(oppositeLeaf: target, adding: newLeaf)
+                branch.first = branch.first.splitting(oppositeLeaf: target, adding: newLeaf,
+                                                      newShare: newShare)
+                branch.second = branch.second.splitting(oppositeLeaf: target, adding: newLeaf,
+                                                        newShare: newShare)
             }
             return .split(branch)
         }
@@ -255,19 +306,59 @@ indirect enum SplitNode: Codable, Hashable {
     }
 
     /// Writes a divider's ratio (clamped), leaving the rest of the tree intact.
+    /// A dragged divider is pinned: the user chose this ratio, so `equalized()`
+    /// must not overwrite it when the group's shape next changes.
     func updatingRatio(branchID: UUID, to ratio: Double) -> SplitNode {
         switch self {
         case .leaf:
             return self
         case .split(var branch):
             if branch.id == branchID {
-                branch.ratio = min(max(ratio, SplitBranch.ratioRange.lowerBound),
-                                   SplitBranch.ratioRange.upperBound)
+                branch.ratio = SplitBranch.clampedRatio(ratio)
+                branch.pinned = true
             } else {
                 branch.first = branch.first.updatingRatio(branchID: branchID, to: ratio)
                 branch.second = branch.second.updatingRatio(branchID: branchID, to: ratio)
             }
             return .split(branch)
+        }
+    }
+
+    /// Redistributes every *unpinned* divider so the panes of a same-direction
+    /// run share its span evenly — split right twice gives thirds, not
+    /// 1/2 + 1/4 + 1/4, and a spawn stack of three companions reads as three
+    /// equal rows. A divider's weight is how many chain segments each side
+    /// holds (a cross-axis subtree counts as one segment, so a lone divider
+    /// stays at half). Pinned dividers keep their ratio; their subtrees still
+    /// equalize within whatever space the pin allots them. Idempotent — the
+    /// store can call it after every structural mutation.
+    func equalized() -> SplitNode {
+        switch self {
+        case .leaf:
+            return self
+        case .split(var branch):
+            if !branch.pinned {
+                let first = branch.first.segmentCount(along: branch.direction)
+                let second = branch.second.segmentCount(along: branch.direction)
+                branch.ratio = SplitBranch.clampedRatio(Double(first) / Double(first + second))
+            }
+            branch.first = branch.first.equalized()
+            branch.second = branch.second.equalized()
+            return .split(branch)
+        }
+    }
+
+    /// How many side-by-side segments this subtree contributes to a run along
+    /// `direction`: same-direction branches flatten into their children's
+    /// counts, anything else — a leaf or a cross-axis split — is one segment.
+    private func segmentCount(along direction: SplitDirection) -> Int {
+        switch self {
+        case .leaf:
+            return 1
+        case .split(let branch):
+            guard branch.direction == direction else { return 1 }
+            return branch.first.segmentCount(along: direction)
+                + branch.second.segmentCount(along: direction)
         }
     }
 

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -303,13 +303,31 @@ extension TermioStore {
                 "No coding agent is enabled — pass --agent <name>.")
         }
 
+        // Placement requests are validated before anything is created, so a
+        // typo'd flag fails the call instead of spawning a session it then
+        // places wrong.
+        let direction: SplitDirection?
+        switch request.direction {
+        case nil: direction = nil
+        case "right": direction = .horizontal
+        case "down": direction = .vertical
+        case let other?:
+            return controlError(request, "bad_direction",
+                "Unknown direction '\(other)'. Use right or down.")
+        }
+        if let ratio = request.ratio, !(0 < ratio && ratio < 1) {
+            return controlError(request, "bad_ratio",
+                "--ratio is the new pane's fraction of the split — a number between 0 and 1.")
+        }
+
         // Beside the caller's pane as a split, not a full-screen swap — the whole
         // reason to spawn a sibling is to see them side by side. Anchoring and
         // focus policy are documented on `addSplitSession`; the selection only
         // moves when the caller is the pane the user is already watching.
         let freshID = addSplitSession(
             in: scope, agent: preset, anchor: caller?.id,
-            takeFocus: caller == nil || caller?.id == selectedSessionID)
+            takeFocus: caller == nil || caller?.id == selectedSessionID,
+            direction: direction, ratio: request.ratio)
         guard let freshID, let fresh = session(freshID) else {
             return controlError(request, "start_failed", "Couldn’t start the session.")
         }

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -53,6 +53,7 @@ extension TermioStore {
         if let group = groupIndex(containing: focusedID) {
             splitGroups[group] = splitGroups[group]
                 .splitting(leaf: focusedID, direction: direction, adding: newSession.id, slot: slot)
+                .equalized()
         } else {
             splitGroups.append(.split(SplitBranch(
                 direction: direction, ratio: 0.5,
@@ -87,10 +88,18 @@ extension TermioStore {
     /// With `takeFocus` false the selection stays where the user put it: the new
     /// pane is mounted invisibly instead (see `activateInBackground`), so its
     /// surface still attaches and can take a queued prompt.
+    ///
+    /// `direction` and `ratio` are the caller's placement request (`spawn
+    /// --direction down --ratio 0.25`): a direction splits the anchor's own
+    /// pane on that axis instead of taking the opposite-stack rule, and a
+    /// ratio is the new pane's share of the split — stated, so it pins the
+    /// divider against later equalization. Both absent means the automatic
+    /// placement above, with the group re-equalized after the insert.
     @discardableResult
     func addSplitSession(
         in scope: ControlScope, agent: AgentPreset = .terminal,
-        anchor: Session.ID? = nil, takeFocus: Bool = true
+        anchor: Session.ID? = nil, takeFocus: Bool = true,
+        direction: SplitDirection? = nil, ratio: Double? = nil
     ) -> Session.ID? {
         let inScope = Set(scope.sessions.map(\.id))
         let anchorID = anchor.flatMap { inScope.contains($0) ? $0 : nil }
@@ -124,18 +133,26 @@ extension TermioStore {
         // A lone anchor opens side by side; an anchor that already has a
         // neighbour keeps its full pane, with the newcomer stacked into the
         // opposite side of its divider (see `splitting(oppositeLeaf:adding:)`).
+        // An explicit direction overrides the stack rule — the caller said
+        // where the pane goes relative to itself, so its own leaf splits.
         if let group = groupIndex(containing: anchorID) {
-            if splitGroups[group].branchDirection(childLeaf: anchorID) != nil {
+            if let direction {
                 splitGroups[group] = splitGroups[group]
-                    .splitting(oppositeLeaf: anchorID, adding: newSession.id)
+                    .splitting(leaf: anchorID, direction: direction, adding: newSession.id,
+                               newShare: ratio)
+            } else if splitGroups[group].branchDirection(childLeaf: anchorID) != nil {
+                splitGroups[group] = splitGroups[group]
+                    .splitting(oppositeLeaf: anchorID, adding: newSession.id, newShare: ratio)
             } else {
                 splitGroups[group] = splitGroups[group]
-                    .splitting(leaf: anchorID, direction: .horizontal, adding: newSession.id)
+                    .splitting(leaf: anchorID, direction: .horizontal, adding: newSession.id,
+                               newShare: ratio)
             }
+            splitGroups[group] = splitGroups[group].equalized()
         } else {
-            splitGroups.append(.split(SplitBranch(direction: .horizontal, ratio: 0.5,
-                                                  first: .leaf(anchorID),
-                                                  second: .leaf(newSession.id))))
+            splitGroups.append(.split(SplitBranch(direction: direction ?? .horizontal,
+                                                  adding: .leaf(newSession.id), at: .second,
+                                                  share: ratio, to: .leaf(anchorID))))
         }
         if takeFocus {
             selectedSessionID = newSession.id
@@ -261,6 +278,7 @@ extension TermioStore {
         if let group = anchorGroup {
             splitGroups[group] = splitGroups[group]
                 .splitting(leaf: anchor, direction: axis, adding: moved, slot: slot)
+                .equalized()
         } else {
             splitGroups.append(.split(SplitBranch(
                 direction: axis, ratio: 0.5,
@@ -329,6 +347,7 @@ extension TermioStore {
             guard let vacated = splitGroups[group].removing(leaf: source) else { return }
             splitGroups[group] = vacated.splitting(leaf: target, direction: direction,
                                                    adding: source, slot: zone.slot)
+                                        .equalized()
         } else {
             splitGroups[group] = splitGroups[group].swapping(source, and: target)
         }
@@ -381,7 +400,7 @@ extension TermioStore {
             for id in removed { pruned = pruned?.removing(leaf: id) }
             // A group needs two panes to mean anything; a lone survivor is just
             // an ungrouped session again.
-            if let pruned, case .split = pruned { return pruned }
+            if let pruned, case .split = pruned { return pruned.equalized() }
             return nil
         }
         if let preferred { selectedSessionID = preferred }
@@ -414,10 +433,11 @@ extension TermioStore {
     }
 
     /// Installs a mutated group, dissolving it when fewer than two panes remain
-    /// (absence of a group *is* the single-pane state).
+    /// (absence of a group *is* the single-pane state). Surviving groups come
+    /// back equalized: a pane leaving a run hands its share back to the run.
     private func setGroup(at index: Int, to tree: SplitNode?) {
         if let tree, case .split = tree {
-            splitGroups[index] = tree
+            splitGroups[index] = tree.equalized()
         } else {
             splitGroups.remove(at: index)
         }

--- a/Tests/termioTests/SplitTreeTests.swift
+++ b/Tests/termioTests/SplitTreeTests.swift
@@ -185,6 +185,85 @@ final class SplitTreeTests: XCTestCase {
                        [above, agent, run2, run1, below])
     }
 
+    /// Splitting right twice must read as thirds, not 1/2 + 1/4 + 1/4 — the
+    /// panes of a same-direction run are peers, so `equalized()` hands each an
+    /// even share regardless of the order the splits happened in.
+    func testEqualizedTurnsASplitChainIntoEvenShares() {
+        let tree = SplitNode.leaf(agent)
+            .splitting(leaf: agent, direction: .horizontal, adding: run1)
+            .splitting(leaf: run1, direction: .horizontal, adding: run2)
+            .equalized()
+        let frames = tree.layout(in: CGRect(x: 0, y: 0, width: 1, height: 1),
+                                 dividerThickness: 0).frames
+        for id in [agent, run1, run2] {
+            XCTAssertEqual(frames[id]!.width, 1.0 / 3.0, accuracy: 0.001)
+        }
+    }
+
+    /// The spawn stack: the anchor keeps half, and its companions divide the
+    /// opposite column evenly — three rows of a third each, not the newest
+    /// companion taking half the column.
+    func testEqualizedSpawnStackGivesCompanionsEvenRows() {
+        let tree = SplitNode.split(SplitBranch(direction: .horizontal, ratio: 0.5,
+                                               first: .leaf(agent), second: .leaf(run1)))
+            .splitting(oppositeLeaf: agent, adding: run2)
+            .splitting(oppositeLeaf: agent, adding: run3)
+            .equalized()
+        let frames = tree.layout(in: CGRect(x: 0, y: 0, width: 1, height: 1),
+                                 dividerThickness: 0).frames
+        // The anchor's own divider stays at half — the stack is one segment of
+        // the horizontal run, not three.
+        XCTAssertEqual(frames[agent]!.width, 0.5, accuracy: 0.001)
+        for id in [run1, run2, run3] {
+            XCTAssertEqual(frames[id]!.height, 1.0 / 3.0, accuracy: 0.001)
+        }
+    }
+
+    /// A dragged divider is the user's stated ratio: `updatingRatio` pins it,
+    /// and equalization redistributes around it instead of over it.
+    func testDraggedDividerSurvivesEqualization() {
+        var tree = SplitNode.split(SplitBranch(direction: .horizontal, ratio: 0.5,
+                                               first: .leaf(agent), second: .leaf(run1)))
+        guard case .split(let branch) = tree else { return XCTFail("expected a branch") }
+        tree = tree.updatingRatio(branchID: branch.id, to: 0.7)
+        tree = tree.splitting(leaf: run1, direction: .horizontal, adding: run2).equalized()
+
+        let frames = tree.layout(in: CGRect(x: 0, y: 0, width: 1, height: 1),
+                                 dividerThickness: 0).frames
+        // The drag holds; only the undragged remainder divides evenly.
+        XCTAssertEqual(frames[agent]!.width, 0.7, accuracy: 0.001)
+        XCTAssertEqual(frames[run1]!.width, 0.15, accuracy: 0.001)
+        XCTAssertEqual(frames[run2]!.width, 0.15, accuracy: 0.001)
+    }
+
+    /// A spawn that states its share (`--ratio 0.25`) gets exactly that and
+    /// keeps it: the divider is pinned at insert, so the next equalization
+    /// pass cannot flatten the requested strip back to an even share.
+    func testExplicitShareIsPinnedAtInsert() {
+        let tree = SplitNode.leaf(agent)
+            .splitting(leaf: agent, direction: .vertical, adding: run1, newShare: 0.25)
+            .equalized()
+        let frames = tree.layout(in: CGRect(x: 0, y: 0, width: 1, height: 1),
+                                 dividerThickness: 0).frames
+        XCTAssertEqual(frames[run1]!.height, 0.25, accuracy: 0.001)
+        XCTAssertEqual(frames[agent]!.height, 0.75, accuracy: 0.001)
+    }
+
+    /// `pinned` postdates persisted trees: a state file written before the
+    /// field existed must decode with every divider unpinned, not fail.
+    func testDecodingTreeWithoutPinnedDefaultsToUnpinned() throws {
+        let tree = SplitNode.split(SplitBranch(direction: .horizontal, ratio: 0.5, pinned: true,
+                                               first: .leaf(agent), second: .leaf(run1)))
+        var json = String(decoding: try JSONEncoder().encode(tree), as: UTF8.self)
+        json = json.replacingOccurrences(of: ",\"pinned\":true", with: "")
+        json = json.replacingOccurrences(of: "\"pinned\":true,", with: "")
+        XCTAssertFalse(json.contains("pinned"), "the fixture must lack the key entirely")
+
+        let decoded = try JSONDecoder().decode(SplitNode.self, from: Data(json.utf8))
+        guard case .split(let branch) = decoded else { return XCTFail("expected a branch") }
+        XCTAssertFalse(branch.pinned)
+    }
+
     /// Two groups whose rows touch stay two runs, and a run already adjacent is
     /// returned untouched — gathering runs after every group edit, so it must be
     /// idempotent and must never fuse neighbouring groups.

--- a/scripts/termio
+++ b/scripts/termio
@@ -42,6 +42,9 @@ usage:
 options:
   --json           machine-readable output (any `sessions` command)
   --agent <id>     agent for `spawn` (e.g. claudeCode, codex, grok, pi; default: caller's kind)
+  --direction <d>  for `spawn`/`run`: where the new pane lands relative to yours — right or down
+  --ratio <0..1>   for `spawn`/`run`: the new pane's share of the split (e.g. 0.25);
+                   a stated ratio holds against later spawns
   --wait           for `spawn`/`run`/`send`: block until the turn settles; the reply carries
                    the final status and the transcript line range to read
                    (exit 0 settled, 1 error — including a stalled/vanished session, 3 timed out)
@@ -102,12 +105,18 @@ closes from the app side (termio quit or died).
 EOF
             ;;
         spawn) cat <<'EOF'
-usage: termio sessions spawn "<prompt>" [--agent <id>] [--wait [--timeout <ms>]] [--json]
+usage: termio sessions spawn "<prompt>" [--agent <id>] [--direction right|down]
+                                        [--ratio <0..1>] [--wait [--timeout <ms>]] [--json]
 
 Start a NEW agent session on the prompt. Replies immediately with the new
 session's termio://session link; the prompt is
 typed in once the agent finishes booting. --agent picks the agent (e.g. claudeCode, codex, grok,
 pi); the default is the calling agent's own kind.
+
+--direction places the new pane relative to yours (right or down) instead of
+the automatic stack; --ratio is the new pane's share of the split (e.g. 0.25
+for a short strip) and holds against later spawns. Panes without a stated
+ratio share their run evenly.
 
 --wait holds the reply until the spawned agent's first turn settles (or
 --timeout ms elapse; default 300000, clamped 1000–600000). The reply then
@@ -123,13 +132,18 @@ exit codes: 0 settled, 1 error (including stalled/vanished), 3 timed out.
 EOF
             ;;
         run) cat <<'EOF'
-usage: termio sessions run "<command>" [--wait [--timeout <ms>]] [--json]
+usage: termio sessions run "<command>" [--direction right|down] [--ratio <0..1>]
+                                       [--wait [--timeout <ms>]] [--json]
 
 Start a NEW plain terminal session and type the shell command into it — a
 dev server, a test run, a build — visible in a split pane, no LLM involved.
 Replies immediately with the session's address; drive it further with
 `send`, read its output with `read` (a plain command has no
 transcript; its screen is the result), close it with `close`.
+
+--direction places the pane relative to yours (right or down); --ratio is its
+share of the split — `--direction down --ratio 0.25` is a log strip under
+your pane, not a column beside it.
 
 --wait settles when the screen goes still after the command's output (or
 returns needs-you / times out, exactly as with send).
@@ -359,6 +373,8 @@ sessions() {
 
     format=text
     agent=""
+    direction=""
+    ratio=""
     targets=""
     text=""
     states=""
@@ -391,6 +407,26 @@ sessions() {
             --agent)
                 [ $# -ge 2 ] || { echo "termio: --agent needs a value" >&2; exit 1; }
                 agent="$2"; shift ;;
+            --direction)
+                [ $# -ge 2 ] || { echo "termio: --direction needs right or down" >&2; exit 1; }
+                case "$2" in
+                    right|down) ;;
+                    *) echo "termio: --direction is right or down" >&2; exit 1 ;;
+                esac
+                direction="$2"; shift ;;
+            --ratio)
+                [ $# -ge 2 ] || { echo "termio: --ratio needs a number between 0 and 1 (e.g. 0.25)" >&2; exit 1; }
+                # Strictly `0.<digits>` — anything else (".5", "0.", "50%") would
+                # land on the wire as invalid JSON or a share the app rejects.
+                case "$2" in
+                    0.*)
+                        fraction="${2#0.}"
+                        case "$fraction" in
+                            ''|*[!0-9]*) echo "termio: --ratio needs a number between 0 and 1 (e.g. 0.25)" >&2; exit 1 ;;
+                        esac ;;
+                    *) echo "termio: --ratio needs a number between 0 and 1 (e.g. 0.25)" >&2; exit 1 ;;
+                esac
+                ratio="$2"; shift ;;
             --state)
                 [ $# -ge 2 ] || { echo "termio: --state needs a value" >&2; exit 1; }
                 states="$2"; shift ;;
@@ -477,6 +513,16 @@ sessions() {
         if [ -z "${TERMIO_CLI_TIMEOUT:-}" ]; then
             CLIENT_TIMEOUT=$(( ${timeout_ms:-300000} / 1000 + 30 ))
         fi
+    fi
+
+    # Placement flags only mean something on a verb that creates a pane.
+    if [ -n "$direction" ] || [ -n "$ratio" ]; then
+        case "$op" in
+            spawn|run) ;;
+            *) echo "termio: --direction/--ratio apply to spawn and run only" >&2; exit 1 ;;
+        esac
+        [ -n "$direction" ] && extra_json="${extra_json:+$extra_json,}\"direction\":\"$direction\""
+        [ -n "$ratio" ] && extra_json="${extra_json:+$extra_json,}\"ratio\":$ratio"
     fi
 
     # --no-enter only reads on a send to an existing session: a spawn's prompt has

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -32,12 +32,19 @@ id-prefix works too).
   detectable. Exits 0 on your Ctrl-C, 2 if Termio itself went away.
 - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
   prompt (`--agent codex` picks the agent; default: your own kind). Replies
-  immediately with the new session's link — use it for every follow-up;
-  the prompt itself is typed in once the agent finishes booting.
+  immediately with the new session's link (`target` in `--json`) — use it
+  for every follow-up; the prompt itself is typed in once the agent
+  finishes booting.
 - `termio sessions run "<command>"` — start a NEW plain terminal session
   typing that shell command (a dev server, a test run) into a visible pane —
   no LLM. Use it instead of your own background shell when the user should
   be able to see and take over the process.
+- `--direction right|down` and `--ratio <0..1>` on `spawn`/`run` — place the
+  new pane beside or below YOUR pane (every spawn anchors to the caller),
+  and give it that share of the split: `--direction down --ratio 0.25` is a
+  log strip under you. Omit both for the default placement. Panes without a
+  stated ratio share their run evenly, and a stated one holds against later
+  spawns — so only state a ratio when the content needs it.
 - `termio sessions send <link> "<text>"` — type text into that existing
   sibling and submit it with a real Return keypress. Send a prompt to drive
   it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. A

--- a/web/landing/public/skill.md
+++ b/web/landing/public/skill.md
@@ -32,12 +32,19 @@ id-prefix works too).
   detectable. Exits 0 on your Ctrl-C, 2 if Termio itself went away.
 - `termio sessions spawn "<prompt>"` — start a NEW agent session on the
   prompt (`--agent codex` picks the agent; default: your own kind). Replies
-  immediately with the new session's link — use it for every follow-up;
-  the prompt itself is typed in once the agent finishes booting.
+  immediately with the new session's link (`target` in `--json`) — use it
+  for every follow-up; the prompt itself is typed in once the agent
+  finishes booting.
 - `termio sessions run "<command>"` — start a NEW plain terminal session
   typing that shell command (a dev server, a test run) into a visible pane —
   no LLM. Use it instead of your own background shell when the user should
   be able to see and take over the process.
+- `--direction right|down` and `--ratio <0..1>` on `spawn`/`run` — place the
+  new pane beside or below YOUR pane (every spawn anchors to the caller),
+  and give it that share of the split: `--direction down --ratio 0.25` is a
+  log strip under you. Omit both for the default placement. Panes without a
+  stated ratio share their run evenly, and a stated one holds against later
+  spawns — so only state a ratio when the content needs it.
 - `termio sessions send <link> "<text>"` — type text into that existing
   sibling and submit it with a real Return keypress. Send a prompt to drive
   it, or a menu choice (`"1"`, `"yes"`) to answer a permission prompt. A


### PR DESCRIPTION
Same-direction split runs now share their span evenly — split right twice reads as thirds, and a spawn stack gives each companion an equal row, instead of every insert halving what was left. Dividers the user drags, or a spawn that states a share, are pinned: equalization redistributes around them rather than over them. Older persisted trees decode with every divider unpinned.

`termio sessions spawn|run` gain the placement request itself: `--direction right|down` places the new pane beside or below the caller, and `--ratio <0..1>` gives it that share of the split (`--direction down --ratio 0.25` is a log strip). Flags are validated in the CLI before the wire and again in the app before the session exists. The `termio` skill documents both.

Verified live by composing a 3×3 monitor grid over the CLI; the persisted tree came out at exactly 1/9 per pane with no pinned dividers.

Release Notes:
- Split panes in a row or column now share the space evenly; dividers you drag keep their place.
- `termio sessions spawn`/`run` accept `--direction right|down` and `--ratio` to say where the new pane lands and how much of the split it takes.