### PR TITLE
Share one leading-whitespace scan between indentation and indent guides

### DIFF
--- a/Sources/termio/Editor/EditorIndentation.swift
+++ b/Sources/termio/Editor/EditorIndentation.swift
@@ -27,6 +27,49 @@ enum EditorIndentation {
     /// Wider steps than this are continuation alignment (a wrapped argument list), not a level.
     private static let maximumDetectedWidth = 8
 
+    // MARK: Line scanning
+
+    /// The leading spaces and tabs of one line: how many characters they span, and how many of
+    /// those were tabs.
+    struct Leading: Equatable {
+        var length: Int
+        var tabs: Int
+    }
+
+    /// Scans the indentation `lineRange` opens with. The range may carry its line terminator —
+    /// the scan stops at the first character that is neither a space nor a tab, so a range taken
+    /// straight from `lineRange(for:)` can be passed in unchanged.
+    ///
+    /// Shared with `IndentGuideRenderer`, which asks the same question of the same buffer on every
+    /// draw. Character-by-character rather than through `substring`: detection runs on every Return
+    /// and Tab over up to `sampleLineLimit` lines, and a String per line is a real allocation on a
+    /// keypress path.
+    static func leading(of lineRange: NSRange, in text: NSString) -> Leading {
+        var length = 0
+        var tabs = 0
+        for index in lineRange.location..<NSMaxRange(lineRange) {
+            switch text.character(at: index) {
+            case 0x20: break
+            case 0x09: tabs += 1
+            default: return Leading(length: length, tabs: tabs)
+            }
+            length += 1
+        }
+        return Leading(length: length, tabs: tabs)
+    }
+
+    /// Whether `lineRange` holds nothing but whitespace. Line terminators count as blank, so a
+    /// range straight from `lineRange(for:)` needs no trimming first.
+    static func isBlank(_ lineRange: NSRange, in text: NSString) -> Bool {
+        for index in lineRange.location..<NSMaxRange(lineRange) {
+            switch text.character(at: index) {
+            case 0x20, 0x09, 0x0A, 0x0D: continue
+            default: return false
+            }
+        }
+        return true
+    }
+
     // MARK: Detection
 
     /// The indent unit `text` already uses. Spaces win ties, so a file with no indentation at
@@ -45,23 +88,13 @@ enum EditorIndentation {
             location = NSMaxRange(lineRange)
             scannedLines += 1
 
-            var index = lineRange.location
-            var tabs = 0
-            scan: while index < NSMaxRange(lineRange) {
-                switch text.character(at: index) {
-                case 0x20: break
-                case 0x09: tabs += 1
-                default: break scan
-                }
-                index += 1
-            }
-            let leading = index - lineRange.location
             // A blank or whitespace-only line says nothing about the file's style, and a run of
             // them must not look like a jump back to column zero either.
-            let content = text.substring(with: NSRange(location: index, length: NSMaxRange(lineRange) - index))
-            guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+            guard !isBlank(lineRange, in: text) else { continue }
+            let indent = leading(of: lineRange, in: text)
+            let leading = indent.length
 
-            if tabs > 0 {
+            if indent.tabs > 0 {
                 tabIndentedLines += 1
                 previousSpaces = nil
                 continue

--- a/Sources/termio/Editor/IndentGuideRenderer.swift
+++ b/Sources/termio/Editor/IndentGuideRenderer.swift
@@ -65,7 +65,7 @@ final class IndentGuideRenderer {
             in: scan,
             options: [.byParagraphs, .substringNotRequired]
         ) { _, lineRange, _, _ in
-            let indent = Self.leadingWhitespace(lineRange, in: content)
+            let indent = EditorIndentation.leading(of: lineRange, in: content).length
             let extent = self.rows(of: lineRange, layoutManager: layoutManager, in: container)
             // An all-whitespace line indents nothing of its own; it waits for the line below.
             guard indent < lineRange.length else {
@@ -177,7 +177,7 @@ final class IndentGuideRenderer {
         var start = content.lineRange(for: NSRange(location: visible.location, length: 0)).location
         var steps = 0
         while start > 0, steps < blankRunLimit,
-              isBlank(content.lineRange(for: NSRange(location: start, length: 0)), in: content) {
+              EditorIndentation.isBlank(content.lineRange(for: NSRange(location: start, length: 0)), in: content) {
             start = content.lineRange(for: NSRange(location: start - 1, length: 0)).location
             steps += 1
         }
@@ -186,34 +186,10 @@ final class IndentGuideRenderer {
         var end = NSMaxRange(content.lineRange(for: NSRange(location: last, length: 0)))
         steps = 0
         while end < content.length, steps < blankRunLimit,
-              isBlank(content.lineRange(for: NSRange(location: end - 1, length: 0)), in: content) {
+              EditorIndentation.isBlank(content.lineRange(for: NSRange(location: end - 1, length: 0)), in: content) {
             end = NSMaxRange(content.lineRange(for: NSRange(location: end, length: 0)))
             steps += 1
         }
         return NSRange(location: start, length: max(0, end - start))
-    }
-
-    /// Whether `lineRange` — a range that may still carry its line terminator — holds only
-    /// whitespace.
-    private static func isBlank(_ lineRange: NSRange, in content: NSString) -> Bool {
-        for index in lineRange.location..<NSMaxRange(lineRange) {
-            switch content.character(at: index) {
-            case 0x20, 0x09, 0x0A, 0x0D: continue
-            default: return false
-            }
-        }
-        return true
-    }
-
-    /// Leading spaces and tabs of `lineRange` (which excludes its line terminator). Equal to the
-    /// range's own length exactly when the line is blank.
-    private static func leadingWhitespace(_ lineRange: NSRange, in content: NSString) -> Int {
-        var count = 0
-        for index in lineRange.location..<NSMaxRange(lineRange) {
-            let character = content.character(at: index)
-            guard character == 0x20 || character == 0x09 else { break }
-            count += 1
-        }
-        return count
     }
 }


### PR DESCRIPTION
Two features landed in parallel and each grew its own copy of the same line scan.
`EditorIndentation.detected` walked a line's leading spaces and tabs inline, and
`IndentGuideRenderer` carried private `leadingWhitespace` and `isBlank` doing the
same walk over the same buffer. Both now go through one pair of helpers on
`EditorIndentation`.

The detection copy also asked whether a line was blank by taking a `substring` and
trimming it — a String allocated per line, on a path that runs on every Return and
Tab over up to 2000 lines. The shared `isBlank` scans characters instead, so the
keypress path stops allocating.

No behavior change: the 717 tests both features shipped cover these scans directly.

Release Notes:
- No user-facing change.