### PR TITLE
Put a DeviceClient port between the iOS UI and the companion wire

### DIFF
--- a/ios/Sources/AppDelegate.swift
+++ b/ios/Sources/AppDelegate.swift
@@ -119,9 +119,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         return args[index + 1]
     }
 
-    /// A `WireFile` for `-demo file`: real Swift source (this file's header),
+    /// A `DeviceFile` for `-demo file`: real Swift source (this file's header),
     /// enough lines to exercise highlighting, scrolling, and the footer.
-    private static func sampleFile() -> WireFile {
+    private static func sampleFile() -> DeviceFile {
         let code = """
         import UIKit
 
@@ -146,12 +146,12 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         """
-        return WireFile(
+        return DeviceFile(
             path: "ios/Sources/RootContainerViewController.swift",
-            base64: Data(code.utf8).base64EncodedString(),
+            data: Data(code.utf8),
             size: code.utf8.count,
-            binary: false,
-            truncated: false
+            isBinary: false,
+            isTruncated: false
         )
     }
 }

--- a/ios/Sources/CompanionBackend.swift
+++ b/ios/Sources/CompanionBackend.swift
@@ -1,0 +1,197 @@
+import Foundation
+import TermioShared
+
+/// `DeviceClient` over the Mac companion wire: one `CompanionClient` socket,
+/// with every wire type mapped to the app's own models on the way through.
+///
+/// The mapping is the point. Before this seam the inspector, the file viewer
+/// and the diff reader all took `Wire*` structs straight off the socket, so
+/// the companion protocol reached the leaf views — and a second backend would
+/// have had to impersonate it. Now the wire stops here.
+final class CompanionBackend: DeviceClient {
+    var onRoster: ((DeviceRoster) -> Void)?
+    var onConnected: ((Bool) -> Void)?
+    var onError: ((String) -> Void)?
+    var onConnectionFailure: ((String) -> Void)?
+    var onStarted: ((String, String?) -> Void)?
+    var onFileList: ((String, [DeviceFileEntry]) -> Void)?
+    var onFile: ((DeviceFile) -> Void)?
+    var onWritten: ((String, Int) -> Void)?
+    var onUploaded: ((String) -> Void)?
+    var onSearchResults: ((String, [String], Bool) -> Void)?
+    var onChanges: (([DeviceChange]) -> Void)?
+    var onDiff: ((DeviceDiff) -> Void)?
+    var onSSHHosts: (([DeviceSSHHost]) -> Void)?
+
+    private let client: CompanionClient
+
+    init(url: URL) {
+        client = CompanionClient(url: url)
+        client.onRoster = { [weak self] roster in
+            self?.onRoster?(DeviceRoster(companion: roster))
+        }
+        client.onConnected = { [weak self] connected in self?.onConnected?(connected) }
+        client.onError = { [weak self] reason in self?.onError?(reason) }
+        client.onConnectionFailure = { [weak self] reason in self?.onConnectionFailure?(reason) }
+        client.onStarted = { [weak self] sessionID, agentID in self?.onStarted?(sessionID, agentID) }
+        client.onFileList = { [weak self] path, entries in
+            self?.onFileList?(path, entries.map(DeviceFileEntry.init(wire:)))
+        }
+        client.onFile = { [weak self] file in self?.onFile?(DeviceFile(wire: file)) }
+        client.onWritten = { [weak self] path, modified in self?.onWritten?(path, modified) }
+        client.onUploaded = { [weak self] path in self?.onUploaded?(path) }
+        client.onSearchResults = { [weak self] query, paths, truncated in
+            self?.onSearchResults?(query, paths, truncated)
+        }
+        client.onChanges = { [weak self] changes in
+            self?.onChanges?(changes.map(DeviceChange.init(wire:)))
+        }
+        client.onDiff = { [weak self] diff in self?.onDiff?(DeviceDiff(wire: diff)) }
+        client.onSSHConfig = { [weak self] hosts in
+            self?.onSSHHosts?(hosts.map(DeviceSSHHost.init(wire:)))
+        }
+    }
+
+    func start() { client.start() }
+    func stop() { client.stop() }
+    func reconnectNow() { client.reconnectNow() }
+
+    func startSession(projectID: String, agentID: String) {
+        client.send(.start(projectID: projectID, agent: agentID))
+    }
+
+    func startTerminal() { client.send(.startTerminal) }
+
+    func startSSH(host: String) { client.send(.startSSH(host: host)) }
+
+    func stopSession(id: String) { client.send(.stop(sessionID: id)) }
+
+    func requestSSHHosts() { client.send(.sshConfigHosts) }
+
+    func listFiles(projectID: String, path: String) {
+        client.send(.listFiles(projectID: projectID, path: path))
+    }
+
+    func readFile(projectID: String, path: String, darkAppearance: Bool) {
+        client.send(.readFile(projectID: projectID, path: path, dark: darkAppearance))
+    }
+
+    func writeFile(projectID: String, path: String, data: Data, baseModifiedMilliseconds: Int) {
+        client.send(.writeFile(
+            projectID: projectID, path: path,
+            base64: data.base64EncodedString(), baseMtime: baseModifiedMilliseconds
+        ))
+    }
+
+    func searchFiles(projectID: String, query: String) {
+        client.send(.searchFiles(projectID: projectID, query: query))
+    }
+
+    func upload(projectID: String, name: String, data: Data) {
+        client.send(.upload(projectID: projectID, name: name, base64: data.base64EncodedString()))
+    }
+
+    func listChanges(projectID: String) {
+        client.send(.listChanges(projectID: projectID))
+    }
+
+    func readDiff(projectID: String, path: String, status: String) {
+        client.send(.readDiff(projectID: projectID, path: path, status: status))
+    }
+}
+
+/// `DeviceSession` over the companion wire: the terminal's own socket, which
+/// carries raw PTY bytes as binary frames once its attach lands.
+final class CompanionDeviceSession: DeviceSession {
+    var onOutput: ((Data) -> Void)? {
+        get { transport.onOutput }
+        set { transport.onOutput = newValue }
+    }
+
+    var onState: ((DeviceSessionState) -> Void)?
+
+    private let transport: CompanionTransport
+
+    init(url: URL, attachSessionID: String?) {
+        transport = CompanionTransport(url: url, attachSessionID: attachSessionID)
+        transport.onState = { [weak self] state in
+            self?.onState?(DeviceSessionState(companion: state))
+        }
+    }
+
+    func start() { transport.start() }
+    func stop() { transport.stop() }
+    func send(_ data: Data) { transport.send(data) }
+    func resize(columns: Int, rows: Int) { transport.resize(cols: columns, rows: rows) }
+    func reassertGrid() { transport.reassertGrid() }
+}
+
+// MARK: - Wire → model
+
+private extension DeviceRoster {
+    init(companion roster: CompanionRoster) {
+        let agentsByID = Dictionary(
+            roster.agents.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest })
+        self.init(
+            deviceID: roster.macID,
+            deviceName: roster.macName,
+            agents: roster.agents,
+            projects: roster.projects.map { MockProject(roster: $0, agentsByID: agentsByID) }
+        )
+    }
+}
+
+private extension DeviceFileEntry {
+    init(wire: WireFileEntry) {
+        self.init(name: wire.name, isDirectory: wire.isDir, changed: wire.changed)
+    }
+}
+
+private extension DeviceFile {
+    init(wire: WireFile) {
+        self.init(
+            path: wire.path,
+            data: wire.data,
+            size: wire.size,
+            isBinary: wire.binary,
+            isTruncated: wire.truncated,
+            modifiedMilliseconds: wire.mtime,
+            renderedHTML: wire.html
+        )
+    }
+}
+
+private extension DeviceChange {
+    init(wire: WireChange) {
+        self.init(
+            path: wire.path, status: wire.status,
+            additions: wire.additions, deletions: wire.deletions,
+            isBinary: wire.isBinary, isStaged: wire.isStaged
+        )
+    }
+}
+
+private extension DeviceDiff {
+    init(wire: WireDiff) {
+        self.init(path: wire.path, text: wire.text, isBinary: wire.binary)
+    }
+}
+
+private extension DeviceSSHHost {
+    init(wire: WireSSHHost) {
+        self.init(alias: wire.alias, hostName: wire.hostName, user: wire.user, port: wire.port)
+    }
+}
+
+private extension DeviceSessionState {
+    init(companion state: CompanionTransport.State) {
+        switch state {
+        case .connecting: self = .connecting
+        case .connected: self = .connected
+        case .reconnecting: self = .reconnecting
+        case .failed(let reason): self = .failed(reason)
+        case .closed: self = .closed
+        }
+    }
+}

--- a/ios/Sources/CompanionClient.swift
+++ b/ios/Sources/CompanionClient.swift
@@ -1,28 +1,14 @@
 import Foundation
-import Network
 import TermioShared
-import UIKit
 
 /// Receives the live project/session roster from the Mac companion server over
-/// a WebSocket, so the home tree shows the same list the desktop sidebar does.
-/// The link self-heals: any drop (Mac app restart, phone sleep, network blip)
-/// schedules a jittered backoff reconnect; returning to the foreground or the
-/// network path coming back retries at once; and a periodic ping catches
-/// half-open sockets that would otherwise never fail `receive`. A fresh
-/// connect repaints immediately because the server pushes the full roster on
-/// accept.
-final class CompanionClient: NSObject {
+/// a `WebSocketLink`, so the home tree shows the same list the desktop sidebar
+/// does. The link owns connect, reconnect and liveness; this type owns only
+/// what is protocol: the auth preamble, the frames that must wait behind it,
+/// and the decode.
+final class CompanionClient {
     private let url: URL
-    private var task: URLSessionWebSocketTask?
-    // Main-queue delegate so all state and callbacks stay on one queue.
-    private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: .main)
-    private var stopped = true
-    private var isConnected = false
-    private var policy = ReconnectPolicy()
-    private var foregroundObserver: NSObjectProtocol?
-    private var pathMonitor: NWPathMonitor?
-    private var lastPathStatus: NWPath.Status?
-    private var pingTimer: Timer?
+    private let link: WebSocketLink
     /// `refuse()` sends one final `.error` and immediately cancels the socket,
     /// while request errors leave it open. Keep the last reason briefly so the
     /// close path can distinguish those two cases without expanding the wire.
@@ -70,88 +56,58 @@ final class CompanionClient: NSObject {
     /// Send a control message (e.g. `.start`) over the roster link. Queued
     /// until the connect + auth handshake if the link isn't up yet.
     func send(_ control: CompanionControl) {
-        guard isConnected else {
+        guard link.isUp else {
             pendingControls.append(control)
             return
         }
-        task?.send(.string(control.encoded())) { _ in }
+        link.send(control.encoded())
     }
 
     init(url: URL) {
         self.url = url
-    }
-
-    deinit {
-        if let observer = foregroundObserver {
-            NotificationCenter.default.removeObserver(observer)
+        link = WebSocketLink(configuration: .init(name: "roster", url: url, delegateQueue: .main))
+        link.onConnecting = { [weak self] in self?.lastServerError = nil }
+        link.onOpen = { [weak self] in self?.sendPreamble() }
+        link.onUp = { [weak self] in self?.onConnected?(true) }
+        link.onDown = { [weak self] in
+            guard let self else { return }
+            let connectionFailure = takeErrorForImmediateDrop()
+            onConnected?(false)
+            if let connectionFailure { onConnectionFailure?(connectionFailure) }
         }
+        link.onText = { [weak self] text in self?.receive(text) }
     }
 
     func start() {
-        stopped = false
-        policy.reset()
-        connect()
-        startPathMonitor()
-        startPingTimer()
-        if foregroundObserver == nil {
-            foregroundObserver = NotificationCenter.default.addObserver(
-                forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main
-            ) { [weak self] _ in
-                // Skip any pending backoff — the socket rarely survives a trip
-                // to the background, and the user is looking at the list now.
-                guard let self, !stopped, !isConnected else { return }
-                policy.reset()
-                connect()
-            }
-        }
+        link.start()
     }
 
     func stop() {
-        stopped = true
-        isConnected = false
-        task?.cancel(with: .goingAway, reason: nil)
-        task = nil
-        pathMonitor?.cancel()
-        pathMonitor = nil
-        lastPathStatus = nil
+        link.stop()
         lastServerError = nil
-        pingTimer?.invalidate()
-        pingTimer = nil
-        if let observer = foregroundObserver {
-            NotificationCenter.default.removeObserver(observer)
-            foregroundObserver = nil
-        }
-    }
-
-    private func connect() {
-        guard !stopped else { return }
-        lastServerError = nil
-        task?.cancel(with: .goingAway, reason: nil)
-        let task = session.webSocketTask(with: url)
-        // A `file` reply for a 1 MB source is ~1.4 MB of base64 JSON — past
-        // the 1 MB default cap, which would kill the socket mid-read.
-        task.maximumMessageSize = 8 << 20
-        self.task = task
-        task.resume()
-        receive(on: task)
     }
 
     /// Force an immediate reconnect, dropping any pending backoff — the "Try
     /// Again" affordance on the stalled zero state.
     func reconnectNow() {
-        guard !stopped, !isConnected else { return }
-        policy.reset()
-        connect()
+        link.reconnectNow()
     }
 
-    private func scheduleReconnect() {
-        guard !stopped else { return }
-        // Fast burst then a slow heartbeat (see ReconnectPolicy): quick to
-        // notice a rebuilt Mac, easy on the radio when the laptop's just closed.
-        let delay = policy.nextDelay()
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self, !stopped, !isConnected else { return }
-            connect()
+    /// Auth rides first on every connect; the roster is the server's reply.
+    /// Anything queued while the link was down follows in order behind it.
+    private func sendPreamble() {
+        if let token = CompanionLink.token(of: url) {
+            link.send(CompanionControl.auth(token: token, wire: Wire.current).encoded())
+        } else {
+            // No `?t=` on the paired URL: the socket opens, but the Mac refuses
+            // it after its ~10s auth grace window, so the link loops
+            // connect→unauthorized→reconnect with no visible cause. Say so.
+            Log.companion.error("roster URL has no pairing token (?t=…) — the Mac will refuse this socket after ~10s. Re-pair via Settings ▸ Mobile.")
+        }
+        let queued = pendingControls
+        pendingControls = []
+        for control in queued {
+            link.send(control.encoded())
         }
     }
 
@@ -163,128 +119,36 @@ final class CompanionClient: NSObject {
         return lastServerError.message
     }
 
-    /// Reconnect the instant the network path comes back (Wi-Fi rejoin, VPN
-    /// toggle) instead of sitting out a scheduled backoff.
-    private func startPathMonitor() {
-        guard pathMonitor == nil else { return }
-        let monitor = NWPathMonitor()
-        monitor.pathUpdateHandler = { [weak self] path in
-            guard let self, !stopped else { return }
-            let cameUp = path.status == .satisfied
-                && lastPathStatus != nil && lastPathStatus != .satisfied
-            lastPathStatus = path.status
-            guard cameUp, !isConnected else { return }
-            policy.reset()
-            connect()
-        }
-        monitor.start(queue: .main)
-        pathMonitor = monitor
-    }
-
-    /// A half-open socket (Mac slept, network switched under us) never fails
-    /// `receive`; a periodic ping is what notices, and its failure forces the
-    /// reconnect loop.
-    private func startPingTimer() {
-        pingTimer?.invalidate()
-        pingTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
-            guard let self, !stopped, isConnected, let task else { return }
-            task.sendPing { [weak self] error in
-                guard error != nil else { return }
-                DispatchQueue.main.async { [weak self] in
-                    guard let self, !stopped, task === self.task, isConnected else { return }
-                    isConnected = false
-                    onConnected?(false)
-                    policy.reset()
-                    connect()
-                }
+    private func receive(_ text: String) {
+        if let roster = CompanionRoster.decode(text) {
+            lastServerError = nil
+            if roster.wire < Wire.minimumServer {
+                onConnectionFailure?(localized("Update Termio on your Mac to connect this phone."))
+                stop()
+            } else {
+                onRoster?(roster)
             }
+            return
         }
-    }
-
-    private func receive(on task: URLSessionWebSocketTask) {
-        task.receive { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .success(let message):
-                if case .string(let text) = message {
-                    if let roster = CompanionRoster.decode(text) {
-                        lastServerError = nil
-                        if roster.wire < Wire.minimumServer {
-                            onConnectionFailure?(localized("Update Termio on your Mac to connect this phone."))
-                            stop()
-                        } else {
-                            onRoster?(roster)
-                        }
-                    } else {
-                        lastServerError = nil
-                        switch CompanionControl.decode(text) {
-                        case .started(let sessionID, let agent): onStarted?(sessionID, agent)
-                        case .fileList(let path, let entries): onFileList?(path, entries)
-                        case .file(let file): onFile?(file)
-                        case .written(let path, let mtime): onWritten?(path, mtime)
-                        case .uploaded(let path): onUploaded?(path)
-                        case .searchResults(let query, let paths, let truncated):
-                            onSearchResults?(query, paths, truncated)
-                        case .changes(let files): onChanges?(files)
-                        case .diff(let diff): onDiff?(diff)
-                        case .error(let reason):
-                            lastServerError = (
-                                message: reason,
-                                uptime: ProcessInfo.processInfo.systemUptime
-                            )
-                            onError?(reason)
-                        case .sshConfigList(let hosts): onSSHConfig?(hosts)
-                        default: break
-                        }
-                    }
-                }
-                receive(on: task)
-            case .failure(let error):
-                // A superseded task's death is not a drop of the current link.
-                guard task === self.task else { return }
-                Log.companion.notice("roster link dropped: \(error.localizedDescription, privacy: .public)")
-                let connectionFailure = takeErrorForImmediateDrop()
-                isConnected = false
-                onConnected?(false)
-                if let connectionFailure { onConnectionFailure?(connectionFailure) }
-                scheduleReconnect()
-            }
+        lastServerError = nil
+        switch CompanionControl.decode(text) {
+        case .started(let sessionID, let agent): onStarted?(sessionID, agent)
+        case .fileList(let path, let entries): onFileList?(path, entries)
+        case .file(let file): onFile?(file)
+        case .written(let path, let mtime): onWritten?(path, mtime)
+        case .uploaded(let path): onUploaded?(path)
+        case .searchResults(let query, let paths, let truncated):
+            onSearchResults?(query, paths, truncated)
+        case .changes(let files): onChanges?(files)
+        case .diff(let diff): onDiff?(diff)
+        case .error(let reason):
+            lastServerError = (
+                message: reason,
+                uptime: ProcessInfo.processInfo.systemUptime
+            )
+            onError?(reason)
+        case .sshConfigList(let hosts): onSSHConfig?(hosts)
+        default: break
         }
-    }
-}
-
-extension CompanionClient: URLSessionWebSocketDelegate {
-    func urlSession(_: URLSession, webSocketTask task: URLSessionWebSocketTask, didOpenWithProtocol _: String?) {
-        guard task === self.task else { return }
-        Log.companion.notice("roster link connected to \(self.url.host ?? "?", privacy: .public)")
-        // Auth rides first on every connect; the roster is the server's reply.
-        if let token = CompanionLink.token(of: url) {
-            task.send(
-                .string(CompanionControl.auth(token: token, wire: Wire.current).encoded())
-            ) { _ in }
-        } else {
-            // No `?t=` on the paired URL: the socket opens, but the Mac refuses
-            // it after its ~10s auth grace window, so the link loops
-            // connect→unauthorized→reconnect with no visible cause. Say so.
-            Log.companion.error("roster URL has no pairing token (?t=…) — the Mac will refuse this socket after ~10s. Re-pair via Settings ▸ Mobile.")
-        }
-        isConnected = true
-        policy.reset()
-        // Auth is on the wire; anything queued behind it follows in order.
-        let queued = pendingControls
-        pendingControls = []
-        for control in queued {
-            task.send(.string(control.encoded())) { _ in }
-        }
-        onConnected?(true)
-    }
-
-    func urlSession(_: URLSession, webSocketTask task: URLSessionWebSocketTask,
-                    didCloseWith _: URLSessionWebSocketTask.CloseCode, reason _: Data?) {
-        guard task === self.task else { return }
-        let connectionFailure = takeErrorForImmediateDrop()
-        isConnected = false
-        onConnected?(false)
-        if let connectionFailure { onConnectionFailure?(connectionFailure) }
     }
 }

--- a/ios/Sources/CompanionTransport.swift
+++ b/ios/Sources/CompanionTransport.swift
@@ -1,22 +1,19 @@
 import Foundation
-import Network
 import TermioShared
-import UIKit
 
-/// v1 companion transport: a WebSocket to the Mac companion server (directly on
-/// LAN, or via a tunnel URL). Binary frames are raw PTY bytes; text frames are
-/// `CompanionControl` JSON. `TerminalViewController` bridges it to an
-/// `InMemoryTerminalSession`.
+/// v1 companion transport: a `WebSocketLink` to the Mac companion server
+/// (directly on LAN, or via a tunnel URL). Binary frames are raw PTY bytes;
+/// text frames are `CompanionControl` JSON. `TerminalViewController` bridges it
+/// to an `InMemoryTerminalSession`.
 ///
-/// The link self-heals: any socket drop (Mac app rebuild, phone sleep, network
-/// blip) schedules a backoff reconnect and re-attaches, and the server replays
-/// its ring buffer on attach so the screen repaints. Only a server-sent `exit`
-/// (the session ended) or `error` (the session no longer exists — e.g. the Mac
-/// app restarted) ends the loop.
+/// The link self-heals and re-attaches, and the server replays its ring buffer
+/// on attach so the screen repaints. Only a server-sent `exit` (the session
+/// ended) or `error` (the session no longer exists — e.g. the Mac app
+/// restarted) ends the loop.
 ///
 /// E2E encryption (CryptoKit) wraps the payloads in the next pass; the PoC
 /// proves the transport + PTY bridge first.
-final class CompanionTransport: NSObject {
+final class CompanionTransport {
     enum State {
         case connecting
         case connected
@@ -33,17 +30,8 @@ final class CompanionTransport: NSObject {
     /// socket opens. nil connects to a server that streams without attach
     /// (the standalone companion PoC).
     private let attachSessionID: String?
-    private var task: URLSessionWebSocketTask?
-    private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-    // Reconnect state, all touched on the main queue.
-    private var stopped = true
-    private var isConnected = false
-    private var policy = ReconnectPolicy()
-    private var foregroundObserver: NSObjectProtocol?
-    private var pathMonitor: NWPathMonitor?
-    private var lastPathStatus: NWPath.Status?
-    private var pingTimer: Timer?
-    /// Only touched on the delegate queue (see `didOpen`).
+    private let link: WebSocketLink
+    /// Only touched on the link's delegate queue (see `sendPreamble`).
     private var everConnected = false
     /// Last grid the terminal reported, re-sent on every (re)connect and on
     /// foreground: the first resize often fires before the socket exists and
@@ -55,20 +43,20 @@ final class CompanionTransport: NSObject {
     private let gridLock = NSLock()
     /// Guards send order: `auth` must be the first frame on the socket. The
     /// terminal view calls `resize` (→ `sendGrid`) as it lays out, which can land
-    /// after `task.resume()` but before `didOpen` — URLSession then flushes that
-    /// queued `resize` *ahead* of the `auth` `didOpen` sends. The server refuses
+    /// after the dial but before the socket opens — URLSession then flushes that
+    /// queued `resize` *ahead* of the `auth` the open sends. The server refuses
     /// any non-`auth` control on an unauthenticated connection, so that stray
     /// `resize` trips "unauthorized" before `auth` is ever read (the roster socket
     /// never sends anything but `auth`, which is why the list works and the
-    /// terminal didn't). So grid and keystroke frames stay suppressed until
-    /// `didOpen` has queued the auth preamble and set this true. Guarded by `gridLock`.
+    /// terminal didn't). So grid and keystroke frames stay suppressed until the
+    /// open has queued the auth preamble and set this true. Guarded by `gridLock`.
     private var authSent = false
     /// Raw PTY input stays closed until the Mac acknowledges auth with its
     /// roster. Control messages remain optimistic because their version-0
     /// meanings are stable. Guarded by `gridLock`.
     private var authAccepted = false
 
-    /// Remote PTY bytes for the terminal. Fired on a URLSession queue.
+    /// Remote PTY bytes for the terminal. Fired on the link's delegate queue.
     var onOutput: ((Data) -> Void)?
     /// State transitions, delivered on the main queue.
     var onState: ((State) -> Void)?
@@ -76,39 +64,34 @@ final class CompanionTransport: NSObject {
     init(url: URL, attachSessionID: String? = nil) {
         self.url = url
         self.attachSessionID = attachSessionID
-    }
-
-    deinit {
-        if let observer = foregroundObserver {
-            NotificationCenter.default.removeObserver(observer)
+        link = WebSocketLink(configuration: .init(
+            name: "session", url: url, delegateQueue: nil, pingRunLoopMode: .common
+        ))
+        link.onConnecting = { [weak self] in
+            // A fresh socket has not sent its auth preamble yet — suppress grid
+            // and keystroke frames until it does, so nothing precedes `auth`.
+            guard let self else { return }
+            gridLock.lock()
+            authSent = false
+            authAccepted = false
+            gridLock.unlock()
         }
+        link.onOpen = { [weak self] in self?.sendPreamble() }
+        link.onUp = { [weak self] in self?.notify(.connected) }
+        link.onDown = { [weak self] in self?.notify(.reconnecting) }
+        link.onForeground = { [weak self] in
+            // The link survived the background trip; coming back to the app is
+            // still a claim — the Mac may have taken the winsize while we were
+            // away.
+            self?.reassertGrid()
+        }
+        link.onData = { [weak self] data in self?.onOutput?(data) }
+        link.onText = { [weak self] text in self?.receive(text) }
     }
 
     func start() {
-        stopped = false
-        policy.reset()
         notify(.connecting)
-        connect()
-        startPathMonitor()
-        startPingTimer()
-        if foregroundObserver == nil {
-            foregroundObserver = NotificationCenter.default.addObserver(
-                forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main
-            ) { [weak self] _ in
-                guard let self, !stopped else { return }
-                if isConnected {
-                    // The link survived the background trip; coming back to
-                    // the app is still a claim — the Mac may have taken the
-                    // winsize while we were away.
-                    reassertGrid()
-                } else {
-                    // Skip any pending backoff — the user is looking at the
-                    // screen now.
-                    policy.reset()
-                    connect()
-                }
-            }
-        }
+        link.start()
     }
 
     func send(_ data: Data) {
@@ -119,7 +102,7 @@ final class CompanionTransport: NSObject {
         // Binary frames are raw PTY bytes permanently. Compression, encryption,
         // or multiplexing needs a separately negotiated mechanism and Wire gate
         // so a stale Mac can never interpret framing as keystrokes.
-        task?.send(.data(data)) { _ in }
+        link.send(data)
     }
 
     func resize(cols: Int, rows: Int) {
@@ -143,167 +126,17 @@ final class CompanionTransport: NSObject {
         let ready = authSent
         gridLock.unlock()
         guard ready, cols > 0, rows > 0 else { return }
-        let control = CompanionControl.resize(cols: cols, rows: rows).encoded()
-        task?.send(.string(control)) { _ in }
+        link.send(CompanionControl.resize(cols: cols, rows: rows).encoded())
     }
 
     func stop() {
-        stopped = true
-        isConnected = false
-        task?.cancel(with: .goingAway, reason: nil)
-        task = nil
-        pathMonitor?.cancel()
-        pathMonitor = nil
-        lastPathStatus = nil
-        pingTimer?.invalidate()
-        pingTimer = nil
-        if let observer = foregroundObserver {
-            NotificationCenter.default.removeObserver(observer)
-            foregroundObserver = nil
-        }
+        link.stop()
     }
 
-    /// Reconnect the instant the network path comes back (Wi-Fi rejoin, cellular
-    /// handoff, VPN toggle) instead of sitting out a scheduled backoff. Without
-    /// this the terminal stays dead for up to the 30s heartbeat after a network
-    /// switch that the phone itself already knows about.
-    private func startPathMonitor() {
-        guard pathMonitor == nil else { return }
-        let monitor = NWPathMonitor()
-        monitor.pathUpdateHandler = { [weak self] path in
-            guard let self, !stopped else { return }
-            let cameUp = path.status == .satisfied
-                && lastPathStatus != nil && lastPathStatus != .satisfied
-            lastPathStatus = path.status
-            guard cameUp, !isConnected else { return }
-            policy.reset()
-            connect()
-        }
-        monitor.start(queue: .main)
-        pathMonitor = monitor
-    }
-
-    /// A half-open socket (the Mac slept, the network switched under us, the
-    /// tunnel dropped the hop) never fails `receive` — the read just waits
-    /// forever on a connection nothing will ever answer, and the session looks
-    /// frozen rather than disconnected. A periodic ping is what notices, and
-    /// its failure forces the reconnect loop.
-    private func startPingTimer() {
-        pingTimer?.invalidate()
-        let timer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
-            guard let self, !stopped, isConnected, let task else { return }
-            task.sendPing { [weak self] error in
-                guard error != nil else { return }
-                DispatchQueue.main.async { [weak self] in
-                    guard let self, !stopped, task === self.task, isConnected else { return }
-                    isConnected = false
-                    notify(.reconnecting)
-                    policy.reset()
-                    connect()
-                }
-            }
-        }
-        // Common mode, or scrolling the scrollback holds the probe off for as
-        // long as the finger is down.
-        RunLoop.main.add(timer, forMode: .common)
-        pingTimer = timer
-    }
-
-    private func connect() {
-        guard !stopped else { return }
-        task?.cancel(with: .goingAway, reason: nil)
-        let task = session.webSocketTask(with: url)
-        // The server replays the session's ring buffer (up to 1 MB) as a single
-        // binary frame on attach; the 1 MB default cap would kill the socket
-        // mid-replay and loop the link in "Reconnecting…" forever.
-        task.maximumMessageSize = 8 << 20
-        self.task = task
-        // A fresh socket has not sent its auth preamble yet — suppress grid and
-        // keystroke frames until `didOpen` does, so nothing precedes `auth`.
-        gridLock.lock()
-        authSent = false
-        authAccepted = false
-        gridLock.unlock()
-        task.resume()
-        receive(on: task)
-    }
-
-    /// The socket died mid-session. Keep trying — the usual cause is the Mac
-    /// app rebuilding, and re-attach is idempotent (the server replays the
-    /// session's ring buffer to a fresh attach).
-    private func dropped(_ task: URLSessionWebSocketTask) {
-        DispatchQueue.main.async { [weak self] in
-            // A superseded task's death is not a drop of the current link.
-            guard let self, task === self.task, !stopped else { return }
-            isConnected = false
-            notify(.reconnecting)
-            // Fast burst then a slow heartbeat (see ReconnectPolicy): re-attach
-            // is idempotent, so quick when the Mac's rebuilding, light when the
-            // laptop's closed.
-            let delay = policy.nextDelay()
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                guard let self, !stopped, !isConnected else { return }
-                connect()
-            }
-        }
-    }
-
-    /// A fatal control arrived — the session itself is over, stop reconnecting.
-    private func finish(_ state: State) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self, !stopped else { return }
-            stopped = true
-            isConnected = false
-            notify(state)
-        }
-    }
-
-    private func receive(on task: URLSessionWebSocketTask) {
-        task.receive { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .success(let message):
-                switch message {
-                case .data(let data):
-                    onOutput?(data)
-                case .string(let text):
-                    if let roster = CompanionRoster.decode(text) {
-                        if roster.wire < Wire.minimumServer {
-                            task.cancel(with: .policyViolation, reason: nil)
-                            finish(.failed(localized("Update Termio on your Mac to connect this phone.")))
-                        } else {
-                            gridLock.lock()
-                            authAccepted = true
-                            gridLock.unlock()
-                        }
-                    } else {
-                        switch CompanionControl.decode(text) {
-                        case .exit:
-                            finish(.closed)
-                        case .error(let message):
-                            finish(.failed(message))
-                        default:
-                            break
-                        }
-                    }
-                @unknown default:
-                    break
-                }
-                receive(on: task)
-            case .failure:
-                dropped(task)
-            }
-        }
-    }
-
-    private func notify(_ state: State) {
-        DispatchQueue.main.async { [onState] in onState?(state) }
-    }
-}
-
-extension CompanionTransport: URLSessionWebSocketDelegate {
-    func urlSession(_: URLSession, webSocketTask task: URLSessionWebSocketTask,
-                    didOpenWithProtocol _: String?) {
+    /// The preamble every (re)connect puts on the wire, in this order: the
+    /// screen reset, auth, the attach it gates, and the grid claim the Mac's
+    /// repaint is driven by.
+    private func sendPreamble() {
         // On a REconnect the terminal still shows the dead link's screen; a
         // full reset (RIS) ahead of the server's ring-buffer replay keeps the
         // two byte streams from interleaving into garbage. Emitted here on the
@@ -315,9 +148,7 @@ extension CompanionTransport: URLSessionWebSocketDelegate {
         // Auth precedes the attach on the same socket — the server refuses
         // the bridge (and everything else) until the token lands.
         if let token = CompanionLink.token(of: url) {
-            task.send(
-                .string(CompanionControl.auth(token: token, wire: Wire.current).encoded())
-            ) { _ in }
+            link.send(CompanionControl.auth(token: token, wire: Wire.current).encoded())
         } else {
             // No `?t=` on the URL: the Mac drops this socket after its ~10s
             // auth grace window, so the session just churns "Reconnecting…"
@@ -325,29 +156,54 @@ extension CompanionTransport: URLSessionWebSocketDelegate {
             Log.companion.error("session URL has no pairing token (?t=…) — the Mac will refuse this socket after ~10s. Re-pair via Settings ▸ Mobile.")
         }
         // Auth is now queued ahead of everything else, so grid/keystroke frames
-        // may flow. `URLSessionWebSocketTask` preserves send-call order, so the
-        // attach and grid below land after auth; and any external `resize` that
-        // fired during the connect stayed suppressed until this moment.
+        // may flow. The link preserves send order, so the attach and grid below
+        // land after auth; and any external `resize` that fired during the
+        // connect stayed suppressed until this moment.
         gridLock.lock()
         authSent = true
         gridLock.unlock()
         if let attachSessionID {
-            let attach = CompanionControl.attach(sessionID: attachSessionID).encoded()
-            task.send(.string(attach)) { _ in }
+            link.send(CompanionControl.attach(sessionID: attachSessionID).encoded())
         }
-        // The grid must follow the attach on every connect — the server's
-        // repaint of the freshly wiped screen is driven by this claim.
         sendGrid()
-        DispatchQueue.main.async { [weak self] in
-            guard let self, task === self.task, !stopped else { return }
-            isConnected = true
-            policy.reset()
-            notify(.connected)
+    }
+
+    private func receive(_ text: String) {
+        if let roster = CompanionRoster.decode(text) {
+            if roster.wire < Wire.minimumServer {
+                finish(
+                    .failed(localized("Update Termio on your Mac to connect this phone.")),
+                    closeCode: .policyViolation
+                )
+            } else {
+                gridLock.lock()
+                authAccepted = true
+                gridLock.unlock()
+            }
+            return
+        }
+        switch CompanionControl.decode(text) {
+        case .exit:
+            finish(.closed)
+        case .error(let message):
+            finish(.failed(message))
+        default:
+            break
         }
     }
 
-    func urlSession(_: URLSession, webSocketTask task: URLSessionWebSocketTask,
-                    didCloseWith _: URLSessionWebSocketTask.CloseCode, reason _: Data?) {
-        dropped(task)
+    /// A fatal control arrived — the session itself is over, stop reconnecting.
+    private func finish(
+        _ state: State, closeCode: URLSessionWebSocketTask.CloseCode = .goingAway
+    ) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !link.isStopped else { return }
+            link.stop(closeCode: closeCode)
+            notify(state)
+        }
+    }
+
+    private func notify(_ state: State) {
+        DispatchQueue.main.async { [onState] in onState?(state) }
     }
 }

--- a/ios/Sources/DeviceClient.swift
+++ b/ios/Sources/DeviceClient.swift
@@ -1,0 +1,228 @@
+import Foundation
+import TermioShared
+
+/// The port the app's screens talk to, so they render *a machine* rather than a
+/// transport. `CompanionBackend` implements it over the Mac companion wire; the
+/// point of the seam is that a second implementation over the Session Protocol
+/// can attach the phone straight to a Linux box with no Mac in the path — see
+/// `docs/design/20260824-ios-as-device-client.md` D1.
+///
+/// It covers exactly what the UI asks for today and nothing more: the roster
+/// push, the four session verbs, the file plane, the git plane, and the SSH
+/// host list. Everything crossing it is a model of this app's, never a wire
+/// type, so a backend change is a backend change.
+protocol DeviceClient: AnyObject {
+    /// A fresh roster arrived — the whole tree, pushed, never polled.
+    var onRoster: ((DeviceRoster) -> Void)? { get set }
+    /// `true` once the link is up, `false` on every drop.
+    var onConnected: ((Bool) -> Void)? { get set }
+    /// The device refused a request (a failed `start`, an unreadable file).
+    var onError: ((String) -> Void)? { get set }
+    /// The device refused the *link* and dropped it; the reason has to survive
+    /// the reconnect loop or it reads as an unexplained outage.
+    var onConnectionFailure: ((String) -> Void)? { get set }
+    /// A `start` landed: the new session id, and the agent the device actually
+    /// launched (nil from a peer that predates the echo).
+    var onStarted: ((String, String?) -> Void)? { get set }
+    /// A directory listing arrived, for the path that was asked for.
+    var onFileList: ((String, [DeviceFileEntry]) -> Void)? { get set }
+    /// One file's contents arrived.
+    var onFile: ((DeviceFile) -> Void)? { get set }
+    /// A write landed: the path, and the file's new modification time (ms).
+    var onWritten: ((String, Int) -> Void)? { get set }
+    /// An upload landed: its absolute path on the device.
+    var onUploaded: ((String) -> Void)? { get set }
+    /// Filename-search matches: the echoed query, device-relative paths, and
+    /// whether the batch was capped.
+    var onSearchResults: ((String, [String], Bool) -> Void)? { get set }
+    /// The project's working-tree changes.
+    var onChanges: (([DeviceChange]) -> Void)? { get set }
+    /// One file's unified diff.
+    var onDiff: ((DeviceDiff) -> Void)? { get set }
+    /// The device's `~/.ssh/config` host blocks.
+    var onSSHHosts: (([DeviceSSHHost]) -> Void)? { get set }
+
+    func start()
+    func stop()
+    /// Drop any pending backoff and dial now — the stalled zero state's
+    /// "Try Again".
+    func reconnectNow()
+
+    func startSession(projectID: String, agentID: String)
+    /// A plain login shell, project-less so it can seed the very first one.
+    func startTerminal()
+    /// `ssh <host>`, where `host` is always an alias the device already knows.
+    func startSSH(host: String)
+    func stopSession(id: String)
+    func requestSSHHosts()
+
+    func listFiles(projectID: String, path: String)
+    /// `darkAppearance` is for the device-rendered Markdown preview, so the
+    /// page matches the screen it lands on.
+    func readFile(projectID: String, path: String, darkAppearance: Bool)
+    func writeFile(projectID: String, path: String, data: Data, baseModifiedMilliseconds: Int)
+    func searchFiles(projectID: String, query: String)
+    func upload(projectID: String, name: String, data: Data)
+    func listChanges(projectID: String)
+    func readDiff(projectID: String, path: String, status: String)
+}
+
+/// The byte plane for one session: the terminal writes keystrokes and its grid
+/// in, remote PTY output comes back out. Attach is implicit in `start()` — a
+/// session object exists only to show a session.
+protocol DeviceSession: AnyObject {
+    /// Remote PTY bytes. Fired off the main queue; the terminal surface takes
+    /// them directly and hops for anything it has to draw.
+    var onOutput: ((Data) -> Void)? { get set }
+    /// Link and lifecycle transitions, delivered on the main queue.
+    var onState: ((DeviceSessionState) -> Void)? { get set }
+
+    func start()
+    func stop()
+    /// Keystrokes, as raw bytes.
+    func send(_ data: Data)
+    func resize(columns: Int, rows: Int)
+    /// Re-claim the PTY's winsize for this device without a size change —
+    /// what a reattach and a returning foreground both need.
+    func reassertGrid()
+}
+
+/// Where a session's link stands. `failed` and `closed` are terminal; the
+/// others are the self-healing loop talking.
+enum DeviceSessionState: Equatable {
+    case connecting
+    case connected
+    /// The socket dropped; a reconnect is scheduled. Not fatal.
+    case reconnecting
+    /// The device refused us — the session no longer exists. Fatal.
+    case failed(String)
+    /// The session exited on the device. Fatal.
+    case closed
+}
+
+// MARK: - Models
+
+/// One roster push, as the screens consume it.
+///
+/// `agents` and `projects` stay in the roster's own vocabulary because they are
+/// what D6's rename settles; re-modelling them now would reach into every
+/// screen for no gain this phase can bank.
+struct DeviceRoster {
+    /// The serving machine's stable id and the name it reports, which the
+    /// paired-device list keys itself by. nil from a peer that names neither.
+    let deviceID: String?
+    let deviceName: String?
+    /// The agents the device has enabled, so the phone never offers one the
+    /// desktop turned off.
+    let agents: [RosterAgent]
+    let projects: [MockProject]
+}
+
+/// One directory entry: a name, whether it opens, and whether the working diff
+/// touches it (or anything under it).
+struct DeviceFileEntry: Equatable {
+    let name: String
+    let isDirectory: Bool
+    let changed: Bool
+
+    init(name: String, isDirectory: Bool, changed: Bool = false) {
+        self.name = name
+        self.isDirectory = isDirectory
+        self.changed = changed
+    }
+}
+
+/// One file's contents. `data` is nil when the payload failed to decode, which
+/// the viewer treats the same as unreadable.
+struct DeviceFile: Equatable {
+    let path: String
+    let data: Data?
+    let size: Int
+    let isBinary: Bool
+    let isTruncated: Bool
+    /// Modification time in milliseconds — the base for conflict-checked
+    /// writes. 0 when the serving peer predates the write plane.
+    let modifiedMilliseconds: Int
+    /// A self-contained rendered preview document, Markdown only: the device
+    /// renders it and the phone drops it into a `WKWebView`.
+    let renderedHTML: String?
+
+    init(
+        path: String, data: Data?, size: Int, isBinary: Bool, isTruncated: Bool,
+        modifiedMilliseconds: Int = 0, renderedHTML: String? = nil
+    ) {
+        self.path = path
+        self.data = data
+        self.size = size
+        self.isBinary = isBinary
+        self.isTruncated = isTruncated
+        self.modifiedMilliseconds = modifiedMilliseconds
+        self.renderedHTML = renderedHTML
+    }
+}
+
+/// One changed file in the device's working tree, as the Changes pane shows
+/// it. Deliberately flatter than the desktop's `GitChange` — the phone lists
+/// and diffs, it never stages.
+struct DeviceChange: Equatable {
+    let path: String
+    /// git's status letter, the desktop's own vocabulary: `M`odified, `A`dded,
+    /// `D`eleted, `R`enamed, `C`opied, `U`ntracked, `!` conflicted.
+    let status: String
+    let additions: Int
+    let deletions: Int
+    /// `--numstat` reported `-` for the counts, so `+`/`−` would be a lie.
+    let isBinary: Bool
+    /// The change sits entirely in the index — what `git commit` would take now.
+    let isStaged: Bool
+
+    init(
+        path: String, status: String, additions: Int, deletions: Int,
+        isBinary: Bool = false, isStaged: Bool = false
+    ) {
+        self.path = path
+        self.status = status
+        self.additions = additions
+        self.deletions = deletions
+        self.isBinary = isBinary
+        self.isStaged = isStaged
+    }
+}
+
+extension DeviceChange {
+    /// The one-line caption both the Changes row and the diff reader's header
+    /// show: where the file lives and what it gained and lost.
+    var caption: String {
+        let directory = (path as NSString).deletingLastPathComponent
+        var parts: [String] = directory.isEmpty ? [] : [directory]
+        parts.append(isBinary ? "binary" : "+\(additions) −\(deletions)")
+        if isStaged { parts.append("staged") }
+        return parts.joined(separator: " · ")
+    }
+
+    var name: String { (path as NSString).lastPathComponent }
+}
+
+/// One file's unified diff. Binary content arrives with empty `text` and the
+/// reader says so rather than rendering git's "Binary files differ" line as
+/// if it were code.
+struct DeviceDiff: Equatable {
+    let path: String
+    let text: String
+    let isBinary: Bool
+
+    init(path: String, text: String, isBinary: Bool = false) {
+        self.path = path
+        self.text = text
+        self.isBinary = isBinary
+    }
+}
+
+/// One `Host` block from the device's `~/.ssh/config`: the alias the user
+/// typed, the resolved `HostName`, and the `User`/`Port` if the config set them.
+struct DeviceSSHHost: Equatable {
+    let alias: String
+    let hostName: String
+    let user: String
+    let port: Int
+}

--- a/ios/Sources/DiffViewController.swift
+++ b/ios/Sources/DiffViewController.swift
@@ -19,7 +19,7 @@ import UIKit
 /// - **Selection feeds the agent.** Long-press → "Send to Agent" bracketed-pastes the
 ///   selected code into the session's PTY: the thing a phone diff is *for*.
 final class DiffViewController: UIViewController {
-    private var files: [WireChange]
+    private var files: [DeviceChange]
     private var index: Int
 
     /// Ask the owner (which holds the companion socket) for one file's diff, passing the
@@ -50,13 +50,13 @@ final class DiffViewController: UIViewController {
     /// A `readDiff` is outstanding, so a failure belongs to this screen.
     var isAwaitingDiff: Bool { pendingPath != nil }
 
-    private var change: WireChange? {
+    private var change: DeviceChange? {
         files.indices.contains(index) ? files[index] : nil
     }
 
     private var document: DiffDocument? { textView.document }
 
-    init(files: [WireChange], index: Int) {
+    init(files: [DeviceChange], index: Int) {
         self.files = files
         self.index = min(max(index, 0), max(files.count - 1, 0))
         super.init(nibName: nil, bundle: nil)
@@ -247,11 +247,11 @@ final class DiffViewController: UIViewController {
     }
 
     /// A `readDiff` reply arrived (routed in by the owner).
-    func receive(_ diff: WireDiff) {
+    func receive(_ diff: DeviceDiff) {
         guard diff.path == pendingPath else { return }
         pendingPath = nil
         spinner.stopAnimating()
-        guard !diff.binary else {
+        guard !diff.isBinary else {
             show(status: localized("Binary file — no text diff to show."))
             return
         }

--- a/ios/Sources/FileListViewController.swift
+++ b/ios/Sources/FileListViewController.swift
@@ -1,4 +1,3 @@
-import TermioShared
 import UIKit
 
 /// What a file list needs from whoever owns the companion socket. The inspector
@@ -6,10 +5,10 @@ import UIKit
 protocol RemoteFileBrowsing: AnyObject {
     /// One directory's entries ("" is the project root). The reply may be slow (it
     /// crosses the wire) or immediate (the offline sample tree).
-    func listEntries(at path: String, then: @escaping ([WireFileEntry]) -> Void)
+    func listEntries(at path: String, then: @escaping ([DeviceFileEntry]) -> Void)
     /// Open a file in the read-only viewer.
     func openFile(at path: String)
-    /// The file's absolute path on the Mac — what "Copy Path" yields, ready to paste
+    /// The file's absolute path on the device — what "Copy Path" yields, ready to paste
     /// into an agent prompt.
     func absolutePath(for path: String) -> String
 }
@@ -21,7 +20,7 @@ protocol RemoteFileBrowsing: AnyObject {
 final class FileListViewController: UITableViewController {
     private let path: String
     private weak var browser: RemoteFileBrowsing?
-    private var entries: [WireFileEntry] = []
+    private var entries: [DeviceFileEntry] = []
     private var loaded = false
     private let spinner = UIActivityIndicatorView(style: .medium)
 
@@ -74,7 +73,7 @@ final class FileListViewController: UITableViewController {
         guard let browser else { return }
         let entry = entries[indexPath.row]
         let child = path.isEmpty ? entry.name : "\(path)/\(entry.name)"
-        if entry.isDir {
+        if entry.isDirectory {
             navigationController?.pushViewController(
                 FileListViewController(path: child, browser: browser), animated: true
             )
@@ -100,14 +99,14 @@ final class FileListViewController: UITableViewController {
 enum FileRow {
     /// `subtitle` is for the flat search results, where a name alone doesn't say which
     /// file it is; a directory listing needs none.
-    static func configure(_ cell: UITableViewCell, entry: WireFileEntry, subtitle: String? = nil) {
+    static func configure(_ cell: UITableViewCell, entry: DeviceFileEntry, subtitle: String? = nil) {
         var config = cell.defaultContentConfiguration()
         config.text = entry.name
         config.textProperties.font = .preferredFont(forTextStyle: .subheadline)
         config.secondaryText = subtitle
         config.secondaryTextProperties.font = .preferredFont(forTextStyle: .caption1)
         config.secondaryTextProperties.color = .secondaryLabel
-        let icon = entry.isDir ? FileIcons.folder() : FileIcons.icon(forFileName: entry.name)
+        let icon = entry.isDirectory ? FileIcons.folder() : FileIcons.icon(forFileName: entry.name)
         config.image = icon.image
         config.imageProperties.tintColor = icon.tint
         // Icons vary in width (folder vs logo vs symbol); a fixed layout box keeps
@@ -119,13 +118,13 @@ enum FileRow {
         // accessory type and a custom accessory view are mutually exclusive, so a row
         // that needs both draws both itself.
         cell.accessoryType = .none
-        cell.accessoryView = accessory(changed: entry.changed, isDir: entry.isDir)
+        cell.accessoryView = accessory(changed: entry.changed, isDirectory: entry.isDirectory)
     }
 
-    private static func accessory(changed: Bool, isDir: Bool) -> UIView? {
+    private static func accessory(changed: Bool, isDirectory: Bool) -> UIView? {
         var pieces: [UIView] = []
         if changed { pieces.append(changedDot()) }
-        if isDir { pieces.append(chevron()) }
+        if isDirectory { pieces.append(chevron()) }
         guard !pieces.isEmpty else { return nil }
         let stack = UIStackView(arrangedSubviews: pieces)
         stack.axis = .horizontal
@@ -142,13 +141,13 @@ enum FileRow {
     }
 
     static func menu(
-        for entry: WireFileEntry, in parent: String, browser: RemoteFileBrowsing
+        for entry: DeviceFileEntry, in parent: String, browser: RemoteFileBrowsing
     ) -> UIContextMenuConfiguration {
         let relative = parent.isEmpty ? entry.name : "\(parent)/\(entry.name)"
         let absolute = browser.absolutePath(for: relative)
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak browser] _ in
             var actions: [UIMenuElement] = []
-            if !entry.isDir {
+            if !entry.isDirectory {
                 actions.append(UIAction(title: localized("Open File"), image: UIImage(systemName: "doc.text")) { _ in
                     browser?.openFile(at: relative)
                 })

--- a/ios/Sources/FileViewerController.swift
+++ b/ios/Sources/FileViewerController.swift
@@ -17,9 +17,9 @@ import WebKit
 final class FileViewerController: UIViewController {
     private let fileName: String
     private let relativePath: String
-    private let file: WireFile
+    private let file: DeviceFile
 
-    /// Ship edited bytes to the Mac: `(payload, baseMtime)`; 0 forces the
+    /// Ship edited bytes to the device: `(payload, baseModifiedMilliseconds)`; 0 forces the
     /// write past the conflict check. nil = viewer stays read-only (offline
     /// demos, truncated reads).
     var onSave: ((Data, Int) -> Void)?
@@ -34,7 +34,7 @@ final class FileViewerController: UIViewController {
     private let editButton = UIButton(type: .system)
     private var rendered = false
 
-    /// The Mac-rendered Markdown preview (`WireFile.html`), shown in a web
+    /// The device-rendered Markdown preview (`DeviceFile.renderedHTML`), shown in a web
     /// view over the text view. Markdown
     /// opens in preview; the pencil flips to source (and editing, when
     /// allowed). One-way per open: the preview HTML was rendered from the
@@ -43,19 +43,20 @@ final class FileViewerController: UIViewController {
     private var previewing = false
 
     private var editMode = false
-    /// mtime (ms) the current buffer is based on; advanced by each `written`.
-    private var baseMtime: Int
+    /// Modification time (ms) the current buffer is based on; advanced by
+    /// each acknowledged write.
+    private var baseModifiedMilliseconds: Int
     /// The last content the Mac acknowledged, so idle flushes skip no-ops.
     private var savedText: String
     /// Content in flight (sent, not yet acked).
     private var pendingSaveText: String?
     private var saveDebounce: DispatchWorkItem?
 
-    init(file: WireFile) {
+    init(file: DeviceFile) {
         self.file = file
         fileName = (file.path as NSString).lastPathComponent
         relativePath = file.path
-        baseMtime = file.mtime
+        baseModifiedMilliseconds = file.modifiedMilliseconds
         savedText = file.data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
@@ -66,7 +67,7 @@ final class FileViewerController: UIViewController {
 
     /// A Quick Look controller for binary payloads, or nil when writing the
     /// temp file fails. The file keeps its real name so QL sniffs the type.
-    static func quickLook(for file: WireFile) -> UIViewController? {
+    static func quickLook(for file: DeviceFile) -> UIViewController? {
         guard let data = file.data else { return nil }
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("companion-preview", isDirectory: true)
@@ -204,7 +205,7 @@ final class FileViewerController: UIViewController {
     /// text view with the same frame, and transparent so the themed page's own
     /// background shows through cleanly.
     private func configurePreview(below header: UIView, above footer: UIView) {
-        guard let html = file.html else { return }
+        guard let html = file.renderedHTML else { return }
         let web = WKWebView()
         web.isOpaque = false
         web.backgroundColor = .clear
@@ -233,7 +234,7 @@ final class FileViewerController: UIViewController {
     // MARK: - Content
 
     private var canEdit: Bool {
-        onSave != nil && !file.binary && !file.truncated
+        onSave != nil && !file.isBinary && !file.isTruncated
     }
 
     private func render() {
@@ -258,7 +259,7 @@ final class FileViewerController: UIViewController {
             CodeHighlighter.language(forFileNamed: fileName) ?? localized("plain text"),
             Self.format(bytes: file.size),
         ]
-        if file.truncated { parts.append(localized("truncated preview")) }
+        if file.isTruncated { parts.append(localized("truncated preview")) }
         if let state { parts.append(state) }
         footerLabel.text = parts.joined(separator: " · ")
     }
@@ -304,12 +305,12 @@ final class FileViewerController: UIViewController {
         guard force || (text != savedText && pendingSaveText == nil) else { return }
         pendingSaveText = text
         updateFooter(state: localized("saving…"))
-        onSave(Data(text.utf8), force ? 0 : baseMtime)
+        onSave(Data(text.utf8), force ? 0 : baseModifiedMilliseconds)
     }
 
     /// The Mac acknowledged the write (routed in by the inspector).
-    func didSave(mtime: Int) {
-        baseMtime = mtime
+    func didSave(modifiedMilliseconds: Int) {
+        baseModifiedMilliseconds = modifiedMilliseconds
         if let pending = pendingSaveText { savedText = pending }
         pendingSaveText = nil
         updateFooter(state: localized("saved"))

--- a/ios/Sources/InspectorViewController.swift
+++ b/ios/Sources/InspectorViewController.swift
@@ -26,17 +26,17 @@ final class InspectorViewController: UIViewController {
     var onSendToAgent: ((String) -> Void)?
 
     /// The project root's entries. Deeper directories live on pushed screens.
-    private var rootEntries: [WireFileEntry] = []
+    private var rootEntries: [DeviceFileEntry] = []
     /// The working-tree changes, newest listing wins.
-    private var changes: [WireChange] = []
+    private var changes: [DeviceChange] = []
     private var changesLoaded = false
 
-    private var client: CompanionClient?
+    private var client: DeviceClient?
     /// Directory listings in flight, keyed by path — a pushed screen's reply must reach
     /// that screen, not whichever list asked last. A path can have more than one waiter
     /// (pull-to-refresh while the first load is still out), and dropping the earlier one
     /// would leave its screen spinning forever.
-    private var listingHandlers: [String: [([WireFileEntry]) -> Void]] = [:]
+    private var listingHandlers: [String: [([DeviceFileEntry]) -> Void]] = [:]
     /// The file path awaiting a `.file` reply, so late/errored replies don't open stale
     /// viewers.
     private var pendingRead: String?
@@ -130,7 +130,7 @@ final class InspectorViewController: UIViewController {
         }
         switch pane {
         case .changes:
-            client?.send(.listChanges(projectID: projectID))
+            client?.listChanges(projectID: projectID)
         case .files:
             listEntries(at: "") { [weak self] entries in
                 self?.rootEntries = entries
@@ -201,7 +201,7 @@ final class InspectorViewController: UIViewController {
         let work = DispatchWorkItem { [weak self] in
             guard let self, let projectID = session.projectRosterID else { return }
             setLoading(true)
-            client?.send(.searchFiles(projectID: projectID, query: query))
+            client?.searchFiles(projectID: projectID, query: query)
         }
         searchDebounce = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: work)
@@ -228,10 +228,10 @@ final class InspectorViewController: UIViewController {
     private func connectFilePlane() {
         guard let companionURL, let projectID = session.projectRosterID else { return }
         setLoading(true)
-        let client = CompanionClient(url: companionURL)
+        let client = CompanionBackend(url: companionURL)
         client.onConnected = { [weak self] connected in
             guard let self, connected else { return }
-            client.send(.listChanges(projectID: projectID))
+            client.listChanges(projectID: projectID)
             if rootEntries.isEmpty {
                 listEntries(at: "") { [weak self] entries in
                     self?.rootEntries = entries
@@ -254,8 +254,8 @@ final class InspectorViewController: UIViewController {
         client.onSearchResults = { [weak self] query, paths, truncated in
             self?.receiveSearchResults(query: query, paths: paths, truncated: truncated)
         }
-        client.onWritten = { [weak self] _, mtime in
-            self?.activeViewer?.didSave(mtime: mtime)
+        client.onWritten = { [weak self] _, modifiedMilliseconds in
+            self?.activeViewer?.didSave(modifiedMilliseconds: modifiedMilliseconds)
         }
         client.onError = { [weak self] message in
             self?.receiveError(message)
@@ -297,7 +297,7 @@ final class InspectorViewController: UIViewController {
         present(alert, animated: true)
     }
 
-    private func receiveChanges(_ files: [WireChange]) {
+    private func receiveChanges(_ files: [DeviceChange]) {
         setLoading(false)
         refreshControl.endRefreshing()
         changes = files
@@ -305,29 +305,29 @@ final class InspectorViewController: UIViewController {
         if pane == .changes { tableView.reloadData() }
     }
 
-    private func receiveListing(path: String, entries: [WireFileEntry]) {
+    private func receiveListing(path: String, entries: [DeviceFileEntry]) {
         setLoading(false)
         refreshControl.endRefreshing()
         guard let waiting = listingHandlers.removeValue(forKey: path) else { return }
         for handler in waiting { handler(entries) }
     }
 
-    private func receiveFile(_ file: WireFile) {
+    private func receiveFile(_ file: DeviceFile) {
         guard file.path == pendingRead else { return }
         pendingRead = nil
         setLoading(false)
-        if file.binary {
+        if file.isBinary {
             guard let quickLook = FileViewerController.quickLook(for: file) else { return }
             present(quickLook, animated: true)
             return
         }
         let viewer = FileViewerController(file: file)
-        viewer.onSave = { [weak self] data, baseMtime in
+        viewer.onSave = { [weak self] data, baseModifiedMilliseconds in
             guard let self, let projectID = session.projectRosterID else { return }
-            client?.send(.writeFile(
+            client?.writeFile(
                 projectID: projectID, path: file.path,
-                base64: data.base64EncodedString(), baseMtime: baseMtime
-            ))
+                data: data, baseModifiedMilliseconds: baseModifiedMilliseconds
+            )
         }
         viewer.onReload = { [weak self] in
             self?.openFile(at: file.path)
@@ -347,10 +347,10 @@ final class InspectorViewController: UIViewController {
         viewer.onRequestDiff = { [weak self, weak viewer] path, status in
             guard let self else { return }
             guard isLive, let projectID = session.projectRosterID else {
-                viewer?.receive(WireDiff(path: path, text: MockChanges.sampleDiff))
+                viewer?.receive(DeviceDiff(path: path, text: MockChanges.sampleDiff))
                 return
             }
-            client?.send(.readDiff(projectID: projectID, path: path, status: status))
+            client?.readDiff(projectID: projectID, path: path, status: status)
         }
         // A plain shell has no prompt to paste into; only an agent session gets the action.
         if session.agent.id != RosterAgent.terminal.id, let onSendToAgent {
@@ -364,26 +364,26 @@ final class InspectorViewController: UIViewController {
 // MARK: - File browsing
 
 extension InspectorViewController: RemoteFileBrowsing {
-    func listEntries(at path: String, then: @escaping ([WireFileEntry]) -> Void) {
+    func listEntries(at path: String, then: @escaping ([DeviceFileEntry]) -> Void) {
         guard isLive, let projectID = session.projectRosterID else {
             then(FileNode.sampleEntries(at: path))
             return
         }
         listingHandlers[path, default: []].append(then)
         setLoading(true)
-        client?.send(.listFiles(projectID: projectID, path: path))
+        client?.listFiles(projectID: projectID, path: path)
     }
 
     func openFile(at path: String) {
         guard isLive, let projectID = session.projectRosterID else { return }
         pendingRead = path
         setLoading(true)
-        client?.send(.readFile(
+        client?.readFile(
             projectID: projectID, path: path,
             // For the Mac-rendered Markdown preview, so the page matches this
             // screen's appearance.
-            dark: traitCollection.userInterfaceStyle == .dark
-        ))
+            darkAppearance: traitCollection.userInterfaceStyle == .dark
+        )
     }
 
     /// Join a project-relative path onto the Mac's absolute project root, so "Copy Path"
@@ -437,7 +437,7 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
             let parent = (path as NSString).deletingLastPathComponent
             FileRow.configure(
                 cell,
-                entry: WireFileEntry(name: (path as NSString).lastPathComponent, isDir: false),
+                entry: DeviceFileEntry(name: (path as NSString).lastPathComponent, isDirectory: false),
                 subtitle: parent.isEmpty ? nil : parent
             )
         case .files:
@@ -476,7 +476,7 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
         case .files:
             guard indexPath.row < rootEntries.count else { return }
             let entry = rootEntries[indexPath.row]
-            if entry.isDir {
+            if entry.isDirectory {
                 navigationController?.pushViewController(
                     FileListViewController(path: entry.name, browser: self), animated: true
                 )
@@ -502,7 +502,7 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
         case .files where isSearching:
             guard indexPath.row < searchResults.count else { return nil }
             let path = searchResults[indexPath.row]
-            let entry = WireFileEntry(name: (path as NSString).lastPathComponent, isDir: false)
+            let entry = DeviceFileEntry(name: (path as NSString).lastPathComponent, isDirectory: false)
             return FileRow.menu(for: entry, in: (path as NSString).deletingLastPathComponent, browser: self)
         case .files:
             guard indexPath.row < rootEntries.count else { return nil }
@@ -511,7 +511,7 @@ extension InspectorViewController: UITableViewDataSource, UITableViewDelegate {
             guard indexPath.row < changes.count else { return nil }
             let change = changes[indexPath.row]
             return FileRow.menu(
-                for: WireFileEntry(name: change.name, isDir: false),
+                for: DeviceFileEntry(name: change.name, isDirectory: false),
                 in: (change.path as NSString).deletingLastPathComponent, browser: self
             )
         }

--- a/ios/Sources/Models.swift
+++ b/ios/Sources/Models.swift
@@ -242,7 +242,7 @@ final class FileNode {
 
     /// One directory's entries in the same shape the wire delivers, so the browser has a
     /// single code path. "" is the root.
-    static func sampleEntries(at path: String) -> [WireFileEntry] {
+    static func sampleEntries(at path: String) -> [DeviceFileEntry] {
         var level = sampleRoot
         if !path.isEmpty {
             for component in path.split(separator: "/") {
@@ -252,7 +252,7 @@ final class FileNode {
             }
         }
         return level.map {
-            WireFileEntry(name: $0.name, isDir: $0.isDirectory, changed: $0.changed || containsChange($0))
+            DeviceFileEntry(name: $0.name, isDirectory: $0.isDirectory, changed: $0.changed || containsChange($0))
         }
     }
 
@@ -273,17 +273,17 @@ final class FileNode {
 
 // MARK: - Mock changes
 
-/// The offline Changes pane and its diff — the same `WireChange` and unified-diff text a
+/// The offline Changes pane and its diff — the same `DeviceChange` and unified-diff text a
 /// live Mac sends, so the demo renders through the real reader rather than a stand-in.
 enum MockChanges {
-    static let samples: [WireChange] = [
-        WireChange(path: "Sources/termio/App.swift", status: "M", additions: 40, deletions: 12),
-        WireChange(path: "Sources/termio/SessionInfoView.swift", status: "M", additions: 18, deletions: 3),
-        WireChange(
+    static let samples: [DeviceChange] = [
+        DeviceChange(path: "Sources/termio/App.swift", status: "M", additions: 40, deletions: 12),
+        DeviceChange(path: "Sources/termio/SessionInfoView.swift", status: "M", additions: 18, deletions: 3),
+        DeviceChange(
             path: "Sources/termio/TermioStore/TermioStore+TerminalSurface.swift",
             status: "M", additions: 62, deletions: 41
         ),
-        WireChange(path: "Sources/termio/SessionHost.swift", status: "A", additions: 120, deletions: 0),
+        DeviceChange(path: "Sources/termio/SessionHost.swift", status: "A", additions: 120, deletions: 0),
     ]
 
     /// Full-context sample: one long unchanged run, so the fold band and its reveal are

--- a/ios/Sources/RosterStore.swift
+++ b/ios/Sources/RosterStore.swift
@@ -26,7 +26,7 @@ final class RosterStore {
     /// never types a host, it only chooses one the Mac already knows (the SSH
     /// twin of Projects ＋ reopening a known folder). Empty until the Mac
     /// answers, or when the config has no hosts.
-    private(set) var sshHosts: [WireSSHHost] = []
+    private(set) var sshHosts: [DeviceSSHHost] = []
     private(set) var companionURL: URL?
     /// `MockSession.key` of the session filling the screen — its row gets the
     /// current-chat pill wherever session rows render.
@@ -38,7 +38,7 @@ final class RosterStore {
     /// A `start` failed on the Mac; the shell presents the alert.
     var onStartError: ((String) -> Void)?
 
-    private var client: CompanionClient?
+    private var client: DeviceClient?
     /// True when the current connection came from the paired-Mac list (not a
     /// `-roster-url` dev launch arg) — only then may a roster's identity be
     /// adopted into that list.
@@ -145,7 +145,7 @@ final class RosterStore {
     func startSession(agent: RosterAgent, in project: MockProject) {
         guard let projectID = project.rosterID else { return }
         pendingStart = (project, agent)
-        client?.send(.start(projectID: projectID, agent: agent.id))
+        client?.startSession(projectID: projectID, agentID: agent.id)
     }
 
     /// The Terminals tab's ＋: open a plain login shell at `~` in the loose
@@ -157,7 +157,7 @@ final class RosterStore {
     /// placeholder stands in until the roster push carries the real container.
     func startNewTerminal() {
         pendingStart = (terminalsProject ?? .terminalsPlaceholder, nil)
-        client?.send(.startTerminal)
+        client?.startTerminal()
     }
 
     /// The Terminals tab's ＋ → "New SSH": an `ssh <host>` terminal in that same
@@ -168,12 +168,12 @@ final class RosterStore {
         let host = host.trimmingCharacters(in: .whitespaces)
         guard !host.isEmpty else { return }
         pendingStart = (terminalsProject ?? .terminalsPlaceholder, nil)
-        client?.send(.startSSH(host: host))
+        client?.startSSH(host: host)
     }
 
     /// Close on the Mac; the next roster push drops the row everywhere.
     func stopSession(_ sessionID: String) {
-        client?.send(.stop(sessionID: sessionID))
+        client?.stopSession(id: sessionID)
     }
 
     // MARK: - Socket
@@ -209,14 +209,14 @@ final class RosterStore {
         connectionIsPersisted = persisted
         companionURL = url
         CompanionLink.state = .connecting
-        let client = CompanionClient(url: url)
+        let client = CompanionBackend(url: url)
         client.onConnected = { [weak self] connected in
             CompanionLink.state = connected ? .connected : .connecting
             // Refresh the SSH host list on every (re)connect so New SSH reflects
             // the Mac's current ~/.ssh/config without a manual pull.
-            if connected { self?.client?.send(.sshConfigHosts) }
+            if connected { self?.client?.requestSSHHosts() }
         }
-        client.onSSHConfig = { [weak self] hosts in
+        client.onSSHHosts = { [weak self] hosts in
             guard let self else { return }
             sshHosts = hosts
             NotificationCenter.default.post(name: Self.didChange, object: nil)
@@ -225,22 +225,19 @@ final class RosterStore {
             guard let self else { return }
             // The roster names its Mac; key the pairing list by that identity
             // (first roster after a fresh pairing, or a rename on the Mac).
-            if connectionIsPersisted, let macID = roster.macID {
-                CompanionLink.adoptIdentity(macID: macID, name: roster.macName)
+            if connectionIsPersisted, let deviceID = roster.deviceID {
+                CompanionLink.adoptIdentity(macID: deviceID, name: roster.deviceName)
             }
             enabledAgents = roster.agents
-            let agentsByID = Dictionary(
-                roster.agents.map { ($0.id, $0) },
-                uniquingKeysWith: { _, latest in latest })
-            projects = roster.projects.map {
-                MockProject(roster: $0, agentsByID: agentsByID)
-            }
+            projects = roster.projects
             NotificationCenter.default.post(name: Self.didChange, object: nil)
             // Open terminals track their session's live status from here —
             // the roster socket is the app's only status feed.
             let statuses = Dictionary(
                 roster.projects.flatMap { project in
-                    project.sessions.map { ($0.id, SessionStatus(wire: $0.status)) }
+                    project.sessions.compactMap { session in
+                        session.rosterID.map { ($0, session.status) }
+                    }
                 },
                 uniquingKeysWith: { first, _ in first }
             )

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -50,7 +50,7 @@ final class TerminalViewController: UIViewController {
     private var lastFittedSize: CGSize = .zero
     private var fitDebounce: DispatchWorkItem?
     private lazy var shellSession = ShellSession(shell: defaultSandboxShell)
-    private var companion: CompanionTransport?
+    private var companion: DeviceSession?
     private var companionSession: InMemoryTerminalSession?
     private let headerBar = UIStackView()
     private let contextLabel = UILabel()
@@ -81,7 +81,7 @@ final class TerminalViewController: UIViewController {
     private var terminalBottomConstraint: NSLayoutConstraint?
     /// Main-thread only — fed from the companion byte stream, read on key taps.
     private var altScreenSniffer = AlternateScreenSniffer()
-    private var uploadClient: CompanionClient?
+    private var uploadClient: DeviceClient?
     private var uploadQueue: [(name: String, data: Data)] = []
     private var uploadInFlight = false
     private var uploadTotal = 0
@@ -601,7 +601,7 @@ final class TerminalViewController: UIViewController {
         uploadInFlight = true
         terminalView.keyBar.setAttachBusy(true, progress: (done: uploadDone, total: uploadTotal))
         if uploadClient == nil {
-            let client = CompanionClient(url: url)
+            let client = CompanionBackend(url: url)
             client.onUploaded = { [weak self] path in
                 guard let self else { return }
                 self.typeUploadedPath(path)
@@ -621,9 +621,7 @@ final class TerminalViewController: UIViewController {
             client.start()
             uploadClient = client
         }
-        uploadClient?.send(
-            .upload(projectID: projectID, name: item.name, base64: item.data.base64EncodedString())
-        )
+        uploadClient?.upload(projectID: projectID, name: item.name, data: item.data)
     }
 
     /// Pastes a diff selection into the TUI's input line — the drawer's "Send to Agent",
@@ -673,7 +671,7 @@ final class TerminalViewController: UIViewController {
         case .demoShell:
             return shellSession.terminalSession
         case .companion(let url):
-            let transport = CompanionTransport(url: url, attachSessionID: session.rosterID)
+            let transport = CompanionDeviceSession(url: url, attachSessionID: session.rosterID)
             // The phone mirrors the Mac's PTY through a live libghostty surface,
             // which answers terminal queries (XTVERSION, DA, DSR) on its own. The
             // Mac's authoritative surface already answered; the phone's duplicate
@@ -689,7 +687,7 @@ final class TerminalViewController: UIViewController {
                     transport?.send(data)
                 },
                 resize: { [weak transport] viewport in
-                    transport?.resize(cols: Int(viewport.columns), rows: Int(viewport.rows))
+                    transport?.resize(columns: Int(viewport.columns), rows: Int(viewport.rows))
                 }
             )
             transport.onOutput = { [weak terminalSession, weak self] data in
@@ -725,7 +723,7 @@ final class TerminalViewController: UIViewController {
         }
     }
 
-    private func companionStateChanged(_ state: CompanionTransport.State) {
+    private func companionStateChanged(_ state: DeviceSessionState) {
         // The status line earns its place only while the link is in doubt;
         // once connected it yields to the project · branch context line.
         statusLabel.isHidden = false

--- a/ios/Sources/WebSocketLink.swift
+++ b/ios/Sources/WebSocketLink.swift
@@ -1,0 +1,301 @@
+import Foundation
+import Network
+import UIKit
+
+/// One self-healing WebSocket, and the only place the app's link behaviour
+/// lives: connect, jittered backoff, network-path wakeups, the foreground
+/// retry, the 15 s liveness ping, and the guarantee that whatever the owner
+/// puts on the wire from `onOpen` gets there first.
+///
+/// It knows nothing about which protocol rides it. The roster link and the
+/// terminal's byte link each carried their own copy of all six, so every link
+/// fix had to be found and made twice.
+///
+/// It never gives up: a link self-heals rather than dead-ending in a
+/// "disconnected" state that needs a manual tap. Only the owner can stop it.
+final class WebSocketLink: NSObject {
+    struct Configuration {
+        /// Names this link in the log, so two live sockets are tellable apart.
+        let name: String
+        let url: URL
+        /// A `file` reply for a 1 MB source is ~1.4 MB of base64 JSON, and the
+        /// ring-buffer replay on attach arrives as one frame of up to 1 MB —
+        /// the 1 MB default cap would kill the socket mid-read.
+        var maximumMessageSize = 8 << 20
+        /// Where delegate callbacks and received frames land. The roster link
+        /// asks for the main queue so all its state stays on one queue; the
+        /// terminal's byte link leaves this nil for a private serial queue, so
+        /// PTY output never waits behind UI work.
+        var delegateQueue: OperationQueue?
+        /// `.common` keeps the liveness probe firing while a finger is down —
+        /// what the terminal needs, since scrolling the scrollback would
+        /// otherwise hold the probe off for the length of the drag.
+        var pingRunLoopMode: RunLoop.Mode = .default
+    }
+
+    /// About to dial. Main queue — reset whatever per-connection state the
+    /// protocol keeps before a frame can arrive.
+    var onConnecting: (() -> Void)?
+    /// The socket is open. Fired on the delegate queue ahead of everything
+    /// else, so an auth preamble sent from here is the first frame on the
+    /// wire; anything sent after it keeps its order behind it.
+    var onOpen: (() -> Void)?
+    /// The link is up. Main queue, after `onOpen`.
+    var onUp: (() -> Void)?
+    /// The link went down and a reconnect is already scheduled. Main queue,
+    /// once per drop however many ways the socket reports it.
+    var onDown: (() -> Void)?
+    /// The app came back to the foreground on a link that was still up — the
+    /// only foreground case the link cannot handle itself.
+    var onForeground: (() -> Void)?
+    /// A text frame, on the delegate queue.
+    var onText: ((String) -> Void)?
+    /// A binary frame, on the delegate queue.
+    var onData: ((Data) -> Void)?
+
+    private let configuration: Configuration
+    private lazy var session = URLSession(
+        configuration: .default, delegate: self, delegateQueue: configuration.delegateQueue
+    )
+    private var task: URLSessionWebSocketTask?
+    /// Main queue only.
+    private var stopped = true
+    private var policy = ReconnectPolicy()
+    private var foregroundObserver: NSObjectProtocol?
+    private var pathMonitor: NWPathMonitor?
+    private var lastPathStatus: NWPath.Status?
+    private var pingTimer: Timer?
+    /// A socket announces the same death through both the failed read and the
+    /// close delegate; the first one wins so a drop dials exactly one
+    /// reconnect. Main queue only, cleared on every dial.
+    private var currentTaskDidDie = false
+    /// Set the moment the socket opens and cleared the moment it dies, on
+    /// whichever queue notices — hence the lock.
+    private var open = false
+    private let openLock = NSLock()
+
+    /// `true` between the socket opening and its death.
+    var isUp: Bool {
+        openLock.lock()
+        defer { openLock.unlock() }
+        return open
+    }
+
+    /// `true` before `start()` and after `stop()` — no reconnect is pending
+    /// and none will be scheduled.
+    var isStopped: Bool { stopped }
+
+    init(configuration: Configuration) {
+        self.configuration = configuration
+        super.init()
+    }
+
+    deinit {
+        if let foregroundObserver {
+            NotificationCenter.default.removeObserver(foregroundObserver)
+        }
+    }
+
+    // MARK: - Lifecycle (main queue)
+
+    func start() {
+        stopped = false
+        policy.reset()
+        connect()
+        startPathMonitor()
+        startPingTimer()
+        startForegroundObserver()
+    }
+
+    /// Tear the link down for good. `closeCode` is how the peer is told; a
+    /// protocol that is refusing this peer says so with `.policyViolation`
+    /// rather than a polite goodbye.
+    func stop(closeCode: URLSessionWebSocketTask.CloseCode = .goingAway) {
+        stopped = true
+        setOpen(false)
+        task?.cancel(with: closeCode, reason: nil)
+        task = nil
+        pathMonitor?.cancel()
+        pathMonitor = nil
+        lastPathStatus = nil
+        pingTimer?.invalidate()
+        pingTimer = nil
+        if let foregroundObserver {
+            NotificationCenter.default.removeObserver(foregroundObserver)
+            self.foregroundObserver = nil
+        }
+    }
+
+    /// Dial now, dropping any pending backoff — the "Try Again" affordance on
+    /// a stalled zero state.
+    func reconnectNow() {
+        guard !stopped, !isUp else { return }
+        policy.reset()
+        connect()
+    }
+
+    /// Put a frame on the current socket. Order is preserved, so the owner's
+    /// `onOpen` preamble stays ahead of everything queued behind it.
+    func send(_ text: String) {
+        task?.send(.string(text)) { _ in }
+    }
+
+    func send(_ data: Data) {
+        task?.send(.data(data)) { _ in }
+    }
+
+    // MARK: - Connect
+
+    private func connect() {
+        guard !stopped else { return }
+        currentTaskDidDie = false
+        task?.cancel(with: .goingAway, reason: nil)
+        let task = session.webSocketTask(with: configuration.url)
+        task.maximumMessageSize = configuration.maximumMessageSize
+        setOpen(false)
+        self.task = task
+        onConnecting?()
+        task.resume()
+        receive(on: task)
+    }
+
+    private func scheduleReconnect() {
+        guard !stopped else { return }
+        // Fast burst then a slow heartbeat (see ReconnectPolicy): quick to
+        // notice a rebuilt peer, easy on the radio when the laptop's just
+        // closed.
+        let delay = policy.nextDelay()
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self, !stopped, !isUp else { return }
+            connect()
+        }
+    }
+
+    /// Reconnect the instant the network path comes back (Wi-Fi rejoin,
+    /// cellular handoff, VPN toggle) instead of sitting out a scheduled
+    /// backoff the phone itself already knows is pointless.
+    private func startPathMonitor() {
+        guard pathMonitor == nil else { return }
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self, !stopped else { return }
+            let cameUp = path.status == .satisfied
+                && lastPathStatus != nil && lastPathStatus != .satisfied
+            lastPathStatus = path.status
+            guard cameUp, !isUp else { return }
+            policy.reset()
+            connect()
+        }
+        monitor.start(queue: .main)
+        pathMonitor = monitor
+    }
+
+    /// A half-open socket (the peer slept, the network switched under us, the
+    /// tunnel dropped the hop) never fails `receive` — the read just waits
+    /// forever on a connection nothing will ever answer, and the screen looks
+    /// frozen rather than disconnected. A periodic ping is what notices, and
+    /// its failure forces the reconnect loop.
+    private func startPingTimer() {
+        pingTimer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
+            guard let self, !stopped, isUp, let task else { return }
+            task.sendPing { [weak self] error in
+                guard error != nil else { return }
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, !stopped, task === self.task, isUp else { return }
+                    setOpen(false)
+                    onDown?()
+                    // The phone knows the link is dead right now, so there is
+                    // nothing to back off from — dial immediately.
+                    policy.reset()
+                    connect()
+                }
+            }
+        }
+        if configuration.pingRunLoopMode != .default {
+            RunLoop.main.add(timer, forMode: configuration.pingRunLoopMode)
+        }
+        pingTimer = timer
+    }
+
+    private func startForegroundObserver() {
+        guard foregroundObserver == nil else { return }
+        foregroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self, !stopped else { return }
+            guard !isUp else {
+                onForeground?()
+                return
+            }
+            // Skip any pending backoff — the socket rarely survives a trip to
+            // the background, and the user is looking at the screen now.
+            policy.reset()
+            connect()
+        }
+    }
+
+    // MARK: - Read
+
+    private func receive(on task: URLSessionWebSocketTask) {
+        task.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let message):
+                switch message {
+                case .string(let text): onText?(text)
+                case .data(let data): onData?(data)
+                @unknown default: break
+                }
+                receive(on: task)
+            case .failure(let error):
+                Log.companion.notice(
+                    "\(self.configuration.name, privacy: .public) link dropped: \(error.localizedDescription, privacy: .public)"
+                )
+                died(task)
+            }
+        }
+    }
+
+    /// The socket died — from a failed read or from the close delegate.
+    private func died(_ deadTask: URLSessionWebSocketTask) {
+        setOpen(false)
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !stopped, !currentTaskDidDie, deadTask === task else { return }
+            currentTaskDidDie = true
+            onDown?()
+            scheduleReconnect()
+        }
+    }
+
+    private func setOpen(_ value: Bool) {
+        openLock.lock()
+        open = value
+        openLock.unlock()
+    }
+}
+
+extension WebSocketLink: URLSessionWebSocketDelegate {
+    func urlSession(
+        _: URLSession, webSocketTask task: URLSessionWebSocketTask, didOpenWithProtocol _: String?
+    ) {
+        guard task === self.task else { return }
+        Log.companion.notice(
+            "\(self.configuration.name, privacy: .public) link connected to \(self.configuration.url.host ?? "?", privacy: .public)"
+        )
+        setOpen(true)
+        onOpen?()
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !stopped, task === self.task else { return }
+            policy.reset()
+            onUp?()
+        }
+    }
+
+    func urlSession(
+        _: URLSession, webSocketTask task: URLSessionWebSocketTask,
+        didCloseWith _: URLSessionWebSocketTask.CloseCode, reason _: Data?
+    ) {
+        died(task)
+    }
+}


### PR DESCRIPTION
P1 and P2 of `docs/design/20260824-ios-as-device-client.md`. Pure refactor: no wire change, no Rust, no renames, and nothing outside `ios/Sources`.

**P1 — the port.** `DeviceClient` / `DeviceSession` cover exactly what the screens ask for: the roster push, the four session verbs, the file plane, the git plane, the SSH host list, and attach / bytes / resize / exit. `CompanionBackend` implements them over today's sockets and maps every wire type on the way through, so `WireFileEntry` / `WireFile` / `WireChange` / `WireDiff` / `WireSSHHost` no longer reach the inspector, the file viewer or the diff reader. The wire stops at the backend.

**P2 — one link.** `CompanionClient` and `CompanionTransport` each reimplemented connect, backoff, `NWPathMonitor`, the foreground retry, the 15 s ping and auth-first ordering — six mechanisms, twice, so every link fix had to be found in two places. `WebSocketLink` owns all six and knows nothing about which protocol rides it; the two types keep only their preamble and their decode.

Two behaviours are consolidated rather than copied, both reported as such:

- A socket announces its death through both the failed read and the close delegate. Each type reacted to both, so a drop dialled two reconnects (the roster's close path dialled none of its own and leaned on the read failure). The link takes the first signal and dials once.
- The terminal's `didOpen` did not check that the task was still the current one before emitting its screen reset and preamble. The link checks, as the roster socket always did.

## Verified

Simulator (the paired iPhone was offline), against this Mac's unchanged companion server, driven by a temporary XCUITest over the live roster:

- Roster push — workspaces, projects, branches, live status dots.
- A session opened and typed into: scrollback replayed, `echo device-port-gate` landed in the agent's prompt.
- Changes — "15 changed files +325 −187", status badges, captions.
- A diff — `App.swift`, full-context folds, syntax highlighting, "1 of 15".
- Files — root listing, two pushed directories, changed-dots.
- File viewer — `Package.swift` highlighted, `README.md` through the Mac-rendered preview.
- Terminals ＋ — the SSH host list, New Terminal opening attached, Close removing the row.

The one difference seen against an unrefactored `origin/main` build running the same test was a slow connect on a freshly started terminal in a single run; two instrumented reruns showed the state machine landing `connecting → open → attach → connected → auth accepted` in under a second, and the screen matching baseline exactly.

Not exercised live: `writeFile`, `upload`, `searchFiles`. All three are single-line delegations with no mapping.

## Release Notes:

None — internal refactor, no user-visible change.
