### PR TITLE
Title the remote explorer with the folder, not the device

### DIFF
--- a/Sources/termio/FileBrowser/RemoteFileTree.swift
+++ b/Sources/termio/FileBrowser/RemoteFileTree.swift
@@ -213,6 +213,16 @@ final class RemoteFileBrowserModel: ObservableObject {
 
     var host: String { checkout.device.name }
 
+    /// What the header calls the tree: the root folder's name, as the local
+    /// explorer shows `root.name`. The header used to show the device instead,
+    /// so every project on one box was titled with the box. The device still
+    /// names the tree where it matters — the failure state, and search — and a
+    /// root with no name to give (`/`, or a bare `~`) falls back to it.
+    var rootName: String {
+        let name = (root as NSString).lastPathComponent
+        return name.isEmpty || name == "/" || name == "~" ? host : name
+    }
+
     func node(at path: String) -> RemoteFileNode? { nodesByPath[path] }
 
     /// Re-lists the tree from the device. Existing rows stay up while the
@@ -458,10 +468,11 @@ struct RemoteFileTreeView: View {
         }
     }
 
-    /// The explorer-style header: the host, and a Refresh that re-roots the tree.
+    /// The explorer-style header: the root folder's name, and a Refresh that
+    /// re-roots the tree.
     private var header: some View {
         HStack(spacing: 2) {
-            Text(model.host)
+            Text(model.rootName)
                 .font(.system(size: 11, weight: .semibold))
                 .textCase(.uppercase)
                 .tracking(0.5)

--- a/Tests/termioTests/RemoteFileTreeRefreshTests.swift
+++ b/Tests/termioTests/RemoteFileTreeRefreshTests.swift
@@ -24,6 +24,17 @@ final class RemoteFileTreeRefreshTests: XCTestCase {
             root: root)
     }
 
+    /// The header names the folder, as the local explorer does — not the device,
+    /// which titled every project on one box with the box's name.
+    func testHeaderNamesTheRootFolderNotTheDevice() {
+        XCTAssertEqual(model().rootName, "api")
+        let home = RemoteFileBrowserModel(
+            checkout: Checkout(
+                device: KnownDevice(alias: "test-box", deviceID: nil), root: "/"),
+            root: "/")
+        XCTAssertEqual(home.rootName, "test-box")
+    }
+
     private func listing(
         _ path: String, _ entries: [(String, FileEntry.Kind)], error: String? = nil
     ) -> Termiod.DirectoryListing {


### PR DESCRIPTION
The remote file tree's header showed the device name ("JKVPS"), so every project on one box was titled with the box. It now shows the root folder's name, the way the local explorer shows `root.name`. The device still names the tree where it is the right word — the failure state and the search pane — and a root with no name to give (`/`, a bare `~`) falls back to it.

Adds a test covering both cases.

Release Notes:
- The file explorer for a project on another machine is titled with the project folder instead of the machine.