### PR TITLE
Point the docs site at the settings that moved

### DIFF
--- a/web/landing/content/docs/custom-agents.mdx
+++ b/web/landing/content/docs/custom-agents.mdx
@@ -34,8 +34,10 @@ A minimal manifest needs only an `id`, a `name`, and the `command` to launch:
 ```
 
 Termio reads the folder **once at launch**, so restart the app after adding or
-editing a manifest. The agent then shows up wherever you start a session; enable,
-reorder, or tweak its command from **Settings ▸ Agents** like any other.
+editing a manifest. The agent then shows up wherever you start a session; enable
+or reorder it from **Settings ▸ Agents** like any other. Where its CLI lives is a
+fact about a machine, so the command path is set per machine, under **Settings ▸
+Machines**.
 
 <DocsImage
   src="/screenshots/docs/26-custom-agent.png"

--- a/web/landing/content/docs/custom-agents.zh-CN.mdx
+++ b/web/landing/content/docs/custom-agents.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 自定义 Agent
 description: 往 ~/.termio/config/agents 里放一个小小的 JSON 清单，就能让 Termio 认识任何命令行工具——给它名字、图标和实时状态识别，它就和内置 Agent 一样是一等公民。
 x-i18n:
   source_path: custom-agents.mdx
-  source_hash: 0e87be1ce606e7b0f2a09299ab9ca2ab42f81068bf8a1fca8322413da7bbe9e9
-  generated_at: 2026-08-18
+  source_hash: 9222958aaf400067e7b29729f6958e953eb6044b01fd766dfd3854969cb42a30
+  generated_at: 2026-08-25
 ---
 
 Termio 内置了常见的编程 Agent，但这个目录是开放的：任何命令行工具都能成为一等 Agent。
@@ -35,8 +35,8 @@ Termio 内置了常见的编程 Agent，但这个目录是开放的：任何命�
 ```
 
 Termio **只在启动时读取一次**这个文件夹，所以添加或修改清单后请重启应用。之后你在任何
-新建会话的地方都能看到它；像其他 Agent 一样，从 **设置 ▸ Agent** 里启用、排序或调整
-它的命令。
+新建会话的地方都能看到它；像其他 Agent 一样，从 **设置 ▸ Agents** 里启用或排序。它的命令行
+工具装在哪里是一台设备的事实，所以命令路径按设备分别设置，在 **设置 ▸ 设备** 中。
 
 <DocsImage
   src="/screenshots/docs/26-custom-agent.png"

--- a/web/landing/content/docs/installation.mdx
+++ b/web/landing/content/docs/installation.mdx
@@ -59,8 +59,8 @@ session.
 
 ## The `termio` command (optional)
 
-Termio ships a small command-line tool. Open **Settings ▸ General** and turn on
-**Command-line tool** to symlink `termio` onto your `PATH`. From then on
+Termio ships a small command-line tool. Open **Settings ▸ Machines ▸ This Mac**
+and turn on **Command-line tool** to symlink `termio` onto your `PATH`. From then on
 `termio` in any directory opens it as a project, and `termio sessions …` lets your
 agents coordinate with each other. It’s entirely optional — see
 [Session control & the CLI](/docs/session-control).

--- a/web/landing/content/docs/installation.zh-CN.mdx
+++ b/web/landing/content/docs/installation.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 安装
 description: 下载 macOS 版 Termio，拖进「应用程序」，之后交给 Sparkle 自动更新——无需账号，也没有许可证密钥。
 x-i18n:
   source_path: installation.mdx
-  source_hash: 29433b9f28d7dfd650eb5d2ef6d79f4530c625566ec756b9f0b6172f88a44765
-  generated_at: 2026-08-19
+  source_hash: 968aba8f624339dfa5dd6d81106ecc061f71f8a91854395c47af9ef268ea7686
+  generated_at: 2026-08-25
 ---
 
 Termio 用同一个下载包同时运行在 Apple 芯片和 Intel 的 Mac 上。安装就是普通的拖进「应用程序」——不用注册账号，
@@ -57,7 +57,7 @@ Agent 安装好之后，新建会话时它就会出现在可启动的选项里�
 
 ## `termio` 命令（可选）
 
-Termio 附带一个小巧的命令行工具。打开 **设置 ▸ 通用**，开启 **命令行工具**，即可把
+Termio 附带一个小巧的命令行工具。打开 **设置 ▸ 设备 ▸ 本机**，开启 **命令行工具**，即可把
 `termio` 软链到你的 `PATH` 上。之后在任意目录执行 `termio` 就会把它作为项目打开，
 而 `termio sessions …` 让你的 Agent 彼此协作。这完全是可选的——参见
 [会话控制与命令行](/zh-CN/docs/session-control)。

--- a/web/landing/content/docs/session-control.mdx
+++ b/web/landing/content/docs/session-control.mdx
@@ -17,13 +17,18 @@ working, finishes, or stops to ask a question, the hook reports that to Termio, 
 the sidebar’s [status dots](/docs/sidebar#status) reflect exactly what’s happening
 instead of being guessed from output.
 
-Turn it on from **Settings ▸ General ▸ Live agent status** (Termio also offers it
+Turn it on from **Settings ▸ Agents ▸ Live agent status** (Termio also offers it
 once on first launch). Toggling it off removes the hooks again, leaving any hooks
 you added yourself untouched.
 
+The switch says whether you want the feature; each machine installs it for its own
+agents. Open a machine under **Settings ▸ Machines** and use **Set up this
+device** — or **Reinstall hooks** — to put the hooks on that box. That is what
+gives an agent running on a VPS the same status dots as one running here.
+
 ## Session control
 
-**Settings ▸ General ▸ Session control** turns on the `termio sessions`
+**Settings ▸ Agents ▸ Session control** turns on the `termio sessions`
 orchestration API below, and teaches your agents it exists by installing a
 `termio` **agent skill** into each agent’s skills folder (`~/.claude/skills`,
 `~/.codex/skills`). The skill loads on demand — an agent carries only its
@@ -54,7 +59,7 @@ npx skills add termio-sh/termio --skill termio
 
 ## The `termio` command-line tool
 
-Turn on **Settings ▸ General ▸ Command-line tool**. It symlinks a `termio`
+Turn on **Settings ▸ Machines ▸ This Mac ▸ Command-line tool**. It symlinks a `termio`
 command onto your `PATH` (at `/usr/local/bin/termio`; macOS asks for permission
 once), and turning it off removes the link again.
 

--- a/web/landing/content/docs/session-control.zh-CN.mdx
+++ b/web/landing/content/docs/session-control.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 会话控制与命令行
 description: Termio 的编排 API——让 Agent 汇报自己在做什么的状态 hooks，以及让你（或另一个 Agent）从 shell 里派生、驱动和监督会话的 termio sessions 命令行。
 x-i18n:
   source_path: session-control.mdx
-  source_hash: c51862ad7e768ef4905dc4f6e02dbd18c66d6e276bb00b2a82601a7c416a647e
-  generated_at: 2026-08-18
+  source_hash: 3a1f2496cddc4948ccc577a9911214fb1fe6cc90b445d5d15beef925156a7bc5
+  generated_at: 2026-08-25
 ---
 
 你在侧栏看到的实时状态背后，是两个相关的可选功能：让 Agent 汇报自己在做什么的**状态
@@ -18,12 +18,16 @@ Cursor 以及基于插件的那些）。当 Agent 开始工作、完成，或者
 汇报给 Termio，于是侧栏的 [状态点](/zh-CN/docs/sidebar#status) 反映的就是实际发生的事，
 而不是从输出里猜出来的。
 
-在 **设置 ▸ 通用 ▸ Agent 实时状态** 里打开（Termio 也会在首次启动时问你一次）。关掉它会
+在 **设置 ▸ Agents ▸ Agent 实时状态** 里打开（Termio 也会在首次启动时问你一次）。关掉它会
 把这些 hooks 移除，同时不动你自己加的任何 hook。
+
+这个开关只决定你是否需要这个功能；安装则由每台设备各自完成。在 **设置 ▸ 设备** 中打开一台
+设备，用 **设置此设备**——或 **重新安装 hooks**——把 hooks 装到那台机器上。这正是让跑在 VPS
+上的 Agent 拥有和本机一样的状态点的原因。
 
 ## 会话控制
 
-**设置 ▸ 通用 ▸ 会话控制** 打开下面这套 `termio sessions` 编排 API，并通过往每个 Agent 的
+**设置 ▸ Agents ▸ 会话控制** 打开下面这套 `termio sessions` 编排 API，并通过往每个 Agent 的
 技能文件夹（`~/.claude/skills`、`~/.codex/skills`）里安装一个 `termio` **Agent 技能**，
 来告诉你的 Agent 它存在。技能按需加载——Agent 平时只带着那一行描述，直到某个任务真的需要
 驱动同伴会话——而 Termio 每次启动都会重新确认它，因此应用更新会自动传播，手改过的内容也会
@@ -50,7 +54,7 @@ npx skills add termio-sh/termio --skill termio
 
 ## `termio` 命令行工具
 
-打开 **设置 ▸ 通用 ▸ 命令行工具**。它会把一个 `termio` 命令软链到你的 `PATH` 上
+打开 **设置 ▸ 设备 ▸ 本机 ▸ 命令行工具**。它会把一个 `termio` 命令软链到你的 `PATH` 上
 （位于 `/usr/local/bin/termio`；macOS 会要求授权一次），关掉则移除这个链接。
 
 ### 打开项目


### PR DESCRIPTION
Follow-up to #446, which merged without this commit — it was pushed to the branch after the merge landed.

`main` currently ships the renamed **Machines** tab and the sections moved off General, while the docs site still tells users to open **Settings ▸ General** for three of them:

| Page | Said | Now |
| --- | --- | --- |
| `installation.mdx` | Settings ▸ General → Command-line tool | Settings ▸ Machines ▸ This Mac |
| `session-control.mdx` | Settings ▸ General ▸ Live agent status | Settings ▸ Agents ▸ Live agent status |
| `session-control.mdx` | Settings ▸ General ▸ Session control | Settings ▸ Agents ▸ Session control |
| `session-control.mdx` | Settings ▸ General ▸ Command-line tool | Settings ▸ Machines ▸ This Mac |
| `custom-agents.mdx` | tweak its command from Settings ▸ Agents | command path is per machine, under Machines |

`session-control.mdx` also gains a short paragraph on why the switch and the install are now in different places: wanting live status is a preference and lives on Agents, installing the hooks is a machine operation and happens per machine. That is also the answer to why an agent on a VPS previously had no status at all.

Only the three English pages that changed are retranslated and restamped. `docs:stamp` re-dates every locale file it sees — it bumped `generated_at` on all fifteen — and a translation nobody touched must not claim it was regenerated today, so the twelve date-only stamps are reverted.

`pnpm docs:check` passes: keybindings, changelog, i18n and links all green.

Known gap, not fixed here: `public/screenshots/docs/25-session-control-settings.png` still shows the old General pane and needs regenerating against Agents ▸ Integration. Its alt text is left describing the image that is actually there rather than the UI it should show.

Release Notes: None — documentation only.