### PR TITLE
Make the agent hooks work on a Linux device

### DIFF
--- a/Sources/termio/Agents/AgentConfigStore.swift
+++ b/Sources/termio/Agents/AgentConfigStore.swift
@@ -92,11 +92,45 @@ extension AgentConfigStore {
     }
 }
 
+/// The XDG base directories as *this* machine has them.
+///
+/// `~/.config` and `~/.local/share` are the spec's default *values*, not directory
+/// names, and every agent termio files under them — OpenCode, Amp, Crush — reads
+/// the variable. Writing to the literal default on a machine whose owner moved
+/// their config puts a skill where the agent never looks.
+///
+/// Kept here beside `SSHAgentConfigStore.quote`, which does the same job in shell,
+/// so the two spellings of one rule sit together and cannot drift apart.
+enum XDGBaseDirectories {
+    private static let bases = [
+        (prefix: ".config", variable: "XDG_CONFIG_HOME"),
+        (prefix: ".local/share", variable: "XDG_DATA_HOME"),
+    ]
+
+    /// Expands a manifest path against this machine, honouring the XDG variables.
+    /// Identical to `expandingTildeInPath` whenever they are unset, which is every
+    /// default macOS account.
+    static func expand(_ path: String) -> String {
+        guard path.hasPrefix("~/") else { return (path as NSString).expandingTildeInPath }
+        let rest = String(path.dropFirst(2))
+        for base in bases {
+            guard rest == base.prefix || rest.hasPrefix(base.prefix + "/"),
+                  // The login shell, not this process: a Finder-launched app
+                  // inherits none of the user's shell environment.
+                  let root = AgentAvailability.loginShellEnvironment(base.variable)
+            else { continue }
+            let tail = rest.dropFirst(base.prefix.count)
+            return root + tail
+        }
+        return (path as NSString).expandingTildeInPath
+    }
+}
+
 /// This Mac. Behaviour is byte-for-byte what the installers did inline before
 /// the store existed.
 struct LocalAgentConfigStore: AgentConfigStore {
     func resolve(_ path: String) -> String {
-        (path as NSString).expandingTildeInPath
+        XDGBaseDirectories.expand(path)
     }
 
     func exists(_ path: String) -> Bool {

--- a/Sources/termio/Agents/AgentConfigStore.swift
+++ b/Sources/termio/Agents/AgentConfigStore.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// The files an agent integration is written into, on whichever machine the
@@ -63,6 +64,31 @@ extension AgentConfigStore {
     func writeIfChanged(_ data: Data, to path: String, executable: Bool = false) -> Bool {
         if read(path) == data { return true }
         return write(data, to: path, executable: executable)
+    }
+
+    /// Commits a **merge**: writes `data` only while the file still holds exactly
+    /// the bytes the merge was computed from. `expected == nil` means it must
+    /// still be absent.
+    ///
+    /// A hook is a merge into a file the user also owns and edits, and over a
+    /// network the read and the write are two round trips with the user's own
+    /// editor in between — read-modify-write there silently discards their edits,
+    /// the one failure this must never produce. Refusing is the whole guarantee;
+    /// re-merging in a loop is not, and a loop that keeps rewriting a file
+    /// somebody is typing in is its own hazard. So a lost race reports the agent
+    /// as not installed, and the machine pane's setup button is the retry.
+    ///
+    /// This generic form still reads and writes separately, which is the best a
+    /// `FileManager` store can do and is honest for one: locally the window is a
+    /// few microseconds inside one process. `SSHAgentConfigStore` overrides it
+    /// with a single remote check-and-rename.
+    @discardableResult
+    func write(_ data: Data, to path: String, ifUnchangedFrom expected: Data?) -> Bool {
+        guard read(path) == expected else {
+            AgentStatusHooks.log("\(path) changed underneath the merge — not writing")
+            return false
+        }
+        return write(data, to: path, executable: false)
     }
 }
 
@@ -172,6 +198,48 @@ struct SSHAgentConfigStore: AgentConfigStore {
         return true
     }
 
+    /// The precondition and the write are one remote command, so nothing can slip
+    /// between the digest and the rename — the check/use race a two-round-trip
+    /// version would still have.
+    ///
+    /// The expected digest is computed here rather than remotely: hashing what we
+    /// already hold costs nothing, and comparing digests rather than shipping the
+    /// old bytes back keeps the command small.
+    @discardableResult
+    func write(_ data: Data, to path: String, ifUnchangedFrom expected: Data?) -> Bool {
+        let quoted = Self.quote(path)
+        let expectedDigest = expected.map(Self.sha256) ?? ""
+        let script = """
+            \(Self.digestFunction)
+            if [ -e \(quoted) ]; then actual=$(__termio_digest < \(quoted)); else actual=""; fi
+            [ "$actual" = '\(expectedDigest)' ] || exit 9
+            mkdir -p "$(dirname \(quoted))" \
+            && base64 -d > \(quoted).termio-tmp \
+            && mv \(quoted).termio-tmp \(quoted)
+            """
+        guard run(script, stdin: data.base64EncodedString()) != nil else {
+            AgentStatusHooks.log("\(host):\(path) changed underneath the merge, or could not be written")
+            return false
+        }
+        return true
+    }
+
+    /// `sha256sum` is GNU coreutils and `shasum` is the Perl one Debian-minimal
+    /// images sometimes lack; `openssl` is the third thing a box that has neither
+    /// usually still has. A machine with none of them fails the precondition
+    /// rather than skipping it — the refusal is the point.
+    private static let digestFunction = """
+        __termio_digest() {
+          if command -v sha256sum >/dev/null 2>&1; then sha256sum | cut -d' ' -f1
+          elif command -v shasum >/dev/null 2>&1; then shasum -a 256 | cut -d' ' -f1
+          else openssl dgst -sha256 -r | cut -d' ' -f1; fi
+        }
+        """
+
+    private static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
     @discardableResult
     func remove(_ path: String) -> Bool {
         guard run("rm -rf \(Self.quote(path))") != nil else {
@@ -189,16 +257,28 @@ struct SSHAgentConfigStore: AgentConfigStore {
     func isCommandInstalled(_ command: String) -> Bool {
         let binary = command.split(separator: " ").first.map(String.init) ?? ""
         guard !binary.isEmpty else { return true }
-        // `command -v` is POSIX, unlike `which`, and is a shell builtin — so this
-        // costs one multiplexed ssh channel and no remote process.
+        // Asked twice, because the shell `ssh` runs a command in is neither
+        // interactive nor a login shell, and the agents worth finding are the ones
+        // that live outside the default `PATH`. On a stock Ubuntu box `claude`
+        // installs to `~/.local/bin`, which only `~/.profile` adds — so the plain
+        // probe answers "no" for an agent that is sitting right there, the machine
+        // reports "No agent CLIs found", and no skill is installed anywhere.
         //
-        // A login shell is what resolves the user's `PATH`: an agent installed by
-        // a version manager lives on a `PATH` that only `~/.profile` sets, and a
-        // non-interactive ssh command does not read it. Answering `true` when the
-        // probe itself fails keeps a broken link from reading as "not installed".
-        guard let result = run(
-            "command -v \(Self.quote(binary)) >/dev/null 2>&1 && echo yes || echo no")
-        else { return true }
+        // The login shell gets the binary as `$0` rather than interpolated into
+        // its script, so nothing about the name can reach the inner parser. A
+        // shell that assigns positional parameters differently (fish) simply finds
+        // nothing on the second pass and the first pass still stands.
+        //
+        // Answering `true` when the probe itself could not run keeps a broken link
+        // from reading as "not installed" — the same don't-cry-wolf rule as local.
+        let quoted = Self.quote(binary)
+        let script = """
+            if command -v \(quoted) >/dev/null 2>&1; then echo yes; exit 0; fi
+            if [ -n "$SHELL" ] && "$SHELL" -lc 'command -v "$0" >/dev/null 2>&1' \(quoted); \
+            then echo yes; exit 0; fi
+            echo no
+            """
+        guard let result = run(script) else { return true }
         return result.trimmingCharacters(in: .whitespacesAndNewlines) != "no"
     }
 
@@ -253,16 +333,27 @@ struct SSHAgentConfigStore: AgentConfigStore {
         // is a no-op there and only ever changes where a device install lands:
         // on a box whose owner moved their config, `~/.config` would write a
         // plugin into a directory the agent does not read.
-        if rest == ".config" { return xdgConfigHome }
-        if rest.hasPrefix(".config/") {
-            return xdgConfigHome + "/" + singleQuoted(String(rest.dropFirst(".config/".count)))
+        for base in xdgBases {
+            if rest == base.prefix { return base.expansion }
+            if rest.hasPrefix(base.prefix + "/") {
+                let tail = String(rest.dropFirst(base.prefix.count + 1))
+                return base.expansion + "/" + singleQuoted(tail)
+            }
         }
         return "\"$HOME\"/" + singleQuoted(rest)
     }
 
-    /// `$XDG_CONFIG_HOME` when the device sets it, and the spec's own default
+    /// The XDG variable when the device sets it, and the spec's own default
     /// otherwise. Double-quoted so a home directory with spaces survives.
-    private static let xdgConfigHome = "\"${XDG_CONFIG_HOME:-$HOME/.config}\""
+    ///
+    /// `.local/share` carries no manifest path the store reads *today* — session
+    /// discovery is a local `FileManager` walk — but it is the same rule, and the
+    /// spelling is what has to be right the moment a remote reader wants
+    /// OpenCode's `resume.discover.root`.
+    private static let xdgBases: [(prefix: String, expansion: String)] = [
+        (".config", "\"${XDG_CONFIG_HOME:-$HOME/.config}\""),
+        (".local/share", "\"${XDG_DATA_HOME:-$HOME/.local/share}\""),
+    ]
 
     private static func singleQuoted(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"

--- a/Sources/termio/Agents/AgentConfigStore.swift
+++ b/Sources/termio/Agents/AgentConfigStore.swift
@@ -244,8 +244,25 @@ struct SSHAgentConfigStore: AgentConfigStore {
     static func quote(_ value: String) -> String {
         if value == "~" { return "\"$HOME\"" }
         guard value.hasPrefix("~/") else { return singleQuoted(value) }
-        return "\"$HOME\"/" + singleQuoted(String(value.dropFirst(2)))
+        let rest = String(value.dropFirst(2))
+        // `~/.config` is not a directory name a manifest picked; it is the
+        // *default value* of `XDG_CONFIG_HOME`, and on Linux the agents that live
+        // there read the variable. OpenCode resolves its global config — plugins
+        // included — under `$XDG_CONFIG_HOME/opencode`, and Amp documents
+        // `$XDG_CONFIG_HOME/amp/plugins`. A Mac never sets the variable, so this
+        // is a no-op there and only ever changes where a device install lands:
+        // on a box whose owner moved their config, `~/.config` would write a
+        // plugin into a directory the agent does not read.
+        if rest == ".config" { return xdgConfigHome }
+        if rest.hasPrefix(".config/") {
+            return xdgConfigHome + "/" + singleQuoted(String(rest.dropFirst(".config/".count)))
+        }
+        return "\"$HOME\"/" + singleQuoted(rest)
     }
+
+    /// `$XDG_CONFIG_HOME` when the device sets it, and the spec's own default
+    /// otherwise. Double-quoted so a home directory with spaces survives.
+    private static let xdgConfigHome = "\"${XDG_CONFIG_HOME:-$HOME/.config}\""
 
     private static func singleQuoted(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
@@ -310,5 +327,34 @@ enum HookReporter: Hashable {
         case .termioCLI: CommandLineTool.supportCopyURL.path
         case .termiodDaemon: Termiod.remoteBinary()
         }
+    }
+
+    /// The binary as it must appear **inside a hook's shell command**.
+    ///
+    /// Single-quoting is right for this Mac — an absolute path that may contain
+    /// spaces — and wrong for a device: `Termiod.remoteBinary()` is a shell
+    /// *expression* (`$HOME/.local/bin/termiod`, the spelling `TermiodClient`
+    /// drops unquoted into its own `ssh` command), so quoting it whole emits a
+    /// literal `$HOME` directory that cannot exist. Every device hook then execs
+    /// a path that is not there and fails on every turn — silently, because the
+    /// command ends in `2>/dev/null || true`, which is exactly the failure this
+    /// form is shaped to hide.
+    var shellBinaryPath: String {
+        let path = binaryPath
+        guard path.hasPrefix("$HOME/") else { return AgentStatusHooks.shellQuote(path) }
+        return "\"$HOME\"/"
+            + AgentStatusHooks.shellQuote(String(path.dropFirst("$HOME/".count)))
+    }
+
+    /// The binary as a **JavaScript expression**, for the plugin dialects whose
+    /// hook is generated source rather than a shell command. A third spelling
+    /// because there is a third escaping context, not because the path differs:
+    /// Bun's `$` escapes each interpolation into one argv token, so handing it
+    /// `$HOME/...` would reach the kernel as a literal `$HOME` the same way the
+    /// over-quoted shell form does.
+    func javaScriptBinaryExpression(quotedAs jsString: (String) -> String) -> String {
+        let path = binaryPath
+        guard path.hasPrefix("$HOME/") else { return jsString(path) }
+        return "(process.env.HOME ?? \"\") + " + jsString(String(path.dropFirst("$HOME".count)))
     }
 }

--- a/Sources/termio/Agents/AgentSessionStore.swift
+++ b/Sources/termio/Agents/AgentSessionStore.swift
@@ -38,7 +38,7 @@ enum AgentSessionStore {
     /// store), and only for `jsonl` records, which double as the transcript.
     static func transcript(agent: AgentPreset, id: String) -> String? {
         guard let spec = agent.resumeSpec.discover, spec.format == .jsonl else { return nil }
-        let root = URL(fileURLWithPath: (spec.root as NSString).expandingTildeInPath)
+        let root = URL(fileURLWithPath: XDGBaseDirectories.expand(spec.root))
         let keys: [URLResourceKey] = [.isRegularFileKey]
         guard let enumerator = FileManager.default.enumerator(
             at: root, includingPropertiesForKeys: keys) else { return nil }
@@ -73,7 +73,7 @@ enum AgentSessionStore {
     private static func match(agent: AgentPreset, directory: String, after launchedAt: Date?,
                               newest: Bool = false) -> (url: URL, id: String)? {
         guard let launchedAt, let spec = agent.resumeSpec.discover else { return nil }
-        let root = URL(fileURLWithPath: (spec.root as NSString).expandingTildeInPath)
+        let root = URL(fileURLWithPath: XDGBaseDirectories.expand(spec.root))
         let target = canonical(directory)
         return bestMatch(in: root, ext: spec.format.fileExtension, after: launchedAt,
                          newest: newest) { url in

--- a/Sources/termio/Agents/HookListener.swift
+++ b/Sources/termio/Agents/HookListener.swift
@@ -358,14 +358,14 @@ enum AgentStatusHooks {
         // dropped rather than emitted as flags the remote binary would reject —
         // see `HookReporter.termiodDaemon`.
         guard reporter == .termioCLI else {
-            var command = "\(shellQuote(reporter.binaryPath)) set-status"
+            var command = "\(reporter.shellBinaryPath) set-status"
             command += " \"$TERMIOD_SESSION_ID\" \(state)"
             command += dialect == .cursorFlat
                 ? " 2>/dev/null; printf '{}'"
                 : " 2>/dev/null || true"
             return command + " \(hookVersionComment)"
         }
-        var command = "\(shellQuote(reporter.binaryPath)) agent report \(state)"
+        var command = "\(reporter.shellBinaryPath) agent report \(state)"
         // Claude feeds each hook a JSON blob on stdin carrying `transcript_path`; the
         // CLI mines it out (jq-free) so termio can address the raw Q&A log. Only enabled
         // for agents that reliably provide stdin, so the CLI's `cat` can't block.
@@ -766,10 +766,16 @@ private struct ScriptHookDirectory: AgentStatusInstaller {
 
 /// Installs agents whose integration is a single dropped-in plugin/extension file
 /// (no host config to merge): OpenCode loads a plugin from `~/.config/opencode/plugin/`,
-/// Pi an extension from `~/.pi/agent/extensions/`. Both run in-process in the PTY,
-/// so they read `TERMIO_SESSION` from the environment and emit the same normalized
-/// report into the socket — OpenCode via its session lifecycle events, Pi via
-/// `agent_start`/`agent_end`. Uninstall removes the file only if it's ours.
+/// Pi an extension from `~/.pi/agent/extensions/`, Amp one from `~/.config/amp/plugins/`.
+/// All three run in-process in the PTY and emit the same normalized report —
+/// OpenCode via its session lifecycle events, Pi via `agent_start`/`agent_end`,
+/// Amp via `agent.start`/`agent.end`. Uninstall removes the file only if it's ours.
+///
+/// Unlike every other dialect, the hook here is generated *source*, not a command
+/// string, so the machine reaches further into the template than a swapped binary
+/// path: this Mac reads `TERMIO_SESSION` and reports through the `termio` CLI to
+/// the app's socket, and a device reads `TERMIOD_SESSION_ID` and reports through
+/// `termiod set-status` to the daemon that owns its PTY.
 private struct PluginFile: AgentStatusInstaller {
     let path: String
     let store: AgentConfigStore
@@ -783,16 +789,13 @@ private struct PluginFile: AgentStatusInstaller {
             AgentStatusHooks.log("\(id): incomplete plugin hook manifest")
             return nil
         }
-        // Unlike every other dialect, a plugin's report path is baked into
-        // JavaScript that shells out to the `termio` CLI and reads
-        // `TERMIO_SESSION` — neither of which exists on a device. Porting the
-        // three templates to `termiod set-status` is real work with no shared
-        // code to lean on, so a device install declines here rather than
-        // dropping a plugin that would fail silently on every turn.
-        guard target.isLocal else {
-            AgentStatusHooks.log("\(id): plugin hooks are not installed on a device yet")
-            return nil
-        }
+        // `termiod set-status` carries a state and a title and nothing else, so a
+        // device build of any of these templates drops the conversation plumbing
+        // rather than tracking an id the daemon has no field for. Stated once
+        // here instead of three times, because it is one fact about the daemon
+        // rather than three facts about plugin APIs (`HookReporter`).
+        let conversation = target.isLocal ? spec.conversation : nil
+        let reporter = target.reporter
         let filename: String
         let legacyFilename: String
         let contents: String
@@ -800,15 +803,17 @@ private struct PluginFile: AgentStatusInstaller {
         case .openCodePlugin:
             filename = "termio.js"
             legacyFilename = "termio-status.js"
-            contents = openCodeSource(events: spec.events, conversationPath: spec.conversation)
+            contents = openCodeSource(
+                events: spec.events, conversationPath: conversation, reporter: reporter)
         case .piPlugin:
             filename = "termio.js"
             legacyFilename = "termio-status.js"
-            contents = piSource(events: spec.events, conversation: spec.conversation)
+            contents = piSource(
+                events: spec.events, conversation: conversation, reporter: reporter)
         case .ampPlugin:
             filename = "termio.ts"
             legacyFilename = "termio-status.ts"
-            contents = ampSource(events: spec.events)
+            contents = ampSource(events: spec.events, reporter: reporter)
         default:
             AgentStatusHooks.log("\(id): hook dialect is not a plugin template")
             return nil
@@ -858,6 +863,31 @@ private struct PluginFile: AgentStatusInstaller {
 
     private static var cliPath: String { AgentStatusHooks.cliPath }
 
+    /// `const cli = …` for a generated plugin: this Mac's channel-stable CLI copy
+    /// as a literal, or the device's `termiod` joined to the target's own `$HOME`
+    /// at load time.
+    private static func cliDeclaration(for reporter: HookReporter) -> String {
+        "const cli = \(reporter.javaScriptBinaryExpression(quotedAs: jsString));"
+    }
+
+    /// The body of a device plugin's `report`. The session id comes from the
+    /// environment the daemon owns (`session::daemon_owned_env` exports
+    /// `TERMIOD_SESSION_ID` after the client's `env`, so it cannot be spoofed),
+    /// and a plugin loaded outside a termiod session reports nothing rather than
+    /// invoking `set-status` with an empty id the daemon would reject.
+    private static func daemonReportBody(shell: String) -> String {
+        """
+            if (!session) return;
+            return \(shell)`${cli} set-status ${session} ${state}`.quiet().nothrow();
+        """
+    }
+
+    /// The `const session = …` line that body needs, or nothing on this Mac,
+    /// where the id rides in on `TERMIO_SESSION` and the CLI reads it itself.
+    private static func sessionDeclaration(for reporter: HookReporter) -> String {
+        reporter == .termioCLI ? "" : "\n  const session = process.env.TERMIOD_SESSION_ID;"
+    }
+
     /// OpenCode plugin: a session is `busy` while working and emits `session.idle`
     /// when the turn ends; `permission.updated` means it's waiting on the user. Each
     /// maps to the public report contract shelled out via Bun's `$`. The session id
@@ -870,7 +900,9 @@ private struct PluginFile: AgentStatusInstaller {
     /// child's id would mis-pin the tab, so the plugin learns which ids are
     /// top-level from `session.created`/`session.updated` (child sessions carry
     /// `parentID`) and forwards only those.
-    private static func openCodeSource(events: [AgentHookEvent], conversationPath: String?) -> String {
+    private static func openCodeSource(
+        events: [AgentHookEvent], conversationPath: String?, reporter: HookReporter
+    ) -> String {
         let conversationExpression = conversationPath.map { path in
             "event" + path.split(separator: ".").map { "?.\($0)" }.joined()
         }
@@ -896,7 +928,7 @@ private struct PluginFile: AgentStatusInstaller {
               if (event.type === "session.deleted") return roots.delete(event.properties?.info?.id);
 
         """
-        let reportBody = conversationExpression == nil ? """
+        let localReportBody = conversationExpression == nil ? """
             return $`${cli} agent report ${state}`.quiet().nothrow();
         """ : """
             if (conversation && roots.has(conversation)) {
@@ -904,12 +936,15 @@ private struct PluginFile: AgentStatusInstaller {
             }
             return $`${cli} agent report ${state}`.quiet().nothrow();
         """
+        let reportBody = reporter == .termioCLI
+            ? localReportBody
+            : daemonReportBody(shell: "$")
         let reportParameters = conversationExpression == nil ? "(state)" : "(state, conversation)"
         return """
         // termio agent status — reports OpenCode session lifecycle to termio.
         // Socket marker: \(AgentStatusHooks.marker)
         export const TermioStatus = async ({ $ }) => {
-          const cli = \(jsString(cliPath));\(identity)
+          \(cliDeclaration(for: reporter))\(sessionDeclaration(for: reporter))\(identity)
           const report = \(reportParameters) => {
         \(reportBody)
           };
@@ -932,10 +967,16 @@ private struct PluginFile: AgentStatusInstaller {
     /// rotation (Pi reloads extensions with a fresh context when it switches
     /// sessions). The id is embedded in a shell command, so it is forwarded only
     /// when it looks like a bare token — Pi's uuidv7 ids always do.
-    private static func piSource(events: [AgentHookEvent], conversation: String?) -> String {
+    private static func piSource(
+        events: [AgentHookEvent], conversation: String?, reporter: HookReporter
+    ) -> String {
+        // Pi is the one template that needs no device branch of its own: it
+        // already shells out through `pi.exec("sh", …)`, so the device form is
+        // whatever `reportCommand` emits for the daemon — the same string the
+        // JSON-manifest and script-directory dialects get.
         guard conversation != nil else {
             let listeners = events.map { event in
-                let command = AgentStatusHooks.reportCommand(state: event.state)
+                let command = AgentStatusHooks.reportCommand(state: event.state, reporter: reporter)
                 return "  pi.on(\(jsString(event.name)), () => pi.exec(\"sh\", [\"-c\", \(jsString(command))]));"
             }.joined(separator: "\n")
             return """
@@ -970,17 +1011,20 @@ private struct PluginFile: AgentStatusInstaller {
     /// API), runs on Bun, and exposes Bun's `$` shell as `amp.$`; the session id
     /// rides in on `TERMIO_SESSION` from the PTY. `.quiet().nothrow()` keeps it a
     /// silent no-op when termio isn't listening.
-    private static func ampSource(events: [AgentHookEvent]) -> String {
+    private static func ampSource(events: [AgentHookEvent], reporter: HookReporter) -> String {
         let listeners = events.map { event in
             "  amp.on(\(jsString(event.name)), () => report(\(jsString(event.state))));"
         }.joined(separator: "\n")
+        let reportBody = reporter == .termioCLI ? """
+            return amp.$`${cli} agent report ${state}`.quiet().nothrow();
+        """ : daemonReportBody(shell: "amp.$")
         return """
         // termio agent status — reports Amp turn lifecycle to termio.
         // Socket marker: \(AgentStatusHooks.marker)
         export default (amp) => {
-          const cli = \(jsString(cliPath));
+          \(cliDeclaration(for: reporter))\(sessionDeclaration(for: reporter))
           const report = (state) => {
-            return amp.$`${cli} agent report ${state}`.quiet().nothrow();
+        \(reportBody)
           };
         \(listeners)
         };

--- a/Sources/termio/Agents/HookListener.swift
+++ b/Sources/termio/Agents/HookListener.swift
@@ -526,16 +526,21 @@ private struct JSONHookFile: AgentStatusInstaller {
     }
 
     private enum FileState {
-        case missing
+        /// No file, or a zero-byte one — nothing to merge into either way. Carries
+        /// whatever is there so the commit's precondition can still name it.
+        case missing(Data?)
         case unreadable
-        case ok([String: Any])
+        case ok([String: Any], Data)
     }
 
     func install() -> Bool {
         let root: [String: Any]
+        /// The exact bytes this merge is computed from; the write commits against
+        /// them so a config edited in between is refused rather than discarded.
+        let expected: Data?
         switch readState(at: path) {
-        case .ok(let dictionary): root = dictionary
-        case .missing: root = [:]
+        case .ok(let dictionary, let data): root = dictionary; expected = data
+        case .missing(let data): root = [:]; expected = data
         case .unreadable:
             AgentStatusHooks.log("refusing to modify unparseable \(path)")
             return false
@@ -575,7 +580,7 @@ private struct JSONHookFile: AgentStatusInstaller {
             hooks[event.name] = groups
         }
         settings["hooks"] = hooks
-        guard write(settings, to: path) else { return false }
+        guard write(settings, to: path, ifUnchangedFrom: expected) else { return false }
 
         // Publish the replacement before removing its predecessor. If the new file
         // could not be written, retain the working legacy integration for next launch.
@@ -595,7 +600,7 @@ private struct JSONHookFile: AgentStatusInstaller {
 
     private func uninstall(at candidatePath: String, removeFileWhenEmpty: Bool) {
         // Nothing to remove if the file is absent; never overwrite one we can't read.
-        guard case .ok(let root) = readState(at: candidatePath) else { return }
+        guard case .ok(let root, let expected) = readState(at: candidatePath) else { return }
         var settings = root
         guard var hooks = settings["hooks"] as? [String: Any] else { return }
         stripTermioEntries(from: &hooks)
@@ -607,7 +612,7 @@ private struct JSONHookFile: AgentStatusInstaller {
         if removeFileWhenEmpty, settings.isEmpty {
             store.remove(candidatePath)
         } else {
-            write(settings, to: candidatePath)
+            write(settings, to: candidatePath, ifUnchangedFrom: expected)
         }
     }
 
@@ -661,27 +666,29 @@ private struct JSONHookFile: AgentStatusInstaller {
     }
 
     private func readState(at candidatePath: String) -> FileState {
-        guard store.exists(candidatePath) else { return .missing }
+        guard store.exists(candidatePath) else { return .missing(nil) }
         guard let data = store.read(candidatePath) else { return .unreadable }
-        if data.isEmpty { return .missing }
+        if data.isEmpty { return .missing(data) }
         guard let object = try? JSONSerialization.jsonObject(with: data),
               let dictionary = object as? [String: Any] else { return .unreadable }
-        return .ok(dictionary)
+        return .ok(dictionary, data)
     }
 
     /// Returns whether the file now holds `settings` — true both for a fresh write
     /// and for the skipped identical one, false only when the write threw.
     @discardableResult
-    private func write(_ settings: [String: Any], to destinationPath: String) -> Bool {
+    private func write(
+        _ settings: [String: Any], to destinationPath: String, ifUnchangedFrom expected: Data?
+    ) -> Bool {
         do {
             let data = try JSONSerialization.data(
                 withJSONObject: settings,
                 options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
-            // The store skips a write whose bytes already match (the common case on
-            // every launch): avoids needless churn on a user-owned file and shrinks
-            // the window where the write could clobber a concurrent hand-edit.
-            // `.sortedKeys` is what makes those bytes stable.
-            return store.writeIfChanged(data, to: destinationPath)
+            // Skip a write whose bytes already match — the common case on every
+            // launch — so a user-owned file sees no churn at all. `.sortedKeys` is
+            // what makes those bytes stable.
+            if data == expected { return true }
+            return store.write(data, to: destinationPath, ifUnchangedFrom: expected)
         } catch {
             AgentStatusHooks.log("could not encode \(destinationPath): \(error)")
             return false
@@ -1071,17 +1078,26 @@ private struct TOMLHookBlock: AgentStatusInstaller {
     }
 
     func install() -> Bool {
-        let existing = store.readText(path) ?? ""
-        let base = Self.stripBlock(from: existing).trimmingCharacters(in: .newlines)
+        // The bytes the merge is computed from, committed against below: this is a
+        // user-owned file, and over a network the read and the write are two round
+        // trips with the user's own editor in between.
+        let expected = store.exists(path) ? store.read(path) : nil
+        let base = Self.stripBlock(from: expected.map { String(decoding: $0, as: UTF8.self) } ?? "")
+            .trimmingCharacters(in: .newlines)
         let block = Self.render(events: events, reporter: reporter)
         let updated = base.isEmpty ? block + "\n" : base + "\n\n" + block + "\n"
-        return store.writeIfChanged(Data(updated.utf8), to: path)
+        let data = Data(updated.utf8)
+        if data == expected { return true }
+        return store.write(data, to: path, ifUnchangedFrom: expected)
     }
 
     func uninstall() {
-        guard let existing = store.readText(path) else { return }
-        let base = Self.stripBlock(from: existing).trimmingCharacters(in: .newlines)
-        store.writeIfChanged(Data((base.isEmpty ? "" : base + "\n").utf8), to: path)
+        guard let expected = store.read(path) else { return }
+        let base = Self.stripBlock(from: String(decoding: expected, as: UTF8.self))
+            .trimmingCharacters(in: .newlines)
+        let data = Data((base.isEmpty ? "" : base + "\n").utf8)
+        if data == expected { return }
+        store.write(data, to: path, ifUnchangedFrom: expected)
     }
 
     /// The termio-managed block: a comment banner around one `[[hooks]]` table per

--- a/Sources/termio/Settings/AgentAvailability.swift
+++ b/Sources/termio/Settings/AgentAvailability.swift
@@ -22,13 +22,17 @@ enum AgentAvailability {
     // Guarded by `pathLock` on every access; the lock is the synchronization the
     // compiler cannot see.
     nonisolated(unsafe) private static var pathCache: [String]?
+    /// The login-shell values of the variables a Finder-launched app never sees.
+    /// Populated by the same probe and guarded by the same lock.
+    nonisolated(unsafe) private static var environmentCache: [String: String]?
 
     private static func pathDirectories() -> [String] {
         pathLock.withLock {
             if let cached = pathCache { return cached }
-            let resolved = resolvePathDirectories()
-            pathCache = resolved
-            return resolved
+            let resolved = probeLoginShell()
+            pathCache = resolved.path
+            environmentCache = resolved.environment
+            return resolved.path
         }
     }
 
@@ -74,22 +78,48 @@ enum AgentAvailability {
         }
     }
 
-    private static func resolvePathDirectories() -> [String] {
+    /// One login-shell spawn answers for everything a GUI-launched app cannot see
+    /// about its user's environment. `PATH` is why this exists; the XDG bases ride
+    /// along because they have the same problem and asking twice would mean paying
+    /// for a second shell whose rc can take seconds.
+    private static func probeLoginShell() -> (path: [String], environment: [String: String]) {
+        let names = ["XDG_CONFIG_HOME", "XDG_DATA_HOME"]
+        // `${VAR-}` rather than `$VAR`, so an unset variable is an empty field and
+        // the fields stay positional under `set -u`.
+        let fields = (["$PATH"] + names.map { "${\($0)-}" })
+            .map { "\"\($0)\"" }
+            .joined(separator: " ")
         let process = Process()
         process.executableURL = URL(fileURLWithPath: loginShell)
-        process.arguments = ["-ilc", "printf %s \"$PATH\""]
+        process.arguments = ["-ilc", "printf '%s\\n' \(fields)"]
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = FileHandle.nullDevice
-        do { try process.run() } catch { return [] }
+        do { try process.run() } catch { return ([], [:]) }
         // Bound the probe: a login shell whose rc blocks must not hang forever.
         DispatchQueue.global().asyncAfter(deadline: .now() + 3) {
             if process.isRunning { process.terminate() }
         }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
-        return String(decoding: data, as: UTF8.self)
-            .split(separator: ":").map(String.init)
+        let lines = String(decoding: data, as: UTF8.self).components(separatedBy: "\n")
+        guard let path = lines.first else { return ([], [:]) }
+        var environment: [String: String] = [:]
+        for (index, name) in names.enumerated() {
+            let value = index + 1 < lines.count ? lines[index + 1] : ""
+            if !value.isEmpty { environment[name] = value }
+        }
+        return (path.split(separator: ":").map(String.init), environment)
+    }
+
+    /// A login-shell environment value, for the variables a Finder launch drops.
+    /// Non-blocking: the process environment until the probe lands, which only
+    /// means an early call answers the way today's code already does.
+    static func loginShellEnvironment(_ name: String) -> String? {
+        if let value = ProcessInfo.processInfo.environment[name], !value.isEmpty { return value }
+        var resolved: [String: String]?
+        pathLock.withLock { resolved = environmentCache }
+        return resolved?[name]
     }
 
     /// The user's real login shell, read from the password database rather than the

--- a/Tests/termioTests/DeviceHookInstallTests.swift
+++ b/Tests/termioTests/DeviceHookInstallTests.swift
@@ -84,11 +84,44 @@ final class DeviceHookInstallTests: XCTestCase {
             "\"${XDG_CONFIG_HOME:-$HOME/.config}\"/'opencode/plugin'")
         XCTAssertEqual(
             SSHAgentConfigStore.quote("~/.config"), "\"${XDG_CONFIG_HOME:-$HOME/.config}\"")
-        // Everything outside `~/.config` is untouched: Pi and Claude Code keep
+        XCTAssertEqual(
+            SSHAgentConfigStore.quote("~/.local/share/opencode/storage"),
+            "\"${XDG_DATA_HOME:-$HOME/.local/share}\"/'opencode/storage'")
+        // Everything outside the XDG bases is untouched: Pi and Claude Code keep
         // their own dot-directories, which no spec relocates.
         XCTAssertEqual(
             SSHAgentConfigStore.quote("~/.pi/agent/extensions"),
             "\"$HOME\"/'.pi/agent/extensions'")
+        // `.configurable` is not `.config`, and a prefix match that ignored the
+        // boundary would rewrite it.
+        XCTAssertEqual(
+            SSHAgentConfigStore.quote("~/.configurable/x"), "\"$HOME\"/'.configurable/x'")
+    }
+
+    /// A merge is computed from bytes that were read a network round trip ago.
+    /// Committing it unconditionally is what silently discards the edit somebody
+    /// made in between — so a stale commit must be refused, not merged over.
+    func testAMergeAgainstStaleBytesIsRefused() {
+        let store = RecordingConfigStore()
+        let path = "~/.claude/settings.json"
+        store.write(Data("{\"a\":1}".utf8), to: path, executable: false)
+        let read = store.read(path)
+        store.write(Data("{\"a\":2}".utf8), to: path, executable: false)
+
+        XCTAssertFalse(store.write(Data("{\"merged\":1}".utf8), to: path, ifUnchangedFrom: read))
+        XCTAssertEqual(store.read(path), Data("{\"a\":2}".utf8), "the newer bytes must survive")
+        XCTAssertTrue(
+            store.write(Data("{\"merged\":1}".utf8), to: path,
+                        ifUnchangedFrom: Data("{\"a\":2}".utf8)))
+    }
+
+    /// `nil` means "must still be absent", so two installs racing to create the
+    /// same config cannot both win.
+    func testCreatingAConfigRequiresItToStillBeAbsent() {
+        let store = RecordingConfigStore()
+        let path = "~/.codex/hooks.json"
+        XCTAssertTrue(store.write(Data("{}".utf8), to: path, ifUnchangedFrom: nil))
+        XCTAssertFalse(store.write(Data("{\"b\":1}".utf8), to: path, ifUnchangedFrom: nil))
     }
 
     /// The three plugin dialects used to decline on a device outright.

--- a/Tests/termioTests/DeviceHookInstallTests.swift
+++ b/Tests/termioTests/DeviceHookInstallTests.swift
@@ -98,6 +98,21 @@ final class DeviceHookInstallTests: XCTestCase {
             SSHAgentConfigStore.quote("~/.configurable/x"), "\"$HOME\"/'.configurable/x'")
     }
 
+    /// The local half of the same rule the remote store spells in shell. Both
+    /// variables are unset on a default macOS account, so this is also the
+    /// assertion that the common path did not move.
+    func testTheLocalStoreExpandsTheSameBasesTheRemoteOneDoes() {
+        let home = NSHomeDirectory()
+        XCTAssertEqual(
+            XDGBaseDirectories.expand("~/.config/opencode/plugin"),
+            ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"].map { $0 + "/opencode/plugin" }
+                ?? home + "/.config/opencode/plugin")
+        XCTAssertEqual(XDGBaseDirectories.expand("~/.pi/agent"), home + "/.pi/agent")
+        XCTAssertEqual(XDGBaseDirectories.expand("/etc/x"), "/etc/x")
+        // A boundary, not a prefix: `.configurable` is not `.config`.
+        XCTAssertEqual(XDGBaseDirectories.expand("~/.configurable"), home + "/.configurable")
+    }
+
     /// A merge is computed from bytes that were read a network round trip ago.
     /// Committing it unconditionally is what silently discards the edit somebody
     /// made in between — so a stale commit must be refused, not merged over.

--- a/Tests/termioTests/DeviceHookInstallTests.swift
+++ b/Tests/termioTests/DeviceHookInstallTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import termio
+
+/// Records what an install wrote instead of touching a machine, so the generated
+/// hook for a device can be asserted without a VPS in the loop.
+private final class RecordingConfigStore: AgentConfigStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var files: [String: Data] = [:]
+
+    func resolve(_ path: String) -> String { path }
+
+    func exists(_ path: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return files[path] != nil
+    }
+
+    func read(_ path: String) -> Data? {
+        lock.lock(); defer { lock.unlock() }
+        return files[path]
+    }
+
+    @discardableResult
+    func write(_ data: Data, to path: String, executable: Bool) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        files[path] = data
+        return true
+    }
+
+    @discardableResult
+    func remove(_ path: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        files.removeValue(forKey: path)
+        return true
+    }
+
+    func listDirectory(_ path: String) -> [String]? { nil }
+
+    /// Every agent is present, so the install is judged on what it generates
+    /// rather than on which CLIs this test machine happens to carry.
+    func isCommandInstalled(_ command: String) -> Bool { true }
+
+    /// The text written to the one path ending in `suffix`.
+    func text(endingIn suffix: String) -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return files.first { $0.key.hasSuffix(suffix) }
+            .flatMap { String(data: $0.value, encoding: .utf8) }
+    }
+
+    var allText: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return files.values.compactMap { String(data: $0, encoding: .utf8) }
+    }
+}
+
+/// The device arm of the hook installers. A hook that names a path the device
+/// does not have fails on every agent turn and is silent about it — the form ends
+/// in `2>/dev/null || true` — so what these emit is asserted, not eyeballed.
+final class DeviceHookInstallTests: XCTestCase {
+    private func install() -> RecordingConfigStore {
+        let store = RecordingConfigStore()
+        AgentStatusHooks.sync(
+            enabled: true,
+            target: AgentIntegrationTarget(store: store, reporter: .termiodDaemon))
+        return store
+    }
+
+    /// `Termiod.remoteBinary()` is a shell *expression*, not a path: quoting it
+    /// whole emits a literal `$HOME` directory that cannot exist, and every
+    /// device hook then execs something that is not there.
+    func testTheDeviceCommandKeepsItsHomeExpandable() {
+        let command = AgentStatusHooks.reportCommand(state: "working", reporter: .termiodDaemon)
+        XCTAssertFalse(
+            command.contains("'$HOME"), "a single-quoted $HOME reaches the kernel literally")
+        XCTAssertTrue(command.contains("\"$HOME\"/"))
+    }
+
+    /// `~/.config` is the default value of `XDG_CONFIG_HOME`, and the agents that
+    /// live there — OpenCode, Amp — read the variable. A device whose owner moved
+    /// their config would otherwise take the plugin into a directory the agent
+    /// never reads.
+    func testConfigPathsFollowXDGOnTheDevice() {
+        XCTAssertEqual(
+            SSHAgentConfigStore.quote("~/.config/opencode/plugin"),
+            "\"${XDG_CONFIG_HOME:-$HOME/.config}\"/'opencode/plugin'")
+        XCTAssertEqual(
+            SSHAgentConfigStore.quote("~/.config"), "\"${XDG_CONFIG_HOME:-$HOME/.config}\"")
+        // Everything outside `~/.config` is untouched: Pi and Claude Code keep
+        // their own dot-directories, which no spec relocates.
+        XCTAssertEqual(
+            SSHAgentConfigStore.quote("~/.pi/agent/extensions"),
+            "\"$HOME\"/'.pi/agent/extensions'")
+    }
+
+    /// The three plugin dialects used to decline on a device outright.
+    func testThePluginDialectsInstallOnADevice() {
+        let store = install()
+        for suffix in ["opencode/plugin/termio.js", "amp/plugins/termio.ts",
+                       ".pi/agent/extensions/termio.js"] {
+            XCTAssertNotNil(store.text(endingIn: suffix), "\(suffix) was not installed")
+        }
+    }
+
+    /// A device has no `termio` binary and no app socket to report into, so no
+    /// generated hook may reach for either — in any dialect.
+    func testNoDeviceHookReachesForTheLocalContract() {
+        for source in install().allText {
+            XCTAssertFalse(source.contains("agent report"), source)
+            XCTAssertFalse(source.contains("TERMIO_SESSION"), source)
+            XCTAssertFalse(source.contains("--conversation"), source)
+        }
+    }
+
+    /// Bun escapes each `$` interpolation into one argv token, so a `$HOME` handed
+    /// to it survives as literal text the same way an over-quoted shell path does.
+    /// The join has to happen in JavaScript.
+    func testGeneratedPluginsJoinTheirBinaryInJavaScript() {
+        let store = install()
+        for suffix in ["opencode/plugin/termio.js", "amp/plugins/termio.ts"] {
+            guard let source = store.text(endingIn: suffix) else {
+                return XCTFail("\(suffix) was not installed")
+            }
+            XCTAssertTrue(source.contains("process.env.HOME"), source)
+            XCTAssertTrue(source.contains("set-status"), source)
+            XCTAssertTrue(source.contains("process.env.TERMIOD_SESSION_ID"), source)
+            // Reporting with an empty id is a call the daemon rejects; a plugin
+            // loaded outside a termiod session stays silent instead.
+            XCTAssertTrue(source.contains("if (!session) return;"), source)
+        }
+    }
+
+    /// Pi shells out through `pi.exec("sh", …)`, so its device form is the very
+    /// string the JSON-manifest dialects get — no second spelling to drift.
+    func testPiCarriesTheSameDaemonCommandAsTheShellDialects() {
+        guard let source = install().text(endingIn: ".pi/agent/extensions/termio.js") else {
+            return XCTFail("the Pi extension was not installed")
+        }
+        XCTAssertTrue(source.contains("$TERMIOD_SESSION_ID"), source)
+        XCTAssertTrue(source.contains("set-status"), source)
+    }
+
+    /// Ownership is what lets uninstall remove our file and refuse a user's. The
+    /// device form drops `agent report`, so it must still carry the socket marker.
+    func testDevicePluginsStayRecognizablyOurs() {
+        for source in install().allText {
+            XCTAssertTrue(
+                source.contains(AgentStatusHooks.marker)
+                    || source.contains(AgentStatusHooks.hookVersionMarker),
+                source)
+        }
+    }
+}

--- a/docs/design/20260824-agent-integration-on-a-device.md
+++ b/docs/design/20260824-agent-integration-on-a-device.md
@@ -31,8 +31,8 @@ re-do it:
 | D2 — device hook command | **Done.** `AgentStatusHooks.reportCommand(reporter:)` emits the `set-status` form, drops the stdin-mining flags, and keeps Cursor's `printf '{}'` contract. `HookReportCommandTests`. |
 | D5 — policy in the client | **Done.** `AgentConfigStore` is the seam; all four hook dialects and the skill installer go through it, and paths stay unexpanded because `~` means the *target's* home. |
 | D6 — the v0 SSH arm | **Done.** `SSHAgentConfigStore`, riding `Termiod.sshArguments(host:)`. |
-| D3 — `home:` dest | Not built. |
-| D4 — `expect_sha256` | Not built. Until it is, the SSH arm's hook merge is read-modify-write with no precondition. |
+| D3 — `home:` dest | Not built. Belongs to the v1 transfer-plane arm; the v0 SSH arm never touches `UploadOpen`. |
+| D4 — `expect_sha256` | **Done on the v0 arm**, which is where the race actually is. `AgentConfigStore.write(_:to:ifUnchangedFrom:)` commits a merge against the bytes it was computed from; `SSHAgentConfigStore` does the digest check and the rename in one remote command, so nothing slips between them. A lost race reports the agent as not installed and the pane's setup button is the retry — no re-merge loop, which would fight a live editor. The protocol-level `UploadCommit { expect_sha256 }` is still owed by the v1 arm. |
 | — | **Done.** A machine's pane calls both installers with `device.integrationTarget` (`MachinePaneModel.setUp`), so §D6's surface exists and a device target now reaches them. |
 | — | **Done.** The plugin dialects install on a device: the three templates take a `HookReporter` and generate the `termiod set-status` form. `DeviceHookInstallTests`. |
 
@@ -50,9 +50,22 @@ because every hook form ends in `2>/dev/null || true`:
   OpenCode resolves its global config under `$XDG_CONFIG_HOME/opencode` and Amp
   documents `$XDG_CONFIG_HOME/amp/plugins`, so a Linux box whose owner moved their
   config would take a plugin into a directory the agent never reads.
-  `SSHAgentConfigStore.quote` emits `${XDG_CONFIG_HOME:-$HOME/.config}`.
-  Still open: `resume.discover.root` for OpenCode is `~/.local/share/opencode/…`,
-  which is `XDG_DATA_HOME` and has the same exposure on a device.
+  `SSHAgentConfigStore.quote` expands both XDG bases.
+- **The probe asked the wrong shell.** `ssh host 'cmd'` is neither interactive nor
+  a login shell, and the agents worth finding are the ones outside the default
+  `PATH`: on a stock Ubuntu box `claude` installs to `~/.local/bin`, which only
+  `~/.profile` adds. A plain `command -v` answered "no" for an agent sitting right
+  there, so the machine reported *No agent CLIs found*, the setup chain stopped at
+  the probe rung, and no skill was installed anywhere. This was the blocker in
+  front of everything else in this table. Now asked twice, the second pass through
+  the login shell with the binary as `$0`.
+
+Still open: the **local** half of the XDG rule. `LocalAgentConfigStore` and
+`AgentSessionStore` resolve with `expandingTildeInPath`, so a *Mac* whose owner
+sets `XDG_CONFIG_HOME` installs skills where OpenCode does not read them. The
+window is narrow (a GUI-launched app does not inherit a login shell's environment,
+so reading the variable would itself need the `AgentAvailability` login-shell
+probe) and no report exists; recorded rather than built.
 
 ## The problem
 

--- a/docs/design/20260824-agent-integration-on-a-device.md
+++ b/docs/design/20260824-agent-integration-on-a-device.md
@@ -60,12 +60,22 @@ because every hook form ends in `2>/dev/null || true`:
   front of everything else in this table. Now asked twice, the second pass through
   the login shell with the binary as `$0`.
 
-Still open: the **local** half of the XDG rule. `LocalAgentConfigStore` and
-`AgentSessionStore` resolve with `expandingTildeInPath`, so a *Mac* whose owner
-sets `XDG_CONFIG_HOME` installs skills where OpenCode does not read them. The
-window is narrow (a GUI-launched app does not inherit a login shell's environment,
-so reading the variable would itself need the `AgentAvailability` login-shell
-probe) and no report exists; recorded rather than built.
+The rule holds on **both** machines. `XDGBaseDirectories.expand` is the local
+spelling of `SSHAgentConfigStore.quote`'s shell one, and it is what
+`LocalAgentConfigStore` and `AgentSessionStore` resolve through — a Mac whose
+owner sets `XDG_CONFIG_HOME` would otherwise install skills where OpenCode does
+not read them, and miss OpenCode's session records under `XDG_DATA_HOME`.
+
+Applying it needed the variables, which a Finder-launched app does not inherit,
+so `AgentAvailability`'s login-shell probe now carries them: one spawn, the same
+bound and the same cache as `PATH`, because a second login shell would pay for
+another rc that can take seconds. Both variables are unset on a default account,
+where this resolves exactly as `expandingTildeInPath` always did.
+
+There is no trade here, which is why it is a plain rule rather than a heuristic:
+every agent termio files under `~/.config` — OpenCode, Amp, Crush — documents
+XDG support. An agent that hardcoded the literal default would be the one case
+this rule got wrong, and the catalog has none.
 
 ## The problem
 

--- a/docs/design/20260824-agent-integration-on-a-device.md
+++ b/docs/design/20260824-agent-integration-on-a-device.md
@@ -33,12 +33,26 @@ re-do it:
 | D6 — the v0 SSH arm | **Done.** `SSHAgentConfigStore`, riding `Termiod.sshArguments(host:)`. |
 | D3 — `home:` dest | Not built. |
 | D4 — `expect_sha256` | Not built. Until it is, the SSH arm's hook merge is read-modify-write with no precondition. |
-| — | **No caller passes a device target yet.** Every entry point defaults to `.thisMac`, so nothing installs remotely until §D6's surface exists. |
+| — | **Done.** A machine's pane calls both installers with `device.integrationTarget` (`MachinePaneModel.setUp`), so §D6's surface exists and a device target now reaches them. |
+| — | **Done.** The plugin dialects install on a device: the three templates take a `HookReporter` and generate the `termiod set-status` form. `DeviceHookInstallTests`. |
 
-Two behaviours worth knowing before reading further: the **plugin dialects**
-(OpenCode, Pi, Amp) decline on a device, because their templates bake the `termio`
-CLI and `TERMIO_SESSION` into JavaScript; and remote status carries **state and
-title only**.
+One behaviour worth knowing before reading further: remote status carries **state
+and title only**.
+
+Two things the device arm learned the hard way, both of which fail *silently*
+because every hook form ends in `2>/dev/null || true`:
+
+- `Termiod.remoteBinary()` is a shell **expression** (`$HOME/.local/bin/termiod`),
+  not a path. Quoting it whole emits a literal `$HOME` directory. There are three
+  escaping contexts for one binary — raw, shell, and JavaScript — and
+  `HookReporter` now spells all three.
+- `~/.config` is the **default value of `XDG_CONFIG_HOME`**, not a directory name.
+  OpenCode resolves its global config under `$XDG_CONFIG_HOME/opencode` and Amp
+  documents `$XDG_CONFIG_HOME/amp/plugins`, so a Linux box whose owner moved their
+  config would take a plugin into a directory the agent never reads.
+  `SSHAgentConfigStore.quote` emits `${XDG_CONFIG_HOME:-$HOME/.config}`.
+  Still open: `resume.discover.root` for OpenCode is `~/.local/share/opencode/…`,
+  which is `XDG_DATA_HOME` and has the same exposure on a device.
 
 ## The problem
 


### PR DESCRIPTION
The device arm of the hook installers shipped in 65f7611, and #446 gave it a caller. Nothing it wrote could run, and nothing it looked for could be found.

Five defects, all silent — every hook form ends in `2>/dev/null || true`, so a broken hook is indistinguishable from an agent that never reported.

**The probe asked the wrong shell.** `ssh host 'cmd'` runs neither an interactive nor a login shell, and the agents worth finding are exactly the ones outside the default `PATH`: on a stock Ubuntu box `claude` lives in `~/.local/bin`, which only `~/.profile` adds. `command -v` answered "no" for an agent sitting right there, so the machine reported *No agent CLIs found*, the setup chain stopped at the probe rung, and no skill was installed anywhere. This was the blocker in front of everything else. Asked twice now, the second pass through the login shell with the binary as `$0` so nothing about the name reaches the inner parser.

**The binary was quoted into a literal.** `Termiod.remoteBinary()` returns `$HOME/.local/bin/termiod` — a shell expression, which is why `TermiodClient` drops it into its own ssh command unquoted. `reportCommand` ran it through `shellQuote`, so every device hook named a literal `$HOME` directory. One binary has three escaping contexts here — raw, shell, and JavaScript, since Bun's `$` escapes an interpolation into one argv token the same way a shell quote does — and `HookReporter` now spells all three.

**`~/.config` was treated as a directory name.** It is the default *value* of `XDG_CONFIG_HOME`. OpenCode resolves its global config (plugins included) under `$XDG_CONFIG_HOME/opencode`, and Amp documents `$XDG_CONFIG_HOME/amp/plugins`. On a Linux box whose owner moved their config, the install landed where the agent never looks. `SSHAgentConfigStore.quote` now expands both XDG bases — a no-op on a Mac, which sets neither.

**The plugin dialects declined outright.** OpenCode, Pi and Amp now install on a device. The templates take a `HookReporter` and generate the `termiod set-status` form; the id comes from `process.env.TERMIOD_SESSION_ID`, and a plugin loaded outside a termiod session reports nothing rather than calling `set-status` with an empty id. Pi needed no device branch of its own — it already shells out through `pi.exec("sh", …)`, so it takes the same string the JSON-manifest dialects get.

**A merge committed unconditionally.** A hook is a merge into a file the user also owns, and over a network the read and the write are two round trips with their editor in between. `write(_:to:ifUnchangedFrom:)` commits against the bytes the merge was computed from; the SSH store does the digest check and the rename in one remote command. A lost race reports the agent as not installed rather than re-merging in a loop that would fight a live editor. This is RFC D4 on the v0 arm, where the race actually is.

## Verification

Installed end to end onto a real Ubuntu box over ssh:

- The probe finds `claude` at `~/.local/bin/claude` (it did not before) and still answers no for an absent binary.
- 12 agents' hooks and the device skill installed, none refused. The device payload landed, not the Mac one.
- The installed hook command was executed on the box: exit 0.
- The box's own `settings.json` keys (`autoMode`, `theme`, `tui`) survived untouched.
- A commit against stale bytes was refused; a fresh one was taken.

Plus, locally: `swift test` — 641 tests, 0 failures. The emitted shell forms run through `sh` with XDG set, unset, and with a home containing a space. The generated plugins pass `node --check`, and driving the Amp one with `HOME=/home/deploy` and `TERMIOD_SESSION_ID=abc-123` yields the argv `["/home/deploy/.local/bin/termiod", "abc-123", "working"]`; with no session id it makes zero shell calls. Local (`.thisMac`) output is byte-identical to before.

The XDG rule holds on **both** machines. `XDGBaseDirectories.expand` is the local spelling of the shell rule the SSH store emits, and `LocalAgentConfigStore` and `AgentSessionStore` resolve through it — a Mac whose owner sets `XDG_CONFIG_HOME` would otherwise install skills where OpenCode does not read them, and miss OpenCode's session records under `XDG_DATA_HOME`. It needs variables a Finder-launched app does not inherit, so `AgentAvailability`'s existing login-shell probe carries them: one spawn, same bound, same cache. Both are unset on a default account, where this resolves exactly as `expandingTildeInPath` always did.

Left undone: RFC D3 (`home:` dest), which belongs to the v1 transfer-plane arm this does not touch.

Release Notes:
- Agent status hooks and skills now install correctly on a Linux device, including OpenCode, Pi and Amp, which were previously skipped.
- Agents installed outside a device's default `PATH` are found instead of reported missing.
