### PR TITLE
Stop a tunnel that cannot serve from minting public URLs forever

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -382,6 +382,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
         )
         companionServer = companion
+        // Serving and publishing are one decision, so they fail as one: a
+        // second instance that loses the race for the port must not leave a
+        // public URL pointing at it.
+        companion.onListenerFailed = {
+            Log.companion.error("not serving — taking the public tunnel down")
+            TunnelManager.shared.suspend()
+        }
         // Mobile Access is the master switch: only serve (and resume the public
         // tunnel) when it's on. The token gate in the server is what makes
         // fronting it with a tunnel safe.

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -190,6 +190,12 @@ final class CompanionServer {
     /// Opens an `ssh <host>` terminal for the phone's Terminals ＋ → SSH
     /// (`.startSSH`); returns the `.started` echo, or nil on failure.
     private let startSSHSession: (String) -> (sessionID: String, agentID: String)?
+    /// Called when this server will not be serving after all — the port is
+    /// held by someone else, or the listener died. Set by whoever owns the
+    /// wiring (`AppDelegate`), because the thing that has to be undone is the
+    /// *tunnel*, and a server that cannot bind must not leave a public URL
+    /// pointing at a port it does not answer on.
+    var onListenerFailed: (() -> Void)?
     private var listener: NWListener?
     private var connections: Set<ObjectIdentifier> = []
     private var connectionByID: [ObjectIdentifier: NWConnection] = [:]
@@ -240,19 +246,30 @@ final class CompanionServer {
         ws.maximumMessageSize = 16 << 20
         params.defaultProtocolStack.applicationProtocols.insert(ws, at: 0)
 
-        guard let listener = try? NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!) else {
+        guard let endpoint = NWEndpoint.Port(rawValue: port),
+              let listener = try? NWListener(using: params, on: endpoint)
+        else {
             Log.companion.error("failed to bind port \(self.port, privacy: .public)")
+            onListenerFailed?()
             return
         }
         listener.newConnectionHandler = { [weak self] connection in
             Task { @MainActor in self?.accept(connection) }
         }
-        listener.stateUpdateHandler = { state in
+        listener.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
             switch state {
             case .ready:
                 Log.companion.notice("listening on ws://localhost:\(self.port, privacy: .public)")
             case .failed(let error):
+                // Terminal, not transient: an NWListener does not recover from
+                // `.failed`, and the common cause is a second instance already
+                // holding the port. Say so and take the public URL down with
+                // it — the alternative is what the log caught, a tunnel
+                // announcing a fresh address every few seconds for a port this
+                // process never answered on.
                 Log.companion.error("listener failed: \(error.localizedDescription, privacy: .public)")
+                Task { @MainActor in self.onListenerFailed?() }
             case .waiting(let error):
                 Log.companion.notice("listener waiting: \(error.localizedDescription, privacy: .public)")
             default:

--- a/Sources/termio/Companion/TunnelManager.swift
+++ b/Sources/termio/Companion/TunnelManager.swift
@@ -163,9 +163,27 @@ final class TunnelManager: ObservableObject {
     private var process: Process?
     private var outputBuffer = Data()
     private var terminationObserver: NSObjectProtocol?
-    /// Unexpected exits since the last healthy URL: the tunnel self-heals on
-    /// relay hiccups but refuses to hot-loop against a hard failure.
+    /// Unexpected exits since the last run that actually held: the tunnel
+    /// self-heals on relay hiccups but refuses to hot-loop against a hard
+    /// failure.
     private var consecutiveFailures = 0
+    /// When the live child started, so its exit can be judged by how long it
+    /// lasted. A tunnel that prints a URL and dies seconds later is a hard
+    /// failure wearing a success's clothes — see `durableRun`.
+    private var processStartedAt: Date?
+
+    /// How long a run must last to count as healthy rather than a flap.
+    ///
+    /// Printing a URL used to be the proof, and it is not one: two app
+    /// instances racing for the same port produced a tunnel that came up,
+    /// announced a fresh public URL, and was killed ~3s later, forever. Each
+    /// cycle looked like a success, so the failure count reset and the cap
+    /// below never tripped — eight public URLs in twenty-two seconds, every one
+    /// of them breaking the QR a paired phone had already scanned.
+    ///
+    /// Well clear of the 3s restart delay, so an ordinary relay hiccup on a
+    /// tunnel that has been up for a while still reads as the hiccup it is.
+    private static let durableRun: TimeInterval = 60
 
     private init() {
         provider = UserDefaults.standard.string(forKey: Self.providerKey)
@@ -335,7 +353,16 @@ final class TunnelManager: ObservableObject {
                 guard let self, self.process === process else { return }
                 pipe.fileHandleForReading.readabilityHandler = nil
                 self.process = nil
-                Log.tunnel.notice("\(provider.binaryName, privacy: .public) exited (status \(process.terminationStatus, privacy: .public))")
+                let uptime = self.processStartedAt.map { Date().timeIntervalSince($0) }
+                self.processStartedAt = nil
+                Log.tunnel.notice("""
+                \(provider.binaryName, privacy: .public) exited \
+                (status \(process.terminationStatus, privacy: .public)) \
+                after \(Int(uptime ?? 0), privacy: .public)s
+                """)
+                // A run that held is what clears the count, not a URL that
+                // appeared: only lasting proves the tunnel was ever usable.
+                if let uptime, uptime >= Self.durableRun { self.consecutiveFailures = 0 }
                 // Quick tunnels drop when the relay blips; restart while the
                 // user still wants one, but don't hot-loop a hard failure.
                 // Each restart mints a NEW public URL — the open QR follows,
@@ -359,6 +386,7 @@ final class TunnelManager: ObservableObject {
         }
         do {
             try process.run()
+            processStartedAt = Date()
             Log.tunnel.info("spawned \(provider.binaryName, privacy: .public) (pid \(process.processIdentifier, privacy: .public))")
             // A custom relay has no argv signature to match on later, so the
             // pid is the only handle a *future* run has on this child.
@@ -392,13 +420,13 @@ final class TunnelManager: ObservableObject {
               let url = URL(string: String(text[range]))
         else { return }
         Log.tunnel.notice("up at \(url.absoluteString, privacy: .public)")
-        consecutiveFailures = 0
         status = .running(url)
     }
 
     private func stopProcess() {
         guard let process else { return }
         process.terminationHandler = nil
+        processStartedAt = nil
         (process.standardOutput as? Pipe)?.fileHandleForReading.readabilityHandler = nil
         process.terminate()
         // We reached this child ourselves, so no later run needs to hunt it.


### PR DESCRIPTION
Found in the dev app's log: two instances raced for the companion port, and the one that lost kept going. It logged `listener failed: Address already in use` and still spawned a tunnel pointed at a port it never answered on. The tunnel came up, announced a fresh public URL, and died seconds later — repeatedly. Eight public URLs in twenty-two seconds, each one breaking the QR an already-paired phone had scanned.

**The amplifier.** The retry cap that exists for this could not see it. `consecutiveFailures` reset the moment the child *printed* a URL, so every three-second cycle looked like a recovery and the count never reached its limit of five. Printing a URL is not proof a tunnel works — lasting is. The count now clears only after a run held for a minute, well clear of the three-second restart delay, so a relay hiccup on a long-lived tunnel still reads as a hiccup while a flap is counted and eventually gives up.

**The trigger.** Serving and publishing were separate decisions: `companion.start()` swallowed the bind failure and returned, and `TunnelManager.startIfEnabled()` ran regardless. `NWListener` does not recover from `.failed`, so the server now reports it through `onListenerFailed`, wired by `AppDelegate` where the start/stop wiring already lives, and the public URL goes down with the socket it was fronting.

The exit log gains the run's duration, since that is the number the policy now turns on. A force-unwrapped `NWEndpoint.Port` on the line being changed became a `guard`.

Not covered by a test: `TunnelManager` is a singleton with a private init that spawns a real child process, and the judgment being fixed is two lines inside a termination handler. Adding a seam for it would be more scaffolding than the logic is worth. Verified by build and the existing 542 tests; the two-instance race itself was not re-run because a second dev instance shares `~/.termio-dev/state.json` with the running one.

Release Notes:

- Fixed the public tunnel repeatedly restarting and issuing a new address when another copy of termio already held the companion port.