### PR TITLE
Stop rendering terminal panes that are off screen

### DIFF
--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -431,6 +431,14 @@ private struct ManagedTerminalSurface: View {
             .onChange(of: surfaceFocus) { _, focused in
                 if focused { onFocused() }
             }
+            // Mounted is not the same as on screen, and only this view knows the
+            // difference. The representable's NSView is not in the hierarchy yet on
+            // the first pass, so the mount-time answer is repeated a runloop turn
+            // later — the same shape, and the same reason, as the focus probe above.
+            .onChange(of: isVisible, initial: true) { _, visible in
+                applySurfaceVisibility(visible, for: context)
+                DispatchQueue.main.async { applySurfaceVisibility(visible, for: context) }
+            }
             // A relaunched session gets a fresh TerminalViewState (see
             // `relaunchSession`); keying the mounted view on the state's identity
             // remounts the NSView for the new surface. Without this the
@@ -438,6 +446,50 @@ private struct ManagedTerminalSurface: View {
             // keeps the first-mounted delegate, which is the old, dead state.
             .id(ObjectIdentifier(context))
     }
+}
+
+/// Tells ghostty whether a mounted surface is actually on screen.
+///
+/// A pane that is not showing stays mounted on purpose — that is this file's whole
+/// premise — so it keeps its frame and is drawn at zero opacity. AppKit is happy to
+/// lay that out, and ghostty, told nothing, is happy to keep rendering it: every
+/// byte a background agent writes costs a frame nobody sees, on a renderer thread
+/// nobody is watching.
+///
+/// The switch for that lives on the *view*, not the surface. `setSurfaceVisible`
+/// composes with the app-active state the surface coordinator already tracks, stops
+/// the display link, gates the PTY-output wakeups that would otherwise tick a hidden
+/// pane, and asks for an immediate frame on the way back in. Setting ghostty's
+/// occlusion flag directly does none of those, and is overwritten the next time the
+/// coordinator re-asserts its own answer.
+@MainActor
+private func applySurfaceVisibility(_ visible: Bool, for state: TerminalViewState) {
+    guard let root = AppDelegate.mainWindow?.contentView,
+          let view = terminalView(matching: state, under: root)
+    else { return }
+    view.setSurfaceVisible(visible)
+}
+
+/// The AppKit terminal view a `TerminalViewState` is mounted in. SwiftUI hands the
+/// representable's NSView to nobody, so both callers that need it — focus, which
+/// must reach the first responder, and visibility, which must reach the surface
+/// coordinator — find it by matching the delegate the state installed.
+@MainActor
+private func terminalView(
+    matching state: TerminalViewState,
+    under root: NSView
+) -> TerminalView? {
+    if let terminal = root as? TerminalView,
+       let delegate = terminal.delegate as AnyObject?,
+       delegate === state {
+        return terminal
+    }
+    for child in root.subviews {
+        if let match = terminalView(matching: state, under: child) {
+            return match
+        }
+    }
+    return nil
 }
 
 private struct TerminalFocusRepairProbe: NSViewRepresentable {
@@ -677,23 +729,6 @@ private final class TerminalFocusDriver {
 
     private func mainWindow() -> NSWindow? {
         AppDelegate.mainWindow
-    }
-
-    private func terminalView(
-        matching state: TerminalViewState,
-        under root: NSView
-    ) -> TerminalView? {
-        if let terminal = root as? TerminalView,
-           let delegate = terminal.delegate as AnyObject?,
-           delegate === state {
-            return terminal
-        }
-        for child in root.subviews {
-            if let match = terminalView(matching: state, under: child) {
-                return match
-            }
-        }
-        return nil
     }
 
     private func resignPreviousSurface(current: NSResponder?, target: TerminalView) {

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -809,16 +809,14 @@ extension TermioStore {
         }
     }
 
-    /// The raw `ghostty_surface_t` behind a session's surface. `TerminalSurface`
-    /// exposes only `sendText` publicly and keeps the C handle in a private stored
-    /// property, so reach it by reflection — the only way to call `ghostty_surface_key`
-    /// (the key-event C entry point, whose Swift wrapper the package marks `internal`).
+    /// The raw `ghostty_surface_t` behind a session's surface — the C entry point
+    /// for `ghostty_surface_key`, whose Swift wrapper the package marks `internal`.
+    /// `rawValue` is the package's documented escape hatch for exactly this; it
+    /// replaced an earlier reflection read of the private stored property, which
+    /// would have started returning nil silently the first time the field was
+    /// renamed upstream.
     private static func rawSurface(from state: TerminalViewState) -> ghostty_surface_t? {
-        guard let terminalSurface = state.surface else { return nil }
-        for child in Mirror(reflecting: terminalSurface).children where child.label == "surface" {
-            if let handle = child.value as? ghostty_surface_t { return handle }
-        }
-        return nil
+        state.surface?.rawValue
     }
 
     /// Sends a Return key press (and release) to the surface — the submit a user makes

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -39,6 +39,13 @@
       "skillPath": "skills/improve-animations/SKILL.md",
       "computedHash": "eeb219a407e325b687af88db25771cc3018e3148245604112f5ac6990b6fd79c"
     },
+    "native-app-profiling": {
+      "source": "patrickserrano/skills",
+      "sourceType": "github",
+      "pinnedCommit": "e90c8321d80b04dd613fba65f5e9076d1c274140",
+      "skillPath": "skills/native-app-profiling/SKILL.md",
+      "computedHash": "35e52c4f40a72c41de889d18919f1e25395495e1b034ef2249aecd2785047014"
+    },
     "pick-ui-library": {
       "source": "emilkowalski/skill",
       "sourceType": "github",
@@ -56,6 +63,21 @@
       "sourceType": "github",
       "skillPath": "skills/review-animations/SKILL.md",
       "computedHash": "b9f669af5ae280c19a592a94611520335a81de25c88f225bf60ae4b2d66c8c7c"
+    },
+    "swift-performance-optimization-skill": {
+      "source": "fal3/claude-skills-collection",
+      "sourceType": "github",
+      "pinnedCommit": "a9c26d7ae6c1127e86baad2dc76e86b5b1e8f06d",
+      "skillPath": "skills/swift-performance-optimization-skill/SKILL.md",
+      "vendoredPath": "skills/swift-performance-optimization-skill/examples",
+      "computedHash": "f6e43a81a1612db94b5f7031466a3b048babb80762c354dbae41d3c8df9e1a7b"
+    },
+    "swiftui-performance-audit": {
+      "source": "patrickserrano/skills",
+      "sourceType": "github",
+      "pinnedCommit": "e90c8321d80b04dd613fba65f5e9076d1c274140",
+      "skillPath": "skills/swiftui-performance-audit/SKILL.md",
+      "computedHash": "0e72f534f959a22803ab673596ac5a2427c121dc380ace28e5427c3cef9e3430"
     }
   }
 }

--- a/skills/native-app-profiling/SKILL.md
+++ b/skills/native-app-profiling/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: native-app-profiling
+description: Profile native macOS/iOS apps using Time Profiler via CLI (xctrace). Use when asked to identify performance hotspots, profile CPU usage, or diagnose slow code paths without opening Instruments.
+---
+
+# Native App Performance Profiling (CLI)
+
+## Overview
+
+Record Time Profiler via `xctrace`, extract samples, symbolicate, and identify hotspots without opening Instruments.
+
+## Quick Start
+
+### 1) Record Time Profiler
+
+**Attach to running process:**
+```bash
+# Get the PID first
+pgrep -x "AppName"
+
+# Record for 90 seconds
+xcrun xctrace record \
+    --template 'Time Profiler' \
+    --time-limit 90s \
+    --output /tmp/App.trace \
+    --attach <pid>
+```
+
+**Launch and record:**
+```bash
+xcrun xctrace record \
+    --template 'Time Profiler' \
+    --time-limit 90s \
+    --output /tmp/App.trace \
+    --launch -- /path/to/App.app/Contents/MacOS/App
+```
+
+### 2) Export Time Samples
+
+List available schemas in the trace:
+```bash
+xcrun xctrace export --input /tmp/App.trace --toc
+```
+
+Export time profile data:
+```bash
+xcrun xctrace export \
+    --input /tmp/App.trace \
+    --xpath '/trace-toc/run/data/table[@schema="time-profile"]' \
+    --output /tmp/time-profile.xml
+```
+
+### 3) Get Load Address for Symbolication
+
+While the app is running, get the `__TEXT` segment load address:
+```bash
+vmmap <pid> | grep "__TEXT"
+```
+
+Look for the load address (typically starts with `0x1...`).
+
+### 4) Symbolicate Stack Frames
+
+Use `atos` to symbolicate addresses:
+```bash
+atos -o /path/to/App.app/Contents/MacOS/App -l 0x100000000 <address>
+```
+
+## Workflow Notes
+
+- **Correct binary**: Confirm you're profiling the right build (local vs /Applications)
+- **Trigger the slow path**: During capture, perform the action that's slow
+- **Capture duration**: If stacks are empty, capture longer or avoid idle time
+- **Symbol matching**: Binary symbols must match the trace (same build)
+
+## Available Templates
+
+List all profiling templates:
+```bash
+xcrun xctrace list templates
+```
+
+Common templates:
+- `Time Profiler` - CPU sampling
+- `Allocations` - Memory allocations
+- `Leaks` - Memory leak detection
+- `System Trace` - System-level activity
+- `Animation Hitches` - UI performance
+
+## Common Commands
+
+| Task | Command |
+|------|---------|
+| List templates | `xcrun xctrace list templates` |
+| List devices | `xcrun xctrace list devices` |
+| Record help | `xcrun xctrace help record` |
+| Export help | `xcrun xctrace help export` |
+| Get PID | `pgrep -x "AppName"` |
+| Get load address | `vmmap <pid> \| grep __TEXT` |
+| Symbolicate | `atos -o <binary> -l <load-addr> <address>` |
+
+## Analyzing Results
+
+### Manual Analysis
+
+1. Export the trace to XML
+2. Parse the call tree data
+3. Look for frames with high sample counts
+4. Focus on your app's code (filter out system frameworks)
+
+### Identify Hotspots
+
+Look for:
+- Functions with high self-time (time spent in function itself)
+- Deep call stacks indicating inefficient algorithms
+- Repeated patterns suggesting optimization opportunities
+
+## Gotchas
+
+- **ASLR**: Runtime `__TEXT` load address changes each launch - get it from `vmmap`
+- **Build mismatch**: Symbols must match the exact build that was profiled
+- **Idle time**: Profiling idle app produces empty/useless data
+- **Permissions**: May need to run with `sudo` for some operations
+
+## iOS Profiling
+
+For iOS apps on simulator:
+```bash
+xcrun xctrace record \
+    --template 'Time Profiler' \
+    --device <simulator-udid> \
+    --time-limit 60s \
+    --output /tmp/iOS-App.trace \
+    --launch -- <bundle-id>
+```
+
+Get simulator UDID:
+```bash
+xcrun simctl list devices | grep Booted
+```
+
+## Automation Script
+
+Basic recording script:
+```bash
+#!/bin/bash
+set -e
+
+APP_NAME="$1"
+DURATION="${2:-60}"
+OUTPUT="${3:-/tmp/$APP_NAME.trace}"
+
+if [ -z "$APP_NAME" ]; then
+    echo "Usage: $0 <app-name> [duration-seconds] [output-path]"
+    exit 1
+fi
+
+PID=$(pgrep -x "$APP_NAME" || true)
+
+if [ -n "$PID" ]; then
+    echo "Attaching to running $APP_NAME (PID: $PID)"
+    xcrun xctrace record \
+        --template 'Time Profiler' \
+        --time-limit "${DURATION}s" \
+        --output "$OUTPUT" \
+        --attach "$PID"
+else
+    echo "App not running. Please start $APP_NAME first."
+    exit 1
+fi
+
+echo "Trace saved to: $OUTPUT"
+echo "To analyze: xcrun xctrace export --input $OUTPUT --toc"
+```
+
+## Checklist
+
+- [ ] Correct binary path identified
+- [ ] App running or launch command ready
+- [ ] Slow path reproducible
+- [ ] Trace recorded during problematic behavior
+- [ ] Load address captured for symbolication
+- [ ] Results analyzed for hotspots

--- a/skills/swift-performance-optimization-skill/SKILL.md
+++ b/skills/swift-performance-optimization-skill/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: Swift Performance Optimization Skill
+description: Use when investigating measured Swift or Apple-platform regressions in CPU, memory, launch, scrolling, animation hitches, image processing, energy, networking, or concurrency, or when designing performance tests and Instruments experiments. Do not use for speculative micro-optimization, ordinary refactoring, or a functional bug without performance evidence.
+---
+
+# Swift Performance Optimization Skill
+
+Optimize from evidence. Preserve behavior, accessibility, data correctness, and lifecycle safety while changing performance characteristics.
+
+## Baseline
+
+The copy-ready examples use Xcode 16, Swift 6 language mode with strict concurrency, and iOS 17. Most principles apply to older targets; verify each API against the app's actual minimum. Material from the OS 27 development cycle is beta relative to stable Xcode 26.6 and requires an explicit request, beta labeling, stable fallback, and availability gate.
+
+## Measurement workflow
+
+1. Define a user-visible symptom and a reproducible scenario.
+2. Record device, OS, build configuration, dataset, thermal state, and network conditions.
+3. Measure an optimized Release build on representative hardware. Simulator-only timing is not release evidence.
+4. Select the instrument that answers the hypothesis.
+5. Save a baseline trace or metric, change one variable, then repeat the same scenario.
+6. Confirm that the bottleneck moved and no memory, energy, correctness, or accessibility regression appeared.
+7. Add a regression threshold where the workload is stable enough to automate.
+
+Useful tools include:
+
+| Symptom | First evidence source |
+|---|---|
+| CPU-bound work | Time Profiler; inspect heavy stacks and self time |
+| SwiftUI update cost | SwiftUI instrument plus Time Profiler |
+| Scroll or animation stalls | Animation Hitches, Core Animation, signposts |
+| Growth or leaks | Allocations, Leaks, Memory Graph, memgraphs |
+| Slow launch | App Launch template and launch signposts |
+| Battery or thermal issues | Energy Log and device testing |
+| Field regressions | MetricKit payloads and app-specific telemetry |
+
+Use `os_signpost` or signposter intervals around important operations so traces answer product questions rather than only showing raw symbols.
+
+## Lifetime and memory safety
+
+- A capture is a cycle only when the closure is retained along a path back to its owner. Do not add `[weak self]` mechanically to every closure.
+- Use `weak` when the owner may legitimately disappear before the callback. Use `unowned` only when the lifetime invariant is proven and documented; a wrong assumption traps.
+- Prefer structured `async` functions over storing completion closures.
+- Cancel owned tasks and invalidate repeating timers when the owner stops needing them and during teardown.
+- Never use `[unowned self]` in a repeating timer merely to silence a cycle.
+
+```swift
+import Foundation
+
+@MainActor
+final class PollingModel {
+    private var task: Task<Void, Never>?
+    private(set) var tickCount = 0
+
+    func start() {
+        stop()
+        task = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+                guard let self else { return }
+                tickCount += 1
+            }
+        }
+    }
+
+    func stop() {
+        task?.cancel()
+        task = nil
+    }
+
+    deinit {
+        task?.cancel()
+    }
+}
+```
+
+If a Foundation `Timer` is required, capture its owner weakly, store the timer, invalidate the old instance before starting another, and invalidate it on stop/deinit.
+
+See [the lifecycle-safe example](examples/example_memory_management.swift).
+
+## Concurrency
+
+- Swift concurrency is the default for new asynchronous flows, but Dispatch and operation queues remain supported interoperability and scheduling tools.
+- Keep UI state on `@MainActor`. Move only verified expensive, concurrency-safe work away from it.
+- Avoid spawning an unbounded task per item. Use task groups with deliberate limits, an actor, an async sequence, or a bounded worker design.
+- Check cancellation before expensive phases and before publishing results.
+- Do not trade actor safety for speed without race-focused tests and trace evidence.
+
+## Collections and computation
+
+- Pick structures by operation: a `Set` or dictionary can replace repeated linear membership searches.
+- Avoid accidental copy-on-write churn in hot paths, but prove it with Allocations or profiling.
+- Reserve capacity only when the final scale is reasonably known.
+- Cache only expensive, repeatable results with a clear invalidation rule and a bounded memory policy.
+- Benchmark optimized code with representative data; debug-build microbenchmarks are misleading.
+
+## SwiftUI
+
+- Stable identity is mandatory for mutable collections. Prefer model IDs, not offsets or a new UUID computed during rendering.
+- `List` already realizes rows lazily. `ScrollView` plus `LazyVStack` offers different styling and interaction behavior; it is not inherently faster.
+- A `body` evaluation is value computation, not proof that all descendants were redrawn. Use the SwiftUI instrument to identify expensive updates.
+- Keep work out of `body`: precompute formatting, filtering, decoding, and image processing at the correct layer.
+- Extract views for responsibility and data-flow clarity. Do not claim extraction alone establishes an isolated rendering boundary.
+- Use `.equatable()`/`EquatableView` only after measurement, and include every visible input in equality.
+- Prefer `.task(id:)` for work tied to a view and input. It cancels prior work when the ID changes.
+
+See [the list identity example](examples/example_list_optimization.swift).
+
+## Images and reusable cells
+
+- Decode and downsample to the rendered pixel size rather than decoding full-resolution assets for thumbnails.
+- Validate HTTP responses, cancel obsolete requests, and check both cancellation and represented URL before assigning an image.
+- Reset image, identity, and task in `prepareForReuse()`.
+- Lay out with constraints or `layoutSubviews`; a one-time frame set during initialization will not follow cell resizing.
+- Use a bounded cache whose cost reflects decoded pixels. Add collection-view prefetching only after measuring its value and cancel prefetches when appropriate.
+- Register cell classes/nibs, implement item counts, and avoid force-casting dequeued cells in copy-ready examples.
+
+See [the complete downsampling and reuse example](examples/example_image_loading.swift).
+
+## Shipping checks
+
+- Compare percentile metrics, not only averages.
+- Set thresholds that account for device classes and natural variance.
+- Keep before/after traces with the scenario and build identifier.
+- Re-test memory warnings, background/foreground transitions, cancellation, large accessibility text, and low-power/thermal conditions.
+- State what was not measured; never market an optimization as proven from code inspection alone.
+
+## Resources
+
+- [List performance example](examples/example_list_optimization.swift)
+- [Task lifetime example](examples/example_memory_management.swift)
+- [Image downsampling and cell reuse](examples/example_image_loading.swift)
+- [Performance investigation prompts](examples/prompts.md)

--- a/skills/swift-performance-optimization-skill/examples/example_image_loading.swift
+++ b/skills/swift-performance-optimization-skill/examples/example_image_loading.swift
@@ -1,0 +1,166 @@
+import Foundation
+import ImageIO
+import UIKit
+
+private func downsampleImage(data: Data, maxPixelSize: CGFloat) -> UIImage? {
+    let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+    guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+        return nil
+    }
+
+    let thumbnailOptions = [
+        kCGImageSourceCreateThumbnailFromImageAlways: true,
+        kCGImageSourceCreateThumbnailWithTransform: true,
+        kCGImageSourceShouldCacheImmediately: true,
+        kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+    ] as CFDictionary
+
+    guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
+        return nil
+    }
+    return UIImage(cgImage: image)
+}
+
+@MainActor
+private final class ThumbnailCache {
+    static let shared = ThumbnailCache()
+
+    private let storage = NSCache<NSString, UIImage>()
+
+    private init() {
+        storage.totalCostLimit = 64 * 1_024 * 1_024
+    }
+
+    func key(for url: URL, maxPixelSize: CGFloat) -> NSString {
+        "\(url.absoluteString)#\(Int(maxPixelSize.rounded(.up)))" as NSString
+    }
+
+    func image(for key: NSString) -> UIImage? {
+        storage.object(forKey: key)
+    }
+
+    func insert(_ image: UIImage, for key: NSString) {
+        let decodedCost = image.cgImage.map { $0.bytesPerRow * $0.height } ?? 0
+        storage.setObject(image, forKey: key, cost: decodedCost)
+    }
+}
+
+@MainActor
+final class ThumbnailCell: UICollectionViewCell {
+    static let reuseIdentifier = "ThumbnailCell"
+
+    private let thumbnailView = UIImageView()
+    private var representedURL: URL?
+    private var loadTask: Task<Void, Never>?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        thumbnailView.translatesAutoresizingMaskIntoConstraints = false
+        thumbnailView.contentMode = .scaleAspectFill
+        thumbnailView.clipsToBounds = true
+        contentView.addSubview(thumbnailView)
+        NSLayoutConstraint.activate([
+            thumbnailView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            thumbnailView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            thumbnailView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            thumbnailView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func configure(url: URL, targetSize: CGSize, scale: CGFloat) {
+        loadTask?.cancel()
+        representedURL = url
+        thumbnailView.image = nil
+
+        let maxPixelSize = max(targetSize.width, targetSize.height) * scale
+        let cacheKey = ThumbnailCache.shared.key(for: url, maxPixelSize: maxPixelSize)
+        if let cachedImage = ThumbnailCache.shared.image(for: cacheKey) {
+            thumbnailView.image = cachedImage
+            loadTask = nil
+            return
+        }
+
+        loadTask = Task { [weak self] in
+            do {
+                let (data, response) = try await URLSession.shared.data(from: url)
+                guard let httpResponse = response as? HTTPURLResponse,
+                      (200..<300).contains(httpResponse.statusCode),
+                      !Task.isCancelled else { return }
+
+                let image = await Task.detached(priority: .utility) {
+                    downsampleImage(data: data, maxPixelSize: maxPixelSize)
+                }.value
+
+                guard let image,
+                      !Task.isCancelled,
+                      self?.representedURL == url else { return }
+                ThumbnailCache.shared.insert(image, for: cacheKey)
+                self?.thumbnailView.image = image
+            } catch is CancellationError {
+                return
+            } catch {
+                guard self?.representedURL == url else { return }
+                self?.thumbnailView.image = nil
+            }
+        }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        loadTask?.cancel()
+        loadTask = nil
+        representedURL = nil
+        thumbnailView.image = nil
+    }
+}
+
+@MainActor
+final class GalleryViewController: UIViewController, UICollectionViewDataSource {
+    private let imageURLs: [URL]
+    private let collectionView: UICollectionView
+
+    init(imageURLs: [URL]) {
+        self.imageURLs = imageURLs
+        let layout = UICollectionViewFlowLayout()
+        layout.itemSize = CGSize(width: 120, height: 120)
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        collectionView.frame = view.bounds
+        collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        collectionView.register(ThumbnailCell.self, forCellWithReuseIdentifier: ThumbnailCell.reuseIdentifier)
+        collectionView.dataSource = self
+        view.addSubview(collectionView)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        imageURLs.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: ThumbnailCell.reuseIdentifier,
+            for: indexPath
+        ) as? ThumbnailCell else {
+            return UICollectionViewCell()
+        }
+
+        cell.configure(
+            url: imageURLs[indexPath.item],
+            targetSize: CGSize(width: 120, height: 120),
+            scale: view.window?.screen.scale ?? UIScreen.main.scale
+        )
+        return cell
+    }
+}

--- a/skills/swift-performance-optimization-skill/examples/example_list_optimization.swift
+++ b/skills/swift-performance-optimization-skill/examples/example_list_optimization.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct PerformanceItem: Identifiable, Sendable {
+    let id: Int
+    let title: String
+}
+
+struct MeasuredListExample: View {
+    let items: [PerformanceItem]
+
+    var body: some View {
+        List(items) { item in
+            HStack {
+                Text(item.title)
+                Spacer()
+                Image(systemName: "star")
+                    .foregroundStyle(.yellow)
+                    .accessibilityHidden(true)
+            }
+        }
+        .listStyle(.plain)
+    }
+}
+
+// List already realizes rows lazily. Choose this variant when custom scrolling
+// behavior or styling requires it, then profile both versions for the real data.
+struct CustomScrollingExample: View {
+    let items: [PerformanceItem]
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading) {
+                ForEach(items) { item in
+                    Text(item.title)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 8)
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+}

--- a/skills/swift-performance-optimization-skill/examples/example_memory_management.swift
+++ b/skills/swift-performance-optimization-skill/examples/example_memory_management.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@MainActor
+final class PollingModel {
+    private var task: Task<Void, Never>?
+    private(set) var tickCount = 0
+
+    func start() {
+        stop()
+        task = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+
+                guard let self else { return }
+                tickCount += 1
+            }
+        }
+    }
+
+    func stop() {
+        task?.cancel()
+        task = nil
+    }
+
+    deinit {
+        task?.cancel()
+    }
+}

--- a/skills/swift-performance-optimization-skill/examples/prompts.md
+++ b/skills/swift-performance-optimization-skill/examples/prompts.md
@@ -1,0 +1,16 @@
+# Prompt scenarios
+
+## Should activate
+
+- "Design a reproducible Time Profiler experiment for this launch regression."
+- "Audit this repeating timer for lifetime, cancellation, and retain-cycle hazards."
+- "Compare `List` and `LazyVStack` for this interaction using measured traces rather than assumptions."
+- "Downsample remote thumbnails safely in reusable collection-view cells."
+- "Add signposts and a percentile regression threshold for this image pipeline."
+- "Investigate SwiftUI hitches without assuming every `body` evaluation redraws the subtree."
+
+## Should not activate
+
+- "Micro-optimize this unmeasured helper because it looks slow."
+- "Fix this incorrect total when there is no performance symptom."
+- "Restyle this animation without a frame-rate or energy regression."

--- a/skills/swiftui-performance-audit/SKILL.md
+++ b/skills/swiftui-performance-audit/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: performance-audit
+description: Audit and improve SwiftUI runtime performance. Use for requests to diagnose slow rendering, janky scrolling, high CPU/memory usage, excessive view updates, or layout thrash in SwiftUI apps.
+---
+
+# SwiftUI Performance Audit
+
+## Overview
+
+Audit SwiftUI view performance from instrumentation and baselining to root-cause analysis and concrete remediation steps.
+
+## Workflow Decision Tree
+
+1. **If user provides code**: Start with Code-First Review
+2. **If user only describes symptoms**: Ask for minimal code/context, then Code-First Review
+3. **If code review is inconclusive**: Guide user to profile with Instruments
+
+## 1. Code-First Review
+
+### Collect
+- Target view/feature code
+- Data flow: state, environment, observable models
+- Symptoms and reproduction steps
+
+### Focus On
+- View invalidation storms from broad state changes
+- Unstable identity in lists (`id` churn, `UUID()` per render)
+- Heavy work in `body` (formatting, sorting, image decoding)
+- Layout thrash (deep stacks, `GeometryReader`, preference chains)
+- Large images without downsampling
+- Over-animated hierarchies (implicit animations on large trees)
+
+### Provide
+- Likely root causes with code references
+- Suggested fixes and refactors
+- Minimal repro or instrumentation suggestion if needed
+
+## 2. Guide User to Profile
+
+If code review is inconclusive, explain how to collect data:
+
+1. Use SwiftUI template in Instruments (Release build)
+2. Reproduce the exact interaction (scroll, navigation, animation)
+3. Capture SwiftUI timeline and Time Profiler
+4. Export or screenshot relevant lanes and call tree
+
+Ask for:
+- Trace export or screenshots
+- Device/OS/build configuration
+
+## 3. Common Code Smells (and Fixes)
+
+### Expensive formatters in `body`
+
+**Bad:**
+```swift
+var body: some View {
+    let formatter = NumberFormatter()  // Slow allocation every render
+    Text(formatter.string(from: value))
+}
+```
+
+**Good:**
+```swift
+final class Formatters {
+    static let number = NumberFormatter()
+}
+
+var body: some View {
+    Text(Formatters.number.string(from: value))
+}
+```
+
+### Computed properties with heavy work
+
+**Bad:**
+```swift
+var filtered: [Item] {
+    items.filter { $0.isEnabled }  // Runs every body eval
+}
+```
+
+**Good:**
+```swift
+@State private var filtered: [Item] = []
+
+.onChange(of: items) {
+    filtered = items.filter { $0.isEnabled }
+}
+```
+
+### Sorting/filtering in ForEach
+
+**Bad:**
+```swift
+ForEach(items.sorted(by: sortRule)) { item in
+    Row(item)
+}
+```
+
+**Good:**
+```swift
+let sortedItems = items.sorted(by: sortRule)  // Compute once
+ForEach(sortedItems) { item in
+    Row(item)
+}
+```
+
+### Unstable identity
+
+**Bad:**
+```swift
+ForEach(items, id: \.self) { item in  // \.self may not be stable
+    Row(item)
+}
+```
+
+**Good:**
+```swift
+ForEach(items, id: \.stableID) { item in
+    Row(item)
+}
+```
+
+### Image decoding on main thread
+
+**Bad:**
+```swift
+Image(uiImage: UIImage(data: data)!)
+```
+
+**Good:**
+```swift
+// Decode/downsample off main thread, cache the result
+@State private var image: UIImage?
+
+.task {
+    image = await ImageLoader.load(data: data, targetSize: size)
+}
+```
+
+### Broad dependencies in observable models
+
+**Bad:**
+```swift
+@Observable class Model {
+    var items: [Item] = []
+}
+
+var body: some View {
+    Row(isFavorite: model.items.contains(item))  // Entire array dependency
+}
+```
+
+**Good:**
+```swift
+// Granular view models or per-item state to reduce update fan-out
+```
+
+## 4. Remediation Strategies
+
+| Issue | Fix |
+|-------|-----|
+| Broad state changes | Narrow scope with `@State`/`@Observable` closer to leaves |
+| Unstable identities | Use stable, unique IDs for `ForEach` |
+| Heavy work in body | Precompute, cache, move to `@State` |
+| Expensive subtrees | Use `equatable()` or value wrappers |
+| Large images | Downsample before rendering |
+| Layout complexity | Reduce nesting, use fixed sizing where possible |
+
+## 5. Verify
+
+Ask user to re-run same capture and compare with baseline:
+- CPU usage
+- Frame drops
+- Memory peak
+
+## Output Format
+
+Provide:
+1. Metrics table (before/after if available)
+2. Top issues (ordered by impact)
+3. Proposed fixes with estimated effort
+
+## Profiling Commands
+
+```bash
+# Build for profiling
+xcodebuild -scheme MyApp -configuration Release -destination 'platform=iOS Simulator,name=iPhone 15 Pro' build
+
+# Open in Instruments
+open -a Instruments
+```
+
+## Instruments Checklist
+
+- [ ] Use Release build (not Debug)
+- [ ] Select SwiftUI template
+- [ ] Reproduce exact problematic interaction
+- [ ] Look at SwiftUI timeline for body evaluations
+- [ ] Check Time Profiler for hot spots
+- [ ] Note frame rate drops in Animation timeline


### PR DESCRIPTION
Every session that has been opened stays mounted for the app's lifetime, hidden at
zero opacity. That is deliberate: the surface owns the rendered grid, so unmounting
a pane returns it blank, and resizing it to nothing is a SIGWINCH the program
answers by repainting (#245). But nothing ever told ghostty a pane was off screen,
so a hidden pane kept a live renderer.

A Time Profiler capture of a release build after a day up, with 55 sessions open:

| | |
| --- | --- |
| Threads | 293 — 55 `renderer` + 55 `io` + 55 `cf_release`, one trio per surface |
| Footprint | 2412 MB, peaking at 4290 MB |
| Of which | 1333 MB IOSurface (238 regions), 263 MB IOAccelerator |
| Renderer threads | parked in `kevent64`, but each spending ~1.4% of wall time in `renderCommandEncoderWithDescriptor:` |

Every byte a background agent wrote cost a Metal frame nobody was looking at.

The pane already computes which surfaces are on screen — it uses that answer for
hit-testing and drop targeting. This hands the same answer to `setSurfaceVisible`,
which sets the state `TerminalSurfaceCoordinator` composes from: occlusion reaches
the core, `stopDisplayLink` runs, `shouldProcessWakeup` stops ticking a hidden
pane, and `requestImmediateTick` repaints on the way back in. Occlusion gates
rendering alone — the VT keeps parsing, the grid stays current, `synchronizeMetrics`
still sizes the surface, and the status tap still reads the viewport.

Setting `ghostty_surface_set_occlusion` on the raw handle instead does none of
that, and measured as a no-op: 50 render ticks in 5s with the pane hidden, 50 with
it visible. It leaves `isDisplayVisible` true, so the display link keeps running and
the coordinator overwrites the flag on the next app activation.

The NSView resolver moved out of `TerminalFocusDriver` so focus and visibility
share one copy of it.

### Verification

`setSurfaceVisible(false)` fires exactly when a pane leaves the screen and `true`
when it returns, confirmed by the wrapper's own `[lifecycle] surface occlusion
visible=false` log. `swift build` clean; `swift test` 673 passed, 0 failures.

The CPU and memory delta is **not** verified — the 55-surface condition needs a
real workload over time. To check it on one:

```
sample <pid> 5       # renderer threads should stay in kevent64, not Metal
footprint -p <pid>   # IOSurface should stop scaling with session count
```

### Also here

- Three vendored performance skills, pinned in `skills-lock.json` (both upstreams
  MIT): `native-app-profiling`, `swiftui-performance-audit`,
  `swift-performance-optimization-skill`.
- `TerminalSurface` gained a documented `rawValue` accessor upstream, so the
  `Mirror` read of its private stored property in session control is obsolete —
  and would have started returning nil silently the first time that field was
  renamed.

Release Notes:

- Terminal panes that are not on screen no longer render. Sessions left open in
  the background, and agents working in them, no longer cost frames or graphics
  memory until you look at them.
