### PR TITLE
Reopen a file when its already-selected row is clicked

### DIFF
--- a/Sources/termio/FileBrowser/FileBrowserState.swift
+++ b/Sources/termio/FileBrowser/FileBrowserState.swift
@@ -6,11 +6,35 @@ import Foundation
 /// writes it) and the hosting controller (which reads it to feed Quick Look). Held
 /// as its own object so the controller can answer `QLPreviewPanel`'s data-source
 /// callbacks without reaching into SwiftUI's view state.
+///
+/// An `NSObject` so it can also be the outline view's action target — see `rowClicked`.
 @MainActor
-final class FileBrowserState: ObservableObject {
+final class FileBrowserState: NSObject, ObservableObject {
     @Published var selection: URL?
     /// The `NSOutlineView` backing the tree, captured by `FileTreeList` so
     /// `FileBrowserView` can expand a folder on the click that selected it. Not
     /// `@Published` — it's an AppKit escape hatch, not view state.
     weak var outlineView: NSOutlineView?
+
+    /// Every primary click on a row, including one landing on the row already selected.
+    /// That click publishes nothing through the `selection` binding — nothing changed —
+    /// yet it is the one a tree must honour: VS Code and Zed leave a row selected after
+    /// its editor closes and re-open the file when you click it again.
+    ///
+    /// The outline view's own action is the only way to see it; a click recognizer on the
+    /// row never gets the event, because `NSOutlineView` runs a tracking loop in
+    /// `mouseDown`. That is also why selection has been serving as the tree's click handler.
+    let rowClicked = PassthroughSubject<Void, Never>()
+
+    /// Points `outline`'s action at this object, re-asserted on every row update (see
+    /// `FileBrowserView`'s `captureOutline`) so a rebuilt list is wired the turn it appears.
+    func observeClicks(on outline: NSOutlineView) {
+        guard outline.target !== self else { return }
+        outline.target = self
+        outline.action = #selector(outlineViewClicked)
+    }
+
+    @objc private func outlineViewClicked() {
+        rowClicked.send()
+    }
 }

--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -172,8 +172,9 @@ struct FileBrowserView: View {
         .onChange(of: browserState.selection) {
             // The table fires native selection on a clean click — reliably, unlike a
             // click recognizer, which `NSOutlineView`'s own primary-button tracking
-            // swallows. So selection IS the click handler: a file opens, a folder opens
-            // (expands). Collapse stays on the disclosure triangle.
+            // swallows. So a selection *change* opens: a file opens, a folder opens
+            // (expands). Collapse stays on the disclosure triangle. This is also what
+            // carries an arrow-key walk through the tree, which sends no click at all.
             if let url = browserState.selection {
                 if isDirectory(url) {
                     toggleSelectedFolder()
@@ -186,6 +187,23 @@ struct FileBrowserView: View {
                 QLPreviewPanel.shared().reloadData()
             }
         }
+        .onReceive(browserState.rowClicked) { activateClickedRow() }
+    }
+
+    /// Opens the file under a click the selection binding cannot report: re-clicking the
+    /// already-selected row changes no selection, so nothing publishes. That is how you
+    /// re-open a file you just closed — closing the detail leaves the row selected, as it
+    /// does in VS Code and Zed, the highlight marking where you are rather than what is
+    /// open — and without this the row stays dead until some other row is clicked first.
+    private func activateClickedRow() {
+        // `clickedRow` is only meaningful during the action send `rowClicked` is delivering.
+        // -1 is the empty area below the rows, which must not re-open what is still selected.
+        guard let outline = browserState.outlineView, outline.clickedRow >= 0 else { return }
+        // Folders belong to the selection handler, which toggles and then clears. Skipping a
+        // file that is already open is both the Zed/VS Code no-op and what stops a click that
+        // *did* move the selection from being opened twice, once down each path.
+        guard let url = browserState.selection, !isDirectory(url), store.openFileURL != url else { return }
+        onActivate(url)
     }
 
     /// Toggle (expand/collapse) the folder whose row was just selected, on the native
@@ -297,7 +315,10 @@ struct FileBrowserView: View {
                 onDrop: { sources, destination in receive(sources, into: destination) },
                 rootURL: root.url,
                 actions: treeActions,
-                captureOutline: { browserState.outlineView = $0 }
+                captureOutline: { outline in
+                    browserState.outlineView = outline
+                    if let outline { browserState.observeClicks(on: outline) }
+                }
             )
             .onKeyPress(.space) {
                 guard browserState.selection != nil else { return .ignored }


### PR DESCRIPTION
The file tree had no click handler: a change to the `selection` binding stood in
for one, because `NSOutlineView` runs a tracking loop in `mouseDown` and never
lets a click recognizer see the event. Closing a detail leaves the row selected,
so clicking that same row again changed no selection, published nothing, and the
row was dead until some other row was clicked first. Opening a diff or a PR
detail clears `openFileURL` too, which left the same row dead the same way.

The outline view's own action does fire on every primary click, including one on
the already-selected row, so `FileBrowserState` now serves as its action target
and republishes it as `rowClicked`. Selection keeps driving the tree for a real
selection change, which is what an arrow-key walk sends.

The row stays selected after its editor closes, as it does in VS Code and Zed:
the highlight marks where you are in the tree, not what happens to be open.
Clicking a file that is already open stays a no-op there and here.

Release Notes:
- Fixed a file in the tree not reopening when you clicked it again after closing it.