### PR TITLE
Let an ended session row drag and drop like a live one

### DIFF
--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -598,22 +598,32 @@ private struct SessionRowDropDelegate: DropDelegate {
 
     /// Refuse outright when neither outcome is available — a row from another
     /// project or worktree shows the no-drop cursor rather than a dead target.
-    func validateDrop(info: DropInfo) -> Bool { outcome(info) != nil }
+    func validateDrop(info: DropInfo) -> Bool {
+        store.resolveDraggedSession()
+        return outcome(info) != nil
+    }
 
-    func dropEntered(info: DropInfo) { track(info) }
+    func dropEntered(info: DropInfo) {
+        store.resolveDraggedSession()
+        track(info)
+    }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
         track(info)
         return DropProposal(operation: .move)
     }
 
-    func dropExited(info: DropInfo) { store.sessionRowDrop = nil }
+    func dropExited(info: DropInfo) {
+        guard store.sessionRowDrop != nil else { return }
+        store.sessionRowDrop = nil
+    }
 
     func performDrop(info: DropInfo) -> Bool {
+        let moved = store.resolveDraggedSession()
         let landing = outcome(info)
         store.sessionRowDrop = nil
         store.draggingSessionID = nil
-        guard let moved = draggedSession, let landing else { return false }
+        guard let moved, let landing else { return false }
         if let side = landing.insert {
             store.reorderSession(moved, relativeTo: session, insert: side)
         } else {
@@ -622,8 +632,13 @@ private struct SessionRowDropDelegate: DropDelegate {
         return true
     }
 
+    /// Published only when it changes, for the reason `PaneDropDelegate.track`
+    /// spells out: `dropUpdated` runs at pointer rate, and every write to the store
+    /// redraws each of the ~25 view types observing it, the whole sidebar included.
     private func track(_ info: DropInfo) {
-        store.sessionRowDrop = outcome(info)
+        let landing = outcome(info)
+        guard store.sessionRowDrop != landing else { return }
+        store.sessionRowDrop = landing
     }
 
     /// What a release here would do, or `nil` when it would do nothing. The zone
@@ -631,7 +646,7 @@ private struct SessionRowDropDelegate: DropDelegate {
     /// and an illegal one is refused rather than quietly turned into the other —
     /// a drop that lands somewhere you did not aim is worse than one that declines.
     private func outcome(_ info: DropInfo) -> TermioStore.SessionRowDrop? {
-        guard let moved = draggedSession, height > 0 else { return nil }
+        guard let moved = store.draggingSessionID, height > 0 else { return nil }
         let third = height / 3
         if info.location.y < third {
             return store.canReorder(moved, relativeTo: session)
@@ -643,12 +658,98 @@ private struct SessionRowDropDelegate: DropDelegate {
         }
         return store.canGroup(moved, with: session) ? .init(row: session, insert: nil) : nil
     }
+}
 
-    /// The dragged session, read off the drag pasteboard — `DropInfo`'s providers
-    /// cannot answer synchronously, and `dropUpdated` has to (see `PaneDropDelegate`).
-    private var draggedSession: Session.ID? {
-        guard let link = NSPasteboard(name: .drag).string(forType: .string) else { return nil }
-        return TermioStore.sessionID(fromLink: link.trimmingCharacters(in: .whitespacesAndNewlines))
+/// The drag and drop a session row carries: lift the whole row to reorder or
+/// group it, and accept another row landing on it.
+///
+/// A modifier rather than a stretch of `SessionRow`'s chain because a row has two
+/// bodies — the live one and `EndedSessionRow` — and only the live one used to
+/// carry this. A session the device buried still holds its slot in the roster and
+/// still opens when clicked, so it stayed reorderable in the context menu while
+/// silently refusing every drag: the gesture went missing with the view swap, which
+/// nobody decided. One modifier is what keeps the two bodies from drifting again.
+private struct SessionRowDragAndDrop: ViewModifier {
+    @EnvironmentObject var store: TermioStore
+    @EnvironmentObject var settings: AppSettings
+    let session: Session
+    let chrome: ChromeTheme?
+    /// Measured, not assumed: the drop zones are fractions of the row, and row
+    /// height follows the interface row padding.
+    @State private var rowHeight: CGFloat = 0
+
+    private var dropCue: TermioStore.SessionRowDrop? {
+        store.sessionRowDrop.flatMap { $0.row == session.id ? $0 : nil }
+    }
+
+    func body(content: Content) -> some View {
+        content
+            // The gap the row would land in. Drawn at the row edge rather than as a
+            // background, because "between two rows" has no row to fill.
+            .overlay(alignment: .top) {
+                RowInsertionLine(chrome: chrome).opacity(dropCue?.insert == .above ? 1 : 0)
+            }
+            .overlay(alignment: .bottom) {
+                RowInsertionLine(chrome: chrome).opacity(dropCue?.insert == .below ? 1 : 0)
+            }
+            .contentShape(Rectangle())
+            // Drag the whole row to reorder it within its bucket (no handle). Uses
+            // `.onDrag` (AppKit's drag session) rather than `.draggable` (SwiftUI's): a
+            // SwiftUI drag settles its preview over ~0.3s on release, while an AppKit drag
+            // image just vanishes on a successful drop — so the row moves crisply. The
+            // drag only carries the session id; nothing reorders until the drop commits
+            // it (see the drop below). It starts at all only because selection rides a
+            // *simultaneous* tap (in the row) — an exclusive `.onTapGesture` kills the drag.
+            .onDrag {
+                store.draggingSessionID = session.id
+                // The payload is the session's canonical deep link, not a private
+                // token: a drag carries plain text, so any text target — a terminal,
+                // an editor, a text field — will accept it. Shipping the link means a
+                // stray drop pastes something that works (`termio://session/<uuid>`,
+                // what `termio sessions` takes) instead of leaking an internal id.
+                // A pane recognises one of these rows by parsing that link back off the
+                // drag pasteboard (see `TermioStore.resolveDraggedSession`), so plain
+                // text is the whole payload: SwiftUI rebuilds the item provider on the
+                // receiving side, and a private type registered here would not survive
+                // the trip.
+                return NSItemProvider(object: store.sessionLink(for: session) as NSString)
+            } preview: {
+                // The drag preview is just the row's identity (icon + title), so the
+                // floating chip never carries the hover-only close button. `.fixedSize`
+                // keeps the label at its natural width — the preview proposes a tight size
+                // that would otherwise squeeze the flexible Text away, leaving only the
+                // fixed-width icon — and the material plate makes the chip legible.
+                HStack(spacing: 6) {
+                    AgentIconView(agent: store.effectiveAgent(for: session), size: 15)
+                        .frame(width: 16)
+                    Text(store.displayTitle(for: session))
+                        .font(settings.interfaceFont)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                }
+                .fixedSize()
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(.regularMaterial)
+                )
+            }
+            // A row answers a dragged session two ways, by where on the row you release:
+            // the gap above or below reorders, the middle groups the two together. That
+            // is the file-tree convention — a line means "between", a highlight means
+            // "into" — and it is what lets one gesture do both without a modifier.
+            //
+            // The height comes off the row itself because the zones are fractions of it;
+            // rows grow with the interface row padding, so a fixed band would drift.
+            .background(
+                GeometryReader { proxy in
+                    Color.clear.onAppear { rowHeight = proxy.size.height }
+                        .onChange(of: proxy.size.height) { _, new in rowHeight = new }
+                }
+            )
+            .onDrop(of: [.text], delegate: SessionRowDropDelegate(
+                session: session.id, height: rowHeight, store: store))
     }
 }
 
@@ -1242,9 +1343,6 @@ private struct SessionRow: View {
     /// per row scanned the workspaces once per row.
     var marksDevice: Bool = true
     @State private var isHovering = false
-    /// Measured, not assumed: the drop zones are fractions of the row, and row
-    /// height follows the interface row padding.
-    @State private var rowHeight: CGFloat = 0
 
     /// What a release over this row would do, or `nil` when the drag is elsewhere
     /// or could not land here.
@@ -1436,71 +1534,7 @@ private struct SessionRow: View {
                     .padding(.leading, max(0, leadingIndent - 16))
             }
         }
-        // The gap the row would land in. Drawn at the row edge rather than as a
-        // background, because "between two rows" has no row to fill.
-        .overlay(alignment: .top) {
-            RowInsertionLine(chrome: chrome).opacity(dropCue?.insert == .above ? 1 : 0)
-        }
-        .overlay(alignment: .bottom) {
-            RowInsertionLine(chrome: chrome).opacity(dropCue?.insert == .below ? 1 : 0)
-        }
-        .contentShape(Rectangle())
-        // Drag the whole row to reorder it within its bucket (no handle). Uses
-        // `.onDrag` (AppKit's drag session) rather than `.draggable` (SwiftUI's): a
-        // SwiftUI drag settles its preview over ~0.3s on release, while an AppKit drag
-        // image just vanishes on a successful drop — so the row moves crisply. The
-        // drag only carries the session id; nothing reorders until the drop commits
-        // it (see the drop below). It starts at all only because selection rides a
-        // *simultaneous* tap (below) — an exclusive `.onTapGesture` kills the drag.
-        .onDrag {
-            store.draggingSessionID = session.id
-            // The payload is the session's canonical deep link, not a private
-            // token: a drag carries plain text, so any text target — a terminal,
-            // an editor, a text field — will accept it. Shipping the link means a
-            // stray drop pastes something that works (`termio://session/<uuid>`,
-            // what `termio sessions` takes) instead of leaking an internal id.
-            // A pane recognises one of these rows by parsing that link back off the
-            // drag pasteboard (see `PaneDropDelegate`), so plain text is the whole
-            // payload: SwiftUI rebuilds the item provider on the receiving side, and
-            // a private type registered here would not survive the trip.
-            return NSItemProvider(object: store.sessionLink(for: session) as NSString)
-        } preview: {
-            // The drag preview is just the row's identity (icon + title), so the
-            // floating chip never carries the hover-only close button. `.fixedSize`
-            // keeps the label at its natural width — the preview proposes a tight size
-            // that would otherwise squeeze the flexible Text away, leaving only the
-            // fixed-width icon — and the material plate makes the chip legible.
-            HStack(spacing: 6) {
-                AgentIconView(agent: store.effectiveAgent(for: session), size: 15)
-                    .frame(width: 16)
-                Text(store.displayTitle(for: session))
-                    .font(settings.interfaceFont)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-            }
-            .fixedSize()
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(.regularMaterial)
-            )
-        }
-        // A row answers a dragged session two ways, by where on the row you release:
-        // the gap above or below reorders, the middle groups the two together. That
-        // is the file-tree convention — a line means "between", a highlight means
-        // "into" — and it is what lets one gesture do both without a modifier.
-        //
-        // The height comes off the row itself because the zones are fractions of it;
-        // rows grow with the interface row padding, so a fixed band would drift.
-        .background(
-            GeometryReader { proxy in
-                Color.clear.onAppear { rowHeight = proxy.size.height }
-                    .onChange(of: proxy.size.height) { _, new in rowHeight = new }
-            }
-        )
-        .onDrop(of: [.text], delegate: SessionRowDropDelegate(
-            session: session.id, height: rowHeight, store: store))
+        .modifier(SessionRowDragAndDrop(session: session, chrome: chrome))
         .onHover { isHovering = $0 }
         // Click-to-select rides a *simultaneous* tap, not `.onTapGesture`: an
         // exclusive tap gesture preempts the row drag (it never starts), while a
@@ -1710,6 +1744,13 @@ private struct EndedSessionRow: View {
 
     private var isSelected: Bool { store.selectedSessionID == session.id }
 
+    /// Grouping this row is the drop that lands *on* it, so it reuses the hover
+    /// lift — the same rule the live row follows.
+    private var isDropTarget: Bool {
+        guard let cue = store.sessionRowDrop, cue.row == session.id else { return false }
+        return cue.insert == nil
+    }
+
     private var reason: String {
         switch tombstone.reason {
         case "exited":
@@ -1741,15 +1782,19 @@ private struct EndedSessionRow: View {
         }
         .padding(.vertical, settings.interfaceRowPadding)
         .padding(.leading, leadingIndent)
-        .contentShape(Rectangle())
+        .modifier(SessionRowDragAndDrop(session: session, chrome: chrome))
         .onHover { isHovering = $0 }
         .simultaneousGesture(TapGesture().onEnded { store.selectedSessionID = session.id })
         .background(SidebarRowContextMenu(items: {
             [.action(localized("Close Session")) { store.requestCloseSession(session.id) }]
         }))
         .listRowBackground(
-            SidebarRowHighlight(isSelected: isSelected, isHovering: isHovering, chrome: chrome)
-                .animation(.easeInOut(duration: 0.12), value: isHovering))
+            SidebarRowHighlight(isSelected: isSelected,
+                                isHovering: isHovering || isDropTarget, chrome: chrome)
+                .animation(.easeInOut(duration: 0.12), value: isHovering)
+                // No animation on the drop cue: it must snap off the instant the
+                // drag leaves or commits, as on the live row.
+                .animation(nil, value: isDropTarget))
     }
 }
 

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -807,11 +807,14 @@ private struct PaneDropDelegate: DropDelegate {
     /// one of our rows is a payload for the prompt, and always lands.
     func validateDrop(info: DropInfo) -> Bool {
         guard isVisible else { return false }
-        guard let moved = draggedSession else { return true }
+        guard let moved = store.resolveDraggedSession() else { return true }
         return store.canGroup(moved, with: pane)
     }
 
-    func dropEntered(info: DropInfo) { track(info) }
+    func dropEntered(info: DropInfo) {
+        store.resolveDraggedSession()
+        track(info)
+    }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
         track(info)
@@ -823,10 +826,13 @@ private struct PaneDropDelegate: DropDelegate {
     /// exit, so this can wipe a cue that was just set — but the new pane's next
     /// `dropUpdated` puts it straight back, a frame later at worst. A cue that
     /// heals itself while the pointer moves beats one that can be left behind.
-    func dropExited(info: DropInfo) { store.sessionDropTarget = nil }
+    func dropExited(info: DropInfo) {
+        guard store.sessionDropTarget != nil else { return }
+        store.sessionDropTarget = nil
+    }
 
     func performDrop(info: DropInfo) -> Bool {
-        let moved = draggedSession
+        let moved = store.resolveDraggedSession()
         store.sessionDropTarget = nil
         store.draggingSessionID = nil
         guard let moved else { return insert(info) }
@@ -837,23 +843,19 @@ private struct PaneDropDelegate: DropDelegate {
 
     /// Lights what the release would commit: the half this pane would give up to a
     /// session being grouped in, or the whole pane for a payload being typed.
+    ///
+    /// Published only when it changes. `dropUpdated` fires at pointer rate, and a
+    /// write to any `@Published` on the store invalidates every view observing it —
+    /// the whole sidebar list and the pane tree — so republishing the zone the cue
+    /// is already showing redraws the app for nothing. Same rule, and the same
+    /// reason, as `PaneDragRearrange.setHover`.
     private func track(_ info: DropInfo) {
         guard isVisible else { return }
-        let zone = draggedSession == nil ? .center : PaneDropZone.edge(at: info.location, in: size)
-        store.sessionDropTarget = SessionDropTarget(pane: pane, zone: zone)
-    }
-
-    /// The session a dragged sidebar row is carrying, parsed back out of the drag
-    /// pasteboard.
-    ///
-    /// `DropInfo`'s own item providers cannot answer this. SwiftUI rebuilds them on
-    /// the receiving side into `public.url` plus plain text, so a private type
-    /// registered at the source never survives the trip — and loading the text back
-    /// is async, while `dropUpdated` has to answer with the pointer still moving.
-    /// The drag pasteboard holds the same payload, synchronously.
-    private var draggedSession: Session.ID? {
-        guard let link = NSPasteboard(name: .drag).string(forType: .string) else { return nil }
-        return TermioStore.sessionID(fromLink: link.trimmingCharacters(in: .whitespacesAndNewlines))
+        let zone = store.draggingSessionID == nil
+            ? .center : PaneDropZone.edge(at: info.location, in: size)
+        let target = SessionDropTarget(pane: pane, zone: zone)
+        guard store.sessionDropTarget != target else { return }
+        store.sessionDropTarget = target
     }
 
     /// Everything that ends up at the prompt: files and folders from the Finder or

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -877,7 +877,7 @@ enum Termiod {
         ///
         /// Omitted when false, so `nil` conflates "idle" with "never sampled".
         /// Harmless: both must read as today's no-confirm behaviour, never as
-        /// "unknown, so confirm" (`remote-to-device.decisions.md` §2).
+        /// "unknown, so confirm" (`20260814-remote-to-device.decisions.md` §2).
         let foregroundJob: Bool?
         /// The child's *current* directory — what `cd` moves, as opposed to `cwd`,
         /// which is where the session was created. A path on the **device**.

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 /// Split-pane actions. The groups themselves live on the store as `splitGroups`
@@ -232,6 +233,31 @@ extension TermioStore {
               anchorHome.sharesRoster(with: movedHome)
         else { return false }
         return session(moved)?.worktreePath == session(anchor)?.worktreePath
+    }
+
+    /// The session a drag is carrying, read off the drag pasteboard and cached in
+    /// `draggingSessionID` for the rest of the drag.
+    ///
+    /// `DropInfo`'s own item providers cannot answer this: SwiftUI rebuilds them on
+    /// the receiving side into `public.url` plus plain text, so a private type
+    /// registered at the source never survives the trip — and loading the text back
+    /// is async, while a drop delegate has to answer with the pointer still moving.
+    /// The drag pasteboard holds the same payload, synchronously.
+    ///
+    /// Called only from the drop delegates' per-entry hooks (`validateDrop`,
+    /// `dropEntered`, `performDrop`); `dropUpdated` fires at pointer rate and reads
+    /// `draggingSessionID` instead. `NSPasteboard(name:)` is a round trip to the
+    /// pasteboard server, and a drag cannot change what it carries between two
+    /// pointer moves.
+    @discardableResult
+    func resolveDraggedSession() -> Session.ID? {
+        let carried = NSPasteboard(name: .drag).string(forType: .string)
+            .flatMap { Self.sessionID(fromLink: $0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        // A drag that carries no session link clears the cue as much as one that
+        // does: dragging a file in after dragging a row out must not inherit the
+        // row's lift.
+        if draggingSessionID != carried { draggingSessionID = carried }
+        return carried
     }
 
     /// Lands a session dragged out of the sidebar on the `zone` half of a visible


### PR DESCRIPTION
A session the device buried keeps its slot in the roster and still opens when
clicked, but its row swaps in a second body that never carried the drag — so it
stayed reorderable from the context menu while silently refusing every gesture.
Both bodies now share one `SessionRowDragAndDrop` modifier, which is what keeps
them from drifting apart again.

The same pass tightens what the drag publishes. `dropUpdated` fires at pointer
rate, and any write to the store invalidates every view observing it — the whole
sidebar list and the pane tree — so the drop cue is now published only when it
actually changes. The drag pasteboard is read once per drop-delegate entry
(`validateDrop` / `dropEntered` / `performDrop`) instead of on every pointer
move; a drag cannot change what it carries between two moves, and
`NSPasteboard(name:)` is a round trip to the pasteboard server.

`swift build` is warning-free and `swift test` passes (637 tests, 21 skipped).
The gesture itself needs a real run to confirm on screen.

Release Notes:
- Sessions that have ended can now be dragged to reorder or group them, the same
  as any other session row.