### PR TITLE
Open a split where the pane it came from is

### DIFF
--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -574,10 +574,11 @@ struct Session: Identifiable, Hashable, Codable {
     var lastWorkingDirectory: String?
 
     /// Where this session was opened, when that isn't its project's own anchor: ⌘T
-    /// records the directory the user was in, so the new shell starts *there* rather
-    /// than at the project root. Persisted, so a relaunch reopens it in the same
-    /// place. `lastWorkingDirectory` outranks it for a loose terminal — a shell that
-    /// reported its own cwd knows better than the seed it was given.
+    /// and every split record the directory the pane they came from was sitting in,
+    /// so the new shell starts *there* rather than at the project root. Persisted, so
+    /// a relaunch reopens it in the same place. `lastWorkingDirectory` outranks it for
+    /// a loose terminal — a shell that reported its own cwd knows better than the seed
+    /// it was given.
     var spawnDirectory: String?
 
     /// The last meaningful terminal title (`OSC 0/2`) the session's agent reported,

--- a/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
+++ b/Sources/termio/TermioStore/TermioStore+ProjectActions.swift
@@ -303,17 +303,52 @@ extension TermioStore {
         addScratchSession(agent: .terminal)
     }
 
+    /// Where a session's shell actually is right now — the directory the actions
+    /// that open a *second* shell beside it start in (New Terminal ⌘T, and every
+    /// split). Three rungs, because a shell says where it is in two different ways
+    /// and neither is guaranteed:
+    ///
+    /// 1. the daemon's own kernel sample of the child (`childCwd`), the rung that
+    ///    always answers — macOS's stock zsh emits `OSC 7` only under
+    ///    `TERM_PROGRAM=Apple_Terminal` and termiod injects no shell integration,
+    ///    so most shells never volunteer one;
+    /// 2. the cwd already on record: an `OSC 7` from a shell that *does* have
+    ///    integration, or the sample a loose terminal keeps;
+    /// 3. the cwd persisted from this session's last run.
+    ///
+    /// Each rung must still name a directory that exists — a shell spawned in a
+    /// deleted one lands at `/`. `nil` for a session that runs on another machine:
+    /// the path it reports exists over *there*, and handing it to a local spawn
+    /// would `chdir` somewhere else entirely, or somewhere that happens to exist
+    /// here. (`remoteWorkingDirectory` is that case's own answer.)
+    func liveWorkingDirectory(for id: Session.ID) -> String? {
+        guard let session = session(id),
+              session.sshHost == nil, session.termiodRemoteHost == nil else { return nil }
+        return Self.existingDirectory(termiodLinks[id]?.latestInformation?.childCwd)
+            ?? Self.existingDirectory(workingDirectory(for: id))
+            ?? Self.existingDirectory(session.lastWorkingDirectory)
+    }
+
+    /// The same question for a session hosted on another machine: where the daemon
+    /// over there last saw that shell. Never checked against this Mac's disk — the
+    /// path describes the far box — and `nil` for anything running locally, so a
+    /// caller can ask both and take whichever answers.
+    func remoteWorkingDirectory(for id: Session.ID) -> String? {
+        guard session(id)?.termiodRemoteHost != nil,
+              let cwd = termiodLinks[id]?.latestInformation?.childCwd,
+              !cwd.isEmpty else { return nil }
+        return cwd
+    }
+
     /// Opens a terminal where the user already is — New Terminal (⌘T). The shell
     /// starts in the focused session's working directory and the row lands beside it:
     /// in the same project and worktree bucket for a real project, in the Terminals
     /// section for a loose shell or a scratch chat (a shell has no business in the
     /// Chats funnel).
     ///
-    /// The directory is the cwd the session reported over OSC 7. A shell without
-    /// integration never reports one, and an SSH terminal reports a path that exists
-    /// only on the remote host, so anything that isn't a local directory falls through
-    /// to the session's own anchor — and to `$HOME` with nothing focused, which is
-    /// what New Terminal at Home does on purpose.
+    /// The directory is wherever that session's shell is now (`liveWorkingDirectory`),
+    /// which falls through to the session's own anchor when nothing knows — and to
+    /// `$HOME` with nothing focused, which is what New Terminal at Home does on purpose.
     func addTerminalHere() {
         guard let id = selectedSessionID, let slot = locate(id) else {
             addScratchTerminal()
@@ -327,8 +362,7 @@ extension TermioStore {
             addRemoteTerminal(host: alias)
             return
         }
-        let reported = Self.existingDirectory(
-            workingDirectory(for: id) ?? session.lastWorkingDirectory)
+        let reported = liveWorkingDirectory(for: id)
         guard case .project(let index, _) = slot else {
             let directory = reported ?? session.spawnDirectory
             addScratchSession(agent: .terminal, spawnDirectory: directory)

--- a/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
+++ b/Sources/termio/TermioStore/TermioStore+SplitPanes.swift
@@ -39,11 +39,22 @@ extension TermioStore {
         // A worktree session runs somewhere other than the project root; the
         // companion shell should land where the focused session actually works.
         newSession.worktreePath = session(focusedID)?.worktreePath
+        // …and "where it works" is where its shell *is*, not just which checkout
+        // it belongs to: a pane split off one sitting in `packages/web` opens in
+        // `packages/web`, so the split costs no `cd` (#497). Ghostty states the
+        // same rule as `split-inherit-working-directory`, on by default.
+        newSession.spawnDirectory = liveWorkingDirectory(for: focusedID)
         // …and "where it works" includes *which machine*. Splitting a session
         // that runs on another device must not silently hand back a shell on
         // this Mac: the pane sits beside its origin and reads as the same
         // place, so it has to be the same place.
         newSession.inheritDevice(from: session(focusedID))
+        // The directory rule holds over there too. `inheritDevice` carried the
+        // directory the origin was *started* in; the daemon on that box says
+        // where its shell has since walked to.
+        if let remote = remoteWorkingDirectory(for: focusedID) {
+            newSession.termiodRemoteCwd = remote
+        }
         // Beside the session it splits, not at the end of the project — the
         // sidebar then reads the split group as adjacent rows, which is what lets
         // it draw the VS Code-style ┌/└ group bracket (see `splitLinkMarks`). The
@@ -124,9 +135,19 @@ extension TermioStore {
         // Share the anchor's working directory so a worktree agent's sibling lands
         // in the same checkout — the same courtesy `splitSelectedPane` extends.
         newSession.worktreePath = session(anchorID)?.worktreePath
+        // A *shell* also follows the anchor down to wherever it has `cd`'d, the
+        // way ⌘D does. An agent does not: where an agent is turned loose is a
+        // decision about what it may read and write, and it is made by the
+        // checkout above, never by wherever a neighbouring shell wandered.
+        if agent == .terminal {
+            newSession.spawnDirectory = liveWorkingDirectory(for: anchorID)
+        }
         // And the anchor's device, for the same reason: a split of a session on
         // another machine stays on that machine.
         newSession.inheritDevice(from: session(anchorID))
+        if agent == .terminal, let remote = remoteWorkingDirectory(for: anchorID) {
+            newSession.termiodRemoteCwd = remote
+        }
         // Adjacent to the anchor, so the sidebar reads the group as neighbouring
         // rows and draws its ┌/└ bracket (see `splitLinkMarks`).
         insertSession(newSession, at: anchorHome.atSession(anchorHome.sessionIndex + 1))


### PR DESCRIPTION
Splitting a pane put the new shell at the project root, even when the pane you split from was sitting three directories down. Every split cost a `cd`.

Two things were wrong. A split inherited the origin session's worktree and device but never its working directory. And termio had nothing to inherit anyway: the cwd a session reports was recorded only for a loose terminal, and macOS's stock zsh emits `OSC 7` only under `TERM_PROGRAM=Apple_Terminal`, which termiod does not set — so a project shell's place was unknown to New Terminal (⌘T) too, whose whole job is to follow it.

`liveWorkingDirectory(for:)` answers the question from the evidence that actually exists: the daemon's own kernel sample of the child (`PROC_PIDVNODEPATHINFO`, already riding every roster row), then a recorded `OSC 7`, then the cwd persisted from the last run — each rung required to still name a directory that exists. Split Right/Left/Down/Up, the CLI's `spawn` / `run --direction`, and ⌘T all seed the new session's `spawnDirectory` from it; a pane on another machine takes the far daemon's sample as its remote cwd instead.

Ghostty states the same rule as `split-inherit-working-directory`, on by default, but resolves it from `OSC 7` alone — it ships the shell integration that emits one. The kernel sample is what makes it hold for a shell with no integration at all.

A CLI split that starts an *agent* is deliberately left alone: where an agent is turned loose is a decision about what it may read and write, and the checkout makes it, not whichever shell happened to be next to it.

Verified end to end on an isolated channel with its own daemon: from a pane in `Sources/termio/Terminal`, View ▸ Split Right and `termio sessions run "pwd" --direction right` both open in `Sources/termio/Terminal`. `swift build` and `swift test` (835 tests) pass.

Closes #497

Release Notes:
- A split pane now opens in the directory the pane it came from is in, instead of the project root. New Terminal (⌘T) follows that directory too, including for shells without shell integration.