### PR TITLE
Stop two devices fighting over one session's size

### DIFF
--- a/Shared/Sources/TermioShared/TerminalDeviceReport.swift
+++ b/Shared/Sources/TermioShared/TerminalDeviceReport.swift
@@ -34,6 +34,14 @@ import Foundation
 /// Everything else is input: arrows and function keys end a CSI in A–Z, `~`
 /// or `u` without `?`; mouse reports carry `<`; a bare Esc is a lone byte;
 /// typed text has no ESC lead-in; a paste arrives inside `ESC [ 200 ~`.
+///
+/// One collision is xterm's, not ours: a modified F3 in the legacy encoding
+/// is `ESC [ 1 ; mod R`, the same shape as a cursor report for row 1. A
+/// report's second parameter is a column, a key's is a modifier in 2…16, and
+/// a cursor sitting in the first sixteen columns of row 1 is answered just
+/// after a clear — so that shape is read as the key. Under the kitty keyboard
+/// protocol, which every agent TUI enables, F3 is `ESC [ 13 ~` and the
+/// collision does not arise.
 public enum TerminalDeviceReport {
     public static func isReport(_ data: Data) -> Bool {
         let bytes = [UInt8](data)
@@ -58,8 +66,10 @@ public enum TerminalDeviceReport {
             // The final byte of a CSI is the first in 0x40–0x7E.
             if byte >= 0x40, byte <= 0x7E {
                 switch byte {
-                case 0x63, 0x6E, 0x52, 0x79, 0x74: // c n R y t
+                case 0x63, 0x6E, 0x79, 0x74: // c n y t
                     return true
+                case 0x52: // R
+                    return !isLegacyModifiedFunctionKey(bytes[2..<index])
                 case 0x75: // u
                     return marker == 0x3F // ?
                 case 0x6D: // m
@@ -73,12 +83,22 @@ public enum TerminalDeviceReport {
         return false
     }
 
+    /// `1 ; 2…16` — the parameters of a modified F1–F4 in the legacy encoding.
+    private static func isLegacyModifiedFunctionKey(_ parameters: ArraySlice<UInt8>) -> Bool {
+        let fields = parameters.split(separator: 0x3B, omittingEmptySubsequences: false)
+        guard fields.count == 2, fields[0] == [0x31],
+              let modifier = Int(String(decoding: fields[1], as: UTF8.self))
+        else { return false }
+        return (2...16).contains(modifier)
+    }
+
     private static func isDeviceControlReport(_ bytes: [UInt8]) -> Bool {
-        if bytes[2] == 0x3E { return true } // ESC P > | …
+        // XTVERSION: `ESC P > |`.
+        if bytes[2] == 0x3E { return bytes.count > 3 && bytes[3] == 0x7C }
+        // DECRQSS `ESC P n $ r` and XTGETTCAP `ESC P n + r`, n a status digit.
         var index = 2
         while index < bytes.count, bytes[index] >= 0x30, bytes[index] <= 0x39 { index += 1 }
-        guard index + 1 < bytes.count else { return false }
-        // `$r` (DECRQSS) or `+r` (XTGETTCAP) after the status digit.
+        guard index > 2, index + 1 < bytes.count else { return false }
         return (bytes[index] == 0x24 || bytes[index] == 0x2B) && bytes[index + 1] == 0x72
     }
 
@@ -90,7 +110,8 @@ public enum TerminalDeviceReport {
             index += 1
             if number > 999 { return false }
         }
-        guard index > 2 else { return false }
+        // The number, then the `;` every reply puts before its payload.
+        guard index > 2, index < bytes.count, bytes[index] == 0x3B else { return false }
         switch number {
         case 4, 5, 10...19, 21, 52:
             return true

--- a/Shared/Sources/TermioShared/TerminalDeviceReport.swift
+++ b/Shared/Sources/TermioShared/TerminalDeviceReport.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Tells a terminal's *device report* apart from the person's keystrokes.
+///
+/// Every attachment to a session runs its own libghostty, and libghostty
+/// answers a host query (XTVERSION, DA, DSR, a colour or clipboard query) on
+/// its own, through the same write path keystrokes take. With one PTY and
+/// several attachments that is one query and several answers — and the
+/// answers are indistinguishable from typing to everything downstream. Two
+/// things go wrong: the late duplicates miss the agent's parse window and
+/// land in its input line as literal text (a stray `>|ghostty 1.3.2…`), and
+/// on a client that claims the write token by writing, an observer's reply
+/// *claims the token* and drags the PTY back to its own grid. So the rule on
+/// both ends is: a report passes only from the writer, and never claims.
+///
+/// libghostty emits each reply as one standalone escape sequence:
+///   • ESC P … (DCS) — XTVERSION `>|ghostty …`, DECRQSS, XTGETTCAP
+///   • ESC ] … (OSC) — colour / clipboard query answers
+///   • ESC [ … c     — Device Attributes (primary / secondary)
+///   • ESC [ … R     — Cursor Position Report
+///
+/// Genuine input never matches: arrows / home / end terminate a CSI in A–H
+/// or `~`, a bare Esc is a lone byte, pasted or typed text carries no ESC
+/// lead-in, and bracketed paste opens with `ESC [ 200 ~`.
+public enum TerminalDeviceReport {
+    public static func isReport(_ data: Data) -> Bool {
+        let bytes = [UInt8](data)
+        guard bytes.first == 0x1B, bytes.count >= 2 else { return false }
+        switch bytes[1] {
+        case 0x50, 0x5D: // ESC P (DCS) / ESC ] (OSC)
+            return true
+        case 0x5B: // ESC [ (CSI): a report only when the final byte is 'c' or 'R'
+            var index = 2
+            while index < bytes.count {
+                let byte = bytes[index]
+                if byte >= 0x40, byte <= 0x7E { return byte == 0x63 || byte == 0x52 }
+                index += 1
+            }
+            return false
+        default:
+            return false
+        }
+    }
+}

--- a/Shared/Sources/TermioShared/TerminalDeviceReport.swift
+++ b/Shared/Sources/TermioShared/TerminalDeviceReport.swift
@@ -3,40 +3,97 @@ import Foundation
 /// Tells a terminal's *device report* apart from the person's keystrokes.
 ///
 /// Every attachment to a session runs its own libghostty, and libghostty
-/// answers a host query (XTVERSION, DA, DSR, a colour or clipboard query) on
-/// its own, through the same write path keystrokes take. With one PTY and
-/// several attachments that is one query and several answers — and the
-/// answers are indistinguishable from typing to everything downstream. Two
-/// things go wrong: the late duplicates miss the agent's parse window and
+/// answers a host query (XTVERSION, DA, DSR, DECRQM, a colour or clipboard
+/// query) on its own, through the same write path keystrokes take. With one
+/// PTY and several attachments that is one query and several answers — and
+/// the answers are indistinguishable from typing to everything downstream.
+/// Two things go wrong: the late duplicates miss the agent's parse window and
 /// land in its input line as literal text (a stray `>|ghostty 1.3.2…`), and
 /// on a client that claims the write token by writing, an observer's reply
 /// *claims the token* and drags the PTY back to its own grid. So the rule on
 /// both ends is: a report passes only from the writer, and never claims.
 ///
-/// libghostty emits each reply as one standalone escape sequence:
-///   • ESC P … (DCS) — XTVERSION `>|ghostty …`, DECRQSS, XTGETTCAP
-///   • ESC ] … (OSC) — colour / clipboard query answers
-///   • ESC [ … c     — Device Attributes (primary / secondary)
-///   • ESC [ … R     — Cursor Position Report
+/// libghostty has no hook that marks a write as generated, so this is a
+/// grammar of exactly the replies it emits (`termio/stream_handler.zig`,
+/// `terminal/modes.zig`, `terminal/formatter.zig`), each as one standalone
+/// write:
 ///
-/// Genuine input never matches: arrows / home / end terminate a CSI in A–H
-/// or `~`, a bare Esc is a lone byte, pasted or typed text carries no ESC
-/// lead-in, and bracketed paste opens with `ESC [ 200 ~`.
+///   • `ESC [ … c`        Device Attributes, primary (`?62;22c`) and secondary (`>1;10;0c`)
+///   • `ESC [ … n`        DSR operating status (`0n`)
+///   • `ESC [ … R`        Cursor Position Report
+///   • `ESC [ … $ y`      DECRQM mode report, with or without `?`
+///   • `ESC [ … t`        XTWINOPS size and title reports
+///   • `ESC [ ? … u`      kitty keyboard protocol flags — only with `?`: a key
+///                        press under that protocol is `ESC [ code ; mods u`
+///   • `ESC [ > … m`      XTQMODKEYS report — only with `>`: SGR mouse input is
+///                        `ESC [ < … M` / `m`
+///   • `ESC P > | …`      XTVERSION;  `ESC P n $ r …` DECRQSS;  `ESC P n + r …` XTGETTCAP
+///   • `ESC ] 4 ; …`, `ESC ] 10–19 ; …`, `ESC ] 21 …`, `ESC ] 52 ; …`
+///                        colour, kitty colour, and clipboard query answers
+///
+/// Everything else is input: arrows and function keys end a CSI in A–Z, `~`
+/// or `u` without `?`; mouse reports carry `<`; a bare Esc is a lone byte;
+/// typed text has no ESC lead-in; a paste arrives inside `ESC [ 200 ~`.
 public enum TerminalDeviceReport {
     public static func isReport(_ data: Data) -> Bool {
         let bytes = [UInt8](data)
-        guard bytes.first == 0x1B, bytes.count >= 2 else { return false }
+        guard bytes.count >= 3, bytes[0] == 0x1B else { return false }
         switch bytes[1] {
-        case 0x50, 0x5D: // ESC P (DCS) / ESC ] (OSC)
-            return true
-        case 0x5B: // ESC [ (CSI): a report only when the final byte is 'c' or 'R'
-            var index = 2
-            while index < bytes.count {
-                let byte = bytes[index]
-                if byte >= 0x40, byte <= 0x7E { return byte == 0x63 || byte == 0x52 }
-                index += 1
-            }
+        case 0x5B: // ESC [
+            return isControlSequenceReport(bytes)
+        case 0x50: // ESC P
+            return isDeviceControlReport(bytes)
+        case 0x5D: // ESC ]
+            return isOperatingSystemCommandReport(bytes)
+        default:
             return false
+        }
+    }
+
+    private static func isControlSequenceReport(_ bytes: [UInt8]) -> Bool {
+        let marker = bytes[2]
+        var index = 2
+        while index < bytes.count {
+            let byte = bytes[index]
+            // The final byte of a CSI is the first in 0x40–0x7E.
+            if byte >= 0x40, byte <= 0x7E {
+                switch byte {
+                case 0x63, 0x6E, 0x52, 0x79, 0x74: // c n R y t
+                    return true
+                case 0x75: // u
+                    return marker == 0x3F // ?
+                case 0x6D: // m
+                    return marker == 0x3E // >
+                default:
+                    return false
+                }
+            }
+            index += 1
+        }
+        return false
+    }
+
+    private static func isDeviceControlReport(_ bytes: [UInt8]) -> Bool {
+        if bytes[2] == 0x3E { return true } // ESC P > | …
+        var index = 2
+        while index < bytes.count, bytes[index] >= 0x30, bytes[index] <= 0x39 { index += 1 }
+        guard index + 1 < bytes.count else { return false }
+        // `$r` (DECRQSS) or `+r` (XTGETTCAP) after the status digit.
+        return (bytes[index] == 0x24 || bytes[index] == 0x2B) && bytes[index + 1] == 0x72
+    }
+
+    private static func isOperatingSystemCommandReport(_ bytes: [UInt8]) -> Bool {
+        var number = 0
+        var index = 2
+        while index < bytes.count, bytes[index] >= 0x30, bytes[index] <= 0x39 {
+            number = number * 10 + Int(bytes[index] - 0x30)
+            index += 1
+            if number > 999 { return false }
+        }
+        guard index > 2 else { return false }
+        switch number {
+        case 4, 5, 10...19, 21, 52:
+            return true
         default:
             return false
         }

--- a/Shared/Sources/TermioShared/TerminalDeviceReport.swift
+++ b/Shared/Sources/TermioShared/TerminalDeviceReport.swift
@@ -36,12 +36,15 @@ import Foundation
 /// typed text has no ESC lead-in; a paste arrives inside `ESC [ 200 ~`.
 ///
 /// One collision is xterm's, not ours: a modified F3 in the legacy encoding
-/// is `ESC [ 1 ; mod R`, the same shape as a cursor report for row 1. A
-/// report's second parameter is a column, a key's is a modifier in 2…16, and
-/// a cursor sitting in the first sixteen columns of row 1 is answered just
-/// after a clear — so that shape is read as the key. Under the kitty keyboard
-/// protocol, which every agent TUI enables, F3 is `ESC [ 13 ~` and the
-/// collision does not arise.
+/// is `ESC [ 1 ; mod R`, the same shape as a cursor report for row 1, columns
+/// 2–16 — and a fresh prompt answering `CSI 6 n` from column 3 of row 1 is
+/// exactly that report. Bytes alone cannot tell the two apart, so the report
+/// reading wins: an observer's modified F3 is dropped, which costs one
+/// keypress, where the other reading would let a real report claim the token
+/// and start the resize storm again. Under the kitty keyboard protocol, which
+/// every agent TUI enables, F3 is `ESC [ 13 ~` and the collision does not
+/// arise. The exact answer is a wrapper hook that marks generated replies at
+/// the write callback; that lives in the libghostty-swift fork.
 public enum TerminalDeviceReport {
     public static func isReport(_ data: Data) -> Bool {
         let bytes = [UInt8](data)
@@ -66,10 +69,8 @@ public enum TerminalDeviceReport {
             // The final byte of a CSI is the first in 0x40–0x7E.
             if byte >= 0x40, byte <= 0x7E {
                 switch byte {
-                case 0x63, 0x6E, 0x79, 0x74: // c n y t
+                case 0x63, 0x6E, 0x52, 0x79, 0x74: // c n R y t
                     return true
-                case 0x52: // R
-                    return !isLegacyModifiedFunctionKey(bytes[2..<index])
                 case 0x75: // u
                     return marker == 0x3F // ?
                 case 0x6D: // m
@@ -81,15 +82,6 @@ public enum TerminalDeviceReport {
             index += 1
         }
         return false
-    }
-
-    /// `1 ; 2…16` — the parameters of a modified F1–F4 in the legacy encoding.
-    private static func isLegacyModifiedFunctionKey(_ parameters: ArraySlice<UInt8>) -> Bool {
-        let fields = parameters.split(separator: 0x3B, omittingEmptySubsequences: false)
-        guard fields.count == 2, fields[0] == [0x31],
-              let modifier = Int(String(decoding: fields[1], as: UTF8.self))
-        else { return false }
-        return (2...16).contains(modifier)
     }
 
     private static func isDeviceControlReport(_ bytes: [UInt8]) -> Bool {

--- a/Shared/Sources/TermioShared/WireProtocol.swift
+++ b/Shared/Sources/TermioShared/WireProtocol.swift
@@ -108,8 +108,15 @@ public enum CompanionControl: Codable, Sendable, Equatable {
     /// The client asks the Mac to close a session (the phone's swipe-to-remove).
     /// No success reply — the next roster push drops the row everywhere.
     case stop(sessionID: String)
-    /// The client's terminal grid changed; the server resizes the PTY.
+    /// The client's terminal grid changed. The server applies it only while
+    /// this client holds the write token; otherwise it is remembered for the
+    /// moment the client types and takes the token.
     case resize(cols: Int, rows: Int)
+    /// The PTY's actual grid and whether this client is the one sizing it.
+    /// Sent on attach and every time either changes, so a client that is only
+    /// watching can lay its surface out at the grid the bytes are wrapped for
+    /// instead of its own window.
+    case grid(cols: Int, rows: Int, writer: Bool)
     /// The remote process exited.
     case exit(code: Int32)
     /// The client asks for one directory's entries (`path` relative to the
@@ -215,6 +222,8 @@ public enum CompanionControl: Codable, Sendable, Equatable {
             return #"{"t":"stop","session":"\#(sessionID)"}"#
         case .resize(let cols, let rows):
             return #"{"t":"resize","cols":\#(cols),"rows":\#(rows)}"#
+        case .grid(let cols, let rows, let writer):
+            return #"{"t":"grid","cols":\#(cols),"rows":\#(rows),"writer":\#(writer)}"#
         case .exit(let code):
             return #"{"t":"exit","code":\#(code)}"#
         // The file messages carry arbitrary user paths, so they go through
@@ -337,6 +346,10 @@ public enum CompanionControl: Codable, Sendable, Equatable {
         case "resize":
             guard let cols = obj["cols"] as? Int, let rows = obj["rows"] as? Int else { return nil }
             return .resize(cols: cols, rows: rows)
+        case "grid":
+            guard let cols = obj["cols"] as? Int, let rows = obj["rows"] as? Int,
+                  let writer = obj["writer"] as? Bool else { return nil }
+            return .grid(cols: cols, rows: rows, writer: writer)
         case "exit":
             let code = (obj["code"] as? Int).map(Int32.init) ?? 0
             return .exit(code: code)

--- a/Sources/termio/Companion/CompanionServer.swift
+++ b/Sources/termio/Companion/CompanionServer.swift
@@ -508,10 +508,10 @@ final class CompanionServer {
                 sendControl(.error(message: "unknown session — pull the list to refresh"), to: connection)
             }
         case .resize(let cols, let rows):
-            // The phone reports its grid on attach, foreground, and layout —
-            // each report claims the write token and with it the size (tmux's
-            // newest-client rule; one PTY has one winsize, per-client grids
-            // don't exist at this layer).
+            // The phone reports its grid on attach, foreground, and layout.
+            // A report is a fact about the phone's screen, not a claim on the
+            // session: it moves the PTY only while the phone holds the write
+            // token, and typing is what takes the token.
             bridges[id]?.applyClientResize(cols: cols, rows: rows)
         case .listFiles(let projectID, let path):
             handleListFiles(projectID: projectID, path: path, on: connection)
@@ -541,7 +541,7 @@ final class CompanionServer {
             Log.companion.notice(
                 "ignoring unsupported control \(Self.loggableTag(type), privacy: .public)"
             )
-        case .auth, .exit, .error, .started, .fileList, .file, .written, .uploaded,
+        case .auth, .exit, .grid, .error, .started, .fileList, .file, .written, .uploaded,
              .searchResults, .sshConfigList, .changes, .diff:
             break
         }
@@ -1051,6 +1051,10 @@ final class SessionBridge: @unchecked Sendable {
     private let lock = NSLock()
     private var pendingBytes = 0
     private var behind = false
+    /// What the daemon last said about the session's grid and this phone's
+    /// standing, guarded by `lock`; sent to the phone once both are known.
+    private var sharedGrid: TerminalGrid?
+    private var isWriter: Bool?
     private static let highWater = 1 << 20   // start dropping above 1 MB in flight
     private static let lowWater = 128 << 10  // recovered once under 128 KB
 
@@ -1073,37 +1077,70 @@ final class SessionBridge: @unchecked Sendable {
         link.onExit = { [weak self] status, _, _ in
             self?.onExit?(status)
         }
+        // The phone lays its surface out from these two facts: while another
+        // device sizes the session, the bytes it receives are wrapped for the
+        // shared grid, and only a surface at that grid shows them faithfully.
+        link.onWriter = { [weak self] writer in
+            self?.publishGrid(writer: writer)
+        }
+        link.onSharedGrid = { [weak self] grid in
+            self?.publishGrid(grid: grid)
+        }
         link.start()
     }
 
-    /// Keystrokes from the phone. The link claims the write token on the way
-    /// through, so a phone typing takes the session back from the Mac the same
-    /// way the Mac takes it back by typing.
+    /// Bytes from the phone's surface. Keystrokes claim the write token on the
+    /// way through the link, so a phone typing takes the session back from the
+    /// Mac the same way the Mac takes it back by typing. A terminal's reply to
+    /// a host query is not the person and takes nothing: it passes only while
+    /// the phone is already the writer (`TerminalDeviceReport`).
     func write(_ data: Data) {
+        guard !TerminalDeviceReport.isReport(data) else {
+            link.sendDeviceReport(data)
+            return
+        }
         link.send(data)
         onInput?()
     }
 
-    /// A resize control from this client. Sizing is the writer's to set, and on
-    /// this path the grid report *is* the claim: the phone sends one when it
-    /// opens a session, comes back to that screen, or rotates — every one of
-    /// them the user arriving at this session on this device. Attaching used to
-    /// take the token by itself, which read the same for a phone opening one
-    /// session and for a Mac window quietly holding fifteen, and let the phone
-    /// pull the shared PTY down to its width behind the Mac's back.
-    ///
-    /// The claim lands first and the grid follows it: `resize` records the size
-    /// whether or not this attachment can send it yet, and the grant re-asserts
-    /// it. So the daemon adopts this grid and answers with a keyframe rendered
-    /// for it — but only once the user has actually shown up here.
+    /// The phone's grid. Sizing is the writer's to set: the link sends this as
+    /// an `R` frame only while it holds the token, and otherwise keeps it for
+    /// the moment the token arrives, when the grant re-asserts it. Reporting a
+    /// grid used to claim the token, so a phone that merely opened a session —
+    /// or came back to the foreground, or rotated — pulled the shared PTY down
+    /// to its width and repainted every other attachment, and the Mac pulled it
+    /// back on the next keystroke. Both ends now move the token by typing only.
     func applyClientResize(cols: Int, rows: Int) {
-        link.claimWriter()
         link.resize(rows: rows, cols: cols)
+    }
+
+    private func publishGrid(grid: TerminalGrid? = nil, writer: Bool? = nil) {
+        lock.lock()
+        if let grid { sharedGrid = grid }
+        if let writer { isWriter = writer }
+        guard let sharedGrid, let isWriter else {
+            lock.unlock()
+            return
+        }
+        lock.unlock()
+        sendControl(.grid(cols: Int(sharedGrid.cols), rows: Int(sharedGrid.rows), writer: isWriter))
+    }
+
+    private func sendControl(_ control: CompanionControl) {
+        let meta = NWProtocolWebSocket.Metadata(opcode: .text)
+        let context = NWConnection.ContentContext(identifier: "control", metadata: [meta])
+        connection.send(
+            content: Data(control.encoded().utf8),
+            contentContext: context,
+            completion: .idempotent
+        )
     }
 
     func stop() {
         link.onOutput = nil
         link.onExit = nil
+        link.onWriter = nil
+        link.onSharedGrid = nil
         onExit = nil
         onInput = nil
         // Detach, never kill: the session belongs to the daemon and outlives

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -419,9 +419,12 @@ private enum TerminalFocusReason {
 ///
 /// The surface is sized to the grid plus half a cell: libghostty floors
 /// `(size − padding) / cell` to get its column count, and an exact multiple can
-/// round to one column short. A shared grid the pane cannot hold is not
-/// letterboxed — nothing smaller than the bytes' own width shows them right, so
-/// the pane keeps its full surface rather than guess.
+/// round to one column short. A shared grid the pane cannot hold is still laid
+/// out at that grid, anchored top-left and clipped: a surface at any other
+/// width wraps the bytes wrong, and a correct screen with its edge cut off
+/// beats a complete one that is scrambled. It also keeps the promise the
+/// resync depends on — the surface *reaches* the shared grid, so the link can
+/// ask for the keyframe that paints it (`observerRepaintPending`).
 private struct SharedGridLetterbox<Content: View>: View {
     let runtime: SessionRuntime
     @ObservedObject var context: TerminalViewState
@@ -438,12 +441,14 @@ private struct SharedGridLetterbox<Content: View>: View {
         // NSView, which is the repaint this file exists to avoid. A nil frame
         // dimension is "no constraint", so the surface fills the pane.
         let size = letterboxSize
-        ZStack {
+        let fits = size.map { $0.width <= paneSize.width && $0.height <= paneSize.height } ?? true
+        ZStack(alignment: fits ? .center : .topLeading) {
             background
             content()
                 .frame(width: size?.width, height: size?.height)
         }
-        .frame(width: paneSize.width, height: paneSize.height)
+        .frame(width: paneSize.width, height: paneSize.height, alignment: .topLeading)
+        .clipped()
     }
 
     private var letterboxSize: CGSize? {
@@ -460,7 +465,6 @@ private struct SharedGridLetterbox<Content: View>: View {
         let paddingY = CGFloat(TermioStore.terminalWindowPaddingY)
         let width = CGFloat(grid.cols) * cellWidth + 2 * paddingX + cellWidth / 2
         let height = CGFloat(grid.rows) * cellHeight + 2 * paddingY + cellHeight / 2
-        guard width <= paneSize.width, height <= paneSize.height else { return nil }
         return CGSize(width: width, height: height)
     }
 }

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -149,15 +149,24 @@ struct TerminalPane: View {
                 // full bounds; its hidden siblings keep their laid-out frames. An
                 // ungrouped session has no split geometry and fills the pane.
                 let rect = zoomed && isSelected ? bounds : (paneFrames[id] ?? bounds)
-                ManagedTerminalSurface(
-                    context: store.surface(for: item.session),
-                    isSelected: isSelected,
-                    isVisible: isVisible,
-                    onFocused: { selectFocusedSurface(id) },
-                    requestFocus: { reason in
-                        requestTerminalFocus(for: id, reason: reason)
-                    }
-                )
+                let context = store.surface(for: item.session)
+                SharedGridLetterbox(
+                    runtime: store.runtime(for: id),
+                    context: context,
+                    paneSize: rect.size,
+                    paddingX: CGFloat(settings.windowPadding),
+                    background: paneBackground
+                ) {
+                    ManagedTerminalSurface(
+                        context: context,
+                        isSelected: isSelected,
+                        isVisible: isVisible,
+                        onFocused: { selectFocusedSurface(id) },
+                        requestFocus: { reason in
+                            requestTerminalFocus(for: id, reason: reason)
+                        }
+                    )
+                }
                 .frame(width: rect.width, height: rect.height)
                 // Dropping a file (dragged from the file-tree inspector, the Issues list or
                 // the Finder) inserts its shell-quoted path at the prompt — the prebuilt
@@ -394,6 +403,65 @@ private enum TerminalFocusReason {
         case .fileDrop: "file-drop"
         case .faultInjector: "fault-injector"
         }
+    }
+}
+
+/// Lays a surface out at the grid another device is sizing the session to.
+///
+/// One PTY has one winsize, and every attachment parses the same bytes. While a
+/// phone holds the write token those bytes are wrapped for the phone's grid, and
+/// a surface stretched across this pane would re-wrap them at its own width —
+/// the §C.5 divergence: every line that wrapped on the phone lands somewhere
+/// else here, and a TUI that repaints incrementally never repairs it. So a
+/// demoted pane shows the session at exactly the shared grid, centred, with the
+/// terminal background around it — the same picture the phone has, at the Mac's
+/// font. Typing takes the token back, and the surface returns to the pane.
+///
+/// The surface is sized to the grid plus half a cell: libghostty floors
+/// `(size − padding) / cell` to get its column count, and an exact multiple can
+/// round to one column short. A shared grid the pane cannot hold is not
+/// letterboxed — nothing smaller than the bytes' own width shows them right, so
+/// the pane keeps its full surface rather than guess.
+private struct SharedGridLetterbox<Content: View>: View {
+    let runtime: SessionRuntime
+    @ObservedObject var context: TerminalViewState
+    let paneSize: CGSize
+    let paddingX: CGFloat
+    let background: Color
+    @ViewBuilder let content: () -> Content
+
+    @Environment(\.displayScale) private var displayScale
+
+    var body: some View {
+        // One structure whether letterboxed or not: a branch here would give
+        // the surface a new identity each time the token moved and remount its
+        // NSView, which is the repaint this file exists to avoid. A nil frame
+        // dimension is "no constraint", so the surface fills the pane.
+        let size = letterboxSize
+        ZStack {
+            background
+            content()
+                .frame(width: size?.width, height: size?.height)
+        }
+        .frame(width: paneSize.width, height: paneSize.height)
+    }
+
+    private var letterboxSize: CGSize? {
+        // Not conditioned on the surface's current grid differing from the
+        // shared one: once letterboxed, the surface *is* at the shared grid,
+        // and that condition would take the letterbox away again.
+        guard !runtime.isWriter,
+              let grid = runtime.sharedGrid,
+              let metrics = context.surfaceSize,
+              metrics.cellWidthPixels > 0, metrics.cellHeightPixels > 0
+        else { return nil }
+        let cellWidth = CGFloat(metrics.cellWidthPixels) / displayScale
+        let cellHeight = CGFloat(metrics.cellHeightPixels) / displayScale
+        let paddingY = CGFloat(TermioStore.terminalWindowPaddingY)
+        let width = CGFloat(grid.cols) * cellWidth + 2 * paddingX + cellWidth / 2
+        let height = CGFloat(grid.rows) * cellHeight + 2 * paddingY + cellHeight / 2
+        guard width <= paneSize.width, height <= paneSize.height else { return nil }
+        return CGSize(width: width, height: height)
     }
 }
 

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -112,15 +112,20 @@ extension TermioStore {
             self?.applyTermiodStatus(status, for: session.id)
         }
         // The link itself acts on this (it stops sending `R` frames the daemon
-        // would reject, and re-asserts the grid when the token returns). Logged
-        // here because a demoted pane looks identical to a live one on screen —
-        // saying it out loud is what makes a silently-ignored keystroke
-        // explainable. Showing it in the pane is a client-UI step, not taken here.
-        link.onWriter = { writer in
+        // would reject, and re-asserts the grid when the token returns). The
+        // pane acts on it too: a demoted surface is letterboxed at the grid the
+        // other device chose (`SessionRuntime.sharedGrid`), so what it shows is
+        // what the bytes were wrapped for rather than a wide window's reflow of
+        // a phone-width screen.
+        link.onWriter = { [weak self] writer in
             Log.termiod.info("""
             session \(session.id.uuidString, privacy: .public) is now \
             \(writer ? "the writer" : "an observer", privacy: .public)
             """)
+            self?.runtime(for: session.id).isWriter = writer
+        }
+        link.onSharedGrid = { [weak self] grid in
+            self?.runtime(for: session.id).sharedGrid = grid
         }
         // What the device knows about the process, gated exactly where the
         // in-process PTY's own kernel poll is gated: that poll is installed only

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -889,6 +889,12 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// the authority — §C.5: a client that parses at its own window size instead
     /// of this one wraps the same bytes differently and diverges from the host.
     private var authoritativeGrid: TerminalGrid?
+    /// An observer whose surface is not yet at the shared grid. The keyframe
+    /// that announced the grid was parsed at the old one, and the surface is
+    /// resized only after `onSharedGrid` reaches the UI — so the first `resize`
+    /// that lands *on* the shared grid asks the daemon for a fresh keyframe,
+    /// and that one paints right.
+    private var observerRepaintPending = false
     /// Set on any deliberate teardown so the reader's EOF is not misread as a
     /// daemon crash.
     private var closed = false
@@ -1058,6 +1064,7 @@ final class TermiodSessionLink: @unchecked Sendable {
                 authoritativeGrid = sharedGrid
                 DispatchQueue.main.async { [self] in onSharedGrid?(sharedGrid) }
                 if isWriter { sentGrid = requested }
+                observerRepaintPending = !isWriter && sharedGrid != requested
                 Log.termiod.info("""
                 attached session=\(self.sessionName, privacy: .public) \
                 device=\(device.id, privacy: .public) \
@@ -1198,8 +1205,16 @@ final class TermiodSessionLink: @unchecked Sendable {
             desiredGrid = size
             guard attached else { return }
             // Observers must not resize the shared PTY out from under the
-            // writer; the daemon would reject the frame anyway.
-            guard isWriter else { return }
+            // writer; the daemon would reject the frame anyway. An observer
+            // arriving at the shared grid is the one moment it does need
+            // something from the daemon: a keyframe it can finally paint.
+            guard isWriter else {
+                if observerRepaintPending, authoritativeGrid == size {
+                    observerRepaintPending = false
+                    requestResyncLocked()
+                }
+                return
+            }
             scheduleResizeLocked()
         }
     }
@@ -1283,17 +1298,20 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// way to know the screen is wrong, so it has to be told. The repaint
     /// arrives as an ordinary snapshot on the reader.
     func requestResync() {
-        workQueue.async { [self] in
-            guard !closed, attached, let transport else { return }
-            do {
-                try Termiod.writeFrame(transport.writeDescriptor, kind: .control,
-                                       payload: Termiod.requestSnapshotPayload())
-            } catch {
-                Log.termiod.error("""
-                resync request on \(self.sessionName, privacy: .public) failed: \
-                \(error.localizedDescription, privacy: .public)
-                """)
-            }
+        workQueue.async { [self] in requestResyncLocked() }
+    }
+
+    /// Must run on `workQueue`.
+    private func requestResyncLocked() {
+        guard !closed, attached, let transport else { return }
+        do {
+            try Termiod.writeFrame(transport.writeDescriptor, kind: .control,
+                                   payload: Termiod.requestSnapshotPayload())
+        } catch {
+            Log.termiod.error("""
+            resync request on \(self.sessionName, privacy: .public) failed: \
+            \(error.localizedDescription, privacy: .public)
+            """)
         }
     }
 
@@ -1557,6 +1575,10 @@ final class TermiodSessionLink: @unchecked Sendable {
             write token on \(self.sessionName, privacy: .public) \
             \(mine ? "claimed" : "lost", privacy: .public)
             """)
+            // Demoted with the surface still at its own grid: the letterbox
+            // will move it, and the resize that lands is what asks for the
+            // keyframe (see `observerRepaintPending`).
+            observerRepaintPending = !mine && authoritativeGrid != desiredGrid
             if mine {
                 do {
                     try sendResizeLocked(desiredGrid)
@@ -1635,6 +1657,7 @@ final class TermiodSessionLink: @unchecked Sendable {
             guard authoritativeGrid != grid else { return }
             authoritativeGrid = grid
             DispatchQueue.main.async { [self] in onSharedGrid?(grid) }
+            if !isWriter { observerRepaintPending = grid != desiredGrid }
             guard grid != desiredGrid else { return }
             Log.termiod.info("""
             \(self.sessionName, privacy: .public) PTY is now \

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -984,6 +984,11 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// on every genuine change. The link already gates its own `R` frames on
     /// this; the callback is for the UI that has to say "read-only" out loud.
     var onWriter: ((Bool) -> Void)?
+    /// The PTY's actual grid, on the main queue: once from `attached` and then
+    /// on every `E resized`. While another client holds the token this is the
+    /// grid the bytes are wrapped for, and the surface that shows them has to
+    /// be laid out at it — see `SessionRuntime.sharedGrid`.
+    var onSharedGrid: ((TerminalGrid) -> Void)?
 
     init(sessionName: String,
          specification: Termiod.CreateSpecification,
@@ -1048,8 +1053,10 @@ final class TermiodSessionLink: @unchecked Sendable {
                 // announces it as `E resized`. Seeding from the reply means an
                 // observer — which never triggers that resize — still knows the
                 // grid its bytes are wrapped at.
-                authoritativeGrid = TerminalGrid(
+                let sharedGrid = TerminalGrid(
                     rows: attachedPayload.rows, cols: attachedPayload.cols)
+                authoritativeGrid = sharedGrid
+                DispatchQueue.main.async { [self] in onSharedGrid?(sharedGrid) }
                 if isWriter { sentGrid = requested }
                 Log.termiod.info("""
                 attached session=\(self.sessionName, privacy: .public) \
@@ -1150,6 +1157,29 @@ final class TermiodSessionLink: @unchecked Sendable {
             } catch {
                 Log.termiod.error("""
                 claiming the write token on \(self.sessionName, privacy: .public) failed: \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            }
+        }
+    }
+
+    /// A reply this client's libghostty generated to a host query (DA, DSR,
+    /// XTVERSION, a colour query). It goes through only while this client is
+    /// the writer, and it never claims: the host asked its terminal one
+    /// question, and the writer's surface is that terminal. An observer's
+    /// answer would arrive as a late duplicate in the agent's input line — and,
+    /// through `send`, would take the token and drag the PTY back to this
+    /// window's grid every time the agent probed. That silent tug-of-war was
+    /// the resize storm two devices watching one session used to produce.
+    func sendDeviceReport(_ data: Data) {
+        guard !data.isEmpty else { return }
+        workQueue.async { [self] in
+            guard !closed, attached, isWriter else { return }
+            do {
+                try sendDataLocked(data)
+            } catch {
+                Log.termiod.error("""
+                device report to \(self.sessionName, privacy: .public) failed: \
                 \(error.localizedDescription, privacy: .public)
                 """)
             }
@@ -1597,13 +1627,14 @@ final class TermiodSessionLink: @unchecked Sendable {
     /// (`InMemoryTerminalSession.dispatchResize` drops an unchanged viewport),
     /// so a PTY moved out from under a still window has no second chance to be
     /// noticed — the screen stays formatted for someone else's grid until the
-    /// user drags the window edge. Letterboxing an *observer's* viewport, which
-    /// cannot resize anything, is the client-side step this foundation still
-    /// leaves open.
+    /// user drags the window edge. An *observer* cannot resize anything, so its
+    /// answer is on the other side of `onSharedGrid`: the pane lays the surface
+    /// out at the shared grid instead (`SharedGridLetterbox`).
     private func applyAuthoritativeGrid(_ grid: TerminalGrid) {
         workQueue.async { [self] in
             guard authoritativeGrid != grid else { return }
             authoritativeGrid = grid
+            DispatchQueue.main.async { [self] in onSharedGrid?(grid) }
             guard grid != desiredGrid else { return }
             Log.termiod.info("""
             \(self.sessionName, privacy: .public) PTY is now \

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1208,8 +1208,13 @@ final class TermiodSessionLink: @unchecked Sendable {
             // writer; the daemon would reject the frame anyway. An observer
             // arriving at the shared grid is the one moment it does need
             // something from the daemon: a keyframe it can finally paint.
+            // Leaving the grid — a font change reports the old frame at new
+            // cell metrics before the letterbox puts it back — arms the next
+            // arrival, so the bytes parsed in between are repainted too.
             guard isWriter else {
-                if observerRepaintPending, authoritativeGrid == size {
+                if authoritativeGrid != size {
+                    observerRepaintPending = true
+                } else if observerRepaintPending {
                     observerRepaintPending = false
                     requestResyncLocked()
                 }

--- a/Sources/termio/TermioStore/SessionRuntime.swift
+++ b/Sources/termio/TermioStore/SessionRuntime.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import TermioShared
 
 /// Per-session live state that changes at agent-tick frequency: the agent's
 /// status, the tool it is running, its live `OSC 0/2` title, and the shell's
@@ -31,4 +32,14 @@ final class SessionRuntime {
     /// The live working directory (shell `OSC 7`); for loose terminals this *is* the
     /// entity's path — it labels the row and roots the inspector.
     var workingDirectory: String?
+    /// Whether this Mac's attachment holds the session's write token. `true`
+    /// until the daemon says otherwise, so a session nothing else is watching
+    /// behaves exactly as it always has.
+    var isWriter = true
+    /// The PTY's real grid, from the daemon. The pane reads it together with
+    /// `isWriter`: while another device is sizing the session, the bytes on the
+    /// wire are wrapped for *this* grid, and the only faithful way to show them
+    /// is a surface laid out at it — letterboxed in the pane, not stretched to
+    /// the window (§C.5 of the session protocol).
+    var sharedGrid: TerminalGrid?
 }

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -288,6 +288,14 @@ extension TermioStore {
             for: session, argv: argv, cwd: spawnPath, env: env)
         let inMemory = InMemoryTerminalSession(
             write: { [weak self] data in
+                // libghostty answers the host's terminal queries through this
+                // same closure. Those are not the user, so they must not claim
+                // the token — and only the writer's surface may answer at all
+                // (`TerminalDeviceReport`).
+                guard !TerminalDeviceReport.isReport(data) else {
+                    termiodLink.sendDeviceReport(data)
+                    return
+                }
                 // Typing on the Mac reclaims the write token, and with it the
                 // winsize, from an attached phone — the size follows the device
                 // being used. `send` does the claiming.
@@ -782,6 +790,10 @@ extension TermioStore {
         }
     }
 
+    /// The surface's top/bottom margin in points. Named because the pane needs
+    /// the same number to size a letterboxed surface to an exact grid.
+    static let terminalWindowPaddingY = 2
+
     /// Translates `AppSettings` (plain values) into Ghostty config commands. This
     /// is the single place terminal-core keys are named, so surface creation and
     /// the live re-style path can never drift apart. Everything here is accepted
@@ -821,7 +833,7 @@ extension TermioStore {
         // directly above the surface, so matching the setting there would open a
         // visible gap between the title and the first prompt line.
         builder.withWindowPaddingX(settings.windowPadding)
-        builder.withWindowPaddingY(2)
+        builder.withWindowPaddingY(Self.terminalWindowPaddingY)
         builder.withBackgroundOpacity(settings.backgroundOpacity)
         builder.withBackgroundBlur(settings.backgroundBlur)
 

--- a/Tests/termioTests/TerminalDeviceReportTests.swift
+++ b/Tests/termioTests/TerminalDeviceReportTests.swift
@@ -1,0 +1,34 @@
+import TermioShared
+import XCTest
+@testable import termio
+
+/// A terminal's reply to a host query shares the write path with keystrokes,
+/// and misclassifying either way is visible: a report treated as typing claims
+/// the write token and drags the PTY to the observer's grid, a keystroke
+/// treated as a report is silently dropped.
+final class TerminalDeviceReportTests: XCTestCase {
+    private func bytes(_ text: String) -> Data { Data(text.utf8) }
+
+    func testRepliesLibghosttyGeneratesAreReports() {
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}P>|ghostty 1.3.2\u{1B}\\")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}]11;rgb:1e1e/1e1e/2e2e\u{1B}\\")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[?62;22c")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[>1;10;0c")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[24;80R")))
+    }
+
+    func testKeystrokesAreNotReports() {
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("ls -la\r")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[A")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[1;5C")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[3~")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[200~pasted\u{1B}[201~")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(Data()))
+    }
+
+    func testGridControlRoundTrips() {
+        let message = CompanionControl.grid(cols: 45, rows: 38, writer: false)
+        XCTAssertEqual(CompanionControl.decode(message.encoded()), message)
+    }
+}

--- a/Tests/termioTests/TerminalDeviceReportTests.swift
+++ b/Tests/termioTests/TerminalDeviceReportTests.swift
@@ -10,11 +10,28 @@ final class TerminalDeviceReportTests: XCTestCase {
     private func bytes(_ text: String) -> Data { Data(text.utf8) }
 
     func testRepliesLibghosttyGeneratesAreReports() {
-        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}P>|ghostty 1.3.2\u{1B}\\")))
-        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}]11;rgb:1e1e/1e1e/2e2e\u{1B}\\")))
+        // Device attributes, status, cursor position.
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[?62;22c")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[?62;22;52c")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[>1;10;0c")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[0n")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[24;80R")))
+        // DECRQM mode reports, private and ANSI.
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[?2026;2$y")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[4;1$y")))
+        // XTWINOPS size reports, kitty keyboard flags, XTQMODKEYS.
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[8;24;80t")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[?1u")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[>4;2m")))
+        // DCS: XTVERSION, DECRQSS, XTGETTCAP.
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}P>|ghostty 1.3.2\u{1B}\\")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}P1$r0 q\u{1B}\\")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}P1+r544e=787465726d\u{1B}\\")))
+        // OSC: colours, kitty colours, clipboard.
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}]4;1;rgb:1e1e/1e1e/2e2e\u{1B}\\")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}]11;rgb:1e1e/1e1e/2e2e\u{1B}\\")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}]21;foreground=rgb:ff/ff/ff\u{1B}\\")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}]52;c;aGVsbG8=\u{1B}\\")))
     }
 
     func testKeystrokesAreNotReports() {
@@ -23,7 +40,20 @@ final class TerminalDeviceReportTests: XCTestCase {
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[A")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[1;5C")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[3~")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}OR")))
+        // A key press under the kitty keyboard protocol ends in `u` too, but
+        // without the `?` a flags report carries.
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[97;5u")))
+        // SGR mouse press and release carry `<`, never the `>` of XTQMODKEYS.
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[<0;10;20M")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[<0;10;20m")))
+        // Bracketed paste, even when the pasted text starts with an escape.
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[200~pasted\u{1B}[201~")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[200~\u{1B}]11;?\u{1B}\\\u{1B}[201~")))
+        // A title OSC or an unlisted DCS is not a reply libghostty emits.
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}]0;title\u{1B}\\")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}Pq#0;2;0;0;0\u{1B}\\")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}]")))
         XCTAssertFalse(TerminalDeviceReport.isReport(Data()))
     }
 

--- a/Tests/termioTests/TerminalDeviceReportTests.swift
+++ b/Tests/termioTests/TerminalDeviceReportTests.swift
@@ -16,6 +16,8 @@ final class TerminalDeviceReportTests: XCTestCase {
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[>1;10;0c")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[0n")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[24;80R")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[1;1R")))
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[1;40R")))
         // DECRQM mode reports, private and ANSI.
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[?2026;2$y")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[4;1$y")))
@@ -41,6 +43,11 @@ final class TerminalDeviceReportTests: XCTestCase {
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[1;5C")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[3~")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}OR")))
+        // Modified F3 in the legacy encoding shares its shape with a cursor
+        // report for row 1; the modifier range decides it.
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[1;5R")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[1;2R")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[13~")))
         // A key press under the kitty keyboard protocol ends in `u` too, but
         // without the `?` a flags report carries.
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[97;5u")))
@@ -50,9 +57,14 @@ final class TerminalDeviceReportTests: XCTestCase {
         // Bracketed paste, even when the pasted text starts with an escape.
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[200~pasted\u{1B}[201~")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[200~\u{1B}]11;?\u{1B}\\\u{1B}[201~")))
-        // A title OSC or an unlisted DCS is not a reply libghostty emits.
+        // A title OSC or an unlisted DCS is not a reply libghostty emits, and
+        // neither is a reply-looking prefix without its introducer.
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}]0;title\u{1B}\\")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}Pq#0;2;0;0;0\u{1B}\\")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}P>q")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}P$r")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}]4x")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}]11")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}]")))
         XCTAssertFalse(TerminalDeviceReport.isReport(Data()))
     }

--- a/Tests/termioTests/TerminalDeviceReportTests.swift
+++ b/Tests/termioTests/TerminalDeviceReportTests.swift
@@ -18,6 +18,9 @@ final class TerminalDeviceReportTests: XCTestCase {
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[24;80R")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[1;1R")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[1;40R")))
+        // Row 1, column 3 — a fresh prompt answering `CSI 6 n`. The same bytes
+        // are a legacy modified F3; the report reading is the safe side.
+        XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[1;3R")))
         // DECRQM mode reports, private and ANSI.
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[?2026;2$y")))
         XCTAssertTrue(TerminalDeviceReport.isReport(bytes("\u{1B}[4;1$y")))
@@ -43,11 +46,10 @@ final class TerminalDeviceReportTests: XCTestCase {
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[1;5C")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[3~")))
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}OR")))
-        // Modified F3 in the legacy encoding shares its shape with a cursor
-        // report for row 1; the modifier range decides it.
-        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[1;5R")))
-        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[1;2R")))
+        // F3 under the kitty keyboard protocol, which agent TUIs enable; the
+        // legacy modified form collides with a cursor report (see the type's doc).
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[13~")))
+        XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[13;5~")))
         // A key press under the kitty keyboard protocol ends in `u` too, but
         // without the `?` a flags report carries.
         XCTAssertFalse(TerminalDeviceReport.isReport(bytes("\u{1B}[97;5u")))

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -3,7 +3,7 @@ title: termiod Session Protocol
 status: draft
 type: design
 created: 2026-07-30
-updated: 2026-08-24
+updated: 2026-08-29
 related:
   - 20260730-termiod-session-mux.md
   - 20260708-session-daemon-architecture.md
@@ -313,19 +313,26 @@ and diverge — the synchronized-state-machine guarantee silently breaks. So:
 `attached` (and the v1 `S` snapshot) **carry `rows`/`cols`**, and a smart client
 maintains an internal grid at *authoritative PTY dimensions* with its own
 *local* viewport layered on top (letterbox / scale / scroll) — never by parsing
-at its own window size. *(`Attached` carries `rows`/`cols` as of Phase 1c. The
-residual gap is client conformance, not the wire: the reference client still
-ignores `Resized`/`WriterChanged` (`client.rs`) — acceptable for a single
-same-size CLI, incorrect the moment a second differently-sized viewer
-attaches.)*
+at its own window size. *(`Attached` carries `rows`/`cols` as of Phase 1c. As
+of 2026-08-29 both app clients conform: the Mac pane letterboxes a demoted
+surface at the shared grid (`SharedGridLetterbox`) and the phone lays its
+surface out at that grid and scales it to fit, both driven by `E resized` and
+`writer_changed`. The reference CLI client still parses at its own size —
+acceptable for a single same-size CLI.)*
 
 **Writer policy — single writer, follows the device being used, observable.**
 A `mode:"interact"` attach takes the write token only when nobody holds it;
 after that the token moves on `claim_writer` alone, which every client sends
-when its user actually shows up (typing, or opening the session on a phone).
+when its user actually shows up — that is, types. Opening a session on a phone,
+bringing it to the foreground, or rotating it is *looking*, and takes nothing;
+a phone's grid report is remembered and applied only once it holds the token.
 The previous writer stays attached but demoted, and *everyone* on the session
 gets `E {ev:"writer_changed", writer:"c_41"}`. Observers' `D`/`R` frames are
-answered with `error {code:"not_writer"}` rather than dropped.
+answered with `error {code:"not_writer"}` rather than dropped. A client's own
+replies to the host's terminal queries (DA, DSR, XTVERSION, colour queries) are
+not its user either: they are sent only by the writer and never claim
+(`TerminalDeviceReport`), so one query gets one answer and an observer's
+surface cannot take the token back every time the agent probes its terminal.
 
 Attach originally took the token unconditionally, which reads identically for a
 phone opening one session and a Mac window quietly holding fifteen: the phone's

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -317,8 +317,11 @@ at its own window size. *(`Attached` carries `rows`/`cols` as of Phase 1c. As
 of 2026-08-29 both app clients conform: the Mac pane letterboxes a demoted
 surface at the shared grid (`SharedGridLetterbox`) and the phone lays its
 surface out at that grid and scales it to fit, both driven by `E resized` and
-`writer_changed`. The reference CLI client still parses at its own size —
-acceptable for a single same-size CLI.)*
+`writer_changed`. The keyframe that announces a new grid reaches an observer
+before its surface has moved, so it is parsed at the old grid; the first
+resize that lands on the shared grid sends `request_snapshot`, and that
+keyframe paints right. The reference CLI client still parses at its own size
+— acceptable for a single same-size CLI.)*
 
 **Writer policy — single writer, follows the device being used, observable.**
 A `mode:"interact"` attach takes the write token only when nobody holds it;

--- a/ios/Sources/CompanionBackend.swift
+++ b/ios/Sources/CompanionBackend.swift
@@ -118,6 +118,11 @@ final class CompanionDeviceSession: DeviceSession {
 
     var onState: ((DeviceSessionState) -> Void)?
 
+    var onSharedGrid: ((TerminalGrid, Bool) -> Void)? {
+        get { transport.onSharedGrid }
+        set { transport.onSharedGrid = newValue }
+    }
+
     private let transport: CompanionTransport
 
     init(url: URL, attachSessionID: String?) {
@@ -130,6 +135,9 @@ final class CompanionDeviceSession: DeviceSession {
     func start() { transport.start() }
     func stop() { transport.stop() }
     func send(_ data: Data) { transport.send(data) }
+    /// The Mac's bridge tells a report from a keystroke and gates it on the
+    /// phone's own attachment, so on this wire it travels like any other byte.
+    func sendDeviceReport(_ data: Data) { transport.send(data) }
     func resize(columns: Int, rows: Int) { transport.resize(cols: columns, rows: rows) }
     func reassertGrid() { transport.reassertGrid() }
 }

--- a/ios/Sources/CompanionTransport.swift
+++ b/ios/Sources/CompanionTransport.swift
@@ -33,9 +33,9 @@ final class CompanionTransport {
     private let link: WebSocketLink
     /// Last grid the terminal reported, re-sent on every (re)connect and on
     /// foreground: the first resize often fires before the socket exists and
-    /// would be silently lost, a reconnect never re-fires it (the view's size
-    /// didn't change), and each report claims the PTY's winsize for this
-    /// device (the Mac may have taken it back while the app was away).
+    /// would be silently lost, and a reconnect never re-fires it (the view's
+    /// size didn't change). The Mac applies a report only while this phone
+    /// holds the write token; typing is what takes the token.
     private var gridCols = 0
     private var gridRows = 0
     private let gridLock = NSLock()
@@ -58,6 +58,9 @@ final class CompanionTransport {
     var onOutput: ((Data) -> Void)?
     /// State transitions, delivered on the main queue.
     var onState: ((State) -> Void)?
+    /// The PTY's grid and whether this phone is sizing it, from the Mac's
+    /// `grid` control; delivered on the main queue.
+    var onSharedGrid: ((TerminalGrid, Bool) -> Void)?
 
     init(url: URL, attachSessionID: String? = nil) {
         self.url = url
@@ -78,9 +81,9 @@ final class CompanionTransport {
         link.onUp = { [weak self] in self?.notify(.connected) }
         link.onDown = { [weak self] in self?.notify(.reconnecting) }
         link.onForeground = { [weak self] in
-            // The link survived the background trip; coming back to the app is
-            // still a claim — the Mac may have taken the winsize while we were
-            // away.
+            // The link survived the background trip. If this phone still holds
+            // the write token the PTY may have moved while it was away; if not,
+            // the Mac ignores the report.
             self?.reassertGrid()
         }
         link.onData = { [weak self] data in self?.onOutput?(data) }
@@ -111,8 +114,9 @@ final class CompanionTransport {
         sendGrid()
     }
 
-    /// Re-claims the PTY's winsize for this device — called when the user
-    /// comes back to this screen (re-opening a parked session).
+    /// Re-sends this phone's grid — on reconnect, foreground, and re-opening a
+    /// parked session. The Mac applies it only while this phone holds the
+    /// write token, and a size the PTY already has costs nothing.
     func reassertGrid() {
         sendGrid()
     }
@@ -182,6 +186,9 @@ final class CompanionTransport {
         switch CompanionControl.decode(text) {
         case .exit:
             finish(.closed)
+        case .grid(let cols, let rows, let writer):
+            let grid = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: cols))
+            DispatchQueue.main.async { [onSharedGrid] in onSharedGrid?(grid, writer) }
         case .error(let message, let code):
             finish(.failed(CompanionRefusal.text(code: code, fallback: message)))
         default:

--- a/ios/Sources/DeviceClient.swift
+++ b/ios/Sources/DeviceClient.swift
@@ -87,13 +87,22 @@ protocol DeviceSession: AnyObject {
     /// Link and lifecycle transitions, delivered on the main queue.
     var onState: ((DeviceSessionState) -> Void)? { get set }
 
+    /// The PTY's actual grid and whether this device is the one sizing it,
+    /// on the main queue: once on attach and on every change of either. While
+    /// another device holds the write token the bytes arriving are wrapped for
+    /// that grid, and the screen lays its surface out at it.
+    var onSharedGrid: ((TerminalGrid, Bool) -> Void)? { get set }
+
     func start()
     func stop()
-    /// Keystrokes, as raw bytes.
+    /// Keystrokes, as raw bytes. Typing is what claims the write token.
     func send(_ data: Data)
+    /// A reply the surface generated to a host query (`TerminalDeviceReport`).
+    /// Passes only while this device is the writer, and never claims.
+    func sendDeviceReport(_ data: Data)
     func resize(columns: Int, rows: Int)
-    /// Re-claim the PTY's winsize for this device without a size change —
-    /// what a reattach and a returning foreground both need.
+    /// Re-send this device's grid: a no-op unless this device holds the write
+    /// token and the PTY is not already that size.
     func reassertGrid()
 }
 

--- a/ios/Sources/TerminalViewController.swift
+++ b/ios/Sources/TerminalViewController.swift
@@ -49,6 +49,23 @@ final class TerminalViewController: UIViewController {
     /// see viewDidLayoutSubviews for why resizes are rationed.
     private var lastFittedSize: CGSize = .zero
     private var fitDebounce: DispatchWorkItem?
+    /// The area the surface may occupy, pinned by constraints between the
+    /// header and the keyboard. The surface is framed by hand inside it
+    /// (`layoutTerminalSurface`): while another device sizes the session, the
+    /// surface has to be laid out at that device's grid, not this rectangle.
+    private let terminalHost: UIView = {
+        let host = UIView()
+        host.clipsToBounds = true
+        host.translatesAutoresizingMaskIntoConstraints = false
+        return host
+    }()
+    /// The PTY's grid and whether this phone is the one sizing it, from the
+    /// session; `isWriter` starts true so a screen the device has not yet
+    /// described lays out exactly as it always did.
+    private var sharedGrid: TerminalGrid?
+    private var isWriter = true
+    /// The live surface's cell size, from the resize delegate.
+    private var surfaceMetrics: TerminalGridMetrics?
     private lazy var shellSession = ShellSession(shell: defaultSandboxShell)
     private var companion: DeviceSession?
     private var companionSession: InMemoryTerminalSession?
@@ -195,9 +212,10 @@ final class TerminalViewController: UIViewController {
                 if let companion { companion.start() } else { shellSession.start() }
             }
         } else if case .device = backend {
-            // Re-entering a parked session claims the PTY's winsize back —
-            // the Mac may own it, and this view's size didn't change, so no
-            // layout pass would re-send the grid.
+            // Re-entering a parked session re-sends this phone's grid: if it
+            // still holds the write token the PTY may have moved while the
+            // screen was away, and this view's size didn't change, so no
+            // layout pass would re-send it. An observer sends nothing.
             companion?.reassertGrid()
         }
     }
@@ -213,6 +231,7 @@ final class TerminalViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         layoutDrawer()
+        layoutTerminalSurface()
         // Refit only when the surface's size actually changed, and coalesce
         // the per-frame passes of keyboard animations into one call
         // after the size settles. Every `setSize` can deadlock against the
@@ -230,6 +249,52 @@ final class TerminalViewController: UIViewController {
         }
         fitDebounce = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: work)
+    }
+
+    /// Frames the surface inside `terminalHost`.
+    ///
+    /// Normally it fills the host. While another device holds the write token
+    /// the PTY is that device's size, and every byte arriving here is wrapped
+    /// for it: a surface at this phone's own grid re-wraps those lines and a TUI
+    /// that repaints incrementally never repairs the result (§C.5 of the
+    /// session protocol). So the surface is laid out at exactly the shared grid
+    /// — the same picture the other device has — and scaled down as a whole to
+    /// fit the host, top-aligned and centred. Typing takes the token, and the
+    /// surface fills the host again at this phone's grid.
+    ///
+    /// Half a cell of slack on each axis: libghostty floors
+    /// `(size − padding) / cell` for its grid, and an exact multiple can round
+    /// to one column short.
+    private func layoutTerminalSurface() {
+        let host = terminalHost.bounds
+        guard host.width > 0, host.height > 0 else { return }
+        // A frame set under a transform is undefined; always start from identity.
+        terminalView.transform = .identity
+        guard case .device = backend, !isWriter,
+              let grid = sharedGrid, let metrics = surfaceMetrics,
+              grid.cols > 0, grid.rows > 0,
+              metrics.cellWidthPixels > 0, metrics.cellHeightPixels > 0
+        else {
+            terminalView.frame = host
+            return
+        }
+        let scale = max(1, traitCollection.displayScale)
+        let cellWidth = CGFloat(metrics.cellWidthPixels) / scale
+        let cellHeight = CGFloat(metrics.cellHeightPixels) / scale
+        let width = CGFloat(grid.cols) * cellWidth + 2 * Self.terminalPaddingX + cellWidth / 2
+        let height = CGFloat(grid.rows) * cellHeight + 2 * Self.terminalPaddingY + cellHeight / 2
+        let fit = min(1, host.width / width, host.height / height)
+        terminalView.bounds = CGRect(x: 0, y: 0, width: width, height: height)
+        terminalView.transform = CGAffineTransform(scaleX: fit, y: fit)
+        terminalView.center = CGPoint(x: host.midX, y: height * fit / 2)
+    }
+
+    /// The session's word on the PTY's grid and this phone's standing.
+    private func applySharedGrid(_ grid: TerminalGrid, writer: Bool) {
+        guard sharedGrid != grid || isWriter != writer else { return }
+        sharedGrid = grid
+        isWriter = writer
+        view.setNeedsLayout()
     }
 
     // MARK: - Header
@@ -339,9 +404,9 @@ final class TerminalViewController: UIViewController {
     /// happen on every return.
     func prepareForReappearance() {
         if !drawerOpen { focusInput() }
-        // Re-entering a parked companion session claims the PTY's winsize back —
-        // the Mac may own it, and this view's size didn't change while parked,
-        // so no layout pass would re-send the grid.
+        // Re-entering a parked session re-sends this phone's grid (applied only
+        // while it holds the write token); the view's size didn't change while
+        // parked, so no layout pass would.
         if case .device = backend { companion?.reassertGrid() }
     }
 
@@ -399,18 +464,18 @@ final class TerminalViewController: UIViewController {
         terminalView.controller = controller
         terminalView.backgroundColor = .clear
         terminalView.isOpaque = false
-        terminalView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(terminalView)
+        view.addSubview(terminalHost)
+        terminalHost.addSubview(terminalView)
 
         // Sits directly above the surface (below the drawer added later),
         // so unhiding it masks libghostty's panel during a rebuild.
         rendererCoverView.backgroundColor = Self.backdropColor()
         view.addSubview(rendererCoverView)
         NSLayoutConstraint.activate([
-            rendererCoverView.topAnchor.constraint(equalTo: terminalView.topAnchor),
-            rendererCoverView.leadingAnchor.constraint(equalTo: terminalView.leadingAnchor),
-            rendererCoverView.trailingAnchor.constraint(equalTo: terminalView.trailingAnchor),
-            rendererCoverView.bottomAnchor.constraint(equalTo: terminalView.bottomAnchor),
+            rendererCoverView.topAnchor.constraint(equalTo: terminalHost.topAnchor),
+            rendererCoverView.leadingAnchor.constraint(equalTo: terminalHost.leadingAnchor),
+            rendererCoverView.trailingAnchor.constraint(equalTo: terminalHost.trailingAnchor),
+            rendererCoverView.bottomAnchor.constraint(equalTo: terminalHost.bottomAnchor),
         ])
 
         // The key bar lives on the terminal (its inputAccessoryView); the
@@ -480,12 +545,12 @@ final class TerminalViewController: UIViewController {
     /// ~5 rows of dead space under bottom-anchored TUIs. The notification's
     /// end frame is unambiguous — overlap is what it says, zero when hidden.
     private func activateTerminalConstraints() {
-        let bottom = terminalView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let bottom = terminalHost.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         terminalBottomConstraint = bottom
         NSLayoutConstraint.activate([
-            terminalView.topAnchor.constraint(equalTo: headerBar.bottomAnchor),
-            terminalView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            terminalView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            terminalHost.topAnchor.constraint(equalTo: headerBar.bottomAnchor),
+            terminalHost.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            terminalHost.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bottom,
         ])
         NotificationCenter.default.addObserver(
@@ -687,16 +752,19 @@ final class TerminalViewController: UIViewController {
                 Log.device.error("no session id to attach to; falling back to the sandbox shell")
                 return shellSession.terminalSession
             }
-            // The phone's mirror surface answers terminal queries (XTVERSION,
-            // DA, DSR) on its own, but the authoritative surface already
-            // answered. The duplicate arrives late, misses the agent's parse
-            // window, and leaks into its input line as literal text — a stray
-            // ">|ghostty 1.3.2…". A mirror must never talk back to the host.
-            // Genuine input never looks like a report, so it passes untouched.
+            // The surface answers the host's terminal queries (XTVERSION, DA,
+            // DSR) on its own, through this same closure. Those are not the
+            // person: they must not claim the write token, and only the
+            // writer's surface may answer at all — an observer's reply lands
+            // late in the agent's input line as literal text, a stray
+            // ">|ghostty 1.3.2…" (`TerminalDeviceReport`).
             let terminalSession = InMemoryTerminalSession(
                 write: { [weak transport] data in
-                    guard !MirrorReportFilter.isDeviceReport(data) else { return }
-                    transport?.send(data)
+                    if TerminalDeviceReport.isReport(data) {
+                        transport?.sendDeviceReport(data)
+                    } else {
+                        transport?.send(data)
+                    }
                 },
                 resize: { [weak transport] viewport in
                     transport?.resize(columns: Int(viewport.columns), rows: Int(viewport.rows))
@@ -704,30 +772,16 @@ final class TerminalViewController: UIViewController {
             )
             transport.onOutput = { [weak terminalSession, weak self] data in
                 terminalSession?.receive(data)
-                DispatchQueue.main.async {
-                    guard let self else { return }
-                    let wasAlternate = self.altScreenSniffer.isAlternate
-                    self.altScreenSniffer.consume(data)
-                    // A slow-starting full-screen agent (Grok) switches into its
-                    // alt-screen TUI only after the phone's on-attach grid claim
-                    // has gone stale, and the host will not re-SIGWINCH an unchanged
-                    // winsize — so the TUI first paints at the wrong grid and only
-                    // a tap (which changes the keyboard geometry) forces a reflow.
-                    // Re-claim the grid the instant the TUI appears; the host
-                    // jiggles when the size is unchanged, so the agent reflows on
-                    // its own. Twice, mirroring the on-connect reassert, in case
-                    // the first lands before the agent finishes its opening paint.
-                    if !wasAlternate, self.altScreenSniffer.isAlternate, case .device = self.backend {
-                        self.companion?.reassertGrid()
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
-                            guard let self, case .device = backend else { return }
-                            companion?.reassertGrid()
-                        }
-                    }
-                }
+                // The sniffer only decides what the key bar's scroll-edge keys
+                // send; a TUI switching screens changes nothing about the grid,
+                // which is the writer's and already what the PTY is.
+                DispatchQueue.main.async { self?.altScreenSniffer.consume(data) }
             }
             transport.onState = { [weak self] state in
                 self?.companionStateChanged(state)
+            }
+            transport.onSharedGrid = { [weak self] grid, writer in
+                self?.applySharedGrid(grid, writer: writer)
             }
             companion = transport
             companionSession = terminalSession
@@ -748,18 +802,10 @@ final class TerminalViewController: UIViewController {
         case .connected:
             statusLabel.isHidden = true
             contextLabel.isHidden = contextLabel.text?.isEmpty ?? true
-            // The host wipes this screen on attach and repaints only once the
-            // grid claim lands — a Mac jiggles the PTY, a device answers the
-            // barrier with a snapshot, and both need the claim. libghostty
-            // dedupes an unchanged size at two layers, so on a cold attach none
-            // fires and the screen stays blank under a correct title. Re-assert
-            // now, and again once the wipe has drained, so the last frame on the
-            // wire is the repaint.
+            // The attach snapshot paints the screen. The grid goes out once
+            // more in case this phone is the writer and the PTY moved while the
+            // link was down; an observer's re-send is a no-op by design.
             companion?.reassertGrid()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
-                guard let self, case .device = backend else { return }
-                companion?.reassertGrid()
-            }
         case .failed(let reason):
             statusLabel.text = localized("Connection failed")
             let alert = UIAlertController(title: localized("Companion connection failed"), message: reason, preferredStyle: .alert)
@@ -793,11 +839,17 @@ final class TerminalViewController: UIViewController {
     /// The settings-driven half of the surface config — the single place the
     /// appearance keys are named, so creation and the live re-style path
     /// can't drift apart (same rule as the Mac app's applyAppearance).
+    /// The surface's margins in points. Named because `layoutTerminalSurface`
+    /// needs the same numbers to size a surface to an exact grid; Y is
+    /// libghostty's default, which the configuration below leaves alone.
+    private static let terminalPaddingX: CGFloat = 8
+    private static let terminalPaddingY: CGFloat = 2
+
     private static func appearanceConfiguration() -> TerminalConfiguration {
         TerminalConfiguration { builder in
             builder.withBackgroundOpacity(0)
             builder.withFontSize(Float(MobileSettings.shared.fontSize))
-            builder.withWindowPaddingX(8)
+            builder.withWindowPaddingX(Int(Self.terminalPaddingX))
             // Without a font-family the phone rendered CJK unlike the Mac —
             // libghostty dropped in proportional PingFang whose metrics fight the
             // Latin face. Set the chain to match the desktop (see `terminalFontChain`).
@@ -1151,6 +1203,18 @@ extension TerminalViewController: UIImagePickerControllerDelegate, UINavigationC
     }
 }
 
+extension TerminalViewController: TerminalSurfaceGridResizeDelegate {
+    /// Cell metrics for `layoutTerminalSurface`; they change with the font, so
+    /// a pinch re-frames a letterboxed surface at the same grid.
+    func terminalDidResize(_ size: TerminalGridMetrics) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, surfaceMetrics != size else { return }
+            surfaceMetrics = size
+            view.setNeedsLayout()
+        }
+    }
+}
+
 extension TerminalViewController: TerminalSurfaceTitleDelegate, TerminalSurfaceCloseDelegate {
     func terminalDidChangeTitle(_ title: String) {
         // The agent's OSC title rides the byte stream (Claude Code updates it
@@ -1274,43 +1338,6 @@ extension TerminalViewController: TerminalSurfaceRendererHealthDelegate {
         // content arrives over the network) so we don't uncover a blank grid.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) { [weak self] in
             self?.rendererCoverView.isHidden = true
-        }
-    }
-}
-
-// MARK: - Mirror response filter
-
-/// Classifies a companion `write` chunk as a terminal device report — a reply
-/// the phone's mirror surface auto-generates to a host query, which the Mac's
-/// authoritative surface has already answered. Dropping these stops the phone's
-/// late duplicate from leaking into the agent's input line (Grok's stray
-/// ">|ghostty 1.3.2-main-+…").
-///
-/// libghostty emits each reply as one standalone escape sequence:
-///   • ESC P … (DCS) — XTVERSION ">|ghostty …", DECRQSS, XTGETTCAP
-///   • ESC ] … (OSC) — color / clipboard query answers
-///   • ESC [ … c     — Device Attributes (primary / secondary)
-///   • ESC [ … R     — Cursor Position Report
-///
-/// Genuine input never matches: arrows / home / end terminate a CSI in A–H or
-/// `~`, a bare Esc is a lone byte, pasted or typed text carries no ESC lead-in.
-private enum MirrorReportFilter {
-    static func isDeviceReport(_ data: Data) -> Bool {
-        let b = [UInt8](data)
-        guard b.first == 0x1B, b.count >= 2 else { return false }
-        switch b[1] {
-        case 0x50, 0x5D: // ESC P (DCS) / ESC ] (OSC)
-            return true
-        case 0x5B: // ESC [ (CSI): a report only when the final byte is 'c' or 'R'
-            var i = 2
-            while i < b.count {
-                let c = b[i]
-                if c >= 0x40, c <= 0x7E { return c == 0x63 || c == 0x52 }
-                i += 1
-            }
-            return false
-        default:
-            return false
         }
     }
 }

--- a/ios/Sources/TermiodSession.swift
+++ b/ios/Sources/TermiodSession.swift
@@ -132,9 +132,13 @@ final class TermiodSession: DeviceSession {
             guard attached, grid.rows > 0, grid.cols > 0 else { return }
             // An observer cannot move the PTY; arriving at the shared grid is
             // the one moment it needs something from the device: a keyframe it
-            // can finally paint.
+            // can finally paint. Leaving the grid — a pinch reports the old
+            // frame at new cell metrics before the layout puts it back — arms
+            // the next arrival, so the bytes parsed in between are repainted too.
             guard isWriter else {
-                if observerRepaintPending, authoritativeGrid == grid {
+                if authoritativeGrid != grid {
+                    observerRepaintPending = true
+                } else if observerRepaintPending {
                     observerRepaintPending = false
                     if let payload = try? Termiod.requestSnapshotPayload() {
                         channel.send(kind: .control, payload: payload)

--- a/ios/Sources/TermiodSession.swift
+++ b/ios/Sources/TermiodSession.swift
@@ -42,6 +42,12 @@ final class TermiodSession: DeviceSession {
     /// differ while a resize is in flight, and while another client owns size.
     private var desiredGrid = TerminalGrid(rows: 0, cols: 0)
     private var authoritativeGrid: TerminalGrid?
+    /// An observer whose surface is not yet at the shared grid. The keyframe
+    /// that announced the grid was parsed at the old one, and the surface is
+    /// re-laid-out only after `onSharedGrid` reaches the screen — so the first
+    /// `resize` that lands *on* the shared grid asks the device for a fresh
+    /// keyframe, and that one paints right.
+    private var observerRepaintPending = false
     private var resizeGeneration: UInt64 = 0
     /// Whether this screen ever had a session, which is what separates "the
     /// device refused a request" from "that session is not there".
@@ -123,7 +129,19 @@ final class TermiodSession: DeviceSession {
         queue.async { [self] in
             let grid = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: columns))
             desiredGrid = grid
-            guard attached, isWriter, grid.rows > 0, grid.cols > 0 else { return }
+            guard attached, grid.rows > 0, grid.cols > 0 else { return }
+            // An observer cannot move the PTY; arriving at the shared grid is
+            // the one moment it needs something from the device: a keyframe it
+            // can finally paint.
+            guard isWriter else {
+                if observerRepaintPending, authoritativeGrid == grid {
+                    observerRepaintPending = false
+                    if let payload = try? Termiod.requestSnapshotPayload() {
+                        channel.send(kind: .control, payload: payload)
+                    }
+                }
+                return
+            }
             // A size the PTY already has would cost every attachment a barrier
             // repaint for nothing.
             guard authoritativeGrid != grid else { return }
@@ -182,6 +200,7 @@ final class TermiodSession: DeviceSession {
             // announces it. Seeding from here is what lets an observer know the
             // grid its bytes are wrapped at.
             authoritativeGrid = TerminalGrid(rows: payload.rows, cols: payload.cols)
+            observerRepaintPending = !isWriter && authoritativeGrid != desiredGrid
             publishSharedGrid()
             if !pendingInput.isEmpty {
                 let buffered = pendingInput
@@ -296,6 +315,7 @@ final class TermiodSession: DeviceSession {
         write token on \(self.sessionName, privacy: .public) \
         \(mine ? "claimed" : "lost", privacy: .public)
         """)
+        observerRepaintPending = !mine && authoritativeGrid != desiredGrid
         publishSharedGrid()
         // A client that was demoted stopped sending resizes, so the PTY can be
         // any size by the time the token comes back.
@@ -310,6 +330,7 @@ final class TermiodSession: DeviceSession {
     private func applyAuthoritativeGrid(_ grid: TerminalGrid) {
         guard authoritativeGrid != grid else { return }
         authoritativeGrid = grid
+        if !isWriter { observerRepaintPending = grid != desiredGrid }
         publishSharedGrid()
         guard grid != desiredGrid, desiredGrid.rows > 0 else { return }
         Log.device.info("""

--- a/ios/Sources/TermiodSession.swift
+++ b/ios/Sources/TermiodSession.swift
@@ -19,6 +19,7 @@ import TermioShared
 final class TermiodSession: DeviceSession {
     var onOutput: ((Data) -> Void)?
     var onState: ((DeviceSessionState) -> Void)?
+    var onSharedGrid: ((TerminalGrid, Bool) -> Void)?
 
     /// How long the grid must hold still before a size goes to the device. Every
     /// distinct size is a host-side barrier — quiesce, resize, fresh keyframe to
@@ -105,6 +106,19 @@ final class TermiodSession: DeviceSession {
         }
     }
 
+    /// The surface's own answer to a host query. The host asked its terminal
+    /// one question and the writer's surface is that terminal, so this goes
+    /// through only while this phone holds the token — an observer's answer
+    /// would arrive late and land in the agent's input line as text — and it
+    /// never claims: a probe is not the person showing up.
+    func sendDeviceReport(_ data: Data) {
+        guard !data.isEmpty else { return }
+        queue.async { [self] in
+            guard attached, isWriter else { return }
+            sendData(data)
+        }
+    }
+
     func resize(columns: Int, rows: Int) {
         queue.async { [self] in
             let grid = TerminalGrid(rows: UInt16(clamping: rows), cols: UInt16(clamping: columns))
@@ -120,11 +134,13 @@ final class TermiodSession: DeviceSession {
     func reassertGrid() {
         queue.async { [self] in
             guard attached, isWriter, desiredGrid.rows > 0, desiredGrid.cols > 0 else { return }
-            // Deliberately past the "already this size" check `resize` applies.
-            // libghostty drops an unchanged viewport at two layers, so on a cold
-            // attach no resize fires and the screen stays blank under a correct
-            // title. This puts an `R` on the wire regardless, and the keyframe
-            // behind it is the repaint.
+            // The same check `resize` applies, on purpose. This used to put an
+            // `R` on the wire regardless, hoping the barrier's keyframe would
+            // repaint a blank screen — but the device ignores a size the PTY
+            // already has (no SIGWINCH, no barrier), so that `R` repainted
+            // nothing, and one that did change the size repainted every other
+            // attachment. The attach snapshot is what paints a cold screen.
+            guard authoritativeGrid != desiredGrid else { return }
             sendResize(desiredGrid)
         }
     }
@@ -166,6 +182,7 @@ final class TermiodSession: DeviceSession {
             // announces it. Seeding from here is what lets an observer know the
             // grid its bytes are wrapped at.
             authoritativeGrid = TerminalGrid(rows: payload.rows, cols: payload.cols)
+            publishSharedGrid()
             if !pendingInput.isEmpty {
                 let buffered = pendingInput
                 pendingInput.removeAll(keepingCapacity: false)
@@ -256,6 +273,10 @@ final class TermiodSession: DeviceSession {
                 channel.send(kind: .control, payload: payload)
             }
         }
+        sendData(data)
+    }
+
+    private func sendData(_ data: Data) {
         var offset = 0
         while offset < data.count {
             let end = min(offset + Termiod.maximumDataFrameSize, data.count)
@@ -275,6 +296,7 @@ final class TermiodSession: DeviceSession {
         write token on \(self.sessionName, privacy: .public) \
         \(mine ? "claimed" : "lost", privacy: .public)
         """)
+        publishSharedGrid()
         // A client that was demoted stopped sending resizes, so the PTY can be
         // any size by the time the token comes back.
         guard mine, desiredGrid.rows > 0 else { return }
@@ -282,11 +304,13 @@ final class TermiodSession: DeviceSession {
     }
 
     /// §C.5: the PTY has one size and every client parses at it. A writer
-    /// answers a divergence by putting its own size back; an observer can only
-    /// record it, because nothing it sends would be honoured.
+    /// answers a divergence by putting its own size back; an observer lays its
+    /// surface out at the shared grid instead (`onSharedGrid`), because nothing
+    /// it sends would be honoured.
     private func applyAuthoritativeGrid(_ grid: TerminalGrid) {
         guard authoritativeGrid != grid else { return }
         authoritativeGrid = grid
+        publishSharedGrid()
         guard grid != desiredGrid, desiredGrid.rows > 0 else { return }
         Log.device.info("""
         \(self.sessionName, privacy: .public) PTY is now \
@@ -312,6 +336,12 @@ final class TermiodSession: DeviceSession {
 
     private func sendResize(_ grid: TerminalGrid) {
         channel.send(kind: .resize, payload: Termiod.resizePayload(grid.rows, grid.cols))
+    }
+
+    private func publishSharedGrid() {
+        guard let grid = authoritativeGrid else { return }
+        let writer = isWriter
+        DispatchQueue.main.async { [onSharedGrid] in onSharedGrid?(grid, writer) }
     }
 
     private func notify(_ state: DeviceSessionState) {


### PR DESCRIPTION
Opening a session on the phone while it was open on the Mac made the two fight over the PTY's size: every phone grid report (attach, foreground, rotation) claimed the write token and resized the PTY, the Mac took it back on the next keystroke, and the Mac's own libghostty — answering the agent's terminal queries through the same write path as typing — took it back on every probe with nobody at the keyboard. Each move was a resize barrier and a full repaint on every attachment.

## What changes

- **The token moves by typing only**, on both the companion wire and the direct attach path. A phone's grid report is remembered and applied only while the phone holds the token (`SessionBridge.applyClientResize` no longer claims).
- **Device reports pass only from the writer and never claim.** `TerminalDeviceReport` (TermioShared) classifies DA / DSR / XTVERSION / colour replies; the Mac surface, the phone surface and the bridge all route them through `sendDeviceReport`, which is gated on the write token. One query, one answer.
- **A demoted surface is laid out at the shared grid** (§C.5). The Mac pane letterboxes it (`SharedGridLetterbox`, driven by `SessionRuntime.isWriter` / `sharedGrid`); the phone lays its surface out at the grid and scales it to fit the screen (`layoutTerminalSurface`). The companion wire gains a `grid {cols, rows, writer}` control; the direct path uses `E resized` + `writer_changed`.
- **No more blind grid re-asserts** on the phone (connect, foreground, alt-screen entry). The daemon ignores a same-size `R`, so they never repainted a blank screen — and a different-size one repainted every attachment.
- Spec §C.5 updated to match.

## Verified

- `swift build`, `swift test` (857 tests, 0 failures; new `TerminalDeviceReportTests`).
- iOS: `xcodebuild` for the simulator succeeds.
- Not verified on a device pair — the phone-side letterbox and the Mac letterbox need a live Mac + iPhone run.

## Review round 2 (`3a814ba`)

A Codex review found two holes in the first cut, both fixed:

- **Grid-before-bytes race.** The keyframe that announces a new grid reaches an observer before its surface has moved (layout is on the main queue; bytes are not), so it was parsed at the old grid and the letterbox could not repair it. An observer now sends `request_snapshot` with the first resize that lands on the shared grid (`observerRepaintPending` on the Mac link and the phone's direct session; the companion bridge gets it through the link). One extra keyframe per token move, only for the observer.
- **Classifier coverage.** libghostty also answers DSR (`0n`), DECRQM (`$y`), XTWINOPS (`t`), kitty keyboard flags (`?…u`) and XTQMODKEYS (`>…m`); any of those from an observer would have claimed the token again. `TerminalDeviceReport` now matches exactly the reply forms libghostty emits (`stream_handler.zig`, `modes.zig`, `formatter.zig`), keeps kitty key presses and SGR mouse as input, and accepts only the DCS/OSC reply shapes rather than any payload. Tests cover each.

## Review round 3

- **Mac resync could never fire when the shared grid did not fit the pane** (the letterbox gave up and left the surface at its own grid). It now lays the surface out at the shared grid regardless, top-left and clipped, so the surface reaches the grid and the resync fires.
- **`ESC [ 1 ; mod R`** (legacy modified F3) collides with a cursor-position report for row 1, columns 2–16 — and a fresh prompt answering `CSI 6 n` from column 3 is exactly that report. Round 3 tried reading it as the key; round 4 reverted that, because it let a real report claim the token again. Every `…R` is a report: an observer's modified F3 is dropped (one keypress), the writer's passes. Under the kitty keyboard protocol agents enable, F3 is `ESC [ 13 ~` and there is no collision. The exact fix — a wrapper hook marking generated replies at the write callback — belongs in the libghostty-swift fork.
- DCS/OSC matchers require their introducers (`>|`, a status digit before `$r`/`+r`, the `;` after an OSC number).

## Review round 4

- An observer whose surface left the shared grid on its own (Mac font change, phone pinch — each reports the old frame at new cell metrics before the letterbox puts it back) came back with the repaint flag already spent. A resize reporting any grid but the shared one now re-arms it.

Five adversarial review rounds (Codex); round 5 returned no findings.

## Not in this PR

The two open iOS kills (#383 EXC_GUARD on surface teardown, #277 renderer mailbox) live in the libghostty-swift fork, not here. Fewer resize barriers means fewer `setSize` races, but those need fork patches.

Release Notes:
- Viewing a session from both the Mac and the iPhone no longer resizes it back and forth. The device you type on sets the size; the other shows the same screen, letterboxed on the Mac and scaled to fit on the phone.





