### PR TITLE
Rename Machines to Devices and scope the per-device pages

### DIFF
--- a/Sources/termio/Agents/InstallOutcome.swift
+++ b/Sources/termio/Agents/InstallOutcome.swift
@@ -16,6 +16,24 @@ struct InstallOutcome {
 
     var isEmpty: Bool { succeeded.isEmpty && failed.isEmpty }
 
+    /// Two installs reported as one. Hooks and the skill are one action to the
+    /// user, so an agent that took both is named once, and an agent that took
+    /// one and refused the other counts as refused — reporting it as installed
+    /// would be the optimistic half of a mixed result.
+    func merged(with other: InstallOutcome) -> InstallOutcome {
+        let refused = Set(failed).union(other.failed)
+        var combined = InstallOutcome()
+        var seen = Set<String>()
+        for name in succeeded + other.succeeded
+        where !refused.contains(name) && seen.insert(name).inserted {
+            combined.record(name, installed: true)
+        }
+        for name in failed + other.failed where seen.insert(name).inserted {
+            combined.record(name, installed: false)
+        }
+        return combined
+    }
+
     mutating func record(_ name: String, installed: Bool) {
         if installed { succeeded.append(name) } else { failed.append(name) }
     }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -2043,6 +2043,16 @@
         }
       }
     },
+    "Device": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备"
+          }
+        }
+      }
+    },
     "Device Unavailable": {
       "localizations": {
         "zh-Hans": {
@@ -2173,12 +2183,12 @@
         }
       }
     },
-    "Drag the list to change the order agents appear in. Readiness is for %@ — open it under Machines to install anything missing.": {
+    "Drag the list to change the order agents appear in. Readiness is for the device above.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "拖动列表可更改 Agent 的显示顺序。就绪状态针对 %@ — 在“设备”中打开它可安装缺少的内容。"
+            "value": "拖动列表可调整 agent 的显示顺序。就绪状态针对上方选中的设备。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -2774,6 +2774,16 @@
         }
       }
     },
+    "Installed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装"
+          }
+        }
+      }
+    },
     "Installed by Termio": {
       "localizations": {
         "zh-Hans": {
@@ -3110,16 +3120,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Agent 实时状态"
-          }
-        }
-      }
-    },
-    "Live agent status and session control are switched on in Settings ▸ Agents; this installs them on %@.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agent 实时状态和会话控制在“设置 ▸ Agents”中开启；这里把它们安装到 %@ 上。"
           }
         }
       }
@@ -3734,16 +3734,6 @@
         }
       }
     },
-    "No agents on your list yet — add one in Settings ▸ Agents.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你的列表中还没有 Agent — 在“设置 ▸ Agents”中添加一个。"
-          }
-        }
-      }
-    },
     "No bundled tool to install from.": {
       "localizations": {
         "zh-Hans": {
@@ -4323,6 +4313,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "粘贴"
+          }
+        }
+      }
+    },
+    "Path": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路径"
           }
         }
       }
@@ -5278,16 +5278,6 @@
         }
       }
     },
-    "Set the path it launches from on each machine, under Machines.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在“设备”中为每台设备设置它的启动路径。"
-          }
-        }
-      }
-    },
     "Set up this device": {
       "localizations": {
         "zh-Hans": {
@@ -5864,6 +5854,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法添加忽略规则。"
+          }
+        }
+      }
+    },
+    "The install page — the same one whichever machine you are installing on.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装页面 —— 无论装在哪台机器上都是同一个页面。"
           }
         }
       }
@@ -6549,22 +6549,12 @@
         }
       }
     },
-    "Where each agent’s CLI lives on %@. Leave a path empty to use the agent’s default.": {
+    "Whether you want these at all, and putting them on the selected device.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "每个 Agent 的命令行工具在 %@ 上的位置。留空则使用该 Agent 的默认值。"
-          }
-        }
-      }
-    },
-    "Whether you want these at all. Each machine installs them for its own agents, under Machines.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "决定你是否需要这些功能。每台设备在“设备”中为自己的 Agent 安装它们。"
+            "value": "是否启用这些功能，以及把它们装到选中的设备上。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -2173,22 +2173,22 @@
         }
       }
     },
+    "Drag an agent onto another to reorder. Readiness is for the device above.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把一个 agent 拖到另一个上面即可调整顺序。就绪状态针对上方选中的设备。"
+          }
+        }
+      }
+    },
     "Drag the list to change the order agents appear in.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "拖动列表可以调整 Agent 出现的顺序。"
-          }
-        }
-      }
-    },
-    "Drag the list to change the order agents appear in. Readiness is for the device above.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "拖动列表可调整 agent 的显示顺序。就绪状态针对上方选中的设备。"
           }
         }
       }
@@ -3240,6 +3240,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "移动访问"
+          }
+        }
+      }
+    },
+    "Move Down": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下移"
+          }
+        }
+      }
+    },
+    "Move Up": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上移"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -441,6 +441,16 @@
         }
       }
     },
+    "Add Device": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加设备"
+          }
+        }
+      }
+    },
     "Add Host": {
       "localizations": {
         "zh-Hans": {
@@ -457,16 +467,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "添加主机…"
-          }
-        }
-      }
-    },
-    "Add Machine": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添加设备"
           }
         }
       }
@@ -2043,6 +2043,16 @@
         }
       }
     },
+    "Device Unavailable": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备不可用"
+          }
+        }
+      }
+    },
     "Devices": {
       "localizations": {
         "zh-Hans": {
@@ -3154,16 +3164,6 @@
         }
       }
     },
-    "Machine Unavailable": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "设备不可用"
-          }
-        }
-      }
-    },
     "Machines": {
       "localizations": {
         "zh-Hans": {
@@ -4223,6 +4223,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 GitHub 上打开"
+          }
+        }
+      }
+    },
+    "Open one to see how it is reached and what it runs.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开一台可查看它的连接方式和运行内容。"
           }
         }
       }
@@ -6028,22 +6038,12 @@
         }
       }
     },
-    "This Mac and the machines you reach from it, and what each one runs": {
+    "This Mac and the machines you reach from it": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "本机以及你能连接的设备，和每台设备上运行的内容"
-          }
-        }
-      }
-    },
-    "This Mac, and every machine you can reach from it. Open one to see what runs there.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本机，以及你能从这里连接的每台设备。打开一台可查看它上面运行的内容。"
+            "value": "本机以及你能连接的设备"
           }
         }
       }
@@ -6104,6 +6104,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "这个检出没有其他分支可以对比。"
+          }
+        }
+      }
+    },
+    "This device is no longer in your configuration.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该设备已不在你的配置中。"
           }
         }
       }
@@ -6174,16 +6184,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "这台主机接受密码登录。Termio 用密钥登录，设置一次之后，会话、文件树和远程终端都能连上它。"
-          }
-        }
-      }
-    },
-    "This machine is no longer in your configuration.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "该设备已不在你的配置中。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -5898,16 +5898,6 @@
         }
       }
     },
-    "The machine you’re on": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你正在使用的设备"
-          }
-        }
-      }
-    },
     "The project and session list. Kept separate from the terminal font, and need not be monospaced.": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1186,8 +1186,6 @@
 	<string>The machine Termio is running on</string>
 	<key>The machine answered with no listing for that folder.</key>
 	<string>The machine answered with no listing for that folder.</string>
-	<key>The machine you’re on</key>
-	<string>The machine you’re on</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>The project and session list. Kept separate from the terminal font, and need not be monospaced.</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -562,6 +562,8 @@
 	<string>Install %@</string>
 	<key>Install Page</key>
 	<string>Install Page</string>
+	<key>Installed</key>
+	<string>Installed</string>
 	<key>Installed by Termio</key>
 	<string>Installed by Termio</string>
 	<key>Installed.</key>
@@ -630,8 +632,6 @@
 	<string>Links `%@` into /usr/local/bin so you (and agents) can run `%@ sessions …` from any shell.</string>
 	<key>Live agent status</key>
 	<string>Live agent status</string>
-	<key>Live agent status and session control are switched on in Settings ▸ Agents; this installs them on %@.</key>
-	<string>Live agent status and session control are switched on in Settings ▸ Agents; this installs them on %@.</string>
 	<key>Live agent status is off</key>
 	<string>Live agent status is off</string>
 	<key>Local</key>
@@ -754,8 +754,6 @@
 	<string>No agent CLIs found on %@.</string>
 	<key>No agent CLIs found.</key>
 	<string>No agent CLIs found.</string>
-	<key>No agents on your list yet — add one in Settings ▸ Agents.</key>
-	<string>No agents on your list yet — add one in Settings ▸ Agents.</string>
 	<key>No bundled tool to install from.</key>
 	<string>No bundled tool to install from.</string>
 	<key>No description provided.</key>
@@ -872,6 +870,8 @@
 	<string>Password</string>
 	<key>Paste</key>
 	<string>Paste</string>
+	<key>Path</key>
+	<string>Path</string>
 	<key>Permissions</key>
 	<string>Permissions</string>
 	<key>Pick a file on the left to see its changes.</key>
@@ -1062,8 +1062,6 @@
 	<string>Set Up Key</string>
 	<key>Set Up Key…</key>
 	<string>Set Up Key…</string>
-	<key>Set the path it launches from on each machine, under Machines.</key>
-	<string>Set the path it launches from on each machine, under Machines.</string>
 	<key>Set up this device</key>
 	<string>Set up this device</string>
 	<key>Settings</key>
@@ -1180,6 +1178,8 @@
 	<string>The folder was removed, but git couldn’t prune its stale worktree metadata.</string>
 	<key>The ignore rule couldn’t be added.</key>
 	<string>The ignore rule couldn’t be added.</string>
+	<key>The install page — the same one whichever machine you are installing on.</key>
+	<string>The install page — the same one whichever machine you are installing on.</string>
 	<key>The listing failed.</key>
 	<string>The listing failed.</string>
 	<key>The machine Termio is running on</key>
@@ -1316,10 +1316,8 @@
 	<string>WeChat group</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
 	<string>When on, selecting text copies it straight to the clipboard.</string>
-	<key>Where each agent’s CLI lives on %@. Leave a path empty to use the agent’s default.</key>
-	<string>Where each agent’s CLI lives on %@. Leave a path empty to use the agent’s default.</string>
-	<key>Whether you want these at all. Each machine installs them for its own agents, under Machines.</key>
-	<string>Whether you want these at all. Each machine installs them for its own agents, under Machines.</string>
+	<key>Whether you want these at all, and putting them on the selected device.</key>
+	<string>Whether you want these at all, and putting them on the selected device.</string>
 	<key>Window</key>
 	<string>Window</string>
 	<key>Working Directory</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -416,6 +416,8 @@
 	<string>Deploys `termiod`, looks for your agent CLIs, then installs Termio’s hooks and skill.</string>
 	<key>Detached at %@</key>
 	<string>Detached at %@</string>
+	<key>Device</key>
+	<string>Device</string>
 	<key>Device Unavailable</key>
 	<string>Device Unavailable</string>
 	<key>Devices</key>
@@ -442,8 +444,8 @@
 	<string>Draft</string>
 	<key>Drag the list to change the order agents appear in.</key>
 	<string>Drag the list to change the order agents appear in.</string>
-	<key>Drag the list to change the order agents appear in. Readiness is for %@ — open it under Machines to install anything missing.</key>
-	<string>Drag the list to change the order agents appear in. Readiness is for %@ — open it under Machines to install anything missing.</string>
+	<key>Drag the list to change the order agents appear in. Readiness is for the device above.</key>
+	<string>Drag the list to change the order agents appear in. Readiness is for the device above.</string>
 	<key>Duplicate to Themes Folder</key>
 	<string>Duplicate to Themes Folder</string>
 	<key>Edit</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -92,12 +92,12 @@
 	<string>Add &amp; Connect</string>
 	<key>Add Agent</key>
 	<string>Add Agent</string>
+	<key>Add Device</key>
+	<string>Add Device</string>
 	<key>Add Host</key>
 	<string>Add Host</string>
 	<key>Add Host…</key>
 	<string>Add Host…</string>
-	<key>Add Machine</key>
-	<string>Add Machine</string>
 	<key>Add SSH Host</key>
 	<string>Add SSH Host</string>
 	<key>Add to Chat</key>
@@ -416,6 +416,8 @@
 	<string>Deploys `termiod`, looks for your agent CLIs, then installs Termio’s hooks and skill.</string>
 	<key>Detached at %@</key>
 	<string>Detached at %@</string>
+	<key>Device Unavailable</key>
+	<string>Device Unavailable</string>
 	<key>Devices</key>
 	<string>Devices</string>
 	<key>Discard %lld Files…</key>
@@ -638,8 +640,6 @@
 	<string>Looking for agent CLIs…</string>
 	<key>Lost the connection to %@. The session is still running there.</key>
 	<string>Lost the connection to %@. The session is still running there.</string>
-	<key>Machine Unavailable</key>
-	<string>Machine Unavailable</string>
 	<key>Machines</key>
 	<string>Machines</string>
 	<key>Match Case</key>
@@ -852,6 +852,8 @@
 	<string>Open in Editor</string>
 	<key>Open on GitHub</key>
 	<string>Open on GitHub</string>
+	<key>Open one to see how it is reached and what it runs.</key>
+	<string>Open one to see how it is reached and what it runs.</string>
 	<key>Open the invite on your iPhone to install it with TestFlight.</key>
 	<string>Open the invite on your iPhone to install it with TestFlight.</string>
 	<key>Opened outside Termio on this device</key>
@@ -1212,10 +1214,8 @@
 	<string>Thicken glyphs</string>
 	<key>This Mac</key>
 	<string>This Mac</string>
-	<key>This Mac and the machines you reach from it, and what each one runs</key>
-	<string>This Mac and the machines you reach from it, and what each one runs</string>
-	<key>This Mac, and every machine you can reach from it. Open one to see what runs there.</key>
-	<string>This Mac, and every machine you can reach from it. Open one to see what runs there.</string>
+	<key>This Mac and the machines you reach from it</key>
+	<string>This Mac and the machines you reach from it</string>
 	<key>This Mac…</key>
 	<string>This Mac…</string>
 	<key>This agent is no longer on your list.</key>
@@ -1228,6 +1228,8 @@
 	<string>This branch has nothing the base branch doesn’t already have.</string>
 	<key>This checkout has no other branch to compare with.</key>
 	<string>This checkout has no other branch to compare with.</string>
+	<key>This device is no longer in your configuration.</key>
+	<string>This device is no longer in your configuration.</string>
 	<key>This device sent a name the file tree can’t show.</key>
 	<string>This device sent a name the file tree can’t show.</string>
 	<key>This device’s termiod is too old to browse files.</key>
@@ -1242,8 +1244,6 @@
 	<string>This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.</string>
 	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>
 	<string>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</string>
-	<key>This machine is no longer in your configuration.</key>
-	<string>This machine is no longer in your configuration.</string>
 	<key>This machine’s termiod is too old to list folders.</key>
 	<string>This machine’s termiod is too old to list folders.</string>
 	<key>This month</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -442,10 +442,10 @@
 	<string>Don’t Compare</string>
 	<key>Draft</key>
 	<string>Draft</string>
+	<key>Drag an agent onto another to reorder. Readiness is for the device above.</key>
+	<string>Drag an agent onto another to reorder. Readiness is for the device above.</string>
 	<key>Drag the list to change the order agents appear in.</key>
 	<string>Drag the list to change the order agents appear in.</string>
-	<key>Drag the list to change the order agents appear in. Readiness is for the device above.</key>
-	<string>Drag the list to change the order agents appear in. Readiness is for the device above.</string>
 	<key>Duplicate to Themes Folder</key>
 	<string>Duplicate to Themes Folder</string>
 	<key>Edit</key>
@@ -656,6 +656,10 @@
 	<string>Mobile</string>
 	<key>Mobile Access</key>
 	<string>Mobile Access</string>
+	<key>Move Down</key>
+	<string>Move Down</string>
+	<key>Move Up</key>
+	<string>Move Up</string>
 	<key>Move to Trash</key>
 	<string>Move to Trash</string>
 	<key>Move to Workspace</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -92,12 +92,12 @@
 	<string>添加并连接</string>
 	<key>Add Agent</key>
 	<string>添加 Agent</string>
+	<key>Add Device</key>
+	<string>添加设备</string>
 	<key>Add Host</key>
 	<string>添加主机</string>
 	<key>Add Host…</key>
 	<string>添加主机…</string>
-	<key>Add Machine</key>
-	<string>添加设备</string>
 	<key>Add SSH Host</key>
 	<string>添加 SSH 主机</string>
 	<key>Add to Chat</key>
@@ -416,6 +416,8 @@
 	<string>部署 `termiod`，查找你的 Agent 命令行工具，然后安装 Termio 的 hooks 和技能。</string>
 	<key>Detached at %@</key>
 	<string>已分离于 %@</string>
+	<key>Device Unavailable</key>
+	<string>设备不可用</string>
 	<key>Devices</key>
 	<string>设备</string>
 	<key>Discard %lld Files…</key>
@@ -638,8 +640,6 @@
 	<string>正在查找 Agent 命令行工具…</string>
 	<key>Lost the connection to %@. The session is still running there.</key>
 	<string>与 %@ 的连接已断开。会话仍在那台机器上运行。</string>
-	<key>Machine Unavailable</key>
-	<string>设备不可用</string>
 	<key>Machines</key>
 	<string>设备</string>
 	<key>Match Case</key>
@@ -852,6 +852,8 @@
 	<string>在编辑器中打开</string>
 	<key>Open on GitHub</key>
 	<string>在 GitHub 上打开</string>
+	<key>Open one to see how it is reached and what it runs.</key>
+	<string>打开一台可查看它的连接方式和运行内容。</string>
 	<key>Open the invite on your iPhone to install it with TestFlight.</key>
 	<string>在 iPhone 上打开邀请链接，用 TestFlight 安装。</string>
 	<key>Opened outside Termio on this device</key>
@@ -1212,10 +1214,8 @@
 	<string>加粗字形</string>
 	<key>This Mac</key>
 	<string>本机</string>
-	<key>This Mac and the machines you reach from it, and what each one runs</key>
-	<string>本机以及你能连接的设备，和每台设备上运行的内容</string>
-	<key>This Mac, and every machine you can reach from it. Open one to see what runs there.</key>
-	<string>本机，以及你能从这里连接的每台设备。打开一台可查看它上面运行的内容。</string>
+	<key>This Mac and the machines you reach from it</key>
+	<string>本机以及你能连接的设备</string>
 	<key>This Mac…</key>
 	<string>本机…</string>
 	<key>This agent is no longer on your list.</key>
@@ -1228,6 +1228,8 @@
 	<string>这个分支没有基础分支尚未包含的内容。</string>
 	<key>This checkout has no other branch to compare with.</key>
 	<string>这个检出没有其他分支可以对比。</string>
+	<key>This device is no longer in your configuration.</key>
+	<string>该设备已不在你的配置中。</string>
 	<key>This device sent a name the file tree can’t show.</key>
 	<string>该设备返回了文件树无法显示的名称。</string>
 	<key>This device’s termiod is too old to browse files.</key>
@@ -1242,8 +1244,6 @@
 	<string>这台主机接受密码登录。Termio 用密钥登录，而 ~/.ssh 里没有 ssh 会自动尝试的密钥——先用 ssh-keygen 生成一个，再回到这里设置。</string>
 	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>
 	<string>这台主机接受密码登录。Termio 用密钥登录，设置一次之后，会话、文件树和远程终端都能连上它。</string>
-	<key>This machine is no longer in your configuration.</key>
-	<string>该设备已不在你的配置中。</string>
 	<key>This machine’s termiod is too old to list folders.</key>
 	<string>这台机器上的 termiod 版本太旧，列不出文件夹。</string>
 	<key>This month</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -562,6 +562,8 @@
 	<string>安装 %@</string>
 	<key>Install Page</key>
 	<string>安装页面</string>
+	<key>Installed</key>
+	<string>已安装</string>
 	<key>Installed by Termio</key>
 	<string>Termio 安装的内容</string>
 	<key>Installed.</key>
@@ -630,8 +632,6 @@
 	<string>将 `%@` 链接到 /usr/local/bin，让你（和 Agent）可在任意 shell 中运行 `%@ sessions …`。</string>
 	<key>Live agent status</key>
 	<string>Agent 实时状态</string>
-	<key>Live agent status and session control are switched on in Settings ▸ Agents; this installs them on %@.</key>
-	<string>Agent 实时状态和会话控制在“设置 ▸ Agents”中开启；这里把它们安装到 %@ 上。</string>
 	<key>Live agent status is off</key>
 	<string>Agent 实时状态已关闭</string>
 	<key>Local</key>
@@ -754,8 +754,6 @@
 	<string>在 %@ 上未找到任何 Agent 命令行工具。</string>
 	<key>No agent CLIs found.</key>
 	<string>未找到任何 Agent 命令行工具。</string>
-	<key>No agents on your list yet — add one in Settings ▸ Agents.</key>
-	<string>你的列表中还没有 Agent — 在“设置 ▸ Agents”中添加一个。</string>
 	<key>No bundled tool to install from.</key>
 	<string>应用包中没有可安装的工具。</string>
 	<key>No description provided.</key>
@@ -872,6 +870,8 @@
 	<string>密码</string>
 	<key>Paste</key>
 	<string>粘贴</string>
+	<key>Path</key>
+	<string>路径</string>
 	<key>Permissions</key>
 	<string>权限</string>
 	<key>Pick a file on the left to see its changes.</key>
@@ -1062,8 +1062,6 @@
 	<string>设置密钥</string>
 	<key>Set Up Key…</key>
 	<string>设置密钥…</string>
-	<key>Set the path it launches from on each machine, under Machines.</key>
-	<string>在“设备”中为每台设备设置它的启动路径。</string>
 	<key>Set up this device</key>
 	<string>设置此设备</string>
 	<key>Settings</key>
@@ -1180,6 +1178,8 @@
 	<string>文件夹已移除，但 git 无法清理其残留的 worktree 元数据。</string>
 	<key>The ignore rule couldn’t be added.</key>
 	<string>无法添加忽略规则。</string>
+	<key>The install page — the same one whichever machine you are installing on.</key>
+	<string>安装页面 —— 无论装在哪台机器上都是同一个页面。</string>
 	<key>The listing failed.</key>
 	<string>读取目录失败。</string>
 	<key>The machine Termio is running on</key>
@@ -1316,10 +1316,8 @@
 	<string>微信群</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
 	<string>开启后，选中文本会直接拷贝到剪贴板。</string>
-	<key>Where each agent’s CLI lives on %@. Leave a path empty to use the agent’s default.</key>
-	<string>每个 Agent 的命令行工具在 %@ 上的位置。留空则使用该 Agent 的默认值。</string>
-	<key>Whether you want these at all. Each machine installs them for its own agents, under Machines.</key>
-	<string>决定你是否需要这些功能。每台设备在“设备”中为自己的 Agent 安装它们。</string>
+	<key>Whether you want these at all, and putting them on the selected device.</key>
+	<string>是否启用这些功能，以及把它们装到选中的设备上。</string>
 	<key>Window</key>
 	<string>窗口</string>
 	<key>Working Directory</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -416,6 +416,8 @@
 	<string>部署 `termiod`，查找你的 Agent 命令行工具，然后安装 Termio 的 hooks 和技能。</string>
 	<key>Detached at %@</key>
 	<string>已分离于 %@</string>
+	<key>Device</key>
+	<string>设备</string>
 	<key>Device Unavailable</key>
 	<string>设备不可用</string>
 	<key>Devices</key>
@@ -442,8 +444,8 @@
 	<string>草稿</string>
 	<key>Drag the list to change the order agents appear in.</key>
 	<string>拖动列表可以调整 Agent 出现的顺序。</string>
-	<key>Drag the list to change the order agents appear in. Readiness is for %@ — open it under Machines to install anything missing.</key>
-	<string>拖动列表可更改 Agent 的显示顺序。就绪状态针对 %@ — 在“设备”中打开它可安装缺少的内容。</string>
+	<key>Drag the list to change the order agents appear in. Readiness is for the device above.</key>
+	<string>拖动列表可调整 agent 的显示顺序。就绪状态针对上方选中的设备。</string>
 	<key>Duplicate to Themes Folder</key>
 	<string>复制到主题文件夹</string>
 	<key>Edit</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1186,8 +1186,6 @@
 	<string>Termio 正在运行的设备</string>
 	<key>The machine answered with no listing for that folder.</key>
 	<string>这台机器没有返回该文件夹的内容。</string>
-	<key>The machine you’re on</key>
-	<string>你正在使用的设备</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>项目与会话列表。与终端字体分开设置，无需等宽字体。</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -442,10 +442,10 @@
 	<string>不对比</string>
 	<key>Draft</key>
 	<string>草稿</string>
+	<key>Drag an agent onto another to reorder. Readiness is for the device above.</key>
+	<string>把一个 agent 拖到另一个上面即可调整顺序。就绪状态针对上方选中的设备。</string>
 	<key>Drag the list to change the order agents appear in.</key>
 	<string>拖动列表可以调整 Agent 出现的顺序。</string>
-	<key>Drag the list to change the order agents appear in. Readiness is for the device above.</key>
-	<string>拖动列表可调整 agent 的显示顺序。就绪状态针对上方选中的设备。</string>
 	<key>Duplicate to Themes Folder</key>
 	<string>复制到主题文件夹</string>
 	<key>Edit</key>
@@ -656,6 +656,10 @@
 	<string>移动设备</string>
 	<key>Mobile Access</key>
 	<string>移动访问</string>
+	<key>Move Down</key>
+	<string>下移</string>
+	<key>Move Up</key>
+	<string>上移</string>
 	<key>Move to Trash</key>
 	<string>移到废纸篓</string>
 	<key>Move to Workspace</key>

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -95,12 +95,24 @@ struct AgentSettingsTab: View {
                         )
                     }
                     .toggleStyle(.switch)
+                    // The switch is the preference; putting the files on a
+                    // machine is a machine operation — but the machine is named
+                    // by the control at the top of this page, so it happens here
+                    // rather than sending you to another tab to finish the job.
+                    InstallButtonRow(title: localized("Install on \(device.name)")) {
+                        .summarizing(
+                            AgentStatusHooks.sync(
+                                enabled: settings.agentHooksEnabled,
+                                target: device.integrationTarget)
+                                .merged(with: SessionSkillInstaller.sync(
+                                    enabled: settings.sessionControlEnabled,
+                                    target: device.integrationTarget)),
+                            headline: localized("Installed"), unit: localized("agents"))
+                    }
                 } header: {
                     SectionHeaderLabel(title: localized("Integration"))
                 } footer: {
-                    // The switch is the preference; installing the files it needs
-                    // is a machine operation and stays on the machine's pane.
-                    Text(localized("Whether you want these at all. Each machine installs them for its own agents, under Machines."))
+                    Text(localized("Whether you want these at all, and putting them on the selected device."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -134,6 +146,7 @@ struct AgentSettingsTab: View {
             AgentDetailPane(
                 settings: settings,
                 preset: preset,
+                device: device,
                 onRemove: { remove(preset) },
                 // Editing and deletion exist only for agents backed by a user
                 // manifest; bundled agents just leave the list.
@@ -341,6 +354,10 @@ private struct AgentListRow: View {
 private struct AgentDetailPane: View {
     @ObservedObject var settings: AppSettings
     let preset: AgentPreset
+    /// The device this pane configures, from the scope control on the roster.
+    /// Where an agent's CLI lives is a fact about a machine, but *which* machine
+    /// is now a control on this page rather than a different tab to go to.
+    let device: KnownDevice
     let onRemove: () -> Void
     /// True for agents backed by a manifest in the user's config folder — the only
     /// ones whose file can be opened or deleted from here.
@@ -365,7 +382,7 @@ private struct AgentDetailPane: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(preset.displayName)
                             .font(.title3.weight(.semibold))
-                        Text(settings.command(for: preset) ?? localized("Login shell"))
+                        Text(settings.command(for: preset, on: device) ?? localized("Login shell"))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -399,11 +416,28 @@ private struct AgentDetailPane: View {
             }
 
             Section {
-                // Where this agent's CLI lives is a fact about a machine, and the
-                // field that sets it now lives on that machine's pane (RFC §D1).
-                // What is left here is the link that gets the CLI in the first
-                // place — an install page on the web, which is the same page
-                // whichever machine you are installing on.
+                // Where an agent's CLI lives is still a fact about a machine —
+                // it is the *machine* that is now named by a control on this page
+                // instead of being a different tab you had to go to.
+                LabeledContent {
+                    TextField(
+                        "",
+                        text: Binding(
+                            get: { settings.commandPath(for: preset, on: device) ?? "" },
+                            set: { settings.setCommandPath($0, for: preset, on: device) }
+                        ),
+                        prompt: Text(preset.command ?? localized("Login shell"))
+                    )
+                    .multilineTextAlignment(.trailing)
+                    .labelsHidden()
+                    .frame(minWidth: 180)
+                } label: {
+                    SettingsLabel(
+                        title: localized("Path"),
+                        subtext: localized("Where \(preset.displayName) launches from on \(device.name). Leave empty to use its default."),
+                        titleFont: .headline
+                    )
+                }
                 LabeledContent {
                     if let url = preset.installURL {
                         Link(localized("Install Page"), destination: url)
@@ -413,7 +447,7 @@ private struct AgentDetailPane: View {
                 } label: {
                     SettingsLabel(
                         title: localized("Get \(preset.displayName)"),
-                        subtext: localized("Set the path it launches from on each machine, under Machines."),
+                        subtext: localized("The install page — the same one whichever machine you are installing on."),
                         titleFont: .headline
                     )
                 }
@@ -491,7 +525,7 @@ private struct AgentDetailPane: View {
         }
     }
 
-    private var effectiveCommand: String { settings.command(for: preset) ?? "" }
+    private var effectiveCommand: String { settings.command(for: preset, on: device) ?? "" }
 }
 
 /// Shown when the pushed agent stops existing while its pane is open — a custom

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -120,14 +120,18 @@ struct AgentSettingsTab: View {
                     // toggle. As a labelled row it reads as its own action, which
                     // is what it is — both switches at once, on one machine.
                     InstallButtonRow(title: localized("Install on \(device.name)")) {
-                        .summarizing(
-                            AgentStatusHooks.sync(
-                                enabled: settings.agentHooksEnabled,
-                                target: device.integrationTarget)
-                                .merged(with: SessionSkillInstaller.sync(
-                                    enabled: settings.sessionControlEnabled,
-                                    target: device.integrationTarget)),
-                            headline: localized("Installed"), unit: localized("agents"))
+                        // Read the preferences here, on the main actor, and do the
+                        // writing off it — see `InstallButtonRow`.
+                        let hooksWanted = settings.agentHooksEnabled
+                        let controlWanted = settings.sessionControlEnabled
+                        let target = device.integrationTarget
+                        return await Task.detached {
+                            .summarizing(
+                                AgentStatusHooks.sync(enabled: hooksWanted, target: target)
+                                    .merged(with: SessionSkillInstaller.sync(
+                                        enabled: controlWanted, target: target)),
+                                headline: localized("Installed"), unit: localized("agents"))
+                        }.value
                     }
                 } header: {
                     SectionHeaderLabel(title: localized("Integration"))

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -45,13 +45,16 @@ struct AgentSettingsTab: View {
     var body: some View {
         let _ = catalogVersion
         VStack(spacing: 0) {
-            // A `List`, not a `Form`: `onMove` is only honoured by an editable
-            // list, so the same rows in a grouped `Form` render fine and silently
-            // stop reordering — and agent order is what the New Chat menu reads.
-            // A roster the user reorders is a list in macOS anyway; `Form` is the
-            // idiom for the controls inside one agent's pane, which is where it
-            // still lives.
-            List {
+            DeviceScopeBar(store: store, selection: $deviceScope)
+            Divider()
+            // A grouped `Form`, like every other pane. It was a `List` because
+            // `onMove` is only honoured by an editable list — in a `Form` the same
+            // rows render and silently stop reordering, and agent order is what
+            // the New Chat menu reads. That is a real constraint, so reordering
+            // was rebuilt rather than dropped: rows are draggable onto each other,
+            // and the context menu carries Move Up / Move Down, which works
+            // whatever a drag does.
+            Form {
                 Section {
                     DefaultChatAgentRow(settings: settings)
                 } header: {
@@ -63,17 +66,31 @@ struct AgentSettingsTab: View {
                         NavigationLink(value: AgentRoute(id: preset.id)) {
                             AgentListRow(settings: settings, preset: preset, device: device)
                         }
+                        .draggable(preset.id)
+                        .dropDestination(for: String.self) { ids, _ in
+                            guard let dragged = ids.first else { return false }
+                            return move(dragged, onto: preset)
+                        }
                         .contextMenu {
+                            Button(localized("Move Up")) { move(preset, by: -1) }
+                                .disabled(listedAgents.first?.id == preset.id)
+                            Button(localized("Move Down")) { move(preset, by: 1) }
+                                .disabled(listedAgents.last?.id == preset.id)
+                            Divider()
                             Button(localized("Remove from List")) { remove(preset) }
                         }
                     }
-                    .onMove(perform: moveListed)
+                    AddAgentRow(
+                        addable: addableAgents,
+                        onAdd: add,
+                        onCustom: createCustomAgent
+                    )
                 } header: {
                     SectionHeaderLabel(title: localized("Agents"))
                 } footer: {
                     // No longer names the device: the picker above does, and a
                     // footnote repeating it goes stale the moment it is changed.
-                    Text(localized("Drag the list to change the order agents appear in. Readiness is for the device above."))
+                    Text(localized("Drag an agent onto another to reorder. Readiness is for the device above."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -99,6 +116,9 @@ struct AgentSettingsTab: View {
                     // machine is a machine operation — but the machine is named
                     // by the control at the top of this page, so it happens here
                     // rather than sending you to another tab to finish the job.
+                    // A bare button under a toggle reads as attached to that
+                    // toggle. As a labelled row it reads as its own action, which
+                    // is what it is — both switches at once, on one machine.
                     InstallButtonRow(title: localized("Install on \(device.name)")) {
                         .summarizing(
                             AgentStatusHooks.sync(
@@ -117,14 +137,7 @@ struct AgentSettingsTab: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            .listStyle(.inset)
-
-            Divider()
-            AddAgentBar(
-                addable: addableAgents,
-                onAdd: add,
-                onCustom: createCustomAgent
-            )
+            .formStyle(.grouped)
         }
         .navigationDestination(for: AgentRoute.self) { route in
             detail(for: route.id)
@@ -214,9 +227,29 @@ struct AgentSettingsTab: View {
 
     /// Persists a drag as the new arrangement; `setEnabledOrder` keeps every
     /// other id ranked behind it so the ordering stays total.
-    private func moveListed(from source: IndexSet, to destination: Int) {
+    /// Drops `draggedID` at `target`'s position. Returns false for a drag that
+    /// changes nothing, so a row dropped on itself is not recorded as an edit.
+    private func move(_ draggedID: String, onto target: AgentPreset) -> Bool {
         var ids = listedAgents.map(\.id)
-        ids.move(fromOffsets: source, toOffset: destination)
+        guard draggedID != target.id,
+              let from = ids.firstIndex(of: draggedID),
+              let to = ids.firstIndex(of: target.id)
+        else { return false }
+        ids.remove(at: from)
+        ids.insert(draggedID, at: to)
+        settings.setEnabledOrder(ids)
+        return true
+    }
+
+    /// The keyboard- and menu-reachable half of reordering. Drag is the nice way;
+    /// this is the way that cannot quietly stop working, which matters because
+    /// the last container change is exactly what broke `onMove`.
+    private func move(_ preset: AgentPreset, by offset: Int) {
+        var ids = listedAgents.map(\.id)
+        guard let from = ids.firstIndex(of: preset.id) else { return }
+        let to = from + offset
+        guard ids.indices.contains(to) else { return }
+        ids.swapAt(from, to)
         settings.setEnabledOrder(ids)
     }
 }
@@ -228,15 +261,17 @@ private struct AgentRoute: Hashable {
     let id: String
 }
 
-/// The list's footer action, shaped like the sidebar bottom bars in Mail and
-/// Reminders: the whole bar is the pull-down's hit target, so the control reads as
-/// part of the pane rather than a small floating button.
-private struct AddAgentBar: View {
+/// The roster's add action, as the last row of the roster.
+///
+/// A pull-down rather than a button: the agents worth adding are a known list,
+/// and a sheet to pick one from it would be a window for a menu's worth of
+/// choice. Styled as a row of the group — inside a grouped `Form` the card
+/// already draws the surface, so a second rounded rect on top of it is what made
+/// this read as bolted on to the window's bottom edge.
+private struct AddAgentRow: View {
     let addable: [AgentPreset]
     let onAdd: (AgentPreset) -> Void
     let onCustom: () -> Void
-
-    @State private var hovering = false
 
     var body: some View {
         Menu {
@@ -248,33 +283,20 @@ private struct AddAgentBar: View {
             if !addable.isEmpty { Divider() }
             Button(localized("Custom Agent…")) { onCustom() }
         } label: {
-            HStack(spacing: 8) {
-                // Same 22pt frame IconBadge uses, so the plus sits in the rows'
-                // icon column instead of starting its own margin.
+            HStack(spacing: 12) {
+                // The rows' icon column, so the label starts where agent names do.
                 Image(systemName: "plus")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.secondary)
-                    .frame(width: 22)
+                    .frame(width: settingsRowIconWidth, height: 26)
                 Text(localized("Add Agent"))
                 Spacer(minLength: 4)
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(.tertiary)
             }
-            .padding(.horizontal, 8)
-            .frame(maxWidth: .infinity, minHeight: 28)
             .contentShape(Rectangle())
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Color.primary.opacity(hovering ? 0.07 : 0))
-            )
         }
         .menuStyle(.button)
         .buttonStyle(.plain)
         .menuIndicator(.hidden)
-        .onHover { hovering = $0 }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 7)
     }
 }
 

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -16,14 +16,16 @@ import SwiftUI
 /// editable here.
 struct AgentSettingsTab: View {
     @ObservedObject var settings: AppSettings
-    /// The store the readiness line reads its machine from. Ambient, so it
-    /// follows a workspace switch — the one thing on this tab that re-targets
-    /// (RFC §Reliability: explicit selections do not, ambient indicators do).
+    /// The store the device roster and the readiness line read from.
     @ObservedObject var store: TermioStore
+    /// Which device this page is about. Shared with the other per-device pages
+    /// (`SettingsView`), so switching here is still in force there.
+    @Binding var deviceScope: String
 
-    /// The machine the readiness line describes: the one the current workspace
-    /// runs on.
-    private var device: KnownDevice { store.currentDevice }
+    /// The machine the readiness line describes. It used to be
+    /// `store.currentDevice` — ambient, invisible, and unchangeable, so the page
+    /// reported one machine's readiness with nothing on screen naming it.
+    private var device: KnownDevice { .onRoster(deviceScope, in: store) }
 
     /// Bumped after every catalog reload. `AgentDefinition` equality is by id, so
     /// without this a rename would leave stale rows on screen; referencing the
@@ -69,7 +71,9 @@ struct AgentSettingsTab: View {
                 } header: {
                     SectionHeaderLabel(title: localized("Agents"))
                 } footer: {
-                    Text(localized("Drag the list to change the order agents appear in. Readiness is for \(device.name) — open it under Machines to install anything missing."))
+                    // No longer names the device: the picker above does, and a
+                    // footnote repeating it goes stale the moment it is changed.
+                    Text(localized("Drag the list to change the order agents appear in. Readiness is for the device above."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/termio/Settings/DevicePane.swift
+++ b/Sources/termio/Settings/DevicePane.swift
@@ -264,16 +264,22 @@ struct DevicePane: View {
                 }
             }
             InstallButtonRow(title: localized("Reinstall hooks")) {
-                .summarizing(
-                    AgentStatusHooks.sync(
-                        enabled: settings.agentHooksEnabled, target: machine.integrationTarget),
-                    headline: localized("Hooks reinstalled"), unit: localized("agents"))
+                let wanted = settings.agentHooksEnabled
+                let target = machine.integrationTarget
+                return await Task.detached {
+                    .summarizing(
+                        AgentStatusHooks.sync(enabled: wanted, target: target),
+                        headline: localized("Hooks reinstalled"), unit: localized("agents"))
+                }.value
             }
             InstallButtonRow(title: localized("Reinstall skill")) {
-                .summarizing(
-                    SessionSkillInstaller.sync(
-                        enabled: settings.sessionControlEnabled, target: machine.integrationTarget),
-                    headline: localized("Skill reinstalled"), unit: localized("agents"))
+                let wanted = settings.sessionControlEnabled
+                let target = machine.integrationTarget
+                return await Task.detached {
+                    .summarizing(
+                        SessionSkillInstaller.sync(enabled: wanted, target: target),
+                        headline: localized("Skill reinstalled"), unit: localized("agents"))
+                }.value
             }
         } header: {
             SectionHeaderLabel(title: localized("Installed by Termio"))
@@ -317,7 +323,7 @@ struct CommandLineToolRow: View {
         if isOn {
             // For re-linking after something else has touched /usr/local/bin;
             // install is idempotent. Reports through its own feedback line.
-            InstallButtonRow(title: buttonTitle) { withAnimation { runInstall() } }
+            InstallButtonRow(title: buttonTitle) { runInstall() }
         }
     }
 

--- a/Sources/termio/Settings/DevicePane.swift
+++ b/Sources/termio/Settings/DevicePane.swift
@@ -15,7 +15,7 @@ import SwiftUI
 /// four rungs with independent states turn choosing a machine into infrastructure
 /// triage. So the pane promises one outcome — "Ready", or "Set up this device" —
 /// and the rungs are the disclosure underneath it.
-struct MachinePane: View {
+struct DevicePane: View {
     let machine: KnownDevice
     let host: SSHConfigHost?
     @ObservedObject var settings: AppSettings
@@ -26,7 +26,7 @@ struct MachinePane: View {
     let onSetUpKey: (String, String) -> Void
     let onEditConfig: () -> Void
 
-    @StateObject private var model: MachinePaneModel
+    @StateObject private var model: DevicePaneModel
     private enum ProbeState { case idle, running, result(SSHProbeResult) }
     @State private var probe: ProbeState = .idle
 
@@ -46,7 +46,7 @@ struct MachinePane: View {
         self.onConnect = onConnect
         self.onSetUpKey = onSetUpKey
         self.onEditConfig = onEditConfig
-        _model = StateObject(wrappedValue: MachinePaneModel(device: machine, settings: settings))
+        _model = StateObject(wrappedValue: DevicePaneModel(device: machine, settings: settings))
     }
 
     var body: some View {

--- a/Sources/termio/Settings/DevicePane.swift
+++ b/Sources/termio/Settings/DevicePane.swift
@@ -66,7 +66,9 @@ struct DevicePane: View {
 
     private var header: some View {
         HStack(spacing: 12) {
-            IconBadge(.symbol(machine.isLocal ? "laptopcomputer" : "server.rack"))
+            SettingsSymbolBadge(
+                symbol: machine.isLocal ? "laptopcomputer" : "server.rack",
+                tint: machine.isLocal ? .secondary : .blue)
                 .scaleEffect(1.4)
                 .frame(width: 30, height: 30)
             VStack(alignment: .leading, spacing: 2) {

--- a/Sources/termio/Settings/DevicePane.swift
+++ b/Sources/termio/Settings/DevicePane.swift
@@ -56,7 +56,6 @@ struct DevicePane: View {
                 SectionHeaderLabel(title: localized("Status"))
             }
             reachedBySection
-            runsSection
             integrationSection
         }
         .formStyle(.grouped)
@@ -241,36 +240,6 @@ struct DevicePane: View {
         }
     }
 
-    // MARK: Runs — the identity half
-
-    private var runsSection: some View {
-        Section {
-            ForEach(listedAgents) { preset in
-                MachineAgentRow(
-                    preset: preset,
-                    machine: machine,
-                    settings: settings,
-                    readiness: model.readiness.isBusy ? nil : model.readiness(for: preset)
-                )
-            }
-            if listedAgents.isEmpty {
-                Text(localized("No agents on your list yet — add one in Settings ▸ Agents."))
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
-        } header: {
-            SectionHeaderLabel(title: localized("Runs"))
-        } footer: {
-            Text(localized("Where each agent’s CLI lives on \(machine.name). Leave a path empty to use the agent’s default."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private var listedAgents: [AgentPreset] {
-        settings.orderedAgents(AgentPreset.codingAgents.filter(settings.isAgentListed))
-    }
-
     // MARK: The ladder, as disclosure
 
     /// The rungs behind the one line. Each is still individually runnable — a
@@ -307,68 +276,9 @@ struct DevicePane: View {
         } header: {
             SectionHeaderLabel(title: localized("Installed by Termio"))
         } footer: {
-            Text(localized("Live agent status and session control are switched on in Settings ▸ Agents; this installs them on \(machine.name)."))
+            Text(localized("What Termio puts on \(machine.name) so its agents can report. Which agents run there, and where each launches from, is Settings ▸ Agents with \(machine.name) selected."))
                 .font(.caption)
                 .foregroundStyle(.secondary)
-        }
-    }
-}
-
-/// One agent's presence on one machine, and the path it launches from there.
-///
-/// The readiness word is D4's three-state rule. `nil` means the probe has not
-/// answered yet and the row says nothing rather than guessing — the same
-/// don't-cry-wolf discipline `AgentAvailability` follows, extended to the case
-/// that only exists once a machine is reached over a network.
-private struct MachineAgentRow: View {
-    let preset: AgentPreset
-    let machine: KnownDevice
-    @ObservedObject var settings: AppSettings
-    let readiness: AgentReadiness?
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 10) {
-                IconBadge(preset.icon)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(preset.displayName)
-                    if let status {
-                        Text(status)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                }
-                Spacer(minLength: 8)
-                TextField(
-                    "",
-                    text: Binding(
-                        get: { settings.commandPath(for: preset, on: machine) ?? "" },
-                        set: { settings.setCommandPath($0, for: preset, on: machine) }
-                    ),
-                    prompt: Text(preset.command ?? localized("Login shell"))
-                )
-                .textFieldStyle(.plain)
-                .multilineTextAlignment(.trailing)
-                .labelsHidden()
-                .frame(minWidth: 140)
-                if readiness == .missing {
-                    Image(systemName: "exclamationmark.circle")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .help(localized("\(preset.displayName) isn’t installed on \(machine.name)"))
-                }
-            }
-        }
-    }
-
-    /// A present CLI says nothing — the path field beside it is already the whole
-    /// answer. The other two states are the ones worth a word.
-    private var status: String? {
-        switch readiness {
-        case .missing: return localized("Not installed on \(machine.name)")
-        case .unknown: return localized("Can’t check on \(machine.name)")
-        case .available, nil: return nil
         }
     }
 }

--- a/Sources/termio/Settings/DeviceReadiness.swift
+++ b/Sources/termio/Settings/DeviceReadiness.swift
@@ -248,9 +248,15 @@ final class DevicePaneModel: ObservableObject {
 
         step = .installIntegration
         let target = device.integrationTarget
-        let hooks = AgentStatusHooks.sync(enabled: settings.agentHooksEnabled, target: target)
-        let skill = SessionSkillInstaller.sync(
-            enabled: settings.sessionControlEnabled, target: target)
+        // Off the main actor: this rung is one blocking `ssh` per config file, and
+        // there is one config file per agent. Left inline it freezes the window for
+        // the length of the whole install.
+        let hooksWanted = settings.agentHooksEnabled
+        let controlWanted = settings.sessionControlEnabled
+        let (hooks, skill) = await Task.detached {
+            (AgentStatusHooks.sync(enabled: hooksWanted, target: target),
+             SessionSkillInstaller.sync(enabled: controlWanted, target: target))
+        }.value
         // A rung that reached the machine but could not write every agent's config
         // is still a failure of *this* rung, and the one worth naming.
         let refused = hooks.failed + skill.failed

--- a/Sources/termio/Settings/DeviceReadiness.swift
+++ b/Sources/termio/Settings/DeviceReadiness.swift
@@ -24,7 +24,7 @@ enum AgentReadiness: String, Sendable {
 /// dependency chain, and four rungs with independent states turn choosing a
 /// machine into infrastructure triage. So the pane shows one outcome and the
 /// ladder becomes the disclosure behind it.
-enum MachineReadiness: Equatable {
+enum DeviceReadinessState: Equatable {
     /// Nothing asked yet, and no cache to draw on.
     case unasked
     case checking
@@ -40,7 +40,7 @@ enum MachineReadiness: Equatable {
 /// The steps behind the one line, in dependency order. Named so the pane can say
 /// what it is doing while it runs, and so a failure can name the rung it stopped
 /// on rather than reporting "setup failed".
-enum MachineSetupStep: Equatable {
+enum DeviceSetupStep: Equatable {
     /// This Mac: link the `termio` CLI onto `PATH`. A device: deploy `termiod`.
     /// Both are "the binary this machine needs before anything else works", which
     /// is why they are one rung rather than a local branch bolted onto a remote
@@ -92,7 +92,7 @@ extension AgentReadiness {
 
 /// Asks a machine what it is. Every method here runs off the main actor and
 /// returns a value; nothing renders, and nothing is cached as authority.
-enum MachineProbe {
+enum DeviceProbe {
     /// A read-only check: what is true on this machine right now.
     ///
     /// The one probe that matters is reachability, and it is asked **first and
@@ -165,7 +165,7 @@ extension DeviceDiscoveredState {
 /// window that fires ssh at every configured host on open is how a sleeping VPS
 /// makes opening preferences take twenty seconds.
 @MainActor
-final class MachinePaneModel: ObservableObject {
+final class DevicePaneModel: ObservableObject {
     let device: KnownDevice
     private let settings: AppSettings
 
@@ -173,10 +173,10 @@ final class MachinePaneModel: ObservableObject {
     /// pane draws something the moment it opens. Replaced by the first live probe
     /// — it is a cache, never the authority.
     @Published private(set) var discovered: DeviceDiscoveredState?
-    @Published private(set) var readiness: MachineReadiness = .unasked
+    @Published private(set) var readiness: DeviceReadinessState = .unasked
     /// The rung in progress, so a chain that takes ten seconds says which part is
     /// slow instead of spinning anonymously.
-    @Published private(set) var step: MachineSetupStep?
+    @Published private(set) var step: DeviceSetupStep?
     /// What the last completed setup left behind, shown once and dismissed.
     @Published var feedback: InstallFeedback?
 
@@ -214,7 +214,7 @@ final class MachinePaneModel: ObservableObject {
         guard !readiness.isBusy else { return }
         readiness = .checking
         step = .foundation
-        let state = await MachineProbe.inspect(device: device, commands: commandPairs)
+        let state = await DeviceProbe.inspect(device: device, commands: commandPairs)
         // Carry the integration stamp forward: a probe asks what is on the
         // machine, and does not un-install what a previous setup put there.
         var merged = state
@@ -239,7 +239,7 @@ final class MachinePaneModel: ObservableObject {
         }
 
         step = .probeAgents
-        var state = await MachineProbe.inspect(device: device, commands: commandPairs)
+        var state = await DeviceProbe.inspect(device: device, commands: commandPairs)
         state.integrationVersion = discovered?.integrationVersion
         apply(state)
         // `resolve` already names the first thing in the way — unreachable, or
@@ -302,7 +302,7 @@ final class MachinePaneModel: ObservableObject {
     /// Order matters more than completeness. A box that does not answer also has
     /// no agent CLIs and no hooks, and saying all three would invite the user to
     /// go install an agent on a machine that is switched off.
-    private func resolve(_ state: DeviceDiscoveredState) -> MachineReadiness {
+    private func resolve(_ state: DeviceDiscoveredState) -> DeviceReadinessState {
         guard state.reachable else { return .blocked(localized("Can’t reach \(device.name).")) }
         guard state.agents.values.contains(AgentReadiness.available.rawValue) else {
             return .blocked(localized("No agent CLIs found on \(device.name)."))

--- a/Sources/termio/Settings/DeviceScopeBar.swift
+++ b/Sources/termio/Settings/DeviceScopeBar.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Which device the page below is about.
+///
+/// Several settings pages are already per-device and only ever said so in a
+/// footnote — the Agents roster reported readiness for whichever machine the
+/// current workspace happened to run on, with no control saying which that was
+/// or letting you change it. A scope that exists but cannot be seen or set is
+/// worse than either having one or not.
+///
+/// It is a **control**, not a sidebar group and not a drill-down:
+///
+/// - A sidebar group would name the axis and still not answer it — you would
+///   arrive under "Device" and have to pick one anyway — and it splits the
+///   sidebar by something nobody navigates by. People look for *Agents*, not for
+///   the device section.
+/// - A drill-down (Devices ▸ a device ▸ what it runs) is right for *inspecting
+///   one box* and wrong for the task these pages serve, which is reading the same
+///   subject across machines. Comparing two devices should not mean backing out
+///   and re-entering.
+///
+/// This is the shape Displays, Sound and Printers & Scanners use: the device
+/// selector sits at the top of the pane and the pane answers for it.
+///
+/// Pinned above the list rather than filed as its first row — the opposite of
+/// where `AddDeviceRow` belongs, and for the opposite reason. An action belongs
+/// with the thing it acts on and may scroll away with it; a scope has to stay
+/// legible while you read what it scopes.
+struct DeviceScopeBar: View {
+    @ObservedObject var store: TermioStore
+    @Binding var selection: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(localized("Device"))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Picker(localized("Device"), selection: $selection) {
+                ForEach(devices, id: \.settingsKey) { device in
+                    Text(device.name).tag(device.settingsKey)
+                }
+            }
+            .labelsHidden()
+            .fixedSize()
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 8)
+        // A roster that lost the selected device — an alias deleted from
+        // `~/.ssh/config` while Settings was open — falls back to this Mac
+        // rather than leaving the picker showing a device that is not there.
+        .onChange(of: devices.map(\.settingsKey), initial: true) { _, keys in
+            guard !keys.contains(selection) else { return }
+            selection = KnownDevice.thisMac.settingsKey
+        }
+    }
+
+    /// The same roster the Devices tab lists, minus the aliases termio has never
+    /// worked on: this control scopes a page to a machine, and a box that has
+    /// never run a session has nothing for one to report.
+    private var devices: [KnownDevice] {
+        DeviceRoster.known(in: store)
+    }
+}
+
+@MainActor
+extension KnownDevice {
+    /// The device a settings scope key names, or this Mac when it names nothing
+    /// on the roster.
+    static func onRoster(_ settingsKey: String, in store: TermioStore) -> KnownDevice {
+        DeviceRoster.known(in: store).first { $0.settingsKey == settingsKey } ?? .thisMac
+    }
+}

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -18,10 +18,13 @@ import SwiftUI
 /// and the public keys in `~/.ssh`. Those are about the user's own credentials,
 /// not about any one box.
 ///
-/// A `List`, not a `Form`, and the roster is the reason: `onMove` is inert inside
-/// a `Form` on macOS, and while nothing reorders machines *today*, this is the
-/// container that would silently stop working if it ever did — the same trap
-/// `AgentSettingsTab` documents.
+/// A grouped `Form`, like every other pane in this window and like System
+/// Settings itself. It was a `List` to keep `onMove` live in case the roster ever
+/// became reorderable — a container chosen for a feature that does not exist and
+/// cannot: the order here is `~/.ssh/config`'s own, and reordering would mean
+/// rewriting the user's file. The cost was real and visible: this was the only
+/// tab in the app without the grouped cards, so its rows sat flat on the window
+/// with full-bleed separators and the first one clipped under the toolbar.
 struct DevicesSettingsTab: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var store: TermioStore
@@ -40,7 +43,7 @@ struct DevicesSettingsTab: View {
     @State private var copiedKeyID: String?
 
     var body: some View {
-        List {
+        Form {
             // No section header: the tab is called Devices and this is the
             // only list of them in it. The add row is the last row of the
             // list it adds to rather than a bar pinned to the window bottom,
@@ -101,7 +104,7 @@ struct DevicesSettingsTab: View {
                 }
             }
         }
-        .listStyle(.inset)
+        .formStyle(.grouped)
         .navigationDestination(for: DeviceRoute.self) { route in
             if let machine = machines.first(where: { $0.settingsKey == route.key }) {
                 DevicePane(
@@ -223,33 +226,27 @@ private struct DeviceListRow: View {
     }
 }
 
-/// The roster's add action, as the last row of the roster. Matches the Agents
-/// tab's, so the two drill-down tabs read as the same kind of surface.
+/// The roster's add action, as the last row of the roster.
+///
+/// Styled as a row of the group rather than a bar with its own inset background:
+/// inside a grouped `Form` the card already draws the surface, and a second
+/// rounded rect on top of it is what made this read as bolted on.
 private struct AddDeviceRow: View {
     let onAdd: () -> Void
-    @State private var hovering = false
 
     var body: some View {
         Button(action: onAdd) {
-            HStack(spacing: 8) {
+            HStack(spacing: 10) {
                 Image(systemName: "plus")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.secondary)
-                    .frame(width: 22)
+                    .frame(width: 22, height: 22)
                 Text(localized("Add Device"))
                 Spacer(minLength: 4)
             }
-            .padding(.horizontal, 8)
-            .frame(maxWidth: .infinity, minHeight: 28)
             .contentShape(Rectangle())
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Color.primary.opacity(hovering ? 0.07 : 0))
-            )
         }
         .buttonStyle(.plain)
-        .onHover { hovering = $0 }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 7)
     }
 }
+

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -198,30 +198,35 @@ private struct DeviceListRow: View {
     let machine: KnownDevice
     let host: SSHConfigHost?
 
+    /// Empty for a Mac whose name cannot be read, so the row is one line rather
+    /// than one line and a gap.
     private var detail: String {
-        guard machine.alias != nil else { return localized("The machine you’re on") }
+        // The host name, not "the machine you're on" — a subtitle restating the
+        // title is a line that costs a row's height and answers nothing. Apple's
+        // rows put the *fact* there ("65 apps", "Off"); here the fact is which
+        // Mac this is.
+        guard machine.alias != nil else { return Host.current().localizedName ?? "" }
         guard let host else { return localized("From your session history") }
         guard let identityFile = host.identityFile else { return host.destinationLabel }
         return "\(host.destinationLabel) · \((identityFile as NSString).lastPathComponent)"
     }
 
     var body: some View {
-        HStack(spacing: 10) {
-            IconBadge(.symbol(machine.isLocal ? "laptopcomputer" : "server.rack"))
+        HStack(spacing: 12) {
+            SettingsSymbolBadge(
+                symbol: machine.isLocal ? "laptopcomputer" : "server.rack",
+                tint: machine.isLocal ? .secondary : .blue)
             VStack(alignment: .leading, spacing: 2) {
                 Text(machine.name)
-                Text(detail)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                if !detail.isEmpty {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
             }
             Spacer(minLength: 4)
-            // `NavigationLink` draws no chevron in an inset list on macOS, so the
-            // only thing saying these rows open was a sentence in the footer.
-            Image(systemName: "chevron.right")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.tertiary)
         }
     }
 }
@@ -236,11 +241,13 @@ private struct AddDeviceRow: View {
 
     var body: some View {
         Button(action: onAdd) {
-            HStack(spacing: 10) {
+            HStack(spacing: 12) {
+                // No badge — an action is not a device — but it takes the same
+                // leading width so its label starts on the roster's text column.
                 Image(systemName: "plus")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.secondary)
-                    .frame(width: 22, height: 22)
+                    .frame(width: settingsRowIconWidth, height: 26)
                 Text(localized("Add Device"))
                 Spacer(minLength: 4)
             }

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -22,7 +22,7 @@ import SwiftUI
 /// a `Form` on macOS, and while nothing reorders machines *today*, this is the
 /// container that would silently stop working if it ever did — the same trap
 /// `AgentSettingsTab` documents.
-struct MachinesSettingsTab: View {
+struct DevicesSettingsTab: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var store: TermioStore
     /// Opens an SSH terminal to the alias in the main window (wired to
@@ -40,71 +40,71 @@ struct MachinesSettingsTab: View {
     @State private var copiedKeyID: String?
 
     var body: some View {
-        VStack(spacing: 0) {
-            List {
+        List {
+            // No section header: the tab is called Devices and this is the
+            // only list of them in it. The add row is the last row of the
+            // list it adds to rather than a bar pinned to the window bottom,
+            // which in a tall window sat a screen away from the roster with
+            // two unrelated sections in between — and so read as adding a
+            // public key.
+            Section {
+                ForEach(machines) { machine in
+                    NavigationLink(value: DeviceRoute(key: machine.settingsKey)) {
+                        DeviceListRow(machine: machine, host: host(for: machine))
+                    }
+                }
+                AddDeviceRow { addingHost = true }
+            } footer: {
+                Text(localized("Open one to see how it is reached and what it runs."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                LabeledContent {
+                    Button(localized("Edit")) { presentEditor(for: nil) }
+                } label: {
+                    SettingsLabel(
+                        title: "~/.ssh/config",
+                        subtext: localized("Reads ~/.ssh/config directly — Termio keeps no separate host list."),
+                        titleFont: .headline
+                    )
+                }
+            } header: {
+                SectionHeaderLabel(title: localized("Config file"))
+            }
+
+            if !publicKeys.isEmpty {
                 Section {
-                    ForEach(machines) { machine in
-                        NavigationLink(value: MachineRoute(key: machine.settingsKey)) {
-                            MachineListRow(machine: machine, host: host(for: machine))
+                    ForEach(publicKeys) { key in
+                        HStack(spacing: 10) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(key.name)
+                                Text(key.comment.isEmpty
+                                     ? key.algorithm : "\(key.algorithm) · \(key.comment)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer(minLength: 8)
+                            Button(copiedKeyID == key.id
+                                   ? localized("Copied") : localized("Copy")) { copy(key) }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
                         }
                     }
                 } header: {
-                    SectionHeaderLabel(title: localized("Machines"))
+                    SectionHeaderLabel(title: localized("Public keys"))
                 } footer: {
-                    Text(localized("This Mac, and every machine you can reach from it. Open one to see what runs there."))
+                    Text(localized("The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-
-                Section {
-                    LabeledContent {
-                        Button(localized("Edit")) { presentEditor(for: nil) }
-                    } label: {
-                        SettingsLabel(
-                            title: "~/.ssh/config",
-                            subtext: localized("Reads ~/.ssh/config directly — Termio keeps no separate host list."),
-                            titleFont: .headline
-                        )
-                    }
-                } header: {
-                    SectionHeaderLabel(title: localized("Config file"))
-                }
-
-                if !publicKeys.isEmpty {
-                    Section {
-                        ForEach(publicKeys) { key in
-                            HStack(spacing: 10) {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(key.name)
-                                    Text(key.comment.isEmpty
-                                         ? key.algorithm : "\(key.algorithm) · \(key.comment)")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                                Spacer(minLength: 8)
-                                Button(copiedKeyID == key.id
-                                       ? localized("Copied") : localized("Copy")) { copy(key) }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
-                            }
-                        }
-                    } header: {
-                        SectionHeaderLabel(title: localized("Public keys"))
-                    } footer: {
-                        Text(localized("The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read."))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
             }
-            .listStyle(.inset)
-
-            Divider()
-            AddMachineBar { addingHost = true }
         }
-        .navigationDestination(for: MachineRoute.self) { route in
+        .listStyle(.inset)
+        .navigationDestination(for: DeviceRoute.self) { route in
             if let machine = machines.first(where: { $0.settingsKey == route.key }) {
-                MachinePane(
+                DevicePane(
                     machine: machine,
                     host: host(for: machine),
                     settings: settings,
@@ -119,9 +119,9 @@ struct MachinesSettingsTab: View {
             } else {
                 // The alias left `~/.ssh/config` while its pane was open.
                 ContentUnavailableView {
-                    Text(localized("Machine Unavailable"))
+                    Text(localized("Device Unavailable"))
                 } description: {
-                    Text(localized("This machine is no longer in your configuration."))
+                    Text(localized("This device is no longer in your configuration."))
                 }
             }
         }
@@ -183,7 +183,7 @@ struct MachinesSettingsTab: View {
 /// What a machine row pushes. A named type rather than the bare key so the
 /// settings window's shared navigation stack can't confuse a machine with the
 /// Agents tab's string destination.
-private struct MachineRoute: Hashable {
+private struct DeviceRoute: Hashable {
     let key: String
 }
 
@@ -191,7 +191,7 @@ private struct MachineRoute: Hashable {
 /// a roster that probed every host on appear would fire ssh at every configured
 /// box each time Settings opens, and a sleeping VPS would make that take as long
 /// as its timeout. The pane asks; the roster lists.
-private struct MachineListRow: View {
+private struct DeviceListRow: View {
     let machine: KnownDevice
     let host: SSHConfigHost?
 
@@ -214,13 +214,18 @@ private struct MachineListRow: View {
                     .truncationMode(.middle)
             }
             Spacer(minLength: 4)
+            // `NavigationLink` draws no chevron in an inset list on macOS, so the
+            // only thing saying these rows open was a sentence in the footer.
+            Image(systemName: "chevron.right")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.tertiary)
         }
     }
 }
 
-/// The roster's footer action, matching the Agents tab's Add Agent bar so the two
-/// drill-down tabs read as the same kind of surface.
-private struct AddMachineBar: View {
+/// The roster's add action, as the last row of the roster. Matches the Agents
+/// tab's, so the two drill-down tabs read as the same kind of surface.
+private struct AddDeviceRow: View {
     let onAdd: () -> Void
     @State private var hovering = false
 
@@ -231,7 +236,7 @@ private struct AddMachineBar: View {
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: 22)
-                Text(localized("Add Machine"))
+                Text(localized("Add Device"))
                 Spacer(minLength: 4)
             }
             .padding(.horizontal, 8)

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -11,7 +11,11 @@ struct IconBadge: View {
 
     var body: some View {
         glyph
-            .frame(width: 22, height: 22)
+            // The same column `SettingsSymbolBadge` occupies. An agent keeps its
+            // own brand mark rather than being forced into a tinted square — the
+            // mark *is* its identity — but it has to start where every other
+            // row's icon starts or the column stops lining up.
+            .frame(width: settingsRowIconWidth, height: settingsRowIconWidth)
     }
 
     @ViewBuilder

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -35,6 +35,39 @@ struct IconBadge: View {
     }
 }
 
+/// A System Settings row icon: a filled, continuous-corner square with the glyph
+/// knocked out in white.
+///
+/// The shape is the cue, not the colour. A macOS list reads as a scannable column
+/// because every row opens with the same filled square at the same size and the
+/// titles line up off its trailing edge. A thin monochrome glyph sitting on the
+/// window background reads as decoration instead, and the column stops existing —
+/// which is most of why the Devices roster did not look like the rest of the
+/// system.
+///
+/// Tints stay semantic and few. This Mac is graphite because it is not somewhere
+/// you connect to; a device is blue because it is. Two colours carrying one
+/// distinction, rather than a palette carrying none.
+struct SettingsSymbolBadge: View {
+    let symbol: String
+    var tint: Color
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(tint.gradient)
+            .frame(width: 26, height: 26)
+            .overlay {
+                Image(systemName: symbol)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+    }
+}
+
+/// The width every row's leading column occupies, badge or not, so a row without
+/// an icon still lines its title up with the ones that have one.
+let settingsRowIconWidth: CGFloat = 26
+
 /// A grouped-section header rendered as a badge plus title, replacing the default
 /// uppercased gray caption so each card reads as a labeled group (Dia style).
 struct SectionHeaderLabel: View {

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -207,16 +207,40 @@ extension View {
 
 /// A settings action that writes outside the app, with its result shown next to
 /// the button: the action performs the install and hands back the line to display.
+///
+/// The action is `async` because on a device it is not a function call — it is
+/// dozens of blocking `ssh` round trips. The hook installers read and write one
+/// config per agent, the skill installer probes and writes one more, and every one
+/// of those is a `Process` with `waitUntilExit()`. Run in the button's handler that
+/// is not a slow button, it is a beachball: the main thread sits in `waitUntilExit`
+/// while the window stops drawing.
+///
+/// So the work is awaited, the button disables itself while it runs, and a spinner
+/// stands where the result will be. The caller is what moves the work off the main
+/// actor; this type's job is to not block on it.
 struct InstallButtonRow: View {
     let title: String
-    let action: () -> InstallFeedback
+    let action: () async -> InstallFeedback
 
     @State private var state = InstallFeedbackState()
+    @State private var running = false
 
     var body: some View {
         HStack(spacing: 10) {
-            Button(title) { withAnimation { state.show(action()) } }
-            if let feedback = state.feedback {
+            Button(title) {
+                running = true
+                Task {
+                    let result = await action()
+                    running = false
+                    withAnimation { state.show(result) }
+                }
+            }
+            .disabled(running)
+            if running {
+                ProgressView()
+                    .controlSize(.small)
+                    .transition(.opacity)
+            } else if let feedback = state.feedback {
                 InstallFeedbackLabel(feedback: feedback)
             }
             Spacer(minLength: 0)

--- a/Sources/termio/Settings/SettingsTab.swift
+++ b/Sources/termio/Settings/SettingsTab.swift
@@ -7,27 +7,29 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case appearance
     case terminal
-    /// Sits above Machines because that is the containment order the app itself
+    /// Sits above Devices because that is the containment order the app itself
     /// uses: a workspace belongs to a device, and everything filed in it lives on
     /// that machine.
     case workspaces
-    /// Every machine sessions can run on — this Mac and each device — as one row
-    /// apiece, drilling into a pane that holds both halves of what a machine is:
-    /// how it is reached, and what it runs.
+    /// The roster: this Mac and every device sessions can run on, one row apiece,
+    /// drilling into how that device is reached.
     ///
-    /// The name went back to **Machines** because the two things it had to name
-    /// were a *route* and an *identity*, and "Devices" was only ever spent on the
-    /// first: the shipped Devices tab was the renamed SSH tab, a `~/.ssh/config`
-    /// projection, leaving machine identity homeless. Rather than two tabs that
-    /// both list machines — which forces the user to learn that distinction to
-    /// find anything — one tab holds both, and the distinction becomes two
-    /// sections inside a pane (RFC §D2).
+    /// **Devices**, matching the word the whole codebase already uses —
+    /// `KnownDevice`, `DeviceRoster`, `DeviceClient`, `deviceInvite` — so the UI
+    /// and the model stop disagreeing. The earlier objection was that "Devices"
+    /// was spent on a `~/.ssh/config` projection; that tab is gone, and the name
+    /// with it.
+    ///
+    /// What this tab is *not* is anywhere a device's behaviour is configured.
+    /// A page that varies by device carries a device scope of its own (see
+    /// `DeviceScopePicker`), because "which machine is this about" is a scope,
+    /// not a place to navigate to.
     ///
     /// The raw value stays `ssh` because it is the value persisted under
     /// `lastOpenKey`; changing it would reopen Settings on another tab for
-    /// everyone who left this one showing. It has now survived three renamings,
+    /// everyone who left this one showing. It has now survived four renamings,
     /// which is the point of it.
-    case machines = "ssh"
+    case devices = "ssh"
     case keyboard
     case agents
     case usage
@@ -46,7 +48,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return localized("Appearance")
         case .terminal: return localized("Terminal")
         case .workspaces: return localized("Workspaces")
-        case .machines: return localized("Machines")
+        case .devices: return localized("Devices")
         case .keyboard: return localized("Keyboard")
         case .agents: return localized("Agents")
         case .usage: return localized("Usage")
@@ -63,7 +65,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return .paintBoard
         case .terminal: return .terminal
         case .workspaces: return .copy
-        case .machines: return .serverStack
+        case .devices: return .serverStack
         case .keyboard: return .keyboard
         case .agents: return .bot
         case .usage: return .chartColumn
@@ -80,7 +82,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: return localized("Theme, fonts, cursor, and window")
         case .terminal: return localized("Scrollback history and text selection")
         case .workspaces: return localized("The workspaces your projects and sessions are filed under")
-        case .machines: return localized("This Mac and the machines you reach from it, and what each one runs")
+        case .devices: return localized("This Mac and the machines you reach from it")
         case .keyboard: return localized("Keyboard shortcuts for every command")
         case .agents: return localized("The coding agents offered when you start a session")
         case .usage: return localized("Token usage for your connected agents")

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -31,6 +31,12 @@ struct SettingsView: View {
     /// whose `navigationDestination` left with its tab would otherwise sit on the
     /// stack unresolvable.
     @State private var path = NavigationPath()
+    /// Which device the per-device pages are about, shared across them so a
+    /// switch on one is still in force on the next — the scope is a property of
+    /// what the user is doing, not of the page they are on. Seeded from the
+    /// current workspace's device, which is what those pages silently assumed
+    /// before the control existed.
+    @State private var deviceScope = KnownDevice.thisMac.settingsKey
 
     init(
         settings: AppSettings,
@@ -46,6 +52,7 @@ struct SettingsView: View {
         self.onSSHConnect = onSSHConnect
         self.onSetUpKey = onSetUpKey
         _selection = State(initialValue: initialTab)
+        _deviceScope = State(initialValue: store.currentDevice.settingsKey)
     }
 
     var body: some View {
@@ -100,7 +107,8 @@ struct SettingsView: View {
                 onConnect: onSSHConnect, onSetUpKey: onSetUpKey
             )
         case .keyboard: KeybindingsSettingsTab()
-        case .agents: AgentSettingsTab(settings: settings, store: store)
+        case .agents:
+            AgentSettingsTab(settings: settings, store: store, deviceScope: $deviceScope)
         case .usage: UsageSettingsTab(settings: settings, usage: usage)
         case .mobile: MobileSettingsTab()
         case .community: CommunitySettingsTab()

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -94,8 +94,8 @@ struct SettingsView: View {
         case .appearance: AppearanceSettingsTab(settings: settings)
         case .terminal: TerminalSettingsTab(settings: settings)
         case .workspaces: WorkspaceSettingsTab(store: store)
-        case .machines:
-            MachinesSettingsTab(
+        case .devices:
+            DevicesSettingsTab(
                 settings: settings, store: store,
                 onConnect: onSSHConnect, onSetUpKey: onSetUpKey
             )

--- a/Tests/termioTests/InstallFeedbackTests.swift
+++ b/Tests/termioTests/InstallFeedbackTests.swift
@@ -66,3 +66,33 @@ final class InstallFeedbackTests: XCTestCase {
         XCTAssertNotEqual(first, state)
     }
 }
+
+/// Hooks and the skill are two installs the user asked for with one click, so
+/// they are reported as one line. What that line may not do is round a mixed
+/// result up: an agent that took its hook and refused the skill is not installed.
+final class InstallOutcomeMergeTests: XCTestCase {
+    private func outcome(succeeded: [String], failed: [String] = []) -> InstallOutcome {
+        var result = InstallOutcome()
+        for name in succeeded { result.record(name, installed: true) }
+        for name in failed { result.record(name, installed: false) }
+        return result
+    }
+
+    func testAnAgentThatTookBothIsNamedOnce() {
+        let merged = outcome(succeeded: ["Claude Code", "Codex"])
+            .merged(with: outcome(succeeded: ["Claude Code", "Codex"]))
+        XCTAssertEqual(merged.succeeded, ["Claude Code", "Codex"])
+        XCTAssertTrue(merged.failed.isEmpty)
+    }
+
+    func testRefusingEitherHalfCountsAsRefused() {
+        let merged = outcome(succeeded: ["Claude Code", "Codex"])
+            .merged(with: outcome(succeeded: ["Codex"], failed: ["Claude Code"]))
+        XCTAssertEqual(merged.succeeded, ["Codex"])
+        XCTAssertEqual(merged.failed, ["Claude Code"])
+    }
+
+    func testNothingToInstallStaysEmpty() {
+        XCTAssertTrue(InstallOutcome().merged(with: InstallOutcome()).isEmpty)
+    }
+}


### PR DESCRIPTION
Three commits, one PR — they all touch the same files, so stacking them would only produce conflicts.

## The word

Every layer under this tab already said *device*: `KnownDevice`, `DeviceRoster`, `DeviceReadiness`, `DeviceClient`, `deviceInvite`. So did every Chinese string in the catalog, which has read 设备 since the tab shipped. Only the English UI said "Machines". The objection that named it was that "Devices" had been spent on a `~/.ssh/config` projection — that tab is gone and the name came with it.

## The layout

Four defects on the roster, all of which made it hard to act on:

- The pane title said Machines and the first section header said Machines again, in the only list of them in the tab.
- The navigation subtitle and the section footer were two spellings of one sentence, and the subtitle was the one that got truncated.
- `Add Machine` was a bar pinned below the whole scroll view — in a tall window, a screen away from the roster with Config file and Public keys in between, so it read as adding a public key. It is now the last row of the list it adds to.
- Nothing said the rows open. `NavigationLink` draws no chevron in an inset list on macOS, so the footer had to explain the interaction in words.

## The scope

The Agents roster was already per-device and would not say so: its readiness line described `store.currentDevice` — whichever machine the current workspace happened to run on — with nothing on screen naming that machine and no way to change it. A scope that cannot be seen or set is worse than either having one or not.

`DeviceScopeBar` is a **control**, not a place:

- A sidebar group would name the axis and still not answer it — you would arrive under "Device" and have to pick one anyway — and it splits the sidebar by something nobody navigates by. People look for *Agents*, not for the device section. It would also leave the Devices list either outside a group called Device, or inside it, which is circular.
- A drill-down is right for inspecting one box and wrong for reading one subject across machines. Comparing two devices should not mean backing out and re-entering.

This is the shape Displays, Sound and Printers & Scanners use. It is pinned above the list — the opposite of where the add row sits, and for the opposite reason: an action belongs with the thing it acts on and may scroll away with it, while a scope has to stay legible while you read what it scopes.

The selection lives in `SettingsView`, shared across the per-device pages, seeded from the current workspace's device — what those pages silently assumed before.

## What moved

With a scope on the roster, "which agents run here and where each launches from" had two homes — the device pane's *Runs* section and the Agents tab — showing the same readiness for the same machine. Split by subject instead:

- **Devices** answers what machines exist and how they are reached, and keeps the ladder (deploy `termiod`, reinstall hooks, reinstall skill) because those are operations on a box.
- **Agents** answers everything about an agent for the device its scope names. The per-device command path moved onto the agent's own pane, where it reads as a field of that agent rather than a column in a machine's table. Integration gained the install action for the selected device, so the job finishes where it starts instead of ending in a footnote pointing at another tab.

`InstallOutcome.merged` reports hooks and skill as one line and refuses to round a mixed result up: an agent that took its hook and refused the skill is not installed.

## Not in this PR

**Mobile keeps its This-Mac-only shape.** The RFC files `Settings ▸ Mobile` as a machine's *Serving* section, and it should get the same scope control — but everything in that tab is this Mac's companion server (the LAN address, the tunnel command that "runs on this Mac with your privileges", the pairing QR, the TestFlight invite). A device has nothing to put there until `termiod serve --wss` lands, which is P0.2 — PR #344, currently red on macos and linux. A picker offering devices that render an empty pane is worse than no picker.

**Usage keeps its This-Mac-only shape.** Not one control short: every provider is hard-wired to this Mac (`ClaudeUsageProvider.swift:17`, `UsageProvider.swift:103` both resolve `homeDirectoryForCurrentUser`). Scoping it means reading another machine's OAuth credential files over ssh — possible, but a decision to make on its own rather than inside a UI reshuffle.

**Devices / device vocabulary in code** (`PairedMac`, `macID`, `CompanionLink`, `MockProject`) is RFC D6/P5 and untouched here.

## Verification

`swift build`, `swift test` — 653 tests, 0 failures, including three new ones for the outcome merge. `scripts/check-strings.sh` clean; the String Catalog carries zh-Hans for every new key and the orphaned keys are removed.

**Not visually verified.** These are layout and control changes and I have not seen them run. Worth a look before merge.

Release Notes:
- Settings ▸ Machines is now Settings ▸ Devices, with the add action attached to the list and rows that show they open.
- The Agents tab now says which device it is reporting on and lets you change it, instead of silently following the current workspace.
- An agent's command path is set on that agent's own pane, for the device you pick, and the integration files can be installed from there.