### PR TITLE
Switch the iOS home screens between workspaces with a left rail

### DIFF
--- a/ios/Sources/Localizable.xcstrings
+++ b/ios/Sources/Localizable.xcstrings
@@ -1481,16 +1481,6 @@
         }
       }
     },
-    "on %@": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在 %@ 上"
-          }
-        }
-      }
-    },
     "plain text": {
       "localizations": {
         "zh-Hans": {
@@ -1687,6 +1677,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "主题"
+          }
+        }
+      }
+    },
+    "Workspaces": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区"
           }
         }
       }

--- a/ios/Sources/ProjectListViewController.swift
+++ b/ios/Sources/ProjectListViewController.swift
@@ -2,55 +2,41 @@ import SwiftUI
 import TermioShared
 import UIKit
 
-/// The root screen: the project list, with a "Needs You" strip pinned above
-/// it. GitHub-mobile shape — the backbone is "what do I have open" (one row
-/// per project, with a status summary so nothing needs opening to check on),
-/// while the strip keeps the phone's highest-frequency question ("which agent
-/// is waiting on me?") answerable at a glance and one tap from its terminal.
-/// Tapping a project pushes its page (sessions + new-session). Lives at the
-/// root of the home navigation stack inside RootContainerViewController.
+/// The root screen: one workspace's project list, with a "Needs You" strip
+/// pinned above it. GitHub-mobile shape — the backbone is "what do I have open"
+/// (one row per project, with a status summary so nothing needs opening to check
+/// on), while the strip keeps the phone's highest-frequency question ("which
+/// agent is waiting on me?") answerable at a glance and one tap from its
+/// terminal.
+///
+/// Slack's split: the title names the workspace you are in, the rail switches
+/// it, and the list underneath is only ever that one workspace's. The strip is
+/// the deliberate exception — it crosses every workspace, which is what makes
+/// showing one at a time safe.
+///
+/// Tapping a project pushes its page (sessions + new-session). Lives at the root
+/// of the home navigation stack inside RootContainerViewController.
 final class ProjectListViewController: UIViewController {
     private let store: RosterStore
-
-    /// One workspace's projects — the group the table draws as a section. The
-    /// Mac's tree is Device → Workspace → Project → Session, and the phone was
-    /// showing only the last two: every machine's checkouts poured into one
-    /// column, a VPS clone indistinguishable from a local one. The workspace is
-    /// the group; `deviceAlias` is the machine it is on, named in the header the
-    /// way the Mac names it, and never a level you navigate.
-    private struct WorkspaceGroup {
-        let id: String
-        let name: String
-        let deviceAlias: String?
-        var projects: [MockProject]
-
-        /// The machine to put after the workspace name, and nil when there is
-        /// nothing to add: this Mac carries no mark — being on the machine you
-        /// paired with is the absence of one — and neither does a workspace
-        /// already named after its box, where the header says it once. Both
-        /// rules are the desktop sidebar's.
-        var machineLabel: String? {
-            guard let deviceAlias,
-                  deviceAlias.caseInsensitiveCompare(name) != .orderedSame
-            else { return nil }
-            return deviceAlias
-        }
-    }
+    /// The workspace on screen. The strip above the list ignores it — see
+    /// `refilter`.
+    private let scope: WorkspaceScope
+    /// Reveal the shell's workspace rail. The shell owns the panel, so the
+    /// title-bar opener only asks for it.
+    var onOpenWorkspaceRail: (() -> Void)?
 
     private enum Section {
         case needsYou
-        /// An index into `groups`.
-        case workspace(Int)
+        case projects
     }
 
     /// The sections currently on screen, rebuilt on every roster change.
     private var sections: [Section] = []
-    /// Cross-project attention sessions (the strip's rows).
+    /// Cross-workspace attention sessions (the strip's rows).
     private var attention: [MockSession] = []
-    /// The store's projects, grouped by workspace in roster order — what the
-    /// table shows. Chats- and Terminals-kind containers are excluded: they have
-    /// their own tabs.
-    private var groups: [WorkspaceGroup] = []
+    /// The workspace's projects, in roster order. Chats- and Terminals-kind
+    /// containers are excluded: they have their own tabs.
+    private var projects: [MockProject] = []
 
     /// Mirrors the Mac sidebar's sort pull-down. The roster arrives in the
     /// Mac's recent-activity order, so "Recent Activity" means "as pushed";
@@ -58,6 +44,12 @@ final class ProjectListViewController: UIViewController {
     private var sortByName = UserDefaults.standard.string(forKey: "sessions.sortOrder") == "name"
 
     private let filterButton = UIButton(type: .system)
+    /// Opens the workspace rail. Absent whenever the rail is (one workspace, or
+    /// none yet), so the common case keeps exactly the title bar it had.
+    private let workspaceButton = UIButton(type: .system)
+    /// The workspace in scope, and the machine it is on when that needs saying.
+    private let pageTitle = UILabel()
+    private let machineLabel = UILabel()
     private let tableView = UITableView(frame: .zero, style: .grouped)
     /// The Telegram/iMessage-style zero state shown when there are no projects
     /// to list — never fake rows. Its copy tracks `CompanionLink.state`.
@@ -69,9 +61,11 @@ final class ProjectListViewController: UIViewController {
     private var rosterObserver: NSObjectProtocol?
     private var linkStateObserver: NSObjectProtocol?
     private var themeObserver: NSObjectProtocol?
+    private var workspaceObserver: NSObjectProtocol?
 
-    init(store: RosterStore) {
+    init(store: RosterStore, scope: WorkspaceScope) {
         self.store = store
+        self.scope = scope
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -98,17 +92,17 @@ final class ProjectListViewController: UIViewController {
         ) { [weak self] _ in
             MainActor.assumeIsolated { self?.updateEmptyState() }
         }
+        workspaceObserver = NotificationCenter.default.addObserver(
+            forName: WorkspaceScope.didChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refilter() }
+        }
     }
 
     deinit {
-        if let rosterObserver {
-            NotificationCenter.default.removeObserver(rosterObserver)
-        }
-        if let linkStateObserver {
-            NotificationCenter.default.removeObserver(linkStateObserver)
-        }
-        if let themeObserver {
-            NotificationCenter.default.removeObserver(themeObserver)
+        let observers = [rosterObserver, linkStateObserver, themeObserver, workspaceObserver]
+        for observer in observers.compactMap({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
         }
         connectingGraceTimer?.invalidate()
     }
@@ -120,10 +114,29 @@ final class ProjectListViewController: UIViewController {
     // MARK: - Top bar (large title + sort)
 
     private func configureTopBar() -> UIView {
-        let pageTitle = UILabel()
-        pageTitle.text = localized("Projects")
+        // The workspace's own name, not the tab's — the title bar says which
+        // context you are in, and the rail is what changes it. A roster that
+        // never names a workspace (the bundled mock, an older Mac) falls back to
+        // the tab's word, so those screens read exactly as they did.
         pageTitle.font = .systemFont(ofSize: 34, weight: .bold)
         pageTitle.textColor = .label
+        pageTitle.lineBreakMode = .byTruncatingTail
+        // The name is the identity; the sort button never gives way for it.
+        pageTitle.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        // Which machine the workspace is on, under its name. It used to ride the
+        // section header; with the header gone the claim belongs to the thing it
+        // qualifies. Hidden for the Mac you paired with — being on that machine
+        // is the absence of a mark.
+        machineLabel.font = .systemFont(ofSize: 13, weight: .regular)
+        machineLabel.textColor = .secondaryLabel
+        machineLabel.lineBreakMode = .byTruncatingTail
+        machineLabel.isHidden = true
+
+        let titleStack = UIStackView(arrangedSubviews: [pageTitle, machineLabel])
+        titleStack.axis = .vertical
+        titleStack.alignment = .leading
+        titleStack.spacing = 0
 
         // The Mac sidebar's sort pull-down, translated to iMessage chrome:
         // a glass circle riding the large title, menu as primary action.
@@ -137,8 +150,20 @@ final class ProjectListViewController: UIViewController {
             },
         ])
 
+        // Leading, where Slack and every sidebar toggle put it: the rail comes
+        // from that edge, so the control that opens it should too. Hidden by
+        // default — a hidden arranged subview contributes neither width nor
+        // spacing, so a one-workspace title bar is untouched.
+        workspaceButton.applyGlassIcon(.sidebarLeft, boxSize: 22)
+        workspaceButton.tintColor = .label
+        workspaceButton.accessibilityIdentifier = "home.workspaceRail"
+        workspaceButton.isHidden = true
+        workspaceButton.addAction(UIAction { [weak self] _ in
+            self?.onOpenWorkspaceRail?()
+        }, for: .touchUpInside)
+
         let spacer = UIView()
-        let bar = UIStackView(arrangedSubviews: [pageTitle, spacer, filterButton])
+        let bar = UIStackView(arrangedSubviews: [workspaceButton, titleStack, spacer, filterButton])
         bar.axis = .horizontal
         bar.alignment = .center
         bar.spacing = 8
@@ -151,6 +176,8 @@ final class ProjectListViewController: UIViewController {
             // Telegram's nav-bar glass buttons are 40pt circles.
             filterButton.widthAnchor.constraint(equalToConstant: 40),
             filterButton.heightAnchor.constraint(equalToConstant: 40),
+            workspaceButton.widthAnchor.constraint(equalToConstant: 40),
+            workspaceButton.heightAnchor.constraint(equalToConstant: 40),
         ])
         return bar
     }
@@ -219,60 +246,46 @@ final class ProjectListViewController: UIViewController {
         ])
     }
 
-    /// Rebuild the section list from the store: the attention strip (only when
-    /// non-empty), then one section per workspace. The loose funnels (Chats,
+    /// Rebuild the page from the store: the attention strip (only when
+    /// non-empty), then the workspace in scope. The loose funnels (Chats,
     /// Terminals) belong to their own tabs, so they're kept out of the folder
     /// list — their attention sessions still surface in the strip here, the
     /// cross-cutting shortcut.
+    ///
+    /// The roster's order is the Mac sidebar's order; "Name" re-sorts locally.
     private func refilter() {
+        // Read straight from the store, past the workspace scope. "Needs You" is
+        // the cross-workspace question the phone is opened to answer, so it is
+        // never scoped — a blocked agent in a workspace that isn't on screen is
+        // exactly the one that would otherwise go unnoticed. It is also what
+        // makes showing one workspace at a time safe.
         attention = store.attentionSessions
-        let folders = store.projects.filter { $0.kind != "chats" && $0.kind != "terminals" }
-        groups = Self.grouped(folders, sortedByName: sortByName)
-        sections = (attention.isEmpty ? [] : [.needsYou]) + groups.indices.map(Section.workspace)
+        projects = store.projects.filter {
+            $0.kind != "chats" && $0.kind != "terminals" && scope.admits($0)
+        }
+        if sortByName {
+            projects.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        }
+        sections = (attention.isEmpty ? [] : [.needsYou]) + (projects.isEmpty ? [] : [.projects])
+        updateTitle()
         tableView.reloadData()
         updateEmptyState()
     }
 
-    /// Projects into workspace groups. Workspaces keep the order the Mac pushed
-    /// them in — the sidebar's own order — and only the projects inside a group
-    /// re-sort when the user picks Name, so switching sort never reshuffles the
-    /// machines out from under them.
-    private static func grouped(_ projects: [MockProject], sortedByName: Bool) -> [WorkspaceGroup] {
-        var groups: [WorkspaceGroup] = []
-        var indexByWorkspace: [String: Int] = [:]
-        for project in projects {
-            if let index = indexByWorkspace[project.workspaceID] {
-                groups[index].projects.append(project)
-                continue
-            }
-            indexByWorkspace[project.workspaceID] = groups.count
-            groups.append(WorkspaceGroup(
-                id: project.workspaceID,
-                name: project.workspaceName,
-                deviceAlias: project.deviceAlias,
-                projects: [project]
-            ))
-        }
-        guard sortedByName else { return groups }
-        return groups.map { group in
-            var sorted = group
-            sorted.projects.sort {
-                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-            }
-            return sorted
-        }
-    }
-
-    /// Every project on screen, in section order.
-    private var visible: [MockProject] { groups.flatMap(\.projects) }
-
-    /// Whether the sections are headed by their workspace. One unnamed local
-    /// workspace is the case almost everyone is in, and the Mac hides its own
-    /// workspace switcher there too — the page title already says "Projects".
-    /// A second workspace, or one that names a machine, is what makes the
-    /// grouping worth a header.
-    private var showsWorkspaceHeaders: Bool {
-        groups.count > 1 || groups.contains { $0.deviceAlias != nil && !$0.name.isEmpty }
+    /// The title names the workspace on screen, with its machine underneath when
+    /// that isn't the paired Mac. The opener beside it appears only when there is
+    /// a second workspace to reach — one workspace is no choice at all, and the
+    /// title then just reads its name.
+    private func updateTitle() {
+        let machines = RailMachine.roster(from: store.projects)
+        let workspace = machines.workspace(id: scope.selectedID)
+        let name = workspace?.name ?? ""
+        pageTitle.text = name.isEmpty ? localized("Projects") : name
+        machineLabel.text = workspace?.machineLabel
+        machineLabel.isHidden = workspace?.machineLabel == nil
+        workspaceButton.isHidden = machines.workspaceCount < 2
+        workspaceButton.accessibilityLabel = localized("Workspaces")
+        workspaceButton.accessibilityValue = pageTitle.text
     }
 
     // MARK: - Empty state
@@ -297,7 +310,7 @@ final class ProjectListViewController: UIViewController {
     /// stalled (the Mac isn't answering — offer Try Again), or connected-but-idle
     /// (nudge toward opening a project on the Mac).
     private func updateEmptyState() {
-        emptyState.isHidden = !visible.isEmpty || !attention.isEmpty
+        emptyState.isHidden = !projects.isEmpty || !attention.isEmpty
         guard !emptyState.isHidden else {
             stopConnectingGraceTimer()
             return
@@ -393,6 +406,10 @@ final class ProjectListViewController: UIViewController {
     }
 }
 
+/// The Projects root shows one workspace at a time, so the shell arms the rail's
+/// edge gesture here.
+extension ProjectListViewController: WorkspaceScoped {}
+
 // MARK: - Table data source / delegate
 
 extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate {
@@ -403,7 +420,7 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch sections[section] {
         case .needsYou: attention.count
-        case .workspace(let index): groups[index].projects.count
+        case .projects: projects.count
         }
     }
 
@@ -415,20 +432,19 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
         switch sections[section] {
         case .needsYou:
             header.configure(title: localized("Needs You"))
-        case .workspace(let index):
-            let group = groups[index]
-            header.configure(
-                title: showsWorkspaceHeaders ? group.name : localized("Projects"),
-                detail: showsWorkspaceHeaders ? group.machineLabel : nil
-            )
+        case .projects:
+            // "Projects", never the workspace's name: the title above already
+            // says which workspace this is, and a caption repeating it is the
+            // section header the title replaced.
+            header.configure(title: localized("Projects"))
         }
         return header
     }
 
-    /// Headers appear when the strip splits the page in two, or when the
-    /// workspaces themselves need naming.
+    /// Headers only earn their space once the strip splits the page in two —
+    /// with a single section the caption would name what the title just named.
     private var showsHeaders: Bool {
-        sections.count > 1 || showsWorkspaceHeaders
+        sections.count > 1
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -463,8 +479,7 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
             }
             .margins(.horizontal, 12)
             .margins(.vertical, 0)
-        case .workspace(let index):
-            let projects = groups[index].projects
+        case .projects:
             cell.contentConfiguration = UIHostingConfiguration {
                 ProjectRow(
                     project: projects[indexPath.row],
@@ -483,9 +498,9 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
             // Straight to the terminal — the strip exists so the blocked
             // session is one tap away, never behind its project page.
             store.openSession(attention[indexPath.row])
-        case .workspace(let index):
+        case .projects:
             navigationController?.pushViewController(
-                ProjectDetailViewController(store: store, project: groups[index].projects[indexPath.row]),
+                ProjectDetailViewController(store: store, project: projects[indexPath.row]),
                 animated: true
             )
         }
@@ -515,8 +530,8 @@ extension ProjectListViewController: UITableViewDataSource, UITableViewDelegate 
         contextMenuConfigurationForRowAt indexPath: IndexPath,
         point: CGPoint
     ) -> UIContextMenuConfiguration? {
-        guard case .workspace(let index) = sections[indexPath.section] else { return nil }
-        let project = groups[index].projects[indexPath.row]
+        guard case .projects = sections[indexPath.section] else { return nil }
+        let project = projects[indexPath.row]
         guard store.companionURL != nil, project.rosterID != nil else { return nil }
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             UIMenu(title: project.name, children: self?.store.newSessionActions(in: project) ?? [])
@@ -592,54 +607,33 @@ private struct ProjectRow: View {
 
 // MARK: - Section header
 
-/// A small gray caps label capping a group, with room for one trailing detail —
-/// the machine a workspace is on. Mail and Files head their groups the same way:
-/// the account or location names the section, and the rows underneath say
+/// A small gray caps label capping a group. Mail and Files head their groups the
+/// same way: the caption names what the rows under it are, and the rows say
 /// nothing more about where they live.
-///
-/// The detail keeps its own case. It is an `~/.ssh/config` alias, a literal the
-/// user typed, and uppercasing it would make it something they can't find again.
 private final class SectionCapView: UITableViewHeaderFooterView {
     static let reuseID = "sectionCap"
 
     private let label = UILabel()
-    private let detailLabel = UILabel()
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
         label.font = .systemFont(ofSize: 13, weight: .semibold)
         label.textColor = .secondaryLabel
         label.translatesAutoresizingMaskIntoConstraints = false
-        detailLabel.font = .systemFont(ofSize: 13, weight: .regular)
-        detailLabel.textColor = .tertiaryLabel
-        detailLabel.textAlignment = .right
-        // The workspace name is the section's identity; the machine gives way
-        // when there isn't room for both.
-        detailLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        detailLabel.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(label)
-        contentView.addSubview(detailLabel)
         NSLayoutConstraint.activate([
             label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 22),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -22),
             label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -6),
-            detailLabel.leadingAnchor.constraint(
-                greaterThanOrEqualTo: label.trailingAnchor, constant: 8),
-            detailLabel.trailingAnchor.constraint(
-                equalTo: contentView.trailingAnchor, constant: -22),
-            detailLabel.firstBaselineAnchor.constraint(equalTo: label.firstBaselineAnchor),
         ])
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    func configure(title: String, detail: String? = nil) {
+    func configure(title: String) {
         label.text = title.uppercased()
-        detailLabel.text = detail
-        detailLabel.isHidden = detail == nil
         isAccessibilityElement = true
         accessibilityTraits = .header
-        // VoiceOver reads the group once, so the machine belongs in the same
-        // breath as the name rather than as a second, orphaned element.
-        accessibilityLabel = detail.map { "\(title), \(localized("on \($0)"))" } ?? title
+        accessibilityLabel = title
     }
 }

--- a/ios/Sources/RootContainerViewController.swift
+++ b/ios/Sources/RootContainerViewController.swift
@@ -27,12 +27,20 @@ import UIKit
 final class RootContainerViewController: UIViewController {
     /// The one live roster model, shared by every home screen.
     let store = RosterStore()
+    /// Which workspace the home screens are showing. Lives here rather than on a
+    /// screen because the rail that sets it is the shell's, and the lists that
+    /// read it are in different tabs.
+    let workspaceScope = WorkspaceScope()
+    /// The Projects tab's root list.
+    private lazy var projectList: ProjectListViewController = {
+        let list = ProjectListViewController(store: store, scope: workspaceScope)
+        list.onOpenWorkspaceRail = { [weak self] in self?.setWorkspaceRail(open: true) }
+        return list
+    }()
     /// The Projects tab's stack: the root list, plus a pushed project page.
     /// Plain UIKit views only — terminals never enter this stack (see the
     /// containment note above), so a real navigation controller is safe here.
-    private lazy var projectsNav = HomeNavigationController(
-        rootViewController: ProjectListViewController(store: store)
-    )
+    private lazy var projectsNav = HomeNavigationController(rootViewController: projectList)
     /// The Chats tab's stack: the flat chat list (nothing pushes onto it yet;
     /// a nav keeps both tabs the same shape).
     private lazy var chatsNav = HomeNavigationController(
@@ -100,19 +108,30 @@ final class RootContainerViewController: UIViewController {
 
     private var themeObserver: NSObjectProtocol?
     private var pairingObserver: NSObjectProtocol?
+    private var rosterObserver: NSObjectProtocol?
 
     deinit {
-        if let themeObserver {
-            NotificationCenter.default.removeObserver(themeObserver)
-        }
-        if let pairingObserver {
-            NotificationCenter.default.removeObserver(pairingObserver)
+        for observer in [themeObserver, pairingObserver, rosterObserver].compactMap({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         themeObserver = installThemeBackdrop()
+
+        // Registered before the tabs load their views, so the first roster has
+        // already named the workspace in scope — and a roster that closes it has
+        // already moved on — by the time the lists re-filter on the same push.
+        rosterObserver = NotificationCenter.default.addObserver(
+            forName: RosterStore.didChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.workspaceScope.reconcile(against: self.store.projects)
+            }
+        }
+        configureWorkspaceRailGesture()
 
         // The native tab controller is the permanent base layer. Its selected
         // navigation stack can change without affecting terminal overlays,
@@ -193,6 +212,7 @@ final class RootContainerViewController: UIViewController {
     func open(_ screen: UIViewController, sessionKey: String? = nil, animated: Bool = true) {
         loadViewIfNeeded()
         guard activeScreen !== screen else { return }
+        dismissWorkspaceRailImmediately()
 
         if let sessionKey {
             recentTerminals[sessionKey] = screen
@@ -275,6 +295,213 @@ final class RootContainerViewController: UIViewController {
             screen.view.frame = offscreen
             finish()
         }
+    }
+
+    // MARK: - Workspace rail
+
+    /// The rail's content; the panel's motion and gestures stay here so one
+    /// place owns its frames and a drag can always take it back mid-flight.
+    private lazy var workspaceRail: WorkspaceRailViewController = {
+        let rail = WorkspaceRailViewController(store: store, scope: workspaceScope)
+        rail.onSelect = { [weak self] in self?.setWorkspaceRail(open: false) }
+        return rail
+    }()
+    /// Holds the dimming and the panel together, so one `isHidden` keeps the
+    /// closed rail from intercepting a single touch.
+    private let railContainer = UIView()
+    private let railDim = UIControl()
+    /// 0 closed, 1 open. The *model* position: during a settle it already holds
+    /// the target, which is why an interrupt reads the layer instead.
+    private var railProgress: CGFloat = 0
+    private var railAnimator: UIViewPropertyAnimator?
+    /// Where the rail stood when the current drag started, so a drag that begins
+    /// mid-settle continues from there instead of snapping to the finger.
+    private var railDragStart: CGFloat = 0
+    private var railInstalled = false
+
+    private var railWidth: CGFloat { min(view.bounds.width * 0.78, 320) }
+
+    /// The rail is offered on a tab-bar home root and nowhere else. On a pushed
+    /// page the left edge is the system back gesture, and inside a terminal the
+    /// surface's own pan already means leftward-drawer / rightward-back — a
+    /// second recognizer on either would be two gestures fighting for one edge.
+    /// A single workspace is no choice at all, so there is nothing to reveal.
+    private var canPresentWorkspaceRail: Bool {
+        guard activeScreen == nil else { return false }
+        guard RailMachine.roster(from: store.projects).workspaceCount > 1 else { return false }
+        guard let nav = homeTabs.selectedViewController as? UINavigationController,
+              nav.viewControllers.count == 1,
+              nav.viewControllers.first is WorkspaceScoped
+        else { return false }
+        return true
+    }
+
+    private func configureWorkspaceRailGesture() {
+        let edge = UIScreenEdgePanGestureRecognizer(
+            target: self, action: #selector(handleRailEdgePan(_:))
+        )
+        edge.edges = .left
+        edge.delegate = self
+        view.addGestureRecognizer(edge)
+    }
+
+    /// The opener beside the page title, and the rail's own dismissals. An edge
+    /// gesture on its own is undiscoverable, so the tap is not a convenience.
+    func setWorkspaceRail(open: Bool) {
+        guard open ? canPresentWorkspaceRail : railInstalled else { return }
+        installWorkspaceRailIfNeeded()
+        if open { presentRailContainer() }
+        settleRail(open: open, velocityX: 0)
+    }
+
+    private func installWorkspaceRailIfNeeded() {
+        guard !railInstalled else { return }
+        railInstalled = true
+
+        railContainer.frame = view.bounds
+        railContainer.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        railContainer.isHidden = true
+        view.addSubview(railContainer)
+
+        railDim.backgroundColor = .black
+        railDim.alpha = 0
+        railDim.frame = railContainer.bounds
+        railDim.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        railDim.addAction(UIAction { [weak self] _ in
+            self?.setWorkspaceRail(open: false)
+        }, for: .touchUpInside)
+        railContainer.addSubview(railDim)
+
+        addChild(workspaceRail)
+        railContainer.addSubview(workspaceRail.view)
+        workspaceRail.didMove(toParent: self)
+        workspaceRail.view.layer.shadowColor = UIColor.black.cgColor
+        workspaceRail.view.layer.shadowOpacity = 0.3
+        workspaceRail.view.layer.shadowRadius = 12
+        workspaceRail.view.layer.shadowOffset = CGSize(width: 4, height: 0)
+
+        // Swiping the open rail leftwards puts it away — the terminal drawer's
+        // close pan, mirrored.
+        let closePan = UIPanGestureRecognizer(target: self, action: #selector(handleRailClosePan(_:)))
+        closePan.delegate = self
+        workspaceRail.view.addGestureRecognizer(closePan)
+
+        layoutRail(progress: 0)
+    }
+
+    /// Bring the rail up as the top layer and give it fresh contents. Called on
+    /// every open, including the first frame of a drag, so a roster push while
+    /// it was away can never be shown stale.
+    private func presentRailContainer() {
+        workspaceRail.reload()
+        railContainer.isHidden = false
+        view.bringSubviewToFront(railContainer)
+    }
+
+    /// Frames only — no `isHidden`, no hit-testing. This runs inside the settle
+    /// animation, where flipping visibility would hide the panel on the first
+    /// frame of a close instead of the last.
+    private func layoutRail(progress: CGFloat) {
+        railProgress = progress
+        let width = railWidth
+        workspaceRail.view.frame = CGRect(
+            x: -width + width * progress, y: 0, width: width, height: view.bounds.height
+        )
+        railDim.alpha = 0.15 * progress
+    }
+
+    /// Take an in-flight settle back at exactly where it is on screen. Reading
+    /// the presentation layer rather than `railProgress` is the whole point: the
+    /// model position is already at the target the moment the animator starts.
+    private func interruptRailAnimation() {
+        guard let animator = railAnimator else { return }
+        railAnimator = nil
+        guard animator.isRunning else { return }
+        let presented = workspaceRail.view.layer.presentation()?.frame.origin.x
+        animator.stopAnimation(true)
+        guard let presented else { return }
+        layoutRail(progress: max(0, min(1, (presented + railWidth) / railWidth)))
+    }
+
+    /// Release: run to open or closed with the fling carried into the spring.
+    /// The velocity is normalized to fractions of the *remaining* travel per
+    /// second toward the committed target, so a flick keeps its speed and a
+    /// reversal or a gentle release starts from rest.
+    private func settleRail(open: Bool, velocityX: CGFloat) {
+        interruptRailAnimation()
+        railDim.isUserInteractionEnabled = open
+        let width = railWidth
+        let remaining = width * (open ? 1 - railProgress : railProgress)
+        let towardTarget = open ? velocityX : -velocityX
+        let initial = remaining > 1 ? min(max(towardTarget / remaining, 0), 30) : 0
+        let timing = UISpringTimingParameters(
+            dampingRatio: 0.9, initialVelocity: CGVector(dx: initial, dy: 0)
+        )
+        let animator = UIViewPropertyAnimator(duration: 0.35, timingParameters: timing)
+        animator.isInterruptible = true
+        animator.addAnimations { self.layoutRail(progress: open ? 1 : 0) }
+        animator.addCompletion { [weak self] position in
+            guard let self, position == .end else { return }
+            railAnimator = nil
+            if !open { railContainer.isHidden = true }
+        }
+        railAnimator = animator
+        animator.startAnimation()
+    }
+
+    /// The reveal: drag right from the left edge of a home screen. Tracks the
+    /// finger from the first `.changed`, never waiting for `.ended`.
+    @objc private func handleRailEdgePan(_ pan: UIScreenEdgePanGestureRecognizer) {
+        switch pan.state {
+        case .began:
+            installWorkspaceRailIfNeeded()
+            interruptRailAnimation()
+            presentRailContainer()
+            railDim.isUserInteractionEnabled = true
+            railDragStart = railProgress
+        case .changed:
+            let progress = railDragStart + pan.translation(in: view).x / railWidth
+            layoutRail(progress: max(0, min(1, progress)))
+        case .ended, .cancelled:
+            let velocityX = pan.velocity(in: view).x
+            // A decisive flick wins over position in either direction; position
+            // only decides a gentle release. Otherwise a hard flick back still
+            // committed the way the finger had already travelled.
+            let open = pan.state == .ended
+                && (abs(velocityX) > 300 ? velocityX > 0 : railProgress > 0.4)
+            settleRail(open: open, velocityX: velocityX)
+        default:
+            break
+        }
+    }
+
+    /// The dismissal: drag the open rail back off the left edge.
+    @objc private func handleRailClosePan(_ pan: UIPanGestureRecognizer) {
+        switch pan.state {
+        case .began:
+            interruptRailAnimation()
+            railDragStart = railProgress
+        case .changed:
+            let progress = railDragStart + pan.translation(in: view).x / railWidth
+            layoutRail(progress: max(0, min(1, progress)))
+        case .ended, .cancelled:
+            let velocityX = pan.velocity(in: view).x
+            let open = pan.state != .ended
+                || (abs(velocityX) > 300 ? velocityX > 0 : railProgress > 0.6)
+            settleRail(open: open, velocityX: velocityX)
+        default:
+            break
+        }
+    }
+
+    /// A terminal is about to cover the shell — the rail has no business over
+    /// it, and the surface owns every pan from here.
+    private func dismissWorkspaceRailImmediately() {
+        guard railInstalled, railProgress > 0 || railAnimator != nil else { return }
+        interruptRailAnimation()
+        railDim.isUserInteractionEnabled = false
+        layoutRail(progress: 0)
+        railContainer.isHidden = true
     }
 
     // MARK: - Interactive back (finger-tracked right-swipe)
@@ -407,6 +634,21 @@ final class RootContainerViewController: UIViewController {
         screen.view.removeFromSuperview()
         (screen as? TerminalViewController)?.releaseOrphanedSurfaceLayers()
         screen.removeFromParent()
+    }
+}
+
+// MARK: - Rail gesture gating
+
+extension RootContainerViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gesture: UIGestureRecognizer) -> Bool {
+        if gesture is UIScreenEdgePanGestureRecognizer {
+            return canPresentWorkspaceRail
+        }
+        // The close pan rides the rail's own view, over a vertically scrolling
+        // table: only a clearly horizontal drag is the rail's.
+        guard let pan = gesture as? UIPanGestureRecognizer else { return true }
+        let velocity = pan.velocity(in: view)
+        return abs(velocity.x) > abs(velocity.y)
     }
 }
 

--- a/ios/Sources/WorkspaceRail.swift
+++ b/ios/Sources/WorkspaceRail.swift
@@ -1,0 +1,377 @@
+import SwiftUI
+import TermioShared
+import UIKit
+
+// MARK: - The scope
+
+/// Which workspace the home lists are showing. Slack's shape all the way down:
+/// the rail is context, the list is content, and the title names the context you
+/// are in — so this is one workspace at a time, never a union of them.
+///
+/// App-scoped rather than owned by a screen. The rail lives in the shell above
+/// the tab bar and the lists that honour it sit in different tabs, so the choice
+/// has to outlive any one of them. It outlives the process too: coming back to
+/// the workspace you left is the whole reason a switcher is worth having.
+///
+/// What this deliberately never reaches is the "Needs You" strip. That strip
+/// answers the cross-workspace question the phone exists for — which agent is
+/// blocked on me, anywhere — so scoping it would hide the very thing the app was
+/// opened to see. It is also what makes a single-workspace list safe: nothing
+/// goes unnoticed just because it is out of scope.
+@MainActor
+final class WorkspaceScope {
+    /// Posted after the scope changes; screens re-filter on it.
+    static let didChange = Notification.Name("WorkspaceScopeDidChange")
+
+    private static let storageKey = "workspace.currentID"
+
+    /// The Mac's workspace id in scope. nil only before the first roster of a
+    /// fresh install has named one.
+    private(set) var selectedID: String?
+
+    init() {
+        let stored = UserDefaults.standard.string(forKey: Self.storageKey)
+        // Empty reads as "nothing chosen", so a launch-argument override can
+        // clear it and `reconcile` picks the roster's first workspace again.
+        selectedID = (stored?.isEmpty ?? true) ? nil : stored
+    }
+
+    /// Does a project belong to the current scope? Everything passes while no
+    /// workspace has been chosen yet, so a roster that arrives a beat ahead of
+    /// `reconcile` shows a full list rather than a blank one.
+    func admits(_ project: MockProject) -> Bool {
+        guard let selectedID else { return true }
+        return project.workspaceID == selectedID
+    }
+
+    func select(_ id: String) {
+        guard id != selectedID else { return }
+        selectedID = id
+        UserDefaults.standard.set(id, forKey: Self.storageKey)
+        NotificationCenter.default.post(name: Self.didChange, object: nil)
+    }
+
+    /// Keep the scope on a workspace the Mac is actually pushing: the first one
+    /// in roster order on a first launch, and again when the one in scope closes
+    /// or the phone switches to a Mac that never heard of it.
+    ///
+    /// An empty roster is left alone — a dropped socket must not spend the
+    /// remembered workspace, because reconnecting is supposed to land back where
+    /// the user was.
+    func reconcile(against projects: [MockProject]) {
+        guard let first = projects.first?.workspaceID else { return }
+        if let selectedID, projects.contains(where: { $0.workspaceID == selectedID }) { return }
+        select(first)
+    }
+}
+
+/// A tab-bar home root that shows one workspace at a time. The rail's edge
+/// gesture and its opener are offered only on screens that adopt this, so a
+/// swipe never reveals a rail that would change nothing.
+@MainActor
+protocol WorkspaceScoped: AnyObject {}
+
+// MARK: - The roster the rail draws
+
+/// One rail row: a workspace the Mac has pushed at least one container for. The
+/// Mac emits nothing at all for an empty workspace, so every row here has
+/// something behind it.
+struct RailWorkspace: Equatable {
+    let id: String
+    let name: String
+    /// The `~/.ssh/config` alias of the machine it is on, nil for the paired Mac.
+    let deviceAlias: String?
+
+    /// The machine to name alongside this workspace, and nil when there is
+    /// nothing to add: the paired Mac carries no mark — being on the machine you
+    /// paired with is the absence of one — and neither does a workspace already
+    /// named after its box. Both rules are the desktop sidebar's.
+    var machineLabel: String? {
+        guard let deviceAlias,
+              deviceAlias.caseInsensitiveCompare(name) != .orderedSame
+        else { return nil }
+        return deviceAlias
+    }
+}
+
+/// One machine's workspaces. A workspace belongs to exactly one machine, so this
+/// grouping costs nothing to derive and is never ambiguous.
+struct RailMachine {
+    /// The `~/.ssh/config` alias, nil for the paired Mac itself.
+    let alias: String?
+    var workspaces: [RailWorkspace]
+
+    /// What heads the group. The paired Mac has no alias, so it borrows the name
+    /// that Mac reports, and falls back to the generic before anything has named
+    /// it.
+    var title: String {
+        alias ?? CompanionLink.activeMac?.name ?? localized("This Mac")
+    }
+
+    /// The roster in the order the Mac pushed it: workspaces in first-appearance
+    /// order, gathered under the machine they are on, machines likewise in the
+    /// order their first workspace appeared. Sorting is never applied here — the
+    /// desktop sidebar's order is the order, and a rail that re-shuffles under
+    /// the finger is a rail nobody builds muscle memory for.
+    static func roster(from projects: [MockProject]) -> [RailMachine] {
+        var machines: [RailMachine] = []
+        var machineIndex: [String: Int] = [:]
+        var seenWorkspaces: Set<String> = []
+        for project in projects where !seenWorkspaces.contains(project.workspaceID) {
+            seenWorkspaces.insert(project.workspaceID)
+            let workspace = RailWorkspace(
+                id: project.workspaceID,
+                name: project.workspaceName,
+                deviceAlias: project.deviceAlias
+            )
+            // nil (this Mac) needs a key of its own that no alias can collide with.
+            let key = project.deviceAlias.map { "alias:\($0)" } ?? "self"
+            if let index = machineIndex[key] {
+                machines[index].workspaces.append(workspace)
+            } else {
+                machineIndex[key] = machines.count
+                machines.append(RailMachine(alias: project.deviceAlias, workspaces: [workspace]))
+            }
+        }
+        return machines
+    }
+}
+
+extension Array where Element == RailMachine {
+    var workspaceCount: Int { reduce(0) { $0 + $1.workspaces.count } }
+
+    func workspace(id: String?) -> RailWorkspace? {
+        guard let id else { return nil }
+        return lazy.flatMap(\.workspaces).first { $0.id == id }
+    }
+}
+
+// MARK: - The rail
+
+/// The workspace rail: Slack's left column on a phone. One row per workspace, in
+/// the Mac's pushed order, under a machine heading once there is a second
+/// machine to tell them apart. Picking one moves the whole home screen into it.
+///
+/// The shell owns the panel's motion and its gestures; this controller is only
+/// the content. That split is what lets the swipe be interruptible — the frames
+/// belong to one place.
+final class WorkspaceRailViewController: UIViewController {
+    private let store: RosterStore
+    private let scope: WorkspaceScope
+
+    /// Fired when a row is picked, so the shell can dismiss the rail.
+    var onSelect: (() -> Void)?
+
+    private var machines: [RailMachine] = []
+
+    private let tableView = UITableView(frame: .zero, style: .grouped)
+    private var rosterObserver: NSObjectProtocol?
+    private var scopeObserver: NSObjectProtocol?
+    private var themeObserver: NSObjectProtocol?
+
+    init(store: RosterStore, scope: WorkspaceScope) {
+        self.store = store
+        self.scope = scope
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    deinit {
+        for observer in [rosterObserver, scopeObserver, themeObserver].compactMap({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Opaque, and on the same themed canvas as the pages behind it: the
+        // shadow and the dimming are what separate the two, not a second color.
+        themeObserver = installThemeBackdrop()
+        let topBar = configureTopBar()
+        configureTable(below: topBar)
+        reload()
+        rosterObserver = NotificationCenter.default.addObserver(
+            forName: RosterStore.didChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.reload() }
+        }
+        scopeObserver = NotificationCenter.default.addObserver(
+            forName: WorkspaceScope.didChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.reload() }
+        }
+    }
+
+    func reload() {
+        machines = RailMachine.roster(from: store.projects)
+        tableView.reloadData()
+    }
+
+    // MARK: - Chrome
+
+    private func configureTopBar() -> UIView {
+        let title = UILabel()
+        title.text = localized("Workspaces")
+        // A step down from the home screens' 34pt: the rail is narrower than a
+        // page, and a title sized for a full width would truncate on this one.
+        title.font = .systemFont(ofSize: 22, weight: .bold)
+        title.textColor = .label
+        title.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(title)
+        NSLayoutConstraint.activate([
+            title.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            title.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 22),
+            title.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -16),
+        ])
+        return title
+    }
+
+    private func configureTable(below topBar: UIView) {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = .clear
+        tableView.separatorStyle = .none
+        tableView.sectionHeaderTopPadding = 0
+        tableView.estimatedSectionHeaderHeight = 0
+        tableView.estimatedSectionFooterHeight = 0
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "row")
+        tableView.register(
+            RailMachineHeaderView.self,
+            forHeaderFooterViewReuseIdentifier: RailMachineHeaderView.reuseID
+        )
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: topBar.bottomAnchor, constant: 12),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    /// The machine only heads its group when there is a second machine to tell it
+    /// apart from — the same rule the Mac's own switcher follows, so one-machine
+    /// users never see a level they don't have.
+    private var showsMachineHeadings: Bool { machines.count > 1 }
+}
+
+// MARK: - Table data source / delegate
+
+extension WorkspaceRailViewController: UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int { machines.count }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        machines[section].workspaces.count
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard showsMachineHeadings else { return nil }
+        guard let header = tableView.dequeueReusableHeaderFooterView(
+            withIdentifier: RailMachineHeaderView.reuseID
+        ) as? RailMachineHeaderView else { return nil }
+        header.configure(title: machines[section].title)
+        return header
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        showsMachineHeadings ? 28 : 0
+    }
+
+    /// A whitespace gap under each group, like every other list in the app.
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat { 12 }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? { UIView() }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "row", for: indexPath)
+        cell.selectionStyle = .none
+        cell.backgroundColor = .clear
+        let workspaces = machines[indexPath.section].workspaces
+        let workspace = workspaces[indexPath.row]
+        cell.contentConfiguration = UIHostingConfiguration {
+            WorkspaceRailRow(
+                name: workspace.name,
+                isSelected: workspace.id == scope.selectedID,
+                showsSeparator: indexPath.row < workspaces.count - 1
+            )
+        }
+        .margins(.horizontal, 12)
+        .margins(.vertical, 0)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        scope.select(machines[indexPath.section].workspaces[indexPath.row].id)
+        onSelect?()
+    }
+}
+
+// MARK: - Rows
+
+/// One workspace. The name, and a checkmark on the one in scope — the same two
+/// halves the Mac's own workspace menu draws, so the two switchers read alike.
+private struct WorkspaceRailRow: View {
+    let name: String
+    let isSelected: Bool
+    var showsSeparator = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(name)
+                .font(.body)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 4)
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 11)
+        .background(
+            isSelected ? Color.primary.opacity(0.08) : .clear,
+            in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay(alignment: .bottom) {
+            if showsSeparator { RowSeparator(leadingInset: 10) }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+}
+
+/// The machine heading over a group of workspaces. Its case is left alone,
+/// unlike the uppercased captions elsewhere: this is an `~/.ssh/config` alias, a
+/// literal the user typed, and recasing it makes it something they can't find
+/// again.
+private final class RailMachineHeaderView: UITableViewHeaderFooterView {
+    static let reuseID = "railMachine"
+
+    private let label = UILabel()
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        label.font = .systemFont(ofSize: 13, weight: .semibold)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 22),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -22),
+            label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -6),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func configure(title: String) {
+        label.text = title
+        isAccessibilityElement = true
+        accessibilityTraits = .header
+        accessibilityLabel = title
+    }
+}


### PR DESCRIPTION
The phone was showing every workspace's checkouts in one column, grouped under `PERSONAL` / `WORK` section captions — a flat list of the last two levels of the Mac's Device → Workspace → Project → Session tree.

This is Slack's split instead. The title names the workspace you are in, a rail swiped in from the left edge switches it, and the list underneath is only ever that one workspace's projects. The machine a workspace lives on moves from a right-aligned section detail to a subtitle under the title, and the rail groups its rows by machine once a second one is paired.

**"Needs You" is never scoped.** It crosses every workspace by design, and it is why people open this app — a blocked agent in a workspace that isn't on screen stays pinned above the list and one tap from its terminal. That exception is what makes showing one workspace at a time safe.

The rail lives on tab-bar home roots and nowhere else: on a pushed project page the left edge is the system back gesture, and inside a terminal `TerminalViewController`'s pan already owns leftward (drawer) and rightward (back). It arms only on a root whose controller adopts `WorkspaceScoped`, so nothing new competes for an edge that already has an owner.

Motion follows the finger from the first `.changed` and carries the release velocity into the settle. A drag that starts while a settle is running takes it back at the position on screen — the interrupt reads the presentation layer, because the model frame is already sitting at the target the moment the animator starts. A glass opener beside the title does the same job for anyone who never finds the swipe; the repo built and deleted a hidden three-finger gesture for exactly that reason.

Selection persists across launches; a first launch, a closed workspace, or a switched Mac falls back to the first workspace in the Mac's pushed roster order. One workspace means no rail and no opener, and the title just reads that workspace's name.

## Verification

Run on the simulator against a fixture roster of three workspaces on two machines (`Personal`, `Work` on this Mac; `Scratch` on `vps-fra`), driven by a throwaway XCUITest harness — 9 checks, all green, harness not committed:

- first launch scopes to the first pushed workspace, titled by its name, listing only its projects, with both blocked agents on the strip
- the opener reveals the rail; picking `Work` re-titles the page, swaps the list, and leaves both `Needs You` rows — including the one from `Personal` — on screen
- `Scratch` names `vps-fra` under the title
- the scope survives a relaunch
- an edge drag held at 36% of the travel parks the rail 36% out under the finger (measured off the framebuffer at 1:1 with the drag), and a gentle release there cancels
- a gentle release past the threshold commits; a short fast flick well short of it opens on velocity alone
- dragging the open rail back closes it
- the edge gesture does not arm on the Settings tab

Mid-flight interruption can't be delivered by XCUITest, which waits for UI quiescence before every event, so it was measured with temporary instrumentation on the production path: 250 ms into a settle the model frame already read the target `0.0` while the panel was actually at `-275.9` of a `313.6` travel; `interruptRailAnimation()` re-based to `-275.9` (progress `0.120`). The instrumentation is not in the commit.

Not covered: the Chats and Terminals tabs still list every workspace's loose sessions. Both files belong to another branch in flight; adopting `WorkspaceScoped` and filtering on `scope.admits` is a two-line change in each once it lands.

Rebased onto `main` after #447 merged; the full harness above was re-run green on the rebased branch.

## Release Notes:

- iPhone: swipe in from the left edge of a home screen, or tap the control beside the title, to switch workspaces. The list shows one workspace at a time; Needs You keeps showing blocked agents from all of them.
