### PR TITLE
Stop warning that quitting ends every session

### DIFF
--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -502,10 +502,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     /// termio is single-window, so terminating with the last window would make ⌘W a
-    /// quit — and quitting kills every session's agent (see `applicationWillTerminate`).
-    /// The app stays running with its sessions alive; the Dock icon brings the window
-    /// back (see `applicationShouldHandleReopen`). ⌘W ends the session it is aimed
-    /// at; only ⌘Q ends all of them at once.
+    /// quit. Quitting no longer ends anything — the daemon owns the PTYs and keeps
+    /// them (see `applicationWillTerminate`) — but it does tear down the mounted
+    /// surfaces and stop the banners, so the app stays running with its window closed
+    /// and the Dock icon brings it back (see `applicationShouldHandleReopen`). ⌘W ends
+    /// the session it is aimed at, which is still the only verb that ends one.
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
     }
@@ -530,41 +531,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         store.repaintSelectedSurface()
     }
 
-    /// Quitting is now the only path that kills sessions, so a quit that would cut
-    /// short an agent mid-turn — or one already waiting on an answer — asks first.
-    /// An all-idle app quits without a word.
-    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        let busy = store.busySessionTitles
-        guard !busy.isEmpty else { return .terminateNow }
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = busy.count == 1
-            ? "“\(busy[0])” is still running."
-            : "\(busy.count) sessions are still running."
-        alert.informativeText =
-            "Quitting stops every session's agent and shell. "
-            + "Closing the window leaves them running."
-        // Return quits, Escape cancels — the same two keys every close confirmation
-        // answers to (see `applyConfirmationKeys`). This replaces a first cut where
-        // Cancel took Return and Quit took ⌘Q; the sheet answers a key the user
-        // pressed on purpose, so the answer belongs on the key they'll press next.
-        alert.addButton(withTitle: "Quit")
-        alert.addButton(withTitle: "Cancel")
-        TermioStore.applyConfirmationKeys(to: alert)
-        return alert.runModal() == .alertFirstButtonReturn ? .terminateNow : .terminateCancel
-    }
-
-    /// Closing the app closes its sessions' processes. Without this there is
-    /// no teardown path at all on quit — the PTYs die with the process and
-    /// agent children that ignore the resulting SIGHUP live on as orphans.
+    /// Quitting detaches; it does not end a session. The daemon owns every PTY and
+    /// outlives the app (`TermiodClient.spawnDaemon` gives it its own session), so a
+    /// working agent keeps working and the next launch reattaches to it. What has to
+    /// happen here is the bookkeeping only the running app holds.
     /// Only a real quit reaches here; closing the window does not.
     func applicationWillTerminate(_ notification: Notification) {
-        // Delivered banners would outlive the sessions they point at.
+        // A delivered banner taps back into a window that is going away.
         TaskNotificationCenter.shared.withdrawAll()
         // Tree edits are debounced (see `persistSoon`), so flush before the
         // process goes away or the last selection change is lost.
         store.persistNow()
-        store.terminateAllSessions()
+        store.detachAllSessions()
         RemotePreviewStorage.cleanup()
     }
 

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1036,16 +1036,14 @@ final class TermioStore: ObservableObject {
     /// row. Keyed by `TermiodRoute.description`.
     var upgradingRoutes: Set<String> = []
 
-    /// App-quit teardown: without this, session children outlive the app — the
-    /// closing PTY's SIGHUP is swallowed by agent TUIs, and they pile up as
-    /// launchd orphans across restarts. Graceful signals first, a short
-    /// synchronous grace so plain shells exit cleanly, then SIGKILL whatever
-    /// remains — the quit path can't rely on `terminate()`'s dispatched
-    /// escalation timer, because the process dies before it fires.
-    func terminateAllSessions() {
+    /// App-quit teardown, from the era when the app owned the PTYs: it had to
+    /// signal every child, because the closing PTY's SIGHUP is swallowed by agent
+    /// TUIs and they piled up as orphans. The daemon owns them now and outlives
+    /// the app, so the teardown is the opposite verb.
+    func detachAllSessions() {
         // Surviving the quit is the whole point, so the channel detaches and
-        // the daemon keeps the process. Kill is reserved for the explicit
-        // Close Session verb.
+        // the daemon keeps the process. Ending a session is reserved for the
+        // explicit Close Session verb.
         for link in termiodLinks.values { link.detach() }
         termiodLinks.removeAll()
     }
@@ -1688,15 +1686,6 @@ final class TermioStore: ObservableObject {
         if all.contains(.working) { return .working }
         if all.contains(.done) { return .done }
         return .idle
-    }
-
-    /// The sessions a quit would cut short: an agent mid-turn, or one already
-    /// blocked on the user. A finished (`.done`) session has nothing left to lose,
-    /// so it doesn't count — the quit confirmation names these and only these.
-    var busySessionTitles: [String] {
-        allSessions
-            .filter { [.working, .needsAttention].contains(status(for: $0.id)) }
-            .map { displayTitle(for: $0) }
     }
 
     func session(_ id: Session.ID) -> Session? {

--- a/Tests/termioTests/TermiodDestroyIntegrationTests.swift
+++ b/Tests/termioTests/TermiodDestroyIntegrationTests.swift
@@ -154,7 +154,7 @@ final class TermiodDestroyIntegrationTests: XCTestCase {
         let (store, _, _, name) = makeStoreWithLiveSession()
         XCTAssertTrue(daemonHoldsSession(named: name), "the fixture never reached the daemon")
 
-        store.terminateAllSessions()
+        store.detachAllSessions()
 
         // Settle long enough that a kill would have landed.
         RunLoop.current.run(until: Date().addingTimeInterval(0.5))

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,7 @@ from the real front matter).
 | draft | rfc | [Review — One path, local sessions run through termiod too](design/20260817-one-path-local-through-termiod.review-claude.md) |
 | draft | rfc | [Settings that know which machine they mean](design/20260824-settings-that-know-which-machine.md) |
 | draft | rfc | [Termiod web client on official Ghostty WASM (Linux first)](design/20260818-termiod-web-client-ghostty-wasm.md) |
+| draft | rfc | [The tab strip is the collapsed sidebar](design/20260829-tab-strip-is-the-collapsed-sidebar.md) |
 | fixed | bug | [New terminal opens unfocused (hollow cursor, beeps until clicked)](bug/terminal-focus-loss-on-new-session-mount.md) |
 | fixed | bug | [Terminal loses focus after window deactivation](bug/terminal-focus-loss-on-window-key.md) |
 | fixed | bug | [Terminal loses focus while the window stays key — sibling-render trigger](bug/terminal-focus-loss-on-sibling-render.md) |

--- a/docs/design/20260829-tab-strip-is-the-collapsed-sidebar.md
+++ b/docs/design/20260829-tab-strip-is-the-collapsed-sidebar.md
@@ -1,0 +1,485 @@
+---
+title: The tab strip is the collapsed sidebar
+status: draft
+type: rfc
+created: 2026-08-29
+updated: 2026-08-29
+related:
+  - 20260702-split-panes.md
+  - 20260628-worktree-information-architecture.md
+  - 20260713-loose-terminal-entity.md
+  - 20260812-keyboard-command-design.md
+  - 20260818-one-workspace-source.md
+---
+
+# The tab strip is the collapsed sidebar
+
+> Give the window a horizontal tab strip that appears only when the sidebar is
+> collapsed, drawn from the same row model the sidebar draws. A tab is a split
+> group (or a lone session); a tab group is a sidebar section or a project, the
+> way a Chrome tab group is a collapsible section in Chrome's vertical tabs.
+> Only the group holding the selection is open; the rest fold to their chips.
+> No new mode, no new setting, no new shortcut, nothing new persisted.
+
+## The one idea
+
+Termio has one session switcher, the sidebar, and one way to hide it, the
+navigator toggle. Hiding it today leaves nothing behind: the band above the
+terminal holds the toggle, the branch picker and the inspector switch, and the
+user is flying blind — no status rings, no way to see which agent went
+`needs-you`, no way to switch except ⌘⇧[ / ⌘⇧], the Session menu, or Open
+Quickly. So nobody collapses the sidebar, and 240pt of a 13" screen stays spent
+on a list they are not reading while an agent works.
+
+Superlogical's two screenshots settle what the fix is. In the vertical one the
+sidebar is open and the title bar carries only the session's name. In the
+horizontal one the sidebar is closed and the title bar carries the tabs. Those
+are not two "tab layouts" the user picks between. They are the sidebar toggle,
+and the strip is what a collapsed sidebar *becomes*.
+
+```
+ sidebar open                                    sidebar collapsed
+ ┌────────────────┬─────────────────────────┐   ┌─────────────────────────────────────────────────────┐
+ │ ☰ Work   ⇅ +   │ termio · main      ⊞ ▤  │   │ ☰ Work ▾│termio·main│● Claude│○ zsh│Terminals│+ ⊞ ▤ │
+ ├────────────────┼─────────────────────────┤   ├─────────────────────────────────────────────────────┤
+ │ ▾ termio       │                         │   │                                                     │
+ │   ● Claude  ◀──┼── selected              │   │  $ claude                                           │
+ │   ○ zsh        │                         │   │  ▌                                                  │
+ │ ▾ Terminals    │                         │   │                                                     │
+ │   ○ zsh        │                         │   │                                                     │
+ └────────────────┴─────────────────────────┘   └─────────────────────────────────────────────────────┘
+                                           ☰ ───────▶
+                    one toggle, one row model, two geometries
+```
+
+That is the whole proposal. The rest of this document is what falls out of it.
+
+## Why this is not the tab strip that was dropped
+
+On 2026-07-06 a Safari-style session tab strip was built for the detail column
+and dropped the same day: "感觉这种UI方式没什么用". It sat *beside* an open
+sidebar and listed the selected project's sessions — a second switcher showing a
+subset of the first. The worktree IA doc records the same verdict against
+pushing sessions into a content-area strip. Both stand.
+
+| | Dropped strip (2026-07-06) | This RFC |
+| --- | --- | --- |
+| Visible when | Always, beside the sidebar | Only while the sidebar is collapsed |
+| Shows | The selected project's sessions | Everything the sidebar shows, same order |
+| Model | Its own | The sidebar's row model, second geometry |
+| Net switchers on screen | Two | One |
+| What it buys | Nothing the sidebar lacked | A collapsed sidebar that still works |
+
+The redundancy argument was correct and it is exactly what the visibility rule
+removes: the strip and the sidebar are never on screen together, so there is
+never a second copy of anything.
+
+## What the neighbours do, and why
+
+### Superlogical
+
+The strip lives in the title bar. Its leading control is a sidebar glyph that
+also opens the workspace menu — *Filter or create…*, a checked **Demo**, *New
+Session ⇧⌘N*, *Add Remote Host…* — so one click either reopens the vertical
+view or changes which workspace the strip is showing. Inactive tabs are
+separated by hairlines that vanish beside the active tab (Chrome's rule); the
+active tab is a lifted pill; `+` trails.
+
+Why the strip shows one workspace and the sidebar shows all of them (**Demo**
+and **Work** are both sections in the vertical view): Superlogical's tree is
+flat — workspace → sessions — so a single row of tabs can carry one workspace
+and nothing else without losing structure. The dropdown is how the other
+workspaces stay one click away. Their tab is one surface; splits are separate
+native windows, so "a tab of several panes" never arises for them.
+
+### Chrome tab groups
+
+On desktop Chrome a group is a contiguous run of tabs headed by a coloured chip
+carrying the group's name, with the colour underlining the run. Clicking the
+chip collapses the run to the chip alone; the tabs stay open, they are just not
+drawn. Dragging a tab into the run joins the group, dragging it out leaves it,
+dragging the chip moves the whole run. The chip's context menu is the group's
+verb set: *New tab in group*, *Ungroup*, *Close group*, *Move group to new
+window*, *Save group*. Pinned tabs sit leftmost, icon-only, outside every
+group. In Chrome's vertical tabs the same groups render as collapsible sections
+of a list — the strip and the list are one model in two geometries, which is
+the property this RFC wants.
+
+Why Chrome needs names and colours: its groups are invented by the user out of
+arbitrary pages, so identity has to be painted on. Why Termio does not: its
+groups are folders. A project's name is its identity and a section's name is
+its kind. Painting colours on top would be a knob with nothing to decide.
+
+Why Chrome's ⌘1–9 reaches tabs and Termio's reaches workspaces: Chrome's
+top-level object is the tab; Termio's is the workspace, decided in the keyboard
+design and already drawn beside each workspace in the switcher. A Chrome
+window is a Termio workspace — one strip, one workspace, switch to see another.
+
+What Chrome does not do: fold the groups you are not in. Collapse is a click
+per group, and the active tab can never sit inside a collapsed group — collapse
+the active group and Chrome moves activation to the next tab outside it. The
+most-installed patch on the feature, *Auto Collapse for Tab Groups*, adds the
+missing rule in one sentence: collapse every group with no focused tab.
+
+### Vivaldi accordion tab stacks
+
+Vivaldi ships that rule natively (4.1, 2021) as one of its three stack styles:
+"the stack will expand automatically when viewing a tab in the stack and
+collapse when viewing other tabs." A collapsed stack is about the width of one
+tab; an open stack's tabs share the bar with everything else. Two knobs ride
+along — double-click pins a stack open, and a setting turns auto-expand off —
+and this RFC takes the rule without them.
+
+Firefox (142+) has the opposite invariant: a collapsed group *may* hold the
+active tab, drawn as the chip plus that one tab, and hovering a collapsed chip
+lists its tabs so one can be picked without opening the group. The list is
+worth taking; the invariant is not, because the accordion makes it moot.
+
+## The mapping
+
+| Chrome | Termio | Note |
+| --- | --- | --- |
+| Window | Workspace | The strip shows `currentWorkspace`; ⌘1–9 switch |
+| Tab group | Terminals section, Chats section, project, worktree | Chip + run; the run draws only for the selection's group |
+| Tab | A split group, or a lone session | The user's rule: every group is one tab, every loose session is one tab |
+| Active tab | The tab containing `selectedSessionID` | `splitRoot` is already "the group containing the selection" |
+| Collapsed group | Every group but the selection's | Derived from `selectedSessionID`, never toggled — see *One group open* |
+| `+` at the strip's end | The sidebar's `+` pull-down | Global by rule (see *plus-menu-is-global*) |
+| *New tab in group* | The project header's quick-add / section header's *New Terminal* / *New Chat* | The chip's context menu is the header's menu, verbatim |
+| Pinned tabs | *(none)* | See *Pinned* below |
+| Tab search | Open Quickly ⌘⇧O | Exists |
+| Vertical tabs | The sidebar | Exists |
+
+A **tab** is precisely what the terminal area can show at once: `visiblePaneIDs`
+is the tab's leaves. A lone session is a tab of one leaf. A split group is a tab
+whose leaves are `splitRoot.leafIDs`. Clicking a pane inside a tab changes the
+focused leaf, not the tab. This keeps the SplitTree invariant its own header
+states — there is no "tabs inside a pane" layer; a leaf is a session — because
+a tab is a whole layout, never a slot within one.
+
+```
+ sidebar (vertical)                     strip (horizontal), same order
+ ──────────────────                     ────────────────────────────────────────────
+ ▾ termio                           ─▶  │ termio·main │                 open: holds the selection
+   ┌ ● Claude Code   split group    ─▶                │ ● Claude Code ⧉2 │
+   └ ○ zsh           (bracketed run)                     one tab, two leaves
+   ○ zsh             lone session   ─▶                                     │ ○ zsh │
+ ▾ fix-auth                         ─▶  │ fix-auth ● │                  folded: chip + status dot
+   ● Codex                                (listed in the chip's menu)
+ ▾ Terminals                        ─▶  │ Terminals │                   folded
+   ○ zsh                                  (listed in the chip's menu)
+```
+
+A bracketed run in the sidebar folds into one tab; a group header becomes a
+chip; the order is untouched. Only the selection's group draws its tabs — the
+others are chips, which is the accordion in *One group open*.
+
+A tab's **title** is the focused leaf's `displayTitle` (the sidebar row's label:
+given title, then live title, then prompt title, then the placeholder), so a tab
+reads exactly as the row it replaces. A multi-leaf tab appends a small pane
+count. A tab's **status** is the most urgent of its leaves' statuses —
+`needsAttention` > `working` > `done` > `idle` — the same fold the menu-bar
+pulse already does across all sessions, applied to one layout.
+
+A tab lives in the **group of its first leaf** in sidebar order. Split groups are
+inserted beside their origin (`splitSelectedPane` places the new row next to the
+focused one so the sidebar can draw its ┌/└ bracket), so a tab's leaves are
+adjacent rows and the strip's order is the sidebar's order with bracketed runs
+folded into one tab.
+
+## One model, three consumers
+
+The sidebar's `body` opens with forty lines that derive the rows: the ordered
+projects partitioned into pinned and unpinned, the pinned worktrees and sessions
+minus what a pinned ancestor already shows, the other-workspace `needs-you`
+rows, whether rows wear a device mark, which sections exist. The Session menu
+derives a second, slightly different flattening in `sidebarSessionGroups`. A
+strip would be a third.
+
+The engineering step underneath this RFC is to lift that derivation into one
+value the store computes:
+
+```swift
+struct SwitcherRows {
+    struct Group: Identifiable {
+        enum Kind { case terminals, chats, project(Project.ID), worktree(Project.ID, Worktree.ID), alsoRunning }
+        let id: String            // stable across rebuilds: kind + owning id
+        let kind: Kind
+        let label: String         // "Terminals", the project's name, the branch
+        let tabs: [Tab]
+    }
+    struct Tab: Identifiable {
+        let id: Session.ID        // the first leaf, in sidebar order
+        let leaves: [Session.ID]  // one for a lone session; splitRoot.leafIDs for a group
+    }
+    let groups: [Group]
+}
+```
+
+`SidebarView` renders it as the tree it renders today (a project group followed
+by its worktree groups is the three-level nest; a multi-leaf tab is the
+bracketed run). `TabStripView` renders it as chips and runs. The Session menu
+renders it as headers and rows. Three geometries, one order — the thing Chrome's
+vertical and horizontal tabs get right and the thing two independent
+derivations would drift on within a month.
+
+```
+                  TermioStore
+      ┌──────────────────────────────────┐
+      │ projects · worktrees · sessions  │
+      │ splitGroups · deviceSessions     │
+      │ selectedSessionID                │
+      └────────────────┬─────────────────┘
+                       │ derive once
+                       ▼
+                 SwitcherRows
+              groups: [Group{tabs}]
+         ┌─────────────┼─────────────┐
+         ▼             ▼             ▼
+    SidebarView   TabStripView   Session menu
+    tree + ┌/└    chips + runs   headers + rows
+    (open)        (collapsed)    (always)
+```
+
+The strip carries no fold state of its own: which group is open is derived
+from the selection (see *One group open*). The sidebar keeps the disclosure
+`@State` it has today — a list can show everything, so its folds stay manual
+and stay unpersisted — and the `StateFile` stays what it is: tree, selection,
+inspector layout.
+
+## Presentation
+
+### Where it sits
+
+In the toolbar band, between the navigator toggle and the branch picker, as one
+`NSToolbarItem` hosting a SwiftUI view — the shape the branch picker already
+takes (`.branchPicker`, an `NSHostingView` with a width constraint that follows
+the terminal pane). The band is otherwise empty once the sidebar is gone, and a
+second row below the toolbar would spend a line of terminal text to draw tabs
+under blank chrome. Superlogical and Safari both put the strip in the title
+bar for the same reason.
+
+Two things make the band *one row of tab titles* rather than tabs squeezed
+beside the chrome that is there today:
+
+- **The branch picker retires while the strip is up.** It is display only —
+  the project's name over its branch, no menu — and both facts move to the
+  group chip: the project's name is the chip, and the primary checkout's chip
+  carries the branch after it (`termio · main`), the way a worktree chip already
+  *is* its branch. With the sidebar open the picker stays, since nothing else in
+  the band says which project the terminal is in.
+- **The band goes compact.** Its height comes from `toolbarStyle`, not from its
+  contents: macOS 26 gets `.automatic` (the tall bar) and earlier systems
+  `.unifiedCompact`. A one-line strip in a two-line band reads as empty, so the
+  strip lands with a switch to `.unifiedCompact` on 26 as well — a paired
+  decision, made once, that also applies while the sidebar is open. This is
+  the vertical saving; the horizontal one is the 240–260pt the sidebar gives
+  back, and that is the larger of the two.
+
+```
+ sidebar open
+ ┌───────────────────────────────────────────────────────────────────────────────────────┐
+ │ ☰ Work         ⇅   +    ┃ termio                                               ⊞ ▤    │
+ └───────────────────────────────────────────────────────────────────────────────────────┘
+   toggleNavigator  flex  sort  new │ sidebarTrackingSeparator │ branchPicker  flex  toggleInspector
+
+ sidebar collapsed
+ ┌───────────────────────────────────────────────────────────────────────────────────────┐
+ │ ☰ Work ▾ │ termio·main │ ● Claude Code ⧉2 │ ○ zsh │ fix-auth ● │ Terminals │ +   ⊞ ▤  │
+ └───────────────────────────────────────────────────────────────────────────────────────┘
+   toggleNavigator │ ───────────── tabStrip: grows to fill, shrinks first ───────────── │ toggleInspector
+   + workspace switcher
+```
+
+The strip takes the branch picker's slot and the sort/`+` pair's freed room;
+the workspace switcher stays on the toggle because it is the strip's workspace
+dropdown.
+
+The existing `sidebarCollapseObserver` is the switch. It already inserts and
+removes the sidebar's toolbar actions on every collapse path (toggle, View
+menu, divider drag) through `setNavigatorItemsVisible`; the strip item is
+inserted where those are removed and removed where they are restored. The
+workspace switcher must stay in the band while collapsed — it is the strip's
+workspace dropdown, and today it rides with the sidebar's region.
+
+### One group open
+
+The strip is an accordion. The open group is the one holding
+`selectedSessionID`; every other group is drawn as its chip alone. Select a
+session in another project and that project unfolds while the one you left
+folds, with no click spent on folding. This is Vivaldi's accordion tab stack
+rule — "expand automatically when viewing a tab in the stack and collapse when
+viewing other tabs" — and what *Auto Collapse for Tab Groups* bolts onto
+Chrome. Terminals, Chats, worktrees and *Also running* are groups like any
+other, so the rule has no special cases.
+
+```
+ selected: Claude Code in termio
+ ┌─────────────────────────────────────────────────────────────────┐
+ │ termio·main │ ● Claude Code ⧉2 │ ○ zsh │ fix-auth ● │ Terminals │
+ └─────────────────────────────────────────────────────────────────┘
+   open: termio                     folded: fix-auth (needs-you dot), Terminals
+
+ selected: Codex in fix-auth
+ ┌─────────────────────────────────────────────────────────┐
+ │ termio·main ◐ │ termio ⎇ fix-auth │ ● Codex │ Terminals │
+ └─────────────────────────────────────────────────────────┘
+   folded: termio (working dot)   open: fix-auth     folded: Terminals
+```
+
+Three things follow:
+
+- **Fold state is not state.** `openGroup == group(of: selectedSessionID)` is
+  the whole of it. Nothing is stored, nothing goes stale, and Chrome's
+  invariant — the active tab is never inside a collapsed group — holds by
+  construction rather than by moving the activation around.
+- **The chip's status dot is load-bearing.** With every other project folded,
+  the aggregate dot is the only place a `needs-you` in another project can
+  show. It carries the same fold the menu-bar pulse does, per group.
+- **A folded chip is a menu, not a toggle.** Clicking it lists the group's
+  tabs (Firefox's panel on a collapsed group); choosing one selects that
+  session, and selecting is what opens the group. Nothing opens a group
+  without selecting into it, so the strip never shows two open groups.
+
+### Anatomy
+
+A tab is the sidebar row turned sideways: agent icon, `StatusRing`, title, and
+the same hover `×` that `SessionRowActionButton` draws. The active tab uses
+`SidebarRowHighlight` — the row's selection vocabulary, not a new one, and not
+an accent-blue fill. Hairline separators between inactive tabs, dropped beside
+the active one, so the active tab's edges are the only edges in the strip.
+
+A group is a chip carrying its label in the secondary colour, followed by its
+run when open. The chip's underline is a hairline in the same colour, not a
+hue: the name carries identity. A worktree group's chip carries the branch name
+with the project's name as a quieter prefix, the way the sidebar row's
+breadcrumb does. A folded chip has no run and gains the group's aggregate
+status dot, so an agent that goes `needs-you` inside a folded project still
+shows.
+
+```
+ open chip            tab (lone)          tab (split, active)         folded chip
+ ┌─────────────┐  ┃  ┌──────────────┐  ┃  ┌─────────────────────────┐  ┃  ┌────────────┐
+ │ termio·main │  ┃  │ ◐ ○ zsh    × │  ┃  │ ◐ ● Claude Code  ⧉2   × │  ┃  │ fix-auth ● │
+ └─────────────┘  ┃  └──────────────┘  ┃  └─────────────────────────┘  ┃  └────────────┘
+  label, secondary   icon ring title ×    SidebarRowHighlight fill;      no run; status dot;
+  hairline under     hover-only ×         hairlines drop beside it       click = its tab menu
+```
+
+Overflow: tabs shrink to a floor (icon, ring, ~80pt of title) and then the
+strip scrolls horizontally, keeping the active tab in view. The accordion
+already holds the strip to one group's tabs plus a chip per other group; past
+that, Open Quickly. No overflow menu.
+
+### Verbs
+
+- **Click a tab** → `selectedSessionID` becomes the tab's last-focused leaf. The
+  terminal area follows through `splitRoot` as it does for a sidebar click.
+- **×** → *Close Session* on a lone session. On a multi-leaf tab, × ends every
+  leaf, each under the ⌘W rule from the keyboard design: a plain shell with a
+  command in front of it confirms, an agent does not. Middle-click is ×.
+- **Click a folded chip** → a menu of that group's tabs, each with its status;
+  choosing one selects it, which opens the group. Clicking the open group's
+  chip does nothing — there is no fold to toggle.
+- **Chip context menu** → the section header's or project header's menu,
+  unchanged: *New Terminal* / *New Chat* / the agent quick-adds, *Close All…*,
+  the project's own items. Chrome's *New tab in group* is what these already are.
+- **Strip `+`** → `makeNewSessionMenu`, the sidebar's global pull-down. It lands
+  in a fixed place regardless of the active tab, per the rule; ⌘T remains the
+  verb that follows focus.
+- **Drag** → the sidebar's `SessionRowDrop` outcomes, sideways: release in the
+  gap between tabs to reorder or move between groups (`moveSessionRow`), release
+  on a tab to *Group with* it (`dropSession`, an edge zone). Release on a chip to
+  move into that group's roster. A multi-leaf tab drags as a unit, the way
+  Chrome drags a group. Drops into the terminal area (`sessionDropTarget`) work
+  as they do from the sidebar.
+- **Keyboard** → nothing new. ⌘⇧[ / ⌘⇧] cycle sessions in the same flattened
+  order and the active tab follows; inside a multi-leaf tab they move the focus
+  across the panes, which is what they do today. ⌘1–9 are workspaces. ⌥⌘ arrows
+  focus panes. ⌘⇧O searches.
+
+### Pinned
+
+The sidebar's **Pinned** working set is a set of shortcut rows: a pinned session
+is drawn there *and* in its tree position. That is fine in a list and wrong in a
+strip, where every tab must be one thing — two tabs for one session cannot both
+be active. The strip therefore omits the Pinned section. Pinning still orders:
+`orderedProjects` already puts pinned projects first, so their groups lead.
+
+The other thing Pinned carries is agents blocked on the user in *other*
+workspaces. In the strip that becomes a dot on the workspace switcher — the
+Chrome answer, where one window shows one window and the taskbar tells you
+another wants you — and the sidebar keeps lifting the rows as it does.
+
+**Also running** — sessions the device reports that no row accounts for — is the
+last group, drawn from the same `deviceSessions` the sidebar reads, so a session
+someone started from the `termiod` CLI shows in the strip and adopts on click
+exactly as its row does.
+
+## What changes in code
+
+1. `TermioStore`: `switcherRows` (the derivation lifted out of `SidebarView.body`
+   and `sidebarSessionGroups`). The Session menu and `selectAdjacentSession`
+   read `switcherRows`; behaviour is unchanged. No fold state is added.
+2. `Sources/termio/Sidebar/SidebarView.swift`: renders `switcherRows`; its fold
+   `@State` stays. A pure refactor with a screenshot before and after.
+3. `Sources/termio/Sidebar/TabStripView.swift` (new — it is the sidebar's other
+   geometry, so it lives beside it): chips, runs, tabs, the `+`, drag and drop
+   through the existing delegates. The accordion is a render-time filter: the
+   group containing `selectedSessionID` draws its tabs, every other group draws
+   its chip.
+4. `Sources/termio/App/App.swift`: a `.tabStrip` toolbar identifier, inserted and
+   removed by `setNavigatorItemsVisible`, swapping the branch picker out and in
+   with it; the workspace switcher survives the collapse; `.unifiedCompact` on
+   macOS 26 in `installToolbar`.
+5. No `StateFile` change, no `AppSettings` change, no `KeyCommandID`, no
+   localized strings beyond the pane-count badge.
+
+In three increments, each shippable: the model extraction alone (nothing
+visible changes; the Session menu is the proof); the strip read-only (click,
+status, the accordion, `+`, chip menus); then × and drag.
+
+## Rejected
+
+- **A "Tabs: sidebar / strip" preference.** Superlogical exposes the choice as a
+  mode; Termio has the navigator toggle, and a second control that means the
+  same thing is a knob. Collapsed means strip. Open means sidebar.
+- **Strip and sidebar together.** Built and dropped 2026-07-06. Two switchers.
+- **A second row under the toolbar.** Xcode's shape. It costs a line of terminal
+  text, and the band above is empty. Kept only as the fallback if NSToolbar
+  refuses a stretching custom item (see *To verify*).
+- **Manual fold in the strip.** Chrome's per-chip collapse, Vivaldi's
+  double-click pin-open, and its auto-expand switch are all fold state the
+  selection does not derive — a second thing to keep in sync, and a knob. The
+  selection is the fold.
+- **Per-group colours.** Chrome needs them because its groups are arbitrary.
+  Termio's groups are folders with names.
+- **Tabs inside a pane.** Rejected by `SplitTree` at birth: a leaf is a session.
+  A tab here is the whole layout, which is the opposite layer.
+- **Native `NSWindow` tabbing.** Every tab would be a window, which fights the
+  single-window split view — the reason Ghostty and Mux0 hand-draw theirs.
+- **⌘1–9 → tab *n*, ⌃Tab → next tab.** ⌘digits are workspaces by decision;
+  ⌘⇧[ / ⌘⇧] already cycle. The strip adds no key.
+- **Showing every workspace in the strip.** One row cannot carry a second
+  dimension. Chrome does not show other windows' tabs; the switcher is the
+  dimension.
+
+## To verify before building
+
+- **NSToolbar stretch.** The branch picker proves a custom-view item with a
+  width constraint works in the band; the strip needs one that *grows* to the
+  space between the toggle and the inspector controls and shrinks first when
+  the window narrows. Confirm the `»` overflow behaviour at the window's minimum width
+  before committing to the band; otherwise fall back to the row.
+- **A split group never spans rosters — holds today, keep it.** `canGroup`
+  refuses a drop unless both sessions share a roster *and* a worktree path, and
+  `splitSelectedPane` inserts the new leaf into the origin's own roster with its
+  worktree inherited. The tab model leans on this; a future spawn path that
+  places a leaf elsewhere would put one tab in two groups.
+- **Full screen.** The strip lives in the title bar, and macOS 26 full-screen
+  chrome has bitten before; the band's autohide must not take the strip with
+  it while the sidebar is collapsed.
+- **Launch order.** The sidebar's autosaved collapse state arrives after the
+  toolbar is installed (`syncInspectorSwitch` exists for the inspector's copy
+  of this problem); the strip must be present on a launch that restores
+  collapsed, not only on a live toggle.

--- a/skills/testflight-release/SKILL.md
+++ b/skills/testflight-release/SKILL.md
@@ -112,8 +112,22 @@ Run from a clean worktree on the commit you want to ship (normally `main`).
      means it still needs submitting, `WAITING_FOR_BETA_REVIEW` means it is
      already in Apple's queue and there is nothing to do but wait, and
      `BETA_TESTING` means it is live on the public link. **Ask the user before
-     submitting** — that ships to real testers. A build of a marketing version
-     that has already cleared review skips this step entirely (see below).
+     submitting** — that ships to real testers.
+
+     It takes **two** commands, and the first one alone looks like it worked:
+
+     ```sh
+     asc builds add-groups --build-id "BUILD_ID" --group fe170244-643a-4c73-9c94-84ab44c254f9
+     asc testflight review submit --build-id "BUILD_ID" --confirm
+     ```
+
+     Adding the group reports success and changes nothing —
+     `externalBuildState` stays `READY_FOR_BETA_SUBMISSION` until the build is
+     actually submitted. This holds even for a marketing version that has
+     already cleared review: 1.1 build 951 still had to be submitted on
+     2026-08-28, having been told here that it would skip the step. What that
+     version buys is the *wait*, not the submission — the state went
+     `WAITING_FOR_REVIEW` → `IN_BETA_TESTING` within a minute rather than hours.
 
 7. **Revert** the pbxproj bump and delete `ios/.asc/` (untracked build
    artifacts, ~10 MB IPA plus the archive).
@@ -171,9 +185,10 @@ you are starting a new version train.**
 Bumping is not free. The *first* build of a new marketing version has to clear
 Apple's Beta App Review before any external tester can install it — it sits at
 `externalBuildState: WAITING_FOR_BETA_REVIEW`, typically hours. Every later
-build of that same version skips review and reaches external testers as soon as
-it finishes processing. Internal testers are never affected either way; they get
-every processed build immediately (`internalBuildState: IN_BETA_TESTING`).
+build of that same version still has to be submitted — see step 6, the
+submission is never automatic — but clears in about a minute instead of hours.
+Internal testers are never affected either way; they get every processed build
+immediately (`internalBuildState: IN_BETA_TESTING`).
 
 So a bump costs one review wait and buys nothing on its own. Bump when the
 version is about to mean something — an App Store submission, or a batch of work


### PR DESCRIPTION
The quit confirmation said:

> “Claude Code” is still running.
> Quitting stops every session's agent and shell. Closing the window leaves them running.

Neither sentence has been true since the daemon became the only session backend. `terminateAllSessions` detaches every attachment and leaves the processes with `termiod`, which is spawned into its own session with stdio on `/dev/null` and outlives the app; the next launch reattaches to them. So the sheet stood between the user and a quit that costs nothing, and told them their agent was about to be cut off mid-turn.

A confirmation that guards nothing is worse than no confirmation — it teaches people to dismiss confirmations. Deleted, along with `busySessionTitles`, whose only caller was the sheet.

`terminateAllSessions` is renamed `detachAllSessions`, because that is what its body does; `testQuittingDetachesRatherThanKilling` already pinned that behavior under the misleading name. The three comments around the quit path described the in-process-PTY world in the same terms — that the PTYs die with the app and agent children survive as orphans — and are rewritten to the daemon's.

⌘W still ends the session it is aimed at. That is unchanged and remains the only verb that ends one.

Verified: `swift build`, `swift test` (854 tests, 0 failures). The removed sheet is a deletion with no replacement UI, so it was not exercised in a running app.

Release Notes:
- Quitting no longer warns that it will stop running agents. It never did — sessions live in the daemon and keep working, and the next launch reattaches to them.