### PR TITLE
Save a file back to the device it was read from

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -286,30 +286,44 @@ public enum Termiod {
     /// session UUID — and the daemon reaps whatever lands there when that
     /// session dies, so a pasted screenshot never outlives the conversation it
     /// belonged to.
+    /// `dest` is either `temp:<name>` with `session` naming whose scratch
+    /// directory receives it — a paste crossing to the device — or a path with
+    /// `root` naming the checkout it must stay inside, which is a **save**. The
+    /// two are the same transfer; only where it lands differs, so they are one
+    /// operation rather than two verbs that would drift apart.
     public struct UploadOpenOperation: Encodable, Sendable {
         public let op = "upload_open"
         public let dest: String
-        public let session: String
+        public let session: String?
+        public let root: String?
         public let size: UInt64
         public let sha256: String
         public let seq: UInt64
 
-        public init(dest: String, session: String, size: UInt64, sha256: String, seq: UInt64) {
+        public init(dest: String, session: String? = nil, root: String? = nil,
+                    size: UInt64, sha256: String, seq: UInt64) {
             self.dest = dest
             self.session = session
+            self.root = root
             self.size = size
             self.sha256 = sha256
             self.seq = seq
         }
     }
 
+    /// `ifUnmodifiedSince` is the version the writer read (`fs_file`'s `mtime`).
+    /// The host refuses the commit when the destination has moved on since,
+    /// which is what stops a save from silently overwriting whoever else is
+    /// working in that checkout. Omitted when the transfer replaces nothing.
     public struct UploadCommitOperation: Encodable, Sendable {
         public let op = "upload_commit"
         public let uploadId: String
+        public let ifUnmodifiedSince: UInt64?
         public let seq: UInt64
 
-        public init(uploadId: String, seq: UInt64) {
+        public init(uploadId: String, ifUnmodifiedSince: UInt64? = nil, seq: UInt64) {
             self.uploadId = uploadId
+            self.ifUnmodifiedSince = ifUnmodifiedSince
             self.seq = seq
         }
     }
@@ -486,9 +500,13 @@ public enum Termiod {
         public let offset: UInt64
         public let length: UInt64
         public let truncated: Bool
+        /// The file's modification time in whole seconds — the version this read
+        /// holds, handed back on save as `ifUnmodifiedSince`. Zero on a host too
+        /// old to report one, which means "no version" and so no check.
+        public let mtime: UInt64
 
         private enum CodingKeys: String, CodingKey {
-            case size, offset, length, truncated
+            case size, offset, length, truncated, mtime
         }
 
         public init(from decoder: Decoder) throws {
@@ -497,6 +515,7 @@ public enum Termiod {
             offset = try container.decode(UInt64.self, forKey: .offset)
             length = try container.decode(UInt64.self, forKey: .length)
             truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+            mtime = try container.decodeIfPresent(UInt64.self, forKey: .mtime) ?? 0
         }
     }
 
@@ -876,6 +895,21 @@ public enum Termiod {
     /// *that* machine, which is the whole point of the transfer.
     public struct UploadCommittedPayload: Decodable, Sendable {
         public let path: String
+        /// The version the write produced. Sent back as `ifUnmodifiedSince` by a
+        /// second save of the same file, which would otherwise claim the version
+        /// the file was opened at and be refused by its own first write. Zero on
+        /// a host too old to report it.
+        public let mtime: UInt64
+
+        private enum CodingKeys: String, CodingKey {
+            case path, mtime
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            path = try container.decode(String.self, forKey: .path)
+            mtime = try container.decodeIfPresent(UInt64.self, forKey: .mtime) ?? 0
+        }
     }
 
     /// Decoded control frames the client reacts to. Anything else — unknown

--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -21,6 +21,18 @@ struct FileEditorView: View {
     let jumpLine: Int?
     /// The original remote name when `url` is a randomized staged copy.
     let displayName: String?
+    /// Where the buffer belongs when it belongs on another machine — `url` is
+    /// then a staged copy on this Mac, and a save has to travel back. `nil` for
+    /// a local file, where writing `url` *is* the save.
+    ///
+    /// A save over the network is not free the way a local write is, so a remote
+    /// document is not auto-saved on the idle timer: ⌘S and closing are what
+    /// send it. That difference is deliberate and is the one place the two kinds
+    /// of document behave differently.
+    let remote: RemoteDocument?
+    /// Records the version a save produced, so the next one claims it rather
+    /// than the version the file was opened at.
+    let onRemoteSave: ((RemoteDocument) -> Void)?
     /// Dismisses the overlay (clears `store.openFileURL`) and hands focus back to the terminal.
     let onClose: () -> Void
 
@@ -61,6 +73,13 @@ struct FileEditorView: View {
     @State private var saveError: String?
     /// The pending debounced write, cancelled and rescheduled on each keystroke.
     @State private var saveTask: Task<Void, Never>?
+    /// The in-flight save to the device, so a second ⌘S doesn't start a race
+    /// with the first.
+    @State private var pushTask: Task<Void, Never>?
+    @State private var pushing = false
+    /// The device's own sentence when it refused a save because the file changed
+    /// under us. Non-nil raises the overwrite question.
+    @State private var conflict: String?
     @State private var findBarVisible = false
     @State private var findQuery = ""
     @State private var findOptions = FindOptions()
@@ -92,6 +111,8 @@ struct FileEditorView: View {
 
     init(url: URL, settings: AppSettings, readOnly: Bool = false, jumpLine: Int? = nil,
          displayName: String? = nil,
+         remote: RemoteDocument? = nil,
+         onRemoteSave: ((RemoteDocument) -> Void)? = nil,
          addToChat: ((String?) -> Void)? = nil, canAddToChat: (() -> Bool)? = nil,
          showsInspectorChrome: Bool = true, onClose: @escaping () -> Void) {
         self.url = url
@@ -99,6 +120,8 @@ struct FileEditorView: View {
         self.readOnly = readOnly
         self.jumpLine = jumpLine
         self.displayName = displayName
+        self.remote = remote
+        self.onRemoteSave = onRemoteSave
         self.addToChat = addToChat
         self.canAddToChat = canAddToChat
         self.showsInspectorChrome = showsInspectorChrome
@@ -194,6 +217,15 @@ struct FileEditorView: View {
             if jumpLine != nil, mode == .preview { mode = .edit }
         }
         .onExitCommand { close() }
+        .alert(
+            localized("\(fileName) changed on \(remote?.host ?? "")"),
+            isPresented: Binding(get: { conflict != nil },
+                                 set: { if !$0 { conflict = nil } }),
+            actions: { conflictAlert },
+            message: {
+                Text(localized(
+                    "Somebody else wrote this file after you opened it. Overwriting replaces their version."))
+            })
         // A safety flush if the overlay goes away without the close button (file switch, app quit).
         .onDisappear {
             if !readOnly { saveTask?.cancel(); writeIfNeeded() }
@@ -282,11 +314,20 @@ struct FileEditorView: View {
                     .truncationMode(.middle)
             }
             // A faint dot while an auto-save is pending — quieter than a word, no button to click.
-            if isDirty {
+            // On a device document the dot means something stronger: the bytes are
+            // still on this Mac only, and it clears when the machine has taken
+            // them. The spinner beside it is the crossing itself.
+            if pushing {
+                ProgressView()
+                    .controlSize(.mini)
+                    .help(localized("Saving to \(remote?.host ?? "")…"))
+            } else if isDirty {
                 Circle()
                     .fill(Color.secondary)
                     .frame(width: 5, height: 5)
-                    .help(localized("Unsaved changes — saving…"))
+                    .help(remote == nil
+                          ? localized("Unsaved changes — saving…")
+                          : localized("Unsaved changes — press ⌘S to save to \(remote?.host ?? "")"))
                     .transition(.opacity)
             }
             if let saveError {
@@ -379,6 +420,10 @@ struct FileEditorView: View {
     /// after the last keystroke actually hits the disk.
     private func scheduleSave() {
         saveTask?.cancel()
+        // A device document saves on ⌘S and on close only — every save is a
+        // round trip to another machine, and arming one on each quiet pause
+        // would send the file over and over as you type.
+        guard remote == nil else { return }
         saveTask = Task {
             try? await Task.sleep(nanoseconds: 600_000_000)
             if Task.isCancelled { return }
@@ -391,6 +436,20 @@ struct FileEditorView: View {
         saveTask?.cancel()
         writeIfNeeded()
         onClose()
+    }
+
+    /// The device refused the save: the file changed after it was read. Overwrite
+    /// re-sends claiming nothing, which is the one case where "I know, do it
+    /// anyway" is the right answer — the alternative, deciding it silently, is
+    /// what loses an agent's work.
+    private var conflictAlert: some View {
+        Group {
+            Button(localized("Overwrite"), role: .destructive) {
+                conflict = nil
+                pushToDevice(text, overwriting: true)
+            }
+            Button(localized("Cancel"), role: .cancel) { conflict = nil }
+        }
     }
 
     /// ⌘F: show the find bar. Skipped in Markdown Preview mode — there's no NSTextView to
@@ -462,11 +521,62 @@ struct FileEditorView: View {
         guard !readOnly, loaded, text != savedText else { return }
         do {
             try text.write(to: url, atomically: true, encoding: .utf8)
-            savedText = text
             saveError = nil
+            // A local file is saved the moment its bytes are on disk. A staged
+            // copy is not: the file the user thinks they saved is on another
+            // machine, so `savedText` — which is what the unsaved dot reads —
+            // only advances once the device has taken it.
+            if remote == nil {
+                savedText = text
+            } else {
+                pushToDevice(text)
+            }
         } catch {
             saveError = localized("Save failed: \(error.localizedDescription)")
         }
+    }
+
+    /// Sends the buffer to the machine it came from, claiming the version it was
+    /// read at. A refusal means somebody else — most likely an agent with a
+    /// shell in the same checkout — wrote the file first, and that is asked
+    /// about rather than decided here.
+    private func pushToDevice(_ contents: String, overwriting: Bool = false) {
+        guard let remote else { return }
+        pushTask?.cancel()
+        pushing = true
+        pushTask = Task { @MainActor in
+            do {
+                let landed = try await remote.provider.write(
+                    remote.path, data: Data(contents.utf8),
+                    ifUnmodifiedSince: overwriting ? nil : versionToClaim(remote))
+                guard !Task.isCancelled else { return }
+                savedText = contents
+                saveError = nil
+                conflict = nil
+                onRemoteSave?(remote.read(at: landed))
+            } catch let error as DeviceFileError {
+                guard !Task.isCancelled else { return }
+                if case .conflict(let message) = error {
+                    conflict = message
+                } else {
+                    saveError = localized("Save failed: \(error.localizedDescription)")
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                guard !(error is CancellationError) else { return }
+                saveError = localized("Save failed: \(error.localizedDescription)")
+            }
+            pushing = false
+        }
+    }
+
+    /// The version a save claims, and `nil` when there is none to claim: a host
+    /// too old to report an mtime answers 0, and sending 0 would fail every
+    /// save against a file whose real mtime is anything else. No version means
+    /// no check — the same bargain every other absent field in this protocol
+    /// makes.
+    private func versionToClaim(_ document: RemoteDocument) -> UInt64? {
+        document.mtime == 0 ? nil : document.mtime
     }
 
     /// Maps a file to a highlight.js language id, matched against grammars the bundled highlight.js

--- a/Sources/termio/FileBrowser/FileSearchView.swift
+++ b/Sources/termio/FileBrowser/FileSearchView.swift
@@ -390,12 +390,15 @@ struct FileSearchView: View {
         let generation = store.filePresentationGeneration
         openTask = Task { @MainActor in
             do {
-                let data = try await provider.read(
+                let file = try await provider.read(
                     path, limit: Termiod.filePreviewByteLimit)
                 try Task.checkCancellation()
-                let lease = try RemotePreviewStorage.stage(data, named: name)
+                let lease = try RemotePreviewStorage.stage(file.data, named: name)
                 store.presentRemoteFilePreview(
-                    lease, expectedGeneration: generation, at: line)
+                    lease, expectedGeneration: generation, at: line,
+                    origin: RemoteDocument(
+                        route: provider.route, root: provider.root, path: path,
+                        mtime: file.mtime, host: host))
             } catch is CancellationError {
                 return
             } catch {

--- a/Sources/termio/FileBrowser/InspectorDetailHost.swift
+++ b/Sources/termio/FileBrowser/InspectorDetailHost.swift
@@ -273,6 +273,8 @@ struct InspectorDetailContent: View {
                                readOnly: store.openFileReadOnly,
                                jumpLine: store.openFileLine,
                                displayName: store.openFileDisplayName,
+                               remote: store.openFileRemote,
+                               onRemoteSave: { store.openFileRemote = $0 },
                                addToChat: { selection in
                                    if let selection {
                                        _ = store.addSnippetToSelectedSessionPrompt(selection)

--- a/Sources/termio/FileBrowser/RemoteFileTree.swift
+++ b/Sources/termio/FileBrowser/RemoteFileTree.swift
@@ -28,6 +28,38 @@ final class RemotePreviewLease {
     }
 }
 
+/// Where a staged file came from, and which version of it — everything a save
+/// needs to put the bytes back where they were read.
+///
+/// Held beside the open file rather than inside the lease: the lease owns a
+/// temp directory's lifetime, and this owns a different claim — that those bytes
+/// *are* that file on that machine, as it stood at that moment. The version is
+/// carried rather than re-read at save time, because re-reading would answer
+/// about a file that may already have changed, which is the one question a save
+/// must not get wrong.
+struct RemoteDocument: Hashable {
+    let route: TermiodRoute
+    /// The checkout the write stays inside. The host confines it too — this is
+    /// the client half of the same rule the tree and search are rooted by.
+    let root: String
+    /// The absolute path on that machine.
+    let path: String
+    /// `fs_file`'s `mtime`, and 0 when the host did not report one. Zero means
+    /// no version, so a save carrying it claims nothing and is not checked —
+    /// the honest behaviour against a daemon too old to answer.
+    let mtime: UInt64
+    /// The machine, for the sentence shown when a save is refused.
+    let host: String
+
+    var provider: DeviceFileProvider { DeviceFileProvider(route: route, root: root) }
+
+    /// The same document, re-versioned after a write landed — what the next save
+    /// must claim, since the file on the device now carries a new mtime.
+    func read(at mtime: UInt64) -> RemoteDocument {
+        RemoteDocument(route: route, root: root, path: path, mtime: mtime, host: host)
+    }
+}
+
 @MainActor
 enum RemotePreviewStorage {
     private static var liveDirectories: Set<URL> = []
@@ -224,13 +256,19 @@ final class RemoteFileBrowserModel: ObservableObject {
     }
 
     /// Downloads the file into a uniquely-named temp file (keeping the device
-    /// file's name, so icon and syntax detection work) for the read-only
-    /// overlay. Throws `DeviceFileError.tooLarge` past the preview cap.
-    func stageForPreview(_ node: RemoteFileNode) async throws -> RemotePreviewLease {
+    /// file's name, so icon and syntax detection work) for the overlay, and
+    /// answers with where it came from so a save can put it back. Throws
+    /// `DeviceFileError.tooLarge` past the preview cap.
+    func stageForPreview(
+        _ node: RemoteFileNode
+    ) async throws -> (lease: RemotePreviewLease, origin: RemoteDocument) {
         guard node.canPreview else { throw DeviceFileError.notRegularFile }
-        let data = try await provider.read(node.path, limit: Self.previewByteLimit)
+        let file = try await provider.read(node.path, limit: Self.previewByteLimit)
         try Task.checkCancellation()
-        return try RemotePreviewStorage.stage(data, named: node.name)
+        let lease = try RemotePreviewStorage.stage(file.data, named: node.name)
+        return (lease, RemoteDocument(
+            route: checkout.device.route, root: root, path: node.path,
+            mtime: file.mtime, host: host))
     }
 
     /// Routes a failure into the pane's state: an already-loaded tree stays up
@@ -409,13 +447,14 @@ struct RemoteFileTreeView: View {
         let presentationGeneration = store.filePresentationGeneration
         previewTask = Task { @MainActor in
             do {
-                let lease = try await model.stageForPreview(node)
+                let staged = try await model.stageForPreview(node)
                 guard !Task.isCancelled, requestID == previewRequestID else { return }
                 // Adoption is conditional on no other local/remote presentation
                 // winning while the download was in flight. HTML/SVG is routed
                 // to source, and failed raster decoding never falls into WebKit.
                 _ = store.presentRemoteFilePreview(
-                    lease, expectedGeneration: presentationGeneration)
+                    staged.lease, expectedGeneration: presentationGeneration,
+                    origin: staged.origin)
             } catch DeviceFileError.tooLarge {
                 guard !Task.isCancelled, requestID == previewRequestID else { return }
                 let alert = NSAlert()

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -21,6 +21,16 @@
         }
       }
     },
+    "%1$@ changed on %2$@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 在 %2$@ 上已被修改"
+          }
+        }
+      }
+    },
     "%@ and %@": {
       "localizations": {
         "zh-Hans": {
@@ -4297,6 +4307,16 @@
         }
       }
     },
+    "Overwrite": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖"
+          }
+        }
+      }
+    },
     "Padding: %lld pt": {
       "localizations": {
         "zh-Hans": {
@@ -5118,6 +5138,16 @@
         }
       }
     },
+    "Saving to %@…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在保存到 %@…"
+          }
+        }
+      }
+    },
     "Scan the QR code with WeChat to join the Chinese community group.": {
       "localizations": {
         "zh-Hans": {
@@ -5484,6 +5514,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "跳过权限确认"
+          }
+        }
+      }
+    },
+    "Somebody else wrote this file after you opened it. Overwriting replaces their version.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在你打开之后，有人写入了这个文件。覆盖会替换掉对方的版本。"
           }
         }
       }
@@ -6475,6 +6515,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "取消固定"
+          }
+        }
+      }
+    },
+    "Unsaved changes — press ⌘S to save to %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有未保存的更改 — 按 ⌘S 保存到 %@"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -8,6 +8,8 @@
 …and %lld more</string>
 	<key> Cost is estimated at API rates.</key>
 	<string> Cost is estimated at API rates.</string>
+	<key>%1$@ changed on %2$@</key>
+	<string>%1$@ changed on %2$@</string>
 	<key>%@ and %@</key>
 	<string>%@ and %@</string>
 	<key>%@ didn’t come up — check the network and retry</key>
@@ -866,6 +868,8 @@
 	<string>Opened outside Termio on this device</string>
 	<key>Opens the ~/.ssh/config entry this machine is defined in.</key>
 	<string>Opens the ~/.ssh/config entry this machine is defined in.</string>
+	<key>Overwrite</key>
+	<string>Overwrite</string>
 	<key>Padding: %lld pt</key>
 	<string>Padding: %lld pt</string>
 	<key>Pair your iPhone and remote access</key>
@@ -1030,6 +1034,8 @@
 	<string>Save</string>
 	<key>Save failed: %@</key>
 	<string>Save failed: %@</string>
+	<key>Saving to %@…</key>
+	<string>Saving to %@…</string>
 	<key>Scan the QR code with WeChat to join the Chinese community group.</key>
 	<string>Scan the QR code with WeChat to join the Chinese community group.</string>
 	<key>Scrollback history and text selection</key>
@@ -1104,6 +1110,8 @@
 	<string>Skill reinstalled</string>
 	<key>Skip permission prompts</key>
 	<string>Skip permission prompts</string>
+	<key>Somebody else wrote this file after you opened it. Overwriting replaces their version.</key>
+	<string>Somebody else wrote this file after you opened it. Overwriting replaces their version.</string>
 	<key>Something else already owns %@.</key>
 	<string>Something else already owns %@.</string>
 	<key>Something went wrong loading this repository. Try again in a moment.</key>
@@ -1302,6 +1310,8 @@
 	<string>Ungroup</string>
 	<key>Unpin</key>
 	<string>Unpin</string>
+	<key>Unsaved changes — press ⌘S to save to %@</key>
+	<string>Unsaved changes — press ⌘S to save to %@</string>
 	<key>Unsaved changes — saving…</key>
 	<string>Unsaved changes — saving…</string>
 	<key>Update</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -8,6 +8,8 @@
 …还有 %lld 个</string>
 	<key> Cost is estimated at API rates.</key>
 	<string>费用按 API 价格估算。</string>
+	<key>%1$@ changed on %2$@</key>
+	<string>%1$@ 在 %2$@ 上已被修改</string>
 	<key>%@ and %@</key>
 	<string>%1$@ 和 %2$@</string>
 	<key>%@ didn’t come up — check the network and retry</key>
@@ -866,6 +868,8 @@
 	<string>在这台设备上由 Termio 之外打开</string>
 	<key>Opens the ~/.ssh/config entry this machine is defined in.</key>
 	<string>打开定义该设备的 ~/.ssh/config 条目。</string>
+	<key>Overwrite</key>
+	<string>覆盖</string>
 	<key>Padding: %lld pt</key>
 	<string>边距：%lld 点</string>
 	<key>Pair your iPhone and remote access</key>
@@ -1030,6 +1034,8 @@
 	<string>存储</string>
 	<key>Save failed: %@</key>
 	<string>存储失败：%@</string>
+	<key>Saving to %@…</key>
+	<string>正在保存到 %@…</string>
 	<key>Scan the QR code with WeChat to join the Chinese community group.</key>
 	<string>用微信扫描二维码加入中文社区群。</string>
 	<key>Scrollback history and text selection</key>
@@ -1104,6 +1110,8 @@
 	<string>技能已重新安装</string>
 	<key>Skip permission prompts</key>
 	<string>跳过权限确认</string>
+	<key>Somebody else wrote this file after you opened it. Overwriting replaces their version.</key>
+	<string>在你打开之后，有人写入了这个文件。覆盖会替换掉对方的版本。</string>
 	<key>Something else already owns %@.</key>
 	<string>%@ 已被其他程序占用。</string>
 	<key>Something went wrong loading this repository. Try again in a moment.</key>
@@ -1302,6 +1310,8 @@
 	<string>取消编组</string>
 	<key>Unpin</key>
 	<string>取消固定</string>
+	<key>Unsaved changes — press ⌘S to save to %@</key>
+	<string>有未保存的更改 — 按 ⌘S 保存到 %@</string>
 	<key>Unsaved changes — saving…</key>
 	<string>未存储的更改 — 正在存储…</string>
 	<key>Update</key>

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -41,6 +41,17 @@ extension Termiod {
     /// coming back": the case it exists for answers in milliseconds or never.
     static let searchIdleTimeoutSeconds = 90
 
+    /// A file as it was on the device: its bytes, and the version they were read
+    /// at. The version travels with the bytes because a reader that may later
+    /// write them back has to be able to say *what it read* — asking again at
+    /// save time would answer about a file that may already have changed.
+    struct DeviceFile: Sendable {
+        let data: Data
+        /// Whole seconds since the epoch, and 0 when the host did not say — no
+        /// version, so a save carrying it can make no claim and asks for none.
+        let mtime: UInt64
+    }
+
     /// One `fs.search` hit: a path relative to the searched root, the 1-based
     /// line it was found on, and that line's text.
     struct SearchHit: Sendable {
@@ -94,7 +105,7 @@ extension Termiod {
     /// Blocking; call it off the main thread.
     static func readFile(
         route: TermiodRoute, path: String, limit: Int = filePreviewByteLimit
-    ) throws -> Data {
+    ) throws -> DeviceFile {
         try withFilesChannel(route: route) { transport in
             let header = try requestFiles(
                 transport, FsReadOperation(path: path, seq: 1)
@@ -114,7 +125,9 @@ extension Termiod {
                 case .file:
                     let chunk = try decodeFileChunk(frame.payload)
                     data.append(chunk.data)
-                    if chunk.last { return data }
+                    if chunk.last {
+                        return DeviceFile(data: data, mtime: header.mtime)
+                    }
                 case .control:
                     if case .error(let failure) = try decodeControl(frame.payload) {
                         throw TermiodClientError.requestFailed(failure.message)
@@ -123,7 +136,7 @@ extension Termiod {
                     continue
                 }
             }
-            return data
+            return DeviceFile(data: data, mtime: header.mtime)
         }
     }
 
@@ -232,6 +245,10 @@ enum DeviceFileError: Error, Equatable {
     /// A name the tree refuses to build a path from.
     case unsafeName
     case notRegularFile
+    /// The device refused the save because what it would replace changed after
+    /// this client read it. Carries the host's own sentence, which names both
+    /// versions. Not a failure so much as a question for the person typing.
+    case conflict(String)
 }
 
 extension FileEntry {
@@ -283,9 +300,26 @@ struct DeviceFileProvider: Sendable {
         }
     }
 
-    func read(_ path: String, limit: Int) async throws -> Data {
+    func read(_ path: String, limit: Int) async throws -> Termiod.DeviceFile {
         try await run { [route] in
             try Termiod.readFile(route: route, path: path, limit: limit)
+        }
+    }
+
+    /// Writes `data` back to `path` on the device, replacing what is there.
+    ///
+    /// `ifUnmodifiedSince` is the version the caller read; the host refuses the
+    /// commit if the file has moved on since, and that refusal arrives as
+    /// `DeviceFileError.conflict`. The write is confined to this provider's own
+    /// root, so a pane can only ever save inside the checkout it is showing.
+    /// - Returns: the version the write produced, for the next save to claim.
+    func write(
+        _ path: String, data: Data, ifUnmodifiedSince: UInt64?
+    ) async throws -> UInt64 {
+        try await run { [route, root] in
+            try Termiod.writeFile(
+                route: route, root: root, path: path, data: data,
+                ifUnmodifiedSince: ifUnmodifiedSince)
         }
     }
 

--- a/Sources/termio/Terminal/Termiod/TermiodTransfer.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodTransfer.swift
@@ -39,30 +39,68 @@ extension Termiod {
         let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
         do {
             return try performUpload(
-                route: route, session: session, name: name, data: data, sha256: digest)
+                route: route, session: session, dest: "temp:\(name)",
+                data: data, sha256: digest).path
         } catch TermiodClientError.connectionClosed {
             Log.termiod.info("""
             transfer to \(session, privacy: .public) lost its pipe; resuming
             """)
             return try performUpload(
-                route: route, session: session, name: name, data: data, sha256: digest)
+                route: route, session: session, dest: "temp:\(name)",
+                data: data, sha256: digest).path
         }
+    }
+
+    /// Writes `data` back to `path` on the device, replacing what is there.
+    ///
+    /// The same transfer as a paste — open, chunk, commit — pointed at a path
+    /// inside a checkout instead of a session's scratch directory. That is what
+    /// makes this *save*: the host lands the bytes in a dotfile beside the
+    /// destination and `rename`s them over it, so a reader on that machine sees
+    /// either the old file or the new one and never a half-written one.
+    ///
+    /// `ifUnmodifiedSince` is the version the caller read. The host refuses the
+    /// commit when the file has changed since, which arrives here as
+    /// `DeviceFileError.conflict` — the person is asked, rather than the other
+    /// writer's work being thrown away.
+    ///
+    /// Blocking; call it off the main thread.
+    /// - Returns: the version the write produced, which the next save of the
+    ///   same file must claim.
+    static func writeFile(
+        route: TermiodRoute,
+        root: String,
+        path: String,
+        data: Data,
+        ifUnmodifiedSince: UInt64?
+    ) throws -> UInt64 {
+        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        // Deliberately not retried on a lost pipe the way a paste is: a resumed
+        // open would re-check the version against a file the retry has already
+        // spent time not holding, and a save is small enough that starting over
+        // costs nothing. The caller sees the failure and can press save again.
+        return try performUpload(
+            route: route, session: nil, root: root, dest: path,
+            data: data, sha256: digest, ifUnmodifiedSince: ifUnmodifiedSince).mtime
     }
 
     private static func performUpload(
         route: TermiodRoute,
-        session: String,
-        name: String,
+        session: String?,
+        root: String? = nil,
+        dest: String,
         data: Data,
-        sha256: String
-    ) throws -> String {
+        sha256: String,
+        ifUnmodifiedSince: UInt64? = nil
+    ) throws -> (path: String, mtime: UInt64) {
         let transport = try Transport.open(route)
         defer { transport.close() }
         try performHello(transport, role: "control", caps: ["upload"])
 
         let opened = try request(transport, UploadOpenOperation(
-            dest: "temp:\(name)",
+            dest: dest,
             session: session,
+            root: root,
             size: UInt64(data.count),
             sha256: sha256,
             seq: 1
@@ -99,12 +137,16 @@ extension Termiod {
         }
 
         let committed = try request(
-            transport, UploadCommitOperation(uploadId: opened.uploadId, seq: 2)
+            transport,
+            UploadCommitOperation(
+                uploadId: opened.uploadId,
+                ifUnmodifiedSince: ifUnmodifiedSince,
+                seq: 2)
         ) { control in
             if case .uploadCommitted(let payload) = control { return payload }
             return nil
         }
-        return committed.path
+        return (committed.path, committed.mtime)
     }
 
     /// Send one request and read frames until `match` claims one. A typed
@@ -130,6 +172,13 @@ extension Termiod {
             let control = try decodeControl(frame.payload)
             if let reply = match(control) { return reply }
             if case .error(let failure) = control {
+                // A refused version is its own answer, not a failed request: the
+                // client asks the person whether to overwrite. The host says so
+                // in the code (`ErrorCode::Conflict`), which is why this reads
+                // the code rather than pattern-matching English.
+                if failure.code == "conflict" {
+                    throw DeviceFileError.conflict(failure.message)
+                }
                 throw TermiodClientError.requestFailed(failure.message)
             }
         }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -259,6 +259,16 @@ final class TermioStore: ObservableObject {
     /// content-search hit (see `FileSearchView`); `nil` for a plain open (top of file).
     @Published var openFileLine: Int?
 
+    /// Where the open file lives when it lives on another machine: the staged
+    /// copy on this Mac is what the editor reads and writes, and this is what a
+    /// save needs to put those bytes back. `nil` for a file on this Mac, which
+    /// is every case where the editor's own write *is* the save.
+    ///
+    /// Re-versioned after each successful save (`RemoteDocument.read(at:)`), so
+    /// a second save claims the version the first one produced rather than the
+    /// one the file was opened at.
+    @Published var openFileRemote: RemoteDocument?
+
     /// Whether the open file should be shown read-only (no editing, no auto-save). Set when the file
     /// was opened by cmd-clicking a link in the terminal — a peek at the source, not an invitation to
     /// edit it by mistake. The inspector's own file opens stay editable (`openFileInEditor`).
@@ -1672,6 +1682,7 @@ final class TermioStore: ObservableObject {
     func openFileInEditor(_ url: URL, at line: Int? = nil) {
         filePresentationGeneration &+= 1
         remotePreviewLease = nil
+        openFileRemote = nil
         openFileDisplayName = nil
         openFileReadOnly = false
         openFileAllowsActiveWebContent = true
@@ -1713,6 +1724,7 @@ final class TermioStore: ObservableObject {
               !isDirectory.boolValue else { return }
         filePresentationGeneration &+= 1
         remotePreviewLease = nil
+        openFileRemote = nil
         openFileDisplayName = nil
         openFileReadOnly = true
         openFileAllowsActiveWebContent = true
@@ -1730,7 +1742,8 @@ final class TermioStore: ObservableObject {
     func presentRemoteFilePreview(
         _ lease: RemotePreviewLease,
         expectedGeneration: UInt64,
-        at line: Int? = nil
+        at line: Int? = nil,
+        origin: RemoteDocument? = nil
     ) -> Bool {
         guard expectedGeneration == filePresentationGeneration,
               FileManager.default.fileExists(atPath: lease.fileURL.path)
@@ -1739,7 +1752,12 @@ final class TermioStore: ObservableObject {
         filePresentationGeneration &+= 1
         remotePreviewLease = lease
         openFileDisplayName = lease.displayName
-        openFileReadOnly = true
+        // Editable when the device said where these bytes came from: the editor
+        // writes the staged copy as always, and `openFileRemote` is what carries
+        // it the rest of the way back. Without an origin the bytes are just a
+        // copy on this Mac, and editing them would be a change that goes nowhere.
+        openFileRemote = origin
+        openFileReadOnly = origin == nil
         openFileAllowsActiveWebContent = false
         openFileLine = line
         openFileURL = lease.fileURL

--- a/Tests/termioTests/TermiodFilesIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFilesIntegrationTests.swift
@@ -126,17 +126,17 @@ final class TermiodFilesIntegrationTests: XCTestCase {
     }
 
     func testAFileComesBackByteForByte() throws {
-        let data = try Termiod.readFile(
+        let file = try Termiod.readFile(
             route: .local, path: root.appendingPathComponent("a.txt").path)
-        XCTAssertEqual(data, Data("hello\n".utf8))
+        XCTAssertEqual(file.data, Data("hello\n".utf8))
     }
 
     /// Several `F` frames' worth, so the chunk loop is genuinely exercised rather
     /// than short-circuited by a payload that fits in one frame.
     func testAMultiChunkFileReassembles() throws {
-        let data = try Termiod.readFile(
+        let file = try Termiod.readFile(
             route: .local, path: root.appendingPathComponent("sub/b.txt").path)
-        XCTAssertEqual(data, Data(nestedContents.utf8))
+        XCTAssertEqual(file.data, Data(nestedContents.utf8))
     }
 
     /// A preview that would be a prefix is refused, so the pane says the file is
@@ -154,6 +154,74 @@ final class TermiodFilesIntegrationTests: XCTestCase {
     func testAMissingFileFailsWithTheDaemonsReason() {
         XCTAssertThrowsError(try Termiod.readFile(
             route: .local, path: root.appendingPathComponent("nope.txt").path))
+    }
+
+    /// Save, end to end: the bytes cross, the version claimed is the one that was
+    /// read, and the file on the device is the file that comes back.
+    func testSavingAFileLandsOnTheDeviceAndReVersionsIt() throws {
+        let path = root.appendingPathComponent("a.txt").path
+        let read = try Termiod.readFile(route: .local, path: path)
+        XCTAssertEqual(read.data, Data("hello\n".utf8))
+        XCTAssertGreaterThan(read.mtime, 0, "the read carries the version it holds")
+
+        let landed = try Termiod.writeFile(
+            route: .local, root: root.path, path: path,
+            data: Data("edited\n".utf8), ifUnmodifiedSince: read.mtime)
+
+        XCTAssertGreaterThan(landed, 0, "the write answers with the version it made")
+        let after = try Termiod.readFile(route: .local, path: path)
+        XCTAssertEqual(after.data, Data("edited\n".utf8))
+        XCTAssertEqual(after.mtime, landed, "the version the write reported is the file's")
+    }
+
+    /// The lost-update guard, over the wire: the agent in that checkout wrote
+    /// first, so this save is refused rather than silently replacing its work.
+    func testSavingIsRefusedWhenTheDeviceFileMovedOn() throws {
+        let path = root.appendingPathComponent("a.txt").path
+        let read = try Termiod.readFile(route: .local, path: path)
+
+        // The other writer. The wait is the resolution of the timestamp itself.
+        Thread.sleep(forTimeInterval: 1.1)
+        try Data("theirs\n".utf8).write(to: URL(fileURLWithPath: path))
+
+        XCTAssertThrowsError(try Termiod.writeFile(
+            route: .local, root: root.path, path: path,
+            data: Data("mine\n".utf8), ifUnmodifiedSince: read.mtime)
+        ) { error in
+            guard case DeviceFileError.conflict(let message) = error else {
+                return XCTFail("expected a conflict, got \(error)")
+            }
+            XCTAssertTrue(message.contains("changed"), message)
+        }
+        XCTAssertEqual(
+            try Data(contentsOf: URL(fileURLWithPath: path)), Data("theirs\n".utf8),
+            "the other writer's file is untouched")
+    }
+
+    /// Claiming nothing is how "overwrite anyway" travels, and it must land even
+    /// though the file has moved on since it was read.
+    func testAnUnversionedSaveOverwritesWhatIsThere() throws {
+        let path = root.appendingPathComponent("a.txt").path
+        Thread.sleep(forTimeInterval: 1.1)
+        try Data("theirs\n".utf8).write(to: URL(fileURLWithPath: path))
+
+        _ = try Termiod.writeFile(
+            route: .local, root: root.path, path: path,
+            data: Data("mine\n".utf8), ifUnmodifiedSince: nil)
+
+        XCTAssertEqual(try Termiod.readFile(route: .local, path: path).data,
+                       Data("mine\n".utf8))
+    }
+
+    /// A save may not walk out of the checkout it is rooted at — the same
+    /// confinement the listing has, on the write side where it matters more.
+    func testASaveOutsideTheRootIsRefused() throws {
+        let outside = root.deletingLastPathComponent()
+            .appendingPathComponent("escaped.txt").path
+        XCTAssertThrowsError(try Termiod.writeFile(
+            route: .local, root: root.path, path: outside,
+            data: Data("nope\n".utf8), ifUnmodifiedSince: nil))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: outside))
     }
 
     /// The Search pane's whole contract in one call: hits stream as events and

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -1230,6 +1230,7 @@ async fn process_control(
                                 offset: window.offset,
                                 length: window.data.len() as u64,
                                 truncated: window.truncated,
+                                mtime: window.mtime,
                                 re: seq,
                             }));
                             send_file_chunks(&out, seq.unwrap_or(0), window.offset, &window.data);
@@ -1340,7 +1341,11 @@ async fn process_control(
             };
             send_response(out, response_cache, seq, response);
         }
-        Control::UploadCommit { upload_id, seq } => {
+        Control::UploadCommit {
+            upload_id,
+            if_unmodified_since,
+            seq,
+        } => {
             let response = if !connection.capabilities.contains("upload") {
                 error(
                     seq,
@@ -1349,11 +1354,18 @@ async fn process_control(
                     false,
                 )
             } else {
-                match manager.uploads.commit(&upload_id) {
-                    Ok(path) => Control::UploadCommitted {
+                match manager.uploads.commit(&upload_id, if_unmodified_since) {
+                    Ok((path, mtime)) => Control::UploadCommitted {
                         path: path.display().to_string(),
+                        mtime,
                         re: seq,
                     },
+                    // A refused *version* is not a refused request: the client
+                    // asks the person whether to overwrite, so it has to be
+                    // able to tell this apart from a denial.
+                    Err(e) if e.to_string().starts_with("conflict: ") => {
+                        error(seq, ErrorCode::Conflict, format!("{e:#}"), false)
+                    }
                     Err(e) => error(seq, ErrorCode::Denied, format!("{e:#}"), false),
                 }
             };

--- a/termiod/src/files.rs
+++ b/termiod/src/files.rs
@@ -25,6 +25,20 @@ pub const READ_SOFT_CAP: u64 = 1024 * 1024;
 /// Directory names the host never walks on its own. These are the watcher's
 /// ignore rules (`resource.rs::classify`) seen from the pull side: what the
 /// watcher drops, the lister stubs as `unloaded_dir`.
+/// A file's modification time in whole seconds, or 0 when the host cannot say.
+/// Whole seconds because that is what the listing has always reported and what
+/// every filesystem here agrees on; sub-second precision differs by filesystem
+/// and would make a version comparison fail for reasons that have nothing to do
+/// with the file changing.
+fn mtime_seconds(metadata: &std::fs::Metadata) -> u64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
 fn is_unloaded_dir_name(name: &str) -> bool {
     name == ".git" || name == ".hg" || name == ".svn"
 }
@@ -120,12 +134,7 @@ fn list_one(
         let Ok(metadata) = std::fs::symlink_metadata(item.path()) else {
             continue;
         };
-        let mtime = metadata
-            .modified()
-            .ok()
-            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|duration| duration.as_secs())
-            .unwrap_or(0);
+        let mtime = mtime_seconds(&metadata);
         let (kind, symlink_target) = if metadata.file_type().is_symlink() {
             let target = std::fs::read_link(item.path())
                 .ok()
@@ -173,6 +182,12 @@ pub struct FileWindow {
     pub size: u64,
     pub offset: u64,
     pub truncated: bool,
+    /// Seconds since the epoch, as the host sees them. This is the *version* a
+    /// reader holds: an editor that means to write the file back sends it to
+    /// `commit` as `if_unmodified_since`, and that is the whole of the
+    /// lost-update check. Zero when the host could not read a timestamp, which
+    /// a writer must treat as "no version" rather than as "epoch".
+    pub mtime: u64,
     pub data: Vec<u8>,
 }
 
@@ -220,6 +235,7 @@ fn read_with_cap(
         size,
         offset: start,
         truncated: serve < asked,
+        mtime: mtime_seconds(&metadata),
         data,
     })
 }
@@ -724,7 +740,20 @@ impl Uploads {
     /// Verify and land the upload: size and sha256 must match what open
     /// declared, then the dotfile is renamed into place — readers only ever
     /// see nothing or the whole verified file.
-    pub fn commit(&self, upload_id: &str) -> Result<PathBuf> {
+    /// Lands a finished upload at its destination.
+    ///
+    /// `if_unmodified_since` is what makes this usable as *save*: the editor
+    /// read a file at a version, and a commit that names that version is
+    /// refused when the file on disk has moved on. Without it two writers —
+    /// and on this host the other writer is usually an agent with a shell in
+    /// the same checkout — silently overwrite each other, with the loser's work
+    /// gone and nothing on screen having said so. `None` keeps the old
+    /// behaviour, which is what a paste into a scratch directory wants.
+    pub fn commit(
+        &self,
+        upload_id: &str,
+        if_unmodified_since: Option<u64>,
+    ) -> Result<(PathBuf, u64)> {
         let mut inner = self.inner.lock().unwrap();
         let state = inner
             .by_id
@@ -747,17 +776,53 @@ impl Uploads {
                 bail!("sha256 mismatch: expected {}, got {actual}", state.sha256);
             }
             state.file.sync_all().context("syncing upload")?;
+            // Read once: the same stat answers both the version check and the
+            // mode to keep, and asking twice would leave a window between them.
+            let existing = std::fs::metadata(&state.dest).ok();
+            if let Some(expected) = if_unmodified_since {
+                let current = existing.as_ref().map(mtime_seconds);
+                match current {
+                    Some(current) if current == expected => {}
+                    Some(current) => bail!(
+                        "conflict: {} changed on this device (read at {expected}, now {current})",
+                        state.dest.display()
+                    ),
+                    None => bail!(
+                        "conflict: {} is no longer there",
+                        state.dest.display()
+                    ),
+                }
+            }
+            use std::os::unix::fs::PermissionsExt;
             let mode = if state.scratch {
                 0o600
             } else {
-                state.mode.unwrap_or(0o644)
+                // The file's own mode outlives the write: replacing an
+                // executable script with a 0644 file is a broken script, and
+                // the writer did not ask for that by saving.
+                state
+                    .mode
+                    .or_else(|| {
+                        existing
+                            .as_ref()
+                            .map(|metadata| metadata.permissions().mode() & 0o7777)
+                    })
+                    .unwrap_or(0o644)
             };
-            use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&state.dotfile, std::fs::Permissions::from_mode(mode))
                 .context("setting upload permissions")?;
             std::fs::rename(&state.dotfile, &state.dest)
                 .with_context(|| format!("renaming into {}", state.dest.display()))?;
-            Ok(state.dest.clone())
+            // The version this write produced. Answered here rather than left
+            // for the client to go and read, because a save that means to be
+            // followed by another save needs to know what it just created —
+            // and a second stat from over there could already be a third
+            // writer's file.
+            let mtime = std::fs::metadata(&state.dest)
+                .as_ref()
+                .map(mtime_seconds)
+                .unwrap_or(0);
+            Ok((state.dest.clone(), mtime))
         })();
         if finish.is_err() {
             let _ = std::fs::remove_file(&state.dotfile);
@@ -1064,7 +1129,7 @@ mod tests {
                 .any(|e| e.file_name() == "out.bin"),
             "nothing lands before commit"
         );
-        let landed = uploads.commit(&id).unwrap();
+        let (landed, _) = uploads.commit(&id, None).unwrap();
         assert_eq!(std::fs::read(&landed).unwrap(), body);
         use std::os::unix::fs::PermissionsExt;
         let mode = std::fs::metadata(&landed).unwrap().permissions().mode() & 0o777;
@@ -1074,7 +1139,85 @@ mod tests {
             1,
             "the dotfile is gone after the rename"
         );
-        assert!(uploads.commit(&id).is_err(), "an upload commits once");
+        assert!(uploads.commit(&id, None).is_err(), "an upload commits once");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Saving a file read at one version over a file that has since changed is
+    /// the lost update this check exists to prevent — and on this host the other
+    /// writer is usually an agent with a shell in the same checkout.
+    #[test]
+    fn upload_commit_refuses_a_destination_that_moved_since_it_was_read() {
+        let root = scratch("save-conflict");
+        let uploads = Uploads::new();
+        touch(&root.join("notes.md"), b"first\n");
+        let read = read(root.join("notes.md").to_str().unwrap(), None, None).unwrap();
+        assert!(read.mtime > 0, "the read reports the version it holds");
+
+        // Somebody else writes, moving the file's version on. The sleep is the
+        // resolution of the timestamp itself, not a race being papered over.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        touch(&root.join("notes.md"), b"theirs\n");
+
+        let body = b"mine\n".to_vec();
+        let dest = resolve_project_dest(root.to_str().unwrap(), "notes.md").unwrap();
+        let (id, _) = uploads
+            .open(dest, body.len() as u64, &hex_sha256(&body), None, None)
+            .unwrap();
+        uploads.chunk(&id, 0, &body).unwrap();
+        let refused = uploads.commit(&id, Some(read.mtime)).unwrap_err().to_string();
+        assert!(refused.starts_with("conflict: "), "got {refused}");
+        assert_eq!(
+            std::fs::read(root.join("notes.md")).unwrap(),
+            b"theirs\n",
+            "the other writer's file is untouched"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The same save with the version the file actually carries goes through —
+    /// the check must not stand in the way of the ordinary case.
+    #[test]
+    fn upload_commit_lands_when_the_destination_is_unchanged() {
+        let root = scratch("save-clean");
+        let uploads = Uploads::new();
+        touch(&root.join("notes.md"), b"first\n");
+        let read = read(root.join("notes.md").to_str().unwrap(), None, None).unwrap();
+
+        let body = b"second\n".to_vec();
+        let dest = resolve_project_dest(root.to_str().unwrap(), "notes.md").unwrap();
+        let (id, _) = uploads
+            .open(dest, body.len() as u64, &hex_sha256(&body), None, None)
+            .unwrap();
+        uploads.chunk(&id, 0, &body).unwrap();
+        let (landed, _) = uploads.commit(&id, Some(read.mtime)).unwrap();
+        assert_eq!(std::fs::read(&landed).unwrap(), body);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A save must not quietly disarm an executable. The mode rides the file,
+    /// not the request, when the request names none.
+    #[test]
+    fn upload_commit_keeps_the_destination_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = scratch("save-mode");
+        let uploads = Uploads::new();
+        let script = root.join("run.sh");
+        touch(&script, b"#!/bin/sh\necho one\n");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let body = b"#!/bin/sh\necho two\n".to_vec();
+        let dest = resolve_project_dest(root.to_str().unwrap(), "run.sh").unwrap();
+        let (id, _) = uploads
+            .open(dest, body.len() as u64, &hex_sha256(&body), None, None)
+            .unwrap();
+        uploads.chunk(&id, 0, &body).unwrap();
+        let (landed, _) = uploads.commit(&id, None).unwrap();
+        assert_eq!(
+            std::fs::metadata(&landed).unwrap().permissions().mode() & 0o777,
+            0o755,
+            "the script is still executable after being saved"
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 
@@ -1087,7 +1230,7 @@ mod tests {
             .open(dest, 4, &hex_sha256(b"good"), None, None)
             .unwrap();
         uploads.chunk(&id, 0, b"evil").unwrap();
-        let error = uploads.commit(&id).unwrap_err().to_string();
+        let error = uploads.commit(&id, None).unwrap_err().to_string();
         assert!(error.contains("sha256 mismatch"), "got: {error}");
         assert_eq!(
             std::fs::read_dir(&root).unwrap().flatten().count(),
@@ -1102,7 +1245,7 @@ mod tests {
         uploads.chunk(&id, 0, b"0123").unwrap();
         assert!(
             uploads
-                .commit(&id)
+                .commit(&id, None)
                 .unwrap_err()
                 .to_string()
                 .contains("declared bytes"),
@@ -1133,7 +1276,7 @@ mod tests {
         assert_eq!(first, second, "same dest + hash + size = same upload");
         assert_eq!(offset, 5, "re-open resumes rather than restarting");
         uploads.chunk(&second, offset, &body[5..]).unwrap();
-        let landed = uploads.commit(&second).unwrap();
+        let (landed, _) = uploads.commit(&second, None).unwrap();
         assert_eq!(std::fs::read(&landed).unwrap(), body);
 
         // A client that ignores the offset restarts from zero, which still
@@ -1145,7 +1288,7 @@ mod tests {
         uploads.chunk(&third, 0, &body[..5]).unwrap();
         uploads.chunk(&third, 0, &body).unwrap();
         assert_eq!(
-            std::fs::read(uploads.commit(&third).unwrap()).unwrap(),
+            std::fs::read(uploads.commit(&third, None).unwrap().0).unwrap(),
             body
         );
 
@@ -1209,7 +1352,7 @@ mod tests {
             )
             .unwrap();
         uploads.chunk(&id, 0, &body).unwrap();
-        let landed = uploads.commit(&id).unwrap();
+        let (landed, _) = uploads.commit(&id, None).unwrap();
         use std::os::unix::fs::PermissionsExt;
         let mode = std::fs::metadata(&landed).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "scratch files are 0600 whatever mode asked");

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -381,6 +381,10 @@ pub enum ErrorCode {
     CreateFailed,
     Denied,
     Busy,
+    /// The write was refused because what it would replace has changed since
+    /// the writer read it. Its own code because a client shows it as a question
+    /// (overwrite, or not) rather than as a failure.
+    Conflict,
     #[default]
     Internal,
 }
@@ -685,6 +689,14 @@ pub enum Control {
     },
     UploadCommit {
         upload_id: String,
+        /// The version the writer read, for a commit that replaces a file it
+        /// read first (§C.12 save). The host refuses the commit when the
+        /// destination has moved on, which is what keeps two writers in one
+        /// checkout — usually a person and an agent — from silently
+        /// overwriting each other. Omitted for a transfer that overwrites
+        /// nothing, like a paste into a scratch directory.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        if_unmodified_since: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
     },
@@ -813,6 +825,12 @@ pub enum Control {
         length: u64,
         #[serde(default)]
         truncated: bool,
+        /// The file's modification time in whole seconds — the version this
+        /// read holds. A client that means to write the file back sends it to
+        /// `upload_commit` as `if_unmodified_since`. Absent from a host too old
+        /// to report it, which reads as 0: no version, so no check.
+        #[serde(default)]
+        mtime: u64,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         re: Option<u64>,
     },
@@ -904,6 +922,12 @@ pub enum Control {
     UploadAck { upload_id: String, offset: u64 },
     UploadCommitted {
         path: String,
+        /// The version the write produced, in whole seconds. A client saving
+        /// the same file again sends this back as `if_unmodified_since`;
+        /// without it the second save would claim the version the file was
+        /// *opened* at and be refused by its own first write.
+        #[serde(default)]
+        mtime: u64,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         re: Option<u64>,
     },


### PR DESCRIPTION
A file opened from a checkout on another machine came up read-only — a staged copy on this Mac with editing switched off. The bytes were already crossing in one direction; this is the other one.

**The write.** A save is the transfer plane (`upload_open` → `U` → `upload_commit`) pointed at a path inside the checkout instead of a session's scratch directory. The host lands it in a dotfile beside the destination and renames it over, so a reader on that box sees the old file or the new one and never a half-written one. The mode now rides the file rather than the request: replacing an executable script with a 0644 file is a broken script, and nobody asked for that by saving.

**The part that needed deciding.** On that machine the other writer is usually an agent with a shell in the same checkout. So `fs_read` now reports the file's `mtime`, `upload_commit` may claim it as `if_unmodified_since`, and the host refuses a commit whose destination has moved on — a new `ErrorCode::Conflict`, because the client shows it as a question rather than a failure. The alert offers Overwrite or Cancel. Deciding it silently is the failure this exists to prevent.

`upload_committed` also reports the version the write produced. Without it a second save would claim the version the file was *opened* at and be refused by its own first write.

**Cadence.** A device document is not auto-saved on the idle timer the way a local file is — every save is a round trip to another machine, so ⌘S and closing are what send it, and the unsaved dot clears when that machine has taken the bytes rather than when this one wrote its copy. A spinner marks the crossing.

A host too old to report an mtime answers 0, which means "no version": the save claims nothing and is not checked, rather than failing every time.

Tests: four end-to-end against a real daemon (lands and re-versions, conflict refused with the other writer's file intact, an unversioned save overwrites, a save outside the root is refused) and three host-side unit tests (version check, clean save, mode preserved).

Release Notes:
- Files opened from another machine can now be edited and saved back with ⌘S.
- A save is refused if something else changed the file first, so an agent's work in the same checkout can't be silently overwritten.