### PR TITLE
Group or reorder by where a dragged sidebar row lands

### DIFF
--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -579,9 +579,100 @@ enum SplitLinkMark {
 /// tick pointing at this row's icon. Drawn (not the ┌ text glyph VS Code uses)
 /// so consecutive rows meet the row boundary exactly and the spine reads as one
 /// continuous bracket.
+/// A session dragged over a sidebar row, answering by where on the row it is:
+/// the top or bottom third reorders into that gap, the middle third groups the two
+/// together (独立 → 联合). One gesture, two outcomes, told apart by a line versus a
+/// filled row — the same distinction a file tree draws between "between these" and
+/// "into this".
+///
+/// Thirds rather than the file tree's usual quarters because a session row is
+/// short: at the row heights the interface padding produces, a quarter band is a
+/// few points tall and the reorder you were aiming for turns into a regroup.
+///
+/// A `DropDelegate` rather than a `dropDestination`, for the reason the panes' one
+/// is: only `dropUpdated` carries the pointer, and `isTargeted:` is a Bool.
+private struct SessionRowDropDelegate: DropDelegate {
+    let session: Session.ID
+    let height: CGFloat
+    let store: TermioStore
+
+    /// Refuse outright when neither outcome is available — a row from another
+    /// project or worktree shows the no-drop cursor rather than a dead target.
+    func validateDrop(info: DropInfo) -> Bool { outcome(info) != nil }
+
+    func dropEntered(info: DropInfo) { track(info) }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        track(info)
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) { store.sessionRowDrop = nil }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let landing = outcome(info)
+        store.sessionRowDrop = nil
+        store.draggingSessionID = nil
+        guard let moved = draggedSession, let landing else { return false }
+        if let side = landing.insert {
+            store.reorderSession(moved, relativeTo: session, insert: side)
+        } else {
+            store.groupSession(moved, with: session)
+        }
+        return true
+    }
+
+    private func track(_ info: DropInfo) {
+        store.sessionRowDrop = outcome(info)
+    }
+
+    /// What a release here would do, or `nil` when it would do nothing. The zone
+    /// decides which outcome is *wanted*; the store decides whether it is *legal*,
+    /// and an illegal one is refused rather than quietly turned into the other —
+    /// a drop that lands somewhere you did not aim is worse than one that declines.
+    private func outcome(_ info: DropInfo) -> TermioStore.SessionRowDrop? {
+        guard let moved = draggedSession, height > 0 else { return nil }
+        let third = height / 3
+        if info.location.y < third {
+            return store.canReorder(moved, relativeTo: session)
+                ? .init(row: session, insert: .above) : nil
+        }
+        if info.location.y > height - third {
+            return store.canReorder(moved, relativeTo: session)
+                ? .init(row: session, insert: .below) : nil
+        }
+        return store.canGroup(moved, with: session) ? .init(row: session, insert: nil) : nil
+    }
+
+    /// The dragged session, read off the drag pasteboard — `DropInfo`'s providers
+    /// cannot answer synchronously, and `dropUpdated` has to (see `PaneDropDelegate`).
+    private var draggedSession: Session.ID? {
+        guard let link = NSPasteboard(name: .drag).string(forType: .string) else { return nil }
+        return TermioStore.sessionID(fromLink: link.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+}
+
+/// The gap a dragged row would land in: a hairline across the row's edge, the
+/// file-tree convention for "between these two" as opposed to the filled
+/// highlight that means "into this one". Takes the sidebar's own foreground
+/// rather than an accent, so the two cues differ in shape, not in palette.
+private struct RowInsertionLine: View {
+    let chrome: ChromeTheme?
+
+    var body: some View {
+        Rectangle()
+            .fill(chrome.map { AnyShapeStyle($0.foreground.opacity(0.8)) }
+                ?? AnyShapeStyle(.primary.opacity(0.8)))
+            .frame(height: 2)
+            .allowsHitTesting(false)
+    }
+}
+
 private struct SplitLinkGlyph: View {
     let mark: SplitLinkMark
     let chrome: ChromeTheme?
+    /// Brightened while a member of this group is being dragged.
+    var isMarked: Bool = false
 
     var body: some View {
         GeometryReader { geo in
@@ -600,8 +691,9 @@ private struct SplitLinkGlyph: View {
                 path.addLine(to: CGPoint(x: x + 5, y: midY))
             }
             .stroke(lineWidth: 1)
-            .foregroundStyle(chrome.map { AnyShapeStyle($0.foreground.opacity(0.35)) }
-                ?? AnyShapeStyle(.tertiary))
+            .foregroundStyle(chrome.map { AnyShapeStyle($0.foreground.opacity(isMarked ? 0.9 : 0.35)) }
+                ?? AnyShapeStyle(isMarked ? AnyShapeStyle(.primary) : AnyShapeStyle(.tertiary)))
+            .animation(.easeInOut(duration: 0.12), value: isMarked)
         }
     }
 }
@@ -1150,10 +1242,29 @@ private struct SessionRow: View {
     /// per row scanned the workspaces once per row.
     var marksDevice: Bool = true
     @State private var isHovering = false
-    /// A same-bucket session is being dragged over this row: light its whole-row
-    /// background (the hover lift) as the reorder drop target. Only set when the
-    /// in-flight session could legally land here (`store.canReorder`).
-    @State private var isDropTarget = false
+    /// Measured, not assumed: the drop zones are fractions of the row, and row
+    /// height follows the interface row padding.
+    @State private var rowHeight: CGFloat = 0
+
+    /// What a release over this row would do, or `nil` when the drag is elsewhere
+    /// or could not land here.
+    private var dropCue: TermioStore.SessionRowDrop? {
+        store.sessionRowDrop.flatMap { $0.row == session.id ? $0 : nil }
+    }
+
+    /// Grouping this row is the drop that lands *on* it, so it reuses the hover
+    /// lift — the same frosted-grey fill, no second background shape.
+    private var isDropTarget: Bool { dropCue?.insert == nil && dropCue != nil }
+
+    /// A group the in-flight session belongs to reads brighter for the length of
+    /// the drag, so the group a release would pull it out of is visible before you
+    /// let go. Without it the only trace is the bracket moving afterwards.
+    private var marksSourceGroup: Bool {
+        guard let dragged = store.draggingSessionID,
+              let group = store.splitGroups.first(where: { $0.contains(dragged) })
+        else { return false }
+        return group.contains(session.id)
+    }
 
     private var isSelected: Bool { store.selectedSessionID == session.id }
 
@@ -1320,10 +1431,18 @@ private struct SessionRow: View {
         // own column while preserving the existing primary-session geometry.
         .overlay(alignment: .leading) {
             if let splitLink {
-                SplitLinkGlyph(mark: splitLink, chrome: chrome)
+                SplitLinkGlyph(mark: splitLink, chrome: chrome, isMarked: marksSourceGroup)
                     .frame(width: 16)
                     .padding(.leading, max(0, leadingIndent - 16))
             }
+        }
+        // The gap the row would land in. Drawn at the row edge rather than as a
+        // background, because "between two rows" has no row to fill.
+        .overlay(alignment: .top) {
+            RowInsertionLine(chrome: chrome).opacity(dropCue?.insert == .above ? 1 : 0)
+        }
+        .overlay(alignment: .bottom) {
+            RowInsertionLine(chrome: chrome).opacity(dropCue?.insert == .below ? 1 : 0)
         }
         .contentShape(Rectangle())
         // Drag the whole row to reorder it within its bucket (no handle). Uses
@@ -1367,25 +1486,21 @@ private struct SessionRow: View {
                     .fill(.regularMaterial)
             )
         }
-        // Reorder on drop: only a payload that parses as a session link counts, so
-        // arbitrary dropped text is still rejected — a self-drop is ignored, and a
-        // cross-bucket drop is a no-op in the store.
-        .dropDestination(for: String.self) { payloads, _ in
-            store.draggingSessionID = nil
-            // Clear the drop lift the instant we commit so it can't linger on this row
-            // (or ghost onto its new neighbour) as the list settles the move.
-            isDropTarget = false
-            guard let moved = payloads.lazy.compactMap(TermioStore.sessionID(fromLink:)).first,
-                  moved != session.id
-            else { return false }
-            store.reorderSession(moved, relativeTo: session.id)
-            return true
-        } isTargeted: { targeted in
-            // Light the background only when the in-flight session could actually land
-            // here — same project + worktree bucket — so a cross-section hover stays inert.
-            isDropTarget = targeted
-                && (store.draggingSessionID.map { store.canReorder($0, relativeTo: session.id) } ?? false)
-        }
+        // A row answers a dragged session two ways, by where on the row you release:
+        // the gap above or below reorders, the middle groups the two together. That
+        // is the file-tree convention — a line means "between", a highlight means
+        // "into" — and it is what lets one gesture do both without a modifier.
+        //
+        // The height comes off the row itself because the zones are fractions of it;
+        // rows grow with the interface row padding, so a fixed band would drift.
+        .background(
+            GeometryReader { proxy in
+                Color.clear.onAppear { rowHeight = proxy.size.height }
+                    .onChange(of: proxy.size.height) { _, new in rowHeight = new }
+            }
+        )
+        .onDrop(of: [.text], delegate: SessionRowDropDelegate(
+            session: session.id, height: rowHeight, store: store))
         .onHover { isHovering = $0 }
         // Click-to-select rides a *simultaneous* tap, not `.onTapGesture`: an
         // exclusive tap gesture preempts the row drag (it never starts), while a

--- a/Sources/termio/Terminal/PaneDragRearrange.swift
+++ b/Sources/termio/Terminal/PaneDragRearrange.swift
@@ -139,9 +139,12 @@ final class PaneDragRearrange {
     /// with the button up — making this the first thing to run after any drag,
     /// however it ended, for the cost of a comparison the rest of the time.
     private func clearStrandedDropCue() {
-        guard let store, store.sessionDropTarget != nil,
-              NSEvent.pressedMouseButtons & 1 == 0 else { return }
+        guard let store, NSEvent.pressedMouseButtons & 1 == 0,
+              store.sessionDropTarget != nil || store.sessionRowDrop != nil
+                  || store.draggingSessionID != nil
+        else { return }
         store.sessionDropTarget = nil
+        store.sessionRowDrop = nil
         store.draggingSessionID = nil
     }
 

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -30,6 +30,11 @@ extension TermioStore {
         return session.id
     }
 
+    /// Which gap a dragged row lands in, relative to the row it was released over.
+    enum RowInsertion {
+        case above, below
+    }
+
     /// Whether `moved` may be drag-reordered next to `target`: both must sit in the
     /// same roster — one project, or one workspace's Terminals or Chats — and the
     /// same worktree bucket. Drives which rows light their background as a legal
@@ -43,24 +48,25 @@ extension TermioStore {
             == sessionBucketKey(self[targetSlot], at: targetSlot)
     }
 
-    /// Moves `moved` next to `target` within their shared roster, committed on drop
-    /// (a cross-roster move is a no-op via `canReorder`). The insert side follows the
-    /// drag direction: dropping onto a row *below* lands `moved` just under the target,
-    /// onto one *above* lands it just over — so the gesture reads as "move toward the
-    /// row you let go on". Persistence rides the tree's `didSet` like every roster edit.
-    func reorderSession(_ moved: Session.ID, relativeTo target: Session.ID) {
+    /// Moves `moved` to the `side` of `target` within their shared roster, committed
+    /// on drop (a cross-roster move is a no-op via `canReorder`). Persistence rides
+    /// the tree's `didSet` like every roster edit.
+    ///
+    /// The side is the caller's, not inferred from which row started higher: the
+    /// sidebar draws an insertion line at the edge the pointer is nearest, and a
+    /// line that showed one gap while the row landed in another would be a lie.
+    func reorderSession(_ moved: Session.ID, relativeTo target: Session.ID,
+                        insert side: RowInsertion) {
         guard canReorder(moved, relativeTo: target),
-              let movedSlot = locate(moved), let targetSlot = locate(target)
+              let movedSlot = locate(moved)
         else { return }
 
         var sessions = roster(at: movedSlot)
-        let movedIndex = movedSlot.sessionIndex
-        let targetIndex = targetSlot.sessionIndex
-        let row = sessions.remove(at: movedIndex)
+        let row = sessions.remove(at: movedSlot.sessionIndex)
         // Re-find the target after the removal so its index stays valid regardless of
-        // which row came first; insert on the side `moved` was dragged from.
+        // which row came first.
         let newTarget = sessions.firstIndex(where: { $0.id == target }) ?? sessions.count - 1
-        sessions.insert(row, at: movedIndex < targetIndex ? newTarget + 1 : newTarget)
+        sessions.insert(row, at: side == .above ? newTarget : newTarget + 1)
         setRoster(sessions, at: movedSlot)
         // A drop that lands between a group's rows would split its bracket in two;
         // rows only join or leave a group through "Group with" / "Ungroup", so the

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -200,6 +200,20 @@ final class TermioStore: ObservableObject {
     /// has to redraw as the pointer crosses zones.
     @Published var sessionDropTarget: SessionDropTarget?
 
+    /// What a release over a sidebar row would do: land in the gap above or below
+    /// it, or group the dragged session with it. Held here rather than in each
+    /// row's `@State` so one writer owns it — a per-row flag can only be cleared by
+    /// the row that set it, and a drag that ends without SwiftUI calling that row
+    /// back leaves the cue on screen (see `PaneDragRearrange.clearStrandedDropCue`).
+    @Published var sessionRowDrop: SessionRowDrop?
+
+    /// A pending drop on a sidebar row: which row, and which gap it would land in —
+    /// `nil` meaning the middle of the row, which groups the two sessions instead.
+    struct SessionRowDrop: Equatable {
+        var row: Session.ID
+        var insert: RowInsertion?
+    }
+
     /// When each project was last active — the moment one of its agents last reported
     /// work, or the user last switched to one of its sessions. Drives the sidebar's
     /// "Recent Activity" sort (see `orderedProjects`). In-memory and `@Published` so a

--- a/Tests/termioTests/SessionDropTests.swift
+++ b/Tests/termioTests/SessionDropTests.swift
@@ -27,9 +27,10 @@ final class SessionDropTests: XCTestCase {
         try await super.tearDown()
     }
 
-    private func makeStore(sessions: [Session]) -> TermioStore {
+    private func makeStore(sessions: [Session], chats: [Session] = []) -> TermioStore {
         var workspace = Workspace(name: "Default")
         workspace.terminals = sessions
+        workspace.chats = chats
         let settings = AppSettings(
             defaults: defaults,
             settingsStore: SettingsStore(
@@ -135,6 +136,64 @@ final class SessionDropTests: XCTestCase {
         store.dropSession(moved.id, onto: anchor.id, zone: .right)
 
         XCTAssertTrue(store.splitGroups.isEmpty)
+    }
+
+    // MARK: - Sidebar row gaps
+
+    /// The insertion line names a gap, so the row lands in that gap — not in the one
+    /// the drag direction would have implied. Dragging downward onto a row's *top*
+    /// third has to land above it, which is the case the old direction-inferred
+    /// reorder got backwards.
+    func testReorderLandsOnTheSideTheCallerNames() {
+        let first = Session(title: "Terminal 1")
+        let second = Session(title: "Terminal 2")
+        let third = Session(title: "Terminal 3")
+        let store = makeStore(sessions: [first, second, third])
+
+        store.reorderSession(first.id, relativeTo: third.id, insert: .above)
+
+        XCTAssertEqual(rowOrder(store), [second.id, first.id, third.id])
+    }
+
+    /// The same drag, the other gap.
+    func testReorderBelowLandsAfterTheTarget() {
+        let first = Session(title: "Terminal 1")
+        let second = Session(title: "Terminal 2")
+        let third = Session(title: "Terminal 3")
+        let store = makeStore(sessions: [first, second, third])
+
+        store.reorderSession(third.id, relativeTo: first.id, insert: .below)
+
+        XCTAssertEqual(rowOrder(store), [first.id, third.id, second.id])
+    }
+
+    /// Dragging upward and dragging downward into the same gap must agree — the
+    /// side is the pointer's, so the row that started lower cannot land elsewhere.
+    func testTheSameGapIsReachedFromEitherDirection() {
+        let a = Session(title: "Terminal 1")
+        let b = Session(title: "Terminal 2")
+        let store = makeStore(sessions: [a, b])
+
+        store.reorderSession(b.id, relativeTo: a.id, insert: .above)
+        XCTAssertEqual(rowOrder(store), [b.id, a.id])
+
+        store.reorderSession(a.id, relativeTo: b.id, insert: .above)
+        XCTAssertEqual(rowOrder(store), [a.id, b.id])
+    }
+
+    /// Rows in different rosters never reorder into each other — a row cannot leave
+    /// its section by being dropped on one — so the gap cue stays dark there rather
+    /// than offering a move that would not happen.
+    func testReorderRefusesAcrossRosters() {
+        let terminal = Session(title: "Terminal 1")
+        let chat = Session(title: "Chat 1")
+        let store = makeStore(sessions: [terminal], chats: [chat])
+
+        XCTAssertFalse(store.canReorder(chat.id, relativeTo: terminal.id))
+        store.reorderSession(chat.id, relativeTo: terminal.id, insert: .above)
+
+        XCTAssertEqual(rowOrder(store), [terminal.id])
+        XCTAssertEqual(store.workspaces.first?.chats.map(\.id), [chat.id])
     }
 
     /// Dropping a row on its own pane is the degenerate case of the same gesture.


### PR DESCRIPTION
Dropping a session row on another row only ever reordered. Now the row answers by *where* on it you release: the top or bottom third reorders into that gap, the middle third groups the two sessions together — the drag form of "Group with", which the pane area already accepts and the sidebar previously offered only through its context menu.

**A line means "between", a filled row means "into".** That is the distinction every file tree draws, and it is what lets one gesture carry both outcomes without a modifier. The line takes the sidebar's own foreground rather than an accent, so the two cues differ in shape, not in palette.

**Thirds, not quarters.** A session row is short — at the heights the interface row padding produces, the usual quarter band is a few points tall, and the reorder you aimed for becomes a regroup.

**The side is now the caller's.** `reorderSession` took the insert side from which row started higher; it now takes it explicitly, because an insertion line that names one gap while the row lands in another is a lie. Dragging downward onto a row's top third lands above it, which the inferred version got backwards.

**A group in flight is visible.** While dragging a session that belongs to a split group, that group's ┌/└ bracket brightens — the release pulls the session out of it, and until now the only trace was the bracket moving afterwards.

**The cue lives on the store.** A per-row `@State` flag can only be cleared by the row that set it, and SwiftUI gives a `DropDelegate` no "session ended" callback — the stranded-highlight failure the pane drop already had to solve, so this one reuses the same cleanup.

An outcome the store refuses is declined rather than quietly swapped for the other: a drop that lands somewhere you did not aim is worse than one that shows the no-drop cursor.

## Testing

`swift build`, `swift test` — 4 new cases covering the gap the row lands in from either drag direction, and cross-roster refusal. Note the two predicates differ and both are exercised: `canReorder` keys on the sidebar bucket (`nil` for every loose session), `canGroup` on `worktreePath` directly.

Release Notes:
- Drop a session on the middle of another row in the sidebar to group them, or on the gap between rows to reorder.