### PR TITLE
Keep the indent on Return and indent line blocks with Tab

### DIFF
--- a/Sources/termio/Editor/EditorIndentation.swift
+++ b/Sources/termio/Editor/EditorIndentation.swift
@@ -1,0 +1,253 @@
+import AppKit
+
+/// The editor's indentation rules — VS Code's defaults (`editor.autoIndent`,
+/// `editor.action.indentLines` / `outdentLines`, `editor.detectIndentation`) — written as pure
+/// functions over the buffer so the behavior is pinned by tests rather than by a window.
+/// Offsets are `NSString` UTF-16 code units throughout, the unit `NSTextView` selections use,
+/// so nothing here transcodes.
+enum EditorIndentation {
+    /// What one level of indentation is in a given buffer.
+    struct Unit: Equatable {
+        /// Tabs only when the buffer plainly indents with tabs; spaces otherwise.
+        var usesTabs: Bool
+        /// Spaces per level — also how far one outdent strips a space-indented line.
+        var width: Int
+
+        var text: String { usesTabs ? "\t" : String(repeating: " ", count: width) }
+    }
+
+    /// Used when the buffer shows no indentation to learn from — a new file, or one that never
+    /// nests.
+    static let fallbackWidth = 4
+
+    /// Only the first lines are sampled: detection runs on every Return and Tab, and a file's
+    /// style is settled long before this many lines.
+    private static let sampleLineLimit = 2_000
+
+    /// Wider steps than this are continuation alignment (a wrapped argument list), not a level.
+    private static let maximumDetectedWidth = 8
+
+    // MARK: Detection
+
+    /// The indent unit `text` already uses. Spaces win ties, so a file with no indentation at
+    /// all — or one whose leading whitespace is inconsistent — comes back as
+    /// `fallbackWidth` spaces.
+    static func detected(in text: NSString) -> Unit {
+        var tabIndentedLines = 0
+        var spaceIndentedLines = 0
+        var votes: [Int: Int] = [:]
+        var previousSpaces: Int?
+        var location = 0
+        var scannedLines = 0
+
+        while location < text.length, scannedLines < sampleLineLimit {
+            let lineRange = text.lineRange(for: NSRange(location: location, length: 0))
+            location = NSMaxRange(lineRange)
+            scannedLines += 1
+
+            var index = lineRange.location
+            var tabs = 0
+            scan: while index < NSMaxRange(lineRange) {
+                switch text.character(at: index) {
+                case 0x20: break
+                case 0x09: tabs += 1
+                default: break scan
+                }
+                index += 1
+            }
+            let leading = index - lineRange.location
+            // A blank or whitespace-only line says nothing about the file's style, and a run of
+            // them must not look like a jump back to column zero either.
+            let content = text.substring(with: NSRange(location: index, length: NSMaxRange(lineRange) - index))
+            guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+
+            if tabs > 0 {
+                tabIndentedLines += 1
+                previousSpaces = nil
+                continue
+            }
+            if leading > 0 { spaceIndentedLines += 1 }
+            if let previous = previousSpaces {
+                let step = abs(leading - previous)
+                if step > 0, step <= maximumDetectedWidth { votes[step, default: 0] += 1 }
+            }
+            previousSpaces = leading
+        }
+
+        // Most-voted step wins; on a tie the narrower one does, since a file indented by two
+        // also produces plenty of four-wide jumps across nested blocks.
+        let best = votes.max { left, right in
+            left.value != right.value ? left.value < right.value : left.key > right.key
+        }
+        return Unit(usesTabs: tabIndentedLines > spaceIndentedLines, width: best?.key ?? fallbackWidth)
+    }
+
+    // MARK: Return
+
+    /// What Return inserts: the newline plus the indentation the new line opens at — the leading
+    /// whitespace of the text before the caret, one level deeper when that text opens a block.
+    static func newlineInsertion(at selection: NSRange, in text: NSString, unit: Unit) -> String {
+        let caret = min(max(selection.location, 0), text.length)
+        let lineStart = text.lineRange(for: NSRange(location: caret, length: 0)).location
+        let prefix = text.substring(with: NSRange(location: lineStart, length: caret - lineStart))
+        var indent = String(prefix.prefix { $0 == " " || $0 == "\t" })
+        // Only what is left of the caret opens a block: pressing Return before a brace should
+        // not indent past it.
+        if let last = prefix.last(where: { !$0.isWhitespace }), "{[(".contains(last) {
+            indent += unit.text
+        }
+        return "\n" + indent
+    }
+
+    // MARK: Tab and Shift-Tab
+
+    /// One line-block rewrite, as data so the caller can land the whole thing as a single
+    /// undoable edit.
+    struct BlockEdit: Equatable {
+        /// The full lines being replaced.
+        var range: NSRange
+        var replacement: String
+        /// Where the selection sits afterwards, its endpoints carried along by the whitespace
+        /// added or removed ahead of them.
+        var selection: NSRange
+    }
+
+    /// Whether `selection` reaches across a line break — the split VS Code draws between Tab
+    /// typing an indent and Tab indenting the selected lines.
+    static func spansLines(_ selection: NSRange, in text: NSString) -> Bool {
+        guard selection.length > 0, NSMaxRange(selection) <= text.length else { return false }
+        return text.rangeOfCharacter(from: .newlines, range: selection).location != NSNotFound
+    }
+
+    /// Every line the selection touches, one level deeper.
+    static func indent(_ selection: NSRange, in text: NSString, unit: Unit) -> BlockEdit {
+        rewrite(selection, in: text) { line in
+            // An empty line gains nothing from a deeper indent, and the trailing spaces it would
+            // leave behind are exactly what a diff flags.
+            line.allSatisfy(\.isWhitespace) ? line : unit.text + line
+        }
+    }
+
+    /// Every line the selection touches, one level shallower. Lines already at column zero are
+    /// left alone, so an outdent can never eat a line's first character.
+    static func outdent(_ selection: NSRange, in text: NSString, unit: Unit) -> BlockEdit {
+        rewrite(selection, in: text) { line in
+            var remaining = Substring(line)
+            // A tab is one level whatever the detected width is; spaces come off up to a level's
+            // worth, so a half-indented line snaps back to column zero rather than staying odd.
+            if remaining.first == "\t" { return String(remaining.dropFirst()) }
+            var removed = 0
+            while removed < unit.width, remaining.first == " " {
+                remaining = remaining.dropFirst()
+                removed += 1
+            }
+            return String(remaining)
+        }
+    }
+
+    private static func rewrite(
+        _ selection: NSRange, in text: NSString, transform: (String) -> String
+    ) -> BlockEdit {
+        let start = min(max(selection.location, 0), text.length)
+        let end = min(max(NSMaxRange(selection), start), text.length)
+        // A selection ending exactly at a line start belongs to the line above it — without the
+        // step back, selecting whole lines would indent the untouched line below them too.
+        let probe = NSRange(location: start, length: end > start ? end - start - 1 : 0)
+        let block = text.lineRange(for: probe)
+
+        var lines: [(range: NSRange, delta: Int)] = []
+        var replacement = ""
+        var location = block.location
+        while location < NSMaxRange(block) {
+            let lineRange = text.lineRange(for: NSRange(location: location, length: 0))
+            let transformed = transform(text.substring(with: lineRange))
+            replacement += transformed
+            lines.append((lineRange, (transformed as NSString).length - lineRange.length))
+            location = NSMaxRange(lineRange)
+        }
+
+        let movedStart = shift(start, through: lines)
+        let movedEnd = shift(end, through: lines)
+        return BlockEdit(
+            range: block,
+            replacement: replacement,
+            selection: NSRange(location: movedStart, length: max(0, movedEnd - movedStart))
+        )
+    }
+
+    /// `offset` moved by the whitespace the rewrite added or removed ahead of it. An offset
+    /// standing inside removed whitespace lands at its line's start instead of before it.
+    private static func shift(_ offset: Int, through lines: [(range: NSRange, delta: Int)]) -> Int {
+        var moved = offset
+        for line in lines {
+            if offset >= NSMaxRange(line.range) {
+                moved += line.delta
+            } else if offset > line.range.location {
+                moved += max(line.delta, line.range.location - offset)
+                break
+            } else {
+                break
+            }
+        }
+        return moved
+    }
+}
+
+extension SavingTextView {
+    /// Detected per keypress rather than cached: the buffer is the only source of truth about
+    /// its own style, and it changes under every edit. The scan is bounded (`sampleLineLimit`).
+    private var indentUnit: EditorIndentation.Unit {
+        EditorIndentation.detected(in: string as NSString)
+    }
+
+    override func insertNewline(_ sender: Any?) {
+        guard isEditable, !hasMarkedText() else { return super.insertNewline(sender) }
+        let insertion = EditorIndentation.newlineInsertion(
+            at: selectedRange(), in: string as NSString, unit: indentUnit
+        )
+        replaceAsOneEdit(selectedRange(), with: insertion, selection: nil)
+    }
+
+    override func insertTab(_ sender: Any?) {
+        guard isEditable, !hasMarkedText() else { return super.insertTab(sender) }
+        let text = string as NSString
+        let selection = selectedRange()
+        guard EditorIndentation.spansLines(selection, in: text) else {
+            replaceAsOneEdit(selection, with: indentUnit.text, selection: nil)
+            return
+        }
+        apply(EditorIndentation.indent(selection, in: text, unit: indentUnit))
+    }
+
+    override func insertBacktab(_ sender: Any?) {
+        guard isEditable, !hasMarkedText() else { return super.insertBacktab(sender) }
+        let text = string as NSString
+        apply(EditorIndentation.outdent(selectedRange(), in: text, unit: indentUnit))
+    }
+
+    private func apply(_ edit: EditorIndentation.BlockEdit) {
+        let text = string as NSString
+        guard NSMaxRange(edit.range) <= text.length,
+              text.substring(with: edit.range) != edit.replacement else { return }
+        replaceAsOneEdit(edit.range, with: edit.replacement, selection: edit.selection)
+    }
+
+    /// One undo step per keypress. `shouldChangeText` is what registers the undo, so a whole
+    /// multi-line indent lands as a single edit there, and `breakUndoCoalescing` on both sides
+    /// stops AppKit folding it into the run of typing around it — ⌘Z steps back exactly one
+    /// indent. The replacement carries `typingAttributes` because the buffer's line metrics live
+    /// in them: plain text would lay out at the font's natural height and the block would jump
+    /// until the highlighter caught up.
+    private func replaceAsOneEdit(_ range: NSRange, with replacement: String, selection: NSRange?) {
+        guard let textStorage, NSMaxRange(range) <= textStorage.length,
+              shouldChangeText(in: range, replacementString: replacement) else { return }
+        breakUndoCoalescing()
+        textStorage.replaceCharacters(
+            in: range, with: NSAttributedString(string: replacement, attributes: typingAttributes)
+        )
+        didChangeText()
+        let inserted = (replacement as NSString).length
+        setSelectedRange(selection ?? NSRange(location: range.location + inserted, length: 0))
+        breakUndoCoalescing()
+    }
+}

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -456,7 +456,7 @@ private final class NotificationObserverBag: @unchecked Sendable {
 /// then lets every other key equivalent fall through unchanged. The editor auto-saves on idle, so
 /// this only serves the reflex of pressing ⌘S — there is still no Save button. It also draws the
 /// Xcode-style current-line band and washes the bracket pair beside the caret.
-private final class SavingTextView: NSTextView {
+final class SavingTextView: NSTextView {
     var onSave: (() -> Void)?
     /// When set, the right-click menu carries a trailing "Close" — the editor's only close
     /// affordance now that it has no chrome button (terminal-style, matching how a session closes).

--- a/Tests/termioTests/EditorTextTests.swift
+++ b/Tests/termioTests/EditorTextTests.swift
@@ -23,6 +23,196 @@ final class TextPositionsTests: XCTestCase {
     }
 }
 
+/// The indent rules the editor's Return, Tab and Shift-Tab keys run on. Every case here is a
+/// keystroke someone would notice getting wrong: a caret landing at column zero, a Tab wiping a
+/// selection, an outdent eating a line's first character.
+final class EditorIndentationTests: XCTestCase {
+    private let fourSpaces = EditorIndentation.Unit(usesTabs: false, width: 4)
+
+    // MARK: Detection
+
+    func testDetectsWidthFromExistingIndentation() {
+        let twoSpace = "class A {\n  func b() {\n    return\n  }\n}\n" as NSString
+        XCTAssertEqual(EditorIndentation.detected(in: twoSpace), EditorIndentation.Unit(usesTabs: false, width: 2))
+
+        let fourSpace = "def a():\n    if b:\n        return\n    return\n" as NSString
+        XCTAssertEqual(EditorIndentation.detected(in: fourSpace), EditorIndentation.Unit(usesTabs: false, width: 4))
+    }
+
+    func testDetectsTabIndentation() {
+        let tabbed = "func main() {\n\tif x {\n\t\treturn\n\t}\n}\n" as NSString
+        XCTAssertEqual(EditorIndentation.detected(in: tabbed), EditorIndentation.Unit(usesTabs: true, width: 4))
+        XCTAssertEqual(EditorIndentation.detected(in: tabbed).text, "\t")
+    }
+
+    /// Nothing to learn from: a flat file, an empty one, and blank lines that must not read as a
+    /// jump back to column zero.
+    func testDetectionFallsBackToFourSpaces() {
+        XCTAssertEqual(EditorIndentation.detected(in: "" as NSString).width, EditorIndentation.fallbackWidth)
+        XCTAssertEqual(EditorIndentation.detected(in: "one\ntwo\n" as NSString).width, EditorIndentation.fallbackWidth)
+        XCTAssertFalse(EditorIndentation.detected(in: "one\ntwo\n" as NSString).usesTabs)
+
+        let blankSeparated = "a:\n  b\n\n  c\n\n  d\n" as NSString
+        XCTAssertEqual(EditorIndentation.detected(in: blankSeparated).width, 2)
+    }
+
+    // MARK: Return
+
+    func testNewlineKeepsThePreviousIndentation() {
+        let text = "    let x = 1\n" as NSString
+        let insertion = EditorIndentation.newlineInsertion(
+            at: NSRange(location: 13, length: 0), in: text, unit: fourSpaces
+        )
+        XCTAssertEqual(insertion, "\n    ")
+    }
+
+    func testNewlineAfterAnOpeningBraceAddsOneLevel() {
+        let text = "  if x {" as NSString
+        let twoSpaces = EditorIndentation.Unit(usesTabs: false, width: 2)
+        XCTAssertEqual(
+            EditorIndentation.newlineInsertion(at: NSRange(location: 8, length: 0), in: text, unit: twoSpaces),
+            "\n    "
+        )
+        // Trailing whitespace after the brace doesn't hide it.
+        let spaced = "func a() {  " as NSString
+        XCTAssertEqual(
+            EditorIndentation.newlineInsertion(at: NSRange(location: 12, length: 0), in: spaced, unit: fourSpaces),
+            "\n    "
+        )
+    }
+
+    /// Only the text left of the caret opens a block — Return placed before the brace stays at
+    /// the line's own level.
+    func testNewlineBeforeTheBraceDoesNotIndent() {
+        let text = "    func a() {" as NSString
+        XCTAssertEqual(
+            EditorIndentation.newlineInsertion(at: NSRange(location: 13, length: 0), in: text, unit: fourSpaces),
+            "\n    "
+        )
+    }
+
+    func testNewlineInsideLeadingWhitespaceCarriesOnlyWhatIsBehindTheCaret() {
+        let text = "        deep\n" as NSString
+        XCTAssertEqual(
+            EditorIndentation.newlineInsertion(at: NSRange(location: 4, length: 0), in: text, unit: fourSpaces),
+            "\n    "
+        )
+        XCTAssertEqual(
+            EditorIndentation.newlineInsertion(at: NSRange(location: 0, length: 0), in: "" as NSString, unit: fourSpaces),
+            "\n"
+        )
+    }
+
+    /// Return over a selection indents from the line the selection starts on.
+    func testNewlineOverASelectionUsesTheStartingLine() {
+        let text = "    one\n    two\n" as NSString
+        XCTAssertEqual(
+            EditorIndentation.newlineInsertion(at: NSRange(location: 7, length: 4), in: text, unit: fourSpaces),
+            "\n    "
+        )
+    }
+
+    // MARK: Tab
+
+    func testSpansLinesOnlyWhenTheSelectionCrossesABreak() {
+        let text = "one\ntwo\nthree\n" as NSString
+        XCTAssertFalse(EditorIndentation.spansLines(NSRange(location: 0, length: 0), in: text))
+        XCTAssertFalse(EditorIndentation.spansLines(NSRange(location: 0, length: 3), in: text))
+        XCTAssertTrue(EditorIndentation.spansLines(NSRange(location: 0, length: 4), in: text))
+        XCTAssertTrue(EditorIndentation.spansLines(NSRange(location: 2, length: 4), in: text))
+    }
+
+    func testIndentShiftsEveryTouchedLineAndCarriesTheSelection() {
+        let text = "one\ntwo\nthree\n" as NSString
+        let edit = EditorIndentation.indent(NSRange(location: 0, length: 7), in: text, unit: fourSpaces)
+        XCTAssertEqual(edit.range, NSRange(location: 0, length: 8))
+        XCTAssertEqual(edit.replacement, "    one\n    two\n")
+        XCTAssertEqual(edit.selection, NSRange(location: 0, length: 15))
+    }
+
+    /// A selection ending exactly at a line start belongs to the line above it — the untouched
+    /// line below full-line selections must not move.
+    func testIndentIgnoresTheLineAfterATrailingNewline() {
+        let text = "one\ntwo\nthree\n" as NSString
+        let edit = EditorIndentation.indent(NSRange(location: 0, length: 4), in: text, unit: fourSpaces)
+        XCTAssertEqual(edit.range, NSRange(location: 0, length: 4))
+        XCTAssertEqual(edit.replacement, "    one\n")
+    }
+
+    func testIndentLeavesBlankLinesEmpty() {
+        let text = "one\n\ntwo\n" as NSString
+        let edit = EditorIndentation.indent(NSRange(location: 0, length: 8), in: text, unit: fourSpaces)
+        XCTAssertEqual(edit.replacement, "    one\n\n    two\n")
+    }
+
+    func testIndentUsesTabsWhenTheFileDoes() {
+        let text = "\tone\n\ttwo\n" as NSString
+        let edit = EditorIndentation.indent(
+            NSRange(location: 0, length: text.length), in: text, unit: EditorIndentation.detected(in: text)
+        )
+        XCTAssertEqual(edit.replacement, "\t\tone\n\t\ttwo\n")
+    }
+
+    // MARK: Shift-Tab
+
+    func testOutdentStripsOneLevelPerLine() {
+        let text = "    one\n    two\n" as NSString
+        let edit = EditorIndentation.outdent(NSRange(location: 0, length: 16), in: text, unit: fourSpaces)
+        XCTAssertEqual(edit.range, NSRange(location: 0, length: 16))
+        XCTAssertEqual(edit.replacement, "one\ntwo\n")
+        XCTAssertEqual(edit.selection, NSRange(location: 0, length: 8))
+    }
+
+    /// Shift-Tab with no selection outdents the caret's own line, and the caret rides along.
+    func testOutdentWithoutASelectionMovesTheCaret() {
+        let text = "        deep\n" as NSString
+        let edit = EditorIndentation.outdent(NSRange(location: 9, length: 0), in: text, unit: fourSpaces)
+        XCTAssertEqual(edit.replacement, "    deep\n")
+        XCTAssertEqual(edit.selection, NSRange(location: 5, length: 0))
+    }
+
+    /// A caret inside the whitespace being removed lands at the line's start, never before it.
+    func testOutdentClampsACaretInsideTheRemovedWhitespace() {
+        let text = "    x\n" as NSString
+        let edit = EditorIndentation.outdent(NSRange(location: 2, length: 0), in: text, unit: fourSpaces)
+        XCTAssertEqual(edit.replacement, "x\n")
+        XCTAssertEqual(edit.selection, NSRange(location: 0, length: 0))
+    }
+
+    func testOutdentNeverEatsContent() {
+        let text = "one\ntwo\n" as NSString
+        let edit = EditorIndentation.outdent(NSRange(location: 0, length: 8), in: text, unit: fourSpaces)
+        XCTAssertEqual(edit.replacement, "one\ntwo\n")
+
+        // A half-indented line snaps to column zero rather than staying odd.
+        let partial = "  x\n" as NSString
+        XCTAssertEqual(
+            EditorIndentation.outdent(NSRange(location: 0, length: 4), in: partial, unit: fourSpaces).replacement,
+            "x\n"
+        )
+    }
+
+    func testOutdentTakesOneTabWhateverTheWidth() {
+        let text = "\t\tx\n" as NSString
+        let edit = EditorIndentation.outdent(
+            NSRange(location: 0, length: 4), in: text, unit: EditorIndentation.Unit(usesTabs: true, width: 4)
+        )
+        XCTAssertEqual(edit.replacement, "\tx\n")
+    }
+
+    /// Indent then outdent is the identity — a Tab the user immediately regrets leaves no trace.
+    func testIndentThenOutdentRoundTrips() {
+        let text = "def a():\n    if b:\n        return\n" as NSString
+        let unit = EditorIndentation.detected(in: text)
+        let indented = EditorIndentation.indent(NSRange(location: 0, length: text.length), in: text, unit: unit)
+        let rewritten = indented.replacement as NSString
+        let outdented = EditorIndentation.outdent(
+            NSRange(location: 0, length: rewritten.length), in: rewritten, unit: unit
+        )
+        XCTAssertEqual(outdented.replacement, text as String)
+    }
+}
+
 final class BracketMatcherTests: XCTestCase {
     func testSimplePair() {
         let text = "f(x)" as NSString


### PR DESCRIPTION
The inspector's editor had no editing behavior of its own: `SavingTextView` overrode no editing methods, so Return dropped the caret to column zero inside any indented block, Tab typed a literal tab whatever the file used, and Tab with several lines selected replaced them.

This adds the table stakes, VS Code's defaults:

- **Return** opens the new line at the leading whitespace ahead of the caret, one level deeper when that text ends in `{`, `[` or `(`.
- **Tab** over a selection that crosses a line break indents every line it touches; **Shift-Tab** outdents them (blank lines stay empty, and an outdent never eats a line's first character). Otherwise Tab inserts one level.
- **The level is read out of the buffer**: the most common step between indented lines, a tab when the file is tab-indented, four spaces when there is nothing to learn from.

The rules live in a new `EditorIndentation.swift` as pure functions over the buffer, so they are pinned by `EditorIndentationTests` rather than by a window; the only change to `HighlightedTextView.swift` is dropping `private` off the class so the extension can reach it. Each keypress lands as one undoable edit — a single ⌘Z steps back a whole multi-line indent — and the replacement carries the view's typing attributes so the block keeps its line metrics.

Tabs get honored rather than rewritten as spaces: a Go file or a Makefile would otherwise gain space indentation on every Return, and Shift-Tab has to recognize a leading tab regardless.

`swift build` and `swift test` (695 tests) pass. The keypress path was additionally exercised end-to-end against an off-screen text view — Return, Tab, Shift-Tab and one-step undo all land as expected — with that scaffolding left out of the commit, since the repo keeps its tests window-free.

Release Notes:

- The editor keeps your indentation when you press Return, and Tab / Shift-Tab now indent and outdent the selected lines using the file's own indent width.