### PR TITLE
Highlight other occurrences of the word under the caret

### DIFF
--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -177,6 +177,13 @@ struct FileEditorView: View {
     private var currentLineColor: NSColor {
         ChromeTheme.overlayInk(onDark: onDarkBackground, alpha: onDarkBackground ? 0.06 : 0.05)
     }
+    /// The wash on other occurrences of the word under the caret. A step above the current-line
+    /// band so it reads as a mark, well below the find bar's yellow so a passive hint never looks
+    /// like a result you searched for. Neutral ink rather than a tint, for the same reason the
+    /// gutter is: a themed color sinks into some backgrounds at any alpha.
+    private var occurrenceHighlightColor: NSColor {
+        ChromeTheme.overlayInk(onDark: onDarkBackground, alpha: onDarkBackground ? 0.14 : 0.11)
+    }
 
     var body: some View {
         // The editor's chrome (header, gutter) already sits in the safe content area below the
@@ -298,6 +305,7 @@ struct FileEditorView: View {
                 caretColor: caretColor,
                 lineNumberColor: lineNumberColor,
                 currentLineColor: currentLineColor,
+                occurrenceHighlightColor: occurrenceHighlightColor,
                 isEditable: !readOnly,
                 jumpToLine: jumpLine,
                 findQuery: findBarVisible ? findQuery : "",

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -19,6 +19,9 @@ struct HighlightedTextView: NSViewRepresentable {
     /// terminal background. Only drawn while the buffer is editable — a read-only peek has no
     /// caret, so a highlighted line would just be a mystery stripe.
     let currentLineColor: NSColor
+    /// The wash on every other occurrence of the word under the caret (`OccurrenceHighlighter`).
+    /// `.clear` turns the behavior off.
+    var occurrenceHighlightColor: NSColor = .clear
     /// When false the text stays selectable (copyable) but cannot be typed into — the read-only
     /// preview path. Defaults to editable so the inspector's own opens are unchanged.
     var isEditable: Bool = true
@@ -249,6 +252,7 @@ struct HighlightedTextView: NSViewRepresentable {
         }
 
         coordinator.onMatchesChanged = onMatchesChanged
+        coordinator.occurrenceHighlightColor = occurrenceHighlightColor
         coordinator.updateFind(query: findQuery, options: findOptions, focusedIndex: findFocusedIndex, in: textView)
     }
 
@@ -345,8 +349,11 @@ struct HighlightedTextView: NSViewRepresentable {
         var wasActive = false
         weak var ruler: LineNumberRulerView?
         var onMatchesChanged: ((Int) -> Void)?
+        /// Refreshed from each update pass; the next repaint is what picks up a theme change.
+        var occurrenceHighlightColor: NSColor = .clear
         private let text: Binding<String>
         private let find = TextFindEngine()
+        private let occurrences = OccurrenceHighlighter()
         private var appliedFindQuery: String = ""
         private var appliedFindOptions: FindOptions = FindOptions()
         private var appliedFocusedIndex: Int = -1
@@ -397,6 +404,8 @@ struct HighlightedTextView: NSViewRepresentable {
         func textViewDidChangeSelection(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
             (textView as? SavingTextView)?.caretDidMove()
+            occurrences.update(in: textView, color: occurrenceHighlightColor,
+                               findActive: !appliedFindQuery.isEmpty)
         }
 
         /// Recompute + repaint after a new query, option change, or focus move. Same query
@@ -406,6 +415,10 @@ struct HighlightedTextView: NSViewRepresentable {
             if queryChanged {
                 appliedFindQuery = query
                 appliedFindOptions = options
+                // A live query owns the highlight layer, so the occurrence wash steps aside; it
+                // comes back on its own once the query clears.
+                occurrences.update(in: textView, color: occurrenceHighlightColor,
+                                   findActive: !query.isEmpty)
                 find.recompute(query: query, options: options, in: textView)
                 notifyMatchCount()
                 appliedFocusedIndex = -1

--- a/Sources/termio/Editor/OccurrenceHighlighter.swift
+++ b/Sources/termio/Editor/OccurrenceHighlighter.swift
@@ -1,0 +1,151 @@
+import AppKit
+
+/// What the occurrence wash is chasing: the text to look for, where that text already sits (so its
+/// own spot stays unwashed), and whether it may only match on word boundaries.
+struct OccurrenceTarget: Equatable {
+    let text: String
+    let range: NSRange
+    let wholeWord: Bool
+
+    /// Past this a selection is a block of text being moved, not a name being read — VS Code draws
+    /// the same line, and chasing a paragraph through the document would wash half the screen.
+    static let maximumSelectionLength = 200
+
+    /// The target for `selection`, or `nil` when nothing about it is worth chasing: a caret sitting
+    /// in whitespace, a selection that crosses lines, a selection of nothing but whitespace, or one
+    /// too long to be a name. `allowsCaretWord` is false on a read-only buffer, where an empty
+    /// selection is a click, not a caret — the same reason the current-line band and the bracket
+    /// wash stay dark there.
+    static func resolve(selection: NSRange, in text: NSString, allowsCaretWord: Bool) -> OccurrenceTarget? {
+        guard text.length > 0, selection.location >= 0,
+              selection.location + selection.length <= text.length else { return nil }
+        guard selection.length > 0 else {
+            guard allowsCaretWord, let word = wordRange(at: selection.location, in: text) else { return nil }
+            return OccurrenceTarget(text: text.substring(with: word), range: word, wholeWord: true)
+        }
+        guard selection.length <= maximumSelectionLength else { return nil }
+        let candidate = text.substring(with: selection)
+        guard !candidate.contains(where: \.isNewline),
+              candidate.contains(where: { !$0.isWhitespace }) else { return nil }
+        // A selection that covers exactly one word is bounded like one, so double-clicking `set`
+        // doesn't light up every `settings`. Anything else — half a word, `foo.bar` — matches
+        // literally, since that is what the user pointed at.
+        let wholeWord = wordRange(at: selection.location, in: text) == selection
+        return OccurrenceTarget(text: candidate, range: selection, wholeWord: wholeWord)
+    }
+
+    /// The word containing `location`, treating a caret parked between a word and anything else as
+    /// belonging to the word it just left — the same "character before the caret wins" rule the
+    /// bracket wash follows.
+    static func wordRange(at location: Int, in text: NSString) -> NSRange? {
+        var anchor = -1
+        if isWordCharacter(at: location - 1, in: text) {
+            anchor = location - 1
+        } else if isWordCharacter(at: location, in: text) {
+            anchor = location
+        }
+        guard anchor >= 0 else { return nil }
+        var start = anchor
+        while start > 0, isWordCharacter(at: start - 1, in: text) { start -= 1 }
+        var end = anchor + 1
+        while end < text.length, isWordCharacter(at: end, in: text) { end += 1 }
+        return NSRange(location: start, length: end - start)
+    }
+
+    private static func isWordCharacter(at index: Int, in text: NSString) -> Bool {
+        guard index >= 0, index < text.length,
+              let scalar = Unicode.Scalar(text.character(at: index)) else { return false }
+        return TextFindEngine.wordCharacters.contains(scalar)
+    }
+}
+
+/// VS Code's `occurrencesHighlight` / `selectionHighlight`: the word under the caret — or a short
+/// selection — gets a faint wash everywhere else it appears, so reading what an agent just wrote
+/// shows where a name is used without typing it into find. This editor is read far more than it is
+/// typed in, and this is the cheapest reading aid it was missing.
+///
+/// It rides the machinery the find bar already has: `TextFindEngine` finds the matches and paints
+/// them as temporary layout attributes. Only the trigger (a selection change instead of a query)
+/// and the colour (weaker, so a passive hint never reads as a search result) differ. Three rules
+/// keep it out of the way:
+///
+/// - **The find bar wins.** While a query is live its highlights own the layer and this stays dark;
+///   it comes back when the query clears.
+/// - **Only its own paint is lifted.** The wash goes on additively and comes off range by range, so
+///   it can share the highlight layer with the bracket match instead of wiping it.
+/// - **Caret moves stay cheap.** The scan is debounced, skipped on a document too big to syntax
+///   highlight, skipped again when the caret is still in the word already washed, and capped in how
+///   many matches it paints.
+@MainActor
+final class OccurrenceHighlighter {
+    /// Ranges currently washed, so the next pass lifts exactly its own paint.
+    private var painted: [NSRange] = []
+    /// What `painted` was computed for — a caret walking inside one word repaints nothing.
+    private var appliedTarget: OccurrenceTarget?
+    /// The document length that memo was taken at. An edit can leave the caret in the same word
+    /// while adding or removing an occurrence, which the target alone can't see.
+    private var appliedLength = -1
+    private var pending: Task<Void, Never>?
+    /// The same matcher the find bar drives, kept per highlighter so the two never share state.
+    private let matcher = TextFindEngine()
+
+    /// A document this long already renders as plain text (`FileEditorView.highlightByteLimit`,
+    /// the same figure counted in UTF-16 units here) because whole-document work on it janks. A
+    /// scan per caret move is exactly that work, so past this the wash stays off.
+    private static let documentLimit = 256 * 1024
+    /// A ceiling on washes from one word: a common token in a large file would otherwise put
+    /// thousands of temporary attributes on the layout manager for a hint nobody can read.
+    private static let matchLimit = 1_000
+    /// Long enough that walking the caret across a line scans once instead of per keystroke, short
+    /// enough that the wash still feels like it belongs to where you stopped.
+    private static let debounce: UInt64 = 150_000_000
+
+    /// Re-derive the wash after a selection change. `findActive` hands the highlight layer to the
+    /// find bar; a clear `color` turns the behaviour off entirely.
+    func update(in textView: NSTextView, color: NSColor, findActive: Bool) {
+        pending?.cancel()
+        pending = nil
+        guard !findActive, color.alphaComponent > 0 else {
+            clear(in: textView)
+            return
+        }
+        pending = Task { [weak self, weak textView] in
+            try? await Task.sleep(nanoseconds: Self.debounce)
+            guard !Task.isCancelled, let self, let textView else { return }
+            self.apply(in: textView, color: color)
+        }
+    }
+
+    private func apply(in textView: NSTextView, color: NSColor) {
+        let text = textView.string as NSString
+        guard text.length <= Self.documentLimit,
+              let target = OccurrenceTarget.resolve(
+                selection: textView.selectedRange(), in: text, allowsCaretWord: textView.isEditable)
+        else {
+            clear(in: textView)
+            return
+        }
+        guard target != appliedTarget || text.length != appliedLength else { return }
+        clear(in: textView)
+        matcher.recompute(
+            query: target.text,
+            options: FindOptions(caseSensitive: true, wholeWord: target.wholeWord, regex: false),
+            in: textView)
+        // The target's own spot is where the eye already is; washing it would just restate the
+        // selection, so only the *other* occurrences light up.
+        painted = Array(matcher.matches
+            .filter { $0.location != target.range.location }
+            .prefix(Self.matchLimit))
+        TextFindEngine.addHighlight(painted, color: color, in: textView)
+        appliedTarget = target
+        appliedLength = text.length
+    }
+
+    private func clear(in textView: NSTextView) {
+        appliedTarget = nil
+        appliedLength = -1
+        guard !painted.isEmpty else { return }
+        TextFindEngine.removeHighlight(painted, in: textView)
+        painted = []
+    }
+}

--- a/Sources/termio/Editor/TextFindEngine.swift
+++ b/Sources/termio/Editor/TextFindEngine.swift
@@ -13,6 +13,10 @@ final class TextFindEngine {
     private static let matchColor = NSColor.systemYellow.withAlphaComponent(0.35)
     private static let focusedColor = NSColor.systemYellow.withAlphaComponent(0.7)
 
+    /// What counts as "inside a word" for whole-word find. Shared with `OccurrenceTarget` so the
+    /// word the occurrence wash picks up and the boundary this engine matches on can't disagree.
+    nonisolated static let wordCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
+
     /// Rebuild the match list for `query` over the text view's current string. Returns the count.
     @discardableResult
     func recompute(query: String, options: FindOptions, in textView: NSTextView) -> Int {
@@ -66,6 +70,36 @@ final class TextFindEngine {
         }
     }
 
+    /// Wash `ranges` in `color` without disturbing anything else already painted — the additive
+    /// counterpart to `paint(focused:reveal:)`, which owns the whole document. The occurrence
+    /// highlight goes through here so it shares the layer with the bracket wash instead of wiping
+    /// it, and `removeHighlight` lifts exactly what this laid down.
+    static func addHighlight(_ ranges: [NSRange], color: NSColor, in textView: NSTextView) {
+        guard let layoutManager = textView.layoutManager else { return }
+        let length = (textView.string as NSString).length
+        for range in ranges {
+            guard let clamped = clamp(range, to: length) else { continue }
+            layoutManager.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: clamped)
+        }
+    }
+
+    static func removeHighlight(_ ranges: [NSRange], in textView: NSTextView) {
+        guard let layoutManager = textView.layoutManager else { return }
+        let length = (textView.string as NSString).length
+        for range in ranges {
+            guard let clamped = clamp(range, to: length) else { continue }
+            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: clamped)
+        }
+    }
+
+    /// `range` cut down to fit a text of `length`, or `nil` when it starts past the end — an edit
+    /// can shrink the document between painting and lifting, and touching an attribute past the
+    /// end raises.
+    private static func clamp(_ range: NSRange, to length: Int) -> NSRange? {
+        guard range.location < length else { return nil }
+        return NSRange(location: range.location, length: min(range.length, length - range.location))
+    }
+
     private func clearHighlights(in textView: NSTextView) {
         guard let layoutManager = textView.layoutManager else { return }
         let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
@@ -73,7 +107,7 @@ final class TextFindEngine {
     }
 
     private static func isWordBoundary(_ range: NSRange, in string: NSString) -> Bool {
-        let letters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
+        let letters = wordCharacters
         if range.location > 0 {
             let prev = string.character(at: range.location - 1)
             if let scalar = Unicode.Scalar(prev), letters.contains(scalar) { return false }

--- a/Tests/termioTests/EditorTextTests.swift
+++ b/Tests/termioTests/EditorTextTests.swift
@@ -59,3 +59,68 @@ final class BracketMatcherTests: XCTestCase {
         XCTAssertNil(BracketMatcher.match(at: 3, in: text))
     }
 }
+
+/// Which selections the occurrence wash chases. The wash itself needs a laid-out text view, but
+/// what it decides to look for is pure — and every rule here is one that, wrong, paints the
+/// document at rest.
+final class OccurrenceTargetTests: XCTestCase {
+    private let source = "let total = count + total\nlet other = total" as NSString
+
+    private func target(_ selection: NSRange, editable: Bool = true) -> OccurrenceTarget? {
+        OccurrenceTarget.resolve(selection: selection, in: source, allowsCaretWord: editable)
+    }
+
+    func testCaretInsideAWordTakesTheWholeWord() {
+        let inside = target(NSRange(location: 6, length: 0)) // "to|tal"
+        XCTAssertEqual(inside?.text, "total")
+        XCTAssertEqual(inside?.range, NSRange(location: 4, length: 5))
+        XCTAssertEqual(inside?.wholeWord, true)
+    }
+
+    /// A caret parked at either edge still belongs to the word — the trailing edge is where you
+    /// land after double-clicking or arrowing to the end of a name.
+    func testCaretAtWordEdges() {
+        XCTAssertEqual(target(NSRange(location: 4, length: 0))?.text, "total")
+        XCTAssertEqual(target(NSRange(location: 9, length: 0))?.text, "total")
+    }
+
+    func testCaretAwayFromAnyWordHasNoTarget() {
+        XCTAssertNil(target(NSRange(location: 10, length: 0))) // on "="
+        XCTAssertNil(target(NSRange(location: 11, length: 0))) // in the gap after it
+    }
+
+    /// A read-only peek shows no caret, so an empty selection there is a click, not a place.
+    func testReadOnlyBufferIgnoresTheCaret() {
+        XCTAssertNil(target(NSRange(location: 6, length: 0), editable: false))
+        // A real selection still counts — that's the reading gesture the peek has.
+        XCTAssertEqual(target(NSRange(location: 4, length: 5), editable: false)?.text, "total")
+    }
+
+    func testSelectionSpanningLinesIsSkipped() {
+        XCTAssertNil(target(NSRange(location: 20, length: 10)))
+    }
+
+    func testWhitespaceOnlySelectionIsSkipped() {
+        XCTAssertNil(target(NSRange(location: 3, length: 1)))
+    }
+
+    func testOversizedSelectionIsSkipped() {
+        let long = String(repeating: "a", count: OccurrenceTarget.maximumSelectionLength + 1) as NSString
+        XCTAssertNil(OccurrenceTarget.resolve(
+            selection: NSRange(location: 0, length: long.length), in: long, allowsCaretWord: true))
+    }
+
+    /// A partial selection matches literally: selecting `tot` must not light up every `total`.
+    func testPartialSelectionDropsTheWordBound() {
+        let partial = target(NSRange(location: 4, length: 3))
+        XCTAssertEqual(partial?.text, "tot")
+        XCTAssertEqual(partial?.wholeWord, false)
+    }
+
+    /// Word scanning walks UTF-16 units, the unit `NSTextView` selections speak — a caret past an
+    /// astral character must not read a surrogate half as a letter and swallow the neighbors.
+    func testSurrogatePairsBoundAWord() {
+        let text = "a🙂name" as NSString
+        XCTAssertEqual(OccurrenceTarget.wordRange(at: 5, in: text), NSRange(location: 3, length: 4))
+    }
+}


### PR DESCRIPTION
The editor is read far more than it is typed in — mostly to see what an agent just wrote — and it had no way to show where a name is used without opening find and typing it. This adds VS Code's `occurrencesHighlight` / `selectionHighlight`: put the caret in a word, or select one, and every other place it appears gets a faint wash.

It rides the find bar's own machinery rather than standing up a second one. `TextFindEngine` finds the matches and paints them; only the trigger (a selection change instead of a query) and the colour differ. Two small additions to the engine — an additive `addHighlight` / `removeHighlight` pair — let the wash go on without clearing the whole document, so it shares the highlight layer with the bracket match instead of wiping it. All the new decisions live in `OccurrenceHighlighter.swift`; `HighlightedTextView` gains a colour and two calls.

Where it stays out of the way:

- A live find query owns the layer. The wash steps aside and comes back when the query clears.
- Only a real target qualifies: a caret in whitespace, a selection crossing lines, a whitespace-only selection, and anything past 200 characters are all skipped. A selection covering exactly one word matches on word boundaries; a partial or punctuated one matches literally.
- A read-only peek shows no caret, so there it only follows a real selection — the same rule the current-line band and bracket wash already follow.
- Caret moves stay cheap: the scan is debounced 150 ms, skipped entirely past the size where the editor stops syntax highlighting, skipped again while the caret stays inside the word already washed, and capped at 1000 painted matches.

The colour is theme-derived next to the current-line band (`ChromeTheme.overlayInk`) — a step above it, well below the find bar's yellow, and neutral ink so it can't sink into a themed background.

`swift build` and `swift test` (685 tests) pass; the new word/selection rules are covered by `OccurrenceTargetTests`.

Release Notes:
- The code editor now highlights every other occurrence of the word under the caret, or of a selected word.