### PR TITLE
Localize the tunnel's failure messages

### DIFF
--- a/Sources/termio/Companion/TunnelManager.swift
+++ b/Sources/termio/Companion/TunnelManager.swift
@@ -295,7 +295,7 @@ final class TunnelManager: ObservableObject {
         // Say so plainly instead of failing deep in binary discovery on an
         // empty command.
         if provider == .custom, provider.spec == nil {
-            status = .failed("set a command and URL pattern for the custom relay")
+            status = .failed(localized("set a command and URL pattern for the custom relay"))
             return
         }
         // Reap any tunnel a prior run left behind. `stopProcess`'s SIGTERM (and
@@ -328,7 +328,8 @@ final class TunnelManager: ObservableObject {
                     binary = try await Self.install(target)
                 } catch {
                     if self.generation == epoch, self.provider == target {
-                        status = .failed("couldn’t install \(target.binaryName): \(error.localizedDescription)")
+                        status = .failed(localized(
+                            "couldn’t install \(target.binaryName): \(error.localizedDescription)"))
                     }
                     return
                 }
@@ -445,8 +446,8 @@ final class TunnelManager: ObservableObject {
                 // cap this replaced at least told the user it had given up; an
                 // indefinite "Starting tunnel…" would be the worse of the two.
                 if delay >= Self.quietRetryDelay {
-                    self.status = .failed(
-                        "\(provider.binaryName) keeps exiting — retrying every \(Int(delay))s")
+                    self.status = .failed(localized(
+                        "\(provider.binaryName) keeps exiting — retrying every \(Int(delay))s"))
                 } else {
                     self.status = .starting
                 }
@@ -486,7 +487,8 @@ final class TunnelManager: ObservableObject {
                 Self.rememberCustomTunnel(pid: process.processIdentifier, binary: binary.path)
             }
         } catch {
-            status = .failed("couldn’t launch \(provider.binaryName): \(error.localizedDescription)")
+            status = .failed(localized(
+                "couldn’t launch \(provider.binaryName): \(error.localizedDescription)"))
             return
         }
         self.process = process
@@ -497,7 +499,8 @@ final class TunnelManager: ObservableObject {
             Task { @MainActor in
                 guard let self, self.process === process, self.status == .starting else { return }
                 self.stopProcess()
-                self.status = .failed("\(provider.binaryName) didn’t come up — check the network and retry")
+                self.status = .failed(localized(
+                    "\(provider.binaryName) didn’t come up — check the network and retry"))
             }
         }
     }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6104,6 +6104,56 @@
           }
         }
       }
+    },
+    "set a command and URL pattern for the custom relay": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "为自定义中继设置命令和 URL 模式"
+          }
+        }
+      }
+    },
+    "couldn’t install %@: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法安装 %1$@：%2$@"
+          }
+        }
+      }
+    },
+    "couldn’t launch %@: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法启动 %1$@：%2$@"
+          }
+        }
+      }
+    },
+    "%@ didn’t come up — check the network and retry": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 未能启动——请检查网络后重试"
+          }
+        }
+      }
+    },
+    "%@ keeps exiting — retrying every %llds": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 反复退出——每 %2$lld 秒重试一次"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 	<string> Cost is estimated at API rates.</string>
 	<key>%@ and %@</key>
 	<string>%@ and %@</string>
+	<key>%@ didn’t come up — check the network and retry</key>
+	<string>%@ didn’t come up — check the network and retry</string>
 	<key>%@ is a dark theme in the %@ slot.</key>
 	<string>%@ is a dark theme in the %@ slot.</string>
 	<key>%@ is a light theme in the %@ slot.</key>
@@ -20,6 +22,8 @@
 	<string>%@ isn’t available on this device yet.</string>
 	<key>%@ isn’t on your PATH</key>
 	<string>%@ isn’t on your PATH</string>
+	<key>%@ keeps exiting — retrying every %llds</key>
+	<string>%@ keeps exiting — retrying every %llds</string>
 	<key>%@ opened %@</key>
 	<string>%@ opened %@</string>
 	<key>%@ tokens</key>
@@ -1190,6 +1194,10 @@
 	<string>agents</string>
 	<key>binary</key>
 	<string>binary</string>
+	<key>couldn’t install %@: %@</key>
+	<string>couldn’t install %@: %@</string>
+	<key>couldn’t launch %@: %@</key>
+	<string>couldn’t launch %@: %@</string>
 	<key>current</key>
 	<string>current</string>
 	<key>e.g. JetBrains Mono</key>
@@ -1210,6 +1218,8 @@
 	<string>optional</string>
 	<key>optional — ~/.ssh/id_ed25519</key>
 	<string>optional — ~/.ssh/id_ed25519</string>
+	<key>set a command and URL pattern for the custom relay</key>
+	<string>set a command and URL pattern for the custom relay</string>
 	<key>ssh unavailable</key>
 	<string>ssh unavailable</string>
 	<key>termio can teach the agents you run (Claude Code, Codex, …) a `termio sessions` command so they can see, drive, and read each other's sessions in a project.

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 	<string>费用按 API 价格估算。</string>
 	<key>%@ and %@</key>
 	<string>%1$@ 和 %2$@</string>
+	<key>%@ didn’t come up — check the network and retry</key>
+	<string>%@ 未能启动——请检查网络后重试</string>
 	<key>%@ is a dark theme in the %@ slot.</key>
 	<string>“%@”是深色主题，与“%@”插槽不匹配。</string>
 	<key>%@ is a light theme in the %@ slot.</key>
@@ -20,6 +22,8 @@
 	<string>%@ 暂不支持这台设备。</string>
 	<key>%@ isn’t on your PATH</key>
 	<string>%@ 不在 PATH 中</string>
+	<key>%@ keeps exiting — retrying every %llds</key>
+	<string>%1$@ 反复退出——每 %2$lld 秒重试一次</string>
 	<key>%@ opened %@</key>
 	<string>%1$@ 创建于 %2$@</string>
 	<key>%@ tokens</key>
@@ -1190,6 +1194,10 @@
 	<string>个 Agent</string>
 	<key>binary</key>
 	<string>二进制</string>
+	<key>couldn’t install %@: %@</key>
+	<string>无法安装 %1$@：%2$@</string>
+	<key>couldn’t launch %@: %@</key>
+	<string>无法启动 %1$@：%2$@</string>
 	<key>current</key>
 	<string>当前</string>
 	<key>e.g. JetBrains Mono</key>
@@ -1210,6 +1218,8 @@
 	<string>可选</string>
 	<key>optional — ~/.ssh/id_ed25519</key>
 	<string>可选 — ~/.ssh/id_ed25519</string>
+	<key>set a command and URL pattern for the custom relay</key>
+	<string>为自定义中继设置命令和 URL 模式</string>
 	<key>ssh unavailable</key>
 	<string>ssh 不可用</string>
 	<key>termio can teach the agents you run (Claude Code, Codex, …) a `termio sessions` command so they can see, drive, and read each other's sessions in a project.

--- a/Tests/termioTests/TunnelStatusLocalizationTests.swift
+++ b/Tests/termioTests/TunnelStatusLocalizationTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import termio
+
+/// That the tunnel's failure messages actually resolve to a translation.
+///
+/// `scripts/check-strings.sh` cannot answer this: it skips interpolated
+/// `localized("…")` calls, because the key they produce carries a format
+/// specifier whose type the scan can't infer from the text. So the one thing
+/// that can go wrong here — Swift generating `%lld` where the catalog says
+/// `%d`, or `%@` where it says `%1$@` — is exactly what nothing else checks,
+/// and it fails silently by falling back to English.
+///
+/// Each case rebuilds the interpolation the way `TunnelManager` writes it, then
+/// asks for zh-Hans explicitly. A mismatched key returns the English source
+/// instead, so the assertion is on the translation itself.
+final class TunnelStatusLocalizationTests: XCTestCase {
+    /// The `zh-Hans.lproj` inside the resource bundle, resolved as its own
+    /// bundle. `String(localized:locale:)` is not enough on its own: `locale`
+    /// steers how the interpolations are formatted, while the *table* still
+    /// comes from the bundle's own language resolution against the tester's
+    /// preferred languages — so on an English Mac it reads en.lproj and every
+    /// assertion here would pass against the English source it is meant to
+    /// catch.
+    private lazy var chineseBundle: Bundle? = {
+        Bundle.termioResources
+            .path(forResource: "zh-Hans", ofType: "lproj")
+            .flatMap(Bundle.init(path:))
+    }()
+
+    private func zh(_ key: String.LocalizationValue) throws -> String {
+        let bundle = try XCTUnwrap(chineseBundle, "zh-Hans.lproj is missing from the resource bundle")
+        return String(localized: key, bundle: bundle, locale: Locale(identifier: "zh-Hans"))
+    }
+
+    func testTheCustomRelayHintIsTranslated() throws {
+        XCTAssertEqual(
+            try zh("set a command and URL pattern for the custom relay"),
+            "为自定义中继设置命令和 URL 模式")
+    }
+
+    func testTheInstallFailureIsTranslated() throws {
+        let binary = "tunelo"
+        let reason = "network down"
+        XCTAssertEqual(
+            try zh("couldn’t install \(binary): \(reason)"),
+            "无法安装 tunelo：network down")
+    }
+
+    func testTheLaunchFailureIsTranslated() throws {
+        let binary = "cloudflared"
+        let reason = "permission denied"
+        XCTAssertEqual(
+            try zh("couldn’t launch \(binary): \(reason)"),
+            "无法启动 cloudflared：permission denied")
+    }
+
+    func testTheDidNotComeUpFailureIsTranslated() throws {
+        let binary = "ngrok"
+        XCTAssertEqual(
+            try zh("\(binary) didn’t come up — check the network and retry"),
+            "ngrok 未能启动——请检查网络后重试")
+    }
+
+    /// The one with a mixed `%@` + `%lld` key, which is the case most likely to
+    /// drift: an `Int` interpolation compiles to `%lld`, not `%d`.
+    func testTheRetryingFailureIsTranslated() throws {
+        let binary = "tunelo"
+        let delay = 48
+        XCTAssertEqual(
+            try zh("\(binary) keeps exiting — retrying every \(delay)s"),
+            "tunelo 反复退出——每 48 秒重试一次")
+    }
+}


### PR DESCRIPTION
The tunnel reports every failure as a `.failed` status whose payload is the sentence the Mobile pane prints, and all five were bare English literals while the pane around them has been translated since #224. #437 left them that way and called it three; it is five.

Each now goes through `localized()`, with keys and zh-Hans translations added to the catalog and the compiled `.lproj` output regenerated by `scripts/compile-strings.sh`. Vocabulary follows what the pane already uses — tunnel is 隧道, relay is 中继.

**`TunnelStatusLocalizationTests` covers what `check-strings.sh` says it cannot.** That script skips interpolated `localized("…")` calls because the key they produce carries a format specifier whose type it can't infer from the text. So a key saying `%d` where Swift emits `%lld` resolves to the English source and looks fine to anyone testing in English — the exact silent failure its own header warns about. The test resolves `zh-Hans.lproj` as its own bundle and asserts the Chinese, which is the only way that mismatch surfaces.

Resolving the bundle by hand is the point: `String(localized:locale:)` steers how interpolations are formatted, but the table still comes from the bundle's language resolution against the tester's preferred languages. Passing a locale alone read `en.lproj` on an English Mac, and all five assertions passed against the English source they exist to catch.

560 tests pass. The catalog edit is a pure addition — no reformatting, key order preserved.

Release Notes:

- The tunnel's error messages in Settings ▸ Mobile are now translated.