### PR TITLE
Stop rebuilding the file detail on every flip

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -97,16 +97,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var overlayObserver: AnyCancellable?
     // Drives the same host straight off the maximize flag, synchronously (see
     // `store.inspectorMaximizedDidChange`), so the handoff to and from the full-window
-    // host lands in the frame the docked detail leaves in.
+    // position lands in the frame the flag flips in.
     private var maximizeObserver: AnyCancellable?
     // Un-collapses the inspector when the user opens a detail (see `store.detailDidOpen`).
     private var detailOpenObserver: AnyCancellable?
     // Previous maximize state, so the observer re-binds the tracking separator on the restore
-    // transition (tearing down the full-window host relayouts the inspector) and not every tick.
+    // transition (handing the host back relayouts the inspector) and not every tick.
     private var detailWasMaximized = false
-    // The full-window host that shows the active inspector detail blown up to cover everything
-    // while `store.inspectorMaximized`; nil when the detail is docked in the inspector.
-    private var maximizedDetailHost: NSHostingView<AnyView>?
+    // Whether `DetailHost.shared` is currently parented here, covering the content area, rather
+    // than docked in the inspector's slot.
+    private var detailMaximized = false
+    // The full-window pins, held so they can be dropped when the host goes back to the inspector.
+    private var maximizedDetailConstraints: [NSLayoutConstraint] = []
     // Whether maximizing is what collapsed the navigator, so restoring re-opens only a sidebar
     // this mode closed — never one the user had already put away.
     private var sidebarCollapsedForMaximize = false
@@ -305,9 +307,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // A detail (file editor, diff, PR/issue) opens in the right inspector, beside the
         // terminal. Its own window controls (hide list / maximize / close) live *in* the detail's
         // header now (see `InspectorDetailChromeButtons`), not the toolbar — so this observer only
-        // mounts and tears down the full-window maximize host. It catches the presentation half of
-        // the state (a detail closing out from under a maximized host); the flag's own half is the
-        // synchronous observer above.
+        // moves the shared host and drops it once nothing is open. It catches the presentation half
+        // of the state (a detail closing out from under a maximized host); the flag's own half is
+        // the synchronous observer above.
         // `objectWillChange` fires before the value lands, so read the settled state next runloop.
         overlayObserver = store.objectWillChange
             .receive(on: RunLoop.main)
@@ -315,6 +317,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 MainActor.assumeIsolated {
                     guard let self else { return }
                     self.applyDetailMaximized(self.store.inspectorMaximized && self.store.isDetailPresented)
+                    // Nothing left to render: let the host go rather than keep a document's editor
+                    // (and its web view) alive behind a closed inspector.
+                    if !self.store.isDetailPresented { DetailHost.shared.discard() }
                 }
             }
 
@@ -1239,34 +1244,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
-    /// Mounts (or removes) the full-window host that shows the active inspector detail blown up to
-    /// cover the content area — an in-window maximize, *not* native macOS fullscreen: the window
-    /// stays put in its Space and the menu bar stays visible. The navigator collapses with it, so
-    /// "fill the window" means the window rather than the window minus a column of chrome; re-open
-    /// it (View menu) and the host slides with it, since its leading edge tracks the split.
-    /// `InspectorDetailContent` is the same view the inspector docks; while it is up the inspector
-    /// hides its own copy (see `InspectorRoot`), so the detail renders once. The toolbar goes with
-    /// the sidebar (see `syncMaximizedChrome`); restore and close ride the detail's own header, and
-    /// Esc still closes.
+    /// Moves the shared detail host between the inspector's slot and the whole content area — an
+    /// in-window maximize, *not* native macOS fullscreen: the window stays put in its Space and the
+    /// menu bar stays visible. The navigator collapses with it, so "fill the window" means the
+    /// window rather than the window minus a column of chrome; re-open it (View menu) and the host
+    /// slides with it, since its leading edge tracks the split. The toolbar goes with the sidebar
+    /// (see `syncMaximizedChrome`); restore and close ride the detail's own header, and Esc still
+    /// closes.
+    ///
+    /// The host is *moved*, never rebuilt (see `DetailHost`): each direction is one `addSubview`
+    /// that re-parents it inside the same window, so the open document crosses the transition
+    /// untouched. No geometry animation, deliberately — the terminal cannot be resized to make
+    /// room (a maximized detail covers it so the panes never take a SIGWINCH, see `TerminalPane`),
+    /// so this is the same rect change that reads as a zoom for a split pane.
     private func setDetailMaximized(_ on: Bool) {
-        guard let container = splitViewController?.view else { return }
+        guard let container = splitViewController?.view, on != detailMaximized else { return }
+        detailMaximized = on
         if on {
-            guard maximizedDetailHost == nil else { return }
-            // Measure the traffic lights rather than assuming their layout: the header runs up into
-            // the titlebar, and where the buttons end (plus a gap) is where its title may start.
-            let buttonsEnd = window?.standardWindowButton(.zoomButton)?.frame.maxX ?? 70
-            let host = NSHostingView(rootView: AnyView(
-                // The header's own leading padding supplies the gap after the buttons.
-                MaximizedDetailContent(trafficLightsInset: buttonsEnd)
-                    .environmentObject(store)
-                    .environmentObject(settings)
-            ))
-            // No SwiftUI-derived sizing constraints: the host is pinned to the content area
-            // below, and the default `.standardBounds` options let auto layout satisfy the
-            // root view's ideal size by resizing the *window* — the just-closed detail is an
-            // EmptyView (ideal height 0) for the one runloop before this host is torn down,
-            // which crushed the whole window to a ~90pt strip.
-            host.sizingOptions = []
+            let host = DetailHost.shared.view(store: store, settings: settings, window: window)
+            NSLayoutConstraint.deactivate(maximizedDetailConstraints)
             host.translatesAutoresizingMaskIntoConstraints = false
             container.addSubview(host, positioned: .above, relativeTo: nil)
             // Pin the leading edge to the *content* area (the terminal/inspector region), not the
@@ -1278,13 +1274,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             let contentLeading = items.count > 1
                 ? items[1].viewController.view.leadingAnchor
                 : container.leadingAnchor
-            NSLayoutConstraint.activate([
+            maximizedDetailConstraints = [
                 host.leadingAnchor.constraint(equalTo: contentLeading),
                 host.trailingAnchor.constraint(equalTo: container.trailingAnchor),
                 host.topAnchor.constraint(equalTo: container.topAnchor),
                 host.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-            ])
-            maximizedDetailHost = host
+            ]
+            NSLayoutConstraint.activate(maximizedDetailConstraints)
             // "Fill the window" means the whole window: the navigator steps aside with the toolbar
             // and comes back on restore. Leaving it up would keep a column of chrome beside a
             // detail the user just asked to blow up — and its own controls (workspace, sort, `+`)
@@ -1295,8 +1291,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
             syncMaximizedChrome()
         } else {
-            maximizedDetailHost?.removeFromSuperview()
-            maximizedDetailHost = nil
+            maximizedDetailConstraints = []
+            // Straight back into the inspector's slot, which stayed mounted for exactly this.
+            // Without one — the detail closed while maximized — there is nowhere to go and the
+            // host is on its way out anyway (see the `isDetailPresented` half of the observer).
+            if let slot = DetailHost.shared.dockedSlot {
+                DetailHost.shared.dock(in: slot)
+            } else {
+                DetailHost.shared.view?.removeFromSuperview()
+            }
             // Only re-open what maximizing closed. A sidebar the user collapsed themselves — before
             // maximizing, or while the detail was up — stays collapsed.
             if sidebarCollapsedForMaximize {
@@ -1304,8 +1307,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 sidebarSplitItem?.isCollapsed = false
             }
             syncMaximizedChrome()
-            // Removing the host re-exposes the terminal, but a tickless surface won't repaint
-            // itself — nudge it so a switch out of a maximized detail can't leave a blank.
+            // Uncovering the content area re-exposes the terminal, but a tickless surface won't
+            // repaint itself — nudge it so a switch out of a maximized detail can't leave a blank.
             store.repaintSelectedSurface()
         }
     }
@@ -1324,7 +1327,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// already matches, because re-asserting visibility churns the tracking separators.
     private func syncMaximizedChrome() {
         guard let window, let toolbar = window.toolbar else { return }
-        let hidesToolbar = maximizedDetailHost != nil && sidebarSplitItem?.isCollapsed == true
+        let hidesToolbar = detailMaximized && sidebarSplitItem?.isCollapsed == true
         guard toolbar.isVisible == hidesToolbar else { return }
         toolbar.isVisible = !hidesToolbar
         // A hidden toolbar stops laying out, so its custom views come back measured against stale

--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -68,6 +68,12 @@ struct FileEditorView: View {
     /// empty placeholder.
     @State private var loaded = false
     @State private var loadFailed = false
+    /// Which faces have been visited. Both stay mounted afterwards (see `editorContent`), but
+    /// neither is built before it is first asked for.
+    @State private var mountedEditor = false
+    @State private var mountedReader = false
+    /// What Preview renders — the buffer as of the last flip into Preview, not the live one.
+    @State private var previewSource = ""
     /// Set when the file is too large for syntax highlighting (see `highlightByteLimit`).
     @State private var highlightDisabled = false
     @State private var saveError: String?
@@ -202,6 +208,10 @@ struct FileEditorView: View {
         // titlebar — no outer `.frame`, which was reserving an empty band above the header.
         .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
         .task { await load() }
+        // Keyed to the load as well as the mode, because the mode is chosen in `init` — before
+        // there is any text to render.
+        .onChange(of: mode, initial: true) { activateMode() }
+        .onChange(of: loaded) { activateMode() }
         .onReceive(NotificationCenter.default.publisher(for: .termioShowFindBar)) { _ in
             openFindBar()
         }
@@ -234,21 +244,51 @@ struct FileEditorView: View {
 
     /// The scrolling body — the Markdown reader in Preview, else the Highlightr source editor. It
     /// scrolls below the fixed header; the source editor also carries the right-click "Close".
+    ///
+    /// Both faces stay mounted once visited; the flip only changes which one shows. An `if`/`else`
+    /// here is a structural branch, so SwiftUI rebuilt one side on every flip — a fresh `WKWebView`
+    /// and page load one way, a whole-document re-highlight and TextKit re-layout the other.
     @ViewBuilder private var editorContent: some View {
+        let showsReader = isMarkdown && mode == .preview
+        ZStack {
+            if mountedReader {
+                // `previewSource`, not `text`: a reader that outlives its own visibility would
+                // re-render the whole document into a hidden web view on every keystroke.
+                MarkdownReaderView(
+                    source: previewSource,
+                    fileURL: url,
+                    settings: settings,
+                    colorScheme: colorScheme,
+                    addToChat: addToChat,
+                    canAddToChat: canAddToChat,
+                    isActive: showsReader
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .allowsHitTesting(showsReader)
+            }
+            if mountedEditor {
+                sourceEditor(isActive: !showsReader)
+                    .allowsHitTesting(!showsReader)
+            }
+        }
+    }
+
+    /// Mounts the face the mode names and hands Preview the current buffer. Only the flip refreshes
+    /// it, so typing in Edit never renders a document nobody is looking at.
+    private func activateMode() {
+        guard loaded else { return }
         if isMarkdown && mode == .preview {
-            // Render the *live* buffer, so flipping over from Edit shows unsaved keystrokes
-            // without a round-trip through disk.
-            MarkdownReaderView(
-                source: text,
-                fileURL: url,
-                settings: settings,
-                colorScheme: colorScheme,
-                addToChat: addToChat,
-                canAddToChat: canAddToChat
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            previewSource = text
+            mountedReader = true
         } else {
-            HighlightedTextView(
+            mountedEditor = true
+        }
+    }
+
+    /// The Highlightr source editor with its find bar. Split out so `editorContent` reads as the
+    /// two faces it switches between.
+    private func sourceEditor(isActive: Bool) -> some View {
+        HighlightedTextView(
                 text: $text,
                 language: highlightDisabled ? nil : language,
                 theme: colorScheme == .dark ? "xcode-dark" : "xcode",
@@ -267,27 +307,28 @@ struct FileEditorView: View {
                     findMatchCount = count
                     if count > 0, findFocusedIndex >= count { findFocusedIndex = 0 }
                 },
-                showsCloseMenuItem: true,
-                addToChat: addToChat,
-                canAddToChat: canAddToChat,
-                onSave: saveNow
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .overlay(alignment: .topTrailing) {
-                if findBarVisible {
-                    FileFindBar(
-                        query: $findQuery,
-                        options: $findOptions,
-                        currentMatch: findMatchCount == 0 ? 0 : findFocusedIndex + 1,
-                        totalMatches: findMatchCount,
-                        onSubmit: submitFind,
-                        onNext: { advanceFind(by: 1) },
-                        onPrevious: { advanceFind(by: -1) },
-                        onClose: closeFindBar,
-                        focusTrigger: findFocusTrigger
-                    )
-                    .transition(.move(edge: .trailing).combined(with: .opacity))
-                }
+            showsCloseMenuItem: true,
+            addToChat: addToChat,
+            canAddToChat: canAddToChat,
+            isActive: isActive,
+            onSave: saveNow
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay(alignment: .topTrailing) {
+            // Gated on `isActive` too: a dormant editor must not leave a bar floating over Preview.
+            if findBarVisible, isActive {
+                FileFindBar(
+                    query: $findQuery,
+                    options: $findOptions,
+                    currentMatch: findMatchCount == 0 ? 0 : findFocusedIndex + 1,
+                    totalMatches: findMatchCount,
+                    onSubmit: submitFind,
+                    onNext: { advanceFind(by: 1) },
+                    onPrevious: { advanceFind(by: -1) },
+                    onClose: closeFindBar,
+                    focusTrigger: findFocusTrigger
+                )
+                .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
     }

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -42,6 +42,10 @@ struct HighlightedTextView: NSViewRepresentable {
     /// is read at menu-open time, so a plain-shell session shows no item.
     var addToChat: ((String?) -> Void)? = nil
     var canAddToChat: (() -> Bool)? = nil
+    /// Whether this is the face on screen. Markdown keeps the editor mounted behind Preview
+    /// (rebuilding it re-highlights the whole document), so a dormant editor hides itself and
+    /// never claims focus. Non-Markdown files only ever have this face, hence the default.
+    var isActive: Bool = true
     /// Invoked when the user presses ⌘S — flushes the buffer to disk immediately.
     let onSave: () -> Void
 
@@ -90,8 +94,11 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-        textView.string = text
+        // Metrics before content, and the content carrying them: `string =` inserts unstyled text,
+        // which TextKit lays out at the font's *natural* line height — the configured leading then
+        // arrived with the async highlight and every line grew at once, the jolt on opening a file.
         apply(to: textView)
+        storage.setAttributedString(NSAttributedString(string: text, attributes: baseAttributes))
 
         let scrollView = NSScrollView()
         scrollView.documentView = textView
@@ -125,14 +132,9 @@ struct HighlightedTextView: NSViewRepresentable {
         scrollView.contentView.postsBoundsChangedNotifications = true
         context.coordinator.observeScroll(of: scrollView)
 
-        // Claim first responder once the editor is in a window, so the Edit menu's Cut/Copy/Paste
-        // (and typing) act on this buffer instead of the terminal surface that held focus beneath
-        // the overlay. The terminal focus driver won't fight back — its `canFocus` bails while a
-        // file is open (see `requestTerminalFocus`).
-        DispatchQueue.main.async { [weak textView] in
-            guard let textView, let window = textView.window else { return }
-            window.makeFirstResponder(textView)
-        }
+        scrollView.isHidden = !isActive
+        context.coordinator.wasActive = isActive
+        if isActive { Self.claimFocus(textView) }
 
         // Reveal the requested line once the view has a real frame — at make time it hasn't been
         // laid out, so scrolling now would land nowhere.
@@ -147,8 +149,24 @@ struct HighlightedTextView: NSViewRepresentable {
         return scrollView
     }
 
+    /// Claims first responder so the Edit menu's Cut/Copy/Paste (and typing) act on this buffer
+    /// instead of the terminal surface beneath the overlay. Deferred because a view being made is
+    /// not yet in a window, and re-checked on arrival: by then Preview may have taken the screen,
+    /// and a hidden text view must not hold focus.
+    private static func claimFocus(_ textView: NSTextView) {
+        DispatchQueue.main.async { [weak textView] in
+            guard let textView, !textView.isHiddenOrHasHiddenAncestor,
+                  let window = textView.window else { return }
+            window.makeFirstResponder(textView)
+        }
+    }
+
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? SavingTextView else { return }
+        if scrollView.isHidden == isActive { scrollView.isHidden = !isActive }
+        // Focus follows the flip, not the mount (see `claimFocus`).
+        if isActive, !context.coordinator.wasActive { Self.claimFocus(textView) }
+        context.coordinator.wasActive = isActive
         // Refresh the save closure each update so ⌘S always flushes the latest buffer (the closure
         // captures the view's current state, which SwiftUI re-creates on every change).
         textView.onSave = onSave
@@ -187,6 +205,12 @@ struct HighlightedTextView: NSViewRepresentable {
                 highlightr.theme.codeParagraphStyle = Self.paragraphStyle(font: font, lineSpacing: lineSpacing)
                 highlightr.theme.codeBaselineOffset = Self.baselineOffset(lineSpacing: lineSpacing)
             }
+            // Re-lay out on the new metrics now rather than when the async pass returns, so a font
+            // or line-height change moves the text once instead of twice. `addAttributes` merges,
+            // leaving the colors already on screen alone until the re-highlight replaces them.
+            if storage.length > 0 {
+                storage.addAttributes(baseAttributes, range: NSRange(location: 0, length: storage.length))
+            }
             storage.language = language
         }
 
@@ -197,7 +221,10 @@ struct HighlightedTextView: NSViewRepresentable {
         // throws the caret to the end of the document on any unrelated SwiftUI re-render.
         if textView.string != text, !textView.hasMarkedText() {
             let selection = textView.selectedRange()
-            textView.string = text
+            // Carrying the metrics for the same reason `makeNSView` does: a bare `string =` drops
+            // to the natural line height until the async highlight returns, so an external change
+            // would make the document jump.
+            storage.setAttributedString(NSAttributedString(string: text, attributes: baseAttributes))
             let length = (text as NSString).length
             let location = min(selection.location, length)
             textView.setSelectedRange(
@@ -256,6 +283,19 @@ struct HighlightedTextView: NSViewRepresentable {
         return leading + baselineOffset(lineSpacing: lineSpacing)
     }
 
+    /// The layout metrics every glyph carries from its first frame: the code face, the fixed line
+    /// box, and the centering lift. Highlightr's theme is configured with exactly these, so its
+    /// pass swaps colors onto text that already sits where it belongs and nothing reflows. They
+    /// also stand alone — a file past `highlightByteLimit`, or in a language hljs doesn't know,
+    /// never gets a highlight pass at all.
+    private var baseAttributes: [NSAttributedString.Key: Any] {
+        [
+            .font: font,
+            .paragraphStyle: Self.paragraphStyle(font: font, lineSpacing: lineSpacing),
+            .baselineOffset: Self.baselineOffset(lineSpacing: lineSpacing),
+        ]
+    }
+
     private func apply(to textView: NSTextView) {
         // `NSText.font` is a whole-document setter — assigning it stamps the plain face over
         // every glyph, wiping the bold/italic variants the markdown highlight applied (invisible
@@ -300,6 +340,9 @@ struct HighlightedTextView: NSViewRepresentable {
         var appliedLanguage: String?
         /// The last jump target acted on, so `updateNSView` only re-scrolls on a genuine new hit.
         var appliedJumpLine: Int?
+        /// Previous `isActive`, so focus is claimed on the flip back to Edit rather than on every
+        /// update pass — re-asserting it would fight the find bar.
+        var wasActive = false
         weak var ruler: LineNumberRulerView?
         var onMatchesChanged: ((Int) -> Void)?
         private let text: Binding<String>

--- a/Sources/termio/Editor/MarkdownReaderView.swift
+++ b/Sources/termio/Editor/MarkdownReaderView.swift
@@ -21,42 +21,85 @@ struct MarkdownReaderView: View {
     /// argument is the reader's selected text, `nil` when nothing is selected.
     var addToChat: ((String?) -> Void)? = nil
     var canAddToChat: (() -> Bool)? = nil
+    /// Whether Preview is the face on screen. The reader stays mounted while Edit shows, so
+    /// anything that costs something — claiming focus, drawing diagrams — keys off this rather
+    /// than off being alive.
+    var isActive: Bool = true
 
     /// Rendered mermaid diagrams, filled in by the task below. Drawing one needs a DOM and
     /// is therefore asynchronous, so the document renders immediately with its diagrams as
     /// source and re-renders once they arrive — the reader already restores scroll across
     /// a re-render, so the swap is where you were looking.
     @State private var diagrams: [String: String] = [:]
+    /// Memo for the render below: now that the reader outlives its own visibility, this body runs
+    /// on every keystroke in the editor beside it, and building the page is not cheap.
+    @State private var cache = RenderCache()
 
     var body: some View {
         let theme = DocumentTheme.resolveReader(settings: settings, colorScheme: colorScheme)
         let mermaidTheme = MermaidRenderer.Theme(theme)
-        let document = MarkdownReaderRenderer.document(
-            source, theme: theme, fontFamily: settings.fontFamily)
-        let sources = MermaidRenderer.sources(in: document)
         // Anything already drawn goes into the first pass, so reopening a file or flipping
         // the theme back shows its diagrams without a flash of source.
         let drawn = diagrams.merging(
-            MermaidRenderer.shared.cachedDiagrams(for: sources, theme: mermaidTheme)) { _, new in new }
+            MermaidRenderer.shared.cachedDiagrams(for: cache.sources, theme: mermaidTheme)) { _, new in new }
+        let key = RenderCache.Key(source: source, theme: theme, fontFamily: settings.fontFamily,
+                                  drawn: Set(drawn.keys))
+        let html = cache.refresh(key: key, drawn: drawn)
         // Relative image paths (`![](./shot.png)`) resolve against the file's own folder.
         MarkdownReaderWebView(
-            html: MermaidRenderer.applying(drawn, to: document),
+            html: html,
             baseURL: fileURL.deletingLastPathComponent(),
             fileURL: fileURL,
             addToChat: addToChat,
-            canAddToChat: canAddToChat
+            canAddToChat: canAddToChat,
+            isActive: isActive
         )
-        .task(id: DiagramRequest(sources: sources, theme: mermaidTheme)) {
-            guard !sources.isEmpty else { return }
-            diagrams = await MermaidRenderer.shared.diagrams(for: sources, theme: mermaidTheme)
+        .task(id: DiagramRequest(sources: cache.sources, theme: mermaidTheme, active: isActive)) {
+            guard isActive, !cache.sources.isEmpty else { return }
+            diagrams = await MermaidRenderer.shared.diagrams(for: cache.sources, theme: mermaidTheme)
         }
     }
 
-    /// What a render depends on: change either the diagrams or the colors and the task
-    /// runs again; type anything else in the editor and it doesn't.
+    /// What a render depends on: change the diagrams or the colors and the task runs again. It
+    /// carries `active` so a document hidden mid-draw finishes drawing on the flip back.
     private struct DiagramRequest: Equatable {
         let sources: [String]
         let theme: MermaidRenderer.Theme
+        let active: Bool
+    }
+
+    /// The rendered page, held across body evaluations so Markdown → HTML, the mermaid scan and
+    /// the diagram substitution are redone only for inputs that moved. A class so `body` can fill
+    /// it without invalidating the view it is already rendering; nothing here is observed.
+    @MainActor
+    private final class RenderCache {
+        struct Key: Equatable {
+            let source: String
+            let theme: DocumentTheme
+            let fontFamily: String
+            /// Which diagrams are drawn, not their SVG bodies — a source renders to the same
+            /// picture unless the theme changes, and the theme is already in this key.
+            let drawn: Set<String>
+        }
+
+        private(set) var sources: [String] = []
+        private var html = ""
+        private var key: Key?
+        /// The page before diagram substitution, so arriving diagrams don't re-parse the Markdown.
+        private var document = ""
+
+        /// The page for these inputs, rebuilt only for the stages whose inputs actually moved.
+        func refresh(key new: Key, drawn: [String: String]) -> String {
+            guard key != new else { return html }
+            if key?.source != new.source || key?.theme != new.theme || key?.fontFamily != new.fontFamily {
+                document = MarkdownReaderRenderer.document(
+                    new.source, theme: new.theme, fontFamily: new.fontFamily)
+                sources = MermaidRenderer.sources(in: document)
+            }
+            key = new
+            html = MermaidRenderer.applying(drawn, to: document)
+            return html
+        }
     }
 }
 
@@ -70,6 +113,9 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
     let fileURL: URL
     var addToChat: ((String?) -> Void)?
     var canAddToChat: (() -> Bool)?
+    /// Whether this is the face on screen. A dormant reader is hidden rather than unmounted, and
+    /// must never take focus (see `claimFocus`).
+    var isActive: Bool
 
     /// `loadHTMLString` pages get no filesystem access in the WebContent process, so a
     /// `file://` image would silently 404 (same reason the reader fonts are embedded as
@@ -99,17 +145,30 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
         view.canAddToChat = canAddToChat
         view.setValue(false, forKey: "drawsBackground")
         view.navigationDelegate = context.coordinator
+        view.isHidden = !isActive
+        context.coordinator.wasActive = isActive
         view.loadHTMLString(html, baseURL: schemeBaseURL)
-        // Take first responder off the terminal surface beneath the overlay so ⌘C copies the
-        // reader's selection (the Edit menu's Copy routes to whoever holds focus).
-        DispatchQueue.main.async { [weak view] in
-            guard let view, let window = view.window else { return }
-            window.makeFirstResponder(view)
-        }
+        if isActive { claimFocus(view) }
         return view
     }
 
+    /// Takes first responder off the terminal surface beneath the overlay so ⌘C copies the
+    /// reader's selection (the Edit menu's Copy routes to whoever holds focus). Deferred because a
+    /// view being made is not yet in a window, and re-checked on arrival: by then the mode may have
+    /// flipped back, and a hidden view must not hold focus.
+    private func claimFocus(_ view: WKWebView) {
+        DispatchQueue.main.async { [weak view] in
+            guard let view, !view.isHidden, let window = view.window else { return }
+            window.makeFirstResponder(view)
+        }
+    }
+
     func updateNSView(_ view: WKWebView, context: Context) {
+        if view.isHidden == isActive { view.isHidden = !isActive }
+        // Focus follows the flip, not the mount: the reader claims it each time Preview becomes
+        // the visible face, and never while it is the dormant one.
+        if isActive, !context.coordinator.wasActive { claimFocus(view) }
+        context.coordinator.wasActive = isActive
         guard context.coordinator.lastHTML != html else { return }
         context.coordinator.lastHTML = html
         // Restore the reader's scroll offset after the new content lays out, so re-rendering
@@ -127,6 +186,9 @@ private struct MarkdownReaderWebView: NSViewRepresentable {
         var lastHTML: String
         var savedScrollY: CGFloat = 0
         var restoreScroll = false
+        /// Previous `isActive`, so focus is claimed on the transition into Preview rather than on
+        /// every update pass — re-asserting it would fight the find bar and the terminal.
+        var wasActive = false
         init(lastHTML: String) { self.lastHTML = lastHTML }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/Sources/termio/FileBrowser/InspectorDetailHost.swift
+++ b/Sources/termio/FileBrowser/InspectorDetailHost.swift
@@ -7,9 +7,9 @@ import AppKit
 /// the list stays put in a narrow leading column and clicking an item only swaps the detail — no
 /// drill-in / back round-trip. Details used to cover the terminal; they live here now, so the
 /// terminal stays live while you read. Below `twoColumnMinWidth` the split would leave the detail
-/// too cramped, so it degrades to detail-only (the list one tab-switch away), Mail-style. When
-/// `store.inspectorMaximized` the detail is hoisted to the app delegate's full-window host, so
-/// `InspectorDetailContent` renders in exactly one place.
+/// too cramped, so it degrades to detail-only (the list one tab-switch away), Mail-style. The
+/// detail itself is not rendered here: `DockedDetailSlot` reserves its space and adopts the one
+/// shared `DetailHost`, which the app delegate borrows while `store.inspectorMaximized`.
 struct InspectorRoot: View {
     @EnvironmentObject var store: TermioStore
     let list: AnyView
@@ -33,7 +33,10 @@ struct InspectorRoot: View {
 
     var body: some View {
         GeometryReader { geo in
-            let showDetail = store.isDetailPresented && !store.inspectorMaximized
+            // Stays true while maximized: the slot keeps its place (empty, since the delegate is
+            // holding the shared host over the whole content area) so restoring is a single
+            // re-parent back into a view that is already laid out, with nothing to re-create.
+            let showDetail = store.isDetailPresented
             // Two-column when there's room AND the user hasn't collapsed the list to focus the detail.
             let twoColumn = showDetail && geo.size.width >= Self.twoColumnMinWidth && !store.inspectorListCollapsed
             // Never let the column eat the detail on a narrow inspector: cap it to leave the detail at
@@ -64,7 +67,7 @@ struct InspectorRoot: View {
                 // is opaque): beside the list in two-column, covering the whole panel — list still
                 // alive beneath — in the narrow or list-collapsed fallbacks.
                 if showDetail {
-                    InspectorDetailContent()
+                    DockedDetailSlot()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .padding(.leading, twoColumn ? width + 1 : 0)
                         .transition(.opacity)
@@ -82,10 +85,8 @@ struct InspectorRoot: View {
             }
             .frame(width: geo.size.width, height: geo.size.height)
             .coordinateSpace(.named(Self.dragSpace))
-            // Keyed to the *presentation*, not to `showDetail`: opening and closing a detail
-            // should cross-fade over the list, but maximizing only hands the same detail off to
-            // the full-window host. Fading there would spend 120ms dissolving the docked copy —
-            // uncovering the file tree it sits on — for a swap the user must not see at all.
+            // Opening and closing a detail cross-fades over the list. Maximizing does not touch
+            // this: the slot stays mounted through it, so there is nothing here to animate.
             .animation(.easeOut(duration: 0.12), value: store.isDetailPresented)
             .animation(.easeOut(duration: 0.12), value: twoColumn)
         }
@@ -114,34 +115,124 @@ struct InspectorRoot: View {
     }
 }
 
-/// The maximized detail's root view. It is the same content the inspector docks, run up under the
-/// titlebar: with the toolbar hidden for the duration (see `setDetailMaximized`) there is no band
-/// above it, so the detail's own header *is* the window's top bar rather than a second one beneath
-/// an empty strip. When the sidebar is collapsed the host reaches the window's leading edge and the
-/// traffic lights land on that header, so it takes an inset that clears them; with the sidebar open
-/// they sit over the sidebar and the header starts flush.
-struct MaximizedDetailContent: View {
+/// The one `NSHostingView` that renders whichever detail is open, moved between two parents rather
+/// than built twice: the inspector's `DockedDetailSlot` and the app delegate's full-window position
+/// while `store.inspectorMaximized`.
+///
+/// Two hosts would mean two SwiftUI trees, and maximizing would drop one and build the other from
+/// nothing — which is what made the transition flash: the file was re-read behind a blank frame,
+/// the Markdown reader built a fresh `WKWebView` and landed back at the top, the mode and find bar
+/// reset, and the copy being dropped fired its `onDisappear` save flush. Re-parenting one `NSView`
+/// inside one window keeps its view graph, so every `@State` and the live web view survive.
+@MainActor
+final class DetailHost {
+    static let shared = DetailHost()
+    private init() {}
+
+    private(set) var view: NSHostingView<AnyView>?
+
+    /// The inspector's slot, while one is mounted. The delegate hands the host back to it on
+    /// restore; a weak reference because SwiftUI, not this object, decides when it goes away.
+    weak var dockedSlot: NSView?
+
+    /// The host, built on first use. Both parents ask for it through here, so whichever one needs
+    /// it first creates it and the other finds the same instance.
+    func view(store: TermioStore, settings: AppSettings, window: NSWindow?) -> NSHostingView<AnyView> {
+        if let view { return view }
+        // Measure the traffic lights rather than assuming their layout: a maximized detail's header
+        // runs up into the titlebar, and where the buttons end is where its title may start.
+        let buttonsEnd = window?.standardWindowButton(.zoomButton)?.frame.maxX ?? 70
+        let host = NSHostingView(rootView: AnyView(
+            DetailHostRoot(trafficLightsInset: buttonsEnd)
+                .environmentObject(store)
+                .environmentObject(settings)
+        ))
+        // No SwiftUI-derived sizing constraints: the host is sized by whichever parent holds it,
+        // and the default `.standardBounds` options let auto layout satisfy the root view's ideal
+        // size by resizing the *window* — which once crushed the whole window to a ~90pt strip.
+        host.sizingOptions = []
+        view = host
+        return host
+    }
+
+    /// Puts the host in the inspector's slot, filling it. Re-parenting from the maximized position
+    /// is this same single `addSubview`: the view is never left without a superview, so it never
+    /// leaves the window and nothing inside it is torn down.
+    func dock(in slot: NSView) {
+        guard let view, view.superview !== slot else { return }
+        view.translatesAutoresizingMaskIntoConstraints = false
+        slot.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: slot.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: slot.trailingAnchor),
+            view.topAnchor.constraint(equalTo: slot.topAnchor),
+            view.bottomAnchor.constraint(equalTo: slot.bottomAnchor),
+        ])
+    }
+
+    /// Drops the host once no detail is open. The next open builds a fresh one, which is right —
+    /// there is no document left for it to hold.
+    func discard() {
+        view?.removeFromSuperview()
+        view = nil
+    }
+}
+
+/// The shared host's root view: the same content the inspector docks, plus the two things that
+/// differ once it fills the window. With the toolbar hidden for the duration (see
+/// `setDetailMaximized`) there is no band above it, so the detail's own header *is* the window's top
+/// bar rather than a second one beneath an empty strip; and when the sidebar is collapsed the host
+/// reaches the window's leading edge, so the header takes an inset that clears the traffic lights.
+/// Both read the store, so one long-lived view covers docked and maximized alike.
+struct DetailHostRoot: View {
     @EnvironmentObject var store: TermioStore
-    /// Leading room the traffic lights need, measured from the live window by the app delegate —
-    /// the buttons' geometry is the system's to change, so it is never hardcoded here.
+    /// Leading room the traffic lights need, measured from the live window — the buttons' geometry
+    /// is the system's to change, so it is never hardcoded here.
     let trafficLightsInset: CGFloat
 
     var body: some View {
         InspectorDetailContent()
             .environment(\.detailHeaderLeadingInset, needsTrafficLightsRoom ? trafficLightsInset : 0)
             // Up into the titlebar only when the toolbar has stepped aside for this detail, which
-            // is exactly when the sidebar is collapsed (see `syncMaximizedChrome`). With the
-            // sidebar up the toolbar keeps the sidebar's controls, so the header stays below it
-            // rather than sliding under a band that is still drawing.
-            .ignoresSafeArea(.container, edges: store.sidebarVisible ? [] : .top)
+            // is exactly when it is maximized with the sidebar collapsed (see `syncMaximizedChrome`).
+            // With the sidebar up the toolbar keeps the sidebar's controls, so the header stays
+            // below it rather than sliding under a band that is still drawing.
+            .ignoresSafeArea(.container, edges: ridesTitlebar ? .top : [])
     }
 
-    /// Only when the buttons are actually sitting on this header. With the sidebar open they land
-    /// on the sidebar, and in fullscreen they are hidden until the pointer summons the titlebar —
+    private var ridesTitlebar: Bool { store.inspectorMaximized && !store.sidebarVisible }
+
+    /// Only when the buttons are actually sitting on this header. Docked, or with the sidebar open,
+    /// they land elsewhere; in fullscreen they are hidden until the pointer summons the titlebar —
     /// which then slides in *over* the content, so holding a gap for them all along only pushes the
     /// title inward for nothing.
-    private var needsTrafficLightsRoom: Bool {
-        !store.sidebarVisible && !store.windowIsFullScreen
+    private var needsTrafficLightsRoom: Bool { ridesTitlebar && !store.windowIsFullScreen }
+}
+
+/// The inspector's slot for the shared detail host. It holds no content of its own — it adopts
+/// `DetailHost.shared` — and stands empty while the detail is maximized, keeping the place the host
+/// comes back to laid out and ready.
+struct DockedDetailSlot: NSViewRepresentable {
+    @EnvironmentObject var store: TermioStore
+    @EnvironmentObject var settings: AppSettings
+
+    func makeNSView(context: Context) -> NSView {
+        NSView()
+    }
+
+    func updateNSView(_ slot: NSView, context: Context) {
+        DetailHost.shared.dockedSlot = slot
+        // While maximized the delegate is holding the host over the whole content area; taking it
+        // back here would yank it out from under the user mid-mode.
+        guard !store.inspectorMaximized else { return }
+        _ = DetailHost.shared.view(store: store, settings: settings, window: slot.window)
+        DetailHost.shared.dock(in: slot)
+    }
+
+    static func dismantleNSView(_ slot: NSView, coordinator: ()) {
+        MainActor.assumeIsolated {
+            if DetailHost.shared.dockedSlot === slot { DetailHost.shared.dockedSlot = nil }
+        }
     }
 }
 

--- a/Sources/termio/Theme/ChromeTheme.swift
+++ b/Sources/termio/Theme/ChromeTheme.swift
@@ -96,7 +96,7 @@ struct ChromeTheme {
 /// those pages match the app. Resolved from the chosen chrome theme, or termio's
 /// built-in light/dark defaults when no Ghostty theme is selected (mirrors
 /// `ChromeTheme.terminalBackgroundColor`'s fallbacks).
-struct DocumentTheme {
+struct DocumentTheme: Equatable {
     let background: String
     let panel: String
     let foreground: String

--- a/Tests/termioTests/EditorLineMetricsTests.swift
+++ b/Tests/termioTests/EditorLineMetricsTests.swift
@@ -1,0 +1,63 @@
+import AppKit
+import XCTest
+@testable import termio
+
+/// Highlighting is a coloring pass: it must never change where a glyph sits. The editor seeds the
+/// text storage with its line metrics up front and configures Highlightr's theme with the same
+/// ones, so the async pass swaps colors onto text that is already laid out correctly. When the two
+/// disagreed, opening a file painted at the font's natural line height and every line then grew by
+/// the configured extra leading at once — a visible jolt a few frames in.
+final class EditorLineMetricsTests: XCTestCase {
+    private let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+    private let lineSpacing: CGFloat = 6
+
+    /// The fixed line box is the font's natural height plus the configured extra, and the glyphs
+    /// are lifted half that to sit centered in it.
+    func testLineBoxIsNaturalHeightPlusConfiguredLeading() {
+        let style = HighlightedTextView.paragraphStyle(font: font, lineSpacing: lineSpacing)
+        let natural = NSLayoutManager().defaultLineHeight(for: font)
+
+        XCTAssertEqual(style.minimumLineHeight, natural + lineSpacing, accuracy: 0.001)
+        XCTAssertEqual(style.maximumLineHeight, style.minimumLineHeight, accuracy: 0.001)
+        XCTAssertEqual(HighlightedTextView.baselineOffset(lineSpacing: lineSpacing), lineSpacing / 2,
+                       accuracy: 0.001)
+    }
+
+    /// The invariant that keeps the editor still: what the highlighter stamps on every token has
+    /// the same metrics as what the storage was seeded with, so the pass moves nothing.
+    func testHighlighterCarriesTheSameMetricsTheStorageIsSeededWith() throws {
+        let highlightr = try XCTUnwrap(Highlightr(), "no highlighter available in this environment")
+        let style = HighlightedTextView.paragraphStyle(font: font, lineSpacing: lineSpacing)
+        let offset = HighlightedTextView.baselineOffset(lineSpacing: lineSpacing)
+        highlightr.theme.setCodeFont(font)
+        highlightr.theme.codeParagraphStyle = style
+        highlightr.theme.codeBaselineOffset = offset
+
+        let highlighted = try XCTUnwrap(highlightr.highlight("let answer = 42", as: "swift"))
+        var applied: [NSAttributedString.Key: Any] = [:]
+        highlighted.enumerateAttributes(in: NSRange(location: 0, length: highlighted.length)) { attrs, _, stop in
+            applied = attrs
+            stop.pointee = true
+        }
+
+        XCTAssertEqual(applied[.paragraphStyle] as? NSParagraphStyle, style)
+        XCTAssertEqual(applied[.baselineOffset] as? CGFloat, offset)
+        XCTAssertEqual((applied[.font] as? NSFont)?.pointSize, font.pointSize)
+    }
+
+    /// A file hljs has no grammar for gets no highlight pass at all, so its metrics can only come
+    /// from the seed — the case that used to render at the wrong line height forever.
+    func testUnhighlightedTextKeepsItsSeededMetrics() {
+        let storage = CodeAttributedString(highlightr: nil)
+        let style = HighlightedTextView.paragraphStyle(font: font, lineSpacing: lineSpacing)
+        storage.setAttributedString(NSAttributedString(string: "plain text\nsecond line", attributes: [
+            .font: font,
+            .paragraphStyle: style,
+            .baselineOffset: HighlightedTextView.baselineOffset(lineSpacing: lineSpacing),
+        ]))
+
+        let attrs = storage.attributes(at: 0, effectiveRange: nil)
+        XCTAssertEqual(attrs[.paragraphStyle] as? NSParagraphStyle, style)
+        XCTAssertEqual(attrs[.baselineOffset] as? CGFloat, lineSpacing / 2)
+    }
+}


### PR DESCRIPTION
Three related stalls in the inspector's file detail, all the same shape: a view being rebuilt where it should have been reused.

**Maximize** built a second `NSHostingView` and dropped the inspector's copy, so the whole SwiftUI tree was re-created on every toggle — the file re-read behind a blank frame, a fresh `WKWebView` landing back at the top of the document, Edit/Preview and the find bar reset, and a save flush on the way out. One host now serves both places and each direction is a single re-parent inside the same window.

**Edit/Preview** was an `if`/`else`, which in SwiftUI is a structural branch: one side torn down and the other built on every flip. Preview paid a fresh `WKWebView` and a full page load, Edit paid a whole-document Highlightr pass and a TextKit re-layout. Both faces now stay mounted once visited, so a flip with no edits does no work at all.

**Opening a file** jolted a few frames in. `makeNSView` assigned the text before the style, and unstyled text lays out at the font's natural line height — the configured leading only arrived with the async highlight, at which point every line grew at once. The storage is now seeded with its metrics before the first layout, so highlighting only changes colors. That also fixes the line height for files that never get a highlight pass at all (past `highlightByteLimit`, or a language hljs doesn't know).

Measured on a 13KB `AGENTS.md`: the page the reader rebuilt is 167KB (136KB of it inlined base64 fonts) at ~19ms per pass, and the return trip cost a 34ms highlight plus a main-thread attribute walk.

Serving the reader's fonts through the existing `WKURLSchemeHandler` instead of base64 would cut the page to 31KB, but whether WebKit then reuses them across loads is an empirical question, and a wrong answer falls back to system sans silently — left for a follow-up that can be checked on screen.

New `EditorLineMetricsTests` pins the invariant the third commit rests on: what the highlighter stamps on every token has the same metrics as what the storage is seeded with, so a highlight pass cannot move a glyph.

Release Notes:
- Switching a Markdown file between Edit and Preview, and maximizing the file detail, no longer rebuild the document — the view keeps its scroll position and no longer flashes.
- Opening a file in the editor no longer jolts once syntax highlighting arrives.