### PR TITLE
Bump libghostty to 1.0.20 and count active installs once a day

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1e1674360033235500cdc0587efcdff497b0d5ce2953c3b9f3830a66307f17dc",
+  "originHash" : "1d64db25bb4aca66c7bd4c6d6e26f9fd862164e32efbcab73143f258f9001bea",
   "pins" : [
     {
       "identity" : "highlightr",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "21d67c485107aa2c0d0ac76cfd6d52d16ad1eafd",
-        "version" : "1.0.18"
+        "revision" : "b0deec8df1dd8795a8025ae51671dd6c5b591eea",
+        "version" : "1.0.20"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // live resize" suspicion that briefly rolled this back to Lakr233 was a
         // misdiagnosis — the real bug was termio's own PTY spawn shape (see
         // docs/bug/terminal-resize-no-reflow-HANDOFF.md §0).
-        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.18"),
+        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.20"),
         // Sparkle powers in-app auto-update (the "Check for Updates…" menu item and
         // background update checks). It reads the appcast published with each GitHub
         // release; the matching EdDSA public key is embedded in packaging/Info.plist.

--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -46,20 +46,9 @@ public enum Termiod {
     public static let controlCapabilities: [String] = []
 
     /// What a client that *renders a whole device* asks for on its control
-    /// channel — the phone's roster socket and its inspector's.
-    ///
-    /// Wider than `controlCapabilities` because every one of these has a
-    /// consumer here, which is the same rule the attach table follows:
-    ///
-    /// | Capability | Consumer |
-    /// | ---------- | -------- |
-    /// | `events`   | `subscribe` on `roster` + `status`, so the session list is pushed rather than polled |
-    /// | `files`    | `fs_list` / `fs_read` / `fs_match` — the Files pane |
-    /// | `upload`   | `upload_open` / `U` / `upload_commit` — saving an edit, and a photo crossing to the device |
-    ///
-    /// `git` is deliberately absent: nothing on this side decodes its replies
-    /// yet, and offering a capability with nothing behind it is worse than not
-    /// offering it.
+    /// channel: a pushed session list, the Files pane, and a save or a paste
+    /// crossing over. `git` is absent because nothing on this side decodes its
+    /// replies yet, and a capability with nothing behind it is worse than none.
     public static let deviceCapabilities = ["events", "files", "upload"]
 
     public static let protocolVersion: UInt32 = 1
@@ -151,14 +140,9 @@ public enum Termiod {
     }
 
     /// Reassembles frames from a transport whose own message boundaries mean
-    /// nothing to this protocol.
-    ///
-    /// `readFrame` above pulls exactly as many bytes as a header says it needs,
-    /// which a blocking descriptor can do and a WebSocket cannot: the daemon's
-    /// listener splices raw stream bytes into binary messages of whatever size
-    /// the copy loop happened to read, so one message may carry three frames, or
-    /// a third of one. Bytes are accumulated here and cut by the 5-byte header
-    /// instead — the same rule, driven by arrival rather than by demand.
+    /// nothing to this protocol. `readFrame` above pulls exactly what a header
+    /// asks for, which a blocking descriptor can do and a WebSocket cannot — one
+    /// message may carry three frames, or a third of one.
     ///
     /// Not thread-safe: its owner feeds it from one queue.
     public struct FrameReader {
@@ -166,12 +150,10 @@ public enum Termiod {
 
         public init() {}
 
-        /// Every frame that `chunk` completed, in order. A partial frame stays
-        /// buffered for the next chunk.
-        ///
-        /// Throws on a length past `maximumFrameSize` or a kind byte this
-        /// protocol does not define: both mean the stream has lost alignment,
-        /// and every later frame would be garbage read at a garbage offset.
+        /// Every frame that `chunk` completed, in order; a partial one stays
+        /// buffered. Throws on an over-long length or an undefined kind byte,
+        /// which both mean the stream has lost alignment and every later frame
+        /// would be read at a garbage offset.
         public mutating func append(
             _ chunk: Data
         ) throws -> [(kind: FrameKind, payload: Data)] {
@@ -514,11 +496,9 @@ public enum Termiod {
         }
     }
 
-    /// Filename search, which is a different question from `fs_search`'s
-    /// content search: this one matches the *names* in the host's index, and is
-    /// what a "jump to file" field asks. Answered from an index the host keeps
-    /// rather than by walking, so the reply carries how much of the tree that
-    /// index has covered.
+    /// Filename search, which is a different question from `fs_search`'s content
+    /// search: this matches *names* in an index the host keeps, so the reply
+    /// carries how much of the tree that index has covered.
     public struct FsMatchOperation: Encodable, Sendable {
         public let op = "fs_match"
         public let root: String
@@ -535,10 +515,8 @@ public enum Termiod {
     }
 
     /// Reply to `fs_match`: root-relative paths, best first. `coverage` is the
-    /// fraction of the tree the index has walked (0–1), and it is load-bearing
-    /// rather than decoration — a host with no index for this root answers with
-    /// no paths at coverage 0, which means *not indexed* and must never be shown
-    /// as "no matches".
+    /// fraction of the tree the index has walked (0–1) — no paths at coverage 0
+    /// means *not indexed*, and must never be shown as "no matches".
     public struct FsMatchedPayload: Decodable, Sendable {
         public let paths: [String]
         public let coverage: Double
@@ -1016,17 +994,13 @@ public enum Termiod {
     }
 
     /// A workstream status delta — `working · idle · needs_you · done · failed ·
-    /// unknown` (§4). The host reports the *state*; which dot, which words, and
-    /// whether it fires a notification are entirely the client's call.
-    /// A session's agent status, as its own daemon reports it.
+    /// unknown`. The host reports the *state*; which dot, which words, and
+    /// whether it fires a notification are the client's call.
     ///
-    /// Everything past `title` used to exist only on this Mac, carried by a hook
-    /// writing the app's own socket, and a device could not say any of it. One
-    /// report path made them the same message — see the `set_status` op.
-    ///
-    /// **Ordering.** This rides the session's own channel, the same FIFO its
-    /// output goes through, so it cannot overtake bytes the daemon has already
-    /// read and a client is right to apply it on arrival.
+    /// Everything past `title` used to exist only on the Mac, carried by a hook
+    /// writing the app's own socket; the `set_status` op made local and remote
+    /// the same message. It rides the session's own FIFO, so it cannot overtake
+    /// bytes the daemon has already read and is right to apply on arrival.
     public struct StatusPayload: Decodable, Sendable {
         public let session: String
         public let status: String
@@ -1465,16 +1439,9 @@ public enum Termiod {
 }
 
 /// Turns `list`'s flat `[SessionInformation]` into the Workspace → container →
-/// Session tree a viewer draws.
-///
-/// The daemon has no notion of a project: it holds sessions, and a session
-/// carries at most the workstream it was started for. So the grouping is the
-/// client's to do — and it belongs here rather than in one client, because a
-/// phone and a browser looking at the same box must not draw two different
-/// trees out of the same list.
-///
-/// The classification mirrors the desktop's `Workspace` exactly
-/// (`Sources/termio/App/Models.swift`), and turns on two fields and no others:
+/// Session tree a viewer draws. The daemon has no notion of a project, so the
+/// grouping is the client's — and it lives here so a phone and a browser looking
+/// at the same box cannot draw two different trees out of one list.
 ///
 /// | Condition | Container |
 /// | --- | --- |
@@ -1482,24 +1449,20 @@ public enum Termiod {
 /// | no project, an agent | the workspace's **Chats** |
 /// | no project, no agent | the workspace's **Terminals** |
 ///
-/// **`cwd` is never consulted.** A loose shell spawns at `$HOME` and then
-/// carries its own cwd wherever the user walks it, so filing by `cwd` would
-/// invent a folder project named after wherever they happened to `cd` — and
-/// both loose containers would starve while folders appeared that nobody
-/// opened. The cwd of a loose session is incidental; the workstream is identity.
-/// See `docs/design/20260713-loose-terminal-entity.md`.
+/// `cwd` is never consulted: a loose session's cwd is wherever the user walked
+/// it, and filing by it would invent folder projects nobody opened. See
+/// `docs/design/20260713-loose-terminal-entity.md`.
 public enum TermiodRoster {
-    /// What a container is, in the companion wire's own `kind` vocabulary so the
-    /// screens that switch on it need no second spelling.
+    /// The companion wire's own `kind` vocabulary, so the screens that switch on
+    /// it need no second spelling.
     public enum Kind: String, Sendable {
         case folder
         case terminals
         case chats
     }
 
-    /// One container's worth of sessions. `id` is stable across pushes — it is
-    /// derived from what the container *is*, never from a position in a list, so
-    /// a row keeps its identity while the roster churns underneath it.
+    /// `id` is derived from what the container *is*, never from a position in a
+    /// list, so a row keeps its identity while the roster churns underneath it.
     public struct Project: Equatable, Sendable {
         public let id: String
         /// The absolute path on the device: a checkout for a folder, and the
@@ -1510,20 +1473,17 @@ public enum TermiodRoster {
         public let sessions: [Termiod.SessionInformation]
     }
 
-    /// The two loose containers' ids. Named rather than derived so a client can
-    /// also *address* one when starting a session into it, the way the companion
-    /// wire addresses a workspace's funnels by `Wire.looseSectionID`.
+    /// Named rather than derived so a client can also *address* one when
+    /// starting a session into it.
     public static let terminalsProjectID = "termiod:terminals"
     public static let chatsProjectID = "termiod:chats"
 
-    /// Where a loose **shell** spawns on the device: the account's home
-    /// directory, the way launching a new terminal window drops you at `~`.
+    /// A new terminal window drops you at `~`, and so does this.
     public static func looseTerminalRoot(homeDirectory: String) -> String { homeDirectory }
 
-    /// Where a loose **agent** session spawns: a scoped scratch directory, never
-    /// `$HOME` — an autonomous agent turned loose in a home directory can read
-    /// and write `~/.ssh` and everything beside it. The desktop's
-    /// `TermioStore.looseChatRoot`, resolved against the device's own home.
+    /// A scoped scratch directory, never `$HOME`: an autonomous agent turned
+    /// loose in a home directory can read and write `~/.ssh` and everything
+    /// beside it. The desktop's `TermioStore.looseChatRoot`, on the device.
     public static func looseChatRoot(homeDirectory: String) -> String {
         (homeDirectory as NSString).appendingPathComponent(".termio/chats")
     }
@@ -1541,17 +1501,11 @@ public enum TermiodRoster {
         return String(id.dropFirst(prefix.count))
     }
 
-    /// Group `sessions` into the containers above.
-    ///
-    /// Terminals, then Chats, then the folder projects — the desktop's own
-    /// emission order (`CompanionServer.companionRoster`), and each loose
-    /// container appears only when it holds something, so a box with no loose
-    /// sessions shows no empty funnels.
-    ///
-    /// Folders are ordered by path rather than by arrival: the daemon walks a
-    /// hash map to answer `list`, so the same set of sessions comes back in a
-    /// different order every time, and a list that reshuffles under the reader
-    /// between two identical pushes is worse than one merely sorted oddly.
+    /// Terminals, then Chats, then folders — the desktop's own emission order,
+    /// with a loose container appearing only when it holds something. Folders
+    /// sort by path because the daemon answers `list` by walking a hash map, and
+    /// a list that reshuffles between two identical pushes is worse than one
+    /// sorted oddly.
     public static func projects(
         from sessions: [Termiod.SessionInformation], homeDirectory: String
     ) -> [Project] {
@@ -1600,8 +1554,7 @@ public enum TermiodRoster {
         }
     }
 
-    /// Oldest first — a fact about the sessions rather than about the hash map
-    /// they came out of, and the tie-break keeps two sessions created in the
+    /// Oldest first, with a tie-break that keeps two sessions created in the
     /// same second from swapping between pushes.
     private static func ordered(
         _ sessions: [Termiod.SessionInformation]

--- a/Sources/termio/App/Analytics.swift
+++ b/Sources/termio/App/Analytics.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+/// The one thing termio measures about itself: how many installs open it on a
+/// given day.
+///
+/// Deliberately **not** PostHog's Swift SDK. `posthog-ios` ships
+/// `PrivacyInfo.xcprivacy` as a bundled resource in two of its targets and pulls
+/// in PLCrashReporter and libwebp behind it — an SPM dependency that ships
+/// resources is the exact shape that has crashed a released termio twice (see
+/// AGENTS.md, "Dependencies and vendored code"). PostHog's capture endpoint is
+/// one JSON POST, and a daily-active count needs nothing else, so the whole
+/// integration is this file: no session replay, no autocapture, no crash
+/// reporter, no background queue.
+///
+/// What leaves the machine, at most once per calendar day: a random install
+/// UUID, the app version, the macOS version, and the preferred language. No
+/// project paths, no session contents, no account, nothing tied to a person.
+/// Events are sent anonymously (`$process_person_profile: false`), so PostHog
+/// stores no person record — daily-unique counts resolve on the install id
+/// alone.
+///
+/// Off in the dev channel, off under `swift run` and `swift test`, and off
+/// entirely when the user turns it off in Settings ▸ General ▸ Privacy.
+@MainActor
+enum Analytics {
+    /// PostHog project API key. Write-only by design: it can capture events and
+    /// read nothing back, which is why PostHog ships it inside client bundles and
+    /// why it is safe in a public repo. Empty disables every path below, so a
+    /// fork that never sets one sends nothing.
+    private static let projectAPIKey = ""
+
+    /// Ingestion host for the project's region. `us.i.posthog.com` for a US
+    /// project, `eu.i.posthog.com` for an EU one — a key posted to the wrong
+    /// region is rejected.
+    private static let ingestionHost = "https://us.i.posthog.com"
+
+    private enum Key {
+        /// A random per-install identifier. Not derived from hardware, the user,
+        /// or anything else that could be correlated back off-device; deleting it
+        /// makes this install a new one and nothing more.
+        static let installID = "analytics.installID"
+        /// The last day already counted, `yyyy-MM-dd` in UTC. Presence of today's
+        /// date is the whole dedupe.
+        static let lastActiveDay = "analytics.lastActiveDay"
+    }
+
+    private static weak var settings: AppSettings?
+    private static var rolloverTimer: Timer?
+
+    /// Counts today, then keeps counting for as long as the app stays open.
+    ///
+    /// The hourly tick is not a send: it re-asks the date question, which is a
+    /// string comparison that answers "already counted" on all but one wake a
+    /// day. Without it an app left running across midnight — the normal state of
+    /// a machine supervising agents — would report the day it launched and never
+    /// another one.
+    static func start(settings: AppSettings) {
+        self.settings = settings
+        recordActiveDay()
+        rolloverTimer?.invalidate()
+        rolloverTimer = Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { _ in
+            MainActor.assumeIsolated { recordActiveDay() }
+        }
+    }
+
+    static func recordActiveDay() {
+        guard isEnabled else { return }
+        let defaults = UserDefaults.standard
+        let today = day(for: Date())
+        guard defaults.string(forKey: Key.lastActiveDay) != today else { return }
+        // Claim the day before the request goes out, so a second launch while the
+        // first is still in flight can't double-count it.
+        defaults.set(today, forKey: Key.lastActiveDay)
+        let identifier = installID
+        Task { @MainActor in
+            let delivered = await send(event: "app_active", distinctID: identifier)
+            guard !delivered else { return }
+            // Hand the day back only if nothing has moved on since — the hourly
+            // tick then retries, which is what makes a closed lid at launch cost
+            // nothing.
+            if defaults.string(forKey: Key.lastActiveDay) == today {
+                defaults.removeObject(forKey: Key.lastActiveDay)
+            }
+        }
+    }
+
+    // MARK: - Consent
+
+    private static var isEnabled: Bool {
+        guard !projectAPIKey.isEmpty else { return false }
+        // An explicit environment answer wins over everything, including the
+        // channel gate — it is how the dev build is exercised at all.
+        switch ProcessInfo.processInfo.environment["TERMIO_ANALYTICS"]?.lowercased() {
+        case "off", "0", "false": return false
+        case "on", "1", "true": return true
+        default: break
+        }
+        // A rebuild loop is not a user, and neither is a test run. Both would
+        // otherwise land in the same daily-active count as a real install.
+        guard AppChannel.isTermioAppBundle, !AppChannel.isDev else { return false }
+        return settings?.analyticsEnabled ?? false
+    }
+
+    // MARK: - Sending
+
+    /// Returns whether PostHog accepted the event. Failure is expected and cheap
+    /// — no network at launch is the common case.
+    private static func send(event: String, distinctID: String) async -> Bool {
+        guard let url = URL(string: ingestionHost + "/i/v0/e/") else { return false }
+        let payload: [String: Any] = [
+            "api_key": projectAPIKey,
+            "event": event,
+            "distinct_id": distinctID,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "properties": [
+                // Anonymous event: no person record, no person properties. Daily
+                // uniques still count on `distinct_id`.
+                "$process_person_profile": false,
+                "$lib": "termio-mac",
+                "app_version": appVersion,
+                "os_version": osVersion,
+                "language": Locale.preferredLanguages.first ?? "und",
+            ],
+        ]
+        guard let body = try? JSONSerialization.data(withJSONObject: payload) else {
+            Log.app.error("analytics: could not encode \(event, privacy: .public)")
+            return false
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        request.timeoutInterval = 15
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return false }
+            guard (200 ..< 300).contains(http.statusCode) else {
+                Log.app.error("""
+                    analytics: \(event, privacy: .public) rejected \
+                    (HTTP \(http.statusCode, privacy: .public))
+                    """)
+                return false
+            }
+            return true
+        } catch {
+            Log.app.info("""
+                analytics: \(event, privacy: .public) not sent — \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            return false
+        }
+    }
+
+    // MARK: - Values
+
+    private static var installID: String {
+        let defaults = UserDefaults.standard
+        if let existing = defaults.string(forKey: Key.installID), !existing.isEmpty {
+            return existing
+        }
+        let fresh = UUID().uuidString
+        defaults.set(fresh, forKey: Key.installID)
+        return fresh
+    }
+
+    private static var appVersion: String {
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "0"
+    }
+
+    private static var osVersion: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+
+    /// UTC, so a machine that travels does not report two active days for one,
+    /// and so the boundary matches the one PostHog's own daily rollup uses.
+    private static func day(for date: Date) -> String {
+        var calendar = Calendar(identifier: .gregorian)
+        if let utc = TimeZone(identifier: "UTC") { calendar.timeZone = utc }
+        let parts = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", parts.year ?? 0, parts.month ?? 0, parts.day ?? 0)
+    }
+}

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -154,6 +154,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Task-completion notifications: the delegate must be installed before a
         // notification click can arrive, so wire it before any session runs.
         TaskNotificationCenter.shared.activate(store: store)
+        // Count this install as active today, and keep counting across midnight
+        // for a Mac that is left running (see `Analytics`).
+        Analytics.start(settings: settings)
         // Menu items cache their key equivalents at build time, so rebuild the
         // whole main menu whenever a user rebinds a shortcut in Settings.
         keybindingsObserver = NotificationCenter.default.addObserver(

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -4797,6 +4797,16 @@
         }
       }
     },
+    "Privacy": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐私"
+          }
+        }
+      }
+    },
     "Project Files": {
       "localizations": {
         "zh-Hans": {
@@ -5594,6 +5604,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "选择"
+          }
+        }
+      }
+    },
+    "Sends one anonymous event a day so the project can count active installs. No project paths, no terminal contents, no account.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每天发送一条匿名事件，用于统计活跃安装数。不含项目路径、终端内容和账号。"
           }
         }
       }
@@ -6985,6 +7005,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "用量"
+          }
+        }
+      }
+    },
+    "Usage statistics": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用统计"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -966,6 +966,8 @@
 	<string>Previous Match</string>
 	<key>Previous Session</key>
 	<string>Previous Session</string>
+	<key>Privacy</key>
+	<string>Privacy</string>
 	<key>Project Files</key>
 	<string>Project Files</string>
 	<key>Projects</key>
@@ -1126,6 +1128,8 @@
 	<string>Select a session to see its info.</string>
 	<key>Selection</key>
 	<string>Selection</string>
+	<key>Sends one anonymous event a day so the project can count active installs. No project paths, no terminal contents, no account.</key>
+	<string>Sends one anonymous event a day so the project can count active installs. No project paths, no terminal contents, no account.</string>
 	<key>Serving</key>
 	<string>Serving</string>
 	<key>Session</key>
@@ -1404,6 +1408,8 @@
 	<string>Updated.</string>
 	<key>Usage</key>
 	<string>Usage</string>
+	<key>Usage statistics</key>
+	<string>Usage statistics</string>
 	<key>Use Regular Expression</key>
 	<string>Use Regular Expression</string>
 	<key>Use Selection for Find</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -966,6 +966,8 @@
 	<string>上一个匹配项</string>
 	<key>Previous Session</key>
 	<string>上一个会话</string>
+	<key>Privacy</key>
+	<string>隐私</string>
 	<key>Project Files</key>
 	<string>项目文件</string>
 	<key>Projects</key>
@@ -1126,6 +1128,8 @@
 	<string>选择一个会话以查看其信息。</string>
 	<key>Selection</key>
 	<string>选择</string>
+	<key>Sends one anonymous event a day so the project can count active installs. No project paths, no terminal contents, no account.</key>
+	<string>每天发送一条匿名事件，用于统计活跃安装数。不含项目路径、终端内容和账号。</string>
 	<key>Serving</key>
 	<string>对外服务</string>
 	<key>Session</key>
@@ -1404,6 +1408,8 @@
 	<string>已更新。</string>
 	<key>Usage</key>
 	<string>用量</string>
+	<key>Usage statistics</key>
+	<string>使用统计</string>
 	<key>Use Regular Expression</key>
 	<string>使用正则表达式</string>
 	<key>Use Selection for Find</key>

--- a/Sources/termio/Settings/GeneralSettingsTab.swift
+++ b/Sources/termio/Settings/GeneralSettingsTab.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import UserNotifications
 
-/// App-and-account settings: language, task-completion notifications, and the
-/// GitHub integration.
+/// App-and-account settings: language, task-completion notifications, the
+/// GitHub integration, and the usage-statistics opt-out.
 ///
 /// It used to also carry the `termio` command-line tool, the session-control
 /// skill and the status hooks. Every one of those installs a file **on a
@@ -47,6 +47,18 @@ struct GeneralSettingsTab: View {
                 .toggleStyle(.switch)
             } header: {
                 SectionHeaderLabel(title: localized("Integrations"))
+            }
+            Section {
+                Toggle(isOn: $settings.analyticsEnabled) {
+                    SettingsLabel(
+                        title: localized("Usage statistics"),
+                        subtext: localized("Sends one anonymous event a day so the project can count active installs. No project paths, no terminal contents, no account."),
+                        titleFont: .headline
+                    )
+                }
+                .toggleStyle(.switch)
+            } header: {
+                SectionHeaderLabel(title: localized("Privacy"))
             }
         }
         .formStyle(.grouped)

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -95,6 +95,7 @@ final class AppSettings: ObservableObject {
         Key.addedAgents, Key.agentOrder, Key.agentHooksEnabled,
         Key.sessionControlEnabled, Key.githubIntegrationEnabled,
         Key.notifyTaskCompletion, Key.notificationSound,
+        Key.analyticsEnabled,
         Key.projectSortOrder, Key.defaultChatAgent,
     ]
 
@@ -142,6 +143,7 @@ final class AppSettings: ObservableObject {
         static let githubIntegrationEnabled = "github.integrationEnabled"
         static let notifyTaskCompletion = "notifications.taskCompletion"
         static let notificationSound = "notifications.sound"
+        static let analyticsEnabled = "privacy.analyticsEnabled"
         static let projectSortOrder = "sidebar.projectSortOrder"
         static let recentProjects = "welcome.recentProjects"
         static let lastChatAgent = "chats.lastAgent"
@@ -463,6 +465,15 @@ final class AppSettings: ObservableObject {
         didSet { store.set(notificationSoundEnabled, forKey: Key.notificationSound) }
     }
 
+    // MARK: Privacy
+
+    /// Whether termio reports one anonymous "active today" event per day, so the
+    /// project can see how many installs are in use. `Analytics` is the whole of
+    /// what that sends and when.
+    @Published var analyticsEnabled: Bool {
+        didSet { store.set(analyticsEnabled, forKey: Key.analyticsEnabled) }
+    }
+
     /// The Ghostty config's contribution to the registration defaults — the middle layer of
     /// termio setting > Ghostty config > built-in default. Only names the bundled catalog
     /// resolves inherit; see `ThemeLibrary.catalogTheme(matching:)` for which those are.
@@ -567,6 +578,10 @@ final class AppSettings: ObservableObject {
             // by default.
             Key.notifyTaskCompletion: true,
             Key.notificationSound: false,
+            // On by default. It is one event a day carrying no path, no content
+            // and no identity, and the toggle beside it says exactly that — a
+            // count nobody can opt into is a count that measures the wrong people.
+            Key.analyticsEnabled: true,
         ]
 
         // Ghostty inheritance: a user's own Ghostty config upgrades the *defaults* only —
@@ -612,6 +627,7 @@ final class AppSettings: ObservableObject {
         claudeKeychainDeclined = defaults.bool(forKey: Key.claudeKeychainDeclined)
         notifyOnTaskCompletion = store.bool(Key.notifyTaskCompletion)
         notificationSoundEnabled = store.bool(Key.notificationSound)
+        analyticsEnabled = store.bool(Key.analyticsEnabled)
         projectSortOrder = store.string(Key.projectSortOrder).flatMap(ProjectSortOrder.init) ?? .name
         recentProjects = defaults.data(forKey: Key.recentProjects)
             .flatMap { try? JSONDecoder().decode([RecentProject].self, from: $0) } ?? []

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -155,25 +155,15 @@ extension TermioStore {
     // MARK: - Host-reported workstream status
 
     /// Lands an `E status` event on the session's row. The vocabulary is the
-    /// protocol's (`working · idle · needs_you · done · failed · unknown`, §4);
-    /// the mapping to a dot, a spinner, or a notification is this client's and
-    /// deliberately mirrors `applyStatusReport` arm for arm, so a session behaves
-    /// the same whether its status came from a local hook or from the daemon.
-    ///
-    /// Unlike the hook path there is no correlation guesswork: the event arrived
-    /// on this session's own attach channel, so it can only be about this
-    /// session. That is also why it is not gated on `effectiveAgent` — a remote
-    /// terminal is created as a plain `.terminal` row (the agent runs over
-    /// there), and gating would silently discard every status a VPS agent
-    /// reports, which is the entire reason this path exists.
+    /// protocol's; the mapping to a dot, a spinner, or a notification mirrors
+    /// `applyStatusReport` arm for arm, so a session behaves the same whether
+    /// its status came from a local hook or from the daemon.
     func applyTermiodStatus(_ report: Termiod.StatusPayload, for id: Session.ID) {
         guard session(id) != nil else { return }
 
-        // Everything from here to the state switch used to live behind the app's
-        // own hook socket and applied only to agents on this Mac. One report path
-        // means a device agent gets it too — the Info pane's transcript address,
-        // the `/new` rotation signal, and the running tool are no longer things
-        // only a local agent could say.
+        // Everything from here to the state switch used to sit behind the app's
+        // own hook socket and reach only agents on this Mac. One report path
+        // means a device agent gets it too.
         if let candidate = report.promptTitle {
             recordPromptTitle(candidate, for: id)
         }
@@ -193,12 +183,9 @@ extension TermioStore {
         // field name could be mined as the id by mistake, while SessionStart and
         // Stop payloads are the agent's own minimal envelope.
         //
-        // What is *no longer* checked here is whether the report named this
-        // session exactly. It used to have to be: hook files are global, every
-        // same-agent process on the machine reported into one socket, and a
-        // cwd-guessed match must never re-pin a tab to an outside run's
-        // conversation. A report now arrives addressed by the daemon that owns
-        // the PTY, so there is nothing to guess and nothing to guard against.
+        // Whether the report named this session exactly is no longer checked.
+        // The hook path had to, because a global socket left it matching by cwd;
+        // a report now arrives addressed by the daemon that owns the PTY.
         if report.status != "working" {
             if let path = carriedTranscript {
                 // A carried path can name a *new* conversation id in its filename
@@ -235,16 +222,12 @@ extension TermioStore {
         }
         switch report.status {
         case "working":
-            // No "is this really an agent row?" guard here, and deliberately.
-            // The local hook path had one, because its reports arrived at a
-            // global socket and could be matched to a session by *cwd* — a
-            // sibling's report could spin an unrelated pane, so it only spun
-            // rows already known to be agents. A report now arrives addressed by
-            // the daemon that owns the PTY, so its arrival is itself the proof
-            // an agent is running in that session. Keeping the guard would
-            // discard every status a remote agent sends (a remote row is a plain
-            // `.terminal` — the agent runs on the far machine), and would drop a
-            // local one whenever the foreground poll had not caught up yet.
+            // No "is this really an agent row?" guard, deliberately: an
+            // addressed report is itself the proof an agent is running there.
+            // Guarding would discard every status a remote agent sends, since a
+            // remote row is a plain `.terminal` — the agent runs on the far
+            // machine — and would drop a local one whenever the foreground poll
+            // had not caught up yet.
             setStatus(.working, for: id)
             setCurrentTool(report.tool, for: id)
             // Remember when work was last seen, so a turn that ends abnormally

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -14,20 +14,14 @@ extension TermioStore {
     /// Brings up the hook socket and aligns `~/.claude/settings.json` with the
     /// current setting. The listener always runs (it is harmless when no hooks are
     /// installed); only the settings-file side is toggled.
-    /// Starts the status upkeep this app still owns.
+    /// Starts the status upkeep this app still owns. It no longer *receives*
+    /// status — every hook reports to the daemon that owns its PTY, and the app
+    /// reads `E status` off the session's own channel.
     ///
-    /// It no longer *receives* status. Every hook reports to the daemon that
-    /// owns its PTY, and the app reads `E status` off the session's own channel
-    /// (`applyTermiodStatus`) — one path, whichever machine the agent runs on.
-    ///
-    /// What stays here is the half that reads a **screen**, because that is the
-    /// half a daemon cannot do for a local session: the stale-working sweep
-    /// below, the streak promotion, and the `OSC 0/2` title classification. For
-    /// a device the authoritative VT is the daemon's; for this Mac it is the
-    /// app's own surface. They are the only status signal an agent with no hook
-    /// system has, so they are not leftovers to tidy away — they stay until the
-    /// VT itself moves (docs/design/20260819-unify-server-plane.md). Deleting
-    /// them would silently take that fallback with them.
+    /// What stays is the half that reads a **screen**: the stale-working sweep,
+    /// the streak promotion, and the `OSC 0/2` title classification. They are
+    /// the only status an agent with no hook system has, so they stay until the
+    /// VT itself moves (docs/design/20260819-unify-server-plane.md).
     func startHookMonitoring() {
         installedHooksEnabled = settings.agentHooksEnabled
         syncHooksInstallation()

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,7 @@ from the real front matter).
 | draft | design | [termiod Session Protocol](design/20260730-termiod-session-protocol.md) |
 | draft | design | [远程访问与中转策略（tunelo / BYO-tunnel）](design/20260705-remote-access-relay-strategy.md) |
 | draft | essay | ["How Claude Code Got the Mouse: Reverse-Engineering the Clickable Terminal"](essays/how-claude-code-got-the-mouse.md) |
+| draft | rfc | [零前置远程访问：把 dev tunnels 的形状搬到 termio](design/20260827-remote-access-dev-tunnels-model.md) |
 | draft | rfc | ["Adversarial review: One workspace source — the inspector reads the session's device"](design/20260818-one-workspace-source.review-codex.md) |
 | draft | rfc | ["Adversarial review: Retire remote — every machine is a device"](design/20260814-remote-to-device.review-codex.md) |
 | draft | rfc | ["RFC: Per-project agent sandbox (Apple Seatbelt)"](design/20260630-sandbox-seatbelt.md) |

--- a/docs/design/20260818-termiod-web-client-ghostty-wasm.md
+++ b/docs/design/20260818-termiod-web-client-ghostty-wasm.md
@@ -3,7 +3,7 @@ title: Termiod web client on official Ghostty WASM (Linux first)
 status: draft
 type: rfc
 created: 2026-08-18
-updated: 2026-08-24
+updated: 2026-08-26
 related:
   - 20260730-termiod-session-protocol.md
   - 20260805-termiod-hot-path-and-client-classes.md
@@ -795,8 +795,26 @@ None on disk for sessions. New files beside `host.id`:
 | --- | --- | --- |
 | `pair.token` | `0600` | `termiod pair` / `pair --rotate` |
 | `wss.bind` | `0600` | `serve --wss` |
+| `wss.origin` | `0600` | `serve --wss-origin` |
 
 Rotating the token does not touch the roster, the graveyard, or any PTY. A running WSS task watching the file drops live splices; a stopped daemon just gets a new file.
+
+**`wss.origin` exists because `pair` is a different process from `serve`.**
+[20260824-ios-as-device-client.md](20260824-ios-as-device-client.md) §D4 says the
+invite's reachable `url` "lives in `--wss-origin`" — but that flag is on the
+*daemon's* argv, and on a headless box (D4 rung 2, the case the whole ladder
+exists for) `pair` has nothing to read. So an explicit `serve --wss-origin`
+persists it exactly as `--wss` persists the bind. Without this file `pair --qr`
+on a VPS always refuses and the ladder has no working rung.
+
+**An Origin is an authority; an invite URL is a base URL.** They are not the same
+value and must not share one. `Origin: https://box.tailnet.ts.net` is
+scheme+host+port by definition — a path in it is invalid — so `--wss-origin`
+cannot express the `/termio/` mount that Tailscale Serve's `--set-path` creates
+(a mount, not a strip; see §"Where WSS lives"). `wss.origin` therefore feeds the
+CSRF check, the invite URL defaults to `<origin>/`, and an operator behind a
+prefix passes `pair --url https://box/termio/`. Do not teach `--wss-origin` to
+accept a path.
 
 Web assets live in a **versioned** directory, e.g. `~/.local/share/termiod/web/<termiod-version>-<ghostty-56e1f3a>/`, with `current` flipped atomically. This layout is **new in PR 5**. Today's `remote deploy` only installs `~/.local/bin/termiod` (device arch §6 specified content-addressed binaries; that install path is not shipped). The unit and the deploy contract point `--web-root` at `%h/.local/share/termiod/web/current`. Missing `current` → log, serve no files, WSS can still bind. We do not bake `ghostty-vt.wasm` into the musl binary, and we do not base64 it into the JS bundle.
 

--- a/docs/design/20260827-remote-access-dev-tunnels-model.md
+++ b/docs/design/20260827-remote-access-dev-tunnels-model.md
@@ -1,0 +1,307 @@
+---
+title: 零前置远程访问：把 dev tunnels 的形状搬到 termio
+status: draft
+type: rfc
+created: 2026-08-27
+updated: 2026-08-27
+related:
+  - 20260705-remote-access-relay-strategy.md
+  - 20260827-termiod-lifecycle-reconcile.md
+  - 20260730-termiod-session-protocol.md
+  - 20260814-remote-to-device.md
+---
+
+# 零前置远程访问：把 dev tunnels 的形状搬到 termio
+
+> 手机扫码连上一台 Linux，用户在那台机器上**不需要预先有任何东西** —— 没有域名、
+> 没有反向代理、没有 root、没有开放端口。这份 RFC 记录 VS Code dev tunnels 的做法、
+> 哪些能搬哪些搬不了、termio 的具体形态、relay 部署在哪，以及公开之前必须先修的东西。
+
+## 0. 动笔前核对过什么
+
+外部事实来自 dev tunnels 的官方文档与逆向分析（见 §9 出处）。仓库内的每一条都在
+`main`（`b5d1f8a`）和 `ukvps` 上当场验证过。
+
+| 结论 | 出处 |
+| --- | --- |
+| termiod 拒绝一切非环回绑定，在解析 flag 时就拒 | `wss.rs` `parse_bind` |
+| termiod 整个 crate 没有 TLS，依赖层面就排除了 | `termiod/Cargo.toml:32`（"No `connect`, no `native-tls`, no `rustls`"） |
+| 任何 TLS 终结器前面，同源回退必然拒绝 | `wss.rs` `origin_worked_examples` 第二条断言 |
+| `pair` 从不接触守护进程，也不检查监听器 | `wss.rs` `run_pair` —— 只读 token 和 origin 文件 |
+| 手机把 `https://h/p/` 转成 `wss://h/p/ws`，origin 取 `scheme://host[:port]` 不带路径 | `ios/Sources/Models.swift` `websocketURL` / `originValue` |
+| 手机配对时会先拨号握手、拿到 `hello_ok` 才落盘 | `Models.swift` `pair(invite:)` |
+| 手机持久化 `address` / `token` / `origin`，按 `host_id` 索引 | `Models.swift` `adopt(invite:hostID:)` |
+| tunelo 的 relay 与客户端共用 `crates/protocol`，两端都已用 `quinn` + `rustls` | `jiweiyuan/tunelo` 三个 `Cargo.toml` |
+| `ukvps` 上的 tunelo 是 **0.2.0** —— `--identity` 是 0.3.0 才有的 | `tunelo --version` |
+| `*.tunelo.net` 通配 DNS 已解析，证书含 `*.tunelo.net` | `getent hosts`、`/etc/nginx/sites-enabled/tunelo.net` |
+
+## 1. 问题
+
+今天要让手机连上一台 Linux，用户必须**已经**拥有：一个域名、一个反向代理、以及
+root。这三样任何一样缺失，流程就断在一句无法执行的错误上。
+
+这不是 onboarding 的门槛，这是**放弃 onboarding**。对照物很清楚：`code tunnel`
+一条命令、设备码登录、URL 当场给你，机器本身零前置。
+
+**本 RFC 的标准线：用户在目标机器上不需要预先有任何东西。**
+
+## 2. dev tunnels 实际是怎么做的
+
+| 机制 | 做法 |
+| --- | --- |
+| 方向 | **两端都出站**，不需要任何入站连接 |
+| 拓扑 | 全局控制面 `global.rel.tunnels.api.visualstudio.com` 分配区域集群 `[clusterId]`，数据面独立域名；集群列表是公开 API |
+| 命名 | 通配 `*.devtunnels.ms`，一条隧道端口一个子域名（`tunnelid-3000.devtunnels.ms`） |
+| TLS | 在服务入口终结，用 Microsoft CA 签的服务证书，之后重写 header |
+| **端到端** | WebSocket 建好之后，**里面再跑一层 SSH**（AES-256-CTR / HMAC-SHA256-ETM），所以 relay 转的是密文 |
+| 外层鉴权 | `tunnel-relay-client` 子协议 + connect JWT；内层 SSH 用户名 `tunnel`、`None` 认证，因为外层已鉴权 |
+| Token | 四种、24 小时过期：client（连）/ host（承载）/ manage-ports / management。刷新必须用真实身份，management token 自己刷不了 |
+| 客户端携带 | `X-Tunnel-Authorization: tunnel <TOKEN>`，**故意不用** `Authorization`，避免和应用自己的鉴权撞车 |
+| 默认可见性 | 私有；`--allow-anonymous` 才公开 |
+| 反滥用 | 浏览器首次访问有反钓鱼插页；非 GET、非 HTML、带 `X-Tunnel-Authorization` 时跳过 |
+
+## 3. 哪些能搬，哪些搬不了
+
+### 能搬，而且我们已经在半路上
+
+**出站-only 的 host。** termiod 的 `parse_bind` 已经拒绝一切非环回地址 —— 最难的
+那一半（"绝不开放端口"）不是要做的事，是**已经做完的事**。
+
+**host token 与 client token 分离。** 这正是 `20260705` 那份 doc 里"防白嫖 = 只
+gate `Register`"的工业级写法：承载隧道要 host token，连接隧道要 client token，两者
+不可互换。visitor 面只能连已注册的 owner，天然守住。
+
+**通配 DNS = 一条记录。** `20260705` 已经点出 BYO cloudflared named tunnel 的天花板
+是**单 zone DNS 记录配额**（一台机器一条）。自建 relay + `*.domain` 通配，全部用户
+共用一条记录 —— 那堵墙对我们不存在。这是自己跑 relay 相对白嫖别人最实在的好处，
+比省流量费实在。
+
+**分区域是后来才做的。** 先全局单点，把集群分配留成一个可加的间接层，不要现在建。
+
+### 搬不了，以及为什么
+
+**SSH-in-WebSocket 的端到端加密。** 这是 dev tunnels 设计里最漂亮的一笔 —— relay
+看不见明文，所以**不需要被信任**。搬不过来，因为它要求 iOS 端有一个 SSH 实现，
+而"never embed SSH or crypto"是 `CLAUDE.md` 的非谈判项 #3。
+
+后果必须直说：**v1 的 relay 看得见终端明文。** 这不是可以含糊过去的细节，它直接
+顶在 `CLAUDE.md` 的另一句上 —— "The code never leaves hardware the user controls"。
+处理方式是 §7 的两条：如实披露 + 逃生口必须一样好用。
+
+**账号身份。** dev tunnels 靠 GitHub / Microsoft 登录。termio 没有账号体系，也不
+打算有。替代方案在 `20260705` 已经定过：**Ed25519 设备密钥对**，
+`subdomain = base32(SHA-256(pubkey))`（Syncthing 同款），归属靠 relay 发 challenge、
+客户端私钥签名自证。理由是身份与证明合一、纯 Rust 跨平台、避开硬件指纹的隐私雷。
+
+**注意这条推翻了一个更早的想法**：用 `host_id` 做路由键是错的。`host_id` 是无证明的
+bearer 标识，谁报谁就是 —— 那正是下面 §6 抢注 bug 的成因。
+
+## 3.5 关键修正：termio 要的是 rendezvous，不是 tunnel
+
+看过 [getpaseo/paseo-relay](https://github.com/getpaseo/paseo-relay)（Elixir/OTP，
+Syn 做分布式所有权注册）之后，上面 §6 的блок清单有一半是**自找的**。
+
+paseo 的路由键**是查询参数，不是主机名**：客户端带 `serverId` / `role` /
+可选 `connectionId` 连上来（每项 ≤256 字节，超了在建状态之前就 400），relay 按
+`serverId` 把两端配对。payload 全程 opaque —— relay 不解析、不关心。
+
+**把路由从主机名换成查询参数，一整类问题直接不存在：**
+
+| 子域名模型（tunelo / dev tunnels） | 查询参数模型（paseo） |
+| --- | --- |
+| 通配 DNS + 通配证书 | **一个主机名，普通证书** |
+| relay 分配子域名 → 可被抢注 | 路由键是**客户端自带的身份**，没有可抢的东西 |
+| 名字会轮转 → 手机被甩掉 | 键 = 设备密钥，只要密钥在就不变 |
+| `--wss-origin` **每台机器一个值**，要钉、会填错 | origin 是 `https://relay.example`，**所有设备同一个常量** |
+| 用户面：子域名、DNS、证书 | 用户面：**一个 relay URL** |
+
+最后两行是重点。§4.3 里那个"三处必须逐字节相同否则 403"的坑，在这个模型下**不是被
+自动化绕过去，而是根本不存在** —— origin 是编译期常量，不是每台机器要配的值。
+
+而 §6 的前两条阻塞项（tunelo 0.2.0 没有 `--identity`、`resolve_subdomain` 抢注）
+**都是子域名分配机制的产物**。换模型即消失，不用修。
+
+### 为什么会绕这一圈
+
+因为 tunelo 是**通用隧道**（把任意本地端口发布成一个公网 URL，ngrok 那类），而
+termio 需要的是**会合**（把两条已经认识彼此的连接接起来）。前者是后者的超集，
+多出来的那部分 —— 公网 HTTP 端点、子域名、通配证书 —— 正是六条阻塞项的全部来源。
+
+**用手上有的工具，不等于用对了工具。**
+
+### 落地取舍
+
+- **偷设计，不偷依赖。** paseo-relay 是 Elixir，而且它的契约是"protocol-compatible
+  with Paseo"；照抄会让 termio 去适配别人的 v2 query contract。会合本身很小 ——
+  Rust 里用 axum + tungstenite 大约几百行，还能继续用 `tunelo-protocol` 那套共享类型。
+- **BEAM 的集群和分区处理是真本事**（Syn 收敛后败方 WebSocket 以 `1012` 关闭）。
+  真到多节点再考虑是不是值得换语言，单节点阶段不需要。
+- **TLS 的负担落在 relay 运营者身上，位置是对的。** paseo relay 默认绑
+  `127.0.0.1:4000`，前面放反代 —— 那是**我们的**机器，不是用户的。用户侧仍然零前置。
+- **E2EE 有现成的挂钩。** paseo 校验 `e2ee_hello` 帧里的 X25519 公钥（canonical padded
+  Base64、32 字节）但不强制 —— **relay 负责撮合，加密留在两端**。这条路以后要走的话，
+  需要开例外的是**端点**，不是 relay。
+
+## 4. 设计
+
+### 4.1 组件
+
+```
+手机 ──wss──▶ relay(你的) ◀──出站 QUIC/wss── tunelo client ──▶ 127.0.0.1:8790 termiod
+                                                （同一台用户机器）
+Mac ──ssh──▶ 用户机器            控制面：部署、配对、验证
+```
+
+四件东西，只有一件是新的（托管 relay）；其余三件都已存在。
+
+### 4.2 零前置安装
+
+"Set Up this device" 现在已经在 scp `termiod`。扩成：
+
+1. 部署 `termiod`（已有）
+2. 部署 `tunelo` 客户端（同一机制，多一个静态二进制）
+3. termiod 绑 loopback 起 `--wss 127.0.0.1:8790`
+4. tunelo 出站连 relay，拿到**稳定**子域名
+5. origin 钉住该子域名 → `termiod pair --json` → 二维码
+6. 两者都挂 `systemctl --user`，配 `loginctl enable-linger`
+
+用户做的事：点一下。
+
+**全程不需要 root。** `~/.local/bin` + `systemctl --user` + linger。nginx 那条路必须
+sudo，而很多人的 VPS 账号没有 sudo，或不愿在安装流程里交出去。这一条本身就足以
+决定默认路径选哪个。
+
+### 4.3 URL 机制（已核对，不是推导）
+
+设子域名为 `d.relay.example`：
+
+- 邀请 `url` = `https://d.relay.example`
+- 手机拨 `wss://d.relay.example/ws`（`websocketURL` 在路径后接 `/ws`）
+- 手机发 `Origin: https://d.relay.example`（`originValue`，不带路径）
+- termiod 侧 `--wss-origin https://d.relay.example`
+
+三处必须**逐字节相同**，否则 403。所以 URL 只能有一个来源：**Mac 把 origin 写到机器上，
+`pair` 从机器自己的 `wss.origin` 派生邀请** —— 绝不在配对时传 `--url`。
+
+### 4.4 分层：按"用户已经有什么"，不按"我们想卖什么"
+
+| 路径 | 用户必须已经有 | 操作 |
+| --- | --- | --- |
+| **托管 relay（默认）** | **什么都不用有** | 点一下 |
+| 自建 relay | 自己的 tunelo / CF named tunnel | 填一个 endpoint |
+| 反向代理 | 域名 + nginx/Caddy + root | 贴一段配置 |
+| Tailscale | tailnet + 手机装 App | 一条命令 |
+
+后三条不是装饰，是 §3 那条"relay 看得见明文"的对价。它们必须和默认路径**一样好用**，
+否则 `termio is FREE` 这句话就站不住。
+
+## 5. Relay 部署在哪
+
+**不要放在 `ukvps`。** 那台机器同时是 tunelo.net 的生产宿主、手工起的 termiod 实验场。
+给付费用户做中转的机器，不该是开发箱。
+
+**一台独立 VPS 起步，不要 nginx，也不要 Traefik。** relay 已经直接依赖 `rustls` 和
+`quinn` —— 它自己就终止 TLS。前面再放一层是第二次终结 + 多一跳，而且 **Traefik 代不了
+tunelo 的 QUIC**（它讲 HTTP/3，tunelo 是 quinn 上的自定义协议）。
+
+- 通配证书 `*.relay.example`，DNS-01
+- **ACME 做在 relay 进程里**（`instant-acme` / `rustls-acme`）→ 一个二进制、一个产物、
+  零 sidecar。这在后面上多区域时直接省掉一整套编排
+
+**也不要用 Go 重写。** `crates/protocol` 是 relay 和客户端共用的；换语言 = 一个线上
+协议两份实现，漂移的症状是"某些用户连不上"这种最难查的类型。
+
+**多区域推迟。** 真撞到"用户在另一个大洲、延迟不能忍"再动，那时优先 Fly.io
+（Dockerfile 已有，Rust 原样跑，anycast），dev-tunnels 那种 global→cluster 分配是
+更后面的事。
+
+## 6. 公开之前必须先修
+
+1. **tunelo 0.3.0 的 `--identity`。** 现场是 0.2.0，子域名每次重启都变 → 钉住的 origin
+   失效 → 手机被甩掉（`address`/`origin` 是持久化在手机上的）。稳定名字是整条路的地基。
+2. **抢注 / DoS。** `crates/relay/src/router.rs::resolve_subdomain` 在 owner 断线时把
+   子域名交给下一个来者；password 只 gate `Attach`，不 gate `Register` 回收。修法 =
+   owner 用私钥自证回收。带着这个上线等于谁都能顶掉别人的机器。
+3. **Register 准入。** 用已有的 Lemon Squeezy 后端签短期 Ed25519 token，relay 内嵌
+   公钥验签 —— 私钥在后端，**开源不泄密**。
+4. **`--max-session 0`。** `crates/tunelo/src/main.rs:100` 默认 86400 秒；常驻 companion
+   必须关掉，否则每天断一次。
+5. **Linux systemd user unit。** 零前置路径必须扛重启。lifecycle RFC §4 目前明确 defer
+   了它，这条依赖要显式提出来。
+6. **滥用预案。** 一个公开的、能把任意本地端口暴露到公网的服务**一定**会被拿去做 C2
+   和钓鱼 —— dev tunnels 的逆向分析文章标题就叫 "The Accidental C2"，微软的反钓鱼插页
+   就是为此而设。上线前要有：滥用举报入口、按 Register token 吊销的能力、以及速率限制。
+
+## 7. 非目标
+
+- **v1 不做端到端加密。** 见 §3。以后要做，路径是 WebSocket 里加一层 Noise/X25519 —— 那
+  需要对非谈判项 #3 开一个有意识的例外，不能顺手做。
+- **不做 P2P / STUN / ICE。** `20260705` 已经算过：termio 只传终端帧、不传视频，纯中转
+  完全够用，不必上打洞那套复杂度。
+- **不做账号体系。** 身份是设备密钥对，准入是签名 token。
+- **不取代 BYO / nginx / Tailscale。** 它们从"兜底"升格为"逃生口"，地位反而更重要。
+
+## 7.1 备选方案：把 tunelo 作为 crate 嵌进 termiod
+
+**方案**：不再部署独立的 tunelo 客户端进程，而是把 `tunelo-client` 作为 crate 编进
+termiod，由 termiod 自己出站连官方 relay，直接在那条连接上跑会话协议。
+
+**它确实更干净，四条都是真的好处：**
+
+1. **一个进程、一个 unit、一个产物。** 部署就是 scp 一个二进制。
+2. **消掉 loopback 那一跳。** 现在是 relay → tunelo → TCP 127.0.0.1:8790 → termiod；
+   嵌进去就是 relay → termiod。少一次拷贝、少一条 TCP 连接。
+3. **`--wss` 监听器可能整个不需要了。** 出站建连就没有端口要绑，`wss.bind` 这个文件、
+   "监听器起没起"这个状态、以及本地端口暴露面，一并消失。
+4. **origin 自己钉自己。** termiod 注册时就知道自己的子域名，`--wss-origin` 不再是
+   一个人要手填、填错就 403 的值。**整条链路里最容易错的一步被消灭了**，而不是被
+   文档绕过去。
+
+**但它撞的是非谈判项 #3，而且撞在记录这条规则的那个文件上。**
+
+`termiod/Cargo.toml:32` 白纸黑字：*"No `connect`, no `native-tls`, no `rustls`"*。
+嵌 tunelo 就是把 `quinn` + `rustls` + `ed25519-dalek` 拉进 **持有用户 shell 的那个
+进程**。termiod 今天连一次出站 TLS 都不发起 —— 这个极小的攻击面是刻意的，不是疏忽。
+
+还有三条次级代价：
+
+- **版本被焊死。** 今天 tunelo 能独立升级（现场 0.2.0 → 需要 0.3.0）；嵌进去之后，
+  relay 协议每动一次就要发一次 termiod。
+- **逃生口被削弱。** 走 nginx / Tailscale / cloudflared 的用户，本来只要"不跑那个进程"；
+  嵌进去之后，那些代码在他们的守护进程里永远存在。
+- **"一个产物"的收益大半是幻觉。** 第二个二进制是 **Mac 替用户装的**，用户那边仍然
+  只点一下。少一个进程对**我们**有价值（少一处监督、少一处调试），对用户几乎无感。
+
+**结论：现在不嵌。**
+
+理由不是"嵌不好"，而是**这两个选择的可逆性不对称**：保持分离，以后想嵌，靠
+`tunelo-protocol` 这个共享 crate 就是一次机械改动；先嵌了再想拆，逃生口和版本解耦
+都已经烂在里面了。在 relay 这个产品还没被验证之前，选可逆的那个。
+
+而且 §7.1 列的四条好处里，**前三条可以不嵌就拿到**：让 sidecar 自己把 `wss.bind` 和
+`wss.origin` 写回去，第 4 条（origin 自动钉）也一并解决 —— 那是自动化，不是架构。
+真正只有嵌入才能拿到的，只有"少一跳 loopback"和"少一个进程"。用一条非谈判项去换
+这两样，不划算。
+
+**若将来要嵌**，前提和上 E2E 一样：对非谈判项 #3 开一个**有意识的、写下来的例外**，
+在这份 RFC 里记录，而不是让它悄悄漂移过去。
+
+## 8. 待评审的问题
+
+1. **免费层拿不拿得到托管 relay？** 若是，白嫖防护就必须先到位（§6.3）；若否，免费层
+   的默认路径退回 BYO cloudflared named tunnel（免费、稳定域名、零服务器），而
+   `termio is FREE` 的成色取决于那条路有多好用。
+2. **明文这件事写在哪、怎么写。** 代码里 `tunnelFootnote` 已有"说清楚手机流量过谁的
+   服务器"的先例。托管 relay 是我们自己的服务器，措辞不能比说 cloudflared 时更含糊。
+3. **配对由谁经手。** 现在是 Mac 通过 SSH 代跑 `termiod pair --json`（控制面在 Mac）。
+   要不要允许手机直接向 relay 报到？前者不需要新协议，后者能去掉"必须有一台 Mac"。
+4. **`upgrading` 与本 RFC 的耦合。** 武装监听器和钉 origin 都需要重启守护进程，也就是
+   lifecycle RFC §5.2 的 `stop --if-idle`。本 RFC **依赖**那一条先落地。
+
+## 9. 出处
+
+- [Developing with Remote Tunnels — VS Code](https://code.visualstudio.com/docs/remote/tunnels)
+- [What are dev tunnels? — Microsoft Learn](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/overview)
+- [Dev tunnels security — Microsoft Learn](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/security)
+- [The Accidental C2: Exploring Dev Tunnels for Remote Access — XPN Infosec](https://blog.xpnsec.com/accidental-c2/)
+- [microsoft/dev-tunnels-ssh](https://github.com/microsoft/dev-tunnels-ssh)

--- a/ios/Sources/Models.swift
+++ b/ios/Sources/Models.swift
@@ -384,11 +384,10 @@ struct DeviceEndpoint: Equatable {
     }
 }
 
-/// One machine this phone has paired with — the Slack-workspace model: several
-/// stay paired, one is active at a time. `id` is the peer's stable identity
-/// (the Mac's `macID`, a box's `host_id`); until the first roster names it (a
-/// fresh companion pairing, or an older Mac that never will) it holds a locally
-/// minted placeholder that `CompanionLink.adoptIdentity` replaces in place.
+/// One machine this phone has paired with — several stay paired, one is active.
+/// `id` is the peer's stable identity (a Mac's `macID`, a box's `host_id`), and
+/// until the first roster names it, a locally minted placeholder that
+/// `CompanionLink.adoptIdentity` replaces in place.
 struct PairedMac: Codable, Equatable {
     var id: String
     var name: String
@@ -404,9 +403,8 @@ struct PairedMac: Codable, Equatable {
     /// the invite's `url`. nil for the companion wire, which checks none.
     var origin: String?
 
-    /// The URL the socket dials. The companion wire carries its token as the
-    /// `t` query param — the shape the Mac's QR encodes and `CompanionClient`
-    /// reads the token back out of; termiod carries it as a subprotocol, so its
+    /// The companion wire carries its token as the `t` query param, the shape
+    /// the Mac's QR encodes; termiod carries it as a subprotocol, so a termiod
     /// address dials as stored.
     var connectURL: URL? {
         guard var components = URLComponents(string: address) else { return nil }
@@ -514,18 +512,12 @@ enum CompanionLink {
     /// Where and how to reach the active peer — nil when nothing is paired.
     static var savedEndpoint: DeviceEndpoint? { activeMac?.endpoint }
 
-    /// A scanned QR or typed address, whichever screen it came from — the
-    /// scanner hands back a raw string and parses nothing, so this is the one
-    /// place a pairing is understood.
-    ///
-    /// A companion address pairs the moment it parses, which is the shipped
-    /// behaviour. A `termio://device` invite does not: per D4 it dials once and
-    /// waits for `hello_ok` before anything is written, because saving an
-    /// unverified address is what produced the companion's worst failure mode —
-    /// paired, silently unreachable, and indistinguishable from a bug.
-    ///
-    /// Returns false for an address that does not parse; `completion` (main
-    /// queue) carries the real outcome, which for an invite arrives later.
+    /// The one place a pairing is understood: the scanner hands back a raw
+    /// string and parses nothing. A companion address pairs the moment it
+    /// parses; a `termio://device` invite dials first and waits for `hello_ok`,
+    /// because saving an unverified address is what left the companion paired
+    /// and silently unreachable. Returns false for an address that does not
+    /// parse — `completion` carries the real outcome, later, on the main queue.
     @discardableResult
     static func pair(
         rawAddress: String, completion: ((Result<Void, PairingFailure>) -> Void)? = nil
@@ -581,9 +573,8 @@ enum CompanionLink {
         }
     }
 
-    /// The four fields `termiod pair` puts in a `termio://device` link. No
-    /// display name: device architecture §4 leaves that to the client, exactly
-    /// as `PairedMac.name` does for a Mac.
+    /// What `termiod pair` puts in a `termio://device` link. No display name:
+    /// the host never supplies one, so `PairedMac.name` stands.
     struct DeviceInvite: Equatable {
         /// The dial URL, already resolved to `ws(s)://…/ws`.
         let url: URL
@@ -651,10 +642,9 @@ enum CompanionLink {
         return "\(webScheme)://\(host)\(port)"
     }
 
-    /// D4's verify-before-save: dial the box, wait for `hello_ok`, and only then
-    /// write it to the paired list — keyed by the identity the daemon answered
-    /// with rather than the one the QR claimed, so a box already known through
-    /// another route is updated instead of duplicated.
+    /// Verify before saving: dial the box, wait for `hello_ok`, and key the
+    /// entry by the identity the daemon answered with rather than the one the QR
+    /// claimed, so a box already known by another route is not duplicated.
     private static func pair(
         invite: DeviceInvite, completion: ((Result<Void, PairingFailure>) -> Void)?
     ) {

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -687,16 +687,12 @@ final class TerminalViewController: UIViewController {
                 Log.device.error("no session id to attach to; falling back to the sandbox shell")
                 return shellSession.terminalSession
             }
-            // The phone mirrors a PTY through a live libghostty surface, which
-            // answers terminal queries (XTVERSION, DA, DSR) on its own. The
-            // authoritative surface on the other end already answered; the
-            // phone's duplicate arrives (late, from libghostty's IO thread) and,
-            // having missed the agent's parse window, leaks into its input line
-            // as literal text — e.g. Grok showing a stray ">|ghostty 1.3.2…".
-            // A mirror must never talk back to the host, and that matters *more*
-            // on a direct attach, where another client is driving the same PTY.
-            // A real keystroke or key-bar sequence never looks like a report, so
-            // genuine input passes through untouched.
+            // The phone's mirror surface answers terminal queries (XTVERSION,
+            // DA, DSR) on its own, but the authoritative surface already
+            // answered. The duplicate arrives late, misses the agent's parse
+            // window, and leaks into its input line as literal text — a stray
+            // ">|ghostty 1.3.2…". A mirror must never talk back to the host.
+            // Genuine input never looks like a report, so it passes untouched.
             let terminalSession = InMemoryTerminalSession(
                 write: { [weak transport] data in
                     guard !MirrorReportFilter.isDeviceReport(data) else { return }
@@ -752,18 +748,13 @@ final class TerminalViewController: UIViewController {
         case .connected:
             statusLabel.isHidden = true
             contextLabel.isHidden = contextLabel.text?.isEmpty ?? true
-            // The host wipes this screen on attach and only repaints once our
-            // grid claim lands — a Mac jiggles the PTY so the shell reprints its
-            // prompt, a device answers the barrier with a fresh snapshot, and
-            // both need the claim. But libghostty dedupes the resize callback at
-            // two layers — the surface coordinator and the in-memory session
-            // both drop an unchanged size — so on a cold attach or a reconnect
-            // no fresh
-            // resize fires, and the `sendGrid` at socket-open can race the very
-            // first dispatch. The result is a blank grid under a correct title.
-            // Re-assert the cached grid now that the socket is definitively up,
-            // and once more after the attach wipe has drained, so the last frame
-            // on the wire is our repaint and never a stray wipe.
+            // The host wipes this screen on attach and repaints only once the
+            // grid claim lands — a Mac jiggles the PTY, a device answers the
+            // barrier with a snapshot, and both need the claim. libghostty
+            // dedupes an unchanged size at two layers, so on a cold attach none
+            // fires and the screen stays blank under a correct title. Re-assert
+            // now, and again once the wipe has drained, so the last frame on the
+            // wire is the repaint.
             companion?.reassertGrid()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
                 guard let self, case .device = backend else { return }

--- a/ios/Sources/TermiodBackend.swift
+++ b/ios/Sources/TermiodBackend.swift
@@ -5,15 +5,10 @@ import TermioShared
 /// `DeviceClient` over the termiod Session Protocol: the phone talking straight
 /// to the box a session runs on, with no Mac in the path.
 ///
-/// The screens above this are the same ones the companion wire feeds — that is
-/// the point of the port (`docs/design/20260824-ios-as-device-client.md` D1).
-/// What differs is everything below: one control channel carrying `list`,
-/// `attach`, `kill` and the `fs.*` plane, and a roster the client *builds*,
-/// because the daemon holds sessions and has never heard of a project.
-///
-/// Where a plane does not exist over here it says so. Nothing in this file
-/// answers a question with an empty list: `onChanges?([])` would read as "no
-/// changes", which is a different sentence from "this device has no git plane".
+/// The roster is built here rather than read off the wire, because the daemon
+/// holds sessions and has never heard of a project. Where a plane does not exist
+/// over here it refuses instead of answering with an empty list — `onChanges?([])`
+/// reads as "no changes", not "this device has no git plane".
 final class TermiodBackend: DeviceClient {
     var onRoster: ((DeviceRoster) -> Void)?
     var onConnected: ((Bool) -> Void)?
@@ -29,26 +24,19 @@ final class TermiodBackend: DeviceClient {
     var onDiff: ((DeviceDiff) -> Void)?
     var onSSHHosts: (([DeviceSSHHost]) -> Void)?
 
-    /// How many filename hits one search asks for. The host stops there and the
-    /// caller is told the batch was capped, rather than the field quietly
-    /// showing a slice of a monorepo as if it were everything.
+    /// The host stops here and the caller is told the batch was capped, rather
+    /// than a slice of a monorepo showing as if it were everything.
     private static let searchLimit: UInt64 = 200
 
     private let endpoint: DeviceEndpoint
-    /// The session this backend serves, when it serves one. Only the upload
-    /// plane needs it: a transfer into a session's scratch directory is reaped
-    /// with that session, so there is nowhere to put a paste without one.
+    /// Only the upload plane needs it: a paste lands in the session's scratch
+    /// directory, so there is nowhere to put one without a session.
     private let sessionID: String?
     private let channel: TermiodChannel
-    /// Every live session the device has reported, keyed by its id. Seeded by
-    /// `list` and kept current by `roster` / `status` events — pushed, never
-    /// polled, which is the same contract the companion roster has.
     private var sessionsByID: [String: Termiod.SessionInformation] = [:]
     private var sessionOrder: [String] = []
-    /// Status the device revised since the row it belongs to was last delivered
-    /// whole. Held beside the rows rather than merged into them because a row is
-    /// what the device said, and a delta is what it said after — folding the two
-    /// would lose which is which the moment a fresh row arrives.
+    /// Status the device revised since its row was last delivered whole. Held
+    /// beside the rows so a fresh row can retire the delta standing in for it.
     private var statusOverrides: [String: StatusDelta] = [:]
     private var hostID: String?
     /// Requests in flight, keyed by the `re` each was sent with.
@@ -72,12 +60,9 @@ final class TermiodBackend: DeviceClient {
     private var transfers: [Transfer] = []
     private var seq: UInt64 = 1
 
-    /// One file crossing to the device — an edit being saved, or a photo being
-    /// pasted into a prompt.
     private struct Transfer {
         enum Destination {
-            /// A save into the checkout, conflict-checked against the version
-            /// the editor read.
+            /// Conflict-checked against the version the editor read.
             case file(path: String, root: String, baseModifiedSeconds: UInt64?)
             /// The session's scratch directory, reaped when the session dies.
             case scratch(name: String)
@@ -128,16 +113,14 @@ final class TermiodBackend: DeviceClient {
             onError?(localized("That project isn't on this device."))
             return
         }
-        // A loose chat belongs to no checkout, so its workstream carries no
-        // project — that empty project is exactly what files it under Chats
-        // rather than inventing a folder named after its scratch directory.
+        // A loose chat belongs to no checkout, and the empty project below is
+        // what files it under Chats rather than under a folder named after its
+        // scratch directory.
         let isLooseChat = projectID == TermiodRoster.chatsProjectID
         create(
-            // The scratch root will not exist on a box nobody has started a chat
-            // on, and a spawn into a missing directory is refused. Creating it
-            // is what `TermioStore.ensureLooseChatRoot` does on the desktop,
-            // and it has to happen over there, so the shell does it on the way
-            // in rather than the cwd asking for a directory nobody made.
+            // A spawn into a missing directory is refused, and the scratch root
+            // will not exist on a box nobody has started a chat on, so the
+            // shell creates it on the way in instead.
             cwd: isLooseChat ? channel.homeDirectory : root,
             argv: isLooseChat
                 ? TermiodAgentLaunch.looseChatArgv(forAgent: agentID, root: root)
@@ -149,9 +132,8 @@ final class TermiodBackend: DeviceClient {
     }
 
     func startTerminal(workspaceID _: String?) {
-        // One device is one workspace here, so there is nothing to route by. No
-        // workstream and no agent is what makes this a loose shell, and it
-        // spawns at `$HOME` the way opening a new terminal window does.
+        // One device is one workspace, so there is nothing to route by. No
+        // workstream and no agent is what makes this a loose shell.
         create(
             cwd: TermiodRoster.looseTerminalRoot(homeDirectory: channel.homeDirectory),
             argv: [], workstream: nil, agentID: nil
@@ -159,9 +141,8 @@ final class TermiodBackend: DeviceClient {
     }
 
     func startSSH(host: String, workspaceID _: String?) {
-        // The Mac reads `~/.ssh/config` and offers what it finds; the Session
-        // Protocol has no verb for that, so there is no list to have picked from
-        // and nothing here can honour a choice made against one.
+        // The Session Protocol has no verb for the host list the Mac reads out
+        // of `~/.ssh/config`, so there is no choice here to honour.
         onError?(localized("Termio can't open an SSH session on \(host) from a device connection."))
     }
 
@@ -178,16 +159,14 @@ final class TermiodBackend: DeviceClient {
         onError?(localized("This device doesn't report its SSH hosts."))
     }
 
-    /// The device's Chats container, which needs no finding-or-creating: it is
-    /// one per box and `startSession` resolves this id to the scratch directory
-    /// a loose agent belongs in.
+    /// One per box, so there is nothing to find or create.
     func looseChatsContainerID(workspaceID _: String) -> String? {
         TermiodRoster.chatsProjectID
     }
 
     /// The device path a container id addresses. A folder carries its own; the
-    /// two loose containers spawn at roots that depend on the account's home
-    /// directory, which only the handshake knows.
+    /// two loose containers hang off the account's home directory, which only
+    /// the handshake knows.
     private func root(ofProjectID id: String) -> String? {
         if let root = TermiodRoster.root(ofProjectID: id) { return root }
         let home = channel.homeDirectory
@@ -201,10 +180,9 @@ final class TermiodBackend: DeviceClient {
         }
     }
 
-    /// `attach` with `create_if_missing` is the only spawn verb the protocol
-    /// has, so starting a session means attaching to a name that does not exist
-    /// yet and then stepping back off it — the terminal screen opens its own
-    /// attachment a moment later.
+    /// `attach` with `create_if_missing` is the protocol's only spawn verb, so
+    /// starting a session means attaching to a name that does not exist yet and
+    /// then stepping back off it; the terminal screen attaches for real after.
     private func create(
         cwd: String,
         argv: [String],
@@ -216,17 +194,15 @@ final class TermiodBackend: DeviceClient {
             endpoint: endpoint, name: "start", role: "attach",
             capabilities: Termiod.attachCapabilities, delegateQueue: .main
         )
-        // A link self-heals rather than giving up, which is right for a session
-        // and wrong for a request someone is waiting on: a device that never
-        // answers has to become a refusal instead of a channel dialling forever
-        // behind a ＋ that looks like it did nothing.
+        // A link self-heals rather than giving up, which is wrong for a request
+        // someone is waiting on: a device that never answers has to become a
+        // refusal instead of a channel dialling forever behind a ＋.
         let deadline = DispatchWorkItem { [weak self] in
             Self.retire(starter)
             self?.onError?(localized("That device didn't answer."))
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 15, execute: deadline)
-        // Held by its own callbacks until the attach is answered; the closures
-        // are the only owner, so clearing them is what frees it.
+        // These closures are the starter's only owner, so clearing them frees it.
         starter.onReady = { [weak self] _ in
             guard let self else { return }
             do {
@@ -251,8 +227,7 @@ final class TermiodBackend: DeviceClient {
             switch reply.control {
             case .attached:
                 deadline.cancel()
-                // Leave the stream without killing what was just created; the
-                // screen that opens next attaches for real.
+                // Detach, not kill: what was just created has to outlive this.
                 if let payload = try? Termiod.detachPayload() {
                     starter.send(kind: .control, payload: payload)
                 }
@@ -303,9 +278,8 @@ final class TermiodBackend: DeviceClient {
             onError?(localized("That project isn't on this device."))
             return
         }
-        // No rendered preview: `fs_read` answers with the file's bytes and the
-        // device has no Markdown renderer to ask. The viewer falls back to
-        // showing the source, which is what it does for every other file type.
+        // No rendered preview: `fs_read` answers with bytes and the device has
+        // no Markdown renderer to ask, so the viewer shows the source.
         //
         // The device is addressed absolutely and answered relatively: the reply
         // carries back the path the caller asked for, and a save sends that same
@@ -346,8 +320,7 @@ final class TermiodBackend: DeviceClient {
             return
         }
         // `fs_match` and not `fs_search`: this field searches *names*, and
-        // `fs_search` is the device's content search (`git grep`). Wiring one to
-        // the other would answer a different question than the one asked.
+        // `fs_search` is the device's content search (`git grep`).
         //
         // Nothing is cancelled when a query is abandoned, and nothing needs to
         // be: `fs_match` is one reply off an index the host already holds, and
@@ -368,9 +341,8 @@ final class TermiodBackend: DeviceClient {
 
     func upload(projectID _: String, name: String, data: Data) {
         // A paste lands in the session's scratch directory, which the device
-        // reaps when that session dies — so a screenshot never outlives the
-        // conversation it belonged to. Without a session there is nowhere for it
-        // to go that would be cleaned up.
+        // reaps when that session dies. Without a session there is nowhere for
+        // it to go that anything would clean up.
         guard sessionID != nil else {
             onError?(localized("Attaching a file needs an open session on this device."))
             return
@@ -395,12 +367,12 @@ final class TermiodBackend: DeviceClient {
     // MARK: - Roster
 
     private func handshakeLanded(_ handshake: Termiod.HelloOkPayload) {
-        // The device's own identity, and the only one the roster is keyed by:
-        // `client_id` names this connection and changes on every reconnect.
+        // The roster is keyed by this and never by `client_id`, which names the
+        // connection and changes on every reconnect.
         hostID = handshake.hostId
         do {
-            // `roster` also carries `writer_changed` and `session_exited`, which
-            // is why two names cover everything the list needs.
+            // `roster` also carries `writer_changed` and `session_exited`, so
+            // two names cover everything the list needs.
             channel.send(kind: .control, payload: try Termiod.subscribePayload(
                 events: ["roster", "status"], seq: nextSeq()))
             channel.send(kind: .control, payload: try Termiod.listPayload(seq: nextSeq()))
@@ -459,14 +431,14 @@ final class TermiodBackend: DeviceClient {
             if let information = update.info {
                 if sessionsByID[information.id] == nil { sessionOrder.append(information.id) }
                 sessionsByID[information.id] = information
-                // A whole row is the device's current word on this session, so
-                // it retires the delta that was standing in for one.
+                // A whole row is the device's current word, so it retires the
+                // delta that was standing in for one.
                 statusOverrides[information.id] = nil
             } else if update.action == "removed" {
                 forget(update.session)
             } else {
-                // An arrival notice with no row: the `list` that answers it is
-                // what fills the gap, and there is nothing to redraw yet.
+                // An arrival notice with no row: nothing to redraw until the
+                // `list` behind it lands.
                 return
             }
             publishRoster()
@@ -484,8 +456,8 @@ final class TermiodBackend: DeviceClient {
     }
 
     private func publishRoster() {
-        // No identity yet means no workspace id, and a roster whose workspace
-        // ids churn between pushes would reshuffle every list on screen.
+        // A workspace id that churned between pushes would reshuffle every list
+        // on screen, so nothing is published until the host names itself.
         guard let hostID else { return }
         let live = sessionOrder.compactMap { sessionsByID[$0] }
         onRoster?(DeviceRoster(
@@ -503,9 +475,8 @@ final class TermiodBackend: DeviceClient {
                 continue
             }
             onFileList?(listing.path, listing.entries.map {
-                // Nothing marks a device entry as changed: that flag comes from
-                // the working diff, which is the git plane this connection does
-                // not have.
+                // Nothing is marked as changed: that flag comes from the working
+                // diff, and this connection has no git plane.
                 DeviceFileEntry(name: $0.name, isDirectory: $0.isDirectory)
             })
         }
@@ -553,8 +524,7 @@ final class TermiodBackend: DeviceClient {
             data: data,
             size: Int(clamping: header.size),
             // The host reports bytes and says nothing about what they are, so
-            // the classification is this side's: a NUL in the first block is
-            // what every diff tool calls binary.
+            // the classification is this side's.
             isBinary: data.prefix(8 << 10).contains(0),
             isTruncated: header.truncated,
             modifiedMilliseconds: Int(clamping: header.mtime) * 1000
@@ -566,9 +536,8 @@ final class TermiodBackend: DeviceClient {
               let query = pendingSearches.removeValue(forKey: request)
         else { return }
         guard !payload.indexIsMissing else {
-            // Zero hits at zero coverage means the device never indexed this
-            // checkout — reporting that as "no matches" would be a lie about
-            // the repository rather than about the connection.
+            // Reporting an unindexed checkout as "no matches" would be a claim
+            // about the repository rather than about the connection.
             onError?(localized("This device hasn't indexed this project's filenames."))
             return
         }
@@ -620,8 +589,8 @@ final class TermiodBackend: DeviceClient {
         sendNextChunk()
     }
 
-    /// One chunk per ack — the daemon's credit-of-one, which is what keeps a
-    /// transfer from starving the keystrokes sharing this connection.
+    /// One chunk per ack — the daemon's credit-of-one, which keeps a transfer
+    /// from starving the keystrokes sharing this connection.
     private func sendNextChunk() {
         guard let transfer = transfers.first, let uploadID = transfer.uploadID else { return }
         let start = Int(clamping: transfer.offset)
@@ -760,10 +729,9 @@ struct DeviceUnreachable: Error {
 }
 
 extension TermiodBackend {
-    /// D4's verify step: dial once, wait for `hello_ok`, and hand back the
-    /// device's own `host_id`. Nothing is written to the paired list until this
-    /// answers — saving an unverified address is what produced the companion's
-    /// worst failure mode, paired and silently unreachable.
+    /// Dial once, wait for `hello_ok`, hand back the device's `host_id`. Nothing
+    /// is written to the paired list until this answers: saving an unverified
+    /// address is what produced the companion's paired-but-unreachable state.
     ///
     /// `completion` runs on the main queue, exactly once.
     static func verify(
@@ -774,9 +742,8 @@ extension TermiodBackend {
             capabilities: Termiod.controlCapabilities, delegateQueue: .main
         )
         var answered = false
-        // The link never gives up on its own, which is right for a session and
-        // wrong for a dialog waiting on an answer: a box that is simply not
-        // there has to become a refusal the person can act on.
+        // The link never gives up on its own, so a box that is not there has to
+        // become a refusal the person can act on.
         let deadline = DispatchWorkItem {
             guard !answered else { return }
             answered = true
@@ -806,7 +773,7 @@ extension TermiodBackend {
 
 private extension DeviceRoster {
     /// The device's flat session list as the Device → Workspace → Project →
-    /// Session tree the screens draw.
+    /// Session tree the screens draw. Three things the wire does not answer:
     ///
     /// Three things the wire does not answer, decided here:
     ///
@@ -820,8 +787,7 @@ private extension DeviceRoster {
     ///   that and is not wired up yet (see the RFC's P4 follow-ups) — a separate
     ///   change from this one, which only fixed how replies find their caller.
     /// - **The workspace.** One device is one workspace, and it carries no
-    ///   `deviceAlias`: the box *is* the paired peer, which is what makes
-    ///   `RosterStore.localWorkspaces` offer it as a place to start a session.
+    ///   `deviceAlias`: the box *is* the paired peer.
     init(
         hostID: String,
         projects: [TermiodRoster.Project],
@@ -832,9 +798,8 @@ private extension DeviceRoster {
             deviceName: nil,
             agents: RosterAgent.legacyDefaults,
             projects: projects.map { project in
-                // The two loose containers are named here rather than on the
-                // wire, for the same reason the device supplies no display name
-                // for itself: the words a person reads are the client's.
+                // Named here rather than on the wire: the words a person reads
+                // are the client's.
                 let name = switch project.kind {
                 case .terminals: localized("Terminals")
                 case .chats: localized("Chats")
@@ -871,11 +836,10 @@ private extension MockSession {
         let title = reported.flatMap { $0.isEmpty ? nil : $0 }
         self.init(
             // A reported title first, then the agent's display name when the
-            // device declared one — `displayLabel` would hand back the raw
-            // `agent_id` there, so a chat would read `terminal` rather than
-            // `Terminal`. A session that declared no agent has no name to
-            // borrow, and `displayLabel` is what turns it into the program
-            // actually running (`zsh`) instead of the daemon's uuid handle.
+            // device declared one: `displayLabel` hands back the raw `agent_id`
+            // there, so a chat would read `terminal` rather than `Terminal`.
+            // Without a declared agent it is what names the program actually
+            // running (`zsh`) instead of the daemon's uuid handle.
             title: title ?? (declared ? agent.name : information.displayLabel),
             project: containerName,
             agent: agent,
@@ -898,19 +862,16 @@ struct StatusDelta: Equatable {
 /// What the client decides about a session the device merely describes: which
 /// agent it is, and what to run when starting a new one.
 enum TermiodAgentLaunch {
-    /// The environment a session inherits from *this* client — how output
-    /// should look, which belongs to the viewer no matter which machine the
-    /// process runs on. Nothing here names a path or an identity: those describe
-    /// where the process runs, and the device owns that.
+    /// How output should look, which belongs to the viewer wherever the process
+    /// runs. Nothing here names a path or an identity — the device owns those.
     static let presentationEnvironment = [
         ["TERM", "xterm-ghostty"],
         ["COLORTERM", "truecolor"],
         ["TERM_PROGRAM", "termio"],
     ]
 
-    /// What to exec for an agent. A login shell runs it so the agent is found
-    /// on the user's own `PATH` — a GUI process's `PATH` is not the shell's, and
-    /// a bare exec is how agents came up dead at 0 ms on the Mac.
+    /// A login shell runs the agent so it is found on the user's own `PATH`; a
+    /// bare exec is how agents came up dead at 0 ms on the Mac.
     static func argv(forAgent id: String) -> [String] {
         guard id != RosterAgent.terminal.id else { return [] }
         return ["/bin/sh", "-lc", "exec \(shellQuoted(id))"]
@@ -927,17 +888,16 @@ enum TermiodAgentLaunch {
                 "mkdir -p \(directory) && cd \(directory) && exec \(shellQuoted(id))"]
     }
 
-    /// Single-quoted for `sh`. An agent id comes from a manifest and a root from
-    /// the device's own handshake, so neither is hostile — but both end up
-    /// inside a shell command, and a path with a space in it would otherwise
-    /// spawn in the wrong place.
+    /// Single-quoted for `sh`. Neither an agent id nor a root is hostile, but
+    /// both land inside a shell command and a path with a space in it would
+    /// otherwise spawn in the wrong place.
     private static func shellQuoted(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
-    /// Which agent a roster row is running. The device's own `agent_id` wins;
-    /// without one the foreground argv is read, because the host reports the
-    /// process and the client owns the mapping.
+    /// The device's own `agent_id` wins; without one the foreground argv is
+    /// read, because the host reports the process and the client owns the
+    /// mapping to an agent.
     static func agent(for information: Termiod.SessionInformation) -> RosterAgent {
         if let id = information.agentID, !id.isEmpty { return RosterAgent.fallback(wire: id) }
         guard let executable = information.foregroundArgv?.first, !executable.isEmpty else {

--- a/ios/Sources/TermiodChannel.swift
+++ b/ios/Sources/TermiodChannel.swift
@@ -6,15 +6,14 @@ import TermioShared
 ///
 /// The daemon's listener is a splice, not a second protocol: it copies the same
 /// framed stream a Unix socket carries into binary messages of whatever size its
-/// copy loop happened to read. So a WebSocket message boundary means nothing
-/// here — one message may hold three frames or a third of one, and
-/// `Termiod.FrameReader` is what cuts them apart. The Mac's `Termiod.readFrame`
-/// pulls exactly what a header asks for from a blocking descriptor and has no
-/// equivalent on this side.
+/// copy loop happened to read, so a message boundary means nothing here — one
+/// may hold three frames or a third of one, and `Termiod.FrameReader` cuts them
+/// apart. Everything link-shaped belongs to `WebSocketLink`; what lives here is
+/// the `hello` that must be frame #1, the reassembly, and the decode.
 ///
-/// Everything link-shaped — dialling, backoff, the liveness ping, the
-/// foreground retry — belongs to `WebSocketLink`. What lives here is the
-/// protocol: the `hello` that must be frame #1, the reassembly, and the decode.
+/// Every callback below fires on the link's delegate queue except `onLinkState`
+/// going down and `onFailure`, which arrive on the main queue where the link
+/// schedules its reconnect.
 final class TermiodChannel {
     /// One control frame, and the request it is an answer to.
     ///
@@ -40,28 +39,20 @@ final class TermiodChannel {
     var onControl: ((Reply) -> Void)?
     /// A decoded `E` frame, on the delegate queue.
     var onEvent: ((Termiod.IncomingEvent) -> Void)?
-    /// Raw PTY bytes (`D`), on the delegate queue.
     var onData: ((Data) -> Void)?
-    /// A snapshot keyframe (`S`) payload, on the delegate queue.
     var onSnapshot: ((Data) -> Void)?
-    /// A file chunk (`F`) payload, on the delegate queue.
     var onFileChunk: ((Data) -> Void)?
-    /// The link came up (`true`, meaning the handshake landed) or went down
-    /// (`false`). `true` arrives on the delegate queue, immediately ahead of
-    /// `onReady`; `false` arrives on the main queue, where the link schedules
-    /// its own reconnect. An owner whose delegate queue is the main queue sees
-    /// both there.
+    /// `true` means the handshake landed, and arrives immediately ahead of
+    /// `onReady`.
     var onLinkState: ((Bool) -> Void)?
-    /// The device refused this connection outright — a rejected handshake, a
-    /// stream that lost alignment. Main queue; the reason has to survive the
-    /// reconnect loop or it reads as an unexplained outage.
+    /// The device refused this connection outright. The reason has to survive
+    /// the reconnect loop or it reads as an unexplained outage.
     var onFailure: ((String) -> Void)?
 
-    /// The client id `hello_ok` named this connection, which is the only way to
-    /// tell whether a `writer_changed` naming a client means us.
+    /// The only way to tell whether a `writer_changed` naming a client means us.
     private(set) var clientID: String?
-    /// The device's home directory, for the verbs that must name a path over
-    /// there. Empty until the handshake lands.
+    /// For the verbs that must name a path over there. Empty until the
+    /// handshake lands.
     private(set) var homeDirectory = "/"
 
     private let name: String
@@ -87,16 +78,14 @@ final class TermiodChannel {
             name: name, url: endpoint.url, delegateQueue: delegateQueue,
             pingRunLoopMode: pingRunLoopMode
         )
-        // D3: the token rides the negotiated subprotocol. A query string on the
-        // Upgrade line is the proxy-log leak the daemon's listener exists to
-        // close, so it is never put back here.
+        // The token rides the negotiated subprotocol. A query string on the
+        // Upgrade line leaks it into proxy logs, so it never goes there.
         if let token = endpoint.token {
             configuration.subprotocols = ["termiod.\(token)"]
         }
-        // D2: the listener's CSRF check refuses a missing Origin, and
-        // `URLSession` sends none from a native app. The phone states the
-        // operator's own allowed origin — a value it chose, which is why the
-        // token remains the only thing authenticating the pipe.
+        // The listener's CSRF check refuses a missing Origin and `URLSession`
+        // sends none from a native app, so the phone states the operator's own
+        // allowed origin. The token stays the only thing authenticating the pipe.
         if let origin = endpoint.origin {
             configuration.headers["Origin"] = origin
         }
@@ -126,9 +115,8 @@ final class TermiodChannel {
         link.send(Termiod.frame(kind: kind, payload: payload))
     }
 
-    /// Encode and send one control operation. Throws rather than swallowing an
-    /// encode failure: the caller is the one holding the request that will now
-    /// never be answered, and it is the only place that knows what to say.
+    /// Throws rather than swallowing an encode failure: the caller holds the
+    /// request that will now never be answered, and knows what to say about it.
     func send(control operation: some Encodable) throws {
         send(kind: .control, payload: try Termiod.encodeControl(operation))
     }
@@ -172,8 +160,8 @@ final class TermiodChannel {
             case .event: receiveEvent(frame.payload)
             case .upload, .history, .grid, .resize:
                 // `R` is client-to-host only, and `H`/`G` need capabilities this
-                // client never offers. Receiving one means the daemon sent a
-                // frame nobody asked for — say so rather than drop it silently.
+                // client never offers, so one arriving is a frame nobody asked
+                // for rather than something to drop silently.
                 Log.device.error("""
                 unnegotiated \(String(UnicodeScalar(frame.kind.rawValue)), privacy: .public) \
                 frame on \(self.name, privacy: .public)
@@ -226,9 +214,8 @@ final class TermiodChannel {
         }
     }
 
-    /// What this client calls itself in `hello`. The shared codec deliberately
-    /// does not supply one — claiming to be a particular client is the one thing
-    /// a shared codec must not do.
+    /// What this client calls itself in `hello`. The shared codec supplies no
+    /// banner — claiming to be a particular client is not its to do.
     private static let clientBanner: String = {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
         return "termio-ios/\(version as? String ?? "dev")"

--- a/ios/Sources/TermiodSession.swift
+++ b/ios/Sources/TermiodSession.swift
@@ -5,33 +5,31 @@ import TermioShared
 /// PTY on the device, carrying keystrokes out and its bytes back.
 ///
 /// Everything the companion transport does over a Mac's relay, this does one hop
-/// earlier — with three differences the protocol makes possible:
+/// earlier, with three differences the protocol makes possible:
 ///
-/// - **A reattach repaints from a snapshot, not a replay.** The daemon's
-///   authoritative VT hands over the *current* screen (`S`) and live bytes
-///   resume on top, instead of a torrent of historical escapes that mangles an
-///   idle TUI. That is the reattach story, and the phone reattaches every time
-///   it unlocks.
-/// - **The grid is arbitrated.** §C.5 makes the PTY's size a host-side barrier
-///   owned by one writer, so `E resized` is the authoritative answer and this
-///   client honours it rather than assuming its own viewport won.
-/// - **Input is gated on a token, not on auth.** Many clients may watch one
-///   session and exactly one may type into it.
+/// - **A reattach repaints from a snapshot, not a replay.** The daemon's VT
+///   hands over the *current* screen (`S`) and live bytes resume on top, rather
+///   than a torrent of historical escapes that mangles an idle TUI. The phone
+///   reattaches every time it unlocks.
+/// - **The grid is arbitrated.** The PTY's size is a host-side barrier owned by
+///   one writer, so `E resized` is authoritative and this client honours it
+///   rather than assuming its own viewport won.
+/// - **Input is gated on a token.** Many clients may watch one session and
+///   exactly one may type into it.
 final class TermiodSession: DeviceSession {
     var onOutput: ((Data) -> Void)?
     var onState: ((DeviceSessionState) -> Void)?
 
     /// How long the grid must hold still before a size goes to the device. Every
-    /// distinct size is a host-side barrier — the session quiesces, resizes, and
-    /// pushes a fresh keyframe to every attachment — so a settling keyboard
-    /// animation must not become a burst of full repaints.
+    /// distinct size is a host-side barrier — quiesce, resize, fresh keyframe to
+    /// every attachment — so a settling keyboard animation must not become a
+    /// burst of full repaints.
     private static let resizeCoalescingInterval = DispatchTimeInterval.milliseconds(50)
 
     private let sessionName: String
     private let channel: TermiodChannel
-    /// Everything below is touched only on `queue`, which is also the channel's
-    /// delegate queue — so a frame's arrival and this state are already serial
-    /// and PTY bytes never wait behind UI work.
+    /// The state below is touched only here, and this is the channel's delegate
+    /// queue, so PTY bytes never wait behind UI work.
     private let queue = DispatchQueue(label: "sh.termio.mobile.termiod-session")
     private var attached = false
     private var isWriter = false
@@ -44,9 +42,8 @@ final class TermiodSession: DeviceSession {
     private var desiredGrid = TerminalGrid(rows: 0, cols: 0)
     private var authoritativeGrid: TerminalGrid?
     private var resizeGeneration: UInt64 = 0
-    /// A reconnect re-attaches rather than opening a second session, and the
-    /// snapshot is what repaints the screen — so the reader must not be told the
-    /// old link's screen is still valid.
+    /// Whether this screen ever had a session, which is what separates "the
+    /// device refused a request" from "that session is not there".
     private var everAttached = false
 
     init(endpoint: DeviceEndpoint, sessionName: String) {
@@ -87,11 +84,10 @@ final class TermiodSession: DeviceSession {
     }
 
     func stop() {
-        // Leave the stream without killing the session — the whole reason it
-        // lives in a daemon. Sent straight through rather than hopping to the
-        // frame queue first: this runs from a view controller's `deinit`, where
-        // capturing self into a later block is not allowed, and a detach on a
-        // channel that never attached is a no-op the device ignores.
+        // Detach without killing the session — the whole reason it lives in a
+        // daemon. Sent straight through rather than by hopping to the frame
+        // queue: this runs from a view controller's `deinit`, where capturing
+        // self into a later block is not allowed.
         if let payload = try? Termiod.detachPayload() {
             channel.send(kind: .control, payload: payload)
         }
@@ -126,9 +122,9 @@ final class TermiodSession: DeviceSession {
             guard attached, isWriter, desiredGrid.rows > 0, desiredGrid.cols > 0 else { return }
             // Deliberately past the "already this size" check `resize` applies.
             // libghostty drops an unchanged viewport at two layers, so on a cold
-            // attach no resize ever fires and the screen stays blank under a
-            // correct title; this is the call that has to put an `R` on the wire
-            // regardless, and the fresh keyframe behind it is the repaint.
+            // attach no resize fires and the screen stays blank under a correct
+            // title. This puts an `R` on the wire regardless, and the keyframe
+            // behind it is the repaint.
             sendResize(desiredGrid)
         }
     }

--- a/ios/TermioMobile.xcodeproj/project.pbxproj
+++ b/ios/TermioMobile.xcodeproj/project.pbxproj
@@ -569,7 +569,7 @@
 			repositoryURL = "https://github.com/termio-sh/libghostty-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.18;
+				minimumVersion = 1.0.20;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "21d67c485107aa2c0d0ac76cfd6d52d16ad1eafd",
-        "version" : "1.0.18"
+        "revision" : "b0deec8df1dd8795a8025ae51671dd6c5b591eea",
+        "version" : "1.0.20"
       }
     },
     {

--- a/termiod/Cargo.lock
+++ b/termiod/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 [[package]]
 name = "libghostty-vt"
 version = "0.2.1"
-source = "git+https://github.com/termio-sh/libghostty-rs?rev=cc05bd1a53842450b595846ca8572c739cb98d66#cc05bd1a53842450b595846ca8572c739cb98d66"
+source = "git+https://github.com/termio-sh/libghostty-rs?rev=eceaf8762536ba13b176b85649fd4f55f6d9f21a#eceaf8762536ba13b176b85649fd4f55f6d9f21a"
 dependencies = [
  "bitflags",
  "int-enum",
@@ -352,7 +352,7 @@ dependencies = [
 [[package]]
 name = "libghostty-vt-sys"
 version = "0.2.1"
-source = "git+https://github.com/termio-sh/libghostty-rs?rev=cc05bd1a53842450b595846ca8572c739cb98d66#cc05bd1a53842450b595846ca8572c739cb98d66"
+source = "git+https://github.com/termio-sh/libghostty-rs?rev=eceaf8762536ba13b176b85649fd4f55f6d9f21a#eceaf8762536ba13b176b85649fd4f55f6d9f21a"
 
 [[package]]
 name = "log"

--- a/termiod/src/agent/install.rs
+++ b/termiod/src/agent/install.rs
@@ -15,16 +15,14 @@
 //!   next destructive writer cannot out-merge us;
 //! - write nothing when the bytes already match.
 //!
-//! There is a fifth rule that only shows up on the *second* install, and it is
-//! the one the SSH arm got wrong: **an install must replace what the last one
-//! wrote.** Each dialect has its own way of recognising its own work — a JSON
-//! group by its command, a script and a plugin by their marker, the TOML block
-//! by its begin/end banner — and every one of them has to hold, or a reinstall
-//! quietly doubles the hooks instead of refreshing them.
+//! A fifth rule only shows up on the *second* install: **it must replace what
+//! the last one wrote.** Each dialect recognises its own work differently — a
+//! JSON group by its command, a script and a plugin by their marker, the TOML
+//! block by its banner — and every one has to hold, or a reinstall doubles the
+//! hooks instead of refreshing them.
 //!
-//! Stages 2 and 3 of `docs/design/20260825-agent-integration-moves-to-termiod.md`:
-//! all six dialects plus the skill. The generated plugin sources live in
-//! [`super::plugin`].
+//! See `docs/design/20260825-agent-integration-moves-to-termiod.md`. The
+//! generated plugin sources live in [`super::plugin`].
 
 use super::machine;
 use super::manifest::{AgentCatalog, AgentDefinition, HookDialect, HookEvent, HookSpec, HookType};
@@ -43,14 +41,10 @@ pub const SOCKET_MARKER: &str = "agent-status.sock";
 pub const CLI_MARKER: &str = "agent report";
 
 /// The same role for a hook on a box, which has no `termio` and no app to report
-/// to and instead names the daemon's own session id.
-///
-/// The SSH arm never had this: it emitted `set-status` hooks it could not
-/// afterwards recognize, so a second install on the same device appended a
-/// duplicate of every entry instead of replacing it. It is the fingerprint
-/// `docs/design/20260824-agent-integration-on-a-device.md` §D2 specified;
-/// spelled with the environment variable so it cannot match a user's own tool
-/// that happens to have a `set-status` verb.
+/// to and instead names the daemon's own session id. Spelled with the
+/// environment variable so it cannot match a user's own tool that happens to
+/// have a `set-status` verb — without a fingerprint a reinstall appends a
+/// duplicate of every entry instead of replacing it, as the SSH arm did.
 pub const DAEMON_MARKER: &str = "set-status \"$TERMIOD_SESSION_ID\"";
 
 /// Fingerprints of third-party status hooks that full-replace the shared `hooks`
@@ -1025,16 +1019,14 @@ impl PluginFile {
 /// Agents that declare hooks as TOML `[[hooks]]` tables inside their main config
 /// file — currently Kimi Code.
 ///
-/// There is no structured merge like the JSON agents get, and deliberately so:
-/// TOML arrays of tables may be non-contiguous, so termio appends one
-/// marker-delimited block at the end of the file and strips it back out by those
-/// markers on reinstall. Only the bytes between the markers are ever touched, so
-/// the user's providers, keys and their own `[[hooks]]` are never disturbed —
-/// the same conservative contract as the JSON dialect, without needing a TOML
-/// parser.
+/// No structured merge, deliberately: TOML arrays of tables may be
+/// non-contiguous, so termio appends one marker-delimited block at the end of
+/// the file and strips it back out by those markers on reinstall. Only the bytes
+/// between the markers are touched, which is the JSON dialect's contract without
+/// needing a TOML parser.
 ///
 /// Kimi reads a hook's exit code (0 = allow) and the shared command ends in
-/// `|| true`, so no clean-stdout handling is required on its blockable events.
+/// `|| true`, so its blockable events need no clean-stdout handling.
 struct TomlHookBlock<'a> {
     path: String,
     spec: Option<&'a HookSpec>,
@@ -1259,22 +1251,16 @@ fn remove(path: &str) {
 /// the merge was computed from. `expected == None` means it must still be
 /// absent.
 ///
-/// A hook is a merge into a file the user also owns and edits, and
+/// A hook merges into a file the user also owns and edits, so a
 /// read-modify-write that ignores what happened in between silently discards
-/// their edits — the one failure this must never produce. Refusing is the whole
-/// guarantee; re-merging in a loop is not, and a loop that keeps rewriting a
-/// file somebody is typing in is its own hazard. So a lost race reports the
-/// agent as not installed, and the setup button is the retry.
+/// their edits. Refusing is the whole guarantee; re-merging in a loop is not,
+/// and rewriting a file somebody is typing in is its own hazard — a lost race
+/// reports the agent as not installed, and the setup button is the retry.
 ///
-/// **The precondition stays now that the writer is on the box.** What went with
-/// the SSH arm is `expect_sha256` — shipping a digest across a network so a
-/// *remote* check-and-swap could be atomic. That existed because the merge and
-/// the file were on opposite ends of a link, and it is gone with the link. The
-/// thing it was protecting is not: the user's own editor is on this machine, and
-/// `~/.claude/settings.json` is a file people keep open. The window is now
-/// microseconds inside one process instead of two round trips, which makes the
-/// check nearly free rather than unnecessary — one extra `read` per file against
-/// silently discarding somebody's edit is not a trade worth taking.
+/// The precondition stays now that the writer runs on the box. The window is
+/// microseconds inside one process rather than two network round trips, which
+/// makes the check nearly free, not unnecessary: the user's editor is on this
+/// machine, and `~/.claude/settings.json` is a file people keep open.
 fn write_if_unchanged(path: &str, data: &[u8], expected: Option<&[u8]>) -> Result<(), String> {
     let current = read_bytes(path);
     if current.as_deref() != expected {

--- a/termiod/src/agent/plugin.rs
+++ b/termiod/src/agent/plugin.rs
@@ -5,43 +5,30 @@
 //! dialect the hook here is generated **source**, not a command string, and the
 //! machine it is for reaches further into it than a swapped binary path.
 //!
-//! Three traps live in this file, and all three fail *silently*, because every
-//! hook form ends in `2>/dev/null || true` or `.quiet().nothrow()`. They are
-//! recorded in `docs/design/20260824-agent-integration-on-a-device.md`:
+//! Two traps live here, and both fail *silently*, because every hook form ends
+//! in `2>/dev/null || true` or `.quiet().nothrow()`. See
+//! `docs/design/20260824-agent-integration-on-a-device.md`:
 //!
-//! 1. **The binary is interpolated by Bun's `$`, which escapes each hole into
-//!    one argv token.** Handing it `$HOME/.local/bin/termiod` reaches the kernel
-//!    as a directory literally named `$HOME`, exactly the way an over-quoted
-//!    shell path does. The SSH arm worked around it by joining the path in
-//!    JavaScript — `(process.env.HOME ?? "") + "/.local/bin/termiod"` — because
-//!    the writer could not see the box. This daemon *is* on the box, so it
-//!    interpolates its own resolved path and the question does not arise. See
-//!    [`cli_declaration`].
-//! 2. **The session id comes from the environment**, `TERMIOD_SESSION_ID`, which
+//! 1. **Bun's `$` escapes each hole into one argv token**, so a path containing
+//!    `$HOME` reaches the kernel as a directory literally named `$HOME`. This
+//!    daemon runs on the box, so it interpolates its own resolved path and the
+//!    question does not arise. See [`cli_declaration`].
+//! 2. **The session id comes from `TERMIOD_SESSION_ID`**, which
 //!    `session::daemon_owned_env` exports after the client's `env` so a client
-//!    cannot spoof it. A plugin loaded *outside* a termiod session has no id, and
-//!    must report nothing rather than call `set-status` with an empty one the
-//!    daemon would reject.
-//! 3. **A device used to drop the conversation plumbing**, because `SetStatus`
-//!    carried a state and a title and nothing else. It carries four more fields
-//!    now, so it does not — and with that gone there is no machine branch left in
-//!    this file at all. One template per dialect, not two.
+//!    cannot spoof it. A plugin loaded outside a termiod session has no id and
+//!    must report nothing rather than send an empty one.
 //!
-//! Pi needs no branch of its own either: it already shells out through
-//! `pi.exec("sh", …)`, so it emits the same command the JSON-manifest and
-//! script-directory dialects get.
+//! Pi needs no branch of its own: it shells out through `pi.exec("sh", …)`, so
+//! it emits the same command the other dialects get.
 
 use super::apple_json;
 use super::install::{InstallRequest, StdinMining, SOCKET_MARKER};
 use super::manifest::{HookDialect, HookEvent};
 
-/// A JavaScript string literal.
-///
-/// Swift builds these with a plain `JSONSerialization.data(withJSONObject:)` and
-/// no `withoutEscapingSlashes`, so a `/` comes out as `\/`. That is legal
-/// JavaScript and means the same thing, and it is also what is on disk in every
-/// plugin termio has already installed — so it is reproduced rather than
-/// tidied, and the files do not churn when the writer changes hands.
+/// A JavaScript string literal, with `/` escaped as `\/`. Legal JavaScript, and
+/// what Swift's `JSONSerialization` put on disk in every plugin termio already
+/// installed — reproduced rather than tidied so the files do not churn now that
+/// the writer has changed hands.
 fn js(value: &str) -> String {
     apple_json::string_literal(value, true)
 }

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -135,15 +135,14 @@ enum Cmd {
 
     /// Set agent/workstream status metadata for a session.
     ///
-    /// This is what every installed hook runs, on every machine. The mining
-    /// flags exist because a hook's host hands it a JSON blob on stdin and the
-    /// hook is the only thing that ever sees it — mining here is what lets a
-    /// device agent carry the transcript path, the conversation id, the running
-    /// tool and a first-prompt label, which before this it could not say at all.
+    /// What every installed hook runs, on every machine. The mining flags exist
+    /// because a hook's host hands it a JSON blob on stdin that nothing else
+    /// sees, so mining here is what lets a device agent carry the transcript
+    /// path, the conversation id, the running tool and a first-prompt label.
     ///
-    /// Flag names match `termio agent report`'s deliberately: that is the public
-    /// hook contract, it now forwards here, and two spellings of one vocabulary
-    /// is how the two report forms drifted apart in the first place.
+    /// Flag names match `termio agent report`'s deliberately: it is the public
+    /// hook contract and now forwards here, and two spellings of one vocabulary
+    /// is how the report forms drifted apart in the first place.
     SetStatus {
         /// Session id or name.
         target: String,
@@ -402,12 +401,9 @@ async fn run_agent(cmd: AgentCmd) -> Result<()> {
     Ok(())
 }
 
-/// The host's JSON payload on stdin, or `None`.
-///
-/// Never read from a tty. A hook invoked without its payload piped in would
-/// otherwise leave this waiting on the terminal forever, while a closed or
-/// absent stdin reads instantly as empty — and a hook that hangs is worse than
-/// one that reports nothing, because it hangs the agent's turn with it.
+/// The host's JSON payload on stdin, or `None`. Never read from a tty: a hook
+/// invoked without its payload piped in would wait on the terminal forever, and
+/// a hook that hangs hangs the agent's turn with it.
 fn read_hook_payload() -> Option<serde_json::Value> {
     use std::io::Read;
     if unsafe { libc::isatty(libc::STDIN_FILENO) } == 1 {

--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -13,14 +13,11 @@ use std::path::PathBuf;
 /// `"-dev"` for a side-by-side dev build, `""` for a release one.
 ///
 /// Mirrors `AppChannel.suffix` in the app, and must keep mirroring it: the two
-/// sides derive this separately and a disagreement puts them on different
-/// sockets. Only a plain name becomes a path component, so a typo in
-/// `TERMIO_CHANNEL` can never open a stray directory beside the real ones — it
-/// falls back to the release channel instead.
-///
-/// The daemon cannot read this the way the app does. The app's channel comes
-/// off its bundle identifier, which a spawned binary has no way to see, so
-/// whoever starts the daemon has to say which channel it serves.
+/// derive it separately and a disagreement puts them on different sockets. Only
+/// a plain name becomes a path component, so a typo in `TERMIO_CHANNEL` falls
+/// back to the release channel instead of opening a stray directory. The app
+/// reads its channel off its bundle identifier, which a spawned binary cannot
+/// see, so whoever starts the daemon has to say which channel it serves.
 pub fn channel_suffix() -> String {
     let requested = std::env::var("TERMIO_CHANNEL")
         .unwrap_or_default()
@@ -81,12 +78,9 @@ pub fn host_id_path() -> Result<PathBuf> {
     Ok(state_dir()?.join("host.id"))
 }
 
-/// The pairing secret that authenticates a WebSocket pipe. Beside `host.id`
-/// for the same reason: two daemons on two sockets must not share a secret.
-///
-/// This is not the session write token. That one arbitrates who may type into
-/// a PTY and is handed out by the daemon; this one decides whether a socket is
-/// allowed to carry frames at all.
+/// The pairing secret that authenticates a WebSocket pipe — never the session
+/// write token, which arbitrates who may type into a PTY. Beside `host.id`
+/// because two daemons on two sockets must not share a secret.
 pub fn pair_token_path() -> Result<PathBuf> {
     Ok(state_dir()?.join("pair.token"))
 }

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -43,13 +43,10 @@ pub const HOST_CAPABILITIES: &[&str] = &[
 /// Snapshot payload carrying packed cells.
 ///
 /// v3 replaced v1's resolved-RGB cell with a tagged colour slot. v1 is gone
-/// rather than kept for compatibility: it could not express "the client's
-/// default" or "palette index N", so every payload it produced had already lost
-/// the information a client needs to apply its own theme. Nothing shipped
-/// consumed it — no client negotiates `grid_diff`, and a `snapshot` client is
-/// served VT (v2) — so retiring it costs nothing and carrying it would keep a
-/// format that is wrong by construction. Old clients hard-refuse on the version
-/// byte, which is the documented behaviour (§C.3: never limp).
+/// rather than kept for compatibility: it could express neither "the client's
+/// default" nor "palette index N", so every payload it produced had already
+/// lost what a client needs to apply its own theme, and nothing shipped
+/// consumed it. Old clients hard-refuse on the version byte rather than limp.
 pub const SNAPSHOT_FORMAT_VERSION: u8 = 3;
 /// Snapshot payload carrying **VT sequences** instead of packed cells.
 ///
@@ -469,17 +466,11 @@ impl Default for CreateSpec {
 
 /// The protocol's workstream vocabulary, from whatever a hook said.
 ///
-/// A manifest declares its events in the hook vocabulary — `working`,
-/// `attention`, `done`, `idle` — and the protocol speaks `working`, `idle`,
-/// `needs_you`, `done`, `failed`, `unknown`. `attention` and `needs_you` are the
-/// same state under two names, and nothing translated between them: a device
-/// agent stopped at a permission prompt reported `attention`, which no client
-/// recognised, so it sat there looking idle. Local hooks never hit it because
-/// they reported to a socket that spoke the hook vocabulary.
-///
-/// One report path means one vocabulary, and this is where the two meet.
-/// Anything else is passed through untouched — the daemon is not the judge of
-/// what a status may be.
+/// A manifest declares its events as `working` / `attention` / `done` / `idle`;
+/// the protocol says `needs_you` where a manifest says `attention`. Untranslated,
+/// a device agent stopped at a permission prompt reported a state no client
+/// recognised and sat there looking idle. Anything else passes through untouched
+/// — the daemon is not the judge of what a status may be.
 pub fn normalize_status(status: &str) -> &str {
     match status {
         "attention" => "needs_you",
@@ -618,18 +609,12 @@ pub enum Control {
     },
     /// Client asks for the write token, without re-attaching to get it.
     ///
-    /// Attaching interactively takes the token only when nobody holds it, which
-    /// is right for the first client and would be wrong for every one after it:
-    /// two devices on one session — a Mac and a phone showing the same agent —
-    /// would otherwise have to tear down and rebuild an attachment every time
-    /// the user's hands moved, whichever attached last would silently mute the
-    /// other, and the newcomer's grid would drag the one shared PTY to its own
-    /// width behind the muted client's back.
-    ///
-    /// So the token follows the device being *used*: a client claims it when
-    /// its user actually types. Observers are refused (§A: observers never
-    /// claim the write token), which is what keeps "many readers" from
-    /// degenerating into a race between writers.
+    /// Attaching takes the token only when nobody holds it, so without this a
+    /// Mac and a phone on one session would rebuild their attachments every time
+    /// the user's hands moved, and the newcomer's grid would drag the shared PTY
+    /// to its own width behind the muted client's back. The token follows the
+    /// device being *used*: a client claims it when its user actually types.
+    /// Observers are refused — they never claim the write token.
     ClaimWriter {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
@@ -796,15 +781,12 @@ pub enum Control {
     },
     /// Report a session's agent status.
     ///
-    /// Everything past `title` is what a hook on *this Mac* used to carry to the
-    /// app's own socket and a hook on a device could not say at all. Growing it
-    /// here is what made one report path an upgrade rather than a reshuffle: the
-    /// Info pane's transcript address, the `/new` rotation signal, the running
-    /// tool, and a first-prompt label are now available wherever the agent runs.
-    ///
-    /// All optional and all additive: an older client ignores what it does not
-    /// know, and a hook that has nothing to say omits the field rather than
-    /// sending an empty one.
+    /// Everything past `title` used to reach only the Mac app's own socket: the
+    /// transcript address, the `/new` rotation signal, the running tool, and a
+    /// first-prompt label are now available wherever the agent runs. All
+    /// optional and additive — an older client ignores what it does not know,
+    /// and a hook with nothing to say omits the field rather than sending an
+    /// empty one.
     SetStatus {
         id: String,
         status: String,
@@ -835,15 +817,14 @@ pub enum Control {
     /// (capability `agents`).
     ///
     /// The machine that owns the files decides what goes in them: the client
-    /// says *which agents are on the user's list* — a preference — and the
-    /// daemon works out where each one keeps its config, whether its CLI is
-    /// even here, and what to merge. What used to be forty to sixty sequential
-    /// `ssh` round trips is this one message.
+    /// names which agents the user enabled — a preference — and the daemon works
+    /// out where each keeps its config, whether its CLI is even here, and what
+    /// to merge. What used to be forty to sixty sequential `ssh` round trips is
+    /// this one message.
     ///
     /// The client never names a destination. Every path written comes from a
-    /// manifest this box already has — the daemon's own bundled roster, or the
-    /// user's own `~/.termio/config/agents` — so the write surface is fixed by
-    /// the box rather than chosen by the caller.
+    /// manifest this box already has, so the write surface is fixed by the box
+    /// rather than chosen by the caller.
     InstallAgents {
         /// The agent ids the user has enabled, or absent for the whole catalog.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1142,15 +1123,13 @@ pub enum Event {
     },
     /// A session's agent status changed.
     ///
-    /// **Ordering.** This is queued into the session's own per-client channel,
-    /// the same FIFO its `D` data goes through, so it cannot overtake output the
-    /// daemon has already read — a client is right to apply it on arrival and
-    /// needs no sequence number to do so. (`SetStatus.seq` is a request id for
-    /// reply de-duplication, not an ordering token; every hook sends 1.) What no
-    /// token could fix is upstream of here: an agent writes to its PTY and runs
-    /// its hook, and the daemon may process the hook before it has read those
-    /// bytes. That race is bounded by one read, and it is the reason `working`
-    /// arriving a few milliseconds early is not worth a buffering client.
+    /// Queued into the session's own per-client channel, the same FIFO its `D`
+    /// data goes through, so it cannot overtake output the daemon has already
+    /// read and needs no sequence number. (`SetStatus.seq` is a request id, not
+    /// an ordering token.) What no token could fix is upstream: an agent may run
+    /// its hook before the daemon has read the bytes it just wrote. That race is
+    /// bounded by one read, so `working` arriving a few milliseconds early is
+    /// not worth a buffering client.
     Status {
         session: String,
         status: String,

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -502,12 +502,72 @@ fn target_for_uname(uname: &str) -> Result<String> {
     Ok(target.to_string())
 }
 
+/// Where the cross-build's tools are, which this process's own `PATH` cannot be
+/// trusted to say. A deploy is usually started by the app, and an app launched
+/// from Finder inherits launchd's `PATH` — `/usr/bin:/bin:/usr/sbin:/sbin`, which
+/// holds neither cargo (`~/.cargo/bin`) nor anything from Homebrew. The login
+/// shell knows both, so it answers instead.
+///
+/// Homebrew's `zig` prefix is added on top of that because `brew` leaves `zig`
+/// off `PATH` entirely whenever a second `zig@N` formula holds the link — the
+/// same case `scripts/build-app.sh` checks for before building the daemon.
+fn toolchain_path() -> Vec<String> {
+    let mut directories = crate::agent::machine::login_path();
+    for prefix in ["/opt/homebrew/opt/zig/bin", "/usr/local/opt/zig/bin"] {
+        if !directories.iter().any(|seen| seen == prefix) {
+            directories.push(prefix.to_string());
+        }
+    }
+    directories
+}
+
+/// `binary` as an absolute path, looked up across `directories`.
+fn find_tool(directories: &[String], binary: &str) -> Option<String> {
+    use std::os::unix::fs::PermissionsExt;
+    directories.iter().find_map(|directory| {
+        let candidate = std::path::Path::new(directory).join(binary);
+        let usable = std::fs::metadata(&candidate)
+            .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false);
+        usable.then(|| candidate.to_string_lossy().into_owned())
+    })
+}
+
 /// `cargo build --release --target <triple>` for this crate; returns the
 /// binary path. Falls back to a clear message if the cross-linker is missing.
 fn cross_compile(target: &str) -> Result<String> {
     let manifest = format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+    let path = toolchain_path();
+    let Some(cargo) = find_tool(&path, "cargo") else {
+        bail!(
+            "cross-compiling for {target} needs cargo, and there is none on this machine.\n  \
+             • install Rust: https://rustup.rs\n  \
+             • or build on the host and deploy with: termiod remote deploy <host> --bin <path>"
+        );
+    };
+    // Checked before cargo runs rather than left to the build script's panic:
+    // the VT engine termiod embeds is built by Zig, and a missing `zig` fails
+    // several minutes in, inside a wall of cargo output, blaming a build script
+    // nobody here wrote.
+    if find_tool(&path, "zig").is_none() {
+        bail!(
+            "cross-compiling for {target} needs zig — the terminal engine termiod embeds\n\
+             is built by it.\n  \
+             • brew install zig\n  \
+             • or build on the host and deploy with: termiod remote deploy <host> --bin <path>"
+        );
+    }
     eprintln!("[deploy] cross-compiling for {target}…");
-    let status = Command::new("cargo")
+    let status = Command::new(cargo)
+        .env("PATH", path.join(":"))
+        // Run *inside* the crate, not merely at it. Cargo discovers
+        // `.cargo/config.toml` by walking up from the working directory —
+        // `--manifest-path` does not move that search. Started from anywhere else
+        // (an app's working directory is `/`), the musl link falls back to Apple's
+        // `cc`, which rejects lld's flags with "ld: unknown options: --as-needed"
+        // and no mention of the config it never read. `termiod/.cargo/config.toml`
+        // is what points the cross-link at the bundled rust-lld.
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
         .args([
             "build",
             "--release",
@@ -517,7 +577,7 @@ fn cross_compile(target: &str) -> Result<String> {
             &manifest,
         ])
         .status()
-        .context("running cargo build (is cargo on PATH?)")?;
+        .context("running cargo build")?;
     if !status.success() {
         bail!(
             "cross-compile for {target} failed.\n\

--- a/termiod/src/wss.rs
+++ b/termiod/src/wss.rs
@@ -3,19 +3,16 @@
 //! A phone or a browser cannot open a Unix socket, so this is the one place
 //! `termiod` accepts TCP. Three rules keep it from becoming a second product:
 //!
-//! - **Loopback only.** TLS lives in Tailscale Serve or Caddy in front. termiod
-//!   never grows a TLS stack, never ships a CA, and never pins a certificate.
-//! - **It is a splice, not a second protocol.** Once the Upgrade is done, this
-//!   copies bytes onto a connected `UnixStream` exactly the way `termiod stdio`
-//!   does. Binary messages are chunks of the same framed stream and are
-//!   concatenated on both ends; one WebSocket message is *not* one protocol
-//!   frame, or a recorded Unix-socket transcript would no longer replay.
-//! - **The pairing token authenticates the pipe.** It is not the session write
-//!   token — that one arbitrates who may type into a PTY and is handed out by
-//!   the daemon, and the two must never be confused.
+//! - **Loopback only.** TLS lives in Tailscale Serve or Caddy in front; termiod
+//!   never grows a TLS stack, ships a CA, or pins a certificate.
+//! - **It is a splice, not a second protocol.** After the Upgrade this copies
+//!   bytes onto a connected `UnixStream` the way `termiod stdio` does. One
+//!   WebSocket message is *not* one protocol frame, or a recorded Unix-socket
+//!   transcript would no longer replay.
+//! - **The pairing token authenticates the pipe**, and is never the session
+//!   write token that arbitrates who may type into a PTY.
 //!
-//! Specified by `docs/design/20260818-termiod-web-client-ghostty-wasm.md`
-//! §"Where WSS lives" and §"Auth".
+//! Specified by `docs/design/20260818-termiod-web-client-ghostty-wasm.md`.
 
 use crate::paths;
 use anyhow::{bail, Context, Result};
@@ -261,11 +258,9 @@ fn env_value(name: &str) -> Option<String> {
 }
 
 /// Resolve the bind, the origins and the token into a listener, or `None` for
-/// "Unix socket only" — the unchanged DEPLOY.md contract.
-///
-/// The seven rules of §"Where WSS lives" land here, because a flag that only
-/// lives on one foreground argv dies on the next crash restart: `spawn_daemon`
-/// execs bare `termiod serve`, and so does the systemd unit.
+/// "Unix socket only". Config outranks the flag because a flag that lives only
+/// on one foreground argv dies on the next crash restart: `spawn_daemon` execs
+/// bare `termiod serve`, and so does the systemd unit.
 pub fn resolve(
     explicit_bind: Option<SocketAddr>,
     explicit_origins: &[Origin],

--- a/termiod/vt/Cargo.toml
+++ b/termiod/vt/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 # script. What stays here is termiod's own snapshot boundary: the wire cell is
 # ours, not the engine's.
 #
-# Pinned to termio-sh/libghostty-rs, our fork, which builds ghostty 74a133e —
+# Pinned to termio-sh/libghostty-rs, our fork, which builds ghostty 8867c37 —
 # the same one libghostty-swift ships to the Mac and iOS clients, so the host
 # and its clients run one VT. That parity is why this engine was chosen over
 # alacritty_terminal in the first place.
@@ -22,8 +22,8 @@ publish = false
 # other.
 #
 # Track libghostty-swift when it releases: its title carries the ghostty it
-# built (`1.0.18 · ghostty v1.3.1-2199-g74a133e`), and that sha is the one to
+# built (`1.0.20 · ghostty v1.3.1-2293-g8867c37`), and that sha is the one to
 # match here. Since ghostty#13759 dropped iOS from the full build, that release
 # also carries a patch putting iOS back, so the two forks move together.
 [dependencies]
-libghostty-vt = { git = "https://github.com/termio-sh/libghostty-rs", rev = "cc05bd1a53842450b595846ca8572c739cb98d66" }
+libghostty-vt = { git = "https://github.com/termio-sh/libghostty-rs", rev = "eceaf8762536ba13b176b85649fd4f55f6d9f21a" }


### PR DESCRIPTION
The batch that was sitting in the working tree, split into its parts:

- **libghostty 1.0.20** on Mac, iOS, and the host's VT engine (matching `libghostty-rs` rev), so all three keep running one ghostty (`v1.3.1-2293-g8867c37`).
- **Usage statistics**: one anonymous PostHog event per day (install id, app version, macOS version, language — nothing else), with Settings ▸ General ▸ Privacy to turn it off. Not the SDK (it ships SPM resources, the shape that has crashed a release twice). The project key is empty in this build, so nothing is sent yet.
- **`termiod deploy` from the app** finds cargo and zig through the login shell instead of Finder's PATH (the fallback path only reached when no bundled slice matches).
- Doc-comment trims across the daemon, the shared protocol and the iOS client; a draft RFC on the dev-tunnels remote-access model.

## Verified
- `swift test`: 821 tests, 0 failures, on 1.0.20.
- `cargo test` on the new engine rev — see the checks.

## Release Notes
- Terminal engine updated to ghostty v1.3.1-2293.
- New Settings ▸ General ▸ Privacy switch for anonymous daily usage statistics (off by default until a project key ships; sends no paths, contents, or identity).
