### PR TITLE
Speed up browsing files on another machine

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -30,9 +30,9 @@ public enum Termiod {
     /// | `scrollback` | no      | `H` carries packed cells to inject *above* the viewport; a byte-stream surface has nowhere to put them |
     /// | `grid_diff`  | no      | `G` would make the host resolve every cell's colour, which overrides the viewer's theme — the §A/§H regression this client exists not to repeat |
     /// | `send_wait`  | no      | `send`/`wait` are control-channel verbs; the app injects through its own attach channel |
-    /// | `resources`  | no      | `subscribe_resource` — live tree and git updates, which need a channel that outlives one request |
+    /// | `resources`  | no      | `subscribe_resource` — live tree and git updates. The channel that outlives a request now exists (`TermiodControlPool.swift`); what is still missing is a tree that applies deltas rather than re-listing |
     /// | `fs_watch`   | no      | ditto |
-    /// | `files`      | no      | `fs.list`/`fs.read` — the Files pane's consumer, on its own control channel (`TermiodFiles.swift`), never an attachment |
+    /// | `files`      | no      | `fs.list`/`fs.read` — the Files pane's consumer, on the device's pooled control channel (`TermiodFiles.swift`), never an attachment |
     /// | `upload`     | no      | remote paste; rides a control channel, not an attachment |
     /// | `git`        | no      | ditto |
     ///
@@ -186,10 +186,12 @@ public enum Termiod {
     /// it to that layout; there is no partial credit on a wire format.
     public static func decodeFileChunk(
         _ payload: Data
-    ) throws -> (offset: UInt64, last: Bool, data: Data) {
+    ) throws -> (request: UInt64, offset: UInt64, last: Bool, data: Data) {
         let headerSize = 17
         guard payload.count >= headerSize else { throw TermiodClientError.malformedFrame }
         let bytes = [UInt8](payload)
+        var request: UInt64 = 0
+        for index in 0 ..< 8 { request = request << 8 | UInt64(bytes[index]) }
         var offset: UInt64 = 0
         for index in 8 ..< 16 { offset = offset << 8 | UInt64(bytes[index]) }
         let last: Bool
@@ -198,7 +200,24 @@ public enum Termiod {
         case 1: last = true
         default: throw TermiodClientError.malformedFrame
         }
-        return (offset, last, payload.dropFirst(headerSize))
+        return (request, offset, last, payload.dropFirst(headerSize))
+    }
+
+    /// The `re` a reply is addressed to, read without decoding the reply itself.
+    ///
+    /// Every response the daemon sends echoes the `seq` of the request that
+    /// caused it (termiod/src/protocol.rs — `re` on `FsListed`, `FsFile`,
+    /// `FsSearched`, `error`, and the rest). On a channel carrying one request
+    /// at a time that field is redundant, which is why nothing read it until
+    /// now; on a channel carrying several it is the only thing that says whose
+    /// answer just arrived. Split out from `decodeControl` so demultiplexing
+    /// costs one small decode and no call site has to change shape.
+    ///
+    /// `nil` for a frame that answers nobody — `hello_ok`, a broadcast event,
+    /// or a daemon too old to stamp its replies.
+    public static func responseID(of payload: Data) -> UInt64? {
+        struct ResponseTag: Decodable { let re: UInt64? }
+        return try? JSONDecoder().decode(ResponseTag.self, from: payload).re
     }
 
     /// `U` payload: id_len u8, upload id, offset u64 big-endian, then bytes —
@@ -461,9 +480,11 @@ public enum Termiod {
     }
 
     /// One batch of `fs.search` hits, addressed to the connection that asked.
-    /// `request` echoes the `fs_search` seq; a channel carrying a single search
-    /// can ignore it, and this client's does.
+    /// `request` echoes the `fs_search` seq — the only routing a streamed reply
+    /// has, since a batch of hits names no session and a pooled channel may be
+    /// carrying a listing and a read alongside the grep.
     public struct SearchResultsPayload: Decodable, Sendable {
+        public let request: UInt64
         public let matches: [SearchMatchPayload]
     }
 

--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -384,6 +384,27 @@ public enum Termiod {
         }
     }
 
+    /// Stops an in-flight cancellable request on the same channel, naming it by
+    /// the `seq` it was sent with (§C.12 — `Control::Cancel` in
+    /// termiod/src/protocol.rs). Idempotent: cancelling something that already
+    /// finished is `ok`, not an error.
+    ///
+    /// Only a multiplexed channel can send this. On a channel carrying one
+    /// request at a time the caller is blocked reading the very descriptor it
+    /// would have to write to, so the only way to stop a search was to hang up —
+    /// which is what the host's `out.closed()` arm exists to notice. A pooled
+    /// channel does not hang up, so it has to say so out loud instead.
+    public struct CancelOperation: Encodable, Sendable {
+        public let op = "cancel"
+        public let request: UInt64
+        public let seq: UInt64
+
+        public init(request: UInt64, seq: UInt64) {
+            self.request = request
+            self.seq = seq
+        }
+    }
+
     /// `limit` is a total across all files, which is what bounds a one-letter
     /// query in a monorepo — the host stops streaming there and says so.
     public struct FsSearchOperation: Encodable, Sendable {

--- a/Sources/termio/FileBrowser/RemoteFileTree.swift
+++ b/Sources/termio/FileBrowser/RemoteFileTree.swift
@@ -175,10 +175,11 @@ final class RemoteFileNode: Identifiable {
 /// `fs.list`/`fs.read` (`TermiodFiles.swift`).
 ///
 /// No watching yet: the tree reloads on pane/app focus and the explicit refresh
-/// button, by dropping the cached nodes — expansion state survives (node
-/// identity is the path) and still-expanded folders re-fetch lazily. Live
-/// updates are the `fs:` resource, which needs a channel that outlives one
-/// request and is deliberately not here.
+/// button. A reload re-lists every directory it is currently showing in one
+/// request and grafts the answers onto the nodes already there, so expansion
+/// survives and nothing re-fetches itself a round trip at a time. Live updates
+/// are the `fs:` resource, which needs a tree that applies deltas and is
+/// deliberately not here.
 @MainActor
 final class RemoteFileBrowserModel: ObservableObject {
     enum Phase {
@@ -214,23 +215,91 @@ final class RemoteFileBrowserModel: ObservableObject {
 
     func node(at path: String) -> RemoteFileNode? { nodesByPath[path] }
 
-    /// Re-roots the tree from the device. Existing rows stay up while the
+    /// Re-lists the tree from the device. Existing rows stay up while the
     /// listing is in flight (no flash to a spinner on an app-focus reconcile);
     /// only the never-loaded state shows `connecting`.
+    ///
+    /// Every directory the tree is currently showing goes out in **one**
+    /// `fs.list`, which is what the `paths` array is for. This used to drop
+    /// `nodesByPath` and rebuild from the root alone, leaving each still-expanded
+    /// folder to re-fetch itself from the `children` getter — so a tree with
+    /// eight folders open cost nine sequential round trips, on every app focus.
+    /// Asking for all nine together costs one.
+    ///
+    /// Directories that answer are replaced in place; ones the reply does not
+    /// mention keep the rows they had, so a folder that failed does not blank
+    /// itself while the rest of the tree refreshes around it.
     func refresh() {
         guard !refreshing else { return }
         refreshing = true
         Task {
             defer { refreshing = false }
+            // Root first: the reply is applied in the order asked, and the root's
+            // children have to exist before a descendant's can be attached.
+            let wanted = [root] + loadedDirectories()
             do {
-                let entries = try await provider.list(root)
-                nodesByPath = [:]
-                rootNodes = nodes(for: entries, under: root)
+                let listings = try await provider.list(wanted)
+                apply(listings)
                 phase = .ready
             } catch {
                 report(error, context: "list \(host):\(root)")
             }
         }
+    }
+
+    /// The directories whose contents the tree is holding, deepest last, so a
+    /// re-list rebuilds parents before the children hanging off them.
+    ///
+    /// Reachable from a test: what a refresh asks for, and the order it applies
+    /// the answers in, is the whole of this change and needs no window to check.
+    func loadedDirectories() -> [String] {
+        nodesByPath.values
+            .filter { $0.isDirectory && $0.loadedChildren != nil }
+            .map(\.path)
+            .sorted {
+                let left = $0.count(where: { $0 == "/" })
+                let right = $1.count(where: { $0 == "/" })
+                return left == right ? $0 < $1 : left < right
+            }
+    }
+
+    /// Grafts a batch of listings onto the tree, keeping expansion state: a
+    /// directory that is still there and still has children keeps them, so the
+    /// outline does not collapse under a refresh.
+    func apply(_ listings: [Termiod.DirectoryListing]) {
+        for listing in listings {
+            // The device's per-path error — a folder deleted since it was
+            // expanded. Leave the rows it had; the parent's own listing is what
+            // removes the row, and that is the answer the tree should follow.
+            guard listing.error == nil else { continue }
+            let previous = listing.path == root
+                ? Dictionary(uniqueKeysWithValues: rootNodes.map { ($0.path, $0) })
+                : Dictionary(
+                    uniqueKeysWithValues: (nodesByPath[listing.path]?.loadedChildren ?? [])
+                        .map { ($0.path, $0) })
+            let rebuilt = nodes(for: listing.entries, under: listing.path, reusing: previous)
+            if listing.path == root {
+                rootNodes = rebuilt
+            } else {
+                nodesByPath[listing.path]?.loadedChildren = rebuilt
+            }
+        }
+        // Nodes that no longer hang off anything would otherwise keep this
+        // dictionary — and the paths `loadedDirectories` asks for — growing for
+        // the life of the pane.
+        pruneUnreachableNodes()
+        objectWillChange.send()
+    }
+
+    /// Drops every node the tree can no longer reach from its roots.
+    private func pruneUnreachableNodes() {
+        var reachable: [String: RemoteFileNode] = [:]
+        var frontier = rootNodes
+        while let node = frontier.popLast() {
+            reachable[node.path] = node
+            frontier.append(contentsOf: node.loadedChildren ?? [])
+        }
+        nodesByPath = reachable
     }
 
     /// Fetches one folder's entries — called from the `children` getter on first
@@ -282,15 +351,32 @@ final class RemoteFileBrowserModel: ObservableObject {
         }
     }
 
-    private func nodes(for entries: [FileEntry], under parent: String) -> [RemoteFileNode] {
+    /// Builds one directory's rows.
+    ///
+    /// `reusing` keeps the node object for a path that survived the re-list.
+    /// Node identity is the path, so the outline would keep its expansion either
+    /// way — but the children hang off the *object*, and minting a fresh one
+    /// would throw away every loaded subtree under it and make the tree fetch
+    /// them all again, one at a time, which is the cost this refresh exists to
+    /// remove.
+    private func nodes(
+        for entries: [FileEntry], under parent: String,
+        reusing existing: [String: RemoteFileNode] = [:]
+    ) -> [RemoteFileNode] {
         let base = parent.hasSuffix("/") ? parent : parent + "/"
         return entries.map { entry in
-            let node = RemoteFileNode(
-                path: base + entry.name, name: entry.name,
-                isDirectory: entry.isDirectory,
-                canPreview: entry.isPreviewable,
-                model: self)
-            nodesByPath[node.path] = node
+            let path = base + entry.name
+            let node: RemoteFileNode
+            if let kept = existing[path], kept.isDirectory == entry.isDirectory {
+                node = kept
+            } else {
+                node = RemoteFileNode(
+                    path: path, name: entry.name,
+                    isDirectory: entry.isDirectory,
+                    canPreview: entry.isPreviewable,
+                    model: self)
+            }
+            nodesByPath[path] = node
             return node
         }
     }

--- a/Sources/termio/FileBrowser/RemoteFolderPicker.swift
+++ b/Sources/termio/FileBrowser/RemoteFolderPicker.swift
@@ -272,7 +272,6 @@ final class RemoteFolderPicker: NSObject {
         // Re-entrant by design: closing the window is one of the ways this is
         // reached, and closing it again from in here would be the second.
         guard completion != nil else { return }
-        lister.close()
         if let window {
             if let parent = window.sheetParent {
                 parent.endSheet(window)

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -379,6 +379,28 @@ extension Termiod {
             self.writeDescriptor = writeDescriptor
             self.route = route
             self.sshPid = sshPid
+            Transport.suppressSignalOnBrokenPipe(writeDescriptor)
+        }
+
+        /// Makes a write to a hung-up peer return `EPIPE` instead of raising
+        /// `SIGPIPE`, whose default disposition kills the process.
+        ///
+        /// A channel opened for one request could barely hit this — the pipe was
+        /// seconds old. A pooled one is held across a laptop sleeping, a VPS
+        /// rebooting and `ControlPersist` reaping the master, so discovering the
+        /// far end is gone *on the way out* is an ordinary Tuesday. The control
+        /// socket in `SessionControl.swift` already learned this; the transport
+        /// had not needed to.
+        ///
+        /// Two calls because the two roads produce different objects: `.local` is
+        /// a socket, where `SO_NOSIGPIPE` is the switch, and `.ssh` is a pipe,
+        /// where it is the `F_SETNOSIGPIPE` descriptor flag. Each is a no-op on
+        /// the other, so both go on unconditionally.
+        private static func suppressSignalOnBrokenPipe(_ descriptor: Int32) {
+            var on: Int32 = 1
+            _ = setsockopt(descriptor, SOL_SOCKET, SO_NOSIGPIPE, &on,
+                           socklen_t(MemoryLayout<Int32>.size))
+            _ = fcntl(descriptor, F_SETNOSIGPIPE, 1)
         }
 
         /// Local Unix socket; the same fd serves both directions.

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -1,0 +1,478 @@
+import Darwin
+import Foundation
+import TermioShared
+
+/// One long-lived, multiplexed control channel per device, shared by every
+/// request the files plane makes.
+///
+/// `withControlChannel` opens a pipe, shakes hands, asks one question and hangs
+/// up. On the local socket that is free. On the SSH road it is not: the pipe is
+/// `ssh <host> termiod stdio`, so every folder expand, every file open and every
+/// search pays an SSH channel open, a remote `termiod` exec and a hello round
+/// trip before it asks anything. Measured against a VPS at 8 ms round trip, that
+/// setup is **32 ms median and 260 ms at p90** — four times the cost of the
+/// question itself, with a tail an order of magnitude worse.
+///
+/// `TermiodDirectoryLister` already reached this conclusion for the folder
+/// picker and holds its own channel open. This is that idea generalised, so the
+/// tree, the file reader and the search share one connection instead of each
+/// growing a private copy — and the picker is now one of its callers rather than
+/// an exception to it.
+///
+/// **Nothing on the host changes.** The daemon already stamps every reply with
+/// `re` — the `seq` of the request that caused it — and already `tokio::spawn`s
+/// each `fs_list`/`fs_read`, so replies may legitimately arrive out of order and
+/// have always been routable. This side simply started reading the field. One
+/// protocol, one version, no new op.
+///
+/// The invariants this holds to:
+///
+/// - **Never behind an attachment.** A pooled channel is its own connection,
+///   keyed by route and capability set, and never a session's attach channel —
+///   a directory listing can no more queue behind PTY bytes than PTY bytes can
+///   queue behind a listing (§A).
+/// - **Never serialised within itself.** Requests are demultiplexed by `re`, so
+///   a slow `git grep` does not hold up the folder expand behind it. Only the
+///   frame writes are serialised, which is what keeps frames whole.
+/// - **System OpenSSH stays the trust plane.** The pool holds a pipe that
+///   `Transport.open` produced; it knows nothing about keys, hosts or crypto.
+extension Termiod {
+    /// Where the reader thread leaves frames for one in-flight request, and the
+    /// only object it and the requesting thread share.
+    ///
+    /// Deliberately dumb: the reader never runs a caller's code, it only appends
+    /// and signals. A demultiplexer that called into consumers would let one
+    /// slow consumer stall every other request on the channel — the same
+    /// head-of-line coupling this whole file exists to remove.
+    final class RequestInbox: @unchecked Sendable {
+        private let condition = NSCondition()
+        private var frames: [(kind: FrameKind, payload: Data)] = []
+        private var failure: Error?
+        private var deliveredAny = false
+
+        /// Whether the host has already said anything about this request. A
+        /// request that has seen part of its answer must never be replayed on a
+        /// fresh channel: half a file plus a whole file is not a file.
+        var hasDelivered: Bool {
+            condition.lock()
+            defer { condition.unlock() }
+            return deliveredAny
+        }
+
+        func deliver(kind: FrameKind, payload: Data) {
+            condition.lock()
+            frames.append((kind, payload))
+            deliveredAny = true
+            condition.signal()
+            condition.unlock()
+        }
+
+        /// Ends every wait on this inbox. Called when the channel dies, so a
+        /// request never outlives the connection it was asked on.
+        func fail(_ error: Error) {
+            condition.lock()
+            if failure == nil { failure = error }
+            condition.broadcast()
+            condition.unlock()
+        }
+
+        /// The next frame for this request, or `timedOut` after `seconds` of the
+        /// host saying nothing *about this request*. Per-request rather than
+        /// per-connection: on a shared channel another caller's traffic is not
+        /// evidence that this one is being answered.
+        func next(timeoutSeconds: Int, operation: String) throws
+            -> (kind: FrameKind, payload: Data) {
+            condition.lock()
+            defer { condition.unlock() }
+            // Monotonic, for the reason `waitForReadable` is: a wall clock that
+            // steps would cut a live request short or stretch it past its bound.
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(timeoutSeconds))
+            while true {
+                if !frames.isEmpty { return frames.removeFirst() }
+                if let failure { throw failure }
+                let remaining = clock.now.duration(to: deadline)
+                guard remaining > .zero else {
+                    throw TermiodClientError.timedOut(operation)
+                }
+                let components = remaining.components
+                let seconds = Double(components.seconds)
+                    + Double(components.attoseconds) / 1e18
+                // A spurious wakeup just re-tests the loop above.
+                _ = condition.wait(until: Date().addingTimeInterval(seconds))
+            }
+        }
+    }
+
+    /// One request's handle on a pooled channel: its `seq`, its inbox, and the
+    /// write side of the connection it was registered on.
+    final class ChannelCall {
+        /// The id every frame of this request's answer is stamped with.
+        let seq: UInt64
+        /// Whether the channel this call went out on was already carrying
+        /// traffic when the request was registered. A channel that was reused
+        /// may have died quietly since — reaped by `ControlPersist`, dropped by
+        /// a sleeping laptop — and that is the one failure worth retrying rather
+        /// than showing.
+        let wasReused: Bool
+        fileprivate let channel: PooledChannel
+        fileprivate let inbox: RequestInbox
+
+        fileprivate init(
+            seq: UInt64, wasReused: Bool, channel: PooledChannel, inbox: RequestInbox
+        ) {
+            self.seq = seq
+            self.wasReused = wasReused
+            self.channel = channel
+            self.inbox = inbox
+        }
+
+        /// Whether this call ever heard anything back — what decides if a lost
+        /// connection may be retried.
+        var hasDelivered: Bool { inbox.hasDelivered }
+
+        func send(kind: FrameKind = .control, payload: Data) throws {
+            try channel.write(kind: kind, payload: payload)
+        }
+
+        func next(timeoutSeconds: Int, operation: String) throws
+            -> (kind: FrameKind, payload: Data) {
+            try inbox.next(timeoutSeconds: timeoutSeconds, operation: operation)
+        }
+
+        /// Unregisters the inbox. Must be called however the request ends, or
+        /// the channel accumulates inboxes nothing will ever read.
+        func finish() {
+            channel.release(seq)
+        }
+    }
+
+    /// One live connection to a device, with a reader thread demultiplexing its
+    /// frames onto the requests in flight.
+    final class PooledChannel: @unchecked Sendable {
+        let route: TermiodRoute
+        let capabilities: Set<String>
+        /// The account's home directory on that machine, from the handshake.
+        let home: String
+
+        private let transport: Transport
+        /// Frames must not interleave on the wire, so writes are serialised —
+        /// and only writes. Nothing waits for a reply under this lock.
+        private let writeLock = NSLock()
+        private let stateLock = NSLock()
+        private var inboxes: [UInt64: RequestInbox] = [:]
+        private var nextSeq: UInt64 = 1
+        private var dead = false
+        private var lastUsed = ContinuousClock.now
+        /// Set once a request has been registered on this channel, so the first
+        /// caller — the one that paid for the connection — can tell a genuine
+        /// failure from a corpse it inherited.
+        private var used = false
+
+        fileprivate var isDead: Bool {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return dead
+        }
+
+        fileprivate var idleDuration: Duration {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return inboxes.isEmpty ? lastUsed.duration(to: .now) : .zero
+        }
+
+        fileprivate init(route: TermiodRoute, caps: [String]) throws {
+            let transport = try Transport.open(route)
+            do {
+                // The handshake is the last thing read inline: from here on the
+                // reader thread owns the descriptor, and two readers on one pipe
+                // would tear frames in half.
+                let handshake = try performHello(transport, role: "control", caps: caps)
+                self.transport = transport
+                self.route = route
+                self.capabilities = handshake.capabilities
+                self.home = handshake.home
+            } catch {
+                transport.close()
+                throw error
+            }
+            startReader()
+        }
+
+        /// Registers a request and hands back its id. `nil` once the channel is
+        /// dead, which tells the caller to open a fresh one rather than wait on
+        /// a pipe nobody is reading.
+        fileprivate func begin() -> ChannelCall? {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            guard !dead else { return nil }
+            let seq = nextSeq
+            nextSeq &+= 1
+            let inbox = RequestInbox()
+            inboxes[seq] = inbox
+            let reused = used
+            used = true
+            return ChannelCall(seq: seq, wasReused: reused, channel: self, inbox: inbox)
+        }
+
+        fileprivate func release(_ seq: UInt64) {
+            stateLock.lock()
+            inboxes.removeValue(forKey: seq)
+            lastUsed = .now
+            stateLock.unlock()
+        }
+
+        /// Writes one frame, or refuses if the channel died first.
+        ///
+        /// The liveness check is inside the write lock, not before it. A shared
+        /// channel has several threads writing and any of them may be the one
+        /// that finds the pipe gone, so "is it alive" and "write to it" have to
+        /// be one step: a descriptor closed between the two could have been
+        /// reused by then, and this would be writing frames into somebody else's
+        /// file. `close` takes the same lock, so a write already underway
+        /// finishes before the descriptor goes.
+        fileprivate func write(kind: FrameKind, payload: Data) throws {
+            writeLock.lock()
+            defer { writeLock.unlock() }
+            guard !isDead else { throw TermiodClientError.connectionClosed }
+            try writeFrame(transport.writeDescriptor, kind: kind, payload: payload)
+        }
+
+        /// Ends the connection and every request riding it. Idempotent.
+        fileprivate func close(_ reason: Error = TermiodClientError.connectionClosed) {
+            stateLock.lock()
+            if dead {
+                stateLock.unlock()
+                return
+            }
+            dead = true
+            let pending = inboxes
+            inboxes.removeAll()
+            stateLock.unlock()
+            // `dead` is set before this lock is taken, so no further write can
+            // start; taking it waits out the one that may already be running.
+            // Released first, so the two locks are never held together in one
+            // order here and the other in `write`.
+            writeLock.lock()
+            writeLock.unlock()
+            transport.close()
+            for inbox in pending.values { inbox.fail(reason) }
+        }
+
+        /// Dedicated blocking-read thread, the same shape a session link uses:
+        /// the frame stream has no natural dispatch-source form once a payload
+        /// spans several reads.
+        private func startReader() {
+            let thread = Thread { [self] in
+                while true {
+                    let frame: (kind: FrameKind, payload: Data)
+                    do {
+                        frame = try readFrame(transport.readDescriptor)
+                    } catch {
+                        close(error)
+                        return
+                    }
+                    guard let seq = Self.requestID(of: frame) else { continue }
+                    stateLock.lock()
+                    let inbox = inboxes[seq]
+                    stateLock.unlock()
+                    // A frame for a request nobody is waiting on is dropped, not
+                    // an error: a search the user moved on from keeps streaming
+                    // until the host notices, and that is not a protocol fault.
+                    inbox?.deliver(kind: frame.kind, payload: frame.payload)
+                }
+            }
+            thread.name = "sh.termio.termiod.pool"
+            thread.stackSize = 512 * 1024
+            thread.start()
+        }
+
+        /// Which request a frame answers, or `nil` for one that answers nobody.
+        ///
+        /// Three shapes, because the protocol has three: a control reply carries
+        /// `re`, an `F` chunk carries the same id in its binary header, and a
+        /// `search_results` event carries it as `request` — the one event
+        /// addressed to a request rather than to a session.
+        private static func requestID(of frame: (kind: FrameKind, payload: Data)) -> UInt64? {
+            switch frame.kind {
+            case .control:
+                return responseID(of: frame.payload)
+            case .file:
+                return (try? decodeFileChunk(frame.payload))?.request
+            case .event:
+                guard case .searchResults(let payload) = try? decodeEvent(frame.payload) else {
+                    return nil
+                }
+                return payload.request
+            default:
+                return nil
+            }
+        }
+    }
+
+    /// The channels themselves, keyed by the device they reach and what they
+    /// negotiated.
+    ///
+    /// Keyed by capability set as well as route because capabilities are settled
+    /// at the handshake: a channel that negotiated `files` cannot answer a `git`
+    /// request, and handing it one would hang on a reply the daemon will never
+    /// send.
+    enum ControlPool {
+        private struct Key: Hashable {
+            let route: TermiodRoute
+            let capabilities: [String]
+        }
+
+        /// How long a channel may sit unused before it is hung up.
+        ///
+        /// A pooled channel is a live SSH connection and a remote process. It is
+        /// worth holding through a browsing session — clicks come seconds apart —
+        /// and not worth holding for a pane nobody has looked at since lunch.
+        /// Paying 32 ms again after two idle minutes is the right trade; holding
+        /// a process on someone's VPS indefinitely is not.
+        static let idleTimeout = Duration.seconds(120)
+
+        private static let lock = NSLock()
+        /// `nonisolated(unsafe)` because every access goes through `lock` — the
+        /// lock is what makes this safe and the compiler cannot see that.
+        nonisolated(unsafe) private static var channels: [Key: PooledChannel] = [:]
+        nonisolated(unsafe) private static var reaper: DispatchSourceTimer?
+
+        /// A channel to `route`, opening one if none is live. Blocking; call it
+        /// off the main thread.
+        ///
+        /// - Parameter discarding: a channel this caller just found dead, hung up
+        ///   and removed before opening its replacement.
+        static func channel(
+            route: TermiodRoute, caps: [String], discarding stale: PooledChannel? = nil
+        ) throws -> PooledChannel {
+            let key = Key(route: route, capabilities: caps.sorted())
+            if let stale {
+                stale.close()
+                lock.lock()
+                if channels[key] === stale { channels.removeValue(forKey: key) }
+                lock.unlock()
+            }
+            lock.lock()
+            let existing = channels[key]
+            lock.unlock()
+            if let existing, !existing.isDead { return existing }
+
+            // Opened outside the lock: this forks `ssh` and waits on a network
+            // round trip, and no lock in this app may be held across either. A
+            // rare duplicate open loses the race below and is hung up.
+            let opened = try PooledChannel(route: route, caps: caps)
+            lock.lock()
+            if let winner = channels[key], !winner.isDead {
+                lock.unlock()
+                opened.close()
+                return winner
+            }
+            channels[key] = opened
+            lock.unlock()
+            startReaperIfNeeded()
+            return opened
+        }
+
+        /// Hangs up every channel to `route`. The teardown verb for a device that
+        /// went away, so the next request opens fresh rather than waiting on a
+        /// pipe whose far end is gone.
+        static func closeAll(route: TermiodRoute? = nil) {
+            lock.lock()
+            let closing = channels.filter { route == nil || $0.key.route == route }
+            for key in closing.keys { channels.removeValue(forKey: key) }
+            lock.unlock()
+            for channel in closing.values { channel.close() }
+        }
+
+        /// Hangs up channels nobody has used in `idleTimeout`, and stops itself
+        /// once the pool is empty — a timer that ticks forever for a feature
+        /// nobody is using is its own small leak.
+        private static func startReaperIfNeeded() {
+            lock.lock()
+            defer { lock.unlock() }
+            guard reaper == nil else { return }
+            let timer = DispatchSource.makeTimerSource(
+                queue: DispatchQueue.global(qos: .utility))
+            timer.schedule(deadline: .now() + 30, repeating: 30)
+            timer.setEventHandler { reap() }
+            reaper = timer
+            timer.resume()
+        }
+
+        private static func reap() {
+            lock.lock()
+            var expired: [PooledChannel] = []
+            for (key, channel) in channels
+            where channel.isDead || channel.idleDuration > idleTimeout {
+                expired.append(channel)
+                channels.removeValue(forKey: key)
+            }
+            let empty = channels.isEmpty
+            if empty {
+                reaper?.cancel()
+                reaper = nil
+            }
+            lock.unlock()
+            for channel in expired { channel.close() }
+        }
+    }
+
+    /// Runs one request over the pooled channel for `route`, retrying once on a
+    /// connection that was already open and turned out to be dead.
+    ///
+    /// The retry is the price of pooling. A one-shot channel could not be stale;
+    /// a held one can be — `ControlPersist` reaps the master, a laptop sleeps,
+    /// a VPS reboots — and discovering that on the user's first click after a
+    /// break must cost a reconnect, not an error dialog. It is deliberately
+    /// narrow: only a channel this caller *inherited*, and only while the host
+    /// has said nothing at all about the request. Once a single frame of the
+    /// answer has landed, replaying the request could duplicate or splice it.
+    ///
+    /// Blocking; call it off the main thread.
+    static func withPooledRequest<Result>(
+        route: TermiodRoute, caps: [String],
+        _ body: (ChannelCall, PooledChannel) throws -> Result
+    ) throws -> Result {
+        var stale: PooledChannel?
+        for attempt in 0 ... 1 {
+            let channel = try ControlPool.channel(route: route, caps: caps, discarding: stale)
+            guard let call = channel.begin() else {
+                stale = channel
+                continue
+            }
+            let reused = call.wasReused
+            defer { call.finish() }
+            do {
+                return try body(call, channel)
+            } catch {
+                guard attempt == 0, reused, !call.hasDelivered, isConnectionLoss(error) else {
+                    throw error
+                }
+                Log.termiod.info("""
+                pooled \(caps.joined(separator: ","), privacy: .public) channel to \
+                \(route.description, privacy: .public) was stale; reconnecting
+                """)
+                stale = channel
+            }
+        }
+        throw TermiodClientError.connectionClosed
+    }
+
+    /// Whether a failure means "this pipe is gone" rather than "the host said
+    /// no". Only the former is worth reconnecting for: a daemon that refused a
+    /// path would refuse it again on a fresh connection.
+    private static func isConnectionLoss(_ error: Error) -> Bool {
+        switch error {
+        case TermiodClientError.connectionClosed, TermiodClientError.malformedFrame:
+            return true
+        case TermiodClientError.timedOut:
+            // A host that stopped answering mid-request is indistinguishable
+            // from one whose pipe died, and on a reused channel the second is
+            // far likelier. One reconnect settles which.
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -80,12 +80,19 @@ extension Termiod {
         /// host saying nothing *about this request*. Per-request rather than
         /// per-connection: on a shared channel another caller's traffic is not
         /// evidence that this one is being answered.
+        /// How long a single `wait` may sleep before the monotonic deadline is
+        /// re-tested. `NSCondition` can only be given a wall-clock `Date`, and a
+        /// wall clock steps — NTP, a laptop waking, the user changing the date.
+        /// A backward step makes that `Date` further away than it was, so a
+        /// single long wait would sleep past a deadline that has already passed.
+        /// Slicing bounds the overshoot to one slice no matter how far the clock
+        /// jumps, while the bound itself stays on `ContinuousClock`.
+        private static let waitSlice = 0.25
+
         func next(timeoutSeconds: Int, operation: String) throws
             -> (kind: FrameKind, payload: Data) {
             condition.lock()
             defer { condition.unlock() }
-            // Monotonic, for the reason `waitForReadable` is: a wall clock that
-            // steps would cut a live request short or stretch it past its bound.
             let clock = ContinuousClock()
             let deadline = clock.now.advanced(by: .seconds(timeoutSeconds))
             while true {
@@ -98,8 +105,10 @@ extension Termiod {
                 let components = remaining.components
                 let seconds = Double(components.seconds)
                     + Double(components.attoseconds) / 1e18
-                // A spurious wakeup just re-tests the loop above.
-                _ = condition.wait(until: Date().addingTimeInterval(seconds))
+                // A spurious wakeup, or a slice expiring early, just re-tests
+                // the loop above; only `deadline` decides when to give up.
+                _ = condition.wait(
+                    until: Date().addingTimeInterval(min(seconds, Self.waitSlice)))
             }
         }
     }
@@ -117,6 +126,11 @@ extension Termiod {
         let wasReused: Bool
         fileprivate let channel: PooledChannel
         fileprivate let inbox: RequestInbox
+        /// Whether abandoning this request obliges the client to tell the host to
+        /// stop. Its own lock because `finish()` may run on a different thread
+        /// from the one that armed it.
+        private let cancelLock = NSLock()
+        private var owesCancelLocked = false
 
         fileprivate init(
             seq: UInt64, wasReused: Bool, channel: PooledChannel, inbox: RequestInbox
@@ -125,6 +139,31 @@ extension Termiod {
             self.wasReused = wasReused
             self.channel = channel
             self.inbox = inbox
+        }
+
+        /// Declares this request cancellable, from the moment it is on the wire
+        /// until the host's terminal reply lands.
+        ///
+        /// Only streaming requests need it, and for a sharp reason. A `git grep`
+        /// keeps running on the device until something stops it, and until this
+        /// change the thing that stopped it was the connection closing — the
+        /// host's `run_search` watches `out.closed()` for exactly that. Pooling
+        /// removed that signal: the channel outlives the request now, so a search
+        /// the client gave up on would keep walking the checkout and streaming
+        /// frames into an inbox that no longer exists. The protocol's own
+        /// `cancel` is what replaces it.
+        func cancelIfAbandoned() {
+            cancelLock.lock()
+            owesCancelLocked = true
+            cancelLock.unlock()
+        }
+
+        /// The host said its last word on this request — a terminal reply, or a
+        /// refusal it has already cleaned up behind. Nothing left to cancel.
+        func completed() {
+            cancelLock.lock()
+            owesCancelLocked = false
+            cancelLock.unlock()
         }
 
         /// Whether this call ever heard anything back — what decides if a lost
@@ -140,9 +179,27 @@ extension Termiod {
             try inbox.next(timeoutSeconds: timeoutSeconds, operation: operation)
         }
 
-        /// Unregisters the inbox. Must be called however the request ends, or
-        /// the channel accumulates inboxes nothing will ever read.
+        /// Unregisters the inbox, and tells the host to stop first if this
+        /// request is being walked away from mid-stream. Must be called however
+        /// the request ends, or the channel accumulates inboxes nothing will
+        /// ever read — and, now, the device keeps working on questions nobody
+        /// is listening to.
+        ///
+        /// The cancel goes out before the inbox is dropped so the ordering reads
+        /// the way it happens: still a live request, then stopped, then gone. A
+        /// write that fails is ignored on purpose — the channel being dead is
+        /// the one case the host still notices on its own.
         func finish() {
+            cancelLock.lock()
+            let owed = owesCancelLocked
+            owesCancelLocked = false
+            cancelLock.unlock()
+            if owed {
+                try? channel.write(
+                    kind: .control,
+                    payload: encodeControl(CancelOperation(
+                        request: seq, seq: channel.nextRequestID())))
+            }
             channel.release(seq)
         }
     }
@@ -213,6 +270,17 @@ extension Termiod {
             let reused = used
             used = true
             return ChannelCall(seq: seq, wasReused: reused, channel: self, inbox: inbox)
+        }
+
+        /// An id for a frame that wants no answer — the `seq` on a `cancel`. Off
+        /// the same counter as a real request so nothing on the wire ever
+        /// collides; no inbox, so the host's `ok` is simply dropped.
+        fileprivate func nextRequestID() -> UInt64 {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            let seq = nextSeq
+            nextSeq &+= 1
+            return seq
         }
 
         fileprivate func release(_ seq: UInt64) {

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -442,9 +442,17 @@ extension Termiod {
             return opened
         }
 
-        /// Hangs up every channel to `route`. The teardown verb for a device that
-        /// went away, so the next request opens fresh rather than waiting on a
-        /// pipe whose far end is gone.
+        /// Hangs up every channel to `route`, or the whole pool when `route` is
+        /// nil, so the next request opens fresh rather than waiting on a pipe
+        /// whose far end is gone.
+        ///
+        /// Nothing in the app calls this, and the comment should say so rather
+        /// than imply a caller: machines come from `~/.ssh/config` and are never
+        /// forgotten, so there is no moment where a device goes away for good. A
+        /// channel to one that stopped answering dies on its own read and is
+        /// reaped. What does need this is a test, which must not hand the next
+        /// test a channel pointed at a daemon it is about to kill — a
+        /// process-wide pool with no way to empty it can only be tested once.
         static func closeAll(route: TermiodRoute? = nil) {
             lock.lock()
             let closing = channels.filter { route == nil || $0.key.route == route }

--- a/Sources/termio/Terminal/Termiod/TermiodDirectoryLister.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodDirectoryLister.swift
@@ -2,49 +2,36 @@ import Foundation
 import TermioShared
 
 extension Termiod {
-    /// One `fs_list` round trip for a single directory. Blocking; the lister
-    /// serialises the calls so a reply always belongs to the request in flight.
+    /// The account's home directory on the device, from the handshake the pooled
+    /// channel already performed. Free once a channel to that machine is open,
+    /// and one connection's worth otherwise — which is what a picker needs
+    /// before it can show the user anywhere at all.
     ///
-    /// Frames that are not this reply are skipped rather than treated as an
-    /// error: a control channel may carry anything the daemon chooses to say,
-    /// and a listing must not fail because something else arrived first.
-    static func requestListing(_ transport: Transport, root: String) throws -> PathListingPayload {
-        let operation = FsListOperation(root: root, paths: [root], seq: 1)
-        try writeFrame(
-            transport.writeDescriptor, kind: .control, payload: encodeControl(operation))
-        while true {
-            let frame = try readFrame(transport.readDescriptor)
-            guard frame.kind == .control else { continue }
-            switch try decodeControl(frame.payload) {
-            case .fsListed(let payload):
-                guard let listing = payload.listings.first else {
-                    throw TermiodClientError.requestFailed(
-                        localized("The machine answered with no listing for that folder."))
-                }
-                return listing
-            case .error(let failure):
-                throw TermiodClientError.requestFailed(failure.message)
-            default:
-                continue
-            }
+    /// Blocking; call it off the main thread.
+    static func deviceHome(route: TermiodRoute, caps: [String] = ["files"]) throws -> String {
+        let channel = try ControlPool.channel(route: route, caps: caps)
+        guard channel.capabilities.contains("files") else {
+            throw DeviceFileError.unsupported
         }
+        return channel.home
     }
 }
 
-/// Lists directories on another machine, one directory at a time, over a
-/// control channel it holds open for as long as a picker needs it.
+/// Lists directories on another machine for a path field — the project picker's
+/// half of the files plane (§C.12, capability `files`).
 ///
-/// This is the request plane's read half (§C.12, capability `files`) and it is
-/// deliberately *not* a file browser: a path field asks for the directory the
+/// Deliberately *not* a file browser: a path field asks for the directory the
 /// user is currently typing inside, and the answer is one `fs.list`. Nothing
 /// walks a tree, so a machine with a huge checkout costs the same as an empty
 /// one.
 ///
-/// The channel is held rather than reopened per keystroke because opening one
-/// means `ssh <host> termiod stdio` — a whole SSH round trip, which would land
-/// on every `/` the user types. It rides its own channel and never a session's
-/// attachment, for the same reason transfers do: byte delivery must not queue
-/// behind a directory listing (anti-100× invariant).
+/// This used to hold a private control channel open, because opening one per
+/// keystroke means `ssh <host> termiod stdio` and a whole SSH round trip on
+/// every `/` the user types. That reasoning was right and is now general:
+/// `ControlPool` holds one channel per device for the tree, the file reader, the
+/// search and this, so a picker opened over a checkout that is already on screen
+/// pays nothing at all. What is left here is the part that was ever specific to
+/// a picker — which entries it keeps and the order it reads them in.
 final class TermiodDirectoryLister: @unchecked Sendable {
     /// A directory that can be descended into, which is all a project picker
     /// offers — a file is never a project root.
@@ -59,37 +46,30 @@ final class TermiodDirectoryLister: @unchecked Sendable {
     }
 
     private let route: TermiodRoute
-    /// Serialises the blocking frame reads: one request is in flight at a time,
-    /// so a reply can never be claimed by the wrong caller.
+    /// Serialises the requests. The channel underneath multiplexes happily, but
+    /// a path field has exactly one question outstanding — the directory the
+    /// caret is in — so overlapping them would only race answers onto the same
+    /// field.
     private let queue = DispatchQueue(label: "sh.termio.termiod.directory-lister")
-    private var transport: Termiod.Transport?
-    private var handshake: Termiod.Handshake?
 
     init(route: TermiodRoute) {
         self.route = route
     }
 
-    /// Connects and reports the home directory to start from. Called once, off
-    /// the main thread; every later `list` reuses the channel it opened.
+    /// Reports the home directory to start from, opening the device's channel if
+    /// this is the first thing to reach it. Called once, off the main thread.
     func connect(completion: @escaping @Sendable (Result<String, Error>) -> Void) {
-        queue.async { [self] in
-            do {
-                let transport = try Termiod.Transport.open(route)
-                let handshake = try Termiod.performHello(
-                    transport, role: "control", caps: ["files"])
-                guard handshake.capabilities.contains("files") else {
-                    transport.close()
+        queue.async { [route] in
+            completion(Result {
+                do {
+                    return try Termiod.deviceHome(route: route)
+                } catch DeviceFileError.unsupported {
                     // An older daemon that never learned the file plane. The
                     // picker still opens; it just cannot complete a path.
                     throw Failure.refused(
                         localized("This machine’s termiod is too old to list folders."))
                 }
-                self.transport = transport
-                self.handshake = handshake
-                completion(.success(handshake.home))
-            } catch {
-                completion(.failure(error))
-            }
+            })
         }
     }
 
@@ -102,18 +82,16 @@ final class TermiodDirectoryLister: @unchecked Sendable {
     /// the user retype the whole path at any moment — anchoring anywhere else
     /// would refuse a sibling directory the user can plainly `cd` to.
     func list(_ path: String, completion: @escaping @Sendable (Result<[Entry], Error>) -> Void) {
-        queue.async { [self] in
-            guard let transport else {
-                completion(.failure(TermiodClientError.connectionClosed))
-                return
-            }
-            do {
-                let listing = try Termiod.requestListing(transport, root: path)
-                if let message = listing.error {
-                    completion(.failure(Failure.refused(message)))
-                    return
+        queue.async { [route] in
+            completion(Result {
+                let listings = try Termiod.listDirectories(
+                    route: route, root: path, paths: [path])
+                guard let listing = listings.first else {
+                    throw Failure.refused(
+                        localized("The machine answered with no listing for that folder."))
                 }
-                let directories = listing.entries
+                if let message = listing.error { throw Failure.refused(message) }
+                return listing.entries
                     .filter(\.isDirectory)
                     .map { Entry(name: $0.name) }
                     .sorted { left, right in
@@ -122,22 +100,7 @@ final class TermiodDirectoryLister: @unchecked Sendable {
                         if leftHidden != rightHidden { return rightHidden }
                         return left.name.localizedStandardCompare(right.name) == .orderedAscending
                     }
-                completion(.success(directories))
-            } catch {
-                // A lost pipe must not leave a dead transport behind answering
-                // every later keystroke with the same corpse.
-                if case TermiodClientError.connectionClosed = error { close() }
-                completion(.failure(error))
-            }
-        }
-    }
-
-    /// Drops the channel. Safe to call more than once, and from any thread.
-    func close() {
-        queue.async { [self] in
-            transport?.close()
-            transport = nil
-            handshake = nil
+            })
         }
     }
 }

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -9,12 +9,18 @@ import TermioShared
 /// SFTP tree, which spoke a second protocol to a second server for the same
 /// question.
 ///
-/// Both verbs are **request/response on one channel**: `fs.list` canonicalises
-/// the root and confines every path under it (`termiod/src/files.rs`), and
-/// `fs.read` answers one `fs_file` header followed by `F` chunks. Neither is a
-/// subscription, so neither needs a connection that outlives the request — which
-/// is why the tree can land before `withControlChannel` becomes durable. Live
-/// change notification (the `fs:` resource) does need that, and is not here.
+/// Every verb here rides the **pooled** control channel for the device
+/// (`TermiodControlPool.swift`): one connection per machine, many requests
+/// multiplexed over it by `re`. Correctness does not depend on that — `fs.list`
+/// canonicalises the root and confines every path under it
+/// (`termiod/src/files.rs`), `fs.read` answers one `fs_file` header followed by
+/// `F` chunks, and neither is a subscription — but latency does. A channel per
+/// request meant `ssh <host> termiod stdio` per folder expand, which measured at
+/// 32 ms median and 260 ms at p90 on a link whose round trip is 8 ms.
+///
+/// Live change notification (the `fs:` resource) is still not here. It needs a
+/// connection that outlives one request, which now exists; what it also needs is
+/// a tree that applies deltas, which does not.
 extension Termiod {
     /// What one directory answered. `error` is the device's own message for a
     /// path that vanished or escaped the root; a batched request fails one path
@@ -77,10 +83,10 @@ extension Termiod {
     static func listDirectories(
         route: TermiodRoute, root: String, paths: [String]
     ) throws -> [DirectoryListing] {
-        try withFilesChannel(route: route) { transport in
-            let listed = try requestFiles(
-                transport, FsListOperation(root: root, paths: paths, seq: 1)
-            ) { control in
+        try withFilesChannel(route: route) { call in
+            let listed = try requestFiles(call, operation: "fs.list") { seq in
+                FsListOperation(root: root, paths: paths, seq: seq)
+            } match: { control in
                 if case .fsListed(let payload) = control { return payload }
                 return nil
             }
@@ -106,10 +112,10 @@ extension Termiod {
     static func readFile(
         route: TermiodRoute, path: String, limit: Int = filePreviewByteLimit
     ) throws -> DeviceFile {
-        try withFilesChannel(route: route) { transport in
-            let header = try requestFiles(
-                transport, FsReadOperation(path: path, seq: 1)
-            ) { control in
+        try withFilesChannel(route: route) { call in
+            let header = try requestFiles(call, operation: "fs.read") { seq in
+                FsReadOperation(path: path, seq: seq)
+            } match: { control in
                 if case .fsFile(let payload) = control { return payload }
                 return nil
             }
@@ -120,7 +126,8 @@ extension Termiod {
             // `length` is the served window; a zero-length file sends no `F`
             // frame at all, so the loop must be able to run zero times.
             while UInt64(data.count) < header.length {
-                let frame = try readFrame(transport.readDescriptor)
+                let frame = try call.next(
+                    timeoutSeconds: requestIdleTimeoutSeconds, operation: "fs.read")
                 switch frame.kind {
                 case .file:
                     let chunk = try decodeFileChunk(frame.payload)
@@ -165,17 +172,13 @@ extension Termiod {
         // Nothing to ask for, and the host would answer one hit anyway: it
         // appends before it compares against the cap.
         guard limit > 0 else { return SearchResult(hits: [], limitHit: false) }
-        return try withFilesChannel(route: route) { transport in
-            try writeFrame(
-                transport.writeDescriptor, kind: .control,
-                payload: encodeControl(FsSearchOperation(
-                    root: root, query: query, limit: UInt64(limit), seq: 1)))
+        return try withFilesChannel(route: route) { call in
+            try call.send(payload: encodeControl(FsSearchOperation(
+                root: root, query: query, limit: UInt64(limit), seq: call.seq)))
             var hits: [SearchHit] = []
             while true {
-                try waitForReadable(
-                    transport.readDescriptor, seconds: idleTimeoutSeconds,
-                    operation: "fs.search")
-                let frame = try readFrame(transport.readDescriptor)
+                let frame = try call.next(
+                    timeoutSeconds: idleTimeoutSeconds, operation: "fs.search")
                 switch frame.kind {
                 case .event:
                     guard case .searchResults(let payload) = try decodeEvent(frame.payload)
@@ -199,29 +202,47 @@ extension Termiod {
         }
     }
 
-    /// Opens a control channel that negotiated `files`, and refuses up front on a
-    /// daemon that did not grant it — the pane then says the device cannot serve
-    /// files rather than hanging on a reply that never comes.
+    /// How long a listing or a read may go without the device saying anything
+    /// before the request is treated as unanswered.
+    ///
+    /// A one-shot channel needed no such bound: the process it hung off died and
+    /// took the wait with it. A pooled one outlives its requests, so a request
+    /// that would once have ended with the connection now has to end on its own
+    /// clock — and a pipe that stops answering must not park the thread that
+    /// asked. Generous, because a cold directory on a slow disk is slow and
+    /// correct; this bounds silence, not work. `fs.search` keeps its own, much
+    /// longer bound: a grep is *expected* to say nothing for a long time.
+    static let requestIdleTimeoutSeconds = 30
+
+    /// Runs `body` against the device's pooled `files` channel, refusing up front
+    /// on a daemon that did not grant the capability — the pane then says the
+    /// device cannot serve files rather than hanging on a reply that never comes.
     private static func withFilesChannel<Result>(
-        route: TermiodRoute, _ body: (Transport) throws -> Result
+        route: TermiodRoute, _ body: (ChannelCall) throws -> Result
     ) throws -> Result {
-        try withControlChannel(route: route, caps: ["files"]) { transport, handshake in
-            guard handshake.capabilities.contains("files") else {
+        try withPooledRequest(route: route, caps: ["files"]) { call, channel in
+            guard channel.capabilities.contains("files") else {
                 throw DeviceFileError.unsupported
             }
-            return try body(transport)
+            return try body(call)
         }
     }
 
+    /// Sends one request and waits for the reply that matches, skipping frames
+    /// that do not. `build` takes the call's own `seq` rather than a fixed 1:
+    /// that id is what the daemon stamps every answering frame with, and on a
+    /// shared channel it is the only thing that tells this reply from the one
+    /// belonging to the expand happening alongside it.
     private static func requestFiles<Operation: Encodable, Reply>(
-        _ transport: Transport,
-        _ operation: Operation,
-        _ match: (IncomingControl) -> Reply?
+        _ call: ChannelCall,
+        operation name: String,
+        build: (UInt64) -> Operation,
+        match: (IncomingControl) -> Reply?
     ) throws -> Reply {
-        try writeFrame(transport.writeDescriptor, kind: .control,
-                       payload: encodeControl(operation))
+        try call.send(payload: encodeControl(build(call.seq)))
         while true {
-            let frame = try readFrame(transport.readDescriptor)
+            let frame = try call.next(
+                timeoutSeconds: requestIdleTimeoutSeconds, operation: name)
             guard frame.kind == .control else { continue }
             let control = try decodeControl(frame.payload)
             if let reply = match(control) { return reply }
@@ -267,12 +288,12 @@ extension FileEntry {
     }
 }
 
-/// The tree's async seam onto the two blocking verbs above. One per pane, so a
+/// The tree's async seam onto the blocking verbs above. One per pane, so a
 /// device that stops answering blocks only its own pane.
 ///
-/// The work runs on a global queue rather than in an actor: each call opens,
-/// hellos, asks and closes on one file descriptor, and blocking a cooperative
-/// pool thread for a network round trip is exactly what that pool is not for.
+/// The work runs on a global queue rather than in an actor: a request blocks on
+/// a network round trip, and blocking a cooperative pool thread for one is
+/// exactly what that pool is not for.
 struct DeviceFileProvider: Sendable {
     let route: TermiodRoute
     /// The checkout root every request is confined under, so a listing can never
@@ -281,14 +302,31 @@ struct DeviceFileProvider: Sendable {
     let root: String
 
     func list(_ path: String) async throws -> [FileEntry] {
-        let listings = try await run { [route, root] in
-            try Termiod.listDirectories(route: route, root: root, paths: [path])
-        }
+        let listings = try await list([path])
         guard let listing = listings.first else { return [] }
         if let error = listing.error {
             throw TermiodClientError.requestFailed(error)
         }
         return listing.entries
+    }
+
+    /// Several directories in **one** request, which is the shape `fs.list` was
+    /// given a `paths` array for: the protocol asks a client to name a rendered
+    /// directory together with the visible directories under it, rather than
+    /// walking the tree a round trip at a time.
+    ///
+    /// It is the difference between one round trip and N. Measured against a VPS
+    /// with a nine-directory checkout open: 339 ms one directory at a time,
+    /// 44 ms asked together — and on the pooled channel, 12 ms.
+    ///
+    /// Failures are per path, not per request: a directory that vanished carries
+    /// its own `error` and the rest of the listings still land. Callers key the
+    /// result by `path`, which the daemon echoes back exactly as asked.
+    func list(_ paths: [String]) async throws -> [Termiod.DirectoryListing] {
+        guard !paths.isEmpty else { return [] }
+        return try await run { [route, root] in
+            try Termiod.listDirectories(route: route, root: root, paths: paths)
+        }
     }
 
     /// Content search under the pane's own root, on the device. Confined the same

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -175,6 +175,11 @@ extension Termiod {
         return try withFilesChannel(route: route) { call in
             try call.send(payload: encodeControl(FsSearchOperation(
                 root: root, query: query, limit: UInt64(limit), seq: call.seq)))
+            // Armed the moment the request is on the wire: from here until the
+            // host's terminal reply, every way out of this closure — the idle
+            // bound, a lost pipe, a thrown decode — is a `git grep` still
+            // walking a checkout on someone else's machine.
+            call.cancelIfAbandoned()
             var hits: [SearchHit] = []
             while true {
                 let frame = try call.next(
@@ -189,8 +194,14 @@ extension Termiod {
                 case .control:
                     switch try decodeControl(frame.payload) {
                     case .fsSearched(let payload):
+                        // The host's last word, whether it finished, hit the cap
+                        // or was already stopped: nothing left to cancel.
+                        call.completed()
                         return SearchResult(hits: hits, limitHit: payload.limitHit)
                     case .error(let failure):
+                        // A refusal the host has already cleaned up behind — no
+                        // grep is running, so cancelling would name nothing.
+                        call.completed()
                         throw TermiodClientError.requestFailed(failure.message)
                     default:
                         continue

--- a/Tests/termioTests/RemoteFileTreeRefreshTests.swift
+++ b/Tests/termioTests/RemoteFileTreeRefreshTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+import TermioShared
+@testable import termio
+
+/// What a refresh of a device's file tree asks for, and what it does with the
+/// answer.
+///
+/// The tree used to drop every node it held and re-list the root alone, leaving
+/// each still-expanded folder to fetch itself from the `children` getter — one
+/// SSH round trip per open folder, on every app focus. It now names them all in
+/// one `fs.list` and grafts the replies onto the nodes already on screen. Both
+/// halves are checkable without a device: the paths it asks for, and whether the
+/// subtree under an open folder survives.
+@MainActor
+final class RemoteFileTreeRefreshTests: XCTestCase {
+    private let root = "/srv/api"
+
+    private func model() -> RemoteFileBrowserModel {
+        // A route nothing will answer on: every assertion here is about what the
+        // model does with listings it is handed, never about fetching them.
+        RemoteFileBrowserModel(
+            checkout: Checkout(
+                device: KnownDevice(alias: "test-box", deviceID: nil), root: root),
+            root: root)
+    }
+
+    private func listing(
+        _ path: String, _ entries: [(String, FileEntry.Kind)], error: String? = nil
+    ) -> Termiod.DirectoryListing {
+        Termiod.DirectoryListing(
+            path: path,
+            entries: entries.map { FileEntry(name: $0.0, kind: $0.1) },
+            error: error)
+    }
+
+    /// The ask: the root plus every directory whose contents the tree is holding,
+    /// parents before children so a graft never runs ahead of the node it hangs
+    /// off.
+    func testARefreshNamesEveryDirectoryTheTreeIsShowing() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory), ("README.md", .file)])])
+        XCTAssertEqual(tree.loadedDirectories(), [], "nothing under the root is open yet")
+
+        tree.apply([listing("\(root)/src", [("deep", .directory)])])
+        tree.apply([listing("\(root)/src/deep", [("x.swift", .file)])])
+
+        XCTAssertEqual(
+            tree.loadedDirectories(), ["\(root)/src", "\(root)/src/deep"],
+            "shallowest first, so a parent's rows exist before its child's land")
+    }
+
+    /// The graft: a folder that is still there keeps the node it had, and so
+    /// keeps everything loaded underneath it. Minting a fresh node would leave
+    /// the outline expanded over an empty folder and send the tree back to
+    /// fetching each level again — the exact cost this refresh removes.
+    func testAnOpenFolderKeepsItsSubtreeAcrossARefresh() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory)])])
+        tree.apply([listing("\(root)/src", [("x.swift", .file)])])
+
+        let before = try? XCTUnwrap(tree.node(at: "\(root)/src"))
+        tree.apply([listing(root, [("src", .directory), ("new.md", .file)])])
+        let after = try? XCTUnwrap(tree.node(at: "\(root)/src"))
+
+        XCTAssertTrue(before === after, "the surviving folder keeps its node")
+        XCTAssertEqual(after?.children?.map(\.name), ["x.swift"])
+        XCTAssertEqual(tree.rootNodes.map(\.name), ["src", "new.md"])
+        XCTAssertEqual(tree.loadedDirectories(), ["\(root)/src"],
+                       "and is still counted as loaded, so it re-lists in the batch")
+    }
+
+    /// A name that changed kind is a different thing wearing the same path, and
+    /// must not inherit the old node's children.
+    func testAPathThatChangedKindIsRebuilt() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory)])])
+        tree.apply([listing("\(root)/src", [("x.swift", .file)])])
+        let directory = tree.node(at: "\(root)/src")
+
+        tree.apply([listing(root, [("src", .file)])])
+
+        let file = tree.node(at: "\(root)/src")
+        XCTAssertFalse(directory === file)
+        XCTAssertNil(file?.children, "a file has no children to inherit")
+    }
+
+    /// `fs.list` fails one path at a time. A folder the device refused keeps the
+    /// rows it had rather than blanking, so one deleted directory does not empty
+    /// the pane around it.
+    func testAPathTheDeviceRefusedLeavesItsRowsAlone() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory)])])
+        tree.apply([listing("\(root)/src", [("x.swift", .file)])])
+
+        tree.apply([
+            listing(root, [("src", .directory)]),
+            listing("\(root)/src", [], error: "No such file or directory"),
+        ])
+
+        XCTAssertEqual(tree.node(at: "\(root)/src")?.children?.map(\.name), ["x.swift"])
+    }
+
+    /// A folder that is gone takes its subtree with it, or the paths a refresh
+    /// asks for would grow for the life of the pane.
+    func testAFolderThatDisappearedStopsBeingAskedFor() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory), ("docs", .directory)])])
+        tree.apply([listing("\(root)/src", [("x.swift", .file)])])
+        tree.apply([listing("\(root)/docs", [("y.md", .file)])])
+        XCTAssertEqual(tree.loadedDirectories().count, 2)
+
+        tree.apply([listing(root, [("docs", .directory)])])
+
+        XCTAssertNil(tree.node(at: "\(root)/src"))
+        XCTAssertEqual(tree.loadedDirectories(), ["\(root)/docs"])
+    }
+}

--- a/Tests/termioTests/TermiodEventTests.swift
+++ b/Tests/termioTests/TermiodEventTests.swift
@@ -461,4 +461,56 @@ final class TermiodEventTests: XCTestCase {
         XCTAssertNoThrow(
             try Termiod.waitForReadable(pair[0], seconds: 5, operation: "fs.search"))
     }
+
+    // MARK: - Routing replies on a shared channel
+
+    /// `re` is what a pooled channel demultiplexes on. It was always on the wire
+    /// and nothing read it, so this is the field most likely to be quietly
+    /// dropped by a codec change — and dropping it does not fail a build, it
+    /// hands one caller another caller's answer.
+    func testAReplyNamesTheRequestItAnswers() throws {
+        guard case .fsListed = try control(#"{"op":"fs_listed","seq":0,"listings":[],"re":7}"#)
+        else { return XCTFail("expected fs_listed") }
+        XCTAssertEqual(
+            Termiod.responseID(of: Data(#"{"op":"fs_listed","seq":0,"listings":[],"re":7}"#.utf8)),
+            7)
+        XCTAssertEqual(
+            Termiod.responseID(of: Data(#"{"op":"error","code":"denied","message":"x","re":9}"#.utf8)),
+            9)
+    }
+
+    /// A reply that answers nobody must route nowhere rather than to request 0.
+    /// `hello_ok` is the real case: it precedes every id there is.
+    func testAReplyThatAnswersNobodyHasNoRequestID() {
+        XCTAssertNil(Termiod.responseID(of: Data(
+            #"{"op":"hello_ok","proto":1,"caps":[],"host_id":"h","host":"t","client_id":"c"}"#.utf8)))
+        XCTAssertNil(Termiod.responseID(of: Data(#"{"ev":"ready","session":"s"}"#.utf8)))
+    }
+
+    /// An `F` chunk carries its request id in the binary header, not in JSON, so
+    /// it is routed by a different reader than every other frame — and a file
+    /// delivered to the wrong request is a corrupted preview, not an error.
+    func testAFileChunkCarriesTheRequestItBelongsTo() throws {
+        var payload = Data()
+        payload.append(contentsOf: [0, 0, 0, 0, 0, 0, 0, 42]) // re
+        payload.append(contentsOf: [0, 0, 0, 0, 0, 0, 0, 8]) // offset
+        payload.append(1) // last
+        payload.append(contentsOf: Array("hello".utf8))
+
+        let chunk = try Termiod.decodeFileChunk(payload)
+        XCTAssertEqual(chunk.request, 42)
+        XCTAssertEqual(chunk.offset, 8)
+        XCTAssertTrue(chunk.last)
+        XCTAssertEqual(chunk.data, Data("hello".utf8))
+    }
+
+    /// A batch of search hits names no session, so `request` is its only route.
+    /// A grep sharing a channel with a folder expand depends on it entirely.
+    func testASearchBatchNamesTheSearchItBelongsTo() throws {
+        guard case .searchResults(let payload) = try event(
+            #"{"ev":"search_results","request":3,"matches":[{"path":"a.txt","line":1,"text":"hi"}]}"#)
+        else { return XCTFail("expected search_results") }
+        XCTAssertEqual(payload.request, 3)
+        XCTAssertEqual(payload.matches.map(\.path), ["a.txt"])
+    }
 }

--- a/Tests/termioTests/TermiodFilesIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFilesIntegrationTests.swift
@@ -16,6 +16,65 @@ final class TermiodFilesIntegrationTests: XCTestCase {
     private var socketDirectory: URL?
     private var socketPath = ""
     private var root = URL(fileURLWithPath: "/")
+    private var shimDirectory = URL(fileURLWithPath: "/")
+
+    // MARK: - A grep that takes a known amount of time
+
+    /// Where the shim reads how long to run, and records that it ran to the end.
+    private var shimSecondsFile: URL { shimDirectory.appendingPathComponent("seconds") }
+    private var shimStartedFile: URL { shimDirectory.appendingPathComponent("started") }
+    private var shimFinishedFile: URL { shimDirectory.appendingPathComponent("finished") }
+
+    /// Installs a `git` that stands in for a long grep over a big checkout.
+    ///
+    /// Everything except `grep` is handed to the real `git`, and so is `grep`
+    /// itself until a test arms the delay — so every search test that wants a
+    /// real answer still gets one. Once armed, a `grep` sleeps for the
+    /// configured time and only then writes `finished`, which makes "the host
+    /// stopped early" observable as the absence of that file rather than as the
+    /// client having returned.
+    private func installGrepShim() throws {
+        shimDirectory = try XCTUnwrap(socketDirectory)
+            .appendingPathComponent("shim")
+        try FileManager.default.createDirectory(
+            at: shimDirectory, withIntermediateDirectories: true)
+        let script = """
+        #!/bin/bash
+        for argument in "$@"; do
+          if [ "$argument" = "grep" ]; then
+            delay=$(cat "\(shimSecondsFile.path)" 2>/dev/null || echo 0)
+            if [ "$delay" != "0" ]; then
+              echo "$$" >> "\(shimStartedFile.path)"
+              sleep "$delay"
+              echo "$$" >> "\(shimFinishedFile.path)"
+              exit 1
+            fi
+            break
+          fi
+        done
+        exec /usr/bin/git "$@"
+        """
+        let shim = shimDirectory.appendingPathComponent("git")
+        try Data(script.utf8).write(to: shim)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: shim.path)
+        try Data("0\n".utf8).write(to: shimSecondsFile)
+    }
+
+    /// Arms the shim to run for `seconds`, and clears the previous run's marks.
+    private func makeSearchTake(seconds: Double) throws {
+        try? FileManager.default.removeItem(at: shimStartedFile)
+        try? FileManager.default.removeItem(at: shimFinishedFile)
+        try Data("\(seconds)\n".utf8).write(to: shimSecondsFile)
+    }
+
+    private var shimStarted: Bool {
+        FileManager.default.fileExists(atPath: shimStartedFile.path)
+    }
+
+    private var shimRanToCompletion: Bool {
+        FileManager.default.fileExists(atPath: shimFinishedFile.path)
+    }
 
     /// Starts a daemon on this test's socket and waits for it to answer. Split
     /// out because one test kills it mid-flight to make sure a pooled channel
@@ -29,8 +88,15 @@ final class TermiodFilesIntegrationTests: XCTestCase {
         let serve = Process()
         serve.executableURL = URL(fileURLWithPath: binary)
         serve.arguments = ["serve"]
-        serve.environment = ProcessInfo.processInfo.environment.merging(
-            ["TERMIOD_SOCK": socketPath]) { _, new in new }
+        serve.environment = ProcessInfo.processInfo.environment.merging([
+            "TERMIOD_SOCK": socketPath,
+            // The daemon runs `git grep` by name, so putting a shim first on its
+            // PATH is how a search can be made to take a known amount of time.
+            // Real `git grep` is far too fast to abandon on purpose — 133 MB of
+            // text answers in 40 ms — so a fixture built out of file count would
+            // pin nothing.
+            "PATH": "\(shimDirectory.path):\(ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin")",
+        ]) { _, new in new }
         serve.standardOutput = FileHandle.nullDevice
         serve.standardError = FileHandle.nullDevice
         try serve.run()
@@ -58,6 +124,7 @@ final class TermiodFilesIntegrationTests: XCTestCase {
         XCTAssertLessThan(socket.utf8.count, 104, "socket path must fit sun_path")
         setenv("TERMIOD_SOCK", socket, 1)
         socketPath = socket
+        try installGrepShim()
         daemon = try startDaemon()
 
         // A tree with one of everything the pane draws: a file, a directory, a
@@ -311,61 +378,194 @@ final class TermiodFilesIntegrationTests: XCTestCase {
     }
 
     /// Requests are demultiplexed by `re`, so several may be outstanding at once
-    /// — the daemon `tokio::spawn`s each one and answers out of order. This is
-    /// the claim that would fail loudest if the routing were wrong: with replies
-    /// matched by arrival instead of by id, a listing would come back holding a
-    /// file's bytes.
-    func testConcurrentRequestsOnOneChannelGetTheirOwnAnswers() throws {
+    /// — the daemon `tokio::spawn`s each one and answers out of order.
+    ///
+    /// The discriminator is *when* the fast two finish, not that they finish. A
+    /// channel that took one request at a time would answer all three correctly
+    /// and simply make the listing wait out the grep, which is exactly the
+    /// behaviour worth ruling out: the pane must stay usable while a search runs.
+    /// So the search is made to take four seconds and the assertion is that the
+    /// listing and the read both landed while it was still going.
+    func testASlowSearchDoesNotHoldUpTheRestOfTheChannel() throws {
+        try makeSearchTake(seconds: 4)
         let done = expectation(description: "all requests answered")
         done.expectedFulfillmentCount = 3
         let listed = UncheckedBox<[Termiod.DirectoryListing]>([])
         let read = UncheckedBox<Data>(Data())
-        let found = UncheckedBox<Termiod.SearchResult?>(nil)
+        let clock = ContinuousClock()
+        let searchEnded = UncheckedBox<ContinuousClock.Instant?>(nil)
+        let listEnded = UncheckedBox<ContinuousClock.Instant?>(nil)
+        let readEnded = UncheckedBox<ContinuousClock.Instant?>(nil)
         let root = root
 
-        // The search is much the slowest of the three, so it is issued first: if
-        // anything serialised behind it, the other two would land after it
-        // rather than while it runs.
         DispatchQueue.global().async {
-            found.value = try? Termiod.searchContents(
-                route: .local, root: root.path, query: "nested", limit: 400)
+            _ = try? Termiod.searchContents(
+                route: .local, root: root.path, query: "anything", limit: 400)
+            searchEnded.value = clock.now
             done.fulfill()
         }
+        // Give the search time to be on the wire and the grep time to start, so
+        // "while it was still running" is a fact rather than a hope.
+        let armed = ContinuousClock.now.advanced(by: .seconds(10))
+        while !shimStarted, ContinuousClock.now < armed { usleep(20_000) }
+        XCTAssertTrue(shimStarted, "the slow grep is what this test measures against")
+
         DispatchQueue.global().async {
             listed.value = (try? Termiod.listDirectories(
                 route: .local, root: root.path, paths: [root.path])) ?? []
+            listEnded.value = clock.now
             done.fulfill()
         }
         DispatchQueue.global().async {
             read.value = (try? Termiod.readFile(
-                route: .local, path: root.appendingPathComponent("sub/b.txt").path))?.data ?? Data()
+                route: .local,
+                path: root.appendingPathComponent("sub/b.txt").path))?.data ?? Data()
+            readEnded.value = clock.now
             done.fulfill()
         }
         wait(for: [done], timeout: 30)
 
-        XCTAssertEqual(listed.value.first?.path, root.path)
         XCTAssertTrue(listed.value.first?.entries.contains { $0.name == "a.txt" } ?? false)
         XCTAssertEqual(read.value, Data(nestedContents.utf8), "the read got its own bytes")
-        XCTAssertEqual(found.value?.hits.count, 400)
+
+        let searchAt = try XCTUnwrap(searchEnded.value)
+        let listAt = try XCTUnwrap(listEnded.value)
+        let readAt = try XCTUnwrap(readEnded.value)
+        XCTAssertTrue(listAt < searchAt, "the listing answered while the grep was still running")
+        XCTAssertTrue(readAt < searchAt, "so did the read")
+        // And by a margin that could not be scheduling noise: both should land
+        // in well under the four seconds the grep is holding the channel for.
+        XCTAssertGreaterThan(listAt.duration(to: searchAt), .seconds(2))
+        XCTAssertGreaterThan(readAt.duration(to: searchAt), .seconds(2))
+    }
+
+    /// Abandoning a search has to stop the `git grep` on the device.
+    ///
+    /// This is the one thing pooling took away and had to give back. A channel
+    /// that lived for one request stopped a grep by hanging up — `run_search`
+    /// watches `out.closed()` for exactly that, and that arm is the whole reason
+    /// an abandoned query did not leave a process walking someone's checkout. A
+    /// pooled channel never hangs up, so the client now sends the protocol's own
+    /// `cancel { request: <seq> }` instead, which only a multiplexed channel
+    /// *can* send: a synchronous one is blocked reading the descriptor it would
+    /// have to write to.
+    ///
+    /// The assertion is on the host's own record. The shim writes `finished`
+    /// only if it runs its full ten seconds, so the client giving up cannot
+    /// produce a pass; the grep really has to have been killed.
+    func testAnAbandonedSearchStopsTheGrepOnTheDevice() throws {
+        try makeSearchTake(seconds: 10)
+
+        let started = ContinuousClock.now
+        XCTAssertThrowsError(
+            try Termiod.searchContents(
+                route: .local, root: root.path, query: "anything", limit: 400,
+                idleTimeoutSeconds: 1)
+        ) { error in
+            guard case TermiodClientError.timedOut = error else {
+                return XCTFail("expected the idle bound to fire, got \(error)")
+            }
+        }
+        XCTAssertTrue(shimStarted, "the grep did start, so there was something to stop")
+
+        // The cancel goes out as the request is retired. Allow a moment for the
+        // host to act on it, then check its record — well inside the ten seconds
+        // an uncancelled grep would still be running for.
+        let deadline = ContinuousClock.now.advanced(by: .seconds(3))
+        var greps = grepProcessCount()
+        while greps > 0, ContinuousClock.now < deadline {
+            usleep(100_000)
+            greps = grepProcessCount()
+        }
+        XCTAssertEqual(greps, 0, "the device's grep was killed, not left running")
+        XCTAssertFalse(
+            shimRanToCompletion, "and killed rather than allowed to finish on its own")
+        XCTAssertLessThan(
+            started.duration(to: .now), .seconds(8),
+            "which happened long before the grep would have ended by itself")
+    }
+
+    /// Shim processes still alive for this test's own fixture directory. Scoped
+    /// by that path — which is in the shim's own argv — so a developer's
+    /// unrelated `git grep` cannot fail the run.
+    private func grepProcessCount() -> Int {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-f", shimDirectory.appendingPathComponent("git").path]
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        guard (try? process.run()) != nil else { return 0 }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(decoding: data, as: UTF8.self)
+            .split(separator: "\n")
+            .filter { !$0.isEmpty }
+            .count
     }
 
     /// The cost of holding a connection: it can die between requests, and the
     /// first click after a laptop wakes must reconnect rather than show an error.
     /// Killing the daemon under a live pooled channel is exactly that.
-    func testAChannelThatDiedBetweenRequestsReconnects() throws {
+    func testTheNextRequestAfterADaemonRestartStillAnswers() throws {
         _ = try Termiod.listDirectories(route: .local, root: root.path, paths: [root.path])
 
         daemon?.terminate()
         daemon?.waitUntilExit()
         daemon = nil
-        // The client is not told; it finds out by writing into a dead pipe,
-        // which is the case this has to survive without raising SIGPIPE.
         let restarted = try startDaemon()
         daemon = restarted
 
         let listings = try Termiod.listDirectories(
             route: .local, root: root.path, paths: [root.path])
         XCTAssertTrue(listings.first?.entries.contains { $0.name == "a.txt" } ?? false)
+    }
+
+    /// The retry policy itself, which the restart above does *not* reach: killing
+    /// a daemon gives the reader a clean EOF, so by the time the next request
+    /// asks for a channel the dead one has already been replaced. The path worth
+    /// pinning is the narrower one — a channel that was still believed live when
+    /// the request went out and turned out not to be — and its three gates.
+    ///
+    /// Driven through the real `withPooledRequest` with a body that fails on
+    /// cue, because the operating-system race cannot be scheduled on demand.
+    func testAnInheritedChannelIsRetriedOnceAndOnlyWhenNothingWasHeard() throws {
+        // Open the channel, so everything after this inherits it.
+        _ = try Termiod.listDirectories(route: .local, root: root.path, paths: [root.path])
+
+        var attempts = 0
+        var reuse: [Bool] = []
+        _ = try? Termiod.withPooledRequest(route: .local, caps: ["files"]) { call, _ in
+            attempts += 1
+            reuse.append(call.wasReused)
+            throw TermiodClientError.connectionClosed
+        }
+        XCTAssertEqual(attempts, 2, "an inherited channel is worth one reconnect")
+        XCTAssertEqual(
+            reuse, [true, false],
+            "the first call inherited a channel; the retry got a freshly opened one — "
+                + "which is also what stops the retry from retrying")
+
+        // A refusal is not a broken pipe: the host would say the same thing again.
+        attempts = 0
+        _ = try? Termiod.withPooledRequest(route: .local, caps: ["files"]) { _, _ in
+            attempts += 1
+            throw TermiodClientError.requestFailed("no such file")
+        }
+        XCTAssertEqual(attempts, 1, "a refusal is answered, not retried")
+
+        // Once part of the answer has landed, replaying would splice two halves
+        // of different answers together.
+        attempts = 0
+        _ = try? Termiod.withPooledRequest(route: .local, caps: ["files"]) { call, _ in
+            attempts += 1
+            try call.send(payload: Termiod.encodeControl(
+                Termiod.FsListOperation(root: root.path, paths: [root.path], seq: call.seq)))
+            _ = try call.next(timeoutSeconds: 10, operation: "fs.list")
+            XCTAssertTrue(call.hasDelivered)
+            throw TermiodClientError.connectionClosed
+        }
+        XCTAssertEqual(attempts, 1, "a request that heard part of its answer is not replayed")
     }
 }
 

--- a/Tests/termioTests/TermiodFilesIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFilesIntegrationTests.swift
@@ -14,7 +14,33 @@ final class TermiodFilesIntegrationTests: XCTestCase {
     private var binary = ""
     private var daemon: Process?
     private var socketDirectory: URL?
+    private var socketPath = ""
     private var root = URL(fileURLWithPath: "/")
+
+    /// Starts a daemon on this test's socket and waits for it to answer. Split
+    /// out because one test kills it mid-flight to make sure a pooled channel
+    /// that died between requests reconnects rather than failing the click.
+    private func startDaemon() throws -> Process {
+        // A killed daemon leaves its socket file behind, and a client that finds
+        // one nobody is listening on would try to autostart a daemon from the
+        // bundle rather than use this test's binary. Wait for *this* daemon's
+        // socket, not for a corpse.
+        try? FileManager.default.removeItem(atPath: socketPath)
+        let serve = Process()
+        serve.executableURL = URL(fileURLWithPath: binary)
+        serve.arguments = ["serve"]
+        serve.environment = ProcessInfo.processInfo.environment.merging(
+            ["TERMIOD_SOCK": socketPath]) { _, new in new }
+        serve.standardOutput = FileHandle.nullDevice
+        serve.standardError = FileHandle.nullDevice
+        try serve.run()
+
+        let deadline = Date().addingTimeInterval(10)
+        while !FileManager.default.fileExists(atPath: socketPath), Date() < deadline {
+            usleep(50_000)
+        }
+        return serve
+    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -31,21 +57,8 @@ final class TermiodFilesIntegrationTests: XCTestCase {
         let socket = directory.appendingPathComponent("termiod.sock").path
         XCTAssertLessThan(socket.utf8.count, 104, "socket path must fit sun_path")
         setenv("TERMIOD_SOCK", socket, 1)
-
-        let serve = Process()
-        serve.executableURL = URL(fileURLWithPath: binary)
-        serve.arguments = ["serve"]
-        serve.environment = ProcessInfo.processInfo.environment.merging(
-            ["TERMIOD_SOCK": socket]) { _, new in new }
-        serve.standardOutput = FileHandle.nullDevice
-        serve.standardError = FileHandle.nullDevice
-        try serve.run()
-        daemon = serve
-
-        let deadline = Date().addingTimeInterval(10)
-        while !FileManager.default.fileExists(atPath: socket), Date() < deadline {
-            usleep(50_000)
-        }
+        socketPath = socket
+        daemon = try startDaemon()
 
         // A tree with one of everything the pane draws: a file, a directory, a
         // nested file, and the VCS directory the host stubs rather than walks.
@@ -76,6 +89,10 @@ final class TermiodFilesIntegrationTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        // The pool is process-wide and keyed by route, so a channel left open
+        // here would be handed to the next test — pointed at a daemon this one
+        // is about to kill.
+        Termiod.ControlPool.closeAll()
         daemon?.terminate()
         daemon?.waitUntilExit()
         if let socketDirectory {
@@ -268,4 +285,94 @@ final class TermiodFilesIntegrationTests: XCTestCase {
         XCTAssertTrue(result.hits.isEmpty)
         XCTAssertFalse(result.limitHit)
     }
+
+    // MARK: - The pooled channel
+
+    /// The premise of the whole pool: a second request reaches the device over
+    /// the connection the first one opened. If this ever stops holding, nothing
+    /// fails — every call still answers — the app just quietly goes back to an
+    /// SSH handshake per folder expand.
+    func testASecondRequestReusesTheFirstsConnection() throws {
+        _ = try Termiod.listDirectories(route: .local, root: root.path, paths: [root.path])
+        let first = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
+        _ = try Termiod.readFile(route: .local, path: root.appendingPathComponent("a.txt").path)
+        let second = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
+        XCTAssertTrue(first === second, "the files plane must hold one channel per device")
+    }
+
+    /// A channel that negotiated one capability set must not answer for another:
+    /// the daemon settles capabilities at the handshake, so handing a `files`
+    /// channel a request it never negotiated would hang on a reply it will not
+    /// send.
+    func testChannelsAreKeyedByWhatTheyNegotiated() throws {
+        let files = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
+        let other = try Termiod.ControlPool.channel(route: .local, caps: ["files", "git"])
+        XCTAssertFalse(files === other)
+    }
+
+    /// Requests are demultiplexed by `re`, so several may be outstanding at once
+    /// — the daemon `tokio::spawn`s each one and answers out of order. This is
+    /// the claim that would fail loudest if the routing were wrong: with replies
+    /// matched by arrival instead of by id, a listing would come back holding a
+    /// file's bytes.
+    func testConcurrentRequestsOnOneChannelGetTheirOwnAnswers() throws {
+        let done = expectation(description: "all requests answered")
+        done.expectedFulfillmentCount = 3
+        let listed = UncheckedBox<[Termiod.DirectoryListing]>([])
+        let read = UncheckedBox<Data>(Data())
+        let found = UncheckedBox<Termiod.SearchResult?>(nil)
+        let root = root
+
+        // The search is much the slowest of the three, so it is issued first: if
+        // anything serialised behind it, the other two would land after it
+        // rather than while it runs.
+        DispatchQueue.global().async {
+            found.value = try? Termiod.searchContents(
+                route: .local, root: root.path, query: "nested", limit: 400)
+            done.fulfill()
+        }
+        DispatchQueue.global().async {
+            listed.value = (try? Termiod.listDirectories(
+                route: .local, root: root.path, paths: [root.path])) ?? []
+            done.fulfill()
+        }
+        DispatchQueue.global().async {
+            read.value = (try? Termiod.readFile(
+                route: .local, path: root.appendingPathComponent("sub/b.txt").path))?.data ?? Data()
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 30)
+
+        XCTAssertEqual(listed.value.first?.path, root.path)
+        XCTAssertTrue(listed.value.first?.entries.contains { $0.name == "a.txt" } ?? false)
+        XCTAssertEqual(read.value, Data(nestedContents.utf8), "the read got its own bytes")
+        XCTAssertEqual(found.value?.hits.count, 400)
+    }
+
+    /// The cost of holding a connection: it can die between requests, and the
+    /// first click after a laptop wakes must reconnect rather than show an error.
+    /// Killing the daemon under a live pooled channel is exactly that.
+    func testAChannelThatDiedBetweenRequestsReconnects() throws {
+        _ = try Termiod.listDirectories(route: .local, root: root.path, paths: [root.path])
+
+        daemon?.terminate()
+        daemon?.waitUntilExit()
+        daemon = nil
+        // The client is not told; it finds out by writing into a dead pipe,
+        // which is the case this has to survive without raising SIGPIPE.
+        let restarted = try startDaemon()
+        daemon = restarted
+
+        let listings = try Termiod.listDirectories(
+            route: .local, root: root.path, paths: [root.path])
+        XCTAssertTrue(listings.first?.entries.contains { $0.name == "a.txt" } ?? false)
+    }
+}
+
+/// A box for handing a result back from a detached queue in a test. The values
+/// are read only after `wait(for:)` has returned, which is the barrier that
+/// makes this safe; the compiler cannot see that.
+private final class UncheckedBox<Value>: @unchecked Sendable {
+    var value: Value
+    init(_ value: Value) { self.value = value }
 }


### PR DESCRIPTION
Browsing a checkout on a VPS was slow for two reasons, both on this side of the wire.

**A connection per request.** `withControlChannel` opens a pipe, shakes hands, asks one question and hangs up. On the SSH road that pipe is `ssh <host> termiod stdio`, so every folder expand, every file open and every search paid an SSH channel open, a remote `termiod` exec and a hello round trip before asking anything. ControlMaster amortises TCP and crypto but not the process spawn or the handshake.

**No batching.** `fs.list` takes a `paths` array and the protocol asks a client to name a rendered directory together with the visible directories under it. The tree sent `paths: [path]` — one directory — and `refresh()` dropped every cached node on each app-focus, leaving every still-expanded folder to re-fetch itself from the `children` getter. Eight open folders meant nine sequential round trips, on every ⌘-tab.

## Numbers

Real box (`ukvps`, 8 ms round trip), through the actual Swift client, alternating before/after runs each starting from a clean SSH master. Two rounds, medians:

| | before | after |
|---|---|---|
| one `fs.list(root)` | 40.7 / 40.0 ms | **8.0 / 8.2 ms** |
| tree refresh, 9 open directories | 370.0 / 334.0 ms | **10.0 / 9.8 ms** |
| open `README.md` | 43.1 / 38.0 ms | **8.3 / 9.9 ms** |

Where the ~40 ms went, from a harness that speaks the protocol directly (n=20): `posix_spawn` 2.5 ms, hello 27.8 ms (p90 260 ms), the request itself 8.3 ms, teardown 0.6 ms. The connection was four times the cost of the question, with a tail an order of magnitude worse.

Batching and pooling are separable and both earned their place. On an already-open channel, nine directories in one request cost 11.9 ms against 9.2 ms for one — 2.7 ms more for eight extra directories, versus 83 ms asking serially.

## What changed

**`TermiodControlPool.swift`** — one long-lived channel per (device, capability set), a reader thread demultiplexing frames onto the requests in flight, and an idle reaper that hangs up after two minutes.

Nothing on the host changed. The daemon already stamps every reply with `re` — the `seq` of the request that caused it — and already `tokio::spawn`s each `fs_list`/`fs_read`, so replies could always arrive out of order and were always routable. This side simply started reading the field. One protocol, one version, no new op. Three frame shapes carry the id: `re` on a control reply, the `F` chunk's binary header, and `request` on a `search_results` event.

`TermiodDirectoryLister` had already reached this conclusion for the folder picker and held a private channel open, for exactly the reason quoted in its own comment. That is now one pool every consumer shares, and the picker keeps only the part that was ever picker-specific.

**Batched refresh** — a reload names every directory the tree is showing in one `fs.list` and grafts the answers onto the nodes already there, so an open folder keeps its node and its subtree instead of re-fetching a level at a time.

**SIGPIPE** — a one-shot channel could barely write into a hung-up pipe; a pooled one is held across a sleeping laptop and a reaped master, so the transport now sets `SO_NOSIGPIPE`/`F_SETNOSIGPIPE` the way `SessionControl.swift` already did. Without it, the default disposition kills the app.

**Retry once** — a request that lost a channel it *inherited*, before the host said anything at all, reconnects instead of surfacing an error on the first click after a break. Deliberately narrow: never a channel this caller opened, and never once a frame has landed, because replaying half a file is not a file.

**Cancelling an abandoned search** — pooling took away the only thing that stopped a `git grep` the client had given up on. A channel that lived for one request stopped one by hanging up; the host's `run_search` watches `out.closed()` for exactly that, and that arm (added in #459) is why a timed-out query did not leave a process walking someone's checkout. A pooled channel never hangs up, so the grep kept running and streaming frames into an inbox that no longer existed.

The replacement is the protocol's own `cancel { request: <seq> }` — and it is the one fix here that only became *possible* because of the multiplexing. On a synchronous channel the caller is blocked reading the very descriptor it would have to write to; on a pooled one the cancel goes out on the same channel while the read is still in flight. A streaming request is armed once it is on the wire and disarmed by the host's terminal reply, so every other exit — the idle bound, a lost pipe, a thrown decode — retires the request by cancelling it.

## Constraints

- **Anti-100×** — nothing here touches the byte path.
- **Never behind an attachment** — a pooled channel is its own connection with role `control`, keyed by route and capabilities, never a session's attach channel. And not serialised within itself: a slow `git grep` does not hold up the folder expand beside it.
- **No embedded SSH or crypto** — the pool holds a pipe `Transport.open` produced and knows nothing about keys or hosts.
- **One protocol** — no new op, no version bump, no daemon change.

## From Zed

Read `crates/remote/`. `RemoteClient` keeps one `ControlMaster=yes -N` master plus one proxy child running `binary proxy --identifier <id>`, and multiplexes every RPC over that child's stdio with `next_message_id` and a `responding_to` field routing replies through `response_channels`. That shape is exactly what transfers, and termio's protocol already had the field for it.

What does not transfer: Zed's 5 s heartbeat with a `HeartbeatMissed → Reconnecting` state machine and message replay, which exists because a Zed remote session holds editor state that must survive a reconnect. The files plane holds none — a request is idempotent and cheap — so an idle reaper plus one narrow retry covers the same ground without a state machine. Its worktree scanner does not transfer either: Zed streams `UpdateWorktree` from a background scanner for the *project*, but its own remote directory picker (`handle_list_remote_directory`) is per-request, like this.

## Deliberately not here

**Speculative prefetch.** With a pooled channel one expand is a single ~8 ms round trip, and prefetching a wide directory's children would trade deterministic traffic for speculative traffic. The `list(_ paths:)` seam is there if it turns out to be wanted.

**`resources` / `fs_watch`.** Live tree updates need a channel that outlives a request, which now exists, and a tree that applies deltas, which does not. `fs_listed` already carries the `fs:` cursor as a freshness proof, so the groundwork is on the wire. That is a feature, not this.

## Review

Codex reviewed this and found the abandoned-grep regression above, a request deadline computed monotonically but waited on as a wall-clock `Date` (now waited in slices that re-test the monotonic bound), and two tests that passed without pinning their claim. All four are fixed in the second commit; the PR text above has been corrected where it stated something the tests did not actually hold.

## Testing

`swift test` — 686 tests, 0 failures, with `TERMIO_TERMIOD_TEST_BIN` pointed at a real `termiod` so the files integration suite runs rather than skips.

New, on pure logic: reply routing (`re`, the `F` chunk header, `search_results.request`), and the refresh graft — what a reload asks for, an open folder keeping its subtree, a path that changed kind being rebuilt, a refused path keeping its rows, a vanished folder being pruned.

New, against a real daemon: channel reuse, capability keying, and three that are worth describing precisely, because two earlier versions of them passed without pinning anything.

- **An abandoned search stops the device's grep.** Asserted on the *host's* record, not the client's return: the fixture writes its completion marker only if it runs its full ten seconds, so a client that merely gave up cannot produce a pass.
- **A slow search does not hold up the rest of the channel.** The discriminator is *when* the fast requests finish. A serialised channel would answer all three correctly and simply make the listing wait, so the assertion is that the listing and the read both land more than two seconds before a four-second search finishes.
- **The retry policy's three gates** — inherited channel, connection loss rather than refusal, nothing delivered yet — driven through the real `withPooledRequest` with a body that fails on cue.

Both of the first two were checked by reintroducing the defect and watching them fail: with the cancel removed, one grep is still running; with a lock forcing serialisation, the listing lands 3 ms *after* the search instead of 2 s before.

Search timing comes from a `git` shim on the daemon's PATH, because real `git grep` answers 133 MB of text in 40 ms — a fixture built out of file count could not make a search slow enough to abandon on purpose. The shim delegates to real `git` unless a test arms it, so every search test that wants a real answer still gets one.

A separate note on what the daemon-restart test proves: killing a daemon gives the reader a clean EOF, so the dead channel is replaced before the next request asks for one. That test pins recovery after a restart, **not** retry-on-an-inherited-dead-channel — which is why the retry policy is tested directly instead.

## Notes

#459 and #462 both landed while this was in flight, so it is now rebased straight onto `main` and stacks on nothing. `readFile` returning `DeviceFile` (from #462's remote save) is carried through the pooled shape; the upload plane it saves over is untouched.

Release Notes:
- Browsing and opening files on another machine is much faster. termio now holds one connection per device instead of opening a new one for every folder, file and search, and refreshes the whole tree in a single request.
