### PR TITLE
Use the product screenshot in EXAMPLE.md

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -192,7 +192,7 @@ $$
 
 Relative image paths resolve against the file's own folder:
 
-![The Termio app icon](packaging/AppIcon.png)
+![Termio in dark mode: a live Claude Code session next to the project sidebar](web/landing/public/screenshots/hero1.png)
 
 ## Collapsed detail
 


### PR DESCRIPTION
The Images section of `EXAMPLE.md` pointed at the app icon. It now uses the same product screenshot the README leads with, so the sample document shows a real screen rather than a logo.

Release Notes:

- None. Sample document only.