### PR TITLE
Retire the maximize constraints when the detail is restored

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1291,6 +1291,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
             syncMaximizedChrome()
         } else {
+            // Retire them here rather than trusting the re-parent to reap them: `removeFromSuperview`
+            // only drops constraints the old ancestor held, and the host does not always leave
+            // through that door — a detail closed while maximized is discarded where it stands. A
+            // set left active outlives the cycle that made it, and the next maximize activates a
+            // second one against the same host: auto layout then breaks whichever it likes, and a
+            // broken trailing edge is a detail that stops at the terminal instead of filling the
+            // window.
+            NSLayoutConstraint.deactivate(maximizedDetailConstraints)
             maximizedDetailConstraints = []
             // Straight back into the inspector's slot, which stayed mounted for exactly this.
             // Without one — the detail closed while maximized — there is nowhere to go and the


### PR DESCRIPTION
Restoring a maximized detail emptied `maximizedDetailConstraints` without deactivating
the constraints it held, so each maximize/restore cycle could leave a live set behind.
The next maximize then activated a second set against the same host, and auto layout
resolved the conflict by breaking one of them — when it broke the trailing edge, the
detail stopped at the terminal's right edge instead of filling the content area, with
the inspector's file tree still showing beside it and the terminal bleeding through
where the reader did not paint.

That also explains why it took several clicks to appear: nothing is wrong on the
first cycle.

Verified with a temporary instrumented build (not included): across 14 maximize
cycles the constraint count on the container referencing the host stays at 4 rather
than climbing, `hasAmbiguousLayout` stays false, and the host's frame matches the
container's bounds exactly every time.

Release Notes:
- Fixed a maximized file or Markdown detail sometimes covering only part of the window after several maximize toggles.