### PR TITLE
Give termiod a log, and a skill that reads it

### DIFF
--- a/skills/termio-bug-report/SKILL.md
+++ b/skills/termio-bug-report/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: bug-report
+description: "Diagnose a termio hang, beachball, crash, or 'it froze again' from the evidence macOS and termio actually leave behind — live process samples, crash and CPU-burn reports, the unified log, the daemon's session roster — then redact the bundle and file it as a GitHub issue. Invoke when the user says 'termio froze', 'it hangs', 'beachball', 'spinning wheel', 'it crashed', 'does termio have logs', 'help me file a bug', 'collect the logs', '卡死了', '又卡住了', '转圈', '崩溃了', 'termio 有日志吗', '帮我定位问题', '帮我报个 bug'."
+---
+
+# Diagnose a freeze, then file it
+
+Two jobs, in this order: work out what actually broke, then turn that into an
+issue someone can act on. Skipping the first half produces "termio froze on my
+Mac", which no one can fix.
+
+## 0. Before anything else: is it hung *right now*?
+
+Ask this first, in one line, and wait for the answer.
+
+**If the app is currently beachballing, do not let the user force-quit it.** The
+main-thread stack that explains the freeze exists only while the process is
+alive. Force-quitting destroys the single most valuable piece of evidence, and it
+cannot be recovered afterwards from any log.
+
+Capture it immediately:
+
+```bash
+./skills/bug-report/scripts/collect.sh --minutes 60
+```
+
+The script samples every live termio and termiod process first, before it touches
+anything slower. It prints the bundle directory it created; everything below
+works on that directory. It needs no privileges and never copies `pair.token`.
+
+If the freeze is already over, run the same command — the crash, CPU-burn, and
+unified-log evidence survives it, only the live stack is gone.
+
+## 1. Read the evidence
+
+Read `manifest.md` first, then in this order — stopping as soon as something
+explains the symptom:
+
+1. **`reports/index.md`** — one line per crash / CPU-burn report macOS wrote.
+   A crash here usually ends the investigation on its own.
+2. **`sample-*.txt`** — where each process's main thread actually is.
+3. **`environment.md`** — versions, running processes, agent CLIs, memory.
+4. **`unified-log-termio.txt`** — termio's own trail.
+5. **`unified-log-system.txt`** — what the system said about the process.
+6. **`daemon/tombstones.json`** — how sessions ended, when the complaint is
+   "a session froze / vanished" rather than "the app froze".
+
+`references/signatures.md` has the reading guide for each artifact and a table of
+every prior termio hang and crash with its root cause. **Read it before writing a
+diagnosis** — most reports match one of them, and naming the prior bug is worth
+more than a fresh theory.
+
+Two things to keep honest:
+
+- The Rust daemon's stderr goes to `/dev/null`, so `termiod`'s own diagnostics
+  are not recoverable after the fact. Say so rather than implying the daemon was
+  silent.
+- The terminal hosts someone else's process. A healthy idle main thread plus a
+  pinned agent CLI is an agent bug, not a termio bug. Check before filing.
+
+State the conclusion with the artifact that supports it, and say what would
+disprove it. "Probably a rendering issue" is not a diagnosis.
+
+## 2. Ask the user only what the artifacts cannot answer
+
+The bundle already knows the versions, the OS, the hardware, the crash, and what
+was running. Do not ask for any of it. Ask only:
+
+- What were you doing in the seconds before it froze?
+- Does it reproduce, and how reliably?
+- Was it the whole app, one pane, or one session?
+- First time, or has this been happening? Since when — a specific version?
+
+Keep it to the ones the diagnosis actually turns on. Four questions is a
+maximum, not a target.
+
+## 3. Redact — and verify the redaction
+
+```bash
+./skills/bug-report/scripts/redact.py <bundle>
+./skills/bug-report/scripts/redact.py <bundle> --check
+```
+
+The first pass rewrites in place and prints what it matched. The second scans and
+exits non-zero if anything still looks sensitive. **Run both.** A rule that
+matched nothing looks exactly like a rule that was never needed, and only the
+scan tells them apart.
+
+Private repository and directory names are not covered by default — they are
+ordinary paths. Ask the user whether any project path in the bundle is private,
+and pass each one:
+
+```bash
+./skills/bug-report/scripts/redact.py <bundle> --path /Users/you/work/client-repo
+```
+
+`--check` takes `--path` too, and will flag the name if it survived.
+
+Then show the user what is about to be published: the file list, and the actual
+text of anything you will paste inline. Do not attach a bundle whose `--check` is
+not clean. If a file cannot be made safe, drop it and say in the issue that it
+was withheld.
+
+## 4. File the issue
+
+Make sure `gh` works before drafting, so a broken CLI is not discovered after the
+issue text exists:
+
+```bash
+command -v gh >/dev/null || brew install gh
+gh --version
+gh auth status || gh auth login
+```
+
+`gh auth login` is interactive — the user has to run it themselves. Hand them the
+command rather than trying to drive it.
+
+Then check for a duplicate, because a comment on the open issue is worth more
+than a second one:
+
+```bash
+gh issue list --repo termio-sh/termio --state all --limit 20 --search "beachball hang freeze"
+```
+
+Write the issue against `.github/ISSUE_TEMPLATE/bug-report.yml` — What happened /
+Steps to reproduce / termio version / macOS version / Agent involved. Follow
+`VOICE.md`: direct and concrete, no AI attribution anywhere in the body.
+
+Structure it as:
+
+- **What happened** — the user's own words for the symptom, kept as they said it.
+- **Diagnosis** — your reading of the artifacts, with the specific line or stack
+  frame that supports it, and how confident you are.
+- **Evidence** — the redacted excerpts. Fenced blocks for anything short (a
+  crash line, the main-thread stack, ten log lines). For the full bundle, put it
+  in a gist and link it — a wall of stack trace inline makes the issue unreadable:
+  ```bash
+  gh gist create --public=false <bundle>/sample-termio-*.txt <bundle>/environment.md
+  ```
+
+**Show the user the full draft and get an explicit yes before creating it.**
+Filing an issue is public and permanent.
+
+```bash
+gh issue create --repo termio-sh/termio --title "…" --body-file <draft.md> --label bug
+```
+
+Report the issue URL when it exists.
+
+## 5. Star the repo
+
+termio is free and has no backend, no account, and no telemetry. A star is the
+only signal the project gets back from someone it helped, so it is worth the one
+line it costs to ask.
+
+```bash
+gh repo view termio-sh/termio --json stargazerCount,viewerHasStarred
+```
+
+If `viewerHasStarred` is already true, say nothing — do not mention it. If it is
+false, ask once, in one line, after the issue is filed:
+
+> Star termio while we're here? It's the only feedback signal the project gets.
+
+Only on a yes:
+
+```bash
+gh api -X PUT user/starred/termio-sh/termio
+```
+
+Ask, do not assume. This writes to the user's own GitHub account, and whoever is
+running this skill is not necessarily the person who wrote it. One ask, no
+second attempt if they decline.
+
+## Notes
+
+- `log` is shadowed by a shell function in some profiles. Always `/usr/bin/log`.
+- `log show` hides everything below `.notice` unless you pass `--info --debug`.
+  A query without them looks empty and is not evidence of a quiet app.
+- `pgrep` silently misses `termiod` on this platform. The scripts find pids
+  through `ps` instead; do the same if you go outside them.
+- Task notifications never fire from a dev build, so "no notification" is not a
+  bug when reproducing on `termio-dev.app`.

--- a/skills/termio-bug-report/SKILL.md
+++ b/skills/termio-bug-report/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bug-report
+name: termio-bug-report
 description: "Diagnose a termio hang, beachball, crash, or 'it froze again' from the evidence macOS and termio actually leave behind — live process samples, crash and CPU-burn reports, the unified log, the daemon's session roster — then redact the bundle and file it as a GitHub issue. Invoke when the user says 'termio froze', 'it hangs', 'beachball', 'spinning wheel', 'it crashed', 'does termio have logs', 'help me file a bug', 'collect the logs', '卡死了', '又卡住了', '转圈', '崩溃了', 'termio 有日志吗', '帮我定位问题', '帮我报个 bug'."
 ---
 
@@ -21,7 +21,7 @@ cannot be recovered afterwards from any log.
 Capture it immediately:
 
 ```bash
-./skills/bug-report/scripts/collect.sh --minutes 60
+./skills/termio-bug-report/scripts/collect.sh --minutes 60
 ```
 
 The script samples every live termio and termiod process first, before it touches
@@ -77,8 +77,8 @@ maximum, not a target.
 ## 3. Redact — and verify the redaction
 
 ```bash
-./skills/bug-report/scripts/redact.py <bundle>
-./skills/bug-report/scripts/redact.py <bundle> --check
+./skills/termio-bug-report/scripts/redact.py <bundle>
+./skills/termio-bug-report/scripts/redact.py <bundle> --check
 ```
 
 The first pass rewrites in place and prints what it matched. The second scans and
@@ -91,7 +91,7 @@ ordinary paths. Ask the user whether any project path in the bundle is private,
 and pass each one:
 
 ```bash
-./skills/bug-report/scripts/redact.py <bundle> --path /Users/you/work/client-repo
+./skills/termio-bug-report/scripts/redact.py <bundle> --path /Users/you/work/client-repo
 ```
 
 `--check` takes `--path` too, and will flag the name if it survived.

--- a/skills/termio-bug-report/references/signatures.md
+++ b/skills/termio-bug-report/references/signatures.md
@@ -1,0 +1,121 @@
+# Known signatures
+
+Every entry here was a real termio bug. Match the artifact against this table
+before writing a fresh diagnosis — most "termio is frozen" reports land on one of
+these, and naming the prior bug is worth more to the issue than a new theory.
+
+A signature that matches is a hypothesis, not a verdict. Say which artifact
+supports it and what would disprove it.
+
+## How to read a `sample`
+
+The whole report is one indented call tree per thread, with a sample count on the
+left. Everything hangs off one question: **where is the main thread?**
+
+```
+853 Thread_3914307: Main Thread   DispatchQueue_<multiple>
+```
+
+- `853` out of 853 samples in `mach_msg2_trap` under `__CFRunLoopServiceMachPort`
+  — the app is **idle and healthy**, parked waiting for events. A beachball
+  report with this stack means the freeze is elsewhere: the GPU, the daemon, or
+  the user's own agent process filling the PTY.
+- Most samples under `CA::Transaction::commit` or SwiftUI's update machinery —
+  the main thread is **doing layout/render work every frame**. Look for an
+  animation driving continuous invalidation.
+- Any main-thread sample inside `psynch_mutexwait`, `__ulock_wait`,
+  `_dispatch_...wait`, or a bare `write`/`read` — the main thread is **blocked**.
+  Read the frames directly above it to find who holds the lock, and check the
+  other threads for the holder.
+
+The `Binary Images` table at the bottom identifies the exact framework and
+libghostty build; keep it. `redact.py` deliberately leaves its version columns
+alone.
+
+## What macOS recorded on its own
+
+The OS keeps its own account of a crash or a stall, and it is often better than
+anything termio logged — a beachball leaves nothing in the app's own log by
+definition, because the thread that would write it is the thread that is stuck.
+`collect.sh` gathers all of it into `reports/` and writes `reports/index.md`, one
+line per report. Read the index first, then open only what it points at.
+
+**`*.ips` with an `exception` key — a crash.** Four fields carry the whole story:
+
+- `exception.signal` — `SIGABRT`, `SIGSEGV`, `SIGKILL`.
+- `termination.namespace` / `indicator` / `reasons[0]` — the *why*. There is no
+  `termination.reason`; reading for it returns nothing and makes an informative
+  report look empty. `DYLD / Library missing / Sparkle.framework` is a packaging
+  bug; `SIGNAL / Abort trap: 6` is a Swift trap or an assertion.
+- `asi` (Application Specific Information) — the abort message, when there is one.
+- Time from `procLaunch` to `captureTime`. Under a second means it died at
+  launch: look at linking, signing, and bundle layout, not at the feature the
+  user was using.
+
+**`*.ips` without an `exception` key — an unresponsiveness report.** macOS only
+writes these when hang reporting is on for the machine, so their absence is not
+evidence that the app was responsive.
+
+**`*.cpu_resource.diag` — the OS caught the process burning CPU.** This is the
+highest-value artifact for a beachball nobody sampled in time: the OS took
+Microstackshots throughout the burn, so the file already contains the stack the
+app was spinning in, plus the exact version and the window it covered. Read it
+the same way as a `sample` — find the heaviest main-thread stack.
+
+**`*.wakeups_resource.diag` — excessive wakeups.** A timer or polling loop firing
+far more often than it should. Shows up as an app that is idle but never lets the
+machine sleep.
+
+**The system side of the unified log** (`unified-log-system.txt`) is where a death
+the app could not report appears: `WindowServer` marking the app unresponsive,
+the kernel's jetsam killing it under memory pressure, code-signing rejections.
+termio's own subsystem cannot log its own kill.
+
+**When the whole UI is frozen, not just termio,** the per-process artifacts will
+not show it. Ask the user to run `sudo spindump 10 -file /tmp/spindump.txt` — it
+needs a password, so `collect.sh` never attempts it — and read which process
+everything else is blocked on.
+
+## The prior bugs
+
+| What you see | Where it shows | What it was |
+| --- | --- | --- |
+| Beachball, main thread blocked in `write` under a surface lock | `sample` main thread | A blocking PTY write held under the surface lock. PTY writes must stay non-blocking. |
+| Beachball, high idle CPU, main thread deep in `CA::Transaction::commit` | `sample` main thread + `top` | An indeterminate `WorkingIndicator` animating `scaleEffect` at 30 Hz, invalidating layout forever. |
+| App freezes minutes after the display sleeps; memory climbs; repeated renderer errors | `unified-log-system.txt`, memory in `environment.md` | Renderer OOM retry storm after display sleep — the retry loop had no ceiling. |
+| Hidden panes burn CPU/GPU with the window in the background | `sample` shows renderer threads busy on non-visible surfaces | Occluded panes kept live renderers. The fix was `setSurfaceVisible`, never raw `set_occlusion`. |
+| A vertical seam / torn frame across a pane | screenshot, not a log | Ghostty's swap chain re-using the on-screen IOSurface when main is late. Fixed in the fork by present backpressure. |
+| Terminal never reflows on window resize | reproduction, not a log | The PTY was spawned with `posix_spawn` instead of `forkpty`. See `docs/bug/terminal-resize-no-reflow-HANDOFF.md`. |
+| New terminal opens with a hollow cursor and beeps until clicked | reproduction | Focus race in the surface wrapper. Three separate variants — see the three `docs/bug/terminal-focus-loss-*.md`. |
+| Agent welcome banner frozen into a narrow column | screenshot | Session opened against a stale narrow grid. `docs/bug/terminal-narrow-grid-frozen-banner-on-open.md`. |
+| A stray `%` at the end of the shell's first line | screenshot | zsh's `PROMPT_SP` reflow against the host grid at spawn. |
+| Phone lists sessions but the terminal says "unauthorized" | companion logs | The phone resized before auth completed — **not** a stale tunnel URL. `docs/bug/companion-terminal-unauthorized-over-tunnel.md`. |
+| iOS app dies on reopening a session (`0x8BADF00D`) | iOS crash report | Renderer mailbox blocked on `cond_not_full`. |
+| iOS app dies switching sessions (`EXC_GUARD`, `close(fd 0)`) | iOS crash report | Surface teardown closed descriptor 0. |
+| iOS "non-functional panel" message | iOS console | libghostty's IO thread died — not a GPU failure. |
+
+## Where the evidence is thin
+
+Two gaps to state honestly in an issue rather than paper over:
+
+- **The Rust daemon's stderr goes to `/dev/null`.** `TermiodClient.spawnDaemon`
+  opens fd 0/1/2 on `/dev/null` so the daemon outlives the app, so `termiod`'s own
+  `eprintln!` diagnostics are not recoverable after the fact. What you *can* get:
+  a `sample` of the live `termiod`, its `roster.json` / `tombstones.json`, and the
+  Swift-side `Log.termiod` trail in `unified-log-termio.txt`. To capture the
+  daemon's own output, the user has to quit termio and run
+  `/Applications/termio.app/Contents/Resources/termiod serve` in a terminal.
+- **`log show` drops `.debug` and `.info` unless you ask.** `collect.sh` passes
+  `--info --debug`; a hand-run `log show` without them looks empty and is not
+  evidence of a quiet app.
+
+## Deciding whether it is even termio
+
+The terminal hosts someone else's process. Before filing against termio, rule out
+the obvious alternative: an agent CLI that is itself wedged.
+
+- `environment.md` lists the agent CLI versions.
+- A `sample` of the app showing a healthy idle main thread, while the *agent*
+  process is pinning a core, is an agent bug.
+- `tombstones.json` records how sessions ended. A session whose child exited on
+  its own is not a termio hang.

--- a/skills/termio-bug-report/references/signatures.md
+++ b/skills/termio-bug-report/references/signatures.md
@@ -98,13 +98,18 @@ everything else is blocked on.
 
 Two gaps to state honestly in an issue rather than paper over:
 
-- **The Rust daemon's stderr goes to `/dev/null`.** `TermiodClient.spawnDaemon`
-  opens fd 0/1/2 on `/dev/null` so the daemon outlives the app, so `termiod`'s own
-  `eprintln!` diagnostics are not recoverable after the fact. What you *can* get:
-  a `sample` of the live `termiod`, its `roster.json` / `tombstones.json`, and the
-  Swift-side `Log.termiod` trail in `unified-log-termio.txt`. To capture the
-  daemon's own output, the user has to quit termio and run
-  `/Applications/termio.app/Contents/Resources/termiod serve` in a terminal.
+- **The Rust daemon keeps its own log**, at `~/Library/Logs/termio/termiod.log`
+  (`termio-dev` for the dev channel), collected into `daemon-log-*/`. It holds
+  one `--- termiod <version> starting, pid N ---` line per daemon run followed by
+  everything that run printed, including a panic message. Read it whenever the
+  complaint is about a session rather than the window: `termiod` owns the PTYs.
+  Note the daemon writes it only when its stderr goes to `/dev/null`, which is
+  how the app and launchd start it — a daemon someone ran by hand in a terminal
+  printed to that terminal instead, and left no file.
+
+  Builds before this existed have no such log at all, so an old report legitimately
+  has nothing here. Check `environment.md` for the version before concluding the
+  daemon was silent.
 - **`log show` drops `.debug` and `.info` unless you ask.** `collect.sh` passes
   `--info --debug`; a hand-run `log show` without them looks empty and is not
   evidence of a quiet app.

--- a/skills/termio-bug-report/scripts/collect.sh
+++ b/skills/termio-bug-report/scripts/collect.sh
@@ -226,6 +226,17 @@ for support in "$HOME/Library/Application Support/termio" "$HOME/Library/Applica
     fi
 done
 
+# The Rust daemon's own log. It owns every PTY, so when the complaint is "a
+# session froze" this is the process that was there.
+for logs in "$HOME/Library/Logs/termio" "$HOME/Library/Logs/termio-dev" \
+            "$HOME/.local/state/termio" "$HOME/.local/state/termio-dev"; do
+    [ -d "$logs" ] || continue
+    dest="$OUT/daemon-log-$(basename "$logs")"
+    mkdir -p "$dest"
+    find "$logs" -maxdepth 1 -type f -name 'termiod.log*' -exec cp {} "$dest/" \; 2>/dev/null
+    note "daemon log from $logs"
+done
+
 for extra in /tmp/termio-status.log /tmp/termio-dev.log; do
     [ -f "$extra" ] && tail -n 2000 "$extra" >"$OUT/$(basename "$extra")" 2>/dev/null
 done

--- a/skills/termio-bug-report/scripts/collect.sh
+++ b/skills/termio-bug-report/scripts/collect.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+# collect.sh — gather everything needed to diagnose a termio hang, crash, or
+# misbehaviour into one directory, ready for redact.py.
+#
+# The single most perishable artifact is a `sample` of a *live* hung process:
+# once the user force-quits, the stack that explains the beachball is gone
+# forever. So sampling runs first, before anything slower.
+#
+# usage: collect.sh [--minutes N] [--out DIR] [--no-sample] [--channel release|dev|both]
+set -uo pipefail
+
+MINUTES=60
+OUT=""
+DO_SAMPLE=1
+CHANNEL=both
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --minutes) MINUTES="$2"; shift 2 ;;
+        --out) OUT="$2"; shift 2 ;;
+        --no-sample) DO_SAMPLE=0; shift ;;
+        --channel) CHANNEL="$2"; shift 2 ;;
+        -h|--help) sed -n '2,10p' "$0"; exit 0 ;;
+        *) echo "collect.sh: unknown option $1" >&2; exit 2 ;;
+    esac
+done
+
+STAMP=$(date +%Y%m%d-%H%M%S)
+[ -n "$OUT" ] || OUT="${TMPDIR:-/tmp}/termio-bugreport-$STAMP"
+mkdir -p "$OUT" || exit 1
+note() { printf '%s\n' "$*" >>"$OUT/collect.log"; }
+note "collect.sh $STAMP  minutes=$MINUTES channel=$CHANNEL sample=$DO_SAMPLE"
+
+# ---------------------------------------------------------------- 1. samples
+# `sample` needs no root for your own processes and takes ~1s longer than the
+# duration you ask for. A hung main thread shows as the whole sample sitting in
+# one call — that line is the answer.
+# `pgrep` is unreliable here: it silently misses `termiod` even with -f, so pid
+# discovery goes through ps, matching the executable path ps reports in COMM.
+pids_matching() { ps -Ao pid=,comm= | awk -v pattern="$1" '$2 ~ pattern { print $1 }'; }
+release_app_pids=$(pids_matching '/termio\.app/Contents/MacOS/termio$')
+dev_app_pids=$(pids_matching 'termio-dev\.app/Contents/MacOS/termio$')
+daemon_pids=$(pids_matching '/termiod$|^termiod$')
+
+case "$CHANNEL" in
+    release) app_pids="$release_app_pids" ;;
+    dev)     app_pids="$dev_app_pids" ;;
+    *)       app_pids="$release_app_pids $dev_app_pids" ;;
+esac
+
+if [ "$DO_SAMPLE" = 1 ]; then
+    for pid in $app_pids $daemon_pids; do
+        [ -n "$pid" ] || continue
+        name=$(basename "$(ps -o comm= -p "$pid" 2>/dev/null)")
+        echo "sampling $name [$pid] for 3s…" >&2
+        /usr/bin/sample "$pid" 3 -file "$OUT/sample-$name-$pid.txt" >/dev/null 2>&1 \
+            && note "sampled $name $pid" \
+            || note "sample failed for $name $pid (already exited, or needs Developer Tools permission)"
+    done
+else
+    note "sampling skipped (--no-sample)"
+fi
+
+# --------------------------------------------------------------- 2. the app
+{
+    echo "# Environment"
+    echo
+    echo "collected: $(date '+%Y-%m-%d %H:%M:%S %z')"
+    echo "macOS:     $(sw_vers -productVersion) ($(sw_vers -buildVersion))"
+    echo "hardware:  $(sysctl -n hw.model 2>/dev/null)  $(sysctl -n machdep.cpu.brand_string 2>/dev/null)"
+    echo "memory:    $(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1073741824 )) GB"
+    echo
+    for app in /Applications/termio.app "$HOME/Applications/termio.app" ./termio-dev.app; do
+        [ -d "$app" ] || continue
+        version=$(/usr/bin/defaults read "$app/Contents/Info" CFBundleShortVersionString 2>/dev/null)
+        build=$(/usr/bin/defaults read "$app/Contents/Info" CFBundleVersion 2>/dev/null)
+        id=$(/usr/bin/defaults read "$app/Contents/Info" CFBundleIdentifier 2>/dev/null)
+        echo "installed: $app — $version ($build) $id"
+    done
+    echo
+    echo "## Processes"
+    ps -Ao pid,ppid,%cpu,%mem,etime,command | grep -i 'termio' | grep -v ' grep ' || echo "(none running)"
+    echo
+    echo "## Daemon"
+    for candidate in /Applications/termio.app/Contents/Resources/termiod \
+                     ./termio-dev.app/Contents/Resources/termiod \
+                     "$(command -v termiod 2>/dev/null)"; do
+        [ -x "$candidate" ] || continue
+        echo "$candidate: $("$candidate" --version 2>&1 | head -1)"
+    done
+    echo
+    echo "## Agent CLIs"
+    for cli in claude codex opencode amp gemini grok cursor-agent; do
+        path=$(command -v "$cli" 2>/dev/null) || continue
+        echo "$cli: $("$cli" --version 2>&1 | head -1)  [$path]"
+    done
+} >"$OUT/environment.md" 2>&1
+
+# ---------------------------------------------------- 3. unified log (os_log)
+# `log` is shadowed by a shell function in some profiles — always the full path.
+# `--info --debug` matters: without them `log show` drops everything below
+# .notice, which is where termio's operational trail and every Trace timing live.
+/usr/bin/log show --last "${MINUTES}m" --info --debug --style compact \
+    --predicate 'subsystem BEGINSWITH "sh.termio"' \
+    >"$OUT/unified-log-termio.txt" 2>&1
+note "unified-log-termio.txt: $(wc -l <"$OUT/unified-log-termio.txt" | tr -d ' ') lines"
+
+# Anything the *system* said about the processes — WindowServer kills, jetsam,
+# hang detection, code signing. termio's own subsystem cannot report its own
+# death. runningboardd is deliberately excluded: it emits thousands of assertion
+# lines per half hour that bury the couple hundred that matter.
+/usr/bin/log show --last "${MINUTES}m" --info --style compact \
+    --predicate 'process == "termio" OR process == "termiod" OR (eventMessage CONTAINS[c] "termio" AND (process == "WindowServer" OR process == "symptomsd" OR process == "kernel"))' \
+    >"$OUT/unified-log-system.txt" 2>&1
+note "unified-log-system.txt: $(wc -l <"$OUT/unified-log-system.txt" | tr -d ' ') lines"
+
+# ------------------------------------ 4. what macOS itself recorded
+# Four different things land in DiagnosticReports and they answer different
+# questions, so all four are collected:
+#   *.ips                       a crash (has "exception" + "termination") or,
+#                               where hang reporting is on, an unresponsiveness
+#                               report (has "duration"/"processByPid", no exception)
+#   *.hang / *.spin             older-style unresponsiveness reports
+#   *.cpu_resource.diag         the OS caught the process burning CPU — the
+#                               Microstackshots in it are a free beachball stack
+#   *.wakeups_resource.diag     the OS caught it waking too often (idle CPU burn)
+# The per-user directory needs no privileges; the system one is world-readable
+# for these files.
+mkdir -p "$OUT/reports"
+for dir in "$HOME/Library/Logs/DiagnosticReports" /Library/Logs/DiagnosticReports; do
+    [ -d "$dir" ] || continue
+    find "$dir" -maxdepth 1 -type f \( -name 'termio*' -o -name 'GhosttyKit*' \) \
+        \( -name '*.ips' -o -name '*.hang' -o -name '*.spin' -o -name '*.crash' -o -name '*.diag' \) \
+        -mtime -14 -exec cp {} "$OUT/reports/" \; 2>/dev/null
+done
+
+# One line per report, so the shape of the evidence is readable without opening
+# a 68 KB JSON blob to find out it was an unrelated launch failure.
+python3 - "$OUT/reports" >"$OUT/reports/index.md" 2>/dev/null <<'INDEX'
+import json, pathlib, sys
+
+directory = pathlib.Path(sys.argv[1])
+print("# Reports macOS wrote\n")
+rows = sorted(p for p in directory.iterdir() if p.suffix != ".md")
+if not rows:
+    print("(none in the last 14 days)")
+for path in rows:
+    if path.suffix == ".diag":
+        text = path.read_text(errors="replace")
+        def field(name):
+            for line in text.splitlines():
+                if line.startswith(name):
+                    return line.split(":", 1)[1].strip()
+            return "?"
+        kind = "CPU burn" if "cpu_resource" in path.name else "excessive wakeups"
+        print(f"- **{path.name}** — {kind}; {field('Version')}; "
+              f"{field('Date/Time')} → {field('End time')}")
+        continue
+    try:
+        header, body = path.read_text(errors="replace").split("\n", 1)
+        head = json.loads(header)
+        payload = json.loads(body)
+    except Exception:
+        print(f"- **{path.name}** — unparsed")
+        continue
+    if "exception" in payload:
+        exception = payload["exception"]
+        signal = exception.get("signal", exception.get("type", "?"))
+        # `termination.reason` does not exist; the useful trio is namespace +
+        # indicator + reasons[0]. SIGABRT alone says nothing — "DYLD / Library
+        # missing / Sparkle.framework" says everything.
+        termination = payload.get("termination") or {}
+        reason = " / ".join(filter(None, [
+            termination.get("namespace"),
+            termination.get("indicator"),
+            (termination.get("reasons") or [""])[0],
+        ]))
+        for note in payload.get("asi") or {}:
+            reason += f" | {note}: {'; '.join((payload['asi'][note] or [])[:1])}"
+        alive = "?"
+        try:
+            from datetime import datetime
+            fmt = "%Y-%m-%d %H:%M:%S.%f %z"
+            started = datetime.strptime(payload["procLaunch"], fmt)
+            ended = datetime.strptime(payload["captureTime"], fmt)
+            alive = f"{(ended - started).total_seconds():.1f}s after launch"
+        except Exception:
+            pass
+        print(f"- **{path.name}** — CRASH {signal} in {head.get('app_version','?')}; "
+              f"died {alive}; faulting thread {payload.get('faultingThread')}; "
+              f"{reason[:200]}")
+    else:
+        duration = payload.get("duration") or payload.get("durationInSeconds") or "?"
+        print(f"- **{path.name}** — HANG/unresponsive, {duration}s, "
+              f"{head.get('app_version','?')}")
+INDEX
+note "reports: $(( $(ls "$OUT/reports" 2>/dev/null | wc -l | tr -d ' ') - 1 )) file(s) from the last 14 days"
+
+# ------------------------------------------------------- 5. daemon state dir
+# roster.json is the live session table; tombstones.json records how sessions
+# died, which is the first thing to read when "a session froze / vanished".
+# pair.token is a live credential and is deliberately never copied.
+for uid_dir in "${TMPDIR:-/tmp}"/termiod-"$(id -u)" "${TMPDIR:-/tmp}"/termiod-"$(id -u)"-dev "${XDG_RUNTIME_DIR:-}"/termiod; do
+    [ -d "$uid_dir" ] || continue
+    dest="$OUT/daemon$(basename "$uid_dir" | sed 's/^termiod-[0-9]*//')"
+    mkdir -p "$dest"
+    for file in roster.json tombstones.json host.id wss.bind; do
+        [ -f "$uid_dir/$file" ] && cp "$uid_dir/$file" "$dest/" 2>/dev/null
+    done
+    ls -la "$uid_dir" >"$dest/listing.txt" 2>&1
+    note "daemon state from $uid_dir (pair.token deliberately skipped)"
+done
+
+# ----------------------------------------------------- 6. app state + extras
+for support in "$HOME/Library/Application Support/termio" "$HOME/Library/Application Support/termio-dev"; do
+    [ -d "$support" ] || continue
+    label=$(basename "$support")
+    mkdir -p "$OUT/$label"
+    ls -la "$support" >"$OUT/$label/listing.txt" 2>&1
+    # state.json is the whole session tree — paths, names, layout. Copied because
+    # layout bugs need it; redact.py scrubs it.
+    [ -f "$support/state.json" ] && cp "$support/state.json" "$OUT/$label/" 2>/dev/null
+    if [ -d "$support/hang_traces" ]; then
+        mkdir -p "$OUT/$label/hang_traces"
+        find "$support/hang_traces" -type f -mtime -14 -exec cp {} "$OUT/$label/hang_traces/" \; 2>/dev/null
+    fi
+done
+
+for extra in /tmp/termio-status.log /tmp/termio-dev.log; do
+    [ -f "$extra" ] && tail -n 2000 "$extra" >"$OUT/$(basename "$extra")" 2>/dev/null
+done
+
+for config in "$HOME/.termio/settings.json" "$HOME/.termio-dev/settings.json"; do
+    [ -f "$config" ] || continue
+    cp "$config" "$OUT/settings-$(basename "$(dirname "$config")").json" 2>/dev/null
+done
+
+# ------------------------------------------------------------- 7. manifest
+{
+    echo "# Bundle manifest"
+    echo
+    find "$OUT" -type f | sed "s|^$OUT/||" | sort | while read -r f; do
+        printf '%8s  %s\n' "$(du -h "$OUT/$f" | cut -f1)" "$f"
+    done
+} >"$OUT/manifest.md"
+
+echo "$OUT"

--- a/skills/termio-bug-report/scripts/redact.py
+++ b/skills/termio-bug-report/scripts/redact.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""redact.py — scrub a collected diagnostic bundle before it goes to a public issue.
+
+Two modes:
+
+    redact.py BUNDLE_DIR              rewrite every text file in place, print what changed
+    redact.py BUNDLE_DIR --check      scan only; report anything that still looks sensitive
+
+`--check` is not optional politeness: run it after redacting and read the output
+before attaching anything to a GitHub issue. A rule that silently matched nothing
+is indistinguishable from a rule that was never needed, and only the scan tells
+the two apart.
+
+Extra project paths worth scrubbing (repo names are often private) can be passed
+with `--path /Users/me/work/secret-repo`, repeatable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+PLACEHOLDER = {
+    "token": "<redacted-token>",
+    "email": "<redacted-email>",
+    "host": "<redacted-host>",
+    "ip": "<redacted-ip>",
+    "user": "USER",
+}
+
+# A rule is (label, pattern, replacement, line_guard). A rule carrying a
+# line_guard is applied line by line and skipped on every line the guard matches.
+Rule = tuple
+
+
+def shell(*command: str) -> str:
+    try:
+        return subprocess.run(
+            command, capture_output=True, text=True, timeout=5
+        ).stdout.strip()
+    except Exception:
+        return ""
+
+
+# A `sample` report ends in a Binary Images table whose version columns
+# ("1104.0.0.1", "21624.1.1.10") are shaped exactly like IPv4 addresses. Letting
+# the IP rule loose on those lines destroys the one section that identifies which
+# framework build a stack came from, so the IP rule skips them.
+IMAGE_LINE = re.compile(r"\.dylib|\.framework|com\.apple\.|\) <[0-9A-F]{8}-")
+
+IPV4 = re.compile(r"\b(?!127\.0\.0\.1\b|0\.0\.0\.0\b|255\.255\.255\.255\b)"
+                  r"(?:\d{1,3}\.){3}\d{1,3}\b")
+
+
+def valid_ipv4(match) -> str:
+    """Substitution guard: an octet above 255 is a version string, not an
+    address. Keeps `6.3.2 - 1104.0.0.1` intact while still scrubbing real IPs."""
+    if all(int(octet) <= 255 for octet in match.group(0).split(".")):
+        return PLACEHOLDER["ip"]
+    return match.group(0)
+
+
+def build_rules(extra_paths):
+    """Rules in application order. Most specific first: a home-directory rule
+    that ran before the token rules would rewrite the context around a token and
+    make it harder to see.
+    """
+    user = os.environ.get("USER") or shell("id", "-un")
+    full_name = shell("id", "-F")
+    computer_name = shell("scutil", "--get", "ComputerName")
+    local_host = shell("scutil", "--get", "LocalHostName")
+
+    rules = [
+        # ---- credentials. Nothing in this block is worth leaking. ----
+        ("private key block",
+         re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+         "<redacted-private-key>", None),
+        ("github token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{16,}\b"), PLACEHOLDER["token"], None),
+        ("anthropic key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b"), PLACEHOLDER["token"], None),
+        ("openai key", re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9]{20,}\b"), PLACEHOLDER["token"], None),
+        ("slack token", re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}\b"), PLACEHOLDER["token"], None),
+        ("aws key id", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"), PLACEHOLDER["token"], None),
+        ("bearer header", re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{16,}"),
+         "Bearer " + PLACEHOLDER["token"], None),
+        # Fields whose *name* says secret, whatever the value happens to look like.
+        ("secret-named field",
+         re.compile(r'("(?:[a-zA-Z_]*(?:token|secret|password|passphrase|api[_-]?key)[a-zA-Z_]*)"\s*:\s*)"[^"]*"', re.I),
+         r'\1"' + PLACEHOLDER["token"] + '"', None),
+
+        # ---- ingress. A live tunnel hostname is a door into the machine. ----
+        ("cloudflare tunnel", re.compile(r"\b[a-z0-9][a-z0-9-]*\.trycloudflare\.com\b", re.I),
+         PLACEHOLDER["host"], None),
+        ("ngrok tunnel", re.compile(r"\b[a-z0-9][a-z0-9-]*\.ngrok(?:-free)?\.(?:app|io|dev)\b", re.I),
+         PLACEHOLDER["host"], None),
+        ("tailnet host", re.compile(r"\b[a-z0-9][a-z0-9.-]*\.ts\.net\b", re.I),
+         PLACEHOLDER["host"], None),
+        ("email", re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+         PLACEHOLDER["email"], None),
+    ]
+
+    # Caller-supplied project paths run BEFORE the home-path rule. Once that rule
+    # has rewritten /Users/<name> to /Users/USER, an absolute path passed on the
+    # command line no longer matches anything — which is how a private repo name
+    # survived a "successful" redaction pass and a clean --check.
+    for path in extra_paths:
+        cleaned = path.rstrip("/")
+        if not cleaned:
+            continue
+        variants = {cleaned}
+        if user:
+            variants.add(cleaned.replace("/Users/" + user + "/", "/Users/USER/"))
+            variants.add(cleaned.replace("/Users/" + user, "~"))
+        for variant in variants:
+            rules.append(("extra path", re.compile(re.escape(variant)), "<redacted-path>", None))
+
+    rules += [
+        ("home path", re.compile(r"""/Users/[^/\s"',:)\]]+"""),
+         "/Users/" + PLACEHOLDER["user"], None),
+        ("device key",
+         re.compile(r'("(?:crashReporterKey|bootSessionUUID|sleepWakeUUID|deviceUDID|serialNumber|host_id)"\s*:\s*)"[^"]*"', re.I),
+         r'\1"<redacted>"', None),
+    ]
+
+    if full_name and len(full_name) > 3:
+        rules.append(("full name", re.compile(re.escape(full_name), re.I), "<redacted-name>", None))
+    for name in (computer_name, local_host):
+        if name and len(name) > 2:
+            rules.append(("machine name", re.compile(re.escape(name), re.I), PLACEHOLDER["host"], None))
+    # The username runs late and only as a whole word: substituting it earlier
+    # would corrupt every path the home-path rule is meant to handle cleanly.
+    if user and len(user) >= 3:
+        rules.append(("username", re.compile(r"\b" + re.escape(user) + r"\b"),
+                      PLACEHOLDER["user"], None))
+
+    rules.append(("ip address", IPV4, valid_ipv4, IMAGE_LINE))
+    return rules
+
+
+# Patterns for --check: what a reviewer would flag in a public issue. The third
+# element is an optional guard — `guard(line, match)` returning False means this
+# hit is a false positive. Without it the IPv4 pattern fires on every dylib
+# version in a sample's Binary Images table, and 156 cried-wolf findings are
+# worse than no check at all.
+def real_ip(line: str, match) -> bool:
+    if IMAGE_LINE.search(line):
+        return False
+    return all(int(octet) <= 255 for octet in match.group(0).split("."))
+
+
+SUSPICIOUS = [
+    ("home path", re.compile(r"""/Users/(?!USER\b)[^/\s"',:)\]]+"""), None),
+    ("email", re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"), None),
+    ("token-shaped", re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9]{16,}|sk-[A-Za-z0-9-]{20,}|xox[abprs]-)"), None),
+    ("tunnel host", re.compile(r"\b[a-z0-9-]+\.(?:trycloudflare\.com|ngrok(?:-free)?\.(?:app|io|dev)|ts\.net)\b", re.I), None),
+    ("routable ip", re.compile(r"\b(?!127\.|0\.0\.0\.0|255\.|10\.|192\.168\.|169\.254\.)(?:\d{1,3}\.){3}\d{1,3}\b"), real_ip),
+    ("secret-named field", re.compile(r'"[a-zA-Z_]*(?:token|secret|password|api[_-]?key)[a-zA-Z_]*"\s*:\s*"(?!<redacted)[^"]+"', re.I), None),
+]
+
+SKIP_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".mov", ".mp4", ".zip", ".gz", ".key"}
+
+
+def text_files(root: pathlib.Path):
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() in SKIP_SUFFIXES:
+            continue
+        try:
+            yield path, path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+
+
+def redact(root: pathlib.Path, extra_paths) -> int:
+    rules = build_rules(extra_paths)
+    counts: dict[str, int] = {}
+    touched = 0
+    for path, original in text_files(root):
+        text = original
+        for label, pattern, replacement, line_guard in rules:
+            if line_guard is None:
+                text, hits = pattern.subn(replacement, text)
+            else:
+                hits = 0
+                lines = text.split("\n")
+                for index, line in enumerate(lines):
+                    if line_guard.search(line):
+                        continue
+                    lines[index], line_hits = pattern.subn(replacement, line)
+                    hits += line_hits
+                text = "\n".join(lines)
+            if hits:
+                counts[label] = counts.get(label, 0) + hits
+        if text != original:
+            path.write_text(text, encoding="utf-8")
+            touched += 1
+
+    print(f"redacted {touched} file(s) under {root}")
+    if counts:
+        width = max(len(label) for label in counts)
+        for label in sorted(counts, key=lambda k: -counts[k]):
+            print(f"  {label:<{width}}  {counts[label]}")
+    else:
+        print("  (no rule matched — verify with --check before trusting that)")
+    return 0
+
+
+def check(root: pathlib.Path, extra_paths=()) -> int:
+    # Paths the caller named as private are scanned for too, or --check would
+    # report clean on a bundle that still spells out a private repo.
+    patterns = list(SUSPICIOUS) + [
+        ("named private path", re.compile(re.escape(path.rstrip('/'))), None)
+        for path in extra_paths if path.strip()
+    ]
+    findings: list[tuple[str, str, int, str]] = []
+    for path, text in text_files(root):
+        for line_number, line in enumerate(text.splitlines(), 1):
+            for label, pattern, guard in patterns:
+                match = pattern.search(line)
+                if match and (guard is None or guard(line, match)):
+                    findings.append((label, str(path.relative_to(root)), line_number,
+                                     match.group(0)[:80]))
+                    break
+
+    if not findings:
+        print(f"clean: nothing suspicious left in {root}")
+        return 0
+
+    by_label: dict[str, list] = {}
+    for label, rel, line_number, sample in findings:
+        by_label.setdefault(label, []).append((rel, line_number, sample))
+    print(f"{len(findings)} line(s) still look sensitive in {root}:\n")
+    for label, rows in by_label.items():
+        print(f"{label} — {len(rows)}")
+        for rel, line_number, sample in rows[:5]:
+            print(f"    {rel}:{line_number}  {sample}")
+        if len(rows) > 5:
+            print(f"    … {len(rows) - 5} more")
+        print()
+    print("Fix with --path for project directories, or delete the offending file "
+          "from the bundle. Do not attach the bundle until this is clean.")
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("bundle", type=pathlib.Path)
+    parser.add_argument("--check", action="store_true",
+                        help="scan without modifying; exit 1 if anything looks sensitive")
+    parser.add_argument("--path", action="append", default=[],
+                        help="an extra absolute path to scrub (repeatable)")
+    arguments = parser.parse_args()
+
+    if not arguments.bundle.is_dir():
+        print(f"redact.py: {arguments.bundle} is not a directory", file=sys.stderr)
+        return 2
+    if arguments.check:
+        return check(arguments.bundle, arguments.path)
+    return redact(arguments.bundle, arguments.path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -367,6 +367,14 @@ pub async fn serve(
     wss_bind: Option<std::net::SocketAddr>,
     wss_origins: Vec<crate::wss::Origin>,
 ) -> Result<()> {
+    // First, before anything that can fail: whoever spawned this daemon most
+    // likely pointed its stderr at /dev/null, and a startup error is exactly the
+    // kind worth keeping. A failure to set up logging is not a reason to refuse
+    // to serve, so it is reported and stepped over.
+    if let Err(error) = crate::log::redirect() {
+        eprintln!("termiod: could not open the log file: {error:#}");
+    }
+
     paths::ensure_runtime_dir()?;
     let sock_path = paths::socket_path()?;
 

--- a/termiod/src/log.rs
+++ b/termiod/src/log.rs
@@ -1,0 +1,320 @@
+//! Where the daemon's own diagnostics go.
+//!
+//! `termiod serve` is normally started by the Mac app with stdio on `/dev/null`
+//! (`TermiodClient.spawnDaemon`) or by launchd, whose plist names no
+//! `StandardErrorPath`. Both discard stderr, so every `eprintln!` in the daemon —
+//! and every panic message, since the release profile aborts — was unrecoverable
+//! after the fact. A user reporting "termio froze" could hand over the app's
+//! unified-log trail and nothing whatsoever from the process that owns the PTYs.
+//!
+//! The fix works at the file-descriptor level rather than by rewriting fifty-odd
+//! call sites: `serve` opens the log file and points fd 1 and fd 2 at it. Nothing
+//! in the daemon has to know it is being logged, and a panic message is captured
+//! for free.
+//!
+//! **Why the file and not a pipe with a formatting thread.** Stamping each line
+//! wants a pump thread between the daemon and the file, and the first version
+//! here did that. It loses the lines that matter most: a daemon that fails during
+//! startup exits before the pump is scheduled, and the error explaining why goes
+//! down with the process — measured, not theorised. Worse, it makes every
+//! `eprintln!` in the daemon that owns every PTY depend on a 64 KB pipe being
+//! drained, and "a blocking write wedges the process" is the exact failure termio
+//! already has a bug doc about. Writing straight to the file is synchronous in
+//! the kernel: nothing is buffered in user space, so nothing is lost however the
+//! process dies, and no writer can ever block on a reader.
+//!
+//! The cost is per-line timestamps, which need the call sites to change and so
+//! belong with adopting `tracing` rather than with restoring the log at all.
+//!
+//! The daemon claims stderr only when it points at `/dev/null` — when the output
+//! is provably going nowhere. Anything else means somebody chose that
+//! destination: a terminal is a person watching, a pipe is a parent collecting
+//! (`Command::output()` in the integration tests, a script reading the refusal
+//! message), a file is a redirect the operator typed. Taking any of those over
+//! would be a regression. "Not a terminal" was the first rule here and it was
+//! too broad: it swallowed the piped case and broke a test that reads the
+//! daemon's refusal off stderr.
+
+use anyhow::{Context, Result};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+
+/// Rotate once the live file reaches this size, keeping `GENERATIONS` older
+/// files — about six megabytes in total.
+///
+/// These are cmux's numbers for the same job (a per-user session daemon), and
+/// they are the right order of magnitude: this file holds lifecycle events, not
+/// traffic, so a cap this size is weeks of ordinary use and still bounds the
+/// pathological case of a session in a crash loop. Zellij's 16 MiB is sized for
+/// a log that swallows plugin stderr; tmux's unbounded file is the anti-pattern.
+///
+/// Rotation happens when the daemon starts, which is the only moment it holds
+/// the file exclusively. A single very long-lived run can therefore exceed the
+/// cap; bounding that needs the formatting layer this deliberately does without.
+const ROTATE_BYTES: u64 = 2 * 1024 * 1024;
+const GENERATIONS: usize = 3;
+
+/// The log records session cwds, agent names, and the text of any error the
+/// daemon hit — a description of what the user is working on. It is readable by
+/// its owner and nobody else, matching the socket beside it.
+const FILE_MODE: u32 = 0o600;
+const DIRECTORY_MODE: u32 = 0o700;
+
+/// Points stdout and stderr at the daemon's log file for the rest of the
+/// process's life. Returns the path, or `None` when stderr is a terminal and the
+/// caller is watching the output directly.
+///
+/// Call this first in `serve`, before anything that can fail: the errors worth
+/// capturing most are the ones from starting up.
+pub fn redirect() -> Result<Option<PathBuf>> {
+    if !discarded(libc::STDERR_FILENO) {
+        return Ok(None);
+    }
+
+    let path = crate::paths::log_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(DIRECTORY_MODE)
+            .create(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+
+    if oversized(&path) {
+        rotate(&path);
+    }
+
+    let mut file = open_sink(&path).with_context(|| format!("opening {}", path.display()))?;
+    // A run boundary, so a reader can tell one daemon's lines from the next.
+    // Written before the redirect, while errors from it are still reportable.
+    let _ = writeln!(
+        file,
+        "--- termiod {} starting, pid {} ---",
+        crate::lifecycle::BUILD_VERSION,
+        std::process::id(),
+    );
+
+    // Both descriptors, not just stderr: a stray `println!` in the daemon is as
+    // lost down /dev/null as a stray `eprintln!`, and there is no reason for the
+    // two to land in different places.
+    for target in [libc::STDOUT_FILENO, libc::STDERR_FILENO] {
+        if unsafe { libc::dup2(file.as_raw_fd(), target) } < 0 {
+            return Err(std::io::Error::last_os_error()).context("pointing stdio at the log");
+        }
+    }
+    // fd 1 and 2 now hold their own references to the open file; this one has
+    // done its job.
+    drop(file);
+
+    Ok(Some(path))
+}
+
+/// True when `descriptor` is the null device, i.e. whoever started this process
+/// is throwing its output away.
+fn discarded(descriptor: libc::c_int) -> bool {
+    let mut current: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { libc::fstat(descriptor, &mut current) } != 0 {
+        return false;
+    }
+    // `st_rdev` is meaningful only for a device, and comparing it on anything
+    // else would match arbitrary files by coincidence.
+    if current.st_mode & libc::S_IFMT != libc::S_IFCHR {
+        return false;
+    }
+    let Ok(null) = std::fs::metadata("/dev/null") else {
+        return false;
+    };
+    use std::os::unix::fs::MetadataExt;
+    current.st_rdev as u64 == null.rdev()
+}
+
+fn oversized(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.len() >= ROTATE_BYTES)
+        .unwrap_or(false)
+}
+
+fn open_sink(path: &Path) -> std::io::Result<File> {
+    use std::os::unix::fs::PermissionsExt;
+    // `mode` applies only when this call creates the file, so a log left by an
+    // older build keeps whatever mode it had. Re-assert rather than trust it.
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(FILE_MODE)
+        .open(path)?;
+    let mut permissions = file.metadata()?.permissions();
+    if permissions.mode() & 0o777 != FILE_MODE {
+        permissions.set_mode(FILE_MODE);
+        let _ = file.set_permissions(permissions);
+    }
+    Ok(file)
+}
+
+/// Shifts `termiod.log` to `termiod.log.1`, `.1` to `.2`, and so on, dropping
+/// the oldest. Renames rather than truncating, so a report someone is already
+/// reading keeps its contents.
+///
+/// Generational suffixes rather than Nomad's `nomad-<unix-nanos>.log`: that
+/// scheme is a long-standing complaint against it, because the newest file is
+/// not identifiable by eye.
+fn rotate(path: &Path) {
+    let generation = |index: usize| -> PathBuf {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(format!(".{index}"));
+        PathBuf::from(name)
+    };
+    let _ = std::fs::remove_file(generation(GENERATIONS));
+    for index in (1..GENERATIONS).rev() {
+        let _ = std::fs::rename(generation(index), generation(index + 1));
+    }
+    let _ = std::fs::rename(path, generation(1));
+}
+
+/// `termiod logs` — the answer to "where are the logs?", which until now was
+/// "there aren't any". Reading the file directly works too; this exists so the
+/// answer is one command rather than a path the user has to be told.
+pub async fn show(path_only: bool, follow: bool, lines: usize) -> Result<()> {
+    let path = crate::paths::log_path()?;
+    if path_only {
+        println!("{}", path.display());
+        return Ok(());
+    }
+    if !path.exists() {
+        // Two very different situations, and guessing between them wastes the
+        // reader's time, so name both.
+        println!(
+            "no log yet at {}\n\
+             The daemon writes one only when its stderr goes to /dev/null, the \
+             way the app and launchd start it. Run in a terminal, or with its \
+             output piped or redirected, it prints there instead.",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading {}", path.display()))?;
+    let all: Vec<&str> = text.lines().collect();
+    let start = if lines == 0 {
+        0
+    } else {
+        all.len().saturating_sub(lines)
+    };
+    for line in &all[start..] {
+        println!("{line}");
+    }
+
+    if !follow {
+        return Ok(());
+    }
+
+    let mut offset = text.len() as u64;
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let Ok(metadata) = std::fs::metadata(&path) else {
+            continue;
+        };
+        // A shrinking file means the daemon restarted and rotated underneath us;
+        // start again from the top rather than seeking past the new file's end.
+        if metadata.len() < offset {
+            offset = 0;
+        }
+        if metadata.len() == offset {
+            continue;
+        }
+        use std::io::{Read, Seek, SeekFrom};
+        let mut file = File::open(&path)?;
+        file.seek(SeekFrom::Start(offset))?;
+        let mut fresh = String::new();
+        file.read_to_string(&mut fresh)?;
+        print!("{fresh}");
+        std::io::stdout().flush()?;
+        offset = metadata.len();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rotate_shifts_generations_and_drops_the_oldest() {
+        let root = std::env::temp_dir().join(format!("termiod-log-rotate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp dir");
+        let path = root.join("termiod.log");
+
+        std::fs::write(&path, "newest").expect("write live file");
+        for index in 1..=GENERATIONS {
+            std::fs::write(
+                root.join(format!("termiod.log.{index}")),
+                format!("gen{index}"),
+            )
+            .expect("write generation");
+        }
+
+        rotate(&path);
+
+        assert!(!path.exists(), "the live file is renamed, not left behind");
+        assert_eq!(
+            std::fs::read_to_string(root.join("termiod.log.1")).expect("newest generation"),
+            "newest"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join(format!("termiod.log.{GENERATIONS}")))
+                .expect("oldest kept generation"),
+            format!("gen{}", GENERATIONS - 1),
+            "each generation shifts down one"
+        );
+        assert_eq!(
+            std::fs::read_dir(&root).expect("listing").count(),
+            GENERATIONS,
+            "the oldest generation is dropped rather than accumulating"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn only_a_discarded_stderr_is_claimed() {
+        use std::os::unix::io::AsRawFd;
+
+        let null = File::open("/dev/null").expect("/dev/null");
+        assert!(discarded(null.as_raw_fd()), "the null device is claimed");
+
+        // A pipe is what `Command::output()` hands a child: a parent collecting
+        // the output, which must keep reaching it.
+        let mut ends = [0 as libc::c_int; 2];
+        assert_eq!(unsafe { libc::pipe(ends.as_mut_ptr()) }, 0);
+        assert!(!discarded(ends[1]), "a pipe means a parent is reading");
+        unsafe {
+            libc::close(ends[0]);
+            libc::close(ends[1]);
+        }
+
+        // So is a plain file, which is what a shell redirect produces.
+        let path = std::env::temp_dir().join(format!("termiod-discard-{}", std::process::id()));
+        let file = File::create(&path).expect("temp file");
+        assert!(!discarded(file.as_raw_fd()), "a redirect names a destination");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn a_new_log_is_private_to_its_owner() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = std::env::temp_dir().join(format!("termiod-log-mode-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp dir");
+        let path = root.join("termiod.log");
+
+        let file = open_sink(&path).expect("open");
+        let mode = file.metadata().expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, FILE_MODE, "the log names what the user is working on");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -14,6 +14,7 @@ mod files;
 mod git;
 mod id;
 mod lifecycle;
+mod log;
 mod paths;
 mod proc;
 mod protocol;
@@ -47,6 +48,21 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
+    /// Print the daemon's log — what it recorded while nobody was attached.
+    Logs {
+        /// Print the path and exit, for piping into an editor or a bug report.
+        #[arg(long)]
+        path: bool,
+
+        /// Keep printing as the daemon writes, like `tail -f`.
+        #[arg(short, long)]
+        follow: bool,
+
+        /// How many trailing lines to print (default 200; 0 for the whole file).
+        #[arg(short = 'n', long, default_value_t = 200)]
+        lines: usize,
+    },
+
     /// Run the session host in the foreground (usually auto-started).
     Serve {
         /// Also accept WebSocket clients on this address (default port 8790).
@@ -431,6 +447,12 @@ fn mine_field(payload: &serde_json::Value, field: &str) -> Option<String> {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
+        Cmd::Logs {
+            path,
+            follow,
+            lines,
+        } => log::show(path, follow, lines).await,
+
         Cmd::Serve { wss, wss_origin } => daemon::serve(wss, wss_origin).await,
 
         Cmd::Pair {

--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -52,6 +52,56 @@ pub fn runtime_dir() -> Result<PathBuf> {
     Ok(base)
 }
 
+/// Where the daemon writes its own diagnostics.
+///
+/// Deliberately **not** under `runtime_dir()` in the ordinary case: that lives in
+/// `$TMPDIR`, which the OS may sweep, and a log whose whole purpose is to explain
+/// a crash that happened yesterday has to outlive the socket beside it. On macOS
+/// that means `~/Library/Logs`, the directory Console.app opens and the one place
+/// a user can be told to look without being handed a path. Elsewhere it is
+/// `$XDG_STATE_HOME/termio{suffix}`, which is already the path
+/// `RemoteTunnelPaths.daemonLog` names for a published Linux box.
+///
+/// An explicit `TERMIOD_SOCK` overrides that and puts the log beside the socket,
+/// for the same reason `host_id_path` and the graveyard hang off `state_dir`: a
+/// daemon pointed at its own socket is its own daemon, and its files must not
+/// land on the real one's. Without this the test suite — which gives each daemon
+/// a temp socket but no channel — appends its runs to the installed app's log.
+/// That is the same accident `AppChannel.isRunningTests` exists to prevent on the
+/// Swift side, where it once overwrote a real user's session tree.
+///
+/// `TERMIOD_LOG` names the file outright, for tests and for anyone who wants it
+/// somewhere else.
+pub fn log_path() -> Result<PathBuf> {
+    if let Some(explicit) = std::env::var_os("TERMIOD_LOG") {
+        return Ok(PathBuf::from(explicit));
+    }
+    if std::env::var_os("TERMIOD_SOCK").is_some() {
+        return Ok(state_dir()?.join("termiod.log"));
+    }
+    durable_log_dir(&channel_suffix())?.map_or_else(
+        || state_dir().map(|dir| dir.join("termiod.log")),
+        |dir| Ok(dir.join("termiod.log")),
+    )
+}
+
+/// The per-user log directory for a channel, or `None` when there is no home to
+/// hang it off — in which case the caller falls back beside the socket rather
+/// than failing to start over a log file.
+fn durable_log_dir(suffix: &str) -> Result<Option<PathBuf>> {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return Ok(None);
+    };
+    let directory = if cfg!(target_os = "macos") {
+        home.join("Library").join("Logs").join(format!("termio{suffix}"))
+    } else if let Some(state) = std::env::var_os("XDG_STATE_HOME") {
+        PathBuf::from(state).join(format!("termio{suffix}"))
+    } else {
+        home.join(".local").join("state").join(format!("termio{suffix}"))
+    };
+    Ok(Some(directory))
+}
+
 /// Full path to the control socket. Overridable with `TERMIOD_SOCK` so tests
 /// (and side-by-side daemons) can isolate.
 pub fn socket_path() -> Result<PathBuf> {


### PR DESCRIPTION
`termiod` threw away every diagnostic it produced. `spawnDaemon` opens fd 0/1/2 on `/dev/null` so the daemon outlives the app, the launchd plist names no `StandardErrorPath`, and the release profile aborts on panic — so a report of a frozen session could carry the app's unified-log trail and nothing from the process that owns the PTYs.

`serve` now opens `~/Library/Logs/termio/termiod.log` and points fd 1 and 2 at it. No call site changes, panics captured, 2 MiB across three generations, mode 0600. `termiod logs` prints it.

Writing to the file rather than through a pipe and a stamping thread is deliberate: the pump version loses the startup errors that matter most, and would make every `eprintln!` in the process that owns every PTY depend on a 64 KB pipe being drained. Per-line timestamps belong with adopting `tracing`.

Two rules were narrowed after they misfired:

- The daemon claims stderr only when it points at `/dev/null`. "Not a terminal" also swallowed the piped case that `wss_bridge` reads its refusal from.
- The path hangs off the configured socket when `TERMIOD_SOCK` is set. Without it the test suite, which gives each daemon a temp socket but no channel, appended its runs to the installed app's log.

The second half is `skills/termio-bug-report`, which collects the freeze evidence — a live `sample` first, since force-quitting destroys it — plus what macOS recorded on its own, then redacts the bundle and verifies the redaction before anything is filed.

## Verification

- `cargo test`: 210 tests, green, full suite run twice.
- Three spawn shapes checked by hand: stdio on `/dev/null` writes the file at 0600; piped stderr is left alone; a 2.2 MB file rotates to `.1`.
- Collector and redactor run end to end, `--check` clean.

`wss_off_removes_the_durable_bind` failed once under full-suite parallel load and did not reproduce in five subsequent runs. Not diagnosed.

## Release Notes:

- `termiod` now keeps a log at `~/Library/Logs/termio/termiod.log`, so a frozen or crashed session leaves evidence behind. `termiod logs` prints it.