### PR TITLE
Give a machine's pane one action instead of the same one twice

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -2774,6 +2774,36 @@
         }
       }
     },
+    "Hooks": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hooks"
+          }
+        }
+      }
+    },
+    "Hooks and skill installed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hooks 和技能已安装"
+          }
+        }
+      }
+    },
+    "Hooks installed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hooks 已安装"
+          }
+        }
+      }
+    },
     "Hooks reinstalled": {
       "localizations": {
         "zh-Hans": {
@@ -5197,6 +5227,16 @@
         }
       }
     },
+    "Report each agent’s status back to Termio.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "把每个 Agent 的状态报告回 Termio。"
+          }
+        }
+      }
+    },
     "Repository": {
       "localizations": {
         "zh-Hans": {
@@ -5778,6 +5818,26 @@
         }
       }
     },
+    "Skill": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "技能"
+          }
+        }
+      }
+    },
+    "Skill installed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "技能已安装"
+          }
+        }
+      }
+    },
     "Skill reinstalled": {
       "localizations": {
         "zh-Hans": {
@@ -6024,6 +6084,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "任务完成"
+          }
+        }
+      }
+    },
+    "Teaches agents the termio session commands.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "教 Agent 使用 termio 的会话命令。"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -562,6 +562,12 @@
 	<string>Hide or show the navigator</string>
 	<key>History</key>
 	<string>History</string>
+	<key>Hooks</key>
+	<string>Hooks</string>
+	<key>Hooks and skill installed</key>
+	<string>Hooks and skill installed</string>
+	<key>Hooks installed</key>
+	<string>Hooks installed</string>
 	<key>Hooks reinstalled</key>
 	<string>Hooks reinstalled</string>
 	<key>Host</key>
@@ -1046,6 +1052,8 @@
 	<string>Replace</string>
 	<key>Replace All</key>
 	<string>Replace All</string>
+	<key>Report each agent’s status back to Termio.</key>
+	<string>Report each agent’s status back to Termio.</string>
 	<key>Repository</key>
 	<string>Repository</string>
 	<key>Request Permission</key>
@@ -1162,6 +1170,10 @@
 	<string>Signs in with the keys ssh offers by default.</string>
 	<key>Size: %lld pt</key>
 	<string>Size: %lld pt</string>
+	<key>Skill</key>
+	<string>Skill</string>
+	<key>Skill installed</key>
+	<string>Skill installed</string>
 	<key>Skill reinstalled</key>
 	<string>Skill reinstalled</string>
 	<key>Skip permission prompts</key>
@@ -1212,6 +1224,8 @@
 	<string>Tallied from %@'s own local session logs across every terminal and editor on this Mac — your actual usage, regardless of how the plan bills.%@</string>
 	<key>Task completion</key>
 	<string>Task completion</string>
+	<key>Teaches agents the termio session commands.</key>
+	<string>Teaches agents the termio session commands.</string>
 	<key>Terminal</key>
 	<string>Terminal</string>
 	<key>Terminal default</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -562,6 +562,12 @@
 	<string>隐藏或显示导航器</string>
 	<key>History</key>
 	<string>历史</string>
+	<key>Hooks</key>
+	<string>Hooks</string>
+	<key>Hooks and skill installed</key>
+	<string>Hooks 和技能已安装</string>
+	<key>Hooks installed</key>
+	<string>Hooks 已安装</string>
 	<key>Hooks reinstalled</key>
 	<string>Hooks 已重新安装</string>
 	<key>Host</key>
@@ -1046,6 +1052,8 @@
 	<string>替换</string>
 	<key>Replace All</key>
 	<string>全部替换</string>
+	<key>Report each agent’s status back to Termio.</key>
+	<string>把每个 Agent 的状态报告回 Termio。</string>
 	<key>Repository</key>
 	<string>仓库</string>
 	<key>Request Permission</key>
@@ -1162,6 +1170,10 @@
 	<string>使用 ssh 默认提供的密钥登录。</string>
 	<key>Size: %lld pt</key>
 	<string>大小：%lld 磅</string>
+	<key>Skill</key>
+	<string>技能</string>
+	<key>Skill installed</key>
+	<string>技能已安装</string>
 	<key>Skill reinstalled</key>
 	<string>技能已重新安装</string>
 	<key>Skip permission prompts</key>
@@ -1212,6 +1224,8 @@
 	<string>根据 %@ 在这台 Mac 上所有终端和编辑器的本地会话日志统计——即你的实际用量，与套餐计费方式无关。%@</string>
 	<key>Task completion</key>
 	<string>任务完成</string>
+	<key>Teaches agents the termio session commands.</key>
+	<string>教 Agent 使用 termio 的会话命令。</string>
 	<key>Terminal</key>
 	<string>终端</string>
 	<key>Terminal default</key>

--- a/Sources/termio/Settings/DevicePane.swift
+++ b/Sources/termio/Settings/DevicePane.swift
@@ -252,42 +252,55 @@ struct DevicePane: View {
 
     // MARK: The ladder, as disclosure
 
-    /// The rungs behind the one line. Each is still individually runnable — a
-    /// config hand-edited after Termio wrote it is exactly what "Reinstall" is
-    /// for — but none of them is the primary action.
+    /// The facts behind the one line. The daemon's row is read-only: putting it
+    /// there, and updating it, is what *Set Up* does, and a second button for
+    /// the same loop was the same action twice under two verbs. The hooks and
+    /// the skill keep a "Reinstall" each because a config hand-edited after
+    /// Termio wrote it is a real case — but neither is the primary action.
     private var integrationSection: some View {
         Section {
             if machine.isLocal {
                 CommandLineToolRow()
             } else {
-                LabeledContent {
-                    Button(localized("Deploy")) { Task { await model.setUp() } }
-                        .disabled(model.readiness.isBusy)
-                } label: {
-                    SettingsLabel(
-                        title: "termiod",
-                        subtext: model.discovered?.termiodVersion.map {
-                            localized("Version \($0) on \(machine.name). Sessions keep running there after you disconnect.")
-                        } ?? localized("The session host on \(machine.name). Sessions keep running there after you disconnect."),
-                        titleFont: .headline
-                    )
+                SettingsLabel(
+                    title: "termiod",
+                    subtext: model.discovered?.termiodVersion.map {
+                        localized("Version \($0) on \(machine.name). Sessions keep running there after you disconnect.")
+                    } ?? localized("The session host on \(machine.name). Sessions keep running there after you disconnect."),
+                    titleFont: .headline
+                )
+            }
+            LabeledContent {
+                InstallButtonRow(title: localized("Reinstall"), trailing: true) {
+                    .summarizing(
+                        await AgentIntegrationInstaller.sync(
+                            hooks: settings.agentHooksEnabled ? .install : .remove,
+                            skills: .leave,
+                            target: machine.integrationTarget),
+                        headline: localized("Hooks reinstalled"), unit: localized("agents"))
                 }
+            } label: {
+                SettingsLabel(
+                    title: localized("Hooks"),
+                    subtext: localized("Report each agent’s status back to Termio."),
+                    titleFont: .headline
+                )
             }
-            InstallButtonRow(title: localized("Reinstall hooks")) {
-                .summarizing(
-                    await AgentIntegrationInstaller.sync(
-                        hooks: settings.agentHooksEnabled ? .install : .remove,
-                        skills: .leave,
-                        target: machine.integrationTarget),
-                    headline: localized("Hooks reinstalled"), unit: localized("agents"))
-            }
-            InstallButtonRow(title: localized("Reinstall skill")) {
-                .summarizing(
-                    await AgentIntegrationInstaller.sync(
-                        hooks: .leave,
-                        skills: settings.sessionControlEnabled ? .install : .remove,
-                        target: machine.integrationTarget),
-                    headline: localized("Skill reinstalled"), unit: localized("agents"))
+            LabeledContent {
+                InstallButtonRow(title: localized("Reinstall"), trailing: true) {
+                    .summarizing(
+                        await AgentIntegrationInstaller.sync(
+                            hooks: .leave,
+                            skills: settings.sessionControlEnabled ? .install : .remove,
+                            target: machine.integrationTarget),
+                        headline: localized("Skill reinstalled"), unit: localized("agents"))
+                }
+            } label: {
+                SettingsLabel(
+                    title: localized("Skill"),
+                    subtext: localized("Teaches agents the termio session commands."),
+                    titleFont: .headline
+                )
             }
         } header: {
             SectionHeaderLabel(title: localized("Installed by Termio"))

--- a/Sources/termio/Settings/DeviceReadiness.swift
+++ b/Sources/termio/Settings/DeviceReadiness.swift
@@ -368,7 +368,15 @@ final class DevicePaneModel: ObservableObject {
         }
         state.integrationVersion = AppInfo.buildStamp
         apply(state)
-        feedback = .success(localized("\(device.name) is ready."))
+        // The outcome line already says "Ready"; what this adds is *what was
+        // put there*, and with both switches off there is nothing to add.
+        let headline: String? = switch (settings.agentHooksEnabled, settings.sessionControlEnabled) {
+        case (true, true): localized("Hooks and skill installed")
+        case (true, false): localized("Hooks installed")
+        case (false, true): localized("Skill installed")
+        case (false, false): nil
+        }
+        feedback = headline.map { .summarizing(outcome, headline: $0, unit: localized("agents")) }
     }
 
     /// The first rung. This Mac needs the `termio` CLI on `PATH` — a hook it

--- a/Sources/termio/Settings/SettingsControls.swift
+++ b/Sources/termio/Settings/SettingsControls.swift
@@ -300,6 +300,10 @@ extension View {
 /// actor; this type's job is to not block on it.
 struct InstallButtonRow: View {
     let title: String
+    /// Laid out as a `LabeledContent` control — the button at the row's
+    /// trailing edge with its result to the left of it — rather than as a
+    /// standalone row that leads with the button.
+    var trailing = false
     let action: () async -> InstallFeedback
 
     @State private var state = InstallFeedbackState()
@@ -307,6 +311,7 @@ struct InstallButtonRow: View {
 
     var body: some View {
         HStack(spacing: 10) {
+            if trailing { result }
             Button(title) {
                 running = true
                 Task {
@@ -316,16 +321,23 @@ struct InstallButtonRow: View {
                 }
             }
             .disabled(running)
-            if running {
-                ProgressView()
-                    .controlSize(.small)
-                    .transition(.opacity)
-            } else if let feedback = state.feedback {
-                InstallFeedbackLabel(feedback: feedback)
+            if !trailing {
+                result
+                Spacer(minLength: 0)
             }
-            Spacer(minLength: 0)
         }
         .autoDismissing($state)
+    }
+
+    @ViewBuilder
+    private var result: some View {
+        if running {
+            ProgressView()
+                .controlSize(.small)
+                .transition(.opacity)
+        } else if let feedback = state.feedback {
+            InstallFeedbackLabel(feedback: feedback)
+        }
     }
 }
 


### PR DESCRIPTION
Settings ▸ Machines ▸ *machine* offered the lifecycle loop twice: *Set Up* on the outcome line and *Deploy* on the termiod row, which called the same `setUp()`. The termiod row is now read-only (version + what it means); the single action stays on the outcome line, where *Update Anyway* also lives.

Also: the two bare *Reinstall hooks* / *Reinstall skill* buttons become labelled rows matching the rest of the pane (`InstallButtonRow` gains a trailing layout), and the success line under "Ready" says what was installed instead of repeating "is ready".

## Release Notes
- The machine pane no longer shows a second Deploy button for the same setup; hooks and skill each get a labelled Reinstall row.
