### PR TITLE
Stop showing a git pane for a folder git doesn't track

### DIFF
--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -60,15 +60,19 @@ struct GitChangesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            topBar
-            switch mode {
-            case .changes: changesBody
-            case .compare: GitCompareView(model: model, repoRoot: repoRoot, chrome: chrome, font: settings.interfaceFont)
-            case .history: GitHistoryView(model: model, repoRoot: repoRoot, chrome: chrome, font: settings.interfaceFont)
+            if model.isRepository {
+                topBar
+                switch mode {
+                case .changes: changesBody
+                case .compare: GitCompareView(model: model, repoRoot: repoRoot, chrome: chrome, font: settings.interfaceFont)
+                case .history: GitHistoryView(model: model, repoRoot: repoRoot, chrome: chrome, font: settings.interfaceFont)
+                }
+                // Only Changes has a real total to report ("N files +A −D"). History's
+                // count would just echo the fetch limit — meaningless, so no bar.
+                if mode == .changes { bottomBar }
+            } else {
+                notARepository
             }
-            // Only Changes has a real total to report ("N files +A −D"). History's
-            // count would just echo the fetch limit — meaningless, so no bar.
-            if mode == .changes { bottomBar }
         }
         .task(id: repoRoot) {
             // Resume the remembered inner mode, then let an open overlay override it:
@@ -154,6 +158,19 @@ struct GitChangesView: View {
         } message: {
             Text(gitignoreErrorMessage ?? localized("The ignore rule couldn’t be added."))
         }
+    }
+
+    /// Shown instead of the whole pane — mode switch and all — when the root isn't a
+    /// git work tree. Changes, Compare, and History are all equally empty there, so one
+    /// honest state replaces three that would each read as "nothing to review". The
+    /// pane offers no `git init`: the git pane reads, the terminal writes.
+    private var notARepository: some View {
+        PaneEmptyState(
+            localized("Not a Git Repository"),
+            icon: .gitBranch,
+            message: localized("This folder isn’t tracked by Git.")
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: Chrome

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -19,6 +19,13 @@ final class GitPanelModel: ObservableObject {
     @Published var changes: [GitChange] = []
     @Published var isLoading = true
 
+    /// Whether `repoRoot` is a git work tree. A loose terminal's cwd follows the shell,
+    /// so the pane is regularly pointed at a folder git knows nothing about; without
+    /// this the empty change list would render as "the working tree is clean". Starts
+    /// `true` so the first pass shows the spinner rather than flashing the non-repo
+    /// state, and is only ever lowered by a completed probe.
+    @Published private(set) var isRepository = true
+
     /// The commit history, loaded lazily the first time the History tab is shown.
     @Published var commits: [GitCommit] = []
     @Published var isLoadingHistory = false
@@ -127,8 +134,12 @@ final class GitPanelModel: ObservableObject {
             loadGeneration += 1
             let generation = loadGeneration
             let loaded = await GitService.changes(in: repoRoot)
+            // A non-empty list is itself proof of a work tree, so the extra `rev-parse`
+            // only runs for the ambiguous case — a clean repo or a plain folder.
+            let repository = loaded.isEmpty ? await GitService.isWorkTree(at: repoRoot) : true
             if generation == loadGeneration || attempt == 1 {
                 changes = loaded
+                isRepository = repository
                 isLoading = false
             }
             if watcher == nil { await armWatcher() }

--- a/Sources/termio/Git/GitService.swift
+++ b/Sources/termio/Git/GitService.swift
@@ -41,6 +41,17 @@ enum GitService {
         await offMain { loadChanges(repoRoot, onUntrackedScan: onUntrackedScan) }
     }
 
+    /// Whether the folder is inside a git work tree at all. `changes(in:)` returns an
+    /// empty list both for a clean repo and for a folder git knows nothing about, and
+    /// the pane must not report the second as the first — a home directory has no
+    /// working tree to call clean.
+    static func isWorkTree(at path: String) async -> Bool {
+        await offMain {
+            run(["rev-parse", "--is-inside-work-tree"], in: path)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) == "true"
+        }
+    }
+
     /// The unified-diff rows for one changed file (staged + unstaged vs `HEAD`, or the
     /// whole file for an untracked one). With `commit` set, the file's diff *at that
     /// commit* instead — the History tab's per-file view.

--- a/Sources/termio/Git/InspectorTabsToolbar.swift
+++ b/Sources/termio/Git/InspectorTabsToolbar.swift
@@ -31,6 +31,10 @@ struct InspectorTabsToolbar: View {
     /// async per selection change; gates the Issues segment together with the
     /// General "GitHub" setting.
     @State private var hasGitHubRemote = false
+    /// Whether the selected session's root is a git work tree — probed per selection
+    /// change, gating the Changes segment. Starts `true`: most roots are repos, so
+    /// assuming otherwise would blink the segment out and back on every switch.
+    @State private var isRepository = true
     /// Slides the selection pill from the old segment to the new one.
     @Namespace private var pillNamespace
     /// Drives the fade-in that syncs the cluster with the inspector pane's slide. The toolbar item
@@ -60,11 +64,20 @@ struct InspectorTabsToolbar: View {
         (.info, .infoCircle, "Info"),
     ]
 
-    /// Issues only exists for a project that actually lives on GitHub (and with the
-    /// integration left on in General) — for anything else the segment disappears
-    /// rather than leading to a dead pane.
+    /// Two segments exist only where they have something to show, rather than leading
+    /// to a dead pane: Issues for a project that actually lives on GitHub (and with the
+    /// integration left on in General), Changes for a root git tracks at all. A loose
+    /// terminal follows its shell, so `cd` in and out of a repo does move the Changes
+    /// segment in and out with it — the pane switch reflows there, which is the cost of
+    /// never offering a git pane for a folder that has no git.
     private var visibleSegments: [(tab: InspectorTab, icon: HugeIcon, help: String)] {
-        segments.filter { $0.tab != .issues || (settings.githubIntegrationEnabled && hasGitHubRemote) }
+        segments.filter { segment in
+            switch segment.tab {
+            case .issues: settings.githubIntegrationEnabled && hasGitHubRemote
+            case .changes: isRepository
+            default: true
+            }
+        }
     }
 
     var body: some View {
@@ -91,6 +104,18 @@ struct InspectorTabsToolbar: View {
                 // turned off, selection moved to a non-GitHub project) — land on Files.
                 if store.inspectorTab == .issues,
                    !(settings.githubIntegrationEnabled && hasGitHubRemote) {
+                    store.inspectorTab = .files
+                }
+            }
+            // Same shape for Changes, keyed on the root alone — a `cd` in a loose
+            // terminal moves this, so it re-runs there and not on GitHub's switch.
+            .task(id: store.inspectorCheckout?.localRoot ?? "") {
+                guard let path = store.inspectorCheckout?.localRoot else {
+                    isRepository = true
+                    return
+                }
+                isRepository = await GitService.isWorkTree(at: path)
+                if store.inspectorTab == .changes, !isRepository {
                     store.inspectorTab = .files
                 }
             }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -4014,6 +4014,16 @@
         }
       }
     },
+    "Not a Git Repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不是 Git 仓库"
+          }
+        }
+      }
+    },
     "Not a valid regular expression": {
       "comment": "Inline warning shown beneath the URL Pattern field when what the user typed does not compile as a regular expression.",
       "localizations": {
@@ -6424,6 +6434,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "这个文件夹没有 git “origin” 远程，无法克隆。"
+          }
+        }
+      }
+    },
+    "This folder isn’t tracked by Git.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个文件夹没有被 Git 跟踪。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -810,6 +810,8 @@
 	<string>None of this project’s remotes point at github.com, so there is no issue tracker to show.</string>
 	<key>Not Now</key>
 	<string>Not Now</string>
+	<key>Not a Git Repository</key>
+	<string>Not a Git Repository</string>
 	<key>Not a valid regular expression</key>
 	<string>Not a valid regular expression</string>
 	<key>Not installed</key>
@@ -1292,6 +1294,8 @@
 	<string>This file is binary — open it on GitHub to view.</string>
 	<key>This folder has no git “origin” remote to clone.</key>
 	<string>This folder has no git “origin” remote to clone.</string>
+	<key>This folder isn’t tracked by Git.</key>
+	<string>This folder isn’t tracked by Git.</string>
 	<key>This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.</key>
 	<string>This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.</string>
 	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -810,6 +810,8 @@
 	<string>该项目的远程仓库都未指向 github.com，因此没有可显示的 issue 跟踪器。</string>
 	<key>Not Now</key>
 	<string>以后再说</string>
+	<key>Not a Git Repository</key>
+	<string>不是 Git 仓库</string>
 	<key>Not a valid regular expression</key>
 	<string>不是有效的正则表达式</string>
 	<key>Not installed</key>
@@ -1292,6 +1294,8 @@
 	<string>此文件为二进制文件，请在 GitHub 上打开查看。</string>
 	<key>This folder has no git “origin” remote to clone.</key>
 	<string>这个文件夹没有 git “origin” 远程，无法克隆。</string>
+	<key>This folder isn’t tracked by Git.</key>
+	<string>这个文件夹没有被 Git 跟踪。</string>
 	<key>This host takes a password. Termio signs in with keys, and ~/.ssh has none that ssh offers on its own — run ssh-keygen to make one, then set it up here.</key>
 	<string>这台主机接受密码登录。Termio 用密钥登录，而 ~/.ssh 里没有 ssh 会自动尝试的密钥——先用 ssh-keygen 生成一个，再回到这里设置。</string>
 	<key>This host takes a password. Termio signs in with keys, so set yours up once and every session, file tree and remote terminal can reach it.</key>

--- a/Tests/termioTests/GitServiceScaleTests.swift
+++ b/Tests/termioTests/GitServiceScaleTests.swift
@@ -165,4 +165,24 @@ final class GitServiceScaleTests: XCTestCase {
         let changes = await GitService.changes(in: repo.path)
         XCTAssertEqual(changes.map(\.path), [".gitignore"])
     }
+
+    /// A clean repo and a folder git knows nothing about both yield an empty change
+    /// list, so the pane can only tell them apart through this probe — without it a
+    /// loose terminal sitting in `$HOME` claimed its working tree was clean.
+    func testWorkTreeProbeSeparatesACleanRepoFromAPlainFolder() async throws {
+        let plain = FileManager.default.temporaryDirectory
+            .appendingPathComponent("termio-git-plain-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: plain, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: plain) }
+
+        let repoChanges = await GitService.changes(in: repo.path)
+        let plainChanges = await GitService.changes(in: plain.path)
+        XCTAssertTrue(repoChanges.isEmpty)
+        XCTAssertTrue(plainChanges.isEmpty, "an empty list is what makes the two ambiguous")
+
+        let isRepo = await GitService.isWorkTree(at: repo.path)
+        let isPlain = await GitService.isWorkTree(at: plain.path)
+        XCTAssertTrue(isRepo)
+        XCTAssertFalse(isPlain)
+    }
 }


### PR DESCRIPTION
The Changes pane reported `No Changes — The working tree is clean.` for a folder with no working tree. An empty change list meant both "a clean repo" and "not a repo at all", and the pane could only render one of them.

A loose terminal follows its shell's cwd, so this showed up any time a session sat somewhere outside a checkout — `~` being the common one.

**What changed**

- `GitService.isWorkTree(at:)` wraps the `rev-parse --is-inside-work-tree` the loader already ran and discarded. It only runs when the change list comes back empty, since a non-empty list is itself proof of a work tree — a dirty repo costs no extra git spawn.
- The Changes segment leaves the pane switch when the root isn't a repo, the same rule Issues already follows for a non-GitHub project. Landing on Changes when it disappears falls back to Files.
- The pane keeps a `Not a Git Repository` state for the two paths that still reach it: the toolbar overflow menu, which has no place to run an async probe, and the window before the probe returns. It replaces the whole pane, mode switch included — Changes, Compare, and History are all equally empty there.

**Known cost**

A loose terminal follows its shell, so `cd` in and out of a repo moves the Changes segment in and out with it, and the switch reflows. That is the price of never offering a git pane for a folder with no git; it's recorded in a comment so it doesn't get "fixed" later.

**Not covered**

`armWatcher` returns early when there are no git dirs, so running `git init` in place leaves the pane stale until the session is reselected. Pre-existing, and the `cd` path self-heals because the root change remounts the pane.

Release Notes:

- The git pane no longer claims a clean working tree for a folder that isn't a Git repository, and the Changes tab is hidden for those folders.