### PR TITLE
Rework Add SSH Host and handle a host that wants a password

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -914,6 +914,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 // The new session is selected in the store; surface the main
                 // window over Settings so the connection is immediately visible.
                 self.window.makeKeyAndOrderFront(nil)
+            },
+            onSetUpKey: { [weak self] host, publicKey in
+                guard let self else { return }
+                self.store.addKeyInstallSession(host: host, publicKey: publicKey)
+                // Same reason as above, and more so: this session opens on a
+                // password prompt waiting to be answered.
+                self.window.makeKeyAndOrderFront(nil)
             }
         ).frame(minWidth: 640, minHeight: 480))
         settingsWindow?.makeKeyAndOrderFront(nil)

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -491,6 +491,17 @@ struct Session: Identifiable, Hashable, Codable {
     /// filesystem, so an SSH terminal is a terminal, not a remote project.
     var sshHost: String?
 
+    /// The public key this session is installing on `sshHost` with `ssh-copy-id`,
+    /// set only by Settings ▸ Devices' Set Up Key action. It rides in the PTY
+    /// precisely because the far side will ask for a password: the user types it
+    /// once, into a real terminal, and termio neither sees nor stores it.
+    ///
+    /// Deliberately outside `CodingKeys`, so it never survives a relaunch. The
+    /// command is a one-shot; restoring it would re-run an install the user
+    /// already completed and ask for that password again. A restored session
+    /// opens the plain `ssh` shell its `sshHost` describes.
+    var sshKeyToInstall: String?
+
     var isSSH: Bool { sshHost != nil }
 
     /// When set, this session runs **inside a `termiod` daemon on an SSH host**

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6195,16 +6195,6 @@
         }
       }
     },
-    "This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "这台主机接受密码登录。Termio 用密钥登录，而 ~/.ssh 里还没有密钥——先用 ssh-keygen 生成一个，再回到这里设置。"
-          }
-        }
-      }
-    },
     "A name can’t contain spaces — it’s what you type after `ssh`.": {
       "localizations": {
         "zh-Hans": {
@@ -6321,6 +6311,36 @@
           "stringUnit": {
             "state": "translated",
             "value": "密钥是到处都能用的凭据，包括跑在那台机器上的会话。密码保存在你的钥匙串里，不会写进 ssh 配置，只在 ssh 需要时才被读取。"
+          }
+        }
+      }
+    },
+    "A line break can’t be written to ssh config.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh 配置无法写入换行。"
+          }
+        }
+      }
+    },
+    "A password can’t contain a line break.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "密码不能包含换行。"
+          }
+        }
+      }
+    },
+    "This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这台主机接受密码登录。Termio 用密钥登录，而 ~/.ssh 里没有 ssh 会自动尝试的密钥——先用 ssh-keygen 生成一个，再回到这里设置。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6154,6 +6154,116 @@
           }
         }
       }
+    },
+    "Set Up Key…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置密钥…"
+          }
+        }
+      }
+    },
+    "Set Up Key": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置密钥"
+          }
+        }
+      }
+    },
+    "Wants a password": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要密码"
+          }
+        }
+      }
+    },
+    "This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这台主机接受密码登录。Termio 用密钥登录，设置一次之后，会话、文件树和远程终端都能连上它。"
+          }
+        }
+      }
+    },
+    "This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这台主机接受密码登录。Termio 用密钥登录，而 ~/.ssh 里还没有密钥——先用 ssh-keygen 生成一个，再回到这里设置。"
+          }
+        }
+      }
+    },
+    "Sign in as": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录身份"
+          }
+        }
+      }
+    },
+    "Other…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其他…"
+          }
+        }
+      }
+    },
+    "Advanced": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高级"
+          }
+        }
+      }
+    },
+    "A name can’t contain spaces — it’s what you type after `ssh`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称不能包含空格——它就是你在 `ssh` 后面输入的内容。"
+          }
+        }
+      }
+    },
+    "A port is a number from 1 to 65535.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "端口是 1 到 65535 之间的数字。"
+          }
+        }
+      }
+    },
+    "A double quote can’t be written to ssh config.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh 配置无法写入双引号。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6205,16 +6205,6 @@
         }
       }
     },
-    "Advanced": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "高级"
-          }
-        }
-      }
-    },
     "A name can’t contain spaces — it’s what you type after `ssh`.": {
       "localizations": {
         "zh-Hans": {
@@ -6271,6 +6261,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 ~/.ssh/config 中添加一个 Host 配置块。"
+          }
+        }
+      }
+    },
+    "Credentials": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录凭据"
+          }
+        }
+      }
+    },
+    "Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termio 用密钥登录——ssh 配置里没有存放密码的地方。只接受密码的主机仍然可以在终端里打开，设备列表会提示把你的密钥装上去。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6205,26 +6205,6 @@
         }
       }
     },
-    "Sign in as": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "登录身份"
-          }
-        }
-      }
-    },
-    "Other…": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "其他…"
-          }
-        }
-      }
-    },
     "Advanced": {
       "localizations": {
         "zh-Hans": {
@@ -6261,6 +6241,36 @@
           "stringUnit": {
             "state": "translated",
             "value": "ssh 配置无法写入双引号。"
+          }
+        }
+      }
+    },
+    "Key": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "密钥"
+          }
+        }
+      }
+    },
+    "Default keys": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认密钥"
+          }
+        }
+      }
+    },
+    "Adds a Host block to ~/.ssh/config.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 ~/.ssh/config 中添加一个 Host 配置块。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6275,12 +6275,52 @@
         }
       }
     },
-    "Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it.": {
+    "Password": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Termio 用密钥登录——ssh 配置里没有存放密码的地方。只接受密码的主机仍然可以在终端里打开，设备列表会提示把你的密钥装上去。"
+            "value": "密码"
+          }
+        }
+      }
+    },
+    "Show": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示"
+          }
+        }
+      }
+    },
+    "Hide": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏"
+          }
+        }
+      }
+    },
+    "Couldn’t save the password to your Keychain.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法把密码保存到钥匙串。"
+          }
+        }
+      }
+    },
+    "A key is the credential that works everywhere, including sessions running on the box. A password is saved to your Keychain, never to ssh config, and only ever read when ssh asks for it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "密钥是到处都能用的凭据，包括跑在那台机器上的会话。密码保存在你的钥匙串里，不会写进 ssh 配置，只在 ssh 需要时才被读取。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -92,6 +92,8 @@
 	<string>Add to Chat</string>
 	<key>Address</key>
 	<string>Address</string>
+	<key>Adds a Host block to ~/.ssh/config.</key>
+	<string>Adds a Host block to ~/.ssh/config.</string>
 	<key>Advanced</key>
 	<string>Advanced</string>
 	<key>Agent</key>
@@ -362,6 +364,8 @@
 	<string>Default Light Theme</string>
 	<key>Default agent</key>
 	<string>Default agent</string>
+	<key>Default keys</key>
+	<string>Default keys</string>
 	<key>Delete</key>
 	<string>Delete</string>
 	<key>Delete %@?</key>
@@ -520,6 +524,8 @@
 	<string>Join</string>
 	<key>Jump to session, project, or file…</key>
 	<string>Jump to session, project, or file…</string>
+	<key>Key</key>
+	<string>Key</string>
 	<key>Key file</key>
 	<string>Key file</string>
 	<key>Keyboard</key>
@@ -762,8 +768,6 @@
 	<string>Open the invite on your iPhone to install it with TestFlight.</string>
 	<key>Opened outside Termio on this device</key>
 	<string>Opened outside Termio on this device</string>
-	<key>Other…</key>
-	<string>Other…</string>
 	<key>Padding: %lld pt</key>
 	<string>Padding: %lld pt</string>
 	<key>Pair your iPhone and remote access</key>
@@ -964,8 +968,6 @@
 	<string>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse. Installs Termio’s hooks into each agent’s config.</string>
 	<key>Sidebar</key>
 	<string>Sidebar</string>
-	<key>Sign in as</key>
-	<string>Sign in as</string>
 	<key>Size: %lld pt</key>
 	<string>Size: %lld pt</string>
 	<key>Skill reinstalled</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -66,6 +66,12 @@
 	<string>1 result</string>
 	<key>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</key>
 	<string>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</string>
+	<key>A double quote can’t be written to ssh config.</key>
+	<string>A double quote can’t be written to ssh config.</string>
+	<key>A name can’t contain spaces — it’s what you type after `ssh`.</key>
+	<string>A name can’t contain spaces — it’s what you type after `ssh`.</string>
+	<key>A port is a number from 1 to 65535.</key>
+	<string>A port is a number from 1 to 65535.</string>
 	<key>A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to.</key>
 	<string>A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to.</string>
 	<key>Activity</key>
@@ -86,6 +92,8 @@
 	<string>Add to Chat</string>
 	<key>Address</key>
 	<string>Address</string>
+	<key>Advanced</key>
+	<string>Advanced</string>
 	<key>Agent</key>
 	<string>Agent</string>
 	<key>Agent skill</key>
@@ -754,6 +762,8 @@
 	<string>Open the invite on your iPhone to install it with TestFlight.</string>
 	<key>Opened outside Termio on this device</key>
 	<string>Opened outside Termio on this device</string>
+	<key>Other…</key>
+	<string>Other…</string>
 	<key>Padding: %lld pt</key>
 	<string>Padding: %lld pt</string>
 	<key>Pair your iPhone and remote access</key>
@@ -934,6 +944,10 @@
 	<string>Session control</string>
 	<key>Sessions</key>
 	<string>Sessions</string>
+	<key>Set Up Key</key>
+	<string>Set Up Key</string>
+	<key>Set Up Key…</key>
+	<string>Set Up Key…</string>
 	<key>Settings</key>
 	<string>Settings</string>
 	<key>Settings…</key>
@@ -950,6 +964,8 @@
 	<string>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse. Installs Termio’s hooks into each agent’s config.</string>
 	<key>Sidebar</key>
 	<string>Sidebar</string>
+	<key>Sign in as</key>
+	<string>Sign in as</string>
 	<key>Size: %lld pt</key>
 	<string>Size: %lld pt</string>
 	<key>Skill reinstalled</key>
@@ -1090,6 +1106,10 @@
 	<string>This file is binary — open it on GitHub to view.</string>
 	<key>This folder has no git “origin” remote to clone.</key>
 	<string>This folder has no git “origin” remote to clone.</string>
+	<key>This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.</key>
+	<string>This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.</string>
+	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>
+	<string>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</string>
 	<key>This machine’s termiod is too old to list folders.</key>
 	<string>This machine’s termiod is too old to list folders.</string>
 	<key>This month</key>
@@ -1154,6 +1174,8 @@
 	<string>View on %@</string>
 	<key>Waiting for the agent’s first status report.</key>
 	<string>Waiting for the agent’s first status report.</string>
+	<key>Wants a password</key>
+	<string>Wants a password</string>
 	<key>WeChat</key>
 	<string>WeChat</string>
 	<key>WeChat group</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -68,6 +68,8 @@
 	<string>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</string>
 	<key>A double quote can’t be written to ssh config.</key>
 	<string>A double quote can’t be written to ssh config.</string>
+	<key>A key is the credential that works everywhere, including sessions running on the box. A password is saved to your Keychain, never to ssh config, and only ever read when ssh asks for it.</key>
+	<string>A key is the credential that works everywhere, including sessions running on the box. A password is saved to your Keychain, never to ssh config, and only ever read when ssh asks for it.</string>
 	<key>A name can’t contain spaces — it’s what you type after `ssh`.</key>
 	<string>A name can’t contain spaces — it’s what you type after `ssh`.</string>
 	<key>A port is a number from 1 to 65535.</key>
@@ -332,6 +334,8 @@
 	<string>Couldn’t remove %@.</string>
 	<key>Couldn’t remove worktree</key>
 	<string>Couldn’t remove worktree</string>
+	<key>Couldn’t save the password to your Keychain.</key>
+	<string>Couldn’t save the password to your Keychain.</string>
 	<key>Couldn’t update %@.</key>
 	<string>Couldn’t update %@.</string>
 	<key>Couldn’t update .gitignore</key>
@@ -474,6 +478,8 @@
 	<string>Grant Org Access…</string>
 	<key>Group with</key>
 	<string>Group with</string>
+	<key>Hide</key>
+	<string>Hide</string>
 	<key>Hide or show the inspector</key>
 	<string>Hide or show the inspector</string>
 	<key>Hide or show the navigator</key>
@@ -774,6 +780,8 @@
 	<string>Pair your iPhone and remote access</string>
 	<key>Panes</key>
 	<string>Panes</string>
+	<key>Password</key>
+	<string>Password</string>
 	<key>Paste</key>
 	<string>Paste</string>
 	<key>Permissions</key>
@@ -958,6 +966,8 @@
 	<string>Settings…</string>
 	<key>Shortcuts must include ⌘ so they can’t shadow a key an agent or the shell needs. While recording, press ⌫ to remove a shortcut, or esc to cancel.</key>
 	<string>Shortcuts must include ⌘ so they can’t shadow a key an agent or the shell needs. While recording, press ⌫ to remove a shortcut, or esc to cancel.</string>
+	<key>Show</key>
+	<string>Show</string>
 	<key>Show Original</key>
 	<string>Show Original</string>
 	<key>Show Project Files</key>
@@ -1038,8 +1048,6 @@
 	<string>Termio for iPhone is in beta</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio is open source — star the repo, report bugs, and request features.</string>
-	<key>Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it.</key>
-	<string>Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it.</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Fifty schemes are built in, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Fifty schemes are built in, and any Ghostty-format file you drop into the Themes folder shows up here too.</string>
 	<key>Test</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -70,8 +70,12 @@
 	<string>A double quote can’t be written to ssh config.</string>
 	<key>A key is the credential that works everywhere, including sessions running on the box. A password is saved to your Keychain, never to ssh config, and only ever read when ssh asks for it.</key>
 	<string>A key is the credential that works everywhere, including sessions running on the box. A password is saved to your Keychain, never to ssh config, and only ever read when ssh asks for it.</string>
+	<key>A line break can’t be written to ssh config.</key>
+	<string>A line break can’t be written to ssh config.</string>
 	<key>A name can’t contain spaces — it’s what you type after `ssh`.</key>
 	<string>A name can’t contain spaces — it’s what you type after `ssh`.</string>
+	<key>A password can’t contain a line break.</key>
+	<string>A password can’t contain a line break.</string>
 	<key>A port is a number from 1 to 65535.</key>
 	<string>A port is a number from 1 to 65535.</string>
 	<key>A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to.</key>
@@ -1118,8 +1122,8 @@
 	<string>This file is binary — open it on GitHub to view.</string>
 	<key>This folder has no git “origin” remote to clone.</key>
 	<string>This folder has no git “origin” remote to clone.</string>
-	<key>This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.</key>
-	<string>This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.</string>
+	<key>This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.</key>
+	<string>This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.</string>
 	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>
 	<string>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</string>
 	<key>This machine’s termiod is too old to list folders.</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -94,8 +94,6 @@
 	<string>Address</string>
 	<key>Adds a Host block to ~/.ssh/config.</key>
 	<string>Adds a Host block to ~/.ssh/config.</string>
-	<key>Advanced</key>
-	<string>Advanced</string>
 	<key>Agent</key>
 	<string>Agent</string>
 	<key>Agent skill</key>
@@ -342,6 +340,8 @@
 	<string>Couldn’t write ~/.ssh/config: %@</string>
 	<key>Create</key>
 	<string>Create</string>
+	<key>Credentials</key>
+	<string>Credentials</string>
 	<key>Current workspace</key>
 	<string>Current workspace</string>
 	<key>Cursor</key>
@@ -1038,6 +1038,8 @@
 	<string>Termio for iPhone is in beta</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio is open source — star the repo, report bugs, and request features.</string>
+	<key>Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it.</key>
+	<string>Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it.</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Fifty schemes are built in, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Fifty schemes are built in, and any Ghostty-format file you drop into the Themes folder shows up here too.</string>
 	<key>Test</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -92,6 +92,8 @@
 	<string>添加到聊天</string>
 	<key>Address</key>
 	<string>地址</string>
+	<key>Adds a Host block to ~/.ssh/config.</key>
+	<string>在 ~/.ssh/config 中添加一个 Host 配置块。</string>
 	<key>Advanced</key>
 	<string>高级</string>
 	<key>Agent</key>
@@ -362,6 +364,8 @@
 	<string>默认浅色主题</string>
 	<key>Default agent</key>
 	<string>默认 Agent</string>
+	<key>Default keys</key>
+	<string>默认密钥</string>
 	<key>Delete</key>
 	<string>删除</string>
 	<key>Delete %@?</key>
@@ -520,6 +524,8 @@
 	<string>加入</string>
 	<key>Jump to session, project, or file…</key>
 	<string>跳转到会话、项目或文件…</string>
+	<key>Key</key>
+	<string>密钥</string>
 	<key>Key file</key>
 	<string>密钥文件</string>
 	<key>Keyboard</key>
@@ -762,8 +768,6 @@
 	<string>在 iPhone 上打开邀请链接，用 TestFlight 安装。</string>
 	<key>Opened outside Termio on this device</key>
 	<string>在这台设备上由 Termio 之外打开</string>
-	<key>Other…</key>
-	<string>其他…</string>
 	<key>Padding: %lld pt</key>
 	<string>边距：%lld 点</string>
 	<key>Pair your iPhone and remote access</key>
@@ -964,8 +968,6 @@
 	<string>显示 Agent 正在工作还是在等待你：侧栏的转圈指示和菜单栏的脉冲。会将 Termio 的 hooks 安装到各 Agent 的配置中。</string>
 	<key>Sidebar</key>
 	<string>侧栏</string>
-	<key>Sign in as</key>
-	<string>登录身份</string>
 	<key>Size: %lld pt</key>
 	<string>大小：%lld 磅</string>
 	<key>Skill reinstalled</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -94,8 +94,6 @@
 	<string>地址</string>
 	<key>Adds a Host block to ~/.ssh/config.</key>
 	<string>在 ~/.ssh/config 中添加一个 Host 配置块。</string>
-	<key>Advanced</key>
-	<string>高级</string>
 	<key>Agent</key>
 	<string>Agent</string>
 	<key>Agent skill</key>
@@ -342,6 +340,8 @@
 	<string>无法写入 ~/.ssh/config：%@</string>
 	<key>Create</key>
 	<string>创建</string>
+	<key>Credentials</key>
+	<string>登录凭据</string>
 	<key>Current workspace</key>
 	<string>当前工作区</string>
 	<key>Cursor</key>
@@ -1038,6 +1038,8 @@
 	<string>Termio for iPhone 正在测试中</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio 是开源软件：欢迎给仓库加星标、报告 bug 和提出功能请求。</string>
+	<key>Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it.</key>
+	<string>Termio 用密钥登录——ssh 配置里没有存放密码的地方。只接受密码的主机仍然可以在终端里打开，设备列表会提示把你的密钥装上去。</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Fifty schemes are built in, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio 会随 macOS 外观变化在两者间切换；将槽位留在默认值即可使用 Termio 自带的画布。内置 50 个精选配色，你放进主题文件夹的 Ghostty 格式文件也会出现在这里。</string>
 	<key>Test</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -70,8 +70,12 @@
 	<string>ssh 配置无法写入双引号。</string>
 	<key>A key is the credential that works everywhere, including sessions running on the box. A password is saved to your Keychain, never to ssh config, and only ever read when ssh asks for it.</key>
 	<string>密钥是到处都能用的凭据，包括跑在那台机器上的会话。密码保存在你的钥匙串里，不会写进 ssh 配置，只在 ssh 需要时才被读取。</string>
+	<key>A line break can’t be written to ssh config.</key>
+	<string>ssh 配置无法写入换行。</string>
 	<key>A name can’t contain spaces — it’s what you type after `ssh`.</key>
 	<string>名称不能包含空格——它就是你在 `ssh` 后面输入的内容。</string>
+	<key>A password can’t contain a line break.</key>
+	<string>密码不能包含换行。</string>
 	<key>A port is a number from 1 to 65535.</key>
 	<string>端口是 1 到 65535 之间的数字。</string>
 	<key>A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to.</key>
@@ -1118,8 +1122,8 @@
 	<string>此文件为二进制文件，请在 GitHub 上打开查看。</string>
 	<key>This folder has no git “origin” remote to clone.</key>
 	<string>这个文件夹没有 git “origin” 远程，无法克隆。</string>
-	<key>This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.</key>
-	<string>这台主机接受密码登录。Termio 用密钥登录，而 ~/.ssh 里还没有密钥——先用 ssh-keygen 生成一个，再回到这里设置。</string>
+	<key>This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.</key>
+	<string>这台主机接受密码登录。Termio 用密钥登录，而 ~/.ssh 里没有 ssh 会自动尝试的密钥——先用 ssh-keygen 生成一个，再回到这里设置。</string>
 	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>
 	<string>这台主机接受密码登录。Termio 用密钥登录，设置一次之后，会话、文件树和远程终端都能连上它。</string>
 	<key>This machine’s termiod is too old to list folders.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -66,6 +66,12 @@
 	<string>1 个结果</string>
 	<key>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</key>
 	<string>另一个 `%@` 已存在于 %@。请先移除，Termio 不会覆盖并非自己创建的文件。</string>
+	<key>A double quote can’t be written to ssh config.</key>
+	<string>ssh 配置无法写入双引号。</string>
+	<key>A name can’t contain spaces — it’s what you type after `ssh`.</key>
+	<string>名称不能包含空格——它就是你在 `ssh` 后面输入的内容。</string>
+	<key>A port is a number from 1 to 65535.</key>
+	<string>端口是 1 到 65535 之间的数字。</string>
 	<key>A workspace scopes the sidebar to the projects and sessions filed under it, on the machine it belongs to.</key>
 	<string>工作区把侧栏限定在归入它的项目和会话上，都在它所属的那台机器上。</string>
 	<key>Activity</key>
@@ -86,6 +92,8 @@
 	<string>添加到聊天</string>
 	<key>Address</key>
 	<string>地址</string>
+	<key>Advanced</key>
+	<string>高级</string>
 	<key>Agent</key>
 	<string>Agent</string>
 	<key>Agent skill</key>
@@ -754,6 +762,8 @@
 	<string>在 iPhone 上打开邀请链接，用 TestFlight 安装。</string>
 	<key>Opened outside Termio on this device</key>
 	<string>在这台设备上由 Termio 之外打开</string>
+	<key>Other…</key>
+	<string>其他…</string>
 	<key>Padding: %lld pt</key>
 	<string>边距：%lld 点</string>
 	<key>Pair your iPhone and remote access</key>
@@ -934,6 +944,10 @@
 	<string>会话控制</string>
 	<key>Sessions</key>
 	<string>会话</string>
+	<key>Set Up Key</key>
+	<string>设置密钥</string>
+	<key>Set Up Key…</key>
+	<string>设置密钥…</string>
 	<key>Settings</key>
 	<string>设置</string>
 	<key>Settings…</key>
@@ -950,6 +964,8 @@
 	<string>显示 Agent 正在工作还是在等待你：侧栏的转圈指示和菜单栏的脉冲。会将 Termio 的 hooks 安装到各 Agent 的配置中。</string>
 	<key>Sidebar</key>
 	<string>侧栏</string>
+	<key>Sign in as</key>
+	<string>登录身份</string>
 	<key>Size: %lld pt</key>
 	<string>大小：%lld 磅</string>
 	<key>Skill reinstalled</key>
@@ -1090,6 +1106,10 @@
 	<string>此文件为二进制文件，请在 GitHub 上打开查看。</string>
 	<key>This folder has no git “origin” remote to clone.</key>
 	<string>这个文件夹没有 git “origin” 远程，无法克隆。</string>
+	<key>This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.</key>
+	<string>这台主机接受密码登录。Termio 用密钥登录，而 ~/.ssh 里还没有密钥——先用 ssh-keygen 生成一个，再回到这里设置。</string>
+	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>
+	<string>这台主机接受密码登录。Termio 用密钥登录，设置一次之后，会话、文件树和远程终端都能连上它。</string>
 	<key>This machine’s termiod is too old to list folders.</key>
 	<string>这台机器上的 termiod 版本太旧，列不出文件夹。</string>
 	<key>This month</key>
@@ -1154,6 +1174,8 @@
 	<string>在 %@ 上查看</string>
 	<key>Waiting for the agent’s first status report.</key>
 	<string>正在等待 Agent 的首次状态报告。</string>
+	<key>Wants a password</key>
+	<string>需要密码</string>
 	<key>WeChat</key>
 	<string>微信</string>
 	<key>WeChat group</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -68,6 +68,8 @@
 	<string>另一个 `%@` 已存在于 %@。请先移除，Termio 不会覆盖并非自己创建的文件。</string>
 	<key>A double quote can’t be written to ssh config.</key>
 	<string>ssh 配置无法写入双引号。</string>
+	<key>A key is the credential that works everywhere, including sessions running on the box. A password is saved to your Keychain, never to ssh config, and only ever read when ssh asks for it.</key>
+	<string>密钥是到处都能用的凭据，包括跑在那台机器上的会话。密码保存在你的钥匙串里，不会写进 ssh 配置，只在 ssh 需要时才被读取。</string>
 	<key>A name can’t contain spaces — it’s what you type after `ssh`.</key>
 	<string>名称不能包含空格——它就是你在 `ssh` 后面输入的内容。</string>
 	<key>A port is a number from 1 to 65535.</key>
@@ -332,6 +334,8 @@
 	<string>无法移除 %@。</string>
 	<key>Couldn’t remove worktree</key>
 	<string>无法移除 worktree</string>
+	<key>Couldn’t save the password to your Keychain.</key>
+	<string>无法把密码保存到钥匙串。</string>
 	<key>Couldn’t update %@.</key>
 	<string>无法更新 %@。</string>
 	<key>Couldn’t update .gitignore</key>
@@ -474,6 +478,8 @@
 	<string>授予组织访问权限…</string>
 	<key>Group with</key>
 	<string>编组到</string>
+	<key>Hide</key>
+	<string>隐藏</string>
 	<key>Hide or show the inspector</key>
 	<string>隐藏或显示检查器</string>
 	<key>Hide or show the navigator</key>
@@ -774,6 +780,8 @@
 	<string>配对 iPhone 与远程访问</string>
 	<key>Panes</key>
 	<string>窗格</string>
+	<key>Password</key>
+	<string>密码</string>
 	<key>Paste</key>
 	<string>粘贴</string>
 	<key>Permissions</key>
@@ -958,6 +966,8 @@
 	<string>设置…</string>
 	<key>Shortcuts must include ⌘ so they can’t shadow a key an agent or the shell needs. While recording, press ⌫ to remove a shortcut, or esc to cancel.</key>
 	<string>快捷键必须包含 ⌘，以免遮蔽 Agent 或 shell 所需的按键。录制时按 ⌫ 可移除快捷键，按 esc 取消。</string>
+	<key>Show</key>
+	<string>显示</string>
 	<key>Show Original</key>
 	<string>显示原身</string>
 	<key>Show Project Files</key>
@@ -1038,8 +1048,6 @@
 	<string>Termio for iPhone 正在测试中</string>
 	<key>Termio is open source — star the repo, report bugs, and request features.</key>
 	<string>Termio 是开源软件：欢迎给仓库加星标、报告 bug 和提出功能请求。</string>
-	<key>Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it.</key>
-	<string>Termio 用密钥登录——ssh 配置里没有存放密码的地方。只接受密码的主机仍然可以在终端里打开，设备列表会提示把你的密钥装上去。</string>
 	<key>Termio switches between these as macOS changes appearance; leave a slot on the default for Termio’s own canvas. Fifty schemes are built in, and any Ghostty-format file you drop into the Themes folder shows up here too.</key>
 	<string>Termio 会随 macOS 外观变化在两者间切换；将槽位留在默认值即可使用 Termio 自带的画布。内置 50 个精选配色，你放进主题文件夹的 Ghostty 格式文件也会出现在这里。</string>
 	<key>Test</key>

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -10,6 +10,9 @@ struct DevicesSettingsTab: View {
     /// Opens an SSH terminal to the alias in the main window (wired to
     /// `TermioStore.addSSHSession` by the app delegate).
     let onConnect: (String) -> Void
+    /// Runs `ssh-copy-id <alias>` with a public key, for a host whose probe found
+    /// it wants a password (wired to `TermioStore.addKeyInstallSession`).
+    let onSetUpKey: (String, String) -> Void
 
     @State private var hosts: [SSHConfigHost] = []
     @State private var publicKeys: [SSHPublicKey] = []
@@ -74,7 +77,9 @@ struct DevicesSettingsTab: View {
             ForEach(hosts) { host in
                 SSHHostRow(
                     host: host,
+                    keyToInstall: SSHConfigFile.publicKeyToInstall(for: host, keys: publicKeys),
                     connect: { onConnect(host.alias) },
+                    setUpKey: { onSetUpKey(host.alias, $0.url.path) },
                     editInConfig: { presentEditor(for: host) }
                 )
             }
@@ -171,7 +176,11 @@ struct DevicesSettingsTab: View {
 /// hosts.
 private struct SSHHostRow: View {
     let host: SSHConfigHost
+    /// The key an install would put on this host, or nil when there is none to
+    /// send — which is what decides whether the password advice can offer a fix.
+    let keyToInstall: SSHPublicKey?
     let connect: () -> Void
+    let setUpKey: (SSHPublicKey) -> Void
     let editInConfig: () -> Void
 
     private enum ProbeState { case idle, running, result(SSHProbeResult) }
@@ -186,29 +195,59 @@ private struct SSHHostRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 10) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(host.alias).font(.headline)
-                Text(subtitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .help(host.identityFile.map { localized("Uses \($0)") } ?? "")
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(host.alias).font(.headline)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .help(host.identityFile.map { localized("Uses \($0)") } ?? "")
+                }
+                Spacer(minLength: 8)
+                probeControl
             }
-            Spacer(minLength: 8)
-            probeControl
+            if case .result(.wantsPassword) = probe { passwordAdvice }
         }
         .contentShape(Rectangle())
         .contextMenu {
             Button(localized("Connect"), action: connect)
             Button(localized("Test Connection"), action: runProbe)
+            if let keyToInstall {
+                Button(localized("Set Up Key…")) { setUpKey(keyToInstall) }
+            }
             Button(localized("Edit in Config"), action: editInConfig)
             Button(localized("Copy ssh Command")) {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString("ssh \(host.alias)", forType: .string)
             }
         }
+    }
+
+    /// The one probe outcome with a fix worth offering in place. A password is a
+    /// dead end for everything but the plain shell — the daemon connections that
+    /// carry sessions and the file tree set `BatchMode=yes` and can never answer a
+    /// prompt — so the row says that plainly and offers the install that ends it.
+    @ViewBuilder
+    private var passwordAdvice: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(keyToInstall == nil
+                 ? localized("This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.")
+                 : localized("This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 8)
+            if let keyToInstall {
+                Button(localized("Set Up Key…")) { setUpKey(keyToInstall) }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .help(localized("Runs ssh-copy-id with \(keyToInstall.name) in a terminal — the host asks for your password once, there."))
+            }
+        }
+        .padding(.top, 2)
     }
 
     /// The trailing control: a Test button that turns into a spinner while the
@@ -253,6 +292,7 @@ private extension SSHProbeResult {
     var label: String {
         switch self {
         case .reachable: return localized("Reachable")
+        case .wantsPassword: return localized("Wants a password")
         case .authFailed: return localized("Auth failed")
         case .unreachable(let reason): return reason
         }
@@ -261,7 +301,7 @@ private extension SSHProbeResult {
     var tint: Color {
         switch self {
         case .reachable: return .green
-        case .authFailed: return .orange
+        case .wantsPassword, .authFailed: return .orange
         case .unreachable: return .red
         }
     }
@@ -269,15 +309,26 @@ private extension SSHProbeResult {
     var detail: String {
         switch self {
         case .reachable: return localized("Connected and authenticated")
-        case .authFailed(let message), .unreachable(let message): return message
+        case .wantsPassword(let message), .authFailed(let message),
+             .unreachable(let message):
+            return message
         }
     }
 }
 
-/// The Add Host sheet: the four fields a `Host` block actually needs, appended
-/// to `~/.ssh/config` as a block indistinguishable from a hand-written one.
-/// Shared by Settings ▸ Devices' Add Host button and the New SSH Connection ▸
-/// Add Host… menu row (which connects to the host right after adding it).
+/// The Add Host sheet, appending a `Host` block to `~/.ssh/config` that is
+/// indistinguishable from a hand-written one. Shared by Settings ▸ Devices' Add
+/// Host button and the New SSH Connection ▸ Add Host… menu row (which connects
+/// to the host right after adding it).
+///
+/// The address leads and everything else follows from it: `you@box.example.com:2222`
+/// fills the user and port, and the name is the address's first label until the
+/// user types their own. What remains is the pair that decides whether the host
+/// will actually let you in — offered as one "Sign in as" row built from the
+/// identities the config already uses, because a machine you add is almost always
+/// reached as the same person with the same key as the last one. Port and an
+/// explicit key stay behind Advanced: they are the exception, and a form that
+/// shows every exception at once reads as five equally likely questions.
 struct AddSSHHostSheet: View {
     let existingAliases: Set<String>
     /// When set (the AppKit-presented menu path), called with the added alias —
@@ -286,54 +337,113 @@ struct AddSSHHostSheet: View {
     var completion: ((String?) -> Void)?
     @Environment(\.dismiss) private var dismiss
 
-    @State private var alias = ""
-    @State private var hostName = ""
+    @State private var address = ""
+    /// Empty until the user types a name of their own; until then the field shows
+    /// (and Add uses) the one derived from the address.
+    @State private var typedAlias = ""
+    @State private var identity: IdentityChoice = .other
     @State private var user = ""
     @State private var port = ""
     @State private var identityFile = ""
+    @State private var advancedExpanded = false
     @State private var writeError: String?
+    /// Read once, on appear: the sheet is modal, so the config cannot change under
+    /// it, and re-deriving per keystroke would re-read every file `Include` pulls in.
+    @State private var suggestions: [SSHIdentity] = []
 
-    private var trimmedAlias: String { alias.trimmingCharacters(in: .whitespaces) }
-    private var aliasTaken: Bool { existingAliases.contains(trimmedAlias) }
+    /// Which credentials the new block will carry: one the config already uses, or
+    /// the fields under Advanced.
+    private enum IdentityChoice: Hashable {
+        case suggested(SSHIdentity)
+        case other
+    }
+
+    private var parsedAddress: (user: String, host: String, port: String) {
+        SSHConfigFile.parseDestination(address)
+    }
+
+    private var derivedAlias: String {
+        SSHConfigFile.suggestedAlias(forHost: parsedAddress.host, avoiding: existingAliases)
+    }
+
+    private var effectiveAlias: String {
+        typedAlias.isEmpty ? derivedAlias : typedAlias.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// The address's own user/port win over the picked identity and the Advanced
+    /// field: they were typed later, and typing them is a correction.
+    private var effectiveUser: String {
+        if !parsedAddress.user.isEmpty { return parsedAddress.user }
+        if case .suggested(let suggestion) = identity { return suggestion.user }
+        return user.trimmingCharacters(in: .whitespaces)
+    }
+
+    private var effectivePort: String {
+        parsedAddress.port.isEmpty ? port.trimmingCharacters(in: .whitespaces) : parsedAddress.port
+    }
+
+    private var effectiveIdentityFile: String {
+        if case .suggested(let suggestion) = identity { return suggestion.identityFile ?? "" }
+        return identityFile.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// The first thing standing between the sheet and a working Add, or nil when
+    /// nothing is. Shown in place rather than left to a greyed-out button, which
+    /// states the problem exists without saying what it is.
+    private var validationMessage: String? {
+        if parsedAddress.host.isEmpty { return nil }
+        if effectiveAlias.contains(" ") {
+            return localized("A name can’t contain spaces — it’s what you type after `ssh`.")
+        }
+        if existingAliases.contains(effectiveAlias) {
+            return localized("“\(effectiveAlias)” is already in your config.")
+        }
+        if !effectivePort.isEmpty, Int(effectivePort).map({ (1...65535).contains($0) }) != true {
+            return localized("A port is a number from 1 to 65535.")
+        }
+        // ssh_config has no escape for a literal double quote — such values can't
+        // be written faithfully, so refuse rather than corrupt the file.
+        let values = [effectiveAlias, parsedAddress.host, effectiveUser, effectiveIdentityFile]
+        if values.contains(where: { $0.contains("\"") }) {
+            return localized("A double quote can’t be written to ssh config.")
+        }
+        return nil
+    }
+
     private var canAdd: Bool {
-        !trimmedAlias.isEmpty && !trimmedAlias.contains(" ")
-            && !hostName.trimmingCharacters(in: .whitespaces).isEmpty
-            && !aliasTaken
-            && (port.isEmpty || Int(port).map { (1...65535).contains($0) } == true)
-            // ssh_config has no escape for a literal double quote — such values
-            // can't be written faithfully, so refuse rather than corrupt.
-            && ![alias, hostName, user, identityFile].contains(where: { $0.contains("\"") })
+        !parsedAddress.host.isEmpty && !effectiveAlias.isEmpty && validationMessage == nil
     }
 
     var body: some View {
         VStack(spacing: 0) {
             Form {
                 Section {
-                    TextField(localized("Alias"), text: $alias, prompt: Text("myserver"))
-                    TextField(localized("Host"), text: $hostName, prompt: Text("server.example.com"))
-                    TextField(localized("User"), text: $user, prompt: Text(localized("optional")))
-                    TextField(localized("Port"), text: $port, prompt: Text("22"))
-                    LabeledContent(localized("Key file")) {
-                        HStack(spacing: 6) {
-                            TextField(
-                                "", text: $identityFile,
-                                prompt: Text(localized("optional — ~/.ssh/id_ed25519"))
-                            )
-                            .labelsHidden()
-                            Button(localized("Choose…"), action: chooseIdentityFile)
-                        }
-                    }
+                    TextField(
+                        localized("Address"), text: $address,
+                        prompt: Text("server.example.com")
+                    )
+                    if !suggestions.isEmpty { identityPicker }
+                    TextField(
+                        localized("Name"), text: $typedAlias,
+                        prompt: Text(derivedAlias.isEmpty ? "myserver" : derivedAlias)
+                    )
                 } header: {
                     SectionHeaderLabel(title: localized("Add SSH Host"))
                 } footer: {
-                    if aliasTaken {
-                        Text(localized("“\(trimmedAlias)” is already in your config."))
-                            .font(.caption)
-                            .foregroundStyle(.orange)
-                    } else {
-                        Text(.init(localized("Appends a Host block to ~/.ssh/config, so the alias works in plain `ssh \(trimmedAlias.isEmpty ? "myserver" : trimmedAlias)` too.")))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                    footer
+                }
+                Section {
+                    DisclosureGroup(isExpanded: $advancedExpanded) {
+                        if suggestions.isEmpty || identity == .other {
+                            TextField(
+                                localized("User"), text: $user,
+                                prompt: Text(localized("optional"))
+                            )
+                            keyFileField
+                        }
+                        TextField(localized("Port"), text: $port, prompt: Text("22"))
+                    } label: {
+                        Text(localized("Advanced"))
                     }
                 }
             }
@@ -357,19 +467,74 @@ struct AddSSHHostSheet: View {
             }
             .padding(12)
         }
-        .frame(width: 440, height: 330)
+        .frame(width: 460, height: advancedExpanded ? 420 : 320)
+        .animation(.easeOut(duration: 0.18), value: advancedExpanded)
+        .onAppear {
+            suggestions = SSHConfigFile.suggestedIdentities(in: SSHConfigFile.hosts())
+            if let first = suggestions.first { identity = .suggested(first) }
+        }
+    }
+
+    /// The identities already in the config, most-used first. The trailing row
+    /// opens the fields under Advanced instead of asking for them up front.
+    private var identityPicker: some View {
+        Picker(localized("Sign in as"), selection: $identity) {
+            ForEach(suggestions) { suggestion in
+                Text(label(for: suggestion)).tag(IdentityChoice.suggested(suggestion))
+            }
+            Divider()
+            Text(localized("Other…")).tag(IdentityChoice.other)
+        }
+        .onChange(of: identity) { _, choice in
+            if choice == .other { advancedExpanded = true }
+        }
+    }
+
+    private var keyFileField: some View {
+        LabeledContent(localized("Key file")) {
+            HStack(spacing: 6) {
+                TextField(
+                    "", text: $identityFile,
+                    prompt: Text(localized("optional — ~/.ssh/id_ed25519"))
+                )
+                .labelsHidden()
+                Button(localized("Choose…"), action: chooseIdentityFile)
+            }
+        }
+    }
+
+    /// Either what's wrong, or what the sheet is about to do — stated as the
+    /// command the user will be able to type, since that is the result they get.
+    @ViewBuilder
+    private var footer: some View {
+        if let validationMessage {
+            Text(.init(validationMessage))
+                .font(.caption)
+                .foregroundStyle(.orange)
+        } else {
+            Text(.init(localized("Adds a Host block to ~/.ssh/config. You’ll be able to run `ssh \(effectiveAlias.isEmpty ? "myserver" : effectiveAlias)` anywhere.")))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// How an identity reads in the menu: `you · id_ed25519`, with whichever half
+    /// it sets. A user it doesn't set is the local one, which is what ssh would do.
+    private func label(for identity: SSHIdentity) -> String {
+        let user = identity.user.isEmpty ? NSUserName() : identity.user
+        return identity.keyName.isEmpty ? user : "\(user) · \(identity.keyName)"
     }
 
     private func add() {
         do {
             try SSHConfigFile.appendHost(
-                alias: trimmedAlias,
-                hostName: hostName.trimmingCharacters(in: .whitespaces),
-                user: user.trimmingCharacters(in: .whitespaces),
-                port: port.trimmingCharacters(in: .whitespaces),
-                identityFile: identityFile.trimmingCharacters(in: .whitespaces)
+                alias: effectiveAlias,
+                hostName: parsedAddress.host,
+                user: effectiveUser,
+                port: effectivePort,
+                identityFile: effectiveIdentityFile
             )
-            finish(trimmedAlias)
+            finish(effectiveAlias)
         } catch {
             writeError = localized("Couldn’t write ~/.ssh/config: \(error.localizedDescription)")
         }

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -323,12 +323,19 @@ private extension SSHProbeResult {
 ///
 /// The address leads and everything else follows from it: `you@box.example.com:2222`
 /// fills the user and port, and the name is the address's first label until the
-/// user types their own. What remains is the pair that decides whether the host
-/// will actually let you in — offered as one "Sign in as" row built from the
-/// identities the config already uses, because a machine you add is almost always
-/// reached as the same person with the same key as the last one. Port and an
-/// explicit key stay behind Advanced: they are the exception, and a form that
-/// shows every exception at once reads as five equally likely questions.
+/// user types their own. Under it sit the two fields that decide whether the host
+/// lets you in — a user and a key — pre-filled from what the rest of the config
+/// already uses, because a machine you add is almost always reached as the same
+/// person with the same key as the last one.
+///
+/// They are filled in rather than hidden behind a picker. An earlier draft offered
+/// the identity as one "Sign in as" row with the fields for the exceptional case
+/// in Advanced, and that is the shape Tabby and XPipe both avoid: whatever names
+/// the credential, the fields it governs belong directly beneath it. Two places for
+/// one question is how a three-field sheet became confusing.
+///
+/// Only `Port` stays behind Advanced. It is the one field with a default nobody
+/// argues with, and the address absorbs it anyway when written as `host:2222`.
 struct AddSSHHostSheet: View {
     let existingAliases: Set<String>
     /// When set (the AppKit-presented menu path), called with the added alias —
@@ -341,21 +348,27 @@ struct AddSSHHostSheet: View {
     /// Empty until the user types a name of their own; until then the field shows
     /// (and Add uses) the one derived from the address.
     @State private var typedAlias = ""
-    @State private var identity: IdentityChoice = .other
     @State private var user = ""
+    @State private var key: KeyChoice = .defaults
     @State private var port = ""
-    @State private var identityFile = ""
     @State private var advancedExpanded = false
     @State private var writeError: String?
-    /// Read once, on appear: the sheet is modal, so the config cannot change under
-    /// it, and re-deriving per keystroke would re-read every file `Include` pulls in.
-    @State private var suggestions: [SSHIdentity] = []
+    /// Read once, on appear: the sheet is modal, so neither the config nor `~/.ssh`
+    /// can change under it, and re-reading per keystroke would walk every file
+    /// `Include` pulls in.
+    @State private var keys: [SSHPublicKey] = []
 
-    /// Which credentials the new block will carry: one the config already uses, or
-    /// the fields under Advanced.
-    private enum IdentityChoice: Hashable {
-        case suggested(SSHIdentity)
-        case other
+    /// What goes on the block's `IdentityFile` line — which is the only question
+    /// ssh_config can answer here, so it is the only one the row asks. `defaults`
+    /// writes no line at all and lets ssh do what it does alone: try the agent,
+    /// then the default key names. It leads for the same reason Tabby's auth
+    /// selector leads with Auto and XPipe's strategy list leads with no identity.
+    private enum KeyChoice: Hashable {
+        case defaults
+        case file(String)
+        /// Not a value — the row that opens the file panel, reverted the moment it
+        /// is chosen so the picker never rests on a verb.
+        case choose
     }
 
     private var parsedAddress: (user: String, host: String, port: String) {
@@ -370,12 +383,10 @@ struct AddSSHHostSheet: View {
         typedAlias.isEmpty ? derivedAlias : typedAlias.trimmingCharacters(in: .whitespaces)
     }
 
-    /// The address's own user/port win over the picked identity and the Advanced
-    /// field: they were typed later, and typing them is a correction.
+    /// A user or port written into the address wins over the field: it was typed
+    /// later and more specifically, and typing it there is a correction.
     private var effectiveUser: String {
-        if !parsedAddress.user.isEmpty { return parsedAddress.user }
-        if case .suggested(let suggestion) = identity { return suggestion.user }
-        return user.trimmingCharacters(in: .whitespaces)
+        parsedAddress.user.isEmpty ? user.trimmingCharacters(in: .whitespaces) : parsedAddress.user
     }
 
     private var effectivePort: String {
@@ -383,8 +394,8 @@ struct AddSSHHostSheet: View {
     }
 
     private var effectiveIdentityFile: String {
-        if case .suggested(let suggestion) = identity { return suggestion.identityFile ?? "" }
-        return identityFile.trimmingCharacters(in: .whitespaces)
+        if case .file(let path) = key { return path }
+        return ""
     }
 
     /// The first thing standing between the sheet and a working Add, or nil when
@@ -422,7 +433,11 @@ struct AddSSHHostSheet: View {
                         localized("Address"), text: $address,
                         prompt: Text("server.example.com")
                     )
-                    if !suggestions.isEmpty { identityPicker }
+                    TextField(
+                        localized("User"), text: $user,
+                        prompt: Text(NSUserName())
+                    )
+                    keyPicker
                     TextField(
                         localized("Name"), text: $typedAlias,
                         prompt: Text(derivedAlias.isEmpty ? "myserver" : derivedAlias)
@@ -434,13 +449,6 @@ struct AddSSHHostSheet: View {
                 }
                 Section {
                     DisclosureGroup(isExpanded: $advancedExpanded) {
-                        if suggestions.isEmpty || identity == .other {
-                            TextField(
-                                localized("User"), text: $user,
-                                prompt: Text(localized("optional"))
-                            )
-                            keyFileField
-                        }
                         TextField(localized("Port"), text: $port, prompt: Text("22"))
                     } label: {
                         Text(localized("Advanced"))
@@ -467,62 +475,69 @@ struct AddSSHHostSheet: View {
             }
             .padding(12)
         }
-        .frame(width: 460, height: advancedExpanded ? 420 : 320)
+        .frame(width: 460, height: advancedExpanded ? 400 : 344)
         .animation(.easeOut(duration: 0.18), value: advancedExpanded)
-        .onAppear {
-            suggestions = SSHConfigFile.suggestedIdentities(in: SSHConfigFile.hosts())
-            if let first = suggestions.first { identity = .suggested(first) }
-        }
+        .onAppear(perform: prefill)
     }
 
-    /// The identities already in the config, most-used first. The trailing row
-    /// opens the fields under Advanced instead of asking for them up front.
-    private var identityPicker: some View {
-        Picker(localized("Sign in as"), selection: $identity) {
-            ForEach(suggestions) { suggestion in
-                Text(label(for: suggestion)).tag(IdentityChoice.suggested(suggestion))
+    /// Fills the credential fields from what the config already does, so the common
+    /// case — another box reached the same way as the last one — is a matter of
+    /// typing an address. Both fields stay visible and editable: a default you can
+    /// see is a suggestion, and one you can't is a trap.
+    private func prefill() {
+        keys = SSHConfigFile.publicKeys()
+        guard let common = SSHConfigFile.suggestedIdentities(in: SSHConfigFile.hosts()).first
+        else { return }
+        user = common.user
+        if let identityFile = common.identityFile { key = .file(identityFile) }
+    }
+
+    /// The keys in `~/.ssh` by name, led by the no-`IdentityFile` default. A key the
+    /// user picked from elsewhere joins the list so the choice they made is a row
+    /// they can see, rather than a path in a field.
+    private var keyPicker: some View {
+        Picker(localized("Key"), selection: $key) {
+            Text(localized("Default keys")).tag(KeyChoice.defaults)
+            ForEach(keyOptions, id: \.self) { path in
+                Text((path as NSString).lastPathComponent).tag(KeyChoice.file(path))
             }
             Divider()
-            Text(localized("Other…")).tag(IdentityChoice.other)
+            Text(localized("Choose…")).tag(KeyChoice.choose)
         }
-        .onChange(of: identity) { _, choice in
-            if choice == .other { advancedExpanded = true }
-        }
-    }
-
-    private var keyFileField: some View {
-        LabeledContent(localized("Key file")) {
-            HStack(spacing: 6) {
-                TextField(
-                    "", text: $identityFile,
-                    prompt: Text(localized("optional — ~/.ssh/id_ed25519"))
-                )
-                .labelsHidden()
-                Button(localized("Choose…"), action: chooseIdentityFile)
-            }
+        .onChange(of: key) { previous, choice in
+            guard choice == .choose else { return }
+            // Never rest on the verb: the panel's outcome decides, and cancelling
+            // leaves the row exactly where the user found it.
+            key = chooseIdentityFile() ?? previous
         }
     }
 
-    /// Either what's wrong, or what the sheet is about to do — stated as the
-    /// command the user will be able to type, since that is the result they get.
+    /// The private-key paths to offer: every `~/.ssh` key, plus one picked from
+    /// elsewhere, `~`-relative the way ssh configs are conventionally written.
+    private var keyOptions: [String] {
+        var paths = keys.map { "~/.ssh/" + $0.name.replacingOccurrences(of: ".pub", with: "") }
+        if case .file(let path) = key, !paths.contains(path) { paths.append(path) }
+        return paths
+    }
+
+    /// Either what's wrong, or what the sheet is about to do — stated as the command
+    /// the user will be able to type, since that is the result they get. Before an
+    /// address exists there is no command to promise, so it says only what it does.
     @ViewBuilder
     private var footer: some View {
         if let validationMessage {
             Text(.init(validationMessage))
                 .font(.caption)
                 .foregroundStyle(.orange)
+        } else if effectiveAlias.isEmpty {
+            Text(localized("Adds a Host block to ~/.ssh/config."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
         } else {
-            Text(.init(localized("Adds a Host block to ~/.ssh/config. You’ll be able to run `ssh \(effectiveAlias.isEmpty ? "myserver" : effectiveAlias)` anywhere.")))
+            Text(.init(localized("Adds a Host block to ~/.ssh/config. You’ll be able to run `ssh \(effectiveAlias)` anywhere.")))
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
-    }
-
-    /// How an identity reads in the menu: `you · id_ed25519`, with whichever half
-    /// it sets. A user it doesn't set is the local one, which is what ssh would do.
-    private func label(for identity: SSHIdentity) -> String {
-        let user = identity.user.isEmpty ? NSUserName() : identity.user
-        return identity.keyName.isEmpty ? user : "\(user) · \(identity.keyName)"
     }
 
     private func add() {
@@ -546,19 +561,24 @@ struct AddSSHHostSheet: View {
 
     /// A file picker starting in `~/.ssh` with hidden files visible (the whole
     /// directory is dot-hidden). The chosen path is stored `~`-relative, the way
-    /// ssh configs are conventionally written.
-    private func chooseIdentityFile() {
+    /// ssh configs are conventionally written. nil when the panel was cancelled.
+    private func chooseIdentityFile() -> KeyChoice? {
         let panel = NSOpenPanel()
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
         panel.showsHiddenFiles = true
         panel.directoryURL = SSHConfigFile.configURL.deletingLastPathComponent()
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard panel.runModal() == .OK, let url = panel.url else { return nil }
         let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
         let path = url.standardizedFileURL.path
-        identityFile = path.hasPrefix(home + "/")
-            ? "~" + path.dropFirst(home.count)
-            : path
+        // `IdentityFile` names the private key; picking the public half is the
+        // easy slip, since that is the file people hand around.
+        let privatePath = path.hasSuffix(".pub") ? String(path.dropLast(4)) : path
+        return .file(
+            privatePath.hasPrefix(home + "/")
+                ? "~" + privatePath.dropFirst(home.count)
+                : privatePath
+        )
     }
 }

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -328,14 +328,19 @@ private extension SSHProbeResult {
 /// already uses, because a machine you add is almost always reached as the same
 /// person with the same key as the last one.
 ///
-/// They are filled in rather than hidden behind a picker. An earlier draft offered
-/// the identity as one "Sign in as" row with the fields for the exceptional case
-/// in Advanced, and that is the shape Tabby and XPipe both avoid: whatever names
-/// the credential, the fields it governs belong directly beneath it. Two places for
-/// one question is how a three-field sheet became confusing.
+/// They are filled in rather than hidden behind a picker, and they sit in a section
+/// of their own headed Credentials — the grouping Termius uses, because signing in
+/// is one question and a form that scatters it across a box of unrelated fields
+/// never reads as one. An earlier draft offered the identity as a "Sign in as" row
+/// whose exceptional case lived in Advanced, which is the shape Tabby and XPipe
+/// both avoid: whatever names the credential owns the fields beneath it.
 ///
-/// Only `Port` stays behind Advanced. It is the one field with a default nobody
-/// argues with, and the address absorbs it anyway when written as `host:2222`.
+/// Nothing is behind a disclosure. `Port` was the only candidate, and hiding one
+/// short field to save one row bought a mode where there could be none.
+///
+/// The Credentials footer says out loud that there is no password field and where
+/// a password host does get handled. Termius has one and termio cannot; leaving
+/// that unsaid makes the sheet look incomplete rather than decided.
 struct AddSSHHostSheet: View {
     let existingAliases: Set<String>
     /// When set (the AppKit-presented menu path), called with the added alias —
@@ -351,7 +356,6 @@ struct AddSSHHostSheet: View {
     @State private var user = ""
     @State private var key: KeyChoice = .defaults
     @State private var port = ""
-    @State private var advancedExpanded = false
     @State private var writeError: String?
     /// Read once, on appear: the sheet is modal, so neither the config nor `~/.ssh`
     /// can change under it, and re-reading per keystroke would walk every file
@@ -433,11 +437,7 @@ struct AddSSHHostSheet: View {
                         localized("Address"), text: $address,
                         prompt: Text("server.example.com")
                     )
-                    TextField(
-                        localized("User"), text: $user,
-                        prompt: Text(NSUserName())
-                    )
-                    keyPicker
+                    TextField(localized("Port"), text: $port, prompt: Text("22"))
                     TextField(
                         localized("Name"), text: $typedAlias,
                         prompt: Text(derivedAlias.isEmpty ? "myserver" : derivedAlias)
@@ -448,11 +448,17 @@ struct AddSSHHostSheet: View {
                     footer
                 }
                 Section {
-                    DisclosureGroup(isExpanded: $advancedExpanded) {
-                        TextField(localized("Port"), text: $port, prompt: Text("22"))
-                    } label: {
-                        Text(localized("Advanced"))
-                    }
+                    TextField(
+                        localized("User"), text: $user,
+                        prompt: Text(NSUserName())
+                    )
+                    keyPicker
+                } header: {
+                    SectionHeaderLabel(title: localized("Credentials"))
+                } footer: {
+                    Text(localized("Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
             .formStyle(.grouped)
@@ -475,8 +481,7 @@ struct AddSSHHostSheet: View {
             }
             .padding(12)
         }
-        .frame(width: 460, height: advancedExpanded ? 400 : 344)
-        .animation(.easeOut(duration: 0.18), value: advancedExpanded)
+        .frame(width: 460, height: 452)
         .onAppear(perform: prefill)
     }
 

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -355,6 +355,8 @@ struct AddSSHHostSheet: View {
     @State private var typedAlias = ""
     @State private var user = ""
     @State private var key: KeyChoice = .defaults
+    @State private var password = ""
+    @State private var passwordRevealed = false
     @State private var port = ""
     @State private var writeError: String?
     /// Read once, on appear: the sheet is modal, so neither the config nor `~/.ssh`
@@ -433,14 +435,11 @@ struct AddSSHHostSheet: View {
         VStack(spacing: 0) {
             Form {
                 Section {
-                    TextField(
-                        localized("Address"), text: $address,
-                        prompt: Text("server.example.com")
-                    )
-                    TextField(localized("Port"), text: $port, prompt: Text("22"))
-                    TextField(
+                    field(localized("Address"), text: $address, prompt: "server.example.com")
+                    field(localized("Port"), text: $port, prompt: "22")
+                    field(
                         localized("Name"), text: $typedAlias,
-                        prompt: Text(derivedAlias.isEmpty ? "myserver" : derivedAlias)
+                        prompt: derivedAlias.isEmpty ? "myserver" : derivedAlias
                     )
                 } header: {
                     SectionHeaderLabel(title: localized("Add SSH Host"))
@@ -448,15 +447,13 @@ struct AddSSHHostSheet: View {
                     footer
                 }
                 Section {
-                    TextField(
-                        localized("User"), text: $user,
-                        prompt: Text(NSUserName())
-                    )
+                    field(localized("User"), text: $user, prompt: NSUserName())
                     keyPicker
+                    passwordField
                 } header: {
                     SectionHeaderLabel(title: localized("Credentials"))
                 } footer: {
-                    Text(localized("Termio signs in with keys — there is nowhere in ssh config to keep a password. A host that only takes one still opens in a terminal, and Devices offers to install your key on it."))
+                    Text(localized("A key is the credential that works everywhere, including sessions running on the box. A password is saved to your Keychain, never to ssh config, and only ever read when ssh asks for it."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -495,6 +492,48 @@ struct AddSSHHostSheet: View {
         else { return }
         user = common.user
         if let identityFile = common.identityFile { key = .file(identityFile) }
+    }
+
+    /// Optional, and last: the credential that works in fewer places belongs under
+    /// the one that works everywhere. Reveal follows the platform — `SecureField`
+    /// until asked, so a shoulder gets nothing by default — and the value goes to
+    /// the Keychain on Add, never into the block being written.
+    private var passwordField: some View {
+        LabeledContent(localized("Password")) {
+            HStack(spacing: 6) {
+                Group {
+                    if passwordRevealed {
+                        TextField("", text: $password, prompt: Text(localized("optional")))
+                    } else {
+                        SecureField("", text: $password, prompt: Text(localized("optional")))
+                    }
+                }
+                .textFieldStyle(.plain)
+                .multilineTextAlignment(.trailing)
+                .labelsHidden()
+                Button {
+                    passwordRevealed.toggle()
+                } label: {
+                    Image(systemName: passwordRevealed ? "eye.slash" : "eye")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help(passwordRevealed ? localized("Hide") : localized("Show"))
+            }
+        }
+    }
+
+    /// One labelled row, values trailing-aligned the way the rest of Settings writes
+    /// them (`AgentSettingsTab`'s Command row). A plain `TextField(label:)` lets each
+    /// row size its own gap, so four fields land at four different left edges — the
+    /// ragged column that made this sheet look thrown together.
+    private func field(_ label: String, text: Binding<String>, prompt: String) -> some View {
+        LabeledContent(label) {
+            TextField("", text: text, prompt: Text(prompt))
+                .textFieldStyle(.plain)
+                .multilineTextAlignment(.trailing)
+                .labelsHidden()
+        }
     }
 
     /// The keys in `~/.ssh` by name, led by the no-`IdentityFile` default. A key the
@@ -554,10 +593,22 @@ struct AddSSHHostSheet: View {
                 port: effectivePort,
                 identityFile: effectiveIdentityFile
             )
-            finish(effectiveAlias)
         } catch {
             writeError = localized("Couldn’t write ~/.ssh/config: \(error.localizedDescription)")
+            return
         }
+        // After the block, and never fatal to it: the host is added and reachable
+        // by hand either way, so a Keychain that refuses is worth reporting rather
+        // than a reason to throw the block away.
+        if !password.isEmpty {
+            do {
+                try SSHPasswordStore.save(password, for: effectiveAlias)
+            } catch {
+                writeError = error.localizedDescription
+                return
+            }
+        }
+        finish(effectiveAlias)
     }
 
     private func finish(_ addedAlias: String?) {

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -234,7 +234,7 @@ private struct SSHHostRow: View {
     private var passwordAdvice: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Text(keyToInstall == nil
-                 ? localized("This host takes a password. Termio signs in with keys, and there is no key in ~/.ssh yet — create one with ssh-keygen, then set it up here.")
+                 ? localized("This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.")
                  : localized("This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it."))
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -418,11 +418,20 @@ struct AddSSHHostSheet: View {
         if !effectivePort.isEmpty, Int(effectivePort).map({ (1...65535).contains($0) }) != true {
             return localized("A port is a number from 1 to 65535.")
         }
+        let values = [effectiveAlias, parsedAddress.host, effectiveUser, effectiveIdentityFile]
         // ssh_config has no escape for a literal double quote — such values can't
         // be written faithfully, so refuse rather than corrupt the file.
-        let values = [effectiveAlias, parsedAddress.host, effectiveUser, effectiveIdentityFile]
         if values.contains(where: { $0.contains("\"") }) {
             return localized("A double quote can’t be written to ssh config.")
+        }
+        // A line break would end the directive, and a pasted address carrying one
+        // could append directives of its own. `appendHost` refuses it as well; this
+        // is so the sheet says why instead of failing at the write.
+        if values.contains(where: SSHConfigFile.isUnwritable) {
+            return localized("A line break can’t be written to ssh config.")
+        }
+        if password.contains(where: \.isNewline) {
+            return localized("A password can’t contain a line break.")
         }
         return nil
     }
@@ -551,8 +560,13 @@ struct AddSSHHostSheet: View {
         .onChange(of: key) { previous, choice in
             guard choice == .choose else { return }
             // Never rest on the verb: the panel's outcome decides, and cancelling
-            // leaves the row exactly where the user found it.
-            key = chooseIdentityFile() ?? previous
+            // leaves the row exactly where the user found it. Presented after this
+            // transaction rather than inside it — `runModal` spins a nested event
+            // loop, and starting one while SwiftUI is still applying the selection
+            // it caused is how a picker flickers or wedges.
+            DispatchQueue.main.async {
+                key = chooseIdentityFile() ?? previous
+            }
         }
     }
 

--- a/Sources/termio/Settings/SSHConfig.swift
+++ b/Sources/termio/Settings/SSHConfig.swift
@@ -16,6 +16,17 @@ enum SSHProbeResult: Equatable {
     case unreachable(String)
 }
 
+enum SSHConfigWriteError: Error, LocalizedError {
+    case valueContainsNewline
+
+    var errorDescription: String? {
+        switch self {
+        case .valueContainsNewline:
+            return localized("A line break can’t be written to ssh config.")
+        }
+    }
+}
+
 /// A `User` + `IdentityFile` pair already in use somewhere in `~/.ssh/config`.
 ///
 /// Termius calls this an *identity* and keeps it in a synced credential vault;
@@ -312,6 +323,12 @@ enum SSHConfigFile {
     static func appendHost(
         alias: String, hostName: String, user: String, port: String, identityFile: String
     ) throws {
+        // A newline in any value ends the directive and lets whatever follows land
+        // in the file as configuration of its own — a pasted address could append
+        // its own `Host` block or a `ProxyCommand`. The sheet rejects it too; it is
+        // refused here as well because this is what writes the file.
+        guard ![alias, hostName, user, port, identityFile].contains(where: isUnwritable)
+        else { throw SSHConfigWriteError.valueContainsNewline }
         // ssh_config quotes arguments that contain spaces (a picked key file
         // under "My Drive" must not split into two tokens). Values containing a
         // double quote are unrepresentable in ssh_config and rejected upstream
@@ -449,12 +466,24 @@ enum SSHConfigFile {
             .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
     }
 
+    /// Whether a value cannot be written into a `Host` block faithfully: a line
+    /// break (which would end the directive and start a new one) or any other
+    /// control character. `ssh_config` has no escape for either.
+    static func isUnwritable(_ value: String) -> Bool {
+        value.unicodeScalars.contains { scalar in
+            scalar.properties.generalCategory == .control
+        }
+    }
+
     /// A destination as people write it — `[user@]host[:port]` — split into the
     /// three fields a `Host` block keeps apart. One Address field can then absorb
     /// a pasted `root@10.0.0.4:2222` instead of asking for it in pieces.
     ///
-    /// Only an all-digit trailing `:port` is taken as a port, and a bracketed
-    /// address is left alone entirely, so an IPv6 literal keeps its colons.
+    /// A colon only means a port when it cannot mean an address. `[2001:db8::1]:22`
+    /// splits on the bracket, and the brackets come off because `HostName` wants the
+    /// literal bare. An unbracketed address with more than one colon is an IPv6
+    /// literal in full — `2001:db8::1` has to stay one host, not become `2001:db8:`
+    /// on port 1, which is both wrong and reachable.
     static func parseDestination(_ text: String) -> (user: String, host: String, port: String) {
         var rest = text.trimmingCharacters(in: .whitespaces)
         var user = ""
@@ -463,15 +492,21 @@ enum SSHConfigFile {
             user = String(rest[rest.startIndex..<at])
             rest = String(rest[rest.index(after: at)...])
         }
-        var port = ""
-        if let colon = rest.lastIndex(of: ":"), !rest.contains("[") {
-            let candidate = String(rest[rest.index(after: colon)...])
-            if !candidate.isEmpty, candidate.allSatisfy(\.isNumber) {
-                port = candidate
-                rest = String(rest[rest.startIndex..<colon])
-            }
+        func portValue(_ candidate: String) -> String? {
+            !candidate.isEmpty && candidate.allSatisfy(\.isNumber) ? candidate : nil
         }
-        return (user, rest, port)
+        if rest.hasPrefix("["), let close = rest.firstIndex(of: "]") {
+            let inside = String(rest[rest.index(after: rest.startIndex)..<close])
+            let trailing = String(rest[rest.index(after: close)...])
+            let port = trailing.hasPrefix(":")
+                ? portValue(String(trailing.dropFirst())) ?? "" : ""
+            return (user, inside, port)
+        }
+        if rest.filter({ $0 == ":" }).count == 1, let colon = rest.lastIndex(of: ":"),
+           let port = portValue(String(rest[rest.index(after: colon)...])) {
+            return (user, String(rest[rest.startIndex..<colon]), port)
+        }
+        return (user, rest, "")
     }
 
     /// The name to give a host at `hostName`: its first label, since that is what
@@ -485,7 +520,11 @@ enum SSHConfigFile {
         else { return "" }
         let base = hostName.allSatisfy { $0.isNumber || $0 == "." } ? hostName : first
         guard taken.contains(base) else { return base }
-        for suffix in 2...99 where !taken.contains("\(base)-\(suffix)") {
+        // Bounded by the number of names that exist: with `taken.count` aliases in
+        // play one of the first `taken.count + 2` suffixes must be free, so this
+        // always returns a name — a fixed ceiling handed back the taken base and
+        // let the sheet reject its own suggestion.
+        for suffix in 2...(taken.count + 2) where !taken.contains("\(base)-\(suffix)") {
             return "\(base)-\(suffix)"
         }
         return base
@@ -517,19 +556,33 @@ enum SSHConfigFile {
     /// A block that pins an `IdentityFile` gets that key's `.pub` sibling and
     /// nothing else: ssh will offer exactly the pinned key, so installing a
     /// different one would leave the host failing for the same reason with a new
-    /// key on it. When the block pins nothing, the strongest key in `~/.ssh` wins.
-    /// nil means there is nothing safe to install and the caller should say so
-    /// rather than guess.
+    /// key on it.
+    ///
+    /// When the block pins nothing, the choice is narrower than "the best key on
+    /// disk": ssh with no `IdentityFile` offers only the agent's keys and the
+    /// default names below, so installing `work_security_key.pub` would report
+    /// success and change nothing — the next connection never offers it. Only a
+    /// key ssh would reach for on its own can be installed without also editing
+    /// the host block, so anything else returns nil and the caller says so.
     static func publicKeyToInstall(for host: SSHConfigHost, keys: [SSHPublicKey]) -> SSHPublicKey? {
         if let identityFile = host.identityFile {
             let expanded = (identityFile as NSString).expandingTildeInPath
             let publicPath = expanded.hasSuffix(".pub") ? expanded : expanded + ".pub"
             return keys.first { $0.url.standardizedFileURL.path == publicPath }
         }
-        let strength = ["ED25519-SK", "ED25519", "ECDSA-SK", "ECDSA", "RSA"]
-        return keys.min {
-            (strength.firstIndex(of: $0.algorithm) ?? strength.count)
-                < (strength.firstIndex(of: $1.algorithm) ?? strength.count)
+        // ssh_config(5)'s default IdentityFile list, strongest first.
+        let defaultNames = [
+            "id_ed25519_sk", "id_ed25519", "id_ecdsa_sk", "id_ecdsa", "id_rsa", "id_dsa",
+        ]
+        let offered = keys.filter {
+            defaultNames.contains($0.name.replacingOccurrences(of: ".pub", with: ""))
+        }
+        return offered.min {
+            let rank: (SSHPublicKey) -> Int = { key in
+                defaultNames.firstIndex(of: key.name.replacingOccurrences(of: ".pub", with: ""))
+                    ?? defaultNames.count
+            }
+            return rank($0) < rank($1)
         }
     }
 }

--- a/Sources/termio/Settings/SSHConfig.swift
+++ b/Sources/termio/Settings/SSHConfig.swift
@@ -6,8 +6,37 @@ import Foundation
 /// human line for the row and the raw detail in a tooltip.
 enum SSHProbeResult: Equatable {
     case reachable
+    /// The server offered password (or keyboard-interactive) authentication and
+    /// we declined to ask. Told apart from `authFailed` because it is the one
+    /// failure with a one-click fix: install a key and the host works everywhere,
+    /// including the paths that can never type a password (see
+    /// `Termiod.sshArguments`, where `BatchMode=yes` is unconditional).
+    case wantsPassword(String)
     case authFailed(String)
     case unreachable(String)
+}
+
+/// A `User` + `IdentityFile` pair already in use somewhere in `~/.ssh/config`.
+///
+/// Termius calls this an *identity* and keeps it in a synced credential vault;
+/// this is the half of that idea which needs no store at all — the pairs are
+/// derived from the config on every read, so picking one in Add Host is a
+/// shortcut for typing what the user's other hosts already say. Nothing is
+/// remembered that `ssh` itself doesn't already resolve.
+struct SSHIdentity: Hashable, Identifiable {
+    /// Empty when no block sets `User` — ssh falls back to the local username.
+    let user: String
+    /// `~`-relative and verbatim, as the config writes it; nil pins no key.
+    let identityFile: String?
+
+    var id: String { "\(user)\u{0}\(identityFile ?? "")" }
+
+    /// The key's filename alone (`id_ed25519`), for a row that has no room for a
+    /// path. Empty when the identity pins no key.
+    var keyName: String {
+        guard let identityFile else { return "" }
+        return (identityFile as NSString).lastPathComponent
+    }
 }
 
 /// One connectable `Host` block parsed from the user's OpenSSH client config —
@@ -390,6 +419,10 @@ enum SSHConfigFile {
         if lower.contains("permission denied")
             || lower.contains("too many authentication failures")
             || lower.contains("no supported authentication methods") {
+            let methods = offeredMethods(stderr)
+            if methods.contains("password") || methods.contains("keyboard-interactive") {
+                return .wantsPassword(lastLine)
+            }
             return .authFailed(lastLine)
         }
         if lower.contains("could not resolve") || lower.contains("name or service not known") {
@@ -399,5 +432,104 @@ enum SSHConfigFile {
         if lower.contains("no route to host") { return .unreachable(localized("No route to host")) }
         if lower.contains("timed out") { return .unreachable(localized("Timed out")) }
         return .unreachable(lastLine)
+    }
+
+    /// The authentication methods the *server* offered, read out of ssh's
+    /// `Permission denied (publickey,password)` line. The parenthesised list is
+    /// the far side's own answer to what it would have accepted, which is the
+    /// only trustworthy way to tell "this box wants a password we refused to
+    /// send" from "this box doesn't know our key". Lowercased; empty when the
+    /// line carries no list (some servers and older ssh versions omit it).
+    static func offeredMethods(_ stderr: String) -> [String] {
+        guard let opening = stderr.range(of: "permission denied (", options: .caseInsensitive),
+              let closing = stderr[opening.upperBound...].firstIndex(of: ")")
+        else { return [] }
+        return stderr[opening.upperBound..<closing]
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+    }
+
+    /// A destination as people write it — `[user@]host[:port]` — split into the
+    /// three fields a `Host` block keeps apart. One Address field can then absorb
+    /// a pasted `root@10.0.0.4:2222` instead of asking for it in pieces.
+    ///
+    /// Only an all-digit trailing `:port` is taken as a port, and a bracketed
+    /// address is left alone entirely, so an IPv6 literal keeps its colons.
+    static func parseDestination(_ text: String) -> (user: String, host: String, port: String) {
+        var rest = text.trimmingCharacters(in: .whitespaces)
+        var user = ""
+        // Last `@`, not the first: a username may legally contain one.
+        if let at = rest.lastIndex(of: "@") {
+            user = String(rest[rest.startIndex..<at])
+            rest = String(rest[rest.index(after: at)...])
+        }
+        var port = ""
+        if let colon = rest.lastIndex(of: ":"), !rest.contains("[") {
+            let candidate = String(rest[rest.index(after: colon)...])
+            if !candidate.isEmpty, candidate.allSatisfy(\.isNumber) {
+                port = candidate
+                rest = String(rest[rest.startIndex..<colon])
+            }
+        }
+        return (user, rest, port)
+    }
+
+    /// The name to give a host at `hostName`: its first label, since that is what
+    /// people call the box (`build.example.com` is "build"), kept unique against
+    /// the names already taken the way the Finder keeps a duplicate unique.
+    ///
+    /// An address that is all digits and dots is an IP, whose first label names
+    /// nothing — the whole address is the only sensible name for it.
+    static func suggestedAlias(forHost hostName: String, avoiding taken: Set<String>) -> String {
+        guard let first = hostName.split(separator: ".").first.map(String.init), !first.isEmpty
+        else { return "" }
+        let base = hostName.allSatisfy { $0.isNumber || $0 == "." } ? hostName : first
+        guard taken.contains(base) else { return base }
+        for suffix in 2...99 where !taken.contains("\(base)-\(suffix)") {
+            return "\(base)-\(suffix)"
+        }
+        return base
+    }
+
+    /// The `User`/`IdentityFile` pairs already in use, most-used first (ties broken
+    /// by config order). Offered by Add Host so the common case — every box signed
+    /// into as the same user with the same key — is pre-filled rather than retyped.
+    /// A pair that sets neither is dropped: it says nothing the defaults don't.
+    static func suggestedIdentities(in hosts: [SSHConfigHost]) -> [SSHIdentity] {
+        var counts: [SSHIdentity: Int] = [:]
+        var order: [SSHIdentity: Int] = [:]
+        for (index, host) in hosts.enumerated() {
+            let identity = SSHIdentity(user: host.user, identityFile: host.identityFile)
+            if identity.user.isEmpty && identity.identityFile == nil { continue }
+            counts[identity, default: 0] += 1
+            if order[identity] == nil { order[identity] = index }
+        }
+        let ranked: [(identity: SSHIdentity, count: Int, order: Int)] = counts.map {
+            (identity: $0.key, count: $0.value, order: order[$0.key] ?? 0)
+        }
+        return ranked
+            .sorted { $0.count == $1.count ? $0.order < $1.order : $0.count > $1.count }
+            .map(\.identity)
+    }
+
+    /// The public key `ssh-copy-id` should install on `host`.
+    ///
+    /// A block that pins an `IdentityFile` gets that key's `.pub` sibling and
+    /// nothing else: ssh will offer exactly the pinned key, so installing a
+    /// different one would leave the host failing for the same reason with a new
+    /// key on it. When the block pins nothing, the strongest key in `~/.ssh` wins.
+    /// nil means there is nothing safe to install and the caller should say so
+    /// rather than guess.
+    static func publicKeyToInstall(for host: SSHConfigHost, keys: [SSHPublicKey]) -> SSHPublicKey? {
+        if let identityFile = host.identityFile {
+            let expanded = (identityFile as NSString).expandingTildeInPath
+            let publicPath = expanded.hasSuffix(".pub") ? expanded : expanded + ".pub"
+            return keys.first { $0.url.standardizedFileURL.path == publicPath }
+        }
+        let strength = ["ED25519-SK", "ED25519", "ECDSA-SK", "ECDSA", "RSA"]
+        return keys.min {
+            (strength.firstIndex(of: $0.algorithm) ?? strength.count)
+                < (strength.firstIndex(of: $1.algorithm) ?? strength.count)
+        }
     }
 }

--- a/Sources/termio/Settings/SSHPassword.swift
+++ b/Sources/termio/Settings/SSHPassword.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// A password for an SSH host, kept in the login Keychain and handed to the
+/// system `ssh` through the one channel OpenSSH itself provides for it.
+///
+/// **Why this shape.** ssh_config has no directive that holds a password, and
+/// termio never links an SSH library, so the password cannot travel with the
+/// host block or through a client we control. What OpenSSH does offer is
+/// `SSH_ASKPASS`: a program it runs when it needs a secret, reading the answer
+/// off that program's stdout. `SSH_ASKPASS_REQUIRE=force` (OpenSSH 8.4+) makes it
+/// use that program even when a terminal is present, which is what lets a session
+/// with a real PTY skip the prompt.
+///
+/// **Where the secret is, and is not.** It is in the Keychain and nowhere else.
+/// The askpass helper is a two-line script that asks `security(1)` for it at the
+/// moment ssh asks, so the password is never in an argument list (`sshpass`'s
+/// flaw — argv is world-readable through `ps`), never in the environment, and
+/// never written to a file. termio itself doesn't read it back; only the helper
+/// does, and only when ssh runs it.
+///
+/// **The trust boundary, stated plainly.** Writing through `security(1)` leaves an
+/// item whose access list trusts `security(1)`, so any process running as this
+/// user can read it back without a prompt. That is the same standing any process
+/// has over an `ssh-add --apple-use-keychain` passphrase, and it is the cost of
+/// letting the system ssh binary — rather than an embedded client — do the
+/// authenticating. A password is offered here because the user asked for one; a
+/// key remains the better credential and the only one the daemon paths can use
+/// without giving up `BatchMode`.
+enum SSHPasswordStore {
+    /// Per-channel, so a dev build's saved passwords are as separate from the
+    /// release app's as every other piece of its state.
+    static var service: String { "sh.termio.ssh" + AppChannel.suffix }
+
+    /// Stores `password` for a `~/.ssh/config` alias, replacing any previous one.
+    ///
+    /// `-w` with no value makes `security` read the password from stdin, asked for
+    /// twice the way an interactive prompt would. That detour exists to keep the
+    /// value out of the argument list.
+    static func save(_ password: String, for alias: String) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = [
+            "add-generic-password", "-U",
+            "-s", service, "-a", alias,
+            "-l", "termio: \(alias)",
+            "-D", "SSH password",
+            "-j", "Used by Termio to sign in to \(alias). Delete this to make Termio ask again.",
+            "-w",
+        ]
+        let input = Pipe()
+        process.standardInput = input
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        let confirmed = Data("\(password)\n\(password)\n".utf8)
+        input.fileHandleForWriting.write(confirmed)
+        input.fileHandleForWriting.closeFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { throw SSHPasswordError.keychainWriteFailed }
+    }
+
+    static func remove(for alias: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = ["delete-generic-password", "-s", service, "-a", alias]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try? process.run()
+        process.waitUntilExit()
+    }
+
+    /// Whether a password is stored, asked without reading the password itself:
+    /// `find-generic-password` without `-w` reports the item's attributes only.
+    static func hasPassword(for alias: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = ["find-generic-password", "-s", service, "-a", alias]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do { try process.run() } catch { return false }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
+
+    /// The environment an `ssh` child needs to answer a password prompt for
+    /// `alias` from the Keychain, or empty when nothing is stored for it — in
+    /// which case ssh behaves exactly as it does today.
+    ///
+    /// `DISPLAY` is set because ssh's older askpass path checks it; `REQUIRE=force`
+    /// makes that irrelevant on 8.4+, and setting both costs nothing. The value is
+    /// deliberately not a real display: nothing ever connects to it.
+    static func askpassEnvironment(for alias: String) -> [String: String] {
+        guard hasPassword(for: alias), let helper = try? helperURL() else { return [:] }
+        return [
+            "SSH_ASKPASS": helper.path,
+            "SSH_ASKPASS_REQUIRE": "force",
+            "DISPLAY": ":0",
+            "TERMIO_SSH_SERVICE": service,
+            "TERMIO_SSH_ALIAS": alias,
+        ]
+    }
+
+    /// The askpass helper on disk, written on first use and rewritten whenever it
+    /// drifts from the text below. It holds no secret — only the lookup — so it is
+    /// safe to leave in the app's support directory between runs.
+    ///
+    /// `exec` rather than a subshell so ssh reads the password straight off
+    /// `security`'s stdout with no shell sitting in between it and the pipe.
+    static func helperURL() throws -> URL {
+        let directory = AppChannel.supportDirectory
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let url = directory.appendingPathComponent("ssh-askpass")
+        let script = """
+            #!/bin/sh
+            # Written by Termio. Answers ssh's password prompt from the login
+            # Keychain; holds no secret itself.
+            exec /usr/bin/security find-generic-password -w \
+            -s "$TERMIO_SSH_SERVICE" -a "$TERMIO_SSH_ALIAS"
+
+            """
+        if (try? String(contentsOf: url, encoding: .utf8)) != script {
+            try script.write(to: url, atomically: true, encoding: .utf8)
+        }
+        // Re-asserted every time: an atomic write lands a fresh file that inherits
+        // the process umask, and ssh silently ignores an askpass it cannot execute.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: url.path
+        )
+        return url
+    }
+}
+
+enum SSHPasswordError: Error, LocalizedError {
+    case keychainWriteFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .keychainWriteFailed: return localized("Couldn’t save the password to your Keychain.")
+        }
+    }
+}

--- a/Sources/termio/Settings/SSHPassword.swift
+++ b/Sources/termio/Settings/SSHPassword.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 
 /// A password for an SSH host, kept in the login Keychain and handed to the
 /// system `ssh` through the one channel OpenSSH itself provides for it.
@@ -37,49 +38,76 @@ enum SSHPasswordStore {
     /// twice the way an interactive prompt would. That detour exists to keep the
     /// value out of the argument list.
     static func save(_ password: String, for alias: String) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = [
+        // A newline can't survive either leg of the trip: `security` reads the
+        // confirmation line-wise, and ssh takes only the helper's first line. Left
+        // unchecked it stores a silently truncated password whose failure looks
+        // like a wrong one.
+        guard !password.contains(where: \.isNewline) else {
+            throw SSHPasswordError.passwordContainsNewline
+        }
+        let status = run([
             "add-generic-password", "-U",
             "-s", service, "-a", alias,
             "-l", "termio: \(alias)",
             "-D", "SSH password",
             "-j", "Used by Termio to sign in to \(alias). Delete this to make Termio ask again.",
             "-w",
-        ]
-        let input = Pipe()
-        process.standardInput = input
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
-        try process.run()
-        let confirmed = Data("\(password)\n\(password)\n".utf8)
-        input.fileHandleForWriting.write(confirmed)
-        input.fileHandleForWriting.closeFile()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else { throw SSHPasswordError.keychainWriteFailed }
+        ], stdin: Data("\(password)\n\(password)\n".utf8))
+        guard status == 0 else { throw SSHPasswordError.keychainWriteFailed }
     }
 
-    static func remove(for alias: String) {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["delete-generic-password", "-s", service, "-a", alias]
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
-        try? process.run()
-        process.waitUntilExit()
+    @discardableResult
+    static func remove(for alias: String) -> Bool {
+        let status = run(["delete-generic-password", "-s", service, "-a", alias])
+        // 44 is "item not found", which is the state the caller asked for.
+        return status == 0 || status == 44
     }
 
-    /// Whether a password is stored, asked without reading the password itself:
-    /// `find-generic-password` without `-w` reports the item's attributes only.
+    /// Whether a password is stored for `alias`.
+    ///
+    /// Asked through `SecItemCopyMatching` rather than `security(1)` because this
+    /// gates every SSH session launch and launches happen on the main actor: a
+    /// subprocess there costs ~50 ms of frozen window per session, and a
+    /// `securityd` having a bad day costs more than that. The query returns no
+    /// data — only whether the item exists — so it neither unlocks the secret nor
+    /// prompts. Writing still goes through `security(1)`, whose access list is
+    /// what lets the askpass helper read the item back without a prompt.
     static func hasPassword(for alias: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: alias,
+            kSecReturnData as String: false,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
+    }
+
+    /// Runs `security` and returns its exit status, draining both pipes before the
+    /// wait. A child blocked writing into a pipe nobody reads never exits, and the
+    /// wait would then never return — the same deadlock `SSHConfigFile.testConnection`
+    /// spells out. `security` is terse enough that it has not happened, which is
+    /// exactly why it would happen on the one machine with a chatty keychain error.
+    private static func run(_ arguments: [String], stdin: Data? = nil) -> Int32 {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["find-generic-password", "-s", service, "-a", alias]
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
-        do { try process.run() } catch { return false }
+        process.arguments = arguments
+        let output = Pipe()
+        let errors = Pipe()
+        process.standardOutput = output
+        process.standardError = errors
+        let input = Pipe()
+        if stdin != nil { process.standardInput = input }
+        do { try process.run() } catch { return -1 }
+        if let stdin {
+            input.fileHandleForWriting.write(stdin)
+            input.fileHandleForWriting.closeFile()
+        }
+        // Read to EOF on both before waiting; EOF arrives when the child exits.
+        _ = output.fileHandleForReading.readDataToEndOfFile()
+        _ = errors.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
-        return process.terminationStatus == 0
+        return process.terminationStatus
     }
 
     /// The environment an `ssh` child needs to answer a password prompt for
@@ -135,10 +163,14 @@ enum SSHPasswordStore {
 
 enum SSHPasswordError: Error, LocalizedError {
     case keychainWriteFailed
+    case passwordContainsNewline
 
     var errorDescription: String? {
         switch self {
-        case .keychainWriteFailed: return localized("Couldn’t save the password to your Keychain.")
+        case .keychainWriteFailed:
+            return localized("Couldn’t save the password to your Keychain.")
+        case .passwordContainsNewline:
+            return localized("A password can’t contain a line break.")
         }
     }
 }

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -21,6 +21,10 @@ struct SettingsView: View {
     /// Devices tab's Connect action, injected by the app delegate because
     /// connecting is a main-window launch, not something this window does.
     let onSSHConnect: (String) -> Void
+    /// Runs `ssh-copy-id` for an alias with the given public key, in the main
+    /// window — injected for the same reason as `onSSHConnect`, since it is also a
+    /// terminal launch rather than something this window can do.
+    let onSetUpKey: (String, String) -> Void
     @State private var selection: SettingsTab
 
     init(
@@ -28,12 +32,14 @@ struct SettingsView: View {
         usage: UsageMonitor,
         store: TermioStore,
         initialTab: SettingsTab = .general,
-        onSSHConnect: @escaping (String) -> Void
+        onSSHConnect: @escaping (String) -> Void,
+        onSetUpKey: @escaping (String, String) -> Void
     ) {
         self.settings = settings
         self.usage = usage
         self.store = store
         self.onSSHConnect = onSSHConnect
+        self.onSetUpKey = onSetUpKey
         _selection = State(initialValue: initialTab)
     }
 
@@ -82,7 +88,10 @@ struct SettingsView: View {
         case .appearance: AppearanceSettingsTab(settings: settings)
         case .terminal: TerminalSettingsTab(settings: settings)
         case .workspaces: WorkspaceSettingsTab(store: store)
-        case .devices: DevicesSettingsTab(settings: settings, onConnect: onSSHConnect)
+        case .devices:
+            DevicesSettingsTab(
+                settings: settings, onConnect: onSSHConnect, onSetUpKey: onSetUpKey
+            )
         case .keyboard: KeybindingsSettingsTab()
         case .agents: AgentSettingsTab(settings: settings)
         case .usage: UsageSettingsTab(settings: settings, usage: usage)

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -436,6 +436,25 @@ extension TermioStore {
         selectedSessionID = session.id
     }
 
+    /// Opens a terminal running `ssh-copy-id` against `host`, installing
+    /// `publicKey` in its `authorized_keys`. Used by Settings ▸ Devices when a
+    /// probe finds a host that wants a password: the session exists so the
+    /// server's password prompt has somewhere to be answered, and what it leaves
+    /// behind — a key — is what the rest of termio can actually use.
+    func addKeyInstallSession(host: String, publicKey: String) {
+        let host = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !host.isEmpty else { return }
+        var session = Session(title: localized("Set Up Key"), agent: .terminal)
+        session.givenTitle = session.title
+        session.sshHost = host
+        session.sshKeyToInstall = publicKey
+
+        let workspaceID = deviceWorkspace(for: host)
+        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
+        workspaces[index].terminals.append(session)
+        selectedSessionID = session.id
+    }
+
     /// Prompts for an SSH destination, then opens a terminal to it. The combo box is
     /// pre-populated with the connectable `Host` aliases from `~/.ssh/config` (the
     /// same list the phone imports), but stays editable so a one-off `user@host` that

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -216,8 +216,10 @@ extension TermioStore {
         // the remote host allocates its own pty over the connection. It never
         // resumes (a local-agent concept), so it short-circuits the agent launch
         // resolution below.
-        let launch = session.sshHost.map { (command: Self.sshCommand(host: $0), resumeID: String?.none) }
-            ?? resolveLaunch(for: session, spawnPath: spawnPath)
+        let launch = session.sshHost.map {
+            (command: Self.sshLaunchCommand(host: $0, keyToInstall: session.sshKeyToInstall),
+             resumeID: String?.none)
+        } ?? resolveLaunch(for: session, spawnPath: spawnPath)
         let agentCommand = launch.command
 
         // Pi checks the pinned `--session-id` against its session store at startup
@@ -509,6 +511,19 @@ extension TermioStore {
     /// that the user's `~/.ssh/config` left the decision to us.
     static func sshCommand(host: String) -> String {
         "ssh -- \(shellQuoted(host))"
+    }
+
+    /// What an SSH session actually launches: normally the shell above, but the
+    /// one-shot `ssh-copy-id` when the session carries a key to install.
+    ///
+    /// `ssh-copy-id` is the only place termio takes part in a password at all, and
+    /// it takes part by getting out of the way — the prompt is the remote server's,
+    /// answered on this PTY by the person sitting here. What it leaves behind is a
+    /// key, which is the one credential the paths that can never prompt
+    /// (`BatchMode=yes` on every termiod connection) are able to use.
+    static func sshLaunchCommand(host: String, keyToInstall: String?) -> String {
+        guard let keyToInstall else { return sshCommand(host: host) }
+        return "ssh-copy-id -i \(shellQuoted(keyToInstall)) -- \(shellQuoted(host))"
     }
 
     /// POSIX single-quote escaping: wraps `value` in `'…'`, splicing any embedded

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -267,6 +267,16 @@ extension TermioStore {
         // (Codex, Aider/Rich) are unaffected.
         env["FORCE_HYPERLINK"] = "1"
 
+        // An SSH session to a host with a saved password answers the prompt from
+        // the Keychain instead of asking. Empty for every other host and for every
+        // host with nothing saved, so ssh behaves exactly as it always has. The
+        // key install is deliberately excluded: `ssh-copy-id` is how a password
+        // host stops being one, and feeding it the password it is trying to
+        // replace would install the key while teaching the user nothing.
+        if let host = session.sshHost, session.sshKeyToInstall == nil {
+            env.merge(SSHPasswordStore.askpassEnvironment(for: host)) { _, new in new }
+        }
+
         // The session runs inside the daemon and this app instance attaches to
         // it, so quitting detaches instead of killing.
         //

--- a/Tests/termioTests/SSHHostSetupTests.swift
+++ b/Tests/termioTests/SSHHostSetupTests.swift
@@ -32,11 +32,40 @@ final class SSHHostSetupTests: XCTestCase {
     }
 
     /// An IPv6 literal is nothing but colons; splitting on the last one would
-    /// truncate the address into a different (and reachable) host.
+    /// truncate the address into a different (and reachable) host. The brackets
+    /// come off because `HostName` wants the literal bare.
     func testBracketedIPv6KeepsItsColons() {
         let parsed = SSHConfigFile.parseDestination("[fe80::1]")
-        XCTAssertEqual(parsed.host, "[fe80::1]")
+        XCTAssertEqual(parsed.host, "fe80::1")
         XCTAssertEqual(parsed.port, "")
+    }
+
+    func testBracketedIPv6WithAPortSplitsOnTheBracket() {
+        let parsed = SSHConfigFile.parseDestination("[2001:db8::1]:2222")
+        XCTAssertEqual(parsed.host, "2001:db8::1")
+        XCTAssertEqual(parsed.port, "2222")
+    }
+
+    /// `2001:db8::1` is a whole address, not `2001:db8:` on port 1 — and the wrong
+    /// reading yields a host that can resolve, so it fails as a mystery later.
+    func testUnbracketedIPv6IsNotSplitIntoAPort() {
+        let parsed = SSHConfigFile.parseDestination("2001:db8::1")
+        XCTAssertEqual(parsed.host, "2001:db8::1")
+        XCTAssertEqual(parsed.port, "")
+    }
+
+    func testUserWithBracketedIPv6AndPort() {
+        let parsed = SSHConfigFile.parseDestination("root@[2001:db8::1]:2222")
+        XCTAssertEqual(parsed.user, "root")
+        XCTAssertEqual(parsed.host, "2001:db8::1")
+        XCTAssertEqual(parsed.port, "2222")
+    }
+
+    func testEmptyAndPartialInputYieldNothingRatherThanGarbage() {
+        XCTAssertEqual(SSHConfigFile.parseDestination("").host, "")
+        let trailingAt = SSHConfigFile.parseDestination("you@")
+        XCTAssertEqual(trailingAt.user, "you")
+        XCTAssertEqual(trailingAt.host, "")
     }
 
     // MARK: - Naming the host
@@ -67,6 +96,35 @@ final class SSHHostSetupTests: XCTestCase {
                 forHost: "build.example.com", avoiding: ["build", "build-2"]
             ),
             "build-3"
+        )
+    }
+
+    /// A fixed ceiling handed back the taken base, so the sheet suggested a name it
+    /// then rejected as a duplicate and Add could never be pressed.
+    func testAliasKeepsCountingPastTheHundredthCollision() {
+        var taken: Set<String> = ["build"]
+        for suffix in 2...100 { taken.insert("build-\(suffix)") }
+        let suggested = SSHConfigFile.suggestedAlias(forHost: "build.example.net", avoiding: taken)
+        XCTAssertEqual(suggested, "build-101")
+        XCTAssertFalse(taken.contains(suggested))
+    }
+
+    // MARK: - What can be written into the config
+
+    func testALineBreakIsRefusedRatherThanWritten() {
+        XCTAssertTrue(SSHConfigFile.isUnwritable("box\n  ProxyCommand /bin/sh"))
+        XCTAssertTrue(SSHConfigFile.isUnwritable("box\rHost other"))
+        XCTAssertFalse(SSHConfigFile.isUnwritable("server.example.com"))
+        // A space is legal in a value; `appendHost` quotes it.
+        XCTAssertFalse(SSHConfigFile.isUnwritable("~/My Keys/id_ed25519"))
+    }
+
+    func testAppendHostRefusesAValueCarryingItsOwnDirective() {
+        XCTAssertThrowsError(
+            try SSHConfigFile.appendHost(
+                alias: "box\nHost evil", hostName: "example.com",
+                user: "", port: "", identityFile: ""
+            )
         )
     }
 
@@ -127,6 +185,27 @@ final class SSHHostSetupTests: XCTestCase {
             keys: [key("id_rsa.pub", algorithm: "RSA"), key("id_ed25519.pub", algorithm: "ED25519")]
         )
         XCTAssertEqual(chosen?.name, "id_ed25519.pub")
+    }
+
+    /// With no `IdentityFile` in the block, ssh offers only its default names and
+    /// the agent. Installing `work_security_key` would report success and change
+    /// nothing, because the next connection never offers that key.
+    func testAKeySshWouldNeverOfferIsNotInstalled() {
+        XCTAssertNil(SSHConfigFile.publicKeyToInstall(
+            for: host("box"),
+            keys: [key("work_security_key.pub", algorithm: "ED25519-SK")]
+        ))
+    }
+
+    func testDefaultNamedKeyIsPreferredOverAStrongerCustomOne() {
+        let chosen = SSHConfigFile.publicKeyToInstall(
+            for: host("box"),
+            keys: [
+                key("work_security_key.pub", algorithm: "ED25519-SK"),
+                key("id_rsa.pub", algorithm: "RSA"),
+            ]
+        )
+        XCTAssertEqual(chosen?.name, "id_rsa.pub")
     }
 
     /// ssh will offer exactly the pinned key, so installing a different one leaves

--- a/Tests/termioTests/SSHHostSetupTests.swift
+++ b/Tests/termioTests/SSHHostSetupTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+
+@testable import termio
+
+/// The pure grammar behind Settings ▸ Devices: what an address means, what a new
+/// host should be called, which credentials to offer, and which key an install
+/// would actually send. All of it decides what lands in `~/.ssh/config` or on a
+/// server's `authorized_keys`, and none of it needs a window.
+final class SSHHostSetupTests: XCTestCase {
+    // MARK: - Reading an address
+
+    func testParsesUserHostAndPort() {
+        let parsed = SSHConfigFile.parseDestination("root@10.0.0.4:2222")
+        XCTAssertEqual(parsed.user, "root")
+        XCTAssertEqual(parsed.host, "10.0.0.4")
+        XCTAssertEqual(parsed.port, "2222")
+    }
+
+    func testPlainHostnameLeavesUserAndPortEmpty() {
+        let parsed = SSHConfigFile.parseDestination("  server.example.com ")
+        XCTAssertEqual(parsed.user, "")
+        XCTAssertEqual(parsed.host, "server.example.com")
+        XCTAssertEqual(parsed.port, "")
+    }
+
+    /// A trailing `:something` is only a port when it is a number. Otherwise it
+    /// belongs to the hostname, and eating it would connect to the wrong box.
+    func testNonNumericSuffixIsNotAPort() {
+        let parsed = SSHConfigFile.parseDestination("server.example.com:staging")
+        XCTAssertEqual(parsed.host, "server.example.com:staging")
+        XCTAssertEqual(parsed.port, "")
+    }
+
+    /// An IPv6 literal is nothing but colons; splitting on the last one would
+    /// truncate the address into a different (and reachable) host.
+    func testBracketedIPv6KeepsItsColons() {
+        let parsed = SSHConfigFile.parseDestination("[fe80::1]")
+        XCTAssertEqual(parsed.host, "[fe80::1]")
+        XCTAssertEqual(parsed.port, "")
+    }
+
+    // MARK: - Naming the host
+
+    func testAliasIsTheFirstLabel() {
+        XCTAssertEqual(
+            SSHConfigFile.suggestedAlias(forHost: "build.example.com", avoiding: []),
+            "build"
+        )
+    }
+
+    func testAliasForAnIPKeepsTheWholeAddress() {
+        XCTAssertEqual(
+            SSHConfigFile.suggestedAlias(forHost: "192.168.1.10", avoiding: []),
+            "192.168.1.10"
+        )
+    }
+
+    /// Two boxes under different domains share a first label. The second must not
+    /// silently claim the first one's name — `ssh build` has to keep meaning one host.
+    func testAliasAvoidsATakenName() {
+        XCTAssertEqual(
+            SSHConfigFile.suggestedAlias(forHost: "build.example.com", avoiding: ["build"]),
+            "build-2"
+        )
+        XCTAssertEqual(
+            SSHConfigFile.suggestedAlias(
+                forHost: "build.example.com", avoiding: ["build", "build-2"]
+            ),
+            "build-3"
+        )
+    }
+
+    // MARK: - Identities to offer
+
+    private func host(
+        _ alias: String, user: String = "", identityFile: String? = nil
+    ) -> SSHConfigHost {
+        SSHConfigHost(
+            alias: alias, hostName: "\(alias).example.com", user: user, port: 22,
+            identityFile: identityFile, file: URL(fileURLWithPath: "/dev/null"), line: 0
+        )
+    }
+
+    func testIdentitiesAreRankedByUse() {
+        let identities = SSHConfigFile.suggestedIdentities(in: [
+            host("a", user: "deploy", identityFile: "~/.ssh/id_work"),
+            host("b", user: "you", identityFile: "~/.ssh/id_ed25519"),
+            host("c", user: "you", identityFile: "~/.ssh/id_ed25519"),
+        ])
+        XCTAssertEqual(identities.count, 2)
+        XCTAssertEqual(identities.first?.user, "you")
+        XCTAssertEqual(identities.first?.keyName, "id_ed25519")
+    }
+
+    /// A host that sets neither field describes the defaults, and offering "sign in
+    /// as (nothing)" is a row that changes nothing when picked.
+    func testIdentityWithNeitherFieldIsNotOffered() {
+        XCTAssertTrue(SSHConfigFile.suggestedIdentities(in: [host("bare")]).isEmpty)
+    }
+
+    // MARK: - Reading ssh's refusal
+
+    func testMethodListNamesWhatTheServerWouldHaveTaken() {
+        XCTAssertEqual(
+            SSHConfigFile.offeredMethods("box: Permission denied (publickey,password)."),
+            ["publickey", "password"]
+        )
+    }
+
+    func testMissingMethodListReadsAsNoMethods() {
+        XCTAssertTrue(SSHConfigFile.offeredMethods("Permission denied, please try again.").isEmpty)
+    }
+
+    // MARK: - Choosing the key to install
+
+    private func key(_ name: String, algorithm: String) -> SSHPublicKey {
+        SSHPublicKey(
+            url: FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".ssh/\(name)"),
+            algorithm: algorithm, comment: ""
+        )
+    }
+
+    func testStrongestKeyWinsWhenTheHostPinsNone() {
+        let chosen = SSHConfigFile.publicKeyToInstall(
+            for: host("box"),
+            keys: [key("id_rsa.pub", algorithm: "RSA"), key("id_ed25519.pub", algorithm: "ED25519")]
+        )
+        XCTAssertEqual(chosen?.name, "id_ed25519.pub")
+    }
+
+    /// ssh will offer exactly the pinned key, so installing a different one leaves
+    /// the host failing for the same reason with an extra key on it.
+    func testPinnedIdentityFileDecidesTheKey() {
+        let chosen = SSHConfigFile.publicKeyToInstall(
+            for: host("box", identityFile: "~/.ssh/id_work"),
+            keys: [key("id_ed25519.pub", algorithm: "ED25519"), key("id_work.pub", algorithm: "RSA")]
+        )
+        XCTAssertEqual(chosen?.name, "id_work.pub")
+    }
+
+    /// The pinned key has no `.pub` on disk: there is nothing safe to send, and
+    /// guessing another key would install one ssh is never going to offer.
+    func testPinnedIdentityWithNoPublicHalfInstallsNothing() {
+        XCTAssertNil(SSHConfigFile.publicKeyToInstall(
+            for: host("box", identityFile: "~/.ssh/id_missing"),
+            keys: [key("id_ed25519.pub", algorithm: "ED25519")]
+        ))
+    }
+}

--- a/Tests/termioTests/SSHPasswordStoreTests.swift
+++ b/Tests/termioTests/SSHPasswordStoreTests.swift
@@ -38,6 +38,30 @@ final class SSHPasswordStoreTests: XCTestCase {
         XCTAssertTrue(SSHPasswordStore.askpassEnvironment(for: alias).isEmpty)
     }
 
+    /// Neither leg of the trip survives one: `security` reads the confirmation
+    /// line-wise and ssh takes only the helper's first line, so accepting it would
+    /// store a truncated password whose failure looks like a wrong one.
+    func testAPasswordWithALineBreakIsRefused() {
+        XCTAssertThrowsError(try SSHPasswordStore.save("two\nlines", for: alias)) { error in
+            XCTAssertEqual(error as? SSHPasswordError, .passwordContainsNewline)
+        }
+        XCTAssertFalse(SSHPasswordStore.hasPassword(for: alias))
+    }
+
+    /// The existence check gates every SSH session launch on the main actor. A
+    /// subprocess there is a visible freeze, so it must not be one.
+    func testExistenceCheckIsFastEnoughForTheMainActor() throws {
+        try SSHPasswordStore.save("hunter2", for: alias)
+        let started = Date()
+        for _ in 0..<50 { _ = SSHPasswordStore.hasPassword(for: alias) }
+        let each = Date().timeIntervalSince(started) / 50
+        XCTAssertLessThan(each, 0.005, "\(Int(each * 1000)) ms per check is a spawn, not a query")
+    }
+
+    func testRemovingSomethingThatIsNotThereStillReportsSuccess() {
+        XCTAssertTrue(SSHPasswordStore.remove(for: alias))
+    }
+
     func testEnvironmentForcesAskpassOverATerminal() throws {
         try SSHPasswordStore.save("hunter2", for: alias)
         let environment = SSHPasswordStore.askpassEnvironment(for: alias)

--- a/Tests/termioTests/SSHPasswordStoreTests.swift
+++ b/Tests/termioTests/SSHPasswordStoreTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+
+@testable import termio
+
+/// Exercises the Keychain round trip and the askpass helper against the real
+/// `security(1)` and a real `ssh`. The item lives under a test-only service name
+/// and is removed in `tearDown`, so nothing touches a password the user saved.
+///
+/// The end-to-end half — that ssh actually signs in with what the helper prints —
+/// needs a server that takes passwords, so it runs only when `TERMIO_TEST_SSH_URL`
+/// names one (`tester@localhost:2223`). Without it the mechanism is still covered
+/// up to the point ssh would be invoked.
+final class SSHPasswordStoreTests: XCTestCase {
+    private let alias = "termio-tests-\(ProcessInfo.processInfo.processIdentifier)"
+
+    override func tearDown() {
+        SSHPasswordStore.remove(for: alias)
+        super.tearDown()
+    }
+
+    func testSavedPasswordIsFoundAndRemoved() throws {
+        XCTAssertFalse(SSHPasswordStore.hasPassword(for: alias))
+        try SSHPasswordStore.save("hunter2", for: alias)
+        XCTAssertTrue(SSHPasswordStore.hasPassword(for: alias))
+        SSHPasswordStore.remove(for: alias)
+        XCTAssertFalse(SSHPasswordStore.hasPassword(for: alias))
+    }
+
+    /// A password with the characters that break naive shell plumbing. It never
+    /// passes through a shell here, and this is what proves it.
+    func testAwkwardPasswordSurvivesTheRoundTrip() throws {
+        let awkward = #"p@ss "w'rd $(echo no) \ %s"#
+        try SSHPasswordStore.save(awkward, for: alias)
+        XCTAssertEqual(try helperOutput(), awkward)
+    }
+
+    func testNothingSavedMeansNoEnvironmentAndSshIsUnchanged() {
+        XCTAssertTrue(SSHPasswordStore.askpassEnvironment(for: alias).isEmpty)
+    }
+
+    func testEnvironmentForcesAskpassOverATerminal() throws {
+        try SSHPasswordStore.save("hunter2", for: alias)
+        let environment = SSHPasswordStore.askpassEnvironment(for: alias)
+        // Without `force`, ssh prefers the tty and the saved password is ignored
+        // on exactly the path that has one — a session.
+        XCTAssertEqual(environment["SSH_ASKPASS_REQUIRE"], "force")
+        XCTAssertEqual(environment["TERMIO_SSH_ALIAS"], alias)
+        XCTAssertEqual(environment["SSH_ASKPASS"], try SSHPasswordStore.helperURL().path)
+    }
+
+    /// ssh silently ignores an askpass it cannot execute, which would look like the
+    /// password was wrong rather than never sent.
+    func testHelperIsExecutableAndOwnerOnly() throws {
+        let url = try SSHPasswordStore.helperURL()
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: url.path))
+        let permissions = try FileManager.default
+            .attributesOfItem(atPath: url.path)[.posixPermissions] as? NSNumber
+        XCTAssertEqual(permissions?.int16Value, 0o700)
+    }
+
+    func testHelperHoldsNoSecret() throws {
+        try SSHPasswordStore.save("hunter2", for: alias)
+        let script = try String(contentsOf: try SSHPasswordStore.helperURL(), encoding: .utf8)
+        XCTAssertFalse(script.contains("hunter2"))
+    }
+
+    func testSshSignsInWithTheSavedPassword() throws {
+        guard let destination = ProcessInfo.processInfo.environment["TERMIO_TEST_SSH_URL"] else {
+            throw XCTSkip("Set TERMIO_TEST_SSH_URL=user@host:port to run the live login")
+        }
+        let parsed = SSHConfigFile.parseDestination(destination)
+        try SSHPasswordStore.save(
+            ProcessInfo.processInfo.environment["TERMIO_TEST_SSH_PASSWORD"] ?? "hunter2",
+            for: alias
+        )
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+        process.arguments = [
+            "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "NumberOfPasswordPrompts=1", "-o", "ConnectTimeout=10",
+            "-p", parsed.port.isEmpty ? "22" : parsed.port,
+            "\(parsed.user)@\(parsed.host)", "echo signed-in",
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment.merge(SSHPasswordStore.askpassEnvironment(for: alias)) { _, new in new }
+        process.environment = environment
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+        try process.run()
+        let text = String(
+            data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8
+        ) ?? ""
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertTrue(text.contains("signed-in"), "ssh printed: \(text)")
+    }
+
+    /// Runs the helper the way ssh would, and returns what ssh would read.
+    private func helperOutput() throws -> String {
+        let process = Process()
+        process.executableURL = try SSHPasswordStore.helperURL()
+        process.environment = SSHPasswordStore.askpassEnvironment(for: alias)
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .newlines) ?? ""
+    }
+}


### PR DESCRIPTION
Add SSH Host asked for five things in an order nobody thinks in, and the failure it walked into — a host that only takes a password — was a dead end that said `Auth failed` and stopped.

**The sheet.** The address leads and the rest follows from it: `you@box.example.com:2222` fills the user and port, and the name is the address's first label until you type your own. User and Key sit under a Credentials heading, pre-filled from the identity the rest of your config already uses, because a machine you add is almost always reached as the same person with the same key as the last one. Key is a popup of the keys you actually have, led by "Default keys" — no `IdentityFile` line, which is what ssh does alone. Nothing is behind a disclosure, and a blocked Add says which field is wrong instead of greying out.

**The password host.** ssh's own refusal carries the diagnosis: `password` in `Permission denied (publickey,password)` is the server saying it would have taken one. The probe reads that list, says "Wants a password", and offers Set Up Key — `ssh-copy-id` in a real session, where the prompt is answered once by the person sitting there and what it leaves behind is a key. That matters because `BatchMode=yes` is unconditional on every termiod connection, so a password host connects in a shell and is dark everywhere else.

**Saving a password.** Optional, and in the login Keychain only. It reaches ssh through `SSH_ASKPASS` with `SSH_ASKPASS_REQUIRE=force`, the mechanism OpenSSH provides for exactly this, so nothing is embedded and nothing is linked. The helper asks `security(1)` for the secret at the moment ssh asks, so it is never in an argument list (`sshpass`'s flaw), never in the environment, and never in a file. Stated plainly because it is the real cost: the item's access list trusts `security(1)`, so any process running as you can read it back without a prompt — the same standing anything already has over an `ssh-add --apple-use-keychain` passphrase.

Verified against a real password-only `sshd` rather than reasoned about: `force` signs in where `BatchMode=yes` refuses, and a wrong password fails in 0.3 s under `NumberOfPasswordPrompts=1`.

A Codex review of the branch found nine defects, all fixed in `5eb9f0b` with a test each — including two wrong answers: Set Up Key could install a key ssh would never offer, and IPv6 addresses were parsed two different wrong ways.

593 tests pass; `check-strings.sh` is green with zh-Hans for every new string.

Release Notes:
- Add SSH Host leads with the address and fills in the user and key your other hosts already use. Paste `you@box.example.com:2222` and the fields sort themselves out.
- A host that only accepts a password now says so, and offers to install your key on it — one password, typed once, and the host works everywhere afterward.
- A host password can be saved to your Keychain. It is never written to ssh config, and only ever read when ssh asks for it.