### PR TITLE
Keep an SSH shell in the workspace you are in

### DIFF
--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -1242,18 +1242,16 @@ extension TermioStore {
     /// uses. It lands in the `.terminals` funnel too, so it needs no project.
     /// Returns the new session's wire id and the `"terminal"` echo.
     ///
-    /// `workspaceID` is a preference here rather than a destination: an `ssh`
-    /// shell has to be filed under a workspace on the box it reaches, or that
-    /// workspace claims a machine it isn't on. It settles which of that box's
-    /// workspaces when there is more than one, and is ignored otherwise.
+    /// `workspaceID` is the workspace the phone is showing, and an `ssh` shell is
+    /// filed where the person asking for it already is (see `sshShellWorkspace`) —
+    /// so the row appears in the list they started from rather than in a workspace
+    /// they would have to go and find.
     func companionStartSSHSession(
         host: String, workspaceID: String?
     ) -> (sessionID: String, agentID: String)? {
         let host = host.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !host.isEmpty else { return nil }
-        let preferred = companionWorkspace(workspaceID)
-            .flatMap { $0.isOn(alias: host, device: nil) ? $0.id : nil }
-        addSSHSession(host: host, preferring: preferred)
+        addSSHSession(host: host, preferring: companionWorkspace(workspaceID)?.id)
         guard let sessionID = selectedSessionID?.uuidString else { return nil }
         return (sessionID, AgentPreset.terminal.wireName)
     }

--- a/Sources/termio/Sidebar/WorkspaceSwitcher.swift
+++ b/Sources/termio/Sidebar/WorkspaceSwitcher.swift
@@ -71,6 +71,10 @@ struct WorkspaceSwitcherToolbarView: View {
     @EnvironmentObject var settings: AppSettings
     @Environment(\.controlActiveState) private var controlActive
 
+    /// Whether the pointer is over the name, or its menu is open. Reported by the
+    /// AppKit overlay below, which is the view the pointer actually lands on.
+    @State private var isHighlighted = false
+
     /// One fixed box, wide enough for an ordinary name and narrow enough to leave the
     /// sort and `+` buttons clear of NSToolbar's `»` overflow at the navigator's 240pt
     /// minimum (the toggle, this box and those two buttons come to roughly 220).
@@ -87,7 +91,21 @@ struct WorkspaceSwitcherToolbarView: View {
     /// Measuring the widest name and sizing to that keeps the box honest but needs
     /// text metrics, a font bridge and a re-measure on every rename — machinery in
     /// exchange for slack the flexible space beside it already absorbs.
-    private static let nameWidth: CGFloat = 104
+    ///
+    /// Ten points of it are the hover chip's inset now (`chipInset` below), so the
+    /// item as a whole is exactly as wide as it was and the `»` budget is untouched.
+    private static let nameWidth: CGFloat = 94
+
+    /// What the hover chip puts around the name. Real padding, not a background
+    /// drawn outside the label's bounds: the toolbar item is only as large as this
+    /// view asks to be, so anything painted past that edge is at the mercy of the
+    /// hosting view's clip — and a chip clipped on one side looks like a bug rather
+    /// than a control.
+    ///
+    /// The leading half is given back as negative padding on the whole box (see
+    /// `body`), so the name still starts at the x the toggle beside it was spaced
+    /// for. Only the trailing half is new width, and it comes out of `nameWidth`.
+    private static let chipInset: CGFloat = 5
 
     var body: some View {
         // The single-workspace collapse. Not "hidden but present": with one scope
@@ -115,11 +133,18 @@ struct WorkspaceSwitcherToolbarView: View {
                 // sit in the middle of the box and the label's left edge would move on each
                 // switch — the same shift by a different route.
                 .frame(width: Self.nameWidth, alignment: .leading)
-                // The overlay owns the press, the tooltip, and the accessibility of
-                // this control — it is the view under the pointer, so a `.help()` here
-                // would be shadowed by it and a SwiftUI accessibility element here would
-                // hide it. See `WorkspaceMenuHost`.
-                .overlay(WorkspaceMenuPopper(store: store))
+                .padding(.horizontal, Self.chipInset)
+                .padding(.vertical, 3)
+                .background(highlight)
+                // The inset given back, so the name keeps the x it had before there
+                // was a chip: the toggle's 6pt of spacing now holds 5pt of chip and
+                // 1pt of gap, and the two controls still read as one band.
+                .padding(.leading, -Self.chipInset)
+                // The overlay owns the press, the hover, the tooltip, and the
+                // accessibility of this control — it is the view under the pointer, so a
+                // `.help()` here would be shadowed by it and a SwiftUI accessibility
+                // element here would hide it. See `WorkspaceMenuHost`.
+                .overlay(WorkspaceMenuPopper(store: store, highlighted: $isHighlighted))
                 .accessibilityHidden(true)
         }
     }
@@ -130,6 +155,26 @@ struct WorkspaceSwitcherToolbarView: View {
     // one control band with them rather than a dimmer `.secondary` label.
     private var color: Color {
         controlActive == .inactive ? Color(nsColor: .disabledControlTextColor) : .primary
+    }
+
+    /// The chip under the name while the pointer is on it — the one thing that says
+    /// this word is a control. Without it the switcher was a label, and it was read
+    /// as one: people ran a whole session without finding out the workspace could be
+    /// changed from here.
+    ///
+    /// Present at every size, not conditional: it is the fill that changes, so the
+    /// box never resizes on hover and no name can be re-truncated by the pointer
+    /// arriving.
+    ///
+    /// A neutral fill of the foreground, the same rounded lift the sidebar's own hover
+    /// controls use, not an accent wash — this is a pointer cue, not a selection.
+    private var highlight: some View {
+        RoundedRectangle(cornerRadius: 5, style: .continuous)
+            .fill(Color.primary.opacity(isHighlighted ? 0.10 : 0))
+            // Hover cues snap: they paint on the next frame and clear on the next
+            // frame. A fade here would still be arriving after the pointer had moved
+            // on, which is what reads as lag.
+            .animation(nil, value: isHighlighted)
     }
 }
 
@@ -144,6 +189,11 @@ struct WorkspaceSwitcherToolbarView: View {
 /// File ▸ Workspace for the same keystroke.
 private struct WorkspaceMenuPopper: NSViewRepresentable {
     let store: TermioStore
+    /// Driven by the host below: the pointer entering or leaving, and the menu
+    /// being up. Hover is answered here rather than by a SwiftUI `.onHover` on the
+    /// label, for the same reason the tooltip is — this view is the one the pointer
+    /// hits, so the label underneath never learns the pointer arrived.
+    @Binding var highlighted: Bool
 
     /// The name as well as the sentence, because the label above draws in a fixed box and
     /// a name too long for it is middle-truncated with nowhere else to be read in place.
@@ -154,12 +204,16 @@ private struct WorkspaceMenuPopper: NSViewRepresentable {
     func makeNSView(context: Context) -> WorkspaceMenuHost {
         let view = WorkspaceMenuHost()
         view.store = store
+        view.onHighlight = { highlighted = $0 }
         view.toolTip = Self.toolTip(for: store)
         return view
     }
 
     func updateNSView(_ nsView: WorkspaceMenuHost, context: Context) {
         nsView.store = store
+        // Rebound every update: the closure captures this struct's binding, and a
+        // stale one writes to a view tree that has been replaced.
+        nsView.onHighlight = { highlighted = $0 }
         // Set here too: the scope changes far more often than this view is made.
         nsView.toolTip = Self.toolTip(for: store)
     }
@@ -171,6 +225,11 @@ private struct WorkspaceMenuPopper: NSViewRepresentable {
 private final class WorkspaceMenuHost: NSView {
     weak var store: TermioStore?
 
+    /// Reports the pointer cue back to the view drawing it. See `highlight`.
+    var onHighlight: ((Bool) -> Void)?
+
+    private var hoverTracking: NSTrackingArea?
+
     /// Flipped so the anchor below reads in the direction the menu opens, rather
     /// than depending on whichever convention the hosting view happens to use.
     override var isFlipped: Bool { true }
@@ -181,6 +240,34 @@ private final class WorkspaceMenuHost: NSView {
 
     override func mouseDown(with event: NSEvent) {
         showMenu()
+    }
+
+    // MARK: - Hover
+    //
+    // Only while the app is active: hovering a background window highlights
+    // nothing on macOS, and the name is drawn in the disabled colour there anyway.
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTracking { removeTrackingArea(hoverTracking) }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            owner: self)
+        addTrackingArea(area)
+        hoverTracking = area
+    }
+
+    override func mouseEntered(with event: NSEvent) { onHighlight?(true) }
+
+    override func mouseExited(with event: NSEvent) { onHighlight?(false) }
+
+    /// Whether the pointer is over this view right now, asked rather than
+    /// remembered — the tracking area is silent while a menu holds the event loop,
+    /// so this is how the cue is settled once the menu has gone.
+    private var isUnderPointer: Bool {
+        guard let location = window?.mouseLocationOutsideOfEventStream else { return false }
+        return bounds.contains(convert(location, from: nil))
     }
 
     // MARK: - Accessibility
@@ -224,9 +311,16 @@ private final class WorkspaceMenuHost: NSView {
         // put — New Terminal on it, Clone to it, File ▸ Connect to… for a box
         // never reached — never a place the window travels to.
 
+        // Held highlighted for as long as the menu is up, the way a pull-down stays
+        // pressed under its own menu. `popUp` runs a nested event loop and returns
+        // once the menu closes, so the cue is settled on the line after it — from
+        // where the pointer actually is, since no exit was delivered while the menu
+        // had the loop.
+        onHighlight?(true)
         // Anchored under the label the way a pull-down opens, rather than at the
         // pointer the way a context menu does.
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: bounds.height + 4), in: self)
+        onHighlight?(isUnderPointer)
     }
 
     private func addAction(_ title: String, to menu: NSMenu, _ action: Selector) {

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -796,8 +796,12 @@ extension TermioStore {
     }
 
     /// Creates the remote `.terminal` session under the machine it runs on — that
-    /// machine's fallback workspace, same as `addSSHSession` — tagging it with the
-    /// per-session remote host + cwd that `makeTermiodLink` threads through.
+    /// machine's fallback workspace — tagging it with the per-session remote host +
+    /// cwd that `makeTermiodLink` threads through.
+    ///
+    /// Filed by machine, unlike the plain `ssh` shell `addSSHSession` opens: this
+    /// process really does live on the box and outlive the connection to it, so the
+    /// workspace holding it is telling the truth about where its work is.
     private func createRemoteTerminalSession(
         host: String,
         device deviceID: String,

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -412,23 +412,27 @@ extension TermioStore {
     }
 
     /// Opens an **SSH terminal** to `host` — a terminal that launches `ssh <host>`
-    /// in a local PTY instead of a local shell (see `Session.sshHost`). It lands in
-    /// that machine's fallback workspace, so an `ssh` shell and a durable termiod
-    /// session on the same box sit together rather than scattering among loose
-    /// local terminals. `host` is a `~/.ssh/config` alias or a bare `user@host`.
+    /// in a local PTY instead of a local shell (see `Session.sshHost`). It lands
+    /// where the user is (see `sshShellWorkspace`). `host` is a `~/.ssh/config`
+    /// alias or a bare `user@host`.
     ///
-    /// `preferring` settles which of that box's workspaces when a caller knows —
-    /// the phone names the workspace on its screen, and a box can hold more than
-    /// one. It is only ever a preference: a caller that names a workspace on
-    /// another machine gets the fallback, because the machine rule above is what
-    /// keeps a workspace from claiming a box it isn't on.
+    /// `preferring` names the workspace the caller is showing, for a caller whose
+    /// scope isn't the sidebar's — the phone names the workspace on its screen.
     func addSSHSession(host: String, preferring preferred: Workspace.ID? = nil) {
         let host = host.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !host.isEmpty else { return }
-        // Named for what it is, not for the box — the workspace already says which
-        // machine. The distinction matters beside the numbered rows: an "SSH Shell"
-        // dies with the connection, while a durable termiod session survives a detach.
-        var session = Session(title: "SSH Shell", agent: .terminal)
+        let workspaceID = sshShellWorkspace(for: host, preferring: preferred)
+        // Named for the box, unless the band above the column already names it —
+        // which is exactly when the row drops its device mark too (see
+        // `bandNamesTheMachine`). Filed among a workspace's own work, `SSH Shell`
+        // three rows running says nothing about which three machines; under a
+        // workspace Termio named after one, the host would be `ukvps ▸ ukvps`, and
+        // what the row has left to say is what kind of session it is — an `ssh`
+        // shell dies with the connection, a durable termiod row survives a detach.
+        let landing = workspaces.first { $0.id == workspaceID }
+        let bandNamesTheMachine =
+            landing?.isAutoCreated == true && landing?.isOn(alias: host, device: nil) == true
+        var session = Session(title: bandNamesTheMachine ? "SSH Shell" : host, agent: .terminal)
         // A name, not a placeholder: it is what makes an `ssh` shell legible next to
         // the durable rows, and nothing better is waiting behind it — the cwd a
         // loose terminal falls back to reports a directory on the far box, which is
@@ -436,12 +440,37 @@ extension TermioStore {
         session.givenTitle = session.title
         session.sshHost = host
 
-        let workspaceID = preferred.flatMap { id in
-            workspaces.first { $0.id == id && $0.isOn(alias: host, device: nil) }?.id
-        } ?? deviceWorkspace(for: host)
         guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         workspaces[index].terminals.append(session)
         selectedSessionID = session.id
+    }
+
+    /// Where a plain `ssh` shell is filed: the workspace already on screen — the
+    /// sidebar's scope, or the one `preferred` names for a caller with a scope of
+    /// its own.
+    ///
+    /// Not the machine's own workspace, and nothing is created here. An `ssh`
+    /// shell is a *local* PTY running `ssh <host>`; the far box owes it no
+    /// workspace, and minting one moved the sidebar out from under someone who
+    /// only asked for a terminal — a scope switch as the side effect of opening a
+    /// shell, into a workspace they had never seen. The row wears its own machine
+    /// mark wherever it is filed, which is what says where it runs; a durable
+    /// termiod session is the one that really lives on the box, and it still files
+    /// by machine (`createRemoteTerminalSession`).
+    ///
+    /// The exception is a workspace Termio named after a *different* box: the band
+    /// above that column names the machine and its rows drop their marks in
+    /// exchange (see `bandNamesTheMachine`), so a shell to another host filed there
+    /// would read as one on that one.
+    private func sshShellWorkspace(
+        for host: String, preferring preferred: Workspace.ID? = nil
+    ) -> Workspace.ID {
+        let target = preferred.flatMap { id in workspaces.first { $0.id == id } } ?? currentWorkspace
+        guard target.isAutoCreated == true,
+              !target.device.isThisMac,
+              !target.isOn(alias: host, device: nil)
+        else { return target.id }
+        return deviceWorkspace(for: host)
     }
 
     /// Opens a terminal running `ssh-copy-id` against `host`, installing
@@ -457,7 +486,10 @@ extension TermioStore {
         session.sshHost = host
         session.sshKeyToInstall = publicKey
 
-        let workspaceID = deviceWorkspace(for: host)
+        // Filed like the `ssh` shell it is: this one runs `ssh-copy-id` here and
+        // is gone as soon as the key is in place, so it has even less business
+        // conjuring a workspace for the machine it is reaching.
+        let workspaceID = sshShellWorkspace(for: host)
         guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         workspaces[index].terminals.append(session)
         selectedSessionID = session.id

--- a/Sources/termio/TermioStore/WorkspaceMigration.swift
+++ b/Sources/termio/TermioStore/WorkspaceMigration.swift
@@ -223,15 +223,24 @@ enum WorkspaceMigration {
         //
         // A device the workspace already names counts as a claim in its own right:
         // its loose sessions were filed there because they run there, and nothing
-        // else records that. A loose shell records its own machine and nothing else
-        // does, so it is a claim exactly like a checkout's. Leaving it out let a
-        // workspace holding local shells and one remote checkout adopt the remote
-        // box — and on a one-workspace tree that left nowhere on this Mac for local
-        // work to go, which is the violation this pass exists to prevent.
+        // else records that. A durable loose session records its own machine and
+        // nothing else does, so it is a claim exactly like a checkout's. Leaving it
+        // out let a workspace holding local shells and one remote checkout adopt the
+        // remote box — and on a one-workspace tree that left nowhere on this Mac for
+        // local work to go, which is the violation this pass exists to prevent.
+        //
+        // A plain `ssh` shell (`sshHost`) claims nothing at all — neither the box
+        // it reaches nor the Mac its PTY runs on. It is filed wherever the user
+        // opened it (`sshShellWorkspace`), so counting it for the far box split the
+        // scope it was opened in on the next launch, and a workspace holding only
+        // those was adopted outright — renaming a local scope after a machine.
+        // Counting it for this Mac would be the same mistake from the other side:
+        // a box's workspace holding one would split off a phantom local half.
         func devices(of workspace: Workspace, claims: [WorkspaceDevice]) -> Set<WorkspaceDevice> {
             var devices = Set(claims)
             for session in workspace.looseSessions {
-                devices.insert(WorkspaceDevice(alias: session.termiodRemoteHost ?? session.sshHost))
+                guard session.termiodRemoteHost != nil || session.sshHost == nil else { continue }
+                devices.insert(WorkspaceDevice(alias: session.termiodRemoteHost))
             }
             if !workspace.device.isThisMac { devices.insert(workspace.device) }
             return devices

--- a/Tests/termioTests/WorkspaceDeviceTests.swift
+++ b/Tests/termioTests/WorkspaceDeviceTests.swift
@@ -98,6 +98,69 @@ final class WorkspaceDeviceTests: XCTestCase {
         XCTAssertEqual(store.deviceWorkspace(for: "ukvps"), named.id)
         XCTAssertEqual(store.workspaces.count, 2)
     }
+
+    // MARK: - Where a plain `ssh` shell is filed
+
+    /// The bug this rule exists to remove: opening an `ssh` shell minted a
+    /// workspace for the box and moved the sidebar into it, so a user who asked
+    /// for a terminal got a scope they had never seen — and had to find the
+    /// switcher to get back.
+    func testAnSSHShellStaysInTheWorkspaceOnScreen() {
+        let home = Workspace(name: "Sessions", isAutoCreated: false)
+        let store = makeStore(workspaces: [home], current: home)
+
+        store.addSSHSession(host: "oracal")
+
+        XCTAssertEqual(store.workspaces.count, 1, "nothing is minted for the box it reaches")
+        XCTAssertEqual(store.currentWorkspaceID, home.id, "and the scope does not move")
+        XCTAssertEqual(store.workspaces[0].terminals.first?.sshHost, "oracal")
+        XCTAssertEqual(store.workspaces[0].terminals.first?.title, "oracal",
+                       "the row names the machine, since the band above it no longer does")
+    }
+
+    /// A workspace Termio named after a box speaks for that box — its band names
+    /// the machine and its rows drop their device marks in exchange — so a shell to
+    /// a *different* host cannot be filed there without reading as one on this one.
+    func testAnSSHShellToAnotherBoxAvoidsAMachinesOwnWorkspace() {
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps", isAutoCreated: true)
+        let store = makeStore(workspaces: [ukvps], current: ukvps)
+
+        store.addSSHSession(host: "oracal")
+
+        XCTAssertEqual(store.workspaces.count, 2)
+        XCTAssertTrue(ukvps.looseSessions.isEmpty)
+        let oracal = store.workspaces.first { $0.deviceAlias == "oracal" }
+        XCTAssertEqual(oracal?.terminals.first?.sshHost, "oracal")
+        XCTAssertEqual(oracal?.terminals.first?.title, "SSH Shell",
+                       "under a band that names the machine, the row says what kind it is")
+    }
+
+    /// The same machine's own workspace still takes its own shell, so `ssh` and a
+    /// durable termiod session on one box sit together when that is where the user
+    /// already is.
+    func testAMachinesOwnWorkspaceKeepsItsOwnSSHShell() {
+        let ukvps = Workspace(name: "ukvps", deviceAlias: "ukvps", isAutoCreated: true)
+        let store = makeStore(workspaces: [ukvps], current: ukvps)
+
+        store.addSSHSession(host: "ukvps")
+
+        XCTAssertEqual(store.workspaces.count, 1)
+        XCTAssertEqual(store.workspaces[0].terminals.first?.sshHost, "ukvps")
+    }
+
+    /// The phone names the workspace it is showing, and the shell lands there for
+    /// the same reason it lands in the sidebar's scope on the Mac.
+    func testTheWorkspaceACallerNamesTakesTheShell() {
+        let home = Workspace(name: "Sessions", isAutoCreated: false)
+        let side = Workspace(name: "Side", isAutoCreated: false)
+        let store = makeStore(workspaces: [home, side], current: home)
+
+        store.addSSHSession(host: "oracal", preferring: side.id)
+
+        XCTAssertEqual(store.workspaces.count, 2)
+        XCTAssertEqual(store.workspaces[1].terminals.first?.sshHost, "oracal")
+        XCTAssertTrue(store.workspaces[0].terminals.isEmpty)
+    }
 }
 
 /// Which workspaces Termio may sweep when they empty out.
@@ -216,5 +279,32 @@ final class WorkspaceDeviceRegressionTests: XCTestCase {
 
         let (workspaces, _) = WorkspaceMigration.reconcile(workspaces: [scope], projects: [])
         XCTAssertEqual(workspaces.first { $0.id == scope.id }?.device, .ssh(alias: "ukvps"))
+    }
+
+    /// A plain `ssh` shell claims neither end. It is a local PTY holding a
+    /// connection open, filed wherever the user opened it, so counting it for the
+    /// far box handed the user's own scope to that machine on the next launch.
+    func testAPlainSSHShellLeavesItsWorkspaceWhereItIs() {
+        var shell = Session(title: "oracal")
+        shell.sshHost = "oracal"
+        let scope = Workspace(name: "Sessions", terminals: [shell], isAutoCreated: false)
+
+        let (workspaces, _) = WorkspaceMigration.reconcile(workspaces: [scope], projects: [])
+        XCTAssertEqual(workspaces.count, 1, "and no half splits off for the box")
+        XCTAssertEqual(workspaces[0].device, .thisMac, "the scope the user named stays theirs")
+        XCTAssertEqual(workspaces[0].terminals.count, 1)
+    }
+
+    /// And the mirror: one filed under a box's own workspace must not split a
+    /// phantom local half off it either.
+    func testAPlainSSHShellLeavesAMachinesWorkspaceWhereItIs() {
+        var shell = Session(title: "SSH Shell")
+        shell.sshHost = "ukvps"
+        let scope = Workspace(
+            name: "ukvps", terminals: [shell], deviceAlias: "ukvps", isAutoCreated: true)
+
+        let (workspaces, _) = WorkspaceMigration.reconcile(workspaces: [scope], projects: [])
+        XCTAssertEqual(workspaces.count, 1)
+        XCTAssertEqual(workspaces[0].device, .ssh(alias: "ukvps"))
     }
 }


### PR DESCRIPTION
Two things from Slack: an `ssh` shell teleported the sidebar into a workspace nobody asked for, and the workspace name in the toolbar gave no sign it could be clicked.

**Filing.** An `ssh` shell is a local PTY running `ssh <host>`, so the far box owes it no workspace. It now lands in the workspace already on screen — nothing is minted, the scope does not move — and takes the host as its title, since the band above the column no longer names the machine. The row's own device mark says where it runs. A durable termiod session still files by machine: that one really does live over there. The exception is a workspace Termio named after a *different* box, whose rows drop their marks in exchange for the band naming the machine.

The device pass in `WorkspaceMigration` stops counting a plain `ssh` shell as a claim on either end. Counting it for the box split the scope it was opened in on the next launch, and adopted a workspace holding only those outright; counting it for this Mac would split a phantom local half off a box's workspace.

**The switcher.** A neutral rounded chip paints under the workspace name while the pointer is on it, and stays up while its menu is open. Hover is owned by the AppKit overlay — the view the pointer actually hits. No fade, and the geometry is unchanged: the chip's inset comes out of the fixed name box and its leading half is given back, so the name keeps its x and the toolbar item keeps its width.

Six new tests cover the filing rule and both migration directions; `swift test` is 777 passing.

Release Notes:
- Opening an SSH connection no longer moves you into a new workspace — the shell lands in the workspace you are already in, named after the machine it reaches.
- The workspace name in the sidebar's toolbar now highlights under the pointer, so it reads as the control it is.