### PR TITLE
Record where the agent-integration migration stands

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ from the real front matter).
 | active | design | [Research brief — termiod Session Protocol (for design agent)](design/20260730-_research-session-protocol-brief.md) |
 | active | design | [Sessions CLI v2 — reliability & command design](design/20260724-sessions-cli-v2.md) |
 | active | research | ["Reading list: PTYs, SSH, and detachable remote terminals"](READING.md) |
+| active | rfc | [Agent integration moves into termiod](design/20260825-agent-integration-moves-to-termiod.md) |
 | active | rfc | [Push-to-talk voice dictation — hold the space bar (iOS shipped, OpenAI)](design/20260704-push-to-talk-voice-dictation.md) |
 | active | rfc | [Unify the server plane in Rust, reduce the Mac app to a viewer](design/20260819-unify-server-plane.md) |
 | approved | design | [会话历史 · 搜索 · 恢复（Session History / Search / Resume）](design/20260628-session-history-search-resume.md) |
@@ -106,7 +107,6 @@ from the real front matter).
 | draft | rfc | ["RFC: Per-project agent sandbox (Apple Seatbelt)"](design/20260630-sandbox-seatbelt.md) |
 | draft | rfc | [A project carries its machine — delete the host container](design/20260818-one-workspace-source.md) |
 | draft | rfc | [Adversarial review — Retire "remote", every machine is a device](design/20260814-remote-to-device.review-claude.md) |
-| draft | rfc | [Agent integration moves into termiod](design/20260825-agent-integration-moves-to-termiod.md) |
 | draft | rfc | [Automation — scheduled agent runs](design/20260702-automation-scheduled-agent-runs.md) |
 | draft | rfc | [Companion Wire Protocol](design/20260810-companion-wire-protocol.md) |
 | draft | rfc | [Device RFC blocking decisions](design/20260814-remote-to-device.decisions.md) |

--- a/docs/design/20260825-agent-integration-moves-to-termiod.md
+++ b/docs/design/20260825-agent-integration-moves-to-termiod.md
@@ -1,9 +1,9 @@
 ---
 title: Agent integration moves into termiod
-status: draft
+status: active
 type: rfc
 created: 2026-08-25
-updated: 2026-08-25
+updated: 2026-08-26
 related:
   - 20260824-agent-integration-on-a-device.md
   - 20260819-unify-server-plane.md
@@ -122,13 +122,51 @@ whole thesis and not a new cost.
 
 Ordered so each one is shippable and none is a big-bang.
 
-| Stage | Deliverable | Gate |
+Stages 1 through 4 are delivered; what each one actually cost and caught is
+recorded below the table, because a stage list that only says *done* is how the
+device RFC's own table came to mislead a reader into re-deciding something that
+had already shipped.
+
+| Stage | Deliverable | Gate | State |
+| --- | --- | --- | --- |
+| **1** | Manifest schema in Rust, parsing the same 15 bundled files plus the user directory. Nothing installs yet. | A fixture test parses every manifest in both languages and asserts the same values. | **Done** #461 |
+| **2** | The two shell-command dialects (JSON manifest, script directory) and the skill installer, behind a new `install` control message. | Installing on `ukvps` through termiod produces byte-identical files to the SSH arm's output. | **Done** #461 |
+| **3** | The plugin dialects and the TOML block. | Same byte-identical gate, all six dialects. | **Done** #465 |
+| **4** | Swift calls it. `AgentConfigStore` and `SSHAgentConfigStore` are deleted; `DevicePaneModel.setUp` becomes one call. | A twelve-agent install is one round trip. The Settings surfaces are unchanged. | **Done** #472 |
+| **3.5** | A per-agent config-home variable (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, …), inserted before Stage 4 so the schema changed once rather than twice. | Six of fifteen agents have a documented one; OpenCode does **not** — `OPENCODE_CONFIG_DIR` adds a search directory rather than moving the config home, so installing under XDG is still always read. | **Done** #467 |
+| **5** | The phone installs. | The iOS device client offers Set up on a directly-attached box, with the Mac quit. | Blocked on P0.2 — PR #344 |
+
+### What the stages actually cost, and what they caught
+
+The round trips were worse than the estimate this RFC was written on. Measured by
+counting `ssh` invocations against a twelve-agent box:
+
+| | before | after |
 | --- | --- | --- |
-| **1** | Manifest schema in Rust, parsing the same 15 bundled files plus the user directory. Nothing installs yet. | A fixture test parses every manifest in both languages and asserts the same values. |
-| **2** | The two shell-command dialects (JSON manifest, script directory) and the skill installer, behind a new `install` control message. | Installing on `ukvps` through termiod produces byte-identical files to the SSH arm's output. |
-| **3** | The plugin dialects and the TOML block. | Same byte-identical gate, all six dialects. |
-| **4** | Swift calls it. `AgentConfigStore` and `SSHAgentConfigStore` are deleted; `DevicePaneModel.setUp` becomes one call. | A twelve-agent install is one round trip. The Settings surfaces are unchanged. |
-| **5** | The phone installs. | The iOS device client offers Set up on a directly-attached box, with the Mac quit. |
+| install | **98** | 1 |
+| probe | **45** | 1 |
+
+Three defects surfaced that no amount of reading would have found, each of them
+silent because every hook form ends in `2>/dev/null || true`:
+
+- **The SSH arm could not recognise its own device hooks.** ` agent report ` and
+  `agent-status.sock` were the only ownership fingerprints, and a device hook
+  invokes `termiod set-status`. Every reinstall appended a second copy of every
+  entry; `ukvps` had accumulated 54 duplicate hook lines. Fixed in #463, and the
+  daemon spells the fingerprint identically (`DAEMON_MARKER`).
+- **`report_command` read `capturesTranscript` off any manifest**, so a scripts or
+  TOML agent would have been handed `--transcript` and blocked waiting on stdin
+  that never arrives. Every *bundled* manifest happened to produce the right bytes,
+  so the byte-identical gate could not have caught it — only a user manifest would
+  have. This is the user-extensible-format risk this RFC accepted, arriving for
+  the first time.
+- **The daemon binary was a guess.** `$HOME/.local/bin/termiod` is where the Mac
+  assumed a deploy put it; a box keeping it elsewhere got a plugin that exec'd a
+  file that was not there. The daemon resolves `current_exe()` instead.
+
+Stage 4 added one decision worth keeping visible: a device whose daemon is too old
+to have the install message is **refused by name, and not redeployed**. Redeploying
+restarts the daemon, which kills its running sessions — `ukvps` had 15.
 
 Stages 1–4 depend on nothing in the iOS work. Stage 5 depends on
 [`ios-as-device-client`](20260824-ios-as-device-client.md) P4, which depends on


### PR DESCRIPTION
Docs only. Stages 1–4 of `20260825-agent-integration-moves-to-termiod.md` are delivered and the document said nothing about it.

That matters more than housekeeping here. The device RFC's own status table is what misled me earlier in this migration: it recorded "no caller passes a device target yet" long after #446 had added one, I read it as current, and proposed re-deciding something that had already shipped. A stage list that goes stale is not neutral — it actively costs someone a wrong decision.

So this records what each stage **cost and caught**, not just that it is done:

- **The round trips were worse than the estimate this RFC was written on.** 98 `ssh` invocations for a twelve-agent install against the 40–60 assumed here, and 45 for a probe. Both are 1 now.
- **Three defects that no amount of reading would have found**, each silent because every hook form ends in `2>/dev/null || true`: the SSH arm could not recognise its own device hooks and had appended 54 duplicate lines on `ukvps`; `report_command` would have handed `--transcript` to a dialect that blocks waiting on stdin, which the byte-identical gate could not catch because every *bundled* manifest happened to produce the right bytes; and the daemon binary was a guess that a box keeping it elsewhere would have exec'd into nothing.
- **Stage 4's skew decision**, which is worth keeping visible: a device whose daemon is too old is refused by name and **not** redeployed, because redeploying restarts the daemon and kills its running sessions — `ukvps` had 15.

Stage 3.5 gets a row it never had, since it was inserted mid-flight, including the finding that OpenCode must *not* get the config-home field — `OPENCODE_CONFIG_DIR` adds a search directory rather than moving the config home, so installing under XDG is still always read.

Status moves `draft` → `active`.

Release Notes:
- None. Design documentation only.