### PR TITLE
Let a termiod update through a tab that is only watching a prompt

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -6879,6 +6879,16 @@
         }
       }
     },
+    "Update Anyway": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仍然更新"
+          }
+        }
+      }
+    },
     "Update ready": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1382,6 +1382,8 @@
 	<string>Unsaved changes — saving…</string>
 	<key>Update</key>
 	<string>Update</string>
+	<key>Update Anyway</key>
+	<string>Update Anyway</string>
 	<key>Update ready</key>
 	<string>Update ready</string>
 	<key>Updated.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1382,6 +1382,8 @@
 	<string>未存储的更改 — 正在存储…</string>
 	<key>Update</key>
 	<string>更新</string>
+	<key>Update Anyway</key>
+	<string>仍然更新</string>
 	<key>Update ready</key>
 	<string>更新已就绪</string>
 	<key>Updated.</key>

--- a/Sources/termio/Settings/DevicePane.swift
+++ b/Sources/termio/Settings/DevicePane.swift
@@ -102,6 +102,11 @@ struct DevicePane: View {
                     ProgressView().controlSize(.small)
                 } else if case .ready = model.readiness {
                     Button(localized("Check Again")) { Task { await model.check() } }
+                } else if case .staged = model.readiness {
+                    // The work holding the old daemon up is named right beside
+                    // this, so the choice is informed; the daemon otherwise
+                    // takes the update the next time it stops on its own.
+                    Button(localized("Update Anyway")) { Task { await model.setUp(force: true) } }
                 } else {
                     Button(localized("Set Up \(machine.name)")) { Task { await model.setUp() } }
                 }

--- a/Sources/termio/Settings/DeviceReadiness.swift
+++ b/Sources/termio/Settings/DeviceReadiness.swift
@@ -105,8 +105,9 @@ enum DeviceReadinessState: Equatable {
     /// consequence instead of the cause.
     case blocked(String)
     /// The new `termiod` is on the machine and the old daemon is still running
-    /// because it holds sessions someone is using — named in the text. Not a
-    /// fault: it takes over once they close, and setup then completes.
+    /// because it has work in progress — a command running, or an agent
+    /// mid-task — named in the text. Not a fault: it takes over once that
+    /// finishes, or when the user says to stop it now.
     case staged(String)
 
     var isBusy: Bool { self == .checking }
@@ -318,14 +319,17 @@ final class DevicePaneModel: ObservableObject {
     /// The whole safe chain, in one click (RFC §D6). Stops at the first rung that
     /// blocks and says what it was — the later rungs cannot succeed anyway, and
     /// reporting all three invites fixing a consequence instead of a cause.
-    func setUp() async {
+    ///
+    /// `force` stops the machine's old daemon even while it has work in
+    /// progress — "Update Anyway", offered only once that work has been named.
+    func setUp(force: Bool = false) async {
         guard !readiness.isBusy else { return }
         readiness = .checking
         feedback = nil
         defer { step = nil }
 
         step = .foundation
-        if let failure = await installFoundation() {
+        if let failure = await installFoundation(force: force) {
             readiness = failure
             return
         }
@@ -364,7 +368,7 @@ final class DevicePaneModel: ObservableObject {
     /// installs invokes it by name. A device needs the `termiod` this build
     /// ships, which is also the reachability check, since deploying requires
     /// reaching it. `nil` when the rung passed; otherwise the state to show.
-    private func installFoundation() async -> DeviceReadinessState? {
+    private func installFoundation(force: Bool) async -> DeviceReadinessState? {
         guard let alias = device.alias else {
             switch CommandLineTool.install() {
             case .installed:
@@ -378,7 +382,7 @@ final class DevicePaneModel: ObservableObject {
                 return .blocked(localized("Couldn’t link `\(CommandLineTool.toolName)` into \(directory)."))
             }
         }
-        switch await TermioStore.remoteReadyCheck(host: alias) {
+        switch await TermioStore.remoteReadyCheck(host: alias, force: force) {
         case .success:
             return nil
         case .failure(let error):

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -998,9 +998,12 @@ extension TermioStore {
     /// `static` because it touches nothing on the store: the device a successful
     /// check reveals is handed back rather than adopted here, so a caller that is
     /// only *inspecting* a machine does not silently rewrite the registry.
-    static func remoteReadyCheck(host: String) async -> RemoteSetupResult {
+    ///
+    /// `force` stops the old daemon even while its sessions have work in
+    /// progress — the pane's "Update Anyway", offered with those sessions named.
+    static func remoteReadyCheck(host: String, force: Bool = false) async -> RemoteSetupResult {
         await Task.detached(priority: .userInitiated) {
-            performRemoteReadyCheck(host: host)
+            performRemoteReadyCheck(host: host, force: force)
         }.value
     }
 
@@ -1010,14 +1013,18 @@ extension TermioStore {
     /// runs on the machine; this side only turns the report into a sentence.
     /// `nonisolated` because it is invoked from a background queue and touches
     /// only process primitives — never `TermioStore`'s main-actor state.
-    private nonisolated static func performRemoteReadyCheck(host: String) -> RemoteSetupResult {
+    private nonisolated static func performRemoteReadyCheck(
+        host: String, force: Bool = false
+    ) -> RemoteSetupResult {
         let localBinary = Termiod.daemonBinaryPath()
         guard FileManager.default.isExecutableFile(atPath: localBinary) else {
             return .failure(RemoteSetupError(
                 state: .failed,
                 message: "The termiod binary to deploy wasn't found at \(localBinary)."))
         }
-        guard let run = runProcess(localBinary, ["deploy", "--host", host, "--json"]) else {
+        var arguments = ["deploy", "--host", host, "--json"]
+        if force { arguments.append("--force") }
+        guard let run = runProcess(localBinary, arguments) else {
             return .failure(RemoteSetupError(
                 state: .failed, message: "Couldn't run termiod deploy."))
         }
@@ -1044,17 +1051,16 @@ extension TermioStore {
                 id: hostID, daemonVersion: version, routes: [.ssh(host)], lastSeen: Date()))
         case .staged:
             // Named, not counted. "1 session" is a number the user cannot act
-            // on: whether to close it depends entirely on whether it is an
-            // agent mid-task or a shell someone left at a prompt, and only the
-            // command answers that.
+            // on: whether to interrupt it depends entirely on what it is doing,
+            // and only the name and the command answer that.
             let names = (report.busy ?? [])
-                .map { "• \($0.name) — \($0.command)" }
+                .map { "• \($0.label)" }
                 .joined(separator: "\n")
             return .failure(RemoteSetupError(
                 state: .staged,
-                message: "termiod \(report.desired) is ready on \(host), and takes over once "
-                    + "the sessions still running there close:\n\(names)\n"
-                    + "Close those on \(host) and set it up again."))
+                message: "termiod \(report.desired) is ready on \(host) and takes over once "
+                    + "this finishes:\n\(names)\n"
+                    + "Update Anyway stops it now."))
         case .unhealthy:
             let rolledBack = report.rolledBack == true
                 ? "\nThe previous termiod is back in place." : ""

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -726,7 +726,17 @@ extension Termiod {
         struct BusySession: Decodable, Sendable {
             let name: String
             let command: String
+            let title: String?
             let status: String
+            let running: Bool?
+
+            /// What to call the session on a pane. The app names daemon
+            /// sessions by its own UUIDs, which say nothing to a person; the
+            /// agent's title does, and the command is the fallback.
+            var label: String {
+                if let title, !title.isEmpty { return title }
+                return UUID(uuidString: name) == nil ? "\(name) — \(command)" : command
+            }
         }
         let state: State
         let node: String

--- a/docs/design/20260827-termiod-lifecycle-reconcile.md
+++ b/docs/design/20260827-termiod-lifecycle-reconcile.md
@@ -362,10 +362,15 @@ the text above, the code is right and the reason is recorded here:
   binary on disk, and the binary on the first upgrade has no `status`. The
   loop reads clap's "unrecognized subcommand" as *older than anything*, stages
   first, and observes again with the new binary.
-- **Idle (open question 1) is decided:** no client attached *and* no session
-  `working` or `needs_you`. `stop` declines by default and names the sessions
-  (exit 3); `--force` overrides. There is no `--if-idle` flag — declining is
-  the default, not an option.
+- **Idle (open question 1) is decided, and §5.2's `attached == 0` is not it.**
+  Busy means *work in progress*: a command running in the foreground
+  (`foreground_job`, the daemon's own "closing this loses work" signal) or a
+  session `working` / `needs_you`. Being attached does not count — the client
+  on an idle prompt is usually the app whose user just asked for the update,
+  and an update the user's own tabs could veto has them closing tabs to get
+  it. `stop` declines by default and names the sessions (exit 3); `--force`
+  overrides, and the pane offers it as "Update Anyway" beside those names.
+  There is no `--if-idle` flag — declining is the default, not an option.
 - **A box a newer app set up is left alone** and reported as `current` with
   `newer: true`; the loop only ever moves a version up.
 - **§5.5 is `TermioStore.upgradingRoutes`:** a roster that fails while the app

--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -136,10 +136,11 @@ termiod deploy --host my-vps
 ```
 
 Each step is skipped when the observed state already matches: a box on the
-current build costs one `status`. A box whose daemon holds a session someone
-is attached to, or an agent still `working`, is left **staged** — the new
-binary is in place and takes over the next time the daemon is stopped — and
-the sessions are named so the decision is the user's. `--force` overrides.
+current build costs one `status`. A box whose daemon has work in progress — a
+command running in a session's foreground, or an agent still `working` — is
+left **staged**: the new binary is in place and takes over the next time the
+daemon is stopped, and the sessions are named so the decision is the user's.
+A client attached to an idle prompt does not hold it up. `--force` overrides.
 The version compared is the app's build stamp (`0.44.0+1533`), carried by the
 daemon at `hello`; a box a newer app set up is left alone.
 

--- a/termiod/README.md
+++ b/termiod/README.md
@@ -112,7 +112,7 @@ this binary carries, asks the old daemon to stop when nothing is in use, checks
 the new one answers, and puts the previous binary back if it does not. Running
 it again is the recovery from any outcome. On the box itself, `termiod status`
 says what is there and `termiod stop` asks the daemon to leave (declined, with
-the sessions named, while one is attached or an agent is mid-task).
+the sessions named, while a command is running or an agent is mid-task).
 
 `my-vps` = `~/.ssh/config` alias. Close the laptop; reattach — agent kept running on the VPS. See [`DEPLOY.md`](DEPLOY.md).
 

--- a/termiod/build.rs
+++ b/termiod/build.rs
@@ -16,6 +16,12 @@ use std::process::Command;
 fn main() {
     println!("cargo:rerun-if-env-changed=TERMIO_VERSION");
     println!("cargo:rerun-if-env-changed=TERMIO_BUILD");
+    // The commit-count fallback below moves with every commit, so the stamp
+    // has to be recomputed when HEAD does — otherwise a checkout keeps
+    // reporting the count of whatever it was first built at.
+    for path in head_paths() {
+        println!("cargo:rerun-if-changed={path}");
+    }
 
     let version = std::env::var("TERMIO_VERSION")
         .ok()
@@ -27,6 +33,34 @@ fn main() {
         .or_else(commit_count)
         .unwrap_or_else(|| "0".to_string());
     println!("cargo:rustc-env=TERMIOD_VERSION={version}+{build}");
+}
+
+/// The files that change when HEAD moves: `HEAD` itself, and the branch ref
+/// it points at. Resolved through git so a worktree's private git dir is
+/// found too. Empty outside a checkout.
+fn head_paths() -> Vec<String> {
+    let git = |args: &[&str]| -> Option<String> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .output()
+            .ok()?;
+        output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+            .filter(|text| !text.is_empty())
+    };
+    let mut paths = Vec::new();
+    if let Some(head) = git(&["rev-parse", "--git-path", "HEAD"]) {
+        paths.push(head);
+    }
+    if let Some(reference) = git(&["symbolic-ref", "-q", "HEAD"]) {
+        if let Some(path) = git(&["rev-parse", "--git-path", &reference]) {
+            paths.push(path);
+        }
+    }
+    paths
 }
 
 /// `git rev-list --count HEAD`, the same number the release workflow stamps as

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -232,8 +232,14 @@ pub struct SessionSummary {
     pub id: String,
     pub name: String,
     pub command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     pub status: String,
     pub attached: usize,
+    /// A command is running in the foreground — the shell is not at its
+    /// prompt. The daemon's own "closing this loses work" signal.
+    #[serde(default)]
+    pub running: bool,
     pub alive: bool,
 }
 
@@ -243,21 +249,28 @@ impl From<SessionInfo> for SessionSummary {
             id: info.id,
             name: info.name,
             command: info.command,
+            title: info.title,
             status: info.status,
             attached: info.attached_clients,
+            running: info.foreground_job,
             alive: info.alive,
         }
     }
 }
 
 impl SessionSummary {
-    /// Whether stopping the daemon would take work from someone. A client
-    /// attached is one answer; an agent still working, or waiting on its
-    /// user, is the other — the workstream status is in the protocol so that
-    /// a daemon does not have to guess from a screen, and an agent nobody is
-    /// watching is exactly the session "lives on the box" promises to keep.
+    /// Whether stopping the daemon would take *work* from someone: a command
+    /// running in the foreground, or an agent still working or waiting on its
+    /// user. The workstream status is in the protocol so a daemon does not
+    /// have to guess from a screen, and an agent nobody is watching is exactly
+    /// the session "lives on the box" promises to keep.
+    ///
+    /// Being attached is deliberately not the test. A client on a shell at its
+    /// prompt loses nothing but the prompt, and that client is usually the
+    /// app whose user just asked for the update — an update the user's own
+    /// idle tabs could veto would have them closing tabs to get it.
     pub fn busy(&self) -> bool {
-        self.alive && (self.attached > 0 || matches!(self.status.as_str(), "working" | "needs_you"))
+        self.alive && (self.running || matches!(self.status.as_str(), "working" | "needs_you"))
     }
 }
 
@@ -437,13 +450,12 @@ pub async fn stop(force: bool) -> Result<StopOutcome> {
             .collect();
         if !busy.is_empty() {
             let message = format!(
-                "{} in use on this machine; close {} or pass --force",
+                "{} still working on this machine; wait, or pass --force",
                 if busy.len() == 1 {
                     "1 session is".to_string()
                 } else {
                     format!("{} sessions are", busy.len())
-                },
-                if busy.len() == 1 { "it" } else { "them" }
+                }
             );
             return Ok(StopOutcome {
                 stopped: false,
@@ -604,12 +616,17 @@ impl Report {
             ),
             Outcome::Staged { version, busy, .. } => {
                 let mut text = format!(
-                    "{node}: termiod {version} is staged, but the daemon still running there is in use:"
+                    "{node}: termiod {version} is staged, but the daemon still running there has work in progress:"
                 );
                 for session in busy {
-                    text.push_str(&format!("\n  • {} — {}", session.name, session.command));
+                    text.push_str(&format!(
+                        "\n  • {} — {} ({})",
+                        session.title.as_deref().unwrap_or(&session.name),
+                        session.command,
+                        session.status
+                    ));
                 }
-                text.push_str(&format!("\nClose those on {node} and run this again, or pass --force."));
+                text.push_str("\nRun this again once it finishes, or pass --force to stop it now.");
                 text
             }
             Outcome::Unhealthy {
@@ -933,23 +950,28 @@ mod tests {
         assert!(Version::parse("0.44.0+abc").is_none());
     }
 
+    /// Busy is about work, not watchers: a command in the foreground or an
+    /// agent mid-task holds the daemon up; a client attached to an idle prompt
+    /// does not, because that client is usually the app asking for the update.
     #[test]
-    fn a_session_is_busy_when_attached_or_the_agent_is_mid_task() {
-        let session = |attached, status: &str, alive| SessionSummary {
+    fn a_session_is_busy_when_work_is_in_progress_not_when_someone_is_attached() {
+        let session = |attached, running, status: &str, alive| SessionSummary {
             id: "1".into(),
             name: "s".into(),
             command: "bash".into(),
+            title: None,
             status: status.into(),
             attached,
+            running,
             alive,
         };
-        assert!(!session(0, "unknown", true).busy());
-        assert!(!session(0, "idle", true).busy());
-        assert!(!session(0, "done", true).busy());
-        assert!(session(1, "idle", true).busy());
-        assert!(session(0, "working", true).busy());
-        assert!(session(0, "needs_you", true).busy());
-        assert!(!session(1, "working", false).busy());
+        assert!(!session(0, false, "unknown", true).busy());
+        assert!(!session(1, false, "idle", true).busy());
+        assert!(!session(3, false, "done", true).busy());
+        assert!(session(0, true, "unknown", true).busy());
+        assert!(session(0, false, "working", true).busy());
+        assert!(session(0, false, "needs_you", true).busy());
+        assert!(!session(1, true, "working", false).busy());
     }
 
     /// The build stamp `build.rs` produces always parses — the loop's desired
@@ -1105,8 +1127,10 @@ mod tests {
                 id: "1".into(),
                 name: "claude".into(),
                 command: "claude".into(),
+                title: None,
                 status: "working".into(),
                 attached: 0,
+                running: true,
                 alive: true,
             }],
             message: "1 session is in use".into(),

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -249,14 +249,15 @@ enum Cmd {
         json: bool,
     },
 
-    /// Ask the daemon to stop. Declines while a session is attached or an
-    /// agent is mid-task, and names them; `--force` stops it regardless.
+    /// Ask the daemon to stop. Declines while a command is running or an
+    /// agent is mid-task, and names the sessions; `--force` stops it regardless.
+    /// A client attached to an idle prompt does not hold it up.
     ///
     /// The daemon is found by the credential on its socket, never by its
     /// command line, so a second daemon someone runs by hand on another socket
     /// is never the one stopped. Exit 3 means "in use", not failure.
     Stop {
-        /// Stop even while sessions are in use. Every session ends.
+        /// Stop even while work is in progress. Every session ends.
         #[arg(long)]
         force: bool,
         #[arg(long)]
@@ -275,7 +276,7 @@ enum Cmd {
         /// this machine's own daemon is checked and restarted if stale.
         #[arg(long)]
         host: Option<String>,
-        /// Stop the old daemon even while its sessions are in use.
+        /// Stop the old daemon even while its sessions have work in progress.
         #[arg(long)]
         force: bool,
         /// Put the binary in place and leave the running daemon alone.

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -88,7 +88,7 @@ pub enum RemoteCmd {
         /// Force a Rust target triple instead of auto-detecting from `uname`.
         #[arg(long)]
         target: Option<String>,
-        /// Stop the old daemon even while its sessions are in use.
+        /// Stop the old daemon even while its sessions have work in progress.
         #[arg(long)]
         force: bool,
         /// Emit the outcome as one JSON document on stdout.


### PR DESCRIPTION
Follow-up to #499. `termiod stop` (and so *Set Up* in Settings ▸ Machines) declined while any client was attached — and the attached client is usually the app whose user just asked for the update, so its own idle tabs vetoed it with "close those and set it up again".

Busy is now **work in progress**: a command running in a session's foreground (`foreground_job`, the signal the daemon already computes for "closing this loses work") or an agent `working` / `needs_you`. A client on a shell at its prompt no longer holds the daemon up. When there is work, the pane names it (by title or command, not the app's UUID) and offers **Update Anyway**, which runs the loop with `--force`.

RFC §11 records the change to the idle definition.

## Verified
- `cargo test` (180 unit + integration suites) and `swift build` / affected Swift tests green.
- Against the VPS with the release app attached to an idle login shell: see the PR comment for the run.

## Release Notes
- Updating termiod on a machine is no longer blocked by your own idle terminals there; when an agent or command is still running, the pane names it and offers Update Anyway.
