### PR TITLE
Answer a device file click before the network does

### DIFF
--- a/Sources/termio/Editor/FileEditorView.swift
+++ b/Sources/termio/Editor/FileEditorView.swift
@@ -33,6 +33,14 @@ struct FileEditorView: View {
     /// Records the version a save produced, so the next one claims it rather
     /// than the version the file was opened at.
     let onRemoteSave: ((RemoteDocument) -> Void)?
+    /// Reports whether the buffer has edits that are not on disk yet.
+    ///
+    /// Read by the remote open path: a device file shown from the cache is
+    /// re-read behind it, and a reply that disagrees replaces the buffer — which
+    /// it must never do to one somebody has started typing into. `isDirty` flips
+    /// on the keystroke itself, well before the debounced write, so this closes
+    /// the window the file's own bytes on disk cannot.
+    let onDirtyChange: ((Bool) -> Void)?
     /// Dismisses the overlay (clears `store.openFileURL`) and hands focus back to the terminal.
     let onClose: () -> Void
 
@@ -124,6 +132,7 @@ struct FileEditorView: View {
          displayName: String? = nil,
          remote: RemoteDocument? = nil,
          onRemoteSave: ((RemoteDocument) -> Void)? = nil,
+         onDirtyChange: ((Bool) -> Void)? = nil,
          addToChat: ((String?) -> Void)? = nil, canAddToChat: (() -> Bool)? = nil,
          showsInspectorChrome: Bool = true, onClose: @escaping () -> Void) {
         self.url = url
@@ -133,6 +142,7 @@ struct FileEditorView: View {
         self.displayName = displayName
         self.remote = remote
         self.onRemoteSave = onRemoteSave
+        self.onDirtyChange = onDirtyChange
         self.addToChat = addToChat
         self.canAddToChat = canAddToChat
         self.showsInspectorChrome = showsInspectorChrome
@@ -249,6 +259,10 @@ struct FileEditorView: View {
         .onChange(of: text) {
             if !readOnly { scheduleSave() }
         }
+        // Both directions, and from the first render: a save clears the flag as
+        // surely as a keystroke sets it, and the mount is what resets whatever
+        // the previously open file left behind.
+        .onChange(of: isDirty, initial: true) { onDirtyChange?(isDirty) }
         // A fresh jump target while a Markdown file sits in Preview (clicking another
         // content-search hit): the jump needs the source editor's lines, so flip to Edit
         // first — Preview has no text view to scroll and would swallow it.

--- a/Sources/termio/FileBrowser/FileSearchView.swift
+++ b/Sources/termio/FileBrowser/FileSearchView.swift
@@ -49,7 +49,6 @@ struct FileSearchView: View {
     /// The in-flight debounce+grep, cancelled by the next keystroke.
     @State private var searchTask: Task<Void, Never>?
     /// The in-flight download of a hit's file, for a device checkout.
-    @State private var openTask: Task<Void, Never>?
     @State private var fieldFocused = false
     @State private var focusRequest = 0
     @State private var isVisible = false
@@ -68,7 +67,6 @@ struct FileSearchView: View {
         .onDisappear {
             isVisible = false
             searchTask?.cancel()
-            openTask?.cancel()
         }
     }
 
@@ -380,22 +378,13 @@ struct FileSearchView: View {
     /// is quoted verbatim. `fallback` says which of the two round trips failed,
     /// since an error with no message of its own tells the user nothing else.
     private static func message(for error: Error, fallback: String) -> String {
-        switch error {
-        case DeviceFileError.unsupported:
-            return localized("This device’s termiod is too old to browse files.")
-        case DeviceFileError.tooLarge:
-            return localized("Preview is capped at 1 MB.")
-        case DeviceFileError.notRegularFile:
-            return localized("Only regular files can be previewed.")
-        case TermiodClientError.timedOut:
-            // Silence, not a refusal — and the likeliest cause is a host that
-            // has never heard of the op, so the sentence names that.
+        // Silence, not a refusal — and the likeliest cause is a host that has
+        // never heard of the op, so the sentence names that. The rest is the
+        // shared table every device pane words its failures from.
+        if case TermiodClientError.timedOut = error {
             return localized("This device didn’t answer. Its termiod may be too old to search.")
-        case TermiodClientError.requestFailed(let detail) where !detail.isEmpty:
-            return detail
-        default:
-            return fallback
         }
+        return RemoteFileFailure.message(for: error, fallback: fallback)
     }
 
     // MARK: - Opening a hit
@@ -422,40 +411,13 @@ struct FileSearchView: View {
             store.openFileInEditor(match.url, at: target)
             return
         }
-        openTask?.cancel()
-        let path = match.url.path
-        let name = match.url.lastPathComponent
-        let line = target
-        let generation = store.filePresentationGeneration
-        openTask = Task { @MainActor in
-            do {
-                let file = try await provider.read(
-                    path, limit: Termiod.filePreviewByteLimit)
-                try Task.checkCancellation()
-                let lease = try RemotePreviewStorage.stage(file.data, named: name)
-                store.presentRemoteFilePreview(
-                    lease, expectedGeneration: generation, at: line,
-                    origin: RemoteDocument(
-                        route: provider.route, root: provider.root, path: path,
-                        mtime: file.mtime, host: host))
-            } catch is CancellationError {
-                return
-            } catch {
-                guard !Task.isCancelled else { return }
-                Log.files.error("""
-                device read \(host, privacy: .public):\(path, privacy: .public): \
-                \(String(describing: error), privacy: .public)
-                """)
-                // The click has to answer for itself: the results list stays on
-                // screen, so a failure recorded only in the pane's empty state
-                // would be a click that did nothing.
-                let alert = NSAlert()
-                alert.messageText = "“\(name)” couldn’t be opened."
-                alert.informativeText = Self.message(
-                    for: error, fallback: localized("The read failed."))
-                alert.runModal()
-            }
-        }
+        // The same open the device's file tree uses: the overlay goes up on the
+        // click, a file read before is shown from the cache while the device is
+        // asked again, and a failure is reported in the overlay rather than in a
+        // modal the click has to be dismissed out of.
+        store.openRemoteFile(
+            path: match.url.path, name: match.url.lastPathComponent,
+            provider: provider, host: host, at: target)
     }
 
     /// The terminal surface fights for first responder; keep asking for a few

--- a/Sources/termio/FileBrowser/InspectorDetailHost.swift
+++ b/Sources/termio/FileBrowser/InspectorDetailHost.swift
@@ -347,6 +347,10 @@ struct InspectorDetailContent: View {
         } else if let item = store.openIssueDetail, let model = store.issuesModel {
             IssueDetailView(item: item, model: model, settings: settings, onBack: close)
                 .id(item.number)
+        } else if let opening = store.openingRemoteFile {
+            // The click is answered before the network is: the file's chrome goes
+            // up now, and the editor replaces it when the bytes land.
+            RemoteFileOpeningView(opening: opening, settings: settings)
         } else if let url = store.openFileURL {
             // Content staged from an SSH host is previewed as source, never as live
             // web content: HTML and SVG from a remote box would otherwise run in
@@ -366,6 +370,7 @@ struct InspectorDetailContent: View {
                                displayName: store.openFileDisplayName,
                                remote: store.openFileRemote,
                                onRemoteSave: { store.openFileRemote = $0 },
+                               onDirtyChange: { store.openFileDirty = $0 },
                                addToChat: { selection in
                                    if let selection {
                                        _ = store.addSnippetToSelectedSessionPrompt(selection)

--- a/Sources/termio/FileBrowser/RemoteFileTree.swift
+++ b/Sources/termio/FileBrowser/RemoteFileTree.swift
@@ -60,6 +60,108 @@ struct RemoteDocument: Hashable {
     }
 }
 
+/// The file a click on a device's tree has asked for, while its bytes are still
+/// crossing the network. What the overlay draws until the editor takes over.
+struct RemoteFileOpening: Equatable {
+    let name: String
+    let host: String
+    /// The device's own sentence when the read failed. The click has to answer
+    /// for itself, and an overlay that opened and then vanished would leave the
+    /// same "did it hear me" question the placeholder exists to end.
+    var failure: String?
+}
+
+/// What went wrong on a device, in the vocabulary the panes show.
+///
+/// The device describes the cause and is quoted verbatim where it has one; only
+/// the cases the client decides for itself are worded here. One table rather
+/// than one per pane, because the tree, the search and the file overlay are all
+/// answering the same question and were drifting apart doing it.
+enum RemoteFileFailure {
+    static func message(
+        for error: Error, fallback: String = localized("The read failed.")
+    ) -> String {
+        switch error {
+        case DeviceFileError.unsupported:
+            return localized("This device’s termiod is too old to browse files.")
+        case DeviceFileError.tooLarge:
+            return localized("Preview is capped at 1 MB.")
+        case DeviceFileError.notRegularFile:
+            return localized("Only regular files can be previewed.")
+        case DeviceFileError.unsafeName:
+            return localized("This device sent a name the file tree can’t show.")
+        case TermiodClientError.requestFailed(let detail) where !detail.isEmpty:
+            return detail
+        default:
+            return fallback
+        }
+    }
+}
+
+/// The bytes of files read from a device, so opening one a second time costs no
+/// round trip.
+///
+/// Kept in memory rather than on disk on purpose: this is VS Code's text model
+/// cache, not a sync product. It survives closing a file and switching sessions,
+/// and dies with the process — nothing on this Mac has to be reconciled with the
+/// machine the bytes came from.
+///
+/// Every hit is still revalidated (`TermioStore.openRemoteFile`): agents rewrite
+/// files constantly, so a cache that answered on its own would be wrong within
+/// seconds. What it removes is the *wait*, not the read.
+@MainActor
+enum RemoteFileContentCache {
+    struct Key: Hashable {
+        let route: TermiodRoute
+        let root: String
+        let path: String
+    }
+
+    struct Entry {
+        let data: Data
+        let mtime: UInt64
+    }
+
+    /// Small on both axes. A file tree is browsed a few files at a time, and the
+    /// entries are whole file contents — this is a convenience for going back to
+    /// what you just read, not a store worth spending memory on.
+    static let capacity = 16
+    static let byteBudget = 8 * 1024 * 1024
+
+    private static var entries: [Key: Entry] = [:]
+    /// Least-recently-used first, so eviction has an order to follow.
+    private static var order: [Key] = []
+    private static var bytes = 0
+
+    static func entry(for key: Key) -> Entry? {
+        guard let entry = entries[key] else { return nil }
+        order.removeAll { $0 == key }
+        order.append(key)
+        return entry
+    }
+
+    static func store(_ entry: Entry, for key: Key) {
+        if let existing = entries[key] {
+            bytes -= existing.data.count
+            order.removeAll { $0 == key }
+        }
+        entries[key] = entry
+        order.append(key)
+        bytes += entry.data.count
+        while order.count > capacity || (bytes > byteBudget && order.count > 1) {
+            guard let oldest = order.first else { break }
+            order.removeFirst()
+            bytes -= entries.removeValue(forKey: oldest)?.data.count ?? 0
+        }
+    }
+
+    static func clear() {
+        entries.removeAll()
+        order.removeAll()
+        bytes = 0
+    }
+}
+
 @MainActor
 enum RemotePreviewStorage {
     private static var liveDirectories: Set<URL> = []
@@ -143,6 +245,12 @@ final class RemoteFileNode: Identifiable {
     nonisolated var id: String { path }
 
     fileprivate var loadedChildren: [RemoteFileNode]?
+    /// Whether a listing for this folder is on the wire with nothing to show
+    /// yet. An unloaded folder answers `[]`, which draws as a folder that is
+    /// genuinely empty — the one thing it is not. The row shows a spinner
+    /// instead, the way the local tree never has to because its answer is
+    /// already there.
+    fileprivate(set) var isLoading = false
     private weak var model: RemoteFileBrowserModel?
 
     fileprivate init(
@@ -166,8 +274,12 @@ final class RemoteFileNode: Identifiable {
     var children: [RemoteFileNode]? {
         guard isDirectory else { return nil }
         if let loadedChildren { return loadedChildren }
+        // `loadChildren` adopts a prefetched listing synchronously, so a folder
+        // whose contents were fetched ahead of this click opens with its rows
+        // already in it — read back here rather than published, because a
+        // publish from inside a getter runs during a view update.
         model?.loadChildren(of: self)
-        return []
+        return loadedChildren ?? []
     }
 }
 
@@ -195,20 +307,50 @@ final class RemoteFileBrowserModel: ObservableObject {
     @Published private(set) var phase: Phase = .connecting
     @Published private(set) var rootNodes: [RemoteFileNode] = []
 
-    /// The same read cap as the iOS companion's file preview and the daemon's
-    /// own `fs.read` soft cap.
-    static let previewByteLimit = Termiod.filePreviewByteLimit
+    /// Listings fetched before anything asked for them: when a folder opens, the
+    /// folders inside it are the ones about to be clicked, and asking for them
+    /// while the user is still reading the rows costs a round trip nobody waits
+    /// on. Consumed by the click, so an expand three levels down is three
+    /// instant openings instead of three sequential waits.
+    ///
+    /// Deliberately not tree state — a prefetched folder is not "loaded", it is
+    /// a guess held aside. Adopting one still asks the device for real, so a
+    /// guess that went stale is corrected within one round trip and never
+    /// survives longer than the first look at it.
+    private var prefetched: [String: [FileEntry]] = [:]
+    /// Directories per prefetch, and in total. A checkout with 400 folders under
+    /// one parent must not turn one expand into a listing of the whole tree; the
+    /// cap is generous enough to cover the folders actually on screen.
+    static let prefetchFanout = 32
+    static let prefetchCeiling = 256
 
     private let provider: DeviceFileProvider
     private var nodesByPath: [String: RemoteFileNode] = [:]
     private var loadsInFlight: Set<String> = []
+    private var prefetchesInFlight: Set<String> = []
     private var refreshing = false
+    /// Holds this device's channel open, and warm, while the pane is on screen.
+    /// See `Termiod.ControlPool.pin`.
+    private var pin: Termiod.ControlPool.ChannelPin?
 
     init(checkout: Checkout, root: String) {
         self.checkout = checkout
         self.root = root
         self.provider = DeviceFileProvider(
             route: checkout.device.route, root: root)
+    }
+
+    /// The pane is on screen: keep the connection it browses over alive, so a
+    /// click seconds from now does not pay to rebuild it.
+    func startWarming() {
+        guard pin == nil else { return }
+        pin = Termiod.ControlPool.pin(route: checkout.device.route, caps: ["files"])
+    }
+
+    /// The pane is gone or hidden. The channel goes back on the idle clock,
+    /// which hangs it up two minutes later if nothing else wants it.
+    func stopWarming() {
+        pin = nil
     }
 
     var host: String { checkout.device.name }
@@ -251,6 +393,10 @@ final class RemoteFileBrowserModel: ObservableObject {
                 let listings = try await provider.list(wanted)
                 apply(listings)
                 phase = .ready
+                // The folders at the top of the tree are the ones about to be
+                // clicked. Asking for them now costs a round trip nobody is
+                // waiting on; asking for them on the click costs one they are.
+                prefetchChildren(of: rootNodes)
             } catch {
                 report(error, context: "list \(host):\(root)")
             }
@@ -272,6 +418,14 @@ final class RemoteFileBrowserModel: ObservableObject {
                 return left == right ? $0 < $1 : left < right
             }
     }
+
+    /// The folders whose contents have been fetched ahead of a click.
+    ///
+    /// Reachable from a test for the same reason `loadedDirectories` is: whether
+    /// a guess is in hand *before* the folder is touched is the whole of the
+    /// claim, and it cannot be seen from the outside once touching it is what
+    /// consumes it.
+    func prefetchedPaths() -> Set<String> { Set(prefetched.keys) }
 
     /// Grafts a batch of listings onto the tree, keeping expansion state: a
     /// directory that is still there and still has children keeps them, so the
@@ -301,6 +455,35 @@ final class RemoteFileBrowserModel: ObservableObject {
         objectWillChange.send()
     }
 
+    /// Asks the device for the contents of the folders in `nodes`, one level
+    /// deep, so the click that opens one of them does not have to wait.
+    ///
+    /// Everything already loaded, already guessed at, or already on the wire is
+    /// skipped, so a refresh that re-lists a tree eight folders deep does not
+    /// re-prefetch what it prefetched the last time. One `fs.list` for the whole
+    /// batch — the same array the refresh uses, for the same reason.
+    private func prefetchChildren(of nodes: [RemoteFileNode]) {
+        guard prefetched.count < Self.prefetchCeiling else { return }
+        let wanted = nodes
+            .filter { $0.isDirectory && $0.loadedChildren == nil }
+            .map(\.path)
+            .filter { prefetched[$0] == nil && !prefetchesInFlight.contains($0) }
+            .prefix(Self.prefetchFanout)
+        guard !wanted.isEmpty else { return }
+        let paths = Array(wanted)
+        prefetchesInFlight.formUnion(paths)
+        Task {
+            defer { prefetchesInFlight.subtract(paths) }
+            // A guess that fails is not worth a word: the click that needed it
+            // asks again for itself, and reports its own failure if it comes to
+            // that.
+            guard let listings = try? await provider.list(paths) else { return }
+            for listing in listings where listing.error == nil {
+                prefetched[listing.path] = listing.entries
+            }
+        }
+    }
+
     /// Drops every node the tree can no longer reach from its roots.
     private func pruneUnreachableNodes() {
         var reachable: [String: RemoteFileNode] = [:]
@@ -310,20 +493,49 @@ final class RemoteFileBrowserModel: ObservableObject {
             frontier.append(contentsOf: node.loadedChildren ?? [])
         }
         nodesByPath = reachable
+        // A guess about a folder that is no longer in the tree answers a click
+        // that can no longer happen.
+        prefetched = prefetched.filter { reachable[$0.key] != nil }
     }
 
     /// Fetches one folder's entries — called from the `children` getter on first
     /// expand, so it must tolerate being re-entered on every list render while
     /// the fetch is in flight.
+    ///
+    /// A folder that was prefetched fills in **synchronously**, before this
+    /// returns, so the getter that called it can hand the rows straight to the
+    /// outline. The device is asked either way: a guess is shown, never trusted.
     fileprivate func loadChildren(of node: RemoteFileNode) {
+        if let ready = prefetched.removeValue(forKey: node.path) {
+            node.loadedChildren = nodes(for: ready, under: node.path)
+        }
         guard !loadsInFlight.contains(node.path) else { return }
         loadsInFlight.insert(node.path)
         Task {
             defer { loadsInFlight.remove(node.path) }
+            // Only when there is nothing to show meanwhile: a folder opened from
+            // a prefetch already has its rows, and a spinner on it would be
+            // reporting work the user has no reason to know about.
+            if node.loadedChildren == nil {
+                node.isLoading = true
+                objectWillChange.send()
+            }
+            defer {
+                if node.isLoading {
+                    node.isLoading = false
+                    objectWillChange.send()
+                }
+            }
             do {
                 let entries = try await provider.list(node.path)
-                node.loadedChildren = nodes(for: entries, under: node.path)
+                // Reusing the nodes already there keeps whatever is expanded
+                // underneath a prefetched folder when its real listing lands.
+                let previous = Dictionary(
+                    uniqueKeysWithValues: (node.loadedChildren ?? []).map { ($0.path, $0) })
+                node.loadedChildren = nodes(
+                    for: entries, under: node.path, reusing: previous)
                 objectWillChange.send()
+                prefetchChildren(of: node.loadedChildren ?? [])
             } catch {
                 // Settle the folder as empty rather than leaving it unloaded —
                 // the getter would re-fire the fetch on every render otherwise.
@@ -334,21 +546,11 @@ final class RemoteFileBrowserModel: ObservableObject {
         }
     }
 
-    /// Downloads the file into a uniquely-named temp file (keeping the device
-    /// file's name, so icon and syntax detection work) for the overlay, and
-    /// answers with where it came from so a save can put it back. Throws
-    /// `DeviceFileError.tooLarge` past the preview cap.
-    func stageForPreview(
-        _ node: RemoteFileNode
-    ) async throws -> (lease: RemotePreviewLease, origin: RemoteDocument) {
-        guard node.canPreview else { throw DeviceFileError.notRegularFile }
-        let file = try await provider.read(node.path, limit: Self.previewByteLimit)
-        try Task.checkCancellation()
-        let lease = try RemotePreviewStorage.stage(file.data, named: node.name)
-        return (lease, RemoteDocument(
-            route: checkout.device.route, root: root, path: node.path,
-            mtime: file.mtime, host: host))
-    }
+    /// How this tree's files are read. The open itself belongs to the store
+    /// (`TermioStore.openRemoteFile`), which is also where the search pane's
+    /// opens go — one path, so the overlay, the cache and the cancellation
+    /// behave the same however a file was clicked.
+    var files: DeviceFileProvider { provider }
 
     /// Routes a failure into the pane's state: an already-loaded tree stays up
     /// (a single folder failing shouldn't blank the pane) and only an empty one
@@ -374,7 +576,11 @@ final class RemoteFileBrowserModel: ObservableObject {
         reusing existing: [String: RemoteFileNode] = [:]
     ) -> [RemoteFileNode] {
         let base = parent.hasSuffix("/") ? parent : parent + "/"
-        return entries.map { entry in
+        // The same order and the same hidden names as the local explorer
+        // (`FileEntry.sortedForTree`): the host sorts by name alone, which put
+        // files above folders and left `.git` in the tree — one browser behaving
+        // two ways depending on which machine the checkout is on.
+        return entries.sortedForTree().map { entry in
             let path = base + entry.name
             let node: RemoteFileNode
             if let kept = existing[path], kept.isDirectory == entry.isDirectory {
@@ -391,22 +597,8 @@ final class RemoteFileBrowserModel: ObservableObject {
         }
     }
 
-    /// The device describes what went wrong; turning that into a sentence is the
-    /// client's job, so the daemon's own message is shown verbatim where it has
-    /// one and only the client-side cases are worded here.
     private static func message(for error: Error) -> String {
-        switch error {
-        case DeviceFileError.unsupported:
-            return localized("This device’s termiod is too old to browse files.")
-        case DeviceFileError.unsafeName:
-            return localized("This device sent a name the file tree can’t show.")
-        case DeviceFileError.notRegularFile:
-            return localized("Only regular files can be previewed.")
-        case TermiodClientError.requestFailed(let detail) where !detail.isEmpty:
-            return detail
-        default:
-            return localized("The listing failed.")
-        }
+        RemoteFileFailure.message(for: error, fallback: localized("The listing failed."))
     }
 }
 
@@ -423,8 +615,6 @@ struct RemoteFileTreeView: View {
     @StateObject private var model: RemoteFileBrowserModel
     @State private var selection: String?
     @State private var outlineView: NSOutlineView?
-    @State private var previewTask: Task<Void, Never>?
-    @State private var previewRequestID = 0
 
     init(checkout: Checkout, root: String) {
         _model = StateObject(
@@ -436,8 +626,11 @@ struct RemoteFileTreeView: View {
             header
             content
         }
-        .onAppear { model.refresh() }
-        .onDisappear { cancelPreviewRequest() }
+        .onAppear {
+            model.startWarming()
+            model.refresh()
+        }
+        .onDisappear { model.stopWarming() }
         // The refresh model (no remote watching): reload when the app comes back
         // to the front — the same reconcile trigger as the git pane — but only
         // while the pane is actually visible.
@@ -446,9 +639,14 @@ struct RemoteFileTreeView: View {
         }
         .onChange(of: store.inspectorVisible) { _, visible in
             if visible {
+                model.startWarming()
                 model.refresh()
             } else {
-                cancelPreviewRequest()
+                // A hidden pane is not worth a connection to somebody's VPS, and
+                // the download behind a click nobody can see is not worth
+                // finishing.
+                model.stopWarming()
+                store.cancelRemoteFileOpen()
             }
         }
         .onChange(of: selection) {
@@ -458,7 +656,9 @@ struct RemoteFileTreeView: View {
             if node.isDirectory {
                 toggleSelectedFolder()
             } else if node.canPreview {
-                preview(node)
+                store.openRemoteFile(
+                    path: node.path, name: node.name,
+                    provider: model.files, host: model.host)
                 // Every click should be observable, including reopening the same
                 // file after the overlay was dismissed.
                 selection = nil
@@ -536,41 +736,62 @@ struct RemoteFileTreeView: View {
         }
         selection = nil
     }
+}
 
-    private func preview(_ node: RemoteFileNode) {
-        previewTask?.cancel()
-        previewRequestID &+= 1
-        let requestID = previewRequestID
-        let presentationGeneration = store.filePresentationGeneration
-        previewTask = Task { @MainActor in
-            do {
-                let staged = try await model.stageForPreview(node)
-                guard !Task.isCancelled, requestID == previewRequestID else { return }
-                // Adoption is conditional on no other local/remote presentation
-                // winning while the download was in flight. HTML/SVG is routed
-                // to source, and failed raster decoding never falls into WebKit.
-                _ = store.presentRemoteFilePreview(
-                    staged.lease, expectedGeneration: presentationGeneration,
-                    origin: staged.origin)
-            } catch DeviceFileError.tooLarge {
-                guard !Task.isCancelled, requestID == previewRequestID else { return }
-                let alert = NSAlert()
-                alert.messageText = "“\(node.name)” is too large to preview."
-                alert.informativeText = "Preview is capped at 1 MB."
-                alert.runModal()
-            } catch is CancellationError {
-                return
-            } catch {
-                guard !Task.isCancelled, requestID == previewRequestID else { return }
-                model.report(error, context: "read \(node.path)")
-            }
-        }
+/// What the overlay shows between the click and the bytes: the file's own header
+/// — icon, name, and a spinner where the editor's save dot goes — over an empty
+/// body.
+///
+/// The header is built to the editor's own measurements (`FileEditorView.header`)
+/// on purpose. When the content lands, only the body below it changes; a
+/// placeholder with a different shape would make every remote open flash a
+/// second layout on its way in.
+struct RemoteFileOpeningView: View {
+    let opening: RemoteFileOpening
+    @ObservedObject var settings: AppSettings
+
+    /// The name is a device path's leaf, so a synthetic local URL is all the
+    /// icon needs to pick the right mark. Never touched on disk.
+    private var iconURL: URL {
+        URL(fileURLWithPath: "/", isDirectory: true).appendingPathComponent(opening.name)
     }
 
-    private func cancelPreviewRequest() {
-        previewRequestID &+= 1
-        previewTask?.cancel()
-        previewTask = nil
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                FileIconView(url: iconURL, size: 15, symbolSize: 13)
+                    .frame(width: 16)
+                Text(opening.name)
+                    .font(.system(size: 12.5, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if opening.failure == nil {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .help(localized("Reading from \(opening.host)…"))
+                }
+                Spacer()
+                InspectorDetailChromeButtons()
+            }
+            .padding(.leading, 20)
+            .padding(.trailing, 12)
+            .frame(height: 32)
+            .modifier(DetailHeaderTitlebarInset())
+            .background(Color(nsColor: settings.terminalBackgroundColor))
+
+            if let failure = opening.failure {
+                PaneEmptyState(
+                    localized("Can’t open \(opening.name)"),
+                    icon: .fileQuestion,
+                    message: failure
+                )
+            } else {
+                // Empty, not a second spinner: the header already says the file
+                // is on its way, and a small file lands inside a frame or two.
+                Color.clear
+            }
+        }
+        .background(Color(nsColor: settings.terminalBackgroundColor).ignoresSafeArea())
     }
 }
 
@@ -603,6 +824,17 @@ private struct RemoteFileRow: View {
                 .font(font)
                 .lineLimit(1)
                 .truncationMode(.middle)
+            // A folder waiting on its listing draws as an empty folder, which is
+            // the one thing it is not. Only while there is nothing to show:
+            // a folder opened from a prefetch has its rows and says nothing.
+            if node.isLoading {
+                // No `scaleEffect`: a continuously animating layer under a
+                // transform re-rasterizes every frame, which is how the working
+                // indicator beachballed the sidebar once already.
+                ProgressView()
+                    .controlSize(.mini)
+                    .padding(.leading, 2)
+            }
         }
         .padding(.vertical, 2)
         .padding(.leading, -6)

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -102,6 +102,7 @@ struct TerminalPane: View {
                 store.openDiff = nil
             } else {
                 store.openFileURL = nil
+                store.cancelRemoteFileOpen()
                 store.openIssueDetail = nil
             }
             requestSelectedTerminalFocus(reason: .overlayClosed)
@@ -275,6 +276,7 @@ struct TerminalPane: View {
                 return store.selectedSessionID == id
                     && store.visiblePaneIDs.contains(id)
                     && store.openFileURL == nil
+                    && store.openingRemoteFile == nil
                     && store.openDiff == nil
                     && store.paletteMode == nil
             }
@@ -294,6 +296,7 @@ struct TerminalPane: View {
                 return store.selectedSessionID == id
                     && store.visiblePaneIDs.contains(id)
                     && store.openFileURL == nil
+                    && store.openingRemoteFile == nil
                     && store.openDiff == nil
                     && store.paletteMode == nil
             },

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -398,6 +398,9 @@ extension Termiod {
         /// and not worth holding for a pane nobody has looked at since lunch.
         /// Paying 32 ms again after two idle minutes is the right trade; holding
         /// a process on someone's VPS indefinitely is not.
+        ///
+        /// A pane that is *on screen* is the case this clock gets wrong, and
+        /// `pin` is the exemption for it (see `ChannelPin`).
         static let idleTimeout = Duration.seconds(120)
 
         private static let lock = NSLock()
@@ -405,6 +408,10 @@ extension Termiod {
         /// lock is what makes this safe and the compiler cannot see that.
         nonisolated(unsafe) private static var channels: [Key: PooledChannel] = [:]
         nonisolated(unsafe) private static var reaper: DispatchSourceTimer?
+        /// How many pins each key is holding. A count rather than a flag: two
+        /// panes on one device must not have the first one closed to unpin the
+        /// second's connection.
+        nonisolated(unsafe) private static var pins: [Key: Int] = [:]
 
         /// A channel to `route`, opening one if none is live. Blocking; call it
         /// off the main thread.
@@ -442,6 +449,120 @@ extension Termiod {
             return opened
         }
 
+        /// Holds the channel to `route` open, and re-opens it in the background
+        /// when it dies, for as long as the returned pin is retained.
+        ///
+        /// The idle clock above is written for a pane nobody is looking at. A
+        /// pane that is **on screen** is the opposite case: its next click is
+        /// seconds away, and making that click pay the 32 ms median / 260 ms p90
+        /// of an SSH channel open plus a remote `termiod` exec is the difference
+        /// between a file tree that answers and one that thinks. VS Code Remote
+        /// never pays it after the first connect — its server is one process held
+        /// for the window's lifetime — and this is the same bargain, scoped to a
+        /// visible pane so an unwatched device still gets hung up.
+        ///
+        /// The re-open is what makes it a *warm* connection rather than merely an
+        /// unreaped one: `ControlPersist` expiring, a laptop waking or a VPS
+        /// rebooting all leave a corpse behind, and finding that out on the user's
+        /// first click costs exactly what the pin exists to avoid. It only ever
+        /// runs when there is no live channel, so the steady state is free.
+        static func pin(route: TermiodRoute, caps: [String]) -> ChannelPin {
+            ChannelPin(route: route, caps: caps)
+        }
+
+        /// A pin's claim on one key, released when it deinits.
+        ///
+        /// `@unchecked Sendable` on the same terms as `PooledChannel`: the timer
+        /// fires on a utility queue, and the backoff state it touches is behind
+        /// `backoffLock`.
+        final class ChannelPin: @unchecked Sendable {
+            private let key: Key
+            private let route: TermiodRoute
+            private let caps: [String]
+            private let timer: DispatchSourceTimer
+            private let backoffLock = NSLock()
+            /// Consecutive failed re-opens, which push the next attempt out. A
+            /// device that is off does not want a fresh `ssh` every 20 seconds
+            /// for as long as its pane is open.
+            private var failures = 0
+            private var nextAttempt = ContinuousClock.now
+
+            /// Slower than the reaper: this is insurance against a connection
+            /// that died between clicks, not a heartbeat the protocol needs.
+            static let interval = Duration.seconds(20)
+            static let backoffCeiling = Duration.seconds(300)
+
+            fileprivate init(route: TermiodRoute, caps: [String]) {
+                self.key = Key(route: route, capabilities: caps.sorted())
+                self.route = route
+                self.caps = caps
+                self.timer = DispatchSource.makeTimerSource(
+                    queue: DispatchQueue.global(qos: .utility))
+                ControlPool.retain(key)
+                let seconds = Double(ChannelPin.interval.components.seconds)
+                timer.schedule(deadline: .now() + seconds, repeating: seconds)
+                timer.setEventHandler { [weak self] in self?.warm() }
+                timer.resume()
+            }
+
+            deinit {
+                timer.cancel()
+                ControlPool.release(key)
+            }
+
+            /// Re-opens the channel if it is gone. Runs on a utility queue, and
+            /// never on the click path — by the time a click asks, this has
+            /// already paid for it.
+            private func warm() {
+                if ControlPool.hasLiveChannel(key) {
+                    backoffLock.withLock { failures = 0 }
+                    return
+                }
+                let due = backoffLock.withLock { ContinuousClock.now >= nextAttempt }
+                guard due else { return }
+                do {
+                    _ = try ControlPool.channel(route: route, caps: caps)
+                    backoffLock.withLock { failures = 0 }
+                } catch {
+                    let attempt = backoffLock.withLock { () -> Int in
+                        failures += 1
+                        let backoff = min(
+                            ChannelPin.interval * Double(1 << min(failures, 4)),
+                            ChannelPin.backoffCeiling)
+                        nextAttempt = .now.advanced(by: backoff)
+                        return failures
+                    }
+                    Log.termiod.debug("""
+                    warming \(self.route.description, privacy: .public) failed \
+                    (\(attempt, privacy: .public)): \
+                    \(String(describing: error), privacy: .public)
+                    """)
+                }
+            }
+        }
+
+        private static func retain(_ key: Key) {
+            lock.lock()
+            pins[key, default: 0] += 1
+            lock.unlock()
+        }
+
+        private static func release(_ key: Key) {
+            lock.lock()
+            if let count = pins[key] {
+                if count <= 1 { pins.removeValue(forKey: key) } else { pins[key] = count - 1 }
+            }
+            lock.unlock()
+        }
+
+        private static func hasLiveChannel(_ key: Key) -> Bool {
+            lock.lock()
+            let channel = channels[key]
+            lock.unlock()
+            guard let channel else { return false }
+            return !channel.isDead
+        }
+
         /// Hangs up every channel to `route`, or the whole pool when `route` is
         /// nil, so the next request opens fresh rather than waiting on a pipe
         /// whose far end is gone.
@@ -471,16 +592,23 @@ extension Termiod {
             let timer = DispatchSource.makeTimerSource(
                 queue: DispatchQueue.global(qos: .utility))
             timer.schedule(deadline: .now() + 30, repeating: 30)
-            timer.setEventHandler { reap() }
+            timer.setEventHandler { reap(idleTimeout: idleTimeout) }
             reaper = timer
             timer.resume()
         }
 
-        private static func reap() {
+        /// - Parameter idleTimeout: how long unused is too long. A parameter only
+        ///   so a test can hand it a threshold every idle channel is already past
+        ///   — the pin's whole effect is what this method does *not* hang up, and
+        ///   waiting two minutes to see it is not a test.
+        static func reap(idleTimeout: Duration) {
             lock.lock()
             var expired: [PooledChannel] = []
+            // A pinned key is exempt from the idle clock but not from death: a
+            // channel whose pipe is gone is removed here as it always was, and
+            // the pin's own timer is what opens its replacement.
             for (key, channel) in channels
-            where channel.isDead || channel.idleDuration > idleTimeout {
+            where channel.isDead || (pins[key] == nil && channel.idleDuration > idleTimeout) {
                 expired.append(channel)
                 channels.removeValue(forKey: key)
             }

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -241,7 +241,15 @@ final class TermioStore: ObservableObject {
                     remotePreviewLease = nil
                     openFileDisplayName = nil
                 }
+                openFileDirty = false
             }
+            // Whatever put a file on screen — or took one off it — settles the
+            // question the placeholder was asking, and ends the download behind
+            // it. The generation guard already stops a late reply from
+            // presenting itself; this stops it from crossing the network at all.
+            // Cancelling the task that is *doing* the presenting is harmless:
+            // the download is over by then, and the cache was written first.
+            if oldValue != openFileURL { cancelRemoteFileOpen() }
             if openFileURL != nil { openDiff = nil; openIssueDetail = nil; noteDetailOpened() }
             // Closing always returns to the editable default; a read-only open re-asserts the flag
             // immediately before setting the URL (see `openTerminalLink`). The jump line clears too,
@@ -277,6 +285,30 @@ final class TermioStore: ObservableObject {
     /// False for files staged from an SSH host. HTML/SVG must then open as
     /// read-only source rather than executing in the local web preview.
     @Published var openFileAllowsActiveWebContent = true
+
+    /// The file on another machine that a click has asked for and whose bytes
+    /// have not landed yet, or `nil` when nothing is on its way.
+    ///
+    /// A remote open is a round trip, and until this existed the click spent it
+    /// showing whatever was already on screen: no chrome, no name, no sign the
+    /// app had heard the click at all. The overlay now goes up on the click and
+    /// the content fills in, which is what makes a device's tree feel like the
+    /// local one — the wire is the same speed either way.
+    @Published private(set) var openingRemoteFile: RemoteFileOpening? {
+        didSet {
+            if openingRemoteFile != nil { openDiff = nil; openIssueDetail = nil; noteDetailOpened() }
+            refreshDetailPresentation()
+        }
+    }
+
+    /// Whether the open file has edits the editor has not written yet, reported
+    /// by `FileEditorView`. Read by the remote open path, which must never
+    /// replace a buffer somebody is typing into (see `openRemoteFile`).
+    @Published var openFileDirty = false
+
+    /// The in-flight remote read. Held so the next open — or the close — ends it
+    /// rather than leaving a download running for a file nobody will see.
+    private var remoteOpenTask: Task<Void, Never>?
 
     /// A monotonically increasing guard for asynchronous remote downloads. Any
     /// local open/close/replacement invalidates a pending remote presentation.
@@ -369,7 +401,8 @@ final class TermioStore: ObservableObject {
     /// Recomputes `isDetailPresented` from the three detail properties and drops the maximize
     /// state once nothing is left to show. Called from each detail setter's `didSet`.
     private func refreshDetailPresentation() {
-        let presented = openFileURL != nil || openDiff != nil || openIssueDetail != nil
+        let presented = openFileURL != nil || openingRemoteFile != nil
+            || openDiff != nil || openIssueDetail != nil
         if isDetailPresented != presented { isDetailPresented = presented }
         if !presented {
             if inspectorMaximized { inspectorMaximized = false }
@@ -1764,6 +1797,119 @@ final class TermioStore: ObservableObject {
         openFileLine = line
         openFileURL = lease.fileURL
         return true
+    }
+
+    /// Opens a file that lives on another machine: the overlay goes up on the
+    /// click, and the bytes fill it in when they land.
+    ///
+    /// The single path both the device's file tree and its content search open
+    /// through, because the interesting part is the same for both and easy to
+    /// get subtly different twice. Three things happen in order:
+    ///
+    /// 1. **The click is answered immediately.** `openingRemoteFile` puts the
+    ///    file's own chrome on screen for the whole round trip. This is the whole
+    ///    difference between a device tree that feels local and one that looks
+    ///    broken: the wire was never the slow part, the silence was.
+    /// 2. **A cached copy is shown at once** when this file has been read before,
+    ///    so going back to a file you just closed costs nothing.
+    /// 3. **The device is asked anyway.** A cache that answered on its own would
+    ///    be wrong the moment an agent touched the file, which here is constantly.
+    ///    The reply replaces what is on screen only when it actually differs and
+    ///    nobody has started typing into it.
+    func openRemoteFile(
+        path: String, name: String, provider: DeviceFileProvider, host: String,
+        at line: Int? = nil
+    ) {
+        let key = RemoteFileContentCache.Key(
+            route: provider.route, root: provider.root, path: path)
+        // Explicitly, not through `openFileURL`'s `didSet`: a second click while
+        // the first file is still on its way never changes that URL, and the
+        // first download would otherwise run on.
+        cancelRemoteFileOpen()
+        openFileURL = nil
+        openingRemoteFile = RemoteFileOpening(name: name, host: host)
+
+        let cached = RemoteFileContentCache.entry(for: key)
+        if let cached {
+            _ = presentRemoteFile(
+                cached.data, mtime: cached.mtime, name: name, path: path,
+                provider: provider, host: host, at: line)
+        }
+        // After the cached present, which bumps the generation itself.
+        let generation = filePresentationGeneration
+        remoteOpenTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let file = try await provider.read(
+                    path, limit: Termiod.filePreviewByteLimit)
+                try Task.checkCancellation()
+                // Before presenting, so the cache is written even for the open
+                // that gets cancelled by the presentation it is performing.
+                RemoteFileContentCache.store(
+                    .init(data: file.data, mtime: file.mtime), for: key)
+                guard generation == self.filePresentationGeneration else { return }
+                if let cached {
+                    // The device agrees with what is already on screen, or the
+                    // person has started typing into it. Either way, rebuilding
+                    // the editor under them would be the wrong answer.
+                    guard file.data != cached.data, !self.openFileDirty else { return }
+                }
+                _ = self.presentRemoteFile(
+                    file.data, mtime: file.mtime, name: name, path: path,
+                    provider: provider, host: host, at: line)
+            } catch is CancellationError {
+                return
+            } catch {
+                Log.files.error("""
+                device read \(host, privacy: .public):\(path, privacy: .public): \
+                \(String(describing: error), privacy: .public)
+                """)
+                // A failed revalidation of bytes already on screen is not the
+                // user's problem — what they are reading is still what the
+                // device last said.
+                guard cached == nil, generation == self.filePresentationGeneration else { return }
+                self.openingRemoteFile = RemoteFileOpening(
+                    name: name, host: host,
+                    failure: RemoteFileFailure.message(for: error))
+            }
+        }
+    }
+
+    /// Stages one device file locally and puts it on screen. Shared by the first
+    /// present and the revalidation that may replace it.
+    private func presentRemoteFile(
+        _ data: Data, mtime: UInt64, name: String, path: String,
+        provider: DeviceFileProvider, host: String, at line: Int?
+    ) -> Bool {
+        do {
+            let lease = try RemotePreviewStorage.stage(data, named: name)
+            return presentRemoteFilePreview(
+                lease, expectedGeneration: filePresentationGeneration, at: line,
+                origin: RemoteDocument(
+                    route: provider.route, root: provider.root, path: path,
+                    mtime: mtime, host: host))
+        } catch {
+            Log.files.error("""
+            staging \(host, privacy: .public):\(path, privacy: .public): \
+            \(String(describing: error), privacy: .public)
+            """)
+            // Only when this open has nothing on screen yet. A revalidation that
+            // failed to stage its replacement leaves the copy already being read
+            // alone rather than covering it with an error about bytes the reader
+            // never asked for.
+            if openFileURL == nil {
+                openingRemoteFile = RemoteFileOpening(
+                    name: name, host: host, failure: RemoteFileFailure.message(for: error))
+            }
+            return false
+        }
+    }
+
+    /// Ends a remote open in flight and takes its placeholder down.
+    func cancelRemoteFileOpen() {
+        remoteOpenTask?.cancel()
+        remoteOpenTask = nil
+        if openingRemoteFile != nil { openingRemoteFile = nil }
     }
 
     /// The working directory of the selected session (its worktree, else the project root), used as

--- a/Tests/termioTests/RemoteFileOpenIntegrationTests.swift
+++ b/Tests/termioTests/RemoteFileOpenIntegrationTests.swift
@@ -1,0 +1,299 @@
+import XCTest
+import TermioShared
+@testable import termio
+
+/// Opening a device's file, against a real daemon.
+///
+/// Opt-in on the same terms as `TermiodFilesIntegrationTests`: point
+/// `TERMIO_TERMIOD_TEST_BIN` at a built `termiod` and it runs, otherwise it
+/// skips. It is the whole path — click, placeholder, read, present — because the
+/// interesting claims are about *when* things are on screen, and only a real
+/// round trip has a "before it answers" to look at.
+@MainActor
+final class RemoteFileOpenIntegrationTests: XCTestCase {
+    private var daemon: Process?
+    private var directory: URL!
+    private var root: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var store: TermioStore!
+
+    private var provider: DeviceFileProvider {
+        DeviceFileProvider(route: .local, root: root.path)
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        let binary = ProcessInfo.processInfo.environment["TERMIO_TERMIOD_TEST_BIN"] ?? ""
+        try XCTSkipIf(binary.isEmpty, "set TERMIO_TERMIOD_TEST_BIN to run this")
+
+        // Short socket directory name: `sun_path` is capped at 104 bytes.
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("rfo-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let socket = directory.appendingPathComponent("termiod.sock").path
+        XCTAssertLessThan(socket.utf8.count, 104, "socket path must fit sun_path")
+        setenv("TERMIOD_SOCK", socket, 1)
+
+        let serve = Process()
+        serve.executableURL = URL(fileURLWithPath: binary)
+        serve.arguments = ["serve"]
+        serve.environment = ProcessInfo.processInfo.environment.merging(
+            ["TERMIOD_SOCK": socket]) { _, new in new }
+        serve.standardOutput = FileHandle.nullDevice
+        serve.standardError = FileHandle.nullDevice
+        try serve.run()
+        daemon = serve
+        let deadline = Date().addingTimeInterval(10)
+        while !FileManager.default.fileExists(atPath: socket), Date() < deadline {
+            usleep(50_000)
+        }
+
+        root = directory.appendingPathComponent("workspace", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("sub/deep", isDirectory: true),
+            withIntermediateDirectories: true)
+        try Data("first\n".utf8).write(to: root.appendingPathComponent("a.txt"))
+        try Data("x\n".utf8).write(to: root.appendingPathComponent("sub/b.txt"))
+        try Data("y\n".utf8).write(to: root.appendingPathComponent("sub/deep/c.txt"))
+
+        suiteName = "remote-open-\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let settings = AppSettings(
+            defaults: defaults,
+            settingsStore: SettingsStore(
+                defaults: defaults,
+                fileURL: directory.appendingPathComponent("settings.json"),
+                domainName: suiteName))
+        store = TermioStore(workspaces: [Workspace(name: "Default")], settings: settings)
+    }
+
+    override func tearDown() async throws {
+        store?.openFileURL = nil
+        store = nil
+        RemoteFileContentCache.clear()
+        // The pool is process-wide, so a channel left open here would be handed
+        // to the next test — pointed at a daemon this one is about to kill.
+        Termiod.ControlPool.closeAll()
+        daemon?.terminate()
+        daemon?.waitUntilExit()
+        defaults?.removePersistentDomain(forName: suiteName)
+        if let directory { try? FileManager.default.removeItem(at: directory) }
+        unsetenv("TERMIOD_SOCK")
+        try await super.tearDown()
+    }
+
+    private var filePath: String { root.appendingPathComponent("a.txt").path }
+
+    private func openedText() -> String? {
+        guard let url = store.openFileURL, let data = try? Data(contentsOf: url) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Polls the main actor until `condition` holds. The thing under test is an
+    /// async round trip, and every assertion here is about what is true before
+    /// or after it lands.
+    private func settle(
+        _ description: String, within seconds: Double = 10,
+        until condition: () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(seconds))
+        while !condition() {
+            if ContinuousClock.now > deadline { return XCTFail("timed out waiting for \(description)") }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+
+    /// The fix this exists for: the click puts the file's chrome on screen before
+    /// the device has said anything. Until it did, a remote open spent its whole
+    /// round trip showing the previous file — a click with no answer.
+    func testTheOverlayIsUpBeforeTheDeviceAnswers() async throws {
+        store.openRemoteFile(
+            path: filePath, name: "a.txt", provider: provider, host: "test-box")
+
+        XCTAssertEqual(store.openingRemoteFile?.name, "a.txt", "answered in the same turn")
+        XCTAssertEqual(store.openingRemoteFile?.host, "test-box")
+        XCTAssertNil(store.openingRemoteFile?.failure)
+        XCTAssertNil(store.openFileURL, "the bytes cannot possibly be here yet")
+        XCTAssertTrue(store.isDetailPresented, "and the overlay counts as presented")
+
+        try await settle("the file to land") { store.openFileURL != nil }
+
+        XCTAssertNil(store.openingRemoteFile, "the editor takes the placeholder's place")
+        XCTAssertEqual(openedText(), "first\n")
+        XCTAssertEqual(store.openFileDisplayName, "a.txt")
+        XCTAssertEqual(store.openFileRemote?.path, filePath)
+        XCTAssertEqual(store.openFileRemote?.host, "test-box")
+        XCTAssertFalse(store.openFileReadOnly, "a file with an origin can be saved back")
+    }
+
+    /// A file read once opens from memory the second time — no placeholder at
+    /// all, because there is nothing to wait for.
+    func testReopeningAFileIsInstant() async throws {
+        store.openRemoteFile(
+            path: filePath, name: "a.txt", provider: provider, host: "test-box")
+        try await settle("the first read") { store.openFileURL != nil }
+        store.openFileURL = nil
+
+        store.openRemoteFile(
+            path: filePath, name: "a.txt", provider: provider, host: "test-box")
+
+        XCTAssertNotNil(store.openFileURL, "shown in the same turn as the click")
+        XCTAssertNil(store.openingRemoteFile)
+        XCTAssertEqual(openedText(), "first\n")
+    }
+
+    /// And is still checked. Agents rewrite files constantly, so what the cache
+    /// removes is the wait, never the read: the stale copy goes up at once and
+    /// the device's answer replaces it.
+    func testAStaleCopyIsShownAtOnceAndThenCorrected() async throws {
+        store.openRemoteFile(
+            path: filePath, name: "a.txt", provider: provider, host: "test-box")
+        try await settle("the first read") { store.openFileURL != nil }
+        store.openFileURL = nil
+        try Data("second\n".utf8).write(to: root.appendingPathComponent("a.txt"))
+
+        store.openRemoteFile(
+            path: filePath, name: "a.txt", provider: provider, host: "test-box")
+        XCTAssertEqual(openedText(), "first\n", "the copy in hand, immediately")
+
+        try await settle("the device to correct it") { openedText() == "second\n" }
+        XCTAssertNil(store.openingRemoteFile)
+    }
+
+    /// Except into a buffer somebody is typing in. The revalidation rebuilds the
+    /// editor, so a swap under an unsaved edit would be the app throwing away
+    /// what the user just wrote.
+    func testAnEditedBufferIsNeverReplacedUnderTheUser() async throws {
+        store.openRemoteFile(
+            path: filePath, name: "a.txt", provider: provider, host: "test-box")
+        try await settle("the first read") { store.openFileURL != nil }
+        store.openFileURL = nil
+        try Data("second\n".utf8).write(to: root.appendingPathComponent("a.txt"))
+
+        store.openRemoteFile(
+            path: filePath, name: "a.txt", provider: provider, host: "test-box")
+        let staged = store.openFileURL
+        // The editor reports this on the keystroke itself, well before its
+        // debounced write — which is the point: the bytes on disk still look
+        // untouched at this moment.
+        store.openFileDirty = true
+
+        try await settle("the read to land") {
+            RemoteFileContentCache.entry(for: RemoteFileContentCache.Key(
+                route: .local, root: root.path, path: filePath))?.mtime ?? 0 > 0
+                && openedText() != nil
+        }
+        // Long enough that a swap would have happened if one were coming.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        XCTAssertEqual(store.openFileURL, staged, "the same buffer is still open")
+        XCTAssertEqual(openedText(), "first\n", "with what was in it")
+    }
+
+    /// A file that cannot be read says so in the overlay the click opened, rather
+    /// than in a modal the click has to be dismissed out of — and rather than
+    /// nowhere, which is what an overlay that quietly vanished would be.
+    func testAFailedReadIsReportedInTheOverlay() async throws {
+        store.openRemoteFile(
+            path: root.appendingPathComponent("missing.txt").path, name: "missing.txt",
+            provider: provider, host: "test-box")
+
+        try await settle("the refusal") { store.openingRemoteFile?.failure != nil }
+
+        XCTAssertNil(store.openFileURL)
+        XCTAssertEqual(store.openingRemoteFile?.name, "missing.txt")
+        XCTAssertTrue(store.isDetailPresented, "the click's answer stays on screen")
+    }
+
+    /// A second click while the first file is still crossing the network wins,
+    /// however slow the loser turns out to be.
+    func testTheLatestClickIsTheOneThatOpens() async throws {
+        try Data("other\n".utf8).write(to: root.appendingPathComponent("b.txt"))
+
+        store.openRemoteFile(
+            path: filePath, name: "a.txt", provider: provider, host: "test-box")
+        store.openRemoteFile(
+            path: root.appendingPathComponent("b.txt").path, name: "b.txt",
+            provider: provider, host: "test-box")
+
+        XCTAssertEqual(store.openingRemoteFile?.name, "b.txt")
+        try await settle("the second file") { store.openFileURL != nil }
+        XCTAssertEqual(openedText(), "other\n")
+        XCTAssertEqual(store.openFileDisplayName, "b.txt")
+    }
+
+    /// The tree and the search open through one path, so a hit's line survives
+    /// into the editor the same way it always did.
+    func testASearchHitOpensAtItsLine() async throws {
+        store.openRemoteFile(
+            path: filePath, name: "a.txt", provider: provider, host: "test-box", at: 3)
+
+        try await settle("the file") { store.openFileURL != nil }
+        XCTAssertEqual(store.openFileLine, 3)
+    }
+
+    // MARK: - The tree
+
+    private func tree() -> RemoteFileBrowserModel {
+        RemoteFileBrowserModel(
+            checkout: Checkout(device: .thisMac, root: root.path), root: root.path)
+    }
+
+    private var subPath: String { root.appendingPathComponent("sub").path }
+
+    /// Expanding a folder used to be a round trip the user watched. The folders
+    /// on screen are the ones about to be clicked, so they are asked for while
+    /// nobody is waiting — and the click that follows opens from what came back,
+    /// in the same turn it happened.
+    func testAFolderOpensFromWhatWasFetchedAheadOfTheClick() async throws {
+        let tree = tree()
+        tree.refresh()
+        try await settle("the root listing") { !tree.rootNodes.isEmpty }
+        try await settle("the folders under it to be fetched ahead") {
+            tree.prefetchedPaths().contains(subPath)
+        }
+
+        // The first touch of `children` is the expand. It must answer with rows,
+        // not with an empty folder and a promise.
+        let node = try XCTUnwrap(tree.node(at: subPath))
+        XCTAssertEqual(node.children?.map(\.name), ["deep", "b.txt"])
+        XCTAssertFalse(node.isLoading, "nothing to wait for, so nothing to say")
+        XCTAssertTrue(tree.loadedDirectories().contains(subPath))
+        XCTAssertFalse(tree.prefetchedPaths().contains(subPath), "the guess was spent")
+    }
+
+    /// A guess is shown, never trusted: the folder is asked for again as it
+    /// opens, so one that changed since is right a round trip later instead of
+    /// staying wrong until the next app focus.
+    func testAnOpenedFolderIsStillAskedForAgain() async throws {
+        let tree = tree()
+        tree.refresh()
+        try await settle("the root listing") { !tree.rootNodes.isEmpty }
+        try await settle("the folders under it to be fetched ahead") {
+            tree.prefetchedPaths().contains(subPath)
+        }
+        try Data("z\n".utf8).write(to: root.appendingPathComponent("sub/new.txt"))
+
+        let node = try XCTUnwrap(tree.node(at: subPath))
+        XCTAssertEqual(node.children?.map(\.name), ["deep", "b.txt"], "the guess, as it stood")
+
+        try await settle("the device's own answer") {
+            node.children?.map(\.name) == ["deep", "b.txt", "new.txt"]
+        }
+    }
+
+    /// And opening it fetches the level below, so walking down a path is one
+    /// wait at the top rather than one at every step.
+    func testOpeningAFolderFetchesTheLevelBelowIt() async throws {
+        let tree = tree()
+        tree.refresh()
+        try await settle("the root listing") { !tree.rootNodes.isEmpty }
+        try await settle("the first level") { tree.prefetchedPaths().contains(subPath) }
+        _ = tree.node(at: subPath)?.children
+
+        try await settle("the level below it") {
+            tree.prefetchedPaths().contains(root.appendingPathComponent("sub/deep").path)
+        }
+    }
+}

--- a/Tests/termioTests/RemoteFileOpenTests.swift
+++ b/Tests/termioTests/RemoteFileOpenTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+import TermioShared
+@testable import termio
+
+/// What a click on a device's file does before the network answers, and what the
+/// answer is allowed to do to what is already on screen.
+///
+/// The pieces here need no device: the cache is a dictionary with an eviction
+/// rule, and the tree's ordering is a pure function of a listing. The round trip
+/// itself is covered against a real daemon in `TermiodFilesIntegrationTests`.
+@MainActor
+final class RemoteFileOpenTests: XCTestCase {
+    private let root = "/srv/api"
+
+    override func tearDown() async throws {
+        RemoteFileContentCache.clear()
+        try await super.tearDown()
+    }
+
+    private func key(_ path: String) -> RemoteFileContentCache.Key {
+        RemoteFileContentCache.Key(route: .ssh("test-box"), root: root, path: path)
+    }
+
+    private func entry(_ bytes: Int, mtime: UInt64 = 1) -> RemoteFileContentCache.Entry {
+        RemoteFileContentCache.Entry(data: Data(repeating: 0x61, count: bytes), mtime: mtime)
+    }
+
+    // MARK: - The cache
+
+    /// The point of the thing: bytes read once are there the second time, with
+    /// the version they were read at — a save from the reopened copy has to be
+    /// able to say what it is replacing.
+    func testAFileReadOnceIsThereTheSecondTime() {
+        RemoteFileContentCache.store(entry(4, mtime: 99), for: key("\(root)/a.swift"))
+
+        let cached = RemoteFileContentCache.entry(for: key("\(root)/a.swift"))
+
+        XCTAssertEqual(cached?.data.count, 4)
+        XCTAssertEqual(cached?.mtime, 99)
+        XCTAssertNil(RemoteFileContentCache.entry(for: key("\(root)/b.swift")),
+                     "a file nobody read is not in it")
+    }
+
+    /// Two machines can hold the same path, and a checkout can be browsed from
+    /// two roots. Neither may answer for the other.
+    func testTheSamePathOnAnotherDeviceIsAnotherEntry() {
+        RemoteFileContentCache.store(entry(4), for: key("\(root)/a.swift"))
+
+        let elsewhere = RemoteFileContentCache.Key(
+            route: .ssh("other-box"), root: root, path: "\(root)/a.swift")
+
+        XCTAssertNil(RemoteFileContentCache.entry(for: elsewhere))
+    }
+
+    /// Least recently *used*, not least recently stored: reading an entry back
+    /// is what keeps it, or browsing away and back would evict the file you keep
+    /// returning to.
+    func testTheLeastRecentlyUsedEntryIsTheOneEvicted() {
+        for index in 0 ..< RemoteFileContentCache.capacity {
+            RemoteFileContentCache.store(entry(1), for: key("\(root)/file\(index)"))
+        }
+        // Touch the oldest, so the second-oldest becomes the eviction candidate.
+        XCTAssertNotNil(RemoteFileContentCache.entry(for: key("\(root)/file0")))
+
+        RemoteFileContentCache.store(entry(1), for: key("\(root)/extra"))
+
+        XCTAssertNotNil(RemoteFileContentCache.entry(for: key("\(root)/file0")),
+                        "the one just read stays")
+        XCTAssertNil(RemoteFileContentCache.entry(for: key("\(root)/file1")),
+                     "the one nobody has touched since goes")
+    }
+
+    /// A cache of whole file contents has to answer for its memory: a few large
+    /// files must not hold megabytes for the life of the process.
+    func testABigFileEvictsUntilTheBudgetIsMet() {
+        let big = RemoteFileContentCache.byteBudget / 2 + 1
+        RemoteFileContentCache.store(entry(big), for: key("\(root)/one"))
+        RemoteFileContentCache.store(entry(big), for: key("\(root)/two"))
+
+        XCTAssertNil(RemoteFileContentCache.entry(for: key("\(root)/one")))
+        XCTAssertNotNil(RemoteFileContentCache.entry(for: key("\(root)/two")))
+    }
+
+    /// A file read again at a new version replaces the old bytes rather than
+    /// stacking beside them.
+    func testRereadingAFileReplacesWhatWasHeldForIt() {
+        RemoteFileContentCache.store(entry(4, mtime: 1), for: key("\(root)/a.swift"))
+        RemoteFileContentCache.store(entry(9, mtime: 2), for: key("\(root)/a.swift"))
+
+        let cached = RemoteFileContentCache.entry(for: key("\(root)/a.swift"))
+        XCTAssertEqual(cached?.data.count, 9)
+        XCTAssertEqual(cached?.mtime, 2)
+    }
+
+    // MARK: - The rows
+
+    private func model() -> RemoteFileBrowserModel {
+        RemoteFileBrowserModel(
+            checkout: Checkout(
+                device: KnownDevice(alias: "test-box", deviceID: nil), root: root),
+            root: root)
+    }
+
+    /// The host sorts a listing by name and hides nothing — its job is a stable
+    /// page order, not a browser's. The tree wears the local explorer's rule
+    /// instead, or one checkout reads two different ways depending on which
+    /// machine it is on.
+    func testTheTreeOrdersAndHidesWhatTheLocalExplorerDoes() {
+        let tree = model()
+        tree.apply([Termiod.DirectoryListing(
+            path: root,
+            entries: [
+                FileEntry(name: ".git", kind: .directory),
+                FileEntry(name: ".DS_Store", kind: .file),
+                FileEntry(name: "README.md", kind: .file),
+                FileEntry(name: "src", kind: .directory),
+                FileEntry(name: "Package.swift", kind: .file),
+                FileEntry(name: "docs", kind: .directory),
+            ],
+            error: nil)])
+
+        XCTAssertEqual(
+            tree.rootNodes.map(\.name), ["docs", "src", "Package.swift", "README.md"],
+            "folders first, each group alphabetized, VCS and OS metadata dropped")
+    }
+}

--- a/Tests/termioTests/TermiodFilesIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFilesIntegrationTests.swift
@@ -614,6 +614,57 @@ final class TermiodFilesIntegrationTests: XCTestCase {
         }
         XCTAssertEqual(attempts, 1, "a request that heard part of its answer is not replayed")
     }
+
+    /// The idle reaper hangs up a connection nobody has used, which is right for
+    /// a device nobody is looking at and wrong for a pane that is on screen: its
+    /// next click is seconds away, and rebuilding the connection for it is the
+    /// 32 ms median / 260 ms p90 the pool exists to stop paying.
+    func testAPinnedChannelSurvivesTheIdleReaper() throws {
+        let channel = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
+        let pin = Termiod.ControlPool.pin(route: .local, caps: ["files"])
+
+        // A threshold every idle channel is already past, so only the exemption
+        // can be what keeps this one.
+        Termiod.ControlPool.reap(idleTimeout: .seconds(-1))
+
+        let held = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
+        XCTAssertTrue(channel === held, "a pinned channel is not hung up for being idle")
+
+        withExtendedLifetime(pin) {}
+    }
+
+    /// And goes back on the clock when the pane does: a pin is a claim, not a
+    /// promotion. Holding somebody's VPS process open for a pane that closed an
+    /// hour ago is the cost this trade was only ever worth paying while looking.
+    func testAReleasedPinPutsTheChannelBackOnTheIdleClock() throws {
+        let channel = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
+        var pin: Termiod.ControlPool.ChannelPin? =
+            Termiod.ControlPool.pin(route: .local, caps: ["files"])
+        XCTAssertNotNil(pin)
+        pin = nil
+
+        Termiod.ControlPool.reap(idleTimeout: .seconds(-1))
+
+        let replacement = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
+        XCTAssertFalse(channel === replacement, "the unpinned channel was hung up")
+    }
+
+    /// Two panes on one device is one connection with two claims on it. The
+    /// first one to close must not take the second one's connection with it.
+    func testTwoPinsOnOneDeviceAreCountedNotFlagged() throws {
+        let channel = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
+        var first: Termiod.ControlPool.ChannelPin? =
+            Termiod.ControlPool.pin(route: .local, caps: ["files"])
+        let second = Termiod.ControlPool.pin(route: .local, caps: ["files"])
+        XCTAssertNotNil(first)
+        first = nil
+
+        Termiod.ControlPool.reap(idleTimeout: .seconds(-1))
+
+        let held = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
+        XCTAssertTrue(channel === held, "the pane still open keeps the connection")
+        withExtendedLifetime(second) {}
+    }
 }
 
 /// A box for handing a result back from a detached queue in a test. The values


### PR DESCRIPTION
Opening a file on another machine was a round trip spent showing nothing: the row cleared its own selection and the previously open file stayed up until the bytes landed. The wire was never the slow part — the silence was.

The overlay now goes up on the click and the content fills it in, through one open path (`TermioStore.openRemoteFile`) shared by the device's file tree and its content search, so the placeholder, the cache and the cancellation behave the same however a file was clicked. A failure is reported in that overlay rather than in a modal the click has to be dismissed out of.

Around it, the four other things that made a device's tree feel remote:

- **A visible pane pins its channel** (`ControlPool.pin`), so a click seconds later does not pay the 32 ms median / 260 ms p90 of an SSH channel open plus a remote `termiod` exec. The pin re-opens the connection in the background, with backoff, when it dies, and releases it when the pane is hidden.
- **Files read once are held in memory**, so reopening one is instant. Every hit is still revalidated — agents rewrite files constantly, so what the cache removes is the wait, never the read. The reply replaces the buffer only when it differs *and* nothing has been typed into it; `FileEditorView` reports that on the keystroke, ahead of its debounced write.
- **Expanding a folder fetches the folders inside it** in one batched `fs.list`, so walking down a path is one wait at the top rather than one at every step. A guess is shown, never trusted: opening it asks the device for real.
- **A folder waiting on its listing shows a spinner** instead of drawing as an empty folder.

The tree also wears `FileEntry.sortedForTree` now, as the local explorer does. The host sorts a listing by name alone, which put files above folders and left `.git` in the tree — one browser behaving two ways depending on which machine the checkout was on.

## Testing

`swift build` clean, 854 tests green, 16 of them new: cache eviction and tree ordering as unit tests, and ten end-to-end against a real `termiod` (placeholder up before the answer, instant reopen, stale-then-corrected, an edited buffer never replaced, the latest click winning, a prefetched folder adopted synchronously and still re-asked). The pool's pin is covered by three more in `TermiodFilesIntegrationTests`.

Not verified on screen: the placeholder's appearance and the folder spinner.

Release Notes:
- Opening a file on a remote machine now shows the file immediately instead of waiting for the whole download, and reopening one is instant.
- Browsing a remote machine's files is faster: the connection stays warm while the pane is open, and folders are fetched before you click them.
- Remote file trees now sort folders first and hide `.git`, matching the local file tree.