### PR TITLE
Come back to the session a workspace was left on

### DIFF
--- a/Sources/termio/TermioStore/StateFile.swift
+++ b/Sources/termio/TermioStore/StateFile.swift
@@ -31,6 +31,10 @@ struct StateFile {
         /// trace is a snapshot of data that gets re-fetched (see `TermioStore.InspectorState`).
         /// Optional so older state files still decode.
         var inspectorLayouts: [String: InspectorLayout]?
+        /// The session each workspace was last left on, keyed by workspace
+        /// `id.uuidString` (see `TermioStore.workspaceSelections`). Optional so older
+        /// state files still decode.
+        var workspaceSelections: [String: Session.ID]?
 
         init(
             workspaces: [Workspace]?,
@@ -39,7 +43,8 @@ struct StateFile {
             selectedSessionID: Session.ID?,
             splitRoot: SplitNode? = nil,
             splitGroups: [SplitNode]?,
-            inspectorLayouts: [String: InspectorLayout]?
+            inspectorLayouts: [String: InspectorLayout]?,
+            workspaceSelections: [String: Session.ID]? = nil
         ) {
             self.workspaces = workspaces
             self.currentWorkspaceID = currentWorkspaceID
@@ -48,11 +53,12 @@ struct StateFile {
             self.splitRoot = splitRoot
             self.splitGroups = splitGroups
             self.inspectorLayouts = inspectorLayouts
+            self.workspaceSelections = workspaceSelections
         }
 
         private enum CodingKeys: String, CodingKey {
             case workspaces, currentWorkspaceID, projects, selectedSessionID, splitRoot,
-                 splitGroups, inspectorLayouts
+                 splitGroups, inspectorLayouts, workspaceSelections
         }
 
         /// `projects` is decoded twice on an upgrade — once as the live shape, once
@@ -72,6 +78,8 @@ struct StateFile {
             splitGroups = try c.decodeIfPresent([SplitNode].self, forKey: .splitGroups)
             inspectorLayouts = try c.decodeIfPresent(
                 [String: InspectorLayout].self, forKey: .inspectorLayouts)
+            workspaceSelections = try c.decodeIfPresent(
+                [String: UUID].self, forKey: .workspaceSelections)
         }
 
         /// `legacyProjects` never round-trips: it is the same `projects` array read
@@ -84,6 +92,7 @@ struct StateFile {
             try c.encodeIfPresent(selectedSessionID, forKey: .selectedSessionID)
             try c.encodeIfPresent(splitGroups, forKey: .splitGroups)
             try c.encodeIfPresent(inspectorLayouts, forKey: .inspectorLayouts)
+            try c.encodeIfPresent(workspaceSelections, forKey: .workspaceSelections)
         }
     }
 

--- a/Sources/termio/TermioStore/TermioStore+Workspaces.swift
+++ b/Sources/termio/TermioStore/TermioStore+Workspaces.swift
@@ -348,10 +348,15 @@ extension TermioStore {
     private func finishArriving(in id: Workspace.ID) {
         let span = Trace.workspace.begin("workspace settle")
         defer { Trace.workspace.end(span) }
-        // Clearing beats guessing: an empty workspace shows the welcome state,
-        // which is the honest picture of a scope with nothing open in it.
+        // Back to the row this scope was left on (`workspaceSelections`), because
+        // coming back to a workspace is resuming what you were doing in it — the
+        // panes, the split group, and the inspector tab all follow the selected
+        // session, so landing on the first row instead reopens someone else's work.
+        // The first row is still the answer for a scope never visited, and clearing
+        // beats guessing for an empty one: the welcome state is the honest picture
+        // of a scope with nothing open in it.
         let selection = Trace.workspace.begin("workspace selection")
-        selectedSessionID = sessions(inWorkspace: id).first?.id
+        selectedSessionID = arrivalSelection(inWorkspace: id)
         Trace.workspace.end(selection)
         // A machine's fallback workspace is also the machine, so entering it asks
         // that device for its roster. A workspace the user made spans machines and
@@ -361,6 +366,18 @@ extension TermioStore {
             switchToDevice(KnownDevice(alias: alias, deviceID: workspace.deviceID))
             Trace.workspace.end(device)
         }
+    }
+
+    /// The row arriving in a workspace lands on: the one that scope was left on when
+    /// it is still there, and its first session otherwise. Validated against the live
+    /// roster rather than trusted, since a remembered session can have been closed
+    /// from another scope (or not have come back after a relaunch).
+    func arrivalSelection(inWorkspace id: Workspace.ID) -> Session.ID? {
+        let sessions = sessions(inWorkspace: id)
+        if let last = workspaceSelections[id], sessions.contains(where: { $0.id == last }) {
+            return last
+        }
+        return sessions.first?.id
     }
 
     /// Follows a session into its workspace. Called from the selection's `didSet`,
@@ -454,10 +471,11 @@ extension TermioStore {
         // captured before the teardown.
         for session in target.looseSessions { closeSession(session.id) }
         workspaces.removeAll { $0.id == id }
+        workspaceSelections.removeValue(forKey: id)
         if currentWorkspaceID == id, let first = workspaces.first {
             currentWorkspaceID = first.id
             settings.currentWorkspaceID = first.id
-            selectedSessionID = sessions(inWorkspace: first.id).first?.id
+            selectedSessionID = arrivalSelection(inWorkspace: first.id)
         }
     }
 

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -85,6 +85,12 @@ final class TermioStore: ObservableObject {
                 // a window showing one scope while the terminal belongs to another
                 // is the same confusion the device context exists to prevent.
                 enterWorkspace(of: id)
+                // Every selection is also the answer to "where was I in this
+                // scope", so the workspace it belongs to remembers it (see
+                // `workspaceSelections`). Filed under the session's *own*
+                // workspace rather than the current one, so a deep link that
+                // jumps scopes records the arrival where it landed.
+                if let owner = workspace(for: id)?.id { workspaceSelections[owner] = id }
                 // Looking at a session is being on its machine. Every path that
                 // moves the selection — a deep link, the palette, a notification,
                 // a split, a freshly opened remote terminal — lands here, so this
@@ -595,6 +601,17 @@ final class TermioStore: ObservableObject {
     /// pruned alongside its runtime in `syncRuntimes`.
     var inspectorStates: [Session.ID: InspectorState] = [:]
 
+    /// The session each workspace was last left on, so switching back lands where the
+    /// user was rather than on whichever row sorts first. Written on every selection
+    /// change and read by `finishArriving`.
+    ///
+    /// Held here rather than on `Workspace` for the same reason `inspectorStates` is:
+    /// this is written on every row click, and `workspaces` is `@Published` — a write
+    /// there would rebuild the sidebar to record something the sidebar already shows.
+    /// Persisted, so the scope you return to after a relaunch is the scope you left.
+    /// Entries for closed sessions are pruned alongside their runtimes in `syncRuntimes`.
+    var workspaceSelections: [Workspace.ID: Session.ID] = [:]
+
     /// True only while `restored()` seeds the saved layouts and hand-applies the selected
     /// one — it suppresses the capture/restore in `selectedSessionID`'s didSet so a
     /// programmatic selection during launch can't overwrite a just-seeded layout.
@@ -719,8 +736,12 @@ final class TermioStore: ObservableObject {
         let live = Set(sessionSlots.sessionIDs)
         for id in live where runtimes[id] == nil { runtimes[id] = SessionRuntime() }
         for id in runtimes.keys where !live.contains(id) { runtimes.removeValue(forKey: id) }
-        // A closed session's saved inspector layout goes with it.
+        // A closed session's saved inspector layout goes with it, and so does its
+        // claim on being the row a workspace comes back to.
         for id in inspectorStates.keys where !live.contains(id) { inspectorStates.removeValue(forKey: id) }
+        for (workspace, id) in workspaceSelections where !live.contains(id) {
+            workspaceSelections.removeValue(forKey: workspace)
+        }
     }
 
     /// Sets a session's status, no-op-guarded so a redundant same-value write (the hook
@@ -1339,6 +1360,16 @@ final class TermioStore: ObservableObject {
                 store.inspectorStates[id] = state
             }
         }
+        // Seed where each workspace was left. Validated against the live tree, since a
+        // session recorded before the quit may not have come back — a workspace whose
+        // row is gone falls back to its first session the way it always did.
+        if let selections = snapshot.workspaceSelections {
+            let live = Set(store.allSessions.map(\.id))
+            for (key, id) in selections {
+                guard let workspace = UUID(uuidString: key), live.contains(id) else { continue }
+                store.workspaceSelections[workspace] = id
+            }
+        }
         // Guard the selection change so its didSet neither captures the (still-default)
         // live inspector over a just-seeded layout nor schedules a startup save.
         store.isRestoringInspector = true
@@ -1385,13 +1416,16 @@ final class TermioStore: ObservableObject {
                 fileReadOnly: state.openFileReadOnly
             )
         }
+        var selections: [String: Session.ID] = [:]
+        for (workspace, id) in workspaceSelections { selections[workspace.uuidString] = id }
         stateFile.save(.init(
             workspaces: workspaces,
             currentWorkspaceID: currentWorkspaceID,
             projects: projects,
             selectedSessionID: selectedSessionID,
             splitGroups: splitGroups,
-            inspectorLayouts: layouts.isEmpty ? nil : layouts
+            inspectorLayouts: layouts.isEmpty ? nil : layouts,
+            workspaceSelections: selections.isEmpty ? nil : selections
         ))
     }
 

--- a/Tests/termioTests/WorkspaceArrivalSelectionTests.swift
+++ b/Tests/termioTests/WorkspaceArrivalSelectionTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+
+@testable import termio
+
+/// Where a workspace switch lands. Coming back to a scope resumes it on the row
+/// it was left on, because the terminal, the split group, and the inspector tab
+/// all follow the selected session — landing on the first row instead reopens
+/// something the user was not working on.
+@MainActor
+final class WorkspaceArrivalSelectionTests: XCTestCase {
+    private var directory: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("workspace-arrival-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        suiteName = "workspace-arrival-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        defaults.removePersistentDomain(forName: suiteName)
+        try await super.tearDown()
+    }
+
+    /// Scratch storage for both settings layers: a test must not rewrite the
+    /// settings file or the defaults domain of the termio the user is running.
+    private func makeStore(_ workspaces: [Workspace]) -> TermioStore {
+        let settings = AppSettings(
+            defaults: defaults,
+            settingsStore: SettingsStore(
+                defaults: defaults,
+                fileURL: directory.appendingPathComponent("settings.json"),
+                domainName: suiteName))
+        return TermioStore(workspaces: workspaces, settings: settings)
+    }
+
+    private func workspace(_ name: String, sessions: Int) -> Workspace {
+        Workspace(
+            name: name,
+            terminals: (1...sessions).map { Session(title: "\(name) \($0)", agent: .terminal) })
+    }
+
+    func testAWorkspaceComesBackToTheSessionItWasLeftOn() {
+        let first = workspace("Left", sessions: 3)
+        let second = workspace("Right", sessions: 2)
+        let store = makeStore([first, second])
+
+        store.selectedSessionID = first.terminals[2].id
+        store.selectedSessionID = second.terminals[0].id
+
+        XCTAssertEqual(store.arrivalSelection(inWorkspace: first.id), first.terminals[2].id)
+        XCTAssertEqual(store.arrivalSelection(inWorkspace: second.id), second.terminals[0].id)
+    }
+
+    /// A scope nobody has been in has nothing to remember, so it opens on its
+    /// first row the way it always did.
+    func testAnUnvisitedWorkspaceLandsOnItsFirstSession() {
+        let first = workspace("Left", sessions: 2)
+        let store = makeStore([first])
+
+        XCTAssertEqual(store.arrivalSelection(inWorkspace: first.id), first.terminals[0].id)
+    }
+
+    /// The remembered row can be closed from elsewhere — a deep link, the phone,
+    /// the daemon — so the arrival is validated against the live roster instead of
+    /// selecting a session the tree no longer holds.
+    func testAClosedSessionFallsBackToTheFirstRow() {
+        let first = workspace("Left", sessions: 3)
+        let store = makeStore([first])
+
+        store.selectedSessionID = first.terminals[2].id
+        store.workspaces[0].terminals.removeLast()
+
+        XCTAssertEqual(store.arrivalSelection(inWorkspace: first.id), first.terminals[0].id)
+    }
+
+    /// An empty scope shows the welcome state rather than borrowing a row from
+    /// the one it replaced.
+    func testAnEmptyWorkspaceSelectsNothing() {
+        let empty = Workspace(name: "Empty")
+        let store = makeStore([empty])
+
+        XCTAssertNil(store.arrivalSelection(inWorkspace: empty.id))
+    }
+}


### PR DESCRIPTION
Arriving in a workspace selected its first session, so returning to a scope reopened whatever sorted first rather than what you were doing. The selection carries the panes, the split group and the inspector tab with it, so landing on the wrong row puts someone else's work on screen.

Each workspace now remembers the row it was left on, written from the selection's `didSet` and read by `finishArriving`. It is filed under the session's own workspace rather than the current one, so a deep link that jumps scopes records the arrival where it landed.

The remembered row is validated against the live roster rather than trusted — a session can be closed from another scope, from the phone, or fail to come back after a relaunch. A scope never visited still opens on its first session, and an empty one still selects nothing so the welcome state shows.

Held on the store beside `inspectorStates` rather than on `Workspace`, which is `@Published`: writing there on every row click would rebuild the sidebar to record something the sidebar already shows. Persisted through `StateFile` as an optional field, so older state files decode unchanged.

`WorkspaceArrivalSelectionTests` covers the four cases — remembered, unvisited, closed-then-fallback, and empty — on scratch settings storage so the suite never touches an installed termio's state.

Release Notes:

- Switching back to a workspace now returns you to the session you were last on, instead of its first one.