### PR TITLE
Fix remote deploy when the app is what starts it

### DIFF
--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -1055,11 +1055,8 @@ extension TermioStore {
         }
         let deploy = runProcess(localBinary, ["remote", "deploy", host])
         guard let deploy, deploy.exitCode == 0 else {
-            let detail = deploy.map { output in
-                (output.standardError + output.standardOutput)
-                    .split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
-                    .last(where: { !$0.isEmpty }) ?? "deploy failed"
-            } ?? "couldn't run termiod remote deploy"
+            let detail = deploy.map { deployFailureDetail(from: $0) }
+                ?? "couldn't run termiod remote deploy"
             return .failure(RemoteSetupError(
                 message: "Couldn't deploy termiod to \(host).\n\(detail)"))
         }
@@ -1081,6 +1078,27 @@ extension TermioStore {
                 message: "Deployed termiod to \(host), but it didn't answer.\n"
                     + error.localizedDescription))
         }
+    }
+
+    /// Why a `termiod remote deploy` failed, as the alert should read it.
+    ///
+    /// `remote deploy` reports through anyhow, which prints one multi-line
+    /// `Error:` block at the end of stderr — the headline followed by the fixes,
+    /// one per line. Keeping only the last line put a dangling bullet under the
+    /// alert's title ("• or build on the host and deploy with: …") with nothing
+    /// naming what had gone wrong, so the whole block is kept and cargo's own
+    /// output above it dropped.
+    private nonisolated static func deployFailureDetail(from output: ProcessOutput) -> String {
+        let lines = (output.standardError + output.standardOutput)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        guard let start = lines.lastIndex(where: { $0.hasPrefix("Error:") }) else {
+            return lines.last(where: { !$0.isEmpty }) ?? "deploy failed"
+        }
+        var block = lines[start...].filter { !$0.isEmpty }
+        block[0] = String(block[0].dropFirst("Error:".count))
+            .trimmingCharacters(in: .whitespaces)
+        return block.joined(separator: "\n")
     }
 
     /// A captured subprocess result — exit code plus drained stdout/stderr.

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -309,12 +309,72 @@ fn target_for_uname(uname: &str) -> Result<String> {
     Ok(target.to_string())
 }
 
+/// Where the cross-build's tools are, which this process's own `PATH` cannot be
+/// trusted to say. A deploy is usually started by the app, and an app launched
+/// from Finder inherits launchd's `PATH` — `/usr/bin:/bin:/usr/sbin:/sbin`, which
+/// holds neither cargo (`~/.cargo/bin`) nor anything from Homebrew. The login
+/// shell knows both, so it answers instead.
+///
+/// Homebrew's `zig` prefix is added on top of that because `brew` leaves `zig`
+/// off `PATH` entirely whenever a second `zig@N` formula holds the link — the
+/// same case `scripts/build-app.sh` checks for before building the daemon.
+fn toolchain_path() -> Vec<String> {
+    let mut directories = crate::agent::machine::login_path();
+    for prefix in ["/opt/homebrew/opt/zig/bin", "/usr/local/opt/zig/bin"] {
+        if !directories.iter().any(|seen| seen == prefix) {
+            directories.push(prefix.to_string());
+        }
+    }
+    directories
+}
+
+/// `binary` as an absolute path, looked up across `directories`.
+fn find_tool(directories: &[String], binary: &str) -> Option<String> {
+    use std::os::unix::fs::PermissionsExt;
+    directories.iter().find_map(|directory| {
+        let candidate = std::path::Path::new(directory).join(binary);
+        let usable = std::fs::metadata(&candidate)
+            .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false);
+        usable.then(|| candidate.to_string_lossy().into_owned())
+    })
+}
+
 /// `cargo build --release --target <triple>` for this crate; returns the
 /// binary path. Falls back to a clear message if the cross-linker is missing.
 fn cross_compile(target: &str) -> Result<String> {
     let manifest = format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+    let path = toolchain_path();
+    let Some(cargo) = find_tool(&path, "cargo") else {
+        bail!(
+            "cross-compiling for {target} needs cargo, and there is none on this machine.\n  \
+             • install Rust: https://rustup.rs\n  \
+             • or build on the host and deploy with: termiod remote deploy <host> --bin <path>"
+        );
+    };
+    // Checked before cargo runs rather than left to the build script's panic:
+    // the VT engine termiod embeds is built by Zig, and a missing `zig` fails
+    // several minutes in, inside a wall of cargo output, blaming a build script
+    // nobody here wrote.
+    if find_tool(&path, "zig").is_none() {
+        bail!(
+            "cross-compiling for {target} needs zig — the terminal engine termiod embeds\n\
+             is built by it.\n  \
+             • brew install zig\n  \
+             • or build on the host and deploy with: termiod remote deploy <host> --bin <path>"
+        );
+    }
     eprintln!("[deploy] cross-compiling for {target}…");
-    let status = Command::new("cargo")
+    let status = Command::new(cargo)
+        .env("PATH", path.join(":"))
+        // Run *inside* the crate, not merely at it. Cargo discovers
+        // `.cargo/config.toml` by walking up from the working directory —
+        // `--manifest-path` does not move that search. Started from anywhere else
+        // (an app's working directory is `/`), the musl link falls back to Apple's
+        // `cc`, which rejects lld's flags with "ld: unknown options: --as-needed"
+        // and no mention of the config it never read. `termiod/.cargo/config.toml`
+        // is what points the cross-link at the bundled rust-lld.
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
         .args([
             "build",
             "--release",
@@ -324,7 +384,7 @@ fn cross_compile(target: &str) -> Result<String> {
             &manifest,
         ])
         .status()
-        .context("running cargo build (is cargo on PATH?)")?;
+        .context("running cargo build")?;
     if !status.success() {
         bail!(
             "cross-compile for {target} failed.\n\


### PR DESCRIPTION
Setting up a machine from the app failed with an alert that named nothing:

```
Couldn't set up ukvps
Couldn't deploy termiod to ukvps.
• or build on the host and deploy with: termiod remote deploy <host> --bin <path>
```

Three causes, stacked.

**Cargo never read `termiod/.cargo/config.toml`.** Cargo discovers it by walking up from the working directory, and `--manifest-path` does not move that search. Started from anywhere but the crate — an app's working directory is `/` — the musl cross-link never saw the config that points it at the bundled rust-lld and fell back to Apple's `cc`: `ld: unknown options: --as-needed -Bstatic -Bdynamic --eh-frame-hdr`. This failed for every caller with a complete toolchain, and is why the deploy could not work from the app at all.

**`cargo` and `zig` were assumed to be on `PATH`.** An app launched from Finder inherits launchd's `PATH` — four directories holding neither cargo nor anything from Homebrew. The lookup now goes through the login shell's `PATH`, the same probe agent discovery already uses, plus Homebrew's zig prefix: brew leaves `zig` off `PATH` entirely whenever a second `zig@N` formula holds the link, the case `scripts/build-app.sh` already checks for. Each missing tool is named before cargo runs — a missing zig used to surface minutes in as a build-script panic, under advice naming the wrong problem.

**The alert kept only the last line of the output.** `remote deploy` reports through anyhow, which prints one multi-line `Error:` block — headline, then the fixes, one per line. Keeping the last line alone is what put a bare bullet under the title. The whole block is kept now, cargo's own output above it dropped.

## Verification

Run under the app's exact environment (`env -i` with launchd's `PATH`), against a real VPS:

```
[deploy] cross-compiling for aarch64-unknown-linux-musl…
[deploy] installing …/aarch64-unknown-linux-musl/release/termiod → ukvps:~/.local/bin/termiod
[deploy] installed: termiod 0.1.0
exit=0
```

Before: `Error: running cargo build (is cargo on PATH?)` immediately, or the `cc` link failure with a full `PATH`.

`cargo build --release` and `swift build` both clean on this branch.

Release Notes:
- Fixed setting up a remote machine from the app, which failed to deploy `termiod` even with a complete Rust toolchain installed.
- Deploy failures now explain what went wrong instead of showing a single stray line.