### PR TITLE
Send phone-started sessions to the workspace the phone is showing

### DIFF
--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -21,6 +21,18 @@ public enum Wire {
     public static let minimumServer = 2
     /// Oldest phone this Mac will serve.
     public static let minimumClient = 2
+
+    /// The wire id of a workspace's loose section — the Terminals or Chats
+    /// container the Mac finds-or-creates rather than the user opening it.
+    ///
+    /// Derived from the workspace so it survives a relaunch, and suffixed
+    /// because one workspace has two sections. Both ends build it: the id is how
+    /// the phone names a section the Mac has not created yet, which is what lets
+    /// a `.start` seed the first chat in a workspace instead of waiting for one
+    /// to exist on the desktop first.
+    public static func looseSectionID(workspaceID: String, chats: Bool) -> String {
+        "\(workspaceID)-\(chats ? "chats" : "terminals")"
+    }
 }
 
 /// The companion wire protocol, shared by the Mac companion server and the iOS
@@ -63,13 +75,24 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     /// `.start`. It carries no project because the funnel is found-or-created by
     /// kind on the Mac (like ⌘T), so — unlike `.start` — the phone can seed the
     /// very first terminal too. Answered with `.started` (agent `"terminal"`).
-    case startTerminal
+    ///
+    /// `workspaceID` names *which* workspace's funnel, because "the funnel" is
+    /// one per workspace and the Mac would otherwise pick the workspace it
+    /// happens to be showing — a choice made by UI state on a device the phone
+    /// user cannot see. Absent means exactly that older behaviour, so an older
+    /// Mac degrades to "the Mac picks" rather than failing.
+    case startTerminal(workspaceID: String?)
     /// The Terminals tab's ＋ → "New SSH": open a loose terminal that runs
     /// `ssh <host>` instead of a local shell. `host` is a `~/.ssh/config` alias
     /// (see `.sshConfigHosts`) or a bare `user@host`. Like `.startTerminal` it
     /// gathers in the `.terminals` funnel and needs no project. Answered with
     /// `.started`.
-    case startSSH(host: String)
+    ///
+    /// `workspaceID` is the same hint as `.startTerminal`'s, and the same
+    /// optional. It is a preference, not an instruction: an `ssh` shell belongs
+    /// to a workspace on the box it reaches, so the Mac honours it only when the
+    /// named workspace is on `host`.
+    case startSSH(host: String, workspaceID: String?)
     /// The client asks the Mac to close a session (the phone's swipe-to-remove).
     /// No success reply — the next roster push drops the row everywhere.
     case stop(sessionID: String)
@@ -161,10 +184,17 @@ public enum CompanionControl: Codable, Sendable, Equatable {
             var fields: [String: Any] = ["t": "started", "session": sessionID]
             if let agent { fields["agent"] = agent }
             return Self.json(fields)
-        case .startTerminal:
-            return #"{"t":"startTerminal"}"#
-        case .startSSH(let host):
-            return Self.json(["t": "startSSH", "host": host])
+        case .startTerminal(let workspaceID):
+            // A nil workspace omits the key, like `.start`'s agent: the older
+            // shape is still what an older Mac reads, and "absent" is already
+            // the value that means "you pick".
+            var fields: [String: Any] = ["t": "startTerminal"]
+            if let workspaceID { fields["workspace"] = workspaceID }
+            return Self.json(fields)
+        case .startSSH(let host, let workspaceID):
+            var fields: [String: Any] = ["t": "startSSH", "host": host]
+            if let workspaceID { fields["workspace"] = workspaceID }
+            return Self.json(fields)
         case .stop(let sessionID):
             return #"{"t":"stop","session":"\#(sessionID)"}"#
         case .resize(let cols, let rows):
@@ -275,10 +305,12 @@ public enum CompanionControl: Codable, Sendable, Equatable {
             guard let sessionID = obj["session"] as? String else { return nil }
             return .started(sessionID: sessionID, agent: obj["agent"] as? String)
         case "startTerminal":
-            return .startTerminal
+            // Missing workspace = "the Mac picks", which is what every phone
+            // built before the field sends.
+            return .startTerminal(workspaceID: obj["workspace"] as? String)
         case "startSSH":
             guard let host = obj["host"] as? String else { return nil }
-            return .startSSH(host: host)
+            return .startSSH(host: host, workspaceID: obj["workspace"] as? String)
         case "stop":
             guard let sessionID = obj["session"] as? String else { return nil }
             return .stop(sessionID: sessionID)

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -374,11 +374,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             stopSession: { [weak store] sessionID in
                 store?.companionStopSession(sessionID: sessionID) ?? false
             },
-            startScratchTerminal: { [weak store] in
-                store?.companionStartScratchTerminal()
+            startScratchTerminal: { [weak store] workspaceID in
+                store?.companionStartScratchTerminal(workspaceID: workspaceID)
             },
-            startSSHSession: { [weak store] host in
-                store?.companionStartSSHSession(host: host)
+            startSSHSession: { [weak store] host, workspaceID in
+                store?.companionStartSSHSession(host: host, workspaceID: workspaceID)
             }
         )
         companionServer = companion

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -185,11 +185,12 @@ final class CompanionServer {
     private let stopSession: (String) -> Bool
     /// Opens a plain shell in the loose terminals funnel for the phone's
     /// Terminals ＋ (`.startTerminal`); returns the `.started` echo, or nil on
-    /// failure. Project-less: the funnel is found-or-created on the Mac.
-    private let startScratchTerminal: () -> (sessionID: String, agentID: String)?
+    /// failure. Project-less: the funnel is found-or-created on the Mac, in the
+    /// workspace the phone named (nil = whichever the Mac is showing).
+    private let startScratchTerminal: (String?) -> (sessionID: String, agentID: String)?
     /// Opens an `ssh <host>` terminal for the phone's Terminals ＋ → SSH
     /// (`.startSSH`); returns the `.started` echo, or nil on failure.
-    private let startSSHSession: (String) -> (sessionID: String, agentID: String)?
+    private let startSSHSession: (String, String?) -> (sessionID: String, agentID: String)?
     /// Called when this server will not be serving after all — the port is
     /// held by someone else, or the listener died. Set by whoever owns the
     /// wiring (`AppDelegate`), because the thing that has to be undone is the
@@ -221,8 +222,8 @@ final class CompanionServer {
         noteInput: @escaping (String) -> Void,
         startSession: @escaping (String, String?) -> (sessionID: String, agentID: String)?,
         stopSession: @escaping (String) -> Bool,
-        startScratchTerminal: @escaping () -> (sessionID: String, agentID: String)?,
-        startSSHSession: @escaping (String) -> (sessionID: String, agentID: String)?
+        startScratchTerminal: @escaping (String?) -> (sessionID: String, agentID: String)?,
+        startSSHSession: @escaping (String, String?) -> (sessionID: String, agentID: String)?
     ) {
         self.port = port
         self.rosterProvider = rosterProvider
@@ -456,10 +457,11 @@ final class CompanionServer {
             } else {
                 sendControl(.error(message: "could not start a session there"), to: connection)
             }
-        case .startTerminal:
-            // "New Terminal": a plain shell in the loose terminals funnel, seeded
-            // on the Mac even if the phone has never seen one there yet.
-            if let started = startScratchTerminal() {
+        case .startTerminal(let workspaceID):
+            // "New Terminal": a plain shell in the loose terminals funnel of the
+            // workspace the phone is showing, seeded on the Mac even if the
+            // phone has never seen one there yet.
+            if let started = startScratchTerminal(workspaceID) {
                 sendControl(
                     .started(sessionID: started.sessionID, agent: started.agentID),
                     to: connection
@@ -467,9 +469,9 @@ final class CompanionServer {
             } else {
                 sendControl(.error(message: "could not open a terminal"), to: connection)
             }
-        case .startSSH(let host):
+        case .startSSH(let host, let workspaceID):
             // "New SSH": a terminal running `ssh <host>` in that same funnel.
-            if let started = startSSHSession(host) {
+            if let started = startSSHSession(host, workspaceID) {
                 sendControl(
                     .started(sessionID: started.sessionID, agent: started.agentID),
                     to: connection
@@ -1213,7 +1215,23 @@ extension TermioStore {
     /// carries no project: `addScratchSession` finds-or-creates the funnel by
     /// kind, so the phone can seed the very first terminal too. Returns the new
     /// session's wire id and the `"terminal"` echo.
-    func companionStartScratchTerminal() -> (sessionID: String, agentID: String)? {
+    ///
+    /// `workspaceID` is the workspace the phone user is looking at. There is one
+    /// funnel per workspace, so without it the destination would be whichever
+    /// workspace this Mac happens to be showing — a decision taken on a screen
+    /// the phone user cannot see. An older phone sends none and keeps that
+    /// behaviour.
+    func companionStartScratchTerminal(
+        workspaceID: String?
+    ) -> (sessionID: String, agentID: String)? {
+        // Switching, not filing directly: `addScratchSession` files against the
+        // current workspace, so moving there first is what makes the row land
+        // where the phone said — the same move `companionStartSession` makes for
+        // a loose-section start. A shell that runs here still cannot be filed
+        // under a workspace on a box, and `addScratchSession` keeps that rule.
+        if let workspace = companionWorkspace(workspaceID) {
+            switchToWorkspace(workspace.id)
+        }
         addScratchSession(agent: .terminal)
         guard let sessionID = selectedSessionID?.uuidString else { return nil }
         return (sessionID, AgentPreset.terminal.wireName)
@@ -1223,12 +1241,29 @@ extension TermioStore {
     /// SSH" (`.startSSH`) — the same `addSSHSession` the desktop's SSH picker
     /// uses. It lands in the `.terminals` funnel too, so it needs no project.
     /// Returns the new session's wire id and the `"terminal"` echo.
-    func companionStartSSHSession(host: String) -> (sessionID: String, agentID: String)? {
+    ///
+    /// `workspaceID` is a preference here rather than a destination: an `ssh`
+    /// shell has to be filed under a workspace on the box it reaches, or that
+    /// workspace claims a machine it isn't on. It settles which of that box's
+    /// workspaces when there is more than one, and is ignored otherwise.
+    func companionStartSSHSession(
+        host: String, workspaceID: String?
+    ) -> (sessionID: String, agentID: String)? {
         let host = host.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !host.isEmpty else { return nil }
-        addSSHSession(host: host)
+        let preferred = companionWorkspace(workspaceID)
+            .flatMap { $0.isOn(alias: host, device: nil) ? $0.id : nil }
+        addSSHSession(host: host, preferring: preferred)
         guard let sessionID = selectedSessionID?.uuidString else { return nil }
         return (sessionID, AgentPreset.terminal.wireName)
+    }
+
+    /// The workspace a phone request names, by the uuid the roster gave it. nil
+    /// for an absent id (an older phone), and for one naming a workspace that is
+    /// gone — both mean "this Mac decides", the behaviour that predates the field.
+    private func companionWorkspace(_ wireID: String?) -> Workspace? {
+        guard let wireID else { return nil }
+        return workspaces.first { $0.id.uuidString.caseInsensitiveCompare(wireID) == .orderedSame }
     }
 
     /// Close a session for a phone `stop` request — the same `closeSession`
@@ -1266,11 +1301,11 @@ extension TermioStore {
         )
     }
 
-    /// The wire id for a workspace's loose section. Derived from the workspace so
-    /// it is stable across launches — the phone sends it back to open a session
-    /// there — and suffixed because one workspace has two sections.
+    /// The wire id for a workspace's loose section. The format is the protocol's
+    /// (`Wire.looseSectionID`), because the phone builds the same id to address a
+    /// section this Mac has not created yet.
     static func looseWireID(workspace: Workspace, chats: Bool) -> String {
-        "\(workspace.id.uuidString)-\(chats ? "chats" : "terminals")"
+        Wire.looseSectionID(workspaceID: workspace.id.uuidString, chats: chats)
     }
 
     /// Snapshot the current projects/sessions as a wire roster, mirroring what

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -416,7 +416,13 @@ extension TermioStore {
     /// that machine's fallback workspace, so an `ssh` shell and a durable termiod
     /// session on the same box sit together rather than scattering among loose
     /// local terminals. `host` is a `~/.ssh/config` alias or a bare `user@host`.
-    func addSSHSession(host: String) {
+    ///
+    /// `preferring` settles which of that box's workspaces when a caller knows —
+    /// the phone names the workspace on its screen, and a box can hold more than
+    /// one. It is only ever a preference: a caller that names a workspace on
+    /// another machine gets the fallback, because the machine rule above is what
+    /// keeps a workspace from claiming a box it isn't on.
+    func addSSHSession(host: String, preferring preferred: Workspace.ID? = nil) {
         let host = host.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !host.isEmpty else { return }
         // Named for what it is, not for the box — the workspace already says which
@@ -430,7 +436,9 @@ extension TermioStore {
         session.givenTitle = session.title
         session.sshHost = host
 
-        let workspaceID = deviceWorkspace(for: host)
+        let workspaceID = preferred.flatMap { id in
+            workspaces.first { $0.id == id && $0.isOn(alias: host, device: nil) }?.id
+        } ?? deviceWorkspace(for: host)
         guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         workspaces[index].terminals.append(session)
         selectedSessionID = session.id

--- a/Tests/termioTests/WireProtocolTests.swift
+++ b/Tests/termioTests/WireProtocolTests.swift
@@ -174,8 +174,44 @@ final class WireProtocolTests: XCTestCase {
     func testUnsupportedDoesNotReEncodeAsARealCommand() {
         let unsupported = CompanionControl.unsupported(type: "startTerminal")
 
-        XCTAssertNotEqual(CompanionControl.decode(unsupported.encoded()), .startTerminal)
+        XCTAssertNotEqual(
+            CompanionControl.decode(unsupported.encoded()), .startTerminal(workspaceID: nil))
         XCTAssertEqual(CompanionControl.decode(unsupported.encoded()), unsupported)
+    }
+
+    /// The workspace a phone-started terminal lands in is additive: a phone that
+    /// predates the field sends the older shape, and it has to keep meaning what
+    /// it meant — "the Mac picks" — rather than failing to decode.
+    func testStartWithoutAWorkspaceStillDecodes() {
+        XCTAssertEqual(
+            CompanionControl.decode(#"{"t":"startTerminal"}"#), .startTerminal(workspaceID: nil))
+        XCTAssertEqual(
+            CompanionControl.decode(#"{"t":"startSSH","host":"vps"}"#),
+            .startSSH(host: "vps", workspaceID: nil))
+    }
+
+    /// And a named workspace survives the round trip, so the Mac resolves the
+    /// funnel where the phone said rather than where its own window is pointed.
+    func testStartCarriesItsWorkspace() {
+        let terminal = CompanionControl.startTerminal(workspaceID: "WS-1")
+        let ssh = CompanionControl.startSSH(host: "vps", workspaceID: "WS-2")
+
+        XCTAssertEqual(CompanionControl.decode(terminal.encoded()), terminal)
+        XCTAssertEqual(CompanionControl.decode(ssh.encoded()), ssh)
+    }
+
+    /// Both ends build a loose section's wire id, so a phone can address the
+    /// Chats funnel of a workspace the Mac has not opened one in yet.
+    @MainActor
+    func testLooseSectionIDMatchesTheMacsOwn() {
+        let workspace = Workspace(name: "Alpha")
+
+        XCTAssertEqual(
+            TermioStore.looseWireID(workspace: workspace, chats: true),
+            Wire.looseSectionID(workspaceID: workspace.id.uuidString, chats: true))
+        XCTAssertEqual(
+            TermioStore.looseWireID(workspace: workspace, chats: false),
+            Wire.looseSectionID(workspaceID: workspace.id.uuidString, chats: false))
     }
 
     /// The tag reaches a `.public` log field and a paired phone picks it, so a

--- a/ios/Sources/ChatListViewController.swift
+++ b/ios/Sources/ChatListViewController.swift
@@ -2,16 +2,21 @@ import SwiftUI
 import TermioShared
 import UIKit
 
-/// The Chats tab: the Mac's loose agent sessions (the `chats`-kind container),
-/// listed flat — the phone twin of the desktop sidebar's Chats section. The
-/// sessions ARE the content: no project page in between, a row goes straight
-/// to its terminal, like the ChatGPT chat list. ＋ starts a new chat in one
-/// tap from the title bar — the Mac picks the agent, the same default ⌘N
-/// launches — with the per-agent menu kept behind a long-press.
+/// The Chats tab: the Mac's loose agent sessions (the `chats`-kind container) —
+/// the phone twin of the desktop sidebar's Chats section. The sessions ARE the
+/// content: no project page in between, a row goes straight to its terminal,
+/// like the ChatGPT chat list. ＋ starts a new chat in one tap — the Mac picks
+/// the agent, the same default ⌘N launches.
+///
+/// Sectioned by workspace, like the Projects list and the Terminals tab: there
+/// is one loose funnel per workspace, so with two machines paired a flat list
+/// would show both boxes' chats as one column with nothing saying which is which.
 final class ChatListViewController: UIViewController {
     private let store: RosterStore
 
-    private var chats: [MockSession] = []
+    /// The store's loose chat containers, grouped by workspace in roster order —
+    /// one section each.
+    private var groups: [WorkspaceGroup] = []
 
     private let newChatButton = UIButton(type: .system)
     private let tableView = UITableView(frame: .zero, style: .grouped)
@@ -98,7 +103,8 @@ final class ChatListViewController: UIViewController {
     /// The compose menu: a tap presents the agent picker directly — choosing
     /// which agent to start is the primary action. Deferred so it always
     /// reflects the roster's current enabled agents (and the button hides while
-    /// unpaired).
+    /// unpaired). The agents sit under a header naming the workspace the chat
+    /// will land in, so the destination is stated where the choice is made.
     private func configureNewChatButton() {
         newChatButton.applyGlassIcon(.add, boxSize: 24)
         newChatButton.tintColor = .label
@@ -106,13 +112,32 @@ final class ChatListViewController: UIViewController {
         newChatButton.showsMenuAsPrimaryAction = true
         newChatButton.menu = UIMenu(children: [
             UIDeferredMenuElement.uncached { [weak self] completion in
-                guard let self, let chatsProject = store.chatsProject else {
-                    completion([])
-                    return
-                }
-                completion(store.newSessionActions(in: chatsProject))
+                completion(self?.composeMenuItems() ?? [])
             },
         ])
+    }
+
+    private func composeMenuItems() -> [UIMenuElement] {
+        guard let chatsProject = store.chatsProject else { return [] }
+        var items: [UIMenuElement] = [
+            UIMenu(
+                title: destinationTitle,
+                options: .displayInline,
+                children: store.newSessionActions(in: chatsProject)
+            ),
+        ]
+        if let destinations = store.destinationPickerMenu() { items.append(destinations) }
+        return items
+    }
+
+    /// "New Chat in Alpha" — the destination stated over the agent list. Empty
+    /// when there is only one workspace to land in: naming a choice nobody has
+    /// is noise, and an empty title draws no header.
+    private var destinationTitle: String {
+        guard store.localWorkspaces.count > 1,
+              let name = store.destinationWorkspace?.name, !name.isEmpty
+        else { return "" }
+        return localized("New Chat in \(name)")
     }
 
     // MARK: - Table
@@ -127,6 +152,10 @@ final class ChatListViewController: UIViewController {
         tableView.estimatedSectionFooterHeight = 0
         tableView.keyboardDismissMode = .onDrag
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "row")
+        tableView.register(
+            WorkspaceSectionHeaderView.self,
+            forHeaderFooterViewReuseIdentifier: WorkspaceSectionHeaderView.reuseID
+        )
         tableView.translatesAutoresizingMaskIntoConstraints = false
         // The native tab controller contributes the correct safe-area and
         // adjusted scroll insets for both the classic and Liquid Glass bars.
@@ -140,11 +169,14 @@ final class ChatListViewController: UIViewController {
     }
 
     private func refilter() {
-        chats = store.chatSessions
+        groups = store.chatGroups
         newChatButton.isHidden = store.chatsProject?.rosterID == nil
         tableView.reloadData()
         updateEmptyState()
     }
+
+    /// Every chat on screen, in section order.
+    private var visible: [MockSession] { groups.flatMap(\.sessions) }
 
     // MARK: - Empty state
 
@@ -164,7 +196,7 @@ final class ChatListViewController: UIViewController {
     /// zero state only answers "no chats yet". The ＋ above is the next step,
     /// so no pill button repeats it.
     private func updateEmptyState() {
-        emptyState.isHidden = !chats.isEmpty
+        emptyState.isHidden = !visible.isEmpty
         guard !emptyState.isHidden else { return }
         emptyState.configure(
             icon: .bubbleChat,
@@ -179,21 +211,51 @@ final class ChatListViewController: UIViewController {
 // MARK: - Table data source / delegate
 
 extension ChatListViewController: UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        groups.count
+    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        chats.count
+        groups[section].sessions.count
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard groups.namesWorkspaces else { return nil }
+        guard let header = tableView.dequeueReusableHeaderFooterView(
+            withIdentifier: WorkspaceSectionHeaderView.reuseID
+        ) as? WorkspaceSectionHeaderView else { return nil }
+        let group = groups[section]
+        header.configure(title: group.name, detail: group.machineLabel)
+        return header
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        groups.namesWorkspaces ? WorkspaceSectionHeaderView.height : 0
+    }
+
+    /// A whitespace gap below each group — the divider-free separator, matching
+    /// the macOS sidebar's spacing-based grouping.
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        12
+    }
+
+    /// An empty (transparent) footer view, so the gap above is just whitespace.
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        UIView()
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "row", for: indexPath)
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
-        let session = chats[indexPath.row]
+        let sessions = groups[indexPath.section].sessions
+        let session = sessions[indexPath.row]
         cell.contentConfiguration = UIHostingConfiguration {
             SessionRow(
                 session: session,
                 isCurrent: session.key == store.currentSessionKey,
                 showsProject: false,
-                showsSeparator: indexPath.row < chats.count - 1
+                showsSeparator: indexPath.row < sessions.count - 1
             )
         }
         .margins(.horizontal, 12)
@@ -203,7 +265,7 @@ extension ChatListViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // The row IS the session — straight to its terminal.
-        store.openSession(chats[indexPath.row])
+        store.openSession(groups[indexPath.section].sessions[indexPath.row])
     }
 
     /// Trailing swipe: the Mac session menu's "Close Session".
@@ -212,7 +274,7 @@ extension ChatListViewController: UITableViewDataSource, UITableViewDelegate {
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
         guard store.companionURL != nil,
-              let sessionID = chats[indexPath.row].rosterID
+              let sessionID = groups[indexPath.section].sessions[indexPath.row].rosterID
         else { return nil }
         let close = UIContextualAction(style: .destructive, title: localized("Close")) { [weak self] _, _, done in
             self?.store.stopSession(sessionID)

--- a/ios/Sources/CompanionBackend.swift
+++ b/ios/Sources/CompanionBackend.swift
@@ -60,9 +60,13 @@ final class CompanionBackend: DeviceClient {
         client.send(.start(projectID: projectID, agent: agentID))
     }
 
-    func startTerminal() { client.send(.startTerminal) }
+    func startTerminal(workspaceID: String?) {
+        client.send(.startTerminal(workspaceID: workspaceID))
+    }
 
-    func startSSH(host: String) { client.send(.startSSH(host: host)) }
+    func startSSH(host: String, workspaceID: String?) {
+        client.send(.startSSH(host: host, workspaceID: workspaceID))
+    }
 
     func stopSession(id: String) { client.send(.stop(sessionID: id)) }
 

--- a/ios/Sources/DeviceClient.swift
+++ b/ios/Sources/DeviceClient.swift
@@ -50,9 +50,13 @@ protocol DeviceClient: AnyObject {
 
     func startSession(projectID: String, agentID: String)
     /// A plain login shell, project-less so it can seed the very first one.
-    func startTerminal()
+    /// `workspaceID` names the workspace it lands in — the one the phone is
+    /// showing, so the destination is never decided by what the Mac's own
+    /// window happens to be pointed at. nil leaves the choice to the device.
+    func startTerminal(workspaceID: String?)
     /// `ssh <host>`, where `host` is always an alias the device already knows.
-    func startSSH(host: String)
+    /// `workspaceID` as above, honoured only when that workspace is on `host`.
+    func startSSH(host: String, workspaceID: String?)
     func stopSession(id: String)
     func requestSSHHosts()
 

--- a/ios/Sources/Localizable.xcstrings
+++ b/ios/Sources/Localizable.xcstrings
@@ -651,6 +651,16 @@
         }
       }
     },
+    "New Chat in %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 %@ 中新建聊天"
+          }
+        }
+      }
+    },
     "New SSH": {
       "localizations": {
         "zh-Hans": {
@@ -667,6 +677,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "新建终端"
+          }
+        }
+      }
+    },
+    "New Terminal in %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 %@ 中新建终端"
           }
         }
       }
@@ -1167,6 +1187,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 Mac 上开始一个会话，它就会显示在这里。"
+          }
+        }
+      }
+    },
+    "Start in": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动于"
           }
         }
       }

--- a/ios/Sources/RosterStore.swift
+++ b/ios/Sources/RosterStore.swift
@@ -31,6 +31,10 @@ final class RosterStore {
     /// `MockSession.key` of the session filling the screen — its row gets the
     /// current-chat pill wherever session rows render.
     var currentSessionKey: String?
+    /// The workspace the phone is working in: the one holding the session last
+    /// opened, or the one picked in the ＋ menu. See `destinationWorkspace`,
+    /// which resolves it against the live roster.
+    private var destinationWorkspaceID: String?
 
     /// Open a session's terminal; `companionURL` is non-nil when it's live.
     /// Fired for row taps (via `openSession`) and for `.started` replies.
@@ -55,28 +59,78 @@ final class RosterStore {
         projects.flatMap(\.sessions).filter { $0.status == .needsAttention }
     }
 
-    /// The Mac's loose-agent-sessions container — the Chats tab's backing
-    /// project (and the target a phone-started chat lands in). nil when
-    /// paired to an older Mac that doesn't send project kinds.
+    /// The Chats tab's sections: one per workspace that has loose agent
+    /// sessions, in the Mac's push order. Grouped rather than flattened for the
+    /// same reason the Projects list is — two paired machines' loose sessions
+    /// are otherwise one undifferentiated list.
+    var chatGroups: [WorkspaceGroup] {
+        WorkspaceGroup.grouped(projects.filter { $0.kind == "chats" })
+    }
+
+    /// The Terminals tab's sections, the shell twin of `chatGroups`.
+    var terminalGroups: [WorkspaceGroup] {
+        WorkspaceGroup.grouped(projects.filter { $0.kind == "terminals" })
+    }
+
+    /// Every workspace on the roster, in the Mac's push order — what the ＋
+    /// destination is picked from.
+    var workspaceGroups: [WorkspaceGroup] {
+        WorkspaceGroup.grouped(projects)
+    }
+
+    /// The workspace the phone is working in: the one holding the session last
+    /// opened, or the one picked in the ＋. The Mac resolves the loose funnels
+    /// per workspace, so without an answer here every phone-started session
+    /// would land wherever the Mac's own window is pointed — a choice made on a
+    /// screen the phone user cannot see.
+    var currentWorkspace: WorkspaceGroup? {
+        let groups = workspaceGroups
+        return groups.first { $0.id == destinationWorkspaceID } ?? groups.first
+    }
+
+    /// Where a session the phone starts *here* lands — a plain shell or a chat,
+    /// both of which run on the Mac. Only a workspace on the Mac itself
+    /// qualifies: one on a box would be claiming a machine the process isn't on,
+    /// and the Mac files it locally regardless, so offering one would promise
+    /// what it will not do. nil when the roster has no local workspace yet,
+    /// which leaves the choice to the Mac.
+    var destinationWorkspace: WorkspaceGroup? {
+        let local = localWorkspaces
+        return local.first { $0.id == currentWorkspace?.id } ?? local.first
+    }
+
+    /// The workspaces on the paired Mac itself — what ＋ can offer as a
+    /// destination (see `destinationWorkspace`).
+    var localWorkspaces: [WorkspaceGroup] {
+        workspaceGroups.filter { $0.deviceAlias == nil }
+    }
+
+    /// The Mac's loose-agent-sessions container in the destination workspace —
+    /// the target a phone-started chat lands in. A workspace with no chats yet
+    /// gets a stand-in addressed by `Wire.looseSectionID`, so the phone can seed
+    /// the first chat there the way `.startTerminal` seeds the first terminal;
+    /// the Mac finds-or-creates the section behind that id. nil only when no
+    /// local workspace exists to land in.
     var chatsProject: MockProject? {
-        projects.first { $0.kind == "chats" }
+        guard let workspace = destinationWorkspace else { return nil }
+        if let existing = workspace.projects.first(where: { $0.kind == "chats" }) { return existing }
+        return MockProject(
+            name: localized("Chats"),
+            path: "",
+            rosterID: Wire.looseSectionID(workspaceID: workspace.id, chats: true),
+            kind: "chats",
+            workspaceID: workspace.id,
+            workspaceName: workspace.name,
+            sessions: []
+        )
     }
 
-    /// The Chats tab's rows, flat and in roster order.
-    var chatSessions: [MockSession] {
-        projects.filter { $0.kind == "chats" }.flatMap(\.sessions)
-    }
-
-    /// The Mac's loose-terminals container — the Terminals tab's backing
-    /// project (and the target a phone-started terminal lands in). The shell
-    /// twin of `chatsProject`; nil until the Mac has opened a loose shell.
-    var terminalsProject: MockProject? {
-        projects.first { $0.kind == "terminals" }
-    }
-
-    /// The Terminals tab's rows, flat and in roster order.
-    var terminalSessions: [MockSession] {
-        projects.filter { $0.kind == "terminals" }.flatMap(\.sessions)
+    /// The Mac's loose-terminals container in the destination workspace, the
+    /// shell twin of `chatsProject`. Only ever the optimistic row's stand-in:
+    /// `.startTerminal` names the workspace itself and needs no container.
+    private var terminalsProject: MockProject? {
+        guard let workspace = destinationWorkspace else { return nil }
+        return workspace.projects.first { $0.kind == "terminals" }
     }
 
     /// The live project for a stable key (path, falling back to name — see
@@ -112,8 +166,25 @@ final class RosterStore {
     }
 
     /// Row tap on any screen: open the session over whatever link we have.
+    /// Opening one is also how the phone says which workspace it is working in,
+    /// so the next ＋ starts alongside what the user was just looking at.
     func openSession(_ session: MockSession) {
+        if let workspaceID = workspaceID(of: session) { destinationWorkspaceID = workspaceID }
         onOpenSession?(session, companionURL)
+    }
+
+    /// Point the ＋ at another workspace (its "Start in" pick).
+    func chooseDestinationWorkspace(_ id: String) {
+        destinationWorkspaceID = id
+        NotificationCenter.default.post(name: Self.didChange, object: nil)
+    }
+
+    /// The workspace a session is filed under, via the container it belongs to.
+    /// A session carries its container's wire id, and the container names the
+    /// workspace — the roster's own chain, so nothing is inferred here.
+    private func workspaceID(of session: MockSession) -> String? {
+        guard let projectRosterID = session.projectRosterID else { return nil }
+        return projects.first { $0.rosterID == projectRosterID }?.workspaceID
     }
 
     /// Force an immediate reconnect (the zero state's "Try Again").
@@ -142,22 +213,43 @@ final class RosterStore {
         }
     }
 
+    /// The ＋'s "Start in" section: one entry per workspace a phone-started
+    /// session can land in, checkmarked on the destination. An inline section
+    /// rather than a sheet — changing where the next session goes is one tap,
+    /// and never a picker standing in front of the thing the user asked for.
+    /// nil when there is one workspace, which is not a choice.
+    func destinationPickerMenu() -> UIMenu? {
+        let workspaces = localWorkspaces
+        guard workspaces.count > 1 else { return nil }
+        let destination = destinationWorkspace?.id
+        return UIMenu(
+            title: localized("Start in"),
+            options: .displayInline,
+            children: workspaces.map { workspace in
+                UIAction(
+                    title: workspace.name,
+                    state: workspace.id == destination ? .on : .off
+                ) { [weak self] _ in self?.chooseDestinationWorkspace(workspace.id) }
+            }
+        )
+    }
+
     func startSession(agent: RosterAgent, in project: MockProject) {
         guard let projectID = project.rosterID else { return }
         pendingStart = (project, agent)
         client?.startSession(projectID: projectID, agentID: agent.id)
     }
 
-    /// The Terminals tab's ＋: open a plain login shell at `~` in the loose
-    /// `.terminals` funnel. The wire agent token `"terminal"` maps to the Mac's
     /// The Terminals tab's ＋ → "New Terminal": a plain login shell in the Mac's
     /// loose `.terminals` funnel. Project-less on the wire (`.startTerminal`), so
     /// — unlike the old `.start` path — it can seed the very first terminal too,
-    /// no container need pre-exist. Opens attached on the `.started` echo, so a
-    /// placeholder stands in until the roster push carries the real container.
+    /// no container need pre-exist. It carries the destination workspace instead,
+    /// because there is one funnel per workspace. Opens attached on the
+    /// `.started` echo, so a placeholder stands in until the roster push carries
+    /// the real container.
     func startNewTerminal() {
         pendingStart = (terminalsProject ?? .terminalsPlaceholder, nil)
-        client?.startTerminal()
+        client?.startTerminal(workspaceID: destinationWorkspace?.id)
     }
 
     /// The Terminals tab's ＋ → "New SSH": an `ssh <host>` terminal in that same
@@ -168,7 +260,10 @@ final class RosterStore {
         let host = host.trimmingCharacters(in: .whitespaces)
         guard !host.isEmpty else { return }
         pendingStart = (terminalsProject ?? .terminalsPlaceholder, nil)
-        client?.startSSH(host: host)
+        // The raw current workspace, not the local destination: an `ssh` shell
+        // is filed on the box it reaches, so the workspace worth naming is the
+        // one the user is looking at even when that one is over there.
+        client?.startSSH(host: host, workspaceID: currentWorkspace?.id)
     }
 
     /// Close on the Mac; the next roster push drops the row everywhere.

--- a/ios/Sources/SessionListUI.swift
+++ b/ios/Sources/SessionListUI.swift
@@ -114,6 +114,134 @@ struct RowSeparator: View {
     }
 }
 
+// MARK: - Workspace grouping
+
+/// One workspace's containers — the group a list draws as a section. The Mac's
+/// tree is Device → Workspace → Project → Session, and a phone list that
+/// flattens it pours every machine's rows into one column, where a VPS clone is
+/// indistinguishable from a local one. The workspace is the group; `deviceAlias`
+/// is the machine it is on, named in the header the way the Mac names it, and
+/// never a level you navigate.
+struct WorkspaceGroup {
+    let id: String
+    let name: String
+    let deviceAlias: String?
+    var projects: [MockProject]
+
+    /// The machine to put after the workspace name, and nil when there is
+    /// nothing to add: this Mac carries no mark — being on the machine you
+    /// paired with is the absence of one — and neither does a workspace already
+    /// named after its box, where the header says it once. Both rules are the
+    /// desktop sidebar's.
+    var machineLabel: String? {
+        guard let deviceAlias,
+              deviceAlias.caseInsensitiveCompare(name) != .orderedSame
+        else { return nil }
+        return deviceAlias
+    }
+
+    /// Every session in the group's containers, in roster order — what the
+    /// session tabs (Terminals, Chats) list under the header, where the
+    /// container itself is the tab and only its sessions are rows.
+    var sessions: [MockSession] { projects.flatMap(\.sessions) }
+
+    /// Containers grouped by workspace. Workspaces keep the order the Mac pushed
+    /// them in — the sidebar's own order — and only the projects inside a group
+    /// re-sort when the caller asks for Name, so switching sort never reshuffles
+    /// the machines out from under the user.
+    static func grouped(_ projects: [MockProject], sortedByName: Bool = false) -> [WorkspaceGroup] {
+        var groups: [WorkspaceGroup] = []
+        var indexByWorkspace: [String: Int] = [:]
+        for project in projects {
+            if let index = indexByWorkspace[project.workspaceID] {
+                groups[index].projects.append(project)
+                continue
+            }
+            indexByWorkspace[project.workspaceID] = groups.count
+            groups.append(WorkspaceGroup(
+                id: project.workspaceID,
+                name: project.workspaceName,
+                deviceAlias: project.deviceAlias,
+                projects: [project]
+            ))
+        }
+        guard sortedByName else { return groups }
+        return groups.map { group in
+            var sorted = group
+            sorted.projects.sort {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+            return sorted
+        }
+    }
+}
+
+extension Array where Element == WorkspaceGroup {
+    /// Whether the sections are headed by their workspace. One unnamed local
+    /// workspace is the case almost everyone is in, and the Mac hides its own
+    /// workspace switcher there too — the page title already says what the list
+    /// is. A second workspace, or one that names a machine, is what makes the
+    /// grouping worth a header.
+    var namesWorkspaces: Bool {
+        count > 1 || contains { $0.deviceAlias != nil && !$0.name.isEmpty }
+    }
+}
+
+/// A small gray caps label capping a workspace group, with room for one
+/// trailing detail — the machine that workspace is on. Mail and Files head their
+/// groups the same way: the account or location names the section, and the rows
+/// underneath say nothing more about where they live.
+///
+/// The detail keeps its own case. It is an `~/.ssh/config` alias, a literal the
+/// user typed, and uppercasing it would make it something they can't find again.
+final class WorkspaceSectionHeaderView: UITableViewHeaderFooterView {
+    static let reuseID = "workspaceSectionHeader"
+    /// The height a table should give it — the Projects list's, so the three
+    /// workspace-grouped lists cap their groups identically.
+    static let height: CGFloat = 28
+
+    private let label = UILabel()
+    private let detailLabel = UILabel()
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        label.font = .systemFont(ofSize: 13, weight: .semibold)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        detailLabel.font = .systemFont(ofSize: 13, weight: .regular)
+        detailLabel.textColor = .tertiaryLabel
+        detailLabel.textAlignment = .right
+        // The workspace name is the section's identity; the machine gives way
+        // when there isn't room for both.
+        detailLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        detailLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(label)
+        contentView.addSubview(detailLabel)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 22),
+            label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -6),
+            detailLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: label.trailingAnchor, constant: 8),
+            detailLabel.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor, constant: -22),
+            detailLabel.firstBaselineAnchor.constraint(equalTo: label.firstBaselineAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func configure(title: String, detail: String? = nil) {
+        label.text = title.uppercased()
+        detailLabel.text = detail
+        detailLabel.isHidden = detail == nil
+        isAccessibilityElement = true
+        accessibilityTraits = .header
+        // VoiceOver reads the group once, so the machine belongs in the same
+        // breath as the name rather than as a second, orphaned element.
+        accessibilityLabel = detail.map { "\(title), \(localized("on \($0)"))" } ?? title
+    }
+}
+
 // MARK: - Empty state view
 
 /// The centered zero state — a quiet glyph (or spinner), a title, a line of

--- a/ios/Sources/TerminalListViewController.swift
+++ b/ios/Sources/TerminalListViewController.swift
@@ -3,17 +3,23 @@ import TermioShared
 import UIKit
 
 /// The Terminals tab: the Mac's loose shell sessions (the `terminals`-kind
-/// container), listed flat — the phone twin of the desktop sidebar's Terminals
-/// section, and the exact mirror of the Chats tab for shells instead of agents.
-/// Loose terminals used to fall through as a project *folder* you had to tap
-/// into; promoting them to their own tab keeps a live shell one tap away, the
-/// same shape Chats already got. A row goes straight to its terminal. The
-/// title-bar ＋ opens a new plain shell at `~` — no agent to pick, so (unlike
-/// Chats) it carries no per-agent menu.
+/// container) — the phone twin of the desktop sidebar's Terminals section, and
+/// the exact mirror of the Chats tab for shells instead of agents. Loose
+/// terminals used to fall through as a project *folder* you had to tap into;
+/// promoting them to their own tab keeps a live shell one tap away, the same
+/// shape Chats already got. A row goes straight to its terminal. The ＋ opens a
+/// new plain shell at `~` — no agent to pick, so (unlike Chats) it carries no
+/// per-agent menu.
+///
+/// Sectioned by workspace, like the Projects list: there is one loose funnel per
+/// workspace, so with two machines paired a flat list would show both boxes'
+/// shells as one column with nothing saying which is which.
 final class TerminalListViewController: UIViewController {
     private let store: RosterStore
 
-    private var terminals: [MockSession] = []
+    /// The store's loose terminal containers, grouped by workspace in roster
+    /// order — one section each.
+    private var groups: [WorkspaceGroup] = []
 
     private let newTerminalButton = UIButton(type: .system)
     private let tableView = UITableView(frame: .zero, style: .grouped)
@@ -98,23 +104,43 @@ final class TerminalListViewController: UIViewController {
     }
 
     /// The compose menu: New Terminal (a plain login shell the Mac gathers into
-    /// the loose `.terminals` funnel) and New SSH. New SSH is a read-only pick
-    /// from the Mac's `~/.ssh/config` aliases — the phone never types a host —
-    /// so it's deferred to reflect the current config.
+    /// the loose `.terminals` funnel) and New SSH. Deferred as a whole because
+    /// both entries read the live roster — New SSH is a read-only pick from the
+    /// Mac's `~/.ssh/config` aliases (the phone never types a host), and New
+    /// Terminal names the workspace it will land in.
     private func configureNewTerminalButton() {
         newTerminalButton.applyGlassIcon(.add, boxSize: 24)
         newTerminalButton.tintColor = .label
         newTerminalButton.accessibilityLabel = localized("New Terminal")
         newTerminalButton.showsMenuAsPrimaryAction = true
         newTerminalButton.menu = UIMenu(children: [
-            UIAction(
-                title: localized("New Terminal"),
-                image: HugeIcon.terminal.strokeImage(boxSize: 22)
-            ) { [weak self] _ in self?.store.startNewTerminal() },
             UIDeferredMenuElement.uncached { [weak self] completion in
-                completion([self?.sshMenu() ?? UIMenu()])
+                completion(self?.composeMenuItems() ?? [])
             },
         ])
+    }
+
+    private func composeMenuItems() -> [UIMenuElement] {
+        var items: [UIMenuElement] = [
+            UIAction(
+                title: newTerminalTitle,
+                image: HugeIcon.terminal.strokeImage(boxSize: 22)
+            ) { [weak self] _ in self?.store.startNewTerminal() },
+            sshMenu(),
+        ]
+        if let destinations = store.destinationPickerMenu() { items.append(destinations) }
+        return items
+    }
+
+    /// "New Terminal in Alpha" — the destination stated on the action itself, so
+    /// starting a shell never means guessing which machine it landed on. Plain
+    /// "New Terminal" when there is only one workspace to land in: naming a
+    /// choice nobody has is noise.
+    private var newTerminalTitle: String {
+        guard store.localWorkspaces.count > 1,
+              let name = store.destinationWorkspace?.name, !name.isEmpty
+        else { return localized("New Terminal") }
+        return localized("New Terminal in \(name)")
     }
 
     /// The "New SSH" submenu: one entry per `~/.ssh/config` host the Mac knows.
@@ -150,6 +176,10 @@ final class TerminalListViewController: UIViewController {
         tableView.estimatedSectionFooterHeight = 0
         tableView.keyboardDismissMode = .onDrag
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "row")
+        tableView.register(
+            WorkspaceSectionHeaderView.self,
+            forHeaderFooterViewReuseIdentifier: WorkspaceSectionHeaderView.reuseID
+        )
         tableView.translatesAutoresizingMaskIntoConstraints = false
         // The native tab controller contributes the correct safe-area and
         // adjusted scroll insets for both the classic and Liquid Glass bars.
@@ -163,13 +193,16 @@ final class TerminalListViewController: UIViewController {
     }
 
     private func refilter() {
-        terminals = store.terminalSessions
+        groups = store.terminalGroups
         // Shown whenever paired: New Terminal is project-less, so it no longer
         // needs an existing terminals container to land in (it seeds the first).
         newTerminalButton.isHidden = store.companionURL == nil
         tableView.reloadData()
         updateEmptyState()
     }
+
+    /// Every terminal on screen, in section order.
+    private var visible: [MockSession] { groups.flatMap(\.sessions) }
 
     // MARK: - Empty state
 
@@ -190,7 +223,7 @@ final class TerminalListViewController: UIViewController {
     /// seed the first terminal, so it's the next step; only while unpaired (＋
     /// hidden) does the message fall back to pointing at the Mac.
     private func updateEmptyState() {
-        emptyState.isHidden = !terminals.isEmpty
+        emptyState.isHidden = !visible.isEmpty
         guard !emptyState.isHidden else { return }
         let canStart = store.companionURL != nil
         emptyState.configure(
@@ -208,21 +241,51 @@ final class TerminalListViewController: UIViewController {
 // MARK: - Table data source / delegate
 
 extension TerminalListViewController: UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        groups.count
+    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        terminals.count
+        groups[section].sessions.count
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard groups.namesWorkspaces else { return nil }
+        guard let header = tableView.dequeueReusableHeaderFooterView(
+            withIdentifier: WorkspaceSectionHeaderView.reuseID
+        ) as? WorkspaceSectionHeaderView else { return nil }
+        let group = groups[section]
+        header.configure(title: group.name, detail: group.machineLabel)
+        return header
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        groups.namesWorkspaces ? WorkspaceSectionHeaderView.height : 0
+    }
+
+    /// A whitespace gap below each group — the divider-free separator, matching
+    /// the macOS sidebar's spacing-based grouping.
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        12
+    }
+
+    /// An empty (transparent) footer view, so the gap above is just whitespace.
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        UIView()
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "row", for: indexPath)
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
-        let session = terminals[indexPath.row]
+        let sessions = groups[indexPath.section].sessions
+        let session = sessions[indexPath.row]
         cell.contentConfiguration = UIHostingConfiguration {
             SessionRow(
                 session: session,
                 isCurrent: session.key == store.currentSessionKey,
                 showsProject: false,
-                showsSeparator: indexPath.row < terminals.count - 1
+                showsSeparator: indexPath.row < sessions.count - 1
             )
         }
         .margins(.horizontal, 12)
@@ -232,7 +295,7 @@ extension TerminalListViewController: UITableViewDataSource, UITableViewDelegate
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // The row IS the session — straight to its terminal.
-        store.openSession(terminals[indexPath.row])
+        store.openSession(groups[indexPath.section].sessions[indexPath.row])
     }
 
     /// Trailing swipe: the Mac session menu's "Close Session".
@@ -241,7 +304,7 @@ extension TerminalListViewController: UITableViewDataSource, UITableViewDelegate
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
         guard store.companionURL != nil,
-              let sessionID = terminals[indexPath.row].rosterID
+              let sessionID = groups[indexPath.section].sessions[indexPath.row].rosterID
         else { return nil }
         let close = UIContextualAction(style: .destructive, title: localized("Close")) { [weak self] _, _, done in
             self?.store.stopSession(sessionID)


### PR DESCRIPTION
Reopened against `main`. This work was merged into `feat/ios-device-port` 23 seconds after that branch itself merged to main (#451 → #447), so it landed on a dead branch and never reached the trunk. Same three commits, rebased onto main, rebuilt and retested there.

Two workspace defects in the iOS companion, both correctness.

**A phone-started terminal landed wherever the Mac was pointed.** `.startTerminal` and `.startSSH` carry no project — the Mac finds-or-creates the loose funnel by kind — but there is one funnel per workspace, so the Mac resolved it in whichever workspace its own window happened to be showing. The destination was decided by UI state on a device the phone user cannot see.

Both messages now take an optional `workspaceID`. Absent means exactly the old behaviour, so an older phone degrades to "the Mac picks" rather than failing; no `Wire` bump, since an additive field with a safe default is not a version event. On the Mac a named workspace is a destination for a plain shell and a *preference* for `ssh`, which still has to be filed under a workspace on the box it reaches. `Wire.looseSectionID` moves the loose-section id format into the protocol, because the phone builds the same id to address a Chats funnel the Mac has not created yet.

**The Terminals and Chats tabs merged every workspace with no marker.** Both flattened `projects.filter { kind == … }` across all workspaces, so two paired machines' loose sessions were one undifferentiated list. They now section on the workspace, reusing the Projects list's grouping — which moves into `SessionListUI` (`WorkspaceGroup`, `WorkspaceSectionHeaderView`) so all three lists share one mechanism. One unnamed local workspace still draws no header.

With the destination now the phone's to choose, ＋ states it: "New Terminal in Alpha", the Chats agent list under the same header, and a "Start in" section that switches destinations in one tap.

**Verification.** Built and run against a Mac serving this branch, with two workspaces (Sessions, Alpha). The Terminals tab drew both as separate sections; ＋ read "New Terminal in Sessions" over a checkmarked "Start in" list. Over the live socket, a `startTerminal` naming Alpha landed the shell in Alpha while the Mac's own current workspace was Sessions; the same request without the field landed in the Mac's current workspace, unchanged; and a `startSSH` naming a local workspace was ignored in favour of the host's own, as designed.

**Follow-up:** `ProjectListViewController` still has its private `WorkspaceGroup` and `SectionCapView`, now duplicates of the shared ones in `SessionListUI.swift`. They should be deleted in favour of them — left alone here because another session owned that file.

Release Notes:
- The iPhone app starts terminals and chats in the workspace you are looking at, instead of wherever the Mac happens to be pointed. ＋ names the destination and switches it in one tap.
- The Terminals and Chats tabs group their sessions by workspace, so two paired machines' shells are no longer one undifferentiated list.