### PR TITLE
Blend iPhone glyphs in the Mac's color space

### DIFF
--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -804,6 +804,10 @@ final class TerminalViewController: UIViewController {
             for family in terminalFontChain() {
                 builder.withFontFamily(family)
             }
+            // Ghostty blends in `native` (Display P3) on macOS but `linear-corrected`
+            // on every other OS, iOS included. Linear blending thins dark-on-light
+            // glyph edges, so the same theme read softer here than on the Mac.
+            builder.withCustom("alpha-blending", "native")
             // The phone is a viewer, not the scrollback of record — the Mac keeps
             // the full history. libghostty's renderer paints its "non-functional"
             // panel when it exhausts a GPU/allocator resource reflowing scrollback


### PR DESCRIPTION
Ghostty defaults `alpha-blending` to `native` on macOS and `linear-corrected` on every other OS, and iOS falls on the "other" side even though the renderer tags its surfaces Display P3 on both. Linear blending thins the edges of dark text on a light background, so the same theme read softer on the phone than on the Mac — glyphs looked like they sat behind frosted glass. The phone now sets `native`, next to the font chain and under the same rule: the phone renders with the Mac's pipeline.

Verified on device with Alabaster, the light theme where the thinning is most visible.

Release Notes:
- iPhone: text edges are as crisp as on the Mac — glyphs blend in the same color space on both.