### PR TITLE
Recognise a device's own hooks so a reinstall replaces them

### DIFF
--- a/Sources/termio/Agents/HookListener.swift
+++ b/Sources/termio/Agents/HookListener.swift
@@ -256,6 +256,30 @@ enum AgentStatusHooks {
     /// or the legacy `marker`, so upgrades cleanly replace old hooks with new ones.
     static let cliMarker = "agent report"
 
+    /// The same fragment for a hook installed on a **device**, which reports to the
+    /// daemon that owns its PTY instead of to an app socket. Spelled with the
+    /// environment variable rather than the bare verb so it cannot claim a user's
+    /// own tool that happens to have a `set-status` command.
+    ///
+    /// Byte-identical to `DAEMON_MARKER` in `termiod/src/agent/install.rs`; the two
+    /// halves of the migration have to recognise each other's work.
+    static let daemonMarker = "set-status \"$TERMIOD_SESSION_ID\""
+
+    /// Whether a hook command is one termio wrote — in any of its three report
+    /// forms, on either kind of machine.
+    ///
+    /// This is what makes an install *replace* rather than append. A device hook
+    /// invokes `termiod set-status` and carries neither ` agent report ` nor the
+    /// socket path, so while those were the only fingerprints, every reinstall on
+    /// a device added a second copy of every entry to a config the user also owns:
+    /// `ukvps` had accumulated 54 duplicate hook lines before this was caught. It
+    /// is silent, because a duplicated hook still works — it just fires twice.
+    static func isTermioCommand(_ command: String) -> Bool {
+        command.contains(cliMarker)
+            || command.contains(marker)
+            || command.contains(daemonMarker)
+    }
+
     /// Fingerprints of third-party status hooks that full-replace the shared `hooks`
     /// block (Claude's `settings.json`, Codex's `hooks.json`) instead of merging, wiping
     /// termio's entries. We strip these on install so a destructive writer can't out-merge
@@ -658,7 +682,7 @@ private struct JSONHookFile: AgentStatusInstaller {
         // strips the old before writing the new instead of doubling up. Cursor's flat
         // entry carries the command directly; Claude/Codex nest it.
         func isOurs(_ command: String) -> Bool {
-            command.contains(AgentStatusHooks.cliMarker) || command.contains(AgentStatusHooks.marker)
+            AgentStatusHooks.isTermioCommand(command)
         }
         if let command = group["command"] as? String { return isOurs(command) }
         guard let hooks = group["hooks"] as? [[String: Any]] else { return false }
@@ -767,7 +791,7 @@ private struct ScriptHookDirectory: AgentStatusInstaller {
     }
 
     private func isOwned(_ source: String) -> Bool {
-        source.contains(AgentStatusHooks.marker) || source.contains(AgentStatusHooks.cliMarker)
+        AgentStatusHooks.isTermioCommand(source)
     }
 }
 
@@ -864,8 +888,7 @@ private struct PluginFile: AgentStatusInstaller {
     }
 
     private func isOwned(_ source: String) -> Bool {
-        source.contains(AgentStatusHooks.marker)
-            || source.contains(AgentStatusHooks.cliMarker)
+        AgentStatusHooks.isTermioCommand(source)
     }
 
     private static var cliPath: String { AgentStatusHooks.cliPath }

--- a/Tests/termioTests/DeviceHookInstallTests.swift
+++ b/Tests/termioTests/DeviceHookInstallTests.swift
@@ -187,6 +187,50 @@ final class DeviceHookInstallTests: XCTestCase {
         XCTAssertTrue(source.contains("set-status"), source)
     }
 
+    /// A reinstall must **replace** what the last one wrote, and what makes that
+    /// work is recognising it. A device hook invokes `termiod set-status` and
+    /// carries neither ` agent report ` nor the socket path, so while those were
+    /// the only fingerprints every reinstall appended a second copy of every entry
+    /// to a config the user also owns — silently, since a duplicated hook still
+    /// fires, just twice.
+    func testReinstallingOnADeviceReplacesRatherThanAppends() throws {
+        let store = RecordingConfigStore()
+        let target = AgentIntegrationTarget(store: store, reporter: .termiodDaemon)
+        AgentStatusHooks.sync(enabled: true, target: target)
+        let afterFirst = try XCTUnwrap(store.text(endingIn: ".claude/settings.json"))
+        AgentStatusHooks.sync(enabled: true, target: target)
+        let afterSecond = try XCTUnwrap(store.text(endingIn: ".claude/settings.json"))
+
+        XCTAssertEqual(afterFirst, afterSecond, "a second install rewrote the config")
+        for (event, count) in try commandCounts(afterSecond) {
+            XCTAssertEqual(count, 1, "\(event) carries \(count) hooks after two installs")
+        }
+    }
+
+    /// Turning the switch off has to find the same entries the install wrote.
+    func testUninstallingOnADeviceRemovesWhatItInstalled() throws {
+        let store = RecordingConfigStore()
+        let target = AgentIntegrationTarget(store: store, reporter: .termiodDaemon)
+        AgentStatusHooks.sync(enabled: true, target: target)
+        AgentStatusHooks.sync(enabled: false, target: target)
+        let remaining = store.text(endingIn: ".claude/settings.json") ?? "{}"
+        XCTAssertFalse(remaining.contains(AgentStatusHooks.daemonMarker), remaining)
+    }
+
+    /// One hook command per event, keyed by event name.
+    private func commandCounts(_ json: String) throws -> [(String, Int)] {
+        let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        let hooks = (object as? [String: Any])?["hooks"] as? [String: Any] ?? [:]
+        return hooks.map { event, groups in
+            let commands = (groups as? [[String: Any]] ?? []).flatMap { group -> [String] in
+                if let command = group["command"] as? String { return [command] }
+                let nested = group["hooks"] as? [[String: Any]] ?? []
+                return nested.compactMap { $0["command"] as? String }
+            }
+            return (event, commands.filter(AgentStatusHooks.isTermioCommand).count)
+        }
+    }
+
     /// Ownership is what lets uninstall remove our file and refuse a user's. The
     /// device form drops `agent report`, so it must still carry the socket marker.
     func testDevicePluginsStayRecognizablyOurs() {


### PR DESCRIPTION
Introduced by #448, found by the Stage 1+2 migration in #461.

A hook termio installs on a device invokes `termiod set-status`. It carries neither fingerprint the strip logic knew — ` agent report ` names a binary a device does not have, `agent-status.sock` names a socket it cannot reach — so termio could not recognise its own work, and every reinstall **appended** a second copy of every entry instead of replacing it. `ukvps` had accumulated 54 duplicate hook lines into a config the user also owns and edits.

It is silent by construction: a duplicated hook still fires, just twice. The only reason it surfaced is that the daemon-side installer in #461 wrote by a fingerprint of its own, and the two disagreed.

## The fix

All three ownership checks now read one helper. The JSON dialects, the script directory and the plugin files were each carrying their own copy of the same two substrings, which is how one of them could fall behind a new report form.

`AgentStatusHooks.daemonMarker` is byte-identical to `DAEMON_MARKER` in `termiod/src/agent/install.rs`. The two halves of the migration have to recognise each other's work, and until Stage 4 deletes the Swift path they are both live. It is spelled `set-status "$TERMIOD_SESSION_ID"` rather than the bare verb, so it cannot claim a user's own tool that happens to have a `set-status` command.

## Verification

- The regression test installs twice against a recording store and asserts one hook per event, plus an uninstall test that the switch-off finds what the install wrote.
- **Run against the bug reintroduced**, where it fails with `Stop carries 0 hooks after two installs` for every event — a passing test on both the fixed and broken code would have proved nothing. Restored, all 12 pass.
- `swift test` — full suite green.
- `ukvps` was already cleaned by #461 and is verified at one entry per event, fingerprint present.

Any other device installed through the Mac before this is still carrying duplicates; re-running Install on it now replaces them.

Release Notes:
- Reinstalling agent integration on a device no longer adds a duplicate copy of every hook.