### PR TITLE
Publish a device from the pane that pairs it

### DIFF
--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -41,12 +41,32 @@
         }
       }
     },
+    "%@ answered as a different machine than %@. Its address is being served by something else.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 回应的是另一台机器，不是 %2$@。这个地址正被别的东西占用。"
+          }
+        }
+      }
+    },
     "%@ answered, but not with a pairing invite. Its termiod is probably older than this app — deploy it again.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ 有响应，但返回的不是配对邀请。它的 termiod 可能比本应用旧——重新部署一次。"
+          }
+        }
+      }
+    },
+    "%@ answered, but not with the handshake termiod sends.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 有回应，但回的不是 termiod 的握手。"
           }
         }
       }
@@ -91,6 +111,26 @@
         }
       }
     },
+    "%@ is not an address the iPhone could dial.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 不是 iPhone 能拨通的地址。"
+          }
+        }
+      }
+    },
+    "%@ is published, but the connection an iPhone would make was refused.\n%@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 已发布，但 iPhone 会发起的那种连接被拒绝了。\n%2$@"
+          }
+        }
+      }
+    },
     "%@ is ready.": {
       "localizations": {
         "zh-Hans": {
@@ -131,12 +171,32 @@
         }
       }
     },
+    "%@ isn’t installed on %@, and Termio doesn’t ship a build of it. Install it there, then try again.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ 上没有安装 %1$@，Termio 也不提供它的构建版本。请先在那台机器上安装，然后重试。"
+          }
+        }
+      }
+    },
     "%@ isn’t on your PATH": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ 不在 PATH 中"
+          }
+        }
+      }
+    },
+    "%@ isn’t published yet": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 尚未发布"
           }
         }
       }
@@ -151,12 +211,62 @@
         }
       }
     },
+    "%@ never answered on its published address.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 始终没有在它发布的地址上回应。"
+          }
+        }
+      }
+    },
     "%@ opened %@": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "%1$@ 创建于 %2$@"
+          }
+        }
+      }
+    },
+    "%@ refused the handshake.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 拒绝了握手。"
+          }
+        }
+      }
+    },
+    "%@ reports an architecture we have no build for: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 报告的架构没有对应的构建版本：%2$@"
+          }
+        }
+      }
+    },
+    "%@ started on %@ but never printed an address.\n%@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 已在 %2$@ 上启动，但始终没有打印地址。\n%3$@"
+          }
+        }
+      }
+    },
+    "%@ stays published only until you log out of it. Termio couldn’t set it to keep services running after that.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 只在你登录期间保持发布。Termio 无法让它在登出后继续运行服务。"
           }
         }
       }
@@ -1142,6 +1252,16 @@
         }
       }
     },
+    "Checking that %@ answers…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在确认 %@ 有回应…"
+          }
+        }
+      }
+    },
     "Checking the machine…": {
       "localizations": {
         "zh-Hans": {
@@ -1832,6 +1952,16 @@
         }
       }
     },
+    "Couldn’t install %@ on %@.\n%@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法在 %2$@ 上安装 %1$@。\n%3$@"
+          }
+        }
+      }
+    },
     "Couldn’t link `%@` into %@.": {
       "localizations": {
         "zh-Hans": {
@@ -1888,6 +2018,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法把密码保存到钥匙串。"
+          }
+        }
+      }
+    },
+    "Couldn’t start %@ on %@.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法在 %2$@ 上启动 %1$@。"
+          }
+        }
+      }
+    },
+    "Couldn’t start termiod on %@ with a listener.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法在 %1$@ 上带监听器启动 termiod。"
           }
         }
       }
@@ -3584,6 +3734,16 @@
         }
       }
     },
+    "Needs `ngrok config add-authtoken` on that machine first. The free address changes on every restart.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要先在那台机器上运行 `ngrok config add-authtoken`。免费版的地址每次重启都会变。"
+          }
+        }
+      }
+    },
     "New": {
       "localizations": {
         "zh-Hans": {
@@ -3984,6 +4144,16 @@
         }
       }
     },
+    "No command to run.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可运行的命令。"
+          }
+        }
+      }
+    },
     "No description provided.": {
       "localizations": {
         "zh-Hans": {
@@ -4120,6 +4290,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有主题与“%@”匹配"
+          }
+        }
+      }
+    },
+    "No tunnel selected.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未选择隧道。"
           }
         }
       }
@@ -4281,6 +4461,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "关闭 — 仅局域网"
+          }
+        }
+      }
+    },
+    "Off — SSH only": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭 — 仅 SSH"
           }
         }
       }
@@ -4517,6 +4707,16 @@
         }
       }
     },
+    "Opening the listener needs the daemon restarted, which ends what it is hosting:\n%@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开监听器需要重启守护进程，这会结束它正在承载的内容：\n%@"
+          }
+        }
+      }
+    },
     "Opens the ~/.ssh/config entry this machine is defined in.": {
       "localizations": {
         "zh-Hans": {
@@ -4647,6 +4847,16 @@
         }
       }
     },
+    "Pick how %@ is reached from outside. Termio runs it there over SSH and reads the address back — you never type one.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择从外部访问 %@ 的方式。Termio 会通过 SSH 在那台机器上运行它，并把地址读回来——你不需要手输任何地址。"
+          }
+        }
+      }
+    },
     "Pick the branch this one would merge into.": {
       "localizations": {
         "zh-Hans": {
@@ -4723,6 +4933,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "播放声音"
+          }
+        }
+      }
+    },
+    "Pointing termiod at %@…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在把 termiod 指向 %@…"
           }
         }
       }
@@ -4843,6 +5063,36 @@
           "stringUnit": {
             "state": "translated",
             "value": "公钥"
+          }
+        }
+      }
+    },
+    "Publish": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发布"
+          }
+        }
+      }
+    },
+    "Publish and End Them": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发布并结束它们"
+          }
+        }
+      }
+    },
+    "Publishing restarts termiod on %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发布会重启 %@ 上的 termiod"
           }
         }
       }
@@ -5277,6 +5527,16 @@
         }
       }
     },
+    "Restarting the tunnel changes the address, and every paired iPhone has to scan again.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重启隧道会更换地址，所有已配对的 iPhone 都需要重新扫码。"
+          }
+        }
+      }
+    },
     "Restore Defaults": {
       "localizations": {
         "zh-Hans": {
@@ -5393,6 +5653,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "运行于 %@"
+          }
+        }
+      }
+    },
+    "Runs on that machine with your login’s privileges — no shell, arguments split on spaces. Use {port} for the daemon’s port.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以你的登录身份在那台机器上运行——不经过 shell，参数按空格切分。用 {port} 代表守护进程的端口。"
           }
         }
       }
@@ -5978,6 +6248,16 @@
         }
       }
     },
+    "Starting %@ on %@…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在 %2$@ 上启动 %1$@…"
+          }
+        }
+      }
+    },
     "Starting tunnel…": {
       "localizations": {
         "zh-Hans": {
@@ -6548,6 +6828,16 @@
         }
       }
     },
+    "This address changes when the tunnel restarts, and every paired iPhone must scan again.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隧道重启后这个地址会变，所有已配对的 iPhone 都必须重新扫码。"
+          }
+        }
+      }
+    },
     "This agent is no longer on your list.": {
       "localizations": {
         "zh-Hans": {
@@ -6744,6 +7034,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "此 PR 未更改任何文件。"
+          }
+        }
+      }
+    },
+    "This relay has no valid URL pattern, so its address could never be read back.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个中转没有有效的 URL 正则，它的地址永远读不回来。"
           }
         }
       }
@@ -7125,6 +7425,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "微信群"
+          }
+        }
+      }
+    },
+    "What the daemon said": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "守护进程的原始输出"
           }
         }
       }
@@ -7521,6 +7831,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "termio 可以教你运行的 Agent（Claude Code、Codex 等）使用 `termio sessions` 命令，让它们在项目中查看、驱动并读取彼此的会话。\n\n启用后会在你的 ~/.claude/CLAUDE.md 中添加一段简短说明并安装状态 hooks。你可以随时在“设置 ▸ Agents”中将其关闭。"
+          }
+        }
+      }
+    },
+    "termiod on %@ never opened its listener.\n%@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 上的 termiod 始终没有打开监听器。\n%2$@"
           }
         }
       }

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -12,8 +12,12 @@
 	<string>%1$@ changed on %2$@</string>
 	<key>%@ and %@</key>
 	<string>%@ and %@</string>
+	<key>%@ answered as a different machine than %@. Its address is being served by something else.</key>
+	<string>%@ answered as a different machine than %@. Its address is being served by something else.</string>
 	<key>%@ answered, but not with a pairing invite. Its termiod is probably older than this app — deploy it again.</key>
 	<string>%@ answered, but not with a pairing invite. Its termiod is probably older than this app — deploy it again.</string>
+	<key>%@ answered, but not with the handshake termiod sends.</key>
+	<string>%@ answered, but not with the handshake termiod sends.</string>
 	<key>%@ didn’t come up — check the network and retry</key>
 	<string>%@ didn’t come up — check the network and retry</string>
 	<key>%@ has nothing to pair against</key>
@@ -22,6 +26,12 @@
 	<string>%@ is a dark theme in the %@ slot.</string>
 	<key>%@ is a light theme in the %@ slot.</key>
 	<string>%@ is a light theme in the %@ slot.</string>
+	<key>%@ is not an address the iPhone could dial.</key>
+	<string>%@ is not an address the iPhone could dial.</string>
+	<key>%@ is published, but the connection an iPhone would make was refused.
+%@</key>
+	<string>%@ is published, but the connection an iPhone would make was refused.
+%@</string>
 	<key>%@ is ready.</key>
 	<string>%@ is ready.</string>
 	<key>%@ isn’t a UTF-8 text file.</key>
@@ -30,12 +40,28 @@
 	<string>%@ isn’t available on this device yet.</string>
 	<key>%@ isn’t installed on %@</key>
 	<string>%@ isn’t installed on %@</string>
+	<key>%@ isn’t installed on %@, and Termio doesn’t ship a build of it. Install it there, then try again.</key>
+	<string>%@ isn’t installed on %@, and Termio doesn’t ship a build of it. Install it there, then try again.</string>
 	<key>%@ isn’t on your PATH</key>
 	<string>%@ isn’t on your PATH</string>
+	<key>%@ isn’t published yet</key>
+	<string>%@ isn’t published yet</string>
 	<key>%@ keeps exiting — retrying every %llds</key>
 	<string>%@ keeps exiting — retrying every %llds</string>
+	<key>%@ never answered on its published address.</key>
+	<string>%@ never answered on its published address.</string>
 	<key>%@ opened %@</key>
 	<string>%@ opened %@</string>
+	<key>%@ refused the handshake.</key>
+	<string>%@ refused the handshake.</string>
+	<key>%@ reports an architecture we have no build for: %@</key>
+	<string>%@ reports an architecture we have no build for: %@</string>
+	<key>%@ started on %@ but never printed an address.
+%@</key>
+	<string>%@ started on %@ but never printed an address.
+%@</string>
+	<key>%@ stays published only until you log out of it. Termio couldn’t set it to keep services running after that.</key>
+	<string>%@ stays published only until you log out of it. Termio couldn’t set it to keep services running after that.</string>
 	<key>%@ tokens</key>
 	<string>%@ tokens</string>
 	<key>%@ · %@ tokens</key>
@@ -236,6 +262,8 @@
 	<string>Check for Updates…</string>
 	<key>Checked out on %@</key>
 	<string>Checked out on %@</string>
+	<key>Checking that %@ answers…</key>
+	<string>Checking that %@ answers…</string>
 	<key>Checking the machine…</key>
 	<string>Checking the machine…</string>
 	<key>Checking…</key>
@@ -374,6 +402,10 @@
 	<string>Couldn’t create worktree session</string>
 	<key>Couldn’t inspect worktree</key>
 	<string>Couldn’t inspect worktree</string>
+	<key>Couldn’t install %@ on %@.
+%@</key>
+	<string>Couldn’t install %@ on %@.
+%@</string>
 	<key>Couldn’t link `%@` into %@.</key>
 	<string>Couldn’t link `%@` into %@.</string>
 	<key>Couldn’t load</key>
@@ -386,6 +418,10 @@
 	<string>Couldn’t remove worktree</string>
 	<key>Couldn’t save the password to your Keychain.</key>
 	<string>Couldn’t save the password to your Keychain.</string>
+	<key>Couldn’t start %@ on %@.</key>
+	<string>Couldn’t start %@ on %@.</string>
+	<key>Couldn’t start termiod on %@ with a listener.</key>
+	<string>Couldn’t start termiod on %@ with a listener.</string>
 	<key>Couldn’t update %@.</key>
 	<string>Couldn’t update %@.</string>
 	<key>Couldn’t update .gitignore</key>
@@ -724,6 +760,8 @@
 	<string>Navigation</string>
 	<key>Navigator</key>
 	<string>Navigator</string>
+	<key>Needs `ngrok config add-authtoken` on that machine first. The free address changes on every restart.</key>
+	<string>Needs `ngrok config add-authtoken` on that machine first. The free address changes on every restart.</string>
 	<key>New</key>
 	<string>New</string>
 	<key>New %@ Session</key>
@@ -804,6 +842,8 @@
 	<string>No agent CLIs found.</string>
 	<key>No bundled tool to install from.</key>
 	<string>No bundled tool to install from.</string>
+	<key>No command to run.</key>
+	<string>No command to run.</string>
 	<key>No description provided.</key>
 	<string>No description provided.</string>
 	<key>No file changes</key>
@@ -832,6 +872,8 @@
 	<string>No textual changes to show.</string>
 	<key>No theme matches “%@”</key>
 	<string>No theme matches “%@”</string>
+	<key>No tunnel selected.</key>
+	<string>No tunnel selected.</string>
 	<key>None</key>
 	<string>None</string>
 	<key>None of this project’s remotes point at github.com, so there is no issue tracker to show.</key>
@@ -864,6 +906,8 @@
 	<string>OK</string>
 	<key>Off — LAN only</key>
 	<string>Off — LAN only</string>
+	<key>Off — SSH only</key>
+	<string>Off — SSH only</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Both devices must share a LAN.</key>
 	<string>On iPhone, tap the Mac pill ▸ Scan QR Code. Both devices must share a LAN.</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The token is minted on %@ and demanded on every connection.</key>
@@ -910,6 +954,10 @@
 	<string>Open the invite on your iPhone to install it with TestFlight.</string>
 	<key>Opened outside Termio on this device</key>
 	<string>Opened outside Termio on this device</string>
+	<key>Opening the listener needs the daemon restarted, which ends what it is hosting:
+%@</key>
+	<string>Opening the listener needs the daemon restarted, which ends what it is hosting:
+%@</string>
 	<key>Opens the ~/.ssh/config entry this machine is defined in.</key>
 	<string>Opens the ~/.ssh/config entry this machine is defined in.</string>
 	<key>Overwrite</key>
@@ -936,6 +984,8 @@
 	<string>Permissions</string>
 	<key>Pick a file on the left to see its changes.</key>
 	<string>Pick a file on the left to see its changes.</string>
+	<key>Pick how %@ is reached from outside. Termio runs it there over SSH and reads the address back — you never type one.</key>
+	<string>Pick how %@ is reached from outside. Termio runs it there over SSH and reads the address back — you never type one.</string>
 	<key>Pick the branch this one would merge into.</key>
 	<string>Pick the branch this one would merge into.</string>
 	<key>Pin</key>
@@ -952,6 +1002,8 @@
 	<string>Plan limits come from %@'s OAuth login; no passwords are stored. Revoking stops all reading of %@'s data.</string>
 	<key>Play sound</key>
 	<string>Play sound</string>
+	<key>Pointing termiod at %@…</key>
+	<string>Pointing termiod at %@…</string>
 	<key>Port</key>
 	<string>Port</string>
 	<key>Posts a notification when an agent finishes or needs you while Termio is in the background.</key>
@@ -976,6 +1028,12 @@
 	<string>Public address</string>
 	<key>Public keys</key>
 	<string>Public keys</string>
+	<key>Publish</key>
+	<string>Publish</string>
+	<key>Publish and End Them</key>
+	<string>Publish and End Them</string>
+	<key>Publishing restarts termiod on %@</key>
+	<string>Publishing restarts termiod on %@</string>
 	<key>Pull Requests</key>
 	<string>Pull Requests</string>
 	<key>Push the current branch to the repository’s remote first, then try again. (The remote also needs to be a forge Termio recognizes: GitHub, GitLab, Bitbucket, or Gitea.)</key>
@@ -1062,6 +1120,8 @@
 	<string>Request Permission</string>
 	<key>Reset Font Size</key>
 	<string>Reset Font Size</string>
+	<key>Restarting the tunnel changes the address, and every paired iPhone has to scan again.</key>
+	<string>Restarting the tunnel changes the address, and every paired iPhone has to scan again.</string>
 	<key>Restore Defaults</key>
 	<string>Restore Defaults</string>
 	<key>Reveal in Finder</key>
@@ -1086,6 +1146,8 @@
 	<string>Runs</string>
 	<key>Runs on %@</key>
 	<string>Runs on %@</string>
+	<key>Runs on that machine with your login’s privileges — no shell, arguments split on spaces. Use {port} for the daemon’s port.</key>
+	<string>Runs on that machine with your login’s privileges — no shell, arguments split on spaces. Use {port} for the daemon’s port.</string>
 	<key>Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.</key>
 	<string>Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.</string>
 	<key>Runs with `%@`. The agent won’t ask before editing files or running commands.</key>
@@ -1202,6 +1264,8 @@
 	<string>Staged — the next git commit takes this file</string>
 	<key>Start an agent in a project.</key>
 	<string>Start an agent in a project.</string>
+	<key>Starting %@ on %@…</key>
+	<string>Starting %@ on %@…</string>
 	<key>Starting tunnel…</key>
 	<string>Starting tunnel…</string>
 	<key>Starting…</key>
@@ -1316,6 +1380,8 @@
 	<string>This Mac and the machines you reach from it</string>
 	<key>This Mac…</key>
 	<string>This Mac…</string>
+	<key>This address changes when the tunnel restarts, and every paired iPhone must scan again.</key>
+	<string>This address changes when the tunnel restarts, and every paired iPhone must scan again.</string>
 	<key>This agent is no longer on your list.</key>
 	<string>This agent is no longer on your list.</string>
 	<key>This branch and the base branch share no commits.</key>
@@ -1356,6 +1422,8 @@
 	<string>This month</string>
 	<key>This pull request changes no files.</key>
 	<string>This pull request changes no files.</string>
+	<key>This relay has no valid URL pattern, so its address could never be read back.</key>
+	<string>This relay has no valid URL pattern, so its address could never be read back.</string>
 	<key>This session couldn’t be started.</key>
 	<string>This session couldn’t be started.</string>
 	<key>This week</key>
@@ -1432,6 +1500,8 @@
 	<string>WeChat</string>
 	<key>WeChat group</key>
 	<string>WeChat group</string>
+	<key>What the daemon said</key>
+	<string>What the daemon said</string>
 	<key>What this workspace is called in the sidebar.</key>
 	<string>What this workspace is called in the sidebar.</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
@@ -1514,6 +1584,10 @@ Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks
 	<string>termio can teach the agents you run (Claude Code, Codex, …) a `termio sessions` command so they can see, drive, and read each other's sessions in a project.
 
 Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks. You can turn it off anytime in Settings ▸ Agents.</string>
+	<key>termiod on %@ never opened its listener.
+%@</key>
+	<string>termiod on %@ never opened its listener.
+%@</string>
 	<key>this Mac</key>
 	<string>this Mac</string>
 	<key>· resets %@</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -12,8 +12,12 @@
 	<string>%1$@ 在 %2$@ 上已被修改</string>
 	<key>%@ and %@</key>
 	<string>%1$@ 和 %2$@</string>
+	<key>%@ answered as a different machine than %@. Its address is being served by something else.</key>
+	<string>%1$@ 回应的是另一台机器，不是 %2$@。这个地址正被别的东西占用。</string>
 	<key>%@ answered, but not with a pairing invite. Its termiod is probably older than this app — deploy it again.</key>
 	<string>%@ 有响应，但返回的不是配对邀请。它的 termiod 可能比本应用旧——重新部署一次。</string>
+	<key>%@ answered, but not with the handshake termiod sends.</key>
+	<string>%@ 有回应，但回的不是 termiod 的握手。</string>
 	<key>%@ didn’t come up — check the network and retry</key>
 	<string>%@ 未能启动——请检查网络后重试</string>
 	<key>%@ has nothing to pair against</key>
@@ -22,6 +26,12 @@
 	<string>“%@”是深色主题，与“%@”插槽不匹配。</string>
 	<key>%@ is a light theme in the %@ slot.</key>
 	<string>“%@”是浅色主题，与“%@”插槽不匹配。</string>
+	<key>%@ is not an address the iPhone could dial.</key>
+	<string>%@ 不是 iPhone 能拨通的地址。</string>
+	<key>%@ is published, but the connection an iPhone would make was refused.
+%@</key>
+	<string>%1$@ 已发布，但 iPhone 会发起的那种连接被拒绝了。
+%2$@</string>
 	<key>%@ is ready.</key>
 	<string>%@ 已就绪。</string>
 	<key>%@ isn’t a UTF-8 text file.</key>
@@ -30,12 +40,28 @@
 	<string>%@ 暂不支持这台设备。</string>
 	<key>%@ isn’t installed on %@</key>
 	<string>%1$@ 未安装在 %2$@ 上</string>
+	<key>%@ isn’t installed on %@, and Termio doesn’t ship a build of it. Install it there, then try again.</key>
+	<string>%2$@ 上没有安装 %1$@，Termio 也不提供它的构建版本。请先在那台机器上安装，然后重试。</string>
 	<key>%@ isn’t on your PATH</key>
 	<string>%@ 不在 PATH 中</string>
+	<key>%@ isn’t published yet</key>
+	<string>%@ 尚未发布</string>
 	<key>%@ keeps exiting — retrying every %llds</key>
 	<string>%1$@ 反复退出——每 %2$lld 秒重试一次</string>
+	<key>%@ never answered on its published address.</key>
+	<string>%@ 始终没有在它发布的地址上回应。</string>
 	<key>%@ opened %@</key>
 	<string>%1$@ 创建于 %2$@</string>
+	<key>%@ refused the handshake.</key>
+	<string>%@ 拒绝了握手。</string>
+	<key>%@ reports an architecture we have no build for: %@</key>
+	<string>%1$@ 报告的架构没有对应的构建版本：%2$@</string>
+	<key>%@ started on %@ but never printed an address.
+%@</key>
+	<string>%1$@ 已在 %2$@ 上启动，但始终没有打印地址。
+%3$@</string>
+	<key>%@ stays published only until you log out of it. Termio couldn’t set it to keep services running after that.</key>
+	<string>%@ 只在你登录期间保持发布。Termio 无法让它在登出后继续运行服务。</string>
 	<key>%@ tokens</key>
 	<string>%@ token</string>
 	<key>%@ · %@ tokens</key>
@@ -236,6 +262,8 @@
 	<string>检查更新…</string>
 	<key>Checked out on %@</key>
 	<string>检出在 %@</string>
+	<key>Checking that %@ answers…</key>
+	<string>正在确认 %@ 有回应…</string>
 	<key>Checking the machine…</key>
 	<string>正在检查设备…</string>
 	<key>Checking…</key>
@@ -374,6 +402,10 @@
 	<string>无法创建 worktree 会话</string>
 	<key>Couldn’t inspect worktree</key>
 	<string>无法检查 worktree</string>
+	<key>Couldn’t install %@ on %@.
+%@</key>
+	<string>无法在 %2$@ 上安装 %1$@。
+%3$@</string>
 	<key>Couldn’t link `%@` into %@.</key>
 	<string>无法将 `%@` 链接到 %@。</string>
 	<key>Couldn’t load</key>
@@ -386,6 +418,10 @@
 	<string>无法移除 worktree</string>
 	<key>Couldn’t save the password to your Keychain.</key>
 	<string>无法把密码保存到钥匙串。</string>
+	<key>Couldn’t start %@ on %@.</key>
+	<string>无法在 %2$@ 上启动 %1$@。</string>
+	<key>Couldn’t start termiod on %@ with a listener.</key>
+	<string>无法在 %1$@ 上带监听器启动 termiod。</string>
 	<key>Couldn’t update %@.</key>
 	<string>无法更新 %@。</string>
 	<key>Couldn’t update .gitignore</key>
@@ -724,6 +760,8 @@
 	<string>导航</string>
 	<key>Navigator</key>
 	<string>导航器</string>
+	<key>Needs `ngrok config add-authtoken` on that machine first. The free address changes on every restart.</key>
+	<string>需要先在那台机器上运行 `ngrok config add-authtoken`。免费版的地址每次重启都会变。</string>
 	<key>New</key>
 	<string>新建</string>
 	<key>New %@ Session</key>
@@ -804,6 +842,8 @@
 	<string>未找到任何 Agent 命令行工具。</string>
 	<key>No bundled tool to install from.</key>
 	<string>应用包中没有可安装的工具。</string>
+	<key>No command to run.</key>
+	<string>没有可运行的命令。</string>
 	<key>No description provided.</key>
 	<string>未提供描述。</string>
 	<key>No file changes</key>
@@ -832,6 +872,8 @@
 	<string>没有可显示的文本更改。</string>
 	<key>No theme matches “%@”</key>
 	<string>没有主题与“%@”匹配</string>
+	<key>No tunnel selected.</key>
+	<string>尚未选择隧道。</string>
 	<key>None</key>
 	<string>无</string>
 	<key>None of this project’s remotes point at github.com, so there is no issue tracker to show.</key>
@@ -864,6 +906,8 @@
 	<string>好</string>
 	<key>Off — LAN only</key>
 	<string>关闭 — 仅局域网</string>
+	<key>Off — SSH only</key>
+	<string>关闭 — 仅 SSH</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. Both devices must share a LAN.</key>
 	<string>在 iPhone 上轻点 Mac 胶囊按钮 ▸ 扫描二维码。两台设备须处于同一局域网。</string>
 	<key>On iPhone, tap the Mac pill ▸ Scan QR Code. The token is minted on %@ and demanded on every connection.</key>
@@ -910,6 +954,10 @@
 	<string>在 iPhone 上打开邀请链接，用 TestFlight 安装。</string>
 	<key>Opened outside Termio on this device</key>
 	<string>在这台设备上由 Termio 之外打开</string>
+	<key>Opening the listener needs the daemon restarted, which ends what it is hosting:
+%@</key>
+	<string>打开监听器需要重启守护进程，这会结束它正在承载的内容：
+%@</string>
 	<key>Opens the ~/.ssh/config entry this machine is defined in.</key>
 	<string>打开定义该设备的 ~/.ssh/config 条目。</string>
 	<key>Overwrite</key>
@@ -936,6 +984,8 @@
 	<string>权限</string>
 	<key>Pick a file on the left to see its changes.</key>
 	<string>在左侧选择一个文件以查看其更改。</string>
+	<key>Pick how %@ is reached from outside. Termio runs it there over SSH and reads the address back — you never type one.</key>
+	<string>选择从外部访问 %@ 的方式。Termio 会通过 SSH 在那台机器上运行它，并把地址读回来——你不需要手输任何地址。</string>
 	<key>Pick the branch this one would merge into.</key>
 	<string>选择这个分支将要合入的分支。</string>
 	<key>Pin</key>
@@ -952,6 +1002,8 @@
 	<string>套餐限额来自 %@ 的 OAuth 登录；不会存储任何密码。撤销后将停止读取 %@ 的所有数据。</string>
 	<key>Play sound</key>
 	<string>播放声音</string>
+	<key>Pointing termiod at %@…</key>
+	<string>正在把 termiod 指向 %@…</string>
 	<key>Port</key>
 	<string>端口</string>
 	<key>Posts a notification when an agent finishes or needs you while Termio is in the background.</key>
@@ -976,6 +1028,12 @@
 	<string>公网地址</string>
 	<key>Public keys</key>
 	<string>公钥</string>
+	<key>Publish</key>
+	<string>发布</string>
+	<key>Publish and End Them</key>
+	<string>发布并结束它们</string>
+	<key>Publishing restarts termiod on %@</key>
+	<string>发布会重启 %@ 上的 termiod</string>
 	<key>Pull Requests</key>
 	<string>PR</string>
 	<key>Push the current branch to the repository’s remote first, then try again. (The remote also needs to be a forge Termio recognizes: GitHub, GitLab, Bitbucket, or Gitea.)</key>
@@ -1062,6 +1120,8 @@
 	<string>请求权限</string>
 	<key>Reset Font Size</key>
 	<string>重设字体大小</string>
+	<key>Restarting the tunnel changes the address, and every paired iPhone has to scan again.</key>
+	<string>重启隧道会更换地址，所有已配对的 iPhone 都需要重新扫码。</string>
 	<key>Restore Defaults</key>
 	<string>恢复默认</string>
 	<key>Reveal in Finder</key>
@@ -1086,6 +1146,8 @@
 	<string>运行</string>
 	<key>Runs on %@</key>
 	<string>运行于 %@</string>
+	<key>Runs on that machine with your login’s privileges — no shell, arguments split on spaces. Use {port} for the daemon’s port.</key>
+	<string>以你的登录身份在那台机器上运行——不经过 shell，参数按空格切分。用 {port} 代表守护进程的端口。</string>
 	<key>Runs on this Mac with your privileges when Custom is selected — no shell, arguments split on spaces. Use {port} for the companion port; the URL pattern is a regex matching the public https URL your relay prints.</key>
 	<string>选择“自定义”后，该命令会以你的权限在这台 Mac 上运行——不经过 shell，参数按空格拆分。用 {port} 表示配套端口；URL 模式是用于匹配中继输出的公开 https URL 的正则表达式。</string>
 	<key>Runs with `%@`. The agent won’t ask before editing files or running commands.</key>
@@ -1202,6 +1264,8 @@
 	<string>已暂存：下一次 git 提交将包含此文件</string>
 	<key>Start an agent in a project.</key>
 	<string>在项目中启动一个 Agent。</string>
+	<key>Starting %@ on %@…</key>
+	<string>正在 %2$@ 上启动 %1$@…</string>
 	<key>Starting tunnel…</key>
 	<string>正在启动隧道…</string>
 	<key>Starting…</key>
@@ -1316,6 +1380,8 @@
 	<string>本机以及你能连接的设备</string>
 	<key>This Mac…</key>
 	<string>本机…</string>
+	<key>This address changes when the tunnel restarts, and every paired iPhone must scan again.</key>
+	<string>隧道重启后这个地址会变，所有已配对的 iPhone 都必须重新扫码。</string>
 	<key>This agent is no longer on your list.</key>
 	<string>该助手已不在你的列表中。</string>
 	<key>This branch and the base branch share no commits.</key>
@@ -1356,6 +1422,8 @@
 	<string>本月</string>
 	<key>This pull request changes no files.</key>
 	<string>此 PR 未更改任何文件。</string>
+	<key>This relay has no valid URL pattern, so its address could never be read back.</key>
+	<string>这个中转没有有效的 URL 正则，它的地址永远读不回来。</string>
 	<key>This session couldn’t be started.</key>
 	<string>这个会话没能启动。</string>
 	<key>This week</key>
@@ -1432,6 +1500,8 @@
 	<string>微信</string>
 	<key>WeChat group</key>
 	<string>微信群</string>
+	<key>What the daemon said</key>
+	<string>守护进程的原始输出</string>
 	<key>What this workspace is called in the sidebar.</key>
 	<string>这个工作区在侧栏中显示的名称。</string>
 	<key>When on, selecting text copies it straight to the clipboard.</key>
@@ -1514,6 +1584,10 @@ Enabling adds a short note to your ~/.claude/CLAUDE.md and installs status hooks
 	<string>termio 可以教你运行的 Agent（Claude Code、Codex 等）使用 `termio sessions` 命令，让它们在项目中查看、驱动并读取彼此的会话。
 
 启用后会在你的 ~/.claude/CLAUDE.md 中添加一段简短说明并安装状态 hooks。你可以随时在“设置 ▸ Agents”中将其关闭。</string>
+	<key>termiod on %@ never opened its listener.
+%@</key>
+	<string>%1$@ 上的 termiod 始终没有打开监听器。
+%2$@</string>
 	<key>this Mac</key>
 	<string>本机</string>
 	<key>· resets %@</key>

--- a/Sources/termio/Settings/RemotePairing.swift
+++ b/Sources/termio/Settings/RemotePairing.swift
@@ -50,21 +50,19 @@ enum RemotePairing {
     /// Asks `<alias>` for an invite. `rotate` issues a new token first, which
     /// signs out every phone already paired with that box.
     ///
-    /// `url` answers the one question the box cannot: what public name fronts
-    /// it. The listener binds loopback on purpose — a daemon that bound `0.0.0.0`
-    /// would be a shell server on the open internet — so nothing on the box can
-    /// derive the address a phone would dial, and `termiod pair` refuses rather
-    /// than mint a QR pointing nowhere.
+    /// The box's own answer, never an override. `termiod pair` takes a `--url`,
+    /// and passing it here would be a trap: it changes only the address the
+    /// invite *prints*, not the origins the daemon will accept, so the QR scans
+    /// and the connection is then refused with a 403 the phone cannot explain.
+    /// The address a box is reachable at is set by arming the daemon
+    /// (`RemoteTunnelService.arm`), which is also what makes `pair` able to
+    /// answer at all — the listener binds loopback on purpose, so nothing on the
+    /// box can derive a public name it was not given.
     ///
     /// Runs on a detached task: this forks `ssh`, and a box that is asleep or
     /// behind a slow link would otherwise block whatever called it.
-    static func invite(
-        from alias: String, url: String? = nil, rotate: Bool = false
-    ) async throws -> Invite {
-        var command = "\(Termiod.remoteBinary()) pair --json\(rotate ? " --rotate" : "")"
-        if let url, !url.isEmpty {
-            command += " --url \(shellQuoted(url))"
-        }
+    static func invite(from alias: String, rotate: Bool = false) async throws -> Invite {
+        let command = "\(Termiod.remoteBinary()) pair --json\(rotate ? " --rotate" : "")"
         let result = try await run(alias: alias, command: command)
         guard result.status == 0 else {
             throw Failure(message: message(from: result))
@@ -76,13 +74,6 @@ enum RemotePairing {
     }
 
     // MARK: - Running it
-
-    /// Single-quoted for the remote's shell, which is what `ssh host <command>`
-    /// hands the string to. A URL is user-typed and reaches a login shell on
-    /// another machine; anything less than quoting is a command injection.
-    private static func shellQuoted(_ value: String) -> String {
-        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
 
     private struct Result {
         let status: Int32
@@ -159,16 +150,36 @@ struct RemotePairingSection: View {
 
     private enum Phase: Equatable {
         case asking
+        /// A remote step is running. Publishing is several of them with real
+        /// latency — installing a binary, waiting for a relay to answer,
+        /// restarting a daemon — so the phase carries which one it is on: a
+        /// spinner that never explains itself is indistinguishable from a hang.
+        case working(String)
         case ready(RemotePairing.Invite)
         case failed(String)
     }
 
+    /// termiod's own default WebSocket port (`DEPLOY.md`) — not the Mac
+    /// companion's 8787/8788, so a Mac running both does not have them fight.
+    private static let daemonPort = 8790
+
     @State private var phase = Phase.asking
     @State private var copied = false
     @State private var confirmRotate = false
-    /// The public address the user typed, kept across a retry so a rotate or a
-    /// failed attempt does not make them type it again.
-    @State private var address = ""
+    /// How this box is published, remembered per machine so re-publishing after
+    /// a reboot is one click rather than a re-decision.
+    @State private var provider = RemoteTunnelProvider.off
+    @State private var custom = RemoteCustomTunnel()
+    /// The sessions arming would end, named. Empty means nothing is at risk and
+    /// Publish proceeds without asking.
+    @State private var atRisk: [String] = []
+    @State private var confirmArm = false
+    /// Whether the box stays published across a reboot. False only when
+    /// `loginctl enable-linger` was refused, which is worth one line on screen
+    /// and is not worth failing a publish over. Read from what the last publish
+    /// found rather than re-probed, so the warning outlives the pane it first
+    /// appeared in.
+    @State private var survivesReboot = true
 
     var body: some View {
         Section {
@@ -193,10 +204,24 @@ struct RemotePairingSection: View {
                             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                     }
                     addressRow(invite)
+                    if !survivesReboot {
+                        Label(
+                            localized("\(machine.name) stays published only until you log out of it. Termio couldn’t set it to keep services running after that."),
+                            systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
                 rotateRow
+            case .working(let step):
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text(step).foregroundStyle(.secondary)
+                }
             case .failed(let message):
-                unreachable(message)
+                unpublished(message)
             }
         } header: {
             SectionHeaderLabel(title: machine.name)
@@ -205,7 +230,11 @@ struct RemotePairingSection: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
-        .task { await ask() }
+        .task {
+            provider = .remembered(device: machine.settingsKey)
+            custom = .load(device: machine.settingsKey)
+            await ask()
+        }
     }
 
     // MARK: - Pieces
@@ -260,57 +289,177 @@ struct RemotePairingSection: View {
         }
     }
 
-    /// The box could not mint an invite. Its own words, verbatim and monospaced —
-    /// they are terminal output, and the fixes they name are commands.
+    /// The box has no way in from outside yet — so this is where you choose one.
     ///
-    /// The address field is the first of those fixes, made typable: `termiod`
-    /// says "pass `--url https://<host>/termio/`", and this is that flag with a
-    /// text box in front of it. Only the box's *name* is missing; everything
-    /// else about pairing already works, which is why one field closes it.
-    private func unreachable(_ message: String) -> some View {
+    /// It offers the same list the Mac's own Mobile Access does, for the same
+    /// reason it exists there: **we cannot be everyone's relay.** Termio's relay
+    /// has finite capacity, so a tunnel the user already owns is a first-class
+    /// answer, not a consolation. The one thing this pane will not do is ask
+    /// someone to type an address: the Mac has SSH to this box, so it can run
+    /// the tunnel and *read the address back* — a value read is a value that
+    /// cannot be mistyped, and it is the value the daemon gets pinned to.
+    private func unpublished(_ message: String) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            Label(localized("\(machine.name) has nothing to pair against"), systemImage: "exclamationmark.triangle")
+            Label(
+                localized("\(machine.name) isn’t published yet"),
+                systemImage: "exclamationmark.triangle")
                 .foregroundStyle(.secondary)
-            Text(message)
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
-            HStack(spacing: 8) {
+
+            LabeledContent(localized("Tunnel")) {
+                Picker("", selection: $provider) {
+                    ForEach(RemoteTunnelProvider.allCases) { option in
+                        Text(option.label).tag(option)
+                    }
+                }
+                .labelsHidden()
+                .fixedSize()
+            }
+
+            if provider == .custom {
                 TextField(
-                    localized("Public address"), text: $address,
-                    prompt: Text(verbatim: "https://example.com/termio/"))
+                    localized("Command"), text: $custom.command,
+                    prompt: Text(verbatim: "cloudflared tunnel run --url http://127.0.0.1:{port} my-tunnel"))
                     .textFieldStyle(.roundedBorder)
-                    .onSubmit { pair(at: address) }
-                Button(localized("Pair")) { pair(at: address) }
-                    .buttonStyle(.bordered)
-                    .disabled(address.trimmingCharacters(in: .whitespaces).isEmpty)
+                TextField(
+                    localized("URL Pattern"), text: $custom.urlPattern,
+                    prompt: Text(verbatim: #"https://[a-z0-9-]+\.example\.com"#))
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            if let note = provider.prerequisite {
+                Text(note).font(.caption).foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if provider != .off, !provider.keepsItsAddress {
+                // Said before the click, not after: an address that rotates is
+                // not a defect to discover later, it is the deal being offered.
+                Label(
+                    localized("This address changes when the tunnel restarts, and every paired iPhone must scan again."),
+                    systemImage: "arrow.triangle.2.circlepath")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 8) {
+                Button(localized("Publish")) { Task { await beginPublish() } }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(provider == .off || (provider == .custom && !custom.isUsable))
                 Button(localized("Try Again")) { Task { await ask() } }
                     .buttonStyle(.bordered)
+                Spacer(minLength: 0)
             }
-            // Said once, here, where someone is about to type an address: this
-            // invite carries it, the next one will not. Persisting it is the
-            // daemon's `--wss-origin`, which is a decision about how the box
-            // runs — not something an app should write behind the user's back.
-            Text(localized("Used for this invite only. To make it stick, start the daemon there with --wss-origin."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            .confirmationDialog(
+                localized("Publishing restarts termiod on \(machine.name)"),
+                isPresented: $confirmArm, titleVisibility: .visible
+            ) {
+                Button(localized("Publish and End Them"), role: .destructive) {
+                    Task { await publish() }
+                }
+                Button(localized("Cancel"), role: .cancel) {}
+            } message: {
+                Text(localized("Opening the listener needs the daemon restarted, which ends what it is hosting:\n\(atRisk.joined(separator: "\n"))"))
+            }
+
+            // The daemon's own words, kept but demoted: they are terminal output
+            // aimed at whoever is fixing the box, not at whoever is choosing a
+            // tunnel. Leading the card with them made a solvable choice look
+            // like a crash.
+            DisclosureGroup(localized("What the daemon said")) {
+                Text(message)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .font(.caption)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// The typed address, or `nil` when there is none — so a rotate carries the
-    /// address that worked rather than dropping back to the box's own idea of
-    /// itself, which is the one that already failed.
-    private var nonEmptyAddress: String? {
-        let trimmed = address.trimmingCharacters(in: .whitespaces)
-        return trimmed.isEmpty ? nil : trimmed
+    /// Asks first when the daemon is hosting something, because arming restarts
+    /// it. A count would not be enough to decide on: whether to end a session
+    /// depends on whether it is an agent mid-task or a shell left at a prompt,
+    /// and only its command line answers that.
+    private func beginPublish() async {
+        guard let alias = machine.alias else { return }
+        // Off the main actor: this forks `ssh`, and a box on a slow link would
+        // otherwise freeze the window for as long as it takes to answer.
+        let live = await Task.detached {
+            (try? Termiod.roster(route: .ssh(alias)))?.sessions.filter(\.alive) ?? []
+        }.value
+        atRisk = live.map { "• \($0.command)" }
+        if atRisk.isEmpty {
+            await publish()
+        } else {
+            confirmArm = true
+        }
     }
 
-    private func pair(at url: String) {
-        let trimmed = url.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        Task { await ask(url: trimmed) }
+    private func publish() async {
+        guard let alias = machine.alias else { return }
+        provider.remember(device: machine.settingsKey)
+        custom.save(device: machine.settingsKey)
+        do {
+            phase = .working(localized("Starting \(provider.label) on \(machine.name)…"))
+            let published = try await RemoteTunnelService.publish(
+                alias: alias, provider: provider,
+                port: Self.daemonPort, custom: custom)
+            survivesReboot = published.survivesReboot
+            RemoteTunnelService.rememberLinger(
+                published.survivesReboot, device: machine.settingsKey)
+            // The address is written to the daemon rather than shown to be
+            // copied: the invite, the daemon's allowed origin and the phone's
+            // stored origin must be one value, and the only way to guarantee
+            // that is for one place to know it.
+            phase = .working(localized("Pointing termiod at \(published.address)…"))
+            try await RemoteTunnelService.arm(
+                alias: alias, origin: published.address, port: Self.daemonPort)
+
+            phase = .working(localized("Checking that \(published.address) answers…"))
+            let invite = try await RemotePairing.invite(from: alias)
+            // Retried, unlike the check on appear: the tunnel is seconds old
+            // here, and a relay's first route can lag its own log line.
+            try await verify(invite, attempts: 3)
+            phase = .ready(invite)
+        } catch let failure as RemoteTunnelService.Failure {
+            phase = .failed(failure.message)
+        } catch let failure as RemotePairing.Failure {
+            phase = .failed(failure.message)
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+
+    /// Dials the box the way the phone will, before showing a QR that says it
+    /// can be dialled.
+    ///
+    /// `termiod pair` never contacts the daemon — it reads the token and the
+    /// origin off disk — so an invite proves only that the box has *opinions*
+    /// about where it is reachable. The path from there to the phone crosses a
+    /// relay, a fresh listener and an origin pin, and every one of them fails as
+    /// a 403 the phone reports as nothing at all.
+    private func verify(_ invite: RemotePairing.Invite, attempts: Int) async throws {
+        var last: Error?
+        for attempt in 0..<max(1, attempts) {
+            if attempt > 0 { try? await Task.sleep(for: .seconds(2)) }
+            do {
+                let answered = try await RemoteTunnelService.handshake(
+                    url: invite.url, token: invite.token)
+                guard answered == invite.hostID else {
+                    // Same address, different machine: a relay handed the name
+                    // to someone else, and pairing would attach the phone to a
+                    // box that is not this one.
+                    throw RemoteTunnelService.Failure(message: localized("\(invite.url) answered as a different machine than \(machine.name). Its address is being served by something else."))
+                }
+                return
+            } catch let failure as RemoteTunnelService.Failure {
+                last = failure
+            }
+        }
+        throw last ?? RemoteTunnelService.Failure(
+            message: localized("\(machine.name) never answered on its published address."))
     }
 
     private var footnote: String {
@@ -318,19 +467,32 @@ struct RemotePairingSection: View {
         case .ready:
             return localized("On iPhone, tap the Mac pill ▸ Scan QR Code. The token is minted on \(machine.name) and demanded on every connection.")
         default:
-            return localized("A box can only be paired with once its termiod is running and reachable from outside — a tunnel, or a proxy in front of it.")
+            return localized("Pick how \(machine.name) is reached from outside. Termio runs it there over SSH and reads the address back — you never type one.")
         }
     }
 
-    /// `url` empty means "ask the box what it knows" — the first attempt, and
-    /// the right one whenever the daemon there was started with `--wss-origin`.
-    private func ask(url: String? = nil, rotate: Bool = false) async {
+    /// Always asks the box what *it* knows. Nothing is passed in: after
+    /// publishing, the daemon's own `wss.origin` is the address, and a second
+    /// source for it is a second chance to disagree.
+    ///
+    /// Then dials it. An invite the box hands over says only what it *believes*
+    /// about where it is reachable — the tunnel in front of it may have died
+    /// since, and a QR minted from a stale belief scans perfectly and then
+    /// connects to nothing. A box that no longer answers is, to the person
+    /// holding the phone, exactly a box that is not published, so it lands in
+    /// the same state and offers the same way out.
+    private func ask(rotate: Bool = false) async {
         guard let alias = machine.alias else { return }
         phase = .asking
+        survivesReboot = RemoteTunnelService.lingers(device: machine.settingsKey)
         do {
-            phase = .ready(try await RemotePairing.invite(
-                from: alias, url: url ?? nonEmptyAddress, rotate: rotate))
+            let invite = try await RemotePairing.invite(from: alias, rotate: rotate)
+            phase = .working(localized("Checking that \(invite.url) answers…"))
+            try await verify(invite, attempts: 1)
+            phase = .ready(invite)
         } catch let failure as RemotePairing.Failure {
+            phase = .failed(failure.message)
+        } catch let failure as RemoteTunnelService.Failure {
             phase = .failed(failure.message)
         } catch {
             phase = .failed(error.localizedDescription)

--- a/Sources/termio/Settings/RemotePairing.swift
+++ b/Sources/termio/Settings/RemotePairing.swift
@@ -414,8 +414,12 @@ struct RemotePairingSection: View {
             // stored origin must be one value, and the only way to guarantee
             // that is for one place to know it.
             phase = .working(localized("Pointing termiod at \(published.address)…"))
+            guard let origin = RemoteTunnelService.originValue(of: published.address) else {
+                throw RemoteTunnelService.Failure(
+                    message: localized("\(published.address) is not an address the iPhone could dial."))
+            }
             try await RemoteTunnelService.arm(
-                alias: alias, origin: published.address, port: Self.daemonPort)
+                alias: alias, origin: origin, port: Self.daemonPort)
 
             phase = .working(localized("Checking that \(published.address) answers…"))
             let invite = try await RemotePairing.invite(from: alias)

--- a/Sources/termio/Settings/RemoteTunnel.swift
+++ b/Sources/termio/Settings/RemoteTunnel.swift
@@ -558,6 +558,18 @@ enum RemoteTunnelService {
 }
 
 extension RemoteTunnelService {
+    /// The value an HTTP client sends in `Origin`: scheme, host, and optional
+    /// port. A published address may have a path (for example, a relay mounted
+    /// at `/termio`), but an origin never does.
+    static func originValue(of address: String) -> String? {
+        guard let components = URLComponents(string: address),
+              let scheme = components.scheme?.lowercased(),
+              let host = components.host else { return nil }
+        let webScheme = scheme == "wss" ? "https" : (scheme == "ws" ? "http" : scheme)
+        let port = components.port.map { ":\($0)" } ?? ""
+        return "\(webScheme)://\(host)\(port)"
+    }
+
     /// Points the daemon at the address the tunnel just published, and restarts
     /// it so the listener actually exists.
     ///

--- a/Sources/termio/Settings/RemoteTunnel.swift
+++ b/Sources/termio/Settings/RemoteTunnel.swift
@@ -1,0 +1,674 @@
+import Foundation
+import TermioShared
+
+/// Running one command on a device over the SSH the app already has.
+///
+/// A sibling of `RemotePairing`'s own runner, which should fold into this once
+/// the two files stop being edited in parallel.
+enum RemoteShell {
+    struct Output {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+        var succeeded: Bool { status == 0 }
+        /// stderr when there is any, else a bare exit code — the shape an alert
+        /// wants, since a remote failure usually explains itself on stderr.
+        var failure: String {
+            let text = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return text.isEmpty ? localized("Exited with status \(Int(status)).") : text
+        }
+    }
+
+    /// Single-quoted for the far shell. Every value that crosses `ssh` is data,
+    /// not code: a URL, a path or a user-typed command reaching a login shell on
+    /// another machine is a command injection unless it is quoted.
+    static func quoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    static func run(alias: String, command: String) async -> Output {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+                process.arguments = Termiod.sshArguments(host: alias) + [alias, command]
+                let out = Pipe(), err = Pipe()
+                process.standardOutput = out
+                process.standardError = err
+                do { try process.run() } catch {
+                    continuation.resume(returning: Output(
+                        status: -1, stdout: "",
+                        stderr: localized("Could not run ssh: \(error.localizedDescription)")))
+                    return
+                }
+                // Both pipes drain before the wait: a child that fills either one
+                // blocks forever against a parent waiting on exit.
+                let stdout = out.fileHandleForReading.readDataToEndOfFile()
+                let stderr = err.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                continuation.resume(returning: Output(
+                    status: process.terminationStatus,
+                    stdout: String(data: stdout, encoding: .utf8) ?? "",
+                    stderr: String(data: stderr, encoding: .utf8) ?? ""))
+            }
+        }
+    }
+}
+
+/// How a device is published to the internet, as a choice the user makes — the
+/// same list the Mac's own Mobile Access offers (`TunnelManager.Provider`), run
+/// on the far box instead of locally.
+///
+/// It is deliberately the same vocabulary. A user who has already picked a
+/// tunnel for their Mac knows what these words mean, and the reason to offer
+/// them at all is the same: **we cannot be everyone's relay.** Termio's own
+/// relay has finite capacity, so every alternative here is a first-class path,
+/// not a grudging fallback.
+enum RemoteTunnelProvider: String, CaseIterable, Identifiable, Sendable {
+    /// Nothing published. The box is reachable over SSH from this Mac and by
+    /// nothing else — which is the correct default, not a broken state.
+    case off
+    case tunelo
+    case cloudflare
+    case ngrok
+    /// A relay the user runs, or a tool we do not bundle: their command, their
+    /// regex. Same contract as the Mac's Custom entry.
+    case custom
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .off: return localized("Off — SSH only")
+        case .tunelo: return "Tunelo"
+        case .cloudflare: return "Cloudflare"
+        case .ngrok: return "ngrok"
+        case .custom: return localized("Custom")
+        }
+    }
+
+    /// Whether the published address survives the tunnel restarting.
+    ///
+    /// On the Mac this was a papercut: a new URL meant pairing again. Here it is
+    /// **correctness**. The phone stores the address *and* the origin it must
+    /// send (`Models.adopt`), and the daemon pins that same origin — so a name
+    /// that rotates strands every paired phone and invalidates the pin, and the
+    /// symptom is a QR that scans and then never connects.
+    ///
+    /// So an unstable provider is offered, but it has to say so.
+    var keepsItsAddress: Bool {
+        switch self {
+        // `--identity` derives the subdomain from a persistent Ed25519 key and
+        // only that machine can reclaim it (tunelo 0.3.0).
+        case .tunelo: return true
+        // A quick tunnel mints a fresh `*.trycloudflare.com` per process. A
+        // *named* tunnel is stable, needs a Cloudflare account and a zone, and
+        // is what Custom is for until we model account-backed tunnels.
+        case .cloudflare: return false
+        // Free ngrok rotates; a reserved domain does not. Same story as above.
+        case .ngrok: return false
+        // Unknowable — it is the user's command. Assume the good case rather
+        // than warn on every custom relay, most of which are stable.
+        case .custom, .off: return true
+        }
+    }
+
+    /// What the user has to have done before this can work.
+    var prerequisite: String? {
+        switch self {
+        case .off: return nil
+        case .tunelo: return nil
+        case .cloudflare:
+            return localized("Restarting the tunnel changes the address, and every paired iPhone has to scan again.")
+        case .ngrok:
+            return localized("Needs `ngrok config add-authtoken` on that machine first. The free address changes on every restart.")
+        case .custom:
+            return localized("Runs on that machine with your login’s privileges — no shell, arguments split on spaces. Use {port} for the daemon’s port.")
+        }
+    }
+
+    /// argv after the binary. `{port}` stands in for the daemon's loopback port,
+    /// exactly as the Mac's Custom field does.
+    ///
+    /// `custom` is passed rather than read from a global: the Mac's own relay
+    /// command and a VPS's are different commands on different machines, and
+    /// sharing one setting between them would configure the wrong box.
+    func arguments(port: Int, custom: RemoteCustomTunnel) -> [String] {
+        switch self {
+        case .off: return []
+        case .tunelo:
+            // The identity file is what makes the subdomain stable; it lives in
+            // the user's own config dir, 0600, minted on first use.
+            return ["port", String(port), "--identity", RemoteTunnelPaths.tuneloIdentity]
+        case .cloudflare:
+            return ["tunnel", "--url", "http://127.0.0.1:\(port)", "--no-autoupdate"]
+        case .ngrok:
+            // `--log stdout` turns off the interactive TUI and prints the public
+            // URL as a logfmt field this can scrape.
+            return ["http", String(port), "--log", "stdout"]
+        case .custom:
+            return custom.command
+                .split(separator: " ").map(String.init).dropFirst()
+                .map { $0.replacingOccurrences(of: "{port}", with: String(port)) }
+        }
+    }
+
+    func binaryName(custom: RemoteCustomTunnel) -> String {
+        switch self {
+        case .off: return ""
+        case .tunelo: return "tunelo"
+        case .cloudflare: return "cloudflared"
+        case .ngrok: return "ngrok"
+        case .custom:
+            return custom.command.split(separator: " ").first.map(String.init) ?? ""
+        }
+    }
+
+    /// Regex matching the public https URL the tool prints when it comes up.
+    func urlPattern(custom: RemoteCustomTunnel) -> String {
+        switch self {
+        case .off: return ""
+        case .tunelo: return #"https://[a-zA-Z0-9-]+\.tunelo\.net"#
+        case .cloudflare: return #"https://[a-zA-Z0-9-]+\.trycloudflare\.com"#
+        case .ngrok: return #"https://[a-zA-Z0-9-]+\.ngrok(?:-free)?\.(?:app|io)"#
+        case .custom: return custom.urlPattern
+        }
+    }
+
+    /// Where to fetch the Linux build, by the architecture the box reports.
+    ///
+    /// `nil` means bring-your-own-on-PATH. ngrok is deliberately in that group:
+    /// it needs `ngrok config add-authtoken` run once against the user's own
+    /// account, so fetching the bare binary would not save the real setup step.
+    func downloadURL(arch: RemoteArchitecture) -> String? {
+        switch self {
+        case .off, .ngrok, .custom: return nil
+        case .tunelo:
+            return "https://github.com/jiweiyuan/tunelo/releases/latest/download/tunelo-linux-\(arch.rawValue)"
+        case .cloudflare:
+            return "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-\(arch.rawValue)"
+        }
+    }
+}
+
+/// The Linux architectures we ship tunnel binaries for, as `uname -m` reports
+/// them. The same two `termiod remote deploy` already cross-compiles for.
+enum RemoteArchitecture: String, Sendable {
+    case arm64
+    case amd64
+
+    init?(uname: String) {
+        switch uname.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case "aarch64", "arm64": self = .arm64
+        case "x86_64", "amd64": self = .amd64
+        default: return nil
+        }
+    }
+}
+
+/// Paths on the far machine. All under the user's own home: publishing a box
+/// must never need root, which is most of why this is a tunnel and not a
+/// reverse proxy.
+enum RemoteTunnelPaths {
+    static let binaryDirectory = "$HOME/.local/bin"
+    static let stateDirectory = "$HOME/.local/state/termio"
+    /// Where `systemctl --user` looks. A *user* unit directory, never
+    /// `/etc/systemd/system`: a system unit needs root, and needing root is the
+    /// thing this whole feature exists to avoid.
+    static let unitDirectory = "$HOME/.config/systemd/user"
+    static let tuneloIdentity = "$HOME/.config/tunelo/termio.key"
+    static var tunnelLog: String { "\(stateDirectory)/tunnel.log" }
+    static var daemonLog: String { "\(stateDirectory)/termiod.log" }
+}
+
+/// A relay the user runs themselves, remembered per machine.
+///
+/// Same contract as the Mac's Custom entry — a command and a regex — because it
+/// is the same job on a different box. Stored per `settingsKey`: the command
+/// that publishes a VPS is not the command that publishes a laptop.
+struct RemoteCustomTunnel: Equatable {
+    var command: String = ""
+    var urlPattern: String = ""
+
+    /// Whether the pattern compiles. A pattern that never matches would leave
+    /// the tunnel "starting" forever, so an unusable one keeps the Publish
+    /// button off rather than failing eight seconds later.
+    var isUsable: Bool {
+        !command.isEmpty && !urlPattern.isEmpty
+            && (try? NSRegularExpression(pattern: urlPattern)) != nil
+    }
+
+    static func load(device: String) -> RemoteCustomTunnel {
+        let defaults = UserDefaults.standard
+        return RemoteCustomTunnel(
+            command: defaults.string(forKey: "remoteTunnel.\(device).command") ?? "",
+            urlPattern: defaults.string(forKey: "remoteTunnel.\(device).urlPattern") ?? "")
+    }
+
+    func save(device: String) {
+        let defaults = UserDefaults.standard
+        defaults.set(command, forKey: "remoteTunnel.\(device).command")
+        defaults.set(urlPattern, forKey: "remoteTunnel.\(device).urlPattern")
+    }
+}
+
+extension RemoteTunnelProvider {
+    /// The provider last chosen for a machine. Remembered so re-publishing after
+    /// a reboot is one click, not a re-decision.
+    static func remembered(device: String) -> RemoteTunnelProvider {
+        UserDefaults.standard.string(forKey: "remoteTunnel.\(device).provider")
+            .flatMap(RemoteTunnelProvider.init(rawValue:)) ?? .off
+    }
+
+    func remember(device: String) {
+        UserDefaults.standard.set(rawValue, forKey: "remoteTunnel.\(device).provider")
+    }
+}
+
+/// The two long-running processes publishing a box needs, expressed as
+/// `systemd --user` units.
+///
+/// A `setsid nohup` outlives the SSH session that started it and nothing else.
+/// That is the wrong lifetime for this: the point of publishing a VPS is that
+/// the phone reaches it later, and "later" includes after the box reboots. So
+/// the supervisor is systemd, at the *user* level — which needs no root, and
+/// which `loginctl enable-linger` extends across logout and reboot.
+///
+/// Using a supervisor at all is also what removes `pkill` from this file. There
+/// is no safe unanchored `pkill -f`: its pattern is matched against **every**
+/// command line on the box, including the `bash -c` that ssh spawned to run the
+/// pkill itself, so a pattern general enough to find the tunnel kills the shell
+/// looking for it. `systemctl --user restart` addresses a unit, not a string.
+struct RemoteSystemdUnit {
+    let name: String
+    let title: String
+    let executable: String
+    let arguments: [String]
+    let log: String
+    /// Whether to empty the log at every start.
+    ///
+    /// True for the tunnel, whose log is read as a *value* — the public address
+    /// it prints — so a stale line from the previous provider must never be
+    /// mistaken for this run's answer. False for the daemon, whose log is read
+    /// as *evidence* and is worth keeping across a restart loop.
+    let freshLog: Bool
+
+    var text: String {
+        let argv = ([executable] + arguments).map(Self.argument).joined(separator: " ")
+        var lines = [
+            "[Unit]",
+            "Description=\(title)",
+            "After=network-online.target",
+            "Wants=network-online.target",
+            // systemd gives up on a unit that restarts five times in ten
+            // seconds and leaves it down for good. That default protects a
+            // machine from a crash loop; here it would turn a relay outage the
+            // tunnel would have ridden out into a box that never comes back,
+            // and the user learns about it from a phone that stopped working.
+            "StartLimitIntervalSec=0",
+            "",
+            "[Service]",
+            "Type=simple",
+            "ExecStartPre=/bin/mkdir -p \(Self.argument(RemoteTunnelPaths.stateDirectory))",
+        ]
+        if freshLog {
+            // The raw path, not a converted one: `argument` does the conversion
+            // itself, and feeding it output that already says `%h` escapes the
+            // specifier into the literal `%%h` and the unit exits 2.
+            lines.append("ExecStartPre=/bin/sh -c \(Self.argument(": > \(log)"))")
+        }
+        lines += [
+            "ExecStart=\(argv)",
+            "StandardOutput=append:\(Self.specifiers(log))",
+            "StandardError=append:\(Self.specifiers(log))",
+            // The tunnel and the daemon are both things the user asked to keep
+            // running; a crash is a reason to come back, not to stay down.
+            "Restart=always",
+            "RestartSec=3",
+            "",
+            "[Install]",
+            "WantedBy=default.target",
+            "",
+        ]
+        return lines.joined(separator: "\n")
+    }
+
+    /// A path as a unit file reads it. `$HOME` is a *shell* expansion, and a
+    /// unit is not run through a shell — systemd spells the same thing `%h`.
+    /// `%` therefore has to be escaped first, or a literal one in a user's own
+    /// command would be read as a specifier.
+    static func specifiers(_ raw: String) -> String {
+        raw.replacingOccurrences(of: "%", with: "%%")
+            .replacingOccurrences(of: "$HOME", with: "%h")
+    }
+
+    /// One `ExecStart` word. systemd splits on whitespace unless the word is
+    /// double-quoted, and expands specifiers before it parses the quotes — so a
+    /// quoted `%h/...` still resolves.
+    static func argument(_ raw: String) -> String {
+        let escaped = specifiers(raw)
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+}
+
+/// Publishing one device: put the tool on it, run it, and read back the address
+/// it was given.
+///
+/// Everything happens under the user's own login — `~/.local/bin`,
+/// `~/.local/state`, `systemctl --user` — so publishing a box never asks for
+/// root. That is the whole reason this is a tunnel rather than a reverse proxy:
+/// nginx needs root and a domain, and requiring either turns "connect my phone"
+/// into sysadmin work.
+enum RemoteTunnelService {
+    struct Failure: Error, Equatable {
+        let message: String
+    }
+
+    /// What publishing a box produced: the address, and whether it will still be
+    /// there tomorrow.
+    struct Publication: Equatable {
+        let address: String
+        /// False when `loginctl enable-linger` was refused. The tunnel and the
+        /// daemon still run — but only until this login ends, so a reboot takes
+        /// the box off the air and nothing on screen would otherwise say so.
+        let survivesReboot: Bool
+    }
+
+    static let tunnelUnit = "termio-tunnel.service"
+    /// The name the daemon already looks for. `termiod service` writes a launchd
+    /// agent and refuses on Linux, but `termiod status` still probes
+    /// `systemctl --user is-active termiod` to name its supervisor
+    /// (`lifecycle.rs`) — so this is the existing convention, not a second one,
+    /// and a box published from here reports `service: systemd --user`.
+    static let daemonUnit = "termiod.service"
+
+    /// `uname -m`, mapped to the builds we publish.
+    static func architecture(of alias: String) async throws -> RemoteArchitecture {
+        let probe = await RemoteShell.run(alias: alias, command: "uname -m")
+        guard probe.succeeded else { throw Failure(message: probe.failure) }
+        guard let arch = RemoteArchitecture(uname: probe.stdout) else {
+            throw Failure(message: localized("\(alias) reports an architecture we have no build for: \(probe.stdout.trimmingCharacters(in: .whitespacesAndNewlines))"))
+        }
+        return arch
+    }
+
+    /// Ensures the tool is on the box, fetching it when we publish a build and
+    /// it is missing. A tool already on `PATH` always wins: the user's own
+    /// install is the one they configured, and ours would shadow it.
+    ///
+    /// The path comes back **absolute**, expanded by the far shell rather than
+    /// assembled here: it goes into a unit file, where `$HOME` is four literal
+    /// characters and the process would fail to exec.
+    static func ensureBinary(
+        alias: String, provider: RemoteTunnelProvider, arch: RemoteArchitecture,
+        custom: RemoteCustomTunnel
+    ) async throws -> String {
+        let name = provider.binaryName(custom: custom)
+        guard !name.isEmpty else { throw Failure(message: localized("No command to run.")) }
+
+        let found = await RemoteShell.run(
+            alias: alias,
+            command: "command -v \(RemoteShell.quoted(name)) 2>/dev/null || ls \(RemoteTunnelPaths.binaryDirectory)/\(name) 2>/dev/null")
+        let path = found.stdout.split(separator: "\n").first.map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let path, path.hasPrefix("/") { return path }
+
+        guard let url = provider.downloadURL(arch: arch) else {
+            throw Failure(message: localized("\(name) isn’t installed on \(alias), and Termio doesn’t ship a build of it. Install it there, then try again."))
+        }
+        // Downloaded beside the target and renamed over it — atomic, and safe to
+        // repeat, the same shape `termiod remote deploy` uses.
+        let install = """
+            mkdir -p \(RemoteTunnelPaths.binaryDirectory) && \
+            curl -fsSL -o \(RemoteTunnelPaths.binaryDirectory)/\(name).new \(RemoteShell.quoted(url)) && \
+            chmod +x \(RemoteTunnelPaths.binaryDirectory)/\(name).new && \
+            mv \(RemoteTunnelPaths.binaryDirectory)/\(name).new \(RemoteTunnelPaths.binaryDirectory)/\(name) && \
+            echo \(RemoteTunnelPaths.binaryDirectory)/\(name)
+            """
+        let fetched = await RemoteShell.run(alias: alias, command: install)
+        let installed = fetched.stdout.split(separator: "\n").last.map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard fetched.succeeded, let installed, installed.hasPrefix("/") else {
+            throw Failure(message: localized("Couldn’t install \(name) on \(alias).\n\(fetched.failure)"))
+        }
+        return installed
+    }
+
+    /// Starts the tunnel under `systemd --user` and returns the public address
+    /// it printed.
+    static func publish(
+        alias: String, provider: RemoteTunnelProvider, port: Int,
+        custom: RemoteCustomTunnel
+    ) async throws -> Publication {
+        guard provider != .off else { throw Failure(message: localized("No tunnel selected.")) }
+        let pattern = provider.urlPattern(custom: custom)
+        guard !pattern.isEmpty,
+              (try? NSRegularExpression(pattern: pattern)) != nil else {
+            // A pattern that never compiles could never match, so the tunnel
+            // would sit "starting" forever. Refuse while it is still fixable.
+            throw Failure(message: localized("This relay has no valid URL pattern, so its address could never be read back."))
+        }
+
+        let arch = try await architecture(of: alias)
+        let binary = try await ensureBinary(
+            alias: alias, provider: provider, arch: arch, custom: custom)
+        let lingering = await enableLinger(alias: alias)
+
+        let unit = RemoteSystemdUnit(
+            name: tunnelUnit,
+            title: "Termio tunnel (\(provider.label))",
+            executable: binary,
+            arguments: provider.arguments(port: port, custom: custom),
+            log: RemoteTunnelPaths.tunnelLog,
+            freshLog: true)
+        try await start(unit, on: alias, failing: localized("Couldn’t start \(provider.label) on \(alias)."))
+
+        // Polled rather than slept on: a cold tunnel that has to dial a relay
+        // takes longer than a warm one, and a fixed wait would either lie or
+        // waste the difference.
+        for _ in 0..<20 {
+            try? await Task.sleep(for: .milliseconds(750))
+            let log = await RemoteShell.run(
+                alias: alias, command: "cat \(RemoteTunnelPaths.tunnelLog) 2>/dev/null")
+            if let address = firstMatch(of: pattern, in: log.stdout) {
+                return Publication(address: address, survivesReboot: lingering)
+            }
+        }
+        throw Failure(message: localized("\(provider.label) started on \(alias) but never printed an address.\n\(await diagnosis(alias: alias, unit: tunnelUnit, log: RemoteTunnelPaths.tunnelLog))"))
+    }
+
+    /// Keeps the user's services running when nobody is logged in — which is
+    /// every minute between closing the laptop and picking up the phone, and
+    /// every minute after a reboot. Without it `systemd --user` stops the whole
+    /// manager at logout and the box quietly goes dark.
+    ///
+    /// Returns whether it took. It is not fatal: the tunnel is up either way,
+    /// and a box whose polkit refuses this is still publishable for as long as
+    /// the login lasts. The caller says so rather than pretending otherwise.
+    /// What the last publish found, per machine. Remembered rather than
+    /// re-probed: the pane is rebuilt every time it appears, and a warning that
+    /// only survives the click that produced it is a warning nobody reads twice.
+    /// Absent means never published from here, which claims nothing either way.
+    static func lingers(device: String) -> Bool {
+        UserDefaults.standard.object(forKey: "remoteTunnel.\(device).lingers") as? Bool ?? true
+    }
+
+    static func rememberLinger(_ on: Bool, device: String) {
+        UserDefaults.standard.set(on, forKey: "remoteTunnel.\(device).lingers")
+    }
+
+    private static func enableLinger(alias: String) async -> Bool {
+        _ = await RemoteShell.run(
+            alias: alias, command: "loginctl enable-linger \"$USER\" 2>/dev/null || true")
+        let state = await RemoteShell.run(
+            alias: alias, command: "loginctl show-user \"$USER\" -p Linger --value 2>/dev/null || true")
+        return state.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "yes"
+    }
+
+    /// Writes the unit, reloads, and (re)starts it enabled.
+    ///
+    /// `enable` and `restart` rather than `enable --now`: the unit is usually
+    /// already installed by the time someone publishes a second time, and
+    /// `--now` would leave the old command running while the new file sat on
+    /// disk unread. `reset-failed` first, because a unit an earlier attempt left
+    /// in `failed` refuses to start again until its counters are cleared, and
+    /// the fix the user just made would look like the same failure.
+    private static func start(
+        _ unit: RemoteSystemdUnit, on alias: String, failing summary: String
+    ) async throws {
+        let path = "\(RemoteTunnelPaths.unitDirectory)/\(unit.name)"
+        let install = """
+            mkdir -p \(RemoteTunnelPaths.unitDirectory) \(RemoteTunnelPaths.stateDirectory) && \
+            printf '%s' \(RemoteShell.quoted(unit.text)) > \(path).new && \
+            mv \(path).new \(path) && \
+            systemctl --user daemon-reload && \
+            systemctl --user enable \(unit.name) > /dev/null && \
+            { systemctl --user reset-failed \(unit.name) 2>/dev/null || true; } && \
+            systemctl --user restart \(unit.name)
+            """
+        let launched = await RemoteShell.run(alias: alias, command: install)
+        guard launched.succeeded else {
+            throw Failure(message: "\(summary)\n\(launched.failure)")
+        }
+    }
+
+    /// What to show when a unit was started and then did not do its job. The
+    /// log alone is not enough: a unit that failed to exec at all never wrote a
+    /// line, and only the journal knows why.
+    private static func diagnosis(alias: String, unit: String, log: String) async -> String {
+        let report = await RemoteShell.run(
+            alias: alias,
+            command: """
+                systemctl --user is-active \(unit); \
+                journalctl --user -u \(unit) -n 8 --no-pager 2>/dev/null; \
+                tail -n 12 \(log) 2>/dev/null
+                """)
+        return report.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func firstMatch(of pattern: String, in text: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(text.startIndex..., in: text)
+        guard let match = regex.firstMatch(in: text, range: range),
+              let found = Range(match.range, in: text) else { return nil }
+        return String(text[found])
+    }
+}
+
+extension RemoteTunnelService {
+    /// Points the daemon at the address the tunnel just published, and restarts
+    /// it so the listener actually exists.
+    ///
+    /// Both halves are needed and both need the restart: `--wss` is what opens
+    /// the loopback listener at all, and `--wss-origin` is what lets the phone's
+    /// `Origin` past the CSRF check. Running `serve` explicitly with the two
+    /// flags also *persists* them (`wss.bind`, `wss.origin`, 0600), so a
+    /// client-triggered autostart on a box whose unit was never installed still
+    /// comes back armed.
+    ///
+    /// **This ends every session the daemon is hosting.** The caller asks first;
+    /// this does not, because it cannot know whether the caller already did.
+    static func arm(alias: String, origin: String, port: Int) async throws {
+        // `termiod stop`, never `pkill`: the daemon is found by the credential
+        // on its socket, so this stops the one actually serving this user and
+        // cannot stop anything else — including the ssh wrapper running the
+        // command, which is what an unanchored pattern match reaches.
+        // `--force` because the caller has already named what will end.
+        _ = await RemoteShell.run(
+            alias: alias,
+            command: "\(Termiod.remoteBinary()) stop --force > /dev/null 2>&1 || true")
+
+        let unit = RemoteSystemdUnit(
+            name: daemonUnit,
+            title: "termiod session host",
+            executable: Termiod.remoteBinary(),
+            arguments: ["serve", "--wss", "127.0.0.1:\(port)", "--wss-origin", origin],
+            log: RemoteTunnelPaths.daemonLog,
+            freshLog: false)
+        try await start(
+            unit, on: alias,
+            failing: localized("Couldn’t start termiod on \(alias) with a listener."))
+
+        // The daemon binds its socket before it serves; wait for it rather than
+        // guessing, so the pair that follows is not answered by a corpse.
+        for _ in 0..<12 {
+            try? await Task.sleep(for: .milliseconds(500))
+            let up = await RemoteShell.run(
+                alias: alias, command: "ss -ltn 2>/dev/null | grep -q ':\(port) ' && echo up || true")
+            if up.stdout.contains("up") { return }
+        }
+        throw Failure(message: localized("termiod on \(alias) never opened its listener.\n\(await diagnosis(alias: alias, unit: daemonUnit, log: RemoteTunnelPaths.daemonLog))"))
+    }
+}
+
+extension RemoteTunnelService {
+    /// Dials the published address the way the iPhone will, and returns the
+    /// `host_id` the daemon answers with.
+    ///
+    /// This exists because a successful `termiod pair` proves nothing about
+    /// reachability: `pair` reads the token and the origin off disk and never
+    /// contacts the daemon, let alone the tunnel in front of it. A QR minted
+    /// from it can scan perfectly and then 403, and the user finds out on the
+    /// phone, alone, with no error to read.
+    ///
+    /// The two derivations below are the phone's, from `Models.websocketURL`
+    /// and `Models.originValue`. They are duplicated rather than shared because
+    /// the point is to *reproduce* what the phone does — a shared helper would
+    /// still agree with itself if the phone's rule changed.
+    static func handshake(url: String, token: String) async throws -> String {
+        guard var components = URLComponents(string: url),
+              let scheme = components.scheme?.lowercased(),
+              let host = components.host else {
+            throw Failure(message: localized("\(url) is not an address the iPhone could dial."))
+        }
+        let secure = scheme == "https" || scheme == "wss"
+        let path = components.path.hasSuffix("/")
+            ? String(components.path.dropLast()) : components.path
+        components.scheme = secure ? "wss" : "ws"
+        components.path = path + "/ws"
+        components.query = nil
+        components.fragment = nil
+        let port = components.port.map { ":\($0)" } ?? ""
+        let origin = "\(secure ? "https" : "http")://\(host)\(port)"
+
+        guard let dial = components.url else {
+            throw Failure(message: localized("\(url) is not an address the iPhone could dial."))
+        }
+
+        var request = URLRequest(url: dial)
+        request.setValue(origin, forHTTPHeaderField: "Origin")
+        // The token rides the subprotocol, never the query string — the daemon
+        // refuses it anywhere else, and a query would leak it into proxy logs.
+        request.setValue("termiod.\(token)", forHTTPHeaderField: "Sec-WebSocket-Protocol")
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 20
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+
+        let socket = session.webSocketTask(with: request)
+        socket.resume()
+        defer { socket.cancel(with: .goingAway, reason: nil) }
+
+        do {
+            let hello = try Termiod.helloPayload(role: "control", caps: [], client: "termio-mac")
+            try await socket.send(.data(Termiod.frame(kind: .control, payload: hello)))
+            let message = try await socket.receive()
+            guard case .data(let bytes) = message, bytes.count > 5 else {
+                throw Failure(message: localized("\(origin) answered, but not with the handshake termiod sends."))
+            }
+            // `[kind: u8][len: u32be][payload]`, frozen since v0.
+            let payload = bytes.dropFirst(5)
+            guard case .helloOk(let handshake) = try Termiod.decodeControl(Data(payload)) else {
+                throw Failure(message: localized("\(origin) refused the handshake."))
+            }
+            return handshake.hostId
+        } catch let failure as Failure {
+            throw failure
+        } catch {
+            throw Failure(message: localized("\(origin) is published, but the connection an iPhone would make was refused.\n\(error.localizedDescription)"))
+        }
+    }
+}

--- a/Tests/termioTests/RemoteTunnelTests.swift
+++ b/Tests/termioTests/RemoteTunnelTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import termio
+
+final class RemoteTunnelTests: XCTestCase {
+    func testOriginValueDropsPathFromPublishedAddress() {
+        XCTAssertEqual(
+            RemoteTunnelService.originValue(of: "https://relay.example.com/termio"),
+            "https://relay.example.com")
+    }
+
+    func testOriginValueKeepsNonDefaultPort() {
+        XCTAssertEqual(
+            RemoteTunnelService.originValue(of: "https://relay.example.com:8443/termio"),
+            "https://relay.example.com:8443")
+    }
+}


### PR DESCRIPTION
Pairing an iPhone with a Linux box required the user to already own a domain, a reverse proxy and root on that machine. The pane's only offer was a text field asking them to type the resulting address — and that field could not work: `--url` changes the invite `termiod pair` prints, not the origins the daemon accepts, so it produced a QR that scanned and then took a 403.

The address must be byte-identical in three places (the invite, the daemon's `--wss-origin`, and the origin the phone stores and sends), which is not something to ask a person to retype. So the pane publishes the box instead of asking about it: the Mac already has SSH there, runs the tunnel on the far machine, and reads the address back.

The choice is the same list the Mac's own Mobile Access offers — Tunelo, Cloudflare, ngrok, Custom — and it exists because Termio's relay has finite capacity: a tunnel the user already owns is a first-class answer, not a consolation. Custom keeps the Mac's command-plus-regex contract but is stored per machine.

Notes:

- **Nothing needs root.** `~/.local/bin`, `~/.local/state`, `systemctl --user` with linger. Requiring root is what turns "connect my phone" into sysadmin work.
- **Stability is modelled, not assumed.** The phone persists the address and origin and the daemon pins it, so a rotating name strands every paired phone. Providers that don't hold their address say so before the click.
- **Arming asks first and names the sessions** it would end, by command line — a count can't inform that choice.
- **Every remote `pkill` is anchored** to the binary path; unanchored, `pkill -f` matches the ssh wrapper's own command line and kills the shell running it.

Verified against a real VPS: Publish installs and starts the tunnel, reads back a stable subdomain, arms the daemon, and the pane draws a QR. Dialling that URL from the Mac with the headers the phone sends returns `101 Switching Protocols` with the subprotocol echoed, answering as the `host_id` the box reports.

Not covered: an actual phone scanning the QR, and the relay's `--max-session` is still the 86400s default, so a tunnel drops after 24h.

Release Notes: Settings ▸ Mobile can now publish a remote device to the internet and pair your iPhone with it — pick a tunnel (Tunelo, Cloudflare, ngrok, or your own), press Publish, and scan the code. Nothing on the device needs root, and the tunnel is set up to survive a reboot.