### PR TITLE
Send the daemon the reporter names it actually has

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -1225,14 +1225,16 @@ public enum Termiod {
         case leave
     }
 
-    /// What an installed hook runs to report status. Only the client knows
-    /// whether an app is listening and where its CLI copy is, so it says.
-    public enum AgentHookReporter: Sendable {
-        /// `termio agent report <state>` into this app's control socket.
-        case termioCommandLineTool(path: String)
-        /// `termiod set-status "$TERMIOD_SESSION_ID" <state>` into the daemon
-        /// that owns the PTY. A box has no `termio` and no app to report to.
-        case termiodDaemon
+    /// Which machine the integration is for. Every hook reports to the daemon
+    /// that owns its PTY, so the daemon resolves the command itself; what
+    /// still differs is the skill payload — a Mac has a `termio` binary to
+    /// teach and a box does not. Spelled exactly as the daemon's `Reporter`
+    /// (`termiod/src/agent/install.rs`): `this_mac`, `device`.
+    public enum AgentHookReporter: String, Sendable {
+        /// This Mac, where the app is running.
+        case thisMac = "this_mac"
+        /// A box reached over the protocol.
+        case device
     }
 
     /// Decoded control frames the client reacts to. Anything else — unknown
@@ -1397,20 +1399,12 @@ public enum Termiod {
         let hookVersion: String
         let seq: Int
 
-        /// Externally tagged the way the daemon spells it: `{kind, …}`.
+        /// Internally tagged the way the daemon spells it: `{"kind": …}`.
         struct Reporter: Encodable {
             let kind: String
-            let path: String?
 
             init(_ reporter: AgentHookReporter) {
-                switch reporter {
-                case .termioCommandLineTool(let path):
-                    kind = "termio_cli"
-                    self.path = path
-                case .termiodDaemon:
-                    kind = "termiod_daemon"
-                    path = nil
-                }
+                kind = reporter.rawValue
             }
         }
     }

--- a/Sources/termio/Agents/AgentIntegrationInstaller.swift
+++ b/Sources/termio/Agents/AgentIntegrationInstaller.swift
@@ -24,31 +24,26 @@ import TermioShared
 /// from — no daemon binary at all — is reported, never swallowed, because a Mac
 /// that could always install its own hooks must not start failing quietly.
 enum AgentIntegrationInstaller {
-    /// Where the integration is written, and what a hook there runs to report.
+    /// Where the integration is written, and which machine's skill it gets.
     ///
-    /// The two travel together because they are one decision. A hook on this Mac
-    /// reports through the `termio` CLI to the app's control socket; a hook on a
-    /// device has neither, and reports through `termiod set-status` to the daemon
-    /// that owns its PTY.
+    /// The two travel together because they are one decision. Every hook
+    /// reports to the daemon that owns its PTY — the daemon builds that command
+    /// itself — but this Mac's skill teaches the `termio` CLI and a device's
+    /// does not.
     struct Target {
         let route: TermiodRoute
         let reporter: Termiod.AgentHookReporter
 
         /// This Mac. The daemon is local, and the app is what listens.
         static var thisMac: Target {
-            Target(
-                route: .local,
-                reporter: .termioCommandLineTool(path: CommandLineTool.supportCopyURL.path))
+            Target(route: .local, reporter: .thisMac)
         }
 
         static func device(host: String) -> Target {
-            Target(route: .ssh(host), reporter: .termiodDaemon)
+            Target(route: .ssh(host), reporter: .device)
         }
 
-        var isLocal: Bool {
-            if case .termioCommandLineTool = reporter { return true }
-            return false
-        }
+        var isLocal: Bool { reporter == .thisMac }
     }
 
     /// Marker + version stamped into every installed hook. The command string
@@ -140,9 +135,12 @@ extension InstallOutcome {
     }
 
     /// The install never reached the machine at all. Named so a Settings row
-    /// says what happened instead of showing an empty success.
+    /// says what happened instead of showing an empty success, and kept apart
+    /// from the per-agent list so a pane can print it as the sentence it is
+    /// rather than as the name of an agent.
     init(failure: String) {
         self.init()
+        self.failure = failure
         record(failure, installed: false)
     }
 }

--- a/Sources/termio/Agents/InstallOutcome.swift
+++ b/Sources/termio/Agents/InstallOutcome.swift
@@ -13,6 +13,10 @@ struct InstallOutcome {
     /// Names of the targets that refused it (unparseable config, failed write, or
     /// a file termio doesn't own sitting at its path).
     private(set) var failed: [String] = []
+    /// Why the request itself failed, when it never reached the machine —
+    /// the daemon refused it, or the connection dropped. `nil` when the
+    /// machine answered, even if it refused every agent.
+    var failure: String?
 
     var isEmpty: Bool { succeeded.isEmpty && failed.isEmpty }
 

--- a/Sources/termio/Settings/DeviceReadiness.swift
+++ b/Sources/termio/Settings/DeviceReadiness.swift
@@ -350,6 +350,13 @@ final class DevicePaneModel: ObservableObject {
             hooks: settings.agentHooksEnabled ? .install : .remove,
             skills: settings.sessionControlEnabled ? .install : .remove,
             target: device.integrationTarget)
+        // A request the machine never acted on is reported in its own words —
+        // it is a sentence, not an agent that refused.
+        if let failure = outcome.failure {
+            apply(state)
+            readiness = .blocked(localized("Couldn’t install hooks on \(device.name).\n\(failure)"))
+            return
+        }
         // A rung that reached the machine but could not write every agent's config
         // is still a failure of *this* rung, and the one worth naming.
         let refused = outcome.failed

--- a/Tests/termioTests/TermiodAgentInstallWireTests.swift
+++ b/Tests/termioTests/TermiodAgentInstallWireTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import TermioShared
+import XCTest
+@testable import termio
+
+/// The `install_agents` reporter is spelled by the daemon's `Reporter` enum
+/// (`termiod/src/agent/install.rs`, internally tagged on `kind`). The two
+/// sides drifted once — the daemon renamed its variants and the app kept
+/// sending the old names, and every hook install in that release failed with
+/// "unknown variant" — so the wire spelling is pinned here.
+final class TermiodAgentInstallWireTests: XCTestCase {
+    private func reporterJSON(_ reporter: Termiod.AgentHookReporter) throws -> [String: Any] {
+        let payload = try Termiod.installAgentsPayload(
+            agents: nil, hooks: .install, skills: .install, reporter: reporter, hookVersion: "1")
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: payload) as? [String: Any])
+        return try XCTUnwrap(object["reporter"] as? [String: Any])
+    }
+
+    func testThisMacIsSpelledTheDaemonsWay() throws {
+        let reporter = try reporterJSON(.thisMac)
+        XCTAssertEqual(reporter["kind"] as? String, "this_mac")
+        XCTAssertEqual(reporter.count, 1, "the daemon resolves the command itself; nothing else travels")
+    }
+
+    func testADeviceIsSpelledTheDaemonsWay() throws {
+        let reporter = try reporterJSON(.device)
+        XCTAssertEqual(reporter["kind"] as? String, "device")
+        XCTAssertEqual(reporter.count, 1)
+    }
+}

--- a/termiod/src/agent/install.rs
+++ b/termiod/src/agent/install.rs
@@ -1328,6 +1328,17 @@ pub(super) mod tests {
     use super::*;
     use crate::agent::manifest::AgentManifest;
 
+    /// The wire spelling the app sends (`Termiod.AgentHookReporter` in
+    /// `TermioShared`). Renaming a variant here without the app is how every
+    /// hook install in one release failed with "unknown variant".
+    #[test]
+    fn a_reporter_is_spelled_the_way_the_app_sends_it() {
+        assert_eq!(serde_json::to_string(&Reporter::ThisMac).unwrap(), r#"{"kind":"this_mac"}"#);
+        assert_eq!(serde_json::to_string(&Reporter::Device).unwrap(), r#"{"kind":"device"}"#);
+        let parsed: Reporter = serde_json::from_str(r#"{"kind":"device"}"#).unwrap();
+        assert_eq!(parsed, Reporter::Device);
+    }
+
     /// A request whose binary is stated rather than resolved, so a test can
     /// assert generated output byte for byte without depending on where the
     /// test binary happens to sit.


### PR DESCRIPTION
`7feae90` (in v0.43.0) renamed the daemon's `Reporter` variants to `this_mac` / `device`, but the app kept sending `termio_cli` / `termiod_daemon`. Every hook install since — this Mac and devices alike — has been refused with `unknown variant`, and Settings ▸ Machines showed the refusal as the name of a failed agent ("Couldn't write the config for invalid control JSON: … on ukvps").

- `Termiod.AgentHookReporter` is now `thisMac` / `device`, spelled as the daemon's enum, with no path (the daemon resolves the command itself since `7feae90`).
- Wire tests on both sides pin the spelling.
- A request the machine never acted on is shown in its own words.

## Release Notes
- Fixes agent hook installation, which failed on every machine in 0.43.0 with "unknown variant".
