### PR TITLE
Wash other occurrences only for a selection, not a bare caret

### DIFF
--- a/Sources/termio/Editor/OccurrenceHighlighter.swift
+++ b/Sources/termio/Editor/OccurrenceHighlighter.swift
@@ -11,19 +11,21 @@ struct OccurrenceTarget: Equatable {
     /// the same line, and chasing a paragraph through the document would wash half the screen.
     static let maximumSelectionLength = 200
 
-    /// The target for `selection`, or `nil` when nothing about it is worth chasing: a caret sitting
-    /// in whitespace, a selection that crosses lines, a selection of nothing but whitespace, or one
-    /// too long to be a name. `allowsCaretWord` is false on a read-only buffer, where an empty
-    /// selection is a click, not a caret — the same reason the current-line band and the bracket
-    /// wash stay dark there.
-    static func resolve(selection: NSRange, in text: NSString, allowsCaretWord: Bool) -> OccurrenceTarget? {
+    /// The target for `selection`, or `nil` when nothing about it is worth chasing: an empty
+    /// selection, one that crosses lines, one of nothing but whitespace, or one too long to be a
+    /// name.
+    ///
+    /// A bare caret is deliberately nothing to chase. VS Code lights up the symbol under the caret
+    /// through `editor.occurrencesHighlight`, but that is answered by a language service's
+    /// document-highlight provider — with none installed, as in a YAML or a plain config file,
+    /// clicking to place the caret highlights nothing at all. What survives without one is
+    /// `editor.selectionHighlight`: matches similar to *the selection*. This editor has no language
+    /// service by design, so it implements the half that stands on its own. Lighting the document
+    /// up on a click meant to park the caret was noise, not information.
+    static func resolve(selection: NSRange, in text: NSString) -> OccurrenceTarget? {
         guard text.length > 0, selection.location >= 0,
               selection.location + selection.length <= text.length else { return nil }
-        guard selection.length > 0 else {
-            guard allowsCaretWord, let word = wordRange(at: selection.location, in: text) else { return nil }
-            return OccurrenceTarget(text: text.substring(with: word), range: word, wholeWord: true)
-        }
-        guard selection.length <= maximumSelectionLength else { return nil }
+        guard selection.length > 0, selection.length <= maximumSelectionLength else { return nil }
         let candidate = text.substring(with: selection)
         guard !candidate.contains(where: \.isNewline),
               candidate.contains(where: { !$0.isWhitespace }) else { return nil }
@@ -34,9 +36,9 @@ struct OccurrenceTarget: Equatable {
         return OccurrenceTarget(text: candidate, range: selection, wholeWord: wholeWord)
     }
 
-    /// The word containing `location`, treating a caret parked between a word and anything else as
-    /// belonging to the word it just left — the same "character before the caret wins" rule the
-    /// bracket wash follows.
+    /// The word containing `location`. Used only to ask whether a selection lands exactly on a word,
+    /// so the position is read the way a selection's own start is: the character before it wins when
+    /// it sits between a word and anything else.
     static func wordRange(at location: Int, in text: NSString) -> NSRange? {
         var anchor = -1
         if isWordCharacter(at: location - 1, in: text) {
@@ -59,10 +61,11 @@ struct OccurrenceTarget: Equatable {
     }
 }
 
-/// VS Code's `occurrencesHighlight` / `selectionHighlight`: the word under the caret — or a short
-/// selection — gets a faint wash everywhere else it appears, so reading what an agent just wrote
-/// shows where a name is used without typing it into find. This editor is read far more than it is
-/// typed in, which is what earns a passive hint its cost.
+/// VS Code's `editor.selectionHighlight`: select a name — a double-click is enough — and every
+/// other place it appears takes a faint wash, so reading what an agent just wrote shows where that
+/// name is used without typing it into find. This editor is read far more than it is typed in,
+/// which is what earns a passive hint its cost. A bare caret washes nothing; see
+/// `OccurrenceTarget.resolve`.
 ///
 /// It rides the machinery the find bar already has: `TextFindEngine` finds the matches and paints
 /// them as temporary layout attributes. Only the trigger (a selection change instead of a query)
@@ -71,10 +74,10 @@ struct OccurrenceTarget: Equatable {
 final class OccurrenceHighlighter {
     /// Ranges currently washed, so the next pass lifts exactly its own paint.
     private var painted: [NSRange] = []
-    /// What `painted` was computed for — a caret walking inside one word repaints nothing.
+    /// What `painted` was computed for — re-selecting the same text repaints nothing.
     private var appliedTarget: OccurrenceTarget?
-    /// The document length that memo was taken at. An edit can leave the caret in the same word
-    /// while adding or removing an occurrence, which the target alone can't see.
+    /// The document length that memo was taken at. An edit can leave the selection untouched while
+    /// adding or removing an occurrence, which the target alone can't see.
     private var appliedLength = -1
     private var pending: Task<Void, Never>?
     /// The same matcher the find bar drives, kept per highlighter so the two never share state.
@@ -82,13 +85,13 @@ final class OccurrenceHighlighter {
 
     /// A document this long already renders as plain text (`FileEditorView.highlightByteLimit`,
     /// the same figure counted in UTF-16 units here) because whole-document work on it janks. A
-    /// scan per caret move is exactly that work, so past this the wash stays off.
+    /// scan per selection change is exactly that work, so past this the wash stays off.
     private static let documentLimit = 256 * 1024
     /// A ceiling on washes from one word: a common token in a large file would otherwise put
     /// thousands of temporary attributes on the layout manager for a hint nobody can read.
     private static let matchLimit = 1_000
-    /// Long enough that walking the caret across a line scans once instead of per keystroke, short
-    /// enough that the wash still feels like it belongs to where you stopped.
+    /// Long enough that dragging a selection across a line scans once at the end rather than at every
+    /// step, short enough that the wash still feels like it belongs to what you just selected.
     private static let debounce: UInt64 = 150_000_000
 
     /// Re-derive the wash after a selection change. `findActive` hands the highlight layer to the
@@ -111,7 +114,7 @@ final class OccurrenceHighlighter {
         let text = textView.string as NSString
         guard text.length <= Self.documentLimit,
               let target = OccurrenceTarget.resolve(
-                selection: textView.selectedRange(), in: text, allowsCaretWord: textView.isEditable)
+                selection: textView.selectedRange(), in: text)
         else {
             clear(in: textView)
             return

--- a/Tests/termioTests/EditorTextTests.swift
+++ b/Tests/termioTests/EditorTextTests.swift
@@ -256,34 +256,25 @@ final class BracketMatcherTests: XCTestCase {
 final class OccurrenceTargetTests: XCTestCase {
     private let source = "let total = count + total\nlet other = total" as NSString
 
-    private func target(_ selection: NSRange, editable: Bool = true) -> OccurrenceTarget? {
-        OccurrenceTarget.resolve(selection: selection, in: source, allowsCaretWord: editable)
+    private func target(_ selection: NSRange) -> OccurrenceTarget? {
+        OccurrenceTarget.resolve(selection: selection, in: source)
     }
 
-    func testCaretInsideAWordTakesTheWholeWord() {
-        let inside = target(NSRange(location: 6, length: 0)) // "to|tal"
-        XCTAssertEqual(inside?.text, "total")
-        XCTAssertEqual(inside?.range, NSRange(location: 4, length: 5))
-        XCTAssertEqual(inside?.wholeWord, true)
+    /// A double-click selects the word, and the whole word is what gets chased.
+    func testSelectedWordIsChasedWholeWord() {
+        let selected = target(NSRange(location: 4, length: 5)) // "total"
+        XCTAssertEqual(selected?.text, "total")
+        XCTAssertEqual(selected?.range, NSRange(location: 4, length: 5))
+        XCTAssertEqual(selected?.wholeWord, true)
     }
 
-    /// A caret parked at either edge still belongs to the word — the trailing edge is where you
-    /// land after double-clicking or arrowing to the end of a name.
-    func testCaretAtWordEdges() {
-        XCTAssertEqual(target(NSRange(location: 4, length: 0))?.text, "total")
-        XCTAssertEqual(target(NSRange(location: 9, length: 0))?.text, "total")
-    }
-
-    func testCaretAwayFromAnyWordHasNoTarget() {
+    /// Placing the caret is not asking a question. Without a language service there is nothing that
+    /// knows the symbol under it, and washing the document on a click was noise.
+    func testBareCaretHasNoTarget() {
+        XCTAssertNil(target(NSRange(location: 6, length: 0))) // inside "total"
+        XCTAssertNil(target(NSRange(location: 4, length: 0))) // at its leading edge
+        XCTAssertNil(target(NSRange(location: 9, length: 0))) // at its trailing edge
         XCTAssertNil(target(NSRange(location: 10, length: 0))) // on "="
-        XCTAssertNil(target(NSRange(location: 11, length: 0))) // in the gap after it
-    }
-
-    /// A read-only peek shows no caret, so an empty selection there is a click, not a place.
-    func testReadOnlyBufferIgnoresTheCaret() {
-        XCTAssertNil(target(NSRange(location: 6, length: 0), editable: false))
-        // A real selection still counts — that's the reading gesture the peek has.
-        XCTAssertEqual(target(NSRange(location: 4, length: 5), editable: false)?.text, "total")
     }
 
     func testSelectionSpanningLinesIsSkipped() {
@@ -297,7 +288,7 @@ final class OccurrenceTargetTests: XCTestCase {
     func testOversizedSelectionIsSkipped() {
         let long = String(repeating: "a", count: OccurrenceTarget.maximumSelectionLength + 1) as NSString
         XCTAssertNil(OccurrenceTarget.resolve(
-            selection: NSRange(location: 0, length: long.length), in: long, allowsCaretWord: true))
+            selection: NSRange(location: 0, length: long.length), in: long))
     }
 
     /// A partial selection matches literally: selecting `tot` must not light up every `total`.


### PR DESCRIPTION
Clicking to place the caret lit up every other instance of the word it landed in, which
reads as the editor searching something you never asked it to search.

VS Code splits this across two settings, and only one of them applies here.
`editor.occurrencesHighlight` lights the symbol under the caret, but it is answered by a
language service's document-highlight provider — open a YAML or a plain config file with
no extension behind it and clicking highlights nothing at all. `editor.selectionHighlight`
is the half that stands on its own: matches similar to *the selection*. This editor has no
language service by design, so it now implements that half only. A double-click still
lights up a name everywhere it is used; parking the caret does not.

Release Notes:
- The editor now highlights other occurrences of a name when you select it, rather than when you click into it.