### PR TITLE
Show a fork's upstream issues in the Issues pane

### DIFF
--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -790,27 +790,118 @@ enum GitService {
         return URL(string: "\(repo.absoluteString)/\(path)")
     }
 
-    /// The `owner/repo` slug when the origin remote points at github.com — the
-    /// Issues pane's zero-config binding (docs/design/20260726-issue-tracker-integration.md).
-    /// `nil` for non-GitHub remotes or a repo with no origin.
-    static func gitHubRepoSlug(in dir: String) async -> String? {
+    /// A git remote that points at github.com, as the Issues pane addresses it.
+    struct GitHubRemote: Hashable, Sendable {
+        let name: String
+        /// `owner/repo`.
+        let slug: String
+    }
+
+    /// Every github.com remote of `dir`, ordered by how likely each is to own the
+    /// project's issue tracker. A fork clone leaves the real tracker on `upstream`
+    /// while `origin` is the user's own copy, so binding to `origin` alone shows an
+    /// empty pane. Two remotes pointing at the same repository collapse into one
+    /// entry under the higher-priority name. Empty for a repo with no GitHub remote
+    /// at all — the Issues pane's `.unbound` zero state.
+    static func gitHubRemotes(in dir: String) async -> [GitHubRemote] {
         await offMain {
-            guard let remote = run(["remote", "get-url", "origin"], in: dir)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-                let parsed = parseRemote(remote)
+            guard let listed = run(["remote"], in: dir) else { return [] }
+            let names = orderedRemoteNames(
+                listed
+                    .split(separator: "\n")
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty })
+            var remotes: [GitHubRemote] = []
+            var seenSlugs: Set<String> = []
+            for name in names {
+                guard let url = run(["remote", "get-url", name], in: dir)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                    let slug = gitHubSlug(fromRemote: url),
+                    seenSlugs.insert(slug).inserted
+                else { continue }
+                remotes.append(GitHubRemote(name: name, slug: slug))
+            }
+            return remotes
+        }
+    }
+
+    /// Remote names in tracker-preference order. `upstream` then `origin` are the
+    /// two names git tooling has a convention for — `gh` and VS Code's GitHub
+    /// extension read the same pair — and everything else keeps a stable
+    /// alphabetical order, so the pane's repository menu can't reshuffle between
+    /// reads of an unchanged repo.
+    static func orderedRemoteNames(_ names: [String]) -> [String] {
+        func rank(_ name: String) -> Int {
+            switch name {
+            case "upstream": return 0
+            case "origin": return 1
+            default: return 2
+            }
+        }
+        return names.sorted { rank($0) == rank($1) ? $0 < $1 : rank($0) < rank($1) }
+    }
+
+    /// The `owner/repo` slug when `remote` points at github.com — the Issues pane's
+    /// binding (docs/design/20260726-issue-tracker-integration.md). `nil` for any
+    /// other host.
+    static func gitHubSlug(fromRemote remote: String) -> String? {
+        guard let parsed = parseRemote(remote), isWellFormedSlug(parsed.path) else { return nil }
+        // A literal github.com host binds directly, whatever the transport.
+        if isGitHubHostName(parsed.host) { return parsed.path }
+        // Otherwise it may be an SSH `~/.ssh/config` alias (`Host github-work`
+        // → `HostName github.com`, the standard trick for juggling accounts).
+        // `sshTarget` is non-nil only for SSH remotes, so an HTTPS host never
+        // triggers `ssh -G` — which would be pointless and could fire a
+        // `Match exec` or falsely bind an unrelated repo to public GitHub.
+        guard let target = parsed.sshTarget,
+              let resolved = resolveSSHHostName(target),
+              isGitHubHostName(resolved)
+        else { return nil }
+        return parsed.path
+    }
+
+    /// Whether `path` is a plain `owner/repo` GitHub accepts — two non-empty
+    /// components drawn from the character set GitHub allows in an account or
+    /// repository name. `parseRemote` is deliberately permissive about paths (it
+    /// serves the forge web links too), but a slug reaches the API as an
+    /// interpolated URL, and one carrying a stray `%` or a third component would
+    /// build a URL that is nil at the point of use. Rejecting it here keeps every
+    /// caller off that path.
+    private static func isWellFormedSlug(_ path: String) -> Bool {
+        let allowed = CharacterSet(charactersIn:
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard components.count == 2 else { return false }
+        return components.allSatisfy {
+            !$0.isEmpty && CharacterSet(charactersIn: String($0)).isSubset(of: allowed)
+        }
+    }
+
+    /// The repository the user explicitly bound the Issues pane to for this
+    /// checkout, from `termio.issuesRepo` in the repo's git config. Read from
+    /// `--local` rather than `--worktree` config on purpose: linked worktrees share
+    /// it, so picking a tracker once holds for every worktree of the repo. `nil` —
+    /// the common case — leaves the pane on its own resolution ladder.
+    static func issuesRepository(in dir: String) async -> String? {
+        await offMain {
+            // `--get` exits non-zero when the key is unset, which `run` maps to nil.
+            guard let value = run(["config", "--local", "--get", "termio.issuesRepo"], in: dir)?
+                .trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty
             else { return nil }
-            // A literal github.com host binds directly, whatever the transport.
-            if isGitHubHostName(parsed.host) { return parsed.path }
-            // Otherwise it may be an SSH `~/.ssh/config` alias (`Host github-work`
-            // → `HostName github.com`, the standard trick for juggling accounts).
-            // `sshTarget` is non-nil only for SSH remotes, so an HTTPS host never
-            // triggers `ssh -G` — which would be pointless and could fire a
-            // `Match exec` or falsely bind an unrelated repo to public GitHub.
-            guard let target = parsed.sshTarget,
-                  let resolved = resolveSSHHostName(target),
-                  isGitHubHostName(resolved)
-            else { return nil }
-            return parsed.path
+            return value
+        }
+    }
+
+    /// Records the user's pick from the Issues pane's repository menu. The only
+    /// write termio makes to a repo's git config, and only ever from that explicit
+    /// choice — resolution is otherwise read-only, and never adds a remote the way
+    /// VS Code's GitHub extension does.
+    static func setIssuesRepository(_ slug: String, in dir: String) async {
+        await offMain {
+            if run(["config", "--local", "termio.issuesRepo", slug], in: dir) == nil {
+                Log.issues.error(
+                    "couldn’t record the issues repository in \(dir, privacy: .public)’s git config")
+            }
         }
     }
 

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -27,7 +27,7 @@ struct InspectorTabsToolbar: View {
     /// selected chip in light mode (the macOS 26 Finder segmented control), a faint light track
     /// with a brighter overlay chip in dark.
     @Environment(\.colorScheme) private var colorScheme
-    /// Whether the current project's origin remote points at github.com — probed
+    /// Whether any of the current project's remotes points at github.com — probed
     /// async per selection change; gates the Issues segment together with the
     /// General "GitHub" setting.
     @State private var hasGitHubRemote = false
@@ -83,7 +83,7 @@ struct InspectorTabsToolbar: View {
             // the check doesn't rerun on unrelated store churn.
             .task(id: "\(settings.githubIntegrationEnabled)|\(store.inspectorCheckout?.localRoot ?? "")") {
                 if let path = store.inspectorCheckout?.localRoot, settings.githubIntegrationEnabled {
-                    hasGitHubRemote = await GitService.gitHubRepoSlug(in: path) != nil
+                    hasGitHubRemote = await !GitService.gitHubRemotes(in: path).isEmpty
                 } else {
                     hasGitHubRemote = false
                 }

--- a/Sources/termio/Issues/GitHubIssueProvider.swift
+++ b/Sources/termio/Issues/GitHubIssueProvider.swift
@@ -90,6 +90,23 @@ struct GitHubIssueProvider: IssueProvider {
         return raw.map { IssueLabel(name: $0.name, colorHex: $0.color ?? "") }
     }
 
+    /// The repository `slug` was forked from, or `nil` when it isn't a fork. The
+    /// half of the fork problem no git remote can answer: `git clone <my-fork>`
+    /// leaves a checkout whose only remote is the fork, and GitHub's own `parent`
+    /// is then the sole record of where the issues actually live. Discovery only —
+    /// termio surfaces the parent as a choice and never writes it back as a remote.
+    func forkParent(of slug: String) async throws -> String? {
+        struct RawRepository: Decodable {
+            struct Parent: Decodable { let fullName: String }
+            let fork: Bool
+            let parent: Parent?
+        }
+        guard let url = URL(string: "https://api.github.com/repos/\(slug)") else { return nil }
+        let raw: RawRepository = try await get(url)
+        guard raw.fork else { return nil }
+        return raw.parent?.fullName
+    }
+
     // MARK: Pull-request extras (GitHub-specific, outside the tracker protocol)
 
     /// The PR's changed files as `GitChange` rows (the git pane's own model) *with the

--- a/Sources/termio/Issues/IssueModels.swift
+++ b/Sources/termio/Issues/IssueModels.swift
@@ -95,6 +95,20 @@ struct IssueContainer: Hashable, Sendable {
     let id: String
 }
 
+/// A repository the Issues pane could bind this project to. Usually there is
+/// exactly one and the pane never mentions it; a fork checkout has several, and
+/// then the user picks (#427).
+struct IssueRepositoryCandidate: Hashable, Identifiable, Sendable {
+    /// `owner/repo` — unique across the list, so it doubles as the identity.
+    let slug: String
+    /// The git remote this came from, or `nil` for a repository the pane knows
+    /// about without the checkout naming it: the fork parent GitHub reported, or
+    /// a slug the user picked before the remote went away.
+    let remoteName: String?
+
+    var id: String { slug }
+}
+
 /// The list request: which kind, and the light filters the top bar offers.
 /// Selected labels combine as AND, GitHub's own filter semantics.
 struct IssueQuery: Hashable, Sendable {

--- a/Sources/termio/Issues/IssuesPanelModel.swift
+++ b/Sources/termio/Issues/IssuesPanelModel.swift
@@ -5,7 +5,7 @@ import AppKit
 
 /// State for the Issues pane, per repo root (recreated by `.id(repoRoot)` like
 /// `GitPanelModel`): the GitHub connection, the container binding resolved from
-/// the origin remote, the list, and the pushed-in detail.
+/// the checkout's remotes, the list, and the pushed-in detail.
 @MainActor
 final class IssuesPanelModel: ObservableObject {
     /// Where the pane is in the connect → bind → read ladder; each step has a
@@ -15,7 +15,7 @@ final class IssuesPanelModel: ObservableObject {
         case disconnected
         /// Device flow underway: show the code, wait for approval in the browser.
         case connecting(userCode: String)
-        /// Connected, but the project's origin remote isn't a github.com repo.
+        /// Connected, but none of the project's remotes is a github.com repo.
         case unbound
         case ready
     }
@@ -38,8 +38,16 @@ final class IssuesPanelModel: ObservableObject {
     @Published private(set) var detailError: String?
 
     @Published var query = IssueQuery() {
-        didSet { if query != oldValue { Task { await loadList() } } }
+        didSet {
+            // A rebind rewrites the query as part of clearing the old repository out;
+            // it issues its own load, so this must not queue a second one against a
+            // container that is still being settled.
+            guard query != oldValue, !isRebinding else { return }
+            Task { await loadList() }
+        }
     }
+
+    private var isRebinding = false
 
     let repoRoot: String
     private var provider: GitHubIssueProvider?
@@ -62,7 +70,7 @@ final class IssuesPanelModel: ObservableObject {
     private var didStart = false
 
     /// Entry point on appear: restore the Keychain token, resolve the binding
-    /// from the origin remote, and load.
+    /// from the checkout's remotes, and load.
     func start() async {
         await ensureReady()
         guard provider != nil else {
@@ -122,6 +130,7 @@ final class IssuesPanelModel: ObservableObject {
         GitHubIssueAuth.deleteToken()
         provider = nil
         items = []
+        candidates = []
         openItem = nil
         detail = nil
         // The token is gone, so a later reconnect (possibly a different account) must not read
@@ -155,15 +164,137 @@ final class IssuesPanelModel: ObservableObject {
 
     // MARK: Loading
 
+    /// Every repository this checkout could show a tracker for, in menu order. One
+    /// entry is the overwhelmingly common case and the pane stays silent about it;
+    /// more than one means a fork, and the top bar offers the choice.
+    @Published private(set) var candidates: [IssueRepositoryCandidate] = []
+
+    /// Fork parents already looked up this launch, keyed by the probed slug — a
+    /// `Set` of slugs probed plus the answers, so "not a fork" is remembered too.
+    /// The model is per-pane and short-lived (a session switch builds a new one),
+    /// so without this the probe would repeat on every remount.
+    private static var probedForForkParent: Set<String> = []
+    private static var forkParents: [String: String] = [:]
+
+    /// What the ladder chose, and the full menu it chose from.
+    struct Binding: Equatable {
+        let selected: IssueRepositoryCandidate
+        let candidates: [IssueRepositoryCandidate]
+    }
+
+    /// The ladder itself, from most to least authoritative: the user's own pick,
+    /// then an `upstream` remote, then the fork parent GitHub reports for the
+    /// leading remote, then that remote. Pure, so the precedence can be pinned
+    /// down in tests without a window, a checkout, or the network; the caller
+    /// gathers the inputs and only pays for `forkParent` when the rungs above it
+    /// miss. `nil` when there is nothing at all to bind to.
+    static func resolveBinding(
+        remotes: [IssueRepositoryCandidate],
+        pick: String?,
+        forkParent: (String) async -> String?
+    ) async -> Binding? {
+        var found = remotes
+
+        /// Binds `slug`, adding it to the menu when no remote already offers it —
+        /// which is how a repository the checkout never names (a fork parent, or a
+        /// pick whose remote is gone) still becomes switchable rather than a
+        /// one-entry menu the pane hides.
+        func bind(_ slug: String) -> Binding {
+            if let match = found.first(where: { $0.slug == slug }) {
+                return Binding(selected: match, candidates: found)
+            }
+            let added = IssueRepositoryCandidate(slug: slug, remoteName: nil)
+            found.append(added)
+            return Binding(selected: added, candidates: found)
+        }
+
+        // Before the empty check: an explicit pick outlives the remote it came from,
+        // so renaming or dropping a remote can't silently drag the pane back to a
+        // repository the user already rejected.
+        if let pick { return bind(pick) }
+        guard let leading = found.first else { return nil }
+        if let upstream = found.first(where: { $0.remoteName == "upstream" }) {
+            return Binding(selected: upstream, candidates: found)
+        }
+        if let parent = await forkParent(leading.slug) { return bind(parent) }
+        return Binding(selected: leading, candidates: found)
+    }
+
     private func resolveContainer() async {
-        if let slug = await GitService.gitHubRepoSlug(in: repoRoot) {
-            container = IssueContainer(provider: .github, id: slug)
+        let remotes = await GitService.gitHubRemotes(in: repoRoot).map {
+            IssueRepositoryCandidate(slug: $0.slug, remoteName: $0.name)
+        }
+        let pick = await GitService.issuesRepository(in: repoRoot)
+        let binding = await Self.resolveBinding(
+            remotes: remotes, pick: pick, forkParent: { await self.forkParent(of: $0) })
+        didResolveContainer = true
+        let previous = container
+        if let binding {
+            candidates = binding.candidates
+            container = IssueContainer(provider: .github, id: binding.selected.slug)
             phase = .ready
         } else {
+            candidates = []
             container = nil
             phase = .unbound
         }
-        didResolveContainer = true
+        // A re-resolve that lands somewhere else — Refresh after a fork-parent probe
+        // that failed on the first try — gets the same reset an explicit pick does, so
+        // the fork's issues can't sit under the parent's name while its list loads.
+        if previous != nil, previous != container { clearRepositoryScopedState() }
+    }
+
+    /// Drops everything belonging to the repository the pane was showing. Both ways
+    /// the binding can move — the user's own pick and a Refresh that re-resolves —
+    /// go through here, so neither can leave one repository's issues, labels, or open
+    /// detail under another's name.
+    private func clearRepositoryScopedState() {
+        items = []
+        openItem = nil
+        detail = nil
+        detailError = nil
+        errorMessage = nil
+        recovery = nil
+        // Labels belong to the repository that offered them, so both the filter menu's
+        // contents and any selection carried over from the previous one are wrong here.
+        availableLabels = []
+        isRebinding = true
+        query.labels = []
+        isRebinding = false
+    }
+
+    /// Whether the last fork-parent probe failed rather than answering — an offline
+    /// launch, a rate limit. The pane is then bound to the fork with a one-entry
+    /// menu it hides, which is the very dead end #427 is about, so an explicit
+    /// Refresh re-runs the whole resolve instead of only re-fetching the list.
+    private var forkParentUnknown = false
+
+    private func forkParent(of slug: String) async -> String? {
+        if Self.probedForForkParent.contains(slug) { return Self.forkParents[slug] }
+        guard let provider else { return nil }
+        do {
+            let parent = try await provider.forkParent(of: slug)
+            Self.probedForForkParent.insert(slug)
+            Self.forkParents[slug] = parent
+            forkParentUnknown = false
+            return parent
+        } catch {
+            // Unrecorded on purpose, so a later attempt can still succeed: one offline
+            // launch must not pin the pane to the fork for the rest of the session.
+            Log.issues.error("fork-parent probe failed for \(slug, privacy: .public): \(error, privacy: .public)")
+            forkParentUnknown = true
+            return nil
+        }
+    }
+
+    /// Rebinds the pane to another of this checkout's repositories and remembers it,
+    /// so the choice survives a relaunch and holds across the repo's worktrees.
+    func selectRepository(slug: String) {
+        guard slug != container?.id, candidates.contains(where: { $0.slug == slug }) else { return }
+        container = IssueContainer(provider: .github, id: slug)
+        clearRepositoryScopedState()
+        Task { await GitService.setIssuesRepository(slug, in: repoRoot) }
+        Task { await loadList() }
     }
 
     /// The repo's labels, for the filter menu — loaded once per pane.
@@ -179,17 +310,30 @@ final class IssuesPanelModel: ObservableObject {
 
     private func loadLabels() async {
         guard let provider, let container, availableLabels.isEmpty else { return }
-        availableLabels = (try? await provider.availableLabels(in: container)) ?? []
+        let loaded = (try? await provider.availableLabels(in: container)) ?? []
+        // Labels belong to the repository that served them; a switch mid-fetch must not
+        // fill the filter menu with the previous one's.
+        guard self.container == container else { return }
+        availableLabels = loaded
     }
 
     /// `force` bypasses the cache for an explicit user refresh (the toolbar button / Try Again),
     /// which must always re-fetch; automatic loads (appear, session switch, filter change) leave it
     /// `false` so they read the cache.
     func loadList(force: Bool = false) async {
+        // An explicit Refresh is also the way out of a binding that a failed fork-parent
+        // probe left on the fork — re-walk the ladder before re-fetching anything.
+        if force, forkParentUnknown {
+            didResolveContainer = false
+            await resolveContainer()
+        }
         guard let provider, let container, phase == .ready else { return }
         if availableLabels.isEmpty { Task { await loadLabels() } }
-        // Capture the query: a filter / kind change mid-fetch queues its own `loadList` (see the
-        // `query` didSet), so guard against publishing this fetch's result over that newer one.
+        // Capture the request's identity: a filter / kind change queues its own `loadList`
+        // (see the `query` didSet) and a repository switch rebinds `container`, either of
+        // which can land while this fetch is in flight. Both are checked before publishing,
+        // so a slow result can never overwrite a newer one — or show repository A's issues
+        // under repository B's name.
         let query = self.query
 
         // Warm: render the cached list instantly (no spinner), then revalidate past the dedupe
@@ -202,7 +346,8 @@ final class IssuesPanelModel: ObservableObject {
             guard Date().timeIntervalSince(cached.fetchedAt) >= Self.revalidateAfter else { return }
             do {
                 let fresh = try await provider.issues(in: container, query: query)
-                guard self.query == query else { return }  // a newer loadList owns the list now
+                // A newer loadList — or another repository — owns the list now.
+                guard self.query == query, self.container == container else { return }
                 cache?.storeList(fresh, container, query)
                 if fresh != items { items = fresh }  // republish only on a real change — no flicker
             } catch {
@@ -217,7 +362,7 @@ final class IssuesPanelModel: ObservableObject {
         recovery = nil
         do {
             let fetched = try await provider.issues(in: container, query: query)
-            guard self.query == query else { isLoading = false; return }
+            guard self.query == query, self.container == container else { isLoading = false; return }
             items = fetched
             cache?.storeList(fetched, container, query)
         } catch {

--- a/Sources/termio/Issues/IssuesView.swift
+++ b/Sources/termio/Issues/IssuesView.swift
@@ -79,6 +79,7 @@ struct IssuesView: View {
     private var topBar: some View {
         HStack(spacing: 2) {
             if model.capabilities?.pullRequests == true { kindSwitch }
+            if model.candidates.count > 1 { repositoryMenu }
             Spacer(minLength: 0)
             refreshButton
                 // Breathing room so refresh and filter don't read as one two-icon cluster.
@@ -99,6 +100,34 @@ struct IssuesView: View {
         TreeHeaderButton(codicon: .refresh, help: localized("Refresh")) {
             Task { await model.loadList(force: true) }
         }
+    }
+
+    /// Which repository the list is reading, shown only when the checkout offers a
+    /// choice — a fork, where the project's real tracker is on `upstream` and the
+    /// pane's identity stops being implied by the project. Truncates from the tail
+    /// so the owner, the part that differs between a fork and its parent, survives
+    /// a narrow inspector.
+    private var repositoryMenu: some View {
+        Menu {
+            Picker(localized("Repository"), selection: Binding(
+                get: { model.container?.id ?? "" },
+                set: { model.selectRepository(slug: $0) }
+            )) {
+                ForEach(model.candidates) { candidate in
+                    Text(candidate.slug).tag(candidate.slug)
+                }
+            }
+            .pickerStyle(.inline)
+        } label: {
+            Text(model.container?.id ?? "")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .menuStyle(.borderlessButton)
+        .padding(.leading, 6)
+        .help(localized("Choose which repository’s issues to show"))
     }
 
     private var kindSwitch: some View {
@@ -215,7 +244,7 @@ struct IssuesView: View {
         case .unbound:
             zeroState(
                 title: localized("No GitHub Repository"),
-                message: localized("This project’s origin remote doesn’t point at github.com, so there is no issue tracker to show.")
+                message: localized("None of this project’s remotes point at github.com, so there is no issue tracker to show.")
             ) {
                 Button(localized("Disconnect GitHub")) { model.disconnect() }
                     .buttonStyle(.bordered)

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -2512,12 +2512,32 @@
         }
       }
     },
-    "This project’s origin remote doesn’t point at github.com, so there is no issue tracker to show.": {
+    "None of this project’s remotes point at github.com, so there is no issue tracker to show.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "该项目的 origin 远程仓库未指向 github.com，因此没有可显示的 issue 跟踪器。"
+            "value": "该项目的远程仓库都未指向 github.com，因此没有可显示的 issue 跟踪器。"
+          }
+        }
+      }
+    },
+    "Repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仓库"
+          }
+        }
+      }
+    },
+    "Choose which repository’s issues to show": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择显示哪个仓库的 issue"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -212,6 +212,8 @@
 	<string>Choose another branch to compare with.</string>
 	<key>Choose how projects are ordered</key>
 	<string>Choose how projects are ordered</string>
+	<key>Choose which repository’s issues to show</key>
+	<string>Choose which repository’s issues to show</string>
 	<key>Choose…</key>
 	<string>Choose…</string>
 	<key>Clear</key>
@@ -718,6 +720,8 @@
 	<string>No textual changes to show.</string>
 	<key>No theme matches “%@”</key>
 	<string>No theme matches “%@”</string>
+	<key>None of this project’s remotes point at github.com, so there is no issue tracker to show.</key>
+	<string>None of this project’s remotes point at github.com, so there is no issue tracker to show.</string>
 	<key>Not Now</key>
 	<string>Not Now</string>
 	<key>Not a valid regular expression</key>
@@ -892,6 +896,8 @@
 	<string>Rename “%@”</string>
 	<key>Rename…</key>
 	<string>Rename…</string>
+	<key>Repository</key>
+	<string>Repository</string>
 	<key>Request Permission</key>
 	<string>Request Permission</string>
 	<key>Reset Font Size</key>
@@ -1130,8 +1136,6 @@
 	<string>This machine’s termiod is too old to list folders.</string>
 	<key>This month</key>
 	<string>This month</string>
-	<key>This project’s origin remote doesn’t point at github.com, so there is no issue tracker to show.</key>
-	<string>This project’s origin remote doesn’t point at github.com, so there is no issue tracker to show.</string>
 	<key>This pull request changes no files.</key>
 	<string>This pull request changes no files.</string>
 	<key>This session couldn’t be started.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -212,6 +212,8 @@
 	<string>请另选一个用于对比的分支。</string>
 	<key>Choose how projects are ordered</key>
 	<string>选取项目的排序方式</string>
+	<key>Choose which repository’s issues to show</key>
+	<string>选择显示哪个仓库的 issue</string>
 	<key>Choose…</key>
 	<string>选取…</string>
 	<key>Clear</key>
@@ -718,6 +720,8 @@
 	<string>没有可显示的文本更改。</string>
 	<key>No theme matches “%@”</key>
 	<string>没有主题与“%@”匹配</string>
+	<key>None of this project’s remotes point at github.com, so there is no issue tracker to show.</key>
+	<string>该项目的远程仓库都未指向 github.com，因此没有可显示的 issue 跟踪器。</string>
 	<key>Not Now</key>
 	<string>以后再说</string>
 	<key>Not a valid regular expression</key>
@@ -892,6 +896,8 @@
 	<string>重命名“%@”</string>
 	<key>Rename…</key>
 	<string>重命名…</string>
+	<key>Repository</key>
+	<string>仓库</string>
 	<key>Request Permission</key>
 	<string>请求权限</string>
 	<key>Reset Font Size</key>
@@ -1130,8 +1136,6 @@
 	<string>这台机器上的 termiod 版本太旧，列不出文件夹。</string>
 	<key>This month</key>
 	<string>本月</string>
-	<key>This project’s origin remote doesn’t point at github.com, so there is no issue tracker to show.</key>
-	<string>该项目的 origin 远程仓库未指向 github.com，因此没有可显示的 issue 跟踪器。</string>
 	<key>This pull request changes no files.</key>
 	<string>此 PR 未更改任何文件。</string>
 	<key>This session couldn’t be started.</key>

--- a/Tests/termioTests/IssueRepositoryBindingTests.swift
+++ b/Tests/termioTests/IssueRepositoryBindingTests.swift
@@ -1,0 +1,235 @@
+import XCTest
+@testable import termio
+
+/// Which repository the Issues pane binds a checkout to. A fork clone has more than
+/// one GitHub remote, and picking the wrong one leaves the pane empty against a repo
+/// whose issues are disabled (#427) — so the ordering and the slug parsing that feed
+/// the choice are worth pinning down without a window.
+final class IssueRepositoryBindingTests: XCTestCase {
+    func testUpstreamOutranksOriginWhichOutranksEverythingElse() {
+        XCTAssertEqual(
+            GitService.orderedRemoteNames(["origin", "fork", "upstream"]),
+            ["upstream", "origin", "fork"])
+    }
+
+    func testRemotesWithoutAConventionalNameStayAlphabetical() {
+        // A stable order matters: the repository menu is rebuilt on every session
+        // switch, and a set-derived order would reshuffle an unchanged repo's list.
+        XCTAssertEqual(
+            GitService.orderedRemoteNames(["zed", "alice", "bob"]),
+            ["alice", "bob", "zed"])
+    }
+
+    func testOrderingIsUnchangedByTheOrderGitListedThem() {
+        let names = ["bob", "upstream", "alice", "origin"]
+        XCTAssertEqual(
+            GitService.orderedRemoteNames(names),
+            GitService.orderedRemoteNames(names.reversed()))
+    }
+
+    func testSlugParsesEveryTransportGitAcceptsForGitHub() {
+        for remote in [
+            "https://github.com/termio-sh/termio.git",
+            "https://github.com/termio-sh/termio",
+            "git@github.com:termio-sh/termio.git",
+            "ssh://git@github.com/termio-sh/termio.git",
+            "https://user@github.com/termio-sh/termio.git",
+        ] {
+            XCTAssertEqual(
+                GitService.gitHubSlug(fromRemote: remote), "termio-sh/termio",
+                "failed for \(remote)")
+        }
+    }
+
+    // MARK: The resolution ladder
+
+    private func candidate(_ slug: String, _ remote: String?) -> IssueRepositoryCandidate {
+        IssueRepositoryCandidate(slug: slug, remoteName: remote)
+    }
+
+    /// A probe that fails the test if the ladder reaches it — the rungs above it are
+    /// supposed to short-circuit, and a stray network round-trip per pane mount is
+    /// the cost of getting that wrong.
+    private func unreachableProbe(_ slug: String) async -> String? {
+        XCTFail("the fork-parent probe should not have run for \(slug)")
+        return nil
+    }
+
+    @MainActor
+    func testUpstreamWinsWithoutProbing() async {
+        let binding = await IssuesPanelModel.resolveBinding(
+            remotes: [
+                candidate("termio-sh/termio", "upstream"),
+                candidate("planetf1/termio", "origin"),
+            ],
+            pick: nil, forkParent: unreachableProbe)
+        XCTAssertEqual(binding?.selected.slug, "termio-sh/termio")
+        XCTAssertEqual(binding?.candidates.count, 2)
+    }
+
+    @MainActor
+    func testExplicitPickOutranksUpstream() async {
+        // Having chosen the fork's own tracker, the user must keep it.
+        let binding = await IssuesPanelModel.resolveBinding(
+            remotes: [
+                candidate("termio-sh/termio", "upstream"),
+                candidate("planetf1/termio", "origin"),
+            ],
+            pick: "planetf1/termio", forkParent: unreachableProbe)
+        XCTAssertEqual(binding?.selected.slug, "planetf1/termio")
+    }
+
+    @MainActor
+    func testExplicitPickSurvivesTheRemoteItCameFrom() async {
+        // The remote was renamed or dropped: the pick still binds, and stays switchable
+        // rather than collapsing to a one-entry menu the pane hides.
+        let binding = await IssuesPanelModel.resolveBinding(
+            remotes: [candidate("planetf1/termio", "origin")],
+            pick: "termio-sh/termio", forkParent: unreachableProbe)
+        XCTAssertEqual(binding?.selected.slug, "termio-sh/termio")
+        XCTAssertEqual(binding?.candidates.map(\.slug), ["planetf1/termio", "termio-sh/termio"])
+    }
+
+    @MainActor
+    func testExplicitPickBindsEvenWithNoGitHubRemoteLeft() async {
+        let binding = await IssuesPanelModel.resolveBinding(
+            remotes: [], pick: "termio-sh/termio", forkParent: unreachableProbe)
+        XCTAssertEqual(binding?.selected.slug, "termio-sh/termio")
+        XCTAssertEqual(binding?.candidates.map(\.slug), ["termio-sh/termio"])
+    }
+
+    @MainActor
+    func testForkParentIsDiscoveredAndBecomesASecondCandidate() async {
+        // #427's harder half: the only remote is the user's fork, so nothing in the
+        // checkout names the real tracker. The menu must appear so the user can go back.
+        let binding = await IssuesPanelModel.resolveBinding(
+            remotes: [candidate("planetf1/termio", "origin")],
+            pick: nil, forkParent: { _ in "termio-sh/termio" })
+        XCTAssertEqual(binding?.selected.slug, "termio-sh/termio")
+        XCTAssertEqual(binding?.candidates.map(\.slug), ["planetf1/termio", "termio-sh/termio"])
+    }
+
+    @MainActor
+    func testANonForkStaysOnOriginWithNoMenu() async {
+        let binding = await IssuesPanelModel.resolveBinding(
+            remotes: [candidate("termio-sh/termio", "origin")],
+            pick: nil, forkParent: { _ in nil })
+        XCTAssertEqual(binding?.selected.slug, "termio-sh/termio")
+        XCTAssertEqual(binding?.candidates.count, 1, "one candidate keeps the picker hidden")
+    }
+
+    @MainActor
+    func testAFailedProbeFallsBackToOriginRatherThanUnbinding() async {
+        // The probe reports nothing (offline, rate-limited). The pane still shows a
+        // tracker; `forkParentUnknown` is what gets the user out on Refresh.
+        let binding = await IssuesPanelModel.resolveBinding(
+            remotes: [candidate("planetf1/termio", "origin")],
+            pick: nil, forkParent: { _ in nil })
+        XCTAssertEqual(binding?.selected.slug, "planetf1/termio")
+    }
+
+    @MainActor
+    func testNoRemotesAndNoPickLeavesThePaneUnbound() async {
+        let binding = await IssuesPanelModel.resolveBinding(
+            remotes: [], pick: nil, forkParent: unreachableProbe)
+        XCTAssertNil(binding)
+    }
+
+    @MainActor
+    func testADiscoveredParentAlreadyOnARemoteIsNotDuplicated() async {
+        let binding = await IssuesPanelModel.resolveBinding(
+            remotes: [
+                candidate("planetf1/termio", "origin"),
+                candidate("termio-sh/termio", "mirror"),
+            ],
+            pick: nil, forkParent: { _ in "termio-sh/termio" })
+        XCTAssertEqual(binding?.selected.remoteName, "mirror")
+        XCTAssertEqual(binding?.candidates.count, 2)
+    }
+
+    // MARK: Against a real checkout
+
+    private var repo: URL!
+
+    override func setUpWithError() throws {
+        repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("termio-issue-binding-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try git(["init", "-q"])
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: repo)
+    }
+
+    private func git(_ args: [String]) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = repo
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, "git \(args.joined(separator: " ")) failed")
+    }
+
+    func testForkCheckoutOffersUpstreamFirst() async throws {
+        try git(["remote", "add", "origin", "https://github.com/planetf1/termio.git"])
+        try git(["remote", "add", "upstream", "git@github.com:termio-sh/termio.git"])
+        try git(["remote", "add", "backup", "https://gitlab.com/planetf1/termio.git"])
+
+        let remotes = await GitService.gitHubRemotes(in: repo.path)
+        // The GitLab remote is dropped; upstream leads, which is what makes the pane
+        // land on the project's real tracker instead of the fork's empty one.
+        XCTAssertEqual(
+            remotes,
+            [
+                GitService.GitHubRemote(name: "upstream", slug: "termio-sh/termio"),
+                GitService.GitHubRemote(name: "origin", slug: "planetf1/termio"),
+            ])
+    }
+
+    func testRemotesPointingAtOneRepositoryCollapse() async throws {
+        // The same repo over both transports is one choice, not two — and it keeps the
+        // higher-priority name.
+        try git(["remote", "add", "origin", "https://github.com/termio-sh/termio.git"])
+        try git(["remote", "add", "upstream", "git@github.com:termio-sh/termio.git"])
+
+        let remotes = await GitService.gitHubRemotes(in: repo.path)
+        XCTAssertEqual(
+            remotes, [GitService.GitHubRemote(name: "upstream", slug: "termio-sh/termio")])
+    }
+
+    func testRepoWithNoGitHubRemoteResolvesToNothing() async throws {
+        try git(["remote", "add", "origin", "https://gitlab.com/planetf1/termio.git"])
+        let remotes = await GitService.gitHubRemotes(in: repo.path)
+        XCTAssertTrue(remotes.isEmpty, "a non-GitHub checkout must leave the pane unbound")
+    }
+
+    func testExplicitPickRoundTripsThroughGitConfig() async throws {
+        let unset = await GitService.issuesRepository(in: repo.path)
+        XCTAssertNil(unset, "an untouched repo must stay on the resolution ladder")
+
+        await GitService.setIssuesRepository("termio-sh/termio", in: repo.path)
+        let stored = await GitService.issuesRepository(in: repo.path)
+        XCTAssertEqual(stored, "termio-sh/termio")
+    }
+
+    func testSlugRejectsOtherForges() {
+        // An HTTPS remote must never reach `ssh -G`, so a lookalike host stays nil
+        // rather than binding an unrelated repo to public GitHub.
+        for remote in [
+            "https://gitlab.com/termio-sh/termio.git",
+            "https://github.example.com/termio-sh/termio.git",
+            "git@codeberg.org:termio-sh/termio.git",
+            "not a remote",
+            // Paths that aren't a plain owner/repo: each would interpolate into a URL
+            // that is nil at the point of use, and the API callers force-unwrap it.
+            "https://github.com/owner/%",
+            "https://github.com/owner/repo/extra",
+            "https://github.com/owner",
+            "https://github.com/owner/re po",
+        ] {
+            XCTAssertNil(GitService.gitHubSlug(fromRemote: remote), "failed for \(remote)")
+        }
+    }
+}


### PR DESCRIPTION
The Issues pane read `origin` and nothing else. On a fork checkout — the standard open-source workflow, where `origin` is your fork and the project lives on `upstream` — it bound to the fork's own tracker, which is usually empty or disabled.

Resolution is now a ladder, each rung short-circuiting the rest:

1. an explicit pick recorded in `termio.issuesRepo`
2. a remote named `upstream`
3. the fork parent GitHub reports for the leading remote
4. that remote

Rung 3 is the half no remote can answer: `git clone <my-fork>` leaves a checkout whose only remote is the fork, so GitHub's own `parent` is the sole record of where the issues live. It costs one request, cached per launch, and only runs when the rungs above it miss. The parent is offered as a choice, never written back as a git remote.

The top bar gains a repository menu, rendered only when the checkout offers more than one repository, so a single-remote project sees no new chrome. A pick is recorded in `--local` git config, which linked worktrees share — choose once, and every worktree of the repo agrees.

Verified with `swift build`, `swift test` (611 passing), and `scripts/check-strings.sh`. `IssueRepositoryBindingTests` drives the ladder directly — precedence, fork-parent discovery, a failed probe, dedupe across transports — plus real temp checkouts for the git layer.

Closes #427

Release Notes:
- The Issues pane now finds a fork's upstream issues instead of showing the fork's empty tracker, and offers a menu to switch repositories when a checkout has more than one.