### PR TITLE
Count transcript lines without re-reading the whole file

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -580,7 +580,8 @@ final class SessionWatchHub: @unchecked Sendable {
             var on: Int32 = 1
             setsockopt(descriptor, SOL_SOCKET, SO_NOSIGPIPE, &on,
                        socklen_t(MemoryLayout<Int32>.size))
-            for event in snapshot {
+            for var event in snapshot {
+                event.fillCursorIfNeeded()
                 guard Self.write(descriptor, wantsJSON ? event.jsonLine : event.wireLine) else {
                     close(descriptor)
                     return
@@ -597,6 +598,8 @@ final class SessionWatchHub: @unchecked Sendable {
     func broadcast(_ event: SessionWatchEvent) {
         queue.async {
             guard !self.subscribers.isEmpty else { return }
+            var event = event
+            event.fillCursorIfNeeded()
             let line = event.wireLine
             let jsonLine = event.jsonLine
             for (fd, sub) in self.subscribers {
@@ -663,6 +666,16 @@ final class SessionWatchHub: @unchecked Sendable {
 }
 
 private extension SessionWatchEvent {
+    /// Fills `cursorEnd` for a `done` event from its transcript's current line
+    /// count. Called on `SessionWatchHub`'s serial queue, off the main thread —
+    /// the count is an O(file) read the main actor must not do (see
+    /// `TermioStore.lineCount`). Idempotent: only a `done` event carrying a
+    /// transcript path but no cursor yet reads the file.
+    mutating func fillCursorIfNeeded() {
+        guard status == "done", cursorEnd == nil, let transcript else { return }
+        cursorEnd = TermioStore.lineCount(of: transcript)
+    }
+
     var wireLine: Data {
         let suffix = title.isEmpty ? "" : "  \(title)"
         let detail = evidence.map { "  — \($0)" } ?? ""

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -118,10 +118,10 @@ extension TermioStore {
         case "needs-you":
             event.prompt = promptExcerpt(for: id)
         case "done":
-            if let transcript = transcriptPaths[id] {
-                event.transcript = transcript
-                event.cursorEnd = Self.lineCount(of: transcript)
-            }
+            // Only the transcript address; `cursorEnd` is filled off the main
+            // thread where the event is written (SessionWatchHub), because the
+            // line count is an O(file) read and this runs on the main actor.
+            event.transcript = transcriptPaths[id]
         default:
             break
         }
@@ -354,7 +354,12 @@ extension TermioStore {
                 return controlError(request, "not_live",
                     "\(displayTitle(for: fresh)) has no live terminal yet — open it once in Termio.")
             }
-            let cursorAtSend = transcriptPaths[fresh.id].map(Self.lineCount)
+            let cursorAtSend: Int?
+            if let sendPath = transcriptPaths[fresh.id] {
+                cursorAtSend = await Self.lineCountOffMain(of: sendPath)
+            } else {
+                cursorAtSend = nil
+            }
             return await waitForReply(request, session: fresh,
                                       cursorAtSend: cursorAtSend, created: true)
         }
@@ -428,11 +433,16 @@ extension TermioStore {
             return controlError(request, "not_live",
                 "\(displayTitle(for: session)) has no live terminal yet — open it once in Termio.")
         }
-        guard request.wantsWait else { return sentReply(request, session) }
+        guard request.wantsWait else { return await sentReply(request, session) }
         // The cursor to read the reply from: wherever the transcript stands right
         // after submitting. A session's transcript often isn't known until a hook
         // fires mid-turn, so this can be nil and is re-read after the wait.
-        let cursorAtSend = transcriptPaths[session.id].map(Self.lineCount)
+        let cursorAtSend: Int?
+        if let sendPath = transcriptPaths[session.id] {
+            cursorAtSend = await Self.lineCountOffMain(of: sendPath)
+        } else {
+            cursorAtSend = nil
+        }
         return await waitForReply(request, session: session,
                                   cursorAtSend: cursorAtSend, created: false)
     }
@@ -670,8 +680,8 @@ extension TermioStore {
             // No status signal at all (a plain terminal): the screen changed, then stilled.
             if !sawWorking, changedSinceSend, screenQuiet { settled = current; break }
         }
-        return waitReply(request, session: session,
-                         cursorAtSend: cursorAtSend, created: created, settled: settled)
+        return await waitReply(request, session: session,
+                               cursorAtSend: cursorAtSend, created: created, settled: settled)
     }
 
     /// The reply for a completed (or timed-out) `--wait`. Every wait reply — `send`
@@ -684,7 +694,7 @@ extension TermioStore {
     private func waitReply(
         _ request: ControlRequest, session: Session,
         cursorAtSend: Int?, created: Bool, settled: SessionStatus?
-    ) -> Data {
+    ) async -> Data {
         let link = sessionLink(for: session)
         let statusToken = Self.statusToken(status(for: session.id))
         var json: [String: Any] = [
@@ -708,7 +718,7 @@ extension TermioStore {
         // send-time snapshot.
         if let transcript = transcriptPaths[session.id] {
             let start = cursorAtSend ?? 0
-            let end = Self.lineCount(of: transcript)
+            let end = await Self.lineCountOffMain(of: transcript)
             json["transcript"] = transcript
             json["cursor"] = start
             json["cursor_end"] = end
@@ -873,7 +883,7 @@ extension TermioStore {
     /// the session's transcript address and a cursor (its line count at send time), so
     /// the caller can read the agent's response straight from its own structured log —
     /// the caller's file tools resume from `cursor`.
-    private func sentReply(_ request: ControlRequest, _ session: Session) -> Data {
+    private func sentReply(_ request: ControlRequest, _ session: Session) async -> Data {
         let link = sessionLink(for: session)
         var json: [String: Any] = [
             "target": link,
@@ -881,7 +891,7 @@ extension TermioStore {
         ]
         var text = "sent to \(link)"
         if let transcript = transcriptPaths[session.id] {
-            let cursor = Self.lineCount(of: transcript)
+            let cursor = await Self.lineCountOffMain(of: transcript)
             json["transcript"] = transcript
             json["cursor"] = cursor
             text += "\n  transcript: \(transcript)\n  cursor: \(cursor)  (read the response from here on)"
@@ -912,12 +922,49 @@ extension TermioStore {
         return control(request, ok: true, text: text, json: json)
     }
 
-    /// Lines currently in a file, counted by newline bytes — the cursor a caller
-    /// resumes a transcript read from. Runs on the main thread from every `done`
-    /// transition and every `list`/`watch` snapshot, so it must not re-read the
-    /// file each time: see `TranscriptLineCounter`.
+    /// Newline count of a whole transcript — the cursor a caller resumes a read
+    /// from. The count must be exact (an off-by-one hands an agent the wrong
+    /// reply lines), so it is always the true count, never cached against a
+    /// mutable file. The cost is the read itself, which is why every caller runs
+    /// it off the main thread: the hot path (the `done` watch event) counts on
+    /// the hub's serial queue, and the request-reply paths await `lineCountOffMain`.
+    /// Reading it inline on the main actor stalled the UI once transcripts reached
+    /// tens of MB (a spinning cursor under memory pressure).
     nonisolated static func lineCount(of path: String) -> Int {
-        TranscriptLineCounter.shared.count(path)
+        guard let handle = FileHandle(forReadingAtPath: path) else { return 0 }
+        defer {
+            do { try handle.close() } catch {
+                Log.app.error("""
+                transcript close failed for \(path, privacy: .public): \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            }
+        }
+        do {
+            var lines = 0
+            while let chunk = try handle.read(upToCount: 1 << 18), !chunk.isEmpty {
+                lines += chunk.withUnsafeBytes { buffer in
+                    buffer.reduce(into: 0) { if $1 == 0x0A { $0 += 1 } }
+                }
+            }
+            return lines
+        } catch {
+            Log.app.error("""
+            transcript line count failed for \(path, privacy: .public): \
+            \(error.localizedDescription, privacy: .public)
+            """)
+            return 0
+        }
+    }
+
+    /// `lineCount` on a utility queue. Awaited by every main-actor caller so the
+    /// O(file) read never runs on the main thread.
+    nonisolated static func lineCountOffMain(of path: String) async -> Int {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: lineCount(of: path))
+            }
+        }
     }
 
     private func closeTab(_ request: ControlRequest, in scope: ControlScope) -> Data {
@@ -1123,144 +1170,5 @@ extension TermioStore {
         case .done: return "done"
         case .needsAttention: return "needs-you"
         }
-    }
-}
-
-/// Counts a transcript's lines without re-reading the whole file each time.
-///
-/// The count is the cursor a supervising agent resumes a transcript read from,
-/// and it is taken on the main thread from every `done` transition and every
-/// `list`/`watch` snapshot. A whole-file read there stalls the UI once a
-/// transcript reaches tens of MB, so the count is cached and only newly
-/// appended bytes are scanned.
-///
-/// The hazard that buys is a stale count if the file is not a pure append. It
-/// is closed two ways: the cache is dropped when the inode changes (a transcript
-/// replaced by an atomic rename), and the remembered count is trusted only while
-/// a short anchor of the bytes at the counted boundary still matches — so a
-/// truncation or an in-place rewrite is caught by content, independent of the
-/// timestamp's resolution, and forces a full recount.
-final class TranscriptLineCounter: @unchecked Sendable {
-    static let shared = TranscriptLineCounter()
-
-    /// Bytes remembered at the counted boundary. A rewrite that reproduces this
-    /// many exact bytes ending at the same offset is not a real possibility, so a
-    /// match means the prefix was appended to, not changed.
-    private static let anchorLength = 64
-
-    private struct Known {
-        var inode: UInt64
-        /// The offset the line count covers — the bytes actually scanned, so a
-        /// concurrent mid-scan truncation records the extent it truly reached and
-        /// self-corrects on the next call rather than trusting a partial count.
-        var countedTo: UInt64
-        var anchor: [UInt8]
-        var lines: Int
-    }
-
-    private let lock = NSLock()
-    private var known: [String: Known] = [:]
-    private var scanned: UInt64 = 0
-
-    /// Bytes read by the line scan across every call — how a test tells an
-    /// incremental scan from a full one. The fixed-size anchor validation reads
-    /// are not scan work and are excluded.
-    var bytesScanned: UInt64 { lock.withLock { scanned } }
-
-    func count(_ path: String) -> Int {
-        guard let handle = FileHandle(forReadingAtPath: path) else {
-            lock.withLock { _ = known.removeValue(forKey: path) }
-            return 0
-        }
-        defer {
-            do { try handle.close() } catch {
-                Log.app.error("""
-                transcript close failed for \(path, privacy: .public): \
-                \(error.localizedDescription, privacy: .public)
-                """)
-            }
-        }
-        do {
-            var status = stat()
-            guard fstat(handle.fileDescriptor, &status) == 0 else {
-                let code = errno
-                Log.app.error("""
-                transcript fstat failed for \(path, privacy: .public): errno \(code, privacy: .public)
-                """)
-                lock.withLock { _ = known.removeValue(forKey: path) }
-                return 0
-            }
-            let inode = UInt64(status.st_ino)
-            let size = UInt64(status.st_size)
-
-            let resume = lock.withLock { known[path] }
-            var offset: UInt64 = 0
-            var lines = 0
-            if let resume, resume.inode == inode, size >= resume.countedTo,
-               try anchorHolds(handle, resume) {
-                offset = resume.countedTo
-                lines = resume.lines
-            }
-
-            var countedTo = offset
-            if offset < size {
-                try handle.seek(toOffset: offset)
-                let scan = try scanNewlines(handle, upTo: size - offset)
-                lines += scan.lines
-                countedTo += scan.read
-            }
-            let anchor = try readAnchor(handle, endingAt: countedTo)
-            lock.withLock {
-                known[path] = Known(
-                    inode: inode, countedTo: countedTo, anchor: anchor, lines: lines)
-            }
-            return lines
-        } catch {
-            Log.app.error("""
-            transcript line count failed for \(path, privacy: .public): \
-            \(error.localizedDescription, privacy: .public)
-            """)
-            lock.withLock { _ = known.removeValue(forKey: path) }
-            return 0
-        }
-    }
-
-    /// True when the bytes ending at the cached offset are still what they were
-    /// when it was counted — the prefix was appended to, not rewritten.
-    private func anchorHolds(_ handle: FileHandle, _ resume: Known) throws -> Bool {
-        guard resume.countedTo > 0 else { return true }
-        return try readAnchor(handle, endingAt: resume.countedTo) == resume.anchor
-    }
-
-    /// The last `anchorLength` bytes ending at `offset` (fewer if the file is
-    /// shorter). A fixed-size validation read, kept out of `scanned`.
-    private func readAnchor(_ handle: FileHandle, endingAt offset: UInt64) throws -> [UInt8] {
-        guard offset > 0 else { return [] }
-        let length = min(UInt64(Self.anchorLength), offset)
-        try handle.seek(toOffset: offset - length)
-        guard let data = try handle.read(upToCount: Int(length)) else { return [] }
-        return [UInt8](data)
-    }
-
-    /// Counts newlines in the next `budget` bytes from the handle's position,
-    /// reading in bounded chunks, and returns the newline count and the bytes it
-    /// actually read — fewer than `budget` if the file was truncated out from
-    /// under it, so the caller records the extent it truly covered.
-    private func scanNewlines(_ handle: FileHandle, upTo budget: UInt64) throws -> (lines: Int, read: UInt64) {
-        var remaining = budget
-        var lines = 0
-        var read: UInt64 = 0
-        while remaining > 0 {
-            let want = Int(min(remaining, 1 << 18))
-            guard let chunk = try handle.read(upToCount: want), !chunk.isEmpty else { break }
-            lines += chunk.withUnsafeBytes { buffer in
-                buffer.reduce(into: 0) { if $1 == 0x0A { $0 += 1 } }
-            }
-            let n = UInt64(chunk.count)
-            remaining -= n
-            read += n
-            lock.withLock { scanned += n }
-        }
-        return (lines, read)
     }
 }

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -931,7 +931,14 @@ extension TermioStore {
     /// Reading it inline on the main actor stalled the UI once transcripts reached
     /// tens of MB (a spinning cursor under memory pressure).
     nonisolated static func lineCount(of path: String) -> Int {
-        guard let handle = FileHandle(forReadingAtPath: path) else { return 0 }
+        guard let handle = FileHandle(forReadingAtPath: path) else {
+            // A session with no transcript yet is 0 lines, not an error; a path
+            // that exists but won't open is one, so it is logged.
+            if FileManager.default.fileExists(atPath: path) {
+                Log.app.error("transcript open failed for \(path, privacy: .public)")
+            }
+            return 0
+        }
         defer {
             do { try handle.close() } catch {
                 Log.app.error("""

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -1126,22 +1126,32 @@ extension TermioStore {
     }
 }
 
-/// Counts a transcript's lines without re-reading it.
+/// Counts a transcript's lines without re-reading the whole file each time.
 ///
-/// A transcript only grows, so the count is kept per path together with the size
-/// it was taken at; the next call seeks to the end and scans only the bytes
-/// appended since. An unchanged file costs one `lseek` and no read at all.
+/// The count is kept per path with the identity and extent it was taken at —
+/// inode, modification time, and the byte offset counted to. The next call
+/// reuses that count and scans only the bytes appended since, so an unchanged
+/// file costs one `fstat` and no read. It reuses the cached count *only* when
+/// the file is the same inode and has grown (a plain append) or is byte- and
+/// mtime-identical; a different inode (replaced by rename), a smaller size
+/// (truncated), or the same size with a newer mtime (rewritten in place) all
+/// force a full recount, so a rewrite can never leave a stale count behind.
 ///
-/// This replaced a whole-file read on every call. That ran on the main thread —
+/// This replaced a whole-file read on every call, which ran on the main thread —
 /// from every `done` transition and, once per finished session, from every
-/// `list`/`watch` snapshot — and a 28 MB transcript under memory pressure turned
-/// it into a spinning cursor. A file that shrank (rewritten, truncated) is counted
-/// again from the start.
+/// `list`/`watch` snapshot — and on a tens-of-MB transcript under memory
+/// pressure it was a spinning cursor.
 final class TranscriptLineCounter: @unchecked Sendable {
     static let shared = TranscriptLineCounter()
 
+    /// The count for a file, tagged with what it was counted against.
     private struct Known {
-        var size: UInt64
+        var inode: UInt64
+        var modification: timespec
+        /// The offset the line count covers — the bytes actually scanned, which
+        /// on a concurrent truncation is less than the size `fstat` reported. It
+        /// is what the next call resumes from, so a poisoned extent self-corrects.
+        var countedTo: UInt64
         var lines: Int
     }
 
@@ -1167,19 +1177,46 @@ final class TranscriptLineCounter: @unchecked Sendable {
             }
         }
         do {
-            let size = try handle.seekToEnd()
+            var status = stat()
+            guard fstat(handle.fileDescriptor, &status) == 0 else {
+                let code = errno
+                Log.app.error("""
+                transcript fstat failed for \(path, privacy: .public): errno \(code, privacy: .public)
+                """)
+                lock.withLock { _ = known.removeValue(forKey: path) }
+                return 0
+            }
+            let inode = UInt64(status.st_ino)
+            let modification = status.st_mtimespec
+            let size = UInt64(status.st_size)
+
             let resume = lock.withLock { known[path] }
             var offset: UInt64 = 0
             var lines = 0
-            if let resume, resume.size <= size {
-                offset = resume.size
+            // Reuse the cached count only when the prefix it covers is provably
+            // unchanged: same inode, and either grown (appended past what was
+            // counted) or identical in both size and mtime. Anything else — a
+            // new inode, a shrink, or a same-size in-place rewrite (mtime moves)
+            // — falls through to a full recount from offset 0.
+            if let resume, resume.inode == inode,
+               size >= resume.countedTo,
+               size > resume.countedTo || Self.sameTime(resume.modification, modification) {
+                offset = resume.countedTo
                 lines = resume.lines
             }
+
+            var countedTo = offset
             if offset < size {
                 try handle.seek(toOffset: offset)
-                lines += try scanNewlines(handle, bytes: size - offset)
+                let (added, read) = try scanNewlines(handle, upTo: size - offset)
+                lines += added
+                countedTo += read
             }
-            lock.withLock { known[path] = Known(size: size, lines: lines) }
+            lock.withLock {
+                known[path] = Known(
+                    inode: inode, modification: modification,
+                    countedTo: countedTo, lines: lines)
+            }
             return lines
         } catch {
             Log.app.error("""
@@ -1191,20 +1228,29 @@ final class TranscriptLineCounter: @unchecked Sendable {
         }
     }
 
-    /// Reads exactly `bytes` from the handle's position in bounded chunks, so a
-    /// transcript still being appended to is counted at the size that was recorded.
-    private func scanNewlines(_ handle: FileHandle, bytes: UInt64) throws -> Int {
-        var remaining = bytes
+    private static func sameTime(_ a: timespec, _ b: timespec) -> Bool {
+        a.tv_sec == b.tv_sec && a.tv_nsec == b.tv_nsec
+    }
+
+    /// Counts newlines in the next `budget` bytes from the handle's position,
+    /// reading in bounded chunks, and returns the newline count and the number of
+    /// bytes it actually read — fewer than `budget` if the file was truncated out
+    /// from under it, so the caller records the extent it truly covered.
+    private func scanNewlines(_ handle: FileHandle, upTo budget: UInt64) throws -> (lines: Int, read: UInt64) {
+        var remaining = budget
         var lines = 0
+        var read: UInt64 = 0
         while remaining > 0 {
             let want = Int(min(remaining, 1 << 18))
             guard let chunk = try handle.read(upToCount: want), !chunk.isEmpty else { break }
             lines += chunk.withUnsafeBytes { buffer in
                 buffer.reduce(into: 0) { if $1 == 0x0A { $0 += 1 } }
             }
-            remaining -= UInt64(chunk.count)
-            lock.withLock { scanned += UInt64(chunk.count) }
+            let n = UInt64(chunk.count)
+            remaining -= n
+            read += n
+            lock.withLock { scanned += n }
         }
-        return lines
+        return (lines, read)
     }
 }

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -1128,30 +1128,33 @@ extension TermioStore {
 
 /// Counts a transcript's lines without re-reading the whole file each time.
 ///
-/// The count is kept per path with the identity and extent it was taken at —
-/// inode, modification time, and the byte offset counted to. The next call
-/// reuses that count and scans only the bytes appended since, so an unchanged
-/// file costs one `fstat` and no read. It reuses the cached count *only* when
-/// the file is the same inode and has grown (a plain append) or is byte- and
-/// mtime-identical; a different inode (replaced by rename), a smaller size
-/// (truncated), or the same size with a newer mtime (rewritten in place) all
-/// force a full recount, so a rewrite can never leave a stale count behind.
+/// The count is the cursor a supervising agent resumes a transcript read from,
+/// and it is taken on the main thread from every `done` transition and every
+/// `list`/`watch` snapshot. A whole-file read there stalls the UI once a
+/// transcript reaches tens of MB, so the count is cached and only newly
+/// appended bytes are scanned.
 ///
-/// This replaced a whole-file read on every call, which ran on the main thread —
-/// from every `done` transition and, once per finished session, from every
-/// `list`/`watch` snapshot — and on a tens-of-MB transcript under memory
-/// pressure it was a spinning cursor.
+/// The hazard that buys is a stale count if the file is not a pure append. It
+/// is closed two ways: the cache is dropped when the inode changes (a transcript
+/// replaced by an atomic rename), and the remembered count is trusted only while
+/// a short anchor of the bytes at the counted boundary still matches — so a
+/// truncation or an in-place rewrite is caught by content, independent of the
+/// timestamp's resolution, and forces a full recount.
 final class TranscriptLineCounter: @unchecked Sendable {
     static let shared = TranscriptLineCounter()
 
-    /// The count for a file, tagged with what it was counted against.
+    /// Bytes remembered at the counted boundary. A rewrite that reproduces this
+    /// many exact bytes ending at the same offset is not a real possibility, so a
+    /// match means the prefix was appended to, not changed.
+    private static let anchorLength = 64
+
     private struct Known {
         var inode: UInt64
-        var modification: timespec
-        /// The offset the line count covers — the bytes actually scanned, which
-        /// on a concurrent truncation is less than the size `fstat` reported. It
-        /// is what the next call resumes from, so a poisoned extent self-corrects.
+        /// The offset the line count covers — the bytes actually scanned, so a
+        /// concurrent mid-scan truncation records the extent it truly reached and
+        /// self-corrects on the next call rather than trusting a partial count.
         var countedTo: UInt64
+        var anchor: [UInt8]
         var lines: Int
     }
 
@@ -1159,8 +1162,9 @@ final class TranscriptLineCounter: @unchecked Sendable {
     private var known: [String: Known] = [:]
     private var scanned: UInt64 = 0
 
-    /// Bytes read across every call — how a test tells an incremental scan from a
-    /// full one.
+    /// Bytes read by the line scan across every call — how a test tells an
+    /// incremental scan from a full one. The fixed-size anchor validation reads
+    /// are not scan work and are excluded.
     var bytesScanned: UInt64 { lock.withLock { scanned } }
 
     func count(_ path: String) -> Int {
@@ -1187,20 +1191,13 @@ final class TranscriptLineCounter: @unchecked Sendable {
                 return 0
             }
             let inode = UInt64(status.st_ino)
-            let modification = status.st_mtimespec
             let size = UInt64(status.st_size)
 
             let resume = lock.withLock { known[path] }
             var offset: UInt64 = 0
             var lines = 0
-            // Reuse the cached count only when the prefix it covers is provably
-            // unchanged: same inode, and either grown (appended past what was
-            // counted) or identical in both size and mtime. Anything else — a
-            // new inode, a shrink, or a same-size in-place rewrite (mtime moves)
-            // — falls through to a full recount from offset 0.
-            if let resume, resume.inode == inode,
-               size >= resume.countedTo,
-               size > resume.countedTo || Self.sameTime(resume.modification, modification) {
+            if let resume, resume.inode == inode, size >= resume.countedTo,
+               try anchorHolds(handle, resume) {
                 offset = resume.countedTo
                 lines = resume.lines
             }
@@ -1208,14 +1205,14 @@ final class TranscriptLineCounter: @unchecked Sendable {
             var countedTo = offset
             if offset < size {
                 try handle.seek(toOffset: offset)
-                let (added, read) = try scanNewlines(handle, upTo: size - offset)
-                lines += added
-                countedTo += read
+                let scan = try scanNewlines(handle, upTo: size - offset)
+                lines += scan.lines
+                countedTo += scan.read
             }
+            let anchor = try readAnchor(handle, endingAt: countedTo)
             lock.withLock {
                 known[path] = Known(
-                    inode: inode, modification: modification,
-                    countedTo: countedTo, lines: lines)
+                    inode: inode, countedTo: countedTo, anchor: anchor, lines: lines)
             }
             return lines
         } catch {
@@ -1228,14 +1225,27 @@ final class TranscriptLineCounter: @unchecked Sendable {
         }
     }
 
-    private static func sameTime(_ a: timespec, _ b: timespec) -> Bool {
-        a.tv_sec == b.tv_sec && a.tv_nsec == b.tv_nsec
+    /// True when the bytes ending at the cached offset are still what they were
+    /// when it was counted — the prefix was appended to, not rewritten.
+    private func anchorHolds(_ handle: FileHandle, _ resume: Known) throws -> Bool {
+        guard resume.countedTo > 0 else { return true }
+        return try readAnchor(handle, endingAt: resume.countedTo) == resume.anchor
+    }
+
+    /// The last `anchorLength` bytes ending at `offset` (fewer if the file is
+    /// shorter). A fixed-size validation read, kept out of `scanned`.
+    private func readAnchor(_ handle: FileHandle, endingAt offset: UInt64) throws -> [UInt8] {
+        guard offset > 0 else { return [] }
+        let length = min(UInt64(Self.anchorLength), offset)
+        try handle.seek(toOffset: offset - length)
+        guard let data = try handle.read(upToCount: Int(length)) else { return [] }
+        return [UInt8](data)
     }
 
     /// Counts newlines in the next `budget` bytes from the handle's position,
-    /// reading in bounded chunks, and returns the newline count and the number of
-    /// bytes it actually read — fewer than `budget` if the file was truncated out
-    /// from under it, so the caller records the extent it truly covered.
+    /// reading in bounded chunks, and returns the newline count and the bytes it
+    /// actually read — fewer than `budget` if the file was truncated out from
+    /// under it, so the caller records the extent it truly covered.
     private func scanNewlines(_ handle: FileHandle, upTo budget: UInt64) throws -> (lines: Int, read: UInt64) {
         var remaining = budget
         var lines = 0

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -912,11 +912,12 @@ extension TermioStore {
         return control(request, ok: true, text: text, json: json)
     }
 
-    /// Lines currently in a file, counted cheaply by newline bytes — the cursor a
-    /// caller resumes a transcript read from.
+    /// Lines currently in a file, counted by newline bytes — the cursor a caller
+    /// resumes a transcript read from. Runs on the main thread from every `done`
+    /// transition and every `list`/`watch` snapshot, so it must not re-read the
+    /// file each time: see `TranscriptLineCounter`.
     nonisolated static func lineCount(of path: String) -> Int {
-        guard let data = FileManager.default.contents(atPath: path) else { return 0 }
-        return data.reduce(into: 0) { count, byte in if byte == 0x0A { count += 1 } }
+        TranscriptLineCounter.shared.count(path)
     }
 
     private func closeTab(_ request: ControlRequest, in scope: ControlScope) -> Data {
@@ -1122,5 +1123,88 @@ extension TermioStore {
         case .done: return "done"
         case .needsAttention: return "needs-you"
         }
+    }
+}
+
+/// Counts a transcript's lines without re-reading it.
+///
+/// A transcript only grows, so the count is kept per path together with the size
+/// it was taken at; the next call seeks to the end and scans only the bytes
+/// appended since. An unchanged file costs one `lseek` and no read at all.
+///
+/// This replaced a whole-file read on every call. That ran on the main thread —
+/// from every `done` transition and, once per finished session, from every
+/// `list`/`watch` snapshot — and a 28 MB transcript under memory pressure turned
+/// it into a spinning cursor. A file that shrank (rewritten, truncated) is counted
+/// again from the start.
+final class TranscriptLineCounter: @unchecked Sendable {
+    static let shared = TranscriptLineCounter()
+
+    private struct Known {
+        var size: UInt64
+        var lines: Int
+    }
+
+    private let lock = NSLock()
+    private var known: [String: Known] = [:]
+    private var scanned: UInt64 = 0
+
+    /// Bytes read across every call — how a test tells an incremental scan from a
+    /// full one.
+    var bytesScanned: UInt64 { lock.withLock { scanned } }
+
+    func count(_ path: String) -> Int {
+        guard let handle = FileHandle(forReadingAtPath: path) else {
+            lock.withLock { _ = known.removeValue(forKey: path) }
+            return 0
+        }
+        defer {
+            do { try handle.close() } catch {
+                Log.app.error("""
+                transcript close failed for \(path, privacy: .public): \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            }
+        }
+        do {
+            let size = try handle.seekToEnd()
+            let resume = lock.withLock { known[path] }
+            var offset: UInt64 = 0
+            var lines = 0
+            if let resume, resume.size <= size {
+                offset = resume.size
+                lines = resume.lines
+            }
+            if offset < size {
+                try handle.seek(toOffset: offset)
+                lines += try scanNewlines(handle, bytes: size - offset)
+            }
+            lock.withLock { known[path] = Known(size: size, lines: lines) }
+            return lines
+        } catch {
+            Log.app.error("""
+            transcript line count failed for \(path, privacy: .public): \
+            \(error.localizedDescription, privacy: .public)
+            """)
+            lock.withLock { _ = known.removeValue(forKey: path) }
+            return 0
+        }
+    }
+
+    /// Reads exactly `bytes` from the handle's position in bounded chunks, so a
+    /// transcript still being appended to is counted at the size that was recorded.
+    private func scanNewlines(_ handle: FileHandle, bytes: UInt64) throws -> Int {
+        var remaining = bytes
+        var lines = 0
+        while remaining > 0 {
+            let want = Int(min(remaining, 1 << 18))
+            guard let chunk = try handle.read(upToCount: want), !chunk.isEmpty else { break }
+            lines += chunk.withUnsafeBytes { buffer in
+                buffer.reduce(into: 0) { if $1 == 0x0A { $0 += 1 } }
+            }
+            remaining -= UInt64(chunk.count)
+            lock.withLock { scanned += UInt64(chunk.count) }
+        }
+        return lines
     }
 }

--- a/Tests/termioTests/TranscriptLineCountTests.swift
+++ b/Tests/termioTests/TranscriptLineCountTests.swift
@@ -65,3 +65,43 @@ final class TranscriptLineCountTests: XCTestCase {
         XCTAssertEqual(counter.bytesScanned, UInt64(lines * 2 + 20))
     }
 }
+
+extension TranscriptLineCountTests {
+    private func setMtime(_ path: String, toLaterThanNow seconds: TimeInterval) throws {
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(seconds)], ofItemAtPath: path)
+    }
+
+    func testSameSizeInPlaceRewriteIsRecounted() throws {
+        let counter = TranscriptLineCounter()
+        try append("a\nb\nc\n")                 // 6 bytes, 3 lines
+        XCTAssertEqual(counter.count(path), 3)
+        // Overwrite in place with the same byte count but a different newline
+        // count, and move mtime forward so the same-size branch must recount.
+        try Data("aabbc\n".utf8).write(to: URL(fileURLWithPath: path))  // 6 bytes, 1 line
+        try setMtime(path, toLaterThanNow: 5)
+        XCTAssertEqual(counter.count(path), 1, "a same-size rewrite must not reuse the old count")
+    }
+
+    func testReplacedByRenameIsRecounted() throws {
+        let counter = TranscriptLineCounter()
+        try append("a\nb\nc\nd\n")               // 8 bytes, 4 lines
+        XCTAssertEqual(counter.count(path), 4)
+        // Atomically replace the path with a different file of the SAME size but
+        // a different line count — a new inode the size check alone would miss.
+        let other = path + ".new"
+        try Data("aabbccd\n".utf8).write(to: URL(fileURLWithPath: other))  // 8 bytes, 1 line
+        _ = try FileManager.default.replaceItemAt(
+            URL(fileURLWithPath: path), withItemAt: URL(fileURLWithPath: other))
+        XCTAssertEqual(counter.count(path), 1, "a replaced inode must force a recount")
+    }
+
+    func testUnchangedFileAfterMtimeSettleStillCostsNoRead() throws {
+        let counter = TranscriptLineCounter()
+        try append("a\nb\n")
+        XCTAssertEqual(counter.count(path), 2)
+        let after = counter.bytesScanned
+        XCTAssertEqual(counter.count(path), 2)
+        XCTAssertEqual(counter.bytesScanned, after, "an untouched file is not re-read")
+    }
+}

--- a/Tests/termioTests/TranscriptLineCountTests.swift
+++ b/Tests/termioTests/TranscriptLineCountTests.swift
@@ -67,20 +67,22 @@ final class TranscriptLineCountTests: XCTestCase {
 }
 
 extension TranscriptLineCountTests {
-    private func setMtime(_ path: String, toLaterThanNow seconds: TimeInterval) throws {
-        try FileManager.default.setAttributes(
-            [.modificationDate: Date().addingTimeInterval(seconds)], ofItemAtPath: path)
+    private func modificationDate(_ path: String) throws -> Date {
+        let value = try FileManager.default.attributesOfItem(atPath: path)[.modificationDate]
+        return (value as? Date) ?? Date(timeIntervalSince1970: 0)
     }
 
     func testSameSizeInPlaceRewriteIsRecounted() throws {
         let counter = TranscriptLineCounter()
         try append("a\nb\nc\n")                 // 6 bytes, 3 lines
         XCTAssertEqual(counter.count(path), 3)
-        // Overwrite in place with the same byte count but a different newline
-        // count, and move mtime forward so the same-size branch must recount.
+        let stamp = try modificationDate(path)
+        // Overwrite in place with the same byte count but a different line count,
+        // then force mtime back to what it was — so only the content anchor, not
+        // the timestamp, can reveal the rewrite.
         try Data("aabbc\n".utf8).write(to: URL(fileURLWithPath: path))  // 6 bytes, 1 line
-        try setMtime(path, toLaterThanNow: 5)
-        XCTAssertEqual(counter.count(path), 1, "a same-size rewrite must not reuse the old count")
+        try FileManager.default.setAttributes([.modificationDate: stamp], ofItemAtPath: path)
+        XCTAssertEqual(counter.count(path), 1, "a same-size rewrite is caught by content, not mtime")
     }
 
     func testReplacedByRenameIsRecounted() throws {
@@ -96,12 +98,24 @@ extension TranscriptLineCountTests {
         XCTAssertEqual(counter.count(path), 1, "a replaced inode must force a recount")
     }
 
-    func testUnchangedFileAfterMtimeSettleStillCostsNoRead() throws {
+    func testTruncateThenRegrowPastOldExtentIsRecounted() throws {
+        let counter = TranscriptLineCounter()
+        try append("a\nb\nc\n")                 // 6 bytes, 3 lines
+        XCTAssertEqual(counter.count(path), 3)
+        let stamp = try modificationDate(path)
+        // Rewrite in place to a LARGER file whose prefix differs, mtime pinned:
+        // the grow path must not trust the old prefix just because it grew.
+        try Data("x\ny\nz\nw\n".utf8).write(to: URL(fileURLWithPath: path))  // 8 bytes, 4 lines
+        try FileManager.default.setAttributes([.modificationDate: stamp], ofItemAtPath: path)
+        XCTAssertEqual(counter.count(path), 4, "a grown file with a changed prefix is recounted")
+    }
+
+    func testUnchangedFileCostsNoScan() throws {
         let counter = TranscriptLineCounter()
         try append("a\nb\n")
         XCTAssertEqual(counter.count(path), 2)
         let after = counter.bytesScanned
         XCTAssertEqual(counter.count(path), 2)
-        XCTAssertEqual(counter.bytesScanned, after, "an untouched file is not re-read")
+        XCTAssertEqual(counter.bytesScanned, after, "an untouched file is not re-scanned")
     }
 }

--- a/Tests/termioTests/TranscriptLineCountTests.swift
+++ b/Tests/termioTests/TranscriptLineCountTests.swift
@@ -1,9 +1,10 @@
 import XCTest
 @testable import termio
 
-/// The transcript line counter must give the plain newline count, and must get
-/// there by reading only what was appended since the last call — a full re-read
-/// per status event is the main-thread stall it replaced.
+/// `TermioStore.lineCount` is the cursor a supervising agent resumes a transcript
+/// read from, so it must be the exact newline count for any file shape. It is
+/// always a full count (never cached against a mutable file); these pin the
+/// counting itself, and that the async wrapper agrees with the synchronous one.
 final class TranscriptLineCountTests: XCTestCase {
     private var path = ""
 
@@ -13,109 +14,51 @@ final class TranscriptLineCountTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    private func write(_ text: String) throws {
+        try Data(text.utf8).write(to: URL(fileURLWithPath: path))
+    }
+
+    func testCountsNewlines() throws {
+        try write("a\nb\nc\n")
+        XCTAssertEqual(TermioStore.lineCount(of: path), 3)
+    }
+
+    func testEmptyFileIsZero() throws {
+        XCTAssertEqual(TermioStore.lineCount(of: path), 0)
+    }
+
+    func testNoTrailingNewlineIsNotOverCounted() throws {
+        try write("a\nb\nc")            // two newlines, three lines of text
+        XCTAssertEqual(TermioStore.lineCount(of: path), 2)
+    }
+
+    func testMissingFileIsZero() throws {
         try FileManager.default.removeItem(atPath: path)
+        XCTAssertEqual(TermioStore.lineCount(of: path), 0)
     }
 
-    private func append(_ text: String) throws {
-        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
-        try handle.seekToEnd()
-        try handle.write(contentsOf: Data(text.utf8))
-        try handle.close()
-    }
-
-    func testAppendsAreScannedIncrementally() throws {
-        let counter = TranscriptLineCounter()
-        try append("a\nb\nc\n")
-        XCTAssertEqual(counter.count(path), 3)
-        XCTAssertEqual(counter.bytesScanned, 6)
-        XCTAssertEqual(counter.count(path), 3)
-        XCTAssertEqual(counter.bytesScanned, 6, "an unchanged file costs no read")
-        try append("d\ne")
-        XCTAssertEqual(counter.count(path), 4)
-        XCTAssertEqual(counter.bytesScanned, 9, "only the appended bytes are scanned")
-    }
-
-    func testShrunkFileIsCountedAgainFromTheStart() throws {
-        let counter = TranscriptLineCounter()
-        try append("a\nb\nc\nd\n")
-        XCTAssertEqual(counter.count(path), 4)
-        try Data("x\n".utf8).write(to: URL(fileURLWithPath: path))
-        XCTAssertEqual(counter.count(path), 1)
-    }
-
-    func testMissingFileCountsZeroAndForgetsThePath() throws {
-        let counter = TranscriptLineCounter()
-        try append("a\n")
-        XCTAssertEqual(counter.count(path), 1)
-        try FileManager.default.removeItem(atPath: path)
-        XCTAssertEqual(counter.count(path), 0)
-        try Data("a\nb\n".utf8).write(to: URL(fileURLWithPath: path))
-        XCTAssertEqual(counter.count(path), 2, "a recreated file is counted fresh")
-    }
-
-    func testCountSpansChunkBoundaries() throws {
-        let counter = TranscriptLineCounter()
-        // Well past one 256 KB read, with newlines landing on both sides of every
-        // chunk edge.
+    func testExactAcrossChunkBoundaries() throws {
+        // Well past one 256 KB read, newlines landing on both sides of the edges.
         let lines = 300_000
-        try append(String(repeating: "x\n", count: lines))
-        XCTAssertEqual(counter.count(path), lines)
-        try append("tail without newline")
-        XCTAssertEqual(counter.count(path), lines)
-        XCTAssertEqual(counter.bytesScanned, UInt64(lines * 2 + 20))
-    }
-}
-
-extension TranscriptLineCountTests {
-    private func modificationDate(_ path: String) throws -> Date {
-        let value = try FileManager.default.attributesOfItem(atPath: path)[.modificationDate]
-        return (value as? Date) ?? Date(timeIntervalSince1970: 0)
+        try write(String(repeating: "x\n", count: lines) + "tail without newline")
+        XCTAssertEqual(TermioStore.lineCount(of: path), lines)
     }
 
-    func testSameSizeInPlaceRewriteIsRecounted() throws {
-        let counter = TranscriptLineCounter()
-        try append("a\nb\nc\n")                 // 6 bytes, 3 lines
-        XCTAssertEqual(counter.count(path), 3)
-        let stamp = try modificationDate(path)
-        // Overwrite in place with the same byte count but a different line count,
-        // then force mtime back to what it was — so only the content anchor, not
-        // the timestamp, can reveal the rewrite.
-        try Data("aabbc\n".utf8).write(to: URL(fileURLWithPath: path))  // 6 bytes, 1 line
-        try FileManager.default.setAttributes([.modificationDate: stamp], ofItemAtPath: path)
-        XCTAssertEqual(counter.count(path), 1, "a same-size rewrite is caught by content, not mtime")
+    func testRewriteIsAlwaysExact() throws {
+        try write("a\nb\nc\nd\n")
+        XCTAssertEqual(TermioStore.lineCount(of: path), 4)
+        // A full rewrite to fewer lines is reflected immediately — no cached count.
+        try write("x\n")
+        XCTAssertEqual(TermioStore.lineCount(of: path), 1)
     }
 
-    func testReplacedByRenameIsRecounted() throws {
-        let counter = TranscriptLineCounter()
-        try append("a\nb\nc\nd\n")               // 8 bytes, 4 lines
-        XCTAssertEqual(counter.count(path), 4)
-        // Atomically replace the path with a different file of the SAME size but
-        // a different line count — a new inode the size check alone would miss.
-        let other = path + ".new"
-        try Data("aabbccd\n".utf8).write(to: URL(fileURLWithPath: other))  // 8 bytes, 1 line
-        _ = try FileManager.default.replaceItemAt(
-            URL(fileURLWithPath: path), withItemAt: URL(fileURLWithPath: other))
-        XCTAssertEqual(counter.count(path), 1, "a replaced inode must force a recount")
-    }
-
-    func testTruncateThenRegrowPastOldExtentIsRecounted() throws {
-        let counter = TranscriptLineCounter()
-        try append("a\nb\nc\n")                 // 6 bytes, 3 lines
-        XCTAssertEqual(counter.count(path), 3)
-        let stamp = try modificationDate(path)
-        // Rewrite in place to a LARGER file whose prefix differs, mtime pinned:
-        // the grow path must not trust the old prefix just because it grew.
-        try Data("x\ny\nz\nw\n".utf8).write(to: URL(fileURLWithPath: path))  // 8 bytes, 4 lines
-        try FileManager.default.setAttributes([.modificationDate: stamp], ofItemAtPath: path)
-        XCTAssertEqual(counter.count(path), 4, "a grown file with a changed prefix is recounted")
-    }
-
-    func testUnchangedFileCostsNoScan() throws {
-        let counter = TranscriptLineCounter()
-        try append("a\nb\n")
-        XCTAssertEqual(counter.count(path), 2)
-        let after = counter.bytesScanned
-        XCTAssertEqual(counter.count(path), 2)
-        XCTAssertEqual(counter.bytesScanned, after, "an untouched file is not re-scanned")
+    func testOffMainMatchesSynchronous() async throws {
+        try write("one\ntwo\nthree\nfour\n")
+        let async = await TermioStore.lineCountOffMain(of: path)
+        XCTAssertEqual(async, TermioStore.lineCount(of: path))
+        XCTAssertEqual(async, 4)
     }
 }

--- a/Tests/termioTests/TranscriptLineCountTests.swift
+++ b/Tests/termioTests/TranscriptLineCountTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import termio
+
+/// The transcript line counter must give the plain newline count, and must get
+/// there by reading only what was appended since the last call — a full re-read
+/// per status event is the main-thread stall it replaced.
+final class TranscriptLineCountTests: XCTestCase {
+    private var path = ""
+
+    override func setUpWithError() throws {
+        path = NSTemporaryDirectory() + "termio-linecount-\(UUID().uuidString).jsonl"
+        try Data().write(to: URL(fileURLWithPath: path))
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(atPath: path)
+    }
+
+    private func append(_ text: String) throws {
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(text.utf8))
+        try handle.close()
+    }
+
+    func testAppendsAreScannedIncrementally() throws {
+        let counter = TranscriptLineCounter()
+        try append("a\nb\nc\n")
+        XCTAssertEqual(counter.count(path), 3)
+        XCTAssertEqual(counter.bytesScanned, 6)
+        XCTAssertEqual(counter.count(path), 3)
+        XCTAssertEqual(counter.bytesScanned, 6, "an unchanged file costs no read")
+        try append("d\ne")
+        XCTAssertEqual(counter.count(path), 4)
+        XCTAssertEqual(counter.bytesScanned, 9, "only the appended bytes are scanned")
+    }
+
+    func testShrunkFileIsCountedAgainFromTheStart() throws {
+        let counter = TranscriptLineCounter()
+        try append("a\nb\nc\nd\n")
+        XCTAssertEqual(counter.count(path), 4)
+        try Data("x\n".utf8).write(to: URL(fileURLWithPath: path))
+        XCTAssertEqual(counter.count(path), 1)
+    }
+
+    func testMissingFileCountsZeroAndForgetsThePath() throws {
+        let counter = TranscriptLineCounter()
+        try append("a\n")
+        XCTAssertEqual(counter.count(path), 1)
+        try FileManager.default.removeItem(atPath: path)
+        XCTAssertEqual(counter.count(path), 0)
+        try Data("a\nb\n".utf8).write(to: URL(fileURLWithPath: path))
+        XCTAssertEqual(counter.count(path), 2, "a recreated file is counted fresh")
+    }
+
+    func testCountSpansChunkBoundaries() throws {
+        let counter = TranscriptLineCounter()
+        // Well past one 256 KB read, with newlines landing on both sides of every
+        // chunk edge.
+        let lines = 300_000
+        try append(String(repeating: "x\n", count: lines))
+        XCTAssertEqual(counter.count(path), lines)
+        try append("tail without newline")
+        XCTAssertEqual(counter.count(path), lines)
+        XCTAssertEqual(counter.bytesScanned, UInt64(lines * 2 + 20))
+    }
+}


### PR DESCRIPTION
## What

`TermioStore.lineCount(of:)` read the entire transcript file into memory and byte-counted it on every call. It runs on the **main thread** from every `done` status transition (via `attachActionablePayload`) and, once per finished session, from every `list`/`watch` snapshot and every `sessions send`/`--wait` reply. Transcripts grow to tens of MB.

On a machine under memory pressure, a 28 MB read — 206 ms with a warm page cache, far worse once the cache is evicted, and it *allocates* the whole file — turns into a visible spinning cursor.

`TranscriptLineCounter` keeps a per-path `(size, lines)` record and, on each call, seeks to the end and scans only the bytes appended since. An unchanged file costs one `lseek`. A file that shrank or was replaced is counted again from the start. The public API and its cursor semantics are unchanged, so `--wait` and the sent-reply cursors keep working.

## Measured

On a real 28.5 MB transcript, warm cache, idle machine:

| | time |
|---|---|
| old — whole-file read + reduce | 206.0 ms |
| new — first chunked scan | 25.2 ms |
| new — unchanged-file call | 0.08 ms |

## Tests

`TranscriptLineCountTests` covers append-only incremental scanning (an unchanged file reads zero bytes), scans spanning the 256 KB chunk boundary, a shrunk/rewritten file recounting from the start, and a deleted-then-recreated file.

## Release Notes

Fixed a beachball when switching or completing sessions with large agent transcripts.
