### PR TITLE
Record that agent integration moves into termiod

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -127,6 +127,50 @@ public enum Termiod {
         return (kind, payload)
     }
 
+    /// Blocks until `descriptor` has a frame's first byte to read, or `seconds`
+    /// pass with nothing arriving.
+    ///
+    /// Every other read here is unbounded, and correctly so: a session's pipe is
+    /// *meant* to sit quiet until the program writes. A request is the opposite —
+    /// it was asked, so an answer is owed. The host does not owe one it has never
+    /// heard of, though: unknown ops are dropped on the floor rather than refused
+    /// (termiod/src/daemon.rs), so a client asking a daemon that predates an op
+    /// waits forever on a reply nobody will send, holding the thread, the
+    /// connection, and on the SSH road a child process with it. This is the bound
+    /// that turns that into an error a pane can show.
+    ///
+    /// Only the first byte is guarded. A host that starts a frame and then stalls
+    /// mid-payload still blocks, which is the same exposure every other read here
+    /// already carries and not what this exists to fix.
+    public static func waitForReadable(
+        _ descriptor: Int32, seconds: Int, operation: String
+    ) throws {
+        // Monotonic: a wall clock that steps — NTP, a laptop waking, the user
+        // changing the date — would cut a live request short or stretch it past
+        // the bound this exists to impose.
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(seconds))
+        while true {
+            let remaining = clock.now.duration(to: deadline)
+            guard remaining > .zero else { throw TermiodClientError.timedOut(operation) }
+            // Whole milliseconds *and* the sub-second remainder: dropping the
+            // remainder would poll for 1 ms on the last stretch and call that a
+            // timeout. Clamped before the conversion, not after — the seconds
+            // come from a caller, and a large one must saturate rather than
+            // overflow on the way to `Int32`.
+            let components = remaining.components
+            let whole = min(components.seconds, Int64(Int32.max) / 1000) * 1000
+            let fraction = components.attoseconds / 1_000_000_000_000_000
+            var descriptors = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+            let ready = poll(&descriptors, 1, Int32(clamping: whole + fraction + 1))
+            if ready > 0 { return }
+            if ready == 0 { throw TermiodClientError.timedOut(operation) }
+            // Interrupted before anything arrived — the deadline above is what
+            // decides whether to keep waiting, not the signal.
+            guard errno == EINTR else { throw TermiodClientError.connectionClosed }
+        }
+    }
+
     /// `R` payload: rows then cols, each a big-endian u16.
     public static func resizePayload(_ rows: UInt16, _ cols: UInt16) -> Data {
         var payload = Data(capacity: 4)
@@ -307,6 +351,23 @@ public enum Termiod {
         }
     }
 
+    /// `limit` is a total across all files, which is what bounds a one-letter
+    /// query in a monorepo — the host stops streaming there and says so.
+    public struct FsSearchOperation: Encodable, Sendable {
+        public let op = "fs_search"
+        public let root: String
+        public let query: String
+        public let limit: UInt64
+        public let seq: UInt64
+
+        public init(root: String, query: String, limit: UInt64, seq: UInt64) {
+            self.root = root
+            self.query = query
+            self.limit = limit
+            self.seq = seq
+        }
+    }
+
     /// Only the `op` tag — the second decode pass picks the payload shape.
     private struct ControlTag: Decodable {
         let op: String
@@ -383,6 +444,38 @@ public enum Termiod {
 
     public struct FsListedPayload: Decodable, Sendable {
         public let listings: [PathListingPayload]
+    }
+
+    /// One batch of `fs.search` hits, addressed to the connection that asked.
+    /// `request` echoes the `fs_search` seq; a channel carrying a single search
+    /// can ignore it, and this client's does.
+    public struct SearchResultsPayload: Decodable, Sendable {
+        public let matches: [SearchMatchPayload]
+    }
+
+    public struct SearchMatchPayload: Decodable, Sendable {
+        public let path: String
+        public let line: UInt64
+        public let text: String
+    }
+
+    /// The terminal reply to `fs_search`: how many hits streamed, and why the
+    /// stream ended.
+    public struct FsSearchedPayload: Decodable, Sendable {
+        public let matches: UInt64
+        public let limitHit: Bool
+        public let canceled: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case matches, limitHit, canceled
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            matches = try container.decodeIfPresent(UInt64.self, forKey: .matches) ?? 0
+            limitHit = try container.decodeIfPresent(Bool.self, forKey: .limitHit) ?? false
+            canceled = try container.decodeIfPresent(Bool.self, forKey: .canceled) ?? false
+        }
     }
 
     /// The reply header for `fs_read`: `length` bytes from `offset` follow as
@@ -735,6 +828,10 @@ public enum Termiod {
         case resized(ResizedPayload)
         case roster(RosterPayload)
         case sessionExited(SessionExitedPayload)
+        /// One batch of `fs.search` hits, streamed to the connection that asked
+        /// (`TermiodFiles.swift`). The only event addressed to a request rather
+        /// than to a session, which is why it carries no `session`.
+        case searchResults(SearchResultsPayload)
         case unknown(String)
     }
 
@@ -799,6 +896,9 @@ public enum Termiod {
         /// tree. It rides the same decode table as everything else, so an
         /// unexpected reply on any channel is ignored rather than fatal.
         case fsFile(FsFilePayload)
+        /// The terminal reply to `fs_search`, closing a stream whose hits
+        /// arrived as `search_results` events.
+        case fsSearched(FsSearchedPayload)
         /// The addressed half of `writer_changed`: sent to one client to tell it
         /// who owns size now (§C.5). Same payload shape, so it feeds the same
         /// handler — a client that only listened to the broadcast would still be
@@ -839,6 +939,8 @@ public enum Termiod {
             return .fsListed(try decoder.decode(FsListedPayload.self, from: payload))
         case "fs_file":
             return .fsFile(try decoder.decode(FsFilePayload.self, from: payload))
+        case "fs_searched":
+            return .fsSearched(try decoder.decode(FsSearchedPayload.self, from: payload))
         case "resize_claim":
             return .resizeClaim(try decoder.decode(WriterChangedPayload.self, from: payload))
         case "error":
@@ -867,6 +969,8 @@ public enum Termiod {
             return .roster(try decoder.decode(RosterPayload.self, from: payload))
         case "session_exited":
             return .sessionExited(try decoder.decode(SessionExitedPayload.self, from: payload))
+        case "search_results":
+            return .searchResults(try decoder.decode(SearchResultsPayload.self, from: payload))
         default:
             return .unknown(tag.ev)
         }
@@ -931,6 +1035,12 @@ public enum TermiodClientError: LocalizedError {
     case malformedFrame
     case handshakeRejected(String)
     case requestFailed(String)
+    /// The device accepted the request and then said nothing for long enough
+    /// that waiting further is worse than answering. Distinct from a closed
+    /// connection: the pipe is open, the host is simply not replying — which is
+    /// exactly what a daemon too old for the op does, since unknown ops are
+    /// dropped rather than refused (`daemon.rs`, the `Control::Unknown` arm).
+    case timedOut(String)
 
     public var errorDescription: String? {
         switch self {
@@ -948,6 +1058,8 @@ public enum TermiodClientError: LocalizedError {
             return "termiod hello rejected: \(message)"
         case .requestFailed(let message):
             return message
+        case .timedOut(let operation):
+            return "the device stopped answering \(operation)"
         }
     }
 }

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -228,13 +228,23 @@ struct FileBrowserView: View {
         case .files:
             EmptyView()
         case .search:
-            if let deviceCheckout {
+            if let deviceCheckout, let deviceRoot = deviceCheckout.root {
+                // The device's own `fs.search`, rooted where its tree is rooted.
+                FileSearchView(
+                    scope: .device(
+                        DeviceFileProvider(
+                            route: deviceCheckout.device.route, root: deviceRoot),
+                        host: deviceCheckout.device.name,
+                        root: deviceRoot),
+                    onDismiss: { store.inspectorTab = .files }
+                )
+                .id(deviceCheckout.deviceIdentity + "\u{1f}" + deviceRoot)
+            } else if let deviceCheckout {
                 unavailable(pane: localized("Search"), on: deviceCheckout)
             } else if let root {
                 FileSearchView(
-                    rootURL: root.url,
-                    onDismiss: { store.inspectorTab = .files },
-                    onOpen: { url, line in store.openFileInEditor(url, at: line) }
+                    scope: .thisMac(root.url),
+                    onDismiss: { store.inspectorTab = .files }
                 )
                 // Fresh identity per project, so a stale query/result set
                 // doesn't carry over when the root moves.

--- a/Sources/termio/FileBrowser/FileSearchView.swift
+++ b/Sources/termio/FileBrowser/FileSearchView.swift
@@ -1,22 +1,36 @@
 import AppKit
 import SwiftUI
+import TermioShared
+
+/// Which machine the Search pane searches, and therefore what a hit opens. The
+/// pane is one pane either way — a field, hits grouped under their file, click to
+/// open — so the two roads differ only here.
+enum SearchScope {
+    /// This Mac: `git grep` under a local root (`ContentSearch`), and a hit opens
+    /// the editor at its line.
+    case thisMac(URL)
+    /// Another machine: that device's own `fs.search`, and a hit opens the
+    /// read-only preview the device's file tree already uses. `root` is a path on
+    /// **that** box, so it is carried as a string; the `URL`s the rows build from
+    /// it are synthetic (names and icons only), exactly like `RemoteFileNode`.
+    case device(DeviceFileProvider, host: String, root: String)
+}
 
 /// The inspector's Search pane — a sibling of Files / Changes / Info on the
 /// toolbar switch, searching file *contents* (VS Code's ⇧⌘F; the filename jump
-/// lives in Open Quickly, ⌘⇧O). Queries run debounced through `ContentSearch`
-/// (`git grep`, ignore rules for free), results group under their file with the
-/// matched substring tinted accent, and clicking a hit opens the editor
-/// scrolled to that line.
+/// lives in Open Quickly, ⌘⇧O). Queries run debounced through `git grep` — this
+/// Mac's own for a local root, the device's for a checkout on another machine —
+/// results group under their file with the matched substring tinted accent, and
+/// clicking a hit opens the file scrolled to that line.
 struct FileSearchView: View {
+    @EnvironmentObject var store: TermioStore
     @EnvironmentObject var settings: AppSettings
     @Environment(\.colorScheme) private var colorScheme
 
-    /// The project (or worktree) root the search runs under.
-    let rootURL: URL
+    /// The root the search runs under, and the machine it lives on.
+    let scope: SearchScope
     /// Leaves the pane (back to the Files tab) — Esc in an empty field.
     let onDismiss: () -> Void
-    /// Opens a hit in the editor at its 1-based line.
-    let onOpen: (_ url: URL, _ line: Int) -> Void
 
     /// Total hits kept per query — past this the footer says so and the user
     /// should sharpen the query rather than scroll.
@@ -28,8 +42,14 @@ struct FileSearchView: View {
     @State private var query = ""
     @State private var matches: [ContentMatch] = []
     @State private var isSearching = false
+    /// What the device said when it refused to search — shown in place of the
+    /// no-matches state, since "nothing here" and "the search never ran" are
+    /// different answers and only one of them is about the query.
+    @State private var failure: String?
     /// The in-flight debounce+grep, cancelled by the next keystroke.
     @State private var searchTask: Task<Void, Never>?
+    /// The in-flight download of a hit's file, for a device checkout.
+    @State private var openTask: Task<Void, Never>?
     @State private var fieldFocused = false
     @State private var focusRequest = 0
     @State private var isVisible = false
@@ -48,7 +68,16 @@ struct FileSearchView: View {
         .onDisappear {
             isVisible = false
             searchTask?.cancel()
+            openTask?.cancel()
         }
+    }
+
+    /// Whether a hit is a file this Mac can hand to the Finder. A device's is
+    /// not: the row's URL names a path over there, so a drag would produce a
+    /// promise nothing can keep.
+    private var allowsDrag: Bool {
+        if case .thisMac = scope { return true }
+        return false
     }
 
     // MARK: - Pieces
@@ -66,9 +95,9 @@ struct FileSearchView: View {
                     text: $query,
                     isFocused: $fieldFocused,
                     focusRequest: focusRequest,
-                    placeholder: localized("Search Project"),
+                    placeholder: placeholder,
                     onSubmit: {
-                        if let first = matches.first { onOpen(first.url, first.line) }
+                        if let first = matches.first { open(first) }
                     },
                     // Esc clears a live query first; a second Esc (empty field)
                     // leaves the pane.
@@ -114,6 +143,15 @@ struct FileSearchView: View {
         }
     }
 
+    /// What the field invites: the project locally, the machine by name for a
+    /// checkout on a device — the same "say which box" rule the empty states use.
+    private var placeholder: String {
+        switch scope {
+        case .thisMac: return localized("Search Project")
+        case .device(_, let host, _): return localized("Search \(host)")
+        }
+    }
+
     /// The field's own chrome, replacing the `NSSearchField` bezel (stripped in
     /// `makeNSView`): a Liquid Glass capsule on macOS 26 — same material recipe as
     /// the toolbar's `InspectorTabsToolbar` track — and a flat capsule fill below.
@@ -137,12 +175,12 @@ struct FileSearchView: View {
     /// empty). Flat rows keyed by `path` / `path:line` make the diff
     /// unambiguous.
     private enum ResultRow: Identifiable {
-        case header(relative: String, url: URL, count: Int, firstLine: Int, isExpanded: Bool)
+        case header(relative: String, url: URL, count: Int, isExpanded: Bool)
         case match(ContentMatch)
 
         var id: String {
             switch self {
-            case .header(let relative, _, _, _, _): return relative
+            case .header(let relative, _, _, _): return relative
             case .match(let match): return "\(match.relative):\(match.line)"
             }
         }
@@ -152,8 +190,8 @@ struct FileSearchView: View {
         var out: [ResultRow] = []
         for group in groups {
             let isExpanded = !collapsedFiles.contains(group.relative)
-            out.append(.header(relative: group.relative, url: group.url, count: group.items.count,
-                               firstLine: group.items[0].line, isExpanded: isExpanded))
+            out.append(.header(relative: group.relative, url: group.url,
+                               count: group.items.count, isExpanded: isExpanded))
             if isExpanded {
                 for match in group.items { out.append(.match(match)) }
             }
@@ -167,7 +205,7 @@ struct FileSearchView: View {
             LazyVStack(spacing: 0, pinnedViews: []) {
                 ForEach(rows) { row in
                     switch row {
-                    case .header(let relative, let url, let count, let firstLine, let isExpanded):
+                    case .header(let relative, let url, let count, let isExpanded):
                         FileHeaderRow(
                             url: url,
                             relative: relative,
@@ -183,14 +221,15 @@ struct FileSearchView: View {
                                     }
                                 }
                             },
-                            open: { onOpen(url, firstLine) }
+                            allowsDrag: allowsDrag,
+                            open: { openFirstHit(inFile: relative) }
                         )
                     case .match(let match):
                         MatchRow(
                             match: match,
                             query: trimmedQuery,
                             chrome: chrome,
-                            open: { onOpen(match.url, match.line) }
+                            open: { open(match) }
                         )
                     }
                 }
@@ -203,12 +242,16 @@ struct FileSearchView: View {
                     Image(systemName: "magnifyingglass")
                         .font(.system(size: 18))
                         .foregroundStyle(.quaternary)
-                    Text(localized("No Matches"))
+                    Text(failure == nil ? localized("No Matches") : localized("Can’t Search"))
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(.secondary)
-                    Text(localized("Try another search term."))
+                    // The device's own words when it refused: it named the cause,
+                    // and "no matches" would be a different — and wrong — answer.
+                    Text(failure ?? localized("Try another search term."))
                         .font(.system(size: 11))
                         .foregroundStyle(.tertiary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
                 }
             }
         }
@@ -249,22 +292,127 @@ struct FileSearchView: View {
     /// exactly what would strand the grep beyond cancellation's reach.
     private func scheduleSearch() {
         searchTask?.cancel()
+        // Cleared here rather than inside the task: the message belongs to the
+        // query that produced it, and the debounce would otherwise leave it
+        // sitting under a quarter second of a different one.
+        failure = nil
         let trimmed = trimmedQuery
         guard !trimmed.isEmpty else {
             matches = []
             isSearching = false
             return
         }
-        let root = rootURL
         let limit = Self.matchLimit
         searchTask = Task {
             try? await Task.sleep(for: Self.debounce)
             guard !Task.isCancelled else { return }
             isSearching = true
-            let found = await ContentSearch.search(trimmed, under: root, limit: limit)
+            let found = await find(trimmed, limit: limit)
             guard !Task.isCancelled else { return }
             matches = found
             isSearching = false
+        }
+    }
+
+    /// Runs one query on whichever machine holds the root. The device's search is
+    /// a network round trip, so its failures are shown rather than swallowed —
+    /// `git grep` outside a repo, a daemon too old for `fs.search`, a box that
+    /// stopped answering.
+    private func find(_ query: String, limit: Int) async -> [ContentMatch] {
+        switch scope {
+        case .thisMac(let root):
+            return await ContentSearch.search(query, under: root, limit: limit)
+        case .device(let provider, let host, let root):
+            do {
+                let result = try await provider.search(query, limit: limit)
+                let base = URL(fileURLWithPath: root, isDirectory: true)
+                return result.hits.map { hit in
+                    ContentMatch(
+                        relative: hit.path,
+                        url: base.appendingPathComponent(hit.path),
+                        line: hit.line,
+                        text: hit.text)
+                }
+            } catch {
+                guard !Task.isCancelled else { return [] }
+                Log.files.error("""
+                device search \(host, privacy: .public):\(root, privacy: .public): \
+                \(String(describing: error), privacy: .public)
+                """)
+                failure = Self.message(for: error, fallback: localized("The search failed."))
+                return []
+            }
+        }
+    }
+
+    /// The device described what went wrong; wording it is this client's job, and
+    /// only for the cases the client decides itself — a daemon that named a cause
+    /// is quoted verbatim. `fallback` says which of the two round trips failed,
+    /// since an error with no message of its own tells the user nothing else.
+    private static func message(for error: Error, fallback: String) -> String {
+        switch error {
+        case DeviceFileError.unsupported:
+            return localized("This device’s termiod is too old to browse files.")
+        case DeviceFileError.tooLarge:
+            return localized("Preview is capped at 1 MB.")
+        case DeviceFileError.notRegularFile:
+            return localized("Only regular files can be previewed.")
+        case TermiodClientError.timedOut:
+            // Silence, not a refusal — and the likeliest cause is a host that
+            // has never heard of the op, so the sentence names that.
+            return localized("This device didn’t answer. Its termiod may be too old to search.")
+        case TermiodClientError.requestFailed(let detail) where !detail.isEmpty:
+            return detail
+        default:
+            return fallback
+        }
+    }
+
+    // MARK: - Opening a hit
+
+    private func openFirstHit(inFile relative: String) {
+        guard let match = matches.first(where: { $0.relative == relative }) else { return }
+        open(match)
+    }
+
+    /// Opens a hit at its line: the editor for a local file, and for a device the
+    /// same read-only preview its file tree opens — the bytes are downloaded,
+    /// never edited in place.
+    private func open(_ match: ContentMatch) {
+        guard case .device(let provider, let host, _) = scope else {
+            store.openFileInEditor(match.url, at: match.line)
+            return
+        }
+        openTask?.cancel()
+        let path = match.url.path
+        let name = match.url.lastPathComponent
+        let line = match.line
+        let generation = store.filePresentationGeneration
+        openTask = Task { @MainActor in
+            do {
+                let data = try await provider.read(
+                    path, limit: Termiod.filePreviewByteLimit)
+                try Task.checkCancellation()
+                let lease = try RemotePreviewStorage.stage(data, named: name)
+                store.presentRemoteFilePreview(
+                    lease, expectedGeneration: generation, at: line)
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                Log.files.error("""
+                device read \(host, privacy: .public):\(path, privacy: .public): \
+                \(String(describing: error), privacy: .public)
+                """)
+                // The click has to answer for itself: the results list stays on
+                // screen, so a failure recorded only in the pane's empty state
+                // would be a click that did nothing.
+                let alert = NSAlert()
+                alert.messageText = "“\(name)” couldn’t be opened."
+                alert.informativeText = Self.message(
+                    for: error, fallback: localized("The read failed."))
+                alert.runModal()
+            }
         }
     }
 
@@ -418,6 +566,9 @@ private struct FileHeaderRow: View {
     let isExpanded: Bool
     let chrome: ChromeTheme?
     let toggleExpanded: () -> Void
+    /// Whether the row's file exists on this Mac. A device's does not, so it is
+    /// not draggable — the URL names a path over there.
+    let allowsDrag: Bool
     let open: () -> Void
 
     @State private var isHovering = false
@@ -471,7 +622,21 @@ private struct FileHeaderRow: View {
                 .animation(.easeInOut(duration: 0.12), value: isHovering)
         )
         .onHover { isHovering = $0 }
-        .draggable(url)
+        .draggableFile(url, when: allowsDrag)
+    }
+}
+
+private extension View {
+    /// Drags the row out as its file, but only when the file is on this Mac. A
+    /// device's row carries a path on that box, and a drag promising the Finder
+    /// a local file at that path would be a promise nothing can keep.
+    @ViewBuilder
+    func draggableFile(_ url: URL, when allowed: Bool) -> some View {
+        if allowed {
+            draggable(url)
+        } else {
+            self
+        }
     }
 }
 

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -912,6 +912,16 @@
         }
       }
     },
+    "Can’t Search": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法搜索"
+          }
+        }
+      }
+    },
     "Can’t browse %@": {
       "localizations": {
         "zh-Hans": {
@@ -4447,6 +4457,16 @@
         }
       }
     },
+    "Preview is capped at 1 MB.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预览上限为 1 MB。"
+          }
+        }
+      }
+    },
     "Previous Match": {
       "localizations": {
         "zh-Hans": {
@@ -5094,6 +5114,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "搜索"
+          }
+        }
+      }
+    },
+    "Search %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索 %@"
           }
         }
       }
@@ -5908,6 +5938,26 @@
         }
       }
     },
+    "The read failed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "读取失败。"
+          }
+        }
+      }
+    },
+    "The search failed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索失败。"
+          }
+        }
+      }
+    },
     "The session host on %@. Sessions keep running there after you disconnect.": {
       "localizations": {
         "zh-Hans": {
@@ -6104,6 +6154,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "这个检出没有其他分支可以对比。"
+          }
+        }
+      }
+    },
+    "This device didn’t answer. Its termiod may be too old to search.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该设备没有响应，其 termiod 版本可能过旧，不支持搜索。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -190,6 +190,8 @@
 	<string>Built-in</string>
 	<key>Cancel</key>
 	<string>Cancel</string>
+	<key>Can’t Search</key>
+	<string>Can’t Search</string>
 	<key>Can’t browse %@</key>
 	<string>Can’t browse %@</string>
 	<key>Can’t check on %@</key>
@@ -896,6 +898,8 @@
 	<string>Press Shortcut…</string>
 	<key>Preview</key>
 	<string>Preview</string>
+	<key>Preview is capped at 1 MB.</key>
+	<string>Preview is capped at 1 MB.</string>
 	<key>Previous Match</key>
 	<string>Previous Match</string>
 	<key>Previous Session</key>
@@ -1026,6 +1030,8 @@
 	<string>Scrollback: %lld MB</string>
 	<key>Search</key>
 	<string>Search</string>
+	<key>Search %@</key>
+	<string>Search %@</string>
 	<key>Search Files</key>
 	<string>Search Files</string>
 	<key>Search Project</key>
@@ -1188,6 +1194,10 @@
 	<string>The project and session list. Kept separate from the terminal font, and need not be monospaced.</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
 	<string>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</string>
+	<key>The read failed.</key>
+	<string>The read failed.</string>
+	<key>The search failed.</key>
+	<string>The search failed.</string>
 	<key>The session host on %@. Sessions keep running there after you disconnect.</key>
 	<string>The session host on %@. Sessions keep running there after you disconnect.</string>
 	<key>The session host went away</key>
@@ -1228,6 +1238,8 @@
 	<string>This branch has nothing the base branch doesn’t already have.</string>
 	<key>This checkout has no other branch to compare with.</key>
 	<string>This checkout has no other branch to compare with.</string>
+	<key>This device didn’t answer. Its termiod may be too old to search.</key>
+	<string>This device didn’t answer. Its termiod may be too old to search.</string>
 	<key>This device sent a name the file tree can’t show.</key>
 	<string>This device sent a name the file tree can’t show.</string>
 	<key>This device’s termiod is too old to browse files.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -190,6 +190,8 @@
 	<string>内置</string>
 	<key>Cancel</key>
 	<string>取消</string>
+	<key>Can’t Search</key>
+	<string>无法搜索</string>
 	<key>Can’t browse %@</key>
 	<string>无法浏览 %@</string>
 	<key>Can’t check on %@</key>
@@ -896,6 +898,8 @@
 	<string>按下快捷键…</string>
 	<key>Preview</key>
 	<string>预览</string>
+	<key>Preview is capped at 1 MB.</key>
+	<string>预览上限为 1 MB。</string>
 	<key>Previous Match</key>
 	<string>上一个匹配项</string>
 	<key>Previous Session</key>
@@ -1026,6 +1030,8 @@
 	<string>回滚：%lld MB</string>
 	<key>Search</key>
 	<string>搜索</string>
+	<key>Search %@</key>
+	<string>搜索 %@</string>
 	<key>Search Files</key>
 	<string>搜索文件</string>
 	<key>Search Project</key>
@@ -1188,6 +1194,10 @@
 	<string>项目与会话列表。与终端字体分开设置，无需等宽字体。</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
 	<string>~/.ssh 中的公钥。可拷贝一个粘贴到服务器的 authorized_keys——私钥永远不会被读取。</string>
+	<key>The read failed.</key>
+	<string>读取失败。</string>
+	<key>The search failed.</key>
+	<string>搜索失败。</string>
 	<key>The session host on %@. Sessions keep running there after you disconnect.</key>
 	<string>%@ 上的会话宿主。断开连接后，会话仍在那里继续运行。</string>
 	<key>The session host went away</key>
@@ -1228,6 +1238,8 @@
 	<string>这个分支没有基础分支尚未包含的内容。</string>
 	<key>This checkout has no other branch to compare with.</key>
 	<string>这个检出没有其他分支可以对比。</string>
+	<key>This device didn’t answer. Its termiod may be too old to search.</key>
+	<string>该设备没有响应，其 termiod 版本可能过旧，不支持搜索。</string>
 	<key>This device sent a name the file tree can’t show.</key>
 	<string>该设备返回了文件树无法显示的名称。</string>
 	<key>This device’s termiod is too old to browse files.</key>

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1337,6 +1337,11 @@ final class TermiodSessionLink: @unchecked Sendable {
             // Snapshot-complete. No action: this reader is serial, so `S` has
             // already been rendered by the time this frame is read.
             break
+        case .searchResults:
+            // Addressed to a request, not to a session: the files channel that
+            // asked reads its own hits (`Termiod.searchContents`). Nothing on a
+            // session's channel can have asked, so there is nobody to give it to.
+            break
         case .unknown(let name):
             Log.termiod.debug("""
             ignoring \(name, privacy: .public) event on \(self.sessionName, privacy: .public)

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -30,6 +30,33 @@ extension Termiod {
     /// preview budget. Asking for more would be answered `truncated` anyway.
     static let filePreviewByteLimit = 1_024 * 1_024
 
+    /// How long a search may go without the device saying anything before it is
+    /// treated as unanswered.
+    ///
+    /// Deliberately far past any search a person would wait for. Silence is
+    /// normal in the *middle* of a grep — the host streams a batch per fifty
+    /// hits, so a query matching nothing says nothing at all until it finishes —
+    /// and a cold, large, or network-backed checkout can spend a long time
+    /// there. This bound is not "the search is slow", it is "the host is not
+    /// coming back": the case it exists for answers in milliseconds or never.
+    static let searchIdleTimeoutSeconds = 90
+
+    /// One `fs.search` hit: a path relative to the searched root, the 1-based
+    /// line it was found on, and that line's text.
+    struct SearchHit: Sendable {
+        let path: String
+        let line: Int
+        let text: String
+    }
+
+    /// What one search answered. `limitHit` means the device stopped at the
+    /// requested cap and more hits exist — the pane says so rather than passing
+    /// off a truncated set as the whole answer.
+    struct SearchResult: Sendable {
+        let hits: [SearchHit]
+        let limitHit: Bool
+    }
+
     /// Lists directories under `root` on the device `route` leads to. Paths are
     /// absolute on that machine — the daemon confines them under `root` and
     /// echoes each one back, so the caller can key its tree by the string it
@@ -97,6 +124,65 @@ extension Termiod {
                 }
             }
             return data
+        }
+    }
+
+    /// Searches file contents under `root` on the device `route` leads to: the
+    /// host runs `git grep` and streams `search_results` events, closing with one
+    /// `fs_searched` reply (§C.12).
+    ///
+    /// Unlike `fs.list` this is a stream, so the hits are collected here and
+    /// handed over whole — the pane renders one result set per query, and a
+    /// channel that lives only for this request cannot outlive it anyway.
+    ///
+    /// Bounded by an idle deadline rather than an overall one: a grep that walks
+    /// a large checkout for a rare string is slow *and* correct, so what is
+    /// waited on is the device saying nothing at all. That bound is what keeps a
+    /// daemon too old to know `fs_search` — which drops the op silently instead
+    /// of refusing it — from parking this thread and its connection forever.
+    ///
+    /// Blocking; call it off the main thread (`DeviceFileProvider` does).
+    ///
+    /// - Parameter idleTimeoutSeconds: the silence bound, a parameter only so a
+    ///   test can hold a stub host silent without waiting the real one out.
+    static func searchContents(
+        route: TermiodRoute, root: String, query: String, limit: Int,
+        idleTimeoutSeconds: Int = searchIdleTimeoutSeconds
+    ) throws -> SearchResult {
+        // Nothing to ask for, and the host would answer one hit anyway: it
+        // appends before it compares against the cap.
+        guard limit > 0 else { return SearchResult(hits: [], limitHit: false) }
+        return try withFilesChannel(route: route) { transport in
+            try writeFrame(
+                transport.writeDescriptor, kind: .control,
+                payload: encodeControl(FsSearchOperation(
+                    root: root, query: query, limit: UInt64(limit), seq: 1)))
+            var hits: [SearchHit] = []
+            while true {
+                try waitForReadable(
+                    transport.readDescriptor, seconds: idleTimeoutSeconds,
+                    operation: "fs.search")
+                let frame = try readFrame(transport.readDescriptor)
+                switch frame.kind {
+                case .event:
+                    guard case .searchResults(let payload) = try decodeEvent(frame.payload)
+                    else { continue }
+                    hits.append(contentsOf: payload.matches.map {
+                        SearchHit(path: $0.path, line: Int(clamping: $0.line), text: $0.text)
+                    })
+                case .control:
+                    switch try decodeControl(frame.payload) {
+                    case .fsSearched(let payload):
+                        return SearchResult(hits: hits, limitHit: payload.limitHit)
+                    case .error(let failure):
+                        throw TermiodClientError.requestFailed(failure.message)
+                    default:
+                        continue
+                    }
+                default:
+                    continue
+                }
+            }
         }
     }
 
@@ -186,6 +272,15 @@ struct DeviceFileProvider: Sendable {
             throw TermiodClientError.requestFailed(error)
         }
         return listing.entries
+    }
+
+    /// Content search under the pane's own root, on the device. Confined the same
+    /// way a listing is: the daemon canonicalises `root` and greps nothing above it.
+    func search(_ query: String, limit: Int) async throws -> Termiod.SearchResult {
+        try await run { [route, root] in
+            try Termiod.searchContents(
+                route: route, root: root, query: query, limit: limit)
+        }
     }
 
     func read(_ path: String, limit: Int) async throws -> Data {

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -513,24 +513,33 @@ final class TermioStore: ObservableObject {
         let session = self[slot]
         let project: Project?
         let localRoot: String?
+        /// Whether this slot's root is wherever the shell wandered, rather than a
+        /// container's fixed path. The same question for both machines: a loose
+        /// terminal follows its `cd` here and on a device, and a project session
+        /// stays at its checkout on both.
+        let followsWorkingDirectory: Bool
         switch slot {
         case .project(let index, _):
             project = projects[index]
             localRoot = session.worktreePath ?? projects[index].path
+            followsWorkingDirectory = false
         case .terminals:
             project = nil
             localRoot = workingDirectory(for: id)
                 ?? session.lastWorkingDirectory
                 ?? Self.looseTerminalRoot
+            followsWorkingDirectory = true
         case .chats:
             project = nil
             localRoot = Self.looseChatRoot
+            followsWorkingDirectory = false
         }
         let alias = session.termiodRemoteHost ?? session.sshHost
         return Self.checkout(
             for: session,
             in: project,
             localRoot: localRoot,
+            liveWorkingDirectory: followsWorkingDirectory ? workingDirectory(for: id) : nil,
             // The route's device, for a session that has never attached and so
             // carries none of its own.
             routeDeviceID: alias.flatMap {
@@ -545,8 +554,14 @@ final class TermioStore: ObservableObject {
     /// `localRoot` is the candidate the tree would have used, and is dropped whole
     /// for a session on another box: a local path that merely shares a name with
     /// the remote one is worse than showing nothing.
+    ///
+    /// `liveWorkingDirectory` is the cwd the session last reported, passed only by
+    /// a slot whose root follows it. It is the same rung the local candidate takes
+    /// first, offered to the other machine too so a `cd` moves the panes wherever
+    /// the shell runs.
     static func checkout(for session: Session, in project: Project?,
-                         localRoot: String?, routeDeviceID: String?) -> Checkout {
+                         localRoot: String?, liveWorkingDirectory: String? = nil,
+                         routeDeviceID: String?) -> Checkout {
         guard let alias = session.termiodRemoteHost ?? session.sshHost else {
             return Checkout(device: .thisMac, root: localRoot)
         }
@@ -555,14 +570,25 @@ final class TermioStore: ObservableObject {
         let device = KnownDevice(alias: alias, deviceID: session.deviceID ?? routeDeviceID)
         return Checkout(
             device: device,
-            root: remoteRoot(for: session, in: project, on: device))
+            root: remoteRoot(for: session, in: project, on: device,
+                             liveWorkingDirectory: liveWorkingDirectory))
     }
 
-    /// Where a session on another device is rooted, as far as this viewer can tell
-    /// without asking the device: the directory the session was spawned in, else
-    /// the checkout recorded for that device when the session sits under a project.
+    /// Where a session on another device is rooted: the directory it is working in
+    /// now, else the one it was spawned in, else the checkout recorded for that
+    /// device when the session sits under a project.
+    ///
+    /// The live cwd is taken only for a **termiod** session, whose PTY runs on the
+    /// device — that report is a path on the machine the panes read. A plain `ssh`
+    /// terminal runs its PTY here, so what the host samples is this Mac's `ssh`
+    /// process sitting in some local directory; feeding that back as a path over
+    /// there is the wrong-machine mixup this whole type exists to prevent.
     private static func remoteRoot(for session: Session, in project: Project?,
-                                   on device: KnownDevice) -> String? {
+                                   on device: KnownDevice,
+                                   liveWorkingDirectory: String?) -> String? {
+        if session.termiodRemoteHost != nil, let cwd = liveWorkingDirectory, !cwd.isEmpty {
+            return cwd
+        }
         if let cwd = session.termiodRemoteCwd { return cwd }
         guard let alias = device.alias, let project else { return nil }
         return project.remoteCheckout(device: device.deviceID, alias: alias)
@@ -1696,10 +1722,15 @@ final class TermioStore: ObservableObject {
     /// Adopts a staged remote file only if no newer presentation won while its
     /// bytes were downloading. The lease owns cleanup and the remote display
     /// name stays separate from the randomized local leaf.
+    ///
+    /// `line` is the 1-based line to scroll to — a search hit's, since the pane
+    /// that opened it knows which line matched. `nil` for the tree, which opens a
+    /// file at its top.
     @discardableResult
     func presentRemoteFilePreview(
         _ lease: RemotePreviewLease,
-        expectedGeneration: UInt64
+        expectedGeneration: UInt64,
+        at line: Int? = nil
     ) -> Bool {
         guard expectedGeneration == filePresentationGeneration,
               FileManager.default.fileExists(atPath: lease.fileURL.path)
@@ -1710,7 +1741,7 @@ final class TermioStore: ObservableObject {
         openFileDisplayName = lease.displayName
         openFileReadOnly = true
         openFileAllowsActiveWebContent = false
-        openFileLine = nil
+        openFileLine = line
         openFileURL = lease.fileURL
         return true
     }

--- a/Tests/termioTests/InspectorCheckoutTests.swift
+++ b/Tests/termioTests/InspectorCheckoutTests.swift
@@ -18,8 +18,10 @@ final class InspectorCheckoutTests: XCTestCase {
     }
 
     private func derive(_ session: Session, in project: Project?,
-                        localRoot: String?, routeDeviceID: String? = nil) -> Checkout {
+                        localRoot: String?, liveWorkingDirectory: String? = nil,
+                        routeDeviceID: String? = nil) -> Checkout {
         TermioStore.checkout(for: session, in: project, localRoot: localRoot,
+                             liveWorkingDirectory: liveWorkingDirectory,
                              routeDeviceID: routeDeviceID)
     }
 
@@ -89,6 +91,52 @@ final class InspectorCheckoutTests: XCTestCase {
         let loose = derive(Session(title: "shell", agent: .terminal),
                            in: nil, localRoot: "/Users/me/elsewhere")
         XCTAssertEqual(loose.localRoot, "/Users/me/elsewhere")
+    }
+
+    /// A loose terminal is wherever it wandered — on this Mac and on a device
+    /// alike. The panes used to follow a local `cd` and pin a remote one to the
+    /// directory the session was spawned in, so the same `cd ..` moved the tree
+    /// here and did nothing there.
+    func testALooseTerminalOnADeviceFollowsItsWorkingDirectory() {
+        var session = Session(title: "ukvps", agent: .terminal)
+        session.termiodRemoteHost = "ukvps"
+        session.deviceID = "device-a"
+        session.termiodRemoteCwd = "/home/me/repo/proto"
+
+        let checkout = derive(session, in: nil, localRoot: nil,
+                              liveWorkingDirectory: "/home/me")
+
+        XCTAssertEqual(checkout.root, "/home/me")
+        XCTAssertNil(checkout.localRoot, "still nothing this Mac may read")
+    }
+
+    /// The slot decides whether the root follows the shell: a project session's
+    /// root is its checkout on both machines, so no live cwd is offered and the
+    /// spawn directory stands.
+    func testAProjectSessionOnADeviceStaysAtItsCheckout() {
+        var session = Session(title: "ukvps", agent: .terminal)
+        session.termiodRemoteHost = "ukvps"
+        session.deviceID = "device-a"
+        session.termiodRemoteCwd = "/home/me/repo/proto"
+
+        let checkout = derive(session, in: project("/Users/me/proto"), localRoot: "/Users/me/proto")
+
+        XCTAssertEqual(checkout.root, "/home/me/repo/proto")
+    }
+
+    /// A plain `ssh` terminal runs its PTY *here*, so the cwd sampled for it is a
+    /// directory on this Mac. Handing that back as a path on the box is the
+    /// wrong-machine mixup the checkout exists to prevent, so it is refused even
+    /// though the slot follows the shell.
+    func testAPlainSSHTerminalNeverTakesTheLocalCwdAsARemoteRoot() {
+        var session = Session(title: "shell", agent: .terminal)
+        session.sshHost = "ukvps"
+
+        let checkout = derive(session, in: nil, localRoot: NSHomeDirectory(),
+                              liveWorkingDirectory: "/Users/me/Documents")
+
+        XCTAssertNil(checkout.root)
+        XCTAssertNil(checkout.localRoot)
     }
 
     /// The identity is the device, not the road to it: the same box reached by a

--- a/Tests/termioTests/TermiodEventTests.swift
+++ b/Tests/termioTests/TermiodEventTests.swift
@@ -399,4 +399,66 @@ final class TermiodEventTests: XCTestCase {
         XCTAssertEqual(hello.clientId, "c_7")
         XCTAssertTrue(hello.caps.isEmpty)
     }
+
+    /// The Search pane's stream: hits arrive as events addressed to the request,
+    /// which is why this is the one event carrying no session.
+    func testSearchResultsCarryTheHits() throws {
+        guard case .searchResults(let payload) = try event("""
+        {"ev":"search_results","request":1,"matches":[
+          {"path":"src/main.rs","line":42,"text":"let widget = 1;"}]}
+        """) else { return XCTFail("expected search results") }
+        XCTAssertEqual(payload.matches.count, 1)
+        XCTAssertEqual(payload.matches.first?.path, "src/main.rs")
+        XCTAssertEqual(payload.matches.first?.line, 42)
+    }
+
+    /// The reply that closes the stream. `limit_hit` is the difference between
+    /// "that is everything" and "there is more" — the pane says so out loud.
+    func testSearchedReplyCarriesWhyTheStreamEnded() throws {
+        guard case .fsSearched(let payload) = try control(
+            #"{"op":"fs_searched","matches":400,"limit_hit":true,"re":1}"#)
+        else { return XCTFail("expected fs_searched") }
+        XCTAssertEqual(payload.matches, 400)
+        XCTAssertTrue(payload.limitHit)
+        XCTAssertFalse(payload.canceled)
+    }
+
+    /// The daemon omits both flags on a clean finish; absent is `false`, not a
+    /// decode failure.
+    func testSearchedReplyWithoutFlagsDecodes() throws {
+        guard case .fsSearched(let payload) = try control(#"{"op":"fs_searched","matches":0}"#)
+        else { return XCTFail("expected fs_searched") }
+        XCTAssertFalse(payload.limitHit)
+        XCTAssertFalse(payload.canceled)
+    }
+
+    /// A request must not wait forever on a host that owes it nothing: a daemon
+    /// too old for an op drops it silently instead of refusing it, so without a
+    /// bound the reader parks a thread and its connection for good.
+    func testAWaitingReadGivesUpOnSilence() throws {
+        var pair: [Int32] = [-1, -1]
+        XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &pair), 0)
+        defer { close(pair[0]); close(pair[1]) }
+
+        XCTAssertThrowsError(
+            try Termiod.waitForReadable(pair[0], seconds: 1, operation: "fs.search")
+        ) { error in
+            guard case TermiodClientError.timedOut = error else {
+                return XCTFail("expected a timeout, got \(error)")
+            }
+        }
+    }
+
+    /// And it returns the moment the device does answer — the bound above must
+    /// not cost a reply that arrived in time.
+    func testAWaitingReadReturnsWhenTheDeviceAnswers() throws {
+        var pair: [Int32] = [-1, -1]
+        XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &pair), 0)
+        defer { close(pair[0]); close(pair[1]) }
+
+        var byte: UInt8 = 0x43
+        XCTAssertEqual(write(pair[1], &byte, 1), 1)
+        XCTAssertNoThrow(
+            try Termiod.waitForReadable(pair[0], seconds: 5, operation: "fs.search"))
+    }
 }

--- a/Tests/termioTests/TermiodFilesIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFilesIntegrationTests.swift
@@ -57,6 +57,22 @@ final class TermiodFilesIntegrationTests: XCTestCase {
         try Data("hello\n".utf8).write(to: root.appendingPathComponent("a.txt"))
         try Data(nestedContents.utf8).write(
             to: root.appendingPathComponent("sub/b.txt"))
+        try Data("Widget lives here\n".utf8).write(
+            to: root.appendingPathComponent("widget.txt"))
+        // `fs.search` is `git grep`, so the workspace has to be a real checkout
+        // for it to run at all. The `.git` directory above is what the listing
+        // tests expect to see; this makes it a repository rather than a husk.
+        try gitInit()
+    }
+
+    private func gitInit() throws {
+        let git = Process()
+        git.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        git.arguments = ["-C", root.path, "init", "--quiet"]
+        git.standardOutput = FileHandle.nullDevice
+        git.standardError = FileHandle.nullDevice
+        try git.run()
+        git.waitUntilExit()
     }
 
     override func tearDownWithError() throws {
@@ -138,5 +154,50 @@ final class TermiodFilesIntegrationTests: XCTestCase {
     func testAMissingFileFailsWithTheDaemonsReason() {
         XCTAssertThrowsError(try Termiod.readFile(
             route: .local, path: root.appendingPathComponent("nope.txt").path))
+    }
+
+    /// The Search pane's whole contract in one call: hits stream as events and
+    /// the terminal reply closes them, paths come back relative to the searched
+    /// root, and the line numbers are the ones the pane jumps to.
+    func testSearchAnswersHitsWithRootRelativePaths() throws {
+        let result = try Termiod.searchContents(
+            route: .local, root: root.path, query: "Widget", limit: 400)
+
+        XCTAssertFalse(result.limitHit)
+        XCTAssertEqual(result.hits.map(\.path), ["widget.txt"])
+        XCTAssertEqual(result.hits.first?.line, 1)
+        XCTAssertEqual(result.hits.first?.text, "Widget lives here")
+    }
+
+    /// Smart case, matching what the local pane has always done: an all-lowercase
+    /// query matches insensitively, and an uppercase letter opts into exactness.
+    func testSearchIsSmartCase() throws {
+        let loose = try Termiod.searchContents(
+            route: .local, root: root.path, query: "widget", limit: 400)
+        XCTAssertEqual(loose.hits.map(\.path), ["widget.txt"])
+
+        let exact = try Termiod.searchContents(
+            route: .local, root: root.path, query: "WIDGET", limit: 400)
+        XCTAssertTrue(exact.hits.isEmpty, "an uppercase query means what it says")
+    }
+
+    /// The cap is what keeps a one-letter query in a monorepo from flooding the
+    /// pane, and the pane says "more exist" only because the reply does.
+    func testSearchStopsAtTheLimitAndSaysSo() throws {
+        let result = try Termiod.searchContents(
+            route: .local, root: root.path, query: "nested", limit: 5)
+
+        XCTAssertTrue(result.limitHit)
+        XCTAssertEqual(result.hits.count, 5)
+        XCTAssertTrue(result.hits.allSatisfy { $0.path == "sub/b.txt" })
+    }
+
+    /// A query nothing matches is an answer, not a failure — `git grep` exits 1
+    /// for it, and the pane must show "no matches" rather than an error.
+    func testSearchWithNoHitsSucceedsEmpty() throws {
+        let result = try Termiod.searchContents(
+            route: .local, root: root.path, query: "nothing-here-at-all", limit: 400)
+        XCTAssertTrue(result.hits.isEmpty)
+        XCTAssertFalse(result.limitHit)
     }
 }

--- a/Tests/termioTests/TermiodSearchTimeoutTests.swift
+++ b/Tests/termioTests/TermiodSearchTimeoutTests.swift
@@ -1,0 +1,127 @@
+import Darwin
+import TermioShared
+import XCTest
+@testable import termio
+
+/// What a search does when the device accepts it and then says nothing.
+///
+/// This is not a hypothetical: unknown control operations are *dropped* by the
+/// daemon rather than refused (`daemon.rs`, the `Control::Unknown` arm), so a
+/// host that predates `fs.search` answers a search with silence on an open,
+/// healthy connection. Without a bound the client parks a thread, a socket, and
+/// on the SSH road a child process, for the life of the app.
+///
+/// The stub is a plain listening socket that completes the handshake and then
+/// holds its end open — the one host that cannot be built out of a real daemon,
+/// because a real daemon always answers.
+final class TermiodSearchTimeoutTests: XCTestCase {
+    private var socketPath = ""
+    private var directory: URL?
+    private var listener: Int32 = -1
+    private var accepted: Int32 = -1
+    private let handshaken = DispatchSemaphore(value: 0)
+    private let release = DispatchSemaphore(value: 0)
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Short path: `sun_path` is capped at 104 bytes.
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tst-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        self.directory = directory
+        socketPath = directory.appendingPathComponent("termiod.sock").path
+        try XCTSkipIf(socketPath.utf8.count >= 104, "socket path must fit sun_path")
+
+        listener = try listen(on: socketPath)
+        setenv("TERMIOD_SOCK", socketPath, 1)
+        serveOneSilentClient()
+    }
+
+    override func tearDownWithError() throws {
+        release.signal()
+        if accepted >= 0 { Darwin.close(accepted) }
+        if listener >= 0 { Darwin.close(listener) }
+        unsetenv("TERMIOD_SOCK")
+        if let directory { try? FileManager.default.removeItem(at: directory) }
+        try super.tearDownWithError()
+    }
+
+    /// The bound has to be wired into the request, not merely available: removing
+    /// the `waitForReadable` call from `searchContents` hangs this test rather
+    /// than failing it, which is the point — it is the hang that is the defect.
+    func testASilentHostEndsTheSearchInsteadOfHangingForever() throws {
+        var caught: Error?
+        let finished = expectation(description: "the search gave up")
+        DispatchQueue.global(qos: .userInitiated).async { [socketPath] in
+            setenv("TERMIOD_SOCK", socketPath, 1)
+            do {
+                _ = try Termiod.searchContents(
+                    route: .local, root: NSTemporaryDirectory(), query: "anything",
+                    limit: 400, idleTimeoutSeconds: 1)
+            } catch {
+                caught = error
+            }
+            finished.fulfill()
+        }
+        wait(for: [finished], timeout: 20)
+
+        guard case TermiodClientError.timedOut(let operation)? = caught else {
+            return XCTFail("expected a timeout, got \(String(describing: caught))")
+        }
+        XCTAssertEqual(operation, "fs.search")
+        XCTAssertEqual(handshaken.wait(timeout: .now()), .success,
+                       "the stub must have been reached, or nothing was proven")
+    }
+
+    // MARK: - The stub host
+
+    private func listen(on path: String) throws -> Int32 {
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw TermiodClientError.connectionClosed }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        _ = withUnsafeMutablePointer(to: &address.sun_path) { field in
+            path.withCString { source in
+                strlcpy(UnsafeMutableRawPointer(field).assumingMemoryBound(to: CChar.self),
+                        source, capacity)
+            }
+        }
+        let size = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(descriptor, $0, size)
+            }
+        }
+        guard bound == 0, Darwin.listen(descriptor, 1) == 0 else {
+            Darwin.close(descriptor)
+            throw TermiodClientError.connectionClosed
+        }
+        return descriptor
+    }
+
+    /// Accepts one client, answers its `hello` granting `files`, and then goes
+    /// quiet without hanging up — the exact shape of a daemon too old to know
+    /// the operation it was just asked for.
+    private func serveOneSilentClient() {
+        DispatchQueue.global(qos: .userInitiated).async { [self] in
+            let client = accept(listener, nil, nil)
+            guard client >= 0 else { return }
+            accepted = client
+            do {
+                _ = try Termiod.readFrame(client)
+                let reply = """
+                {"op":"hello_ok","proto":1,"host_id":"h_stub","host":"stub",
+                 "client_id":"c_1","caps":["files"],"home":"/tmp"}
+                """
+                try Termiod.writeFrame(client, kind: .control, payload: Data(reply.utf8))
+                handshaken.signal()
+            } catch {
+                return
+            }
+            // Hold the connection open: closing it would end the client's read
+            // with EOF, which is a different answer from the silence under test.
+            release.wait()
+        }
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,7 @@ from the real front matter).
 | draft | rfc | ["RFC: Per-project agent sandbox (Apple Seatbelt)"](design/20260630-sandbox-seatbelt.md) |
 | draft | rfc | [A project carries its machine — delete the host container](design/20260818-one-workspace-source.md) |
 | draft | rfc | [Adversarial review — Retire "remote", every machine is a device](design/20260814-remote-to-device.review-claude.md) |
+| draft | rfc | [Agent integration moves into termiod](design/20260825-agent-integration-moves-to-termiod.md) |
 | draft | rfc | [Automation — scheduled agent runs](design/20260702-automation-scheduled-agent-runs.md) |
 | draft | rfc | [Companion Wire Protocol](design/20260810-companion-wire-protocol.md) |
 | draft | rfc | [Device RFC blocking decisions](design/20260814-remote-to-device.decisions.md) |

--- a/docs/design/20260824-agent-integration-on-a-device.md
+++ b/docs/design/20260824-agent-integration-on-a-device.md
@@ -3,8 +3,9 @@ title: Installing termio's agent integration on a device
 status: draft
 type: rfc
 created: 2026-08-24
-updated: 2026-08-24
+updated: 2026-08-25
 related:
+  - 20260825-agent-integration-moves-to-termiod.md
   - 20260824-ios-as-device-client.md
   - 20260814-remote-to-device.md
   - 20260805-termiod-device-architecture.md
@@ -221,6 +222,15 @@ conflict fingerprints, and the refusal rules to exist in Rust *as well as*
 Swift, and the catalog they read is user-extensible.
 
 ### D5 — Policy stays in the client; the daemon owns only path safety
+
+> **Reversed 2026-08-25** by
+> [`20260825-agent-integration-moves-to-termiod.md`](20260825-agent-integration-moves-to-termiod.md).
+> The duplication argument below is still the true cost, and that RFC pays it. What
+> it prices that this one did not is the shape D5 forces: policy in Swift and files
+> on another machine puts the plan and the filesystem on opposite ends of a network,
+> so a twelve-agent install is 40–60 sequential `ssh` round trips. It also leaves
+> the phone and the browser unable to install at all, since neither has the Swift
+> that holds the policy. Read D5 for the argument, not for the decision.
 
 The daemon never learns what an agent is, where `.claude` lives, or which agents
 are enabled. It answers "write these bytes under `$HOME`, safely" and nothing

--- a/docs/design/20260825-agent-integration-moves-to-termiod.md
+++ b/docs/design/20260825-agent-integration-moves-to-termiod.md
@@ -1,0 +1,146 @@
+---
+title: Agent integration moves into termiod
+status: draft
+type: rfc
+created: 2026-08-25
+updated: 2026-08-25
+related:
+  - 20260824-agent-integration-on-a-device.md
+  - 20260819-unify-server-plane.md
+  - 20260817-one-path-local-through-termiod.md
+  - 20260824-ios-as-device-client.md
+  - 20260718-agent-abstraction-and-configuration.md
+---
+
+# Agent integration moves into termiod
+
+> The machine that owns the files decides what goes in them. `AgentCatalog` and
+> both installers move to Rust, and Swift asks for an install instead of
+> performing one — reversing §D5 of the device RFC, and settling which of two
+> active documents was right.
+
+## The contradiction this settles
+
+Two live documents disagree, and the disagreement is load-bearing:
+
+- [`20260824-agent-integration-on-a-device.md`](20260824-agent-integration-on-a-device.md)
+  **§D5** — "The daemon never learns what an agent is, where `.claude` lives, or
+  which agents are enabled. It answers *write these bytes under `$HOME`, safely*
+  and nothing more. `AgentCatalog` — including user-authored agents with their own
+  `skills` declaration — stays in Swift, one implementation."
+- [`20260819-unify-server-plane.md`](20260819-unify-server-plane.md) **Stage 10** —
+  the CLI moves verb by verb, ending with "`agent report` → `set-status` plus
+  **hook installation on the device**."
+
+D5 is the newer document and the narrower claim, so it has been the one in force.
+This RFC reverses it. Stage 10 was right.
+
+## Why D5 loses
+
+D5's argument was about **duplication**: four hook dialects, the conflict
+fingerprints and the refusal rules would have to exist in Rust as well as Swift,
+and the catalog they read is user-extensible — a user drops a JSON manifest in
+`AgentCatalog.userAgentsDirectory` and it becomes a real agent. That cost is real
+and this RFC pays it rather than denies it.
+
+What D5 did not price is the shape it forces. Policy in Swift and files on another
+machine means **the plan and the filesystem are on opposite ends of a network**,
+and every step of the plan is a question that has to cross it:
+
+| | |
+| --- | --- |
+| Hook install, per agent | `exists` + `read` + `write` |
+| Skill install, per agent | `isCommandInstalled` + `read` + `write` |
+| A twelve-agent box | **40–60 sequential `ssh` invocations** |
+
+Each is a `Process` with `waitUntilExit()`. Run from the button handler, that was
+a beachball — the window stopped drawing until the last write returned. That has
+been fixed by making the install `async`, which is the correct fix for *freezing*
+and does nothing for the round trips: the install is still one blocking
+conversation per file, and on a link with 200 ms of latency it is tens of seconds
+of spinner.
+
+Batching would cut it to two round trips — read everything, merge in Swift, write
+everything with `expect_sha256` preconditions — and it is a genuinely good
+intermediate step. But it is a workaround for the split, not a fix: it needs a
+batch read and a batch write on the transfer plane that do not exist
+(§D3's `home:` dest is unbuilt), it keeps two implementations of *reachability*
+(the SSH arm and the protocol arm), and it leaves the phone and the browser unable
+to install anything at all, because both lack the Swift that holds the policy.
+
+The deciding argument is the one Stage 10 already made: **the machine that owns
+the files is the machine that should decide what goes in them.** An install is a
+local operation that has been performed remotely by accident of where the code
+lives.
+
+## What moves
+
+| Swift today | Lines | Goes to Rust |
+| --- | --- | --- |
+| `AgentDefinition.swift` — manifest schema, `AgentCatalog`, bundled + user manifests | 1308 | The catalog and the schema. |
+| `HookListener.swift` — six dialect writers, conflict fingerprints, refusal rules | 1134 | The installers. **Not** the listener half — the socket that receives reports stays where the app is. |
+| `SessionControl.swift` — skill installer, skill payload selection | 1031 | The installer and both payloads. |
+| `AgentConfigStore.swift` — the local/SSH seam | 486 | **Deleted.** Its whole reason was that the writer was on the wrong machine. |
+| `InstallOutcome.swift` | 35 | Becomes a protocol reply. |
+
+The 15 bundled manifests under `Sources/termio/Resources/agents/` become a
+termiod resource. The user's own manifests stay exactly where they are, in the
+same format — that is the compatibility line this must not cross.
+
+## What Swift keeps
+
+Everything that is a **preference** rather than a fact about a machine:
+
+- which agents are on the user's list, and in what order
+- the default New Chat agent
+- whether live status and session control are wanted at all
+- the per-device command path override
+
+Swift's call becomes one message — *install the integration for this set of
+enabled agents* — and one reply. `AgentSettingsTab` and `DevicePane` lose their
+`Task.detached` wrappers because there is nothing left to detach.
+
+## The cost, stated plainly
+
+**A second parser for a user-extensible format.** Rust must read the same manifest
+JSON Swift reads, and a manifest the two disagree about is a bug the user sees as
+"my agent works in the list but gets no hooks". Mitigation: the schema is data,
+not behaviour — one set of fixture manifests, parsed by both, asserted equal. That
+test is the contract, and it belongs in CI from the first stage.
+
+**Swift does not stop parsing manifests.** It still renders the roster, so it
+still needs names, icons and commands. What it stops doing is *writing* from them.
+The duplication is therefore in the schema, not in the dialects — which is the
+smaller half, and the half that changes rarely.
+
+**A local install becomes an IPC call.** On this Mac the installers currently run
+in-process. After this they go through termiod like everything else, which is
+[`one-path-local-through-termiod`](20260817-one-path-local-through-termiod.md)'s
+whole thesis and not a new cost.
+
+## Stages
+
+Ordered so each one is shippable and none is a big-bang.
+
+| Stage | Deliverable | Gate |
+| --- | --- | --- |
+| **1** | Manifest schema in Rust, parsing the same 15 bundled files plus the user directory. Nothing installs yet. | A fixture test parses every manifest in both languages and asserts the same values. |
+| **2** | The two shell-command dialects (JSON manifest, script directory) and the skill installer, behind a new `install` control message. | Installing on `ukvps` through termiod produces byte-identical files to the SSH arm's output. |
+| **3** | The plugin dialects and the TOML block. | Same byte-identical gate, all six dialects. |
+| **4** | Swift calls it. `AgentConfigStore` and `SSHAgentConfigStore` are deleted; `DevicePaneModel.setUp` becomes one call. | A twelve-agent install is one round trip. The Settings surfaces are unchanged. |
+| **5** | The phone installs. | The iOS device client offers Set up on a directly-attached box, with the Mac quit. |
+
+Stages 1–4 depend on nothing in the iOS work. Stage 5 depends on
+[`ios-as-device-client`](20260824-ios-as-device-client.md) P4, which depends on
+P0.2 — `termiod serve --wss`, currently PR #344 with failing CI.
+
+## Non-goals
+
+- **The hook listener does not move.** `agent-status.sock` receives reports for an
+  app to render; the daemon already has `set-status` for the device case.
+- **No new transfer-plane work.** §D3's `home:` dest and §D4's `expect_sha256`
+  were the shape needed to write files *from* the client. With the writer on the
+  box, neither is required for this — D4's precondition remains correct for the
+  SSH arm until Stage 4 deletes it.
+- **The user manifest format does not change.** A format migration and a language
+  migration at once is how both fail.

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -1519,7 +1519,8 @@ async fn run_search(
             return;
         }
     };
-    let spawned = tokio::process::Command::new("git")
+    let mut command = tokio::process::Command::new("git");
+    command
         .arg("-C")
         .arg(&root)
         .arg("grep")
@@ -1527,7 +1528,16 @@ async fn run_search(
         .arg("-I")
         .arg("--no-color")
         .arg("--untracked")
-        .arg("--fixed-strings")
+        .arg("--fixed-strings");
+    // Smart case, the fzf/ripgrep default every client already expects: an
+    // all-lowercase query matches insensitively, and one uppercase letter opts
+    // back into exactness. Decided from the query itself rather than a flag on
+    // the wire, so a client cannot ask two hosts for the same search and get two
+    // different answers.
+    if query == query.to_lowercase() {
+        command.arg("--ignore-case");
+    }
+    let spawned = command
         .arg("-e")
         .arg(&query)
         .stdout(std::process::Stdio::piped())
@@ -1569,6 +1579,17 @@ async fn run_search(
             // Err means the sender vanished without an explicit cancel — the
             // connection is gone; stop doing work nobody can receive.
             _ = &mut cancel_rx => {
+                canceled = true;
+                break;
+            }
+            // The connection itself going away. Not covered by `cancel_rx`: a
+            // search addressed by a request id parks its cancel sender in the
+            // shared map, and *this task* holds a reference to that map — so the
+            // sender outlives the connection that owned it and the receiver never
+            // resolves. Without this arm a client that hung up (a timeout, a
+            // keystroke abandoning the query) leaves its grep running to
+            // completion, writing into a channel nobody reads.
+            _ = out.closed() => {
                 canceled = true;
                 break;
             }


### PR DESCRIPTION
Two active documents disagreed, and the disagreement decided how a whole feature is built:

- `20260824-agent-integration-on-a-device.md` **§D5** — `AgentCatalog` and both installers stay in Swift; the daemon only "writes these bytes under `$HOME`, safely".
- `20260819-unify-server-plane.md` **Stage 10** — the CLI moves verb by verb, ending with "hook installation on the device".

D5 was the newer and narrower claim, so it had been the one in force. This RFC reverses it and records why.

## What D5 did not price

Its argument was duplication: six hook dialects, the conflict fingerprints and the refusal rules would need to exist in Rust as well as Swift, and the catalog they read is user-extensible. That cost is real and the new RFC pays it rather than denying it.

What it missed is the shape D5 forces. Policy in Swift with the files on another machine puts the plan and the filesystem on opposite ends of a network, so every step of the plan has to cross it — `exists` + `read` + `write` per agent for hooks, `isCommandInstalled` + `read` + `write` per agent for the skill. On a twelve-agent box that is 40–60 sequential `ssh` invocations, each a `Process` with `waitUntilExit()`.

That is what beachballed the Settings window when clicking Install on a VPS (fixed separately in #458 by making the action async — the correct fix for *freezing*, and no fix at all for the round trips).

Batching to two round trips is a good intermediate step and still a workaround: it needs a batch read and write on the transfer plane that do not exist, keeps two implementations of reachability, and leaves the phone and the browser unable to install anything, since neither has the Swift that holds the policy.

## Stages

Five, each shippable, each gated on **byte-identical output** against today's SSH arm — starting with a fixture test that parses every manifest in both languages and asserts the same values, and ending with `AgentConfigStore` deleted. Stages 1–4 depend on nothing in the iOS work; Stage 5 depends on `ios-as-device-client` P4, which depends on P0.2 (PR #344, failing CI).

Docs only — no code changes. §D5 keeps its argument and gains a banner pointing here, so a reader cannot follow a reversed decision by accident.

Release Notes:
- None. Design documentation only.