### PR TITLE
Bump libghostty to 1.0.21 to stop torn frames under a late main thread

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1d64db25bb4aca66c7bd4c6d6e26f9fd862164e32efbcab73143f258f9001bea",
+  "originHash" : "a83592c4d9fb3055470b79fbbc78031fb4b941cf7b2fe049079fb5b2dceedfca",
   "pins" : [
     {
       "identity" : "highlightr",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "b0deec8df1dd8795a8025ae51671dd6c5b591eea",
-        "version" : "1.0.20"
+        "revision" : "7f7720b7ded2406822bca6dca32cc07e5cf317ff",
+        "version" : "1.0.21"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // live resize" suspicion that briefly rolled this back to Lakr233 was a
         // misdiagnosis — the real bug was termio's own PTY spawn shape (see
         // docs/bug/terminal-resize-no-reflow-HANDOFF.md §0).
-        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.20"),
+        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.21"),
         // Sparkle powers in-app auto-update (the "Check for Updates…" menu item and
         // background update checks). It reads the appcast published with each GitHub
         // release; the matching EdDSA public key is embedded in packaging/Info.plist.

--- a/ios/TermioMobile.xcodeproj/project.pbxproj
+++ b/ios/TermioMobile.xcodeproj/project.pbxproj
@@ -569,7 +569,7 @@
 			repositoryURL = "https://github.com/termio-sh/libghostty-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.20;
+				minimumVersion = 1.0.21;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "b0deec8df1dd8795a8025ae51671dd6c5b591eea",
-        "version" : "1.0.20"
+        "revision" : "7f7720b7ded2406822bca6dca32cc07e5cf317ff",
+        "version" : "1.0.21"
       }
     },
     {


### PR DESCRIPTION
Same ghostty sha as 1.0.20; the fork's new patch `0010-metal-present-backpressure` (termio-sh/libghostty-swift#4) makes the Metal renderer refuse to draw into an IOSurface while a present is still queued on the main thread or that surface is the one on screen. That is the mechanism behind #506: the swap chain freed a target on GPU completion, and a main thread ≥2 frames late (a SwiftUI re-render across panes on the status change a sent message triggers) let the next frame be drawn into the surface still displayed — a half-written frame with a vertical seam.

Reviewed adversarially (two rounds; a teardown use-after-free in the first version was found and fixed with a refcounted present state), compiled and tested on all five Apple targets by the fork's workflow.

Mac, iOS project, and both `Package.resolved` files move together.

Refs #506

## Release Notes
- Fixed: a terminal pane could briefly show two frames side by side (a vertical seam) when a TUI redrew while the app was busy.
