### PR TITLE
Add Replace and the Mac find keys to the editor's find bar

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -1205,6 +1205,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         NotificationCenter.default.post(name: .termioShowFindBar, object: nil)
     }
 
+    /// ⌘G / ⇧⌘G: step the open find bar through its matches. Broadcast the way ⌘F is, so they
+    /// work with the keyboard in the find field or in the document.
+    @objc func findNextMatch(_ sender: Any?) {
+        NotificationCenter.default.post(name: .termioFindNext, object: nil)
+    }
+
+    @objc func findPreviousMatch(_ sender: Any?) {
+        NotificationCenter.default.post(name: .termioFindPrevious, object: nil)
+    }
+
+    /// ⌘E: the editor's selection becomes the find query.
+    @objc func useSelectionForFind(_ sender: Any?) {
+        NotificationCenter.default.post(name: .termioUseSelectionForFind, object: nil)
+    }
+
     /// Reveals the inspector for a freshly opened detail: un-collapses it if hidden, and otherwise
     /// leaves its width alone. It comes back at whatever the split last had (the user's own width,
     /// restored from the autosave), and the responsive `InspectorRoot` — two-column when there's
@@ -2899,11 +2914,36 @@ private func buildMainMenu() -> NSMenu {
     editMenu.addItem(withTitle: localized("Paste"), action: #selector(NSText.paste(_:)), keyEquivalent: "v")
     editMenu.addItem(withTitle: localized("Select All"), action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
     editMenu.addItem(.separator())
-    // ⌘F opens the current file's in-editor find bar. Broadcast via notification so the
-    // shortcut works regardless of first-responder — the terminal receives no find behaviour.
-    let findItem = NSMenuItem(title: localized("Find…"),
-                              action: #selector(AppDelegate.showEditorFindBar(_:)),
-                              keyEquivalent: "f")
+    // Edit ▸ Find, where every Mac app keeps it, on the keys people already have in their
+    // fingers: ⌘F opens the current file's in-editor find bar, ⌘G / ⇧⌘G step through the
+    // matches, ⌘E makes the selection the query. All four broadcast via notification so they
+    // work regardless of first-responder — the terminal receives no find behaviour.
+    //
+    // They stay hardwired here rather than joining `KeyCommandCatalog`, which is the table of
+    // rebindable *app* verbs — window, session, pane — every one of which acts whatever is on
+    // screen. These four only mean anything while an editor overlay is open, they are macOS
+    // standard keys nobody rebinds, and ⌘F has always lived here; splitting the family so one
+    // of them is rebindable and three are not would be worse than either.
+    let findItem = NSMenuItem(title: localized("Find"), action: nil, keyEquivalent: "")
+    let findMenu = NSMenu(title: localized("Find"))
+    findMenu.addItem(withTitle: localized("Find…"),
+                     action: #selector(AppDelegate.showEditorFindBar(_:)),
+                     keyEquivalent: "f")
+    findMenu.addItem(withTitle: localized("Find Next"),
+                     action: #selector(AppDelegate.findNextMatch(_:)),
+                     keyEquivalent: "g")
+    let findPreviousItem = findMenu.addItem(
+        withTitle: localized("Find Previous"),
+        action: #selector(AppDelegate.findPreviousMatch(_:)),
+        keyEquivalent: "g")
+    findPreviousItem.keyEquivalentModifierMask = [.command, .shift]
+    findMenu.addItem(withTitle: localized("Use Selection for Find"),
+                     action: #selector(AppDelegate.useSelectionForFind(_:)),
+                     keyEquivalent: "e")
+    // Target left nil before the submenu is attached: AppKit installs its own `submenuAction:`
+    // and only adopts the submenu as the target when there isn't one already (see
+    // `SubmenuParentEnablementTests`).
+    findItem.submenu = findMenu
     editMenu.addItem(findItem)
     editItem.submenu = editMenu
 

--- a/Sources/termio/Editor/EditorIndentation.swift
+++ b/Sources/termio/Editor/EditorIndentation.swift
@@ -279,9 +279,14 @@ extension SavingTextView {
     /// indent. The replacement carries `typingAttributes` because the buffer's line metrics live
     /// in them: plain text would lay out at the font's natural height and the block would jump
     /// until the highlighter caught up.
-    func replaceAsOneEdit(_ range: NSRange, with replacement: String, selection: NSRange?) {
+    ///
+    /// Shared with `EditorLineCommands` and with the find bar's Replace, which both need exactly
+    /// this shape — hence the returned flag: a caller that steps the find focus forward must know
+    /// whether the edit actually landed, since `shouldChangeText` can refuse.
+    @discardableResult
+    func replaceAsOneEdit(_ range: NSRange, with replacement: String, selection: NSRange?) -> Bool {
         guard let textStorage, NSMaxRange(range) <= textStorage.length,
-              shouldChangeText(in: range, replacementString: replacement) else { return }
+              shouldChangeText(in: range, replacementString: replacement) else { return false }
         breakUndoCoalescing()
         textStorage.replaceCharacters(
             in: range, with: NSAttributedString(string: replacement, attributes: typingAttributes)
@@ -290,5 +295,6 @@ extension SavingTextView {
         let inserted = (replacement as NSString).length
         setSelectedRange(selection ?? NSRange(location: range.location + inserted, length: 0))
         breakUndoCoalescing()
+        return true
     }
 }

--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -96,6 +96,11 @@ struct FileEditorView: View {
     @State private var findLastSubmittedQuery = ""
     /// Bumped on every ⌘F so the find bar re-focuses even when already on screen.
     @State private var findFocusTrigger = 0
+    /// What Replace puts in a match's place. Empty deletes the match, which is what an empty
+    /// replacement field means everywhere else too.
+    @State private var findReplacement = ""
+    /// Replace edits the text view, not the `text` binding — see `FindReplaceController`.
+    @State private var findReplace = FindReplaceController()
 
     /// Past this size the file renders as plain text: highlight.js parses off-main, but
     /// *applying* its result is thousands of main-thread `setAttributes` calls plus a
@@ -228,6 +233,17 @@ struct FileEditorView: View {
         .onReceive(NotificationCenter.default.publisher(for: .termioShowFindBar)) { _ in
             openFindBar()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .termioFindNext)) { _ in
+            guard findBarVisible else { return }
+            advanceFind(by: 1)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .termioFindPrevious)) { _ in
+            guard findBarVisible else { return }
+            advanceFind(by: -1)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .termioUseSelectionForFind)) { _ in
+            useSelectionForFind()
+        }
         // Auto-save: debounce a write after each edit; Escape closes (flushing first). A read-only
         // peek never writes, so neither the debounce nor the exit flush is armed.
         .onChange(of: text) {
@@ -322,6 +338,7 @@ struct FileEditorView: View {
                     findMatchCount = count
                     if count > 0, findFocusedIndex >= count { findFocusedIndex = 0 }
                 },
+                findReplace: findReplace,
             showsCloseMenuItem: true,
             addToChat: addToChat,
             canAddToChat: canAddToChat,
@@ -341,7 +358,13 @@ struct FileEditorView: View {
                     onNext: { advanceFind(by: 1) },
                     onPrevious: { advanceFind(by: -1) },
                     onClose: closeFindBar,
-                    focusTrigger: findFocusTrigger
+                    focusTrigger: findFocusTrigger,
+                    // No replace row over a read-only peek — there is nothing to write back.
+                    replace: readOnly ? nil : .init(
+                        text: $findReplacement,
+                        current: replaceCurrentMatch,
+                        all: replaceAllMatches
+                    )
                 )
                 .transition(.move(edge: .trailing).combined(with: .opacity))
             }
@@ -523,9 +546,44 @@ struct FileEditorView: View {
         withAnimation(.spring(response: 0.3, dampingFraction: 1)) { findBarVisible = false }
         findQuery = ""
         findLastSubmittedQuery = ""
+        findReplacement = ""
         findMatchCount = 0
         findFocusedIndex = 0
         findOptions = FindOptions()
+    }
+
+    /// ⌘E: the editor's selection becomes the find query. Only when this editor's own text view
+    /// holds the keyboard — the verb is broadcast the way ⌘F is, and a diff overlay mounted behind
+    /// this one must not take its query from a buffer the user isn't in. Read before the bar
+    /// opens, since opening it takes first responder away from the text view.
+    ///
+    /// The query counts as already submitted, so the very next Return — or ⌘G — advances to the
+    /// second match instead of re-running the search that just ran.
+    private func useSelectionForFind() {
+        guard mode == .edit, let selection = findReplace.focusedSelection() else { return }
+        openFindBar()
+        findQuery = selection
+        findLastSubmittedQuery = selection
+        findFocusedIndex = 0
+    }
+
+    /// Replace: the focused match becomes the replacement, and the focus steps to the next match
+    /// past it. The match list and the "n of m" counter refresh on their own — the edit fires
+    /// `textDidChange`, which is where the find engine already recomputes.
+    private func replaceCurrentMatch() {
+        guard !readOnly, findMatchCount > 0 else { return }
+        guard let next = findReplace.replaceCurrent(
+            at: findFocusedIndex, query: findQuery, options: findOptions, template: findReplacement)
+        else { return }
+        findFocusedIndex = next
+    }
+
+    /// Replace All: every match at once, as a single edit — so ⌘Z takes the whole document back
+    /// in one step rather than one step per match.
+    private func replaceAllMatches() {
+        guard !readOnly, findMatchCount > 0 else { return }
+        findReplace.replaceAll(query: findQuery, options: findOptions, template: findReplacement)
+        findFocusedIndex = 0
     }
 
     /// Return: fresh query → jump to match 1; same query → next match.

--- a/Sources/termio/Editor/FileFindBar.swift
+++ b/Sources/termio/Editor/FileFindBar.swift
@@ -2,6 +2,8 @@ import AppKit
 import SwiftUI
 
 /// In-editor find bar. Return re-runs a fresh query or advances on the same query; Esc closes.
+/// Where the buffer can be written it also carries VS Code's replace disclosure on its leading
+/// edge — closed by default, so a plain search is the bar it has always been.
 struct FileFindBar: View {
     @Binding var query: String
     @Binding var options: FindOptions
@@ -12,10 +14,48 @@ struct FileFindBar: View {
     let onPrevious: () -> Void
     let onClose: () -> Void
     var focusTrigger: Int = 0
+    /// The replace row's wiring, or nil where the text can't be written — the diff overlay
+    /// searches a read-only document, so it gets no disclosure at all.
+    var replace: Replace? = nil
+
+    /// Everything the replace row needs, grouped so a caller can't wire half of it.
+    struct Replace {
+        @Binding var text: String
+        /// Replace the focused match and step to the next one.
+        let current: () -> Void
+        let all: () -> Void
+    }
 
     @FocusState private var focused: Bool
+    /// VS Code's find widget opens collapsed: searching is the common case, and the replacement
+    /// field is one click away. The bar is rebuilt on each open, so it always starts closed.
+    @State private var showsReplace = false
 
     var body: some View {
+        HStack(alignment: .top, spacing: 4) {
+            if replace != nil { disclosure }
+            VStack(alignment: .leading, spacing: 6) {
+                findRow
+                if let replace, showsReplace { replaceRow(replace) }
+            }
+        }
+        // The disclosure claims the leading room it needs; without one the bar keeps its original
+        // inset, so the diff overlay's find bar is unchanged to the pixel.
+        .padding(.leading, replace == nil ? 12 : 6)
+        .padding(.trailing, 8)
+        .padding(.vertical, 6)
+        // One Liquid Glass shell — the same recipe as `FileSearchView`/`InspectorTabsToolbar`,
+        // with a flat-material fallback below macOS 26. A single sheet, never glass-on-glass.
+        .findBarGlass(expanded: showsReplace)
+        .fixedSize()
+        .padding(.trailing, 12)
+        .padding(.top, 6)
+        .onExitCommand(perform: onClose)
+        .onAppear { requestFocus() }
+        .onChange(of: focusTrigger) { _, _ in requestFocus() }
+    }
+
+    private var findRow: some View {
         HStack(spacing: 8) {
             searchFieldGroup
             // A vibrant hairline splits the query+modifiers from the count/nav cluster —
@@ -26,18 +66,61 @@ struct FileFindBar: View {
             iconButton("chevron.down", disabled: totalMatches == 0, tooltip: localized("Next Match"), action: onNext)
             iconButton("xmark", disabled: false, tooltip: localized("Close (Esc)"), action: onClose)
         }
-        .padding(.leading, 12)
-        .padding(.trailing, 8)
-        .padding(.vertical, 6)
-        // One Liquid Glass capsule — the same recipe as `FileSearchView`/`InspectorTabsToolbar`,
-        // with a flat-material fallback below macOS 26. A single sheet, never glass-on-glass.
-        .findBarGlass()
-        .fixedSize()
-        .padding(.trailing, 12)
-        .padding(.top, 6)
-        .onExitCommand(perform: onClose)
-        .onAppear { requestFocus() }
-        .onChange(of: focusTrigger) { _, _ in requestFocus() }
+    }
+
+    /// The one control that opens and closes the replace row, on the leading edge where VS Code
+    /// puts it — a turning chevron rather than a labelled button, since the row it reveals says
+    /// what it is.
+    private var disclosure: some View {
+        Button {
+            withAnimation(.snappy(duration: 0.2)) { showsReplace.toggle() }
+        } label: {
+            Image(systemName: "chevron.right")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .rotationEffect(.degrees(showsReplace ? 90 : 0))
+                .frame(width: 14, height: 20)
+                .contentShape(.rect)
+        }
+        .buttonStyle(.borderless)
+        .help(showsReplace ? localized("Hide Replace") : localized("Show Replace"))
+    }
+
+    /// The replacement field and its two verbs. Return in the field replaces the focused match,
+    /// the way Return in the query field advances to it.
+    private func replaceRow(_ replace: Replace) -> some View {
+        HStack(spacing: 4) {
+            // Lines the replacement field's leading edge up with the query field's, without
+            // inventing an icon for a row that has nothing to say with one.
+            Color.clear.frame(width: 11, height: 0)
+            TextField(localized("Replace"), text: replace.$text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .onSubmit(replace.current)
+                .frame(minWidth: 140, maxWidth: 260)
+            replaceButton(localized("Replace"), action: replace.current)
+            replaceButton(localized("Replace All"), action: replace.all)
+        }
+    }
+
+    private func replaceButton(_ title: String, action: @escaping () -> Void) -> some View {
+        let enabled = totalMatches > 0
+        return Button(action: action) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                // The same neutral grey chip the option toggles wear, never an accent fill.
+                .foregroundStyle(enabled ? Color.primary : .secondary)
+                .padding(.horizontal, 7)
+                .frame(height: 18)
+                .background(
+                    Color.primary.opacity(enabled ? 0.12 : 0.06),
+                    in: RoundedRectangle(cornerRadius: 4)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .buttonStyle(.borderless)
+        .disabled(!enabled)
+        .help(title)
     }
 
     /// Focus is deferred by a runloop tick so AppKit has time to place the field in the
@@ -126,17 +209,33 @@ struct FileFindBar: View {
     }
 }
 
+/// The expanded bar's corner, concentric with the capsule it grows out of.
+private let expandedCornerRadius: CGFloat = 14
+
 private extension View {
     /// The floating find bar's Liquid Glass shell: a single `.regular` glass capsule on
     /// macOS 26 (matching `FileSearchView`'s field and the inspector toolbar's track), and a
     /// plain material capsule with a hairline on macOS 14/15 where the effect doesn't exist.
+    ///
+    /// A capsule is right for one row. Two rows in one bow out at the ends, so the expanded bar
+    /// takes a rounded rectangle instead — the shape changes, the material never does.
     @ViewBuilder
-    func findBarGlass() -> some View {
+    func findBarGlass(expanded: Bool) -> some View {
         if #available(macOS 26.0, *) {
-            glassEffect(.regular, in: .capsule)
+            if expanded {
+                glassEffect(.regular, in: .rect(cornerRadius: expandedCornerRadius))
+            } else {
+                glassEffect(.regular, in: .capsule)
+            }
         } else {
-            background(.regularMaterial, in: Capsule())
-                .overlay(Capsule().stroke(Color(nsColor: .separatorColor), lineWidth: 0.5))
+            if expanded {
+                let shape = RoundedRectangle(cornerRadius: expandedCornerRadius, style: .continuous)
+                background(.regularMaterial, in: shape)
+                    .overlay(shape.stroke(Color(nsColor: .separatorColor), lineWidth: 0.5))
+            } else {
+                background(.regularMaterial, in: Capsule())
+                    .overlay(Capsule().stroke(Color(nsColor: .separatorColor), lineWidth: 0.5))
+            }
         }
     }
 }

--- a/Sources/termio/Editor/FindNotification.swift
+++ b/Sources/termio/Editor/FindNotification.swift
@@ -4,4 +4,10 @@ extension Notification.Name {
     /// ⌘F broadcast. Broadcast instead of the responder chain so the menu item stays enabled
     /// whenever an editor is on screen even if the terminal holds first responder.
     static let termioShowFindBar = Notification.Name("termio.showFindBar")
+    /// ⌘G / ⇧⌘G. Broadcast for the same reason ⌘F is; a find bar that isn't open ignores them.
+    static let termioFindNext = Notification.Name("termio.findNext")
+    static let termioFindPrevious = Notification.Name("termio.findPrevious")
+    /// ⌘E. Only the editor whose own text view holds the keyboard acts on it, so a second
+    /// overlay mounted behind the first can't take its query from a buffer nobody is in.
+    static let termioUseSelectionForFind = Notification.Name("termio.useSelectionForFind")
 }

--- a/Sources/termio/Editor/FindReplace.swift
+++ b/Sources/termio/Editor/FindReplace.swift
@@ -1,0 +1,147 @@
+import AppKit
+
+/// The replace half of the find bar, written as pure functions over the buffer so the two things
+/// that are easy to get quietly wrong — what `$1` means, and how many undo steps a Replace All is —
+/// are pinned by tests rather than by a window. The matches come from `TextFindEngine`, so what the
+/// bar counts and what Replace acts on can never drift apart.
+enum FindReplace {
+    /// One match and the text that takes its place.
+    struct Replacement: Equatable {
+        var range: NSRange
+        var text: String
+    }
+
+    /// Every match of `query`, paired with what `template` turns it into.
+    ///
+    /// In regex mode the template is expanded the way `NSRegularExpression` does it: `$1`…`$9`
+    /// insert capture groups, `$0` the whole match, and `\$` a literal dollar — the same `$1` VS
+    /// Code's find widget supports. In literal mode a `$1` is just those two characters. There are
+    /// no groups to name without a pattern, and eating a dollar sign out of replaced text would be
+    /// a worse answer than not offering the feature.
+    static func plan(
+        query: String, options: FindOptions, template: String, in text: NSString
+    ) -> [Replacement] {
+        guard !query.isEmpty, text.length > 0 else { return [] }
+        guard options.regex,
+              let regex = TextFindEngine.regularExpression(for: query, options: options) else {
+            return TextFindEngine.matches(of: query, options: options, in: text)
+                .map { Replacement(range: $0, text: template) }
+        }
+        // Same filter as `TextFindEngine.matches`, so the ranges here are the very ranges the bar
+        // is counting — only the results are kept as well, since expanding a capture group needs
+        // the match, not just where it sat.
+        return regex.matches(in: text as String, range: NSRange(location: 0, length: text.length))
+            .filter { $0.range.length > 0 }
+            .filter { !options.wholeWord || TextFindEngine.isWordBoundary($0.range, in: text) }
+            .map { result in
+                Replacement(
+                    range: result.range,
+                    text: regex.replacementString(
+                        for: result, in: text as String, offset: 0, template: template))
+            }
+    }
+
+    /// The single edit that lands every replacement at once: one range reaching from the first
+    /// match's start to the last match's end, with the untouched text between them stitched back
+    /// in. Replace All has to be one `replaceCharacters` — one edit is one undo step, and undoing
+    /// a hundred replacements a hundred times is not what ⌘Z means here. Nil when there is nothing
+    /// to replace.
+    static func coalesced(_ replacements: [Replacement], in text: NSString) -> Replacement? {
+        guard let first = replacements.first, let last = replacements.last else { return nil }
+        let span = NSRange(location: first.range.location,
+                           length: NSMaxRange(last.range) - first.range.location)
+        guard span.location >= 0, NSMaxRange(span) <= text.length else { return nil }
+
+        var stitched = ""
+        var cursor = span.location
+        // Matches arrive in document order and never overlap, so each one starts at or after the
+        // previous one's end; the condition only keeps a malformed list from asking for a
+        // negative-length substring.
+        for replacement in replacements where replacement.range.location >= cursor {
+            stitched += text.substring(
+                with: NSRange(location: cursor, length: replacement.range.location - cursor))
+            stitched += replacement.text
+            cursor = NSMaxRange(replacement.range)
+        }
+        return Replacement(range: span, text: stitched)
+    }
+
+    /// Which match takes the focus after an edit: the first one starting at or after `location`,
+    /// wrapping to the top when the edit consumed the last one. `location` is the end of what was
+    /// just inserted, so replacing `foo` with `foobar` steps past the replacement instead of
+    /// landing back inside it and replacing itself forever.
+    static func focusIndex(startingAt location: Int, in matches: [NSRange]) -> Int {
+        matches.firstIndex { $0.location >= location } ?? 0
+    }
+}
+
+/// The bridge from the find bar's Replace buttons to the buffer they act on.
+///
+/// Replace cannot go through the editor's `text` binding: assigning it replaces the whole document,
+/// which drops the undo stack and throws the caret to the top. So the edit is made on the text view
+/// through `replaceAsOneEdit` — the same one-edit-one-undo-step shape Tab and Return already use —
+/// and the editor hands this controller down to `HighlightedTextView`, which attaches its view.
+///
+/// Nothing here repaints or recounts: the edit fires `textDidChange`, which is already where the
+/// match list is rebuilt and the "n of m" counter refreshed, so the bar stays honest for free.
+@MainActor
+final class FindReplaceController {
+    private weak var textView: SavingTextView?
+
+    func attach(_ textView: SavingTextView) {
+        self.textView = textView
+    }
+
+    /// The selection in this controller's own text view, when that view holds the keyboard — what
+    /// ⌘E turns into the find query. Nil when the editor isn't focused (the find field is, or
+    /// another overlay is), so a broadcast verb can't pull text out of a buffer nobody is in.
+    func focusedSelection() -> String? {
+        guard let textView, let window = textView.window,
+              window.isKeyWindow, window.firstResponder === textView else { return nil }
+        let range = textView.selectedRange()
+        let text = textView.string as NSString
+        guard range.length > 0, NSMaxRange(range) <= text.length else { return nil }
+        return text.substring(with: range)
+    }
+
+    /// Replaces the focused match and reports which match should take the focus next. Nil when
+    /// nothing was replaced — no such match, a read-only buffer, or a refused edit.
+    func replaceCurrent(
+        at index: Int, query: String, options: FindOptions, template: String
+    ) -> Int? {
+        guard let textView, textView.isEditable else { return nil }
+        let plan = FindReplace.plan(
+            query: query, options: options, template: template, in: textView.string as NSString)
+        guard plan.indices.contains(index) else { return nil }
+        let replacement = plan[index]
+        guard textView.replaceAsOneEdit(replacement.range, with: replacement.text, selection: nil)
+        else { return nil }
+
+        let landed = replacement.range.location + (replacement.text as NSString).length
+        let remaining = TextFindEngine.matches(
+            of: query, options: options, in: textView.string as NSString)
+        let next = FindReplace.focusIndex(startingAt: landed, in: remaining)
+        reveal(remaining.indices.contains(next) ? remaining[next] : nil, in: textView)
+        return next
+    }
+
+    /// Replaces every match as one edit. Returns how many matches it landed.
+    @discardableResult
+    func replaceAll(query: String, options: FindOptions, template: String) -> Int {
+        guard let textView, textView.isEditable else { return 0 }
+        let text = textView.string as NSString
+        let plan = FindReplace.plan(query: query, options: options, template: template, in: text)
+        guard let edit = FindReplace.coalesced(plan, in: text),
+              textView.replaceAsOneEdit(edit.range, with: edit.text, selection: nil) else { return 0 }
+        return plan.count
+    }
+
+    /// Scrolls the match that inherits the focus into view and pulses the find indicator over it.
+    /// The repaint after an edit deliberately never scrolls (the user is typing, not navigating),
+    /// but a replace *is* navigation — the next match is usually somewhere else on the page.
+    private func reveal(_ range: NSRange?, in textView: NSTextView) {
+        guard let range, NSMaxRange(range) <= (textView.string as NSString).length else { return }
+        textView.scrollRangeToVisible(range)
+        textView.showFindIndicator(for: range)
+    }
+}

--- a/Sources/termio/Editor/HighlightedTextView.swift
+++ b/Sources/termio/Editor/HighlightedTextView.swift
@@ -38,6 +38,10 @@ struct HighlightedTextView: NSViewRepresentable {
     var findFocusedIndex: Int = 0
     /// Fires with the total match count after any recompute (new query, options, or edit).
     var onMatchesChanged: ((Int) -> Void)? = nil
+    /// Attached so the find bar's Replace buttons can edit this buffer through the text view
+    /// rather than through the `text` binding, which would replace the whole document and drop
+    /// undo. Nil wherever replace isn't offered.
+    var findReplace: FindReplaceController? = nil
     /// Appends a "Close" item to the right-click menu — the editor closes terminal-style, alongside
     /// the toolbar button. Left off wherever the text view isn't the closable editor overlay.
     var showsCloseMenuItem: Bool = false
@@ -80,6 +84,7 @@ struct HighlightedTextView: NSViewRepresentable {
         layoutManager.addTextContainer(container)
 
         let textView = SavingTextView(frame: .zero, textContainer: container)
+        findReplace?.attach(textView)
         textView.onSave = onSave
         textView.showsCloseMenuItem = showsCloseMenuItem
         textView.addToChat = addToChat
@@ -169,6 +174,9 @@ struct HighlightedTextView: NSViewRepresentable {
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? SavingTextView else { return }
+        // Re-attached each pass: the representable is recreated on every render, and a controller
+        // still pointing at a torn-down view would replace text nobody can see.
+        findReplace?.attach(textView)
         if scrollView.isHidden == isActive { scrollView.isHidden = !isActive }
         // Focus follows the flip, not the mount (see `claimFocus`).
         if isActive, !context.coordinator.wasActive { Self.claimFocus(textView) }

--- a/Sources/termio/Editor/TextFindEngine.swift
+++ b/Sources/termio/Editor/TextFindEngine.swift
@@ -20,36 +20,48 @@ final class TextFindEngine {
     /// Rebuild the match list for `query` over the text view's current string. Returns the count.
     @discardableResult
     func recompute(query: String, options: FindOptions, in textView: NSTextView) -> Int {
-        matches.removeAll()
-        guard !query.isEmpty else { return 0 }
-        let full = textView.string as NSString
-        let total = full.length
-        guard total > 0 else { return 0 }
+        matches = Self.matches(of: query, options: options, in: textView.string as NSString)
+        return matches.count
+    }
+
+    /// Every match of `query` in `text`, in document order. The scan itself, with no text view in
+    /// it — `FindReplace` asks the same question of the same buffer when it plans a replacement,
+    /// and a match list the two could disagree about is a wrong "n of m" waiting to happen.
+    nonisolated static func matches(of query: String, options: FindOptions, in text: NSString) -> [NSRange] {
+        guard !query.isEmpty, text.length > 0 else { return [] }
+        let total = text.length
 
         if options.regex {
-            var regexOptions: NSRegularExpression.Options = []
-            if !options.caseSensitive { regexOptions.insert(.caseInsensitive) }
-            guard let regex = try? NSRegularExpression(pattern: query, options: regexOptions) else { return 0 }
-            for match in regex.matches(in: textView.string, range: NSRange(location: 0, length: total))
-            where match.range.length > 0 {
-                if options.wholeWord, !Self.isWordBoundary(match.range, in: full) { continue }
-                matches.append(match.range)
-            }
-            return matches.count
+            guard let regex = regularExpression(for: query, options: options) else { return [] }
+            return regex.matches(in: text as String, range: NSRange(location: 0, length: total))
+                .map(\.range)
+                .filter { $0.length > 0 && (!options.wholeWord || isWordBoundary($0, in: text)) }
         }
 
+        var found: [NSRange] = []
         var searchOptions: NSString.CompareOptions = []
         if !options.caseSensitive { searchOptions.insert(.caseInsensitive) }
         var searchStart = 0
         while searchStart < total {
             let searchRange = NSRange(location: searchStart, length: total - searchStart)
-            let hit = full.range(of: query, options: searchOptions, range: searchRange)
+            let hit = text.range(of: query, options: searchOptions, range: searchRange)
             if hit.location == NSNotFound { break }
-            if !options.wholeWord || Self.isWordBoundary(hit, in: full) { matches.append(hit) }
+            if !options.wholeWord || isWordBoundary(hit, in: text) { found.append(hit) }
             // `hit.length` can be zero for a pathological pattern; step by 1 to guarantee termination.
             searchStart = hit.location + max(hit.length, 1)
         }
-        return matches.count
+        return found
+    }
+
+    /// The compiled pattern behind a `.*`-mode query, or nil while it is still half-typed and
+    /// doesn't parse. Shared with the replace planner, which needs the match *results* — not just
+    /// their ranges — to expand `$1` capture groups.
+    nonisolated static func regularExpression(
+        for query: String, options: FindOptions
+    ) -> NSRegularExpression? {
+        var regexOptions: NSRegularExpression.Options = []
+        if !options.caseSensitive { regexOptions.insert(.caseInsensitive) }
+        return try? NSRegularExpression(pattern: query, options: regexOptions)
     }
 
     /// Repaint every match, tinting `focused` brighter. `reveal` scrolls the focused match into
@@ -106,7 +118,7 @@ final class TextFindEngine {
         layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: fullRange)
     }
 
-    private static func isWordBoundary(_ range: NSRange, in string: NSString) -> Bool {
+    nonisolated static func isWordBoundary(_ range: NSRange, in string: NSString) -> Bool {
         let letters = wordCharacters
         if range.location > 0 {
             let prev = string.character(at: range.location - 1)

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -74,6 +74,17 @@ struct GitDiffView: View {
         .onReceive(NotificationCenter.default.publisher(for: .termioShowFindBar)) { _ in
             openFindBar()
         }
+        // ⌘G / ⇧⌘G reach the diff's find bar too — it is the same bar, over the same engine.
+        // ⌘E is not wired here: the buffer is read-only, and the verb belongs to the editor
+        // whose text view holds the keyboard.
+        .onReceive(NotificationCenter.default.publisher(for: .termioFindNext)) { _ in
+            guard findBarVisible else { return }
+            advanceFind(by: 1)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .termioFindPrevious)) { _ in
+            guard findBarVisible else { return }
+            advanceFind(by: -1)
+        }
     }
 
     // MARK: Find

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -2423,6 +2423,26 @@
         }
       }
     },
+    "Find Next": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查找下一个"
+          }
+        }
+      }
+    },
+    "Find Previous": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查找上一个"
+          }
+        }
+      }
+    },
     "Find…": {
       "localizations": {
         "zh-Hans": {
@@ -2600,6 +2620,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "隐藏"
+          }
+        }
+      }
+    },
+    "Hide Replace": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏替换"
           }
         }
       }
@@ -4937,6 +4967,26 @@
         }
       }
     },
+    "Replace": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "替换"
+          }
+        }
+      }
+    },
+    "Replace All": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部替换"
+          }
+        }
+      }
+    },
     "Repository": {
       "localizations": {
         "zh-Hans": {
@@ -5424,6 +5474,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "显示项目文件"
+          }
+        }
+      }
+    },
+    "Show Replace": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示替换"
           }
         }
       }
@@ -6575,6 +6635,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "使用正则表达式"
+          }
+        }
+      }
+    },
+    "Use Selection for Find": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用所选内容查找"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -492,6 +492,10 @@
 	<string>Filter</string>
 	<key>Find</key>
 	<string>Find</string>
+	<key>Find Next</key>
+	<string>Find Next</string>
+	<key>Find Previous</key>
+	<string>Find Previous</string>
 	<key>Find…</key>
 	<string>Find…</string>
 	<key>Focus Pane Down</key>
@@ -528,6 +532,8 @@
 	<string>Group with</string>
 	<key>Hide</key>
 	<string>Hide</string>
+	<key>Hide Replace</key>
+	<string>Hide Replace</string>
 	<key>Hide or show the inspector</key>
 	<string>Hide or show the inspector</string>
 	<key>Hide or show the navigator</key>
@@ -994,6 +1000,10 @@
 	<string>Rename “%@”</string>
 	<key>Rename…</key>
 	<string>Rename…</string>
+	<key>Replace</key>
+	<string>Replace</string>
+	<key>Replace All</key>
+	<string>Replace All</string>
 	<key>Repository</key>
 	<string>Repository</string>
 	<key>Request Permission</key>
@@ -1092,6 +1102,8 @@
 	<string>Show Original</string>
 	<key>Show Project Files</key>
 	<string>Show Project Files</string>
+	<key>Show Replace</key>
+	<string>Show Replace</string>
 	<key>Shows the Issues pane in the inspector for projects whose remote is on GitHub.</key>
 	<string>Shows the Issues pane in the inspector for projects whose remote is on GitHub.</string>
 	<key>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse.</key>
@@ -1322,6 +1334,8 @@
 	<string>Usage</string>
 	<key>Use Regular Expression</key>
 	<string>Use Regular Expression</string>
+	<key>Use Selection for Find</key>
+	<string>Use Selection for Find</string>
 	<key>User</key>
 	<string>User</string>
 	<key>Uses %@</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -492,6 +492,10 @@
 	<string>过滤</string>
 	<key>Find</key>
 	<string>查找</string>
+	<key>Find Next</key>
+	<string>查找下一个</string>
+	<key>Find Previous</key>
+	<string>查找上一个</string>
 	<key>Find…</key>
 	<string>查找…</string>
 	<key>Focus Pane Down</key>
@@ -528,6 +532,8 @@
 	<string>编组到</string>
 	<key>Hide</key>
 	<string>隐藏</string>
+	<key>Hide Replace</key>
+	<string>隐藏替换</string>
 	<key>Hide or show the inspector</key>
 	<string>隐藏或显示检查器</string>
 	<key>Hide or show the navigator</key>
@@ -994,6 +1000,10 @@
 	<string>重命名“%@”</string>
 	<key>Rename…</key>
 	<string>重命名…</string>
+	<key>Replace</key>
+	<string>替换</string>
+	<key>Replace All</key>
+	<string>全部替换</string>
 	<key>Repository</key>
 	<string>仓库</string>
 	<key>Request Permission</key>
@@ -1092,6 +1102,8 @@
 	<string>显示原身</string>
 	<key>Show Project Files</key>
 	<string>显示项目文件</string>
+	<key>Show Replace</key>
+	<string>显示替换</string>
 	<key>Shows the Issues pane in the inspector for projects whose remote is on GitHub.</key>
 	<string>为远程仓库位于 GitHub 的项目在检查器中显示 Issues 窗格。</string>
 	<key>Shows when an agent is working or waiting on you — the sidebar spinner and menu-bar pulse.</key>
@@ -1322,6 +1334,8 @@
 	<string>用量</string>
 	<key>Use Regular Expression</key>
 	<string>使用正则表达式</string>
+	<key>Use Selection for Find</key>
+	<string>用所选内容查找</string>
 	<key>User</key>
 	<string>用户</string>
 	<key>Uses %@</key>

--- a/Tests/termioTests/FindReplaceTests.swift
+++ b/Tests/termioTests/FindReplaceTests.swift
@@ -1,0 +1,243 @@
+import XCTest
+@testable import termio
+
+/// The find bar's replace half. Everything here is a case someone would notice getting wrong: a
+/// `$1` that came out literal, a Replace All that needed a hundred ⌘Z presses to take back, a
+/// replacement that matched itself and got replaced again on the next press.
+final class FindReplaceTests: XCTestCase {
+    private let literal = FindOptions()
+    private let regex = FindOptions(caseSensitive: false, wholeWord: false, regex: true)
+
+    /// The whole document after `edit` lands — the string the text view would be holding.
+    private func applying(_ edit: FindReplace.Replacement, to text: NSString) -> String {
+        let result = NSMutableString(string: text)
+        result.replaceCharacters(in: edit.range, with: edit.text)
+        return result as String
+    }
+
+    /// Every match run through `plan` + `coalesced` and applied, which is exactly what Replace All
+    /// does to the buffer.
+    private func replacingAll(
+        _ query: String, with template: String, options: FindOptions, in source: String
+    ) -> String {
+        let text = source as NSString
+        let plan = FindReplace.plan(query: query, options: options, template: template, in: text)
+        guard let edit = FindReplace.coalesced(plan, in: text) else { return source }
+        return applying(edit, to: text)
+    }
+
+    // MARK: Planning
+
+    func testLiteralPlanPairsEveryMatchWithTheTemplate() {
+        let text = "one two one two one" as NSString
+        let plan = FindReplace.plan(query: "one", options: literal, template: "1", in: text)
+        XCTAssertEqual(plan.map(\.range), [NSRange(location: 0, length: 3),
+                                          NSRange(location: 8, length: 3),
+                                          NSRange(location: 16, length: 3)])
+        XCTAssertEqual(Set(plan.map(\.text)), ["1"])
+    }
+
+    /// The ranges the bar counts and the ranges Replace acts on must be the same list, or the
+    /// "n of m" counter is lying about what the next press will touch.
+    func testPlanRangesMatchTheEnginesMatchList() {
+        let text = "Foo foo FOO foobar" as NSString
+        for options in [literal,
+                        FindOptions(caseSensitive: true, wholeWord: false, regex: false),
+                        FindOptions(caseSensitive: false, wholeWord: true, regex: false)] {
+            XCTAssertEqual(
+                FindReplace.plan(query: "foo", options: options, template: "x", in: text).map(\.range),
+                TextFindEngine.matches(of: "foo", options: options, in: text))
+        }
+    }
+
+    func testEmptyQueryOrEmptyDocumentPlansNothing() {
+        XCTAssertTrue(FindReplace.plan(query: "", options: literal, template: "x", in: "abc").isEmpty)
+        XCTAssertTrue(FindReplace.plan(query: "abc", options: literal, template: "x", in: "").isEmpty)
+    }
+
+    /// A pattern that doesn't parse yet — the user is still typing it — replaces nothing rather
+    /// than falling back to a literal search for the pattern text.
+    func testUnparseablePatternPlansNothing() {
+        let text = "a(b(c" as NSString
+        XCTAssertTrue(FindReplace.plan(query: "(unclosed", options: regex, template: "x", in: text).isEmpty)
+    }
+
+    // MARK: Capture groups
+
+    func testRegexTemplateExpandsCaptureGroups() {
+        let text = "let a = 1\nlet b = 2\n" as NSString
+        XCTAssertEqual(
+            replacingAll(#"let (\w+) = (\d+)"#, with: "var $1: Int = $2", options: regex, in: text as String),
+            "var a: Int = 1\nvar b: Int = 2\n")
+    }
+
+    func testRegexTemplateExpandsTheWholeMatchAndEscapesADollar() {
+        let text = "price 10" as NSString
+        XCTAssertEqual(replacingAll(#"\d+"#, with: "[$0]", options: regex, in: text as String), "price [10]")
+        // A backslash-escaped dollar is a literal one — the only way to type a dollar sign into a
+        // regex-mode replacement.
+        XCTAssertEqual(replacingAll(#"\d+"#, with: #"\$$0"#, options: regex, in: text as String), "price $10")
+    }
+
+    /// A group the pattern doesn't have expands to nothing rather than raising.
+    func testMissingCaptureGroupExpandsToNothing() {
+        XCTAssertEqual(replacingAll("(a)", with: "$2", options: regex, in: "abc"), "bc")
+    }
+
+    /// In literal mode there are no groups to name, so `$1` is just those two characters. Eating a
+    /// dollar sign out of replaced text would be a worse answer than not offering the feature.
+    func testLiteralModeTreatsDollarAsPlainText() {
+        XCTAssertEqual(replacingAll("cost", with: "$1", options: literal, in: "cost and cost"),
+                       "$1 and $1")
+        XCTAssertEqual(replacingAll("USD", with: #"\$"#, options: literal, in: "10 USD"), #"10 \$"#)
+    }
+
+    func testWholeWordFilterAppliesToRegexReplacements() throws {
+        let text = "cat category cat" as NSString
+        var options = regex
+        options.wholeWord = true
+        let plan = FindReplace.plan(query: "cat", options: options, template: "dog", in: text)
+        XCTAssertEqual(plan.map(\.range), [NSRange(location: 0, length: 3), NSRange(location: 13, length: 3)])
+        XCTAssertEqual(applying(try XCTUnwrap(FindReplace.coalesced(plan, in: text)), to: text),
+                       "dog category dog")
+    }
+
+    // MARK: One edit for the whole document
+
+    /// Replace All is one `replaceCharacters` over one range — one edit is one undo step, which is
+    /// the whole reason the replacements are coalesced instead of applied one at a time.
+    func testReplaceAllCoalescesIntoASingleEdit() throws {
+        let text = "a x a x a" as NSString
+        let plan = FindReplace.plan(query: "a", options: literal, template: "bb", in: text)
+        XCTAssertEqual(plan.count, 3)
+        let edit = try XCTUnwrap(FindReplace.coalesced(plan, in: text))
+        // One range, reaching from the first match's start to the last match's end — the text
+        // between the matches is carried along inside the replacement, untouched.
+        XCTAssertEqual(edit.range, NSRange(location: 0, length: 9))
+        XCTAssertEqual(edit.text, "bb x bb x bb")
+        XCTAssertEqual(applying(edit, to: text), "bb x bb x bb")
+    }
+
+    /// The span stops at the last match: text before the first and after the last is never part of
+    /// the edit, so an undo restores exactly what was replaced.
+    func testCoalescedEditSpansOnlyTheMatches() throws {
+        let text = "head one tail" as NSString
+        let plan = FindReplace.plan(query: "one", options: literal, template: "two", in: text)
+        let edit = try XCTUnwrap(FindReplace.coalesced(plan, in: text))
+        XCTAssertEqual(edit.range, NSRange(location: 5, length: 3))
+        XCTAssertEqual(edit.text, "two")
+        XCTAssertEqual(applying(edit, to: text), "head two tail")
+    }
+
+    func testNothingToReplaceCoalescesToNoEdit() {
+        XCTAssertNil(FindReplace.coalesced([], in: "abc"))
+    }
+
+    /// An empty replacement field deletes the matches, the way it does everywhere else.
+    func testEmptyTemplateDeletesEveryMatch() {
+        XCTAssertEqual(replacingAll(", ", with: "", options: literal, in: "a, b, c"), "abc")
+    }
+
+    /// A replacement that contains the query is the case a naive replace-each-match loop never
+    /// finishes: the plan is taken over the buffer as it stands, so every match is replaced once.
+    func testAReplacementContainingTheQueryIsStillReplacedOnce() {
+        XCTAssertEqual(replacingAll("foo", with: "foobar", options: literal, in: "foo foo"),
+                       "foobar foobar")
+    }
+
+    /// Offsets are UTF-16 units, the unit `NSTextView` selections use — a surrogate pair ahead of a
+    /// match must not shift where the edit lands.
+    func testOffsetsCountUTF16Units() throws {
+        let text = "🙂 one 🙂 one" as NSString
+        let plan = FindReplace.plan(query: "one", options: literal, template: "two", in: text)
+        XCTAssertEqual(plan.map(\.range), [NSRange(location: 3, length: 3), NSRange(location: 10, length: 3)])
+        XCTAssertEqual(applying(try XCTUnwrap(FindReplace.coalesced(plan, in: text)), to: text),
+                       "🙂 two 🙂 two")
+    }
+
+    // MARK: Where the focus lands afterwards
+
+    /// Replace steps to the first match *past* what it just inserted. Replacing `foo` with
+    /// `foobar` otherwise lands back inside the replacement and replaces it again on every press.
+    func testFocusStepsPastTheInsertedText() {
+        let replaced = "foobar foo foo" as NSString
+        let matches = TextFindEngine.matches(of: "foo", options: literal, in: replaced)
+        XCTAssertEqual(matches.map(\.location), [0, 7, 11])
+        XCTAssertEqual(FindReplace.focusIndex(startingAt: 6, in: matches), 1)
+    }
+
+    func testFocusWrapsToTheTopAfterTheLastMatch() {
+        let replaced = "one two one" as NSString
+        let matches = TextFindEngine.matches(of: "one", options: literal, in: replaced)
+        XCTAssertEqual(FindReplace.focusIndex(startingAt: replaced.length, in: matches), 0)
+    }
+
+    func testFocusStaysAtTheTopWhenNothingIsLeft() {
+        XCTAssertEqual(FindReplace.focusIndex(startingAt: 0, in: []), 0)
+    }
+
+    // MARK: Coexisting with the line commands
+
+    /// ⌘/ and Replace land through the same `replaceAsOneEdit`, so a replacement inside a block
+    /// that was just commented is still one edit — one range, one undo step — rather than one per
+    /// commented line.
+    func testReplacingInsideACommentedBlockIsStillOneEdit() throws {
+        let source = "let a = old\nlet b = old\n" as NSString
+        let marker = try XCTUnwrap(EditorLineCommands.commentMarker(for: "swift"))
+        let commented = try XCTUnwrap(EditorLineCommands.toggleComment(
+            NSRange(location: 0, length: source.length), in: source, marker: marker))
+        let text = applying(
+            FindReplace.Replacement(range: commented.range, text: commented.replacement),
+            to: source) as NSString
+        XCTAssertEqual(text as String, "// let a = old\n// let b = old\n")
+
+        let plan = FindReplace.plan(query: "old", options: literal, template: "new", in: text)
+        XCTAssertEqual(plan.count, 2)
+        let edit = try XCTUnwrap(FindReplace.coalesced(plan, in: text))
+        XCTAssertEqual(edit.range, NSRange(location: 11, length: 18))
+        XCTAssertEqual(applying(edit, to: text), "// let a = new\n// let b = new\n")
+    }
+
+    /// A line command edits the buffer under a live query, and the find bar recounts from the
+    /// notification that edit fires — so the count it lands on has to be the count of the
+    /// *commented* text, markers and all.
+    func testMatchesStayHonestAfterALineCommand() throws {
+        let source = "old\nold\n" as NSString
+        XCTAssertEqual(TextFindEngine.matches(of: "old", options: literal, in: source).count, 2)
+
+        let marker = try XCTUnwrap(EditorLineCommands.commentMarker(for: "python"))
+        let commented = try XCTUnwrap(EditorLineCommands.toggleComment(
+            NSRange(location: 0, length: source.length), in: source, marker: marker))
+        let text = applying(
+            FindReplace.Replacement(range: commented.range, text: commented.replacement),
+            to: source) as NSString
+        XCTAssertEqual(text as String, "# old\n# old\n")
+        XCTAssertEqual(TextFindEngine.matches(of: "old", options: literal, in: text).map(\.location),
+                       [2, 8])
+    }
+
+    /// Neither feature can swallow the other's keys: the line-command hook sits on `keyDown`,
+    /// which only ever sees what no menu key equivalent claimed, and it claims none of the four
+    /// find keys anyway.
+    func testTheLineCommandHookIgnoresTheFindKeys() {
+        for key in ["f", "g", "e"] {
+            XCTAssertNil(EditorLineCommands.command(for: [.command], key: key))
+            XCTAssertNil(EditorLineCommands.command(for: [.command, .shift], key: key))
+        }
+        // And the keys it does claim are ones no find menu item asks for.
+        XCTAssertEqual(EditorLineCommands.command(for: [.command], key: "/"), .toggleComment)
+    }
+
+    /// Replacing the first of several leaves the focus on what was the second match, which is now
+    /// the first — the counter reads "1 of 2" and the next press acts on the right text.
+    func testFocusAfterReplacingTheFirstOfSeveral() {
+        let source = "cat cat cat" as NSString
+        let plan = FindReplace.plan(query: "cat", options: literal, template: "dog", in: source)
+        let replaced = applying(plan[0], to: source) as NSString
+        XCTAssertEqual(replaced as String, "dog cat cat")
+        let remaining = TextFindEngine.matches(of: "cat", options: literal, in: replaced)
+        XCTAssertEqual(remaining.count, 2)
+        let landed = plan[0].range.location + (plan[0].text as NSString).length
+        XCTAssertEqual(FindReplace.focusIndex(startingAt: landed, in: remaining), 0)
+    }
+}


### PR DESCRIPTION
The editor's find bar could search but not replace, and it had no keyboard verbs at all.

## Replace and Replace All

VS Code's shape: a disclosure on the leading edge of the bar expands a second row holding the replacement field, Replace, and Replace All. Collapsed is the default, so a plain search is the bar it has always been. The diff overlay searches a read-only buffer, so it gets no disclosure — its find bar is unchanged to the pixel.

Both verbs edit the text view, never the SwiftUI `text` binding: assigning through the binding replaces the whole document, which drops undo and throws the caret to the top. The edit goes through `SavingTextView.replaceAsOneEdit` — the `shouldChangeText` / `breakUndoCoalescing` / `didChangeText` shape Tab and Return already use — so **one replace is one undo step, and Replace All is one undo step for the whole document**: the replacements are stitched into a single range spanning the first match through the last before anything lands. The replacement carries `typingAttributes`, so the buffer's line metrics travel with it and nothing reflows while the highlighter catches up.

Nothing recounts by hand. The edit fires `textDidChange`, which is already where the match list is rebuilt and "n of m" refreshed, so the counter stays honest for free. `OccurrenceHighlighter`'s `findActive` contract is untouched — the query is still live after a replace, so the wash stays out of the way.

After a single Replace the focus steps to the first match *past* what was just inserted, wrapping to the top when the last one is consumed. Without that, replacing `foo` with `foobar` lands back inside the replacement and replaces it again on every press.

### Capture groups

In `.*` mode the replacement is an ICU template, expanded by `NSRegularExpression`: `$1`…`$9` insert capture groups, `$0` the whole match, `\$` a literal dollar. That is the `$1` VS Code supports. In literal mode a `$1` is just those two characters — there are no groups to name without a pattern, and eating a dollar sign out of replaced text would be a worse answer than not offering the feature. A group the pattern doesn't have expands to nothing rather than raising.

## Keyboard verbs

⌘G next match, ⇧⌘G previous match, ⌘E use the selection as the find query — joining ⌘F in an **Edit ▸ Find** submenu, where every Mac app keeps them.

They are hardwired as menu items rather than registered in `KeyCommandCatalog`. The catalog is the table of rebindable *app* verbs — window, session, pane — every one of which acts whatever is on screen; these four only mean anything while an editor overlay is open, they are macOS standard keys nobody rebinds, and ⌘F has been a hardwired item there since it shipped. Splitting the family so one is rebindable and three are not would be worse than either choice.

Because they stay out of the catalog, `pnpm keybindings:sync` is not needed and no shortcut table on the docs site goes stale — `web/landing/content/docs/keyboard.mdx` renders catalog categories only, and it has never documented the editor's find keys.

⌘G / ⇧⌘G reach the diff overlay's find bar too; it is the same bar over the same engine. ⌘E is editor-only, and acts only when the editor's own text view holds the keyboard, so a diff mounted behind it can't take its query from a buffer the user isn't in.

## Shape of the change

- New `Sources/termio/Editor/FindReplace.swift` — the planner (what each match becomes), the coalescer (one edit for the whole document), the focus rule, and the small `FindReplaceController` that owns the text view.
- `TextFindEngine` gains a pure `matches(of:options:in:)` over an `NSString`. The replace planner asks the same function the bar counts through, so the two lists cannot drift.
- `HighlightedTextView` gains one property and two attach lines.
- `replaceAsOneEdit` is no longer private and now reports whether the edit landed.

## Verification

`swift build` and `swift test` both clean — 734 tests, 0 failures. 19 new tests in `Tests/termioTests/FindReplaceTests.swift` cover the single-edit coalescing, `$1` / `$0` / `\$` expansion, literal mode's plain-text dollar, whole-word filtering through the planner, an unparseable pattern, UTF-16 offsets, and the focus rule. `scripts/check-strings.sh` passes with the new keys and their zh-Hans translations.

Not verified on screen: the task ruled out rebuilding the dev app, so the two-row bar's layout and the undo behavior in a live window haven't been eyeballed. The undo shape is the one already proven by Tab and Return in this same file.

Release Notes:
- The editor's find bar can now replace: a disclosure on its leading edge opens a replacement field with Replace and Replace All. Replace All takes one ⌘Z to undo, not one per match. In regular-expression mode the replacement understands `$1` capture groups.
- Added the standard find shortcuts: ⌘G for the next match, ⇧⌘G for the previous one, and ⌘E to search for the selected text. They live in Edit ▸ Find alongside ⌘F.