### PR TITLE
Bump libghostty to 1.0.22 to stop the beachball on a stalled session reader

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a83592c4d9fb3055470b79fbbc78031fb4b941cf7b2fe049079fb5b2dceedfca",
+  "originHash" : "618c4e27b8aedb12a95ce833079485730a5bf9e60e8dcea2aa8a3d77ff615e69",
   "pins" : [
     {
       "identity" : "highlightr",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "7f7720b7ded2406822bca6dca32cc07e5cf317ff",
-        "version" : "1.0.21"
+        "revision" : "84af6e4a766110efa7ceb09a2a02cac4c2ad684f",
+        "version" : "1.0.22"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // live resize" suspicion that briefly rolled this back to Lakr233 was a
         // misdiagnosis — the real bug was termio's own PTY spawn shape (see
         // docs/bug/terminal-resize-no-reflow-HANDOFF.md §0).
-        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.21"),
+        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.22"),
         // Sparkle powers in-app auto-update (the "Check for Updates…" menu item and
         // background update checks). It reads the appcast published with each GitHub
         // release; the matching EdDSA public key is embedded in packaging/Info.plist.

--- a/ios/TermioMobile.xcodeproj/project.pbxproj
+++ b/ios/TermioMobile.xcodeproj/project.pbxproj
@@ -569,7 +569,7 @@
 			repositoryURL = "https://github.com/termio-sh/libghostty-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.21;
+				minimumVersion = 1.0.22;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/TermioMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "7f7720b7ded2406822bca6dca32cc07e5cf317ff",
-        "version" : "1.0.21"
+        "revision" : "84af6e4a766110efa7ceb09a2a02cac4c2ad684f",
+        "version" : "1.0.22"
       }
     },
     {


### PR DESCRIPTION
Same ghostty sha as 1.0.21; the wrapper fix is termio-sh/libghostty-swift#5. `InMemoryTerminalSession` used one `NSLock` for the surface pointer, the resize state, and every call into libghostty. A live `sample` of 0.46.0 showed the chain: the termiod reader held that lock inside `ghostty_surface_write_buffer`, parked in the io mailbox's `push(.forever)` with 64 replies queued; the surface's io thread — the one that drains that mailbox — blocked on the same lock from `receiveResizeCallback → dispatchResize` before arming its wakeup; and the main thread hung behind both, once from `waitForReply → readViewportText` and once from AppKit layout → `dispatchResize`. A session whose attach replay answers 64+ terminal queries reproduced it on every launch.

The wrapper now keeps an `NSCondition` for the surface pointer plus an in-flight use count (`clearSurface` still waits before the caller frees), a lock of its own for `lastResize`, and a writer-only lock that keeps the pre-surface flush ordered ahead of live bytes. Nothing is held across `read_text` or `process_exit`.

Verified in a dev build against the fork branch: 300 `ESC[6n` queries in one write are answered, the pane keeps responding, no reader thread parks in `__ulock_wait2`. The 104 package tests pass; the fork's workflow compiled all five Apple targets for the release.

Mac, iOS project, and both `Package.resolved` files move together.

## Release Notes
- Fixed: the app could freeze with a beachball when a session reattached with a large backlog of terminal output; the terminal core's reader and the main thread no longer share a lock.