### PR TITLE
Hold the agent reordering arithmetic to what it claims

### DIFF
--- a/Sources/termio/Settings/AgentOrdering.swift
+++ b/Sources/termio/Settings/AgentOrdering.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// What a drag or a Move Up *means* for an ordered list of agent ids.
+///
+/// Kept out of `AgentSettingsTab` because it is arithmetic, and arithmetic
+/// inside a `View` is arithmetic nobody can test. The reordering it describes
+/// was rebuilt by hand once already — `onMove` is only honoured by an editable
+/// `List`, so moving the roster into a grouped `Form` silently stopped it — and
+/// the replacement shipped with no test at all. That is the gap this closes:
+/// the drag is the pleasant path and the menu is the one that cannot quietly
+/// break, but neither is worth much if the arithmetic under both is wrong.
+///
+/// Every operation returns `nil` for "this changes nothing", so a row dropped on
+/// itself or a Move Up at the top is not recorded as an edit.
+enum AgentOrdering {
+    /// Drops `draggedID` at `targetID`'s position, shifting the rest along.
+    static func moving(_ draggedID: String, onto targetID: String, in ids: [String]) -> [String]? {
+        guard draggedID != targetID,
+              let from = ids.firstIndex(of: draggedID),
+              let to = ids.firstIndex(of: targetID)
+        else { return nil }
+        var moved = ids
+        moved.remove(at: from)
+        moved.insert(draggedID, at: to)
+        return moved
+    }
+
+    /// Swaps `id` with its neighbour `offset` places away. A swap rather than a
+    /// re-insert because that is what "up one" means when you are looking at a
+    /// list: the two rows trade places, and repeating it walks the row through
+    /// the list one step at a time.
+    static func moving(_ id: String, by offset: Int, in ids: [String]) -> [String]? {
+        guard let from = ids.firstIndex(of: id) else { return nil }
+        let to = from + offset
+        guard ids.indices.contains(to), to != from else { return nil }
+        var moved = ids
+        moved.swapAt(from, to)
+        return moved
+    }
+}

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -330,18 +330,15 @@ struct AgentSettingsTab: View {
     }
 
     /// Persists a drag as the new arrangement; `setEnabledOrder` keeps every
-    /// other id ranked behind it so the ordering stays total.
-    /// Drops `draggedID` at `target`'s position. Returns false for a drag that
-    /// changes nothing, so a row dropped on itself is not recorded as an edit.
+    /// other id ranked behind it so the ordering stays total. Returns false for a
+    /// drag that changes nothing, so a row dropped on itself is not an edit.
+    ///
+    /// The arithmetic lives in `AgentOrdering`, where it can be tested.
     private func move(_ draggedID: String, onto target: AgentPreset) -> Bool {
-        var ids = listedAgents.map(\.id)
-        guard draggedID != target.id,
-              let from = ids.firstIndex(of: draggedID),
-              let to = ids.firstIndex(of: target.id)
+        guard let moved = AgentOrdering.moving(
+            draggedID, onto: target.id, in: listedAgents.map(\.id))
         else { return false }
-        ids.remove(at: from)
-        ids.insert(draggedID, at: to)
-        settings.setEnabledOrder(ids)
+        settings.setEnabledOrder(moved)
         return true
     }
 
@@ -349,12 +346,10 @@ struct AgentSettingsTab: View {
     /// this is the way that cannot quietly stop working, which matters because
     /// the last container change is exactly what broke `onMove`.
     private func move(_ preset: AgentPreset, by offset: Int) {
-        var ids = listedAgents.map(\.id)
-        guard let from = ids.firstIndex(of: preset.id) else { return }
-        let to = from + offset
-        guard ids.indices.contains(to) else { return }
-        ids.swapAt(from, to)
-        settings.setEnabledOrder(ids)
+        guard let moved = AgentOrdering.moving(
+            preset.id, by: offset, in: listedAgents.map(\.id))
+        else { return }
+        settings.setEnabledOrder(moved)
     }
 }
 

--- a/Tests/termioTests/AgentOrderingTests.swift
+++ b/Tests/termioTests/AgentOrderingTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import termio
+
+/// The arithmetic under both halves of reordering the agent roster.
+///
+/// It shipped without any. That mattered more than usual here: `onMove` is only
+/// honoured by an editable `List`, so moving the roster into a grouped `Form`
+/// stopped reordering *silently* — the rows still rendered, they just stopped
+/// obeying a drag. The replacement is a drag plus Move Up / Move Down, and the
+/// only reason the menu half exists is that it cannot break that quietly. Both
+/// deserve to be held to what they claim.
+final class AgentOrderingTests: XCTestCase {
+    private let roster = ["claude", "codex", "droid", "cursor"]
+
+    // MARK: Drag
+
+    func testDraggingDownLandsOnTheTargetAndShiftsTheRestUp() {
+        XCTAssertEqual(
+            AgentOrdering.moving("claude", onto: "droid", in: roster),
+            ["codex", "droid", "claude", "cursor"])
+    }
+
+    func testDraggingUpLandsOnTheTargetAndPushesItDown() {
+        XCTAssertEqual(
+            AgentOrdering.moving("cursor", onto: "codex", in: roster),
+            ["claude", "cursor", "codex", "droid"])
+    }
+
+    /// Dropping a row on itself is the commonest accidental drag there is, and it
+    /// must not be recorded as an edit — writing the order back would be a
+    /// no-op that still churns the settings file.
+    func testDroppingARowOnItselfChangesNothing() {
+        XCTAssertNil(AgentOrdering.moving("codex", onto: "codex", in: roster))
+    }
+
+    /// A drag whose payload names an agent that has since left the list — removed
+    /// from another window while the drag was in flight — is refused rather than
+    /// resolved to some nearby index.
+    func testADragFromOutsideTheListIsRefused() {
+        XCTAssertNil(AgentOrdering.moving("ghost", onto: "codex", in: roster))
+        XCTAssertNil(AgentOrdering.moving("codex", onto: "ghost", in: roster))
+    }
+
+    /// Dragging the ends is where an off-by-one shows up as a row that vanishes
+    /// or reappears in the wrong place.
+    func testTheEndsSurviveADrag() {
+        XCTAssertEqual(
+            AgentOrdering.moving("claude", onto: "cursor", in: roster),
+            ["codex", "droid", "cursor", "claude"])
+        XCTAssertEqual(
+            AgentOrdering.moving("cursor", onto: "claude", in: roster),
+            ["cursor", "claude", "codex", "droid"])
+    }
+
+    // MARK: Move Up / Move Down
+
+    func testMovingUpTradesPlacesWithTheRowAbove() {
+        XCTAssertEqual(
+            AgentOrdering.moving("droid", by: -1, in: roster),
+            ["claude", "droid", "codex", "cursor"])
+    }
+
+    func testMovingDownTradesPlacesWithTheRowBelow() {
+        XCTAssertEqual(
+            AgentOrdering.moving("codex", by: 1, in: roster),
+            ["claude", "droid", "codex", "cursor"])
+    }
+
+    /// The menu items are disabled at the ends, but a disabled control is a
+    /// presentation decision and this is the layer that has to hold anyway.
+    func testTheEndsRefuseToMoveOffTheList() {
+        XCTAssertNil(AgentOrdering.moving("claude", by: -1, in: roster))
+        XCTAssertNil(AgentOrdering.moving("cursor", by: 1, in: roster))
+    }
+
+    /// Repeating Move Up walks a row to the top one step at a time, which is what
+    /// makes the menu a usable substitute for dragging rather than a single nudge.
+    func testRepeatedMovesWalkARowToTheTop() {
+        var ids = roster
+        while ids.first != "cursor" {
+            guard let moved = AgentOrdering.moving("cursor", by: -1, in: ids) else {
+                return XCTFail("stopped walking at \(ids)")
+            }
+            ids = moved
+        }
+        XCTAssertEqual(ids, ["cursor", "claude", "codex", "droid"])
+    }
+
+    func testAnUnknownRowDoesNotMove() {
+        XCTAssertNil(AgentOrdering.moving("ghost", by: 1, in: roster))
+    }
+
+    /// Every operation is a permutation: reordering must never lose or duplicate
+    /// an agent, which is the failure that would silently drop one from the
+    /// New Chat menu.
+    func testEveryOperationIsAPermutation() {
+        var results: [[String]] = []
+        for a in roster {
+            for b in roster { AgentOrdering.moving(a, onto: b, in: roster).map { results.append($0) } }
+            for offset in [-1, 1] { AgentOrdering.moving(a, by: offset, in: roster).map { results.append($0) } }
+        }
+        XCTAssertFalse(results.isEmpty)
+        for result in results {
+            XCTAssertEqual(result.sorted(), roster.sorted(), "not a permutation: \(result)")
+        }
+    }
+}


### PR DESCRIPTION
Reordering the agent roster shipped in #458 with no test, and this closes that.

It matters more than an ordinary coverage gap. `onMove` is only honoured by an editable `List`, so moving the roster into a grouped `Form` stopped reordering **silently** — the rows still rendered, they just stopped obeying a drag. The replacement is a drag plus Move Up / Move Down, and the whole reason the menu half exists is that it cannot break that quietly. Neither half was held to anything.

The arithmetic moves out of `AgentSettingsTab` into `AgentOrdering`, because arithmetic inside a `View` is arithmetic nobody can test. The view keeps its two `move` methods as thin callers; `nil` carries the "changes nothing" case the `Bool` return used to.

Eleven tests, covering the parts where this kind of code actually breaks: both ends of the list, a drag whose payload names an agent that has since left it, that repeated Move Up walks a row to the top rather than nudging once, and that **every operation is a permutation** — losing or duplicating an id is the failure that would quietly drop an agent from the New Chat menu.

## Verified by mutation

A passing test proves nothing on its own. Reintroducing two bugs — inserting at `to + 1`, and dropping the self-drop guard — fails three tests by name:

```
testDraggingDownLandsOnTheTargetAndShiftsTheRestUp  failed
testDraggingUpLandsOnTheTargetAndPushesItDown       failed
testDroppingARowOnItselfChangesNothing              failed
```

Restored, all eleven pass.

Still unverified and not addressable here: whether the drag *gesture* works in a grouped `Form`, and whether the disclosure chevron renders once, twice or not at all. Those are pixels, and this machine has no screen-recording permission — the arithmetic under the gesture is what this covers.

Release Notes:
- None. Tests and a refactor with no behaviour change.