### PR TITLE
Scope settings to the machine they mean

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -61,6 +61,16 @@
         }
       }
     },
+    "%@ is ready.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已就绪。"
+          }
+        }
+      }
+    },
     "%@ isn’t a UTF-8 text file.": {
       "localizations": {
         "zh-Hans": {
@@ -77,6 +87,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 暂不支持这台设备。"
+          }
+        }
+      }
+    },
+    "%@ isn’t installed on %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 未安装在 %2$@ 上"
           }
         }
       }
@@ -531,6 +551,26 @@
         }
       }
     },
+    "Agents on %@ can run, and report their status back here.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 上的 Agent 可以运行，并把状态报告回这里。"
+          }
+        }
+      }
+    },
+    "Agents on %@ can run.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 上的 Agent 可以运行。"
+          }
+        }
+      }
+    },
     "Agents won’t show as working.": {
       "localizations": {
         "zh-Hans": {
@@ -698,6 +738,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "应用"
+          }
+        }
+      }
+    },
+    "Asking %@ what it has.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在询问 %@ 上有什么。"
           }
         }
       }
@@ -872,6 +922,16 @@
         }
       }
     },
+    "Can’t check on %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法在 %@ 上检查"
+          }
+        }
+      }
+    },
     "Can’t open as text": {
       "localizations": {
         "zh-Hans": {
@@ -898,6 +958,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "连不上 %@"
+          }
+        }
+      }
+    },
+    "Can’t reach %@.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法连接 %@。"
           }
         }
       }
@@ -2093,6 +2163,16 @@
         }
       }
     },
+    "Drag the list to change the order agents appear in. Readiness is for %@ — open it under Machines to install anything missing.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖动列表可更改 Agent 的显示顺序。就绪状态针对 %@ — 在“设备”中打开它可安装缺少的内容。"
+          }
+        }
+      }
+    },
     "Duplicate to Themes Folder": {
       "localizations": {
         "zh-Hans": {
@@ -2404,6 +2484,16 @@
         }
       }
     },
+    "Get %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取 %@"
+          }
+        }
+      }
+    },
     "Git ignore patterns cannot represent a filename containing a line break.": {
       "localizations": {
         "zh-Hans": {
@@ -2704,6 +2794,16 @@
         }
       }
     },
+    "Installs the `%@` command-line tool, then Termio’s hooks and skill for each agent.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装 `%@` 命令行工具，然后为每个 Agent 安装 Termio 的 hooks 和技能。"
+          }
+        }
+      }
+    },
     "Integration": {
       "localizations": {
         "zh-Hans": {
@@ -2990,6 +3090,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Agent 实时状态"
+          }
+        }
+      }
+    },
+    "Live agent status and session control are switched on in Settings ▸ Agents; this installs them on %@.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent 实时状态和会话控制在“设置 ▸ Agents”中开启；这里把它们安装到 %@ 上。"
           }
         }
       }
@@ -3594,6 +3704,16 @@
         }
       }
     },
+    "No agent CLIs found on %@.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 %@ 上未找到任何 Agent 命令行工具。"
+          }
+        }
+      }
+    },
     "No agent CLIs found.": {
       "localizations": {
         "zh-Hans": {
@@ -3811,6 +3931,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "未安装"
+          }
+        }
+      }
+    },
+    "Not installed on %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未安装在 %@ 上"
           }
         }
       }
@@ -5098,6 +5228,16 @@
         }
       }
     },
+    "Set Up %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置 %@"
+          }
+        }
+      }
+    },
     "Set Up Key": {
       "localizations": {
         "zh-Hans": {
@@ -5234,6 +5374,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "侧栏"
+          }
+        }
+      }
+    },
+    "Signs in with %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 %@ 登录"
           }
         }
       }
@@ -5754,6 +5904,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "~/.ssh 中的公钥。可拷贝一个粘贴到服务器的 authorized_keys——私钥永远不会被读取。"
+          }
+        }
+      }
+    },
+    "The session host on %@. Sessions keep running there after you disconnect.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 上的会话宿主。断开连接后，会话仍在那里继续运行。"
           }
         }
       }
@@ -6375,6 +6535,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "开启后，选中文本会直接拷贝到剪贴板。"
+          }
+        }
+      }
+    },
+    "Where each agent’s CLI lives on %@. Leave a path empty to use the agent’s default.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每个 Agent 的命令行工具在 %@ 上的位置。留空则使用该 Agent 的默认值。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -441,6 +441,16 @@
         }
       }
     },
+    "Add Machine": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加设备"
+          }
+        }
+      }
+    },
     "Add SSH Host": {
       "localizations": {
         "zh-Hans": {
@@ -952,6 +962,16 @@
         }
       }
     },
+    "Check Again": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新检查"
+          }
+        }
+      }
+    },
     "Check for Updates…": {
       "localizations": {
         "zh-Hans": {
@@ -968,6 +988,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "检出在 %@"
+          }
+        }
+      }
+    },
+    "Checking the machine…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查设备…"
+          }
+        }
+      }
+    },
+    "Checking…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查中…"
           }
         }
       }
@@ -1903,6 +1943,26 @@
         }
       }
     },
+    "Deploy": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部署"
+          }
+        }
+      }
+    },
+    "Deploys `termiod`, looks for your agent CLIs, then installs Termio’s hooks and skill.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部署 `termiod`，查找你的 Agent 命令行工具，然后安装 Termio 的 hooks 和技能。"
+          }
+        }
+      }
+    },
     "Detached at %@": {
       "localizations": {
         "zh-Hans": {
@@ -2324,6 +2384,16 @@
         }
       }
     },
+    "From your session history": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来自你的会话历史"
+          }
+        }
+      }
+    },
     "General": {
       "localizations": {
         "zh-Hans": {
@@ -2454,6 +2524,16 @@
         }
       }
     },
+    "Host block": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Host 配置块"
+          }
+        }
+      }
+    },
     "Host not found": {
       "localizations": {
         "zh-Hans": {
@@ -2574,6 +2654,26 @@
         }
       }
     },
+    "Install Page": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装页面"
+          }
+        }
+      }
+    },
+    "Installed by Termio": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termio 安装的内容"
+          }
+        }
+      }
+    },
     "Installed.": {
       "localizations": {
         "zh-Hans": {
@@ -2590,6 +2690,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在安装 %@…"
+          }
+        }
+      }
+    },
+    "Installing hooks and skill…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在安装 hooks 和技能…"
+          }
+        }
+      }
+    },
+    "Integration": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "集成"
           }
         }
       }
@@ -2724,6 +2844,16 @@
         }
       }
     },
+    "Language, notifications, and GitHub": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言、通知和 GitHub"
+          }
+        }
+      }
+    },
     "Last 30 days": {
       "localizations": {
         "zh-Hans": {
@@ -2780,6 +2910,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "让你的 Agent 相互协作？"
+          }
+        }
+      }
+    },
+    "Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让 Agent 通过 `termio sessions` 命令查看并驱动本项目中的同级会话。"
           }
         }
       }
@@ -2884,12 +3024,42 @@
         }
       }
     },
+    "Looking for agent CLIs…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在查找 Agent 命令行工具…"
+          }
+        }
+      }
+    },
     "Lost the connection to %@. The session is still running there.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "与 %@ 的连接已断开。会话仍在那台机器上运行。"
+          }
+        }
+      }
+    },
+    "Machine Unavailable": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备不可用"
+          }
+        }
+      }
+    },
+    "Machines": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备"
           }
         }
       }
@@ -3424,6 +3594,26 @@
         }
       }
     },
+    "No agent CLIs found.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到任何 Agent 命令行工具。"
+          }
+        }
+      }
+    },
+    "No agents on your list yet — add one in Settings ▸ Agents.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的列表中还没有 Agent — 在“设置 ▸ Agents”中添加一个。"
+          }
+        }
+      }
+    },
     "No bundled tool to install from.": {
       "localizations": {
         "zh-Hans": {
@@ -3574,6 +3764,16 @@
         }
       }
     },
+    "None": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无"
+          }
+        }
+      }
+    },
     "None of this project’s remotes point at github.com, so there is no issue tracker to show.": {
       "localizations": {
         "zh-Hans": {
@@ -3641,6 +3841,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有可安装的内容。"
+          }
+        }
+      }
+    },
+    "Nothing to reach — this is the machine you’re on.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无需连接 — 这就是你正在使用的设备。"
           }
         }
       }
@@ -3903,6 +4113,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "在这台设备上由 Termio 之外打开"
+          }
+        }
+      }
+    },
+    "Opens the ~/.ssh/config entry this machine is defined in.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开定义该设备的 ~/.ssh/config 条目。"
           }
         }
       }
@@ -4197,6 +4417,26 @@
         }
       }
     },
+    "Reached by": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接方式"
+          }
+        }
+      }
+    },
+    "Reached over SSH": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过 SSH 连接"
+          }
+        }
+      }
+    },
     "Reaching %@…": {
       "localizations": {
         "zh-Hans": {
@@ -4213,6 +4453,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "直接读取 ~/.ssh/config——Termio 不保留单独的主机列表。"
+          }
+        }
+      }
+    },
+    "Ready": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已就绪"
           }
         }
       }
@@ -4577,6 +4827,16 @@
         }
       }
     },
+    "Run Termio from the built app to install its command-line tool.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从打包后的 App 运行 Termio 才能安装其命令行工具。"
+          }
+        }
+      }
+    },
     "Run a command…": {
       "localizations": {
         "zh-Hans": {
@@ -4593,6 +4853,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在运行的终端会话将会结束。你也可以稍后再重新启动。"
+          }
+        }
+      }
+    },
+    "Runs": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行"
           }
         }
       }
@@ -4848,6 +5118,26 @@
         }
       }
     },
+    "Set the path it launches from on each machine, under Machines.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在“设备”中为每台设备设置它的启动路径。"
+          }
+        }
+      }
+    },
+    "Set up this device": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置此设备"
+          }
+        }
+      }
+    },
     "Settings": {
       "localizations": {
         "zh-Hans": {
@@ -4918,6 +5208,16 @@
         }
       }
     },
+    "Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示 Agent 正在工作还是在等你 — 侧栏的转圈和菜单栏的脉冲。"
+          }
+        }
+      }
+    },
     "Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse. Installs Termio’s hooks into each agent’s config.": {
       "localizations": {
         "zh-Hans": {
@@ -4934,6 +5234,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "侧栏"
+          }
+        }
+      }
+    },
+    "Signs in with the keys ssh offers by default.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 ssh 默认提供的密钥登录。"
           }
         }
       }
@@ -5398,12 +5708,32 @@
         }
       }
     },
+    "The machine Termio is running on": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termio 正在运行的设备"
+          }
+        }
+      }
+    },
     "The machine answered with no listing for that folder.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "这台机器没有返回该文件夹的内容。"
+          }
+        }
+      }
+    },
+    "The machine you’re on": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你正在使用的设备"
           }
         }
       }
@@ -5538,6 +5868,26 @@
         }
       }
     },
+    "This Mac and the machines you reach from it, and what each one runs": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机以及你能连接的设备，和每台设备上运行的内容"
+          }
+        }
+      }
+    },
+    "This Mac, and every machine you can reach from it. Open one to see what runs there.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机，以及你能从这里连接的每台设备。打开一台可查看它上面运行的内容。"
+          }
+        }
+      }
+    },
     "This Mac…": {
       "localizations": {
         "zh-Hans": {
@@ -5664,6 +6014,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "这台主机接受密码登录。Termio 用密钥登录，设置一次之后，会话、文件树和远程终端都能连上它。"
+          }
+        }
+      }
+    },
+    "This machine is no longer in your configuration.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该设备已不在你的配置中。"
           }
         }
       }
@@ -6015,6 +6375,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "开启后，选中文本会直接拷贝到剪贴板。"
+          }
+        }
+      }
+    },
+    "Whether you want these at all. Each machine installs them for its own agents, under Machines.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "决定你是否需要这些功能。每台设备在“设备”中为自己的 Agent 安装它们。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -92,6 +92,8 @@
 	<string>Add Host</string>
 	<key>Add Host…</key>
 	<string>Add Host…</string>
+	<key>Add Machine</key>
+	<string>Add Machine</string>
 	<key>Add SSH Host</key>
 	<string>Add SSH Host</string>
 	<key>Add to Chat</key>
@@ -198,10 +200,16 @@
 	<string>Chat with the developer and other users.</string>
 	<key>Chats</key>
 	<string>Chats</string>
+	<key>Check Again</key>
+	<string>Check Again</string>
 	<key>Check for Updates…</key>
 	<string>Check for Updates…</string>
 	<key>Checked out on %@</key>
 	<string>Checked out on %@</string>
+	<key>Checking the machine…</key>
+	<string>Checking the machine…</string>
+	<key>Checking…</key>
+	<string>Checking…</string>
 	<key>Choose a different name.</key>
 	<string>Choose a different name.</string>
 	<key>Choose a name for this workspace.</key>
@@ -388,6 +396,10 @@
 	<string>Deletes the custom agent’s manifest from this Mac.</string>
 	<key>Delete…</key>
 	<string>Delete…</string>
+	<key>Deploy</key>
+	<string>Deploy</string>
+	<key>Deploys `termiod`, looks for your agent CLIs, then installs Termio’s hooks and skill.</key>
+	<string>Deploys `termiod`, looks for your agent CLIs, then installs Termio’s hooks and skill.</string>
 	<key>Detached at %@</key>
 	<string>Detached at %@</string>
 	<key>Devices</key>
@@ -472,6 +484,8 @@
 	<string>Font name</string>
 	<key>From your Ghostty config</key>
 	<string>From your Ghostty config</string>
+	<key>From your session history</key>
+	<string>From your session history</string>
 	<key>General</key>
 	<string>General</string>
 	<key>Git ignore patterns cannot represent a filename containing a line break.</key>
@@ -498,6 +512,8 @@
 	<string>Hooks reinstalled</string>
 	<key>Host</key>
 	<string>Host</string>
+	<key>Host block</key>
+	<string>Host block</string>
 	<key>Host not found</key>
 	<string>Host not found</string>
 	<key>Hosts</key>
@@ -522,10 +538,18 @@
 	<string>Inspector Pane</string>
 	<key>Install %@</key>
 	<string>Install %@</string>
+	<key>Install Page</key>
+	<string>Install Page</string>
+	<key>Installed by Termio</key>
+	<string>Installed by Termio</string>
 	<key>Installed.</key>
 	<string>Installed.</string>
 	<key>Installing %@…</key>
 	<string>Installing %@…</string>
+	<key>Installing hooks and skill…</key>
+	<string>Installing hooks and skill…</string>
+	<key>Integration</key>
+	<string>Integration</string>
 	<key>Integrations</key>
 	<string>Integrations</string>
 	<key>Interface</key>
@@ -552,6 +576,8 @@
 	<string>Labels</string>
 	<key>Language</key>
 	<string>Language</string>
+	<key>Language, notifications, and GitHub</key>
+	<string>Language, notifications, and GitHub</string>
 	<key>Last 30 days</key>
 	<string>Last 30 days</string>
 	<key>Last 7 days</key>
@@ -564,6 +590,8 @@
 	<string>Launch</string>
 	<key>Let your agents coordinate?</key>
 	<string>Let your agents coordinate?</string>
+	<key>Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command.</key>
+	<string>Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command.</string>
 	<key>Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command. Installs the termio skill into each agent's skills folder.</key>
 	<string>Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command. Installs the termio skill into each agent's skills folder.</string>
 	<key>Light</key>
@@ -584,8 +612,14 @@
 	<string>Local</string>
 	<key>Login shell</key>
 	<string>Login shell</string>
+	<key>Looking for agent CLIs…</key>
+	<string>Looking for agent CLIs…</string>
 	<key>Lost the connection to %@. The session is still running there.</key>
 	<string>Lost the connection to %@. The session is still running there.</string>
+	<key>Machine Unavailable</key>
+	<string>Machine Unavailable</string>
+	<key>Machines</key>
+	<string>Machines</string>
 	<key>Match Case</key>
 	<string>Match Case</string>
 	<key>Match Whole Word</key>
@@ -692,6 +726,10 @@
 	<string>No Pull Requests</string>
 	<key>No Session</key>
 	<string>No Session</string>
+	<key>No agent CLIs found.</key>
+	<string>No agent CLIs found.</string>
+	<key>No agents on your list yet — add one in Settings ▸ Agents.</key>
+	<string>No agents on your list yet — add one in Settings ▸ Agents.</string>
 	<key>No bundled tool to install from.</key>
 	<string>No bundled tool to install from.</string>
 	<key>No description provided.</key>
@@ -722,6 +760,8 @@
 	<string>No textual changes to show.</string>
 	<key>No theme matches “%@”</key>
 	<string>No theme matches “%@”</string>
+	<key>None</key>
+	<string>None</string>
 	<key>None of this project’s remotes point at github.com, so there is no issue tracker to show.</key>
 	<string>None of this project’s remotes point at github.com, so there is no issue tracker to show.</string>
 	<key>Not Now</key>
@@ -736,6 +776,8 @@
 	<string>Nothing to Compare</string>
 	<key>Nothing to install.</key>
 	<string>Nothing to install.</string>
+	<key>Nothing to reach — this is the machine you’re on.</key>
+	<string>Nothing to reach — this is the machine you’re on.</string>
 	<key>Notifications</key>
 	<string>Notifications</string>
 	<key>Notifications for Termio are turned off in System Settings.</key>
@@ -788,6 +830,8 @@
 	<string>Open the invite on your iPhone to install it with TestFlight.</string>
 	<key>Opened outside Termio on this device</key>
 	<string>Opened outside Termio on this device</string>
+	<key>Opens the ~/.ssh/config entry this machine is defined in.</key>
+	<string>Opens the ~/.ssh/config entry this machine is defined in.</string>
 	<key>Padding: %lld pt</key>
 	<string>Padding: %lld pt</string>
 	<key>Pair your iPhone and remote access</key>
@@ -846,10 +890,16 @@
 	<string>Range</string>
 	<key>Reachable</key>
 	<string>Reachable</string>
+	<key>Reached by</key>
+	<string>Reached by</string>
+	<key>Reached over SSH</key>
+	<string>Reached over SSH</string>
 	<key>Reaching %@…</key>
 	<string>Reaching %@…</string>
 	<key>Reads ~/.ssh/config directly — Termio keeps no separate host list.</key>
 	<string>Reads ~/.ssh/config directly — Termio keeps no separate host list.</string>
+	<key>Ready</key>
+	<string>Ready</string>
 	<key>Recent</key>
 	<string>Recent</string>
 	<key>Recent Activity</key>
@@ -922,10 +972,14 @@
 	<string>Rotate the pairing token?</string>
 	<key>Row padding</key>
 	<string>Row padding</string>
+	<key>Run Termio from the built app to install its command-line tool.</key>
+	<string>Run Termio from the built app to install its command-line tool.</string>
 	<key>Run a command…</key>
 	<string>Run a command…</string>
 	<key>Running terminal sessions will end. You can relaunch later instead.</key>
 	<string>Running terminal sessions will end. You can relaunch later instead.</string>
+	<key>Runs</key>
+	<string>Runs</string>
 	<key>Runs on %@</key>
 	<string>Runs on %@</string>
 	<key>Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.</key>
@@ -976,6 +1030,10 @@
 	<string>Set Up Key</string>
 	<key>Set Up Key…</key>
 	<string>Set Up Key…</string>
+	<key>Set the path it launches from on each machine, under Machines.</key>
+	<string>Set the path it launches from on each machine, under Machines.</string>
+	<key>Set up this device</key>
+	<string>Set up this device</string>
 	<key>Settings</key>
 	<string>Settings</string>
 	<key>Settings…</key>
@@ -990,10 +1048,14 @@
 	<string>Show Project Files</string>
 	<key>Shows the Issues pane in the inspector for projects whose remote is on GitHub.</key>
 	<string>Shows the Issues pane in the inspector for projects whose remote is on GitHub.</string>
+	<key>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse.</key>
+	<string>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse.</string>
 	<key>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse. Installs Termio’s hooks into each agent’s config.</key>
 	<string>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse. Installs Termio’s hooks into each agent’s config.</string>
 	<key>Sidebar</key>
 	<string>Sidebar</string>
+	<key>Signs in with the keys ssh offers by default.</key>
+	<string>Signs in with the keys ssh offers by default.</string>
 	<key>Size: %lld pt</key>
 	<string>Size: %lld pt</string>
 	<key>Skill reinstalled</key>
@@ -1086,8 +1148,12 @@
 	<string>The ignore rule couldn’t be added.</string>
 	<key>The listing failed.</key>
 	<string>The listing failed.</string>
+	<key>The machine Termio is running on</key>
+	<string>The machine Termio is running on</string>
 	<key>The machine answered with no listing for that folder.</key>
 	<string>The machine answered with no listing for that folder.</string>
+	<key>The machine you’re on</key>
+	<string>The machine you’re on</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>The project and session list. Kept separate from the terminal font, and need not be monospaced.</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
@@ -1114,6 +1180,10 @@
 	<string>Thicken glyphs</string>
 	<key>This Mac</key>
 	<string>This Mac</string>
+	<key>This Mac and the machines you reach from it, and what each one runs</key>
+	<string>This Mac and the machines you reach from it, and what each one runs</string>
+	<key>This Mac, and every machine you can reach from it. Open one to see what runs there.</key>
+	<string>This Mac, and every machine you can reach from it. Open one to see what runs there.</string>
 	<key>This Mac…</key>
 	<string>This Mac…</string>
 	<key>This agent is no longer on your list.</key>
@@ -1140,6 +1210,8 @@
 	<string>This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.</string>
 	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>
 	<string>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</string>
+	<key>This machine is no longer in your configuration.</key>
+	<string>This machine is no longer in your configuration.</string>
 	<key>This machine’s termiod is too old to list folders.</key>
 	<string>This machine’s termiod is too old to list folders.</string>
 	<key>This month</key>
@@ -1210,6 +1282,8 @@
 	<string>WeChat group</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
 	<string>When on, selecting text copies it straight to the clipboard.</string>
+	<key>Whether you want these at all. Each machine installs them for its own agents, under Machines.</key>
+	<string>Whether you want these at all. Each machine installs them for its own agents, under Machines.</string>
 	<key>Window</key>
 	<string>Window</string>
 	<key>Working Directory</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -16,10 +16,14 @@
 	<string>%@ is a dark theme in the %@ slot.</string>
 	<key>%@ is a light theme in the %@ slot.</key>
 	<string>%@ is a light theme in the %@ slot.</string>
+	<key>%@ is ready.</key>
+	<string>%@ is ready.</string>
 	<key>%@ isn’t a UTF-8 text file.</key>
 	<string>%@ isn’t a UTF-8 text file.</string>
 	<key>%@ isn’t available on this device yet.</key>
 	<string>%@ isn’t available on this device yet.</string>
+	<key>%@ isn’t installed on %@</key>
+	<string>%@ isn’t installed on %@</string>
 	<key>%@ isn’t on your PATH</key>
 	<string>%@ isn’t on your PATH</string>
 	<key>%@ keeps exiting — retrying every %llds</key>
@@ -110,6 +114,10 @@
 	<string>Agent skill</string>
 	<key>Agents</key>
 	<string>Agents</string>
+	<key>Agents on %@ can run, and report their status back here.</key>
+	<string>Agents on %@ can run, and report their status back here.</string>
+	<key>Agents on %@ can run.</key>
+	<string>Agents on %@ can run.</string>
 	<key>Agents won’t show as working.</key>
 	<string>Agents won’t show as working.</string>
 	<key>Alias</key>
@@ -148,6 +156,8 @@
 	<string>Appends a Host block to ~/.ssh/config, so the alias works in plain `ssh %@` too.</string>
 	<key>Apply</key>
 	<string>Apply</string>
+	<key>Asking %@ what it has.</key>
+	<string>Asking %@ what it has.</string>
 	<key>Assigned to Me</key>
 	<string>Assigned to Me</string>
 	<key>Assignee</key>
@@ -182,12 +192,16 @@
 	<string>Cancel</string>
 	<key>Can’t browse %@</key>
 	<string>Can’t browse %@</string>
+	<key>Can’t check on %@</key>
+	<string>Can’t check on %@</string>
 	<key>Can’t open as text</key>
 	<string>Can’t open as text</string>
 	<key>Can’t preview</key>
 	<string>Can’t preview</string>
 	<key>Can’t reach %@</key>
 	<string>Can’t reach %@</string>
+	<key>Can’t reach %@.</key>
+	<string>Can’t reach %@.</string>
 	<key>Can’t reach %@: %@</key>
 	<string>Can’t reach %@: %@</string>
 	<key>Change Theme…</key>
@@ -426,6 +440,8 @@
 	<string>Draft</string>
 	<key>Drag the list to change the order agents appear in.</key>
 	<string>Drag the list to change the order agents appear in.</string>
+	<key>Drag the list to change the order agents appear in. Readiness is for %@ — open it under Machines to install anything missing.</key>
+	<string>Drag the list to change the order agents appear in. Readiness is for %@ — open it under Machines to install anything missing.</string>
 	<key>Duplicate to Themes Folder</key>
 	<string>Duplicate to Themes Folder</string>
 	<key>Edit</key>
@@ -488,6 +504,8 @@
 	<string>From your session history</string>
 	<key>General</key>
 	<string>General</string>
+	<key>Get %@</key>
+	<string>Get %@</string>
 	<key>Git ignore patterns cannot represent a filename containing a line break.</key>
 	<string>Git ignore patterns cannot represent a filename containing a line break.</string>
 	<key>Git worktree</key>
@@ -548,6 +566,8 @@
 	<string>Installing %@…</string>
 	<key>Installing hooks and skill…</key>
 	<string>Installing hooks and skill…</string>
+	<key>Installs the `%@` command-line tool, then Termio’s hooks and skill for each agent.</key>
+	<string>Installs the `%@` command-line tool, then Termio’s hooks and skill for each agent.</string>
 	<key>Integration</key>
 	<string>Integration</string>
 	<key>Integrations</key>
@@ -606,6 +626,8 @@
 	<string>Links `%@` into /usr/local/bin so you (and agents) can run `%@ sessions …` from any shell.</string>
 	<key>Live agent status</key>
 	<string>Live agent status</string>
+	<key>Live agent status and session control are switched on in Settings ▸ Agents; this installs them on %@.</key>
+	<string>Live agent status and session control are switched on in Settings ▸ Agents; this installs them on %@.</string>
 	<key>Live agent status is off</key>
 	<string>Live agent status is off</string>
 	<key>Local</key>
@@ -726,6 +748,8 @@
 	<string>No Pull Requests</string>
 	<key>No Session</key>
 	<string>No Session</string>
+	<key>No agent CLIs found on %@.</key>
+	<string>No agent CLIs found on %@.</string>
 	<key>No agent CLIs found.</key>
 	<string>No agent CLIs found.</string>
 	<key>No agents on your list yet — add one in Settings ▸ Agents.</key>
@@ -770,6 +794,8 @@
 	<string>Not a valid regular expression</string>
 	<key>Not installed</key>
 	<string>Not installed</string>
+	<key>Not installed on %@</key>
+	<string>Not installed on %@</string>
 	<key>Not pushed to upstream</key>
 	<string>Not pushed to upstream</string>
 	<key>Nothing to Compare</key>
@@ -1026,6 +1052,8 @@
 	<string>Session control</string>
 	<key>Sessions</key>
 	<string>Sessions</string>
+	<key>Set Up %@</key>
+	<string>Set Up %@</string>
 	<key>Set Up Key</key>
 	<string>Set Up Key</string>
 	<key>Set Up Key…</key>
@@ -1054,6 +1082,8 @@
 	<string>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse. Installs Termio’s hooks into each agent’s config.</string>
 	<key>Sidebar</key>
 	<string>Sidebar</string>
+	<key>Signs in with %@</key>
+	<string>Signs in with %@</string>
 	<key>Signs in with the keys ssh offers by default.</key>
 	<string>Signs in with the keys ssh offers by default.</string>
 	<key>Size: %lld pt</key>
@@ -1158,6 +1188,8 @@
 	<string>The project and session list. Kept separate from the terminal font, and need not be monospaced.</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
 	<string>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</string>
+	<key>The session host on %@. Sessions keep running there after you disconnect.</key>
+	<string>The session host on %@. Sessions keep running there after you disconnect.</string>
 	<key>The session host went away</key>
 	<string>The session host went away</string>
 	<key>The sidebar shows this workspace</key>
@@ -1282,6 +1314,8 @@
 	<string>WeChat group</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
 	<string>When on, selecting text copies it straight to the clipboard.</string>
+	<key>Where each agent’s CLI lives on %@. Leave a path empty to use the agent’s default.</key>
+	<string>Where each agent’s CLI lives on %@. Leave a path empty to use the agent’s default.</string>
 	<key>Whether you want these at all. Each machine installs them for its own agents, under Machines.</key>
 	<string>Whether you want these at all. Each machine installs them for its own agents, under Machines.</string>
 	<key>Window</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -16,10 +16,14 @@
 	<string>“%@”是深色主题，与“%@”插槽不匹配。</string>
 	<key>%@ is a light theme in the %@ slot.</key>
 	<string>“%@”是浅色主题，与“%@”插槽不匹配。</string>
+	<key>%@ is ready.</key>
+	<string>%@ 已就绪。</string>
 	<key>%@ isn’t a UTF-8 text file.</key>
 	<string>%@ 不是 UTF-8 文本文件。</string>
 	<key>%@ isn’t available on this device yet.</key>
 	<string>%@ 暂不支持这台设备。</string>
+	<key>%@ isn’t installed on %@</key>
+	<string>%1$@ 未安装在 %2$@ 上</string>
 	<key>%@ isn’t on your PATH</key>
 	<string>%@ 不在 PATH 中</string>
 	<key>%@ keeps exiting — retrying every %llds</key>
@@ -110,6 +114,10 @@
 	<string>Agent 技能</string>
 	<key>Agents</key>
 	<string>Agent</string>
+	<key>Agents on %@ can run, and report their status back here.</key>
+	<string>%@ 上的 Agent 可以运行，并把状态报告回这里。</string>
+	<key>Agents on %@ can run.</key>
+	<string>%@ 上的 Agent 可以运行。</string>
 	<key>Agents won’t show as working.</key>
 	<string>Agent 将不会显示为工作中。</string>
 	<key>Alias</key>
@@ -148,6 +156,8 @@
 	<string>将 Host 块追加到 ~/.ssh/config，该别名也可直接用于 `ssh %@`。</string>
 	<key>Apply</key>
 	<string>应用</string>
+	<key>Asking %@ what it has.</key>
+	<string>正在询问 %@ 上有什么。</string>
 	<key>Assigned to Me</key>
 	<string>指派给我</string>
 	<key>Assignee</key>
@@ -182,12 +192,16 @@
 	<string>取消</string>
 	<key>Can’t browse %@</key>
 	<string>无法浏览 %@</string>
+	<key>Can’t check on %@</key>
+	<string>无法在 %@ 上检查</string>
 	<key>Can’t open as text</key>
 	<string>无法以文本打开</string>
 	<key>Can’t preview</key>
 	<string>无法预览</string>
 	<key>Can’t reach %@</key>
 	<string>连不上 %@</string>
+	<key>Can’t reach %@.</key>
+	<string>无法连接 %@。</string>
 	<key>Can’t reach %@: %@</key>
 	<string>连不上 %@：%@</string>
 	<key>Change Theme…</key>
@@ -426,6 +440,8 @@
 	<string>草稿</string>
 	<key>Drag the list to change the order agents appear in.</key>
 	<string>拖动列表可以调整 Agent 出现的顺序。</string>
+	<key>Drag the list to change the order agents appear in. Readiness is for %@ — open it under Machines to install anything missing.</key>
+	<string>拖动列表可更改 Agent 的显示顺序。就绪状态针对 %@ — 在“设备”中打开它可安装缺少的内容。</string>
 	<key>Duplicate to Themes Folder</key>
 	<string>复制到主题文件夹</string>
 	<key>Edit</key>
@@ -488,6 +504,8 @@
 	<string>来自你的会话历史</string>
 	<key>General</key>
 	<string>通用</string>
+	<key>Get %@</key>
+	<string>获取 %@</string>
 	<key>Git ignore patterns cannot represent a filename containing a line break.</key>
 	<string>Git 忽略模式无法表示包含换行符的文件名。</string>
 	<key>Git worktree</key>
@@ -548,6 +566,8 @@
 	<string>正在安装 %@…</string>
 	<key>Installing hooks and skill…</key>
 	<string>正在安装 hooks 和技能…</string>
+	<key>Installs the `%@` command-line tool, then Termio’s hooks and skill for each agent.</key>
+	<string>安装 `%@` 命令行工具，然后为每个 Agent 安装 Termio 的 hooks 和技能。</string>
 	<key>Integration</key>
 	<string>集成</string>
 	<key>Integrations</key>
@@ -606,6 +626,8 @@
 	<string>将 `%@` 链接到 /usr/local/bin，让你（和 Agent）可在任意 shell 中运行 `%@ sessions …`。</string>
 	<key>Live agent status</key>
 	<string>Agent 实时状态</string>
+	<key>Live agent status and session control are switched on in Settings ▸ Agents; this installs them on %@.</key>
+	<string>Agent 实时状态和会话控制在“设置 ▸ Agents”中开启；这里把它们安装到 %@ 上。</string>
 	<key>Live agent status is off</key>
 	<string>Agent 实时状态已关闭</string>
 	<key>Local</key>
@@ -726,6 +748,8 @@
 	<string>没有 PR</string>
 	<key>No Session</key>
 	<string>没有会话</string>
+	<key>No agent CLIs found on %@.</key>
+	<string>在 %@ 上未找到任何 Agent 命令行工具。</string>
 	<key>No agent CLIs found.</key>
 	<string>未找到任何 Agent 命令行工具。</string>
 	<key>No agents on your list yet — add one in Settings ▸ Agents.</key>
@@ -770,6 +794,8 @@
 	<string>不是有效的正则表达式</string>
 	<key>Not installed</key>
 	<string>未安装</string>
+	<key>Not installed on %@</key>
+	<string>未安装在 %@ 上</string>
 	<key>Not pushed to upstream</key>
 	<string>尚未推送到上游</string>
 	<key>Nothing to Compare</key>
@@ -1026,6 +1052,8 @@
 	<string>会话控制</string>
 	<key>Sessions</key>
 	<string>会话</string>
+	<key>Set Up %@</key>
+	<string>设置 %@</string>
 	<key>Set Up Key</key>
 	<string>设置密钥</string>
 	<key>Set Up Key…</key>
@@ -1054,6 +1082,8 @@
 	<string>显示 Agent 正在工作还是在等待你：侧栏的转圈指示和菜单栏的脉冲。会将 Termio 的 hooks 安装到各 Agent 的配置中。</string>
 	<key>Sidebar</key>
 	<string>侧栏</string>
+	<key>Signs in with %@</key>
+	<string>使用 %@ 登录</string>
 	<key>Signs in with the keys ssh offers by default.</key>
 	<string>使用 ssh 默认提供的密钥登录。</string>
 	<key>Size: %lld pt</key>
@@ -1158,6 +1188,8 @@
 	<string>项目与会话列表。与终端字体分开设置，无需等宽字体。</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
 	<string>~/.ssh 中的公钥。可拷贝一个粘贴到服务器的 authorized_keys——私钥永远不会被读取。</string>
+	<key>The session host on %@. Sessions keep running there after you disconnect.</key>
+	<string>%@ 上的会话宿主。断开连接后，会话仍在那里继续运行。</string>
 	<key>The session host went away</key>
 	<string>承载会话的进程消失了</string>
 	<key>The sidebar shows this workspace</key>
@@ -1282,6 +1314,8 @@
 	<string>微信群</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
 	<string>开启后，选中文本会直接拷贝到剪贴板。</string>
+	<key>Where each agent’s CLI lives on %@. Leave a path empty to use the agent’s default.</key>
+	<string>每个 Agent 的命令行工具在 %@ 上的位置。留空则使用该 Agent 的默认值。</string>
 	<key>Whether you want these at all. Each machine installs them for its own agents, under Machines.</key>
 	<string>决定你是否需要这些功能。每台设备在“设备”中为自己的 Agent 安装它们。</string>
 	<key>Window</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -92,6 +92,8 @@
 	<string>添加主机</string>
 	<key>Add Host…</key>
 	<string>添加主机…</string>
+	<key>Add Machine</key>
+	<string>添加设备</string>
 	<key>Add SSH Host</key>
 	<string>添加 SSH 主机</string>
 	<key>Add to Chat</key>
@@ -198,10 +200,16 @@
 	<string>与开发者和其他用户交流。</string>
 	<key>Chats</key>
 	<string>聊天</string>
+	<key>Check Again</key>
+	<string>重新检查</string>
 	<key>Check for Updates…</key>
 	<string>检查更新…</string>
 	<key>Checked out on %@</key>
 	<string>检出在 %@</string>
+	<key>Checking the machine…</key>
+	<string>正在检查设备…</string>
+	<key>Checking…</key>
+	<string>检查中…</string>
 	<key>Choose a different name.</key>
 	<string>请选取其他名称。</string>
 	<key>Choose a name for this workspace.</key>
@@ -388,6 +396,10 @@
 	<string>从这台 Mac 上删除该自定义 Agent 的 manifest。</string>
 	<key>Delete…</key>
 	<string>删除…</string>
+	<key>Deploy</key>
+	<string>部署</string>
+	<key>Deploys `termiod`, looks for your agent CLIs, then installs Termio’s hooks and skill.</key>
+	<string>部署 `termiod`，查找你的 Agent 命令行工具，然后安装 Termio 的 hooks 和技能。</string>
 	<key>Detached at %@</key>
 	<string>已分离于 %@</string>
 	<key>Devices</key>
@@ -472,6 +484,8 @@
 	<string>字体名称</string>
 	<key>From your Ghostty config</key>
 	<string>来自 Ghostty 配置</string>
+	<key>From your session history</key>
+	<string>来自你的会话历史</string>
 	<key>General</key>
 	<string>通用</string>
 	<key>Git ignore patterns cannot represent a filename containing a line break.</key>
@@ -498,6 +512,8 @@
 	<string>Hooks 已重新安装</string>
 	<key>Host</key>
 	<string>主机</string>
+	<key>Host block</key>
+	<string>Host 配置块</string>
 	<key>Host not found</key>
 	<string>找不到主机</string>
 	<key>Hosts</key>
@@ -522,10 +538,18 @@
 	<string>检查器窗格</string>
 	<key>Install %@</key>
 	<string>安装 %@</string>
+	<key>Install Page</key>
+	<string>安装页面</string>
+	<key>Installed by Termio</key>
+	<string>Termio 安装的内容</string>
 	<key>Installed.</key>
 	<string>已安装。</string>
 	<key>Installing %@…</key>
 	<string>正在安装 %@…</string>
+	<key>Installing hooks and skill…</key>
+	<string>正在安装 hooks 和技能…</string>
+	<key>Integration</key>
+	<string>集成</string>
 	<key>Integrations</key>
 	<string>集成</string>
 	<key>Interface</key>
@@ -552,6 +576,8 @@
 	<string>标签</string>
 	<key>Language</key>
 	<string>语言</string>
+	<key>Language, notifications, and GitHub</key>
+	<string>语言、通知和 GitHub</string>
 	<key>Last 30 days</key>
 	<string>过去 30 天</string>
 	<key>Last 7 days</key>
@@ -564,6 +590,8 @@
 	<string>启动</string>
 	<key>Let your agents coordinate?</key>
 	<string>让你的 Agent 相互协作？</string>
+	<key>Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command.</key>
+	<string>让 Agent 通过 `termio sessions` 命令查看并驱动本项目中的同级会话。</string>
 	<key>Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command. Installs the termio skill into each agent's skills folder.</key>
 	<string>允许 Agent 通过 `termio sessions` 命令查看并驱动本项目中的其他会话。会将 termio 技能安装到各 Agent 的技能文件夹中。</string>
 	<key>Light</key>
@@ -584,8 +612,14 @@
 	<string>本地</string>
 	<key>Login shell</key>
 	<string>登录 shell</string>
+	<key>Looking for agent CLIs…</key>
+	<string>正在查找 Agent 命令行工具…</string>
 	<key>Lost the connection to %@. The session is still running there.</key>
 	<string>与 %@ 的连接已断开。会话仍在那台机器上运行。</string>
+	<key>Machine Unavailable</key>
+	<string>设备不可用</string>
+	<key>Machines</key>
+	<string>设备</string>
 	<key>Match Case</key>
 	<string>区分大小写</string>
 	<key>Match Whole Word</key>
@@ -692,6 +726,10 @@
 	<string>没有 PR</string>
 	<key>No Session</key>
 	<string>没有会话</string>
+	<key>No agent CLIs found.</key>
+	<string>未找到任何 Agent 命令行工具。</string>
+	<key>No agents on your list yet — add one in Settings ▸ Agents.</key>
+	<string>你的列表中还没有 Agent — 在“设置 ▸ Agents”中添加一个。</string>
 	<key>No bundled tool to install from.</key>
 	<string>应用包中没有可安装的工具。</string>
 	<key>No description provided.</key>
@@ -722,6 +760,8 @@
 	<string>没有可显示的文本更改。</string>
 	<key>No theme matches “%@”</key>
 	<string>没有主题与“%@”匹配</string>
+	<key>None</key>
+	<string>无</string>
 	<key>None of this project’s remotes point at github.com, so there is no issue tracker to show.</key>
 	<string>该项目的远程仓库都未指向 github.com，因此没有可显示的 issue 跟踪器。</string>
 	<key>Not Now</key>
@@ -736,6 +776,8 @@
 	<string>没有可对比的分支</string>
 	<key>Nothing to install.</key>
 	<string>没有可安装的内容。</string>
+	<key>Nothing to reach — this is the machine you’re on.</key>
+	<string>无需连接 — 这就是你正在使用的设备。</string>
 	<key>Notifications</key>
 	<string>通知</string>
 	<key>Notifications for Termio are turned off in System Settings.</key>
@@ -788,6 +830,8 @@
 	<string>在 iPhone 上打开邀请链接，用 TestFlight 安装。</string>
 	<key>Opened outside Termio on this device</key>
 	<string>在这台设备上由 Termio 之外打开</string>
+	<key>Opens the ~/.ssh/config entry this machine is defined in.</key>
+	<string>打开定义该设备的 ~/.ssh/config 条目。</string>
 	<key>Padding: %lld pt</key>
 	<string>边距：%lld 点</string>
 	<key>Pair your iPhone and remote access</key>
@@ -846,10 +890,16 @@
 	<string>范围</string>
 	<key>Reachable</key>
 	<string>可连接</string>
+	<key>Reached by</key>
+	<string>连接方式</string>
+	<key>Reached over SSH</key>
+	<string>通过 SSH 连接</string>
 	<key>Reaching %@…</key>
 	<string>正在连接 %@…</string>
 	<key>Reads ~/.ssh/config directly — Termio keeps no separate host list.</key>
 	<string>直接读取 ~/.ssh/config——Termio 不保留单独的主机列表。</string>
+	<key>Ready</key>
+	<string>已就绪</string>
 	<key>Recent</key>
 	<string>最近</string>
 	<key>Recent Activity</key>
@@ -922,10 +972,14 @@
 	<string>要更换配对 Token 吗？</string>
 	<key>Row padding</key>
 	<string>行边距</string>
+	<key>Run Termio from the built app to install its command-line tool.</key>
+	<string>从打包后的 App 运行 Termio 才能安装其命令行工具。</string>
 	<key>Run a command…</key>
 	<string>运行命令…</string>
 	<key>Running terminal sessions will end. You can relaunch later instead.</key>
 	<string>正在运行的终端会话将会结束。你也可以稍后再重新启动。</string>
+	<key>Runs</key>
+	<string>运行</string>
 	<key>Runs on %@</key>
 	<string>运行于 %@</string>
 	<key>Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.</key>
@@ -976,6 +1030,10 @@
 	<string>设置密钥</string>
 	<key>Set Up Key…</key>
 	<string>设置密钥…</string>
+	<key>Set the path it launches from on each machine, under Machines.</key>
+	<string>在“设备”中为每台设备设置它的启动路径。</string>
+	<key>Set up this device</key>
+	<string>设置此设备</string>
 	<key>Settings</key>
 	<string>设置</string>
 	<key>Settings…</key>
@@ -990,10 +1048,14 @@
 	<string>显示项目文件</string>
 	<key>Shows the Issues pane in the inspector for projects whose remote is on GitHub.</key>
 	<string>为远程仓库位于 GitHub 的项目在检查器中显示 Issues 窗格。</string>
+	<key>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse.</key>
+	<string>显示 Agent 正在工作还是在等你 — 侧栏的转圈和菜单栏的脉冲。</string>
 	<key>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse. Installs Termio’s hooks into each agent’s config.</key>
 	<string>显示 Agent 正在工作还是在等待你：侧栏的转圈指示和菜单栏的脉冲。会将 Termio 的 hooks 安装到各 Agent 的配置中。</string>
 	<key>Sidebar</key>
 	<string>侧栏</string>
+	<key>Signs in with the keys ssh offers by default.</key>
+	<string>使用 ssh 默认提供的密钥登录。</string>
 	<key>Size: %lld pt</key>
 	<string>大小：%lld 磅</string>
 	<key>Skill reinstalled</key>
@@ -1086,8 +1148,12 @@
 	<string>无法添加忽略规则。</string>
 	<key>The listing failed.</key>
 	<string>读取目录失败。</string>
+	<key>The machine Termio is running on</key>
+	<string>Termio 正在运行的设备</string>
 	<key>The machine answered with no listing for that folder.</key>
 	<string>这台机器没有返回该文件夹的内容。</string>
+	<key>The machine you’re on</key>
+	<string>你正在使用的设备</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>项目与会话列表。与终端字体分开设置，无需等宽字体。</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
@@ -1114,6 +1180,10 @@
 	<string>加粗字形</string>
 	<key>This Mac</key>
 	<string>本机</string>
+	<key>This Mac and the machines you reach from it, and what each one runs</key>
+	<string>本机以及你能连接的设备，和每台设备上运行的内容</string>
+	<key>This Mac, and every machine you can reach from it. Open one to see what runs there.</key>
+	<string>本机，以及你能从这里连接的每台设备。打开一台可查看它上面运行的内容。</string>
 	<key>This Mac…</key>
 	<string>本机…</string>
 	<key>This agent is no longer on your list.</key>
@@ -1140,6 +1210,8 @@
 	<string>这台主机接受密码登录。Termio 用密钥登录，而 ~/.ssh 里没有 ssh 会自动尝试的密钥——先用 ssh-keygen 生成一个，再回到这里设置。</string>
 	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>
 	<string>这台主机接受密码登录。Termio 用密钥登录，设置一次之后，会话、文件树和远程终端都能连上它。</string>
+	<key>This machine is no longer in your configuration.</key>
+	<string>该设备已不在你的配置中。</string>
 	<key>This machine’s termiod is too old to list folders.</key>
 	<string>这台机器上的 termiod 版本太旧，列不出文件夹。</string>
 	<key>This month</key>
@@ -1210,6 +1282,8 @@
 	<string>微信群</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
 	<string>开启后，选中文本会直接拷贝到剪贴板。</string>
+	<key>Whether you want these at all. Each machine installs them for its own agents, under Machines.</key>
+	<string>决定你是否需要这些功能。每台设备在“设备”中为自己的 Agent 安装它们。</string>
 	<key>Window</key>
 	<string>窗口</string>
 	<key>Working Directory</key>

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -6,8 +6,24 @@ import SwiftUI
 /// name and a status line, and each row pushing that agent's configuration onto the
 /// settings window's own navigation stack. The earlier master–detail split gave the
 /// window a third column no other tab had.
+///
+/// This tab is *what you use*, and nothing here is a fact about a machine (RFC
+/// §D1). The enabled set, the order, the default agent and the integration
+/// switches are preferences; where an agent's CLI lives and whether it is
+/// installed belong to the machine that would run it, and are edited on that
+/// machine's pane. What the roster carries of that is one **passive** readiness
+/// line per agent, reported for the current workspace's device and never
+/// editable here.
 struct AgentSettingsTab: View {
     @ObservedObject var settings: AppSettings
+    /// The store the readiness line reads its machine from. Ambient, so it
+    /// follows a workspace switch — the one thing on this tab that re-targets
+    /// (RFC §Reliability: explicit selections do not, ambient indicators do).
+    @ObservedObject var store: TermioStore
+
+    /// The machine the readiness line describes: the one the current workspace
+    /// runs on.
+    private var device: KnownDevice { store.currentDevice }
 
     /// Bumped after every catalog reload. `AgentDefinition` equality is by id, so
     /// without this a rename would leave stale rows on screen; referencing the
@@ -43,7 +59,7 @@ struct AgentSettingsTab: View {
                 Section {
                     ForEach(listedAgents) { preset in
                         NavigationLink(value: AgentRoute(id: preset.id)) {
-                            AgentListRow(settings: settings, preset: preset)
+                            AgentListRow(settings: settings, preset: preset, device: device)
                         }
                         .contextMenu {
                             Button(localized("Remove from List")) { remove(preset) }
@@ -53,7 +69,34 @@ struct AgentSettingsTab: View {
                 } header: {
                     SectionHeaderLabel(title: localized("Agents"))
                 } footer: {
-                    Text(localized("Drag the list to change the order agents appear in."))
+                    Text(localized("Drag the list to change the order agents appear in. Readiness is for \(device.name) — open it under Machines to install anything missing."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section {
+                    Toggle(isOn: $settings.agentHooksEnabled) {
+                        SettingsLabel(
+                            title: localized("Live agent status"),
+                            subtext: localized("Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse."),
+                            titleFont: .headline
+                        )
+                    }
+                    .toggleStyle(.switch)
+                    Toggle(isOn: $settings.sessionControlEnabled) {
+                        SettingsLabel(
+                            title: localized("Session control"),
+                            subtext: localized("Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command."),
+                            titleFont: .headline
+                        )
+                    }
+                    .toggleStyle(.switch)
+                } header: {
+                    SectionHeaderLabel(title: localized("Integration"))
+                } footer: {
+                    // The switch is the preference; installing the files it needs
+                    // is a machine operation and stays on the machine's pane.
+                    Text(localized("Whether you want these at all. Each machine installs them for its own agents, under Machines."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -226,21 +269,32 @@ private struct AddAgentBar: View {
 private struct AgentListRow: View {
     @ObservedObject var settings: AppSettings
     let preset: AgentPreset
+    /// The machine the readiness word describes — the current workspace's device,
+    /// not this Mac, which is the whole point of the line.
+    let device: KnownDevice
 
-    /// `nil` while the PATH probe is still running (show nothing rather than a
-    /// premature warning); `false` once we've confirmed the command isn't resolvable.
-    @State private var available: Bool?
+    /// `nil` while the probe is still running: show nothing rather than a
+    /// premature warning.
+    @State private var readiness: AgentReadiness?
 
     /// Nothing to say about an enabled agent whose CLI is present — the common
     /// case, where the line is the command alone.
+    ///
+    /// The `unknown` word is the one this row could not say before. A machine
+    /// reached over a network fails to answer for reasons that are nothing to do
+    /// with the agent, and a `(!)` reading "not installed" would send the user to
+    /// reinstall a CLI that is already there.
     private var status: String? {
         if !settings.isAgentEnabled(preset) { return localized("Off") }
-        if available == false { return localized("Not installed") }
-        return nil
+        switch readiness {
+        case .missing: return localized("Not installed")
+        case .unknown: return localized("Can’t check on \(device.name)")
+        case .available, nil: return nil
+        }
     }
 
     private var detail: String {
-        let command = settings.command(for: preset) ?? localized("Login shell")
+        let command = settings.command(for: preset, on: device) ?? localized("Login shell")
         guard let status else { return command }
         return localized("\(status) · \(command)")
     }
@@ -257,16 +311,22 @@ private struct AgentListRow: View {
                     .truncationMode(.middle)
             }
             Spacer(minLength: 4)
-            if available == false {
+            // Only `missing` earns the badge. `unknown` says so in words instead:
+            // a warning glyph for "we could not ask" is the false alarm.
+            if readiness == .missing {
                 Image(systemName: "exclamationmark.circle")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
-                    .help(localized("\(preset.displayName) isn’t on your PATH"))
+                    .help(localized("\(preset.displayName) isn’t installed on \(device.name)"))
             }
         }
-        .task(id: settings.command(for: preset) ?? "") {
-            available = await AgentAvailability.isCommandAvailable(
-                settings.command(for: preset) ?? "")
+        // Re-probed when the machine changes, so a workspace switch re-targets
+        // this line and nothing else on the tab redraws.
+        .task(id: "\(device.settingsKey)#\(settings.command(for: preset, on: device) ?? "")") {
+            readiness = await AgentReadiness.passive(
+                agent: preset,
+                command: settings.command(for: preset, on: device) ?? "",
+                on: device)
         }
     }
 }
@@ -335,23 +395,23 @@ private struct AgentDetailPane: View {
             }
 
             Section {
-                LabeledContent(localized("Command")) {
-                    TextField(
-                        "",
-                        text: Binding(
-                            get: { settings.agentCommandOverrides[preset.rawValue] ?? "" },
-                            set: { settings.agentCommandOverrides[preset.rawValue] = $0 }
-                        ),
-                        prompt: Text(preset.command ?? "")
-                    )
-                    .textFieldStyle(.plain)
-                    .multilineTextAlignment(.trailing)
-                    .labelsHidden()
-                }
-                if available == false, let url = preset.installURL {
-                    Link(destination: url) {
-                        Label(localized("Install \(preset.displayName)"), systemImage: "arrow.down.circle")
+                // Where this agent's CLI lives is a fact about a machine, and the
+                // field that sets it now lives on that machine's pane (RFC §D1).
+                // What is left here is the link that gets the CLI in the first
+                // place — an install page on the web, which is the same page
+                // whichever machine you are installing on.
+                LabeledContent {
+                    if let url = preset.installURL {
+                        Link(localized("Install Page"), destination: url)
+                    } else {
+                        Text(localized("None")).foregroundStyle(.secondary)
                     }
+                } label: {
+                    SettingsLabel(
+                        title: localized("Get \(preset.displayName)"),
+                        subtext: localized("Set the path it launches from on each machine, under Machines."),
+                        titleFont: .headline
+                    )
                 }
             } header: {
                 SectionHeaderLabel(title: localized("Launch"))

--- a/Sources/termio/Settings/DeviceReadiness.swift
+++ b/Sources/termio/Settings/DeviceReadiness.swift
@@ -1,0 +1,335 @@
+import Foundation
+
+/// Whether an agent's CLI is on a machine — with the third answer the local probe
+/// never needed (RFC §D4).
+///
+/// `AgentAvailability` answers *available* when its own probe fails rather than
+/// crying wolf, which is right for this Mac: the only way to fail is a login shell
+/// that would not print its `PATH`, and that is rare. A machine reached over a
+/// network fails constantly — asleep box, dead tunnel, wrong alias, key not
+/// loaded — so folding "we could not ask" into either answer is a lie in one
+/// direction or the other. Reported as "not installed" it sends the user to
+/// reinstall a CLI that is already there; reported as "available" it promises a
+/// launch that cannot happen.
+enum AgentReadiness: String, Sendable {
+    case available
+    case missing
+    /// We could not reach the machine to ask. Never a defect in the agent.
+    case unknown
+}
+
+/// One machine's whole answer, as one line (RFC §D6).
+///
+/// Deploy `termiod` → probe the agent CLIs → install hooks and skill is a real
+/// dependency chain, and four rungs with independent states turn choosing a
+/// machine into infrastructure triage. So the pane shows one outcome and the
+/// ladder becomes the disclosure behind it.
+enum MachineReadiness: Equatable {
+    /// Nothing asked yet, and no cache to draw on.
+    case unasked
+    case checking
+    case ready
+    /// The **first** blocking step, in words. Only the first: a machine with no
+    /// `termiod` also has no hooks, and listing both invites the user to fix the
+    /// consequence instead of the cause.
+    case blocked(String)
+
+    var isBusy: Bool { self == .checking }
+}
+
+/// The steps behind the one line, in dependency order. Named so the pane can say
+/// what it is doing while it runs, and so a failure can name the rung it stopped
+/// on rather than reporting "setup failed".
+enum MachineSetupStep: Equatable {
+    /// This Mac: link the `termio` CLI onto `PATH`. A device: deploy `termiod`.
+    /// Both are "the binary this machine needs before anything else works", which
+    /// is why they are one rung rather than a local branch bolted onto a remote
+    /// flow (RFC §D8: installing a CLI on a machine is a machine operation).
+    case foundation
+    case probeAgents
+    case installIntegration
+
+    var label: String {
+        switch self {
+        case .foundation: return localized("Checking the machine…")
+        case .probeAgents: return localized("Looking for agent CLIs…")
+        case .installIntegration: return localized("Installing hooks and skill…")
+        }
+    }
+}
+
+extension AgentReadiness {
+    /// The answer a **passive** line may give: this Mac is probed live, and any
+    /// other machine is read from its device file or left `unknown`.
+    ///
+    /// Passive is the constraint, not a shortcut. The Agents tab draws one of
+    /// these per row, and a live remote probe there would fire an `ssh` per agent
+    /// every time the tab is opened or a workspace is switched — several seconds
+    /// of Settings hanging on a sleeping box, to decorate a line the user did not
+    /// ask about. So the tab reports what is known and says "can't check" when
+    /// nothing is; the machine's pane is where asking happens, and it writes the
+    /// file this reads.
+    ///
+    /// Keyed by agent rather than by command, so a path edited since the last
+    /// probe reads as whatever the old path resolved to until the machine's pane
+    /// is opened again. That is the cache being a cache; it is never the thing
+    /// that decides whether a launch happens.
+    static func passive(
+        agent: AgentPreset, command: String, on device: KnownDevice
+    ) async -> AgentReadiness {
+        guard device.alias != nil else {
+            return await AgentAvailability.isCommandAvailable(command) ? .available : .missing
+        }
+        let key = device.settingsKey
+        guard let cached = await Task.detached(priority: .utility, operation: {
+            DeviceStateCache.load(key)
+        }).value else { return .unknown }
+        return cached.readiness(for: agent)
+    }
+}
+
+// MARK: - Probing
+
+/// Asks a machine what it is. Every method here runs off the main actor and
+/// returns a value; nothing renders, and nothing is cached as authority.
+enum MachineProbe {
+    /// A read-only check: what is true on this machine right now.
+    ///
+    /// The one probe that matters is reachability, and it is asked **first and
+    /// once**: a machine that does not answer makes every agent `.unknown` in one
+    /// step, instead of paying an ssh timeout per agent to reach the same
+    /// conclusion eight times.
+    static func inspect(
+        device: KnownDevice, commands: [(id: String, command: String)]
+    ) async -> DeviceDiscoveredState {
+        let now = Date()
+        guard let alias = device.alias else {
+            // This Mac always answers. Its readiness is `AgentAvailability`'s
+            // login-shell PATH — the exact PATH a session launches with.
+            var agents: [String: String] = [:]
+            for entry in commands {
+                agents[entry.id] = await AgentAvailability.isCommandAvailable(entry.command)
+                    ? AgentReadiness.available.rawValue
+                    : AgentReadiness.missing.rawValue
+            }
+            return DeviceDiscoveredState(checkedAt: now, reachable: true, agents: agents)
+        }
+
+        let probe = await SSHConfigFile.testConnection(alias: alias)
+        guard case .reachable = probe else {
+            return DeviceDiscoveredState(checkedAt: now, reachable: false)
+        }
+        let store = SSHAgentConfigStore(host: alias)
+        return await Task.detached(priority: .userInitiated) {
+            var agents: [String: String] = [:]
+            for entry in commands {
+                agents[entry.id] = store.isCommandInstalled(entry.command)
+                    ? AgentReadiness.available.rawValue
+                    : AgentReadiness.missing.rawValue
+            }
+            return DeviceDiscoveredState(
+                checkedAt: now, reachable: true,
+                termiodVersion: nil, agents: agents)
+        }.value
+    }
+}
+
+// MARK: - The device file's integration stamp
+
+extension DeviceDiscoveredState {
+    /// Whether the hooks and skill installed on this machine were installed by
+    /// *this* build.
+    ///
+    /// Stamped rather than re-derived: a hook is a line inside each agent's own
+    /// config in four different dialects, and re-parsing all of them on every pane
+    /// open would fork the installers' knowledge into a second reader that can
+    /// drift from them. The stamp costs one honest failure mode — a config
+    /// hand-edited after we wrote it still reads as installed — and the ladder's
+    /// "Reinstall hooks" is exactly the disclosure that answers it.
+    ///
+    /// Compared against the build, not merely checked for presence, because a
+    /// local hook embeds the CLI's path and a device hook embeds `termiod`'s: an
+    /// upgrade that moves either leaves a hook that cannot exec.
+    var carriesCurrentIntegration: Bool {
+        integrationVersion != nil && integrationVersion == AppInfo.buildStamp
+    }
+}
+
+// MARK: - What a machine's pane runs on
+
+/// The state behind one machine's pane: what we last learned, what we are asking
+/// now, and the single outcome line.
+///
+/// Owned by the pane rather than the app because a machine is only asked about
+/// while someone is looking at it. Nothing here probes on launch: a Settings
+/// window that fires ssh at every configured host on open is how a sleeping VPS
+/// makes opening preferences take twenty seconds.
+@MainActor
+final class MachinePaneModel: ObservableObject {
+    let device: KnownDevice
+    private let settings: AppSettings
+
+    /// The last probe's answer, seeded from `~/.termio/devices/<key>.json` so the
+    /// pane draws something the moment it opens. Replaced by the first live probe
+    /// — it is a cache, never the authority.
+    @Published private(set) var discovered: DeviceDiscoveredState?
+    @Published private(set) var readiness: MachineReadiness = .unasked
+    /// The rung in progress, so a chain that takes ten seconds says which part is
+    /// slow instead of spinning anonymously.
+    @Published private(set) var step: MachineSetupStep?
+    /// What the last completed setup left behind, shown once and dismissed.
+    @Published var feedback: InstallFeedback?
+
+    init(device: KnownDevice, settings: AppSettings) {
+        self.device = device
+        self.settings = settings
+        discovered = DeviceStateCache.load(device.settingsKey)
+        // Seeded from the cache, but never *blocked* by it: a box that was asleep
+        // when we last looked must not greet the user with a failure we have not
+        // re-confirmed. It reads as "not set up yet" until a live probe says more.
+        if let discovered, discovered.carriesCurrentIntegration, discovered.reachable {
+            readiness = .ready
+        }
+    }
+
+    /// The agents whose presence this machine is judged on: the ones the user
+    /// actually keeps on their list. Judging on the whole catalog would report a
+    /// machine unready for an agent its owner has never used.
+    private var listedAgents: [AgentPreset] {
+        settings.orderedAgents(AgentPreset.codingAgents.filter(settings.isAgentListed))
+    }
+
+    private var commandPairs: [(id: String, command: String)] {
+        listedAgents.map { ($0.rawValue, settings.command(for: $0, on: device) ?? "") }
+    }
+
+    func readiness(for agent: AgentPreset) -> AgentReadiness {
+        guard let discovered else { return .unknown }
+        return discovered.readiness(for: agent)
+    }
+
+    /// Asks the machine, without changing anything on it. The pane's own refresh,
+    /// and what the roster row calls when it first appears.
+    func check() async {
+        guard !readiness.isBusy else { return }
+        readiness = .checking
+        step = .foundation
+        let state = await MachineProbe.inspect(device: device, commands: commandPairs)
+        // Carry the integration stamp forward: a probe asks what is on the
+        // machine, and does not un-install what a previous setup put there.
+        var merged = state
+        merged.integrationVersion = discovered?.integrationVersion
+        apply(merged)
+        step = nil
+    }
+
+    /// The whole safe chain, in one click (RFC §D6). Stops at the first rung that
+    /// blocks and says what it was — the later rungs cannot succeed anyway, and
+    /// reporting all three invites fixing a consequence instead of a cause.
+    func setUp() async {
+        guard !readiness.isBusy else { return }
+        readiness = .checking
+        feedback = nil
+        defer { step = nil }
+
+        step = .foundation
+        if let failure = await installFoundation() {
+            readiness = .blocked(failure)
+            return
+        }
+
+        step = .probeAgents
+        var state = await MachineProbe.inspect(device: device, commands: commandPairs)
+        state.integrationVersion = discovered?.integrationVersion
+        apply(state)
+        // `resolve` already names the first thing in the way — unreachable, or
+        // nothing to run — and those are exactly the two that stop the chain.
+        if case .blocked = readiness { return }
+
+        step = .installIntegration
+        let target = device.integrationTarget
+        let hooks = AgentStatusHooks.sync(enabled: settings.agentHooksEnabled, target: target)
+        let skill = SessionSkillInstaller.sync(
+            enabled: settings.sessionControlEnabled, target: target)
+        // A rung that reached the machine but could not write every agent's config
+        // is still a failure of *this* rung, and the one worth naming.
+        let refused = hooks.failed + skill.failed
+        guard refused.isEmpty else {
+            apply(state)
+            readiness = .blocked(localized(
+                "Couldn’t write the config for \(InstallOutcome.list(refused, unit: localized("agents"))) on \(device.name)."))
+            return
+        }
+        state.integrationVersion = AppInfo.buildStamp
+        apply(state)
+        feedback = .success(localized("\(device.name) is ready."))
+    }
+
+    /// The first rung. This Mac needs the `termio` CLI on `PATH` — a hook it
+    /// installs invokes it by name. A device needs `termiod`, which is also the
+    /// reachability check, since deploying requires reaching it.
+    private func installFoundation() async -> String? {
+        guard let alias = device.alias else {
+            switch CommandLineTool.install() {
+            case .installed:
+                return nil
+            case .conflict:
+                return localized("Something else already owns \(CommandLineTool.installURL.path).")
+            case .unavailable:
+                return localized("Run Termio from the built app to install its command-line tool.")
+            case .notInstalled, .stale:
+                let directory = CommandLineTool.installURL.deletingLastPathComponent().path
+                return localized("Couldn’t link `\(CommandLineTool.toolName)` into \(directory).")
+            }
+        }
+        switch await TermioStore.remoteReadyCheck(host: alias) {
+        case .success: return nil
+        case .failure(let error): return error.message
+        }
+    }
+
+    private func apply(_ state: DeviceDiscoveredState) {
+        discovered = state
+        readiness = resolve(state)
+        let key = device.settingsKey
+        Task.detached(priority: .utility) { DeviceStateCache.save(state, for: key) }
+    }
+
+    /// What a completed probe means, in one line: ready when the machine
+    /// answered, something on it can run, and this build put its hooks there —
+    /// and otherwise the **first** thing standing in the way, in that order.
+    ///
+    /// Order matters more than completeness. A box that does not answer also has
+    /// no agent CLIs and no hooks, and saying all three would invite the user to
+    /// go install an agent on a machine that is switched off.
+    private func resolve(_ state: DeviceDiscoveredState) -> MachineReadiness {
+        guard state.reachable else { return .blocked(localized("Can’t reach \(device.name).")) }
+        guard state.agents.values.contains(AgentReadiness.available.rawValue) else {
+            return .blocked(localized("No agent CLIs found on \(device.name)."))
+        }
+        // Not blocked, just not done — the setup button is the whole next step, so
+        // it reads as "set up this device" rather than as a fault.
+        return state.carriesCurrentIntegration ? .ready : .unasked
+    }
+}
+
+extension KnownDevice {
+    /// Where this machine's agent integration is written, and what a hook there
+    /// runs to report status. The seam `AgentConfigStore` exists for; a machine's
+    /// pane is its first caller.
+    var integrationTarget: AgentIntegrationTarget {
+        alias.map { .device(host: $0) } ?? .thisMac
+    }
+}
+
+/// The build a device file's integration stamp is compared against.
+enum AppInfo {
+    /// Version plus build number: a version alone would not notice a dev rebuild
+    /// that moved the CLI copy the hooks point at.
+    static let buildStamp: String = {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "0"
+        let build = info?["CFBundleVersion"] as? String ?? "0"
+        return "\(version)+\(build)"
+    }()
+}

--- a/Sources/termio/Settings/DeviceSettings.swift
+++ b/Sources/termio/Settings/DeviceSettings.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+/// Per-machine values, split by who wrote them.
+///
+/// A setting that names a machine has two halves with different lifecycles, and
+/// conflating them is what made Settings mean "this Mac" in the first place:
+///
+/// - **Authored** — the command path the user chose for an agent on that box.
+///   A choice, so it belongs beside every other choice in `settings.json` and
+///   survives anything.
+/// - **Discovered** — whether the box answered, whether a CLI is on its `PATH`.
+///   A probe result, so it belongs in `~/.termio/devices/<host_id>.json` and is
+///   safe to delete at any moment.
+///
+/// The rule that keeps them apart: **the discovered file is never read as
+/// authority.** It exists so a machine's pane can draw something the instant it
+/// opens instead of an empty pane with a spinner, and every value in it is
+/// replaced by a live probe as soon as one answers. One read path that trusts it
+/// recreates the bug this whole split exists to fix.
+
+// MARK: - Which machine a value belongs to
+
+extension KnownDevice {
+    /// The key a machine's values are filed under.
+    ///
+    /// The `host_id` once a handshake has revealed one, the alias until then —
+    /// the same bootstrap/stable split `Checkout.deviceIdentity` and
+    /// `TermioStore.isAuthored(_:for:)` already use, so one box reached by a LAN
+    /// name, a WAN name and a tailnet name keeps one blob of settings instead of
+    /// forking into three.
+    ///
+    /// This Mac spells it `local` rather than the empty string `id` uses: this is
+    /// a JSON object key a human reads and hand-edits, and `"": {…}` is neither.
+    var settingsKey: String { deviceID ?? alias ?? "local" }
+}
+
+// MARK: - Authored
+
+/// One machine's authored values, as stored. Absent fields mean the user never
+/// chose one for that machine — never "the default is X", which is why nothing
+/// here has a non-optional stored form.
+struct DeviceAuthoredSettings: Codable, Equatable {
+    /// Command paths by `AgentPreset.rawValue`, for agents on this machine. The
+    /// per-app `agents.commandOverrides` this replaces had no machine dimension,
+    /// so a full path typed for a Homebrew install on the Mac was also handed to
+    /// a VPS where nothing lives at that path.
+    var agentCommands: [String: String]?
+
+    var isEmpty: Bool { (agentCommands?.isEmpty ?? true) }
+}
+
+/// The `devices` section of `settings.json`: authored values for every machine
+/// the user has set one on.
+///
+/// Read and written through `SettingsStore` like every other preference — the
+/// same file, the same "only keys the user set" rule — rather than a second
+/// store with its own lifetime. A user who has never typed a command path on any
+/// machine has no `devices` key at all.
+struct DeviceSettingsSection: Codable, Equatable {
+    var byDevice: [String: DeviceAuthoredSettings]
+
+    init(byDevice: [String: DeviceAuthoredSettings] = [:]) {
+        self.byDevice = byDevice
+    }
+
+    subscript(key: String) -> DeviceAuthoredSettings {
+        get { byDevice[key] ?? DeviceAuthoredSettings() }
+        // An emptied machine drops out entirely, so clearing the last value a
+        // machine had leaves the file as short as it was before it was set.
+        set { byDevice[key] = newValue.isEmpty ? nil : newValue }
+    }
+
+    /// The JSON object `SettingsStore` persists. Round-tripped through
+    /// `JSONSerialization` because that store holds plist-shaped `Any`, and a
+    /// `Codable` value is the only honest way to keep the schema in one place.
+    var jsonObject: [String: Any]? {
+        guard !byDevice.isEmpty,
+              let data = try? JSONEncoder().encode(self.byDevice),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return object
+    }
+
+    init(jsonObject: [String: Any]?) {
+        guard let jsonObject,
+              let data = try? JSONSerialization.data(withJSONObject: jsonObject),
+              let decoded = try? JSONDecoder().decode([String: DeviceAuthoredSettings].self, from: data)
+        else {
+            self.init()
+            return
+        }
+        self.init(byDevice: decoded)
+    }
+}
+
+// MARK: - Discovered
+
+/// What a probe last learned about one machine — a cache, and labelled one from
+/// the day it is written (RFC §D7).
+///
+/// Nothing here is a decision. Every field is regenerable by asking the machine
+/// again, the file may be deleted between any two launches, and a missing file
+/// is not an error state: it means "we have not asked yet", which is exactly
+/// what `AgentReadiness.unknown` renders.
+struct DeviceDiscoveredState: Codable, Equatable {
+    /// When the probe that produced this ran. Shown as "Checked <time>" so a
+    /// cached answer never passes for a fresh one.
+    var checkedAt: Date
+    /// Whether the machine answered at all. `false` is what turns every agent row
+    /// on that machine into "can't check" rather than "not installed".
+    var reachable: Bool
+    /// The `termiod` build the machine reported, when it has one.
+    var termiodVersion: String?
+    /// Per-agent probe results by `AgentPreset.rawValue`, as
+    /// `AgentReadiness.rawValue`.
+    var agents: [String: String]
+    /// The build stamp of the termio that last installed hooks and the skill here
+    /// (`AppInfo.buildStamp`), or `nil` if none has. See
+    /// `carriesCurrentIntegration` for why this is stamped rather than re-derived.
+    var integrationVersion: String?
+
+    init(
+        checkedAt: Date, reachable: Bool, termiodVersion: String? = nil,
+        agents: [String: String] = [:], integrationVersion: String? = nil
+    ) {
+        self.checkedAt = checkedAt
+        self.reachable = reachable
+        self.termiodVersion = termiodVersion
+        self.agents = agents
+        self.integrationVersion = integrationVersion
+    }
+
+    func readiness(for agent: AgentPreset) -> AgentReadiness {
+        guard reachable else { return .unknown }
+        return agents[agent.rawValue].flatMap(AgentReadiness.init(rawValue:)) ?? .unknown
+    }
+}
+
+/// Reads and writes `~/.termio/devices/<host_id>.json`.
+///
+/// Deliberately not `@MainActor`: probing a machine happens off the main thread
+/// and writing the result should not have to hop back. Every failure is
+/// swallowed to a `nil` — a cache that cannot be read is indistinguishable from
+/// one that was never written, and neither is worth interrupting the user for.
+enum DeviceStateCache {
+    static var directory: URL {
+        AppChannel.homeConfigDirectory.appendingPathComponent("devices", isDirectory: true)
+    }
+
+    /// One machine's file. The key is sanitized because it may be a
+    /// `~/.ssh/config` alias before a handshake has produced a `host_id`, and an
+    /// alias is whatever the user typed — including a `/`, which would otherwise
+    /// name a subdirectory.
+    static func url(for key: String) -> URL {
+        let safe = key.map { $0.isLetterOrDigitOrSafe ? $0 : "_" }
+        return directory.appendingPathComponent(String(safe) + ".json", isDirectory: false)
+    }
+
+    static func load(_ key: String) -> DeviceDiscoveredState? {
+        guard let data = try? Data(contentsOf: url(for: key)) else { return nil }
+        return try? JSONDecoder.deviceCache.decode(DeviceDiscoveredState.self, from: data)
+    }
+
+    static func save(_ state: DeviceDiscoveredState, for key: String) {
+        let file = url(for: key)
+        do {
+            try FileManager.default.createDirectory(
+                at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let data = try JSONEncoder.deviceCache.encode(state)
+            try data.write(to: file, options: .atomic)
+        } catch {
+            // A cache that could not be written costs one extra probe next launch.
+            Log.app.debug(
+                "could not cache device state: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Forgets what we think we know about a machine. The pane's "Check Again"
+    /// path, and the reason nothing may treat this file as authority.
+    static func forget(_ key: String) {
+        try? FileManager.default.removeItem(at: url(for: key))
+    }
+}
+
+private extension Character {
+    var isLetterOrDigitOrSafe: Bool {
+        isLetter || isNumber || self == "-" || self == "_" || self == "."
+    }
+}
+
+private extension JSONEncoder {
+    /// Pretty-printed with ISO dates: the file is meant to be openable when
+    /// someone is working out why a machine reads as unreachable.
+    static var deviceCache: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}
+
+private extension JSONDecoder {
+    static var deviceCache: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/termio/Settings/GeneralSettingsTab.swift
+++ b/Sources/termio/Settings/GeneralSettingsTab.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 import UserNotifications
 
-/// App-level settings that aren't about a specific surface: the `termio`
-/// command-line tool, the machine-wide agent integrations (the session-control
-/// skill, status hooks), and task-completion notifications. The first three
-/// install termio's wiring outside the app — PATH, agent configs, instruction
-/// files — rather than configure a particular agent, so they live here rather
-/// than in the Agents tab.
+/// App-and-account settings: language, task-completion notifications, and the
+/// GitHub integration.
+///
+/// It used to also carry the `termio` command-line tool, the session-control
+/// skill and the status hooks. Every one of those installs a file **on a
+/// machine** — an agent's config directory, `/usr/local/bin` — so presented here
+/// they read as app-wide and silently meant this Mac, which is why a VPS agent
+/// had no hook status and nobody could see why. They now live on a machine's pane
+/// (RFC §D8), and this tab stops lying about its scope.
 struct GeneralSettingsTab: View {
     @ObservedObject var settings: AppSettings
 
@@ -16,49 +19,6 @@ struct GeneralSettingsTab: View {
                 LanguageRow()
             } header: {
                 SectionHeaderLabel(title: localized("Language"))
-            }
-            Section {
-                CommandLineToolRow()
-            } header: {
-                SectionHeaderLabel(title: localized("Command line"))
-            }
-            Section {
-                Toggle(isOn: $settings.sessionControlEnabled) {
-                    SettingsLabel(
-                        title: localized("Session control"),
-                        subtext: localized("Lets an agent see and drive its sibling sessions in this project via the `termio sessions` command. Installs the termio skill into each agent's skills folder."),
-                        titleFont: .headline
-                    )
-                }
-                .toggleStyle(.switch)
-                if settings.sessionControlEnabled {
-                    InstallButtonRow(title: localized("Reinstall skill")) {
-                        .summarizing(SessionSkillInstaller.sync(enabled: true),
-                                     headline: localized("Skill reinstalled"), unit: localized("agents"))
-                    }
-                }
-            } header: {
-                SectionHeaderLabel(title: localized("Agent skill"))
-            }
-            Section {
-                Toggle(isOn: $settings.agentHooksEnabled) {
-                    SettingsLabel(
-                        title: localized("Live agent status"),
-                        subtext: localized("Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse. Installs Termio’s hooks into each agent’s config."),
-                        titleFont: .headline
-                    )
-                }
-                .toggleStyle(.switch)
-                if settings.agentHooksEnabled {
-                    // For re-applying after the user (or another tool) has edited
-                    // ~/.claude/settings.json; install is idempotent.
-                    InstallButtonRow(title: localized("Reinstall hooks")) {
-                        .summarizing(AgentStatusHooks.sync(enabled: true),
-                                     headline: localized("Hooks reinstalled"), unit: localized("agents"))
-                    }
-                }
-            } header: {
-                SectionHeaderLabel(title: localized("Status"))
             }
             Section {
                 Toggle(isOn: $settings.notifyOnTaskCompletion) {
@@ -143,109 +103,5 @@ private struct NotificationPermissionRow: View {
         ) { _ in
             Task { status = await TaskNotificationCenter.authorizationStatus() }
         }
-    }
-}
-
-/// Installs and reports the `termio` command-line tool, as a switch like the other
-/// feature rows: on means the PATH symlink exists, off removes it. The switch is
-/// bound to the audit, not a stored preference, so it always reflects reality (a
-/// declined admin prompt snaps it back). It audits on appear (a moved app shows
-/// "Update") and re-audits after every action so the caption updates in place.
-private struct CommandLineToolRow: View {
-    @State private var status: CommandLineTool.Status = .notInstalled
-    @State private var state = InstallFeedbackState()
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Toggle(isOn: Binding(get: { isOn }, set: { setEnabled($0) })) {
-                SettingsLabel(
-                    title: localized("Command-line tool"), subtext: description, titleFont: .headline)
-            }
-            .toggleStyle(.switch)
-            .disabled(!isSwitchable)
-            if let feedback = state.feedback {
-                InstallFeedbackLabel(feedback: feedback)
-            }
-        }
-        .onAppear { status = CommandLineTool.audit() }
-        .autoDismissing($state)
-        if isOn {
-            // For re-linking after something else has touched /usr/local/bin;
-            // install is idempotent. Reports through its own feedback line.
-            InstallButtonRow(title: buttonTitle) { withAnimation { runInstall() } }
-        }
-    }
-
-    private var isOn: Bool {
-        switch status {
-        case .installed, .stale: return true
-        case .notInstalled, .conflict, .unavailable: return false
-        }
-    }
-
-    /// A conflicting file isn't ours to remove and a bare binary has nothing to
-    /// link, so in both states the switch is disabled and the caption explains.
-    private var isSwitchable: Bool {
-        switch status {
-        case .installed, .stale, .notInstalled: return true
-        case .conflict, .unavailable: return false
-        }
-    }
-
-    private func setEnabled(_ enabled: Bool) {
-        withAnimation {
-            if enabled {
-                state.show(runInstall())
-            } else {
-                status = CommandLineTool.uninstall()
-                state.show(isOn
-                    ? .failure(localized("Couldn’t remove \(CommandLineTool.installURL.path)."))
-                    : .success(localized("Removed from PATH.")))
-            }
-        }
-    }
-
-    /// Installs, then reports the fresh audit. The caption alone can't carry this:
-    /// a declined admin prompt leaves the row reading exactly as it did before the
-    /// click, so success and cancellation would be indistinguishable. The
-    /// confirmation stays short — the caption above it already names the path — and
-    /// echoes the verb that was offered: an "Update" that lands says "Updated."
-    private func runInstall() -> InstallFeedback {
-        let wasStale: Bool
-        if case .stale = status { wasStale = true } else { wasStale = false }
-        let result = CommandLineTool.install()
-        status = result
-        switch result {
-        case .installed:
-            return .success(wasStale ? localized("Updated.") : localized("Installed."))
-        case .conflict:
-            return .failure(localized("Something else already owns \(CommandLineTool.installURL.path)."))
-        case .unavailable:
-            return .failure(localized("No bundled tool to install from."))
-        case .notInstalled, .stale:
-            let directory = CommandLineTool.installURL.deletingLastPathComponent().path
-            return .failure(localized("Couldn’t link `\(CommandLineTool.toolName)` into \(directory)."))
-        }
-    }
-
-    private var description: String {
-        let tool = CommandLineTool.toolName
-        switch status {
-        case .installed:
-            return localized("`\(tool)` is on your PATH. Run `\(tool) sessions …` to drive sibling sessions, or `\(tool) .` to open a folder.")
-        case .stale(let path):
-            return localized("An older install points at \(path). Update it to this version of Termio.")
-        case .notInstalled:
-            return localized("Links `\(tool)` into /usr/local/bin so you (and agents) can run `\(tool) sessions …` from any shell.")
-        case .conflict:
-            return localized("A different `\(tool)` already exists at \(CommandLineTool.installURL.path). Remove it first — Termio won’t overwrite a file it didn’t create.")
-        case .unavailable:
-            return localized("Available when Termio runs from the built app bundle.")
-        }
-    }
-
-    private var buttonTitle: String {
-        if case .stale = status { return localized("Update") }
-        return localized("Reinstall")
     }
 }

--- a/Sources/termio/Settings/MachinePane.swift
+++ b/Sources/termio/Settings/MachinePane.swift
@@ -1,0 +1,471 @@
+import AppKit
+import SwiftUI
+
+/// One machine's pane: the outcome line, how it is reached, and what it runs.
+///
+/// The section order is the D2 decision made visible. *Reached by* is the route —
+/// the `~/.ssh/config` half the old Devices tab was entirely made of. *Runs* is
+/// the identity — what is installed on that box, which had nowhere to live
+/// before. A machine is both, and reading them in that order is how someone
+/// works out why a box is not ready: you cannot install anything on a machine you
+/// cannot reach.
+///
+/// Above both sits D6's single line. Deploy `termiod` → probe agent CLIs →
+/// install hooks and skill is a real dependency chain, and a wrong primary UI:
+/// four rungs with independent states turn choosing a machine into infrastructure
+/// triage. So the pane promises one outcome — "Ready", or "Set up this device" —
+/// and the rungs are the disclosure underneath it.
+struct MachinePane: View {
+    let machine: KnownDevice
+    let host: SSHConfigHost?
+    @ObservedObject var settings: AppSettings
+    /// The key an install would put on this host, or `nil` when there is none to
+    /// send — which decides whether the password advice can offer a fix.
+    let keyToInstall: SSHPublicKey?
+    let onConnect: (String) -> Void
+    let onSetUpKey: (String, String) -> Void
+    let onEditConfig: () -> Void
+
+    @StateObject private var model: MachinePaneModel
+    private enum ProbeState { case idle, running, result(SSHProbeResult) }
+    @State private var probe: ProbeState = .idle
+
+    init(
+        machine: KnownDevice,
+        host: SSHConfigHost?,
+        settings: AppSettings,
+        keyToInstall: SSHPublicKey?,
+        onConnect: @escaping (String) -> Void,
+        onSetUpKey: @escaping (String, String) -> Void,
+        onEditConfig: @escaping () -> Void
+    ) {
+        self.machine = machine
+        self.host = host
+        self.settings = settings
+        self.keyToInstall = keyToInstall
+        self.onConnect = onConnect
+        self.onSetUpKey = onSetUpKey
+        self.onEditConfig = onEditConfig
+        _model = StateObject(wrappedValue: MachinePaneModel(device: machine, settings: settings))
+    }
+
+    var body: some View {
+        Form {
+            Section { header }
+            Section { outcome } header: {
+                SectionHeaderLabel(title: localized("Status"))
+            }
+            reachedBySection
+            runsSection
+            integrationSection
+        }
+        .formStyle(.grouped)
+        .navigationTitle(machine.name)
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            IconBadge(.symbol(machine.isLocal ? "laptopcomputer" : "server.rack"))
+                .scaleEffect(1.4)
+                .frame(width: 30, height: 30)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(machine.name)
+                    .font(.title3.weight(.semibold))
+                Text(machine.isLocal
+                     ? localized("The machine Termio is running on")
+                     : host?.destinationLabel ?? localized("Reached over SSH"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let alias = machine.alias {
+                Spacer(minLength: 8)
+                Button(localized("Connect")) { onConnect(alias) }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: D6 — one outcome
+
+    @ViewBuilder
+    private var outcome: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                SettingsLabel(title: outcomeTitle, subtext: outcomeSubtext, titleFont: .headline)
+                Spacer(minLength: 8)
+                if model.readiness.isBusy {
+                    ProgressView().controlSize(.small)
+                } else if case .ready = model.readiness {
+                    Button(localized("Check Again")) { Task { await model.check() } }
+                } else {
+                    Button(localized("Set Up \(machine.name)")) { Task { await model.setUp() } }
+                }
+            }
+            if let feedback = model.feedback {
+                InstallFeedbackLabel(feedback: feedback)
+            }
+        }
+        .task {
+            // Asked when the pane opens, not when the roster draws: one machine,
+            // because someone is looking at it.
+            guard case .unasked = model.readiness, model.discovered == nil else { return }
+            await model.check()
+        }
+    }
+
+    private var outcomeTitle: String {
+        switch model.readiness {
+        case .ready: return localized("Ready")
+        case .checking: return model.step?.label ?? localized("Checking…")
+        case .blocked, .unasked: return localized("Set up this device")
+        }
+    }
+
+    private var outcomeSubtext: String {
+        switch model.readiness {
+        case .ready:
+            return localized("Agents on \(machine.name) can run, and report their status back here.")
+        case .checking:
+            return localized("Asking \(machine.name) what it has.")
+        case .blocked(let reason):
+            // Only the first blocking rung, by design: a machine with no `termiod`
+            // also has no hooks, and naming both invites fixing the consequence.
+            return reason
+        case .unasked:
+            return machine.isLocal
+                ? localized("Installs the `\(CommandLineTool.toolName)` command-line tool, then Termio’s hooks and skill for each agent.")
+                : localized("Deploys `termiod`, looks for your agent CLIs, then installs Termio’s hooks and skill.")
+        }
+    }
+
+    // MARK: Reached by — the route half
+
+    @ViewBuilder
+    private var reachedBySection: some View {
+        Section {
+            if machine.isLocal {
+                Text(localized("Nothing to reach — this is the machine you’re on."))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                LabeledContent {
+                    probeControl
+                } label: {
+                    SettingsLabel(
+                        title: host?.destinationLabel ?? machine.name,
+                        subtext: host?.identityFile.map { localized("Signs in with \($0)") }
+                            ?? localized("Signs in with the keys ssh offers by default."),
+                        titleFont: .headline
+                    )
+                }
+                if case .result(.wantsPassword) = probe { passwordAdvice }
+                LabeledContent {
+                    Button(localized("Edit"), action: onEditConfig)
+                } label: {
+                    SettingsLabel(
+                        title: localized("Host block"),
+                        subtext: localized("Opens the ~/.ssh/config entry this machine is defined in."),
+                        titleFont: .headline
+                    )
+                }
+            }
+        } header: {
+            SectionHeaderLabel(title: localized("Reached by"))
+        }
+    }
+
+    /// The one probe outcome with a fix worth offering in place. A password is a
+    /// dead end for everything but the plain shell — the daemon connections that
+    /// carry sessions and the file tree set `BatchMode=yes` and can never answer a
+    /// prompt — so the row says that plainly and offers the install that ends it.
+    @ViewBuilder
+    private var passwordAdvice: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(keyToInstall == nil
+                 ? localized("This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.")
+                 : localized("This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 8)
+            if let keyToInstall, let alias = machine.alias {
+                Button(localized("Set Up Key…")) { onSetUpKey(alias, keyToInstall.url.path) }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .help(localized("Runs ssh-copy-id with \(keyToInstall.name) in a terminal — the host asks for your password once, there."))
+            }
+        }
+        .padding(.top, 2)
+    }
+
+    @ViewBuilder
+    private var probeControl: some View {
+        switch probe {
+        case .idle:
+            Button(localized("Test"), action: runProbe)
+        case .running:
+            ProgressView()
+                .controlSize(.small)
+                .frame(minWidth: 44)
+        case .result(let outcome):
+            Button(action: runProbe) {
+                Text(outcome.label)
+                    .foregroundStyle(outcome.tint)
+                    .lineLimit(1)
+            }
+            .buttonStyle(.borderless)
+            .help(localized("\(outcome.detail) — click to re-test"))
+        }
+    }
+
+    private func runProbe() {
+        guard let alias = machine.alias else { return }
+        probe = .running
+        Task { @MainActor in
+            probe = .result(await SSHConfigFile.testConnection(alias: alias))
+        }
+    }
+
+    // MARK: Runs — the identity half
+
+    private var runsSection: some View {
+        Section {
+            ForEach(listedAgents) { preset in
+                MachineAgentRow(
+                    preset: preset,
+                    machine: machine,
+                    settings: settings,
+                    readiness: model.readiness.isBusy ? nil : model.readiness(for: preset)
+                )
+            }
+            if listedAgents.isEmpty {
+                Text(localized("No agents on your list yet — add one in Settings ▸ Agents."))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            SectionHeaderLabel(title: localized("Runs"))
+        } footer: {
+            Text(localized("Where each agent’s CLI lives on \(machine.name). Leave a path empty to use the agent’s default."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var listedAgents: [AgentPreset] {
+        settings.orderedAgents(AgentPreset.codingAgents.filter(settings.isAgentListed))
+    }
+
+    // MARK: The ladder, as disclosure
+
+    /// The rungs behind the one line. Each is still individually runnable — a
+    /// config hand-edited after Termio wrote it is exactly what "Reinstall" is
+    /// for — but none of them is the primary action.
+    private var integrationSection: some View {
+        Section {
+            if machine.isLocal {
+                CommandLineToolRow()
+            } else {
+                LabeledContent {
+                    Button(localized("Deploy")) { Task { await model.setUp() } }
+                        .disabled(model.readiness.isBusy)
+                } label: {
+                    SettingsLabel(
+                        title: "termiod",
+                        subtext: localized("The session host on \(machine.name). Sessions keep running there after you disconnect."),
+                        titleFont: .headline
+                    )
+                }
+            }
+            InstallButtonRow(title: localized("Reinstall hooks")) {
+                .summarizing(
+                    AgentStatusHooks.sync(
+                        enabled: settings.agentHooksEnabled, target: machine.integrationTarget),
+                    headline: localized("Hooks reinstalled"), unit: localized("agents"))
+            }
+            InstallButtonRow(title: localized("Reinstall skill")) {
+                .summarizing(
+                    SessionSkillInstaller.sync(
+                        enabled: settings.sessionControlEnabled, target: machine.integrationTarget),
+                    headline: localized("Skill reinstalled"), unit: localized("agents"))
+            }
+        } header: {
+            SectionHeaderLabel(title: localized("Installed by Termio"))
+        } footer: {
+            Text(localized("Live agent status and session control are switched on in Settings ▸ Agents; this installs them on \(machine.name)."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+/// One agent's presence on one machine, and the path it launches from there.
+///
+/// The readiness word is D4's three-state rule. `nil` means the probe has not
+/// answered yet and the row says nothing rather than guessing — the same
+/// don't-cry-wolf discipline `AgentAvailability` follows, extended to the case
+/// that only exists once a machine is reached over a network.
+private struct MachineAgentRow: View {
+    let preset: AgentPreset
+    let machine: KnownDevice
+    @ObservedObject var settings: AppSettings
+    let readiness: AgentReadiness?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 10) {
+                IconBadge(preset.icon)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(preset.displayName)
+                    if let status {
+                        Text(status)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 8)
+                TextField(
+                    "",
+                    text: Binding(
+                        get: { settings.commandPath(for: preset, on: machine) ?? "" },
+                        set: { settings.setCommandPath($0, for: preset, on: machine) }
+                    ),
+                    prompt: Text(preset.command ?? localized("Login shell"))
+                )
+                .textFieldStyle(.plain)
+                .multilineTextAlignment(.trailing)
+                .labelsHidden()
+                .frame(minWidth: 140)
+                if readiness == .missing {
+                    Image(systemName: "exclamationmark.circle")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .help(localized("\(preset.displayName) isn’t installed on \(machine.name)"))
+                }
+            }
+        }
+    }
+
+    /// A present CLI says nothing — the path field beside it is already the whole
+    /// answer. The other two states are the ones worth a word.
+    private var status: String? {
+        switch readiness {
+        case .missing: return localized("Not installed on \(machine.name)")
+        case .unknown: return localized("Can’t check on \(machine.name)")
+        case .available, nil: return nil
+        }
+    }
+}
+
+/// Installs and reports the `termio` command-line tool on **this Mac**.
+///
+/// It moved off the General tab because installing a CLI on a machine is a
+/// machine operation (RFC §D8) — here it sits beside "deploy `termiod`", which is
+/// the same rung on every other machine's pane.
+///
+/// Installs and reports the `termio` command-line tool, as a switch like the other
+/// feature rows: on means the PATH symlink exists, off removes it. The switch is
+/// bound to the audit, not a stored preference, so it always reflects reality (a
+/// declined admin prompt snaps it back). It audits on appear (a moved app shows
+/// "Update") and re-audits after every action so the caption updates in place.
+struct CommandLineToolRow: View {
+    @State private var status: CommandLineTool.Status = .notInstalled
+    @State private var state = InstallFeedbackState()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle(isOn: Binding(get: { isOn }, set: { setEnabled($0) })) {
+                SettingsLabel(
+                    title: localized("Command-line tool"), subtext: description, titleFont: .headline)
+            }
+            .toggleStyle(.switch)
+            .disabled(!isSwitchable)
+            if let feedback = state.feedback {
+                InstallFeedbackLabel(feedback: feedback)
+            }
+        }
+        .onAppear { status = CommandLineTool.audit() }
+        .autoDismissing($state)
+        if isOn {
+            // For re-linking after something else has touched /usr/local/bin;
+            // install is idempotent. Reports through its own feedback line.
+            InstallButtonRow(title: buttonTitle) { withAnimation { runInstall() } }
+        }
+    }
+
+    private var isOn: Bool {
+        switch status {
+        case .installed, .stale: return true
+        case .notInstalled, .conflict, .unavailable: return false
+        }
+    }
+
+    /// A conflicting file isn't ours to remove and a bare binary has nothing to
+    /// link, so in both states the switch is disabled and the caption explains.
+    private var isSwitchable: Bool {
+        switch status {
+        case .installed, .stale, .notInstalled: return true
+        case .conflict, .unavailable: return false
+        }
+    }
+
+    private func setEnabled(_ enabled: Bool) {
+        withAnimation {
+            if enabled {
+                state.show(runInstall())
+            } else {
+                status = CommandLineTool.uninstall()
+                state.show(isOn
+                    ? .failure(localized("Couldn’t remove \(CommandLineTool.installURL.path)."))
+                    : .success(localized("Removed from PATH.")))
+            }
+        }
+    }
+
+    /// Installs, then reports the fresh audit. The caption alone can't carry this:
+    /// a declined admin prompt leaves the row reading exactly as it did before the
+    /// click, so success and cancellation would be indistinguishable. The
+    /// confirmation stays short — the caption above it already names the path — and
+    /// echoes the verb that was offered: an "Update" that lands says "Updated."
+    private func runInstall() -> InstallFeedback {
+        let wasStale: Bool
+        if case .stale = status { wasStale = true } else { wasStale = false }
+        let result = CommandLineTool.install()
+        status = result
+        switch result {
+        case .installed:
+            return .success(wasStale ? localized("Updated.") : localized("Installed."))
+        case .conflict:
+            return .failure(localized("Something else already owns \(CommandLineTool.installURL.path)."))
+        case .unavailable:
+            return .failure(localized("No bundled tool to install from."))
+        case .notInstalled, .stale:
+            let directory = CommandLineTool.installURL.deletingLastPathComponent().path
+            return .failure(localized("Couldn’t link `\(CommandLineTool.toolName)` into \(directory)."))
+        }
+    }
+
+    private var description: String {
+        let tool = CommandLineTool.toolName
+        switch status {
+        case .installed:
+            return localized("`\(tool)` is on your PATH. Run `\(tool) sessions …` to drive sibling sessions, or `\(tool) .` to open a folder.")
+        case .stale(let path):
+            return localized("An older install points at \(path). Update it to this version of Termio.")
+        case .notInstalled:
+            return localized("Links `\(tool)` into /usr/local/bin so you (and agents) can run `\(tool) sessions …` from any shell.")
+        case .conflict:
+            return localized("A different `\(tool)` already exists at \(CommandLineTool.installURL.path). Remove it first — Termio won’t overwrite a file it didn’t create.")
+        case .unavailable:
+            return localized("Available when Termio runs from the built app bundle.")
+        }
+    }
+
+    private var buttonTitle: String {
+        if case .stale = status { return localized("Update") }
+        return localized("Reinstall")
+    }
+}

--- a/Sources/termio/Settings/MachinePane.swift
+++ b/Sources/termio/Settings/MachinePane.swift
@@ -126,7 +126,13 @@ struct MachinePane: View {
     private var outcomeSubtext: String {
         switch model.readiness {
         case .ready:
-            return localized("Agents on \(machine.name) can run, and report their status back here.")
+            // Only promise the reporting when it was actually asked for: with both
+            // integration switches off, setup deliberately installs nothing, and
+            // "reports their status back here" would be a claim about hooks that
+            // are not there.
+            return reportsStatus
+                ? localized("Agents on \(machine.name) can run, and report their status back here.")
+                : localized("Agents on \(machine.name) can run.")
         case .checking:
             return localized("Asking \(machine.name) what it has.")
         case .blocked(let reason):
@@ -138,6 +144,13 @@ struct MachinePane: View {
                 ? localized("Installs the `\(CommandLineTool.toolName)` command-line tool, then Termio’s hooks and skill for each agent.")
                 : localized("Deploys `termiod`, looks for your agent CLIs, then installs Termio’s hooks and skill.")
         }
+    }
+
+    /// Whether anything on this machine is meant to report status — the two
+    /// switches live on the Agents tab, because wanting the feature is a
+    /// preference and installing it is a machine operation (RFC §D1).
+    private var reportsStatus: Bool {
+        settings.agentHooksEnabled || settings.sessionControlEnabled
     }
 
     // MARK: Reached by — the route half

--- a/Sources/termio/Settings/MachinesSettingsTab.swift
+++ b/Sources/termio/Settings/MachinesSettingsTab.swift
@@ -1,0 +1,250 @@
+import AppKit
+import SwiftUI
+
+/// Settings ▸ Machines: one row per machine sessions can run on, each pushing
+/// that machine's pane.
+///
+/// This tab is where the RFC's D2 collision was resolved. The shipped "Devices"
+/// tab was the renamed SSH tab — a `~/.ssh/config` projection, which
+/// `docs/design/20260814-remote-to-device.decisions.md` §1 classifies as *routes* —
+/// so machine identity had no home and the name it wanted was taken. Two tabs
+/// that both list machines would force the user to learn the route/identity
+/// distinction before they could find anything; one pane that shows both does
+/// not. So: **one tab, one row per machine, and the two halves are sections
+/// inside a machine's pane** — *Reached by* (alias, destination, key, Test
+/// Connection, Edit in Config) above *Runs* (what is installed on it).
+///
+/// What stays at this level is what is not per-machine: `~/.ssh/config` itself,
+/// and the public keys in `~/.ssh`. Those are about the user's own credentials,
+/// not about any one box.
+///
+/// A `List`, not a `Form`, and the roster is the reason: `onMove` is inert inside
+/// a `Form` on macOS, and while nothing reorders machines *today*, this is the
+/// container that would silently stop working if it ever did — the same trap
+/// `AgentSettingsTab` documents.
+struct MachinesSettingsTab: View {
+    @ObservedObject var settings: AppSettings
+    @ObservedObject var store: TermioStore
+    /// Opens an SSH terminal to the alias in the main window (wired to
+    /// `TermioStore.addSSHSession` by the app delegate).
+    let onConnect: (String) -> Void
+    /// Runs `ssh-copy-id <alias>` with a public key, for a host whose probe found
+    /// it wants a password (wired to `TermioStore.addKeyInstallSession`).
+    let onSetUpKey: (String, String) -> Void
+
+    @State private var hosts: [SSHConfigHost] = []
+    @State private var publicKeys: [SSHPublicKey] = []
+    @State private var addingHost = false
+    @State private var configEditor: SSHConfigEditorTarget?
+    /// The key whose Copy button is briefly confirming, so the click visibly took.
+    @State private var copiedKeyID: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            List {
+                Section {
+                    ForEach(machines) { machine in
+                        NavigationLink(value: MachineRoute(key: machine.settingsKey)) {
+                            MachineListRow(machine: machine, host: host(for: machine))
+                        }
+                    }
+                } header: {
+                    SectionHeaderLabel(title: localized("Machines"))
+                } footer: {
+                    Text(localized("This Mac, and every machine you can reach from it. Open one to see what runs there."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section {
+                    LabeledContent {
+                        Button(localized("Edit")) { presentEditor(for: nil) }
+                    } label: {
+                        SettingsLabel(
+                            title: "~/.ssh/config",
+                            subtext: localized("Reads ~/.ssh/config directly — Termio keeps no separate host list."),
+                            titleFont: .headline
+                        )
+                    }
+                } header: {
+                    SectionHeaderLabel(title: localized("Config file"))
+                }
+
+                if !publicKeys.isEmpty {
+                    Section {
+                        ForEach(publicKeys) { key in
+                            HStack(spacing: 10) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(key.name)
+                                    Text(key.comment.isEmpty
+                                         ? key.algorithm : "\(key.algorithm) · \(key.comment)")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer(minLength: 8)
+                                Button(copiedKeyID == key.id
+                                       ? localized("Copied") : localized("Copy")) { copy(key) }
+                                    .buttonStyle(.bordered)
+                                    .controlSize(.small)
+                            }
+                        }
+                    } header: {
+                        SectionHeaderLabel(title: localized("Public keys"))
+                    } footer: {
+                        Text(localized("The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .listStyle(.inset)
+
+            Divider()
+            AddMachineBar { addingHost = true }
+        }
+        .navigationDestination(for: MachineRoute.self) { route in
+            if let machine = machines.first(where: { $0.settingsKey == route.key }) {
+                MachinePane(
+                    machine: machine,
+                    host: host(for: machine),
+                    settings: settings,
+                    keyToInstall: host(for: machine).flatMap {
+                        SSHConfigFile.publicKeyToInstall(for: $0, keys: publicKeys)
+                    },
+                    onConnect: onConnect,
+                    onSetUpKey: onSetUpKey,
+                    onEditConfig: { presentEditor(for: host(for: machine)) }
+                )
+                .id(route.key)
+            } else {
+                // The alias left `~/.ssh/config` while its pane was open.
+                ContentUnavailableView {
+                    Text(localized("Machine Unavailable"))
+                } description: {
+                    Text(localized("This machine is no longer in your configuration."))
+                }
+            }
+        }
+        .onAppear(perform: reload)
+        .sheet(isPresented: $addingHost, onDismiss: reload) {
+            AddSSHHostSheet(existingAliases: Set(hosts.map(\.alias)))
+        }
+        .sheet(item: $configEditor, onDismiss: reload) { target in
+            SSHConfigEditorSheet(target: target, settings: settings) { configEditor = nil }
+        }
+    }
+
+    /// This Mac first, then every machine Termio has worked on, then the aliases
+    /// in `~/.ssh/config` it has not. The last group matters: a box you configured
+    /// but never opened is exactly the one you came here to set up.
+    private var machines: [KnownDevice] {
+        let known = DeviceRoster.known(in: store)
+        return known + DeviceRoster.unusedAliases(known: known)
+            .map { KnownDevice(alias: $0, deviceID: nil) }
+    }
+
+    /// The `~/.ssh/config` block that reaches this machine, when one names it.
+    /// `nil` for this Mac, and for a device known only from a session record.
+    private func host(for machine: KnownDevice) -> SSHConfigHost? {
+        machine.alias.flatMap { alias in hosts.first { $0.alias == alias } }
+    }
+
+    private func presentEditor(for host: SSHConfigHost?) {
+        // Symlinks resolve before the editor opens: its atomic auto-save would
+        // otherwise replace a dotfile-managed link with a plain file.
+        if let host {
+            configEditor = SSHConfigEditorTarget(
+                url: host.file.resolvingSymlinksInPath(), line: host.line)
+        } else {
+            try? SSHConfigFile.ensureConfigExists()
+            configEditor = SSHConfigEditorTarget(url: SSHConfigFile.writableConfigURL, line: nil)
+        }
+    }
+
+    private func reload() {
+        hosts = SSHConfigFile.hosts()
+        publicKeys = SSHConfigFile.publicKeys()
+    }
+
+    private func copy(_ key: SSHPublicKey) {
+        guard let text = try? String(contentsOf: key.url, encoding: .utf8) else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(
+            text.trimmingCharacters(in: .whitespacesAndNewlines), forType: .string
+        )
+        copiedKeyID = key.id
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            if copiedKeyID == key.id { copiedKeyID = nil }
+        }
+    }
+}
+
+/// What a machine row pushes. A named type rather than the bare key so the
+/// settings window's shared navigation stack can't confuse a machine with the
+/// Agents tab's string destination.
+private struct MachineRoute: Hashable {
+    let key: String
+}
+
+/// One machine on the roster: its name over how it is reached. No status here —
+/// a roster that probed every host on appear would fire ssh at every configured
+/// box each time Settings opens, and a sleeping VPS would make that take as long
+/// as its timeout. The pane asks; the roster lists.
+private struct MachineListRow: View {
+    let machine: KnownDevice
+    let host: SSHConfigHost?
+
+    private var detail: String {
+        guard machine.alias != nil else { return localized("The machine you’re on") }
+        guard let host else { return localized("From your session history") }
+        guard let identityFile = host.identityFile else { return host.destinationLabel }
+        return "\(host.destinationLabel) · \((identityFile as NSString).lastPathComponent)"
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            IconBadge(.symbol(machine.isLocal ? "laptopcomputer" : "server.rack"))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(machine.name)
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 4)
+        }
+    }
+}
+
+/// The roster's footer action, matching the Agents tab's Add Agent bar so the two
+/// drill-down tabs read as the same kind of surface.
+private struct AddMachineBar: View {
+    let onAdd: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: onAdd) {
+            HStack(spacing: 8) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22)
+                Text(localized("Add Machine"))
+                Spacer(minLength: 4)
+            }
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, minHeight: 28)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.primary.opacity(hovering ? 0.07 : 0))
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 7)
+    }
+}

--- a/Sources/termio/Settings/SSHHostControls.swift
+++ b/Sources/termio/Settings/SSHHostControls.swift
@@ -1,294 +1,64 @@
 import AppKit
 import SwiftUI
 
-/// Settings ▸ Devices: the connectable hosts from `~/.ssh/config`, each one click
-/// away from a terminal. The config file stays the single source of truth —
-/// termio reads the same hosts `ssh` itself resolves and writes nothing behind
-/// the user's back: Add Host appends a plain block, Edit opens the raw file.
-struct DevicesSettingsTab: View {
-    @ObservedObject var settings: AppSettings
-    /// Opens an SSH terminal to the alias in the main window (wired to
-    /// `TermioStore.addSSHSession` by the app delegate).
-    let onConnect: (String) -> Void
-    /// Runs `ssh-copy-id <alias>` with a public key, for a host whose probe found
-    /// it wants a password (wired to `TermioStore.addKeyInstallSession`).
-    let onSetUpKey: (String, String) -> Void
+/// The `~/.ssh/config` half of a machine — how it is reached — as controls the
+/// Machines surface composes.
+///
+/// This file was `DevicesSettingsTab`, a top-level tab that was only ever the
+/// route half. RFC §D2 folded it into a machine's pane so a box's route and its
+/// capabilities read as one thing; what is left here is the shared pieces that
+/// pane and the roster both draw with, plus the Add Host sheet the File menu also
+/// opens.
 
-    @State private var hosts: [SSHConfigHost] = []
-    @State private var publicKeys: [SSHPublicKey] = []
-    @State private var addingHost = false
-    @State private var configEditor: ConfigEditorTarget?
-    /// The key whose Copy button is briefly confirming, so the click visibly took.
-    @State private var copiedKeyID: String?
-
-    /// Which file the editor sheet shows — usually `~/.ssh/config`, but a host
-    /// defined in an `Include`d file opens that file, at its `Host` line.
-    private struct ConfigEditorTarget: Identifiable {
-        let url: URL
-        let line: Int?
-        var id: String { "\(url.path)#\(line ?? 0)" }
-    }
-
-    var body: some View {
-        Form {
-            hostsSection
-            configSection
-            if !publicKeys.isEmpty { keysSection }
-        }
-        .formStyle(.grouped)
-        .onAppear(perform: reload)
-        .sheet(isPresented: $addingHost, onDismiss: reload) {
-            AddSSHHostSheet(existingAliases: Set(hosts.map(\.alias)))
-        }
-        .sheet(item: $configEditor, onDismiss: reload) { target in
-            FileEditorView(
-                url: target.url,
-                settings: settings,
-                jumpLine: target.line,
-                showsInspectorChrome: false,
-                onClose: { configEditor = nil }
-            )
-            .frame(minWidth: 640, minHeight: 460)
-            // The editor's own header controls belong to the inspector, which a sheet
-            // doesn't have — so supply the one control that still applies. Escape closes
-            // too; the visible button is the guaranteed way out.
-            .overlay(alignment: .topTrailing) {
-                Button { configEditor = nil } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 24, height: 24)
-                        .background(.thinMaterial, in: Circle())
-                }
-                .buttonStyle(.plain)
-                .keyboardShortcut(.cancelAction)
-                .help(localized("Close (Esc)"))
-                .padding(8)
-            }
-        }
-    }
-
-    private var hostsSection: some View {
-        Section {
-            if hosts.isEmpty {
-                Text(localized("No hosts yet — add one, or write a Host block in ~/.ssh/config."))
-                    .foregroundStyle(.secondary)
-            }
-            ForEach(hosts) { host in
-                SSHHostRow(
-                    host: host,
-                    keyToInstall: SSHConfigFile.publicKeyToInstall(for: host, keys: publicKeys),
-                    connect: { onConnect(host.alias) },
-                    setUpKey: { onSetUpKey(host.alias, $0.url.path) },
-                    editInConfig: { presentEditor(for: host) }
-                )
-            }
-            Button { addingHost = true } label: {
-                Label(localized("Add Host"), systemImage: "plus")
-            }
-        } header: {
-            SectionHeaderLabel(title: localized("Hosts"))
-        } footer: {
-            Text(.init(localized("Your Host entries from ~/.ssh/config — the same aliases `ssh` resolves. Right-click a host to connect.")))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private var configSection: some View {
-        Section {
-            LabeledContent {
-                Button(localized("Edit")) { presentEditor(for: nil) }
-            } label: {
-                SettingsLabel(
-                    title: "~/.ssh/config",
-                    subtext: localized("Reads ~/.ssh/config directly — Termio keeps no separate host list."),
-                    titleFont: .headline
-                )
-            }
-        } header: {
-            SectionHeaderLabel(title: localized("Config file"))
-        }
-    }
-
-    private var keysSection: some View {
-        Section {
-            ForEach(publicKeys) { key in
-                HStack(spacing: 10) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(key.name)
-                        Text(key.comment.isEmpty ? key.algorithm : "\(key.algorithm) · \(key.comment)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer(minLength: 8)
-                    Button(copiedKeyID == key.id ? localized("Copied") : localized("Copy")) { copy(key) }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                }
-            }
-        } header: {
-            SectionHeaderLabel(title: localized("Public keys"))
-        } footer: {
-            Text(localized("The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    /// Opens the editor sheet on a host's defining file at its `Host` line, or on
-    /// `~/.ssh/config` itself. The config is created empty first when missing so
-    /// the editor never opens onto a nonexistent file.
-    private func presentEditor(for host: SSHConfigHost?) {
-        // Symlinks resolve before the editor opens: its atomic auto-save would
-        // otherwise replace a dotfile-managed link with a plain file.
-        if let host {
-            configEditor = ConfigEditorTarget(url: host.file.resolvingSymlinksInPath(), line: host.line)
-        } else {
-            try? SSHConfigFile.ensureConfigExists()
-            configEditor = ConfigEditorTarget(url: SSHConfigFile.writableConfigURL, line: nil)
-        }
-    }
-
-    private func reload() {
-        hosts = SSHConfigFile.hosts()
-        publicKeys = SSHConfigFile.publicKeys()
-    }
-
-    private func copy(_ key: SSHPublicKey) {
-        guard let text = try? String(contentsOf: key.url, encoding: .utf8) else { return }
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(
-            text.trimmingCharacters(in: .whitespacesAndNewlines), forType: .string
-        )
-        copiedKeyID = key.id
-        Task {
-            try? await Task.sleep(for: .seconds(1.5))
-            if copiedKeyID == key.id { copiedKeyID = nil }
-        }
-    }
-}
-
-/// One host row: alias over its `user@host` destination (with the pinned key's
-/// filename when the block sets one), and a Test Connection probe. Live
-/// connecting is a launch, not a setting — it lives in the context menu (and
-/// the sidebar / File menu), keeping this pane about configuring and verifying
-/// hosts.
-private struct SSHHostRow: View {
-    let host: SSHConfigHost
-    /// The key an install would put on this host, or nil when there is none to
-    /// send — which is what decides whether the password advice can offer a fix.
-    let keyToInstall: SSHPublicKey?
-    let connect: () -> Void
-    let setUpKey: (SSHPublicKey) -> Void
-    let editInConfig: () -> Void
-
-    private enum ProbeState { case idle, running, result(SSHProbeResult) }
-    @State private var probe: ProbeState = .idle
-
-    /// `user@host`, plus the identity file's name when the block pins one — the
-    /// full path stays in the tooltip.
-    private var subtitle: String {
-        guard let identityFile = host.identityFile else { return host.destinationLabel }
-        let keyName = (identityFile as NSString).lastPathComponent
-        return "\(host.destinationLabel) · \(keyName)"
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 10) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(host.alias).font(.headline)
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .help(host.identityFile.map { localized("Uses \($0)") } ?? "")
-                }
-                Spacer(minLength: 8)
-                probeControl
-            }
-            if case .result(.wantsPassword) = probe { passwordAdvice }
-        }
-        .contentShape(Rectangle())
-        .contextMenu {
-            Button(localized("Connect"), action: connect)
-            Button(localized("Test Connection"), action: runProbe)
-            if let keyToInstall {
-                Button(localized("Set Up Key…")) { setUpKey(keyToInstall) }
-            }
-            Button(localized("Edit in Config"), action: editInConfig)
-            Button(localized("Copy ssh Command")) {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString("ssh \(host.alias)", forType: .string)
-            }
-        }
-    }
-
-    /// The one probe outcome with a fix worth offering in place. A password is a
-    /// dead end for everything but the plain shell — the daemon connections that
-    /// carry sessions and the file tree set `BatchMode=yes` and can never answer a
-    /// prompt — so the row says that plainly and offers the install that ends it.
-    @ViewBuilder
-    private var passwordAdvice: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text(keyToInstall == nil
-                 ? localized("This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.")
-                 : localized("This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 8)
-            if let keyToInstall {
-                Button(localized("Set Up Key…")) { setUpKey(keyToInstall) }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .help(localized("Runs ssh-copy-id with \(keyToInstall.name) in a terminal — the host asks for your password once, there."))
-            }
-        }
-        .padding(.top, 2)
-    }
-
-    /// The trailing control: a Test button that turns into a spinner while the
-    /// probe runs, then a tinted result badge that re-tests on click.
-    @ViewBuilder
-    private var probeControl: some View {
-        switch probe {
-        case .idle:
-            Button(localized("Test"), action: runProbe)
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-        case .running:
-            ProgressView()
-                .controlSize(.small)
-                .frame(minWidth: 44)
-        case .result(let outcome):
-            Button(action: runProbe) {
-                Text(outcome.label)
-                    .foregroundStyle(outcome.tint)
-                    .lineLimit(1)
-            }
-            .buttonStyle(.borderless)
-            .controlSize(.small)
-            .help(localized("\(outcome.detail) — click to re-test"))
-        }
-    }
-
-    /// Runs the non-interactive probe off the main thread, hopping back to update
-    /// the badge. A fresh click just re-arms it.
-    private func runProbe() {
-        probe = .running
-        Task { @MainActor in
-            probe = .result(await SSHConfigFile.testConnection(alias: host.alias))
-        }
-    }
-}
-
-/// How each probe outcome reads in the row: a short tinted label — the wording
+/// How each probe outcome reads in a row: a short tinted label — the wording
 /// itself distinguishes outcomes, so color is reinforcement, not the only
 /// signal — with the raw ssh detail in the tooltip.
-private extension SSHProbeResult {
+
+/// Which file the config editor shows — usually `~/.ssh/config`, but a host
+/// defined in an `Include`d file opens that file, at its `Host` line.
+struct SSHConfigEditorTarget: Identifiable {
+    let url: URL
+    let line: Int?
+    var id: String { "\(url.path)#\(line ?? 0)" }
+}
+
+/// The raw-config editor, presented as a sheet from the Machines tab. The config
+/// file stays the single source of truth: Termio reads the hosts `ssh` itself
+/// resolves and never writes a separate list behind the user's back.
+struct SSHConfigEditorSheet: View {
+    let target: SSHConfigEditorTarget
+    @ObservedObject var settings: AppSettings
+    let onClose: () -> Void
+
+    var body: some View {
+        FileEditorView(
+            url: target.url,
+            settings: settings,
+            jumpLine: target.line,
+            showsInspectorChrome: false,
+            onClose: onClose
+        )
+        .frame(minWidth: 640, minHeight: 460)
+        // The editor's own header controls belong to the inspector, which a sheet
+        // doesn't have — so supply the one control that still applies. Escape closes
+        // too; the visible button is the guaranteed way out.
+        .overlay(alignment: .topTrailing) {
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24, height: 24)
+                    .background(.thinMaterial, in: Circle())
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .help(localized("Close (Esc)"))
+            .padding(8)
+        }
+    }
+}
+
+extension SSHProbeResult {
     var label: String {
         switch self {
         case .reachable: return localized("Reachable")

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -90,7 +90,8 @@ final class AppSettings: ObservableObject {
         Key.backgroundOpacity, Key.backgroundBlur,
         Key.scrollbackMegabytes, Key.copyOnSelect,
         Key.interfaceFontFamily, Key.interfaceFontSize, Key.interfaceRowPadding,
-        Key.agentCommands, Key.bypassPermissionAgents, Key.disabledAgents,
+        Key.agentCommands, Key.devices,
+        Key.bypassPermissionAgents, Key.disabledAgents,
         Key.addedAgents, Key.agentOrder, Key.agentHooksEnabled,
         Key.sessionControlEnabled, Key.githubIntegrationEnabled,
         Key.notifyTaskCompletion, Key.notificationSound,
@@ -122,7 +123,13 @@ final class AppSettings: ObservableObject {
         static let interfaceFontFamily = "interface.fontFamily"
         static let interfaceFontSize = "interface.fontSize"
         static let interfaceRowPadding = "interface.rowPadding"
+        /// Legacy per-app command overrides, read once to migrate an existing
+        /// install into `devices` — where a command path has the machine
+        /// dimension it always needed.
         static let agentCommands = "agents.commandOverrides"
+        /// The per-machine section. Nested rather than flat because its keys are
+        /// machine identities, which are discovered, not enumerable up front.
+        static let devices = "devices"
         static let bypassPermissionAgents = "agents.bypassPermissions"
         static let disabledAgents = "agents.disabled"
         static let addedAgents = "agents.added"
@@ -342,11 +349,15 @@ final class AppSettings: ObservableObject {
 
     // MARK: Agents
 
-    /// Per-agent command overrides keyed by `AgentPreset.rawValue`. An entry lets
-    /// the user run, say, `claude --dangerously-skip-permissions` instead of the
-    /// built-in default. An empty/whitespace value is treated as "no override".
-    @Published var agentCommandOverrides: [String: String] {
-        didSet { store.set(agentCommandOverrides, forKey: Key.agentCommands) }
+    /// Authored per-machine values, by machine (`KnownDevice.settingsKey`).
+    ///
+    /// A command path is a fact about one box — `/opt/homebrew/bin/claude` names
+    /// nothing on a Linux VPS — so it is keyed by machine rather than held once
+    /// for the app, which is what the flat `agents.commandOverrides` this replaces
+    /// got wrong. Edited only from a machine's pane (RFC D1: location in the UI is
+    /// the scope).
+    @Published var deviceSettings: DeviceSettingsSection {
+        didSet { store.set(deviceSettings.jsonObject, forKey: Key.devices) }
     }
 
     /// Agents whose permission/approval prompts should be bypassed, by `rawValue`.
@@ -589,7 +600,7 @@ final class AppSettings: ObservableObject {
         interfaceFontFamily = store.string(Key.interfaceFontFamily) ?? ""
         interfaceFontSize = store.double(Key.interfaceFontSize)
         interfaceRowPadding = store.double(Key.interfaceRowPadding)
-        agentCommandOverrides = store.stringDictionary(Key.agentCommands) ?? [:]
+        deviceSettings = DeviceSettingsSection(jsonObject: store.object(Key.devices))
         bypassPermissionAgents = Set(store.stringArray(Key.bypassPermissionAgents) ?? [])
         disabledAgents = Set(store.stringArray(Key.disabledAgents) ?? [])
         addedAgents = Set(store.stringArray(Key.addedAgents) ?? [])
@@ -610,20 +621,65 @@ final class AppSettings: ObservableObject {
         currentWorkspaceID = defaults.string(forKey: Key.currentWorkspace).flatMap(UUID.init)
 
         pruneRedundantThemeCopies()
+        migrateCommandOverridesToThisMac()
     }
 
-    /// Effective command for an agent: the user's override if it's non-empty,
-    /// otherwise the preset's built-in default (`nil` for a plain login shell),
-    /// with the permission-bypass flag appended when that switch is on. The flag
-    /// is only added if it isn't already present, so a user who typed it into the
-    /// override by hand doesn't get it twice.
-    func command(for agent: AgentPreset) -> String? {
-        let override = agentCommandOverrides[agent.rawValue]?.trimmingCharacters(in: .whitespaces)
-        let base = (override?.isEmpty == false ? override : agent.command)
+    /// Moves an existing install's per-app command overrides onto **this Mac**,
+    /// which is the only machine they could ever have described: they were typed
+    /// while Settings meant this one, and the paths in them (`/opt/homebrew/…`)
+    /// name this filesystem. Runs once — the legacy key is cleared as it is read,
+    /// so a later Mac-side edit is never re-migrated over.
+    private func migrateCommandOverridesToThisMac() {
+        guard let legacy = store.stringDictionary(Key.agentCommands), !legacy.isEmpty else { return }
+        var thisMac = deviceSettings[KnownDevice.thisMac.settingsKey]
+        // Anything already authored per-machine wins: the user set it in the new
+        // world, and a stale flat value must not overwrite it.
+        thisMac.agentCommands = legacy.merging(thisMac.agentCommands ?? [:]) { _, authored in authored }
+        deviceSettings[KnownDevice.thisMac.settingsKey] = thisMac
+        store.set(nil, forKey: Key.agentCommands)
+    }
+
+    /// Effective command for an agent **on a machine**: the path authored for that
+    /// machine if it's non-empty, otherwise the preset's built-in default (`nil`
+    /// for a plain login shell), with the permission-bypass flag appended when
+    /// that switch is on. The flag is only added if it isn't already present, so a
+    /// user who typed it into the path by hand doesn't get it twice.
+    ///
+    /// The path is per-machine and the bypass switch is not: where a CLI lives is
+    /// a fact about a box, while running an agent without its prompts is a
+    /// standing decision about that agent (RFC §The model).
+    func command(for agent: AgentPreset, on device: KnownDevice = .thisMac) -> String? {
+        let authored = commandPath(for: agent, on: device)
+        let base = (authored?.isEmpty == false ? authored : agent.command)
         guard let base else { return nil }
         guard bypassesPermissions(agent), let flag = agent.permissionBypassFlag,
               !base.contains(flag) else { return base }
         return "\(base) \(flag)"
+    }
+
+    /// The command path the user authored for this agent on this machine, before
+    /// any bypass flag — what the machine's pane edits. `nil` when they never set
+    /// one, which is how the field shows the built-in default as its placeholder
+    /// rather than pinning today's value as a choice.
+    func commandPath(for agent: AgentPreset, on device: KnownDevice) -> String? {
+        deviceSettings[device.settingsKey].agentCommands?[agent.rawValue]?
+            .trimmingCharacters(in: .whitespaces)
+    }
+
+    func setCommandPath(_ path: String?, for agent: AgentPreset, on device: KnownDevice) {
+        var machine = deviceSettings[device.settingsKey]
+        var commands = machine.agentCommands ?? [:]
+        let trimmed = path?.trimmingCharacters(in: .whitespaces)
+        // An emptied field hands the agent back to its built-in default instead of
+        // storing "" — the same rule `SettingsStore.set(nil:)` follows for a
+        // cleared preference.
+        if let trimmed, !trimmed.isEmpty {
+            commands[agent.rawValue] = trimmed
+        } else {
+            commands.removeValue(forKey: agent.rawValue)
+        }
+        machine.agentCommands = commands.isEmpty ? nil : commands
+        deviceSettings[device.settingsKey] = machine
     }
 
     func bypassesPermissions(_ agent: AgentPreset) -> Bool {

--- a/Sources/termio/Settings/SettingsFile.swift
+++ b/Sources/termio/Settings/SettingsFile.swift
@@ -80,6 +80,15 @@ final class SettingsStore {
             ?? defaults.dictionary(forKey: key) as? [String: String]
     }
 
+    /// A nested JSON object, for the one setting that is a *section* rather than a
+    /// value: the per-machine block (`DeviceSettingsSection`). No `UserDefaults`
+    /// fallback, deliberately — a section has never lived in the registration
+    /// domain, and a Ghostty config cannot express one, so "absent" here means
+    /// exactly "the user has not set a per-machine value" with nothing beneath it.
+    func object(_ key: String) -> [String: Any]? {
+        chosen[key] as? [String: Any]
+    }
+
     /// Whether the user chose this key themselves, as opposed to inheriting it.
     /// Lets a Reset control clear the value instead of writing today's default
     /// back in as if it were a choice.

--- a/Sources/termio/Settings/SettingsTab.swift
+++ b/Sources/termio/Settings/SettingsTab.swift
@@ -7,20 +7,27 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case appearance
     case terminal
-    /// Sits above Devices because that is the containment order the app itself
+    /// Sits above Machines because that is the containment order the app itself
     /// uses: a workspace belongs to a device, and everything filed in it lives on
     /// that machine.
     case workspaces
-    /// A **device** is a machine identified by its `host_id` and reached by one
-    /// or more `~/.ssh/config` aliases — the term the session protocol, the
-    /// daemon and `TermiodDevice` all already use. This tab was called
-    /// "Machines" while the app had no other name for the far end.
+    /// Every machine sessions can run on — this Mac and each device — as one row
+    /// apiece, drilling into a pane that holds both halves of what a machine is:
+    /// how it is reached, and what it runs.
+    ///
+    /// The name went back to **Machines** because the two things it had to name
+    /// were a *route* and an *identity*, and "Devices" was only ever spent on the
+    /// first: the shipped Devices tab was the renamed SSH tab, a `~/.ssh/config`
+    /// projection, leaving machine identity homeless. Rather than two tabs that
+    /// both list machines — which forces the user to learn that distinction to
+    /// find anything — one tab holds both, and the distinction becomes two
+    /// sections inside a pane (RFC §D2).
     ///
     /// The raw value stays `ssh` because it is the value persisted under
     /// `lastOpenKey`; changing it would reopen Settings on another tab for
-    /// everyone who left this one showing. It has now survived two renamings,
+    /// everyone who left this one showing. It has now survived three renamings,
     /// which is the point of it.
-    case devices = "ssh"
+    case machines = "ssh"
     case keyboard
     case agents
     case usage
@@ -39,7 +46,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return localized("Appearance")
         case .terminal: return localized("Terminal")
         case .workspaces: return localized("Workspaces")
-        case .devices: return localized("Devices")
+        case .machines: return localized("Machines")
         case .keyboard: return localized("Keyboard")
         case .agents: return localized("Agents")
         case .usage: return localized("Usage")
@@ -56,7 +63,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return .paintBoard
         case .terminal: return .terminal
         case .workspaces: return .copy
-        case .devices: return .serverStack
+        case .machines: return .serverStack
         case .keyboard: return .keyboard
         case .agents: return .bot
         case .usage: return .chartColumn
@@ -69,11 +76,11 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     /// matching macOS System Settings' navigation subtitle.
     var subtitle: String {
         switch self {
-        case .general: return localized("The termio command-line tool, agent skill, and notifications")
+        case .general: return localized("Language, notifications, and GitHub")
         case .appearance: return localized("Theme, fonts, cursor, and window")
         case .terminal: return localized("Scrollback history and text selection")
         case .workspaces: return localized("The workspaces your projects and sessions are filed under")
-        case .devices: return localized("The devices in your ~/.ssh/config, and the keys that reach them")
+        case .machines: return localized("This Mac and the machines you reach from it, and what each one runs")
         case .keyboard: return localized("Keyboard shortcuts for every command")
         case .agents: return localized("The coding agents offered when you start a session")
         case .usage: return localized("Token usage for your connected agents")

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -94,12 +94,13 @@ struct SettingsView: View {
         case .appearance: AppearanceSettingsTab(settings: settings)
         case .terminal: TerminalSettingsTab(settings: settings)
         case .workspaces: WorkspaceSettingsTab(store: store)
-        case .devices:
-            DevicesSettingsTab(
-                settings: settings, onConnect: onSSHConnect, onSetUpKey: onSetUpKey
+        case .machines:
+            MachinesSettingsTab(
+                settings: settings, store: store,
+                onConnect: onSSHConnect, onSetUpKey: onSetUpKey
             )
         case .keyboard: KeybindingsSettingsTab()
-        case .agents: AgentSettingsTab(settings: settings)
+        case .agents: AgentSettingsTab(settings: settings, store: store)
         case .usage: UsageSettingsTab(settings: settings, usage: usage)
         case .mobile: MobileSettingsTab()
         case .community: CommunitySettingsTab()

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -888,6 +888,20 @@ extension TermioStore {
         }
     }
 
+    /// The same check without the HUD, for a caller that already shows its own
+    /// progress — Settings ▸ Machines runs it as the first rung of "Set up this
+    /// device", where a borderless panel over the preferences window would be
+    /// chrome fighting chrome.
+    ///
+    /// `static` because it touches nothing on the store: the device a successful
+    /// check reveals is handed back rather than adopted here, so a caller that is
+    /// only *inspecting* a machine does not silently rewrite the registry.
+    static func remoteReadyCheck(host: String) async -> RemoteSetupResult {
+        await Task.detached(priority: .userInitiated) {
+            performRemoteReadyCheck(host: host)
+        }.value
+    }
+
     /// The blocking half of `ensureRemoteReady`, run off-main. Probes for the
     /// remote binary and, when missing, invokes the local `termiod remote deploy`.
     /// `nonisolated` because it is invoked from a background queue and touches only

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -562,7 +562,12 @@ extension TermioStore {
     /// Pure — it reads session state but mutates nothing; `recordLaunch` does the write.
     private func resolveLaunch(for session: Session, spawnPath: String)
         -> (command: String?, resumeID: String?) {
-        guard let base = settings.command(for: session.agent) else {
+        // Resolved against the machine the session runs on: a command path typed
+        // for this Mac's Homebrew install names nothing on a VPS, so handing it to
+        // one is the "settings silently mean this Mac" bug at its most expensive —
+        // the agent dies at 0 ms with "not found".
+        let device = KnownDevice.running(session) ?? .thisMac
+        guard let base = settings.command(for: session.agent, on: device) else {
             return (nil, nil) // plain login shell — nothing to resume
         }
         let agent = session.agent

--- a/Tests/termioTests/DeviceSettingsTests.swift
+++ b/Tests/termioTests/DeviceSettingsTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import termio
+
+/// Which machine a setting means, and how that survives a round trip to disk.
+///
+/// These are the two rules the RFC's storage split rests on: an authored value is
+/// keyed by machine identity rather than by the road taken to it, and a probe
+/// nobody could run reads as *unknown* rather than as *missing*.
+final class DeviceSettingsTests: XCTestCase {
+
+    // MARK: Identity
+
+    func testOneMachineReachedTwoWaysKeepsOneBlob() {
+        // The same box behind a LAN name and a WAN name. Once a handshake has
+        // revealed the `host_id`, both must file under it — otherwise a command
+        // path typed over the tailnet is invisible when reached over the WAN.
+        let lan = KnownDevice(alias: "box.local", deviceID: "h_3f0a")
+        let wan = KnownDevice(alias: "box.example.com", deviceID: "h_3f0a")
+        XCTAssertEqual(lan.settingsKey, wan.settingsKey)
+    }
+
+    func testAnUnhandshakenMachineFallsBackToItsAlias() {
+        // Before the first handshake there is no `host_id`, and the alias is the
+        // only name there is. It must still be storable, or a path typed on a box
+        // Termio has never opened would be dropped.
+        XCTAssertEqual(KnownDevice(alias: "vps", deviceID: nil).settingsKey, "vps")
+    }
+
+    func testThisMacIsNamedRatherThanEmpty() {
+        // A JSON object key a human reads and hand-edits; `"": {…}` is neither.
+        XCTAssertEqual(KnownDevice.thisMac.settingsKey, "local")
+    }
+
+    // MARK: Storage
+
+    func testAuthoredValuesSurviveTheRoundTripToJSON() {
+        var section = DeviceSettingsSection()
+        section["h_3f0a"] = DeviceAuthoredSettings(agentCommands: ["claudeCode": "/usr/bin/claude"])
+        section["local"] = DeviceAuthoredSettings(agentCommands: ["codex": "codex"])
+
+        let restored = DeviceSettingsSection(jsonObject: section.jsonObject)
+        XCTAssertEqual(restored, section)
+        XCTAssertEqual(restored["h_3f0a"].agentCommands?["claudeCode"], "/usr/bin/claude")
+    }
+
+    func testAMachineWithNothingLeftDropsOutOfTheFile() {
+        // The file's whole premise is that it holds only what the user set, so
+        // clearing the last value on a machine must leave no trace of it — not an
+        // empty object that grows the file forever.
+        var section = DeviceSettingsSection()
+        section["vps"] = DeviceAuthoredSettings(agentCommands: ["codex": "codex"])
+        section["vps"] = DeviceAuthoredSettings(agentCommands: [:])
+
+        XCTAssertTrue(section.byDevice.isEmpty)
+        XCTAssertNil(section.jsonObject, "an empty section writes no key at all")
+    }
+
+    func testAnAbsentSectionIsEmptyRatherThanAFailure() {
+        // A settings.json written before this feature existed has no `devices`
+        // key, and that is the ordinary case, not a parse error.
+        XCTAssertTrue(DeviceSettingsSection(jsonObject: nil).byDevice.isEmpty)
+    }
+
+    // MARK: Readiness
+
+    func testAnUnreachableMachineReportsUnknownNotMissing() {
+        // The rule the whole third state exists for: a `(!)` meaning "we could not
+        // reach the box" sends the user to reinstall something already installed.
+        let state = DeviceDiscoveredState(
+            checkedAt: Date(timeIntervalSince1970: 0), reachable: false,
+            agents: [AgentPreset.claudeCode.rawValue: AgentReadiness.available.rawValue])
+        XCTAssertEqual(state.readiness(for: .claudeCode), .unknown)
+    }
+
+    func testAnAgentTheProbeNeverAskedAboutIsUnknown() {
+        let state = DeviceDiscoveredState(
+            checkedAt: Date(timeIntervalSince1970: 0), reachable: true, agents: [:])
+        XCTAssertEqual(state.readiness(for: .claudeCode), .unknown)
+    }
+
+    func testAReachableMachineReportsWhatItAnswered() {
+        let state = DeviceDiscoveredState(
+            checkedAt: Date(timeIntervalSince1970: 0), reachable: true,
+            agents: [AgentPreset.claudeCode.rawValue: AgentReadiness.missing.rawValue])
+        XCTAssertEqual(state.readiness(for: .claudeCode), .missing)
+    }
+
+    // MARK: The cache is a cache
+
+    func testTheDeviceFileRoundTripsAndIsDeletable() throws {
+        let key = "test-\(UUID().uuidString)"
+        let state = DeviceDiscoveredState(
+            checkedAt: Date(timeIntervalSince1970: 1_700_000_000), reachable: true,
+            termiodVersion: "0.42.0",
+            agents: ["codex": AgentReadiness.available.rawValue],
+            integrationVersion: "0.42.0+900")
+
+        DeviceStateCache.save(state, for: key)
+        XCTAssertEqual(DeviceStateCache.load(key), state)
+
+        // Deleting it at any moment is safe by construction: the next read is
+        // simply "we have not asked yet".
+        DeviceStateCache.forget(key)
+        XCTAssertNil(DeviceStateCache.load(key))
+    }
+
+    func testAnAliasWithAPathSeparatorCannotEscapeTheDirectory() {
+        // An alias is whatever the user typed into ~/.ssh/config, and a `/` in one
+        // would otherwise name a subdirectory — or somewhere else entirely.
+        let url = DeviceStateCache.url(for: "../../etc/passwd")
+        XCTAssertEqual(url.deletingLastPathComponent().path, DeviceStateCache.directory.path)
+        XCTAssertFalse(url.lastPathComponent.contains("/"))
+    }
+}


### PR DESCRIPTION
Settings silently meant *this Mac*. `AgentAvailability` probed this Mac's `PATH` to decide whether an agent was installed, `agents.commandOverrides` held one value per agent with no machine dimension, and the hook and skill installers wrote into this Mac's `$HOME`. Switching to a VPS workspace changed nothing on the page.

Implements `docs/design/20260824-settings-that-know-which-machine.md`, D2 and D4 and D6 through D8. Device tint (D3) and Mobile as a Serving section (D9) are deliberately not in this pass.

## D2, the blocker, and what was decided

`SettingsTab.swift` was `case devices = "ssh"` — the shipped Devices tab was the renamed SSH tab, a `~/.ssh/config` projection, which `20260814-remote-to-device.decisions.md` §1 classifies as *routes*. Machine identity therefore had no home and the name it wanted was taken. #440 landed while this was in flight and made that tab a substantially richer route editor (Keychain passwords, `ssh-copy-id`, credential grouping) without adding any identity surface, which strengthens rather than changes the answer.

**Decision: one tab, called Machines, one row per machine, and the route/identity distinction becomes two sections inside a machine's pane** — *Reached by* (destination, key, Test Connection, Edit in Config) above *Runs* (agent CLIs and their per-machine paths). Two tabs that both list machines would force the user to learn that distinction before they could find anything; one pane that shows both does not.

What stays at tab level is what is genuinely not per-machine: `~/.ssh/config` itself, and the public keys in `~/.ssh`. The raw value stays `ssh`, so `lastOpenKey` survives its third renaming.

`DevicesSettingsTab.swift` becomes `SSHHostControls.swift` — the shared route pieces plus the Add Host sheet the File menu also opens.

## What moved (D8)

| Was | Now |
| --- | --- |
| General ▸ Agent skill, General ▸ Status | the machine's pane, as installers |
| the two switches behind them | Agents ▸ Integration — wanting the feature is a preference |
| General ▸ Command line | This Mac's pane, beside deploy-`termiod` |
| Agents ▸ per-agent command path | the machine's pane |

General is now language, notifications and GitHub, and the tab stops lying about its scope.

## Storage (D7)

Authored values go in a `devices` section of `settings.json`, through the same `SettingsStore` that already writes only the keys the user set. Discovered state goes in `~/.termio/devices/<host_id>.json` — a cache, named one from the day it is written, safe to delete at any moment and never read as authority. Keying is `deviceID ?? alias ?? "local"`, the bootstrap/stable split `KnownDevice` and `Checkout.deviceIdentity` already use, so one box reached three ways keeps one blob.

Existing `agents.commandOverrides` migrate onto this Mac — the only machine they could ever have described — and the legacy key is cleared as it is read.

`resolveLaunch` now resolves the command against the machine the session runs on, so a per-machine path actually takes effect instead of handing a Homebrew path to a Linux VPS.

## Three readiness states (D4)

| State | Row shows |
| --- | --- |
| available | the command alone |
| missing | `Not installed · <command>` + `(!)` |
| **unknown** | `Can't check on vps · <command>`, no badge |

Reachability is asked once per machine rather than once per agent, so an unreachable box makes every agent unknown in one step instead of paying an ssh timeout eight times. The Agents tab's line is deliberately **passive** — it reads the device file and never fires ssh — because a tab that probed every configured host on open would hang on a sleeping VPS to decorate a line nobody asked for.

## One outcome, not a ladder (D6)

A machine's pane shows *Ready* or *Set up this device*. One click runs deploy `termiod` → probe agent CLIs → install hooks and skill, and surfaces only the **first** blocking failure: a box that does not answer also has no agent CLIs and no hooks, and naming all three invites fixing a consequence instead of a cause. The rungs remain individually runnable underneath as disclosure. This is the first caller to pass a target to `AgentConfigStore`.

## Verification

- `swift build` clean; `swift test` 632 tests, 0 failures (11 new in `DeviceSettingsTests`).
- `check-strings.sh` reports zero missing keys. The second commit adds the seventeen `%@` keys the checker structurally cannot see — every scoped line names its machine, so all of it is interpolated, and it would otherwise have shipped English to Simplified Chinese users while passing the gate.
- **Not verified on screen.** Screen Recording is denied to this environment, so `screencapture` fails and I could not read the layout back. Spacing, alignment and the drill-down chrome need a look on a real display before merge.

Release Notes: Settings now say which machine they mean. The Devices tab becomes Machines: one row per machine, opening to how it is reached and what it runs. Each machine gets its own agent command paths, its own hooks and skill install, and one "Set up this device" button that does the whole chain. An agent on a machine Termio can't reach now reads "Can't check" instead of "Not installed".