### PR TITLE
Make termiod install and update one reconcile loop

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -578,6 +578,10 @@ public enum Termiod {
         /// name a path on that machine. Empty on a daemon too old to send it, and
         /// on one that could not read `HOME`; read it through `homeDirectory`.
         public let home: String
+        /// The daemon's build, `<app version>+<build>` — the version of the app
+        /// that shipped it. `nil` on a daemon that predates the field, which
+        /// every reader treats as older than anything that reports one.
+        public let version: String?
 
         /// `home`, or `/` when the daemon did not answer with an absolute path.
         /// Never empty, so a picker always has somewhere to start — and one rule,
@@ -585,7 +589,7 @@ public enum Termiod {
         public var homeDirectory: String { home.hasPrefix("/") ? home : "/" }
 
         private enum CodingKeys: String, CodingKey {
-            case hostId, host, clientId, caps, home
+            case hostId, host, clientId, caps, home, version
         }
 
         public init(from decoder: Decoder) throws {
@@ -595,6 +599,7 @@ public enum Termiod {
             clientId = try container.decode(String.self, forKey: .clientId)
             caps = try container.decodeIfPresent([String].self, forKey: .caps) ?? []
             home = try container.decodeIfPresent(String.self, forKey: .home) ?? ""
+            version = try container.decodeIfPresent(String.self, forKey: .version)
         }
     }
 

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -2728,6 +2728,12 @@ private struct NavigatorToggleToolbarView: View {
     /// gap on screen is a few points past this.
     private static let nameSpacing: CGFloat = 6
 
+    /// In fullscreen there are no traffic lights to hold the toolbar's leading edge open, so the
+    /// item lands flush against the window edge. This inset puts the glyph's leading edge on the
+    /// same line the section labels and rows in the column below start on (`sidebarLeadingTrim`
+    /// pulls that column back to meet it), so the sidebar has one left margin rather than two.
+    private static let fullScreenLeadingInset: CGFloat = 10.5
+
     var body: some View {
         HStack(spacing: Self.nameSpacing) {
             toggle
@@ -2735,6 +2741,7 @@ private struct NavigatorToggleToolbarView: View {
                 WorkspaceSwitcherToolbarView()
             }
         }
+        .padding(.leading, store.windowIsFullScreen ? Self.fullScreenLeadingInset : 0)
     }
 
     private var toggle: some View {

--- a/Sources/termio/FileBrowser/FileTreeList.swift
+++ b/Sources/termio/FileBrowser/FileTreeList.swift
@@ -586,14 +586,22 @@ struct OutlineViewCapture: NSViewRepresentable {
 ///   feel like every other Mac list. Trackpads send precise pixel deltas and never
 ///   consult it.
 struct OutlineViewFixups: NSViewRepresentable {
+    /// Overrides the table's style. Left `nil` everywhere the source list's own
+    /// metrics are wanted; the settings sidebar passes `.fullWidth` because
+    /// `.sourceList` reserves a leading strip for a disclosure column that a flat
+    /// list never uses, and that strip is not reachable from `listRowInsets` —
+    /// it lands *outside* them, so the rows can only ever start further right
+    /// than the traffic lights they should line up under.
+    var style: NSTableView.Style?
+
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
-        DispatchQueue.main.async { Self.apply(from: view) }
+        DispatchQueue.main.async { Self.apply(from: view, style: style) }
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        DispatchQueue.main.async { Self.apply(from: nsView) }
+        DispatchQueue.main.async { Self.apply(from: nsView, style: style) }
     }
 
     /// Reasserts the wheel increment on an outline captured earlier (see
@@ -604,13 +612,19 @@ struct OutlineViewFixups: NSViewRepresentable {
         scroll.verticalLineScroll = 24
     }
 
-    private static func apply(from view: NSView) {
+    private static func apply(from view: NSView, style: NSTableView.Style?) {
         var ancestor = view.superview
         while let current = ancestor {
             // NSOutlineView is an NSTableView subclass, so this catches the tree.
             if let table = current as? NSTableView {
                 if table.selectionHighlightStyle != .none {
                     table.selectionHighlightStyle = .none
+                }
+                if let style, table.style != style {
+                    table.style = style
+                    // The other half of the same strip: an outline indents every
+                    // row by one level's worth even when nothing is nested.
+                    (table as? NSOutlineView)?.indentationPerLevel = 0
                 }
                 if let scroll = table.enclosingScrollView {
                     if scroll.verticalLineScroll != 24 {

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -41,12 +41,32 @@
         }
       }
     },
+    "%@ answered, but not with a pairing invite. Its termiod is probably older than this app — deploy it again.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 有响应，但返回的不是配对邀请。它的 termiod 可能比本应用旧——重新部署一次。"
+          }
+        }
+      }
+    },
     "%@ didn’t come up — check the network and retry": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ 未能启动——请检查网络后重试"
+          }
+        }
+      }
+    },
+    "%@ has nothing to pair against": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 上没有可配对的目标"
           }
         }
       }
@@ -327,6 +347,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 个结果"
+          }
+        }
+      }
+    },
+    "A box can only be paired with once its termiod is running and reachable from outside — a tunnel, or a proxy in front of it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "只有当机器上的 termiod 正在运行、并且可以从外部访问时才能配对——需要隧道，或在它前面加一层代理。"
           }
         }
       }
@@ -758,6 +788,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在询问 %@ 上有什么。"
+          }
+        }
+      }
+    },
+    "Asking %@…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在询问 %@…"
           }
         }
       }
@@ -1372,6 +1412,16 @@
         }
       }
     },
+    "Closes every session in it. The folders on disk are left alone.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "会关闭其中的所有会话。磁盘上的文件夹不受影响。"
+          }
+        }
+      }
+    },
     "Closing it stops %lld session(s). The folders on disk are left alone.": {
       "localizations": {
         "zh-Hans": {
@@ -1642,6 +1692,16 @@
         }
       }
     },
+    "Copy Invite": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝邀请"
+          }
+        }
+      }
+    },
     "Copy Link": {
       "localizations": {
         "zh-Hans": {
@@ -1718,6 +1778,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "拷贝 ssh 命令"
+          }
+        }
+      }
+    },
+    "Could not run ssh: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法运行 ssh：%@"
           }
         }
       }
@@ -2073,6 +2143,16 @@
         }
       }
     },
+    "Device": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备"
+          }
+        }
+      }
+    },
     "Device Unavailable": {
       "localizations": {
         "zh-Hans": {
@@ -2353,12 +2433,32 @@
         }
       }
     },
+    "Every iPhone paired with %@ is signed out and must re-scan the new QR to reconnect.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有与 %@ 配对的 iPhone 都会退出登录，需重新扫描新的二维码才能重新连接。"
+          }
+        }
+      }
+    },
     "Every paired iPhone is signed out and must re-scan the new QR to reconnect.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "所有已配对的 iPhone 都会退出登录，需重新扫描新的二维码才能重新连接。"
+          }
+        }
+      }
+    },
+    "Exited with status %lld.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出状态 %lld。"
           }
         }
       }
@@ -3314,6 +3414,16 @@
         }
       }
     },
+    "Mobile": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手机"
+          }
+        }
+      }
+    },
     "Mobile Access": {
       "localizations": {
         "zh-Hans": {
@@ -4135,16 +4245,6 @@
         }
       }
     },
-    "Off": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未开启"
-          }
-        }
-      }
-    },
     "Off — LAN only": {
       "localizations": {
         "zh-Hans": {
@@ -4161,6 +4261,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。两台设备须处于同一局域网。"
+          }
+        }
+      }
+    },
+    "On iPhone, tap the Mac pill ▸ Scan QR Code. The token is minted on %@ and demanded on every connection.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 iPhone 上，点按 Mac 药丸 ▸ 扫描二维码。Token 在 %@ 上生成，每次连接都会验证。"
           }
         }
       }
@@ -4407,12 +4517,32 @@
         }
       }
     },
+    "Pair": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配对"
+          }
+        }
+      }
+    },
     "Pair a Phone…": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "配对手机…"
+          }
+        }
+      }
+    },
+    "Pair your iPhone with the machines you work on": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把 iPhone 与你正在使用的机器配对"
           }
         }
       }
@@ -4653,6 +4783,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "项目"
+          }
+        }
+      }
+    },
+    "Public address": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公网地址"
           }
         }
       }
@@ -4973,6 +5113,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "移除此自定义 Agent 及其配置文件。现有会话会继续运行。"
+          }
+        }
+      }
+    },
+    "Remove…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除…"
           }
         }
       }
@@ -6118,6 +6268,16 @@
         }
       }
     },
+    "The machine everything filed under this workspace lives on.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归入这个工作区的一切所在的机器。"
+          }
+        }
+      }
+    },
     "The project and session list. Kept separate from the terminal font, and need not be monospaced.": {
       "localizations": {
         "zh-Hans": {
@@ -6518,6 +6678,16 @@
         }
       }
     },
+    "This workspace is no longer on your list.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个工作区已不在你的列表中。"
+          }
+        }
+      }
+    },
     "Timed out": {
       "localizations": {
         "zh-Hans": {
@@ -6749,6 +6919,16 @@
         }
       }
     },
+    "Used for this invite only. To make it stick, start the daemon there with --wss-origin.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅用于本次邀请。要长期生效，请在那台机器上用 --wss-origin 启动守护进程。"
+          }
+        }
+      }
+    },
     "User": {
       "localizations": {
         "zh-Hans": {
@@ -6829,6 +7009,16 @@
         }
       }
     },
+    "What this workspace is called in the sidebar.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个工作区在侧栏中显示的名称。"
+          }
+        }
+      }
+    },
     "When on, selecting text copies it straight to the clipboard.": {
       "localizations": {
         "zh-Hans": {
@@ -6865,6 +7055,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "是否启用这些功能，以及把它们装到这台 Mac 上。"
+          }
+        }
+      }
+    },
+    "Which machine your iPhone connects to. Each one serves its own sessions.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone 连接到哪台机器。每台机器各自提供自己的会话。"
           }
         }
       }
@@ -6909,12 +7109,12 @@
         }
       }
     },
-    "Workspace actions": {
+    "Workspace Unavailable": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "工作区操作"
+            "value": "工作区不可用"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6879,6 +6879,16 @@
         }
       }
     },
+    "Update ready": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新已就绪"
+          }
+        }
+      }
+    },
     "Updated.": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -12,8 +12,12 @@
 	<string>%1$@ changed on %2$@</string>
 	<key>%@ and %@</key>
 	<string>%@ and %@</string>
+	<key>%@ answered, but not with a pairing invite. Its termiod is probably older than this app — deploy it again.</key>
+	<string>%@ answered, but not with a pairing invite. Its termiod is probably older than this app — deploy it again.</string>
 	<key>%@ didn’t come up — check the network and retry</key>
 	<string>%@ didn’t come up — check the network and retry</string>
+	<key>%@ has nothing to pair against</key>
+	<string>%@ has nothing to pair against</string>
 	<key>%@ is a dark theme in the %@ slot.</key>
 	<string>%@ is a dark theme in the %@ slot.</string>
 	<key>%@ is a light theme in the %@ slot.</key>
@@ -70,6 +74,8 @@
 	<string>%lldw</string>
 	<key>1 result</key>
 	<string>1 result</string>
+	<key>A box can only be paired with once its termiod is running and reachable from outside — a tunnel, or a proxy in front of it.</key>
+	<string>A box can only be paired with once its termiod is running and reachable from outside — a tunnel, or a proxy in front of it.</string>
 	<key>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</key>
 	<string>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</string>
 	<key>A double quote can’t be written to ssh config.</key>
@@ -160,6 +166,8 @@
 	<string>Apply</string>
 	<key>Asking %@ what it has.</key>
 	<string>Asking %@ what it has.</string>
+	<key>Asking %@…</key>
+	<string>Asking %@…</string>
 	<key>Assigned to Me</key>
 	<string>Assigned to Me</string>
 	<key>Assignee</key>
@@ -282,6 +290,8 @@
 	<string>Close the session and open it again to reattach.</string>
 	<key>Closed</key>
 	<string>Closed</string>
+	<key>Closes every session in it. The folders on disk are left alone.</key>
+	<string>Closes every session in it. The folders on disk are left alone.</string>
 	<key>Closing it stops %lld session(s). The folders on disk are left alone.</key>
 	<string>Closing it stops %lld session(s). The folders on disk are left alone.</string>
 	<key>Collapse All</key>
@@ -336,6 +346,8 @@
 	<string>Copy Diff</string>
 	<key>Copy Image</key>
 	<string>Copy Image</string>
+	<key>Copy Invite</key>
+	<string>Copy Invite</string>
 	<key>Copy Link</key>
 	<string>Copy Link</string>
 	<key>Copy Path</key>
@@ -352,6 +364,8 @@
 	<string>Copy on select</string>
 	<key>Copy ssh Command</key>
 	<string>Copy ssh Command</string>
+	<key>Could not run ssh: %@</key>
+	<string>Could not run ssh: %@</string>
 	<key>Couldn’t change the Themes folder</key>
 	<string>Couldn’t change the Themes folder</string>
 	<key>Couldn’t create the worktrees folder: %@</key>
@@ -422,6 +436,8 @@
 	<string>Deploys `termiod`, looks for your agent CLIs, then installs Termio’s hooks and skill.</string>
 	<key>Detached at %@</key>
 	<string>Detached at %@</string>
+	<key>Device</key>
+	<string>Device</string>
 	<key>Device Unavailable</key>
 	<string>Device Unavailable</string>
 	<key>Devices</key>
@@ -478,8 +494,12 @@
 	<string>Enter a path that starts with “/”. “~/” works too, once %@ has said where home is.</string>
 	<key>Enter an absolute path</key>
 	<string>Enter an absolute path</string>
+	<key>Every iPhone paired with %@ is signed out and must re-scan the new QR to reconnect.</key>
+	<string>Every iPhone paired with %@ is signed out and must re-scan the new QR to reconnect.</string>
 	<key>Every paired iPhone is signed out and must re-scan the new QR to reconnect.</key>
 	<string>Every paired iPhone is signed out and must re-scan the new QR to reconnect.</string>
+	<key>Exited with status %lld.</key>
+	<string>Exited with status %lld.</string>
 	<key>Expand Results</key>
 	<string>Expand Results</string>
 	<key>Family</key>
@@ -670,6 +690,8 @@
 	<string>Minimize</string>
 	<key>Missing on %lld devices</key>
 	<string>Missing on %lld devices</string>
+	<key>Mobile</key>
+	<string>Mobile</string>
 	<key>Mobile Access</key>
 	<string>Mobile Access</string>
 	<key>Move Down</key>
@@ -834,12 +856,12 @@
 	<string>Notifications for Termio are turned off in System Settings.</string>
 	<key>OK</key>
 	<string>OK</string>
-	<key>Off</key>
-	<string>Off</string>
 	<key>Off — LAN only</key>
 	<string>Off — LAN only</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Both devices must share a LAN.</key>
 	<string>On iPhone, tap the Mac pill ▸ Scan QR Code. Both devices must share a LAN.</string>
+	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The token is minted on %@ and demanded on every connection.</key>
+	<string>On iPhone, tap the Mac pill ▸ Scan QR Code. The token is minted on %@ and demanded on every connection.</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network, and terminates on the provider's servers. Pick Custom to run your own relay instead.</key>
 	<string>On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network, and terminates on the provider's servers. Pick Custom to run your own relay instead.</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Traffic crosses the relay you run yourself — no third party in the path.</key>
@@ -888,8 +910,12 @@
 	<string>Overwrite</string>
 	<key>Padding: %lld pt</key>
 	<string>Padding: %lld pt</string>
+	<key>Pair</key>
+	<string>Pair</string>
 	<key>Pair a Phone…</key>
 	<string>Pair a Phone…</string>
+	<key>Pair your iPhone with the machines you work on</key>
+	<string>Pair your iPhone with the machines you work on</string>
 	<key>Pairing Token</key>
 	<string>Pairing Token</string>
 	<key>Panes</key>
@@ -938,6 +964,8 @@
 	<string>Project Files</string>
 	<key>Projects</key>
 	<string>Projects</string>
+	<key>Public address</key>
+	<string>Public address</string>
 	<key>Public keys</key>
 	<string>Public keys</string>
 	<key>Pull Requests</key>
@@ -1002,6 +1030,8 @@
 	<string>Removed from PATH.</string>
 	<key>Removes this custom agent and its configuration file. Existing sessions keep running.</key>
 	<string>Removes this custom agent and its configuration file. Existing sessions keep running.</string>
+	<key>Remove…</key>
+	<string>Remove…</string>
 	<key>Rename</key>
 	<string>Rename</string>
 	<key>Rename Session</key>
@@ -1230,6 +1260,8 @@
 	<string>The machine Termio is running on</string>
 	<key>The machine answered with no listing for that folder.</key>
 	<string>The machine answered with no listing for that folder.</string>
+	<key>The machine everything filed under this workspace lives on.</key>
+	<string>The machine everything filed under this workspace lives on.</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>The project and session list. Kept separate from the terminal font, and need not be monospaced.</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
@@ -1310,6 +1342,8 @@
 	<string>This session couldn’t be started.</string>
 	<key>This week</key>
 	<string>This week</string>
+	<key>This workspace is no longer on your list.</key>
+	<string>This workspace is no longer on your list.</string>
 	<key>Timed out</key>
 	<string>Timed out</string>
 	<key>Today</key>
@@ -1356,6 +1390,8 @@
 	<string>Use Regular Expression</string>
 	<key>Use Selection for Find</key>
 	<string>Use Selection for Find</string>
+	<key>Used for this invite only. To make it stick, start the daemon there with --wss-origin.</key>
+	<string>Used for this invite only. To make it stick, start the daemon there with --wss-origin.</string>
 	<key>User</key>
 	<string>User</string>
 	<key>Uses %@</key>
@@ -1372,6 +1408,8 @@
 	<string>WeChat</string>
 	<key>WeChat group</key>
 	<string>WeChat group</string>
+	<key>What this workspace is called in the sidebar.</key>
+	<string>What this workspace is called in the sidebar.</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
 	<string>When on, selecting text copies it straight to the clipboard.</string>
 	<key>Where each device launches %@ from. Leave empty to use its default.</key>
@@ -1380,6 +1418,8 @@
 	<string>Whether you want these at all, and putting them on every device.</string>
 	<key>Whether you want these at all, and putting them on this Mac.</key>
 	<string>Whether you want these at all, and putting them on this Mac.</string>
+	<key>Which machine your iPhone connects to. Each one serves its own sessions.</key>
+	<string>Which machine your iPhone connects to. Each one serves its own sessions.</string>
 	<key>Window</key>
 	<string>Window</string>
 	<key>Working Directory</key>
@@ -1388,8 +1428,8 @@
 	<string>Workspace</string>
 	<key>Workspace Settings…</key>
 	<string>Workspace Settings…</string>
-	<key>Workspace actions</key>
-	<string>Workspace actions</string>
+	<key>Workspace Unavailable</key>
+	<string>Workspace Unavailable</string>
 	<key>Workspaces</key>
 	<string>Workspaces</string>
 	<key>Worktree has changes</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1382,6 +1382,8 @@
 	<string>Unsaved changes — saving…</string>
 	<key>Update</key>
 	<string>Update</string>
+	<key>Update ready</key>
+	<string>Update ready</string>
 	<key>Updated.</key>
 	<string>Updated.</string>
 	<key>Usage</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1382,6 +1382,8 @@
 	<string>未存储的更改 — 正在存储…</string>
 	<key>Update</key>
 	<string>更新</string>
+	<key>Update ready</key>
+	<string>更新已就绪</string>
 	<key>Updated.</key>
 	<string>已更新。</string>
 	<key>Usage</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -12,8 +12,12 @@
 	<string>%1$@ 在 %2$@ 上已被修改</string>
 	<key>%@ and %@</key>
 	<string>%1$@ 和 %2$@</string>
+	<key>%@ answered, but not with a pairing invite. Its termiod is probably older than this app — deploy it again.</key>
+	<string>%@ 有响应，但返回的不是配对邀请。它的 termiod 可能比本应用旧——重新部署一次。</string>
 	<key>%@ didn’t come up — check the network and retry</key>
 	<string>%@ 未能启动——请检查网络后重试</string>
+	<key>%@ has nothing to pair against</key>
+	<string>%@ 上没有可配对的目标</string>
 	<key>%@ is a dark theme in the %@ slot.</key>
 	<string>“%@”是深色主题，与“%@”插槽不匹配。</string>
 	<key>%@ is a light theme in the %@ slot.</key>
@@ -70,6 +74,8 @@
 	<string>%lld 周</string>
 	<key>1 result</key>
 	<string>1 个结果</string>
+	<key>A box can only be paired with once its termiod is running and reachable from outside — a tunnel, or a proxy in front of it.</key>
+	<string>只有当机器上的 termiod 正在运行、并且可以从外部访问时才能配对——需要隧道，或在它前面加一层代理。</string>
 	<key>A different `%@` already exists at %@. Remove it first — Termio won’t overwrite a file it didn’t create.</key>
 	<string>另一个 `%@` 已存在于 %@。请先移除，Termio 不会覆盖并非自己创建的文件。</string>
 	<key>A double quote can’t be written to ssh config.</key>
@@ -160,6 +166,8 @@
 	<string>应用</string>
 	<key>Asking %@ what it has.</key>
 	<string>正在询问 %@ 上有什么。</string>
+	<key>Asking %@…</key>
+	<string>正在询问 %@…</string>
 	<key>Assigned to Me</key>
 	<string>指派给我</string>
 	<key>Assignee</key>
@@ -282,6 +290,8 @@
 	<string>关闭会话后重新打开即可接回。</string>
 	<key>Closed</key>
 	<string>已关闭</string>
+	<key>Closes every session in it. The folders on disk are left alone.</key>
+	<string>会关闭其中的所有会话。磁盘上的文件夹不受影响。</string>
 	<key>Closing it stops %lld session(s). The folders on disk are left alone.</key>
 	<string>关闭它会停止 %lld 个会话。磁盘上的文件夹不受影响。</string>
 	<key>Collapse All</key>
@@ -336,6 +346,8 @@
 	<string>拷贝差异</string>
 	<key>Copy Image</key>
 	<string>拷贝图像</string>
+	<key>Copy Invite</key>
+	<string>拷贝邀请</string>
 	<key>Copy Link</key>
 	<string>拷贝链接</string>
 	<key>Copy Path</key>
@@ -352,6 +364,8 @@
 	<string>选中即拷贝</string>
 	<key>Copy ssh Command</key>
 	<string>拷贝 ssh 命令</string>
+	<key>Could not run ssh: %@</key>
+	<string>无法运行 ssh：%@</string>
 	<key>Couldn’t change the Themes folder</key>
 	<string>无法修改主题文件夹</string>
 	<key>Couldn’t create the worktrees folder: %@</key>
@@ -422,6 +436,8 @@
 	<string>部署 `termiod`，查找你的 Agent 命令行工具，然后安装 Termio 的 hooks 和技能。</string>
 	<key>Detached at %@</key>
 	<string>已分离于 %@</string>
+	<key>Device</key>
+	<string>设备</string>
 	<key>Device Unavailable</key>
 	<string>设备不可用</string>
 	<key>Devices</key>
@@ -478,8 +494,12 @@
 	<string>请输入以“/”开头的路径。等 %@ 报出主目录之后，“~/”也可以用。</string>
 	<key>Enter an absolute path</key>
 	<string>请输入绝对路径</string>
+	<key>Every iPhone paired with %@ is signed out and must re-scan the new QR to reconnect.</key>
+	<string>所有与 %@ 配对的 iPhone 都会退出登录，需重新扫描新的二维码才能重新连接。</string>
 	<key>Every paired iPhone is signed out and must re-scan the new QR to reconnect.</key>
 	<string>所有已配对的 iPhone 都会退出登录，需重新扫描新的二维码才能重新连接。</string>
+	<key>Exited with status %lld.</key>
+	<string>退出状态 %lld。</string>
 	<key>Expand Results</key>
 	<string>展开结果</string>
 	<key>Family</key>
@@ -670,6 +690,8 @@
 	<string>最小化</string>
 	<key>Missing on %lld devices</key>
 	<string>%lld 台设备上缺失</string>
+	<key>Mobile</key>
+	<string>手机</string>
 	<key>Mobile Access</key>
 	<string>移动访问</string>
 	<key>Move Down</key>
@@ -834,12 +856,12 @@
 	<string>Termio 的通知已在“系统设置”中关闭。</string>
 	<key>OK</key>
 	<string>好</string>
-	<key>Off</key>
-	<string>未开启</string>
 	<key>Off — LAN only</key>
 	<string>关闭 — 仅局域网</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Both devices must share a LAN.</key>
 	<string>在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。两台设备须处于同一局域网。</string>
+	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The token is minted on %@ and demanded on every connection.</key>
+	<string>在 iPhone 上，点按 Mac 药丸 ▸ 扫描二维码。Token 在 %@ 上生成，每次连接都会验证。</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The tunnel address works from any network, and terminates on the provider's servers. Pick Custom to run your own relay instead.</key>
 	<string>在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。隧道地址可在任意网络使用，并终结于服务商的服务器。若要改用自己的中继，请选择“自定义”。</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Traffic crosses the relay you run yourself — no third party in the path.</key>
@@ -888,8 +910,12 @@
 	<string>覆盖</string>
 	<key>Padding: %lld pt</key>
 	<string>边距：%lld 点</string>
+	<key>Pair</key>
+	<string>配对</string>
 	<key>Pair a Phone…</key>
 	<string>配对手机…</string>
+	<key>Pair your iPhone with the machines you work on</key>
+	<string>把 iPhone 与你正在使用的机器配对</string>
 	<key>Pairing Token</key>
 	<string>配对 Token</string>
 	<key>Panes</key>
@@ -938,6 +964,8 @@
 	<string>项目文件</string>
 	<key>Projects</key>
 	<string>项目</string>
+	<key>Public address</key>
+	<string>公网地址</string>
 	<key>Public keys</key>
 	<string>公钥</string>
 	<key>Pull Requests</key>
@@ -1002,6 +1030,8 @@
 	<string>已从 PATH 中移除。</string>
 	<key>Removes this custom agent and its configuration file. Existing sessions keep running.</key>
 	<string>移除此自定义 Agent 及其配置文件。现有会话会继续运行。</string>
+	<key>Remove…</key>
+	<string>移除…</string>
 	<key>Rename</key>
 	<string>重命名</string>
 	<key>Rename Session</key>
@@ -1230,6 +1260,8 @@
 	<string>Termio 正在运行的设备</string>
 	<key>The machine answered with no listing for that folder.</key>
 	<string>这台机器没有返回该文件夹的内容。</string>
+	<key>The machine everything filed under this workspace lives on.</key>
+	<string>归入这个工作区的一切所在的机器。</string>
 	<key>The project and session list. Kept separate from the terminal font, and need not be monospaced.</key>
 	<string>项目与会话列表。与终端字体分开设置，无需等宽字体。</string>
 	<key>The public keys in ~/.ssh. Copy one to paste into a server’s authorized_keys — private keys are never read.</key>
@@ -1310,6 +1342,8 @@
 	<string>这个会话没能启动。</string>
 	<key>This week</key>
 	<string>本周</string>
+	<key>This workspace is no longer on your list.</key>
+	<string>这个工作区已不在你的列表中。</string>
 	<key>Timed out</key>
 	<string>连接超时</string>
 	<key>Today</key>
@@ -1356,6 +1390,8 @@
 	<string>使用正则表达式</string>
 	<key>Use Selection for Find</key>
 	<string>用所选内容查找</string>
+	<key>Used for this invite only. To make it stick, start the daemon there with --wss-origin.</key>
+	<string>仅用于本次邀请。要长期生效，请在那台机器上用 --wss-origin 启动守护进程。</string>
 	<key>User</key>
 	<string>用户</string>
 	<key>Uses %@</key>
@@ -1372,6 +1408,8 @@
 	<string>微信</string>
 	<key>WeChat group</key>
 	<string>微信群</string>
+	<key>What this workspace is called in the sidebar.</key>
+	<string>这个工作区在侧栏中显示的名称。</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
 	<string>开启后，选中文本会直接拷贝到剪贴板。</string>
 	<key>Where each device launches %@ from. Leave empty to use its default.</key>
@@ -1380,6 +1418,8 @@
 	<string>是否启用这些功能，以及把它们装到每台设备上。</string>
 	<key>Whether you want these at all, and putting them on this Mac.</key>
 	<string>是否启用这些功能，以及把它们装到这台 Mac 上。</string>
+	<key>Which machine your iPhone connects to. Each one serves its own sessions.</key>
+	<string>iPhone 连接到哪台机器。每台机器各自提供自己的会话。</string>
 	<key>Window</key>
 	<string>窗口</string>
 	<key>Working Directory</key>
@@ -1388,8 +1428,8 @@
 	<string>工作区</string>
 	<key>Workspace Settings…</key>
 	<string>工作区设置…</string>
-	<key>Workspace actions</key>
-	<string>工作区操作</string>
+	<key>Workspace Unavailable</key>
+	<string>工作区不可用</string>
 	<key>Workspaces</key>
 	<string>工作区</string>
 	<key>Worktree has changes</key>

--- a/Sources/termio/Settings/AgentSettingsTab.swift
+++ b/Sources/termio/Settings/AgentSettingsTab.swift
@@ -71,43 +71,6 @@ struct AgentSettingsTab: View {
             }
 
             Section {
-                ForEach(listedAgents) { preset in
-                    NavigationLink(value: AgentRoute(id: preset.id)) {
-                        AgentListRow(settings: settings, preset: preset, devices: devices)
-                    }
-                    .draggable(preset.id)
-                    .dropDestination(for: String.self) { ids, _ in
-                        guard let dragged = ids.first else { return false }
-                        return move(dragged, onto: preset)
-                    }
-                    .contextMenu {
-                        Button(localized("Move Up")) { move(preset, by: -1) }
-                            .disabled(listedAgents.first?.id == preset.id)
-                        Button(localized("Move Down")) { move(preset, by: 1) }
-                            .disabled(listedAgents.last?.id == preset.id)
-                        Divider()
-                        Button(localized("Remove from List")) { remove(preset) }
-                    }
-                }
-                AddAgentRow(
-                    addable: addableAgents,
-                    onAdd: add,
-                    onCustom: createCustomAgent
-                )
-            } header: {
-                SectionHeaderLabel(title: localized("Agents"))
-            } footer: {
-                // Only worth saying once there is more than one machine to cover.
-                // On a roster of one the sentence would be true and pointless, and
-                // this page's whole claim is that a single machine costs nothing.
-                Text(devices.count > 1
-                    ? localized("Drag an agent onto another to reorder. Readiness covers every device you work on.")
-                    : localized("Drag an agent onto another to reorder."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Section {
                 Toggle(isOn: $settings.agentHooksEnabled) {
                     SettingsLabel(
                         title: localized("Live agent status"),
@@ -142,6 +105,43 @@ struct AgentSettingsTab: View {
                 Text(devices.count > 1
                     ? localized("Whether you want these at all, and putting them on every device.")
                     : localized("Whether you want these at all, and putting them on this Mac."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                ForEach(listedAgents) { preset in
+                    NavigationLink(value: AgentRoute(id: preset.id)) {
+                        AgentListRow(settings: settings, preset: preset, devices: devices)
+                    }
+                    .draggable(preset.id)
+                    .dropDestination(for: String.self) { ids, _ in
+                        guard let dragged = ids.first else { return false }
+                        return move(dragged, onto: preset)
+                    }
+                    .contextMenu {
+                        Button(localized("Move Up")) { move(preset, by: -1) }
+                            .disabled(listedAgents.first?.id == preset.id)
+                        Button(localized("Move Down")) { move(preset, by: 1) }
+                            .disabled(listedAgents.last?.id == preset.id)
+                        Divider()
+                        Button(localized("Remove from List")) { remove(preset) }
+                    }
+                }
+                AddAgentGutter(
+                    addable: addableAgents,
+                    onAdd: add,
+                    onCustom: createCustomAgent
+                )
+            } header: {
+                SectionHeaderLabel(title: localized("Agents"))
+            } footer: {
+                // Only worth saying once there is more than one machine to cover.
+                // On a roster of one the sentence would be true and pointless, and
+                // this page's whole claim is that a single machine costs nothing.
+                Text(devices.count > 1
+                    ? localized("Drag an agent onto another to reorder. Readiness covers every device you work on.")
+                    : localized("Drag an agent onto another to reorder."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -365,50 +365,51 @@ private struct AgentRoute: Hashable {
     let id: String
 }
 
-/// The roster's add action, as the last row of the roster.
+/// The roster's add and remove actions, in the list's own gutter (see
+/// `SettingsListGutter`).
 ///
-/// A pull-down rather than a button: the agents worth adding are a known list,
-/// and a sheet to pick one from it would be a window for a menu's worth of
-/// choice. Styled as a row of the group — inside a grouped `Form` the card
-/// already draws the surface, so a second rounded rect on top of it is what made
-/// this read as bolted on to the window's bottom edge.
-private struct AddAgentRow: View {
+/// The roster's add action, in the list's own gutter (see `SettingsListGutter`).
+///
+/// A pull-down rather than a plain button: the agents worth adding are a known
+/// list, and a sheet to pick one from it would be a window for a menu's worth of
+/// choice.
+private struct AddAgentGutter: View {
     let addable: [AgentPreset]
     let onAdd: (AgentPreset) -> Void
     let onCustom: () -> Void
 
     var body: some View {
-        Menu {
-            // Plain text rows: AppKit menus rasterize custom SwiftUI icon views
-            // at their natural image size, not the badge frame.
-            ForEach(addable) { preset in
-                Button(preset.displayName) { onAdd(preset) }
+        SettingsListGutter {
+            Menu {
+                // Plain text rows: AppKit menus rasterize custom SwiftUI icon
+                // views at their natural image size, not the badge frame.
+                ForEach(addable) { preset in
+                    Button(preset.displayName) { onAdd(preset) }
+                }
+                if !addable.isEmpty { Divider() }
+                Button(localized("Custom Agent…")) { onCustom() }
+            } label: {
+                SettingsGutterGlyph(symbol: "plus")
             }
-            if !addable.isEmpty { Divider() }
-            Button(localized("Custom Agent…")) { onCustom() }
-        } label: {
-            HStack(spacing: 12) {
-                // The rows' icon column, so the label starts where agent names do.
-                Image(systemName: "plus")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: settingsRowIconWidth, height: 26)
-                Text(localized("Add Agent"))
-                Spacer(minLength: 4)
-            }
-            .contentShape(Rectangle())
+            .menuStyle(.button)
+            .buttonStyle(.plain)
+            .menuIndicator(.hidden)
+            .help(localized("Add Agent"))
+            .accessibilityLabel(localized("Add Agent"))
         }
-        .menuStyle(.button)
-        .buttonStyle(.plain)
-        .menuIndicator(.hidden)
     }
 }
 
-/// One agent on the roster: brand mark, name, and a second line — no controls, the
-/// way a Notifications row carries no switch. The second line is the command the
-/// agent actually launches with, bypass flag and all, so the roster answers "what
-/// will this run?" without opening every row; anything blocking that launch (the
-/// agent switched off, its CLI missing) leads the same line.
+/// One agent on the roster: brand mark, name, a second line, and the switch that
+/// decides whether the agent is offered at all — the shape a Sharing row has, where
+/// the on/off state is the thing you came to read and the row still opens onto the
+/// details behind it.
+///
+/// The switch lived in the pushed pane, which made the roster's whole point — which
+/// agents are on — a click deep per row, and cost the line a leading "Off ·" to say
+/// what a switch says by being off. The second line is now only ever the command
+/// the agent launches with, bypass flag and all, led by anything that blocks that
+/// launch.
 private struct AgentListRow: View {
     @ObservedObject var settings: AppSettings
     let preset: AgentPreset
@@ -421,12 +422,15 @@ private struct AgentListRow: View {
     /// premature warning.
     @State private var fleet: AgentFleetReadiness?
 
-    /// Nothing to say about an enabled agent present everywhere — the common
-    /// case, where the line is the command alone.
-    private var status: String? {
-        if !settings.isAgentEnabled(preset) { return localized("Off") }
-        return fleet?.summary
-    }
+    /// Whether *this Mac* can launch it, which is what the switch is allowed to
+    /// gate. The fleet answer is the wrong one for that: an agent installed here
+    /// and missing on a sleeping VPS is still perfectly launchable, and a switch
+    /// dimmed by a box you are not sitting at cannot be argued with.
+    @State private var availableHere: Bool?
+
+    /// Nothing to say about an agent present everywhere — the common case, where
+    /// the line is the command alone.
+    private var status: String? { fleet?.summary }
 
     /// This Mac's command. A machine with its own path shows it on its own row in
     /// the pushed pane; repeating four of them here would make the roster a table.
@@ -461,11 +465,28 @@ private struct AgentListRow: View {
                     .foregroundStyle(.tertiary)
                     .help(missingHelp)
             }
+            Toggle(isOn: Binding(
+                get: { settings.isAgentEnabled(preset) },
+                set: { settings.setAgent(preset, enabled: $0) }
+            )) {
+                EmptyView()
+            }
+            .toggleStyle(.switch)
+            .labelsHidden()
+            // A missing CLI can't be launched, so it can't be switched on — only
+            // off (an already-on agent stays revocable while the badge shows).
+            .disabled(availableHere == false && !settings.isAgentEnabled(preset))
+            .help(localized("Offers \(preset.displayName) in the new-session menus."))
+            .accessibilityLabel(localized("Enable \(preset.displayName)"))
         }
         // Re-probed when any machine's command changes, or when the roster does.
         .task(id: probeTargets.map { "\($0.device.settingsKey)=\($0.command)" }
             .joined(separator: "|")) {
             fleet = await AgentReadiness.acrossFleet(agent: preset, on: probeTargets)
+        }
+        .task(id: settings.command(for: preset) ?? "") {
+            availableHere = await AgentAvailability.isCommandAvailable(
+                settings.command(for: preset) ?? "")
         }
     }
 
@@ -494,8 +515,6 @@ private struct AgentDetailPane: View {
     /// Set only for user-manifest agents: deletes the manifest file.
     var onDelete: (() -> Void)?
 
-    /// Same probe semantics as the list row (see `AgentListRow.available`).
-    @State private var available: Bool?
     @State private var confirmingDelete = false
     /// Removing or deleting takes the row away, so the pane it opened has to go
     /// back with it.
@@ -526,22 +545,6 @@ private struct AgentDetailPane: View {
                     }
                 }
                 .padding(.vertical, 2)
-            }
-
-            Section {
-                Toggle(isOn: Binding(
-                    get: { settings.isAgentEnabled(preset) },
-                    set: { settings.setAgent(preset, enabled: $0) }
-                )) {
-                    SettingsLabel(
-                        title: localized("Enable \(preset.displayName)"),
-                        subtext: localized("Offers \(preset.displayName) in the new-session menus.")
-                    )
-                }
-                .toggleStyle(.switch)
-                // A missing CLI can't be launched, so it can't be switched on — only
-                // off (an already-on agent stays revocable while the hint shows).
-                .disabled(available == false && !settings.isAgentEnabled(preset))
             }
 
             Section {
@@ -635,22 +638,7 @@ private struct AgentDetailPane: View {
         }
         .formStyle(.grouped)
         .navigationTitle(preset.displayName)
-        // Re-checks whenever the effective command changes, so typing a valid path
-        // clears the install link. The PATH probe runs once (cached); each check is
-        // an in-memory lookup. The leading sleep debounces per-keystroke edits into
-        // one probe once the user pauses.
-        .task(id: effectiveCommand) {
-            try? await Task.sleep(for: .milliseconds(300))
-            guard !Task.isCancelled else { return }
-            available = await AgentAvailability.isCommandAvailable(effectiveCommand)
-        }
     }
-
-    /// This Mac's command. The switch it gates is a preference with no machine
-    /// dimension, and the one machine that is certainly there is the one whose
-    /// answer can be trusted to arrive: `available` for a remote box means "its
-    /// device file said so", which is not a reason to refuse the switch.
-    private var effectiveCommand: String { settings.command(for: preset) ?? "" }
 }
 
 /// One machine's command path for this agent.

--- a/Sources/termio/Settings/DevicePane.swift
+++ b/Sources/termio/Settings/DevicePane.swift
@@ -57,11 +57,8 @@ struct DevicePane: View {
             }
             reachedBySection
             integrationSection
-            // Only this Mac serves anything today: `termiod` has no `serve --wss`
-            // yet, so a Serving section on a remote pane would offer a switch
-            // that cannot turn anything on. It appears on a device's pane when
-            // the daemon can answer for it, not before.
-            if machine.isLocal { DeviceServingSection() }
+            // What this Mac serves to phones is Settings ▸ Mobile, not a second
+            // copy here: one set of controls, one place they live.
         }
         .formStyle(.grouped)
         .navigationTitle(machine.name)

--- a/Sources/termio/Settings/DevicePane.swift
+++ b/Sources/termio/Settings/DevicePane.swift
@@ -122,6 +122,7 @@ struct DevicePane: View {
         switch model.readiness {
         case .ready: return localized("Ready")
         case .checking: return model.step?.label ?? localized("Checking…")
+        case .staged: return localized("Update ready")
         case .blocked, .unasked: return localized("Set up this device")
         }
     }
@@ -138,7 +139,7 @@ struct DevicePane: View {
                 : localized("Agents on \(machine.name) can run.")
         case .checking:
             return localized("Asking \(machine.name) what it has.")
-        case .blocked(let reason):
+        case .blocked(let reason), .staged(let reason):
             // Only the first blocking rung, by design: a machine with no `termiod`
             // also has no hooks, and naming both invites fixing the consequence.
             return reason
@@ -260,7 +261,9 @@ struct DevicePane: View {
                 } label: {
                     SettingsLabel(
                         title: "termiod",
-                        subtext: localized("The session host on \(machine.name). Sessions keep running there after you disconnect."),
+                        subtext: model.discovered?.termiodVersion.map {
+                            localized("Version \($0) on \(machine.name). Sessions keep running there after you disconnect.")
+                        } ?? localized("The session host on \(machine.name). Sessions keep running there after you disconnect."),
                         titleFont: .headline
                     )
                 }

--- a/Sources/termio/Settings/DeviceReadiness.swift
+++ b/Sources/termio/Settings/DeviceReadiness.swift
@@ -104,6 +104,10 @@ enum DeviceReadinessState: Equatable {
     /// `termiod` also has no hooks, and listing both invites the user to fix the
     /// consequence instead of the cause.
     case blocked(String)
+    /// The new `termiod` is on the machine and the old daemon is still running
+    /// because it holds sessions someone is using — named in the text. Not a
+    /// fault: it takes over once they close, and setup then completes.
+    case staged(String)
 
     var isBusy: Bool { self == .checking }
 }
@@ -202,9 +206,12 @@ enum DeviceProbe {
                     ? AgentReadiness.available.rawValue
                     : AgentReadiness.missing.rawValue
             }
+            // Every handshake records the daemon's build in the registry, and
+            // the probe just made one.
             return DeviceDiscoveredState(
                 checkedAt: now, reachable: true,
-                termiodVersion: nil, agents: agents)
+                termiodVersion: TermiodDeviceRegistry.shared.device(for: .ssh(alias))?.daemonVersion,
+                agents: agents)
         } catch {
             // Reached over ssh, but the daemon could not answer — an old
             // termiod, or one that will not start. Reported as reachable with
@@ -319,7 +326,7 @@ final class DevicePaneModel: ObservableObject {
 
         step = .foundation
         if let failure = await installFoundation() {
-            readiness = .blocked(failure)
+            readiness = failure
             return
         }
 
@@ -354,25 +361,28 @@ final class DevicePaneModel: ObservableObject {
     }
 
     /// The first rung. This Mac needs the `termio` CLI on `PATH` — a hook it
-    /// installs invokes it by name. A device needs `termiod`, which is also the
-    /// reachability check, since deploying requires reaching it.
-    private func installFoundation() async -> String? {
+    /// installs invokes it by name. A device needs the `termiod` this build
+    /// ships, which is also the reachability check, since deploying requires
+    /// reaching it. `nil` when the rung passed; otherwise the state to show.
+    private func installFoundation() async -> DeviceReadinessState? {
         guard let alias = device.alias else {
             switch CommandLineTool.install() {
             case .installed:
                 return nil
             case .conflict:
-                return localized("Something else already owns \(CommandLineTool.installURL.path).")
+                return .blocked(localized("Something else already owns \(CommandLineTool.installURL.path)."))
             case .unavailable:
-                return localized("Run Termio from the built app to install its command-line tool.")
+                return .blocked(localized("Run Termio from the built app to install its command-line tool."))
             case .notInstalled, .stale:
                 let directory = CommandLineTool.installURL.deletingLastPathComponent().path
-                return localized("Couldn’t link `\(CommandLineTool.toolName)` into \(directory).")
+                return .blocked(localized("Couldn’t link `\(CommandLineTool.toolName)` into \(directory)."))
             }
         }
         switch await TermioStore.remoteReadyCheck(host: alias) {
-        case .success: return nil
-        case .failure(let error): return error.message
+        case .success:
+            return nil
+        case .failure(let error):
+            return error.state == .staged ? .staged(error.message) : .blocked(error.message)
         }
     }
 

--- a/Sources/termio/Settings/DeviceServing.swift
+++ b/Sources/termio/Settings/DeviceServing.swift
@@ -1,24 +1,66 @@
 import CoreImage
 import SwiftUI
 
-/// What a machine serves to phones: the companion port, the pairing token, the
-/// QR carrying both, and the tunnel fronting them (RFC §D9).
+/// Settings ▸ Mobile: what this Mac serves to phones — the companion port, the
+/// pairing token, the QR carrying both, and the tunnel fronting them (RFC §D9).
 ///
-/// This was a top-level **Mobile** tab, and every line of it was already a fact
-/// about *one machine* — this Mac's port, this Mac's token, the phones paired to
-/// this Mac. It only read as app-wide because this Mac is currently the only
-/// machine that serves anything, which `termiod serve --wss` ends. A tab whose
-/// scope is a single machine is the same lie the Agents tab told, so it moves to
-/// the place that already answers for one machine.
+/// This lived inside Devices ▸ this Mac for a while, on the argument that every
+/// line of it is a fact about *one machine*: this Mac's port, this Mac's token,
+/// the phones paired to this Mac. The scope reading was right; the placement it
+/// implied was not. Pairing is the one step a new user cannot guess at, and it
+/// was three levels down a tab named after something else — so nobody found it.
 ///
-/// Unlike a command path, serving config is **not** comparable across machines —
-/// every box has its own port, its own token, its own QR — so this is the case
-/// where a drill-down is right and rows would be nonsense. It is the other half
-/// of the same rule: the machine's pane owns what is true of exactly one machine.
-///
-/// The QR being one level deeper is a real cost, paid the way §D9 says: pairing
-/// is an *action*, and it lives in the command palette ("Pair a phone…"), not as
-/// a duplicate settings entry.
+/// So the tab is back, and the scope objection is answered where it belongs: a
+/// machine picker at the top, and the card named after whichever machine is
+/// showing. A phone pairs with a *box*, and this Mac is only the nearest one —
+/// the VPS the user actually leaves agents running on is the case that matters,
+/// and it was unreachable from the UI entirely.
+struct MobileSettingsTab: View {
+    @ObservedObject var store: TermioStore
+    /// The machine being paired with, by `settingsKey`. Defaults to this Mac:
+    /// it is the one that always answers, and on a roster of one it is the only
+    /// choice — in which case the picker does not appear at all.
+    @State private var scope = KnownDevice.thisMac.settingsKey
+
+    private var machines: [KnownDevice] { DeviceRoster.known(in: store) }
+
+    /// Falls back to this Mac when the selected box leaves the roster, so the
+    /// pane never renders against a machine that is no longer there.
+    private var selected: KnownDevice {
+        machines.first { $0.settingsKey == scope } ?? .thisMac
+    }
+
+    var body: some View {
+        Form {
+            if machines.count > 1 {
+                Section {
+                    Picker(localized("Device"), selection: $scope) {
+                        ForEach(machines) { machine in
+                            Text(machine.name).tag(machine.settingsKey)
+                        }
+                    }
+                } footer: {
+                    Text(localized("Which machine your iPhone connects to. Each one serves its own sessions."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if selected.isLocal {
+                DeviceServingSection()
+            } else {
+                RemotePairingSection(machine: selected)
+                    // Rebuilt per machine: the pane's whole state is one box's
+                    // invite, and carrying the previous box's QR into the next
+                    // selection would offer a working code for the wrong host.
+                    .id(selected.settingsKey)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+/// The pane's one card: everything this Mac serves, under the machine's own name
+/// so the scope is on screen rather than assumed.
 struct DeviceServingSection: View {
     /// The reachable addresses, refreshed on open: Wi-Fi/Ethernet IPv4s
     /// first (the proven path), the Bonjour `.local` name as a fallback that
@@ -57,12 +99,9 @@ struct DeviceServingSection: View {
         return false
     }
 
-    /// One section, matching the machine pane's other three. The four cards this
-    /// was as a tab do not survive the move: on a pane that already carries
-    /// Status, Reached by and Installed by Termio, a fifth and sixth card for one
-    /// switch apiece would read as four unrelated subjects rather than one. So
-    /// the two lone-control cards fold into rows with their sentence as subtext,
-    /// which is the shape every other row on this pane already has.
+    /// One card, not the four this was the first time it was a tab: a card per
+    /// lone switch read as four unrelated subjects. The switches stay rows with
+    /// their sentence as subtext, which is the shape every settings row has.
     var body: some View {
         Section {
             Toggle(isOn: $mobile.isEnabled) {
@@ -139,7 +178,9 @@ struct DeviceServingSection: View {
                 betaRow
             }
         } header: {
-            SectionHeaderLabel(title: localized("Serving"))
+            // The machine, not "Serving": this pane answers for exactly one Mac,
+            // and naming it is what keeps the settings from reading as app-wide.
+            SectionHeaderLabel(title: KnownDevice.thisMac.name)
         } footer: {
             // Say plainly whose server the phone's traffic crosses, so the
             // "can I self-host the relay?" question is answered in the app: the
@@ -400,15 +441,19 @@ struct DeviceServingSection: View {
         return name.hasSuffix(".local") ? name : nil
     }
 
-    /// Plain CoreImage QR (medium error correction), rendered nearest-neighbor
-    /// so the modules stay sharp at display size.
-    private static func qrImage(for string: String) -> NSImage? {
-        let filter = CIFilter(name: "CIQRCodeGenerator")
-        filter?.setValue(Data(string.utf8), forKey: "inputMessage")
-        filter?.setValue("M", forKey: "inputCorrectionLevel")
-        guard let output = filter?.outputImage else { return nil }
-        let scaled = output.transformed(by: CGAffineTransform(scaleX: 8, y: 8))
-        guard let cg = CIContext().createCGImage(scaled, from: scaled.extent) else { return nil }
-        return NSImage(cgImage: cg, size: NSSize(width: scaled.extent.width, height: scaled.extent.height))
-    }
+    private static func qrImage(for string: String) -> NSImage? { pairingQRImage(for: string) }
+}
+
+/// Plain CoreImage QR (medium error correction), rendered nearest-neighbor so
+/// the modules stay sharp at display size. Shared by both arms of the pane:
+/// this Mac encodes its own `ws://…` address, a remote box encodes the
+/// `termio://device` invite its own `termiod pair` minted.
+func pairingQRImage(for string: String) -> NSImage? {
+    let filter = CIFilter(name: "CIQRCodeGenerator")
+    filter?.setValue(Data(string.utf8), forKey: "inputMessage")
+    filter?.setValue("M", forKey: "inputCorrectionLevel")
+    guard let output = filter?.outputImage else { return nil }
+    let scaled = output.transformed(by: CGAffineTransform(scaleX: 8, y: 8))
+    guard let cg = CIContext().createCGImage(scaled, from: scaled.extent) else { return nil }
+    return NSImage(cgImage: cg, size: NSSize(width: scaled.extent.width, height: scaled.extent.height))
 }

--- a/Sources/termio/Settings/DevicesSettingsTab.swift
+++ b/Sources/termio/Settings/DevicesSettingsTab.swift
@@ -45,18 +45,24 @@ struct DevicesSettingsTab: View {
     var body: some View {
         Form {
             // No section header: the tab is called Devices and this is the
-            // only list of them in it. The add row is the last row of the
-            // list it adds to rather than a bar pinned to the window bottom,
-            // which in a tall window sat a screen away from the roster with
-            // two unrelated sections in between — and so read as adding a
-            // public key.
+            // only list of them in it. The add control is the roster's own
+            // gutter rather than a bar pinned to the window bottom, which in a
+            // tall window sat a screen away from the roster with two unrelated
+            // sections in between — and so read as adding a public key.
             Section {
                 ForEach(machines) { machine in
                     NavigationLink(value: DeviceRoute(key: machine.settingsKey)) {
                         DeviceListRow(machine: machine, host: host(for: machine))
                     }
                 }
-                AddDeviceRow { addingHost = true }
+                SettingsListGutter {
+                    Button { addingHost = true } label: {
+                        SettingsGutterGlyph(symbol: "plus")
+                    }
+                    .buttonStyle(.plain)
+                    .help(localized("Add Device"))
+                    .accessibilityLabel(localized("Add Device"))
+                }
             } footer: {
                 Text(localized("Open one to see how it is reached and what it runs."))
                     .font(.caption)
@@ -234,29 +240,4 @@ private struct DeviceListRow: View {
     }
 }
 
-/// The roster's add action, as the last row of the roster.
-///
-/// Styled as a row of the group rather than a bar with its own inset background:
-/// inside a grouped `Form` the card already draws the surface, and a second
-/// rounded rect on top of it is what made this read as bolted on.
-private struct AddDeviceRow: View {
-    let onAdd: () -> Void
-
-    var body: some View {
-        Button(action: onAdd) {
-            HStack(spacing: 12) {
-                // No badge — an action is not a device — but it takes the same
-                // leading width so its label starts on the roster's text column.
-                Image(systemName: "plus")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: settingsRowIconWidth, height: 26)
-                Text(localized("Add Device"))
-                Spacer(minLength: 4)
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-}
 

--- a/Sources/termio/Settings/RemotePairing.swift
+++ b/Sources/termio/Settings/RemotePairing.swift
@@ -1,0 +1,339 @@
+import AppKit
+import SwiftUI
+import TermioShared
+
+/// Pairing a phone with a box that is not this Mac.
+///
+/// The invite is minted **on the box**, by the `termiod` already deployed there:
+/// `termiod pair --json` prints the URL it is reachable at, the token it will
+/// demand, and its `host_id`. This Mac only carries the answer over the SSH it
+/// already has and draws the QR — it never invents a token, and it never decides
+/// where a remote box is reachable, because only the box knows either.
+///
+/// That is the ladder `termiod`'s own `run_pair` describes: a Mac with SSH runs
+/// `--json` and pushes the invite; an operator sitting on the box runs `--qr`
+/// and scans the screen in front of them. This is the first rung, wired to a UI.
+enum RemotePairing {
+    /// What `termiod pair --json` prints. `host_id` is the box's identity, not a
+    /// name — the phone names the box itself (device architecture §4).
+    struct Invite: Equatable {
+        let url: String
+        let token: String
+        let hostID: String
+        let proto: Int
+
+        /// The `termio://device` link the iPhone parses, from a scanned QR or a
+        /// paste. Built here rather than asked of the box so it stays in step
+        /// with `Models.parseDeviceInvite` on the phone.
+        var link: String {
+            var components = URLComponents()
+            components.scheme = "termio"
+            components.host = "device"
+            components.queryItems = [
+                URLQueryItem(name: "url", value: url),
+                URLQueryItem(name: "token", value: token),
+                URLQueryItem(name: "host_id", value: hostID),
+                URLQueryItem(name: "proto", value: String(proto)),
+            ]
+            return components.string ?? ""
+        }
+    }
+
+    /// The box refused, and said why. `termiod`'s own message is carried through
+    /// verbatim: it already names the two ways out ("pass `--url …`", "start the
+    /// daemon with `--wss-origin …`"), and a sentence written here would be a
+    /// worse copy of one written next to the code that failed.
+    struct Failure: Error, Equatable {
+        let message: String
+    }
+
+    /// Asks `<alias>` for an invite. `rotate` issues a new token first, which
+    /// signs out every phone already paired with that box.
+    ///
+    /// `url` answers the one question the box cannot: what public name fronts
+    /// it. The listener binds loopback on purpose — a daemon that bound `0.0.0.0`
+    /// would be a shell server on the open internet — so nothing on the box can
+    /// derive the address a phone would dial, and `termiod pair` refuses rather
+    /// than mint a QR pointing nowhere.
+    ///
+    /// Runs on a detached task: this forks `ssh`, and a box that is asleep or
+    /// behind a slow link would otherwise block whatever called it.
+    static func invite(
+        from alias: String, url: String? = nil, rotate: Bool = false
+    ) async throws -> Invite {
+        var command = "\(Termiod.remoteBinary()) pair --json\(rotate ? " --rotate" : "")"
+        if let url, !url.isEmpty {
+            command += " --url \(shellQuoted(url))"
+        }
+        let result = try await run(alias: alias, command: command)
+        guard result.status == 0 else {
+            throw Failure(message: message(from: result))
+        }
+        guard let invite = decode(result.stdout) else {
+            throw Failure(message: localized("\(alias) answered, but not with a pairing invite. Its termiod is probably older than this app — deploy it again."))
+        }
+        return invite
+    }
+
+    // MARK: - Running it
+
+    /// Single-quoted for the remote's shell, which is what `ssh host <command>`
+    /// hands the string to. A URL is user-typed and reaches a login shell on
+    /// another machine; anything less than quoting is a command injection.
+    private static func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private struct Result {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+    }
+
+    private static func run(alias: String, command: String) async throws -> Result {
+        try await withCheckedThrowingContinuation { continuation in
+            // `.userInitiated`: someone is looking at a spinner.
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+                // The app's own ssh options — multiplexing, BatchMode, the
+                // connect timeout — so this pays the same 26–33 ms a warm master
+                // costs rather than a fresh handshake, and never stalls on a
+                // password prompt nobody can answer.
+                process.arguments = Termiod.sshArguments(host: alias) + [alias, command]
+                let out = Pipe()
+                let err = Pipe()
+                process.standardOutput = out
+                process.standardError = err
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: Failure(
+                        message: localized("Could not run ssh: \(error.localizedDescription)")))
+                    return
+                }
+                // Both pipes drain before the wait: a child that fills either one
+                // blocks forever against a parent waiting on exit.
+                let stdout = out.fileHandleForReading.readDataToEndOfFile()
+                let stderr = err.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                continuation.resume(returning: Result(
+                    status: process.terminationStatus,
+                    stdout: String(data: stdout, encoding: .utf8) ?? "",
+                    stderr: String(data: stderr, encoding: .utf8) ?? ""))
+            }
+        }
+    }
+
+    /// What to show when the command failed. `termiod`'s message when it has one;
+    /// otherwise ssh's, which is the case where the box was never reached at all.
+    private static func message(from result: Result) -> String {
+        let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard stderr.isEmpty else { return stderr }
+        return localized("Exited with status \(Int(result.status)).")
+    }
+
+    private static func decode(_ json: String) -> Invite? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let url = object["url"] as? String,
+              let token = object["token"] as? String,
+              let hostID = object["host_id"] as? String
+        else { return nil }
+        // `proto` is informational here — the phone enforces it on the handshake,
+        // which is the only place that can refuse a mismatch honestly.
+        let proto = object["proto"] as? Int ?? 0
+        return Invite(url: url, token: token, hostID: hostID, proto: proto)
+    }
+}
+
+/// The Mobile pane's remote arm: one card for one box, holding whatever that box
+/// last said when asked for an invite.
+///
+/// It asks on appear rather than behind a button. Everything the card can show —
+/// the QR, the address, the reason there is neither — is the answer to the same
+/// single question, so making the user press something first would only add a
+/// state in which the card says nothing at all.
+struct RemotePairingSection: View {
+    let machine: KnownDevice
+
+    private enum Phase: Equatable {
+        case asking
+        case ready(RemotePairing.Invite)
+        case failed(String)
+    }
+
+    @State private var phase = Phase.asking
+    @State private var copied = false
+    @State private var confirmRotate = false
+    /// The public address the user typed, kept across a retry so a rotate or a
+    /// failed attempt does not make them type it again.
+    @State private var address = ""
+
+    var body: some View {
+        Section {
+            switch phase {
+            case .asking:
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text(localized("Asking \(machine.name)…"))
+                        .foregroundStyle(.secondary)
+                }
+            case .ready(let invite):
+                // QR and its link are one unit — "scan this, or send yourself the
+                // same thing" — so no divider comes between them.
+                VStack(spacing: 12) {
+                    if let qr = pairingQRImage(for: invite.link) {
+                        Image(nsImage: qr)
+                            .interpolation(.none)
+                            .resizable()
+                            .frame(width: 180, height: 180)
+                            .padding(10)
+                            .background(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    }
+                    addressRow(invite)
+                }
+                rotateRow
+            case .failed(let message):
+                unreachable(message)
+            }
+        } header: {
+            SectionHeaderLabel(title: machine.name)
+        } footer: {
+            Text(footnote)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .task { await ask() }
+    }
+
+    // MARK: - Pieces
+
+    private func addressRow(_ invite: RemotePairing.Invite) -> some View {
+        HStack(spacing: 8) {
+            Text(invite.url)
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+            Spacer(minLength: 8)
+            // The *link*, not the address: a bare URL is not enough to pair
+            // with, and copying one that looks like it should be is how someone
+            // spends ten minutes wondering why the phone refuses it.
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(invite.link, forType: .string)
+                copied = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copied = false }
+            } label: {
+                Label(
+                    copied ? localized("Copied") : localized("Copy Invite"),
+                    systemImage: copied ? "checkmark" : "doc.on.doc")
+            }
+            .buttonStyle(.borderless)
+            .fixedSize()
+        }
+    }
+
+    private var rotateRow: some View {
+        LabeledContent {
+            Button(localized("Rotate Token…")) { confirmRotate = true }
+                .confirmationDialog(
+                    localized("Rotate the pairing token?"),
+                    isPresented: $confirmRotate,
+                    titleVisibility: .visible
+                ) {
+                    Button(localized("Rotate Token"), role: .destructive) {
+                        Task { await ask(rotate: true) }
+                    }
+                    Button(localized("Cancel"), role: .cancel) {}
+                } message: {
+                    Text(localized("Every iPhone paired with \(machine.name) is signed out and must re-scan the new QR to reconnect."))
+                }
+        } label: {
+            SettingsLabel(
+                title: localized("Pairing Token"),
+                subtext: localized("Issues a new token and revokes every paired iPhone."),
+                titleFont: .headline)
+        }
+    }
+
+    /// The box could not mint an invite. Its own words, verbatim and monospaced —
+    /// they are terminal output, and the fixes they name are commands.
+    ///
+    /// The address field is the first of those fixes, made typable: `termiod`
+    /// says "pass `--url https://<host>/termio/`", and this is that flag with a
+    /// text box in front of it. Only the box's *name* is missing; everything
+    /// else about pairing already works, which is why one field closes it.
+    private func unreachable(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(localized("\(machine.name) has nothing to pair against"), systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.secondary)
+            Text(message)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                TextField(
+                    localized("Public address"), text: $address,
+                    prompt: Text(verbatim: "https://example.com/termio/"))
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit { pair(at: address) }
+                Button(localized("Pair")) { pair(at: address) }
+                    .buttonStyle(.bordered)
+                    .disabled(address.trimmingCharacters(in: .whitespaces).isEmpty)
+                Button(localized("Try Again")) { Task { await ask() } }
+                    .buttonStyle(.bordered)
+            }
+            // Said once, here, where someone is about to type an address: this
+            // invite carries it, the next one will not. Persisting it is the
+            // daemon's `--wss-origin`, which is a decision about how the box
+            // runs — not something an app should write behind the user's back.
+            Text(localized("Used for this invite only. To make it stick, start the daemon there with --wss-origin."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// The typed address, or `nil` when there is none — so a rotate carries the
+    /// address that worked rather than dropping back to the box's own idea of
+    /// itself, which is the one that already failed.
+    private var nonEmptyAddress: String? {
+        let trimmed = address.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func pair(at url: String) {
+        let trimmed = url.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        Task { await ask(url: trimmed) }
+    }
+
+    private var footnote: String {
+        switch phase {
+        case .ready:
+            return localized("On iPhone, tap the Mac pill ▸ Scan QR Code. The token is minted on \(machine.name) and demanded on every connection.")
+        default:
+            return localized("A box can only be paired with once its termiod is running and reachable from outside — a tunnel, or a proxy in front of it.")
+        }
+    }
+
+    /// `url` empty means "ask the box what it knows" — the first attempt, and
+    /// the right one whenever the daemon there was started with `--wss-origin`.
+    private func ask(url: String? = nil, rotate: Bool = false) async {
+        guard let alias = machine.alias else { return }
+        phase = .asking
+        do {
+            phase = .ready(try await RemotePairing.invite(
+                from: alias, url: url ?? nonEmptyAddress, rotate: rotate))
+        } catch let failure as RemotePairing.Failure {
+            phase = .failed(failure.message)
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -72,6 +72,86 @@ struct SettingsSymbolBadge: View {
 /// an icon still lines its title up with the ones that have one.
 let settingsRowIconWidth: CGFloat = 26
 
+/// The gutter AppKit hangs under an editable table — the `+` strip in System
+/// Settings' Login Items and Users & Groups. Sits as the last row of the section
+/// whose list it acts on, wearing its own faint fill so it reads as the list's
+/// chrome rather than as one more entry.
+///
+/// It replaces a full-width "Add Device" / "Add Agent" row, which was the same
+/// height, in the same text column, with the same hit target as the entries
+/// above it — so the roster looked like it contained a device named Add Device.
+///
+/// There is no `−`. AppKit's minus acts on the table's selected row, and these
+/// rosters drill into a pane on click rather than select; the pane a row opens
+/// already carries that row's Remove. Both ways of paying for a minus here were
+/// built and dropped: a pull-down naming its own target is a menu pretending to
+/// be a button, and giving the rows a selection to act on costs the click that
+/// opens them — a mode, a highlight and a double-click, so that a verb one click
+/// away can have a second door.
+struct SettingsListGutter<Content: View>: View {
+    /// The gutter's control — a `SettingsGutterGlyph`, which spans the strip.
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        content()
+            .frame(height: settingsGutterHeight)
+            // Rounded on all four corners rather than square, because the strip cannot
+            // reach the card's own corners and inherit their curve the way an AppKit
+            // table's gutter does: the grouped `Form` insets every row about 10pt from
+            // the card edge, and that inset survives `listRowInsets(EdgeInsets())` both
+            // on the row and on its background — both were tried. Inset and square it
+            // read as a rectangle dropped inside a rounded card; inset and rounded it
+            // reads as the control it actually is.
+            .background(
+                RoundedRectangle(cornerRadius: settingsGutterCornerRadius, style: .continuous)
+                    .fill(Color.primary.opacity(0.04))
+            )
+            // The Form already rules off the row above; the strip drawing a second
+            // hairline of its own put two lines a row's padding apart.
+            .listRowSeparator(.hidden)
+    }
+}
+
+/// The gutter's control: a glyph parked in the rows' icon column, and behind it a
+/// hit target spanning the whole strip.
+///
+/// AppKit sizes its gutter segments to their glyph, which left a 30pt square to
+/// aim at under a card several hundred points wide — the rest of the strip looked
+/// like a button and wasn't one. A row-wide target costs nothing to draw and is
+/// the size Fitts' law says the only control on a line should be. The hover fill
+/// is what says so before the click: it lands on the next frame, no fade, like
+/// every other hover cue in the app.
+struct SettingsGutterGlyph: View {
+    let symbol: String
+
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Image(systemName: symbol)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: 30)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, minHeight: settingsGutterHeight)
+        .background(
+            RoundedRectangle(cornerRadius: settingsGutterCornerRadius, style: .continuous)
+                .fill(hovering ? Color.primary.opacity(0.06) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+    }
+}
+
+/// AppKit's table gutter is a hair shorter than a list row, which is what keeps
+/// it reading as chrome rather than as one more entry.
+private let settingsGutterHeight: CGFloat = 28
+
+/// The strip's own curve. Small enough to read as a control sitting in the card
+/// rather than as a second card inside the first.
+private let settingsGutterCornerRadius: CGFloat = 6
+
 /// A grouped-section header rendered as a badge plus title, replacing the default
 /// uppercased gray caption so each card reads as a labeled group (Dia style).
 struct SectionHeaderLabel: View {

--- a/Sources/termio/Settings/SettingsTab.swift
+++ b/Sources/termio/Settings/SettingsTab.swift
@@ -8,12 +8,12 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case appearance
     case terminal
     case keyboard
-    /// Sits directly above Devices because that is the containment order the app
-    /// itself uses: a workspace belongs to a device, and everything filed in it
-    /// lives on that machine.
-    case workspaces
     /// The roster: this Mac and every device sessions can run on, one row apiece,
     /// drilling into how that device is reached.
+    ///
+    /// Sits directly above Workspaces because that is the containment order the
+    /// app itself uses: a workspace belongs to a device, so the machine is named
+    /// before the things filed on it.
     ///
     /// **Devices**, matching the word the whole codebase already uses —
     /// `KnownDevice`, `DeviceRoster`, `DeviceClient`, `deviceInvite` — so the UI
@@ -31,18 +31,28 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     /// everyone who left this one showing. It has now survived four renamings,
     /// which is the point of it.
     case devices = "ssh"
+    case workspaces
     case agents
     case usage
+    /// Pairing an iPhone, and the tunnel that carries it.
+    ///
+    /// This was folded into Devices ▸ this Mac ▸ Serving on the argument that
+    /// every line of it is a fact about one machine (see `DeviceServingSection`).
+    /// That argument was right about scope and wrong about cost: it put the QR —
+    /// the one step a new user cannot guess at — three levels down a tab named
+    /// after something else. A setting nobody finds is not a setting. It is
+    /// first-level again, and the card names the machine it answers for, which
+    /// is what the scope objection was actually asking for.
+    case mobile
     case community
 
     var id: String { rawValue }
 
-    /// Opens a new sidebar group. Workspaces starts the run about the machines
-    /// this Mac reaches and what runs on them — a workspace, the device holding
-    /// it, the agents, their usage, the phone watching them — where the group
-    /// above is how the app itself behaves; Community stands alone because it
-    /// leaves the app entirely.
-    var startsGroup: Bool { self == .workspaces || self == .community }
+    /// Opens a new sidebar group. Devices starts the run about the machines this
+    /// Mac reaches and what runs on them — the device, the workspaces filed on
+    /// it, the agents, their usage — where the group above is how the app itself
+    /// behaves; Community stands alone because it leaves the app entirely.
+    var startsGroup: Bool { self == .devices || self == .community }
 
     /// `allCases` cut into the sidebar's groups, which System Settings separates
     /// with a gap rather than a header. Derived from `startsGroup` so a new tab
@@ -72,6 +82,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .keyboard: return localized("Keyboard")
         case .agents: return localized("Agents")
         case .usage: return localized("Usage")
+        case .mobile: return localized("Mobile")
         case .community: return localized("Community")
         }
     }
@@ -88,6 +99,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .keyboard: return .keyboard
         case .agents: return .bot
         case .usage: return .chartColumn
+        case .mobile: return .smartPhoneWifi
         case .community: return .bubbleChat
         }
     }
@@ -104,6 +116,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .keyboard: return localized("Keyboard shortcuts for every command")
         case .agents: return localized("The coding agents offered when you start a session")
         case .usage: return localized("Token usage for your connected agents")
+        case .mobile: return localized("Pair your iPhone with the machines you work on")
         case .community: return localized("Discord, GitHub, and the WeChat group")
         }
     }

--- a/Sources/termio/Settings/SettingsView.swift
+++ b/Sources/termio/Settings/SettingsView.swift
@@ -67,13 +67,20 @@ struct SettingsView: View {
                             // `Section` — which does leave the right gap — squares
                             // off the top corners of its first row's pill.
                             .padding(.top, index > 0 && position == 0 ? 13 : 0)
-                            .listRowInsets(EdgeInsets(top: 1, leading: 10, bottom: 1, trailing: 10))
+                            // Leading is left at zero and paid back in `row(for:)`
+                            // instead — see `settingsSidebarBaseIndent`. Trailing
+                            // behaves, so it is set here and only has to make up
+                            // the ~4pt the list already leaves on that side.
+                            .listRowInsets(EdgeInsets(
+                                top: 1, leading: 0,
+                                bottom: 1, trailing: settingsSidebarPillInset - 4))
                             .tag(tab)
                             // Strips the source list's own selection fill, which
                             // would otherwise draw the full row height behind the
-                            // pill. Mounted in a row: that is where the walk-up
-                            // reaches the table (see `OutlineViewFixups`).
-                            .background(OutlineViewFixups())
+                            // pill, and takes its leading indent with it. Mounted
+                            // in a row: that is where the walk-up reaches the
+                            // table (see `OutlineViewFixups`).
+                            .background(OutlineViewFixups(style: .fullWidth))
                     }
                 }
             }
@@ -90,7 +97,28 @@ struct SettingsView: View {
                         // title + subtitle into one inline "Title – Subtitle" line
                         // beside the traffic lights. An empty principal item forces
                         // the full-height two-line chrome on every pane (macOS 26).
-                        ToolbarItem(placement: .principal) { Text("") }
+                        //
+                        // It carries a definite 1×1 frame: a bare `Text("")`
+                        // measures zero in both axes, and AppKit answers that by
+                        // re-measuring the item under ambiguous constraints and
+                        // logging about it — four times per tab switch, on the
+                        // main thread, which is work the switch pays for.
+                        //
+                        // macOS 26 backs every toolbar item with the shared glass,
+                        // and at this item's 1pt width that backing is all you see:
+                        // a stray hairline standing in the middle of the title bar.
+                        // The item has to stay — it is what keeps the two-line
+                        // chrome — so the background is what goes.
+                        if #available(macOS 26.0, *) {
+                            ToolbarItem(placement: .principal) {
+                                Color.clear.frame(width: 1, height: 1)
+                            }
+                            .sharedBackgroundVisibility(.hidden)
+                        } else {
+                            ToolbarItem(placement: .principal) {
+                                Color.clear.frame(width: 1, height: 1)
+                            }
+                        }
                     }
                     .toolbarBackground(.regularMaterial, for: .windowToolbar)
             }
@@ -121,12 +149,15 @@ struct SettingsView: View {
             HugeIconView(icon: tab.icon, size: 15, color: isSelected ? .white : .primary)
         }
         .foregroundStyle(isSelected ? Color.white : Color.primary)
-        .padding(.horizontal, 8)
+        .padding(.horizontal, settingsSidebarPillPadding)
         .frame(maxWidth: .infinity, minHeight: 30, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 7, style: .continuous)
                 .fill(isSelected ? Color.accentColor : Color.clear)
         )
+        // Applied *after* the pill so the pill widens with the row rather than
+        // sliding out from under it, and last so nothing downstream re-insets it.
+        .padding(.leading, settingsSidebarPillInset - settingsSidebarBaseIndent)
     }
 
     @ViewBuilder
@@ -145,7 +176,30 @@ struct SettingsView: View {
         case .agents:
             AgentSettingsTab(settings: settings, store: store)
         case .usage: UsageSettingsTab(settings: settings, usage: usage)
+        case .mobile: MobileSettingsTab(store: store)
         case .community: CommunitySettingsTab()
         }
     }
 }
+
+/// Where a sidebar row lands. `pillInset + pillPadding` is the icon's leading
+/// edge, aimed at the close button's — a sidebar whose items hang to the right of
+/// the traffic lights reads as a column that was nudged and never lined back up,
+/// and it is the first thing the eye checks, since the two are the only things on
+/// that edge.
+///
+/// `baseIndent` is what the sidebar list indents every row by before any inset of
+/// ours, and it is the reason the first three attempts at this moved nothing:
+/// it is not reachable from `listRowInsets`, from `contentMargins` at either
+/// placement, or from the table's style — each was tried and measured, and the
+/// pill stayed at 26.7pt. So it is paid back rather than removed, with a negative
+/// leading padding on the row.
+///
+/// The number is measured off a screenshot, not guessed: the window's left edge
+/// comes from fitting its rounded corner, the scale from the sidebar's own 184pt
+/// minimum width, and the indent is then pill-left minus the inset that produced
+/// it. Re-measure the same way if a macOS release moves it; a wrong value shows
+/// up immediately as rows that overhang the window or sit short of the lights.
+private let settingsSidebarBaseIndent: CGFloat = 18.7
+private let settingsSidebarPillInset: CGFloat = 10
+private let settingsSidebarPillPadding: CGFloat = 6

--- a/Sources/termio/Settings/WorkspaceSettingsTab.swift
+++ b/Sources/termio/Settings/WorkspaceSettingsTab.swift
@@ -17,14 +17,22 @@ struct WorkspaceSettingsTab: View {
         Form {
             Section {
                 ForEach(store.orderedWorkspaces) { workspace in
-                    WorkspaceSettingsRow(
-                        workspace: workspace,
-                        isCurrent: workspace.id == store.currentWorkspaceID,
-                        sessionCount: store.sessions(inWorkspace: workspace.id).count,
-                        canRemove: store.hasMultipleWorkspaces,
-                        rename: { store.presentRenameWorkspacePanel(workspace.id) },
-                        remove: { store.confirmRemoveWorkspace(workspace.id) }
-                    )
+                    NavigationLink(value: WorkspaceRoute(id: workspace.id)) {
+                        WorkspaceSettingsRow(
+                            workspace: workspace,
+                            isCurrent: workspace.id == store.currentWorkspaceID,
+                            sessionCount: store.sessions(inWorkspace: workspace.id).count
+                        )
+                    }
+                    .contextMenu {
+                        Button(localized("Rename…")) {
+                            store.presentRenameWorkspacePanel(workspace.id)
+                        }
+                        Button(localized("Remove"), role: .destructive) {
+                            store.confirmRemoveWorkspace(workspace.id)
+                        }
+                        .disabled(!store.hasMultipleWorkspaces)
+                    }
                 }
                 newWorkspaceControl
             } header: {
@@ -38,63 +46,74 @@ struct WorkspaceSettingsTab: View {
             }
         }
         .formStyle(.grouped)
+        .navigationDestination(for: WorkspaceRoute.self) { route in
+            WorkspacePane(store: store, id: route.id)
+        }
     }
 
-    /// A plain verb on one machine, a device pull-down once there is a second box
+    /// A plain `+` on one machine, a device pull-down once there is a second box
     /// to put a workspace on — the same collapse the menus make
     /// (`refreshNewWorkspaceItem`). A workspace belongs to exactly one machine, so
     /// the choice has to be made somewhere; making it here keeps the device level
     /// invisible to someone who owns one machine.
+    ///
+    /// Both branches live in the list's gutter (see `SettingsListGutter`), which
+    /// is what keeps them looking alike: the glyph is the same either way, and
+    /// only whether it opens a menu changes.
     @ViewBuilder
     private var newWorkspaceControl: some View {
         let others = DeviceRoster.cloneTargets(in: store)
-        if others.isEmpty {
-            Button {
-                store.presentNewWorkspacePanel(on: .thisMac)
-            } label: {
-                Label(localized("New Workspace"), systemImage: "plus")
-            }
-        } else {
-            Menu {
-                Button(localized("This Mac")) {
+        SettingsListGutter {
+            if others.isEmpty {
+                Button {
                     store.presentNewWorkspacePanel(on: .thisMac)
+                } label: {
+                    SettingsGutterGlyph(symbol: "plus")
                 }
-                ForEach(others) { device in
-                    Button(device.name) {
-                        store.presentNewWorkspacePanel(on: WorkspaceDevice(alias: device.alias))
+                .buttonStyle(.plain)
+                .help(localized("New Workspace"))
+                .accessibilityLabel(localized("New Workspace"))
+            } else {
+                Menu {
+                    Button(localized("This Mac")) {
+                        store.presentNewWorkspacePanel(on: .thisMac)
                     }
+                    ForEach(others) { device in
+                        Button(device.name) {
+                            store.presentNewWorkspacePanel(on: WorkspaceDevice(alias: device.alias))
+                        }
+                    }
+                } label: {
+                    SettingsGutterGlyph(symbol: "plus")
                 }
-            } label: {
-                Label(localized("New Workspace"), systemImage: "plus")
+                .menuStyle(.button)
+                .buttonStyle(.plain)
+                .menuIndicator(.hidden)
+                .help(localized("New Workspace"))
+                .accessibilityLabel(localized("New Workspace"))
             }
-            // Borderless so the two branches of this control look alike: with one
-            // machine it is a plain row (the `Button` above, matching Devices' "Add
-            // Host"), and the bordered pull-down default would turn the same verb
-            // into the only filled slab on the pane the moment a second machine
-            // exists. The bezel comes back on hover, the way every row-level
-            // control in System Settings behaves.
-            .menuStyle(.borderlessButton)
-            .fixedSize()
         }
     }
 }
 
-/// One workspace: its name, the machine and session count under it, and the two
-/// verbs that reshape it behind a trailing menu.
+/// What a row pushes. A named type so the settings window's shared navigation
+/// stack can't confuse a workspace with another pane's string destination.
+private struct WorkspaceRoute: Hashable {
+    let id: Workspace.ID
+}
+
+/// One workspace: its name, the machine and session count under it, and a mark
+/// when it is the one on screen. No controls — the row opens onto them.
 ///
-/// The row carries exactly one control, at the trailing edge, and says everything
-/// else in type — the shape every list row in System Settings has. An earlier
-/// version put the name in a bordered text field and Remove in a bordered button
-/// on every row, which stacked two control chromes inside a grouped row that
-/// already draws its own background: three rows of boxes inside boxes, with the
-/// name's baseline pushed off the caption's leading edge by the field's insets.
+/// The mark sits at the trailing edge. Leading, it needed a reserved column on
+/// every row to keep the names on one edge, which is a column of blank space
+/// paid for by every workspace so that one of them can be ticked — and the names
+/// still read as indented from the card. Trailing, it lands beside the chevron,
+/// where a list puts its state.
 private struct WorkspaceSettingsRow: View {
     let workspace: Workspace
     let isCurrent: Bool
     let sessionCount: Int
-    let canRemove: Bool
-    let rename: () -> Void
-    let remove: () -> Void
 
     /// The machine the workspace is on, and what removing it would cost. Zero
     /// sessions say so by omission rather than reading "0 sessions".
@@ -106,14 +125,6 @@ private struct WorkspaceSettingsRow: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            // The same mark the switcher menu puts beside the workspace on screen,
-            // holding its width on every row so the names share one leading edge.
-            Image(systemName: "checkmark")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(isCurrent ? Color.secondary : Color.clear)
-                .frame(width: 12)
-                .accessibilityHidden(!isCurrent)
-                .accessibilityLabel(localized("Current workspace"))
             VStack(alignment: .leading, spacing: 2) {
                 Text(workspace.name)
                     .font(.headline)
@@ -126,35 +137,109 @@ private struct WorkspaceSettingsRow: View {
                     .truncationMode(.middle)
             }
             Spacer(minLength: 8)
-            actions
+            if isCurrent {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(localized("Current workspace"))
+            }
         }
-        .contentShape(Rectangle())
-        .contextMenu { actionButtons }
+    }
+}
+
+/// One workspace's pane: what it is called, where it lives, and how to get rid of
+/// it — the two verbs that used to hide behind a `⋯` on every row.
+///
+/// Renaming happens in the field rather than in the modal panel the menus open:
+/// a panel is the right shape when the verb is invoked from a menu with no pane
+/// to put a field in, and the wrong one when you are already looking at the
+/// thing's own page.
+private struct WorkspacePane: View {
+    @ObservedObject var store: TermioStore
+    let id: Workspace.ID
+
+    /// The name being typed, committed on return or on leaving. Bound straight to
+    /// the store, an emptied field would read back as the old name on the very
+    /// next keystroke and make the name impossible to retype.
+    @State private var draftName = ""
+    @Environment(\.dismiss) private var dismiss
+
+    private var workspace: Workspace? {
+        store.orderedWorkspaces.first { $0.id == id }
     }
 
-    /// The trailing overflow menu. Borderless and unindicated so the row reads as
-    /// type with one affordance in it, rather than as a row of buttons.
-    private var actions: some View {
-        Menu {
-            actionButtons
-        } label: {
-            Image(systemName: "ellipsis.circle")
-                .font(.system(size: 13))
-                .foregroundStyle(.secondary)
+    var body: some View {
+        if let workspace {
+            Form {
+                Section {
+                    LabeledContent {
+                        TextField("", text: $draftName, prompt: Text(workspace.name))
+                            .multilineTextAlignment(.trailing)
+                            .labelsHidden()
+                            .frame(minWidth: 180)
+                            .onSubmit { commit() }
+                    } label: {
+                        SettingsLabel(
+                            title: localized("Name"),
+                            subtext: localized("What this workspace is called in the sidebar."),
+                            titleFont: .headline
+                        )
+                    }
+                    LabeledContent {
+                        Text(workspace.device.displayName).foregroundStyle(.secondary)
+                    } label: {
+                        SettingsLabel(
+                            title: localized("Device"),
+                            subtext: localized("The machine everything filed under this workspace lives on."),
+                            titleFont: .headline
+                        )
+                    }
+                }
+
+                Section {
+                    LabeledContent {
+                        Button(localized("Remove…"), role: .destructive) {
+                            store.confirmRemoveWorkspace(id)
+                            // The alert runs modally, so by here the answer is in:
+                            // gone means leave, cancelled means stay.
+                            if workspaceIsGone { dismiss() }
+                        }
+                        // The store refuses to remove the last workspace — the
+                        // sidebar has to have a scope to show — so the button dims
+                        // rather than answering a click with nothing.
+                        .disabled(!store.hasMultipleWorkspaces)
+                    } label: {
+                        SettingsLabel(
+                            title: localized("Remove Workspace"),
+                            subtext: localized("Closes every session in it. The folders on disk are left alone.")
+                        )
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle(workspace.name)
+            .task(id: id) { draftName = workspace.name }
+            .onDisappear { commit() }
+        } else {
+            // The workspace went away under us — removed from the switcher while
+            // its pane was open.
+            ContentUnavailableView {
+                Text(localized("Workspace Unavailable"))
+            } description: {
+                Text(localized("This workspace is no longer on your list."))
+            }
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .accessibilityLabel(localized("Workspace actions"))
     }
 
-    @ViewBuilder
-    private var actionButtons: some View {
-        Button(localized("Rename…"), action: rename)
-        // The store refuses to remove the last workspace — the sidebar has to have
-        // a scope to show — so the row dims rather than answering a click with
-        // nothing.
-        Button(localized("Remove"), role: .destructive, action: remove)
-            .disabled(!canRemove)
+    private var workspaceIsGone: Bool {
+        !store.orderedWorkspaces.contains { $0.id == id }
+    }
+
+    /// Writes the draft back. The store drops an empty or whitespace-only name, so
+    /// the field is resynced from what actually landed rather than from what was
+    /// typed.
+    private func commit() {
+        store.renameWorkspace(id, to: draftName)
+        draftName = workspace?.name ?? draftName
     }
 }

--- a/Sources/termio/Sidebar/SidebarView.swift
+++ b/Sources/termio/Sidebar/SidebarView.swift
@@ -13,6 +13,12 @@ extension AppSettings {
     }
 }
 
+/// SwiftUI's `.sidebar` list style insets every row about 18pt from the column's leading edge —
+/// two points past the 16pt baseline the navigator toggle above the column sits on. Every row and
+/// section label pulls back by this much, so the whole left side of the sidebar — the toggle in
+/// the toolbar, the section labels, the project and session rows — starts on one line.
+private let sidebarLeadingTrim: CGFloat = 2
+
 /// Left column: projects, each a section containing its sessions. Hovering a
 /// project header reveals VSCode-style quick-add buttons (one per agent preset).
 /// One pinned worktree lifted into the sidebar's top working set, paired with its
@@ -84,7 +90,7 @@ private struct SidebarSectionHeader: View {
         // No `listRowInsets` override — the header keeps the rows' default inset so both
         // share one left baseline. The small leading then lands the label's left edge on
         // the folder/terminal glyph's own inset in its 16pt slot, so they read aligned.
-        .padding(.leading, 2.5)
+        .padding(.leading, 2.5 - sidebarLeadingTrim)
         .contentShape(Rectangle())
         .onTapGesture { toggleCollapsed() }
         .background {
@@ -1068,7 +1074,7 @@ private struct ProjectHeader: View {
             .allowsHitTesting(isHovering)
         }
         .padding(.vertical, 3)
-        .padding(.leading, leadingIndent)
+        .padding(.leading, leadingIndent - sidebarLeadingTrim)
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .onTapGesture { toggleCollapsed() }
@@ -1519,7 +1525,7 @@ private struct SessionRow: View {
         // list. The selection highlight (listRowBackground) stays full-width — the
         // standard macOS source-list look where children inset but the lift spans
         // the row.
-        .padding(.leading, leadingIndent)
+        .padding(.leading, leadingIndent - sidebarLeadingTrim)
         // Keep the bracket in the final 16-point gutter immediately before the child
         // icon. At worktree depth this avoids laying its spine over the branch node's
         // own column while preserving the existing primary-session geometry.
@@ -1527,7 +1533,7 @@ private struct SessionRow: View {
             if let splitLink {
                 SplitLinkGlyph(mark: splitLink, chrome: chrome, isMarked: marksSourceGroup)
                     .frame(width: 16)
-                    .padding(.leading, max(0, leadingIndent - 16))
+                    .padding(.leading, max(0, leadingIndent - 16) - sidebarLeadingTrim)
             }
         }
         .modifier(SessionRowDragAndDrop(session: session, chrome: chrome))
@@ -1618,7 +1624,7 @@ private struct SidebarNoticeRow: View {
             Spacer(minLength: 4)
         }
         .padding(.vertical, settings.interfaceRowPadding)
-        .padding(.leading, 16)
+        .padding(.leading, 16 - sidebarLeadingTrim)
         .contentShape(Rectangle())
         .help(detail ?? title)
     }
@@ -1684,7 +1690,7 @@ private struct DeviceOnlySessionRow: View {
             }
         }
         .padding(.vertical, settings.interfaceRowPadding)
-        .padding(.leading, 16)
+        .padding(.leading, 16 - sidebarLeadingTrim)
         .contentShape(Rectangle())
         .help(helpText)
         .simultaneousGesture(TapGesture().onEnded { store.adoptDeviceSession(information) })
@@ -1777,7 +1783,7 @@ private struct EndedSessionRow: View {
             Spacer(minLength: 4)
         }
         .padding(.vertical, settings.interfaceRowPadding)
-        .padding(.leading, leadingIndent)
+        .padding(.leading, leadingIndent - sidebarLeadingTrim)
         .modifier(SessionRowDragAndDrop(session: session, chrome: chrome))
         .onHover { isHovering = $0 }
         .simultaneousGesture(TapGesture().onEnded { store.selectedSessionID = session.id })

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -574,6 +574,13 @@ extension TermioStore {
         switch outcome {
         case .failure(let error):
             let message = error.localizedDescription
+            // A daemon this app asked to stop is between builds, not gone. The
+            // column keeps its spinner; the loop refreshes it when it is done.
+            if upgradingRoutes.contains(key) {
+                deviceSessions = .loading
+                deviceSessionsRoute = key
+                return
+            }
             // The last good answer is no longer this device's answer, so it
             // cannot stand in for the next reply: a machine that comes back must
             // repaint even if it comes back holding exactly what it held before.
@@ -937,18 +944,29 @@ extension TermioStore {
     }
 
     struct RemoteSetupError {
+        /// The states the lifecycle loop can leave a machine in short of ready
+        /// (RFC §8). `staged` is the one that is not a fault: the binary is in
+        /// place and takes over once the sessions named in `message` close.
+        enum State {
+            case unreachable, staged, unhealthy, failed
+        }
+        let state: State
         let message: String
     }
 
-    /// Ensures `host` has `termiod` deployed before an attach — the same
-    /// idempotent check the CLI's `remote open` runs (`test -x ~/.local/bin/termiod`,
-    /// deploy if absent, see termiod/src/remote.rs). Runs off the main thread with a
-    /// borderless "Setting up host…" HUD; `completion` fires back on the main queue.
-    /// The deploy step shells out to the *local* `termiod remote deploy <host>`
-    /// (which cross-compiles + scps), so the app never re-implements the deploy.
+    /// Ensures `host` runs the `termiod` this app ships before an attach, by
+    /// running the daemon's own lifecycle loop against it (`termiod deploy
+    /// --host`): observe, stage the binary if older, stop the old daemon if it
+    /// is idle, verify the new one answers, roll back if it does not. Runs off
+    /// the main thread with a borderless "Setting up host…" HUD; `completion`
+    /// fires back on the main queue.
     func ensureRemoteReady(host: String, completion: @escaping (RemoteSetupResult) -> Void) {
         let hud = RemoteSetupHUD(message: "Setting up \(host)…")
         hud.show()
+        // While the loop may have the daemon down, a failed roster is the restart
+        // in progress, not an unreachable machine (RFC §5.5).
+        let route = TermiodRoute.ssh(host)
+        upgradingRoutes.insert(route.description)
         // Only the probe leaves the main actor. `completion` is the caller's
         // closure and captures main-actor state, so it must never be sent to
         // another isolation domain — it is called here, where it was formed.
@@ -957,11 +975,16 @@ extension TermioStore {
                 Self.performRemoteReadyCheck(host: host)
             }.value
             hud.dismiss()
+            guard let self else { return }
+            self.upgradingRoutes.remove(route.description)
             // Whatever the caller does next, the alias has now resolved to a
             // machine — write that down before handing back, so state keyed by
             // device is addressable by the time it is read.
             if case .success(let device) = result {
-                self?.adoptDevice(device, forRoute: .ssh(host))
+                self.adoptDevice(device, forRoute: route)
+            }
+            if self.currentDevice.route == route {
+                self.refreshDeviceSessions()
             }
             completion(result)
         }
@@ -981,105 +1004,72 @@ extension TermioStore {
         }.value
     }
 
-    /// The blocking half of `ensureRemoteReady`, run off-main. Probes for the
-    /// remote binary and, when missing, invokes the local `termiod remote deploy`.
-    /// `nonisolated` because it is invoked from a background queue and touches only
-    /// process/filesystem primitives — never `TermioStore`'s main-actor state.
+    /// The blocking half of `ensureRemoteReady`, run off-main: one process, one
+    /// JSON document. The loop itself lives in the daemon (`lifecycle.rs`) so
+    /// that every state a machine can be in is decided by the binary that also
+    /// runs on the machine; this side only turns the report into a sentence.
+    /// `nonisolated` because it is invoked from a background queue and touches
+    /// only process primitives — never `TermioStore`'s main-actor state.
     private nonisolated static func performRemoteReadyCheck(host: String) -> RemoteSetupResult {
-        // Which device is behind this alias, asked with a hello and hung up. The
-        // handshake is the only thing that can answer it, and it is the same
-        // handshake the attach would run anyway.
-        func identify() -> Result<TermiodDevice, Error> {
-            Result { try Termiod.probeDevice(route: .ssh(host)) }
-        }
-
-        // A quick reachability + presence probe. `BatchMode=yes` keeps it from
-        // hanging on a password prompt (the user's key/agent must already work,
-        // exactly as `ssh <host>` in a plain terminal would need). The remote path
-        // mirrors `Termiod.remoteBinary()` (`$HOME/.local/bin/termiod`).
-        let probe = runProcess(
-            "/usr/bin/ssh",
-            ["-o", "BatchMode=yes",
-             "-o", "ConnectTimeout=\(Termiod.connectTimeoutSeconds)", host,
-             "test -x $HOME/.local/bin/termiod && echo yes || echo no"]
-        )
-        guard let probe else {
-            return .failure(RemoteSetupError(message: "Couldn't run ssh to reach \(host)."))
-        }
-        if probe.exitCode != 0 {
-            // A non-zero ssh exit before our echo means the connection or auth
-            // failed — surface ssh's own last line, which names the cause.
-            let detail = probe.standardError
-                .split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
-                .last(where: { !$0.isEmpty }) ?? "Connection failed"
-            return .failure(RemoteSetupError(
-                message: "Couldn't reach \(host) over SSH.\n\(detail)"))
-        }
-        /// Whether the daemon answering on this host can install agent
-        /// integration. Since the installers moved onto the box, a daemon that
-        /// predates the `agents` capability writes nothing — where before the
-        /// move the same box still got its hooks, because the Mac did the
-        /// writing over ssh. That regression must not be silent.
-        func canInstallAgents() -> Bool {
-            (try? Termiod.supportsAgentInstall(route: .ssh(host))) ?? false
-        }
-
-        var upgrading = false
-        if probe.standardOutput.contains("yes") {
-            // Already deployed — the common case after first use.
-            switch identify() {
-            case .success(let device):
-                if canInstallAgents() { return .success(device) }
-                // Present is not the same as current. Put the new binary in
-                // place; whether the *running* daemon picks it up is the next
-                // question, and it is not ours to force.
-                upgrading = true
-            case .failure(let error):
-                // The binary is there but will not shake hands: a stale daemon, a
-                // protocol mismatch, a half-written deploy. Say so rather than
-                // opening a pane that dies on attach for an unexplained reason.
-                return .failure(RemoteSetupError(
-                    message: "termiod on \(host) didn't answer.\n\(error.localizedDescription)"))
-            }
-        }
-
-        // Missing: deploy via the local termiod binary's `remote deploy`, which
-        // cross-compiles the aarch64-musl daemon and scps it (termiod/DEPLOY.md).
         let localBinary = Termiod.daemonBinaryPath()
         guard FileManager.default.isExecutableFile(atPath: localBinary) else {
-            let what = upgrading
-                ? "termiod on \(host) is too old to install agent integration, and the local"
-                : "termiod isn't deployed on \(host), and the local"
             return .failure(RemoteSetupError(
-                message: "\(what) termiod binary to deploy it wasn't found at \(localBinary)."))
+                state: .failed,
+                message: "The termiod binary to deploy wasn't found at \(localBinary)."))
         }
-        let deploy = runProcess(localBinary, ["remote", "deploy", host])
-        guard let deploy, deploy.exitCode == 0 else {
-            let detail = deploy.map { output in
-                (output.standardError + output.standardOutput)
-                    .split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
-                    .last(where: { !$0.isEmpty }) ?? "deploy failed"
-            } ?? "couldn't run termiod remote deploy"
+        guard let run = runProcess(localBinary, ["deploy", "--host", host, "--json"]) else {
             return .failure(RemoteSetupError(
-                message: "Couldn't deploy termiod to \(host).\n\(detail)"))
+                state: .failed, message: "Couldn't run termiod deploy."))
         }
-        switch identify() {
-        case .success(let device):
-            guard upgrading, !canInstallAgents() else { return .success(device) }
-            // The new binary is in place and the *running* daemon is still the
-            // old one: `mv` over a running executable leaves the process holding
-            // the old inode, which is the whole reason the deploy is safe. It is
-            // not restarted from here on purpose — a termiod restart kills every
-            // session it owns, and detach-≠-kill is the promise the daemon
-            // exists for. So this names the state and the cost, and stops.
+        let report: Termiod.LifecycleReport
+        do {
+            report = try Termiod.LifecycleReport.decode(Data(run.standardOutput.utf8))
+        } catch {
+            // No report means the loop never ran to a state: the binary could
+            // not start, or died. Its last words are the diagnosis.
+            let detail = run.standardError
+                .split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+                .last(where: { !$0.isEmpty }) ?? "termiod deploy exited \(run.exitCode)"
             return .failure(RemoteSetupError(
-                message: "Updated termiod on \(host), but the daemon still running there is "
-                    + "the older one and can't install agent integration. It takes over once "
-                    + "that daemon exits — close the sessions on \(host) and set it up again."))
-        case .failure(let error):
+                state: .failed, message: "Couldn't set up termiod on \(host).\n\(detail)"))
+        }
+        switch report.state {
+        case .current:
+            guard let hostID = report.hostId, let version = report.version else {
+                return .failure(RemoteSetupError(
+                    state: .failed,
+                    message: "termiod on \(host) answered without saying which machine it is."))
+            }
+            return .success(TermiodDevice(
+                id: hostID, daemonVersion: version, routes: [.ssh(host)], lastSeen: Date()))
+        case .staged:
+            // Named, not counted. "1 session" is a number the user cannot act
+            // on: whether to close it depends entirely on whether it is an
+            // agent mid-task or a shell someone left at a prompt, and only the
+            // command answers that.
+            let names = (report.busy ?? [])
+                .map { "• \($0.name) — \($0.command)" }
+                .joined(separator: "\n")
             return .failure(RemoteSetupError(
-                message: "Deployed termiod to \(host), but it didn't answer.\n"
-                    + error.localizedDescription))
+                state: .staged,
+                message: "termiod \(report.desired) is ready on \(host), and takes over once "
+                    + "the sessions still running there close:\n\(names)\n"
+                    + "Close those on \(host) and set it up again."))
+        case .unhealthy:
+            let rolledBack = report.rolledBack == true
+                ? "\nThe previous termiod is back in place." : ""
+            return .failure(RemoteSetupError(
+                state: .unhealthy,
+                message: "Updated termiod on \(host), but the new one didn't answer.\n"
+                    + "\(report.message ?? "")\(rolledBack)"))
+        case .unreachable:
+            return .failure(RemoteSetupError(
+                state: .unreachable,
+                message: "Couldn't reach \(host) over SSH.\n\(report.message ?? "")"))
+        case .failed:
+            return .failure(RemoteSetupError(
+                state: .failed,
+                message: "Couldn't set up termiod on \(host).\n\(report.message ?? "")"))
         }
     }
 

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -235,8 +235,8 @@ extension Termiod {
     /// safe, and the compiler cannot see that.
     nonisolated(unsafe) private static var sshArgumentsCache: [String: [String]] = [:]
 
-    /// Matches the remote-readiness probe in `TermioStore+Termiod.swift`, so
-    /// both roads to a host give up on the same clock.
+    /// Matches the daemon's own ssh (`termiod/src/remote.rs`), so both roads
+    /// to a host give up on the same clock.
     static let connectTimeoutSeconds = 10
 
     /// The argument list itself, taking what the probe found rather than
@@ -592,8 +592,11 @@ extension Termiod {
         guard reply.kind == .control else { throw TermiodClientError.malformedFrame }
         switch try decodeControl(reply.payload) {
         case .helloOk(let payload):
+            // The build stamp when the daemon has one; the banner it has always
+            // sent (`termiod/0.1.0 linux-aarch64`) for one that predates it.
             let device = TermiodDeviceRegistry.shared.record(
-                hostID: payload.hostId, daemonVersion: payload.host, route: transport.route)
+                hostID: payload.hostId, daemonVersion: payload.version ?? payload.host,
+                route: transport.route)
             // An offer the daemon dropped is not an error — negotiate, never
             // lockstep — but it does change what this connection can expect, so
             // it is worth saying out loud once per channel.
@@ -649,20 +652,6 @@ extension Termiod {
     /// cannot install, and says so at the handshake rather than at the write —
     /// which is what turns version skew into a sentence instead of a no-op.
     static let agentCapability = "agents"
-
-    /// Whether the daemon on this route can install agent integration.
-    ///
-    /// Asked with the handshake the caller was going to run anyway, so it costs
-    /// nothing. Used by the device pane's foundation rung: a box whose termiod
-    /// is too old is *redeployed*, so the answer to skew is the rung the user
-    /// was already pressing, not an error they have to act on.
-    static func supportsAgentInstall(route: TermiodRoute) throws -> Bool {
-        let transport = try Transport.open(route)
-        defer { transport.close() }
-        let handshake = try performHello(
-            transport, role: "control", caps: [agentCapability])
-        return handshake.capabilities.contains(agentCapability)
-    }
 
     /// Install (or remove) termio's agent integration on the machine this route
     /// reaches. One round trip for the whole roster.
@@ -724,6 +713,36 @@ extension Termiod {
                     continue
                 }
             }
+        }
+    }
+
+    /// What `termiod deploy --json` left a machine as — the lifecycle loop's
+    /// report (`termiod/src/lifecycle.rs`), read rather than reconstructed.
+    /// The daemon runs the loop; this side only says what the state means.
+    struct LifecycleReport: Decodable, Sendable {
+        enum State: String, Decodable, Sendable {
+            case current, staged, unhealthy, unreachable, failed
+        }
+        struct BusySession: Decodable, Sendable {
+            let name: String
+            let command: String
+            let status: String
+        }
+        let state: State
+        let node: String
+        let desired: String
+        let version: String?
+        let hostId: String?
+        let newer: Bool?
+        let daemon: String?
+        let busy: [BusySession]?
+        let message: String?
+        let rolledBack: Bool?
+
+        static func decode(_ data: Data) throws -> LifecycleReport {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return try decoder.decode(LifecycleReport.self, from: data)
         }
     }
 

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -997,6 +997,12 @@ final class TermioStore: ObservableObject {
 
     var rosterFetches: [String: RosterFetch] = [:]
 
+    /// Routes whose daemon this app has asked to stop and is waiting to see come
+    /// back (`ensureRemoteReady`). A roster that fails meanwhile is the restart
+    /// in progress, not a dead machine — without this the two are the same red
+    /// row. Keyed by `TermiodRoute.description`.
+    var upgradingRoutes: Set<String> = []
+
     /// App-quit teardown: without this, session children outlive the app — the
     /// closing PTY's SIGHUP is swallowed by agent TUIs, and they pile up as
     /// launchd orphans across restarts. Graceful signals first, a short

--- a/Tests/termioTests/TermiodLifecycleReportTests.swift
+++ b/Tests/termioTests/TermiodLifecycleReportTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import TermioShared
+import XCTest
+@testable import termio
+
+/// `termiod deploy --json` is the one document the app reads a machine's
+/// lifecycle state from. These pin the field names the daemon writes
+/// (`termiod/src/lifecycle.rs`, `Report` and `Outcome`) so a rename on either
+/// side fails here rather than as a machine that reads as broken.
+final class TermiodLifecycleReportTests: XCTestCase {
+    func testCurrentCarriesTheVersionAndIdentity() throws {
+        let report = try Termiod.LifecycleReport.decode(Data("""
+        {"node":"ukvps","desired":"0.44.0+1600","state":"current",
+         "version":"0.44.0+1600","host_id":"h_1","newer":false}
+        """.utf8))
+        XCTAssertEqual(report.state, .current)
+        XCTAssertEqual(report.version, "0.44.0+1600")
+        XCTAssertEqual(report.hostId, "h_1")
+        XCTAssertEqual(report.newer, false)
+    }
+
+    func testStagedNamesTheSessionsThatKeptTheOldDaemonUp() throws {
+        let report = try Termiod.LifecycleReport.decode(Data("""
+        {"node":"ukvps","desired":"0.44.0+1600","state":"staged",
+         "version":"0.44.0+1600","daemon":"0.43.0+1500",
+         "busy":[{"id":"1","name":"claude","command":"claude","status":"working",
+                  "attached":0,"alive":true}]}
+        """.utf8))
+        XCTAssertEqual(report.state, .staged)
+        XCTAssertEqual(report.daemon, "0.43.0+1500")
+        XCTAssertEqual(report.busy?.map(\.name), ["claude"])
+        XCTAssertEqual(report.busy?.first?.status, "working")
+    }
+
+    func testUnhealthySaysWhetherItRolledBack() throws {
+        let report = try Termiod.LifecycleReport.decode(Data("""
+        {"node":"ukvps","desired":"0.44.0+1600","state":"unhealthy",
+         "message":"no protocol reply within 10s (Exec format error)","rolled_back":true}
+        """.utf8))
+        XCTAssertEqual(report.state, .unhealthy)
+        XCTAssertEqual(report.rolledBack, true)
+        XCTAssertEqual(report.message, "no protocol reply within 10s (Exec format error)")
+    }
+
+    /// A state this build has never heard of must fail loudly, not decode as
+    /// something it is not.
+    func testAnUnknownStateDoesNotDecode() {
+        XCTAssertThrowsError(try Termiod.LifecycleReport.decode(Data("""
+        {"node":"ukvps","desired":"0.44.0+1600","state":"rebooting"}
+        """.utf8)))
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,5 +127,6 @@ from the real front matter).
 | in-review | rfc | [Every machine is a device, every place you work is a project](design/20260814-remote-to-device.md) |
 | in-review | rfc | [One path — local sessions run through termiod too](design/20260817-one-path-local-through-termiod.md) |
 | in-review | rfc | [Split panes — Ghostty-style splits in the terminal column](design/20260702-split-panes.md) |
+| in-review | rfc | [termiod lifecycle — install and update as one reconcile loop](design/20260827-termiod-lifecycle-reconcile.md) |
 | resolved | bug | [iOS terminal fails "unauthorized" while the session list works (companion over tunnel)](bug/companion-terminal-unauthorized-over-tunnel.md) |
 <!-- END docs-index -->

--- a/docs/design/20260827-termiod-lifecycle-reconcile.md
+++ b/docs/design/20260827-termiod-lifecycle-reconcile.md
@@ -1,0 +1,393 @@
+---
+title: termiod lifecycle — install and update as one reconcile loop
+status: in-review
+type: rfc
+created: 2026-08-27
+updated: 2026-08-27
+related:
+  - 20260825-agent-integration-moves-to-termiod.md
+  - 20260824-agent-integration-on-a-device.md
+  - 20260819-unify-server-plane.md
+  - 20260814-remote-to-device.md
+  - 20260730-termiod-session-protocol.md
+---
+
+# termiod lifecycle: install and update as one reconcile loop
+
+> The Mac is a control plane and every termiod is a data-plane node. Install
+> and update are not two features; they are one loop — observe the node, diff
+> against what should be there, act, verify, roll back — and the node reports
+> its own state instead of being probed. This RFC specifies that loop, the two
+> protocol additions it needs, and the one thing it deliberately does not do.
+
+## 0. What was checked before writing
+
+Every claim below about shipped code was verified against
+`fix/termiod-remote-deploy` (PR #496) and against the daemon running on the
+author's VPS on 2026-08-27.
+
+| Claim | Where |
+| --- | --- |
+| The app bundle already ships static Linux daemons for both architectures | `termio.app/Contents/Resources/termiod-{x86_64,aarch64}-unknown-linux-musl`; `scripts/build-app.sh:298` |
+| Deploy is already atomic: upload beside, `rename(2)` over | `termiod/src/remote.rs` `deploy()` |
+| The handshake carries a protocol number and capabilities but **no build version** | `protocol.rs` `Hello { proto, min_proto, role, caps, client }`, `HelloOk { proto, caps, host_id, host, client_id, home }` |
+| `PROTOCOL_VERSION` has been `1` since the first commit | `protocol.rs:28` |
+| The daemon already drains cleanly on `SIGTERM` | `daemon.rs:449–490` — `begin_draining` / `finish_draining`, socket removed last |
+| Supervision exists on macOS only (launchd); Linux is `setsid` autostart on first client contact | `service.rs` header; `client.rs:75` `spawn_daemon` |
+| "Set up this device" is a ladder of **ten** sequential ssh round trips across two languages | `TermioStore+Termiod.swift:970–1090` `performRemoteReadyCheck` |
+| The ladder never reads a version; it infers "old" from the absence of the `agents` capability | `TermiodClient.swift:658` `supportsAgentInstall` |
+| The restart step can never match: `$HOME` is interpolated inside single quotes and `pkill` exit 1 is accepted as success | `TermioStore+Termiod.swift:1134–1137` |
+| The idle check computes `attachedClients`, prints "nobody attached", then ignores it | `TermioStore+Termiod.swift:1099–1110` `staleDaemonHolds` |
+| A previous binary is already kept on the box and nothing uses it | `~/.local/bin/termiod.prev` on the VPS, written by an earlier deploy |
+
+The VPS at the time of writing had six `termiod serve` processes from protocol
+testing, on six different sockets. An argv-matched `pkill` would have hit two
+of them; the one on the canonical socket was holding a login shell nobody had
+attached to for eleven hours.
+
+## 1. The problem
+
+Setting up a machine today fails in a way the user cannot act on:
+
+> Updated termiod on ukvps, but the daemon still running there is the older one
+> and can't install agent integration. Restarting it would kill what it is
+> hosting, so it is left alone: • /bin/bash (login shell) · nobody attached.
+> Close those on ukvps and set it up again.
+
+Four things are wrong at once, and they share one root:
+
+1. The Mac cannot tell *what version* is on the box, only *whether a capability
+   is present*, so it redeploys on every skew and cannot distinguish "old
+   daemon" from "old binary" from "handshake failed".
+2. The Mac tries to restart the daemon by guessing its process from its command
+   line, and the guess is wrong by construction.
+3. The Mac has the information to know the daemon is idle and does not use it.
+4. Install and update are two code paths with a third — the failure above —
+   that is neither, and has no command that resumes it.
+
+The root: **the control plane is reconstructing the node's state from shell
+probes instead of asking the node**, and it has separate procedures for each
+state it can imagine instead of one loop that handles any state.
+
+## 2. The model
+
+Every modern control plane — the kubelet, Terraform, Ansible, Teleport's agent
+updater — is the same abstraction:
+
+```
+reconcile(desired, observed) → actions
+```
+
+Install is reconcile from an empty box. Update is reconcile from a stale one.
+Repair is reconcile from a broken one. There is one code path; it is idempotent;
+and **recovery from any failure is "run it again"**. The screenshot above stops
+being an error with instructions and becomes a state the loop resumes from.
+
+For termiod, `desired` is fixed by the Mac's own bundle: *the daemon version
+this app ships, running, with this user's agent integration installed.*
+`observed` comes from the node.
+
+## 3. Observe: the node reports itself
+
+Add one read-only subcommand, run on the box by whatever binary is on disk:
+
+```
+termiod status --json
+```
+
+```json
+{
+  "binary":  { "version": "0.44.0", "path": "/home/ubuntu/.local/bin/termiod" },
+  "daemon":  { "running": true, "version": "0.43.0", "pid": 2496439,
+               "socket": "/run/user/1001/termiod/termiod.sock" },
+  "sessions": [
+    { "id": "1c2be530", "command": "/bin/bash (login shell)",
+      "attached": 0, "alive": true }
+  ],
+  "host_id": "…",
+  "supervisor": "none" | "launchd" | "systemd-user"
+}
+```
+
+Three rules:
+
+- **One round trip.** This replaces `test -x`, two handshakes, and a roster
+  read. Latency to a VPS is 200–300 ms per fresh ssh; the ladder today is
+  two to three seconds of pure waiting before anything is written.
+- **The daemon's version comes from the daemon, not from `--version` of the
+  file on disk.** They differ exactly when an update has been staged but not
+  activated, and that is the state the loop most needs to see.
+- **`daemon.pid` comes from the socket, not from `ps`.** The CLI connects to the
+  canonical socket and reads `SO_PEERCRED`. This identifies the process that
+  *owns the socket*, which is the only process the loop may ever stop. It
+  works against a daemon of any version because it never speaks the protocol.
+
+For a daemon too old to answer a `status` control message, the CLI falls back
+to what old daemons can answer — `list` over the existing protocol — and
+reports `daemon.version: null`. The loop treats null as "older than anything
+that reports a version", which is correct.
+
+## 4. Install
+
+Install is the `observed = {}` branch of the loop. Four principles, each
+already the shape of the shipped code or a one-line change to it:
+
+**The bootstrap channel is borrowed.** System ssh, the user's `~/.ssh/config`
+as the authority. This is non-negotiable §3 of the session protocol and it is
+also what every agentless system does (Ansible is nothing but ssh). Nothing
+here adds a transport.
+
+**The artifact is one static binary, chosen by the control plane.** The bundle
+ships musl builds for both Linux architectures; `uname -sm` picks one. The box
+never needs cargo, zig, or a package manager. `cross_compile()` in `remote.rs`
+stays as a developer fallback and is never reached from the app.
+
+**The daemon is handed to the OS supervisor when there is one.** `service.rs`
+does this for launchd. The Linux half — a systemd `--user` unit plus
+`loginctl enable-linger` — is specified there and not built. This RFC does not
+build it either; it records that `status.supervisor` is the field that will
+tell the loop whether "restart" means `systemctl --user restart termiod` or
+"stop it and let the next client autostart it". Both paths converge on the same
+loop; only the activate step differs.
+
+**Install produces an identity, not just a file.** `host.id` is already written
+on first start. The loop's last step registers it in the device list, which is
+what makes every later run a lookup instead of a probe.
+
+## 5. Update
+
+Update is where the real tension lives: **the process being replaced holds
+state that cannot be rebuilt** — a PTY with an agent in it. The loop splits
+this into four steps with different risk, and names the state between each.
+
+### 5.1 Stage
+
+Upload beside the target, `rename(2)` over it. Already shipped and already
+correct: atomic on the filesystem, safe against a running daemon (it keeps the
+old inode), safe to repeat. One addition: **keep the previous binary** as
+`termiod.prev` before the rename. This is an A/B slot, the precondition for
+rollback in §5.4, and it is what the box already has by accident.
+
+After stage, the node is in a named state: **staged** — binary new, daemon
+old. This is not an error. The device pane shows it as one line ("Update ready,
+waiting for the daemon to be idle"), not as a failure.
+
+### 5.2 Activate
+
+The one disruptive step. It is a request to the node, made by the *new* CLI
+running on the box:
+
+```
+termiod stop --if-idle [--force]
+```
+
+- Find the daemon by `SO_PEERCRED` on the socket (§3). Never by argv.
+- Ask it what it holds — `list` over the existing protocol, which every
+  shipped daemon answers.
+- **Idle** means every live session has `attached == 0`. Exit code 0 after
+  `SIGTERM` and waiting for the socket to disappear; the daemon's existing
+  drain path handles the rest.
+- **Busy** means at least one session has a client attached. Print the
+  sessions by name — the user decides whether to close an agent mid-task, and
+  a count cannot inform that decision — and exit non-zero. `--force` overrides.
+
+Two properties matter here:
+
+*It works on the first upgrade.* The old daemon needs no new protocol message;
+`SO_PEERCRED` and `SIGTERM` are kernel facilities and `list` is protocol v1.
+There is no "upgrade once by hand to get graceful upgrades after that".
+
+*"Idle" is decided by the node, with the node's information.* The Mac never
+computes it. This is the HDFS `shutdownDatanode … upgrade` shape: the control
+plane requests, the node — which alone knows what it holds — decides how to
+leave.
+
+The daemon comes back on the next client contact via the autostart that
+already exists. On a supervised box the same command becomes
+`systemctl --user restart` once §4's Linux unit lands; the loop does not
+change.
+
+### 5.3 Verify
+
+Handshake with the new daemon and compare `HelloOk.version` (§6) to the
+bundled version. Then install agent integration through the existing
+`install_agents` message. Success is *verified*, not inferred from `pkill`
+having exited.
+
+### 5.4 Roll back
+
+If the handshake fails, or the new daemon never binds its socket within a
+timeout: `mv termiod.prev termiod`, stop whatever is running, let autostart
+bring the old one back, and report the failure with the new binary's stderr.
+The user is left on the version that worked. Teleport's updater does exactly
+this; so do ChromeOS and Android at the partition level.
+
+### 5.5 The Mac's bookkeeping
+
+While a device is between 5.2 and 5.3, the Mac marks it **upgrading**. Not
+offline, not unreachable. No reconnect storm, no red dot, no "device
+unreachable" alert. A timeout degrades it to unreachable. This is the cheapest
+rule in the RFC and the one the current code most visibly lacks: today, a
+daemon the Mac itself asked to exit looks identical to a dead machine.
+
+## 6. Protocol changes
+
+Two, both additive under protocol v1:
+
+1. **`HelloOk` gains `version: String`** — the daemon's build version
+   (`CARGO_PKG_VERSION`). Optional with `serde(default)`, so old clients ignore
+   it and old daemons omit it. From this point `PROTOCOL_VERSION` starts
+   meaning something: the Mac states the range it supports, and skew is a
+   sentence ("termiod 0.43 on ukvps; this app needs 0.44") instead of a
+   silently missing capability.
+2. **`Control::Status` / `Control::StatusReply`** carrying the fields in §3.
+   Answered by daemons from this version on; §3 defines the fallback for older
+   ones.
+
+No message is needed for *stop*. A control-message shutdown would be cleaner
+than `SIGTERM`, but it would only work against daemons that already have it,
+which is the bootstrap problem this RFC is avoiding. It can be added later as a
+refinement; the `SO_PEERCRED` + `SIGTERM` path stays as the floor.
+
+## 7. What the Swift side becomes
+
+`performRemoteReadyCheck` today is ~120 lines that probe, deploy, re-probe,
+inspect the roster, and try to `pkill`. Under this RFC it is:
+
+```
+status   ← ssh host termiod status --json          (or "no binary")
+if binary missing or binary.version < bundled:
+    scp + rename                                    (stage)
+if daemon.version < bundled:
+    ssh host termiod stop --if-idle                 (activate; busy → report names)
+hello → verify version → install_agents            (verify)
+on failure → mv termiod.prev termiod               (roll back)
+```
+
+Three to four ssh operations, one decision, all state read from one JSON
+document. The `$HOME`-in-single-quotes bug, the two redundant handshakes, and
+the `.sessions`-ignores-`attached` bug are deleted, not fixed.
+
+## 8. Control-plane state machine
+
+The device pane today has one cached state. It needs these, and §3 supplies
+every one of them from a single read:
+
+| State | Meaning | Shown as |
+| --- | --- | --- |
+| `absent` | reachable, no binary | "Set up this device" |
+| `staged` | binary new, daemon old, busy | "Update ready — close *n* sessions" (named) |
+| `upgrading` | Mac asked the daemon to stop; waiting | spinner, no alert |
+| `current` | daemon version == bundled, hooks installed | nothing to do |
+| `unhealthy` | new daemon failed verify; rolled back | the new binary's error |
+| `unreachable` | ssh failed | ssh's own last line |
+
+`staged` and `upgrading` are the two the current code cannot represent, and
+the absence of each produces one of the confusing messages users see today.
+
+## 9. What this RFC does not do
+
+**It does not make sessions survive an upgrade.** Under this RFC, activating an
+update still kills the daemon's sessions — it only refuses to do so when a
+client is attached, and asks first.
+
+The correct fix is known and it is not small. Docker, Kubernetes, and Nomad all
+converged on the same shape: *the process that changes often must not be the
+process that holds the irreplaceable state.* A per-session holder process — the
+`containerd-shim` / Nomad `executor` pattern — owns the PTY master and outlives
+the daemon; the daemon re-adopts its sessions on start. That gives
+upgrade-survival and crash-survival in one move, at the price of one process per
+session and a reattach protocol whose failure modes are a long tail (Nomad's
+issue tracker is the honest preview).
+
+Two alternatives were considered and rejected for this data plane:
+
+- **In-process handoff** (nginx / HAProxy hot restart, systemd's fd store):
+  pass the PTY fds to a new instance of the daemon. This is the right tool when
+  the thing handed over is *retryable* — a listening socket; if the new process
+  fails, clients reconnect. A PTY with an agent in it is not retryable; a
+  failed handoff loses it with no fallback.
+- **Persist and re-adopt** (YARN NodeManager work-preserving restart): only
+  possible when the manager holds no lifeline fd to the work. YARN redirects
+  container I/O to files; termiod holds the PTY master, and closing it SIGHUPs
+  the shell.
+
+The holder-process design should be its own RFC, and **this RFC is its
+precondition**: without version negotiation (§6), a status report (§3), and a
+verify-and-roll-back loop (§5.3–5.4), a reattach failure would be
+undiagnosable. Build the loop first.
+
+**It does not add pull-based updates.** Teleport, Tailscale, and cloudflared
+agents poll for their desired version. termio has no hosted control plane to
+poll and, by design, never will; the Mac pushes over the channel the user
+already trusts. The cost — a machine does not update while the Mac is closed —
+is accepted for the fleet size this targets (one to a few machines the user
+owns) and is consistent with "the session lives on the box": the update is not
+part of the session.
+
+## 10. Prior art
+
+| System | What it contributes here |
+| --- | --- |
+| Kubernetes kubelet / Terraform / Ansible | one reconcile loop; install = reconcile from empty |
+| HDFS `shutdownDatanode … upgrade` | stop is a request with intent; control plane marks "restarting ≠ dead" |
+| Teleport Managed Updates v2 | control plane owns the version; verify after switch; automatic rollback; updater is not the updated |
+| k3s | single static binary, zero host dependencies; systemd unit on install |
+| ChromeOS / Android / CoreOS | A/B slots: keep the previous artifact to make rollback possible |
+| cloudflared graceful restart | new process up and connected *before* the old one drains |
+| Docker / Nomad / containerd | the stability gradient — deferred to the holder-process RFC (§9) |
+
+## 11. Implementation notes
+
+Built as `termiod/src/lifecycle.rs` on 2026-08-27. Where the code departs from
+the text above, the code is right and the reason is recorded here:
+
+- **The loop lives in the daemon, not the app.** `termiod deploy [--host]`
+  runs observe → stage → activate → verify → roll back against a `Node` — this
+  machine, or a box over the user's ssh — and prints one JSON `Report` in the
+  §8 vocabulary. `termiod remote deploy` is the same loop. §7's Swift is one
+  process call and a decode (`Termiod.LifecycleReport`); the ladder, its
+  `pkill`, and `supportsAgentInstall` are deleted. One ssh wrapper remains.
+- **The version is the app's build stamp**, `0.44.0+1533`, not the crate
+  version (pinned at 0.1.0 and never comparable). `termiod/build.rs` takes it
+  from the same `TERMIO_VERSION`/`TERMIO_BUILD` the bundle is stamped with; a
+  checkout reports `0.0.0+<commit count>`, which orders below every release so
+  a dev build never stages itself over a released box. Compared as
+  `(semver, build)`.
+- **§6 item 2 (`Control::Status`) was not added.** `hello_ok.version` plus the
+  existing `list` answer every field of §3, and both work against the daemons
+  already deployed; a status message only new daemons answer is the bootstrap
+  problem this RFC set out to avoid.
+- **§3's bootstrap gap is wider than an old daemon:** `status` runs by the
+  binary on disk, and the binary on the first upgrade has no `status`. The
+  loop reads clap's "unrecognized subcommand" as *older than anything*, stages
+  first, and observes again with the new binary.
+- **Idle (open question 1) is decided:** no client attached *and* no session
+  `working` or `needs_you`. `stop` declines by default and names the sessions
+  (exit 3); `--force` overrides. There is no `--if-idle` flag — declining is
+  the default, not an option.
+- **A box a newer app set up is left alone** and reported as `current` with
+  `newer: true`; the loop only ever moves a version up.
+- **§5.5 is `TermioStore.upgradingRoutes`:** a roster that fails while the app
+  itself has the daemon between builds keeps its spinner instead of turning
+  into an unreachable row.
+
+Not built here: the systemd `--user` unit (question 4) and the holder
+process (§9). `status.supervisor` is the field that lets both land without
+touching the loop.
+
+## 12. Open questions for review
+
+1. **Idle definition.** `attached == 0` treats an agent running unattended as
+   killable. Should idle instead require the session's *status* to be `idle` or
+   `done` — i.e. respect the workstream status the protocol already carries —
+   so a `working` agent nobody is watching is still protected?
+2. **Timeout for `upgrading`.** Autostart is on next contact; the verify
+   handshake is that contact. Ten seconds from `stop` to a bound socket seems
+   generous. Is there a case (slow disk, first-run migration) that needs more?
+3. **Should stage run eagerly?** Once the Mac can see `staged`, it could stage
+   on every app launch and only ever ask the user about activation. That is the
+   Chrome model. It makes the update the user sees a one-click restart instead
+   of a deploy — at the cost of writing to the box without being asked.
+4. **systemd user unit.** §4 defers it. Is `enable-linger` an acceptable ask
+   in the install flow, given it changes the box's logout behavior?

--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -102,8 +102,9 @@ rustup target add aarch64-unknown-linux-musl   # ARM VPS (Graviton, Ampere, Pi)
 rustup target add x86_64-unknown-linux-musl     # Intel/AMD VPS
 ```
 
-`termiod remote deploy <host>` runs `uname -m` on the host, picks the matching
-target, cross-compiles, and installs. Manual build:
+`termiod deploy --host <host>` runs `uname -sm` on the host, picks the matching
+target — the slice bundled beside the binary when there is one, a cross-compile
+otherwise — and installs. Manual build:
 
 ```sh
 cargo build --release --target x86_64-unknown-linux-musl
@@ -121,13 +122,26 @@ termiod remote deploy my-vps --bin path/to/linux/termiod
 
 ## What deploy does
 
+One reconcile loop (`src/lifecycle.rs`; the design is
+`docs/design/20260827-termiod-lifecycle-reconcile.md`):
+
 ```sh
-termiod remote deploy my-vps
-#  ssh  my-vps mkdir -p ~/.local/bin
-#  scp  <built binary>  my-vps:.local/bin/termiod
-#  ssh  my-vps chmod +x ~/.local/bin/termiod
-#  ssh  my-vps ~/.local/bin/termiod --version      # verify
+termiod deploy --host my-vps
+#  ssh  my-vps ~/.local/bin/termiod status --json   # observe: binary, daemon, sessions
+#  scp  <bundled slice>  my-vps:.local/bin/termiod.new
+#  ssh  my-vps 'chmod +x … && mv termiod termiod.prev && mv termiod.new termiod'   # stage
+#  ssh  my-vps ~/.local/bin/termiod stop --json     # activate — declined while in use (exit 3)
+#  ssh  my-vps ~/.local/bin/termiod stdio           # verify: hello, compare the version
+#  on failure: mv termiod.prev termiod               # roll back
 ```
+
+Each step is skipped when the observed state already matches: a box on the
+current build costs one `status`. A box whose daemon holds a session someone
+is attached to, or an agent still `working`, is left **staged** — the new
+binary is in place and takes over the next time the daemon is stopped — and
+the sessions are named so the decision is the user's. `--force` overrides.
+The version compared is the app's build stamp (`0.44.0+1533`), carried by the
+daemon at `hello`; a box a newer app set up is left alone.
 
 Install path is `~/.local/bin/termiod`. Override with `TERMIOD_REMOTE_BIN`
 (e.g. `/usr/local/bin/termiod`) on the client for both deploy and attach.

--- a/termiod/README.md
+++ b/termiod/README.md
@@ -100,11 +100,19 @@ host (zmx lesson).
 Transport is **system OpenSSH** only — no public listener. The **host still runs on the VPS**; SSH only reaches it.
 
 ```sh
-termiod remote deploy my-vps           # cross-compile musl → ~/.local/bin/termiod
+termiod deploy --host my-vps           # install or update ~/.local/bin/termiod, verify it
 termiod remote list my-vps
 termiod remote attach my-vps demo -- bash
 termiod remote open my-vps --cwd '~/proj' --agent shell
 ```
+
+`deploy` is one loop for every state a box can be in — nothing installed, an
+older binary, a newer binary the daemon has not picked up. It stages the build
+this binary carries, asks the old daemon to stop when nothing is in use, checks
+the new one answers, and puts the previous binary back if it does not. Running
+it again is the recovery from any outcome. On the box itself, `termiod status`
+says what is there and `termiod stop` asks the daemon to leave (declined, with
+the sessions named, while one is attached or an agent is mid-task).
 
 `my-vps` = `~/.ssh/config` alias. Close the laptop; reattach — agent kept running on the VPS. See [`DEPLOY.md`](DEPLOY.md).
 

--- a/termiod/build.rs
+++ b/termiod/build.rs
@@ -1,0 +1,46 @@
+//! Stamps the build version into the binary as `TERMIOD_VERSION`.
+//!
+//! The crate version in `Cargo.toml` never moves with the app's releases, so
+//! comparing it would call every daemon current. The app is stamped from
+//! `TERMIO_VERSION` and `TERMIO_BUILD` (`scripts/build-app.sh`, set by the
+//! release workflow from the tag), and the daemon takes the same two so the
+//! version a daemon reports is the version of the app that shipped it:
+//! `0.44.0+1533`. The build number is what orders two dev builds of one
+//! version, and it is also the fallback when there is no tag — a checkout
+//! reports `0.0.0+<commit count>`, which compares older than any release
+//! (a dev build never stages itself over a released daemon) but still
+//! advances between two dev builds.
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=TERMIO_VERSION");
+    println!("cargo:rerun-if-env-changed=TERMIO_BUILD");
+
+    let version = std::env::var("TERMIO_VERSION")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "0.0.0".to_string());
+    let build = std::env::var("TERMIO_BUILD")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(commit_count)
+        .unwrap_or_else(|| "0".to_string());
+    println!("cargo:rustc-env=TERMIOD_VERSION={version}+{build}");
+}
+
+/// `git rev-list --count HEAD`, the same number the release workflow stamps as
+/// the app's build number. `None` outside a checkout, or without git.
+fn commit_count() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-list", "--count", "HEAD"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let count = String::from_utf8(output.stdout).ok()?;
+    let count = count.trim();
+    count.parse::<u64>().ok().map(|_| count.to_string())
+}

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -606,11 +606,12 @@ async fn handle_conn(stream: UnixStream, manager: Manager) -> Result<()> {
                     host_id: (*manager.host_id).clone(),
                     host: format!(
                         "termiod/{} {}-{}",
-                        env!("CARGO_PKG_VERSION"),
+                        crate::lifecycle::BUILD_VERSION,
                         std::env::consts::OS,
                         std::env::consts::ARCH
                     ),
                     client_id: client_id.to_string(),
+                    version: Some(crate::lifecycle::BUILD_VERSION.to_string()),
                     home: std::env::var("HOME").unwrap_or_default(),
                 },
             )

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -1,0 +1,1201 @@
+//! The daemon's lifecycle — install, update, repair — as one reconcile loop
+//! (`docs/design/20260827-termiod-lifecycle-reconcile.md`).
+//!
+//! Two halves. The **node** half runs on the box, by whatever binary is on
+//! disk: `status` reports what is there and `stop` asks the daemon to leave.
+//! The **control-plane** half, `reconcile`, runs wherever the desired build
+//! lives — the Mac, usually — against a [`Node`], and is the same function for
+//! this machine and for a box over ssh; only the transport behind the trait
+//! differs. Install is the loop from an empty box, update is the loop from a
+//! stale one, and recovery from any failure is running it again.
+//!
+//! Nothing here needs a daemon that already knows about this module. The
+//! daemon is found by the credential the kernel attaches to its socket, asked
+//! what it holds with `list` (protocol v1), and stopped with `SIGTERM`, which
+//! its drain path has always handled — so the first upgrade works the same as
+//! every later one.
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::UnixStream;
+
+use crate::paths;
+use crate::protocol::{
+    read_frame, write_control, ChannelRole, Control, Frame, SessionInfo, PROTOCOL_VERSION,
+};
+
+/// The build this binary is: `<app version>+<build number>`, stamped by
+/// `build.rs` from the same two values the app bundle carries.
+pub const BUILD_VERSION: &str = env!("TERMIOD_VERSION");
+
+/// How long the loop waits for a daemon to answer after it has been asked to
+/// start or stop. Autostart binds within a second on a loaded box; the drain
+/// after `SIGTERM` has to bury every session first.
+const SETTLE: Duration = Duration::from_secs(15);
+
+/// Exit code for a stop the daemon declined because it holds work someone is
+/// using. Distinct from failure: the state is named, and running again after
+/// the sessions close is the whole recovery.
+pub const EXIT_BUSY: i32 = 3;
+
+// MARK: Versions
+
+/// `major.minor.patch+build`, ordered as written. `build` breaks ties between
+/// two builds of one version, which is every dev build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+    major: u64,
+    minor: u64,
+    patch: u64,
+    build: u64,
+}
+
+impl Version {
+    pub fn parse(text: &str) -> Option<Version> {
+        let (semver, build) = match text.trim().split_once('+') {
+            Some((semver, build)) => (semver, build.parse().ok()?),
+            None => (text.trim(), 0),
+        };
+        let mut parts = semver.split('.').map(|part| part.parse::<u64>().ok());
+        let major = parts.next()??;
+        let minor = parts.next()??;
+        let patch = parts.next()??;
+        if parts.next().is_some() {
+            return None;
+        }
+        Some(Version {
+            major,
+            minor,
+            patch,
+            build,
+        })
+    }
+}
+
+// MARK: The handshake, without a client
+
+/// What a daemon says about itself at `hello`.
+pub struct DaemonHello {
+    /// Absent on a daemon that predates the field — older than anything that
+    /// reports one, which is how the loop reads it.
+    pub version: Option<String>,
+    pub host_id: String,
+}
+
+/// `hello` as a control channel with no capabilities, returning the daemon's
+/// self-description. Works against every daemon that speaks protocol v1.
+pub async fn handshake<R, W>(reader: &mut R, writer: &mut W) -> Result<DaemonHello>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    write_control(
+        writer,
+        &Control::Hello {
+            proto: PROTOCOL_VERSION,
+            min_proto: PROTOCOL_VERSION,
+            role: ChannelRole::Control,
+            caps: Vec::new(),
+            client: format!("termiod-cli/{BUILD_VERSION}"),
+        },
+    )
+    .await?;
+    match read_frame(reader).await? {
+        Some(Frame::Control(Control::HelloOk {
+            version, host_id, ..
+        })) => Ok(DaemonHello {
+            version: version.filter(|value| !value.is_empty()),
+            host_id,
+        }),
+        Some(Frame::Control(Control::HelloErr { supported, .. })) => bail!(
+            "the daemon speaks protocol {supported:?}; this binary speaks {PROTOCOL_VERSION}"
+        ),
+        Some(_) => bail!("the daemon answered hello with something other than hello_ok"),
+        None => bail!("the daemon closed the connection during hello"),
+    }
+}
+
+async fn list_sessions<R, W>(reader: &mut R, writer: &mut W) -> Result<Vec<SessionInfo>>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    write_control(writer, &Control::List { seq: Some(1) }).await?;
+    loop {
+        match read_frame(reader).await? {
+            Some(Frame::Control(Control::Sessions { sessions, .. })) => return Ok(sessions),
+            Some(Frame::Control(Control::Error { message, .. })) => bail!(message),
+            Some(_) => continue,
+            None => bail!("the daemon closed the connection before answering list"),
+        }
+    }
+}
+
+/// A connection to the daemon on `socket`, or `None` when nothing answers.
+/// Never autostarts: the question here is what *is* running.
+async fn connect_existing(socket: &Path) -> Option<UnixStream> {
+    tokio::time::timeout(Duration::from_secs(5), UnixStream::connect(socket))
+        .await
+        .ok()?
+        .ok()
+}
+
+/// The pid of the process on the far end of `stream`, from the kernel. This is
+/// the process that *owns the socket* — the only one the loop may ever stop —
+/// and it needs no protocol, so it identifies a daemon of any age. Never argv:
+/// a box running a second daemon by hand on another socket has the same
+/// command line, and matching it is how an upgrade kills the wrong process.
+fn peer_pid(stream: &UnixStream) -> Option<i32> {
+    use std::os::fd::AsRawFd;
+    let descriptor = stream.as_raw_fd();
+    #[cfg(target_os = "linux")]
+    {
+        let mut credential = libc::ucred {
+            pid: 0,
+            uid: 0,
+            gid: 0,
+        };
+        let mut length = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+        let result = unsafe {
+            libc::getsockopt(
+                descriptor,
+                libc::SOL_SOCKET,
+                libc::SO_PEERCRED,
+                &mut credential as *mut libc::ucred as *mut libc::c_void,
+                &mut length,
+            )
+        };
+        (result == 0 && credential.pid > 0).then_some(credential.pid)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        const SOL_LOCAL: libc::c_int = 0;
+        const LOCAL_PEERPID: libc::c_int = 0x002;
+        let mut pid: libc::pid_t = 0;
+        let mut length = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
+        let result = unsafe {
+            libc::getsockopt(
+                descriptor,
+                SOL_LOCAL,
+                LOCAL_PEERPID,
+                &mut pid as *mut libc::pid_t as *mut libc::c_void,
+                &mut length,
+            )
+        };
+        (result == 0 && pid > 0).then_some(pid)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = descriptor;
+        None
+    }
+}
+
+// MARK: Node side — `termiod status`
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeStatus {
+    pub binary: BinaryStatus,
+    pub daemon: DaemonStatus,
+    pub sessions: Vec<SessionSummary>,
+    /// The identity written on the daemon's first start. Present without a
+    /// running daemon: it is a file beside the socket.
+    pub host_id: Option<String>,
+    pub supervisor: Supervisor,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BinaryStatus {
+    /// The build of the binary answering — the one on disk.
+    pub version: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonStatus {
+    pub running: bool,
+    /// The *running* daemon's build, from its own `hello`. Differs from the
+    /// binary's exactly when an update is staged and not yet activated, which
+    /// is the state the loop most needs to see. `None` on a daemon too old to
+    /// say, or none running.
+    pub version: Option<String>,
+    pub pid: Option<i32>,
+    pub socket: String,
+}
+
+/// One session, reduced to what a stop decision needs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSummary {
+    pub id: String,
+    pub name: String,
+    pub command: String,
+    pub status: String,
+    pub attached: usize,
+    pub alive: bool,
+}
+
+impl From<SessionInfo> for SessionSummary {
+    fn from(info: SessionInfo) -> SessionSummary {
+        SessionSummary {
+            id: info.id,
+            name: info.name,
+            command: info.command,
+            status: info.status,
+            attached: info.attached_clients,
+            alive: info.alive,
+        }
+    }
+}
+
+impl SessionSummary {
+    /// Whether stopping the daemon would take work from someone. A client
+    /// attached is one answer; an agent still working, or waiting on its
+    /// user, is the other — the workstream status is in the protocol so that
+    /// a daemon does not have to guess from a screen, and an agent nobody is
+    /// watching is exactly the session "lives on the box" promises to keep.
+    pub fn busy(&self) -> bool {
+        self.alive && (self.attached > 0 || matches!(self.status.as_str(), "working" | "needs_you"))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Supervisor {
+    None,
+    Launchd,
+    SystemdUser,
+}
+
+/// What this machine has, from the binary that answers: its own build, the
+/// daemon on the canonical socket, and that daemon's sessions. One process,
+/// one connection — this replaces `test -x`, two handshakes and a roster read
+/// as separate round trips over ssh.
+pub async fn status() -> Result<NodeStatus> {
+    let socket = paths::socket_path()?;
+    let binary = BinaryStatus {
+        version: BUILD_VERSION.to_string(),
+        path: std::env::current_exe()
+            .map(|path| path.display().to_string())
+            .unwrap_or_default(),
+    };
+    let host_id = paths::host_id_path()
+        .ok()
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty());
+    let mut daemon = DaemonStatus {
+        running: false,
+        version: None,
+        pid: None,
+        socket: socket.display().to_string(),
+    };
+    let mut sessions = Vec::new();
+    if let Some(mut stream) = connect_existing(&socket).await {
+        daemon.running = true;
+        daemon.pid = peer_pid(&stream);
+        let (mut reader, mut writer) = stream.split();
+        let asked = tokio::time::timeout(Duration::from_secs(5), async {
+            let hello = handshake(&mut reader, &mut writer).await;
+            let list = list_sessions(&mut reader, &mut writer).await;
+            (hello, list)
+        })
+        .await;
+        if let Ok((hello, list)) = asked {
+            daemon.version = hello.ok().and_then(|hello| hello.version);
+            sessions = list
+                .unwrap_or_default()
+                .into_iter()
+                .map(SessionSummary::from)
+                .collect();
+        }
+    }
+    Ok(NodeStatus {
+        binary,
+        daemon,
+        sessions,
+        host_id,
+        supervisor: detect_supervisor().await,
+    })
+}
+
+/// Which init owns the daemon, if any. This is what decides what "restart"
+/// means for a node: a supervised daemon is bounced by its supervisor, an
+/// unsupervised one is stopped and autostarted by the next client.
+async fn detect_supervisor() -> Supervisor {
+    if cfg!(target_os = "macos") {
+        let target = format!("gui/{}/{}", unsafe { libc::getuid() }, crate::service::label());
+        let loaded = tokio::process::Command::new("launchctl")
+            .args(["print", &target])
+            .output()
+            .await
+            .map(|output| output.status.success())
+            .unwrap_or(false);
+        return if loaded {
+            Supervisor::Launchd
+        } else {
+            Supervisor::None
+        };
+    }
+    let active = tokio::process::Command::new("systemctl")
+        .args(["--user", "is-active", "--quiet", "termiod"])
+        .output()
+        .await
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+    if active {
+        Supervisor::SystemdUser
+    } else {
+        Supervisor::None
+    }
+}
+
+pub fn print_status(status: &NodeStatus) {
+    println!("binary:  {} ({})", status.binary.version, status.binary.path);
+    match (&status.daemon.running, &status.daemon.version, status.daemon.pid) {
+        (false, _, _) => println!("daemon:  not running ({})", status.daemon.socket),
+        (true, version, pid) => println!(
+            "daemon:  {} pid {} ({})",
+            version.as_deref().unwrap_or("older than this binary, no version"),
+            pid.map(|pid| pid.to_string()).unwrap_or_else(|| "?".to_string()),
+            status.daemon.socket
+        ),
+    }
+    if let Some(host_id) = &status.host_id {
+        println!("host:    {host_id}");
+    }
+    println!(
+        "service: {}",
+        match status.supervisor {
+            Supervisor::None => "none (autostarts on first contact)",
+            Supervisor::Launchd => "launchd",
+            Supervisor::SystemdUser => "systemd --user",
+        }
+    );
+    for session in &status.sessions {
+        println!(
+            "  {:<10} {:<14} {:<9} {} — {}",
+            session.id,
+            session.name,
+            session.status,
+            if session.attached > 0 {
+                "attached"
+            } else {
+                "nobody attached"
+            },
+            session.command
+        );
+    }
+}
+
+// MARK: Node side — `termiod stop`
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StopOutcome {
+    pub stopped: bool,
+    /// The sessions that kept the daemon up, by name — the user decides
+    /// whether to close an agent mid-task, and a count cannot inform that.
+    pub busy: Vec<SessionSummary>,
+    pub message: String,
+}
+
+/// Ask the daemon on the canonical socket to leave. Declines while any session
+/// is in use unless `force`; nothing running is already the state wanted, so
+/// it is success rather than an error.
+pub async fn stop(force: bool) -> Result<StopOutcome> {
+    let socket = paths::socket_path()?;
+    let Some(mut stream) = connect_existing(&socket).await else {
+        return Ok(StopOutcome {
+            stopped: true,
+            busy: Vec::new(),
+            message: "no daemon is running".to_string(),
+        });
+    };
+    let Some(pid) = peer_pid(&stream) else {
+        bail!(
+            "could not identify the process behind {}; not stopping one by guess",
+            socket.display()
+        );
+    };
+    if !force {
+        let (mut reader, mut writer) = stream.split();
+        let sessions = tokio::time::timeout(Duration::from_secs(5), async {
+            // The version is not the question here; the handshake is what
+            // makes `list` answerable on a negotiated channel.
+            let _ = handshake(&mut reader, &mut writer).await;
+            list_sessions(&mut reader, &mut writer).await
+        })
+        .await
+        .context("the daemon did not answer in time")?
+        .context("asking the daemon what it holds — not stopping it blind")?;
+        let busy: Vec<SessionSummary> = sessions
+            .into_iter()
+            .map(SessionSummary::from)
+            .filter(SessionSummary::busy)
+            .collect();
+        if !busy.is_empty() {
+            let message = format!(
+                "{} in use on this machine; close {} or pass --force",
+                if busy.len() == 1 {
+                    "1 session is".to_string()
+                } else {
+                    format!("{} sessions are", busy.len())
+                },
+                if busy.len() == 1 { "it" } else { "them" }
+            );
+            return Ok(StopOutcome {
+                stopped: false,
+                busy,
+                message,
+            });
+        }
+    }
+    drop(stream);
+
+    if unsafe { libc::kill(pid, libc::SIGTERM) } != 0 {
+        bail!(
+            "sending SIGTERM to pid {pid}: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    // The daemon removes its socket last, after burying every session, so the
+    // socket going away is the drain having finished — not merely begun.
+    let deadline = Instant::now() + SETTLE;
+    loop {
+        let process_gone = unsafe { libc::kill(pid, 0) } != 0;
+        if process_gone || !socket.exists() {
+            return Ok(StopOutcome {
+                stopped: true,
+                busy: Vec::new(),
+                message: format!("stopped pid {pid}"),
+            });
+        }
+        if Instant::now() >= deadline {
+            bail!("pid {pid} was asked to stop and is still holding {} after {}s", socket.display(), SETTLE.as_secs());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+// MARK: Control-plane side — the loop
+
+/// What one command on a node produced. `Err` from [`Node::run`] is reserved
+/// for the transport failing; a command that ran and failed is an `Ok(Run)`
+/// with a non-zero code, because the two mean different things to the loop.
+#[derive(Debug, Clone, Default)]
+pub struct Run {
+    pub code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// The transport to a node failed — ssh could not connect, or authenticate.
+/// Its own error type so the loop can name the state (`unreachable`) rather
+/// than fold it into "something failed".
+#[derive(Debug)]
+pub struct Unreachable(pub String);
+
+impl std::fmt::Display for Unreachable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for Unreachable {}
+
+/// A machine the loop can act on. Everything the loop needs from a node is
+/// these five operations; the arms — this machine, a Linux box over ssh, a
+/// Mac over ssh — differ only in how they carry them out.
+pub trait Node {
+    /// How the node is named in messages: the ssh alias, or "this Mac".
+    fn label(&self) -> String;
+    /// The daemon binary's path, as the node's own shell should see it.
+    fn binary(&self) -> String;
+    /// Run a shell command on the node.
+    fn run(&self, command: &str) -> impl std::future::Future<Output = Result<Run>> + Send;
+    /// Copy `local` to `<name>` beside the daemon binary on the node.
+    fn put(&self, local: &Path, name: &str) -> impl std::future::Future<Output = Result<()>> + Send;
+    /// The daemon this control plane would install on the node.
+    fn artifact(&self) -> impl std::future::Future<Output = Result<PathBuf>> + Send;
+    /// Handshake with the node's daemon, starting it if nothing answers —
+    /// which is the contact that brings a freshly staged binary up.
+    fn hello(&self) -> impl std::future::Future<Output = Result<DaemonHello>> + Send;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Options {
+    /// Stop the daemon even while sessions are in use.
+    pub force: bool,
+    /// Put the binary in place and stop there; the daemon is not touched.
+    pub stage_only: bool,
+}
+
+/// The state a node was left in. Every variant is a place the loop can resume
+/// from by being run again; none is an instruction to the user beyond what the
+/// variant carries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum Outcome {
+    /// The daemon running is the desired build, or a newer one.
+    Current {
+        version: String,
+        host_id: String,
+        /// Another control plane put a newer build here. Left alone.
+        newer: bool,
+    },
+    /// The binary is in place and the daemon still running is the old one.
+    /// `busy` is why it was not stopped — empty when stopping was not asked for.
+    Staged {
+        version: String,
+        daemon: Option<String>,
+        busy: Vec<SessionSummary>,
+    },
+    /// The new daemon did not verify. `rolled_back` means the previous binary is
+    /// back in place and whatever it autostarts next is the build that worked.
+    Unhealthy { message: String, rolled_back: bool },
+    /// The transport failed; nothing on the node was touched.
+    Unreachable { message: String },
+    /// A step failed in a way the loop could not classify.
+    Failed { message: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Report {
+    pub node: String,
+    pub desired: String,
+    #[serde(flatten)]
+    pub outcome: Outcome,
+}
+
+impl Report {
+    pub fn exit_code(&self) -> i32 {
+        match self.outcome {
+            Outcome::Current { .. } => 0,
+            Outcome::Staged { .. } => EXIT_BUSY,
+            _ => 1,
+        }
+    }
+
+    /// One line per state, for a terminal.
+    pub fn describe(&self) -> String {
+        let node = &self.node;
+        match &self.outcome {
+            Outcome::Current {
+                version,
+                host_id,
+                newer,
+            } => format!(
+                "{node}: termiod {version} is running (host {host_id}){}",
+                if *newer {
+                    " — newer than this build, left alone"
+                } else {
+                    ""
+                }
+            ),
+            Outcome::Staged {
+                version,
+                daemon,
+                busy,
+            } if busy.is_empty() => format!(
+                "{node}: termiod {version} is staged; the running daemon ({}) takes over once it is stopped",
+                daemon.as_deref().unwrap_or("no version")
+            ),
+            Outcome::Staged { version, busy, .. } => {
+                let mut text = format!(
+                    "{node}: termiod {version} is staged, but the daemon still running there is in use:"
+                );
+                for session in busy {
+                    text.push_str(&format!("\n  • {} — {}", session.name, session.command));
+                }
+                text.push_str(&format!("\nClose those on {node} and run this again, or pass --force."));
+                text
+            }
+            Outcome::Unhealthy {
+                message,
+                rolled_back,
+            } => format!(
+                "{node}: the new termiod did not come up — {message}{}",
+                if *rolled_back {
+                    "\nThe previous binary is back in place."
+                } else {
+                    ""
+                }
+            ),
+            Outcome::Unreachable { message } => format!("{node}: unreachable — {message}"),
+            Outcome::Failed { message } => format!("{node}: {message}"),
+        }
+    }
+}
+
+enum Observed {
+    /// No binary at the path.
+    Absent,
+    /// A binary that predates `status` — it cannot say what it is, only that
+    /// it is older than this build.
+    OldBinary,
+    Reported(NodeStatus),
+}
+
+/// Observe → stage → activate → verify → roll back, and a report of where
+/// that left the node. Never returns an error: every failure is a state.
+pub async fn reconcile<N: Node>(node: &N, desired: &str, options: Options) -> Report {
+    let outcome = match run_loop(node, desired, options).await {
+        Ok(outcome) => outcome,
+        Err(error) => match error.downcast_ref::<Unreachable>() {
+            Some(unreachable) => Outcome::Unreachable {
+                message: unreachable.0.clone(),
+            },
+            None => Outcome::Failed {
+                message: format!("{error:#}"),
+            },
+        },
+    };
+    Report {
+        node: node.label(),
+        desired: desired.to_string(),
+        outcome,
+    }
+}
+
+async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<Outcome> {
+    let want = Version::parse(desired)
+        .with_context(|| format!("desired version {desired:?} is not a build stamp"))?;
+    let label = node.label();
+
+    let mut observed = observe(node).await?;
+    let needs_stage = match &observed {
+        Observed::Absent | Observed::OldBinary => true,
+        Observed::Reported(status) => {
+            Version::parse(&status.binary.version).map_or(true, |have| have < want)
+        }
+    };
+    let mut staged = false;
+    if needs_stage {
+        eprintln!("[deploy] installing termiod {desired} on {label}…");
+        stage(node).await?;
+        staged = true;
+        observed = observe(node).await?;
+    }
+    let Observed::Reported(status) = observed else {
+        bail!("termiod was installed on {label} but does not answer `status` there");
+    };
+
+    if options.stage_only {
+        return Ok(Outcome::Staged {
+            version: status.binary.version,
+            daemon: status.daemon.version,
+            busy: Vec::new(),
+        });
+    }
+
+    let daemon_is_stale = status.daemon.running
+        && status
+            .daemon
+            .version
+            .as_deref()
+            .and_then(Version::parse)
+            .map_or(true, |have| have < want);
+    if daemon_is_stale {
+        eprintln!("[deploy] asking the daemon on {label} to stop…");
+        let command = format!(
+            "{} stop --json{}",
+            node.binary(),
+            if options.force { " --force" } else { "" }
+        );
+        let run = node.run(&command).await?;
+        match run.code {
+            0 => {}
+            EXIT_BUSY => {
+                let outcome: StopOutcome = serde_json::from_str(run.stdout.trim())
+                    .context("reading the daemon's answer to stop")?;
+                return Ok(Outcome::Staged {
+                    version: status.binary.version,
+                    daemon: status.daemon.version,
+                    busy: outcome.busy,
+                });
+            }
+            _ => bail!("stopping termiod on {label}: {}", last_line(&run.stderr)),
+        }
+    }
+
+    match verify(node, want).await {
+        Ok((hello, version)) => Ok(Outcome::Current {
+            version: hello.version.unwrap_or_default(),
+            host_id: hello.host_id,
+            newer: version > want,
+        }),
+        Err(error) => {
+            let message = format!("{error:#}");
+            let rolled_back = staged && roll_back(node).await.is_ok();
+            Ok(Outcome::Unhealthy {
+                message,
+                rolled_back,
+            })
+        }
+    }
+}
+
+async fn observe<N: Node>(node: &N) -> Result<Observed> {
+    let run = node
+        .run(&format!("{} status --json", node.binary()))
+        .await?;
+    if run.code == 0 {
+        let status: NodeStatus = serde_json::from_str(run.stdout.trim())
+            .context("reading the node's status report")?;
+        return Ok(Observed::Reported(status));
+    }
+    let stderr = run.stderr.to_ascii_lowercase();
+    // The shell's own verdicts. 127 is "command not found"; clap exits 2 for a
+    // subcommand this binary does not have, which only an older build lacks.
+    if run.code == 127 || stderr.contains("no such file") || stderr.contains("not found") {
+        return Ok(Observed::Absent);
+    }
+    if run.code == 2 && (stderr.contains("unrecognized subcommand") || stderr.contains("unexpected argument")) {
+        return Ok(Observed::OldBinary);
+    }
+    bail!(
+        "termiod on {} could not report its status: {}",
+        node.label(),
+        last_line(&run.stderr)
+    )
+}
+
+/// Upload beside the target and rename over it, keeping the previous binary
+/// as `.prev`. Atomic on the filesystem, and safe against a running daemon —
+/// it keeps the old inode until it exits, which is the handover wanted. Linux
+/// refuses to open a running executable for writing (`ETXTBSY`), so writing
+/// in place is the one shape that always fails when a box is in use.
+async fn stage<N: Node>(node: &N) -> Result<()> {
+    let artifact = node.artifact().await?;
+    node.put(&artifact, "termiod.new").await?;
+    let binary = node.binary();
+    let command = format!(
+        "chmod +x {binary}.new && {{ [ ! -e {binary} ] || mv -f {binary} {binary}.prev; }} && mv -f {binary}.new {binary}"
+    );
+    let run = node.run(&command).await?;
+    if run.code != 0 {
+        bail!(
+            "installing the binary on {}: {}",
+            node.label(),
+            last_line(&run.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// Handshake with whatever answers now — which, after a stop, is the daemon
+/// autostart brings up from the staged binary — and check it is the build
+/// wanted, or a newer one.
+async fn verify<N: Node>(node: &N, want: Version) -> Result<(DaemonHello, Version)> {
+    let deadline = Instant::now() + SETTLE;
+    let mut last_error = None;
+    while Instant::now() < deadline {
+        match node.hello().await {
+            Ok(hello) => {
+                let Some(version) = hello.version.as_deref().and_then(Version::parse) else {
+                    // A daemon with no version is the old one, still up: the
+                    // socket it is draining has not gone yet. Ask again.
+                    last_error = Some(anyhow::anyhow!(
+                        "the daemon that answered is an older build with no version"
+                    ));
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    continue;
+                };
+                if version < want {
+                    last_error = Some(anyhow::anyhow!(
+                        "the daemon that answered is {}, older than {}",
+                        hello.version.as_deref().unwrap_or_default(),
+                        BUILD_VERSION
+                    ));
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    continue;
+                }
+                return Ok((hello, version));
+            }
+            Err(error) => {
+                last_error = Some(error);
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("no daemon answered")))
+}
+
+/// Put the previous binary back and stop whatever the new one started, so the
+/// next contact autostarts the build that worked.
+async fn roll_back<N: Node>(node: &N) -> Result<()> {
+    let binary = node.binary();
+    eprintln!("[deploy] rolling {} back to the previous binary…", node.label());
+    let _ = node.run(&format!("{binary} stop --force --json")).await;
+    let run = node
+        .run(&format!("[ -e {binary}.prev ] && mv -f {binary}.prev {binary}"))
+        .await?;
+    if run.code != 0 {
+        bail!("no previous binary to roll back to on {}", node.label());
+    }
+    Ok(())
+}
+
+fn last_line(text: &str) -> String {
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .last()
+        .unwrap_or("no output")
+        .to_string()
+}
+
+// MARK: This machine
+
+/// The node this process runs on. Its daemon is the binary running this code,
+/// so there is nothing to stage: the loop here is observe → stop-if-idle →
+/// verify, which is what picks a new build up after the app updated.
+pub struct LocalNode;
+
+impl Node for LocalNode {
+    fn label(&self) -> String {
+        "this machine".to_string()
+    }
+
+    fn binary(&self) -> String {
+        std::env::current_exe()
+            .map(|path| shell_quote(&path.display().to_string()))
+            .unwrap_or_else(|_| "termiod".to_string())
+    }
+
+    async fn run(&self, command: &str) -> Result<Run> {
+        let output = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .output()
+            .await
+            .context("running sh")?;
+        Ok(Run {
+            code: output.status.code().unwrap_or(1),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+
+    async fn put(&self, _local: &Path, _name: &str) -> Result<()> {
+        bail!("this machine's termiod ships inside the app; update the app to update it")
+    }
+
+    async fn artifact(&self) -> Result<PathBuf> {
+        bail!("this machine's termiod ships inside the app; update the app to update it")
+    }
+
+    async fn hello(&self) -> Result<DaemonHello> {
+        let mut stream = crate::client::connect().await?;
+        let (mut reader, mut writer) = stream.split();
+        tokio::time::timeout(Duration::from_secs(5), handshake(&mut reader, &mut writer))
+            .await
+            .context("the daemon did not answer hello in time")?
+    }
+}
+
+/// Single-quote shell escaping for a path this loop hands to `sh -c`.
+pub fn shell_quote(text: &str) -> String {
+    if !text.is_empty()
+        && text
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'/' | b'=' | b'@' | b':'))
+    {
+        return text.to_string();
+    }
+    format!("'{}'", text.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn versions_order_by_release_then_build() {
+        let parse = |text| Version::parse(text).expect(text);
+        assert!(parse("0.43.0+100") < parse("0.44.0+1"));
+        assert!(parse("0.44.0+1") < parse("0.44.0+2"));
+        assert!(parse("0.44.0") == parse("0.44.0+0"));
+        assert!(parse("0.0.0+1533") < parse("0.1.0+0"));
+        assert!(parse("1.0.0+5") > parse("0.99.99+999"));
+    }
+
+    #[test]
+    fn a_crate_version_or_garbage_is_not_a_build_stamp() {
+        assert!(Version::parse("").is_none());
+        assert!(Version::parse("termiod/0.1.0 linux-aarch64").is_none());
+        assert!(Version::parse("0.44").is_none());
+        assert!(Version::parse("0.44.0.1").is_none());
+        assert!(Version::parse("0.44.0+abc").is_none());
+    }
+
+    #[test]
+    fn a_session_is_busy_when_attached_or_the_agent_is_mid_task() {
+        let session = |attached, status: &str, alive| SessionSummary {
+            id: "1".into(),
+            name: "s".into(),
+            command: "bash".into(),
+            status: status.into(),
+            attached,
+            alive,
+        };
+        assert!(!session(0, "unknown", true).busy());
+        assert!(!session(0, "idle", true).busy());
+        assert!(!session(0, "done", true).busy());
+        assert!(session(1, "idle", true).busy());
+        assert!(session(0, "working", true).busy());
+        assert!(session(0, "needs_you", true).busy());
+        assert!(!session(1, "working", false).busy());
+    }
+
+    /// The build stamp `build.rs` produces always parses — the loop's desired
+    /// version is never garbage.
+    #[test]
+    fn this_build_has_a_comparable_version() {
+        assert!(Version::parse(BUILD_VERSION).is_some(), "{BUILD_VERSION}");
+    }
+
+    /// A node scripted as a sequence of answers, one per operation, so every
+    /// state in the RFC's table can be walked without a machine.
+    struct FakeNode {
+        runs: RefCell<VecDeque<Run>>,
+        hellos: RefCell<VecDeque<Result<DaemonHello>>>,
+        commands: RefCell<Vec<String>>,
+        puts: RefCell<Vec<String>>,
+    }
+
+    impl FakeNode {
+        fn new(runs: Vec<Run>, hellos: Vec<Result<DaemonHello>>) -> FakeNode {
+            FakeNode {
+                runs: RefCell::new(runs.into()),
+                hellos: RefCell::new(hellos.into()),
+                commands: RefCell::new(Vec::new()),
+                puts: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    // The fake is single-threaded by construction; the trait's `Send` bound
+    // is for the ssh arm's sake.
+    unsafe impl Sync for FakeNode {}
+
+    impl Node for FakeNode {
+        fn label(&self) -> String {
+            "box".to_string()
+        }
+        fn binary(&self) -> String {
+            "$HOME/.local/bin/termiod".to_string()
+        }
+        async fn run(&self, command: &str) -> Result<Run> {
+            self.commands.borrow_mut().push(command.to_string());
+            self.runs
+                .borrow_mut()
+                .pop_front()
+                .ok_or_else(|| anyhow::anyhow!("unscripted command: {command}"))
+        }
+        async fn put(&self, local: &Path, name: &str) -> Result<()> {
+            self.puts.borrow_mut().push(format!("{} → {name}", local.display()));
+            Ok(())
+        }
+        async fn artifact(&self) -> Result<PathBuf> {
+            Ok(PathBuf::from("/bundle/termiod-aarch64-unknown-linux-musl"))
+        }
+        async fn hello(&self) -> Result<DaemonHello> {
+            self.hellos
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or_else(|| Err(anyhow::anyhow!("unscripted hello")))
+        }
+    }
+
+    fn ok(stdout: &str) -> Run {
+        Run {
+            code: 0,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    fn failed(code: i32, stderr: &str) -> Run {
+        Run {
+            code,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+        }
+    }
+
+    fn status_json(binary: &str, daemon: Option<&str>, running: bool) -> String {
+        serde_json::to_string(&NodeStatus {
+            binary: BinaryStatus {
+                version: binary.to_string(),
+                path: "/home/u/.local/bin/termiod".to_string(),
+            },
+            daemon: DaemonStatus {
+                running,
+                version: daemon.map(str::to_string),
+                pid: running.then_some(4242),
+                socket: "/run/user/1001/termiod/termiod.sock".to_string(),
+            },
+            sessions: Vec::new(),
+            host_id: Some("h_1".to_string()),
+            supervisor: Supervisor::None,
+        })
+        .expect("status serializes")
+    }
+
+    fn hello(version: Option<&str>) -> Result<DaemonHello> {
+        Ok(DaemonHello {
+            version: version.map(str::to_string),
+            host_id: "h_1".to_string(),
+        })
+    }
+
+    const WANT: &str = "0.44.0+1600";
+
+    /// Install from an empty box: the binary is staged, nothing is stopped, and
+    /// the verify handshake is what starts the daemon.
+    #[tokio::test]
+    async fn an_empty_box_is_installed_and_verified() {
+        let node = FakeNode::new(
+            vec![
+                failed(127, "bash: /home/u/.local/bin/termiod: No such file or directory"),
+                ok(""), // chmod + mv
+                ok(&status_json(WANT, None, false)),
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { ref version, newer: false, .. } if version == WANT), "{report:?}");
+        assert_eq!(node.puts.borrow().len(), 1);
+        assert!(!node.commands.borrow().iter().any(|command| command.contains(" stop")));
+    }
+
+    /// A binary too old to answer `status` is staged first and asked again with
+    /// the new one — the first-upgrade path, which needs nothing from the old
+    /// build but a path.
+    #[tokio::test]
+    async fn an_old_binary_is_staged_before_it_is_asked_anything() {
+        let node = FakeNode::new(
+            vec![
+                failed(2, "error: unrecognized subcommand 'status'"),
+                ok(""),
+                ok(&status_json(WANT, None, true)), // old daemon: running, no version
+                ok(""),                            // stop
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+        let commands = node.commands.borrow();
+        assert!(commands[1].contains("termiod.prev"), "{}", commands[1]);
+        assert!(commands[3].ends_with("stop --json"), "{}", commands[3]);
+    }
+
+    /// The daemon declining to stop is a named state with the sessions in it,
+    /// not a failure — the binary stays staged for the next run.
+    #[tokio::test]
+    async fn a_busy_daemon_leaves_the_update_staged() {
+        let busy = StopOutcome {
+            stopped: false,
+            busy: vec![SessionSummary {
+                id: "1".into(),
+                name: "claude".into(),
+                command: "claude".into(),
+                status: "working".into(),
+                attached: 0,
+                alive: true,
+            }],
+            message: "1 session is in use".into(),
+        };
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                ok(""),
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                Run {
+                    code: EXIT_BUSY,
+                    stdout: serde_json::to_string(&busy).unwrap(),
+                    stderr: String::new(),
+                },
+            ],
+            vec![],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        match &report.outcome {
+            Outcome::Staged { busy, daemon, .. } => {
+                assert_eq!(busy.len(), 1);
+                assert_eq!(busy[0].name, "claude");
+                assert_eq!(daemon.as_deref(), Some("0.43.0+1500"));
+            }
+            other => panic!("expected staged, got {other:?}"),
+        }
+        assert_eq!(report.exit_code(), EXIT_BUSY);
+    }
+
+    /// A new daemon that never verifies is rolled back, and the report says so.
+    #[tokio::test]
+    async fn a_daemon_that_does_not_come_up_is_rolled_back() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                ok(""),
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                ok(""), // stop
+                ok(""), // roll back: stop --force
+                ok(""), // roll back: mv prev
+            ],
+            (0..40)
+                .map(|_| Err(anyhow::anyhow!("no protocol reply")))
+                .collect(),
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Unhealthy { rolled_back: true, .. }), "{report:?}");
+        let commands = node.commands.borrow();
+        assert!(commands.last().unwrap().contains("termiod.prev"), "{commands:?}");
+    }
+
+    /// A box another, newer control plane set up is left alone and reported as
+    /// such, rather than downgraded.
+    #[tokio::test]
+    async fn a_newer_box_is_left_alone() {
+        let node = FakeNode::new(
+            vec![ok(&status_json("0.45.0+1700", Some("0.45.0+1700"), true))],
+            vec![hello(Some("0.45.0+1700"))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { newer: true, .. }), "{report:?}");
+        assert!(node.puts.borrow().is_empty());
+    }
+
+    /// ssh failing is `unreachable`, kept apart from a step that ran and failed.
+    #[tokio::test]
+    async fn a_transport_failure_is_unreachable() {
+        struct Down;
+        impl Node for Down {
+            fn label(&self) -> String {
+                "vps".into()
+            }
+            fn binary(&self) -> String {
+                "termiod".into()
+            }
+            async fn run(&self, _: &str) -> Result<Run> {
+                Err(Unreachable("ssh: connect to host vps port 22: Operation timed out".into()).into())
+            }
+            async fn put(&self, _: &Path, _: &str) -> Result<()> {
+                unreachable!()
+            }
+            async fn artifact(&self) -> Result<PathBuf> {
+                unreachable!()
+            }
+            async fn hello(&self) -> Result<DaemonHello> {
+                unreachable!()
+            }
+        }
+        let report = reconcile(&Down, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Unreachable { ref message } if message.contains("timed out")), "{report:?}");
+    }
+}

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -13,6 +13,7 @@ mod daemon;
 mod files;
 mod git;
 mod id;
+mod lifecycle;
 mod paths;
 mod proc;
 mod protocol;
@@ -32,7 +33,7 @@ use std::net::SocketAddr;
 #[derive(Parser)]
 #[command(
     name = "termiod",
-    version,
+    version = lifecycle::BUILD_VERSION,
     about = "Durable session host — viewers attach; detach ≠ kill (#164 POC)",
     long_about = "termiod is a session host (not a window manager).\n\
 A session lives in the host; Mac/iOS/CLI only attach.\n\
@@ -237,6 +238,53 @@ enum Cmd {
     /// it lets a native client speak the same framed protocol to a remote host
     /// that it speaks to a local Unix socket. The daemon auto-starts.
     Stdio,
+
+    /// What this machine has: the binary, the daemon on its socket, and the
+    /// daemon's sessions. Read-only, one process, one connection.
+    ///
+    /// The daemon's version comes from the daemon, not from the file on disk:
+    /// the two differ exactly when an update is staged and not yet running.
+    Status {
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Ask the daemon to stop. Declines while a session is attached or an
+    /// agent is mid-task, and names them; `--force` stops it regardless.
+    ///
+    /// The daemon is found by the credential on its socket, never by its
+    /// command line, so a second daemon someone runs by hand on another socket
+    /// is never the one stopped. Exit 3 means "in use", not failure.
+    Stop {
+        /// Stop even while sessions are in use. Every session ends.
+        #[arg(long)]
+        force: bool,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Install or update termiod here or on an SSH host, and verify it.
+    ///
+    /// One loop for every state the machine can be in: nothing installed, an
+    /// older binary, a newer binary the daemon has not picked up. It stages
+    /// the binary this build carries, asks the old daemon to stop when it is
+    /// idle, checks the new one answers, and puts the previous binary back if
+    /// it does not. Running it again is the recovery from any outcome.
+    Deploy {
+        /// SSH host alias from `~/.ssh/config` (or user@host). Without it,
+        /// this machine's own daemon is checked and restarted if stale.
+        #[arg(long)]
+        host: Option<String>,
+        /// Stop the old daemon even while its sessions are in use.
+        #[arg(long)]
+        force: bool,
+        /// Put the binary in place and leave the running daemon alone.
+        #[arg(long)]
+        stage_only: bool,
+        /// Emit the outcome as one JSON document on stdout.
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Remote (SSH) deploy and attach — see `termiod remote --help`.
     Remote {
@@ -616,6 +664,58 @@ async fn main() -> Result<()> {
         Cmd::Agent { cmd } => run_agent(cmd).await,
 
         Cmd::Stdio => client::stdio().await,
+
+        Cmd::Status { json } => {
+            let status = lifecycle::status().await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&status)?);
+            } else {
+                lifecycle::print_status(&status);
+            }
+            Ok(())
+        }
+
+        Cmd::Stop { force, json } => {
+            let outcome = lifecycle::stop(force).await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&outcome)?);
+            } else {
+                println!("{}", outcome.message);
+                for session in &outcome.busy {
+                    println!("  • {} — {}", session.name, session.command);
+                }
+            }
+            if !outcome.stopped {
+                std::process::exit(lifecycle::EXIT_BUSY);
+            }
+            Ok(())
+        }
+
+        Cmd::Deploy {
+            host,
+            force,
+            stage_only,
+            json,
+        } => {
+            let options = lifecycle::Options { force, stage_only };
+            let report = match host {
+                Some(host) => remote::reconcile(&remote::SshNode::new(host), options).await,
+                None => {
+                    lifecycle::reconcile(&lifecycle::LocalNode, lifecycle::BUILD_VERSION, options)
+                        .await
+                }
+            };
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                println!("{}", report.describe());
+            }
+            let code = report.exit_code();
+            if code != 0 {
+                std::process::exit(code);
+            }
+            Ok(())
+        }
 
         Cmd::Remote { cmd } => remote::run(cmd).await,
 

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -540,6 +540,14 @@ pub enum Control {
         host_id: String,
         host: String,
         client_id: String,
+        /// The daemon's build, `<app version>+<build>` — the version of the
+        /// app that shipped it (`lifecycle::BUILD_VERSION`). This is what
+        /// lets a control plane say "termiod 0.43 on ukvps; this app needs
+        /// 0.44" instead of inferring age from a missing capability. Absent
+        /// from a daemon that predates it, which the lifecycle loop reads as
+        /// older than anything that reports one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
         /// This account's home directory on the device, so a client that has
         /// to name a path over here — a project picker, a `~`-prefixed entry —
         /// starts where the user's work is instead of at `/`. Sent at the

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -7,10 +7,18 @@
 //! `ssh host termiod attach <id>` runs the *client* on the remote host, whose
 //! stdin/stdout are the SSH channel; the daemon it starts survives the SSH
 //! disconnect because it is in its own session. Detach ≠ kill, remotely, free.
+//!
+//! Installing and updating the daemon on a host is the lifecycle loop
+//! (`lifecycle::reconcile`); this module is its ssh arm — [`SshNode`] — plus
+//! the artifact selection: which of the bundled daemons a host gets.
 
 use anyhow::{bail, Context, Result};
 use clap::Subcommand;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
+
+use crate::lifecycle::{self, DaemonHello, Node, Options, Report, Run, Unreachable};
 
 /// Where the binary is installed on the remote host. `$HOME` is expanded by
 /// the remote shell. Overridable with `TERMIOD_REMOTE_BIN` for custom install
@@ -53,18 +61,39 @@ fn control_path() -> Option<String> {
     Some(dir.join("%C").display().to_string())
 }
 
+/// The options every non-interactive ssh here runs with. Nobody can answer a
+/// prompt on these channels — the app runs them with no terminal at all — so
+/// `BatchMode` turns a passphrase prompt into a prompt failure in a second,
+/// and `ConnectTimeout` bounds a host that swallows the connect.
+fn batch_args() -> Vec<String> {
+    let mut args = vec![
+        "-o".to_string(),
+        "BatchMode=yes".to_string(),
+        "-o".to_string(),
+        "ConnectTimeout=10".to_string(),
+    ];
+    args.extend(ssh_multiplex_args());
+    args
+}
+
 #[derive(Subcommand)]
 pub enum RemoteCmd {
-    /// Build for the remote's arch and install `termiod` over SSH.
+    /// Install or update `termiod` on a host over SSH — `termiod deploy --host`.
     Deploy {
         /// SSH host alias from `~/.ssh/config` (or user@host).
         host: String,
-        /// Use this prebuilt Linux binary instead of cross-compiling.
+        /// Use this prebuilt binary instead of the bundled or cross-compiled one.
         #[arg(long)]
         bin: Option<String>,
         /// Force a Rust target triple instead of auto-detecting from `uname`.
         #[arg(long)]
         target: Option<String>,
+        /// Stop the old daemon even while its sessions are in use.
+        #[arg(long)]
+        force: bool,
+        /// Emit the outcome as one JSON document on stdout.
+        #[arg(long)]
+        json: bool,
     },
 
     /// List sessions on a remote host.
@@ -107,17 +136,63 @@ pub enum RemoteCmd {
 }
 
 pub async fn run(cmd: RemoteCmd) -> Result<()> {
-    // These shell out to ssh/scp; run them on a blocking thread so the async
-    // runtime stays free.
-    tokio::task::spawn_blocking(move || run_blocking(cmd)).await?
+    match cmd {
+        RemoteCmd::Deploy {
+            host,
+            bin,
+            target,
+            force,
+            json,
+        } => {
+            let mut node = SshNode::new(host);
+            node.prebuilt = bin.map(PathBuf::from);
+            node.target = target;
+            let report = reconcile(&node, Options { force, stage_only: false }).await;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                println!("{}", report.describe());
+            }
+            let code = report.exit_code();
+            if code != 0 {
+                std::process::exit(code);
+            }
+            Ok(())
+        }
+        RemoteCmd::Open {
+            host,
+            cwd,
+            agent,
+            name,
+            no_deploy,
+        } => {
+            if !no_deploy {
+                // The same loop the app runs before an attach. A daemon left
+                // staged behind busy sessions is still a working daemon, so
+                // that is a note rather than a stop.
+                let report = reconcile(&SshNode::new(host.clone()), Options::default()).await;
+                match report.outcome {
+                    lifecycle::Outcome::Current { .. } => {}
+                    lifecycle::Outcome::Staged { .. } => eprintln!("{}", report.describe()),
+                    _ => bail!("{}", report.describe()),
+                }
+            }
+            tokio::task::spawn_blocking(move || open(&host, cwd.as_deref(), &agent, name.as_deref()))
+                .await?
+        }
+        // These shell out to ssh; run them on a blocking thread so the async
+        // runtime stays free.
+        other => tokio::task::spawn_blocking(move || run_blocking(other)).await?,
+    }
+}
+
+/// The lifecycle loop against a host, for the build this binary is.
+pub async fn reconcile(node: &SshNode, options: Options) -> Report {
+    lifecycle::reconcile(node, lifecycle::BUILD_VERSION, options).await
 }
 
 fn run_blocking(cmd: RemoteCmd) -> Result<()> {
     match cmd {
-        RemoteCmd::Deploy { host, bin, target } => {
-            deploy(&host, bin.as_deref(), target.as_deref())?;
-            Ok(())
-        }
         RemoteCmd::List { host, json } => {
             let bin = remote_bin();
             let flag = if json { " --json" } else { "" };
@@ -134,13 +209,9 @@ fn run_blocking(cmd: RemoteCmd) -> Result<()> {
             let status = ssh_interactive(&host, !observe, &remote)?;
             std::process::exit(status);
         }
-        RemoteCmd::Open {
-            host,
-            cwd,
-            agent,
-            name,
-            no_deploy,
-        } => open(&host, cwd.as_deref(), &agent, name.as_deref(), no_deploy),
+        RemoteCmd::Deploy { .. } | RemoteCmd::Open { .. } => {
+            unreachable!("handled on the async path")
+        }
     }
 }
 
@@ -161,23 +232,8 @@ fn build_attach_cmd(target: &str, observe: bool, argv: &[String]) -> String {
     s
 }
 
-fn open(
-    host: &str,
-    cwd: Option<&str>,
-    agent: &str,
-    name: Option<&str>,
-    no_deploy: bool,
-) -> Result<()> {
+fn open(host: &str, cwd: Option<&str>, agent: &str, name: Option<&str>) -> Result<()> {
     let bin = remote_bin();
-    if !no_deploy {
-        // Deploy if the binary is missing (cheap idempotent check).
-        let present = ssh_capture(host, &format!("test -x {bin} && echo yes || echo no"))?;
-        if present.trim() != "yes" {
-            eprintln!("termiod not found on {host}; deploying…");
-            deploy(host, None, None)?;
-        }
-    }
-
     let argv: Vec<String> = match agent {
         "shell" | "" => Vec::new(),
         other => vec![other.to_string()],
@@ -207,46 +263,189 @@ fn open(
     std::process::exit(status);
 }
 
-/// Cross-compile (or take a prebuilt binary) and install it on the remote.
-fn deploy(host: &str, prebuilt: Option<&str>, target_override: Option<&str>) -> Result<()> {
-    let bin_path = match prebuilt {
-        Some(p) => p.to_string(),
-        None => {
-            let target = match target_override {
-                Some(t) => t.to_string(),
-                None => detect_target(host)?,
-            };
-            match shipped_binary(&target) {
-                Some(path) => {
-                    eprintln!("[deploy] using the bundled {target} binary");
-                    path
+// MARK: The ssh arm of the lifecycle loop
+
+/// A machine reached with the user's own `ssh`, as `~/.ssh/config` defines it.
+/// The daemon installed is whichever of the bundled builds matches the box's
+/// `uname`, or this very binary for another Mac.
+pub struct SshNode {
+    pub host: String,
+    /// A binary to install instead of choosing one — the developer override.
+    pub prebuilt: Option<PathBuf>,
+    /// A Rust target triple instead of asking `uname`.
+    pub target: Option<String>,
+}
+
+impl SshNode {
+    pub fn new(host: String) -> SshNode {
+        SshNode {
+            host,
+            prebuilt: None,
+            target: None,
+        }
+    }
+
+    fn ssh(&self) -> tokio::process::Command {
+        let mut command = tokio::process::Command::new("ssh");
+        command.args(batch_args());
+        command
+    }
+
+    /// The directory the daemon lives in, spelled for the remote shell and for
+    /// scp — which does not expand `$HOME`, but resolves a relative path
+    /// against it.
+    fn install_directory(&self) -> (String, String) {
+        let binary = remote_bin();
+        let directory = match binary.rsplit_once('/') {
+            Some((directory, _)) if !directory.is_empty() => directory.to_string(),
+            _ => "$HOME/.local/bin".to_string(),
+        };
+        let for_scp = directory
+            .strip_prefix("$HOME/")
+            .or_else(|| directory.strip_prefix("~/"))
+            .map(str::to_string)
+            .unwrap_or_else(|| directory.clone());
+        (directory, for_scp)
+    }
+}
+
+impl Node for SshNode {
+    fn label(&self) -> String {
+        self.host.clone()
+    }
+
+    fn binary(&self) -> String {
+        remote_bin()
+    }
+
+    async fn run(&self, command: &str) -> Result<Run> {
+        let output = self
+            .ssh()
+            .arg(&self.host)
+            .arg(command)
+            .output()
+            .await
+            .context("spawning ssh")?;
+        let code = output.status.code().unwrap_or(1);
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        // 255 is ssh's own exit status — connection or authentication, never
+        // the remote command's. It is the line between "unreachable" and
+        // "reached, and this failed".
+        if code == 255 {
+            return Err(Unreachable(last_line(&stderr)).into());
+        }
+        Ok(Run {
+            code,
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr,
+        })
+    }
+
+    async fn put(&self, local: &Path, name: &str) -> Result<()> {
+        let (directory, for_scp) = self.install_directory();
+        let made = self.run(&format!("mkdir -p {directory}")).await?;
+        if made.code != 0 {
+            bail!("creating {directory} on {}: {}", self.host, last_line(&made.stderr));
+        }
+        eprintln!(
+            "[deploy] copying {} → {}:{for_scp}/{name}",
+            local.display(),
+            self.host
+        );
+        let output = tokio::process::Command::new("scp")
+            .args(batch_args())
+            .arg(local)
+            .arg(format!("{}:{for_scp}/{name}", self.host))
+            .output()
+            .await
+            .context("spawning scp")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if output.status.code() == Some(255) {
+                return Err(Unreachable(last_line(&stderr)).into());
+            }
+            bail!("copying the binary to {}: {}", self.host, last_line(&stderr));
+        }
+        Ok(())
+    }
+
+    async fn artifact(&self) -> Result<PathBuf> {
+        if let Some(prebuilt) = &self.prebuilt {
+            return Ok(prebuilt.clone());
+        }
+        let target = match &self.target {
+            Some(target) => target.clone(),
+            None => {
+                let uname = self.run("uname -sm").await?;
+                if uname.code != 0 {
+                    bail!("asking {} its uname: {}", self.host, last_line(&uname.stderr));
                 }
-                None => cross_compile(&target)?,
+                target_for_uname(uname.stdout.trim())?
+            }
+        };
+        if let Some(path) = shipped_binary(&target) {
+            eprintln!("[deploy] using the bundled {target} binary");
+            return Ok(PathBuf::from(path));
+        }
+        let built = tokio::task::spawn_blocking(move || cross_compile(&target)).await??;
+        Ok(PathBuf::from(built))
+    }
+
+    async fn hello(&self) -> Result<DaemonHello> {
+        let mut child = self
+            .ssh()
+            .arg(&self.host)
+            .arg(format!("{} stdio", remote_bin()))
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .context("spawning ssh")?;
+        let mut reader = child.stdout.take().context("ssh stdout")?;
+        let mut writer = child.stdin.take().context("ssh stdin")?;
+        let answer = tokio::time::timeout(
+            Duration::from_secs(10),
+            lifecycle::handshake(&mut reader, &mut writer),
+        )
+        .await;
+        match answer {
+            Ok(Ok(hello)) => Ok(hello),
+            other => {
+                // The remote binary's own words are the diagnosis — "Exec
+                // format error" for a wrong slice, ssh's line for auth — so
+                // they are read before the child is discarded.
+                let _ = child.kill().await;
+                let mut stderr = String::new();
+                if let Some(mut stream) = child.stderr.take() {
+                    use tokio::io::AsyncReadExt;
+                    let _ = tokio::time::timeout(
+                        Duration::from_secs(2),
+                        stream.read_to_string(&mut stderr),
+                    )
+                    .await;
+                }
+                let reason = match other {
+                    Ok(Err(error)) => format!("{error:#}"),
+                    _ => "no protocol reply within 10s".to_string(),
+                };
+                let detail = last_line(&stderr);
+                if detail == "no output" {
+                    bail!("{reason}")
+                }
+                bail!("{reason} ({detail})")
             }
         }
-    };
+    }
+}
 
-    eprintln!("[deploy] installing {bin_path} → {host}:~/.local/bin/termiod");
-    run_cmd(Command::new("ssh").args([host, "mkdir -p ~/.local/bin"]))?;
-    // Uploaded beside the target and renamed over it, never written in place: a
-    // deployed daemon is usually *running*, and Linux refuses to open a running
-    // executable for writing (ETXTBSY) — so writing directly is the one case
-    // that always fails, upgrading a machine already in use. `mv` within a
-    // directory is `rename(2)`: atomic, and it leaves the running daemon holding
-    // the old inode until it exits, which is exactly the handover wanted.
-    //
-    // scp expands `~` on the remote for OpenSSH.
-    run_cmd(Command::new("scp").args([&bin_path, &format!("{host}:.local/bin/termiod.new")]))?;
-    run_cmd(Command::new("ssh").args([
-        host,
-        "chmod +x ~/.local/bin/termiod.new && mv ~/.local/bin/termiod.new ~/.local/bin/termiod",
-    ]))?;
-
-    let bin = remote_bin();
-    let version = ssh_capture(host, &format!("{bin} --version"))?;
-    eprintln!("[deploy] installed: {}", version.trim());
-    eprintln!("[deploy] daemon auto-starts on first attach/list (no service needed).");
-    Ok(())
+fn last_line(text: &str) -> String {
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .last()
+        .unwrap_or("no output")
+        .to_string()
 }
 
 /// A daemon for `target` shipped beside this executable.
@@ -279,20 +478,14 @@ fn shipped_binary(target: &str) -> Option<String> {
         .then(|| candidate.to_string_lossy().into_owned())
 }
 
-/// Ask the remote `uname` and map it to a Rust target.
+/// The `uname -sm` half of target detection, split out so the mapping can be
+/// checked without a machine to ask.
 ///
 /// Macs are here because a device is a machine the user owns, and plenty of them
 /// are a Mac mini or a Studio on the same desk — "remote" describes the road, not
 /// the thing at the end of it. The daemon's own build already covers Darwin (it is
 /// what runs local sessions), so supporting it costs a branch here rather than a
 /// new artifact.
-fn detect_target(host: &str) -> Result<String> {
-    let uname = ssh_capture(host, "uname -sm")?;
-    target_for_uname(uname.trim())
-}
-
-/// The `uname -sm` half of `detect_target`, split out so the mapping can be
-/// checked without a machine to ask.
 fn target_for_uname(uname: &str) -> Result<String> {
     let arm = uname.contains("aarch64") || uname.contains("arm64");
     let intel = uname.contains("x86_64") || uname.contains("amd64");
@@ -359,7 +552,6 @@ fn ssh_interactive(host: &str, tty: bool, remote_cmd: &str) -> Result<i32> {
     Ok(status.code().unwrap_or(1))
 }
 
-/// Run an SSH command and capture stdout (for create/list/version probes).
 /// One host's session table, for the cross-host view. Failure is returned per
 /// host rather than aborting the sweep — a cloud fleet always has one box
 /// that is rebooting, and that must not blank the other rows.
@@ -378,12 +570,10 @@ pub async fn list_json(host: &str) -> (String, Result<Vec<crate::protocol::Sessi
     }
 }
 
+/// Run an SSH command and capture stdout (for create/list probes).
 fn ssh_capture(host: &str, remote_cmd: &str) -> Result<String> {
     let mut cmd = Command::new("ssh");
-    cmd.arg("-o").arg("BatchMode=yes");
-    for arg in ssh_multiplex_args() {
-        cmd.arg(arg);
-    }
+    cmd.args(batch_args());
     let out = cmd
         .args([host, remote_cmd])
         .output()
@@ -397,26 +587,9 @@ fn ssh_capture(host: &str, remote_cmd: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).to_string())
 }
 
-fn run_cmd(cmd: &mut Command) -> Result<()> {
-    let status = cmd.status().context("spawning subprocess")?;
-    if !status.success() {
-        bail!("command failed: {:?}", cmd);
-    }
-    Ok(())
-}
-
 /// Minimal single-quote shell escaping for remote command args.
 fn shell_quote(s: &str) -> String {
-    if s.is_empty() {
-        return "''".to_string();
-    }
-    if s
-        .bytes()
-        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'/' | b'=' | b'@' | b':'))
-    {
-        return s.to_string();
-    }
-    format!("'{}'", s.replace('\'', "'\\''"))
+    lifecycle::shell_quote(s)
 }
 
 #[cfg(test)]
@@ -450,5 +623,18 @@ mod tests {
         let running = std::env::current_exe().ok().and_then(|p| p.to_str().map(str::to_owned));
         assert_eq!(shipped_binary("aarch64-apple-darwin"), running);
         assert_eq!(shipped_binary("x86_64-apple-darwin"), running);
+    }
+
+    /// scp does not expand `$HOME`; the default install path has to reach it
+    /// as a path relative to the login directory, and a custom absolute path
+    /// has to reach it untouched.
+    #[test]
+    fn the_install_directory_is_spelled_for_scp() {
+        let node = SshNode::new("box".into());
+        std::env::remove_var("TERMIOD_REMOTE_BIN");
+        assert_eq!(
+            node.install_directory(),
+            ("$HOME/.local/bin".to_string(), ".local/bin".to_string())
+        );
     }
 }

--- a/termiod/tests/lifecycle.rs
+++ b/termiod/tests/lifecycle.rs
@@ -1,0 +1,179 @@
+//! `termiod status` and `termiod stop` against a real daemon on an isolated
+//! socket — the node half of the lifecycle loop, exercised the way the control
+//! plane runs it: as the binary on disk, over the canonical socket.
+
+use serde_json::Value;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const BIN: &str = env!("CARGO_BIN_EXE_termiod");
+const VERSION: &str = env!("TERMIOD_VERSION");
+
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new() -> TestDir {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before epoch")
+            .as_nanos();
+        // Unix-domain socket paths are short on macOS; the per-user temporary
+        // directory can consume most of that limit before the test adds a name.
+        let path = PathBuf::from(format!("/tmp/tlc-{}-{nonce:x}", std::process::id()));
+        std::fs::create_dir(&path).expect("create isolated daemon state directory");
+        TestDir(path)
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct Daemon {
+    child: Child,
+}
+
+impl Daemon {
+    fn start(socket: &Path) -> Daemon {
+        let mut child = Command::new(BIN)
+            .arg("serve")
+            .env("TERMIOD_SOCK", socket)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn isolated daemon");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !socket.exists() {
+            if let Some(status) = child.try_wait().expect("poll daemon startup") {
+                let mut stderr = String::new();
+                if let Some(mut stream) = child.stderr.take() {
+                    let _ = stream.read_to_string(&mut stderr);
+                }
+                panic!("daemon exited {status} before binding its socket: {stderr}");
+            }
+            assert!(Instant::now() < deadline, "daemon never bound its socket");
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        Daemon { child }
+    }
+
+    fn wait_exit(&mut self) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if self.child.try_wait().expect("poll daemon").is_some() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        false
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn termiod(socket: &Path, args: &[&str]) -> Output {
+    Command::new(BIN)
+        .args(args)
+        .env("TERMIOD_SOCK", socket)
+        .output()
+        .expect("run termiod")
+}
+
+fn json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout is not JSON ({error}): {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+/// One process, one connection: the report names this build for the binary
+/// and the daemon, finds the daemon's pid from the socket, and reports its
+/// sessions. Without a daemon it still reports the binary, and says so.
+#[test]
+fn status_reports_the_binary_the_daemon_and_its_sessions() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("d.sock");
+
+    let before = termiod(&socket, &["status", "--json"]);
+    assert!(before.status.success());
+    let report = json(&before);
+    assert_eq!(report["binary"]["version"], VERSION);
+    assert_eq!(report["daemon"]["running"], false);
+    assert!(report["daemon"]["version"].is_null());
+
+    let daemon = Daemon::start(&socket);
+    let created = termiod(&socket, &["create", "--name", "shell", "--", "sleep", "300"]);
+    assert!(created.status.success(), "{}", String::from_utf8_lossy(&created.stderr));
+
+    let during = termiod(&socket, &["status", "--json"]);
+    assert!(during.status.success(), "{}", String::from_utf8_lossy(&during.stderr));
+    let report = json(&during);
+    assert_eq!(report["daemon"]["running"], true);
+    assert_eq!(report["daemon"]["version"], VERSION);
+    assert_eq!(report["daemon"]["pid"], daemon.child.id());
+    assert_eq!(report["sessions"].as_array().map(Vec::len), Some(1));
+    assert_eq!(report["sessions"][0]["name"], "shell");
+    assert_eq!(report["sessions"][0]["attached"], 0);
+    assert!(report["host_id"].as_str().is_some_and(|id| !id.is_empty()));
+}
+
+/// An idle daemon — sessions, but nobody attached and no agent mid-task —
+/// leaves on request, and the socket is gone once it has.
+#[test]
+fn stop_takes_an_idle_daemon_down() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("d.sock");
+    let mut daemon = Daemon::start(&socket);
+    let created = termiod(&socket, &["create", "--name", "shell", "--", "sleep", "300"]);
+    assert!(created.status.success());
+
+    let stopped = termiod(&socket, &["stop", "--json"]);
+    assert!(stopped.status.success(), "{}", String::from_utf8_lossy(&stopped.stderr));
+    assert_eq!(json(&stopped)["stopped"], true);
+    assert!(daemon.wait_exit(), "daemon still running after stop");
+    assert!(!socket.exists(), "socket left behind after stop");
+
+    // Nothing running is the state wanted, so asking again is success.
+    let again = termiod(&socket, &["stop", "--json"]);
+    assert!(again.status.success());
+    assert_eq!(json(&again)["stopped"], true);
+}
+
+/// A session whose agent reports `working` keeps the daemon up, and the
+/// refusal names it: the decision is the user's, and a count cannot inform
+/// it. `--force` overrides.
+#[test]
+fn stop_declines_while_an_agent_is_mid_task_unless_forced() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("d.sock");
+    let mut daemon = Daemon::start(&socket);
+    let created = termiod(&socket, &["create", "--name", "claude", "--", "sleep", "300"]);
+    assert!(created.status.success());
+    let id = String::from_utf8_lossy(&created.stdout).trim().to_string();
+    let marked = termiod(&socket, &["set-status", &id, "working"]);
+    assert!(marked.status.success(), "{}", String::from_utf8_lossy(&marked.stderr));
+
+    let declined = termiod(&socket, &["stop", "--json"]);
+    assert_eq!(declined.status.code(), Some(3), "{}", String::from_utf8_lossy(&declined.stderr));
+    let report = json(&declined);
+    assert_eq!(report["stopped"], false);
+    assert_eq!(report["busy"][0]["name"], "claude");
+    assert_eq!(report["busy"][0]["status"], "working");
+    assert!(daemon.child.try_wait().expect("poll").is_none(), "daemon exited on a declined stop");
+
+    let forced = termiod(&socket, &["stop", "--force", "--json"]);
+    assert!(forced.status.success(), "{}", String::from_utf8_lossy(&forced.stderr));
+    assert!(daemon.wait_exit(), "daemon still running after --force");
+}


### PR DESCRIPTION
Implements `docs/design/20260827-termiod-lifecycle-reconcile.md`: install, update and repair of the daemon become one loop — observe the machine, stage the binary if older, stop the old daemon when idle, verify the new one, roll back if it does not answer — run by the daemon itself and read by the app as one JSON report.

## What changed

- **The daemon knows its version.** `termiod/build.rs` stamps `TERMIO_VERSION+TERMIO_BUILD` (the values the bundle already carries) into the binary; `hello_ok` gains `version`. A checkout reports `0.0.0+<commit count>`, which orders below every release, so a dev build never stages itself over a released box.
- **`termiod status --json`** — binary, daemon and sessions in one connection. The daemon's pid comes from the socket's peer credential, never from `pkill -f`; its version from its own hello, so a staged-but-not-activated update is visible.
- **`termiod stop`** — declines while a session is attached or an agent is `working`/`needs_you`, names the sessions, exits 3. `--force` overrides.
- **`termiod deploy [--host <alias>] [--json] [--force]`** — the loop, against this machine or a box over the user's own ssh. `remote deploy` is the same loop; `remote open` runs it first. Keeps the previous binary as `termiod.prev` and puts it back on a failed verify.
- **Settings ▸ Machines** runs the loop instead of its own ten-step ladder. New `staged` state ("Update ready", with the sessions holding the old daemon), and `upgradingRoutes` on the store so a roster that fails mid-restart keeps its spinner instead of reading as unreachable. The daemon's version is recorded on the device and shown on the pane.

Deleted: the Swift probe/deploy/re-probe/pkill ladder, `staleDaemonHolds`, `restartStaleDaemon`, `supportsAgentInstall`.

Departures from the RFC are recorded in its §11: no `Control::Status` message (hello + `list` answer everything and work against old daemons), the version is the app's build stamp, idle also protects a working agent, and a binary too old to answer `status` is staged first.

## Verified

- `cargo test`: 180 unit tests plus `tests/lifecycle.rs` (status against a live daemon, idle stop, busy refusal and `--force`) and the existing integration suites.
- `swift test`: 807 tests, including the new report-decoding tests.
- Against a real VPS running the old daemon: first run staged the binary and declined to stop (one attached login shell named), `--force` activated and verified in 0.24 s, a third run was a no-op. Six stray test daemons on other sockets were untouched by the loop.

Not built here: the systemd `--user` unit and the holder process (RFC §9).

## Release Notes

- Setting up a machine from Settings ▸ Machines now installs or updates termiod in one step, tells you when an update is waiting on sessions still in use — by name — and rolls back if the new daemon does not start.
- New commands on the daemon: `termiod status`, `termiod stop`, and `termiod deploy --host <alias>`.
- termiod reports the version of the app that shipped it.
