### PR TITLE
Make ANSI white readable on light themes

### DIFF
--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -858,21 +858,57 @@ extension TermioStore {
     /// The light/dark theme pair libghostty switches between as the system
     /// appearance changes. Each slot resolves its own chosen Ghostty theme, falling
     /// back to termio's default when none is chosen (or the name no longer
-    /// resolves). The light default is a pure-white canvas rather than libghostty's
-    /// Alabaster (#F7F7F7): the agent UIs paint their own grey panels over it, so an
-    /// off-white background just reads as unstyled. The dark default is Afterglow.
+    /// resolves). The light default is `lightDefaultTheme` — a pure-white canvas
+    /// rather than libghostty's Alabaster (#F7F7F7), because the agent UIs paint
+    /// their own grey panels over it and an off-white background just reads as
+    /// unstyled. The dark default is Afterglow.
     private func makeTheme() -> TerminalTheme {
         TerminalTheme(
-            light: themeConfiguration(named: settings.lightThemeName) ?? .alabaster.background("FFFFFF"),
-            dark: themeConfiguration(named: settings.darkThemeName) ?? .afterglow
+            light: Self.themeConfiguration(named: settings.lightThemeName) ?? Self.lightDefaultTheme,
+            dark: Self.themeConfiguration(named: settings.darkThemeName) ?? .afterglow
         )
     }
 
+    /// termio's light default: Alabaster on a pure-white canvas, with ANSI white and
+    /// bright white moved from paper to ink.
+    ///
+    /// Alabaster names slots 7 and 15 by literal color (#F7F7F7 — its own original
+    /// background) rather than by role, so anything an agent prints as "white" lands
+    /// at 1.07:1 against the canvas and disappears. That is issue #426: Claude Code
+    /// draws its version, cwd and shortcut hints in ANSI white, which is legible on
+    /// the dark terminal it assumes and invisible here. Light themes that read well
+    /// (Xcode Light, Monokai Pro Light) map both slots to the foreground instead; 7
+    /// stays the softer of the two so a secondary line still reads as secondary.
+    static let lightDefaultTheme = TerminalConfiguration.alabaster
+        .background("FFFFFF")
+        .palette(7, color: "#4D4D4D")
+        .palette(15, color: "#262626")
+        .minimumContrast(lightContrastFloor)
+
+    /// The WCAG floor libghostty enforces per glyph, against that glyph's own
+    /// background, for light themes only.
+    ///
+    /// It is a floor rather than a remap because a theme's palette is not the only
+    /// way text arrives — an agent can set a color directly, or rewrite the palette
+    /// at runtime through OSC 4. 1.5 is the knee measured across the bundled
+    /// catalog: it rescues every entry that is invisible against its own background
+    /// while flattening none that a reader could already make out. Higher is worse,
+    /// not better — libghostty snaps a failing foreground to pure black or white
+    /// rather than nudging it, so a 3.0 floor turns legible yellows and greens
+    /// black. Dark themes get no floor: their one sub-floor slot is ANSI black on a
+    /// dark canvas, which every dark theme does on purpose.
+    static let lightContrastFloor = 1.5
+
     /// Resolves a chosen theme name to its terminal configuration, or `nil` when the
-    /// slot is left on the default or the name no longer resolves.
-    private func themeConfiguration(named name: String) -> TerminalConfiguration? {
+    /// slot is left on the default or the name no longer resolves. The contrast floor
+    /// follows the theme's own brightness rather than the slot it was chosen into, so
+    /// a light theme parked in the Dark slot keeps its protection and a dark one
+    /// parked in the Light slot keeps its intentional black-on-black.
+    static func themeConfiguration(named name: String) -> TerminalConfiguration? {
         guard !name.isEmpty, let definition = ThemeLibrary.theme(named: name) else { return nil }
-        return definition.toTerminalConfiguration()
+        let configuration = definition.toTerminalConfiguration()
+        guard !definition.isDark else { return configuration }
+        return configuration.minimumContrast(Self.lightContrastFloor)
     }
 
     /// Drives `ghostty_app_tick` at display rate for a short window so a config

--- a/Tests/termioTests/ThemeLibraryTests.swift
+++ b/Tests/termioTests/ThemeLibraryTests.swift
@@ -1,5 +1,7 @@
 import XCTest
+import GhosttyTerminal
 import GhosttyTheme
+import SwiftUI
 import TermioShared
 @testable import termio
 
@@ -208,6 +210,85 @@ final class ThemeLibraryTests: XCTestCase {
         return GhosttyThemeCatalog.allThemes.first {
             $0.isDark == dark && !builtIn.contains($0.name) && !userOwned.contains($0.name)
         }
+    }
+
+    // MARK: - Light contrast
+
+    /// Issue #426: the light default inherited Alabaster's ANSI white and bright
+    /// white — #F7F7F7, the color Alabaster also uses for paper — so every line an
+    /// agent printed as "white" landed at 1.07:1 on the canvas and disappeared. Both
+    /// slots have to stay ink.
+    func testLightDefaultRendersAnsiWhiteAsInk() throws {
+        let config = TermioStore.lightDefaultTheme.rendered
+        let background = try XCTUnwrap(lastValue(of: "background", in: config))
+        for slot in [7, 15] {
+            let color = try XCTUnwrap(lastPaletteValue(slot, in: config))
+            let ratio = contrast(color, background)
+            XCTAssertGreaterThan(ratio, 3, "ANSI \(slot) reads at \(ratio):1 against \(background)")
+        }
+    }
+
+    /// The palette above only covers the default; the floor is what covers the other
+    /// light themes, the ones a user drops into the Themes folder, and a palette an
+    /// agent rewrites at runtime over OSC 4. It has to ride on every light theme and
+    /// on none of the dark ones — a dark theme's ANSI black sits on its background
+    /// on purpose.
+    func testTheContrastFloorFollowsThemeBrightness() throws {
+        for definition in ThemeLibrary.builtInThemes {
+            let rendered = try XCTUnwrap(TermioStore.themeConfiguration(named: definition.name)).rendered
+            let floor = lastValue(of: "minimum-contrast", in: rendered)
+            if definition.isDark {
+                XCTAssertNil(floor, definition.name)
+            } else {
+                XCTAssertEqual(floor.flatMap(Double.init), TermioStore.lightContrastFloor, definition.name)
+            }
+        }
+        XCTAssertEqual(
+            lastValue(of: "minimum-contrast", in: TermioStore.lightDefaultTheme.rendered)
+                .flatMap(Double.init),
+            TermioStore.lightContrastFloor
+        )
+    }
+
+    /// Both halves of the fix are keys libghostty has to accept: a rejected config
+    /// does not fall back to the previous colors, it leaves the whole theme
+    /// unapplied. So build the real thing and let ghostty parse it.
+    func testTheLightDefaultIsAConfigGhosttyAccepts() {
+        let state = TerminalViewState(
+            theme: TerminalTheme(light: TermioStore.lightDefaultTheme, dark: .afterglow))
+        XCTAssertNil(state.controller.lastConfigurationIssue)
+        // `effectiveColorScheme` starts light, so this is the slot under test.
+        XCTAssertTrue(state.renderedConfig.contains("palette = 7=#4D4D4D"), state.renderedConfig)
+        XCTAssertTrue(state.renderedConfig.contains("palette = 15=#262626"), state.renderedConfig)
+        XCTAssertTrue(state.renderedConfig.contains("minimum-contrast = 1.5"), state.renderedConfig)
+    }
+
+    /// A floor above 2 would be worse than the bug: libghostty snaps a failing
+    /// foreground to pure black or white rather than nudging it, and the bundled
+    /// light palettes put their legible-but-dim greys and yellows just above 2:1.
+    func testTheContrastFloorStaysBelowTheFlatteningPoint() {
+        XCTAssertGreaterThan(TermioStore.lightContrastFloor, 1)
+        XCTAssertLessThanOrEqual(TermioStore.lightContrastFloor, 1.75)
+    }
+
+    /// `rendered` is append-only, so an override lands as a second line for the same
+    /// key — the way Ghostty itself resolves a repeated key, last one wins.
+    private func lastValue(of key: String, in config: String) -> String? {
+        config.split(separator: "\n")
+            .last { $0.hasPrefix("\(key) = ") }
+            .map { String($0.dropFirst(key.count + 3)) }
+    }
+
+    private func lastPaletteValue(_ slot: Int, in config: String) -> String? {
+        let prefix = "palette = \(slot)="
+        return config.split(separator: "\n")
+            .last { $0.hasPrefix(prefix) }
+            .map { String($0.dropFirst(prefix.count)) }
+    }
+
+    private func contrast(_ first: String, _ second: String) -> Double {
+        guard let first = Color(hex: first), let second = Color(hex: second) else { return 1 }
+        return ChromeTheme.contrastRatio(first, second)
     }
 
     // MARK: - Distinctness metric


### PR DESCRIPTION
Anything an agent prints as ANSI white was invisible on the light theme. termio's light default is Alabaster on a pure-white canvas, and Alabaster names palette slots 7 and 15 by literal color — `#F7F7F7`, its own original paper — rather than by role. That put "white" at 1.07:1 against the background. Claude Code draws its version, cwd and shortcut hints that way, which is legible on the dark terminal it assumes and gone here.

Both slots move to ink, the way the light themes that read well map them (Xcode Light, Monokai Pro Light):

| slot | before | after | contrast on `#FFFFFF` |
|---|---|---|---|
| 7 `white` | `#F7F7F7` | `#4D4D4D` | 1.07:1 → 7.6:1 |
| 15 `bright white` | `#F7F7F7` | `#262626` | 1.07:1 → 15.1:1 |

7 stays the softer of the two so a secondary line still reads as secondary.

A palette edit only covers the default, so every light theme also carries libghostty's per-glyph `minimum-contrast` floor at 1.5. That reaches the other 44 light themes in the bundled catalog with the same flaw, themes dropped into the Themes folder, and a palette an agent rewrites at runtime over OSC 4. Higher is not safer: libghostty snaps a failing foreground to pure black or white rather than nudging it, so 3.0 would turn the light default's bright yellow, bright green and cyan black. Sweeping all 1,360 light and 6,400 dark palette entries in the catalog, 1.5 is the knee — it rescues every entry invisible against its own background and flattens none that was already legible.

Dark themes get no floor. Their one sub-floor slot is ANSI black on a dark canvas, which every dark theme does on purpose. The floor follows a theme's own brightness rather than the slot it was chosen into, so a light theme parked in the Dark slot keeps its protection.

Four tests cover it: both palette slots stay above 3:1, the floor rides on every light built-in and no dark one, the floor stays under the flattening point, and — the one that matters — a real `TerminalViewState` builds with this theme and reports no configuration issue, since a rejected config leaves the whole theme unapplied rather than falling back.

Closes #426

Release Notes:
- Fixed text an agent printed in white being invisible on light themes.
