### PR TITLE
fix(ios): prevent companion reconnect flicker

### DIFF
--- a/ios/Sources/CompanionTransport.swift
+++ b/ios/Sources/CompanionTransport.swift
@@ -137,13 +137,10 @@ final class CompanionTransport {
     /// screen reset, auth, the attach it gates, and the grid claim the Mac's
     /// repaint is driven by.
     private func sendPreamble() {
-        // On a REconnect the terminal still shows the dead link's screen; a
-        // full reset (RIS) ahead of the server's ring-buffer replay keeps the
-        // two byte streams from interleaving into garbage. Emitted here on the
-        // serial delegate queue so it precedes the replayed bytes.
-        if everConnected {
-            onOutput?(Data("\u{1B}c".utf8))
-        }
+        // The server's attach response is the authoritative snapshot boundary.
+        // Do not emit RIS here: a transient reconnect can otherwise clear the
+        // visible terminal before the snapshot arrives, which reads as a flash
+        // and is especially noticeable during iOS foreground/network churn.
         everConnected = true
         // Auth precedes the attach on the same socket — the server refuses
         // the bridge (and everything else) until the token lands.

--- a/ios/Sources/WebSocketLink.swift
+++ b/ios/Sources/WebSocketLink.swift
@@ -69,6 +69,10 @@ final class WebSocketLink: NSObject {
     /// close delegate; the first one wins so a drop dials exactly one
     /// reconnect. Main queue only, cleared on every dial.
     private var currentTaskDidDie = false
+    /// Prevents foreground/path/reconnect callbacks from opening overlapping
+    /// sockets while the previous dial is still in flight. Overlapping dials
+    /// make the companion receive competing attach and resize streams.
+    private var dialing = false
     /// Set the moment the socket opens and cleared the moment it dies, on
     /// whichever queue notices — hence the lock.
     private var open = false
@@ -147,7 +151,8 @@ final class WebSocketLink: NSObject {
     // MARK: - Connect
 
     private func connect() {
-        guard !stopped else { return }
+        guard !stopped, !dialing else { return }
+        dialing = true
         currentTaskDidDie = false
         task?.cancel(with: .goingAway, reason: nil)
         let task = session.webSocketTask(with: configuration.url)
@@ -259,6 +264,7 @@ final class WebSocketLink: NSObject {
 
     /// The socket died — from a failed read or from the close delegate.
     private func died(_ deadTask: URLSessionWebSocketTask) {
+        dialing = false
         setOpen(false)
         DispatchQueue.main.async { [weak self] in
             guard let self, !stopped, !currentTaskDidDie, deadTask === task else { return }
@@ -280,6 +286,7 @@ extension WebSocketLink: URLSessionWebSocketDelegate {
         _: URLSession, webSocketTask task: URLSessionWebSocketTask, didOpenWithProtocol _: String?
     ) {
         guard task === self.task else { return }
+        dialing = false
         Log.companion.notice(
             "\(self.configuration.name, privacy: .public) link connected to \(self.configuration.url.host ?? "?", privacy: .public)"
         )


### PR DESCRIPTION
## Summary
- serialize WebSocket dials so foreground/network/reconnect callbacks cannot overlap sockets
- stop sending RIS on reconnect; the attach snapshot is the authoritative repaint boundary

## Root cause
iOS could open overlapping companion sockets during reconnect triggers, while each reconnect emitted ESC c before the server snapshot arrived. That cleared the visible terminal and caused repeated attach/resize streams to appear as flicker.

## Validation
- `git diff --check` passes
- changed Swift sources compile during `swift test` build
- full `swift test` could not complete in this environment; the build ended with `error: fatalError` after dependency compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)