### PR TITLE
Make the remote file tree live over the fs: resource

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -30,7 +30,7 @@ public enum Termiod {
     /// | `scrollback` | no      | `H` carries packed cells to inject *above* the viewport; a byte-stream surface has nowhere to put them |
     /// | `grid_diff`  | no      | `G` would make the host resolve every cell's colour, which overrides the viewer's theme — the §A/§H regression this client exists not to repeat |
     /// | `send_wait`  | no      | `send`/`wait` are control-channel verbs; the app injects through its own attach channel |
-    /// | `resources`  | no      | `subscribe_resource` — live tree and git updates. The channel that outlives a request now exists (`TermiodControlPool.swift`); what is still missing is a tree that applies deltas rather than re-listing |
+    /// | `resources`  | no      | `subscribe_resource` — the live file tree (`Termiod.ResourceWatch`), on the same pooled control channel the listings ride, never an attachment |
     /// | `fs_watch`   | no      | ditto |
     /// | `files`      | no      | `fs.list`/`fs.read` — the Files pane's consumer, on the device's pooled control channel (`TermiodFiles.swift`), never an attachment |
     /// | `upload`     | no      | remote paste; rides a control channel, not an attachment |
@@ -445,6 +445,35 @@ public enum Termiod {
         }
     }
 
+    /// Resumable subscription to a durable host resource (§C.10). `since` is
+    /// the highest `seq` already applied; omitted on a first subscribe, which
+    /// asks for the cursor rather than a replay. Requires the `resources`
+    /// capability — a daemon that did not grant it answers `error`, and the
+    /// caller falls back to re-listing.
+    public struct SubscribeResourceOperation: Encodable, Sendable {
+        public let op = "subscribe_resource"
+        public let resource: String
+        public let since: UInt64?
+        public let seq: UInt64
+
+        public init(resource: String, since: UInt64?, seq: UInt64) {
+            self.resource = resource
+            self.since = since
+            self.seq = seq
+        }
+    }
+
+    public struct UnsubscribeResourceOperation: Encodable, Sendable {
+        public let op = "unsubscribe_resource"
+        public let resource: String
+        public let seq: UInt64
+
+        public init(resource: String, seq: UInt64) {
+            self.resource = resource
+            self.seq = seq
+        }
+    }
+
     /// No `offset`/`length`: an unranged read is what makes `size` and
     /// `truncated` mean "the whole file" rather than "the window you asked for".
     public struct FsReadOperation: Encodable, Sendable {
@@ -617,6 +646,70 @@ public enum Termiod {
 
     public struct FsListedPayload: Decodable, Sendable {
         public let listings: [PathListingPayload]
+        /// The `fs:` resource's cursor at listing time — the freshness proof
+        /// that lets a subscriber know which batches this listing already
+        /// includes, so a batch that arrived while the listing was in flight is
+        /// applied and one it already reflects is dropped. Zero from a daemon
+        /// running no watch, which reads as "nothing will invalidate this".
+        public let seq: UInt64
+
+        private enum CodingKeys: String, CodingKey {
+            case listings, seq
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            listings = try container.decodeIfPresent([PathListingPayload].self, forKey: .listings) ?? []
+            seq = try container.decodeIfPresent(UInt64.self, forKey: .seq) ?? 0
+        }
+    }
+
+    /// Reply to `subscribe_resource`. `seq` is the cursor the subscription
+    /// starts from; `gap` means the host could not replay from the `since` that
+    /// was asked for — the ring aged out, or this is a first subscribe — so the
+    /// subscriber must re-read what it holds rather than trust its cache.
+    public struct SubscribedPayload: Decodable, Sendable {
+        public let resource: String
+        public let seq: UInt64
+        public let gap: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case resource, seq, gap
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            resource = try container.decode(String.self, forKey: .resource)
+            seq = try container.decodeIfPresent(UInt64.self, forKey: .seq) ?? 0
+            gap = try container.decodeIfPresent(Bool.self, forKey: .gap) ?? false
+        }
+    }
+
+    /// One watcher batch for an `fs:` resource (§C.10). `paths` names the
+    /// directories whose contents changed, absolute on the device. `fullRescan`
+    /// means the path set is not authoritative and a subscriber must re-walk
+    /// what it has realized — the wire equivalent of FSEvents' `MustScanSubDirs`.
+    /// `gitMeta` means index/HEAD/refs moved; object-store churn is dropped
+    /// host-side and never arrives here.
+    public struct FsChangedPayload: Decodable, Sendable {
+        public let resource: String
+        public let seq: UInt64
+        public let paths: [String]
+        public let fullRescan: Bool
+        public let gitMeta: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case resource, seq, paths, fullRescan, gitMeta
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            resource = try container.decode(String.self, forKey: .resource)
+            seq = try container.decodeIfPresent(UInt64.self, forKey: .seq) ?? 0
+            paths = try container.decodeIfPresent([String].self, forKey: .paths) ?? []
+            fullRescan = try container.decodeIfPresent(Bool.self, forKey: .fullRescan) ?? false
+            gitMeta = try container.decodeIfPresent(Bool.self, forKey: .gitMeta) ?? false
+        }
     }
 
     /// One batch of `fs.search` hits, addressed to the connection that asked.
@@ -1076,6 +1169,12 @@ public enum Termiod {
         /// (`TermiodFiles.swift`). The only event addressed to a request rather
         /// than to a session, which is why it carries no `session`.
         case searchResults(SearchResultsPayload)
+        /// One filesystem batch for a subscribed `fs:` resource. Like
+        /// `searchResults` it names no session — but unlike it, it is addressed
+        /// to no request either: it is the first event on this plane that
+        /// belongs to the *channel*, which is why the pool grew an observer for
+        /// frames answering nobody (`TermiodControlPool.swift`).
+        case fsChanged(FsChangedPayload)
         case unknown(String)
     }
 
@@ -1224,6 +1323,9 @@ public enum Termiod {
         case uploadAck(UploadAckPayload)
         case uploadCommitted(UploadCommittedPayload)
         case fsListed(FsListedPayload)
+        /// The reply to `subscribe_resource` (§C.10) — the cursor a live tree
+        /// starts counting batches from.
+        case subscribed(SubscribedPayload)
         /// The read half of the files plane (`TermiodFiles.swift`). `fs_listed`
         /// above answers both the path picker and the tree; this one only the
         /// tree. It rides the same decode table as everything else, so an
@@ -1276,6 +1378,8 @@ public enum Termiod {
             return .uploadCommitted(try decoder.decode(UploadCommittedPayload.self, from: payload))
         case "fs_listed":
             return .fsListed(try decoder.decode(FsListedPayload.self, from: payload))
+        case "subscribed":
+            return .subscribed(try decoder.decode(SubscribedPayload.self, from: payload))
         case "fs_file":
             return .fsFile(try decoder.decode(FsFilePayload.self, from: payload))
         case "fs_searched":
@@ -1314,6 +1418,8 @@ public enum Termiod {
             return .roster(try decoder.decode(RosterPayload.self, from: payload))
         case "session_exited":
             return .sessionExited(try decoder.decode(SessionExitedPayload.self, from: payload))
+        case "fs_changed":
+            return .fsChanged(try decoder.decode(FsChangedPayload.self, from: payload))
         case "search_results":
             return .searchResults(try decoder.decode(SearchResultsPayload.self, from: payload))
         default:

--- a/Sources/termio/FileBrowser/RemoteFileTree.swift
+++ b/Sources/termio/FileBrowser/RemoteFileTree.swift
@@ -286,12 +286,17 @@ final class RemoteFileNode: Identifiable {
 /// Drives the tree for a checkout on another machine, over that device's
 /// `fs.list`/`fs.read` (`TermiodFiles.swift`).
 ///
-/// No watching yet: the tree reloads on pane/app focus and the explicit refresh
-/// button. A reload re-lists every directory it is currently showing in one
-/// request and grafts the answers onto the nodes already there, so expansion
-/// survives and nothing re-fetches itself a round trip at a time. Live updates
-/// are the `fs:` resource, which needs a tree that applies deltas and is
-/// deliberately not here.
+/// The tree is **live**: it subscribes to the device's `fs:` resource
+/// (`Termiod.ResourceWatch`) and re-lists only the directories a batch names and
+/// the tree is actually showing — VS Code's rule, which refreshes on a file
+/// event only when the event touched a *visible* item, rather than re-reading
+/// the tree because something somewhere moved.
+///
+/// The whole-tree reload is still here, and still one request for every open
+/// directory, but it is now the exception rather than the beat: a first load, a
+/// `full_rescan` batch, a dropped subscription, and the refresh button. It used
+/// to run on every app focus, which on a box where an agent is writing files
+/// meant re-listing everything each time you came back to the window.
 @MainActor
 final class RemoteFileBrowserModel: ObservableObject {
     enum Phase {
@@ -329,6 +334,10 @@ final class RemoteFileBrowserModel: ObservableObject {
     private var loadsInFlight: Set<String> = []
     private var prefetchesInFlight: Set<String> = []
     private var refreshing = false
+    /// The live subscription, held while the pane is on screen. `nil` on a
+    /// device whose daemon does not serve `resources`, where the tree falls back
+    /// to exactly the manual refresh it always had.
+    private var watch: Termiod.ResourceWatch?
     /// Holds this device's channel open, and warm, while the pane is on screen.
     /// See `Termiod.ControlPool.pin`.
     private var pin: Termiod.ControlPool.ChannelPin?
@@ -345,12 +354,20 @@ final class RemoteFileBrowserModel: ObservableObject {
     func startWarming() {
         guard pin == nil else { return }
         pin = Termiod.ControlPool.pin(route: checkout.device.route, caps: ["files"])
+        guard watch == nil else { return }
+        watch = provider.watch { [weak self] update in
+            Task { @MainActor in self?.applyWatch(update) }
+        }
     }
 
     /// The pane is gone or hidden. The channel goes back on the idle clock,
     /// which hangs it up two minutes later if nothing else wants it.
     func stopWarming() {
         pin = nil
+        // Retiring the subscription is the point: a watch is a recursive
+        // `notify` on the device, and one per pane nobody is looking at is how
+        // a box runs out of inotify handles.
+        watch = nil
     }
 
     var host: String { checkout.device.name }
@@ -390,8 +407,12 @@ final class RemoteFileBrowserModel: ObservableObject {
             // children have to exist before a descendant's can be attached.
             let wanted = [root] + loadedDirectories()
             do {
-                let listings = try await provider.list(wanted)
-                apply(listings)
+                let listed = try await provider.listing(wanted)
+                apply(listed.listings)
+                // Tells the watch which batches this listing already reflects,
+                // so a change raised *before* it lands does not send the tree
+                // back to ask the device a question it just answered.
+                watch?.noteListed(at: listed.seq)
                 phase = .ready
                 // The folders at the top of the tree are the ones about to be
                 // clicked. Asking for them now costs a round trip nobody is
@@ -401,6 +422,88 @@ final class RemoteFileBrowserModel: ObservableObject {
                 report(error, context: "list \(host):\(root)")
             }
         }
+    }
+
+    /// Applies one update from the device's `fs:` subscription.
+    ///
+    /// The whole point is what it does *not* do. A batch names every directory
+    /// that changed anywhere under the checkout — an agent's build output, a
+    /// `node_modules` install, a `git checkout` — and almost none of it is on
+    /// screen. Only the directories the tree has actually realized are asked
+    /// about, in one request; a batch that touches nothing realized costs
+    /// nothing at all. This is `doesFileEventAffect` from VS Code's explorer
+    /// (`explorerService.ts`), which walks the model and returns early unless a
+    /// *visible* item was hit.
+    ///
+    /// `fullRescan` and `.reset` both mean the same thing — what is held may be
+    /// wrong and the path set cannot be trusted — so both fall back to the
+    /// whole-tree reload.
+    func applyWatch(_ update: Termiod.ResourceWatch.Update) {
+        switch update {
+        case .reset:
+            refresh()
+        case .batch(let batch):
+            guard !batch.fullRescan else {
+                refresh()
+                return
+            }
+            let changed = directoriesToRelist(
+                for: batch.paths, watchedRoot: watch?.watchedRoot)
+            guard !changed.isEmpty else { return }
+            Task {
+                do {
+                    let listed = try await provider.listing(changed)
+                    apply(listed.listings)
+                    watch?.noteListed(at: listed.seq)
+                    Log.files.debug(
+                        "\(self.host, privacy: .public) batch \(batch.seq, privacy: .public): \(batch.paths.count, privacy: .public) changed, \(changed.count, privacy: .public) on screen")
+                } catch {
+                    report(error, context: "relist \(host):\(changed.count) dirs")
+                }
+            }
+        }
+    }
+
+    /// Which of a batch's changed directories this tree actually has to re-read.
+    ///
+    /// A batch names the directory whose *contents* moved, so a folder created
+    /// or deleted arrives as a change to its parent — the row the tree draws —
+    /// and nothing has to walk upward to find it. Everything else is dropped:
+    /// a checkout has thousands of directories and the tree is showing a
+    /// handful, so the common batch (a build wrote into `target/`, an agent
+    /// rewrote a file three folders down from anything open) costs no round trip
+    /// at all.
+    ///
+    /// Reachable from a test because it is the whole claim: the tree used to
+    /// re-list every open directory whenever anything anywhere changed, and what
+    /// it re-lists now is the only thing that changed about that.
+    func directoriesToRelist(
+        for changed: [String], watchedRoot: String? = nil
+    ) -> [String] {
+        let realized = Set([root] + loadedDirectories())
+        var seen: Set<String> = []
+        return changed.compactMap { path -> String? in
+            guard let local = localPath(for: path, watchedRoot: watchedRoot) else { return nil }
+            guard realized.contains(local), seen.insert(local).inserted else { return nil }
+            return local
+        }
+    }
+
+    /// A batch's path in the spelling this tree holds.
+    ///
+    /// The daemon canonicalises the root it watches, so a checkout reached
+    /// through a symlink — `/home/ubuntu/x` where `/home` is a link, or a macOS
+    /// `/var/folders` path, which is really `/private/var/folders` — is reported
+    /// under a prefix no row in the tree carries. Swapping the watched root back
+    /// for the tree's own is the whole translation: everything below it is the
+    /// same relative path either way.
+    private func localPath(for path: String, watchedRoot: String?) -> String? {
+        guard let watchedRoot, watchedRoot != root else { return path }
+        if path == watchedRoot { return root }
+        let prefix = watchedRoot.hasSuffix("/") ? watchedRoot : watchedRoot + "/"
+        guard path.hasPrefix(prefix) else { return nil }
+        let base = root.hasSuffix("/") ? String(root.dropLast()) : root
+        return base + "/" + path.dropFirst(prefix.count)
     }
 
     /// The directories whose contents the tree is holding, deepest last, so a
@@ -631,12 +734,13 @@ struct RemoteFileTreeView: View {
             model.refresh()
         }
         .onDisappear { model.stopWarming() }
-        // The refresh model (no remote watching): reload when the app comes back
-        // to the front — the same reconcile trigger as the git pane — but only
-        // while the pane is actually visible.
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            if store.inspectorVisible { model.refresh() }
-        }
+        // No app-focus reload. The subscription is what keeps the tree honest
+        // now, and it kept running while the window was in the back — so coming
+        // back to the front is not news, and re-listing every open directory on
+        // it was the tree's largest recurring cost against a box where an agent
+        // is writing files. A subscription that could not be kept up says so
+        // itself (`ResourceWatch.Update.reset`), which is the case this used to
+        // be standing in for.
         .onChange(of: store.inspectorVisible) { _, visible in
             if visible {
                 model.startWarming()

--- a/Sources/termio/FileBrowser/RemoteFileTree.swift
+++ b/Sources/termio/FileBrowser/RemoteFileTree.swift
@@ -334,6 +334,16 @@ final class RemoteFileBrowserModel: ObservableObject {
     private var loadsInFlight: Set<String> = []
     private var prefetchesInFlight: Set<String> = []
     private var refreshing = false
+    /// A refresh that arrived while one was already running, to be run after it.
+    ///
+    /// Dropping it instead is how the `established` reconcile lost its whole
+    /// point: the subscription and the pane's first listing are both started by
+    /// `onAppear` and are both one network round trip, so the subscribe landing
+    /// *during* the first listing is the ordinary case, not a rare one. The
+    /// reconcile then hit this guard, returned, and the listing it was waiting to
+    /// correct settled at `seq == 0` behind it — the exact stale tree the signal
+    /// exists to repair. Not private so a test can see the queueing.
+    var refreshQueued = false
     /// The `fs:` cursor the tree's rows were last stamped at. Zero means the
     /// listing was taken while the device had no watch running, so nothing
     /// invalidates it and nothing will — the state `established` exists to
@@ -404,10 +414,23 @@ final class RemoteFileBrowserModel: ObservableObject {
     /// mention keep the rows they had, so a folder that failed does not blank
     /// itself while the rest of the tree refreshes around it.
     func refresh() {
-        guard !refreshing else { return }
+        guard !refreshing else {
+            refreshQueued = true
+            return
+        }
         refreshing = true
+        refreshQueued = false
         Task {
-            defer { refreshing = false }
+            defer {
+                refreshing = false
+                // The queued one re-reads what the finished one could not know
+                // it needed to. Bounded: only a settled signal queues a refresh,
+                // and each is consumed before the next can be raised.
+                if refreshQueued {
+                    refreshQueued = false
+                    refresh()
+                }
+            }
             // Root first: the reply is applied in the order asked, and the root's
             // children have to exist before a descendant's can be attached.
             let wanted = [root] + loadedDirectories()

--- a/Sources/termio/FileBrowser/RemoteFileTree.swift
+++ b/Sources/termio/FileBrowser/RemoteFileTree.swift
@@ -334,6 +334,11 @@ final class RemoteFileBrowserModel: ObservableObject {
     private var loadsInFlight: Set<String> = []
     private var prefetchesInFlight: Set<String> = []
     private var refreshing = false
+    /// The `fs:` cursor the tree's rows were last stamped at. Zero means the
+    /// listing was taken while the device had no watch running, so nothing
+    /// invalidates it and nothing will — the state `established` exists to
+    /// repair.
+    private var listedSeq: UInt64 = 0
     /// The live subscription, held while the pane is on screen. `nil` on a
     /// device whose daemon does not serve `resources`, where the tree falls back
     /// to exactly the manual refresh it always had.
@@ -412,7 +417,7 @@ final class RemoteFileBrowserModel: ObservableObject {
                 // Tells the watch which batches this listing already reflects,
                 // so a change raised *before* it lands does not send the tree
                 // back to ask the device a question it just answered.
-                watch?.noteListed(at: listed.seq)
+                noteListed(at: listed.seq)
                 phase = .ready
                 // The folders at the top of the tree are the ones about to be
                 // clicked. Asking for them now costs a round trip nobody is
@@ -440,6 +445,15 @@ final class RemoteFileBrowserModel: ObservableObject {
     /// whole-tree reload.
     func applyWatch(_ update: Termiod.ResourceWatch.Update) {
         switch update {
+        case .established:
+            // The rows on screen may predate the watch. A listing taken before
+            // the daemon had one carries `seq == 0` — nothing raised a batch for
+            // a change in that window, and the watch now starts at a cursor
+            // already past it, so no later event will ever repair the tree. One
+            // re-read closes the window; a listing that was already stamped by a
+            // running watch needs nothing.
+            guard needsReconcileOnEstablish else { return }
+            refresh()
         case .reset:
             refresh()
         case .batch(let batch):
@@ -454,7 +468,7 @@ final class RemoteFileBrowserModel: ObservableObject {
                 do {
                     let listed = try await provider.listing(changed)
                     apply(listed.listings)
-                    watch?.noteListed(at: listed.seq)
+                    noteListed(at: listed.seq)
                     Log.files.debug(
                         "\(self.host, privacy: .public) batch \(batch.seq, privacy: .public): \(batch.paths.count, privacy: .public) changed, \(changed.count, privacy: .public) on screen")
                 } catch {
@@ -463,6 +477,30 @@ final class RemoteFileBrowserModel: ObservableObject {
             }
         }
     }
+
+    /// Records the cursor a listing was stamped at. Called by the tree's own
+    /// loads; separate from the watch's copy because the two answer different
+    /// questions — the watch's decides which batches to drop, this one decides
+    /// whether the rows predate the watch entirely.
+    func noteListed(at seq: UInt64) {
+        listedSeq = max(listedSeq, seq)
+        watch?.noteListed(at: seq)
+    }
+
+    /// Whether the rows on screen were listed before any watch existed, and so
+    /// have to be re-read now that one does.
+    ///
+    /// Reachable from a test: the window it closes is a race nothing can observe
+    /// from the outside once it has been closed.
+    var needsReconcileOnEstablish: Bool { listedSeq == 0 }
+
+    /// Whether the device is telling this tree about changes.
+    ///
+    /// False on a daemon too old to grant `resources`, and while a dropped
+    /// subscription is being re-established. The pane keeps its app-focus
+    /// reconcile for exactly those windows — a live tree does not need it, and a
+    /// tree that cannot have one still does.
+    var isLive: Bool { watch?.isSubscribed ?? false }
 
     /// Which of a batch's changed directories this tree actually has to re-read.
     ///
@@ -734,13 +772,16 @@ struct RemoteFileTreeView: View {
             model.refresh()
         }
         .onDisappear { model.stopWarming() }
-        // No app-focus reload. The subscription is what keeps the tree honest
-        // now, and it kept running while the window was in the back — so coming
-        // back to the front is not news, and re-listing every open directory on
-        // it was the tree's largest recurring cost against a box where an agent
-        // is writing files. A subscription that could not be kept up says so
-        // itself (`ResourceWatch.Update.reset`), which is the case this used to
-        // be standing in for.
+        // The app-focus reload, now only when nothing is watching. A live
+        // subscription kept running while the window was in the back, so coming
+        // back to the front is not news — and re-listing every open directory on
+        // it was this tree's largest recurring cost against a box where an agent
+        // is writing files. But a daemon too old to grant `resources` never gets
+        // a subscription at all, and dropping this unconditionally would leave
+        // those trees with nothing but the refresh button.
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            if store.inspectorVisible, !model.isLive { model.refresh() }
+        }
         .onChange(of: store.inspectorVisible) { _, visible in
             if visible {
                 model.startWarming()

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -1501,6 +1501,11 @@ final class TermiodSessionLink: @unchecked Sendable {
             // asked reads its own hits (`Termiod.searchContents`). Nothing on a
             // session's channel can have asked, so there is nobody to give it to.
             break
+        case .fsChanged:
+            // Addressed to a *channel*, not to a session: only a channel
+            // carrying a resource subscription can have asked, and a session's
+            // link never does (`Termiod.ResourceWatch`).
+            break
         case .unknown(let name):
             Log.termiod.debug("""
             ignoring \(name, privacy: .public) event on \(self.sessionName, privacy: .public)

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -338,6 +338,15 @@ extension Termiod {
             try write(kind: .control, payload: build(nextRequestID()))
         }
 
+        /// How many unaddressed-event sinks are registered. For tests: a watch
+        /// that re-subscribes must replace its observer rather than stack a
+        /// second one, and the count is the only way to see that from outside.
+        var observerCount: Int {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return eventObservers.count
+        }
+
         fileprivate func release(_ seq: UInt64) {
             stateLock.lock()
             inboxes.removeValue(forKey: seq)

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -113,6 +113,21 @@ extension Termiod {
         }
     }
 
+    /// What a channel tells a resource subscriber about. Two signals rather
+    /// than one, because a subscription's two failure modes are different
+    /// answers: a batch is progress, and a close means the cursor this watch
+    /// was counting from is on a connection that no longer exists.
+    enum ChannelSignal: Sendable {
+        /// An event the host addressed to no request — an `fs_changed` batch.
+        case event(IncomingEvent)
+        /// The connection is gone. Whatever was subscribed on it is not any
+        /// more, and a subscriber must re-subscribe (and, since batches were
+        /// missed while it was down, re-read what it holds).
+        case closed
+    }
+
+    typealias ChannelObserver = @Sendable (ChannelSignal) -> Void
+
     /// One request's handle on a pooled channel: its `seq`, its inbox, and the
     /// write side of the connection it was registered on.
     final class ChannelCall {
@@ -218,6 +233,12 @@ extension Termiod {
         private let writeLock = NSLock()
         private let stateLock = NSLock()
         private var inboxes: [UInt64: RequestInbox] = [:]
+        /// Sinks for frames that answer no request — today the `fs:` plane's
+        /// batches (§C.10). A request's answer goes to its inbox and dies with
+        /// it; a resource's batches belong to the *channel* and outlive every
+        /// request on it, which is why they need a second delivery path rather
+        /// than a long-lived fake request.
+        private var eventObservers: [UUID: ChannelObserver] = [:]
         private var nextSeq: UInt64 = 1
         private var dead = false
         private var lastUsed = ContinuousClock.now
@@ -226,7 +247,7 @@ extension Termiod {
         /// failure from a corpse it inherited.
         private var used = false
 
-        fileprivate var isDead: Bool {
+        var isDead: Bool {
             stateLock.lock()
             defer { stateLock.unlock() }
             return dead
@@ -283,6 +304,40 @@ extension Termiod {
             return seq
         }
 
+        /// Starts delivering unaddressed events to `handler`, until the
+        /// returned token is passed back to `removeObserver`. Runs on the reader
+        /// thread: a handler must hand off and return, never block, or it stalls
+        /// every request sharing this channel.
+        ///
+        /// Registering on a channel that is already dead still succeeds and
+        /// immediately reports `.closed`, so a caller cannot lose the race
+        /// between "is it alive" and "start listening" and end up subscribed to
+        /// a corpse in silence.
+        func addObserver(_ handler: @escaping ChannelObserver) -> UUID {
+            let token = UUID()
+            stateLock.lock()
+            let alreadyDead = dead
+            if !alreadyDead { eventObservers[token] = handler }
+            stateLock.unlock()
+            if alreadyDead { handler(.closed) }
+            return token
+        }
+
+        func removeObserver(_ token: UUID) {
+            stateLock.lock()
+            eventObservers.removeValue(forKey: token)
+            stateLock.unlock()
+        }
+
+        /// Sends one control frame that wants no answer, stamped with an id off
+        /// the same counter so nothing on the wire collides. No inbox, so the
+        /// host's `ok` is dropped — which is the whole shape of a teardown
+        /// message: it is worth sending on the connection that carries the
+        /// state, and worth nothing at all on a fresh one.
+        func post(_ build: (UInt64) throws -> Data) throws {
+            try write(kind: .control, payload: build(nextRequestID()))
+        }
+
         fileprivate func release(_ seq: UInt64) {
             stateLock.lock()
             inboxes.removeValue(forKey: seq)
@@ -316,6 +371,8 @@ extension Termiod {
             dead = true
             let pending = inboxes
             inboxes.removeAll()
+            let observers = eventObservers
+            eventObservers.removeAll()
             stateLock.unlock()
             // `dead` is set before this lock is taken, so no further write can
             // start; taking it waits out the one that may already be running.
@@ -325,6 +382,10 @@ extension Termiod {
             writeLock.unlock()
             transport.close()
             for inbox in pending.values { inbox.fail(reason) }
+            // After the inboxes, so a watch that re-subscribes on `.closed`
+            // cannot land on this same corpse: `dead` is already set, so its
+            // request for a channel opens a fresh one.
+            for observer in observers.values { observer(.closed) }
         }
 
         /// Dedicated blocking-read thread, the same shape a session link uses:
@@ -340,7 +401,10 @@ extension Termiod {
                         close(error)
                         return
                     }
-                    guard let seq = Self.requestID(of: frame) else { continue }
+                    guard let seq = Self.requestID(of: frame) else {
+                        deliverUnaddressed(frame)
+                        continue
+                    }
                     stateLock.lock()
                     let inbox = inboxes[seq]
                     stateLock.unlock()
@@ -353,6 +417,20 @@ extension Termiod {
             thread.name = "sh.termio.termiod.pool"
             thread.stackSize = 512 * 1024
             thread.start()
+        }
+
+        /// Hands an event addressed to no request to whoever is listening for
+        /// one. Decoded once here rather than per observer, and skipped entirely
+        /// when nobody is listening — which is every channel that is not
+        /// carrying a resource subscription.
+        private func deliverUnaddressed(_ frame: (kind: FrameKind, payload: Data)) {
+            guard frame.kind == .event else { return }
+            stateLock.lock()
+            let observers = eventObservers
+            stateLock.unlock()
+            guard !observers.isEmpty else { return }
+            guard let event = try? decodeEvent(frame.payload) else { return }
+            for observer in observers.values { observer(.event(event)) }
         }
 
         /// Which request a frame answers, or `nil` for one that answers nobody.

--- a/Sources/termio/Terminal/Termiod/TermiodDirectoryLister.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodDirectoryLister.swift
@@ -86,7 +86,7 @@ final class TermiodDirectoryLister: @unchecked Sendable {
             completion(Result {
                 let listings = try Termiod.listDirectories(
                     route: route, root: path, paths: [path])
-                guard let listing = listings.first else {
+                guard let listing = listings.listings.first else {
                     throw Failure.refused(
                         localized("The machine answered with no listing for that folder."))
                 }

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -303,10 +303,15 @@ extension Termiod {
             self.channel = channel
             observerToken = token
             lock.unlock()
-            // `withPooledRequest` retries a stale channel *inside* one attempt,
-            // without this watch's generation moving — so the thing being
-            // replaced here is usually the first try's own corpse.
-            if let previousToken, previousChannel !== channel {
+            // Keyed on the token, not the channel. `withPooledRequest` retries
+            // inside one attempt without this watch's generation moving, and a
+            // retry can land right back on the same pooled channel — a second
+            // registration on it, with a different token. Skipping the removal
+            // whenever the channel matched left that first observer registered
+            // with nothing holding its token, so it could never be removed: two
+            // deliveries of every batch, and one more on every duplicate claim.
+            // The token is what identifies a registration, so it is what decides.
+            if let previousToken, previousToken != token {
                 previousChannel?.removeObserver(previousToken)
             }
             return true

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -219,14 +219,23 @@ extension Termiod {
                     // installed afterwards would miss the ones already on the
                     // wire.
                     let token = channel.addObserver { [weak self] signal in
-                        self?.handle(signal, generation: generation)
+                        self?.handle(signal, generation: generation, from: channel)
+                    }
+                    // Claimed *before* the subscribe answers, not after. The
+                    // host replays from `since` as events following the reply,
+                    // and a signal is only acted on when it comes from the
+                    // channel the watch is holding — so a channel claimed only
+                    // afterwards would have its replay thrown away as coming
+                    // from a stranger.
+                    guard self.claim(channel: channel, token: token, generation: generation)
+                    else {
+                        channel.removeObserver(token)
+                        return
                     }
                     do {
                         let subscribed = try Self.subscribe(
                             call, resource: resource, since: since)
-                        self.adopt(
-                            channel: channel, token: token, generation: generation,
-                            resource: subscribed.resource)
+                        self.resolve(resource: subscribed.resource, generation: generation)
                         // A first subscribe always reports a gap — there is
                         // nothing to replay from. Reporting that as a reset
                         // would open every pane with two full listings instead
@@ -244,7 +253,10 @@ extension Termiod {
                         }
                         self.lock.withLock { self.failures = 0 }
                     } catch {
-                        channel.removeObserver(token)
+                        // Give the claim back with the observer, or `isSubscribed`
+                        // would keep answering yes for a channel this attempt
+                        // has already abandoned.
+                        self.release(channel: channel, token: token, generation: generation)
                         throw error
                     }
                 }
@@ -274,28 +286,66 @@ extension Termiod {
             }
         }
 
-        private func adopt(
-            channel: PooledChannel, token: UUID, generation: UInt64, resource: String
-        ) {
+        /// Makes `channel` the one this watch listens to, dropping whatever it
+        /// held before. `false` when a `deinit` or a newer attempt has taken the
+        /// watch over — this subscription is already history and the caller
+        /// unregisters rather than fighting for it.
+        private func claim(
+            channel: PooledChannel, token: UUID, generation: UInt64
+        ) -> Bool {
             lock.lock()
-            // A `deinit` or a newer attempt that landed while this one was on
-            // the wire owns the watch now; this subscription is already history.
             guard !stopped, generation == self.generation else {
                 lock.unlock()
-                channel.removeObserver(token)
-                return
+                return false
             }
             let previousChannel = self.channel
             let previousToken = observerToken
             self.channel = channel
             observerToken = token
-            if !resource.isEmpty { resolvedResource = resource }
             lock.unlock()
-            if let previousToken { previousChannel?.removeObserver(previousToken) }
+            // `withPooledRequest` retries a stale channel *inside* one attempt,
+            // without this watch's generation moving — so the thing being
+            // replaced here is usually the first try's own corpse.
+            if let previousToken, previousChannel !== channel {
+                previousChannel?.removeObserver(previousToken)
+            }
+            return true
         }
 
-        private func handle(_ signal: ChannelSignal, generation: UInt64) {
-            let current = lock.withLock { !stopped && generation == self.generation }
+        /// Undoes a claim whose subscribe never landed.
+        private func release(
+            channel: PooledChannel, token: UUID, generation: UInt64
+        ) {
+            lock.lock()
+            if !stopped, generation == self.generation, self.channel === channel {
+                self.channel = nil
+                observerToken = nil
+            }
+            lock.unlock()
+            channel.removeObserver(token)
+        }
+
+        /// Records the id the host answered with, once the subscribe has landed.
+        private func resolve(resource: String, generation: UInt64) {
+            guard !resource.isEmpty else { return }
+            lock.withLock {
+                guard !stopped, generation == self.generation else { return }
+                resolvedResource = resource
+            }
+        }
+
+        private func handle(
+            _ signal: ChannelSignal, generation: UInt64, from source: PooledChannel
+        ) {
+            // The generation alone is not enough. `withPooledRequest` retries a
+            // stale channel inside one attempt without moving it, so the first
+            // try's channel can close *after* the retry's has been claimed — and
+            // acting on that close would clear a subscription that is working,
+            // leaving `isSubscribed` permanently false and arming a duplicate.
+            // A signal counts only from the channel this watch is holding.
+            let current = lock.withLock {
+                !stopped && generation == self.generation && self.channel === source
+            }
             guard current else { return }
             switch signal {
             case .event(.fsChanged(let batch)):
@@ -308,6 +358,7 @@ extension Termiod {
                 // `isSubscribed` reports the outage while it lasts and a
                 // caller's own reconcile can cover it.
                 lock.withLock {
+                    guard channel === source else { return }
                     channel = nil
                     observerToken = nil
                 }

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -204,6 +204,19 @@ extension Termiod {
         private func connect() {
             lock.lock()
             guard !stopped else { lock.unlock(); return }
+            // One failure can arm two recoveries. A channel that closes *during*
+            // the subscribe both reaches `handle` — which schedules a retry —
+            // and fails the request, which `withPooledRequest` retries on a
+            // fresh channel inside the same call. When that inner retry
+            // succeeds, the outer one is still armed, and firing it would
+            // re-subscribe on a channel already carrying this watch: a wasted
+            // round trip, a second registration, and a `gap` that re-lists the
+            // whole tree for nothing. Holding a live channel means there is
+            // nothing to reconnect.
+            if let channel, !channel.isDead {
+                lock.unlock()
+                return
+            }
             generation &+= 1
             let generation = self.generation
             let since = cursor

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -18,10 +18,283 @@ import TermioShared
 /// request meant `ssh <host> termiod stdio` per folder expand, which measured at
 /// 32 ms median and 260 ms at p90 on a link whose round trip is 8 ms.
 ///
-/// Live change notification (the `fs:` resource) is still not here. It needs a
-/// connection that outlives one request, which now exists; what it also needs is
-/// a tree that applies deltas, which does not.
+/// Live change notification is `ResourceWatch` below: the `fs:` resource
+/// (§C.10), which the daemon has served since it grew a watcher and nothing
+/// here subscribed to. It is what replaces re-listing the whole tree every time
+/// the app takes focus — the update model VS Code and Zed both settled on, where
+/// the host says what moved and the client re-reads only that.
 extension Termiod {
+    /// A live subscription to one host resource, held for as long as the object
+    /// is retained.
+    ///
+    /// The `fs:` plane is the first consumer: one recursive watch per workspace
+    /// on the device, batched behind a 0.3 s quiet window, delivered as the set
+    /// of **directories** whose contents changed. A subscriber re-lists exactly
+    /// those and nothing else.
+    ///
+    /// Two things make this survivable rather than merely live:
+    ///
+    /// - **The cursor.** Every batch carries a monotonic `seq`, and `fs_listed`
+    ///   carries the cursor its listing was taken at. A reconnect re-subscribes
+    ///   with `since`, so batches that landed while the link was down are
+    ///   replayed rather than lost — and a batch the listing already reflects is
+    ///   dropped rather than re-fetched.
+    /// - **The reset.** When the host cannot replay from `since` (the ring aged
+    ///   out) it answers `gap`, and a dropped connection means the same thing.
+    ///   Both surface as `.reset`, whose only correct handling is to re-read what
+    ///   is held. A watch that quietly resumed after a gap would show a tree that
+    ///   is wrong in exactly the way nobody would notice.
+    ///
+    /// `@unchecked Sendable`: the state is behind `lock`, and every callback is
+    /// raised off the caller's queue.
+    final class ResourceWatch: @unchecked Sendable {
+        enum Update: Sendable {
+            /// The directories named have changed. `fullRescan` means the set is
+            /// not authoritative and everything realized must be re-read.
+            case batch(FsChangedPayload)
+            /// The subscription could not be continued from where it left off.
+            /// Whatever is held may be stale; re-read it.
+            case reset
+        }
+
+        /// The capability the daemon must have granted. A device too old to
+        /// serve it never gets a subscription, and its tree keeps the manual
+        /// refresh it always had.
+        static let capability = "resources"
+
+        /// How long a failed subscribe waits before trying again, and the
+        /// ceiling it backs off to. Slower than the channel pin's own warm-up:
+        /// the pin is what re-opens the connection, and this only has to notice
+        /// that it came back.
+        static let retryInterval = Duration.seconds(5)
+        static let retryCeiling = Duration.seconds(120)
+
+        private let route: TermiodRoute
+        private let caps: [String]
+        private let resource: String
+        private let onUpdate: @Sendable (Update) -> Void
+        private let queue: DispatchQueue
+        private let pin: ControlPool.ChannelPin
+
+        private let lock = NSLock()
+        /// Which subscribe attempt the observer belongs to. A channel found
+        /// stale mid-subscribe closes *after* this has moved on, and its late
+        /// `.closed` must not reset a subscription that has already been
+        /// re-established on the replacement.
+        private var generation: UInt64 = 0
+        private var channel: PooledChannel?
+        private var observerToken: UUID?
+        /// The highest batch applied, replayed from on reconnect. `nil` until
+        /// the first subscribe answers, which is what makes that first one ask
+        /// for the cursor rather than a replay.
+        private var cursor: UInt64?
+        private var failures = 0
+        private var stopped = false
+        /// The id the **host** answered with, which is what batches are tagged
+        /// with. Clients name a workspace root and the daemon canonicalises it
+        /// (`daemon.rs` — "two spellings of one repo share a single watch"), so
+        /// on macOS a root under `/var/folders` comes back as `/private/var/...`
+        /// and a subscriber matching on what it asked for hears nothing at all.
+        private var resolvedResource: String?
+
+        /// Subscribes, and keeps the subscription up. `onUpdate` is raised on an
+        /// arbitrary queue and must hop wherever it needs to be.
+        init(
+            route: TermiodRoute, caps: [String], resource: String,
+            onUpdate: @escaping @Sendable (Update) -> Void
+        ) {
+            self.route = route
+            self.caps = caps
+            self.resource = resource
+            self.onUpdate = onUpdate
+            self.queue = DispatchQueue(
+                label: "sh.termio.termiod.watch", qos: .utility)
+            self.pin = ControlPool.pin(route: route, caps: caps)
+            queue.async { [weak self] in self?.connect() }
+        }
+
+        deinit {
+            lock.lock()
+            stopped = true
+            let channel = self.channel
+            let token = observerToken
+            let resolved = resolvedResource
+            self.channel = nil
+            observerToken = nil
+            lock.unlock()
+            if let token { channel?.removeObserver(token) }
+            // Best effort: a daemon whose client vanished retires the watch on
+            // its own when the connection ends, and the connection outliving
+            // this object is exactly the case worth telling it about.
+            guard let channel, !channel.isDead else { return }
+            let resource = resolved ?? self.resource
+            queue.async {
+                try? channel.post { seq in
+                    try encodeControl(
+                        UnsubscribeResourceOperation(resource: resource, seq: seq))
+                }
+            }
+        }
+
+        /// The root the host is actually watching, canonicalised — `resolved`
+        /// minus its `fs:` prefix. The tree needs it to translate a batch's
+        /// paths back into its own spelling: the daemon reports changes under
+        /// the real path, while every path the tree holds came from an `fs.list`
+        /// reply, which echoes the path *as asked*. On a root reached through a
+        /// symlink the two differ, and a tree comparing them literally would
+        /// match nothing and never re-list.
+        var watchedRoot: String? {
+            lock.withLock {
+                resolvedResource.map { String($0.dropFirst("fs:".count)) }
+            }
+        }
+
+        /// Tells the watch which cursor a listing was taken at, so batches the
+        /// listing already includes are not applied over it. Called by the tree
+        /// after every `fs.list` it grafts.
+        func noteListed(at seq: UInt64) {
+            guard seq > 0 else { return }
+            lock.lock()
+            if cursor == nil || seq > cursor! { cursor = seq }
+            lock.unlock()
+        }
+
+        /// Whether a batch is news to this watch, and records it if so. The
+        /// listing that answered a previous batch may have been taken *after*
+        /// the batch that follows it was raised, and re-listing on that one
+        /// would ask the device a question it has already answered.
+        private func admit(_ batch: FsChangedPayload) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard batch.resource == (resolvedResource ?? resource) else { return false }
+            if let cursor, batch.seq <= cursor { return false }
+            cursor = batch.seq
+            return true
+        }
+
+        private func connect() {
+            lock.lock()
+            guard !stopped else { lock.unlock(); return }
+            generation &+= 1
+            let generation = self.generation
+            let since = cursor
+            lock.unlock()
+
+            do {
+                try withPooledRequest(route: route, caps: caps) { call, channel in
+                    guard channel.capabilities.contains(Self.capability) else {
+                        throw DeviceFileError.unsupported
+                    }
+                    // Registered before the request goes out: the host replays
+                    // from `since` as events *after* the reply, and an observer
+                    // installed afterwards would miss the ones already on the
+                    // wire.
+                    let token = channel.addObserver { [weak self] signal in
+                        self?.handle(signal, generation: generation)
+                    }
+                    do {
+                        let subscribed = try Self.subscribe(
+                            call, resource: resource, since: since)
+                        self.adopt(
+                            channel: channel, token: token, generation: generation,
+                            resource: subscribed.resource)
+                        // A first subscribe always reports a gap — there is
+                        // nothing to replay from. That is not news: the caller
+                        // is loading anyway, and reporting it would make every
+                        // pane open with two full listings instead of one.
+                        if subscribed.gap, since != nil { self.onUpdate(.reset) }
+                        self.lock.withLock { self.failures = 0 }
+                    } catch {
+                        channel.removeObserver(token)
+                        throw error
+                    }
+                }
+            } catch {
+                retry(after: error, generation: generation)
+            }
+        }
+
+        private static func subscribe(
+            _ call: ChannelCall, resource: String, since: UInt64?
+        ) throws -> SubscribedPayload {
+            try call.send(payload: encodeControl(SubscribeResourceOperation(
+                resource: resource, since: since, seq: call.seq)))
+            while true {
+                let frame = try call.next(
+                    timeoutSeconds: requestIdleTimeoutSeconds,
+                    operation: "subscribe_resource")
+                guard frame.kind == .control else { continue }
+                switch try decodeControl(frame.payload) {
+                case .subscribed(let payload):
+                    return payload
+                case .error(let failure):
+                    throw TermiodClientError.requestFailed(failure.message)
+                default:
+                    continue
+                }
+            }
+        }
+
+        private func adopt(
+            channel: PooledChannel, token: UUID, generation: UInt64, resource: String
+        ) {
+            lock.lock()
+            // A `deinit` or a newer attempt that landed while this one was on
+            // the wire owns the watch now; this subscription is already history.
+            guard !stopped, generation == self.generation else {
+                lock.unlock()
+                channel.removeObserver(token)
+                return
+            }
+            let previousChannel = self.channel
+            let previousToken = observerToken
+            self.channel = channel
+            observerToken = token
+            if !resource.isEmpty { resolvedResource = resource }
+            lock.unlock()
+            if let previousToken { previousChannel?.removeObserver(previousToken) }
+        }
+
+        private func handle(_ signal: ChannelSignal, generation: UInt64) {
+            let current = lock.withLock { !stopped && generation == self.generation }
+            guard current else { return }
+            switch signal {
+            case .event(.fsChanged(let batch)):
+                guard admit(batch) else { return }
+                onUpdate(.batch(batch))
+            case .event:
+                break
+            case .closed:
+                // Batches raised while the link was down are replayed from
+                // `cursor` on the way back — but only as far as the host's ring
+                // reaches, so the tree is told to re-read regardless.
+                onUpdate(.reset)
+                retry(after: TermiodClientError.connectionClosed, generation: generation)
+            }
+        }
+
+        private func retry(after error: Error, generation: UInt64) {
+            let delay: Duration? = lock.withLock {
+                guard !stopped, generation == self.generation else { return nil }
+                // A device that cannot serve resources at all will never start,
+                // so it is not worth a timer: the tree keeps its manual refresh.
+                if case DeviceFileError.unsupported = error { return nil }
+                failures += 1
+                return min(
+                    Self.retryInterval * Double(1 << min(failures, 5)),
+                    Self.retryCeiling)
+            }
+            guard let delay else { return }
+            Log.files.debug("""
+            \(self.resource, privacy: .public) watch on             \(self.route.description, privacy: .public) retrying:             \(String(describing: error), privacy: .public)
+            """)
+            let seconds = Double(delay.components.seconds)
+            queue.asyncAfter(deadline: .now() + seconds) { [weak self] in
+                self?.connect()
+            }
+        }
+    }
+
     /// What one directory answered. `error` is the device's own message for a
     /// path that vanished or escaped the root; a batched request fails one path
     /// at a time rather than as a whole.
@@ -29,6 +302,15 @@ extension Termiod {
         let path: String
         let entries: [FileEntry]
         let error: String?
+    }
+
+    /// A batch of listings and the `fs:` cursor they were taken at — what a
+    /// subscriber needs to tell a batch it has already answered from one it has
+    /// not. Zero when the device is running no watch, which reads as "nothing
+    /// will invalidate this".
+    struct DirectoryListings: Sendable {
+        let listings: [DirectoryListing]
+        let seq: UInt64
     }
 
     /// Reading a file for preview is capped at the same 1 MiB the daemon serves
@@ -90,7 +372,7 @@ extension Termiod {
     /// Blocking; call it off the main thread (`DeviceFileProvider` does).
     static func listDirectories(
         route: TermiodRoute, root: String, paths: [String]
-    ) throws -> [DirectoryListing] {
+    ) throws -> DirectoryListings {
         try withFilesChannel(route: route) { call in
             let listed = try requestFiles(call, operation: "fs.list") { seq in
                 FsListOperation(root: root, paths: paths, seq: seq)
@@ -98,12 +380,14 @@ extension Termiod {
                 if case .fsListed(let payload) = control { return payload }
                 return nil
             }
-            return listed.listings.map { listing in
-                DirectoryListing(
-                    path: listing.path,
-                    entries: listing.entries.map(FileEntry.init(wire:)),
-                    error: listing.error)
-            }
+            return DirectoryListings(
+                listings: listed.listings.map { listing in
+                    DirectoryListing(
+                        path: listing.path,
+                        entries: listing.entries.map(FileEntry.init(wire:)),
+                        error: listing.error)
+                },
+                seq: listed.seq)
         }
     }
 
@@ -355,10 +639,30 @@ struct DeviceFileProvider: Sendable {
     /// its own `error` and the rest of the listings still land. Callers key the
     /// result by `path`, which the daemon echoes back exactly as asked.
     func list(_ paths: [String]) async throws -> [Termiod.DirectoryListing] {
-        guard !paths.isEmpty else { return [] }
+        try await listing(paths).listings
+    }
+
+    /// The same request, with the `fs:` cursor the answer was taken at. The tree
+    /// uses this one: without the cursor it cannot tell a batch its listing
+    /// already includes from one raised after it, and would re-list on every
+    /// change it had just finished reading.
+    func listing(_ paths: [String]) async throws -> Termiod.DirectoryListings {
+        guard !paths.isEmpty else {
+            return Termiod.DirectoryListings(listings: [], seq: 0)
+        }
         return try await run { [route, root] in
             try Termiod.listDirectories(route: route, root: root, paths: paths)
         }
+    }
+
+    /// Subscribes to this checkout's `fs:` resource. Held by the tree for as
+    /// long as its pane is alive; releasing it retires the watch.
+    func watch(
+        onUpdate: @escaping @Sendable (Termiod.ResourceWatch.Update) -> Void
+    ) -> Termiod.ResourceWatch {
+        Termiod.ResourceWatch(
+            route: route, caps: ["files", Termiod.ResourceWatch.capability],
+            resource: "fs:" + root, onUpdate: onUpdate)
     }
 
     /// Content search under the pane's own root, on the device. Confined the same

--- a/Sources/termio/Terminal/Termiod/TermiodFiles.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodFiles.swift
@@ -55,6 +55,19 @@ extension Termiod {
             /// The subscription could not be continued from where it left off.
             /// Whatever is held may be stale; re-read it.
             case reset
+            /// The **first** subscribe of this watch's life has landed.
+            ///
+            /// Sent once, because it answers a question that can only be asked
+            /// at the start: a listing taken before the daemon had any watch is
+            /// stamped `seq == 0`, and anything that changed between that
+            /// listing and this moment raised no batch anybody was subscribed
+            /// for. No later event repairs it — the watch begins at a cursor
+            /// already past the change. A caller holding such a listing has to
+            /// re-read here.
+            ///
+            /// Later re-subscribes say `reset` instead: those have a `since` to
+            /// replay from, and their failure to use it is what `gap` reports.
+            case established
         }
 
         /// The capability the daemon must have granted. A device too old to
@@ -90,6 +103,8 @@ extension Termiod {
         private var cursor: UInt64?
         private var failures = 0
         private var stopped = false
+        /// Whether a subscribe has ever landed, so `established` fires once.
+        private var hasEstablished = false
         /// The id the **host** answered with, which is what batches are tagged
         /// with. Clients name a workspace root and the daemon canonicalises it
         /// (`daemon.rs` — "two spellings of one repo share a single watch"), so
@@ -133,6 +148,20 @@ extension Termiod {
                     try encodeControl(
                         UnsubscribeResourceOperation(resource: resource, seq: seq))
                 }
+            }
+        }
+
+        /// Whether a subscription is up right now.
+        ///
+        /// False before the first subscribe lands, while a dropped one is being
+        /// re-established, and forever on a daemon that never granted
+        /// `resources`. A caller that had a reconcile of its own before this
+        /// existed keeps it as the fallback for that last case: a watch that
+        /// cannot run must not take the old behaviour down with it.
+        var isSubscribed: Bool {
+            lock.withLock {
+                guard !stopped, let channel else { return false }
+                return !channel.isDead
             }
         }
 
@@ -199,10 +228,20 @@ extension Termiod {
                             channel: channel, token: token, generation: generation,
                             resource: subscribed.resource)
                         // A first subscribe always reports a gap — there is
-                        // nothing to replay from. That is not news: the caller
-                        // is loading anyway, and reporting it would make every
-                        // pane open with two full listings instead of one.
-                        if subscribed.gap, since != nil { self.onUpdate(.reset) }
+                        // nothing to replay from. Reporting that as a reset
+                        // would open every pane with two full listings instead
+                        // of one. What the caller does need is to know the watch
+                        // is armed, so a listing taken before it can be
+                        // reconsidered.
+                        let first = self.lock.withLock { () -> Bool in
+                            defer { self.hasEstablished = true }
+                            return !self.hasEstablished
+                        }
+                        if first {
+                            self.onUpdate(.established)
+                        } else if subscribed.gap {
+                            self.onUpdate(.reset)
+                        }
                         self.lock.withLock { self.failures = 0 }
                     } catch {
                         channel.removeObserver(token)
@@ -265,6 +304,13 @@ extension Termiod {
             case .event:
                 break
             case .closed:
+                // Dropped here rather than left for the next `adopt`, so
+                // `isSubscribed` reports the outage while it lasts and a
+                // caller's own reconcile can cover it.
+                lock.withLock {
+                    channel = nil
+                    observerToken = nil
+                }
                 // Batches raised while the link was down are replayed from
                 // `cursor` on the way back — but only as far as the host's ring
                 // reaches, so the tree is told to re-read regardless.

--- a/Tests/termioTests/RemoteFileTreeRefreshTests.swift
+++ b/Tests/termioTests/RemoteFileTreeRefreshTests.swift
@@ -194,4 +194,39 @@ final class RemoteFileTreeRefreshTests: XCTestCase {
             tree.directoriesToRelist(for: ["\(root)/src"]), [],
             "a path the tree no longer holds is not worth a round trip")
     }
+
+    // MARK: - The window between the first listing and the first batch
+
+    /// A listing taken before the device had any watch is stamped `seq == 0`.
+    /// Anything that changed between it and the subscription raised no batch
+    /// anybody was subscribed for, and the watch then starts at a cursor already
+    /// past it — so nothing later repairs the tree. `established` is when that
+    /// has to be re-read.
+    func testATreeListedBeforeTheWatchExistedReconcilesWhenItArrives() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory)])])
+        XCTAssertTrue(
+            tree.needsReconcileOnEstablish,
+            "nothing has stamped these rows, so they may already be stale")
+    }
+
+    /// The opposite, which is the common case and must not cost a second full
+    /// listing: the load happened while a watch was already running, so the
+    /// cursor on it proves what the rows include.
+    func testATreeListedUnderARunningWatchNeedsNoReconcile() {
+        let tree = model()
+        tree.noteListed(at: 42)
+        XCTAssertFalse(
+            tree.needsReconcileOnEstablish,
+            "a stamped listing already reflects everything up to its cursor")
+    }
+
+    /// A tree with no subscription — a daemon too old to grant `resources` —
+    /// keeps the app-focus reconcile it always had. Dropping that unconditionally
+    /// left those trees with nothing but the refresh button.
+    func testATreeWithNoSubscriptionIsNotLive() {
+        XCTAssertFalse(
+            model().isLive,
+            "no watch means the pane's own reconcile is still the only signal")
+    }
 }

--- a/Tests/termioTests/RemoteFileTreeRefreshTests.swift
+++ b/Tests/termioTests/RemoteFileTreeRefreshTests.swift
@@ -125,4 +125,73 @@ final class RemoteFileTreeRefreshTests: XCTestCase {
         XCTAssertNil(tree.node(at: "\(root)/src"))
         XCTAssertEqual(tree.loadedDirectories(), ["\(root)/docs"])
     }
+
+    // MARK: - What a live batch re-lists
+
+    /// The rule the subscription exists for: a batch names every directory that
+    /// changed under the checkout, and the tree asks about the ones it is
+    /// actually drawing. This is VS Code's `doesFileEventAffect` — refresh on a
+    /// file event only when a *visible* item was hit.
+    func testABatchOnlyRelistsDirectoriesTheTreeIsShowing() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory), ("target", .directory)])])
+        tree.apply([listing("\(root)/src", [("app.swift", .file)])])
+
+        XCTAssertEqual(
+            tree.directoriesToRelist(for: ["\(root)/src"]), ["\(root)/src"],
+            "an open folder that changed is re-read")
+        XCTAssertEqual(
+            tree.directoriesToRelist(for: ["\(root)"]), ["\(root)"],
+            "the root is always realized")
+    }
+
+    /// The case that used to cost a full re-list and now costs nothing: an agent
+    /// writing into a directory nobody has expanded. `target` is a row on screen,
+    /// but its *contents* are not — so a change inside it is not news.
+    func testABatchUnderAnUnopenedFolderAsksForNothing() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory), ("target", .directory)])])
+        tree.apply([listing("\(root)/src", [("app.swift", .file)])])
+
+        XCTAssertEqual(
+            tree.directoriesToRelist(for: [
+                "\(root)/target",
+                "\(root)/target/debug",
+                "\(root)/src/generated/nested",
+            ]),
+            [],
+            "nothing realized was touched, so the device is not asked anything")
+    }
+
+    /// A batch repeats a directory when several files under it moved inside one
+    /// quiet window. The tree asks once — `fs.list` is batched, and naming a path
+    /// twice would list it twice.
+    func testARepeatedDirectoryIsAskedForOnce() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory)])])
+        tree.apply([listing("\(root)/src", [("app.swift", .file)])])
+
+        XCTAssertEqual(
+            tree.directoriesToRelist(for: [
+                "\(root)/src", "\(root)/src", "\(root)/nope", "\(root)",
+            ]),
+            ["\(root)/src", "\(root)"],
+            "deduplicated, in the order the batch named them")
+    }
+
+    /// A folder that was open and has since been collapsed out of the tree stops
+    /// being asked about — the same pruning `loadedDirectories` already does for
+    /// the whole-tree refresh.
+    func testACollapsedFolderIsNoLongerRelisted() {
+        let tree = model()
+        tree.apply([listing(root, [("src", .directory)])])
+        tree.apply([listing("\(root)/src", [("app.swift", .file)])])
+        XCTAssertEqual(tree.directoriesToRelist(for: ["\(root)/src"]), ["\(root)/src"])
+
+        // The folder is gone from the root's listing, so `apply` prunes it.
+        tree.apply([listing(root, [("docs", .directory)])])
+        XCTAssertEqual(
+            tree.directoriesToRelist(for: ["\(root)/src"]), [],
+            "a path the tree no longer holds is not worth a round trip")
+    }
 }

--- a/Tests/termioTests/RemoteFileTreeRefreshTests.swift
+++ b/Tests/termioTests/RemoteFileTreeRefreshTests.swift
@@ -229,4 +229,21 @@ final class RemoteFileTreeRefreshTests: XCTestCase {
             model().isLive,
             "no watch means the pane's own reconcile is still the only signal")
     }
+
+    /// The bug the `established` reconcile shipped with: a refresh raised while
+    /// one is in flight used to be dropped on the floor. At startup that is the
+    /// ordinary case — `onAppear` starts the subscription and the first listing
+    /// together, both one round trip — so the reconcile hit the guard, returned,
+    /// and the listing it was meant to correct settled at `seq == 0` behind it.
+    func testARefreshRaisedDuringOneIsQueuedRatherThanDropped() {
+        let tree = model()
+        XCTAssertFalse(tree.refreshQueued)
+
+        tree.refresh()   // takes the guard synchronously; its listing never answers
+        tree.refresh()   // this is the reconcile, and it must not vanish
+
+        XCTAssertTrue(
+            tree.refreshQueued,
+            "the second refresh is held for after the first, not discarded")
+    }
 }

--- a/Tests/termioTests/TermiodFilesIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFilesIntegrationTests.swift
@@ -764,6 +764,41 @@ final class TermiodFilesIntegrationTests: XCTestCase {
             listed.listings.first?.entries.contains { $0.name == "cursor.txt" } ?? false,
             "and the listing the cursor is stamped on is the one that includes the write")
     }
+
+    /// A watch that loses its channel and comes back re-subscribes, and leaves
+    /// exactly one observer on the channel it lands on.
+    ///
+    /// This covers the reconnect path, not the same-channel double-claim: a
+    /// hung-up channel is closed, so the retry necessarily opens a different one
+    /// and `claim` replaces the observer either way. It passes with and without
+    /// that guard, which is stated here rather than left for the next reader to
+    /// discover — a test that cannot fail for the reason its name suggests is
+    /// worse than no test.
+    func testAReconnectingWatchReplacesItsObserverRatherThanStackingOne() throws {
+        let watch = Termiod.ResourceWatch(
+            route: .local,
+            caps: ["files", Termiod.ResourceWatch.capability],
+            resource: "fs:" + root.path
+        ) { _ in }
+
+        let armed = Date().addingTimeInterval(30)
+        while !watch.isSubscribed, Date() < armed { usleep(100_000) }
+        XCTAssertTrue(watch.isSubscribed, "the first subscribe never landed")
+
+        // Hang the channel up under it, which is what a ControlPersist expiry or
+        // a sleeping laptop does.
+        Termiod.ControlPool.closeAll(route: .local)
+        let backAgain = Date().addingTimeInterval(90)
+        while !watch.isSubscribed, Date() < backAgain { usleep(200_000) }
+        XCTAssertTrue(watch.isSubscribed, "the watch never re-established")
+
+        let channel = try Termiod.ControlPool.channel(
+            route: .local, caps: ["files", Termiod.ResourceWatch.capability])
+        XCTAssertEqual(
+            channel.observerCount, 1,
+            "one watch, one observer — a second would double every batch")
+        withExtendedLifetime(watch) {}
+    }
 }
 
 extension TermiodFilesIntegrationTests {

--- a/Tests/termioTests/TermiodFilesIntegrationTests.swift
+++ b/Tests/termioTests/TermiodFilesIntegrationTests.swift
@@ -173,7 +173,7 @@ final class TermiodFilesIntegrationTests: XCTestCase {
 
     func testTheRootListsAsTheTreeWouldDrawIt() throws {
         let listings = try Termiod.listDirectories(
-            route: .local, root: root.path, paths: [root.path])
+            route: .local, root: root.path, paths: [root.path]).listings
         XCTAssertEqual(listings.count, 1)
         let listing = try XCTUnwrap(listings.first)
         XCTAssertNil(listing.error)
@@ -191,7 +191,7 @@ final class TermiodFilesIntegrationTests: XCTestCase {
     func testASubdirectoryListsUnderTheSameRoot() throws {
         let listings = try Termiod.listDirectories(
             route: .local, root: root.path,
-            paths: [root.appendingPathComponent("sub").path])
+            paths: [root.appendingPathComponent("sub").path]).listings
         let listing = try XCTUnwrap(listings.first)
         XCTAssertNil(listing.error)
         XCTAssertEqual(listing.entries.map(\.name), ["b.txt"])
@@ -203,7 +203,7 @@ final class TermiodFilesIntegrationTests: XCTestCase {
     func testAPathOutsideTheRootIsRefusedOnItsOwn() throws {
         let outside = root.deletingLastPathComponent().path
         let listings = try Termiod.listDirectories(
-            route: .local, root: root.path, paths: [root.path, outside])
+            route: .local, root: root.path, paths: [root.path, outside]).listings
         XCTAssertEqual(listings.count, 2)
         XCTAssertNil(listings[0].error, "the confined path still answers")
         XCTAssertNotNil(listings[1].error, "the escape is refused")
@@ -459,7 +459,7 @@ final class TermiodFilesIntegrationTests: XCTestCase {
 
         DispatchQueue.global().async {
             listed.value = (try? Termiod.listDirectories(
-                route: .local, root: root.path, paths: [root.path])) ?? []
+                route: .local, root: root.path, paths: [root.path]))?.listings ?? []
             listEnded.value = clock.now
             done.fulfill()
         }
@@ -564,7 +564,7 @@ final class TermiodFilesIntegrationTests: XCTestCase {
         daemon = restarted
 
         let listings = try Termiod.listDirectories(
-            route: .local, root: root.path, paths: [root.path])
+            route: .local, root: root.path, paths: [root.path]).listings
         XCTAssertTrue(listings.first?.entries.contains { $0.name == "a.txt" } ?? false)
     }
 
@@ -664,6 +664,114 @@ final class TermiodFilesIntegrationTests: XCTestCase {
         let held = try Termiod.ControlPool.channel(route: .local, caps: ["files"])
         XCTAssertTrue(channel === held, "the pane still open keeps the connection")
         withExtendedLifetime(second) {}
+    }
+
+    // MARK: - The live subscription
+
+    /// The `fs:` plane end to end: subscribe, touch a file, and see the batch
+    /// name the directory it landed in.
+    ///
+    /// This is the half the client had never exercised. The daemon has served
+    /// `fs:` since it grew a watcher; nothing here listened, so the tree re-read
+    /// everything on app focus instead. What is worth pinning is precisely what
+    /// used to be missing: that a frame answering *no request* reaches a
+    /// subscriber at all (`PooledChannel.addObserver`), and that the batch names
+    /// the changed directory rather than the changed file.
+    func testAWatchDeliversABatchNamingTheChangedDirectory() throws {
+        let batches = UncheckedBox<[Termiod.FsChangedPayload]>([])
+        let arrived = expectation(description: "a batch names the directory")
+        arrived.assertForOverFulfill = false
+        let watch = Termiod.ResourceWatch(
+            route: .local,
+            caps: ["files", Termiod.ResourceWatch.capability],
+            resource: "fs:" + root.path
+        ) { update in
+            guard case .batch(let batch) = update else { return }
+            batches.value.append(batch)
+            arrived.fulfill()
+        }
+
+        // The subscribe is asynchronous; a write that beats it would be watched
+        // by nobody. Poll the write rather than sleep once, so a slow machine
+        // lengthens the test instead of failing it.
+        let armed = Date().addingTimeInterval(20)
+        while watch.watchedRoot == nil, Date() < armed { usleep(20_000) }
+        let subscribed = Date()
+        try Data("live\n".utf8).write(to: root.appendingPathComponent("watched.txt"))
+        wait(for: [arrived], timeout: 20)
+        let latency = Date().timeIntervalSince(subscribed)
+        print(String(format: "fs: batch latency after one write: %.0f ms", latency * 1000))
+        XCTAssertLessThan(
+            latency, 5,
+            "a change is meant to reach the tree while the user is still looking at it")
+        withExtendedLifetime(watch) {}
+
+        // The host canonicalises the root it watches, so a `/var/folders` path
+        // comes back as `/private/var/folders`. Comparing the resolved spelling
+        // is the point rather than an allowance: a client that matched on what
+        // it asked for would hear nothing, which is what this test caught.
+        // `realpath` rather than `resolvingSymlinksInPath`, which deliberately
+        // rewrites `/private/var` *back* to `/var` and would agree with the bug.
+        let canonical = try XCTUnwrap(Self.realPath(of: root.path))
+        let named = Set(batches.value.flatMap(\.paths))
+        XCTAssertTrue(
+            named.contains(canonical) || batches.value.contains(where: \.fullRescan),
+            "the batch names the directory the file landed in, not the file: \(named)")
+        XCTAssertEqual(
+            watch.watchedRoot, canonical,
+            "the watch adopts the host's spelling, which is what the tree translates by")
+        XCTAssertTrue(
+            batches.value.allSatisfy { $0.resource == "fs:" + canonical },
+            "every batch is tagged with the resource that raised it")
+    }
+
+    /// The cursor, which is what keeps a live tree from re-reading what it just
+    /// read: a batch at or below the `seq` a listing was taken at is already
+    /// reflected in that listing and must not send the tree back to the device.
+    func testAListingCarriesTheCursorItWasTakenAt() throws {
+        // `fs_listed.seq` is 0 until something is watching the root — the
+        // daemon's honest "nothing will invalidate this". So the subscription
+        // has to exist before the listing can carry a cursor at all, which is
+        // the ordering the tree uses too: subscribe on appear, then load.
+        let delivered = UncheckedBox<[UInt64]>([])
+        let watch = Termiod.ResourceWatch(
+            route: .local,
+            caps: ["files", Termiod.ResourceWatch.capability],
+            resource: "fs:" + root.path
+        ) { update in
+            guard case .batch(let batch) = update else { return }
+            delivered.value.append(batch.seq)
+        }
+        let armed = Date().addingTimeInterval(20)
+        while watch.watchedRoot == nil, Date() < armed { usleep(100_000) }
+        XCTAssertNotNil(watch.watchedRoot, "the subscription is what stamps a listing")
+
+        try Data("cursor\n".utf8).write(to: root.appendingPathComponent("cursor.txt"))
+        var listed = try Termiod.listDirectories(
+            route: .local, root: root.path, paths: [root.path])
+        let cursorDeadline = Date().addingTimeInterval(20)
+        while listed.seq == 0, Date() < cursorDeadline {
+            usleep(200_000)
+            listed = try Termiod.listDirectories(
+                route: .local, root: root.path, paths: [root.path])
+        }
+        withExtendedLifetime(watch) {}
+
+        XCTAssertGreaterThan(
+            listed.seq, 0,
+            "a listing taken while a watch is running carries that watch's cursor")
+        XCTAssertTrue(
+            listed.listings.first?.entries.contains { $0.name == "cursor.txt" } ?? false,
+            "and the listing the cursor is stamped on is the one that includes the write")
+    }
+}
+
+extension TermiodFilesIntegrationTests {
+    /// The path the daemon canonicalises to, resolved the same way it does.
+    static func realPath(of path: String) -> String? {
+        guard let resolved = realpath(path, nil) else { return nil }
+        defer { free(resolved) }
+        return String(cString: resolved)
     }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,7 @@ from the real front matter).
 | draft | rfc | [Review — One path, local sessions run through termiod too](design/20260817-one-path-local-through-termiod.review-claude.md) |
 | draft | rfc | [Settings that know which machine they mean](design/20260824-settings-that-know-which-machine.md) |
 | draft | rfc | [Termiod web client on official Ghostty WASM (Linux first)](design/20260818-termiod-web-client-ghostty-wasm.md) |
+| draft | rfc | [The tab strip is the collapsed sidebar](design/20260829-tab-strip-is-the-collapsed-sidebar.md) |
 | fixed | bug | [New terminal opens unfocused (hollow cursor, beeps until clicked)](bug/terminal-focus-loss-on-new-session-mount.md) |
 | fixed | bug | [Terminal loses focus after window deactivation](bug/terminal-focus-loss-on-window-key.md) |
 | fixed | bug | [Terminal loses focus while the window stays key — sibling-render trigger](bug/terminal-focus-loss-on-sibling-render.md) |

--- a/docs/design/20260829-tab-strip-is-the-collapsed-sidebar.md
+++ b/docs/design/20260829-tab-strip-is-the-collapsed-sidebar.md
@@ -1,0 +1,485 @@
+---
+title: The tab strip is the collapsed sidebar
+status: draft
+type: rfc
+created: 2026-08-29
+updated: 2026-08-29
+related:
+  - 20260702-split-panes.md
+  - 20260628-worktree-information-architecture.md
+  - 20260713-loose-terminal-entity.md
+  - 20260812-keyboard-command-design.md
+  - 20260818-one-workspace-source.md
+---
+
+# The tab strip is the collapsed sidebar
+
+> Give the window a horizontal tab strip that appears only when the sidebar is
+> collapsed, drawn from the same row model the sidebar draws. A tab is a split
+> group (or a lone session); a tab group is a sidebar section or a project, the
+> way a Chrome tab group is a collapsible section in Chrome's vertical tabs.
+> Only the group holding the selection is open; the rest fold to their chips.
+> No new mode, no new setting, no new shortcut, nothing new persisted.
+
+## The one idea
+
+Termio has one session switcher, the sidebar, and one way to hide it, the
+navigator toggle. Hiding it today leaves nothing behind: the band above the
+terminal holds the toggle, the branch picker and the inspector switch, and the
+user is flying blind — no status rings, no way to see which agent went
+`needs-you`, no way to switch except ⌘⇧[ / ⌘⇧], the Session menu, or Open
+Quickly. So nobody collapses the sidebar, and 240pt of a 13" screen stays spent
+on a list they are not reading while an agent works.
+
+Superlogical's two screenshots settle what the fix is. In the vertical one the
+sidebar is open and the title bar carries only the session's name. In the
+horizontal one the sidebar is closed and the title bar carries the tabs. Those
+are not two "tab layouts" the user picks between. They are the sidebar toggle,
+and the strip is what a collapsed sidebar *becomes*.
+
+```
+ sidebar open                                    sidebar collapsed
+ ┌────────────────┬─────────────────────────┐   ┌─────────────────────────────────────────────────────┐
+ │ ☰ Work   ⇅ +   │ termio · main      ⊞ ▤  │   │ ☰ Work ▾│termio·main│● Claude│○ zsh│Terminals│+ ⊞ ▤ │
+ ├────────────────┼─────────────────────────┤   ├─────────────────────────────────────────────────────┤
+ │ ▾ termio       │                         │   │                                                     │
+ │   ● Claude  ◀──┼── selected              │   │  $ claude                                           │
+ │   ○ zsh        │                         │   │  ▌                                                  │
+ │ ▾ Terminals    │                         │   │                                                     │
+ │   ○ zsh        │                         │   │                                                     │
+ └────────────────┴─────────────────────────┘   └─────────────────────────────────────────────────────┘
+                                           ☰ ───────▶
+                    one toggle, one row model, two geometries
+```
+
+That is the whole proposal. The rest of this document is what falls out of it.
+
+## Why this is not the tab strip that was dropped
+
+On 2026-07-06 a Safari-style session tab strip was built for the detail column
+and dropped the same day: "感觉这种UI方式没什么用". It sat *beside* an open
+sidebar and listed the selected project's sessions — a second switcher showing a
+subset of the first. The worktree IA doc records the same verdict against
+pushing sessions into a content-area strip. Both stand.
+
+| | Dropped strip (2026-07-06) | This RFC |
+| --- | --- | --- |
+| Visible when | Always, beside the sidebar | Only while the sidebar is collapsed |
+| Shows | The selected project's sessions | Everything the sidebar shows, same order |
+| Model | Its own | The sidebar's row model, second geometry |
+| Net switchers on screen | Two | One |
+| What it buys | Nothing the sidebar lacked | A collapsed sidebar that still works |
+
+The redundancy argument was correct and it is exactly what the visibility rule
+removes: the strip and the sidebar are never on screen together, so there is
+never a second copy of anything.
+
+## What the neighbours do, and why
+
+### Superlogical
+
+The strip lives in the title bar. Its leading control is a sidebar glyph that
+also opens the workspace menu — *Filter or create…*, a checked **Demo**, *New
+Session ⇧⌘N*, *Add Remote Host…* — so one click either reopens the vertical
+view or changes which workspace the strip is showing. Inactive tabs are
+separated by hairlines that vanish beside the active tab (Chrome's rule); the
+active tab is a lifted pill; `+` trails.
+
+Why the strip shows one workspace and the sidebar shows all of them (**Demo**
+and **Work** are both sections in the vertical view): Superlogical's tree is
+flat — workspace → sessions — so a single row of tabs can carry one workspace
+and nothing else without losing structure. The dropdown is how the other
+workspaces stay one click away. Their tab is one surface; splits are separate
+native windows, so "a tab of several panes" never arises for them.
+
+### Chrome tab groups
+
+On desktop Chrome a group is a contiguous run of tabs headed by a coloured chip
+carrying the group's name, with the colour underlining the run. Clicking the
+chip collapses the run to the chip alone; the tabs stay open, they are just not
+drawn. Dragging a tab into the run joins the group, dragging it out leaves it,
+dragging the chip moves the whole run. The chip's context menu is the group's
+verb set: *New tab in group*, *Ungroup*, *Close group*, *Move group to new
+window*, *Save group*. Pinned tabs sit leftmost, icon-only, outside every
+group. In Chrome's vertical tabs the same groups render as collapsible sections
+of a list — the strip and the list are one model in two geometries, which is
+the property this RFC wants.
+
+Why Chrome needs names and colours: its groups are invented by the user out of
+arbitrary pages, so identity has to be painted on. Why Termio does not: its
+groups are folders. A project's name is its identity and a section's name is
+its kind. Painting colours on top would be a knob with nothing to decide.
+
+Why Chrome's ⌘1–9 reaches tabs and Termio's reaches workspaces: Chrome's
+top-level object is the tab; Termio's is the workspace, decided in the keyboard
+design and already drawn beside each workspace in the switcher. A Chrome
+window is a Termio workspace — one strip, one workspace, switch to see another.
+
+What Chrome does not do: fold the groups you are not in. Collapse is a click
+per group, and the active tab can never sit inside a collapsed group — collapse
+the active group and Chrome moves activation to the next tab outside it. The
+most-installed patch on the feature, *Auto Collapse for Tab Groups*, adds the
+missing rule in one sentence: collapse every group with no focused tab.
+
+### Vivaldi accordion tab stacks
+
+Vivaldi ships that rule natively (4.1, 2021) as one of its three stack styles:
+"the stack will expand automatically when viewing a tab in the stack and
+collapse when viewing other tabs." A collapsed stack is about the width of one
+tab; an open stack's tabs share the bar with everything else. Two knobs ride
+along — double-click pins a stack open, and a setting turns auto-expand off —
+and this RFC takes the rule without them.
+
+Firefox (142+) has the opposite invariant: a collapsed group *may* hold the
+active tab, drawn as the chip plus that one tab, and hovering a collapsed chip
+lists its tabs so one can be picked without opening the group. The list is
+worth taking; the invariant is not, because the accordion makes it moot.
+
+## The mapping
+
+| Chrome | Termio | Note |
+| --- | --- | --- |
+| Window | Workspace | The strip shows `currentWorkspace`; ⌘1–9 switch |
+| Tab group | Terminals section, Chats section, project, worktree | Chip + run; the run draws only for the selection's group |
+| Tab | A split group, or a lone session | The user's rule: every group is one tab, every loose session is one tab |
+| Active tab | The tab containing `selectedSessionID` | `splitRoot` is already "the group containing the selection" |
+| Collapsed group | Every group but the selection's | Derived from `selectedSessionID`, never toggled — see *One group open* |
+| `+` at the strip's end | The sidebar's `+` pull-down | Global by rule (see *plus-menu-is-global*) |
+| *New tab in group* | The project header's quick-add / section header's *New Terminal* / *New Chat* | The chip's context menu is the header's menu, verbatim |
+| Pinned tabs | *(none)* | See *Pinned* below |
+| Tab search | Open Quickly ⌘⇧O | Exists |
+| Vertical tabs | The sidebar | Exists |
+
+A **tab** is precisely what the terminal area can show at once: `visiblePaneIDs`
+is the tab's leaves. A lone session is a tab of one leaf. A split group is a tab
+whose leaves are `splitRoot.leafIDs`. Clicking a pane inside a tab changes the
+focused leaf, not the tab. This keeps the SplitTree invariant its own header
+states — there is no "tabs inside a pane" layer; a leaf is a session — because
+a tab is a whole layout, never a slot within one.
+
+```
+ sidebar (vertical)                     strip (horizontal), same order
+ ──────────────────                     ────────────────────────────────────────────
+ ▾ termio                           ─▶  │ termio·main │                 open: holds the selection
+   ┌ ● Claude Code   split group    ─▶                │ ● Claude Code ⧉2 │
+   └ ○ zsh           (bracketed run)                     one tab, two leaves
+   ○ zsh             lone session   ─▶                                     │ ○ zsh │
+ ▾ fix-auth                         ─▶  │ fix-auth ● │                  folded: chip + status dot
+   ● Codex                                (listed in the chip's menu)
+ ▾ Terminals                        ─▶  │ Terminals │                   folded
+   ○ zsh                                  (listed in the chip's menu)
+```
+
+A bracketed run in the sidebar folds into one tab; a group header becomes a
+chip; the order is untouched. Only the selection's group draws its tabs — the
+others are chips, which is the accordion in *One group open*.
+
+A tab's **title** is the focused leaf's `displayTitle` (the sidebar row's label:
+given title, then live title, then prompt title, then the placeholder), so a tab
+reads exactly as the row it replaces. A multi-leaf tab appends a small pane
+count. A tab's **status** is the most urgent of its leaves' statuses —
+`needsAttention` > `working` > `done` > `idle` — the same fold the menu-bar
+pulse already does across all sessions, applied to one layout.
+
+A tab lives in the **group of its first leaf** in sidebar order. Split groups are
+inserted beside their origin (`splitSelectedPane` places the new row next to the
+focused one so the sidebar can draw its ┌/└ bracket), so a tab's leaves are
+adjacent rows and the strip's order is the sidebar's order with bracketed runs
+folded into one tab.
+
+## One model, three consumers
+
+The sidebar's `body` opens with forty lines that derive the rows: the ordered
+projects partitioned into pinned and unpinned, the pinned worktrees and sessions
+minus what a pinned ancestor already shows, the other-workspace `needs-you`
+rows, whether rows wear a device mark, which sections exist. The Session menu
+derives a second, slightly different flattening in `sidebarSessionGroups`. A
+strip would be a third.
+
+The engineering step underneath this RFC is to lift that derivation into one
+value the store computes:
+
+```swift
+struct SwitcherRows {
+    struct Group: Identifiable {
+        enum Kind { case terminals, chats, project(Project.ID), worktree(Project.ID, Worktree.ID), alsoRunning }
+        let id: String            // stable across rebuilds: kind + owning id
+        let kind: Kind
+        let label: String         // "Terminals", the project's name, the branch
+        let tabs: [Tab]
+    }
+    struct Tab: Identifiable {
+        let id: Session.ID        // the first leaf, in sidebar order
+        let leaves: [Session.ID]  // one for a lone session; splitRoot.leafIDs for a group
+    }
+    let groups: [Group]
+}
+```
+
+`SidebarView` renders it as the tree it renders today (a project group followed
+by its worktree groups is the three-level nest; a multi-leaf tab is the
+bracketed run). `TabStripView` renders it as chips and runs. The Session menu
+renders it as headers and rows. Three geometries, one order — the thing Chrome's
+vertical and horizontal tabs get right and the thing two independent
+derivations would drift on within a month.
+
+```
+                  TermioStore
+      ┌──────────────────────────────────┐
+      │ projects · worktrees · sessions  │
+      │ splitGroups · deviceSessions     │
+      │ selectedSessionID                │
+      └────────────────┬─────────────────┘
+                       │ derive once
+                       ▼
+                 SwitcherRows
+              groups: [Group{tabs}]
+         ┌─────────────┼─────────────┐
+         ▼             ▼             ▼
+    SidebarView   TabStripView   Session menu
+    tree + ┌/└    chips + runs   headers + rows
+    (open)        (collapsed)    (always)
+```
+
+The strip carries no fold state of its own: which group is open is derived
+from the selection (see *One group open*). The sidebar keeps the disclosure
+`@State` it has today — a list can show everything, so its folds stay manual
+and stay unpersisted — and the `StateFile` stays what it is: tree, selection,
+inspector layout.
+
+## Presentation
+
+### Where it sits
+
+In the toolbar band, between the navigator toggle and the branch picker, as one
+`NSToolbarItem` hosting a SwiftUI view — the shape the branch picker already
+takes (`.branchPicker`, an `NSHostingView` with a width constraint that follows
+the terminal pane). The band is otherwise empty once the sidebar is gone, and a
+second row below the toolbar would spend a line of terminal text to draw tabs
+under blank chrome. Superlogical and Safari both put the strip in the title
+bar for the same reason.
+
+Two things make the band *one row of tab titles* rather than tabs squeezed
+beside the chrome that is there today:
+
+- **The branch picker retires while the strip is up.** It is display only —
+  the project's name over its branch, no menu — and both facts move to the
+  group chip: the project's name is the chip, and the primary checkout's chip
+  carries the branch after it (`termio · main`), the way a worktree chip already
+  *is* its branch. With the sidebar open the picker stays, since nothing else in
+  the band says which project the terminal is in.
+- **The band goes compact.** Its height comes from `toolbarStyle`, not from its
+  contents: macOS 26 gets `.automatic` (the tall bar) and earlier systems
+  `.unifiedCompact`. A one-line strip in a two-line band reads as empty, so the
+  strip lands with a switch to `.unifiedCompact` on 26 as well — a paired
+  decision, made once, that also applies while the sidebar is open. This is
+  the vertical saving; the horizontal one is the 240–260pt the sidebar gives
+  back, and that is the larger of the two.
+
+```
+ sidebar open
+ ┌───────────────────────────────────────────────────────────────────────────────────────┐
+ │ ☰ Work         ⇅   +    ┃ termio                                               ⊞ ▤    │
+ └───────────────────────────────────────────────────────────────────────────────────────┘
+   toggleNavigator  flex  sort  new │ sidebarTrackingSeparator │ branchPicker  flex  toggleInspector
+
+ sidebar collapsed
+ ┌───────────────────────────────────────────────────────────────────────────────────────┐
+ │ ☰ Work ▾ │ termio·main │ ● Claude Code ⧉2 │ ○ zsh │ fix-auth ● │ Terminals │ +   ⊞ ▤  │
+ └───────────────────────────────────────────────────────────────────────────────────────┘
+   toggleNavigator │ ───────────── tabStrip: grows to fill, shrinks first ───────────── │ toggleInspector
+   + workspace switcher
+```
+
+The strip takes the branch picker's slot and the sort/`+` pair's freed room;
+the workspace switcher stays on the toggle because it is the strip's workspace
+dropdown.
+
+The existing `sidebarCollapseObserver` is the switch. It already inserts and
+removes the sidebar's toolbar actions on every collapse path (toggle, View
+menu, divider drag) through `setNavigatorItemsVisible`; the strip item is
+inserted where those are removed and removed where they are restored. The
+workspace switcher must stay in the band while collapsed — it is the strip's
+workspace dropdown, and today it rides with the sidebar's region.
+
+### One group open
+
+The strip is an accordion. The open group is the one holding
+`selectedSessionID`; every other group is drawn as its chip alone. Select a
+session in another project and that project unfolds while the one you left
+folds, with no click spent on folding. This is Vivaldi's accordion tab stack
+rule — "expand automatically when viewing a tab in the stack and collapse when
+viewing other tabs" — and what *Auto Collapse for Tab Groups* bolts onto
+Chrome. Terminals, Chats, worktrees and *Also running* are groups like any
+other, so the rule has no special cases.
+
+```
+ selected: Claude Code in termio
+ ┌─────────────────────────────────────────────────────────────────┐
+ │ termio·main │ ● Claude Code ⧉2 │ ○ zsh │ fix-auth ● │ Terminals │
+ └─────────────────────────────────────────────────────────────────┘
+   open: termio                     folded: fix-auth (needs-you dot), Terminals
+
+ selected: Codex in fix-auth
+ ┌─────────────────────────────────────────────────────────┐
+ │ termio·main ◐ │ termio ⎇ fix-auth │ ● Codex │ Terminals │
+ └─────────────────────────────────────────────────────────┘
+   folded: termio (working dot)   open: fix-auth     folded: Terminals
+```
+
+Three things follow:
+
+- **Fold state is not state.** `openGroup == group(of: selectedSessionID)` is
+  the whole of it. Nothing is stored, nothing goes stale, and Chrome's
+  invariant — the active tab is never inside a collapsed group — holds by
+  construction rather than by moving the activation around.
+- **The chip's status dot is load-bearing.** With every other project folded,
+  the aggregate dot is the only place a `needs-you` in another project can
+  show. It carries the same fold the menu-bar pulse does, per group.
+- **A folded chip is a menu, not a toggle.** Clicking it lists the group's
+  tabs (Firefox's panel on a collapsed group); choosing one selects that
+  session, and selecting is what opens the group. Nothing opens a group
+  without selecting into it, so the strip never shows two open groups.
+
+### Anatomy
+
+A tab is the sidebar row turned sideways: agent icon, `StatusRing`, title, and
+the same hover `×` that `SessionRowActionButton` draws. The active tab uses
+`SidebarRowHighlight` — the row's selection vocabulary, not a new one, and not
+an accent-blue fill. Hairline separators between inactive tabs, dropped beside
+the active one, so the active tab's edges are the only edges in the strip.
+
+A group is a chip carrying its label in the secondary colour, followed by its
+run when open. The chip's underline is a hairline in the same colour, not a
+hue: the name carries identity. A worktree group's chip carries the branch name
+with the project's name as a quieter prefix, the way the sidebar row's
+breadcrumb does. A folded chip has no run and gains the group's aggregate
+status dot, so an agent that goes `needs-you` inside a folded project still
+shows.
+
+```
+ open chip            tab (lone)          tab (split, active)         folded chip
+ ┌─────────────┐  ┃  ┌──────────────┐  ┃  ┌─────────────────────────┐  ┃  ┌────────────┐
+ │ termio·main │  ┃  │ ◐ ○ zsh    × │  ┃  │ ◐ ● Claude Code  ⧉2   × │  ┃  │ fix-auth ● │
+ └─────────────┘  ┃  └──────────────┘  ┃  └─────────────────────────┘  ┃  └────────────┘
+  label, secondary   icon ring title ×    SidebarRowHighlight fill;      no run; status dot;
+  hairline under     hover-only ×         hairlines drop beside it       click = its tab menu
+```
+
+Overflow: tabs shrink to a floor (icon, ring, ~80pt of title) and then the
+strip scrolls horizontally, keeping the active tab in view. The accordion
+already holds the strip to one group's tabs plus a chip per other group; past
+that, Open Quickly. No overflow menu.
+
+### Verbs
+
+- **Click a tab** → `selectedSessionID` becomes the tab's last-focused leaf. The
+  terminal area follows through `splitRoot` as it does for a sidebar click.
+- **×** → *Close Session* on a lone session. On a multi-leaf tab, × ends every
+  leaf, each under the ⌘W rule from the keyboard design: a plain shell with a
+  command in front of it confirms, an agent does not. Middle-click is ×.
+- **Click a folded chip** → a menu of that group's tabs, each with its status;
+  choosing one selects it, which opens the group. Clicking the open group's
+  chip does nothing — there is no fold to toggle.
+- **Chip context menu** → the section header's or project header's menu,
+  unchanged: *New Terminal* / *New Chat* / the agent quick-adds, *Close All…*,
+  the project's own items. Chrome's *New tab in group* is what these already are.
+- **Strip `+`** → `makeNewSessionMenu`, the sidebar's global pull-down. It lands
+  in a fixed place regardless of the active tab, per the rule; ⌘T remains the
+  verb that follows focus.
+- **Drag** → the sidebar's `SessionRowDrop` outcomes, sideways: release in the
+  gap between tabs to reorder or move between groups (`moveSessionRow`), release
+  on a tab to *Group with* it (`dropSession`, an edge zone). Release on a chip to
+  move into that group's roster. A multi-leaf tab drags as a unit, the way
+  Chrome drags a group. Drops into the terminal area (`sessionDropTarget`) work
+  as they do from the sidebar.
+- **Keyboard** → nothing new. ⌘⇧[ / ⌘⇧] cycle sessions in the same flattened
+  order and the active tab follows; inside a multi-leaf tab they move the focus
+  across the panes, which is what they do today. ⌘1–9 are workspaces. ⌥⌘ arrows
+  focus panes. ⌘⇧O searches.
+
+### Pinned
+
+The sidebar's **Pinned** working set is a set of shortcut rows: a pinned session
+is drawn there *and* in its tree position. That is fine in a list and wrong in a
+strip, where every tab must be one thing — two tabs for one session cannot both
+be active. The strip therefore omits the Pinned section. Pinning still orders:
+`orderedProjects` already puts pinned projects first, so their groups lead.
+
+The other thing Pinned carries is agents blocked on the user in *other*
+workspaces. In the strip that becomes a dot on the workspace switcher — the
+Chrome answer, where one window shows one window and the taskbar tells you
+another wants you — and the sidebar keeps lifting the rows as it does.
+
+**Also running** — sessions the device reports that no row accounts for — is the
+last group, drawn from the same `deviceSessions` the sidebar reads, so a session
+someone started from the `termiod` CLI shows in the strip and adopts on click
+exactly as its row does.
+
+## What changes in code
+
+1. `TermioStore`: `switcherRows` (the derivation lifted out of `SidebarView.body`
+   and `sidebarSessionGroups`). The Session menu and `selectAdjacentSession`
+   read `switcherRows`; behaviour is unchanged. No fold state is added.
+2. `Sources/termio/Sidebar/SidebarView.swift`: renders `switcherRows`; its fold
+   `@State` stays. A pure refactor with a screenshot before and after.
+3. `Sources/termio/Sidebar/TabStripView.swift` (new — it is the sidebar's other
+   geometry, so it lives beside it): chips, runs, tabs, the `+`, drag and drop
+   through the existing delegates. The accordion is a render-time filter: the
+   group containing `selectedSessionID` draws its tabs, every other group draws
+   its chip.
+4. `Sources/termio/App/App.swift`: a `.tabStrip` toolbar identifier, inserted and
+   removed by `setNavigatorItemsVisible`, swapping the branch picker out and in
+   with it; the workspace switcher survives the collapse; `.unifiedCompact` on
+   macOS 26 in `installToolbar`.
+5. No `StateFile` change, no `AppSettings` change, no `KeyCommandID`, no
+   localized strings beyond the pane-count badge.
+
+In three increments, each shippable: the model extraction alone (nothing
+visible changes; the Session menu is the proof); the strip read-only (click,
+status, the accordion, `+`, chip menus); then × and drag.
+
+## Rejected
+
+- **A "Tabs: sidebar / strip" preference.** Superlogical exposes the choice as a
+  mode; Termio has the navigator toggle, and a second control that means the
+  same thing is a knob. Collapsed means strip. Open means sidebar.
+- **Strip and sidebar together.** Built and dropped 2026-07-06. Two switchers.
+- **A second row under the toolbar.** Xcode's shape. It costs a line of terminal
+  text, and the band above is empty. Kept only as the fallback if NSToolbar
+  refuses a stretching custom item (see *To verify*).
+- **Manual fold in the strip.** Chrome's per-chip collapse, Vivaldi's
+  double-click pin-open, and its auto-expand switch are all fold state the
+  selection does not derive — a second thing to keep in sync, and a knob. The
+  selection is the fold.
+- **Per-group colours.** Chrome needs them because its groups are arbitrary.
+  Termio's groups are folders with names.
+- **Tabs inside a pane.** Rejected by `SplitTree` at birth: a leaf is a session.
+  A tab here is the whole layout, which is the opposite layer.
+- **Native `NSWindow` tabbing.** Every tab would be a window, which fights the
+  single-window split view — the reason Ghostty and Mux0 hand-draw theirs.
+- **⌘1–9 → tab *n*, ⌃Tab → next tab.** ⌘digits are workspaces by decision;
+  ⌘⇧[ / ⌘⇧] already cycle. The strip adds no key.
+- **Showing every workspace in the strip.** One row cannot carry a second
+  dimension. Chrome does not show other windows' tabs; the switcher is the
+  dimension.
+
+## To verify before building
+
+- **NSToolbar stretch.** The branch picker proves a custom-view item with a
+  width constraint works in the band; the strip needs one that *grows* to the
+  space between the toggle and the inspector controls and shrinks first when
+  the window narrows. Confirm the `»` overflow behaviour at the window's minimum width
+  before committing to the band; otherwise fall back to the row.
+- **A split group never spans rosters — holds today, keep it.** `canGroup`
+  refuses a drop unless both sessions share a roster *and* a worktree path, and
+  `splitSelectedPane` inserts the new leaf into the origin's own roster with its
+  worktree inherited. The tab model leans on this; a future spawn path that
+  places a leaf elsewhere would put one tab in two groups.
+- **Full screen.** The strip lives in the title bar, and macOS 26 full-screen
+  chrome has bitten before; the band's autohide must not take the strip with
+  it while the sidebar is collapsed.
+- **Launch order.** The sidebar's autosaved collapse state arrives after the
+  toolbar is installed (`syncInspectorSwitch` exists for the inspector's copy
+  of this problem); the strip must be present on a launch that restores
+  collapsed, not only on a live toggle.

--- a/skills/testflight-release/SKILL.md
+++ b/skills/testflight-release/SKILL.md
@@ -112,8 +112,22 @@ Run from a clean worktree on the commit you want to ship (normally `main`).
      means it still needs submitting, `WAITING_FOR_BETA_REVIEW` means it is
      already in Apple's queue and there is nothing to do but wait, and
      `BETA_TESTING` means it is live on the public link. **Ask the user before
-     submitting** — that ships to real testers. A build of a marketing version
-     that has already cleared review skips this step entirely (see below).
+     submitting** — that ships to real testers.
+
+     It takes **two** commands, and the first one alone looks like it worked:
+
+     ```sh
+     asc builds add-groups --build-id "BUILD_ID" --group fe170244-643a-4c73-9c94-84ab44c254f9
+     asc testflight review submit --build-id "BUILD_ID" --confirm
+     ```
+
+     Adding the group reports success and changes nothing —
+     `externalBuildState` stays `READY_FOR_BETA_SUBMISSION` until the build is
+     actually submitted. This holds even for a marketing version that has
+     already cleared review: 1.1 build 951 still had to be submitted on
+     2026-08-28, having been told here that it would skip the step. What that
+     version buys is the *wait*, not the submission — the state went
+     `WAITING_FOR_REVIEW` → `IN_BETA_TESTING` within a minute rather than hours.
 
 7. **Revert** the pbxproj bump and delete `ios/.asc/` (untracked build
    artifacts, ~10 MB IPA plus the archive).
@@ -171,9 +185,10 @@ you are starting a new version train.**
 Bumping is not free. The *first* build of a new marketing version has to clear
 Apple's Beta App Review before any external tester can install it — it sits at
 `externalBuildState: WAITING_FOR_BETA_REVIEW`, typically hours. Every later
-build of that same version skips review and reaches external testers as soon as
-it finishes processing. Internal testers are never affected either way; they get
-every processed build immediately (`internalBuildState: IN_BETA_TESTING`).
+build of that same version still has to be submitted — see step 6, the
+submission is never automatic — but clears in about a minute instead of hours.
+Internal testers are never affected either way; they get every processed build
+immediately (`internalBuildState: IN_BETA_TESTING`).
 
 So a bump costs one review wait and buys nothing on its own. Bump when the
 version is about to mean something — an App Store submission, or a batch of work


### PR DESCRIPTION
The remote file tree re-listed every directory it was showing on every app focus. On a box where an agent is writing files, that is a full round of `fs.list` each time you come back to the window — to learn that nothing you can see has changed.

`termiod` has served the `fs:` resource since it grew a watcher (`a6a1204`, shipped in v0.37.0). Nothing on the Swift side ever subscribed; `TermiodFiles.swift` said so in a comment.

## What was missing

**The pool dropped every frame that answered no request.** A request's answer belongs to its inbox and dies with it; a resource's batches belong to the *channel* and outlive every request on it. `PooledChannel` grew a second delivery path (`addObserver` / `ChannelSignal`) alongside the inboxes.

**The tree had no way to apply a delta.** It does now. A batch names the directories whose contents moved; only the ones the tree has actually realized are re-listed, in one request. A batch that touches nothing on screen costs nothing at all — the rule VS Code's explorer uses, where a file event refreshes only when it hit a visible item.

The whole-tree reload is still here and still one request for every open directory, but it is the exception now rather than the beat: a first load, a `full_rescan` batch, a dropped subscription, and the refresh button.

## Two details the wire forces

**The host canonicalises the resource id.** `daemon.rs`: *"Clients name a workspace root; the host canonicalises it, so two spellings of one repo share a single watch."* A root reached through a symlink comes back under a prefix no row in the tree carries. The watch adopts the id the host answers with, and the tree translates batch paths back into its own spelling — every path it holds came from an `fs.list` reply, which echoes the path as asked.

**A first subscribe always reports `gap`**, having nothing to replay from. That is not news to a caller that is loading anyway, so it is reported only on a re-subscribe; otherwise every pane opened with two full listings instead of one.

Both were caught by the integration tests, not by reading.

## Measured

| | |
| --- | --- |
| batch after one write, local daemon | 314 ms |
| batch over SSH to a VPS | 507 ms |

Both are the daemon's own 0.3 s quiet window plus the link. Against a real checkout the first batch after subscribe named 200+ directories, which is the filter earning its keep: with only the root realized that is one round trip, not two hundred.

## Testing

- 860 tests pass, with and without a real daemon.
- New unit tests on the relist filter: visible-only, dedup, collapsed folders, changes under an unopened subtree.
- New integration tests against a live daemon: batch delivery names the changed *directory*, and a listing taken under a watch carries that watch's cursor.
- Verified over SSH against a real box: the subscription resolves, and a remote `touch` lands in 507 ms.

Not verified on screen — the claim that a file created on the box appears in the tree untouched has no screenshot behind it.

Release Notes: The file tree for a remote project now updates itself when files change on that machine, instead of reloading when you switch back to the window.