### PR TITLE
Draw indentation guides in the code editor

### DIFF
--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -184,6 +184,12 @@ struct FileEditorView: View {
     private var occurrenceHighlightColor: NSColor {
         ChromeTheme.overlayInk(onDark: onDarkBackground, alpha: onDarkBackground ? 0.14 : 0.11)
     }
+    /// The rules at each indent level, from the same overlay ink at the same weight as the
+    /// occurrence wash: a one-point rule has a fraction of either wash's area to read from, so at
+    /// the current-line band's alpha it would disappear into the background entirely.
+    private var indentGuideColor: NSColor {
+        ChromeTheme.overlayInk(onDark: onDarkBackground, alpha: onDarkBackground ? 0.14 : 0.11)
+    }
 
     var body: some View {
         // The editor's chrome (header, gutter) already sits in the safe content area below the
@@ -306,6 +312,7 @@ struct FileEditorView: View {
                 lineNumberColor: lineNumberColor,
                 currentLineColor: currentLineColor,
                 occurrenceHighlightColor: occurrenceHighlightColor,
+                indentGuideColor: indentGuideColor,
                 isEditable: !readOnly,
                 jumpToLine: jumpLine,
                 findQuery: findBarVisible ? findQuery : "",

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -22,6 +22,9 @@ struct HighlightedTextView: NSViewRepresentable {
     /// The wash on every other occurrence of the word under the caret (`OccurrenceHighlighter`).
     /// `.clear` turns the behavior off.
     var occurrenceHighlightColor: NSColor = .clear
+    /// Ink for the rules at each indent level (`IndentGuideRenderer`), a step stronger than the
+    /// band above. `.clear` turns the behavior off.
+    var indentGuideColor: NSColor = .clear
     /// When false the text stays selectable (copyable) but cannot be typed into — the read-only
     /// preview path. Defaults to editable so the inspector's own opens are unchanged.
     var isEditable: Bool = true
@@ -314,6 +317,7 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.typingAttributes[.baselineOffset] = Self.baselineOffset(lineSpacing: lineSpacing)
         if let saving = textView as? SavingTextView {
             saving.currentLineColor = currentLineColor
+            saving.indentGuideColor = indentGuideColor
             saving.caretIndicatorColor = caretColor
             // The matched pair glows in the caret's own accent, dimmed to a wash.
             saving.bracketHighlightColor = caretColor.withAlphaComponent(0.28)
@@ -487,6 +491,12 @@ final class SavingTextView: NSTextView {
     }
     /// Background wash on a bracket pair when the caret sits against one of them.
     var bracketHighlightColor: NSColor = .clear
+    /// Ink for the indent guides; change-gated for the same reason `currentLineColor` is.
+    var indentGuideColor: NSColor = .clear {
+        didSet { if indentGuideColor != oldValue { needsDisplay = true } }
+    }
+    /// Holds the indent width it derived between draws; the geometry lives in the renderer.
+    private let indentGuides = IndentGuideRenderer()
 
     /// The system insertion indicator (macOS 14's `NSTextInsertionIndicator`) in place of the
     /// legacy hard-blink caret — the same soft fade-and-glide caret Xcode shows. TextKit 2 text
@@ -730,6 +740,7 @@ final class SavingTextView: NSTextView {
     /// highlight — and only while editable, since a read-only peek shows no caret.
     override func drawBackground(in rect: NSRect) {
         super.drawBackground(in: rect)
+        indentGuides.draw(in: self, dirtyRect: rect, color: indentGuideColor)
         guard isEditable, currentLineColor.alphaComponent > 0,
               let layoutManager, let textContainer else { return }
         let selection = selectedRange()

--- a/Sources/termio/Editor/IndentGuideRenderer.swift
+++ b/Sources/termio/Editor/IndentGuideRenderer.swift
@@ -1,0 +1,219 @@
+import AppKit
+
+/// VS Code's `editor.guides.indentation` for the inspector's code editor: a thin vertical rule at
+/// every indent level a line sits inside, painted behind the text. The editor lives in a narrow
+/// column and is mostly used to *read* agent-written code, where the line that opened the block has
+/// usually scrolled off the top — the rules are what say how deep you are.
+///
+/// An instance is held by the text view so the derived indent width survives between draws;
+/// everything else is recomputed per paint from the visible range only.
+@MainActor
+final class IndentGuideRenderer {
+    /// A rule is one point wide, snapped to the backing store — two device pixels on Retina, the
+    /// same weight VS Code's guides carry.
+    private static let thickness: CGFloat = 1
+
+    /// How far the walk may run past the viewport looking for the non-blank line a blank run takes
+    /// its guides from. A cap, because a document can open with a thousand empty lines.
+    private static let blankRunLimit = 64
+
+    /// The indent width last derived, tagged with the document length it came from.
+    private var cachedUnit: (documentLength: Int, unit: Int)?
+
+    /// Paints the guides for the lines currently on screen. `dirtyRect` only gates the fills —
+    /// AppKit's copy-on-scroll hands us a thin strip, and a rule outside it is already on screen.
+    func draw(in textView: NSTextView, dirtyRect: NSRect, color: NSColor) {
+        guard color.alphaComponent > 0 else { return }
+        let rules = self.rules(in: textView)
+        guard !rules.isEmpty else { return }
+        color.setFill()
+        for rule in rules where rule.intersects(dirtyRect) { rule.fill() }
+    }
+
+    /// Every guide rule for the lines currently on screen, in the text view's own coordinates and
+    /// already snapped to the backing store. Split from `draw` so the geometry can be checked
+    /// against a laid-out text view instead of only by eye.
+    func rules(in textView: NSTextView) -> [NSRect] {
+        guard let layoutManager = textView.layoutManager,
+              let container = textView.textContainer else { return [] }
+        let content = textView.string as NSString
+        guard content.length > 0 else { return [] }
+        // A file that never nests yields no levels on any line, so no rules — the detected width
+        // is only ever a divisor here, never something that invents indentation.
+        let unit = indentUnit(in: content)
+
+        let origin = textView.textContainerOrigin
+        var viewport = textView.visibleRect
+        viewport.origin.x -= origin.x
+        viewport.origin.y -= origin.y
+        let visibleGlyphs = layoutManager.glyphRange(forBoundingRect: viewport, in: container)
+        let visible = layoutManager.characterRange(forGlyphRange: visibleGlyphs, actualGlyphRange: nil)
+        guard visible.length > 0 else { return [] }
+
+        // Blank lines inside a block keep the block's rules, so a run straddling the top or bottom
+        // edge of the viewport needs the non-blank neighbour just outside it.
+        let scan = Self.scanRange(around: visible, in: content)
+
+        // Where the last non-blank line put its rules, so a blank run can inherit the positions
+        // rather than re-derive them from indentation it doesn't have — which is also what keeps
+        // the carried rules correct in a tab-indented file.
+        var previousLevelXs: [CGFloat] = []
+        var pendingBlanks: [NSRect] = []
+        var rules: [NSRect] = []
+
+        content.enumerateSubstrings(
+            in: scan,
+            options: [.byParagraphs, .substringNotRequired]
+        ) { _, lineRange, _, _ in
+            let indent = Self.leadingWhitespace(lineRange, in: content)
+            let extent = self.rows(of: lineRange, layoutManager: layoutManager, in: container)
+            // An all-whitespace line indents nothing of its own; it waits for the line below.
+            guard indent < lineRange.length else {
+                pendingBlanks.append(extent)
+                return
+            }
+
+            var levelXs: [CGFloat] = []
+            levelXs.reserveCapacity(indent / unit)
+            for level in 0..<(indent / unit) {
+                guard let x = self.columnX(
+                    at: lineRange.location + level * unit, layoutManager: layoutManager
+                ) else { break }
+                levelXs.append(x + origin.x)
+            }
+
+            if !pendingBlanks.isEmpty {
+                // VS Code carries the guides straight through a blank run, at the shallower of the
+                // two lines bracketing it: a blank line between two statements keeps the block's
+                // rules, and one that closes a block doesn't sprout a deeper rule out of nothing.
+                let carried = previousLevelXs.prefix(levelXs.count)
+                for blank in pendingBlanks {
+                    rules.append(contentsOf: Self.rules(at: carried, over: blank, in: textView))
+                }
+                pendingBlanks.removeAll(keepingCapacity: true)
+            }
+            // One rule per level spanning the whole logical line — including its soft-wrapped
+            // rows. A continuation row has no indentation of its own to read, so deriving guides
+            // per visual row is what invents the spurious ones.
+            rules.append(contentsOf: Self.rules(at: levelXs[...], over: extent, in: textView))
+            previousLevelXs = levelXs
+        }
+        // A blank run reaching the end of the document has no lower neighbour to inherit from, so
+        // it draws nothing — the same answer VS Code gives past the last line of code.
+        return rules
+    }
+
+    private static func rules(
+        at columns: ArraySlice<CGFloat>, over extent: NSRect, in textView: NSTextView
+    ) -> [NSRect] {
+        guard extent.height > 0 else { return [] }
+        let top = extent.minY + textView.textContainerOrigin.y
+        return columns.map { x in
+            // Snapped to whole device pixels or a one-point rule lands across a pixel boundary and
+            // renders as a blurry smear that shimmers under scrolling. The vertical edges round
+            // outward so consecutive lines' rules meet without a hairline gap between them.
+            textView.backingAlignedRect(
+                NSRect(x: x, y: top, width: thickness, height: extent.height),
+                options: [.alignMinXNearest, .alignWidthNearest, .alignMinYOutward, .alignMaxYOutward]
+            )
+        }
+    }
+
+    /// Where the character at `index` starts, in text-container coordinates. Asking the layout
+    /// manager rather than multiplying a column by an advance keeps the rules correct for tab
+    /// indentation, whose width is the view's tab stops rather than the font's.
+    private func columnX(at index: Int, layoutManager: NSLayoutManager) -> CGFloat? {
+        let glyphs = layoutManager.glyphRange(
+            forCharacterRange: NSRange(location: index, length: 1), actualCharacterRange: nil
+        )
+        guard glyphs.length > 0, glyphs.location < layoutManager.numberOfGlyphs else { return nil }
+        let fragment = layoutManager.lineFragmentRect(forGlyphAt: glyphs.location, effectiveRange: nil)
+        return fragment.minX + layoutManager.location(forGlyphAt: glyphs.location).x
+    }
+
+    /// The vertical band a logical line occupies, wrapped rows included. An empty line has no
+    /// glyphs to measure, so its fragment rect stands in.
+    private func rows(
+        of lineRange: NSRange, layoutManager: NSLayoutManager, in container: NSTextContainer
+    ) -> NSRect {
+        if lineRange.length > 0 {
+            let glyphs = layoutManager.glyphRange(forCharacterRange: lineRange, actualCharacterRange: nil)
+            if glyphs.length > 0 {
+                return layoutManager.boundingRect(forGlyphRange: glyphs, in: container)
+            }
+        }
+        let anchor = layoutManager.glyphRange(
+            forCharacterRange: NSRange(location: lineRange.location, length: 0), actualCharacterRange: nil
+        )
+        guard anchor.location < layoutManager.numberOfGlyphs else {
+            return layoutManager.extraLineFragmentRect
+        }
+        return layoutManager.lineFragmentRect(forGlyphAt: anchor.location, effectiveRange: nil)
+    }
+
+    // MARK: Indent width
+
+    /// Whitespace characters per level, from the buffer's own indentation. `EditorIndentation`
+    /// owns the detection because it owns the *answer*: it is what Return and Tab insert, so a
+    /// second opinion here would draw the rules at columns the Tab key never produces. A
+    /// tab-indented file is one character per level whatever width the view renders it at.
+    ///
+    /// Cached against the document length. Scrolling is the hot path and never changes the
+    /// length, so it never re-derives; an edit does, which is both cheap and exactly when the
+    /// answer could have moved.
+    private func indentUnit(in content: NSString) -> Int {
+        if let cached = cachedUnit, cached.documentLength == content.length { return cached.unit }
+        let detected = EditorIndentation.detected(in: content)
+        let unit = detected.usesTabs ? 1 : max(1, detected.width)
+        cachedUnit = (content.length, unit)
+        return unit
+    }
+
+    // MARK: Line helpers
+
+    /// The visible range grown to whole lines, then out past any blank run at either edge to the
+    /// non-blank line that run inherits its guides from.
+    static func scanRange(around visible: NSRange, in content: NSString) -> NSRange {
+        var start = content.lineRange(for: NSRange(location: visible.location, length: 0)).location
+        var steps = 0
+        while start > 0, steps < blankRunLimit,
+              isBlank(content.lineRange(for: NSRange(location: start, length: 0)), in: content) {
+            start = content.lineRange(for: NSRange(location: start - 1, length: 0)).location
+            steps += 1
+        }
+
+        let last = min(max(NSMaxRange(visible) - 1, 0), max(content.length - 1, 0))
+        var end = NSMaxRange(content.lineRange(for: NSRange(location: last, length: 0)))
+        steps = 0
+        while end < content.length, steps < blankRunLimit,
+              isBlank(content.lineRange(for: NSRange(location: end - 1, length: 0)), in: content) {
+            end = NSMaxRange(content.lineRange(for: NSRange(location: end, length: 0)))
+            steps += 1
+        }
+        return NSRange(location: start, length: max(0, end - start))
+    }
+
+    /// Whether `lineRange` — a range that may still carry its line terminator — holds only
+    /// whitespace.
+    private static func isBlank(_ lineRange: NSRange, in content: NSString) -> Bool {
+        for index in lineRange.location..<NSMaxRange(lineRange) {
+            switch content.character(at: index) {
+            case 0x20, 0x09, 0x0A, 0x0D: continue
+            default: return false
+            }
+        }
+        return true
+    }
+
+    /// Leading spaces and tabs of `lineRange` (which excludes its line terminator). Equal to the
+    /// range's own length exactly when the line is blank.
+    private static func leadingWhitespace(_ lineRange: NSRange, in content: NSString) -> Int {
+        var count = 0
+        for index in lineRange.location..<NSMaxRange(lineRange) {
+            let character = content.character(at: index)
+            guard character == 0x20 || character == 0x09 else { break }
+            count += 1
+        }
+        return count
+    }
+}

--- a/Tests/termioTests/IndentGuideTests.swift
+++ b/Tests/termioTests/IndentGuideTests.swift
@@ -1,0 +1,228 @@
+import AppKit
+import XCTest
+@testable import termio
+
+/// How far past the viewport the walk has to reach so a blank run still carries its block's
+/// rules. Silent when wrong — the blank line just drops the rules — so it's pinned here rather
+/// than judged on screen. (The indent width itself is `EditorIndentation.detected`, tested with
+/// the Return/Tab behavior that shares it.)
+@MainActor
+final class IndentGuideScanRangeTests: XCTestCase {
+    private let source = "a\n    b\n\n\n    c\n    d\n" as NSString
+
+    /// A viewport landing on the blank run alone still reaches the indented lines bracketing it,
+    /// which is where the run's rules come from.
+    func testBlankRunReachesBothNeighbours() {
+        let blanks = NSRange(location: 8, length: 2) // the two empty lines
+        let scan = IndentGuideRenderer.scanRange(around: blanks, in: source)
+        XCTAssertLessThanOrEqual(scan.location, 2)             // includes "    b"
+        XCTAssertGreaterThanOrEqual(NSMaxRange(scan), 15)      // includes "    c"
+    }
+
+    /// A viewport already sitting on real code is not grown — the walk only pays for blank runs.
+    func testNonBlankEdgesAreNotGrown() {
+        let body = NSRange(location: 2, length: 5) // "    b"
+        let scan = IndentGuideRenderer.scanRange(around: body, in: source)
+        XCTAssertEqual(scan.location, 2)
+        XCTAssertEqual(NSMaxRange(scan), 8)
+    }
+
+    /// The document's first and last lines have nothing beyond them; the walk must stop rather
+    /// than index past either end.
+    func testWholeDocumentIsClamped() {
+        let scan = IndentGuideRenderer.scanRange(
+            around: NSRange(location: 0, length: source.length), in: source
+        )
+        XCTAssertEqual(scan.location, 0)
+        XCTAssertEqual(NSMaxRange(scan), source.length)
+    }
+
+    func testEmptyDocumentDoesNotRunOffTheEnd() {
+        let empty = "" as NSString
+        let scan = IndentGuideRenderer.scanRange(around: NSRange(location: 0, length: 0), in: empty)
+        XCTAssertEqual(scan.length, 0)
+    }
+}
+
+/// The rules themselves, measured off a real laid-out text view rather than judged by eye: which
+/// lines get how many, where each one lands, and that a wrapped line stays one set of rules.
+@MainActor
+final class IndentGuideGeometryTests: XCTestCase {
+    /// A monospaced text view wide enough not to wrap, laid out and scrolled to the top.
+    private func textView(_ source: String, width: CGFloat = 800) -> NSTextView {
+        let storage = NSTextStorage(string: source)
+        let layoutManager = NSLayoutManager()
+        storage.addLayoutManager(layoutManager)
+        let container = NSTextContainer(size: NSSize(width: width, height: .greatestFiniteMagnitude))
+        container.widthTracksTextView = true
+        layoutManager.addTextContainer(container)
+        let view = NSTextView(frame: NSRect(x: 0, y: 0, width: width, height: 600),
+                              textContainer: container)
+        view.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        storage.addAttributes([.font: view.font ?? .systemFont(ofSize: 12)],
+                              range: NSRange(location: 0, length: storage.length))
+        layoutManager.ensureLayout(for: container)
+        return view
+    }
+
+    /// The x each rule sits at, deduplicated and sorted — the set of indent columns on screen.
+    private func columns(_ rules: [NSRect]) -> [CGFloat] {
+        Array(Set(rules.map(\.minX))).sorted()
+    }
+
+    func testOneRulePerEnclosingLevel() {
+        let view = textView("""
+        func outer() {
+            if condition {
+                body()
+            }
+        }
+        """)
+        let rules = IndentGuideRenderer().rules(in: view)
+        // Indents 0, 4, 8, 4, 0 → 0 + 1 + 2 + 1 + 0 rules.
+        XCTAssertEqual(rules.count, 4)
+        XCTAssertEqual(columns(rules).count, 2)
+    }
+
+    /// The rules land on the indent columns, not between them: the second sits exactly one level
+    /// to the right of the first.
+    func testRulesLandOnTheIndentColumns() {
+        let view = textView("""
+        a:
+            b:
+                c()
+        """)
+        let columns = self.columns(IndentGuideRenderer().rules(in: view))
+        XCTAssertEqual(columns.count, 2)
+        guard columns.count == 2 else { return }
+        let advance = ("    " as NSString)
+            .size(withAttributes: [.font: view.font ?? .systemFont(ofSize: 12)]).width
+        XCTAssertEqual(columns[1] - columns[0], advance, accuracy: 1)
+    }
+
+    /// The width comes from the file, not a house constant: the same nesting drawn from a
+    /// two-space file puts its rules half as far apart as a four-space one.
+    func testWidthFollowsTheFile() {
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        let advance = ("  " as NSString).size(withAttributes: [.font: font]).width
+
+        let twoSpace = columns(IndentGuideRenderer().rules(in: textView("""
+        a:
+          b:
+            c()
+        """)))
+        XCTAssertEqual(twoSpace.count, 2)
+        guard twoSpace.count == 2 else { return }
+        XCTAssertEqual(twoSpace[1] - twoSpace[0], advance, accuracy: 1)
+
+        // Same shape at four spaces — one level, so twice the gap.
+        let fourSpace = columns(IndentGuideRenderer().rules(in: textView("""
+        a:
+            b:
+                c()
+        """)))
+        XCTAssertEqual(fourSpace.count, 2)
+        guard fourSpace.count == 2 else { return }
+        XCTAssertEqual(fourSpace[1] - fourSpace[0], advance * 2, accuracy: 1)
+    }
+
+    /// A tab-indented file is one level per tab character, whatever width the view renders it at.
+    func testTabIndentedFile() {
+        let rules = IndentGuideRenderer().rules(in: textView("a:\n\tb:\n\t\tc()\n"))
+        XCTAssertEqual(rules.count, 3) // one on "\tb:", two on "\t\tc()"
+        XCTAssertEqual(columns(rules).count, 2)
+    }
+
+    /// A blank line inside a block keeps the block's rules; one past the end of the code does not
+    /// invent any.
+    func testBlankLineInsideABlockCarriesTheGuides() {
+        let inside = IndentGuideRenderer().rules(in: textView("""
+        a:
+            b()
+
+            c()
+        """))
+        XCTAssertEqual(inside.count, 3) // b(), the blank, c()
+
+        let trailing = IndentGuideRenderer().rules(in: textView("a:\n    b()\n\n"))
+        XCTAssertEqual(trailing.count, 1) // only b(); nothing past the last line of code
+    }
+
+    /// A soft-wrapped line is one logical line: its rules span every row it occupies, and no
+    /// continuation row contributes rules of its own.
+    func testWrappedLineDrawsOneSetOfRules() {
+        let long = String(repeating: "word ", count: 60)
+        let view = textView("a:\n    \(long)\n    b()\n", width: 220)
+        let rules = IndentGuideRenderer().rules(in: view)
+        XCTAssertEqual(rules.count, 2) // one for the wrapped line, one for b()
+        guard let wrapped = rules.max(by: { $0.height < $1.height }) else { return XCTFail("no rules") }
+        // The wrapped line's rule is taller than a single row, i.e. it runs down the whole block.
+        XCTAssertGreaterThan(wrapped.height, view.layoutManager.map {
+            $0.defaultLineHeight(for: view.font ?? .systemFont(ofSize: 12)) * 1.5
+        } ?? 0)
+    }
+
+    /// Every rule is a whole number of device pixels wide and starts on a pixel boundary — the
+    /// difference between a crisp hairline and a smear that shimmers while scrolling.
+    func testRulesAreSnappedToDevicePixels() {
+        let view = textView("""
+        a:
+            b:
+                c()
+        """)
+        let scale = view.window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
+        for rule in IndentGuideRenderer().rules(in: view) {
+            XCTAssertEqual((rule.minX * scale).rounded(), rule.minX * scale, accuracy: 0.001)
+            XCTAssertEqual((rule.width * scale).rounded(), rule.width * scale, accuracy: 0.001)
+            XCTAssertGreaterThan(rule.width, 0)
+        }
+    }
+
+    /// The indent guides and the occurrence highlight land on the same view without cancelling
+    /// each other: the guides are filled in `drawBackground`, the wash is a layout-manager
+    /// temporary attribute drawn over it, so neither reads or clears the other's state.
+    func testCoexistsWithTheOccurrenceHighlight() {
+        let view = textView("""
+        a:
+            value = value
+                value()
+        """)
+        let renderer = IndentGuideRenderer()
+        let before = renderer.rules(in: view)
+        XCTAssertFalse(before.isEmpty)
+
+        let text = view.string as NSString
+        var occurrences: [NSRange] = []
+        var search = NSRange(location: 0, length: text.length)
+        while true {
+            let hit = text.range(of: "value", options: [], range: search)
+            guard hit.location != NSNotFound else { break }
+            occurrences.append(hit)
+            let next = NSMaxRange(hit)
+            guard next < text.length else { break }
+            search = NSRange(location: next, length: text.length - next)
+        }
+        XCTAssertGreaterThan(occurrences.count, 1)
+        TextFindEngine.addHighlight(occurrences, color: .systemGray, in: view)
+
+        // The wash is on the layout manager...
+        var washed = 0
+        for range in occurrences where view.layoutManager?.temporaryAttribute(
+            .backgroundColor, atCharacterIndex: range.location, effectiveRange: nil) != nil {
+            washed += 1
+        }
+        XCTAssertEqual(washed, occurrences.count)
+        // ...and the guides are untouched by it, in count and in position.
+        XCTAssertEqual(renderer.rules(in: view), before)
+
+        // Lifting the wash likewise leaves the guides alone.
+        TextFindEngine.removeHighlight(occurrences, in: view)
+        XCTAssertEqual(renderer.rules(in: view), before)
+    }
+
+    /// A file with no indentation draws nothing rather than guessing a width.
+    func testFlatFileDrawsNothing() {
+        XCTAssertTrue(IndentGuideRenderer().rules(in: textView("one\ntwo\nthree\n")).isEmpty)
+        XCTAssertTrue(IndentGuideRenderer().rules(in: textView("")).isEmpty)
+    }
+}


### PR DESCRIPTION
A thin vertical rule at each indent level a line sits inside — VS Code's `editor.guides.indentation`. The editor lives in a narrow inspector column beside the terminal and is used mostly to *read* agent-written code, where the line that opened the block has usually scrolled off the top.

The geometry lives in a new `IndentGuideRenderer`; `HighlightedTextView` gains one call in the `drawBackground` pass it already runs for the current-line band, plus the colour it passes down.

- **Indent width comes from `EditorIndentation.detected`,** the detection #474 added for Return and Tab. That one is authoritative — it is what the Tab key actually inserts — so deriving a second opinion here would draw the rules at columns Tab never produces. A tab-indented file is one level per tab character. Cached against document length, so scrolling never re-derives it.
- **Visible range only.** The walk covers the lines on screen plus the nearest non-blank neighbour past any blank run at either edge.
- **Soft wrap.** Guides come from the logical line and span all of its wrapped rows; a continuation row has no indentation of its own to read, which is what would invent a spurious rule. Column x comes from the layout manager's own glyph positions rather than a column × advance, which is also what keeps tab indentation correct.
- **Blank lines.** A blank run inside a block keeps that block's rules, at the shallower of the two lines bracketing it. A run past the last line of code draws nothing.
- **Colour.** `ChromeTheme.overlayInk` beside the existing current-line band and occurrence wash, at the occurrence wash's weight — a one-point rule has a fraction of either wash's area to read from.
- **Pixel snapping.** Every rule goes through `backingAlignedRect`, x and width to the nearest device pixel and the vertical edges outward so consecutive lines' rules meet without a gap.

Rebased onto `main` over #474 and #475. Both siblings' changes are kept: `SavingTextView` stays non-`private`, and `indentGuideColor` is a defaulted `var` next to `occurrenceHighlightColor` so neither is load-bearing at a call site that doesn't care. The two features don't interact — the occurrence wash is a layout-manager temporary attribute drawn over the guides, which are filled in `drawBackground` — and a test asserts the guides are unchanged in count and position while the wash is applied and lifted.

`swift build` and `swift test` are clean (717 tests). The geometry is covered headlessly against a laid-out `NSTextView` — rule counts per nesting level, column positions at two- and four-space and tab indentation, the wrapped-line case, the blank-line case, and the snapping — rather than only by eye; it has not been looked at in a running app.

Release Notes:
- The code editor now draws indentation guides, so nesting stays readable when the line that opened a block has scrolled away.