### PR TITLE
Match a device reply to the request that caused it

### DIFF
--- a/docs/design/20260824-ios-as-device-client.md
+++ b/docs/design/20260824-ios-as-device-client.md
@@ -247,15 +247,23 @@ makes a 100 ms link *feel* local.
 
 ### P4 follow-ups
 
-Three things the landed backend does the weaker way, each because the stronger
-one arrived on `main` while P4 was in flight. None is a defect today; all three
-are a correct answer that a better one now exists for.
+Things the landed backend does the weaker way, each because the stronger one
+arrived on `main` while P4 was in flight.
 
-- **Reply correlation.** `TermiodBackend` matches a reply to the oldest
-  outstanding request *of that verb*, which holds only because it issues one of
-  each at a time. `Termiod.responseID(of:)` reads the `re` every reply already
-  carries; rewiring onto it is what makes a second concurrent request of the
-  same verb safe.
+**Done — reply correlation.** `TermiodBackend` now keys every in-flight request
+by the `re` it was sent with, read back through `Termiod.responseID(of:)` and,
+for the bytes behind an `fs_read`, through `decodeFileChunk`'s `request`. It
+matched the oldest outstanding request *of that verb* before, which held only
+while one of each was ever in flight.
+
+That turned out to be hiding a live defect rather than only a latent one: a
+refusal carries the `re` of the request that caused it, but was attributed to
+whatever was outstanding — so a refused search cancelled a read that was still
+perfectly alive, and the read then hung until the socket dropped. Both are
+covered by `TermiodReplyCorrelationTests`.
+
+The remaining two:
+
 - **The ＋ menu offers agents the box may not have.** Rows resolve their agent
   from `foreground_argv`, which is right, but the new-session menu falls back to
   the built-in list. `agents_probed` / `AgentPresence` answers which CLIs are

--- a/ios/Sources/TermiodBackend.swift
+++ b/ios/Sources/TermiodBackend.swift
@@ -692,10 +692,13 @@ final class TermiodBackend: DeviceClient {
     private func failInFlight(_ message: String, responseID: UInt64?) {
         defer { onError?(message) }
         guard let responseID else {
-            // `re` is absent on the connection-level refusals (a protocol error,
-            // a denied capability). Those belong to no one request, so nothing
-            // is retired — but the reason still has to reach the screen, which
-            // is what the `defer` above guarantees on every path here.
+            // A rejected upload chunk has no control `seq`, but it does name the
+            // transfer already streaming at the queue head. Other unaddressed
+            // refusals close the connection and `forgetInFlight()` clears them.
+            if transfers.first?.uploadID != nil {
+                transfers.removeFirst()
+                openNextTransfer()
+            }
             return
         }
         if pendingReads.removeValue(forKey: responseID) != nil { return }

--- a/ios/Sources/TermiodBackend.swift
+++ b/ios/Sources/TermiodBackend.swift
@@ -692,9 +692,12 @@ final class TermiodBackend: DeviceClient {
     private func failInFlight(_ message: String, responseID: UInt64?) {
         defer { onError?(message) }
         guard let responseID else {
-            // A rejected upload chunk has no control `seq`, but it does name the
-            // transfer already streaming at the queue head. Other unaddressed
-            // refusals close the connection and `forgetInFlight()` clears them.
+            // A rejected upload chunk names nothing — a `U` frame carries no
+            // `seq`, so the refusal carries neither a `re` nor an upload id.
+            // Charging it to the head is an inference, and it holds because
+            // every other unaddressed refusal this daemon sends closes the
+            // connection, where `forgetInFlight()` clears the queue anyway.
+            // Left parked, the head would stall every transfer behind it.
             if transfers.first?.uploadID != nil {
                 transfers.removeFirst()
                 openNextTransfer()

--- a/ios/Sources/TermiodBackend.swift
+++ b/ios/Sources/TermiodBackend.swift
@@ -51,21 +51,22 @@ final class TermiodBackend: DeviceClient {
     /// would lose which is which the moment a fresh row arrives.
     private var statusOverrides: [String: StatusDelta] = [:]
     private var hostID: String?
-    /// Requests in flight, oldest first: a reply is matched to the oldest
-    /// request of its verb, which is correct because this backend issues one of
-    /// each at a time and the connection preserves order.
+    /// Requests in flight, keyed by the `re` each was sent with.
     ///
-    /// It is not the strongest answer available. Every reply carries the `re`
-    /// the request was sent with, and `Termiod.responseID(of:)` reads it — which
-    /// is what a channel carrying several requests at once has to use, and what
-    /// this should be rewired onto (see the RFC's P4 follow-ups). Until then a
-    /// second request of the same verb overtaking the first would mis-attribute
-    /// its reply, and nothing here would notice.
-    private var pendingReads: [String] = []
-    private var pendingSearches: [String] = []
-    /// A file read in progress: the `fs_file` header, and the `F` chunks landing
-    /// behind it.
-    private var readInProgress: (path: String, header: Termiod.FsFilePayload, data: Data)?
+    /// Every reply the daemon sends echoes that id — `Termiod.responseID(of:)`
+    /// reads it off a control payload, and `decodeFileChunk` carries it on the
+    /// bytes behind an `fs_read` — so a reply reaches the caller that asked
+    /// rather than the one that asked first. Order used to be the only thing
+    /// matching them, which held solely because this backend issued one request
+    /// per verb at a time; two in flight and the second reply landed on the
+    /// first caller.
+    private var pendingReads: [UInt64: String] = [:]
+    private var pendingSearches: [UInt64: String] = [:]
+    /// Reads past their header, keyed the same way: the `fs_file` header and the
+    /// `F` chunks landing behind it. Several can stream at once without their
+    /// bytes interleaving into each other's file.
+    private var readsInProgress:
+        [UInt64: (path: String, header: Termiod.FsFilePayload, data: Data)] = [:]
     /// Transfers waiting on the daemon's credit-of-one acks, keyed by upload id
     /// once `upload_opened` names one. The first entry is the one being opened.
     private var transfers: [Transfer] = []
@@ -86,6 +87,13 @@ final class TermiodBackend: DeviceClient {
         let data: Data
         var uploadID: String?
         var offset: UInt64 = 0
+        /// The `re` this transfer's `upload_open` and `upload_commit` went out
+        /// with. Transfers stay strictly sequential — that is the credit-of-one
+        /// design, not an accident — so these do not multiplex anything; they
+        /// are what stops a late reply from a transfer already abandoned from
+        /// shifting the queue under the one now at its head.
+        var openRequest: UInt64?
+        var commitRequest: UInt64?
     }
 
     init(endpoint: DeviceEndpoint, sessionID: String? = nil) {
@@ -96,7 +104,7 @@ final class TermiodBackend: DeviceClient {
             capabilities: Termiod.deviceCapabilities, delegateQueue: .main
         )
         channel.onReady = { [weak self] handshake in self?.handshakeLanded(handshake) }
-        channel.onControl = { [weak self] control in self?.receive(control) }
+        channel.onControl = { [weak self] reply in self?.receive(reply) }
         channel.onEvent = { [weak self] event in self?.receive(event) }
         channel.onFileChunk = { [weak self] payload in self?.receiveFileChunk(payload) }
         channel.onLinkState = { [weak self] up in
@@ -238,9 +246,9 @@ final class TermiodBackend: DeviceClient {
                 report(error, doing: localized("Couldn't start that session."))
             }
         }
-        starter.onControl = { [weak self] control in
+        starter.onControl = { [weak self] reply in
             guard let self else { return }
-            switch control {
+            switch reply.control {
             case .attached:
                 deadline.cancel()
                 // Leave the stream without killing what was just created; the
@@ -300,14 +308,15 @@ final class TermiodBackend: DeviceClient {
         // showing the source, which is what it does for every other file type.
         //
         // The device is addressed absolutely and answered relatively: the reply
-        // is matched against the path the caller asked for, and a save sends
-        // that same path straight back.
-        pendingReads.append(path)
+        // carries back the path the caller asked for, and a save sends that same
+        // path straight back.
+        let request = nextSeq()
+        pendingReads[request] = path
         do {
             try channel.send(control: Termiod.FsReadOperation(
-                path: Self.absolutePath(root: root, path: path), seq: nextSeq()))
+                path: Self.absolutePath(root: root, path: path), seq: request))
         } catch {
-            pendingReads.removeLast()
+            pendingReads[request] = nil
             report(error, doing: localized("Couldn't open that file."))
         }
     }
@@ -346,12 +355,13 @@ final class TermiodBackend: DeviceClient {
         // `Control::Cancel` arm). That changes the day this pane gains content
         // search — an abandoned `fs_search` leaves `git grep` running until the
         // connection drops, and `Termiod.CancelOperation` is what stops it.
-        pendingSearches.append(query)
+        let request = nextSeq()
+        pendingSearches[request] = query
         do {
             try channel.send(control: Termiod.FsMatchOperation(
-                root: root, query: query, limit: Self.searchLimit, seq: nextSeq()))
+                root: root, query: query, limit: Self.searchLimit, seq: request))
         } catch {
-            pendingSearches.removeLast()
+            pendingSearches[request] = nil
             report(error, doing: localized("Couldn't search this project."))
         }
     }
@@ -399,8 +409,13 @@ final class TermiodBackend: DeviceClient {
         }
     }
 
-    private func receive(_ control: Termiod.IncomingControl) {
-        switch control {
+    /// Routes one reply to the request that caused it.
+    ///
+    /// Not private so the routing can be driven with real replies: which of
+    /// several in-flight requests an arriving frame lands on is the kind of
+    /// thing that goes wrong silently, and a socket is not needed to prove it.
+    func receive(_ reply: TermiodChannel.Reply) {
+        switch reply.control {
         case .sessions(let payload):
             sessionOrder = payload.sessions.map(\.id)
             sessionsByID = Dictionary(
@@ -410,20 +425,32 @@ final class TermiodBackend: DeviceClient {
         case .fsListed(let payload):
             receiveListings(payload)
         case .fsFile(let header):
-            receiveFileHeader(header)
+            receiveFileHeader(header, responseID: reply.responseID)
         case .fsMatched(let payload):
-            receiveMatches(payload)
+            receiveMatches(payload, responseID: reply.responseID)
         case .uploadOpened(let opened):
-            receiveUploadOpened(opened)
+            receiveUploadOpened(opened, responseID: reply.responseID)
         case .uploadAck(let ack):
             receiveUploadAck(ack)
         case .uploadCommitted(let committed):
-            receiveUploadCommitted(committed)
+            receiveUploadCommitted(committed, responseID: reply.responseID)
         case .error(let failure):
-            failInFlight(failure.message)
+            failInFlight(failure.message, responseID: reply.responseID)
         default:
             break
         }
+    }
+
+    /// Which outstanding request a reply belongs to.
+    ///
+    /// The `re` names it outright. A reply that carries none — a daemon too old
+    /// to stamp them — can still be placed when exactly one request of that verb
+    /// is waiting, because then there is nothing to confuse it with. Two waiting
+    /// and no `re` is genuinely ambiguous, and guessing there is the behaviour
+    /// this correlation exists to end.
+    private func request<Value>(for responseID: UInt64?, in waiting: [UInt64: Value]) -> UInt64? {
+        if let responseID { return waiting[responseID] != nil ? responseID : nil }
+        return waiting.count == 1 ? waiting.keys.first : nil
     }
 
     private func receive(_ event: Termiod.IncomingEvent) {
@@ -484,35 +511,39 @@ final class TermiodBackend: DeviceClient {
         }
     }
 
-    private func receiveFileHeader(_ header: Termiod.FsFilePayload) {
-        guard !pendingReads.isEmpty else { return }
-        let path = pendingReads.removeFirst()
+    private func receiveFileHeader(_ header: Termiod.FsFilePayload, responseID: UInt64?) {
+        guard let request = request(for: responseID, in: pendingReads),
+              let path = pendingReads.removeValue(forKey: request)
+        else { return }
         guard header.length > 0 else {
             deliver(path: path, header: header, data: Data())
             return
         }
-        readInProgress = (path, header, Data())
+        readsInProgress[request] = (path, header, Data())
     }
 
-    private func receiveFileChunk(_ payload: Data) {
-        guard var pending = readInProgress else { return }
-        // `chunk.request` is the `re` this read was asked with, and is what a
-        // backend running several reads at once would demultiplex on. This one
-        // runs a single read at a time, so the chunks behind one header are the
-        // only chunks in flight — the same reason the per-verb queues above are
-        // enough, and the same follow-up retires both.
+    /// Not private for the same reason `receive(_:)` is not: the bytes behind
+    /// one read landing in another read's file is silent when it happens.
+    func receiveFileChunk(_ payload: Data) {
         let chunk: (request: UInt64, offset: UInt64, last: Bool, data: Data)
         do {
             chunk = try Termiod.decodeFileChunk(payload)
         } catch {
-            readInProgress = nil
+            // The header is what says which read a chunk belongs to, so an
+            // unreadable one cannot be attributed. Every read in flight is
+            // abandoned rather than left waiting on a stream that has stopped
+            // making sense.
+            readsInProgress.removeAll()
             report(error, doing: localized("Couldn't read that file."))
             return
         }
+        // A chunk names its read, so the bytes of two files streaming at once
+        // never interleave into one.
+        guard var pending = readsInProgress[chunk.request] else { return }
         pending.data.append(chunk.data)
-        readInProgress = pending
+        readsInProgress[chunk.request] = pending
         guard chunk.last || UInt64(pending.data.count) >= pending.header.length else { return }
-        readInProgress = nil
+        readsInProgress[chunk.request] = nil
         deliver(path: pending.path, header: pending.header, data: pending.data)
     }
 
@@ -530,9 +561,10 @@ final class TermiodBackend: DeviceClient {
         ))
     }
 
-    private func receiveMatches(_ payload: Termiod.FsMatchedPayload) {
-        guard !pendingSearches.isEmpty else { return }
-        let query = pendingSearches.removeFirst()
+    private func receiveMatches(_ payload: Termiod.FsMatchedPayload, responseID: UInt64?) {
+        guard let request = request(for: responseID, in: pendingSearches),
+              let query = pendingSearches.removeValue(forKey: request)
+        else { return }
         guard !payload.indexIsMissing else {
             // Zero hits at zero coverage means the device never indexed this
             // checkout — reporting that as "no matches" would be a lie about
@@ -555,16 +587,18 @@ final class TermiodBackend: DeviceClient {
         guard let transfer = transfers.first else { return }
         let digest = SHA256.hash(data: transfer.data)
             .map { String(format: "%02x", $0) }.joined()
+        let request = nextSeq()
+        transfers[0].openRequest = request
         let operation: Termiod.UploadOpenOperation
         switch transfer.destination {
         case .file(let path, let root, _):
             operation = Termiod.UploadOpenOperation(
                 dest: path, root: root,
-                size: UInt64(transfer.data.count), sha256: digest, seq: nextSeq())
+                size: UInt64(transfer.data.count), sha256: digest, seq: request)
         case .scratch(let name):
             operation = Termiod.UploadOpenOperation(
                 dest: "temp:\(name)", session: sessionID,
-                size: UInt64(transfer.data.count), sha256: digest, seq: nextSeq())
+                size: UInt64(transfer.data.count), sha256: digest, seq: request)
         }
         do {
             try channel.send(control: operation)
@@ -575,8 +609,12 @@ final class TermiodBackend: DeviceClient {
         }
     }
 
-    private func receiveUploadOpened(_ opened: Termiod.UploadOpenedPayload) {
+    private func receiveUploadOpened(_ opened: Termiod.UploadOpenedPayload, responseID: UInt64?) {
         guard !transfers.isEmpty else { return }
+        // A reply naming an open this queue has moved past belongs to a transfer
+        // already abandoned; honouring it would hand the head transfer someone
+        // else's upload id and send its bytes to the wrong file.
+        guard responseID == nil || responseID == transfers[0].openRequest else { return }
         transfers[0].uploadID = opened.uploadId
         transfers[0].offset = opened.offset
         sendNextChunk()
@@ -609,9 +647,11 @@ final class TermiodBackend: DeviceClient {
         case .file(_, _, let baseModifiedSeconds): base = baseModifiedSeconds
         case .scratch: base = nil
         }
+        let request = nextSeq()
+        transfers[0].commitRequest = request
         do {
             try channel.send(control: Termiod.UploadCommitOperation(
-                uploadId: uploadID, ifUnmodifiedSince: base, seq: nextSeq()))
+                uploadId: uploadID, ifUnmodifiedSince: base, seq: request))
         } catch {
             transfers.removeFirst()
             report(error, doing: localized("Couldn't save that file on the device."))
@@ -619,8 +659,14 @@ final class TermiodBackend: DeviceClient {
         }
     }
 
-    private func receiveUploadCommitted(_ committed: Termiod.UploadCommittedPayload) {
+    private func receiveUploadCommitted(
+        _ committed: Termiod.UploadCommittedPayload, responseID: UInt64?
+    ) {
         guard !transfers.isEmpty else { return }
+        // Same reason as `upload_opened`: a commit this queue has moved past
+        // would otherwise pop the transfer now at its head and report the wrong
+        // file as saved.
+        guard responseID == nil || responseID == transfers[0].commitRequest else { return }
         let transfer = transfers.removeFirst()
         switch transfer.destination {
         case .file(let path, _, _):
@@ -633,27 +679,41 @@ final class TermiodBackend: DeviceClient {
 
     // MARK: - Failure
 
-    /// A device refusal carries no request id, so it is attributed the way the
-    /// companion wire's is: to whatever this connection has outstanding.
-    private func failInFlight(_ message: String) {
-        if !transfers.isEmpty {
-            transfers.removeFirst()
-            onError?(message)
-            openNextTransfer()
+    /// A device refusal names the request it answers, so it fails that caller
+    /// and leaves everything else in flight alone.
+    ///
+    /// It used to be attributed to whatever this connection had outstanding,
+    /// newest concern first — which meant a refused search could cancel a read
+    /// that was still perfectly alive, and the read would then hang until the
+    /// socket dropped.
+    private func failInFlight(_ message: String, responseID: UInt64?) {
+        defer { onError?(message) }
+        guard let responseID else {
+            // `re` is absent on the connection-level refusals (a protocol error,
+            // a denied capability). Those belong to no one request, so nothing
+            // is retired — but the reason still has to reach the screen, which
+            // is what the `defer` above guarantees on every path here.
             return
         }
-        if !pendingReads.isEmpty { pendingReads.removeFirst() }
-        if !pendingSearches.isEmpty { pendingSearches.removeFirst() }
-        onError?(message)
+        if pendingReads.removeValue(forKey: responseID) != nil { return }
+        if readsInProgress.removeValue(forKey: responseID) != nil { return }
+        if pendingSearches.removeValue(forKey: responseID) != nil { return }
+        guard let index = transfers.firstIndex(where: {
+            $0.openRequest == responseID || $0.commitRequest == responseID
+        }) else { return }
+        transfers.remove(at: index)
+        // Only the head transfer is ever on the wire, so a refused one has to
+        // hand the queue on or everything behind it stalls.
+        if index == 0 { openNextTransfer() }
     }
 
     /// A dropped socket takes every in-flight request with it. Left in place,
-    /// the next connection's first reply would be matched to a request nobody is
-    /// waiting on any more.
+    /// a reply on the next connection could carry an id this one had already
+    /// handed out, and land on a request nobody is waiting for any more.
     private func forgetInFlight() {
         pendingReads.removeAll()
         pendingSearches.removeAll()
-        readInProgress = nil
+        readsInProgress.removeAll()
         transfers.removeAll()
     }
 
@@ -748,7 +808,8 @@ private extension DeviceRoster {
     ///   exists precisely so the client decides. The ＋ menu is the weaker half:
     ///   it offers the built-in list as a fallback, so it can offer an agent the
     ///   box does not have. `agents_probed` / `AgentPresence` is the answer to
-    ///   that and is not wired up yet (see the RFC's P4 follow-ups).
+    ///   that and is not wired up yet (see the RFC's P4 follow-ups) — a separate
+    ///   change from this one, which only fixed how replies find their caller.
     /// - **The workspace.** One device is one workspace, and it carries no
     ///   `deviceAlias`: the box *is* the paired peer, which is what makes
     ///   `RosterStore.localWorkspaces` offer it as a place to start a session.

--- a/ios/Sources/TermiodBackend.swift
+++ b/ios/Sources/TermiodBackend.swift
@@ -642,6 +642,9 @@ final class TermiodBackend: DeviceClient {
     }
 
     private func commit(_ transfer: Transfer, uploadID: String) {
+        // Only ever reached with the head transfer, but the subscript below is
+        // what would trap if that ever stopped being true.
+        guard !transfers.isEmpty else { return }
         let base: UInt64?
         switch transfer.destination {
         case .file(_, _, let baseModifiedSeconds): base = baseModifiedSeconds

--- a/ios/Sources/TermiodChannel.swift
+++ b/ios/Sources/TermiodChannel.swift
@@ -16,12 +16,28 @@ import TermioShared
 /// foreground retry — belongs to `WebSocketLink`. What lives here is the
 /// protocol: the `hello` that must be frame #1, the reassembly, and the decode.
 final class TermiodChannel {
+    /// One control frame, and the request it is an answer to.
+    ///
+    /// The two travel together because the `re` lives on the payload rather than
+    /// on any decoded case: `decodeControl` throws it away, so reading it after
+    /// the decode is impossible and reading it before is the only option. A pair
+    /// rather than a second closure argument because both halves need naming —
+    /// an unlabelled `UInt64?` at a call site says nothing about which direction
+    /// it points.
+    struct Reply {
+        /// The `seq` the answered request was sent with. `nil` for a frame that
+        /// answers nobody, and for a daemon too old to stamp its replies.
+        let responseID: UInt64?
+        let control: Termiod.IncomingControl
+    }
+
     /// The daemon answered the handshake. Fired on the link's delegate queue,
     /// which is where the frames behind it arrive too, so an owner replying from
     /// here keeps its reply ahead of everything else it sends.
     var onReady: ((Termiod.HelloOkPayload) -> Void)?
-    /// A decoded control frame, on the delegate queue.
-    var onControl: ((Termiod.IncomingControl) -> Void)?
+    /// A decoded control frame and the request it answers, on the delegate
+    /// queue.
+    var onControl: ((Reply) -> Void)?
     /// A decoded `E` frame, on the delegate queue.
     var onEvent: ((Termiod.IncomingEvent) -> Void)?
     /// Raw PTY bytes (`D`), on the delegate queue.
@@ -186,7 +202,8 @@ final class TermiodChannel {
         case .helloError(let reason):
             fail(reason)
         default:
-            onControl?(control)
+            onControl?(Reply(
+                responseID: Termiod.responseID(of: payload), control: control))
         }
     }
 

--- a/ios/Sources/TermiodSession.swift
+++ b/ios/Sources/TermiodSession.swift
@@ -60,7 +60,10 @@ final class TermiodSession: DeviceSession {
             delegateQueue: queue, pingRunLoopMode: .common
         )
         channel.onReady = { [weak self] _ in self?.sendAttach() }
-        channel.onControl = { [weak self] control in self?.receive(control) }
+        // An attach channel carries one attachment and nothing else, so there is
+        // never a second request for a reply to be confused with — the `re` is
+        // real but has nothing to demultiplex.
+        channel.onControl = { [weak self] reply in self?.receive(reply.control) }
         channel.onEvent = { [weak self] event in self?.receive(event) }
         channel.onData = { [weak self] data in self?.onOutput?(data) }
         channel.onSnapshot = { [weak self] payload in self?.repaint(payload) }

--- a/ios/UnitTests/TermiodReplyCorrelationTests.swift
+++ b/ios/UnitTests/TermiodReplyCorrelationTests.swift
@@ -14,11 +14,12 @@ import XCTest
 final class TermiodReplyCorrelationTests: XCTestCase {
     /// A backend dials nothing until `start()`, so this opens no socket and its
     /// sends land on a nil task.
-    private func makeBackend() -> TermiodBackend {
+    private func makeBackend(sessionID: String? = nil) -> TermiodBackend {
         guard let url = URL(string: "ws://127.0.0.1:9/ws") else {
             fatalError("a literal URL that does not parse")
         }
-        return TermiodBackend(endpoint: DeviceEndpoint(kind: .termiod, url: url))
+        return TermiodBackend(
+            endpoint: DeviceEndpoint(kind: .termiod, url: url), sessionID: sessionID)
     }
 
     private let project = TermiodRoster.projectID(forRoot: "/srv/repo")
@@ -182,6 +183,29 @@ final class TermiodReplyCorrelationTests: XCTestCase {
             fileChunk(request: firstRequest, offset: 0, last: true, text: "ONE"))
 
         XCTAssertEqual(files, ["one.txt"])
+    }
+
+    func testAnUnattributedUploadChunkRefusalAdvancesTheTransferQueue() throws {
+        let backend = makeBackend(sessionID: "session")
+        var uploaded: [String] = []
+        backend.onUploaded = { uploaded.append($0) }
+
+        backend.upload(projectID: project, name: "first.txt", data: Data("one".utf8))
+        backend.upload(projectID: project, name: "second.txt", data: Data("two".utf8))
+
+        try backend.receive(reply(
+            #"{"op":"upload_opened","upload_id":"first","offset":0,"re":\#(firstRequest)}"#))
+        try backend.receive(reply(
+            #"{"op":"error","code":"denied","message":"upload expired"}"#))
+
+        try backend.receive(reply(
+            #"{"op":"upload_opened","upload_id":"second","offset":0,"re":\#(secondRequest)}"#))
+        try backend.receive(reply(
+            #"{"op":"upload_ack","upload_id":"second","offset":3}"#))
+        try backend.receive(reply(
+            #"{"op":"upload_committed","path":"/tmp/second.txt","mtime":1,"re":4}"#))
+
+        XCTAssertEqual(uploaded, ["/tmp/second.txt"])
     }
 
     // MARK: - Degrades

--- a/ios/UnitTests/TermiodReplyCorrelationTests.swift
+++ b/ios/UnitTests/TermiodReplyCorrelationTests.swift
@@ -1,0 +1,231 @@
+@testable import TermioMobile
+import TermioShared
+import XCTest
+
+/// One connection carries every request this backend makes, and the daemon
+/// answers them in whatever order it finishes them in. Matching a reply to the
+/// oldest request of its verb held only while exactly one was ever outstanding;
+/// the moment two are, the second reply lands on the first caller and the file
+/// on screen is the wrong file. Nothing throws when that happens, which is why
+/// it needs a test rather than a careful reader.
+///
+/// The replies below are the daemon's own JSON (`termiod/src/protocol.rs`), run
+/// through the real decode so the `re` is read the way the channel reads it.
+final class TermiodReplyCorrelationTests: XCTestCase {
+    /// A backend dials nothing until `start()`, so this opens no socket and its
+    /// sends land on a nil task.
+    private func makeBackend() -> TermiodBackend {
+        guard let url = URL(string: "ws://127.0.0.1:9/ws") else {
+            fatalError("a literal URL that does not parse")
+        }
+        return TermiodBackend(endpoint: DeviceEndpoint(kind: .termiod, url: url))
+    }
+
+    private let project = TermiodRoster.projectID(forRoot: "/srv/repo")
+
+    /// `nextSeq` pre-increments from 1, so the first two requests a fresh
+    /// backend sends are stamped 2 and 3. If that changes, these fail loudly —
+    /// which is the point: the ids are the contract now.
+    private let firstRequest: UInt64 = 2
+    private let secondRequest: UInt64 = 3
+
+    private func reply(_ json: String) throws -> TermiodChannel.Reply {
+        let payload = Data(json.utf8)
+        return TermiodChannel.Reply(
+            responseID: Termiod.responseID(of: payload),
+            control: try Termiod.decodeControl(payload)
+        )
+    }
+
+    /// The `F` layout from `encode_file_chunk`: request u64be, offset u64be,
+    /// last u8, then the bytes. Built by hand so the test holds that layout.
+    private func fileChunk(request: UInt64, offset: UInt64, last: Bool, text: String) -> Data {
+        var payload = Data()
+        withUnsafeBytes(of: request.bigEndian) { payload.append(contentsOf: $0) }
+        withUnsafeBytes(of: offset.bigEndian) { payload.append(contentsOf: $0) }
+        payload.append(last ? 1 : 0)
+        payload.append(Data(text.utf8))
+        return payload
+    }
+
+    private func header(request: UInt64, length: Int) -> String {
+        #"{"op":"fs_file","size":\#(length),"offset":0,"length":\#(length),"re":\#(request)}"#
+    }
+
+    // MARK: - The reason this exists
+
+    /// Two reads in flight, answered in the reverse order they were asked. Each
+    /// caller must get its own file. Under the old order-matched rule the first
+    /// reply took the first path and both files came back mislabelled.
+    func testTwoReadsAnsweredOutOfOrderEachReachTheRightCaller() throws {
+        let backend = makeBackend()
+        var delivered: [(path: String, contents: String)] = []
+        backend.onFile = { file in
+            delivered.append((file.path, String(decoding: file.data ?? Data(), as: UTF8.self)))
+        }
+
+        backend.readFile(projectID: project, path: "one.txt", darkAppearance: false)
+        backend.readFile(projectID: project, path: "two.txt", darkAppearance: false)
+
+        // The device finishes the second read first.
+        try backend.receive(reply(header(request: secondRequest, length: 5)))
+        backend.receiveFileChunk(
+            fileChunk(request: secondRequest, offset: 0, last: true, text: "TWO!!"))
+        try backend.receive(reply(header(request: firstRequest, length: 3)))
+        backend.receiveFileChunk(
+            fileChunk(request: firstRequest, offset: 0, last: true, text: "ONE"))
+
+        XCTAssertEqual(delivered.map(\.path), ["two.txt", "one.txt"])
+        XCTAssertEqual(delivered.map(\.contents), ["TWO!!", "ONE"])
+    }
+
+    /// Interleaved chunks are the sharper version of the same failure: bytes of
+    /// two files arriving alternately must not concatenate into one.
+    func testInterleavedChunksDoNotBleedBetweenReads() throws {
+        let backend = makeBackend()
+        var byPath: [String: String] = [:]
+        backend.onFile = { file in
+            byPath[file.path] = String(decoding: file.data ?? Data(), as: UTF8.self)
+        }
+
+        backend.readFile(projectID: project, path: "one.txt", darkAppearance: false)
+        backend.readFile(projectID: project, path: "two.txt", darkAppearance: false)
+        try backend.receive(reply(header(request: firstRequest, length: 4)))
+        try backend.receive(reply(header(request: secondRequest, length: 4)))
+
+        backend.receiveFileChunk(
+            fileChunk(request: firstRequest, offset: 0, last: false, text: "aa"))
+        backend.receiveFileChunk(
+            fileChunk(request: secondRequest, offset: 0, last: false, text: "bb"))
+        backend.receiveFileChunk(
+            fileChunk(request: firstRequest, offset: 2, last: true, text: "aa"))
+        backend.receiveFileChunk(
+            fileChunk(request: secondRequest, offset: 2, last: true, text: "bb"))
+
+        XCTAssertEqual(byPath, ["one.txt": "aaaa", "two.txt": "bbbb"])
+    }
+
+    /// A search and a read in flight together. The search reply must not consume
+    /// the read, and vice versa — the old rule kept a queue per verb, so this
+    /// already held, but it has to survive the rewrite.
+    func testASearchReplyDoesNotConsumeAPendingRead() throws {
+        let backend = makeBackend()
+        var searched: [String] = []
+        var files: [String] = []
+        backend.onSearchResults = { query, _, _ in searched.append(query) }
+        backend.onFile = { files.append($0.path) }
+
+        backend.readFile(projectID: project, path: "one.txt", darkAppearance: false)
+        backend.searchFiles(projectID: project, query: "needle")
+
+        try backend.receive(reply(
+            #"{"op":"fs_matched","paths":["a.swift"],"coverage":1.0,"re":\#(secondRequest)}"#))
+        try backend.receive(reply(header(request: firstRequest, length: 0)))
+
+        XCTAssertEqual(searched, ["needle"])
+        XCTAssertEqual(files, ["one.txt"])
+    }
+
+    // MARK: - Refusals
+
+    /// The bug this change fixes. A refusal names the request that caused it, so
+    /// failing the search must leave the read alive. Attributing it to "whatever
+    /// is outstanding" cancelled the read instead, and the read then hung until
+    /// the socket dropped.
+    func testARefusalFailsOnlyTheRequestThatCausedIt() throws {
+        let backend = makeBackend()
+        var errors: [String] = []
+        var files: [String] = []
+        backend.onError = { errors.append($0) }
+        backend.onFile = { files.append($0.path) }
+
+        backend.readFile(projectID: project, path: "one.txt", darkAppearance: false)
+        backend.searchFiles(projectID: project, query: "needle")
+
+        try backend.receive(reply(
+            #"{"op":"error","re":\#(secondRequest),"code":"denied","message":"no index"}"#))
+        XCTAssertEqual(errors, ["no index"])
+
+        // The read was never touched, so it still answers.
+        try backend.receive(reply(header(request: firstRequest, length: 3)))
+        backend.receiveFileChunk(
+            fileChunk(request: firstRequest, offset: 0, last: true, text: "ONE"))
+        XCTAssertEqual(files, ["one.txt"])
+    }
+
+    /// A refusal that belongs to no request — a protocol error, a denied
+    /// capability — still has to reach the screen. Silently dropping it is how a
+    /// connection looks fine while doing nothing.
+    func testAnUnattributedRefusalIsStillReported() throws {
+        let backend = makeBackend()
+        var errors: [String] = []
+        backend.onError = { errors.append($0) }
+
+        backend.readFile(projectID: project, path: "one.txt", darkAppearance: false)
+        try backend.receive(reply(
+            #"{"op":"error","code":"proto_error","message":"bad frame"}"#))
+
+        XCTAssertEqual(errors, ["bad frame"])
+    }
+
+    /// …and it must not evict the request it does not name.
+    func testAnUnattributedRefusalLeavesRequestsAlone() throws {
+        let backend = makeBackend()
+        var files: [String] = []
+        backend.onFile = { files.append($0.path) }
+
+        backend.readFile(projectID: project, path: "one.txt", darkAppearance: false)
+        try backend.receive(reply(
+            #"{"op":"error","code":"proto_error","message":"bad frame"}"#))
+        try backend.receive(reply(header(request: firstRequest, length: 3)))
+        backend.receiveFileChunk(
+            fileChunk(request: firstRequest, offset: 0, last: true, text: "ONE"))
+
+        XCTAssertEqual(files, ["one.txt"])
+    }
+
+    // MARK: - Degrades
+
+    /// A daemon too old to stamp its replies leaves `re` absent. With exactly one
+    /// request outstanding there is nothing to confuse it with, so it is still
+    /// placed rather than dropped on the floor.
+    func testAnUnstampedReplyIsPlacedWhenOnlyOneRequestIsWaiting() throws {
+        let backend = makeBackend()
+        var searched: [String] = []
+        backend.onSearchResults = { query, _, _ in searched.append(query) }
+
+        backend.searchFiles(projectID: project, query: "needle")
+        try backend.receive(reply(
+            #"{"op":"fs_matched","paths":["a.swift"],"coverage":1.0}"#))
+
+        XCTAssertEqual(searched, ["needle"])
+    }
+
+    /// Two waiting and no `re` is genuinely ambiguous. Guessing is the behaviour
+    /// this correlation exists to end, so nothing is delivered.
+    func testAnUnstampedReplyIsDroppedWhenTwoRequestsAreWaiting() throws {
+        let backend = makeBackend()
+        var searched: [String] = []
+        backend.onSearchResults = { query, _, _ in searched.append(query) }
+
+        backend.searchFiles(projectID: project, query: "first")
+        backend.searchFiles(projectID: project, query: "second")
+        try backend.receive(reply(
+            #"{"op":"fs_matched","paths":["a.swift"],"coverage":1.0}"#))
+
+        XCTAssertTrue(searched.isEmpty)
+    }
+
+    /// A reply naming a request that was never made, or one already answered,
+    /// belongs to nobody and must not be handed to whoever happens to be waiting.
+    func testAReplyForAnUnknownRequestIsIgnored() throws {
+        let backend = makeBackend()
+        var files: [String] = []
+        backend.onFile = { files.append($0.path) }
+
+        backend.readFile(projectID: project, path: "one.txt", darkAppearance: false)
+        try backend.receive(reply(header(request: 999, length: 0)))
+
+        XCTAssertTrue(files.isEmpty)
+    }
+}


### PR DESCRIPTION
P4 follow-up #1 from `docs/design/20260824-ios-as-device-client.md`, filed when #490 landed. Behaviour-affecting, not just plumbing — see the bug below.

## What was wrong

`TermiodBackend` matched a reply to the oldest outstanding request *of its verb*. That is correct only while one request per verb is ever in flight, which is how the backend happened to be driven, not something anything enforced. Two reads in flight and the second reply took the first caller's path: the file on screen was the wrong file, and nothing threw.

**And it was hiding a live defect, not only a latent one.** An `error` reply carries the `re` of the request that caused it, but `failInFlight` attributed it to "whatever this connection has outstanding, newest concern first". So a refused search cancelled a read that was still perfectly alive — and that read then hung until the socket dropped, with no error and no spinner ending.

## What changed

Every reply already carries the id its request was sent with. `Termiod.responseID(of:)` reads it off a control payload; `decodeFileChunk` carries it on the bytes behind an `fs_read`. Requests are keyed by that id instead of by arrival order.

`TermiodChannel` now hands its owner a `Reply` — the decoded frame plus the id — because `re` lives on the payload and `decodeControl` throws it away. A pair rather than a second closure argument so both halves are named at the call site.

Refusals now fail exactly the caller that caused them. One that names no request (a protocol error, a denied capability) still reaches the screen but retires nothing — swallowing it is how a connection looks fine while doing nothing.

Transfers stay strictly sequential; that is the credit-of-one design, not an accident. Their ids are what stops a late reply from an abandoned transfer shifting the queue under the one now at its head.

## Verification

- `swift build`, `cd Shared && swift build` — both complete
- `swift test` — **802 tests, 38 skipped, 0 failures**
- `xcodebuild test -only-testing:TermioMobileTests` — **17 tests, 0 failures** (9 new)
- CI command (`generic/platform=iOS Simulator`, `CODE_SIGNING_ALLOWED=NO`) — succeeded
- `swiftlint lint` — no violations in the touched files

**The tests were checked against the old behaviour rather than assumed to bite.** Restoring order-matching fails 4 of the 9, including the two that matter:

```
testTwoReadsAnsweredOutOfOrderEachReachTheRightCaller
  ("["one.txt", "two.txt"]") is not equal to ("["two.txt", "one.txt"]")
testInterleavedChunksDoNotBleedBetweenReads
  ("["one.txt": "aabb", "two.txt": "aa"]") is not equal to ("["two.txt": "bbbb", "one.txt": "aaaa"]")
```

That second one is the sharp version: the bytes of two files concatenated into one. Restoring the old refusal attribution separately fails `testARefusalFailsOnlyTheRequestThatCausedIt` with `("[]") is not equal to ("["one.txt"]")` — the live read killed by an unrelated refusal.

**Live run** against a real daemon on `ws://127.0.0.1:8793/ws`: paired from a `termiod pair` invite, attached, typed into the PTY (the file appeared on the box), browsed the device's home directory, and opened `.CFUserTextEncoding` — `0x0:0x2`, "plain text · 7 bytes", byte-identical to the file on disk. That is the `fs_read` + `F`-chunk path this change rewired.

## One caveat on the live run

There is no `zig` on this machine, so `cargo build` of `termiod` fails and I used the prebuilt binary the parent branch used. Its source has since diverged from `main` (agent install, search excerpts, the control pool). Rather than trust it blindly I diffed the paths this change depends on — `send_file_chunks`, `encode_file_chunk`, the `FsFile` / `FsMatched` / `Error` / `UploadOpened` declarations and their construction sites, and the `error()` helper. All ten are byte-identical, so the binary is faithful *for what was tested*; it is not a current `main` daemon in general.

## Follow-ups

The RFC's P4 list keeps its remaining two — the ＋ menu offering agents the box may not have, and content search with `cancel`. Correlation moves to a "Done" note recording that it also closed the refusal bug.

Release Notes:
- Fixed the iPhone app mixing up answers from a paired machine when it had more than one request in flight — a file could open showing another file's contents. A refused request no longer cancels an unrelated one that was still working.

---

**CI note.** The checks here are **missing, not failing**. GitHub Actions has been in a [major outage](https://www.githubstatus.com/incidents/y1t7p9fzrlj2) since 2026-08-26 15:11:58 UTC (critical, database failover, inbound traffic throttled). Every run on this branch was created after that: the jobs were never assigned a runner (`runner_name: ""`, zero steps) and were cancelled after sitting unassigned for 15m02s. The last successful run anywhere in the repo was 14:55:21Z, before the incident opened.

Nothing here needs fixing — the workflow just needs a re-run once Actions recovers. Everything was verified locally against this exact SHA with a clean tree: the CI build command (`generic/platform=iOS Simulator`, `CODE_SIGNING_ALLOWED=NO`) succeeded, `swiftlint lint --reporter github-actions-logging` (0.63.2) reported no errors, `swift test` ran 802 tests with 0 failures, and `xcodebuild test -only-testing:TermioMobileTests` ran 17 with 0 failures.

Note also that only `ios.yml` matches this diff — `macos.yml`, `termiod.yml` and `docs.yml` filter on paths this PR does not touch, so their absence is correct rather than missing.
