### PR TITLE
Snap the file tree hover highlight instead of fading it

### DIFF
--- a/Sources/termio/FileBrowser/FileTreeList.swift
+++ b/Sources/termio/FileBrowser/FileTreeList.swift
@@ -206,7 +206,10 @@ private struct FileRow: View {
             .padding(.leading, -6)
             .animation(.easeInOut(duration: 0.12), value: isSelected)
             .animation(.easeInOut(duration: 0.12), value: isTargeted)
-            .animation(.easeInOut(duration: 0.12), value: isHovering)
+            // No animation on hover: a fade is latency on a cue whose job is to track
+            // the cursor. At 120ms over a 0.10-alpha wash the highlight only landed
+            // once the pointer had already left the row.
+            .animation(nil, value: isHovering)
         )
         // Right-click menu via an AppKit `NSMenu`, NOT SwiftUI's `.contextMenu` —
         // the latter paints an accent highlight ring around the targeted row that


### PR DESCRIPTION
The file tree's row hover ran through a 120ms ease-in-out fade, on a highlight
that is only a 0.10-alpha accent wash to begin with. Sweeping the tree, the
highlight landed after the pointer had already left the row while the previous
row was still fading out — a smear rather than a cue that follows the cursor.
Hover now paints on the next frame; selection and the folder drop target keep
their 120ms, since those are state changes rather than pointer tracking.

Release Notes:
- Fixed the file tree's hover highlight lagging behind the pointer.