### PR TITLE
Stop the editor line-number gutter from shimmering while scrolling

### DIFF
--- a/Sources/termio/Editor/LineNumberRulerView.swift
+++ b/Sources/termio/Editor/LineNumberRulerView.swift
@@ -77,9 +77,18 @@ final class LineNumberRulerView: NSRulerView {
             let size = string.size(withAttributes: attributes)
             let x = self.ruleThickness - size.width - 6
             let y = fragMinY + inset + yOffset + self.baselineShift
+            // `yOffset` carries the live scroll position, and a trackpad reports it in fractional
+            // pixels, so an unsnapped origin rasterizes the digits at a different subpixel phase
+            // every frame — the gutter shimmers. Landing the origin on a device pixel holds the
+            // glyphs still. The code text is immune because its glyphs sit at fixed positions in
+            // the text view's own coordinate space.
+            let origin = self.backingAlignedRect(
+                NSRect(x: x, y: y, width: size.width, height: size.height),
+                options: .alignAllEdgesNearest
+            ).origin
             let topClipInset = self.window.map { 1 / $0.backingScaleFactor } ?? 0
-            guard y > self.bounds.minY + topClipInset else { return }
-            string.draw(at: NSPoint(x: x, y: y), withAttributes: attributes)
+            guard origin.y > self.bounds.minY + topClipInset else { return }
+            string.draw(at: origin, withAttributes: attributes)
         }
 
         let visibleGlyphRange = layoutManager.glyphRange(forBoundingRect: textView.visibleRect, in: container)


### PR DESCRIPTION
The gutter draws each line number at an absolute position derived from the live scroll offset. A trackpad reports that offset in fractional pixels, so every frame rasterized the digits at a new subpixel phase and the numbers shimmered. The code text is immune — its glyphs sit at fixed positions in the text view's own coordinate space.

Snap the draw origin to device pixels with `backingAlignedRect(_:options:.alignAllEdgesNearest)` before drawing, and run the existing top-clip guard against the aligned origin.

Release Notes:
- Line numbers in the editor gutter no longer shimmer while scrolling.