### PR TITLE
Replace the termiod binary without dropping sessions

### DIFF
--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -22,10 +22,9 @@ export DEVELOPER_DIR=/Library/Developer/CommandLineTools
 cargo build
 alias tio=./target/debug/termiod
 
-# 2. Deploy to the VPS. Two gotchas: a RUNNING daemon keeps executing the old
-#    binary image (and scp onto a running binary fails with ETXTBSY), so stop
-#    it first. Existing sessions die with it — this is a dev-loop step.
-ssh ukvps pkill -x termiod || true
+# 2. Deploy to the VPS. The running daemon keeps executing the old image until
+#    it is told otherwise, so deploy stages the new binary beside it and then
+#    asks it to hand off — same pid, same PTYs, sessions intact.
 tio remote deploy ukvps
 
 # 3. Open a durable session and attach (creates + attaches in one command;
@@ -130,17 +129,27 @@ termiod deploy --host my-vps
 #  ssh  my-vps ~/.local/bin/termiod status --json   # observe: binary, daemon, sessions
 #  scp  <bundled slice>  my-vps:.local/bin/termiod.new
 #  ssh  my-vps 'chmod +x … && mv termiod termiod.prev && mv termiod.new termiod'   # stage
-#  ssh  my-vps ~/.local/bin/termiod stop --json     # activate — declined while in use (exit 3)
-#  ssh  my-vps ~/.local/bin/termiod stdio           # verify: hello, compare the version
-#  on failure: mv termiod.prev termiod               # roll back
+#  ssh  my-vps ~/.local/bin/termiod handoff --json  # activate — execve in place, sessions kept
+#  ssh  my-vps ~/.local/bin/termiod stop --json      # only if the daemon is too old to hand off
+#  ssh  my-vps ~/.local/bin/termiod stdio            # verify: hello, compare the version
+#  on failure: mv termiod.prev termiod                # roll back
 ```
 
 Each step is skipped when the observed state already matches: a box on the
-current build costs one `status`. A box whose daemon has work in progress — a
-command running in a session's foreground, or an agent still `working` — is
-left **staged**: the new binary is in place and takes over the next time the
-daemon is stopped, and the sessions are named so the decision is the user's.
-A client attached to an idle prompt does not hold it up. `--force` overrides.
+current build costs one `status`.
+
+Activation is a **handoff**: the running daemon `execve`s the staged binary,
+keeping its pid, its children and every PTY master, so the sessions on the box
+do not notice the upgrade and work in progress is never a reason to postpone
+one. Clients are disconnected — their sockets die with the image — and reattach
+by session id to find the session alive.
+
+Stopping is the fallback, for a daemon too old to know the verb. There a box
+whose daemon has work in progress — a command running in a session's
+foreground, or an agent still `working` — is left **staged**: the new binary is
+in place and takes over the next time the daemon is stopped, and the sessions
+are named so the decision is the user's. A client attached to an idle prompt
+does not hold it up. `--force` overrides.
 The version compared is the app's build stamp (`0.44.0+1533`), carried by the
 daemon at `hello`; a box a newer app set up is left alone.
 

--- a/termiod/README.md
+++ b/termiod/README.md
@@ -108,11 +108,17 @@ termiod remote open my-vps --cwd '~/proj' --agent shell
 
 `deploy` is one loop for every state a box can be in — nothing installed, an
 older binary, a newer binary the daemon has not picked up. It stages the build
-this binary carries, asks the old daemon to stop when nothing is in use, checks
-the new one answers, and puts the previous binary back if it does not. Running
-it again is the recovery from any outcome. On the box itself, `termiod status`
-says what is there and `termiod stop` asks the daemon to leave (declined, with
-the sessions named, while a command is running or an agent is mid-task).
+this binary carries, asks the running daemon to take it on, checks the new one
+answers, and puts the previous binary back if it does not. Running it again is
+the recovery from any outcome.
+
+Taking it on is an **`execve`**, not a restart: the daemon replaces its own
+image while keeping its pid, its children and every PTY master, so upgrading a
+box does not cost the work running on it. On the box itself, `termiod handoff`
+is that verb by hand, `termiod status` says what is there, and `termiod stop`
+asks the daemon to leave — declined, with the sessions named, while a command is
+running or an agent is mid-task. Stopping is now only the fallback for a daemon
+too old to replace itself.
 
 `my-vps` = `~/.ssh/config` alias. Close the laptop; reattach — agent kept running on the VPS. See [`DEPLOY.md`](DEPLOY.md).
 

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -1173,12 +1173,26 @@ async fn process_control(
         }
         Control::Kill { id, seq } => {
             let response = match manager.resolve(&id).await {
-                Some(handle) => {
-                    handle.send(SessionMsg::Kill {
+                // Same window as `Send`, and the same rule: a kill nobody
+                // received must not read as a kill that happened. The session
+                // is about to cross into the new image alive, and a caller told
+                // otherwise would stop watching something still running.
+                Some(handle)
+                    if handle.send(SessionMsg::Kill {
                         reason: EndReason::Killed,
-                    });
+                    }) =>
+                {
                     Control::Ok { re: seq }
                 }
+                Some(_) => error(
+                    seq,
+                    ErrorCode::Busy,
+                    format!(
+                        "session {id} is being handed to a new daemon; \
+                         it was not killed — reconnect and ask again"
+                    ),
+                    true,
+                ),
                 None => error(
                     seq,
                     ErrorCode::NoSuchSession,
@@ -1249,10 +1263,24 @@ async fn process_control(
         }
         Control::Send { id, data, seq } => {
             let response = match manager.resolve(&id).await {
-                Some(handle) => {
-                    handle.send(SessionMsg::Inject { data });
+                // A handle outlives the actor it addresses: `carry_all` makes
+                // each actor return, and the manager keeps its handle until the
+                // `execve`. A send in that window reaches nobody, and answering
+                // `ok` to it is the one failure this whole feature exists to
+                // prevent — an agent hook told its input landed when the bytes
+                // are gone. `Busy` says the same thing a reconnect will fix.
+                Some(handle) if handle.send(SessionMsg::Inject { data }) => {
                     Control::Ok { re: seq }
                 }
+                Some(_) => error(
+                    seq,
+                    ErrorCode::Busy,
+                    format!(
+                        "session {id} is being handed to a new daemon; \
+                         the write was not delivered — reconnect and send it again"
+                    ),
+                    true,
+                ),
                 None => error(
                     seq,
                     ErrorCode::NoSuchSession,

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -523,7 +523,8 @@ pub async fn serve(
             Ok(graveyard) => graveyard,
             Err(error) if adopted => {
                 eprintln!("termiod: the tombstone log did not open after the handoff: {error:#}");
-                eprintln!("termiod: sessions are unaffected; losses will go unrecorded until a restart");
+                eprintln!("termiod: sessions are unaffected, but nothing this daemon does will be recorded — no roster, no tombstones");
+                eprintln!("termiod: fix the state directory and hand off again; a restart would take the sessions with it");
                 Graveyard::detached()
             }
             Err(error) => return Err(error),
@@ -724,8 +725,11 @@ async fn hand_over(
         Err(error) => return error.context("staging the handoff blob"),
     };
     let host_id = manager.host_id.to_string();
+    // Held, not released: like the session masters, this is committed by `pack`
+    // once the blob is written, so a failure before then closes it instead of
+    // leaving a listener nothing owns.
     let listener_fd = match crate::handoff::duplicate_for_exec(listener.as_raw_fd()) {
-        Ok(fd) => fd.into_raw_fd(),
+        Ok(fd) => fd,
         Err(error) => return error.context("carrying the listener"),
     };
 
@@ -750,10 +754,11 @@ async fn hand_over(
         format: crate::handoff::FORMAT_VERSION,
         from_build: crate::lifecycle::BUILD_VERSION.to_string(),
         host_id,
-        listener_fd,
+        // Assigned by `pack`, with the session masters.
+        listener_fd: -1,
         sessions: Vec::new(),
     };
-    let blob_fd = match crate::handoff::pack(blob, sessions, staged) {
+    let blob_fd = match crate::handoff::pack(blob, listener_fd, sessions, staged) {
         Ok(fd) => fd.into_raw_fd(),
         Err(error) => return error.context("packing the handoff blob"),
     };

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -193,25 +193,25 @@ impl Manager {
         &self,
         sessions: Vec<(crate::handoff::CarriedSession, std::os::fd::OwnedFd, Vec<Bytes>)>,
     ) -> Vec<String> {
-        use std::os::fd::{AsRawFd, IntoRawFd};
+        use std::os::fd::IntoRawFd;
         let mut lost = Vec::new();
         for (mut info, master, ring) in sessions {
-            info.master_fd = master.as_raw_fd();
             let id = info.id.clone();
             let mut bytes = Vec::new();
             for chunk in &ring {
                 bytes.extend_from_slice(chunk);
             }
-            match self.adopt(info, bytes) {
-                // The adopted session owns the descriptor now, so this one must
-                // let go of it rather than close it out from under the actor.
-                Ok(()) => {
-                    let _ = master.into_raw_fd();
-                }
-                Err(error) => {
-                    eprintln!("termiod: session {id} could not be put back: {error:#}");
-                    lost.push(id);
-                }
+            // Ownership goes before the call, not after it succeeds.
+            // `Pty::adopt` wraps the number in an `OwnedFd` the instant it is
+            // entered and closes it itself if any of its own steps fail — so
+            // holding on here to close it on the error path would close the
+            // descriptor twice. By the second close the number can already have
+            // been handed to something else, and what dies is whatever that is:
+            // another session's master, the listener, a client's socket.
+            info.master_fd = master.into_raw_fd();
+            if let Err(error) = self.adopt(info, bytes) {
+                eprintln!("termiod: session {id} could not be put back: {error:#}");
+                lost.push(id);
             }
         }
         // Only once every session is installed again: a create that slipped in

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -178,6 +178,49 @@ impl Manager {
         Ok(())
     }
 
+    /// Put carried sessions back and start serving them again.
+    ///
+    /// The undo half of `carry_all`. A session that has handed over its PTY
+    /// exists only as a descriptor and a replay ring, and `adopt` is already the
+    /// code that turns exactly that back into a running session — it is what the
+    /// *new* image does on the other side of a successful exec. An aborted
+    /// handoff is the same problem with the same answer, so it uses the same
+    /// path rather than a second one written for failures only.
+    ///
+    /// A session that cannot be adopted back is genuinely lost, and is named:
+    /// its descriptor closes with the `OwnedFd` and its child takes SIGHUP.
+    fn restore(
+        &self,
+        sessions: Vec<(crate::handoff::CarriedSession, std::os::fd::OwnedFd, Vec<Bytes>)>,
+    ) -> Vec<String> {
+        use std::os::fd::{AsRawFd, IntoRawFd};
+        let mut lost = Vec::new();
+        for (mut info, master, ring) in sessions {
+            info.master_fd = master.as_raw_fd();
+            let id = info.id.clone();
+            let mut bytes = Vec::new();
+            for chunk in &ring {
+                bytes.extend_from_slice(chunk);
+            }
+            match self.adopt(info, bytes) {
+                // The adopted session owns the descriptor now, so this one must
+                // let go of it rather than close it out from under the actor.
+                Ok(()) => {
+                    let _ = master.into_raw_fd();
+                }
+                Err(error) => {
+                    eprintln!("termiod: session {id} could not be put back: {error:#}");
+                    lost.push(id);
+                }
+            }
+        }
+        // Only once every session is installed again: a create that slipped in
+        // before this point would have been spawned into a daemon that was
+        // still handing over.
+        self.inner.lock().unwrap().draining = false;
+        lost
+    }
+
     fn find(&self, id: &SessionId) -> Option<SessionHandle> {
         self.inner.lock().unwrap().sessions.get(id).cloned()
     }
@@ -628,42 +671,63 @@ pub async fn serve(
     };
     tokio::pin!(shutdown_signal);
 
-    let mut becoming: Option<std::path::PathBuf> = None;
-    loop {
-        tokio::select! {
-            biased;
-            result = &mut shutdown_signal => {
-                result?;
-                break;
+    // Serving is a loop around the accept loop, not the accept loop itself: a
+    // handoff that cannot go ahead puts its sessions back and comes out here to
+    // carry on serving them. Only a shutdown, or a handoff that lost sessions,
+    // leaves.
+    'serving: loop {
+        let mut becoming: Option<std::path::PathBuf> = None;
+        loop {
+            tokio::select! {
+                biased;
+                result = &mut shutdown_signal => {
+                    result?;
+                    break;
+                }
+                requested = handoff_rx.recv() => {
+                    let Some(binary) = requested else { continue };
+                    becoming = Some(binary);
+                    break;
+                }
+                accepted = listener.accept() => {
+                    let (stream, _addr) = accepted?;
+                    let manager = manager.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_conn(stream, manager).await {
+                            eprintln!("termiod: connection error: {e:#}");
+                        }
+                    });
+                }
             }
-            requested = handoff_rx.recv() => {
-                let Some(binary) = requested else { continue };
-                becoming = Some(binary);
-                break;
+        }
+
+        let Some(binary) = becoming else { break 'serving };
+        match hand_over(&manager, &listener, &binary).await {
+            // Every session that was carried is back in the roster and running.
+            // Nothing was lost, so there is nothing to exit for — go back to
+            // accepting. Whoever asked for the upgrade can ask again.
+            Handoff::Aborted(error) => {
+                eprintln!(
+                    "termiod: handoff to {} aborted: {error:#}",
+                    binary.display()
+                );
+                eprintln!("termiod: every session is still here; carrying on");
+                continue 'serving;
             }
-            accepted = listener.accept() => {
-                let (stream, _addr) = accepted?;
-                let manager = manager.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = handle_conn(stream, manager).await {
-                        eprintln!("termiod: connection error: {e:#}");
-                    }
-                });
+            Handoff::Lost(error) => {
+                eprintln!("termiod: handoff to {} failed: {error:#}", binary.display());
+                eprintln!(
+                    "termiod: the sessions this daemon held are lost; the next start will bury them"
+                );
+                std::process::exit(1);
             }
         }
     }
 
+    // After the serving loop, not before the handoff: an aborted upgrade goes
+    // back to serving, and taking the WebSocket listener down on the way past
+    // would leave the phone disconnected from a daemon that never went anywhere.
     let _ = wss_shutdown.send(true);
-
-    if let Some(binary) = becoming {
-        // From here the daemon is committed. `hand_over` returns only on
-        // failure, and by then the session actors have already given up their
-        // PTYs — there is no daemon left to go back to being.
-        let error = hand_over(&manager, &listener, &binary).await;
-        eprintln!("termiod: handoff to {} failed: {error:#}", binary.display());
-        eprintln!("termiod: the sessions this daemon held are lost; the next start will bury them");
-        std::process::exit(1);
-    }
 
     manager.begin_draining(EndReason::DaemonStopped);
     let drained = manager.finish_draining(EndReason::DaemonStopped).await;
@@ -709,20 +773,30 @@ fn adopt_listener(fd: std::os::fd::RawFd) -> Result<UnixListener> {
 /// read-only filesystem, a listener that cannot be duplicated — happen before
 /// the point of no return rather than after it. The far side answers the rest
 /// by degrading instead of exiting; see `serve`.
+/// How a handoff attempt ended. Only `Lost` is worth exiting over: `Aborted`
+/// means every session is back in the roster and the daemon can go on serving,
+/// which is the whole point of being able to put them back.
+enum Handoff {
+    /// Nothing was carried, or everything carried was restored.
+    Aborted(anyhow::Error),
+    /// Sessions were carried and could not be put back. They are gone.
+    Lost(anyhow::Error),
+}
+
 async fn hand_over(
     manager: &Manager,
     listener: &UnixListener,
     binary: &std::path::Path,
-) -> anyhow::Error {
+) -> Handoff {
     use std::os::fd::{AsRawFd, IntoRawFd};
 
     let state_dir = match paths::state_dir() {
         Ok(dir) => dir,
-        Err(error) => return error.context("locating the state directory"),
+        Err(error) => return Handoff::Aborted(error.context("locating the state directory")),
     };
     let staged = match crate::handoff::stage_blob(&state_dir) {
         Ok(file) => file,
-        Err(error) => return error.context("staging the handoff blob"),
+        Err(error) => return Handoff::Aborted(error.context("staging the handoff blob")),
     };
     let host_id = manager.host_id.to_string();
     // Held, not released: like the session masters, this is committed by `pack`
@@ -730,20 +804,34 @@ async fn hand_over(
     // leaving a listener nothing owns.
     let listener_fd = match crate::handoff::duplicate_for_exec(listener.as_raw_fd()) {
         Ok(fd) => fd,
-        Err(error) => return error.context("carrying the listener"),
+        Err(error) => return Handoff::Aborted(error.context("carrying the listener")),
     };
 
     // Past here the sessions are no longer readable by anything in this image.
     let (carried, stranded) = manager.carry_all().await;
-    for id in &stranded {
-        eprintln!(
-            "termiod: session {id} did not hand over its pty and will not survive the upgrade"
-        );
-    }
     let sessions: Vec<_> = carried
         .into_iter()
         .map(|one| (one.info, one.master, one.ring))
         .collect();
+    // An upgrade that takes most of the sessions is not the feature. A session
+    // misses the deadline because its actor is busy or its VT sidecar is slow
+    // to join — not because it is unhealthy — and going ahead would send SIGHUP
+    // to a running agent whose PTY was fine. Put back the ones that did carry
+    // and leave the daemon exactly as it was; the upgrade can be asked for
+    // again when whatever was slow has finished.
+    if !stranded.is_empty() {
+        let lost = manager.restore(sessions);
+        let error = anyhow::anyhow!(
+            "session(s) {} did not hand over their pty within {:?}",
+            stranded.join(", "),
+            crate::handoff::CARRY_TIMEOUT
+        );
+        return if lost.is_empty() {
+            Handoff::Aborted(error)
+        } else {
+            Handoff::Lost(error.context(format!("and {} could not be put back", lost.join(", "))))
+        };
+    }
     eprintln!(
         "termiod: handing off to {} with {} session(s)",
         binary.display(),
@@ -760,9 +848,25 @@ async fn hand_over(
     };
     let blob_fd = match crate::handoff::pack(blob, listener_fd, sessions, staged) {
         Ok(fd) => fd.into_raw_fd(),
-        Err(error) => return error.context("packing the handoff blob"),
+        // The write ran out of space, or the sync failed. Every descriptor came
+        // back, so every session goes back into the roster and the daemon keeps
+        // running — this used to close the lot and take every shell with it.
+        Err(failed) => {
+            let lost = manager.restore(failed.sessions);
+            let error = failed.error.context("packing the handoff blob");
+            return if lost.is_empty() {
+                Handoff::Aborted(error)
+            } else {
+                Handoff::Lost(
+                    error.context(format!("and {} could not be put back", lost.join(", "))),
+                )
+            };
+        }
     };
-    crate::handoff::exec(binary, blob_fd)
+    // `exec` returns only if it failed, and by then the descriptors belong to an
+    // image that never started. Nothing owns them any more, so there is nothing
+    // to put back.
+    Handoff::Lost(crate::handoff::exec(binary, blob_fd))
 }
 
 #[derive(Clone)]

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -26,6 +26,9 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch, Notify};
 
 const EVENT_BUFFER: usize = 1024;
 const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long a handoff waits for its own `ok` to reach the requesting socket
+/// before exec'ing anyway.
+const HANDOFF_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
 
 struct ManagerInner {
     sessions: HashMap<SessionId, SessionHandle>,
@@ -430,13 +433,30 @@ pub async fn serve(
         eprintln!("termiod: could not open the log file: {error:#}");
     }
 
-    paths::ensure_runtime_dir()?;
     let sock_path = paths::socket_path()?;
 
     let inherited = match handoff_fd {
         Some(fd) => Some(crate::handoff::unpack(fd).context("reading the handoff blob")?),
         None => None,
     };
+
+    // From here to the accept loop, every failure on the handoff path costs the
+    // sessions this image was handed: their masters are held by descriptors
+    // nothing would be left to read. So each step that a cold start is right to
+    // refuse over is, here, something to log and go without. The daemon is worth
+    // less with no WebSocket listener or no tombstone log; it is worth nothing
+    // to the person whose agent was mid-task if it exits instead.
+    let adopted = inherited.is_some();
+    match paths::ensure_runtime_dir() {
+        Ok(_) => {}
+        // The directory is already there and already holds the socket this
+        // image inherited — a failure here is about creating it, which is a
+        // question that was answered before the previous daemon started.
+        Err(error) if adopted => {
+            eprintln!("termiod: runtime directory check failed after the handoff: {error:#}");
+        }
+        Err(error) => return Err(error),
+    }
 
     let listener = match &inherited {
         Some((blob, _)) => adopt_listener(blob.listener_fd)?,
@@ -461,10 +481,25 @@ pub async fn serve(
 
     // Resolved before anything else starts, because an explicit `--wss` with
     // no pairing token refuses the whole start: the operator asked for a
-    // listener that cannot authenticate.
-    let wss = crate::wss::resolve(wss_bind, &wss_origins)?;
+    // listener that cannot authenticate. After a handoff that same refusal
+    // would be a refusal to keep running sessions alive, so it degrades.
+    let wss = match crate::wss::resolve(wss_bind, &wss_origins) {
+        Ok(wss) => wss,
+        Err(error) if adopted => {
+            eprintln!("termiod: the WebSocket configuration did not resolve after the handoff: {error:#}");
+            eprintln!("termiod: sessions are unaffected; `termiod pair` and a restart re-establish it");
+            None
+        }
+        Err(error) => return Err(error),
+    };
 
-    let host_id = paths::load_or_create_host_id()?;
+    // Carried rather than re-read: the identity must not change across a
+    // handoff, and the read that would establish it is one more thing that can
+    // fail where failing is expensive.
+    let host_id = match &inherited {
+        Some((blob, _)) => blob.host_id.clone(),
+        None => paths::load_or_create_host_id()?,
+    };
     if inherited.is_none() {
         // Scratch dirs are session-scoped and every session died with the
         // previous daemon, so the whole tree is stale by definition here.
@@ -483,15 +518,21 @@ pub async fn serve(
         .iter()
         .flat_map(|(blob, _)| blob.sessions.iter().map(|session| session.id.clone()))
         .collect();
-    let graveyard = Arc::new(Graveyard::open_retaining(
-        &paths::state_dir()?,
-        &carried_ids,
-    )?);
+    let graveyard = Arc::new(
+        match paths::state_dir().and_then(|dir| Graveyard::open_retaining(&dir, &carried_ids)) {
+            Ok(graveyard) => graveyard,
+            Err(error) if adopted => {
+                eprintln!("termiod: the tombstone log did not open after the handoff: {error:#}");
+                eprintln!("termiod: sessions are unaffected; losses will go unrecorded until a restart");
+                Graveyard::detached()
+            }
+            Err(error) => return Err(error),
+        },
+    );
     let (on_exit_tx, mut on_exit_rx) = mpsc::unbounded_channel::<SessionEnded>();
     let (handoff_tx, mut handoff_rx) = mpsc::unbounded_channel::<std::path::PathBuf>();
     let manager = Manager::new(on_exit_tx, host_id, graveyard, handoff_tx);
 
-    let adopted_sessions = inherited.is_some();
     if let Some((blob, rings)) = inherited {
         let from = blob.from_build.clone();
         let mut adopted = 0usize;
@@ -503,10 +544,12 @@ pub async fn serve(
                 // session around it. Dropping it closes the master and hangs
                 // the program up, which is the honest outcome — the session is
                 // gone either way, and leaving the descriptor open would only
-                // hide it. It stays on the roster and is buried as
-                // `daemon_lost` at the next start; the log is what names it now.
+                // hide it. Burying it here is what keeps the roster honest too:
+                // it was retained as alive on the strength of being carried,
+                // and it is not.
                 Err(error) => {
                     eprintln!("termiod: could not adopt session {id} after handoff: {error:#}");
+                    manager.graveyard.bury_by_id(&id, EndReason::DaemonLost);
                 }
             }
         }
@@ -546,7 +589,7 @@ pub async fn serve(
         });
     }
 
-    if !adopted_sessions {
+    if !adopted {
         // Not printed after a handoff: the socket was never unbound, so
         // "listening on" would read as a start that did not happen. The
         // handoff line above is the event.
@@ -565,7 +608,7 @@ pub async fn serve(
             // refusing. After a handoff the same failure would take every
             // carried session down with it, which is a far worse answer to
             // "the phone cannot connect" than the phone not connecting.
-            Err(error) if adopted_sessions => {
+            Err(error) if adopted => {
                 eprintln!("termiod: the WebSocket listener did not come back after the handoff: {error:#}");
                 eprintln!("termiod: sessions are unaffected; `termiod pair` and a restart re-establish it");
             }
@@ -653,10 +696,18 @@ fn adopt_listener(fd: std::os::fd::RawFd) -> Result<UnixListener> {
 
 /// Pack every session and become `binary`. Returns only on failure.
 ///
-/// The order is the safety property. Duplicating the listener and collecting
-/// the sessions comes *after* the binary has been vetted, and writing the blob
-/// comes after both, so the only step left once anything is irreversible is the
-/// exec itself.
+/// Order is what keeps this survivable. Everything fallible that does *not*
+/// need the sessions runs first — resolving the state directory, creating and
+/// unlinking the file the blob will go in, duplicating the listener — while the
+/// daemon is still whole and a failure is an ordinary error. Only then are the
+/// actors asked for their PTYs, which is the step that cannot be undone.
+///
+/// It is not the case that nothing can fail afterwards. Writing the blob can
+/// still run out of space, and the new image can still fail to start. What the
+/// ordering buys is that the *likely* failures — a missing directory, a
+/// read-only filesystem, a listener that cannot be duplicated — happen before
+/// the point of no return rather than after it. The far side answers the rest
+/// by degrading instead of exiting; see `serve`.
 async fn hand_over(
     manager: &Manager,
     listener: &UnixListener,
@@ -664,19 +715,31 @@ async fn hand_over(
 ) -> anyhow::Error {
     use std::os::fd::{AsRawFd, IntoRawFd};
 
+    let state_dir = match paths::state_dir() {
+        Ok(dir) => dir,
+        Err(error) => return error.context("locating the state directory"),
+    };
+    let staged = match crate::handoff::stage_blob(&state_dir) {
+        Ok(file) => file,
+        Err(error) => return error.context("staging the handoff blob"),
+    };
+    let host_id = manager.host_id.to_string();
     let listener_fd = match crate::handoff::duplicate_for_exec(listener.as_raw_fd()) {
-        Ok(fd) => fd,
+        Ok(fd) => fd.into_raw_fd(),
         Err(error) => return error.context("carrying the listener"),
     };
 
+    // Past here the sessions are no longer readable by anything in this image.
     let (carried, stranded) = manager.carry_all().await;
     for id in &stranded {
-        eprintln!("termiod: session {id} did not hand over its pty and will not survive the upgrade");
+        eprintln!(
+            "termiod: session {id} did not hand over its pty and will not survive the upgrade"
+        );
     }
-    let (sessions, rings): (Vec<_>, Vec<_>) = carried
+    let sessions: Vec<_> = carried
         .into_iter()
-        .map(|one| (one.info, one.ring))
-        .unzip();
+        .map(|one| (one.info, one.master, one.ring))
+        .collect();
     eprintln!(
         "termiod: handing off to {} with {} session(s)",
         binary.display(),
@@ -684,15 +747,13 @@ async fn hand_over(
     );
 
     let blob = crate::handoff::Blob {
+        format: crate::handoff::FORMAT_VERSION,
         from_build: crate::lifecycle::BUILD_VERSION.to_string(),
+        host_id,
         listener_fd,
-        sessions,
+        sessions: Vec::new(),
     };
-    let state_dir = match paths::state_dir() {
-        Ok(dir) => dir,
-        Err(error) => return error.context("locating the state directory"),
-    };
-    let blob_fd = match crate::handoff::pack(&blob, &rings, &state_dir) {
+    let blob_fd = match crate::handoff::pack(blob, sessions, staged) {
         Ok(fd) => fd.into_raw_fd(),
         Err(error) => return error.context("packing the handoff blob"),
     };
@@ -1151,7 +1212,22 @@ async fn process_control(
                         send_response(out, response_cache, seq, Control::Ok { re: seq });
                         let (flushed, on_wire) = oneshot::channel();
                         if out.send(Outbound::Flushed(flushed)).is_ok() {
-                            let _ = on_wire.await;
+                            // Bounded, because the queue ahead of the marker is
+                            // not this connection's to drain: a client that has
+                            // stopped reading its own terminal output blocks the
+                            // writer on a payload that came before the request,
+                            // and waiting on that forever would let any attached
+                            // client veto an upgrade by going quiet. The `ok` is
+                            // a courtesy; the handoff is not.
+                            if tokio::time::timeout(HANDOFF_FLUSH_TIMEOUT, on_wire)
+                                .await
+                                .is_err()
+                            {
+                                eprintln!(
+                                    "termiod: the handoff reply could not be flushed in {}s; going ahead without it",
+                                    HANDOFF_FLUSH_TIMEOUT.as_secs()
+                                );
+                            }
                         }
                         let _ = manager.handoff.send(path);
                         return Ok(ControlFlow::Continue);

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -34,6 +34,11 @@ struct ManagerInner {
     sessions: HashMap<SessionId, SessionHandle>,
     id_counter: u32,
     draining: bool,
+    /// Whether a handoff has been accepted and not yet finished. Nothing
+    /// serialised them before: two clients asking at once both got `ok`, both
+    /// requests reached the accept loop, and the second carried a roster the
+    /// first had already emptied. One at a time, and the loser is told so.
+    handing_off: bool,
 }
 
 #[derive(Clone)]
@@ -73,6 +78,7 @@ impl Manager {
                 sessions: HashMap::new(),
                 id_counter: 0,
                 draining: false,
+            handing_off: false,
             })),
             next_client_id: Arc::new(AtomicU64::new(1)),
             on_exit,
@@ -216,9 +222,29 @@ impl Manager {
         }
         // Only once every session is installed again: a create that slipped in
         // before this point would have been spawned into a daemon that was
-        // still handing over.
+        // still handing over. The handoff claim goes with it — this attempt is
+        // over, and the next one is allowed to try.
         self.inner.lock().unwrap().draining = false;
         lost
+    }
+
+    /// Claims the right to hand over, or reports who already has it. Released
+    /// by `restore`, which is the end of every attempt that comes back.
+    fn begin_handoff(&self) -> bool {
+        let mut guard = self.inner.lock().unwrap();
+        if guard.handing_off {
+            return false;
+        }
+        guard.handing_off = true;
+        true
+    }
+
+    /// Gives the claim back. Called where every attempt that comes back
+    /// converges — not in `restore`, which the early failures never reach: they
+    /// fail before anything is carried, and latching the gate on those would
+    /// mean one unreadable state directory blocked every upgrade until restart.
+    fn end_handoff(&self) {
+        self.inner.lock().unwrap().handing_off = false;
     }
 
     fn find(&self, id: &SessionId) -> Option<SessionHandle> {
@@ -712,6 +738,7 @@ pub async fn serve(
                     binary.display()
                 );
                 eprintln!("termiod: every session is still here; carrying on");
+                manager.end_handoff();
                 continue 'serving;
             }
             Handoff::Lost(error) => {
@@ -863,10 +890,48 @@ async fn hand_over(
             };
         }
     };
-    // `exec` returns only if it failed, and by then the descriptors belong to an
-    // image that never started. Nothing owns them any more, so there is nothing
-    // to put back.
-    Handoff::Lost(crate::handoff::exec(binary, blob_fd))
+    let error = crate::handoff::exec(binary, blob_fd);
+
+    // `exec` returns only if it failed — the binary was replaced or removed
+    // between the probe and here, or is busy. "Nothing owns the descriptors any
+    // more" was the reason this used to give up, and it was wrong: unowned is
+    // not closed. Every master is still open in this process, and the blob that
+    // was just written names all of them along with the rings. Reading it back
+    // is exactly what the new image would have done, so the recovery is the same
+    // adoption, run here instead of there.
+    let recovered = match crate::handoff::unpack(blob_fd) {
+        Ok((blob, rings)) => {
+            let sessions: Vec<_> = blob
+                .sessions
+                .into_iter()
+                .zip(rings)
+                .map(|(info, ring)| {
+                    // Taking back ownership of a number this process released to
+                    // an image that never ran. Safe for the same reason the far
+                    // side's adoption is: nothing else holds it.
+                    let master = unsafe {
+                        <std::os::fd::OwnedFd as std::os::fd::FromRawFd>::from_raw_fd(
+                            info.master_fd,
+                        )
+                    };
+                    (info, master, vec![Bytes::from(ring)])
+                })
+                .collect();
+            manager.restore(sessions)
+        }
+        // Without the blob there is no list of what to put back. The descriptors
+        // stay open and unreferenced for the life of the process, which is worse
+        // than a leak only in that the sessions behind them are unreachable.
+        Err(read) => {
+            eprintln!("termiod: the handoff blob could not be read back: {read:#}");
+            vec!["<unknown>".to_string()]
+        }
+    };
+    if recovered.is_empty() {
+        Handoff::Aborted(error)
+    } else {
+        Handoff::Lost(error.context(format!("and {} could not be put back", recovered.join(", "))))
+    }
 }
 
 #[derive(Clone)]
@@ -1325,6 +1390,16 @@ async fn process_control(
                     .map_err(|error| anyhow::anyhow!("{error}"))
                     .and_then(|result| result);
                 match vetted {
+                    // A second request while one is already under way would
+                    // carry a roster the first has emptied and pack a blob of
+                    // nothing. It is refused where every other refusal happens:
+                    // while there is still a connection to refuse on.
+                    Ok(_) if !manager.begin_handoff() => error(
+                        seq,
+                        ErrorCode::Busy,
+                        "a handoff is already under way",
+                        true,
+                    ),
                     Ok(path) => {
                         // The reply goes out *before* the accept loop is told,
                         // and this waits for it to reach the socket: the exec
@@ -2521,10 +2596,25 @@ async fn run_attach(
         };
         match frame {
             Ok(Some(Frame::Data(data))) => {
-                handle.send(SessionMsg::Input {
+                // The same window `Send` and `Kill` answer `busy` for, reached
+                // by the other door: a client typing into an attachment whose
+                // actor has already handed over its PTY. There is nothing to
+                // answer here — an attachment is a stream, not a request — so
+                // the honest move is to say the attachment is over and let the
+                // client reattach. Swallowing the keystrokes would leave someone
+                // typing into a window that stopped listening without saying so.
+                if !handle.send(SessionMsg::Input {
                     id: client_id.clone(),
                     data,
-                });
+                }) {
+                    let _ = out.send(Outbound::Control(error(
+                        None,
+                        ErrorCode::Busy,
+                        "this session is being handed to a new daemon; reattach to keep typing",
+                        true,
+                    )));
+                    break;
+                }
             }
             Ok(Some(Frame::Resize { rows, cols })) => {
                 handle.send(SessionMsg::Resize {

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -51,6 +51,10 @@ pub struct Manager {
     /// "nothing was running" rather than "everything was lost".
     graveyard: Arc<Graveyard>,
     session_removed: Arc<Notify>,
+    /// Where a `handoff` request goes. The accept loop owns the listener and
+    /// the runtime, so replacing the image is its move to make; a connection
+    /// task only vets the request and passes it along.
+    handoff: mpsc::UnboundedSender<std::path::PathBuf>,
 }
 
 impl Manager {
@@ -58,6 +62,7 @@ impl Manager {
         on_exit: mpsc::UnboundedSender<SessionEnded>,
         host_id: String,
         graveyard: Arc<Graveyard>,
+        handoff: mpsc::UnboundedSender<std::path::PathBuf>,
     ) -> Manager {
         let (events, _) = broadcast::channel(EVENT_BUFFER);
         Manager {
@@ -74,7 +79,39 @@ impl Manager {
             uploads: crate::files::Uploads::new(),
             graveyard,
             session_removed: Arc::new(Notify::new()),
+            handoff,
         }
+    }
+
+    /// Ask every session for its PTY, so an `execve` can carry them.
+    ///
+    /// Sequential rather than concurrent, and bounded: a session that does not
+    /// answer within `handoff::CARRY_TIMEOUT` is left out of the blob and
+    /// returned as stranded. It loses its PTY at the exec, and naming it in the
+    /// log is the difference between an upgrade with a known cost and an
+    /// upgrade that quietly ate someone's work.
+    async fn carry_all(&self) -> (Vec<session::Carried>, Vec<String>) {
+        let handles: Vec<SessionHandle> = {
+            let mut guard = self.inner.lock().unwrap();
+            // Nothing new may start once the PTYs are being handed over: a
+            // session spawned after this point has no descriptor in the blob.
+            guard.draining = true;
+            guard.sessions.values().cloned().collect()
+        };
+        let mut carried = Vec::new();
+        let mut stranded = Vec::new();
+        for handle in handles {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if !handle.send(SessionMsg::Carry { reply: reply_tx }) {
+                stranded.push(handle.id.to_string());
+                continue;
+            }
+            match tokio::time::timeout(crate::handoff::CARRY_TIMEOUT, reply_rx).await {
+                Ok(Ok(one)) => carried.push(one),
+                _ => stranded.push(handle.id.to_string()),
+            }
+        }
+        (carried, stranded)
     }
 
     fn alloc_client_id(&self) -> ClientId {
@@ -125,6 +162,17 @@ impl Manager {
         .context("spawning session")?;
         guard.sessions.insert(id.clone(), handle);
         Ok(id)
+    }
+
+    /// Install a session that crossed a handoff. Not a `create`: nothing is
+    /// spawned, no id is minted, and the roster entry the previous daemon wrote
+    /// is already correct — this session never stopped being alive.
+    fn adopt(&self, carried: crate::handoff::CarriedSession, ring: Vec<u8>) -> Result<()> {
+        let id = SessionId::new(carried.id.clone());
+        let handle = session::adopt(carried, ring, self.on_exit.clone(), self.events.clone())
+            .context("adopting session")?;
+        self.inner.lock().unwrap().sessions.insert(id, handle);
+        Ok(())
     }
 
     fn find(&self, id: &SessionId) -> Option<SessionHandle> {
@@ -363,9 +411,16 @@ impl Manager {
 }
 
 /// Run the daemon: bind the socket and accept forever.
+///
+/// `handoff_fd` is set only when this image is the far side of an `execve` from
+/// a previous one (`crate::handoff`). Everything that would otherwise be
+/// startup — binding the socket, wiping the scratch tree, reading the roster as
+/// evidence of a crash — is instead adoption: the listener and the sessions are
+/// already there, on descriptors this process inherited from itself.
 pub async fn serve(
     wss_bind: Option<std::net::SocketAddr>,
     wss_origins: Vec<crate::wss::Origin>,
+    handoff_fd: Option<std::os::fd::RawFd>,
 ) -> Result<()> {
     // First, before anything that can fail: whoever spawned this daemon most
     // likely pointed its stderr at /dev/null, and a startup error is exactly the
@@ -378,21 +433,31 @@ pub async fn serve(
     paths::ensure_runtime_dir()?;
     let sock_path = paths::socket_path()?;
 
-    if sock_path.exists() {
-        match UnixStream::connect(&sock_path).await {
-            Ok(_) => {
-                anyhow::bail!("termiod already running at {}", sock_path.display());
-            }
-            Err(_) => {
-                let _ = std::fs::remove_file(&sock_path);
-            }
-        }
-    }
+    let inherited = match handoff_fd {
+        Some(fd) => Some(crate::handoff::unpack(fd).context("reading the handoff blob")?),
+        None => None,
+    };
 
-    let listener = UnixListener::bind(&sock_path)
-        .with_context(|| format!("binding {}", sock_path.display()))?;
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600))?;
+    let listener = match &inherited {
+        Some((blob, _)) => adopt_listener(blob.listener_fd)?,
+        None => {
+            if sock_path.exists() {
+                match UnixStream::connect(&sock_path).await {
+                    Ok(_) => {
+                        anyhow::bail!("termiod already running at {}", sock_path.display());
+                    }
+                    Err(_) => {
+                        let _ = std::fs::remove_file(&sock_path);
+                    }
+                }
+            }
+            let listener = UnixListener::bind(&sock_path)
+                .with_context(|| format!("binding {}", sock_path.display()))?;
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600))?;
+            listener
+        }
+    };
 
     // Resolved before anything else starts, because an explicit `--wss` with
     // no pairing token refuses the whole start: the operator asked for a
@@ -400,17 +465,56 @@ pub async fn serve(
     let wss = crate::wss::resolve(wss_bind, &wss_origins)?;
 
     let host_id = paths::load_or_create_host_id()?;
-    // Scratch dirs are session-scoped and every session died with the
-    // previous daemon, so the whole tree is stale by definition here.
-    if let Ok(scratch) = paths::scratch_root() {
-        let _ = std::fs::remove_dir_all(&scratch);
+    if inherited.is_none() {
+        // Scratch dirs are session-scoped and every session died with the
+        // previous daemon, so the whole tree is stale by definition here.
+        // After a handoff the sessions are the same sessions, and so are
+        // their scratch dirs.
+        if let Ok(scratch) = paths::scratch_root() {
+            let _ = std::fs::remove_dir_all(&scratch);
+        }
     }
     // Opening the graveyard is also the crash check: anything the previous
     // daemon left on its roster is adopted as `daemon_lost` here, before this
-    // one accepts a single connection.
-    let graveyard = Arc::new(Graveyard::open(&paths::state_dir()?)?);
+    // one accepts a single connection. A session that crossed a handoff is on
+    // that roster and is alive, so it is retained instead — while one that was
+    // stranded at the exec is on it too, and is buried like any other loss.
+    let carried_ids: Vec<String> = inherited
+        .iter()
+        .flat_map(|(blob, _)| blob.sessions.iter().map(|session| session.id.clone()))
+        .collect();
+    let graveyard = Arc::new(Graveyard::open_retaining(
+        &paths::state_dir()?,
+        &carried_ids,
+    )?);
     let (on_exit_tx, mut on_exit_rx) = mpsc::unbounded_channel::<SessionEnded>();
-    let manager = Manager::new(on_exit_tx, host_id, graveyard);
+    let (handoff_tx, mut handoff_rx) = mpsc::unbounded_channel::<std::path::PathBuf>();
+    let manager = Manager::new(on_exit_tx, host_id, graveyard, handoff_tx);
+
+    let adopted_sessions = inherited.is_some();
+    if let Some((blob, rings)) = inherited {
+        let from = blob.from_build.clone();
+        let mut adopted = 0usize;
+        for (carried, ring) in blob.sessions.into_iter().zip(rings) {
+            let id = carried.id.clone();
+            match manager.adopt(carried, ring) {
+                Ok(()) => adopted += 1,
+                // The descriptor arrived but this image could not build a
+                // session around it. Dropping it closes the master and hangs
+                // the program up, which is the honest outcome — the session is
+                // gone either way, and leaving the descriptor open would only
+                // hide it. It stays on the roster and is buried as
+                // `daemon_lost` at the next start; the log is what names it now.
+                Err(error) => {
+                    eprintln!("termiod: could not adopt session {id} after handoff: {error:#}");
+                }
+            }
+        }
+        eprintln!(
+            "termiod: handoff from {from} to {} complete — {adopted} session(s) carried",
+            crate::lifecycle::BUILD_VERSION
+        );
+    }
 
     {
         let manager = manager.clone();
@@ -442,14 +546,31 @@ pub async fn serve(
         });
     }
 
-    eprintln!("termiod listening on {}", sock_path.display());
+    if !adopted_sessions {
+        // Not printed after a handoff: the socket was never unbound, so
+        // "listening on" would read as a start that did not happen. The
+        // handoff line above is the event.
+        eprintln!("termiod listening on {}", sock_path.display());
+    }
 
     // The WSS listener stops accepting and drops its splices on the same signal
     // that ends the accept loop, so nothing attaches into a daemon that is
     // already burying its sessions.
     let (wss_shutdown, wss_shutdown_rx) = watch::channel(false);
     if let Some(config) = wss {
-        crate::wss::start(config, wss_shutdown_rx).await?;
+        match crate::wss::start(config, wss_shutdown_rx).await {
+            Ok(()) => {}
+            // On a cold start, an operator who asked for a listener and did not
+            // get one wants to know immediately, and nothing is lost by
+            // refusing. After a handoff the same failure would take every
+            // carried session down with it, which is a far worse answer to
+            // "the phone cannot connect" than the phone not connecting.
+            Err(error) if adopted_sessions => {
+                eprintln!("termiod: the WebSocket listener did not come back after the handoff: {error:#}");
+                eprintln!("termiod: sessions are unaffected; `termiod pair` and a restart re-establish it");
+            }
+            Err(error) => return Err(error),
+        }
     }
 
     let mut terminate =
@@ -463,11 +584,17 @@ pub async fn serve(
     };
     tokio::pin!(shutdown_signal);
 
+    let mut becoming: Option<std::path::PathBuf> = None;
     loop {
         tokio::select! {
             biased;
             result = &mut shutdown_signal => {
                 result?;
+                break;
+            }
+            requested = handoff_rx.recv() => {
+                let Some(binary) = requested else { continue };
+                becoming = Some(binary);
                 break;
             }
             accepted = listener.accept() => {
@@ -483,6 +610,17 @@ pub async fn serve(
     }
 
     let _ = wss_shutdown.send(true);
+
+    if let Some(binary) = becoming {
+        // From here the daemon is committed. `hand_over` returns only on
+        // failure, and by then the session actors have already given up their
+        // PTYs — there is no daemon left to go back to being.
+        let error = hand_over(&manager, &listener, &binary).await;
+        eprintln!("termiod: handoff to {} failed: {error:#}", binary.display());
+        eprintln!("termiod: the sessions this daemon held are lost; the next start will bury them");
+        std::process::exit(1);
+    }
+
     manager.begin_draining(EndReason::DaemonStopped);
     let drained = manager.finish_draining(EndReason::DaemonStopped).await;
     // Keeping the bound listener through the drain prevents an autostarting
@@ -494,6 +632,71 @@ pub async fn serve(
         Err(error) => eprintln!("termiod: could not remove socket during shutdown: {error}"),
     }
     drained
+}
+
+/// Re-establish a `UnixListener` on a descriptor that crossed an `execve`.
+///
+/// The socket was never unlinked and never re-bound, so anything that connected
+/// during the crossing is sitting in the kernel's accept backlog and is served
+/// the moment this listener starts accepting.
+fn adopt_listener(fd: std::os::fd::RawFd) -> Result<UnixListener> {
+    use std::os::fd::FromRawFd;
+    let listener = unsafe { std::os::unix::net::UnixListener::from_raw_fd(fd) };
+    // Tokio polls the descriptor and will not block for it; the previous image
+    // set this on the same open file description, but a carried descriptor is
+    // exactly the kind of assumption worth not making twice.
+    listener
+        .set_nonblocking(true)
+        .context("making the carried listener non-blocking")?;
+    UnixListener::from_std(listener).context("adopting the carried listener")
+}
+
+/// Pack every session and become `binary`. Returns only on failure.
+///
+/// The order is the safety property. Duplicating the listener and collecting
+/// the sessions comes *after* the binary has been vetted, and writing the blob
+/// comes after both, so the only step left once anything is irreversible is the
+/// exec itself.
+async fn hand_over(
+    manager: &Manager,
+    listener: &UnixListener,
+    binary: &std::path::Path,
+) -> anyhow::Error {
+    use std::os::fd::{AsRawFd, IntoRawFd};
+
+    let listener_fd = match crate::handoff::duplicate_for_exec(listener.as_raw_fd()) {
+        Ok(fd) => fd,
+        Err(error) => return error.context("carrying the listener"),
+    };
+
+    let (carried, stranded) = manager.carry_all().await;
+    for id in &stranded {
+        eprintln!("termiod: session {id} did not hand over its pty and will not survive the upgrade");
+    }
+    let (sessions, rings): (Vec<_>, Vec<_>) = carried
+        .into_iter()
+        .map(|one| (one.info, one.ring))
+        .unzip();
+    eprintln!(
+        "termiod: handing off to {} with {} session(s)",
+        binary.display(),
+        sessions.len()
+    );
+
+    let blob = crate::handoff::Blob {
+        from_build: crate::lifecycle::BUILD_VERSION.to_string(),
+        listener_fd,
+        sessions,
+    };
+    let state_dir = match paths::state_dir() {
+        Ok(dir) => dir,
+        Err(error) => return error.context("locating the state directory"),
+    };
+    let blob_fd = match crate::handoff::pack(&blob, &rings, &state_dir) {
+        Ok(fd) => fd.into_raw_fd(),
+        Err(error) => return error.context("packing the handoff blob"),
+    };
+    crate::handoff::exec(binary, blob_fd)
 }
 
 #[derive(Clone)]
@@ -511,6 +714,10 @@ enum Outbound {
     History(Metered),
     Grid(Metered),
     File(Bytes),
+    /// Not a message: a marker the writer answers once everything queued ahead
+    /// of it is on the socket. One caller needs it — `handoff`, which must not
+    /// replace the process image while its own `ok` is still in a channel.
+    Flushed(oneshot::Sender<()>),
 }
 
 async fn write_outbound(
@@ -549,6 +756,10 @@ async fn write_outbound(
                 result
             }
             Outbound::File(payload) => write_file_payload(&mut wr, &payload).await,
+            Outbound::Flushed(signal) => {
+                let _ = signal.send(());
+                Ok(())
+            }
         };
         if result.is_err() {
             break;
@@ -908,6 +1119,50 @@ async fn process_control(
                     format!("no such session: {id}"),
                     false,
                 ),
+            };
+            send_response(out, response_cache, seq, response);
+        }
+        Control::Handoff { binary, seq } => {
+            let response = if !connection.capabilities.contains("handoff") {
+                error(
+                    seq,
+                    ErrorCode::Denied,
+                    "the handoff capability was not negotiated",
+                    false,
+                )
+            } else {
+                // Vetting runs on a blocking thread because it *runs* the
+                // candidate binary, and the answer decides whether the daemon
+                // is still whole a moment from now. Everything that can refuse
+                // refuses here, while there is still a connection to refuse on.
+                let path = std::path::PathBuf::from(&binary);
+                let vetted = tokio::task::spawn_blocking(move || crate::handoff::vet(&path))
+                    .await
+                    .map_err(|error| anyhow::anyhow!("{error}"))
+                    .and_then(|result| result);
+                match vetted {
+                    Ok(path) => {
+                        // The reply goes out *before* the accept loop is told,
+                        // and this waits for it to reach the socket: the exec
+                        // that follows takes the connection with it, so an `ok`
+                        // still sitting in a channel is an `ok` the client
+                        // never sees — and a successful handoff that reads, at
+                        // the other end, as a daemon that died mid-request.
+                        send_response(out, response_cache, seq, Control::Ok { re: seq });
+                        let (flushed, on_wire) = oneshot::channel();
+                        if out.send(Outbound::Flushed(flushed)).is_ok() {
+                            let _ = on_wire.await;
+                        }
+                        let _ = manager.handoff.send(path);
+                        return Ok(ControlFlow::Continue);
+                    }
+                    Err(reason) => error(
+                        seq,
+                        ErrorCode::Denied,
+                        format!("{binary} cannot be handed off to: {reason:#}"),
+                        false,
+                    ),
+                }
             };
             send_response(out, response_cache, seq, response);
         }

--- a/termiod/src/handoff.rs
+++ b/termiod/src/handoff.rs
@@ -60,6 +60,28 @@ pub const HANDOFF_FLAG: &str = "--handoff";
 
 const MAGIC: &[u8; 8] = b"TERMIOD\x01";
 
+/// The shape of what crosses. Bumped whenever [`Blob`] or [`CarriedSession`]
+/// changes in a way the far side would misread — a renamed field, a new
+/// descriptor, a different order for the ring runs.
+///
+/// It is checked *before* the exec, not after: by the time a new image could
+/// notice it cannot read the blob, the old one is gone and so are the sessions.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// What `termiod handoff --probe` prints, and the only thing `vet` accepts.
+///
+/// Whether a candidate can be handed off to is not a question `--version`
+/// answers. Every termiod ever built answers `--version`, including the ones
+/// that have never heard of `serve --handoff`; so does `/usr/bin/true` with a
+/// wrapper around it. Exec'ing one of those replaces the daemon with a program
+/// that exits, and every PTY master closes behind it.
+///
+/// So the probe asks the one question that matters — "do you implement this
+/// exact contract" — and the candidate answers by naming the format it speaks.
+pub fn probe_token() -> String {
+    format!("termiod-handoff {FORMAT_VERSION}")
+}
+
 /// How long the daemon waits for a session actor to hand its PTY over. A
 /// session that misses this is left behind rather than holding the upgrade
 /// open, and is named in the daemon's log on the way out.
@@ -84,19 +106,47 @@ pub struct CarriedSession {
     #[serde(default)]
     pub workstream: Option<crate::protocol::WorkstreamSpec>,
     /// The PTY master, as a descriptor number in the process about to `execve`.
+    ///
+    /// Filled in at [`pack`] time, from the owning descriptor the session actor
+    /// handed over, and *only* for the sessions that actually reach the blob.
+    /// A number written here earlier would outlive the decision to carry it:
+    /// a session dropped for missing the carry deadline would have left an open
+    /// master with no owner and no reader on the far side of the exec — a
+    /// process alive, un-hung-up, and invisible.
     pub master_fd: RawFd,
     /// How many bytes of replay ring follow this session's header in the blob.
     pub ring_len: u64,
+    /// Whether replaying that ring into a blank terminal of these dimensions
+    /// draws the screen the program is actually looking at.
+    ///
+    /// False once the ring has evicted anything, or the session was resized
+    /// after those bytes were written. The new image starts its VT stale rather
+    /// than answering snapshots from a reconstruction it has been told is
+    /// wrong. Defaults to false for a blob that predates the field: a daemon
+    /// that did not think about the question is not evidence the answer is yes.
+    #[serde(default)]
+    pub ring_reconstructs_screen: bool,
 }
 
 /// The header the new image reads before it has any state of its own. Ring
 /// bytes follow it, one run per session in `sessions` order.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Blob {
+    /// What [`FORMAT_VERSION`] was when this was written. `vet` has already
+    /// refused a candidate that speaks a different one, so a mismatch here is
+    /// not a version skew but a corrupt or forged blob.
+    pub format: u32,
     /// The build that packed this. Recorded for the log line the new image
     /// writes: "0.46.0+1201 handed off to 0.47.0+1240" is the one fact that
     /// makes an upgrade legible after the fact.
     pub from_build: String,
+    /// This host's stable identity, carried rather than re-read.
+    ///
+    /// The new image could load it from disk the way a cold start does, but
+    /// that is a fallible read on a path where a failure costs every carried
+    /// session — and the identity must not change across a handoff anyway,
+    /// which carrying it states outright.
+    pub host_id: String,
     /// The already-bound Unix listener. See the module docs for why this is
     /// carried rather than re-bound.
     pub listener_fd: RawFd,
@@ -107,14 +157,16 @@ pub struct Blob {
 /// daemon takes a single session apart.
 ///
 /// The order matters more than the checks do. Once the session actors have
-/// given up their PTYs there is no way back: the actors are gone, the rings are
-/// in a blob, and the only paths left are `execve` or death. So everything that
-/// can say no says it here, while the daemon is still whole and the client is
-/// still holding a socket that can carry the refusal.
+/// given up their PTYs there is no way back. So everything that can say no says
+/// it here, while the daemon is still whole and the client is still holding a
+/// socket that can carry the refusal.
 ///
-/// The last check is the strong one: the candidate is *run*. A binary for the
-/// wrong architecture, or missing an interpreter, or truncated by an upload
-/// that lost its connection, all fail `--version` and all look fine to `stat`.
+/// The last check is the strong one: the candidate is *run*, and it has to
+/// answer [`probe_token`]. That catches all of the same things `stat` cannot —
+/// a binary for the wrong architecture, one missing an interpreter, one
+/// truncated by an upload that lost its connection — and, unlike `--version`,
+/// also catches the case that actually happens: a termiod old enough to answer
+/// but too old to know what `serve --handoff` means.
 pub fn vet(binary: &Path) -> Result<PathBuf> {
     if !binary.is_absolute() {
         bail!("{} is not an absolute path", binary.display());
@@ -128,44 +180,81 @@ pub fn vet(binary: &Path) -> Result<PathBuf> {
         bail!("{} is not a regular file", binary.display());
     }
     let probe = std::process::Command::new(&binary)
-        .arg("--version")
+        .arg("handoff")
+        .arg("--probe")
         .stdin(std::process::Stdio::null())
         .output()
-        .with_context(|| format!("running {} --version", binary.display()))?;
+        .with_context(|| format!("running {} handoff --probe", binary.display()))?;
     if !probe.status.success() {
         bail!(
-            "{} --version exited {}: {}",
+            "{} does not implement the handoff contract ({} exited {})",
             binary.display(),
-            probe.status,
-            String::from_utf8_lossy(&probe.stderr).trim()
+            "handoff --probe",
+            probe.status
         );
     }
-    if String::from_utf8_lossy(&probe.stdout).trim().is_empty() {
-        bail!("{} --version printed nothing", binary.display());
+    let spoken = String::from_utf8_lossy(&probe.stdout).trim().to_string();
+    let wanted = probe_token();
+    if spoken != wanted {
+        bail!(
+            "{} speaks {:?} where this daemon speaks {wanted:?}",
+            binary.display(),
+            spoken
+        );
     }
     Ok(binary)
 }
 
-/// Write the blob to an unlinked file and return its descriptor, rewound and
-/// exec-safe.
-pub fn pack(blob: &Blob, rings: &[Vec<Bytes>], state_dir: &Path) -> Result<OwnedFd> {
+/// Create the file the blob will be written to, before anything irreversible
+/// has happened.
+///
+/// Split from [`pack`] because it is the fallible half: a missing state
+/// directory, a read-only filesystem, no space. Doing it while the daemon is
+/// still whole turns those from "the sessions are gone and so is the daemon"
+/// into an ordinary refusal the client is told about.
+///
+/// The file is unlinked before it is returned, so it has no name for anything
+/// to open and the kernel reclaims it when the last descriptor closes. That
+/// matters: it is about to hold every session's replay ring, which is raw
+/// terminal output — an agent's transcript, whatever `env` printed, a token
+/// someone echoed. A handoff must not become a way of writing that to disk
+/// behind the user's back.
+pub fn stage_blob(state_dir: &Path) -> Result<std::fs::File> {
     let path = state_dir.join(format!("handoff.{}", std::process::id()));
-    let mut file = std::fs::OpenOptions::new()
-        .create_new(true)
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
         .read(true)
         .write(true)
         .open(&path)
         .with_context(|| format!("opening {}", path.display()))?;
-    // Before a byte goes in. From here the file has no name: nothing can open
-    // it, and the kernel reclaims it when the last descriptor closes — which,
-    // on the success path, is the new image closing it after the read.
     std::fs::remove_file(&path).with_context(|| format!("unlinking {}", path.display()))?;
+    Ok(file)
+}
 
-    let header = serde_json::to_vec(blob).context("encoding the handoff header")?;
+/// Write the blob into the staged file and return its descriptor, rewound and
+/// exec-safe.
+///
+/// Consumes the owning master descriptors: a session's number is written into
+/// the header at the moment it is committed to the blob, and not before.
+pub fn pack(
+    mut blob: Blob,
+    sessions: Vec<(CarriedSession, OwnedFd, Vec<Bytes>)>,
+    mut file: std::fs::File,
+) -> Result<OwnedFd> {
+    let mut rings = Vec::with_capacity(sessions.len());
+    for (mut info, master, ring) in sessions {
+        info.master_fd = master.into_raw_fd();
+        set_inheritable(info.master_fd)?;
+        rings.push(ring);
+        blob.sessions.push(info);
+    }
+
+    let header = serde_json::to_vec(&blob).context("encoding the handoff header")?;
     file.write_all(MAGIC)?;
     file.write_all(&(header.len() as u32).to_le_bytes())?;
     file.write_all(&header)?;
-    for ring in rings {
+    for ring in &rings {
         for chunk in ring {
             file.write_all(chunk)?;
         }
@@ -194,6 +283,12 @@ pub fn unpack(fd: RawFd) -> Result<(Blob, Vec<Vec<u8>>)> {
     let mut header = vec![0u8; u32::from_le_bytes(length) as usize];
     file.read_exact(&mut header)?;
     let blob: Blob = serde_json::from_slice(&header).context("decoding the handoff header")?;
+    if blob.format != FORMAT_VERSION {
+        bail!(
+            "the handoff blob is format {} where this build reads {FORMAT_VERSION}",
+            blob.format
+        );
+    }
 
     let mut rings = Vec::with_capacity(blob.sessions.len());
     for session in &blob.sessions {
@@ -212,7 +307,7 @@ pub fn unpack(fd: RawFd) -> Result<(Blob, Vec<Vec<u8>>)> {
 /// be dropped normally on its way out: its `OwnedFd` closes, this copy stays,
 /// and both named the same open file description all along — the same PTY
 /// master, at the same offset, with the same termios.
-pub fn duplicate_for_exec(fd: RawFd) -> Result<RawFd> {
+pub fn duplicate_for_exec(fd: RawFd) -> Result<OwnedFd> {
     let copy = unsafe { libc::dup(fd) };
     if copy < 0 {
         bail!(
@@ -223,7 +318,7 @@ pub fn duplicate_for_exec(fd: RawFd) -> Result<RawFd> {
     // `dup` already clears `FD_CLOEXEC` on the copy. Set it anyway: the one
     // invariant this whole module rests on should not be an inherited default.
     set_inheritable(copy)?;
-    Ok(copy)
+    Ok(unsafe { OwnedFd::from_raw_fd(copy) })
 }
 
 fn set_inheritable(fd: RawFd) -> Result<()> {
@@ -294,19 +389,35 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("termiod-handoff-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let blob = Blob {
+            format: FORMAT_VERSION,
             from_build: "0.1.0+1".to_string(),
+            host_id: "h_1".to_string(),
             listener_fd: 7,
-            sessions: vec![session("a", 3), session("b", 5)],
+            sessions: Vec::new(),
         };
-        let rings = vec![
-            vec![Bytes::from_static(b"abc")],
-            vec![Bytes::from_static(b"de"), Bytes::from_static(b"fgh")],
+        // Two descriptors that are not ptys but are perfectly good stand-ins
+        // for "an owning fd the actor handed over".
+        let sessions = vec![
+            (session("a", 3), devnull(), vec![Bytes::from_static(b"abc")]),
+            (
+                session("b", 5),
+                devnull(),
+                vec![Bytes::from_static(b"de"), Bytes::from_static(b"fgh")],
+            ),
         ];
-        let fd = pack(&blob, &rings, &dir).unwrap();
+        let file = stage_blob(&dir).unwrap();
+        let fd = pack(blob, sessions, file).unwrap();
         let (read_back, read_rings) = unpack(fd.into_raw_fd()).unwrap();
         assert_eq!(read_back.listener_fd, 7);
         assert_eq!(read_back.from_build, "0.1.0+1");
+        assert_eq!(read_back.host_id, "h_1");
         assert_eq!(read_rings, vec![b"abc".to_vec(), b"defgh".to_vec()]);
+        // The numbers were assigned at pack time, from the descriptors handed
+        // over — never the placeholder the caller built the header with.
+        for carried in &read_back.sessions {
+            assert!(carried.master_fd > 2, "{}", carried.master_fd);
+            unsafe { libc::close(carried.master_fd) };
+        }
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -328,6 +439,29 @@ mod tests {
         );
     }
 
+    /// The property the stranded-session path rests on: what a session actor
+    /// hands over is *owned*, so a `Carried` nobody takes closes the master
+    /// instead of leaking an un-hung-up process into the next image. Only
+    /// `pack` gives that ownership up, and only for what reaches the blob.
+    #[test]
+    fn a_carried_descriptor_that_is_dropped_is_closed() {
+        let original = devnull();
+        let copy = duplicate_for_exec(original.as_raw_fd()).unwrap();
+        let number = copy.as_raw_fd();
+        assert!(unsafe { libc::fcntl(number, libc::F_GETFD) } >= 0);
+        drop(copy);
+        assert!(
+            unsafe { libc::fcntl(number, libc::F_GETFD) } < 0,
+            "descriptor {number} outlived the Carried that held it"
+        );
+    }
+
+    fn devnull() -> OwnedFd {
+        std::fs::File::open("/dev/null")
+            .expect("open /dev/null")
+            .into()
+    }
+
     fn session(id: &str, ring_len: u64) -> CarriedSession {
         CarriedSession {
             id: id.to_string(),
@@ -341,8 +475,9 @@ mod tests {
             status: "unknown".to_string(),
             title: None,
             workstream: None,
-            master_fd: 10,
+            master_fd: -1,
             ring_len,
+            ring_reconstructs_screen: true,
         }
     }
 }

--- a/termiod/src/handoff.rs
+++ b/termiod/src/handoff.rs
@@ -380,7 +380,15 @@ fn write_blob(
     sessions: &[(CarriedSession, OwnedFd, Vec<Bytes>)],
     mut file: std::fs::File,
 ) -> Result<OwnedFd> {
-    if std::env::var_os(FAIL_AFTER_CARRY).is_some() {
+    if let Some(setting) = std::env::var_os(FAIL_AFTER_CARRY) {
+        // A number holds the failure open that many milliseconds first. The
+        // instant failure is enough to prove the rollback, but not to prove
+        // anything about what happens *during* a handoff: a second request
+        // arriving after the first has already aborted is not a race. Holding
+        // the window open is what makes it one.
+        if let Some(ms) = setting.to_str().and_then(|value| value.parse::<u64>().ok()) {
+            std::thread::sleep(std::time::Duration::from_millis(ms));
+        }
         bail!("{FAIL_AFTER_CARRY} is set");
     }
     set_inheritable(listener.as_raw_fd())?;

--- a/termiod/src/handoff.rs
+++ b/termiod/src/handoff.rs
@@ -308,28 +308,90 @@ fn run_probe(binary: &Path) -> Result<String> {
 ///
 /// Consumes the owning master descriptors: a session's number is written into
 /// the header at the moment it is committed to the blob, and not before.
+/// What a failed [`pack`] gives back: the error, and every descriptor it was
+/// handed, still owned and still open.
+///
+/// Returning them is the whole difference between an upgrade that fails and an
+/// upgrade that destroys. By the time `pack` runs, `carry_all` has already made
+/// every actor exit — the sessions exist only as these descriptors. Dropping
+/// them here, which is what this used to do, closes every PTY master at once
+/// and every shell and agent behind them takes SIGHUP. Handed back, they can be
+/// adopted again and the daemon goes on as though nothing happened.
+impl std::fmt::Debug for PackFailed {
+    /// Only the error: the descriptors are numbers whose meaning died with the
+    /// process that held them, and printing them invites reading them.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PackFailed")
+            .field("error", &format_args!("{:#}", self.error))
+            .field("sessions", &self.sessions.len())
+            .finish()
+    }
+}
+
+pub struct PackFailed {
+    pub error: anyhow::Error,
+    pub listener: OwnedFd,
+    pub sessions: Vec<(CarriedSession, OwnedFd, Vec<Bytes>)>,
+}
+
 pub fn pack(
-    mut blob: Blob,
+    blob: Blob,
     listener: OwnedFd,
     sessions: Vec<(CarriedSession, OwnedFd, Vec<Bytes>)>,
+    file: std::fs::File,
+) -> std::result::Result<OwnedFd, PackFailed> {
+    // Everything fallible happens against borrows, so a failure anywhere leaves
+    // the caller holding exactly what it passed in. Ownership moves only after
+    // the last of it has succeeded, which is the instant the crossing becomes
+    // certain.
+    match write_blob(blob, &listener, &sessions, file) {
+        Ok(fd) => {
+            // Committed. From here the descriptors belong to the next image, so
+            // they must not be closed by this one.
+            let _ = listener.into_raw_fd();
+            for (_, master, _) in sessions {
+                let _ = master.into_raw_fd();
+            }
+            Ok(fd)
+        }
+        Err(error) => Err(PackFailed {
+            error,
+            listener,
+            sessions,
+        }),
+    }
+}
+
+/// Writes the header and every replay ring into `file`, and hands back its
+/// descriptor rewound and exec-safe. Borrows throughout: see [`pack`].
+/// Fault injection for the one path that cannot be reached any other way.
+///
+/// The claim this whole rollback exists to make — that a blob write failing
+/// after `carry_all` costs nothing — is only true if it has been watched
+/// happening. A real ENOSPC cannot be arranged inside a test, and the failure
+/// is the difference between an upgrade that aborts and one that kills every
+/// session on the box, so it is worth a gate to reach. Read once, from the
+/// environment of the daemon under test.
+const FAIL_AFTER_CARRY: &str = "TERMIOD_HANDOFF_FAIL_AFTER_CARRY";
+
+fn write_blob(
+    mut blob: Blob,
+    listener: &OwnedFd,
+    sessions: &[(CarriedSession, OwnedFd, Vec<Bytes>)],
     mut file: std::fs::File,
 ) -> Result<OwnedFd> {
-    // The descriptors stay owned for the whole of this function. Their numbers
-    // are stable while they are held — that is what a descriptor number is —
-    // so the header can name them without anything giving up ownership, and a
-    // failure anywhere below drops the lot: every master closes, every carried
-    // program is hung up, and nothing is left half-committed. Ownership is
-    // released only after the last fallible step has succeeded, which is the
-    // point at which the crossing is going to happen.
+    if std::env::var_os(FAIL_AFTER_CARRY).is_some() {
+        bail!("{FAIL_AFTER_CARRY} is set");
+    }
     set_inheritable(listener.as_raw_fd())?;
     blob.listener_fd = listener.as_raw_fd();
-    let mut masters = Vec::with_capacity(sessions.len());
-    let mut rings = Vec::with_capacity(sessions.len());
-    for (mut info, master, ring) in sessions {
+    for (info, master, _) in sessions {
         set_inheritable(master.as_raw_fd())?;
+        let mut info = info.clone();
+        // A descriptor number is stable while something owns it, and these are
+        // owned by the caller for the whole of this function — so the header
+        // can name them without anything giving up ownership.
         info.master_fd = master.as_raw_fd();
-        masters.push(master);
-        rings.push(ring);
         blob.sessions.push(info);
     }
 
@@ -337,7 +399,7 @@ pub fn pack(
     file.write_all(MAGIC)?;
     file.write_all(&(header.len() as u32).to_le_bytes())?;
     file.write_all(&header)?;
-    for ring in &rings {
+    for (_, _, ring) in sessions {
         for chunk in ring {
             file.write_all(chunk)?;
         }
@@ -351,12 +413,6 @@ pub fn pack(
     file.seek(SeekFrom::Start(0))?;
     let fd = unsafe { OwnedFd::from_raw_fd(file.into_raw_fd()) };
     set_inheritable(fd.as_raw_fd())?;
-
-    // Committed. From here the descriptors belong to the next image.
-    let _ = listener.into_raw_fd();
-    for master in masters {
-        let _ = master.into_raw_fd();
-    }
     Ok(fd)
 }
 

--- a/termiod/src/handoff.rs
+++ b/termiod/src/handoff.rs
@@ -1,0 +1,348 @@
+//! Replacing the daemon's binary without replacing the daemon.
+//!
+//! Every other way of upgrading the host ends with the sessions dead, and not
+//! by oversight. A PTY's master is a descriptor held by this process; when this
+//! process goes the descriptor closes, the slave side raises `SIGHUP`, and the
+//! agent that was mid-task goes with it. Writing state down does not help — a
+//! file can describe a session but cannot hold a running process.
+//!
+//! `execve` is the exception. It replaces the process *image* while keeping the
+//! *process*: same pid, same children, same open descriptors (anything without
+//! `FD_CLOEXEC`), same session and process group. So the PTY masters stay open,
+//! the shells never see a hangup, and the only thing that changes is which code
+//! is on the other end of the descriptor. This is what makes "detach ≠ kill"
+//! survive an upgrade rather than only a disconnect: the lifecycle loop can
+//! stop asking the user to close their work before a new build goes on.
+//!
+//! What it costs is that nothing in memory survives. Tasks, the session table,
+//! the replay rings, the client connections: gone the instant `execve` succeeds.
+//! Whatever the new image needs, this one has to write down first and pass along
+//! by descriptor number. That is what a [`Blob`] is.
+//!
+//! The blob is written to a file that is unlinked before a byte goes into it,
+//! so it has no name for anything to open and the kernel frees it when the last
+//! descriptor closes. That matters: it holds every session's replay ring, which
+//! is raw terminal output — an agent's transcript, whatever `env` printed, a
+//! token someone echoed. A handoff must not become a way of writing that to
+//! disk behind the user's back.
+//!
+//! Not everything crosses:
+//!
+//! - **Client connections.** A Mac or a phone is holding a socket to us; that
+//!   socket dies with the image. Clients reconnect and re-attach by session id,
+//!   which is the path they already use after any restart — except that this
+//!   time the attach finds the session alive, with its ring and its running
+//!   program.
+//! - **The WebSocket listener.** Re-bound by the new image from the same
+//!   on-disk configuration rather than carried, so its splices end the way a
+//!   dropped tunnel already does.
+//! - **The VT sidecar.** A parser is state in memory, not a descriptor. The new
+//!   image starts a fresh one and replays the carried ring through it, which
+//!   reconstructs the screen from the same bytes that produced it.
+//!
+//! The Unix listener *is* carried, on its own descriptor. Re-binding would mean
+//! unlinking and re-creating the socket, and a client connecting in that window
+//! would find nothing there and autostart a second daemon over a state
+//! directory this one still owns. Carrying it means connects queue in the
+//! kernel's backlog and are served by whichever image is up when they are
+//! accepted.
+
+use anyhow::{bail, Context, Result};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use std::path::{Path, PathBuf};
+
+/// The flag that tells a starting daemon it is the far side of a handoff. Its
+/// value is the descriptor number the blob can be read from.
+pub const HANDOFF_FLAG: &str = "--handoff";
+
+const MAGIC: &[u8; 8] = b"TERMIOD\x01";
+
+/// How long the daemon waits for a session actor to hand its PTY over. A
+/// session that misses this is left behind rather than holding the upgrade
+/// open, and is named in the daemon's log on the way out.
+pub const CARRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// One session, packed for the crossing. The descriptor numbers are meaningless
+/// to anything but the process that wrote them, which is the same process that
+/// reads them back — that is the whole point of the exec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CarriedSession {
+    pub id: String,
+    pub name: String,
+    pub cwd: String,
+    pub command: String,
+    pub pid: i32,
+    pub rows: u16,
+    pub cols: u16,
+    pub created_unix: u64,
+    pub status: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub workstream: Option<crate::protocol::WorkstreamSpec>,
+    /// The PTY master, as a descriptor number in the process about to `execve`.
+    pub master_fd: RawFd,
+    /// How many bytes of replay ring follow this session's header in the blob.
+    pub ring_len: u64,
+}
+
+/// The header the new image reads before it has any state of its own. Ring
+/// bytes follow it, one run per session in `sessions` order.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Blob {
+    /// The build that packed this. Recorded for the log line the new image
+    /// writes: "0.46.0+1201 handed off to 0.47.0+1240" is the one fact that
+    /// makes an upgrade legible after the fact.
+    pub from_build: String,
+    /// The already-bound Unix listener. See the module docs for why this is
+    /// carried rather than re-bound.
+    pub listener_fd: RawFd,
+    pub sessions: Vec<CarriedSession>,
+}
+
+/// Whether `binary` can be handed off to at all, checked *before* the running
+/// daemon takes a single session apart.
+///
+/// The order matters more than the checks do. Once the session actors have
+/// given up their PTYs there is no way back: the actors are gone, the rings are
+/// in a blob, and the only paths left are `execve` or death. So everything that
+/// can say no says it here, while the daemon is still whole and the client is
+/// still holding a socket that can carry the refusal.
+///
+/// The last check is the strong one: the candidate is *run*. A binary for the
+/// wrong architecture, or missing an interpreter, or truncated by an upload
+/// that lost its connection, all fail `--version` and all look fine to `stat`.
+pub fn vet(binary: &Path) -> Result<PathBuf> {
+    if !binary.is_absolute() {
+        bail!("{} is not an absolute path", binary.display());
+    }
+    let binary = binary
+        .canonicalize()
+        .with_context(|| format!("resolving {}", binary.display()))?;
+    let metadata =
+        std::fs::metadata(&binary).with_context(|| format!("reading {}", binary.display()))?;
+    if !metadata.is_file() {
+        bail!("{} is not a regular file", binary.display());
+    }
+    let probe = std::process::Command::new(&binary)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .with_context(|| format!("running {} --version", binary.display()))?;
+    if !probe.status.success() {
+        bail!(
+            "{} --version exited {}: {}",
+            binary.display(),
+            probe.status,
+            String::from_utf8_lossy(&probe.stderr).trim()
+        );
+    }
+    if String::from_utf8_lossy(&probe.stdout).trim().is_empty() {
+        bail!("{} --version printed nothing", binary.display());
+    }
+    Ok(binary)
+}
+
+/// Write the blob to an unlinked file and return its descriptor, rewound and
+/// exec-safe.
+pub fn pack(blob: &Blob, rings: &[Vec<Bytes>], state_dir: &Path) -> Result<OwnedFd> {
+    let path = state_dir.join(format!("handoff.{}", std::process::id()));
+    let mut file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    // Before a byte goes in. From here the file has no name: nothing can open
+    // it, and the kernel reclaims it when the last descriptor closes — which,
+    // on the success path, is the new image closing it after the read.
+    std::fs::remove_file(&path).with_context(|| format!("unlinking {}", path.display()))?;
+
+    let header = serde_json::to_vec(blob).context("encoding the handoff header")?;
+    file.write_all(MAGIC)?;
+    file.write_all(&(header.len() as u32).to_le_bytes())?;
+    file.write_all(&header)?;
+    for ring in rings {
+        for chunk in ring {
+            file.write_all(chunk)?;
+        }
+    }
+    file.flush()?;
+    file.seek(SeekFrom::Start(0))?;
+
+    let fd = unsafe { OwnedFd::from_raw_fd(file.into_raw_fd()) };
+    set_inheritable(fd.as_raw_fd())?;
+    Ok(fd)
+}
+
+/// Read back what [`pack`] wrote. Consumes the descriptor: the blob has served
+/// its purpose the moment it is in memory, and leaving it open would keep every
+/// session's terminal output alive in a file for the daemon's whole life.
+pub fn unpack(fd: RawFd) -> Result<(Blob, Vec<Vec<u8>>)> {
+    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+    let mut magic = [0u8; 8];
+    file.read_exact(&mut magic)
+        .context("reading the handoff blob")?;
+    if &magic != MAGIC {
+        bail!("descriptor {fd} does not hold a handoff blob");
+    }
+    let mut length = [0u8; 4];
+    file.read_exact(&mut length)?;
+    let mut header = vec![0u8; u32::from_le_bytes(length) as usize];
+    file.read_exact(&mut header)?;
+    let blob: Blob = serde_json::from_slice(&header).context("decoding the handoff header")?;
+
+    let mut rings = Vec::with_capacity(blob.sessions.len());
+    for session in &blob.sessions {
+        let mut ring = vec![0u8; session.ring_len as usize];
+        file.read_exact(&mut ring)
+            .with_context(|| format!("reading the replay ring for session {}", session.id))?;
+        rings.push(ring);
+    }
+    Ok((blob, rings))
+}
+
+/// A descriptor the new image will need, duplicated so it outlives whatever
+/// owns the original and cleared for exec.
+///
+/// Duplicating rather than leaking the original is what lets the session actor
+/// be dropped normally on its way out: its `OwnedFd` closes, this copy stays,
+/// and both named the same open file description all along — the same PTY
+/// master, at the same offset, with the same termios.
+pub fn duplicate_for_exec(fd: RawFd) -> Result<RawFd> {
+    let copy = unsafe { libc::dup(fd) };
+    if copy < 0 {
+        bail!(
+            "duplicating descriptor {fd}: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    // `dup` already clears `FD_CLOEXEC` on the copy. Set it anyway: the one
+    // invariant this whole module rests on should not be an inherited default.
+    set_inheritable(copy)?;
+    Ok(copy)
+}
+
+fn set_inheritable(fd: RawFd) -> Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        bail!("F_GETFD on {fd}: {}", std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+        bail!(
+            "clearing FD_CLOEXEC on {fd}: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(())
+}
+
+/// This daemon's own `serve` invocation, with any previous handoff flag taken
+/// out. Re-passing the arguments verbatim is what keeps an explicit `--wss` or
+/// `--wss-origin` in force across an upgrade; stripping the old `--handoff`
+/// keeps the second handoff of a daemon's life from pointing the new image at a
+/// descriptor number that meant something two builds ago.
+pub fn serve_arguments() -> Vec<std::ffi::OsString> {
+    strip_handoff(std::env::args_os().skip(1))
+}
+
+fn strip_handoff(arguments: impl Iterator<Item = std::ffi::OsString>) -> Vec<std::ffi::OsString> {
+    let prefixed = format!("{HANDOFF_FLAG}=");
+    let mut kept = Vec::new();
+    let mut arguments = arguments.peekable();
+    while let Some(argument) = arguments.next() {
+        if argument == HANDOFF_FLAG {
+            let _ = arguments.next();
+            continue;
+        }
+        if argument
+            .to_str()
+            .is_some_and(|text| text.starts_with(&prefixed))
+        {
+            continue;
+        }
+        kept.push(argument);
+    }
+    kept
+}
+
+/// Become `binary`. Returns only on failure — success has no return address.
+///
+/// The caller has already given up every session actor by the time this runs,
+/// so a failure here is not recoverable: the PTYs are held by descriptors this
+/// process still owns but nothing is left that knows how to read them. The
+/// error is for the log and for the exit that follows it.
+pub fn exec(binary: &Path, blob_fd: RawFd) -> anyhow::Error {
+    use std::os::unix::process::CommandExt;
+
+    let mut command = std::process::Command::new(binary);
+    command.args(serve_arguments());
+    command.arg(HANDOFF_FLAG).arg(blob_fd.to_string());
+    let error = command.exec();
+    anyhow::Error::new(error).context(format!("exec {}", binary.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_packed_blob_reads_back_with_its_rings_in_order() {
+        let dir = std::env::temp_dir().join(format!("termiod-handoff-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let blob = Blob {
+            from_build: "0.1.0+1".to_string(),
+            listener_fd: 7,
+            sessions: vec![session("a", 3), session("b", 5)],
+        };
+        let rings = vec![
+            vec![Bytes::from_static(b"abc")],
+            vec![Bytes::from_static(b"de"), Bytes::from_static(b"fgh")],
+        ];
+        let fd = pack(&blob, &rings, &dir).unwrap();
+        let (read_back, read_rings) = unpack(fd.into_raw_fd()).unwrap();
+        assert_eq!(read_back.listener_fd, 7);
+        assert_eq!(read_back.from_build, "0.1.0+1");
+        assert_eq!(read_rings, vec![b"abc".to_vec(), b"defgh".to_vec()]);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_previous_handoff_flag_never_reaches_the_next_image() {
+        let kept = strip_handoff(
+            ["serve", "--handoff", "9", "--wss", "127.0.0.1:8790"]
+                .into_iter()
+                .map(std::ffi::OsString::from),
+        );
+        assert_eq!(kept, ["serve", "--wss", "127.0.0.1:8790"]);
+        assert_eq!(
+            strip_handoff(
+                ["serve", "--handoff=9"]
+                    .into_iter()
+                    .map(std::ffi::OsString::from)
+            ),
+            ["serve"]
+        );
+    }
+
+    fn session(id: &str, ring_len: u64) -> CarriedSession {
+        CarriedSession {
+            id: id.to_string(),
+            name: id.to_string(),
+            cwd: String::new(),
+            command: "sh".to_string(),
+            pid: 1,
+            rows: 24,
+            cols: 80,
+            created_unix: 0,
+            status: "unknown".to_string(),
+            title: None,
+            workstream: None,
+            master_fd: 10,
+            ring_len,
+        }
+    }
+}

--- a/termiod/src/handoff.rs
+++ b/termiod/src/handoff.rs
@@ -40,6 +40,26 @@
 //!   image starts a fresh one and replays the carried ring through it, which
 //!   reconstructs the screen from the same bytes that produced it.
 //!
+//! ## What is still not proven
+//!
+//! The probe below asks a candidate whether it implements this contract, and a
+//! candidate that lies passes. Nothing short of running `serve --handoff` for
+//! real would prove otherwise, and running it for real is the thing that cannot
+//! be taken back — by the time a new image could report that it cannot start,
+//! the old one no longer exists to hear it.
+//!
+//! So the residual risk is stated rather than hidden: **a binary that answers
+//! the probe correctly and then fails to start takes every session with it.**
+//! What the probe does close is the case that actually happens — a termiod old
+//! enough to answer `--version` and too old to know this verb — and what keeps
+//! the rest small is that the caller with any business asking for a handoff is
+//! `deploy`, handing off to a binary it staged from its own bundle moments
+//! earlier and has just seen answer `status`.
+//!
+//! The far side helps where it can: every startup step that a cold start is
+//! right to refuse over degrades instead, because on this path refusing means
+//! killing what it was handed. See `daemon::serve`.
+//!
 //! The Unix listener *is* carried, on its own descriptor. Re-binding would mean
 //! unlinking and re-creating the socket, and a client connecting in that window
 //! would find nothing there and autostart a second daemon over a state
@@ -179,21 +199,8 @@ pub fn vet(binary: &Path) -> Result<PathBuf> {
     if !metadata.is_file() {
         bail!("{} is not a regular file", binary.display());
     }
-    let probe = std::process::Command::new(&binary)
-        .arg("handoff")
-        .arg("--probe")
-        .stdin(std::process::Stdio::null())
-        .output()
-        .with_context(|| format!("running {} handoff --probe", binary.display()))?;
-    if !probe.status.success() {
-        bail!(
-            "{} does not implement the handoff contract ({} exited {})",
-            binary.display(),
-            "handoff --probe",
-            probe.status
-        );
-    }
-    let spoken = String::from_utf8_lossy(&probe.stdout).trim().to_string();
+    let probe = run_probe(&binary)?;
+    let spoken = probe.trim().to_string();
     let wanted = probe_token();
     if spoken != wanted {
         bail!(
@@ -232,6 +239,70 @@ pub fn stage_blob(state_dir: &Path) -> Result<std::fs::File> {
     Ok(file)
 }
 
+/// How long a candidate binary gets to answer the probe, and how much it may
+/// say. A binary that hangs must not hang the daemon with it: `vet` runs on a
+/// control task, and a handoff that never resolves is a daemon that can no
+/// longer be upgraded — by anyone, ever, until it is stopped.
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const PROBE_MAX_OUTPUT: u64 = 4 * 1024;
+
+/// Ask a candidate what handoff contract it speaks, without letting it decide
+/// how long that takes or how much it costs.
+///
+/// The process is waited on *before* its output is read, which is the only
+/// order that bounds anything. Reading first looks natural and is a trap: a
+/// child that never writes and never exits holds its end of the pipe open, the
+/// read blocks in the kernel, and no deadline written after it is ever
+/// evaluated — the daemon's control task waits forever on a program whose whole
+/// contribution was to sleep. Killing the child on the deadline closes that
+/// pipe, which is what makes the read below terminate.
+fn run_probe(binary: &Path) -> Result<String> {
+    use std::io::Read as _;
+
+    let mut child = std::process::Command::new(binary)
+        .arg("handoff")
+        .arg("--probe")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .with_context(|| format!("running {} handoff --probe", binary.display()))?;
+
+    let deadline = std::time::Instant::now() + PROBE_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                bail!(
+                    "{} did not answer handoff --probe within {}s",
+                    binary.display(),
+                    PROBE_TIMEOUT.as_secs()
+                );
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(20)),
+            Err(error) => bail!("waiting for {} handoff --probe: {error}", binary.display()),
+        }
+    };
+
+    let mut spoken = String::new();
+    if let Some(stdout) = child.stdout.take() {
+        // Capped: an answer longer than this is not an answer, and a candidate
+        // does not get to spend the daemon's memory saying it. A child that
+        // wrote more than a pipe holds never exited, so it was killed above and
+        // never reaches here.
+        let _ = stdout.take(PROBE_MAX_OUTPUT).read_to_string(&mut spoken);
+    }
+    if !status.success() {
+        bail!(
+            "{} does not implement the handoff contract (handoff --probe exited {status})",
+            binary.display()
+        );
+    }
+    Ok(spoken)
+}
+
 /// Write the blob into the staged file and return its descriptor, rewound and
 /// exec-safe.
 ///
@@ -239,13 +310,25 @@ pub fn stage_blob(state_dir: &Path) -> Result<std::fs::File> {
 /// the header at the moment it is committed to the blob, and not before.
 pub fn pack(
     mut blob: Blob,
+    listener: OwnedFd,
     sessions: Vec<(CarriedSession, OwnedFd, Vec<Bytes>)>,
     mut file: std::fs::File,
 ) -> Result<OwnedFd> {
+    // The descriptors stay owned for the whole of this function. Their numbers
+    // are stable while they are held — that is what a descriptor number is —
+    // so the header can name them without anything giving up ownership, and a
+    // failure anywhere below drops the lot: every master closes, every carried
+    // program is hung up, and nothing is left half-committed. Ownership is
+    // released only after the last fallible step has succeeded, which is the
+    // point at which the crossing is going to happen.
+    set_inheritable(listener.as_raw_fd())?;
+    blob.listener_fd = listener.as_raw_fd();
+    let mut masters = Vec::with_capacity(sessions.len());
     let mut rings = Vec::with_capacity(sessions.len());
     for (mut info, master, ring) in sessions {
-        info.master_fd = master.into_raw_fd();
-        set_inheritable(info.master_fd)?;
+        set_inheritable(master.as_raw_fd())?;
+        info.master_fd = master.as_raw_fd();
+        masters.push(master);
         rings.push(ring);
         blob.sessions.push(info);
     }
@@ -260,10 +343,20 @@ pub fn pack(
         }
     }
     file.flush()?;
+    // The bytes have to be on the file, not in this process's buffers: the
+    // reader is a different program image and shares nothing with this one but
+    // the descriptor.
+    file.sync_data()
+        .context("flushing the handoff blob to disk")?;
     file.seek(SeekFrom::Start(0))?;
-
     let fd = unsafe { OwnedFd::from_raw_fd(file.into_raw_fd()) };
     set_inheritable(fd.as_raw_fd())?;
+
+    // Committed. From here the descriptors belong to the next image.
+    let _ = listener.into_raw_fd();
+    for master in masters {
+        let _ = master.into_raw_fd();
+    }
     Ok(fd)
 }
 
@@ -392,7 +485,7 @@ mod tests {
             format: FORMAT_VERSION,
             from_build: "0.1.0+1".to_string(),
             host_id: "h_1".to_string(),
-            listener_fd: 7,
+            listener_fd: -1,
             sessions: Vec::new(),
         };
         // Two descriptors that are not ptys but are perfectly good stand-ins
@@ -406,9 +499,12 @@ mod tests {
             ),
         ];
         let file = stage_blob(&dir).unwrap();
-        let fd = pack(blob, sessions, file).unwrap();
+        let listener = devnull();
+        let listener_number = listener.as_raw_fd();
+        let fd = pack(blob, listener, sessions, file).unwrap();
         let (read_back, read_rings) = unpack(fd.into_raw_fd()).unwrap();
-        assert_eq!(read_back.listener_fd, 7);
+        assert_eq!(read_back.listener_fd, listener_number);
+        unsafe { libc::close(read_back.listener_fd) };
         assert_eq!(read_back.from_build, "0.1.0+1");
         assert_eq!(read_back.host_id, "h_1");
         assert_eq!(read_rings, vec![b"abc".to_vec(), b"defgh".to_vec()]);

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -543,6 +543,12 @@ pub async fn handoff(binary: Option<PathBuf>) -> Result<HandoffOutcome> {
     let binary = binary
         .canonicalize()
         .with_context(|| format!("resolving {}", binary.display()))?;
+    // What the daemon should be afterwards is the version of the binary it is
+    // becoming, which is only this build when the default was taken. An
+    // explicit `--binary` naming an older compatible build is a legitimate
+    // request — a rollback — and checking it against this CLI's own stamp would
+    // report a handoff that worked as one that failed.
+    let (want, want_text) = binary_version(&binary);
 
     let socket = paths::socket_path()?;
     let Some(mut stream) = connect_existing(&socket).await else {
@@ -607,7 +613,6 @@ pub async fn handoff(binary: Option<PathBuf>) -> Result<HandoffOutcome> {
     };
     drop(stream);
 
-    let want = Version::parse(BUILD_VERSION);
     let deadline = Instant::now() + SETTLE;
     let mut last = None;
     while Instant::now() < deadline {
@@ -644,22 +649,49 @@ pub async fn handoff(binary: Option<PathBuf>) -> Result<HandoffOutcome> {
             .await
             .map(|list| list.len())
             .unwrap_or(0);
+        let to = hello.version;
         return Ok(HandoffOutcome {
             pid: now_pid,
             from: from.clone(),
-            to: hello.version,
+            to: to.clone(),
             sessions: carried,
             message: format!(
                 "pid {} is now termiod {}; {carried} of {sessions} session(s) carried",
                 now_pid.map(|value| value.to_string()).unwrap_or_else(|| "?".to_string()),
-                BUILD_VERSION
+                to.as_deref().unwrap_or("an unnamed build")
             ),
         });
     }
     bail!(
-        "the daemon did not come back as {BUILD_VERSION} within {}s (last seen: {})",
+        "the daemon did not come back as {} within {}s (last seen: {})",
+        want_text.as_deref().unwrap_or("the requested build"),
         SETTLE.as_secs(),
         last.as_deref().unwrap_or("nothing answering")
+    )
+}
+
+/// The build stamp a candidate binary reports — parsed, and as it printed it.
+///
+/// `None` is not a failure: it means the version check is skipped and the
+/// handoff is judged on the pid and the reconnect alone. Refusing to hand off
+/// to a binary whose `--version` this build cannot parse would be refusing on
+/// the strength of a string.
+fn binary_version(binary: &Path) -> (Option<Version>, Option<String>) {
+    let Ok(output) = std::process::Command::new(binary)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .output()
+    else {
+        return (None, None);
+    };
+    let printed = String::from_utf8_lossy(&output.stdout);
+    let stamp = printed
+        .split_whitespace()
+        .find(|word| Version::parse(word).is_some())
+        .map(str::to_string);
+    (
+        stamp.as_deref().and_then(Version::parse),
+        stamp,
     )
 }
 

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -600,15 +600,25 @@ pub async fn handoff(binary: Option<PathBuf>) -> Result<HandoffOutcome> {
             Some(_) => bail!("the daemon answered handoff with something else"),
             None => bail!("the daemon closed the connection without answering handoff"),
         }
-        // This connection dies with the image, so its EOF *is* the exec. Waiting
-        // for it is what makes the check below meaningful: without it the very
-        // next handshake can be answered by the old daemon, still up, still
-        // reporting a version — which on a same-build handoff is indistinguishable
-        // from success.
-        let _ = tokio::time::timeout(SETTLE, async {
+        // This connection dies with the image, so its EOF *is* the exec. That
+        // makes it the only honest signal a client has: an `ok` here means the
+        // request was accepted, not that anything happened, and a handoff that
+        // aborts leaves this connection open and serving. Waiting was already
+        // right; throwing the answer away was not. On a same-build handoff the
+        // version cannot tell the two apart, so without this the CLI reported an
+        // aborted upgrade as a completed one.
+        let crossed = tokio::time::timeout(SETTLE, async {
             while let Ok(Some(_)) = read_frame(&mut reader).await {}
         })
-        .await;
+        .await
+        .is_ok();
+        if !crossed {
+            bail!(
+                "the daemon accepted the handoff but is still answering on the \
+                 connection that asked for it, so the exec never happened — the \
+                 sessions are untouched; its log says why"
+            );
+        }
         (hello.version, sessions.len())
     };
     drop(stream);

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -83,11 +83,29 @@ pub struct DaemonHello {
     /// reports one, which is how the loop reads it.
     pub version: Option<String>,
     pub host_id: String,
+    /// What the daemon can do, from its own `hello_ok`. Read for one thing: a
+    /// daemon that does not list `handoff` has to be stopped to be upgraded,
+    /// and the loop needs to know that before it takes the destructive path.
+    pub caps: Vec<String>,
 }
 
 /// `hello` as a control channel with no capabilities, returning the daemon's
 /// self-description. Works against every daemon that speaks protocol v1.
 pub async fn handshake<R, W>(reader: &mut R, writer: &mut W) -> Result<DaemonHello>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    handshake_asking(reader, writer, Vec::new()).await
+}
+
+/// `handshake`, negotiating capabilities. A verb the daemon gates on one — as
+/// `handoff` is — is refused unless it was asked for here.
+pub async fn handshake_asking<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    ask: Vec<String>,
+) -> Result<DaemonHello>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
@@ -98,17 +116,21 @@ where
             proto: PROTOCOL_VERSION,
             min_proto: PROTOCOL_VERSION,
             role: ChannelRole::Control,
-            caps: Vec::new(),
+            caps: ask,
             client: format!("termiod-cli/{BUILD_VERSION}"),
         },
     )
     .await?;
     match read_frame(reader).await? {
         Some(Frame::Control(Control::HelloOk {
-            version, host_id, ..
+            version,
+            host_id,
+            caps,
+            ..
         })) => Ok(DaemonHello {
             version: version.filter(|value| !value.is_empty()),
             host_id,
+            caps,
         }),
         Some(Frame::Control(Control::HelloErr { supported, .. })) => bail!(
             "the daemon speaks protocol {supported:?}; this binary speaks {PROTOCOL_VERSION}"
@@ -491,6 +513,167 @@ pub async fn stop(force: bool) -> Result<StopOutcome> {
     }
 }
 
+// MARK: Node side — `termiod handoff`
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandoffOutcome {
+    /// The daemon's pid. Unchanged across a handoff — that is the claim, and
+    /// printing it is what lets a human check it.
+    pub pid: Option<i32>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub sessions: usize,
+    pub message: String,
+}
+
+/// The capability a daemon must advertise before it can be asked to hand off.
+pub const HANDOFF_CAPABILITY: &str = "handoff";
+
+/// Ask the daemon on the canonical socket to become `binary`.
+///
+/// Defaults to this executable, which is the shape a control plane wants: stage
+/// the new build over the old path, then run the new build's own `handoff`. The
+/// daemon vets the path before it takes a single session apart, so a refusal
+/// here costs nothing.
+pub async fn handoff(binary: Option<PathBuf>) -> Result<HandoffOutcome> {
+    let binary = match binary {
+        Some(path) => path,
+        None => std::env::current_exe().context("resolving this executable")?,
+    };
+    let binary = binary
+        .canonicalize()
+        .with_context(|| format!("resolving {}", binary.display()))?;
+
+    let socket = paths::socket_path()?;
+    let Some(mut stream) = connect_existing(&socket).await else {
+        return Ok(HandoffOutcome {
+            pid: None,
+            from: None,
+            to: None,
+            sessions: 0,
+            message: "no daemon is running; the next client to connect starts this build"
+                .to_string(),
+        });
+    };
+    let pid = peer_pid(&stream);
+
+    let (from, sessions) = {
+        let (mut reader, mut writer) = stream.split();
+        let hello = tokio::time::timeout(
+            Duration::from_secs(5),
+            handshake_asking(
+                &mut reader,
+                &mut writer,
+                vec![HANDOFF_CAPABILITY.to_string()],
+            ),
+        )
+        .await
+        .context("the daemon did not answer hello in time")?
+        .context("asking the daemon what it is")?;
+        if !hello.caps.iter().any(|cap| cap == HANDOFF_CAPABILITY) {
+            bail!(
+                "the daemon running here ({}) cannot replace its own binary; stop it to upgrade",
+                hello.version.as_deref().unwrap_or("no version")
+            );
+        }
+        let sessions = list_sessions(&mut reader, &mut writer).await.unwrap_or_default();
+        write_control(
+            &mut writer,
+            &Control::Handoff {
+                binary: binary.display().to_string(),
+                seq: Some(1),
+            },
+        )
+        .await?;
+        // The reply says the daemon accepted, not that it finished: the exec
+        // follows it and takes this connection with it. Anything after this is
+        // read from the *new* image, over a new connection.
+        match read_frame(&mut reader).await? {
+            Some(Frame::Control(Control::Ok { .. })) => {}
+            Some(Frame::Control(Control::Error { message, .. })) => bail!(message),
+            Some(_) => bail!("the daemon answered handoff with something else"),
+            None => bail!("the daemon closed the connection without answering handoff"),
+        }
+        // This connection dies with the image, so its EOF *is* the exec. Waiting
+        // for it is what makes the check below meaningful: without it the very
+        // next handshake can be answered by the old daemon, still up, still
+        // reporting a version — which on a same-build handoff is indistinguishable
+        // from success.
+        let _ = tokio::time::timeout(SETTLE, async {
+            while let Ok(Some(_)) = read_frame(&mut reader).await {}
+        })
+        .await;
+        (hello.version, sessions.len())
+    };
+    drop(stream);
+
+    let want = Version::parse(BUILD_VERSION);
+    let deadline = Instant::now() + SETTLE;
+    let mut last = None;
+    while Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let Some(mut stream) = connect_existing(&socket).await else {
+            continue;
+        };
+        let now_pid = peer_pid(&stream);
+        let (mut reader, mut writer) = stream.split();
+        let Ok(Ok(hello)) = tokio::time::timeout(
+            Duration::from_secs(5),
+            handshake(&mut reader, &mut writer),
+        )
+        .await
+        else {
+            continue;
+        };
+        let reported = hello.version.as_deref().and_then(Version::parse);
+        if want.is_some() && reported < want {
+            last = hello.version;
+            continue;
+        }
+        // A different pid means the daemon was replaced rather than rebuilt:
+        // something stopped it and something else autostarted. The sessions did
+        // not survive that, so it must not be reported as a handoff.
+        if pid.is_some() && now_pid != pid {
+            bail!(
+                "the daemon answering now is pid {} where the handoff started at pid {} — it was restarted, not handed off",
+                now_pid.map(|value| value.to_string()).unwrap_or_else(|| "?".to_string()),
+                pid.map(|value| value.to_string()).unwrap_or_else(|| "?".to_string())
+            );
+        }
+        let carried = list_sessions(&mut reader, &mut writer)
+            .await
+            .map(|list| list.len())
+            .unwrap_or(0);
+        return Ok(HandoffOutcome {
+            pid: now_pid,
+            from: from.clone(),
+            to: hello.version,
+            sessions: carried,
+            message: format!(
+                "pid {} is now termiod {}; {carried} of {sessions} session(s) carried",
+                now_pid.map(|value| value.to_string()).unwrap_or_else(|| "?".to_string()),
+                BUILD_VERSION
+            ),
+        });
+    }
+    bail!(
+        "the daemon did not come back as {BUILD_VERSION} within {}s (last seen: {})",
+        SETTLE.as_secs(),
+        last.as_deref().unwrap_or("nothing answering")
+    )
+}
+
+/// `termiod handoff` — the CLI around [`handoff`].
+pub async fn run_handoff(json: bool, binary: Option<PathBuf>) -> Result<()> {
+    let outcome = handoff(binary).await?;
+    if json {
+        println!("{}", serde_json::to_string(&outcome)?);
+    } else {
+        println!("{}", outcome.message);
+    }
+    Ok(())
+}
+
 // MARK: Control-plane side — the loop
 
 /// What one command on a node produced. `Err` from [`Node::run`] is reserved
@@ -715,25 +898,40 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             .and_then(Version::parse)
             .map_or(true, |have| have < want);
     if daemon_is_stale {
-        eprintln!("[deploy] asking the daemon on {label} to stop…");
-        let command = format!(
-            "{} stop --json{}",
-            node.binary(),
-            if options.force { " --force" } else { "" }
-        );
-        let run = node.run(&command).await?;
-        match run.code {
-            0 => {}
-            EXIT_BUSY => {
-                let outcome: StopOutcome = serde_json::from_str(run.stdout.trim())
-                    .context("reading the daemon's answer to stop")?;
-                return Ok(Outcome::Staged {
-                    version: status.binary.version,
-                    daemon: status.daemon.version,
-                    busy: outcome.busy,
-                });
+        // Handoff first, always. It is not an optimisation over stopping: it is
+        // the difference between an upgrade the user pays for in lost work and
+        // one they do not notice. Stopping stays as the fallback for a daemon
+        // too old to replace its own image, and as what `--force` reaches for
+        // when the handoff itself fails.
+        eprintln!("[deploy] asking the daemon on {label} to take on the new binary…");
+        let handoff = node.run(&format!("{} handoff --json", node.binary())).await?;
+        if handoff.code == 0 {
+            eprintln!("[deploy] {}", handoff_line(&handoff.stdout));
+        } else {
+            eprintln!(
+                "[deploy] {label} could not hand off ({}); stopping it instead",
+                last_line(&handoff.stderr)
+            );
+            eprintln!("[deploy] asking the daemon on {label} to stop…");
+            let command = format!(
+                "{} stop --json{}",
+                node.binary(),
+                if options.force { " --force" } else { "" }
+            );
+            let run = node.run(&command).await?;
+            match run.code {
+                0 => {}
+                EXIT_BUSY => {
+                    let outcome: StopOutcome = serde_json::from_str(run.stdout.trim())
+                        .context("reading the daemon's answer to stop")?;
+                    return Ok(Outcome::Staged {
+                        version: status.binary.version,
+                        daemon: status.daemon.version,
+                        busy: outcome.busy,
+                    });
+                }
+                _ => bail!("stopping termiod on {label}: {}", last_line(&run.stderr)),
             }
-            _ => bail!("stopping termiod on {label}: {}", last_line(&run.stderr)),
         }
     }
 
@@ -853,6 +1051,14 @@ async fn roll_back<N: Node>(node: &N) -> Result<()> {
         bail!("no previous binary to roll back to on {}", node.label());
     }
     Ok(())
+}
+
+/// The one line worth showing from a `handoff --json` reply, falling back to
+/// the raw output when the node answered with something this build cannot read.
+fn handoff_line(stdout: &str) -> String {
+    serde_json::from_str::<HandoffOutcome>(stdout.trim())
+        .map(|outcome| outcome.message)
+        .unwrap_or_else(|_| last_line(stdout))
 }
 
 fn last_line(text: &str) -> String {
@@ -1073,7 +1279,25 @@ mod tests {
         Ok(DaemonHello {
             version: version.map(str::to_string),
             host_id: "h_1".to_string(),
+            caps: vec![HANDOFF_CAPABILITY.to_string()],
         })
+    }
+
+    /// What a daemon that can replace its own image answers `handoff --json`.
+    fn handed_off(sessions: usize) -> Run {
+        ok(&serde_json::to_string(&HandoffOutcome {
+            pid: Some(4242),
+            from: Some("0.43.0+1500".to_string()),
+            to: Some(WANT.to_string()),
+            sessions,
+            message: format!("pid 4242 is now termiod {WANT}; {sessions} of {sessions} session(s) carried"),
+        })
+        .unwrap())
+    }
+
+    /// What a daemon too old to know the verb answers.
+    fn cannot_hand_off() -> Run {
+        failed(2, "error: unrecognized subcommand 'handoff'")
     }
 
     const WANT: &str = "0.44.0+1600";
@@ -1106,7 +1330,8 @@ mod tests {
                 failed(2, "error: unrecognized subcommand 'status'"),
                 ok(""),
                 ok(&status_json(WANT, None, true)), // old daemon: running, no version
-                ok(""),                            // stop
+                cannot_hand_off(),
+                ok(""), // stop
             ],
             vec![hello(Some(WANT))],
         );
@@ -1114,7 +1339,46 @@ mod tests {
         assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
         let commands = node.commands.borrow();
         assert!(commands[1].contains("termiod.prev"), "{}", commands[1]);
-        assert!(commands[3].ends_with("stop --json"), "{}", commands[3]);
+        assert!(commands[3].ends_with("handoff --json"), "{}", commands[3]);
+        assert!(commands[4].ends_with("stop --json"), "{}", commands[4]);
+    }
+
+    /// The whole point: a daemon that can take on the new binary is never
+    /// stopped, so the sessions running under it are never asked about.
+    #[tokio::test]
+    async fn a_daemon_that_can_hand_off_is_never_stopped() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                ok(""), // chmod + mv
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                handed_off(3),
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+        let commands = node.commands.borrow();
+        assert!(commands.iter().any(|command| command.ends_with("handoff --json")), "{commands:?}");
+        assert!(!commands.iter().any(|command| command.contains(" stop")), "{commands:?}");
+    }
+
+    /// A daemon busy enough to refuse a stop is upgraded anyway when it can
+    /// hand off — the state that used to leave a box permanently staged.
+    #[tokio::test]
+    async fn a_busy_daemon_is_upgraded_by_handing_off() {
+        let node = FakeNode::new(
+            vec![
+                ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
+                ok(""),
+                ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                handed_off(1),
+            ],
+            vec![hello(Some(WANT))],
+        );
+        let report = reconcile(&node, WANT, Options::default()).await;
+        assert!(matches!(report.outcome, Outcome::Current { .. }), "{report:?}");
+        assert_eq!(report.exit_code(), 0);
     }
 
     /// The daemon declining to stop is a named state with the sessions in it,
@@ -1140,6 +1404,7 @@ mod tests {
                 ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
                 ok(""),
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                cannot_hand_off(),
                 Run {
                     code: EXIT_BUSY,
                     stdout: serde_json::to_string(&busy).unwrap(),
@@ -1168,6 +1433,7 @@ mod tests {
                 ok(&status_json("0.43.0+1500", Some("0.43.0+1500"), true)),
                 ok(""),
                 ok(&status_json(WANT, Some("0.43.0+1500"), true)),
+                cannot_hand_off(),
                 ok(""), // stop
                 ok(""), // roll back: stop --force
                 ok(""), // roll back: mv prev

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -131,6 +131,14 @@ enum Cmd {
         /// Hand off to this binary instead of the one running this command.
         #[arg(long, value_name = "PATH")]
         binary: Option<std::path::PathBuf>,
+        /// Print the handoff contract this build speaks and exit.
+        ///
+        /// How a running daemon decides whether a candidate binary can be
+        /// exec'd in its place. Hidden because it is a machine's question: it
+        /// is asked of the *new* binary, by the *old* daemon, before it takes
+        /// itself apart.
+        #[arg(long, hide = true)]
+        probe: bool,
     },
 
     /// Create a new session and print its id.
@@ -487,7 +495,18 @@ async fn main() -> Result<()> {
             handoff_fd,
         } => daemon::serve(wss, wss_origin, handoff_fd).await,
 
-        Cmd::Handoff { json, binary } => lifecycle::run_handoff(json, binary).await,
+        Cmd::Handoff {
+            json,
+            binary,
+            probe,
+        } => {
+            if probe {
+                println!("{}", handoff::probe_token());
+                Ok(())
+            } else {
+                lifecycle::run_handoff(json, binary).await
+            }
+        }
 
         Cmd::Pair {
             json,

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -12,6 +12,7 @@ mod client;
 mod daemon;
 mod files;
 mod git;
+mod handoff;
 mod id;
 mod lifecycle;
 mod log;
@@ -80,6 +81,15 @@ enum Cmd {
         /// compares the page's Origin against a loopback Host and refuses.
         #[arg(long, value_name = "URL", value_parser = wss::parse_origin, value_delimiter = ',')]
         wss_origin: Vec<wss::Origin>,
+
+        /// Adopt the sessions on this descriptor instead of starting empty.
+        ///
+        /// Set by a daemon replacing its own image (`termiod handoff`) and by
+        /// nothing else: the number means something only inside the process
+        /// that wrote it, which is the same process, on the far side of an
+        /// `execve`.
+        #[arg(long = "handoff", value_name = "FD", hide = true)]
+        handoff_fd: Option<std::os::fd::RawFd>,
     },
 
     /// Print the pairing token that lets a phone or a browser attach.
@@ -103,6 +113,24 @@ enum Cmd {
         /// `--wss-origin` — a tunnel, or a proxy mounted under a path.
         #[arg(long, value_name = "URL")]
         url: Option<String>,
+    },
+
+    /// Replace the running daemon's binary without stopping it.
+    ///
+    /// The host `execve`s the new binary, keeping its pid, its children and
+    /// every PTY, so nothing running in a session notices. This is what makes
+    /// upgrading a box with work in progress free rather than destructive.
+    ///
+    /// The binary handed over to is this executable, which is what makes
+    /// `termiod handoff` the right thing for a control plane to run right after
+    /// staging a new build.
+    Handoff {
+        /// Emit the result as JSON — pid, version, sessions.
+        #[arg(long)]
+        json: bool,
+        /// Hand off to this binary instead of the one running this command.
+        #[arg(long, value_name = "PATH")]
+        binary: Option<std::path::PathBuf>,
     },
 
     /// Create a new session and print its id.
@@ -453,7 +481,13 @@ async fn main() -> Result<()> {
             lines,
         } => log::show(path, follow, lines).await,
 
-        Cmd::Serve { wss, wss_origin } => daemon::serve(wss, wss_origin).await,
+        Cmd::Serve {
+            wss,
+            wss_origin,
+            handoff_fd,
+        } => daemon::serve(wss, wss_origin, handoff_fd).await,
+
+        Cmd::Handoff { json, binary } => lifecycle::run_handoff(json, binary).await,
 
         Cmd::Pair {
             json,

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -39,6 +39,7 @@ pub const HOST_CAPABILITIES: &[&str] = &[
     "upload",
     "git",
     "agents",
+    "handoff",
 ];
 /// Snapshot payload carrying packed cells.
 ///
@@ -690,6 +691,26 @@ pub enum Control {
         root: String,
         query: String,
         limit: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seq: Option<u64>,
+    },
+    /// Replace the daemon's own binary without stopping it (capability
+    /// `handoff`). The host `execve`s `binary`, keeping its pid, its children
+    /// and every PTY master, so no session is lost to the upgrade.
+    ///
+    /// `binary` is the path the *client* wants the host to become, absolute and
+    /// on the host's own filesystem — normally the client's own executable,
+    /// because the thing that asks for a handoff is the new build that was just
+    /// staged there. The socket is owner-only, and anyone who can reach it can
+    /// already ask for a session running anything, so naming an executable here
+    /// grants nothing that was not already granted.
+    ///
+    /// The reply is `ok` and it means the host accepted, not that it finished:
+    /// the exec follows it, and it takes the connection with it. A client
+    /// confirms by reconnecting and reading the version at the handshake — with
+    /// the pid unchanged, which is the whole claim.
+    Handoff {
+        binary: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
     },

--- a/termiod/src/pty.rs
+++ b/termiod/src/pty.rs
@@ -432,6 +432,32 @@ impl Pty {
     /// master side is exempt from the "must be your controlling terminal" check
     /// that would otherwise refuse the daemon. `None` when the slave has no
     /// session (the child is gone, or has not exec'd yet).
+    /// Take over a PTY master that crossed an `execve` (see `crate::handoff`).
+    ///
+    /// There is no child to spawn and no `Child` to hand back: the process on
+    /// the far side of this descriptor has been running since before the
+    /// upgrade, and it is still this process's own child — `execve` keeps the
+    /// pid, so the parentage the kernel recorded at `fork` is untouched. What
+    /// is gone is every bit of userspace bookkeeping, which is why the pid
+    /// arrives as a number and is reaped with `waitpid` rather than through
+    /// `std::process::Child`.
+    pub fn adopt(master: RawFd, pid: i32) -> Result<Pty> {
+        let master = unsafe { OwnedFd::from_raw_fd(master) };
+        // Both flags are properties of the *descriptor*, not of the open file
+        // description, so neither survived the duplication that carried it
+        // here. Re-establish the pair `spawn` establishes.
+        set_cloexec(master.as_raw_fd())?;
+        set_nonblocking(master.as_raw_fd())?;
+        let master = AsyncFd::new(master)?;
+        Ok(Pty { master, pid })
+    }
+
+    /// The master descriptor, for the one caller that needs the number rather
+    /// than the I/O: packing this PTY into a handoff blob.
+    pub fn master_fd(&self) -> RawFd {
+        self.master.get_ref().as_raw_fd()
+    }
+
     pub fn foreground_pgid(&self) -> Option<i32> {
         let pgid = unsafe { libc::tcgetpgrp(self.master.get_ref().as_raw_fd()) };
         (pgid > 0).then_some(pgid)

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -2716,6 +2716,119 @@ mod tests {
         (handle, events_rx, on_exit_rx)
     }
 
+    /// A resize invalidates the ring as a source of truth for the screen: the
+    /// bytes already in it were written into a differently shaped grid, and
+    /// replaying them into this one puts them in the wrong places. Nothing in
+    /// this daemon cares — its VT was fed every byte as it arrived — but the far
+    /// side of a handoff has only the ring, and must be told not to trust it.
+    #[tokio::test]
+    async fn a_resize_makes_the_ring_stop_describing_the_screen() {
+        let untouched = attached_session().await;
+        let carried = carry(&untouched.handle).await;
+        assert!(
+            carried.info.ring_reconstructs_screen,
+            "a session nothing has resized should carry a usable ring"
+        );
+
+        let resized = attached_session().await;
+        resized.handle.send(SessionMsg::Resize {
+            id: ClientId::new("writer"),
+            rows: 40,
+            cols: 120,
+        });
+        let carried = carry(&resized.handle).await;
+        assert!(
+            !carried.info.ring_reconstructs_screen,
+            "a resized session must not claim its ring still draws its screen"
+        );
+    }
+
+    /// A session handed over with a ring that cannot draw its screen comes back
+    /// with its VT stale, so snapshots fall back to ring replay instead of the
+    /// host asserting a grid it reconstructed from bytes it was told are wrong.
+    #[tokio::test]
+    async fn an_unfaithful_ring_comes_back_with_a_vt_that_refuses_snapshots() {
+        let session = attached_session().await;
+        session.handle.send(SessionMsg::Resize {
+            id: ClientId::new("writer"),
+            rows: 40,
+            cols: 120,
+        });
+        let mut carried = carry(&session.handle).await;
+        assert!(!carried.info.ring_reconstructs_screen);
+
+        // Adopt it the way a new image would.
+        use std::os::fd::IntoRawFd as _;
+        carried.info.master_fd = carried.master.into_raw_fd();
+        let (on_exit, _on_exit_rx) = mpsc::unbounded_channel();
+        let (events, mut events_rx) = broadcast::channel(64);
+        let adopted = super::adopt(carried.info, Vec::new(), on_exit, events)
+            .expect("adopting the carried session");
+
+        // The adopting actor declares its VT unusable rather than answering
+        // snapshots from a screen it reconstructed out of bytes it was told
+        // are wrong.
+        let stale = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                match events_rx.recv().await {
+                    Ok(Event::VtStale { reason, .. }) => return reason,
+                    Ok(_) => continue,
+                    Err(error) => panic!("event stream ended: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("the adopted session declared its VT stale");
+        assert!(stale.contains("handoff"), "{stale}");
+
+        adopted.send(SessionMsg::Kill {
+            reason: EndReason::Killed,
+        });
+    }
+
+    /// A live session with an interactive client holding the write token.
+    ///
+    /// The client's receiver is held for as long as the session is: dropping it
+    /// closes the channel, the actor removes the client on its next send, and
+    /// the write token goes with it — after which a `Resize` is refused as
+    /// coming from a stranger and the test silently stops testing anything.
+    struct Attached {
+        handle: SessionHandle,
+        _client: mpsc::UnboundedReceiver<ClientEvent>,
+        _events: broadcast::Receiver<Event>,
+        _on_exit: mpsc::UnboundedReceiver<super::SessionEnded>,
+    }
+
+    async fn attached_session() -> Attached {
+        let (handle, events, on_exit) = start_session(vec!["/bin/sh".to_string()], "/");
+        let (client_tx, client_rx) = mpsc::unbounded_channel();
+        let (reply, answer) = oneshot::channel();
+        handle.send(SessionMsg::AddClient {
+            id: ClientId::new("writer"),
+            interactive: true,
+            out: client_tx,
+            backlog: Arc::new(ClientBacklog::new()),
+            snapshot: false,
+            scrollback: false,
+            grid_diff: false,
+            reply,
+        });
+        let granted = answer.await.expect("attached");
+        assert!(granted.writer, "the first interactive client takes the token");
+        Attached {
+            handle,
+            _client: client_rx,
+            _events: events,
+            _on_exit: on_exit,
+        }
+    }
+
+    async fn carry(handle: &SessionHandle) -> super::Carried {
+        let (reply, answer) = oneshot::channel();
+        assert!(handle.send(SessionMsg::Carry { reply }));
+        answer.await.expect("the session handed itself over")
+    }
+
     /// The whole point: a live session can name the program in its terminal,
     /// say where that program is standing, and pin the binary behind it —
     /// against a real child, not a fixture.

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -344,6 +344,19 @@ struct Session {
     next_snapshot_request: u64,
     ring: VecDeque<Bytes>,
     ring_bytes: usize,
+    /// Whether the ring, replayed from its start into a blank terminal of the
+    /// current size, still reconstructs this screen.
+    ///
+    /// It stops being true the moment the ring evicts a chunk (the bytes that
+    /// drew what is still on screen may be the ones dropped) or the session is
+    /// resized (the bytes that remain were written into a differently shaped
+    /// grid, and replaying them into this one lands them elsewhere).
+    ///
+    /// Nothing about *this* daemon reads it: the live VT has been fed every
+    /// byte as it arrived and answers snapshots from what it holds, not from a
+    /// replay. It exists for the far side of a handoff, which has only the ring
+    /// and would otherwise present a confidently wrong screen.
+    ring_reconstructs_screen: bool,
     events: broadcast::Sender<Event>,
     vt: Vt,
     /// Who is in the tty's foreground and where the child is standing.
@@ -417,8 +430,11 @@ impl Session {
     /// and closes normally when this actor drops. Handing out the raw number
     /// instead would leave the new image reading a descriptor the old one had
     /// already closed.
+    ///
+    /// The copy is handed over *owned*, so that a `Carried` nobody takes is a
+    /// session hung up rather than a descriptor orphaned.
     fn into_carried(self) -> anyhow::Result<Carried> {
-        let master_fd = crate::handoff::duplicate_for_exec(self.pty.master_fd())?;
+        let master = crate::handoff::duplicate_for_exec(self.pty.master_fd())?;
         let ring: Vec<Bytes> = self.ring.iter().cloned().collect();
         Ok(Carried {
             info: crate::handoff::CarriedSession {
@@ -433,9 +449,13 @@ impl Session {
                 status: self.status.clone(),
                 title: self.title.clone(),
                 workstream: self.workstream.clone(),
-                master_fd,
+                // Assigned by `handoff::pack`, at the moment this session is
+                // committed to the blob.
+                master_fd: -1,
                 ring_len: self.ring_bytes as u64,
+                ring_reconstructs_screen: self.ring_reconstructs_screen,
             },
+            master,
             ring,
         })
     }
@@ -446,6 +466,7 @@ impl Session {
         while self.ring_bytes > RING_CAP {
             if let Some(evicted) = self.ring.pop_front() {
                 self.ring_bytes -= evicted.len();
+                self.ring_reconstructs_screen = false;
             }
         }
     }
@@ -1133,6 +1154,14 @@ fn daemon_owned_env(id: &SessionId, mut env: Vec<(String, String)>) -> Vec<(Stri
 /// the screen back without asking the program to redraw it.
 pub struct Carried {
     pub info: crate::handoff::CarriedSession,
+    /// The PTY master, **owned**. Its number reaches the blob only when the
+    /// daemon commits this session to the crossing; until then, dropping this
+    /// closes the master and the program in the session is hung up like any
+    /// other loss. That is what a session which misses the carry deadline
+    /// needs to happen — the alternative is a descriptor with no owner and no
+    /// reader surviving the exec, and a process alive inside a session nothing
+    /// can see.
+    pub master: std::os::fd::OwnedFd,
     pub ring: Vec<Bytes>,
 }
 
@@ -1188,7 +1217,7 @@ pub fn spawn(
         },
         pty,
         waiter,
-        Vec::new(),
+        Replay::none(),
         on_exit,
         events,
     )
@@ -1209,10 +1238,13 @@ pub fn adopt(
 ) -> anyhow::Result<SessionHandle> {
     let pty = Pty::adopt(carried.master_fd, carried.pid)?;
     let waiter = reap(carried.pid);
-    let replay = if ring.is_empty() {
-        Vec::new()
-    } else {
-        vec![Bytes::from(ring)]
+    let replay = Replay {
+        chunks: if ring.is_empty() {
+            Vec::new()
+        } else {
+            vec![Bytes::from(ring)]
+        },
+        faithful: carried.ring_reconstructs_screen,
     };
     start(
         Facts {
@@ -1260,6 +1292,25 @@ fn reap(pid: i32) -> tokio::task::JoinHandle<i32> {
     })
 }
 
+/// Output this session has already produced, for an actor that is taking over
+/// rather than starting: the bytes, and whether replaying them still draws the
+/// screen they drew the first time.
+struct Replay {
+    chunks: Vec<Bytes>,
+    /// See `Session::ring_reconstructs_screen`. False means this actor's VT
+    /// must not claim to know what is on the screen.
+    faithful: bool,
+}
+
+impl Replay {
+    fn none() -> Replay {
+        Replay {
+            chunks: Vec::new(),
+            faithful: true,
+        }
+    }
+}
+
 /// What describes a session independently of how this daemon came by it.
 struct Facts {
     id: SessionId,
@@ -1280,7 +1331,7 @@ fn start(
     facts: Facts,
     pty: Pty,
     waiter: tokio::task::JoinHandle<i32>,
-    replay: Vec<Bytes>,
+    replay: Replay,
     on_exit: mpsc::UnboundedSender<SessionEnded>,
     events: broadcast::Sender<Event>,
 ) -> anyhow::Result<SessionHandle> {
@@ -1321,15 +1372,31 @@ fn start(
         next_snapshot_request: 1,
         ring: VecDeque::new(),
         ring_bytes: 0,
+        ring_reconstructs_screen: true,
         events,
         vt: Vt::live(sidecar.commands, sidecar.queue),
         foreground: Foreground::default(),
     };
-    for chunk in replay {
+    for chunk in replay.chunks {
         // Through the same two paths a live byte takes, in the same order: the
         // ring it will be replayed from, and the VT that answers snapshots.
         session.send_sidecar(SidecarCommand::Write(chunk.clone()));
         session.push_ring(chunk);
+    }
+    // `push_ring` may have set this itself, if what was carried no longer fits
+    // the cap; either way the previous actor's verdict still applies.
+    session.ring_reconstructs_screen &= replay.faithful;
+    if !session.ring_reconstructs_screen {
+        // The VT this actor started is blank plus a replay, and the replay does
+        // not draw the screen the program believes it is looking at — output
+        // older than the ring is gone, or was written into a different grid.
+        // Snapshots fall back to ring replay, which is wrong in exactly the
+        // same way but is the client's own terminal being wrong about bytes it
+        // was given, not this host asserting a screen it cannot know. The
+        // program repaints on its next output either way.
+        session.mark_vt_stale(
+            "the output that drew this screen did not survive the handoff".to_string(),
+        );
     }
 
     tokio::spawn(run(
@@ -1833,6 +1900,11 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
                 }
                 session.rows = rows;
                 session.cols = cols;
+                // The bytes already in the ring were written into the old grid.
+                // Replaying them into this one would put them in the wrong
+                // places, which only matters where a replay is all there is —
+                // the far side of a handoff.
+                session.ring_reconstructs_screen = false;
                 session.send_sidecar(SidecarCommand::Resize { rows, cols });
                 session.begin_snapshot_barrier();
                 session.emit_event(Event::Resized {
@@ -2039,6 +2111,7 @@ mod tests {
                 next_snapshot_request: 1,
                 ring: VecDeque::new(),
                 ring_bytes: 0,
+                ring_reconstructs_screen: true,
                 events,
                 vt: Vt::live(sidecar_tx, sidecar_queue),
                 foreground: super::Foreground::default(),
@@ -2546,6 +2619,7 @@ mod tests {
             next_snapshot_request: 1,
             ring: VecDeque::new(),
             ring_bytes: 0,
+            ring_reconstructs_screen: true,
             events,
             vt: Vt::live(sidecar_tx, Arc::new(SidecarQueue::new())),
             foreground: super::Foreground::default(),

--- a/termiod/src/session.rs
+++ b/termiod/src/session.rs
@@ -108,6 +108,13 @@ pub enum SessionMsg {
     Info {
         reply: oneshot::Sender<SessionInfo>,
     },
+    /// The daemon is about to replace its own image and needs this session's
+    /// PTY on a descriptor that survives the `execve`. The actor answers and
+    /// stops — without killing anything, and without a burial: the process in
+    /// there is about to be someone else's to read.
+    Carry {
+        reply: oneshot::Sender<Carried>,
+    },
     Kill {
         reason: EndReason,
     },
@@ -400,6 +407,37 @@ impl Session {
         let request_id = self.next_snapshot_request;
         self.next_snapshot_request = self.next_snapshot_request.wrapping_add(1);
         request_id
+    }
+
+    /// Pack this session for a handoff and give up the actor's claim on it.
+    ///
+    /// The PTY master is *duplicated* rather than surrendered. The copy names
+    /// the same open file description — the same master, the same termios, the
+    /// same foreground process group — while the original stays with the `Pty`
+    /// and closes normally when this actor drops. Handing out the raw number
+    /// instead would leave the new image reading a descriptor the old one had
+    /// already closed.
+    fn into_carried(self) -> anyhow::Result<Carried> {
+        let master_fd = crate::handoff::duplicate_for_exec(self.pty.master_fd())?;
+        let ring: Vec<Bytes> = self.ring.iter().cloned().collect();
+        Ok(Carried {
+            info: crate::handoff::CarriedSession {
+                id: self.id.to_string(),
+                name: self.name.clone(),
+                cwd: self.cwd.clone(),
+                command: self.command.clone(),
+                pid: self.pid,
+                rows: self.rows,
+                cols: self.cols,
+                created_unix: self.created_unix,
+                status: self.status.clone(),
+                title: self.title.clone(),
+                workstream: self.workstream.clone(),
+                master_fd,
+                ring_len: self.ring_bytes as u64,
+            },
+            ring,
+        })
     }
 
     fn push_ring(&mut self, data: Bytes) {
@@ -1089,6 +1127,15 @@ fn daemon_owned_env(id: &SessionId, mut env: Vec<(String, String)>) -> Vec<(Stri
     env
 }
 
+/// Everything a session actor hands over when its daemon is about to `execve`
+/// (see `crate::handoff`): the facts that describe it, the PTY master as a
+/// descriptor the exec can carry, and the replay ring so the new image can put
+/// the screen back without asking the program to redraw it.
+pub struct Carried {
+    pub info: crate::handoff::CarriedSession,
+    pub ring: Vec<Bytes>,
+}
+
 /// Spawn a session task. On process exit the session id is sent to the
 /// manager so it can remove the handle from the table.
 #[allow(clippy::too_many_arguments)]
@@ -1112,12 +1159,133 @@ pub fn spawn(
     };
     let env = daemon_owned_env(&id, env);
     let (pty, child) = Pty::spawn(&argv, cwd_opt, &env, rows, cols)?;
-    let pty = Arc::new(pty);
-    let pid = pty.pid;
     let created_unix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
+    let waiter = tokio::task::spawn_blocking(move || {
+        let mut child = child;
+        match child.wait() {
+            Ok(status) => status.code().unwrap_or_else(|| {
+                use std::os::unix::process::ExitStatusExt;
+                status.signal().map(|s| 128 + s).unwrap_or(-1)
+            }),
+            Err(_) => -1,
+        }
+    });
+    start(
+        Facts {
+            id,
+            name,
+            cwd,
+            command,
+            rows,
+            cols,
+            created_unix,
+            status: "unknown".to_string(),
+            title: None,
+            workstream,
+        },
+        pty,
+        waiter,
+        Vec::new(),
+        on_exit,
+        events,
+    )
+}
+
+/// Take a session back over after a handoff: same PTY, same child, same ring,
+/// a new actor around them.
+///
+/// The screen is rebuilt rather than re-fetched. Feeding the carried ring
+/// through a fresh VT sidecar is exactly what the previous image did with those
+/// same bytes as they arrived, so the snapshot the first re-attaching client
+/// gets is the screen it would have got had nothing happened.
+pub fn adopt(
+    carried: crate::handoff::CarriedSession,
+    ring: Vec<u8>,
+    on_exit: mpsc::UnboundedSender<SessionEnded>,
+    events: broadcast::Sender<Event>,
+) -> anyhow::Result<SessionHandle> {
+    let pty = Pty::adopt(carried.master_fd, carried.pid)?;
+    let waiter = reap(carried.pid);
+    let replay = if ring.is_empty() {
+        Vec::new()
+    } else {
+        vec![Bytes::from(ring)]
+    };
+    start(
+        Facts {
+            id: SessionId::new(carried.id),
+            name: carried.name,
+            cwd: carried.cwd,
+            command: carried.command,
+            rows: carried.rows,
+            cols: carried.cols,
+            created_unix: carried.created_unix,
+            status: carried.status,
+            title: carried.title,
+            workstream: carried.workstream,
+        },
+        pty,
+        waiter,
+        replay,
+        on_exit,
+        events,
+    )
+}
+
+/// Reap a child this process still owns but no longer has a `Child` for — the
+/// shape every carried session is in, because `execve` kept the parentage and
+/// destroyed the bookkeeping.
+fn reap(pid: i32) -> tokio::task::JoinHandle<i32> {
+    tokio::task::spawn_blocking(move || loop {
+        let mut status: libc::c_int = 0;
+        let reaped = unsafe { libc::waitpid(pid, &mut status, 0) };
+        if reaped < 0 {
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return -1;
+        }
+        if libc::WIFEXITED(status) {
+            return libc::WEXITSTATUS(status);
+        }
+        if libc::WIFSIGNALED(status) {
+            return 128 + libc::WTERMSIG(status);
+        }
+        // Stopped or continued. Neither was asked for — no `WUNTRACED`, no
+        // `WCONTINUED` — but a spurious wake is cheaper to loop on than to
+        // reason about.
+    })
+}
+
+/// What describes a session independently of how this daemon came by it.
+struct Facts {
+    id: SessionId,
+    name: String,
+    cwd: String,
+    command: String,
+    rows: u16,
+    cols: u16,
+    created_unix: u64,
+    status: String,
+    title: Option<String>,
+    workstream: Option<WorkstreamSpec>,
+}
+
+/// The half of session startup that a fresh spawn and a carried session share:
+/// the writer task, the VT sidecar, the ring, and the actor around them.
+fn start(
+    facts: Facts,
+    pty: Pty,
+    waiter: tokio::task::JoinHandle<i32>,
+    replay: Vec<Bytes>,
+    on_exit: mpsc::UnboundedSender<SessionEnded>,
+    events: broadcast::Sender<Event>,
+) -> anyhow::Result<SessionHandle> {
+    let pty = Arc::new(pty);
+    let pid = pty.pid;
 
     let (input_tx, mut input_rx) = mpsc::unbounded_channel::<Vec<u8>>();
     let writer_pty = pty.clone();
@@ -1129,22 +1297,22 @@ pub fn spawn(
         }
     });
 
-    let sidecar = spawn_sidecar(rows, cols)?;
+    let sidecar = spawn_sidecar(facts.rows, facts.cols)?;
 
     let (tx, rx) = mpsc::unbounded_channel();
     let termination_reason = Arc::new(Mutex::new(None));
-    let session = Session {
-        id: id.clone(),
-        name,
-        cwd,
-        command,
+    let mut session = Session {
+        id: facts.id.clone(),
+        name: facts.name,
+        cwd: facts.cwd,
+        command: facts.command,
         pid,
-        rows,
-        cols,
-        created_unix,
-        status: "unknown".to_string(),
-        title: None,
-        workstream,
+        rows: facts.rows,
+        cols: facts.cols,
+        created_unix: facts.created_unix,
+        status: facts.status,
+        title: facts.title,
+        workstream: facts.workstream,
         pty,
         input_tx,
         clients: HashMap::new(),
@@ -1157,17 +1325,12 @@ pub fn spawn(
         vt: Vt::live(sidecar.commands, sidecar.queue),
         foreground: Foreground::default(),
     };
-
-    let waiter = tokio::task::spawn_blocking(move || {
-        let mut child = child;
-        match child.wait() {
-            Ok(status) => status.code().unwrap_or_else(|| {
-                use std::os::unix::process::ExitStatusExt;
-                status.signal().map(|s| 128 + s).unwrap_or(-1)
-            }),
-            Err(_) => -1,
-        }
-    });
+    for chunk in replay {
+        // Through the same two paths a live byte takes, in the same order: the
+        // ring it will be replayed from, and the VT that answers snapshots.
+        session.send_sidecar(SidecarCommand::Write(chunk.clone()));
+        session.push_ring(chunk);
+    }
 
     tokio::spawn(run(
         session,
@@ -1179,7 +1342,7 @@ pub fn spawn(
         termination_reason.clone(),
     ));
     Ok(SessionHandle {
-        id,
+        id: facts.id,
         pid,
         tx,
         termination_reason,
@@ -1392,6 +1555,40 @@ async fn run(
             }
             msg = rx.recv() => {
                 let Some(msg) = msg else { break };
+                if let SessionMsg::Carry { reply } = msg {
+                    let session_id = session.id.clone();
+                    // The one exit from this loop that is not an ending. No
+                    // reap, no `on_exit`, no tombstone: the child keeps running
+                    // and the daemon that reads it next is this same process
+                    // with different code in it. Returning here drops the
+                    // `Session` — and with it the original PTY descriptor,
+                    // which is why `into_carried` duplicated one first.
+                    session.send_sidecar(SidecarCommand::Shutdown);
+                    let carried = session.into_carried();
+                    // The parser is a few kilobytes of grid and a thread that
+                    // has already been told to stop; joining it here costs a
+                    // scheduler turn on a runtime that is about to cease to
+                    // exist, and skipping it would leave the thread running
+                    // into the exec.
+                    let _ = tokio::task::spawn_blocking(move || sidecar_thread.join()).await;
+                    match carried {
+                        Ok(carried) => {
+                            let _ = reply.send(carried);
+                            return;
+                        }
+                        Err(error) => {
+                            // The descriptor could not be duplicated, so this
+                            // session cannot cross. Dropping `reply` is what
+                            // tells the daemon so, in time for it to name the
+                            // session in its report rather than lose it
+                            // silently at the exec.
+                            eprintln!(
+                                "termiod: session {session_id} cannot be carried across a handoff: {error:#}"
+                            );
+                            return;
+                        }
+                    }
+                }
                 if let Some(reason) = handle_msg(&mut session, msg) {
                     end_reason = reason;
                     break;
@@ -1674,6 +1871,12 @@ fn handle_msg(session: &mut Session, msg: SessionMsg) -> Option<EndReason> {
         SessionMsg::Info { reply } => {
             let _ = reply.send(session.info());
         }
+        // Intercepted in `run` before it reaches here: handing a session over
+        // ends the actor without ending the session, which is not something a
+        // handler returning `Option<EndReason>` can express. Dropping `reply`
+        // un-answered is the right degradation anyway — the daemon reads a
+        // dropped reply as a session that could not be carried, and names it.
+        SessionMsg::Carry { .. } => {}
         SessionMsg::Kill { reason } => {
             // The child is a session leader, so pgid == pid.
             unsafe {

--- a/termiod/src/tombstone.rs
+++ b/termiod/src/tombstone.rs
@@ -256,6 +256,49 @@ impl Graveyard {
     /// nobody buried — the previous daemon died holding it. Adopting those as
     /// `daemon_lost` here is what turns a crash from a silently empty list into
     /// an explanation.
+    /// A graveyard that records nothing, for the one caller that must not fail:
+    /// a daemon that has just inherited live sessions across an `execve`.
+    ///
+    /// Opening the real one reads and rewrites two files, and on that path a
+    /// failure would end the process — taking with it the PTYs it was handed,
+    /// which are the only things in this system that cannot be recreated. A
+    /// daemon with no tombstone log explains a later loss worse. A daemon that
+    /// exited caused one.
+    pub fn detached() -> Graveyard {
+        Graveyard {
+            graves_path: PathBuf::new(),
+            roster_path: PathBuf::new(),
+            state: Mutex::new(State {
+                graves: Vec::new(),
+                roster: HashMap::new(),
+                buried: HashSet::new(),
+            }),
+        }
+    }
+
+    /// Move a session from the roster to the graves by id, for a caller that
+    /// knows the session is gone but never held its `SessionInfo` — the
+    /// adoption path, where what is known about a session is whatever the
+    /// previous daemon wrote down.
+    pub fn bury_by_id(&self, id: &str, reason: EndReason) {
+        {
+            let mut state = self.state.lock().unwrap();
+            let key = SessionId::new(id.to_string());
+            let Some(entry) = state.roster.remove(&key) else {
+                return;
+            };
+            let grave = entry.into_tombstone(reason);
+            let grave_key = GraveKey::from_grave(&grave);
+            if state.buried.insert(grave_key) {
+                state.graves.insert(0, grave);
+                state.graves.truncate(MAX_GRAVES);
+            }
+        }
+        if let Err(error) = self.persist_graves().and_then(|_| self.persist_roster()) {
+            eprintln!("termiod: could not record the loss of session {id}: {error:#}");
+        }
+    }
+
     /// Open the graveyard, keeping `alive` on the roster instead of burying it.
     ///
     /// The roster's whole meaning is "these were running when a daemon last
@@ -370,11 +413,25 @@ impl Graveyard {
     }
 
     fn persist_graves(&self) -> Result<()> {
+        if self.detached_from_disk() {
+            return Ok(());
+        }
         let graves = self.state.lock().unwrap().graves.clone();
         write_json(&self.graves_path, &graves)
     }
 
+    /// A `detached` graveyard has no files. Writing is a success that writes
+    /// nothing rather than an error, so the callers that already treat a
+    /// persist failure as "a worse explanation later, never a broken terminal
+    /// now" do not fill the log saying so on every session.
+    fn detached_from_disk(&self) -> bool {
+        self.graves_path.as_os_str().is_empty()
+    }
+
     fn persist_roster(&self) -> Result<()> {
+        if self.detached_from_disk() {
+            return Ok(());
+        }
         let mut roster: Vec<RosterEntry> = self
             .state
             .lock()

--- a/termiod/src/tombstone.rs
+++ b/termiod/src/tombstone.rs
@@ -264,6 +264,12 @@ impl Graveyard {
     /// which are the only things in this system that cannot be recreated. A
     /// daemon with no tombstone log explains a later loss worse. A daemon that
     /// exited caused one.
+    ///
+    /// The cost is larger than "no history": every session this daemon goes on
+    /// to create is invisible to the roster too, so a later crash cannot
+    /// explain their loss either, and this does not heal by itself. The way
+    /// back is to repair the state directory and hand off again — a restart
+    /// would end the very sessions the fallback existed to keep.
     pub fn detached() -> Graveyard {
         Graveyard {
             graves_path: PathBuf::new(),

--- a/termiod/src/tombstone.rs
+++ b/termiod/src/tombstone.rs
@@ -256,7 +256,14 @@ impl Graveyard {
     /// nobody buried — the previous daemon died holding it. Adopting those as
     /// `daemon_lost` here is what turns a crash from a silently empty list into
     /// an explanation.
-    pub fn open(dir: &Path) -> Result<Graveyard> {
+    /// Open the graveyard, keeping `alive` on the roster instead of burying it.
+    ///
+    /// The roster's whole meaning is "these were running when a daemon last
+    /// wrote this file, and nobody buried them" — which is a crash everywhere
+    /// except one place: a handoff, where the new image inherits the very
+    /// processes the roster names. Those are alive and must stay on the roster;
+    /// anything else in the file is the loss it has always been.
+    pub fn open_retaining(dir: &Path, alive: &[String]) -> Result<Graveyard> {
         let graveyard = Graveyard {
             graves_path: dir.join("tombstones.json"),
             roster_path: dir.join("roster.json"),
@@ -268,7 +275,10 @@ impl Graveyard {
         };
 
         let mut graves: Vec<Tombstone> = read_json(&graveyard.graves_path).unwrap_or_default();
-        let orphans: Vec<RosterEntry> = read_json(&graveyard.roster_path).unwrap_or_default();
+        let entries: Vec<RosterEntry> = read_json(&graveyard.roster_path).unwrap_or_default();
+        let (survivors, orphans): (Vec<RosterEntry>, Vec<RosterEntry>) = entries
+            .into_iter()
+            .partition(|entry| alive.contains(&entry.id));
         // Newest first, so the cap drops the oldest history rather than the
         // sessions that just died.
         for orphan in orphans.into_iter().rev() {
@@ -282,10 +292,14 @@ impl Graveyard {
             // Index what was just loaded, so the invariant holds from the first
             // burial rather than from the first one this daemon happens to make.
             state.buried = state.graves.iter().map(GraveKey::from_grave).collect();
+            // The roster starts with the survivors and nothing else: whatever
+            // the last daemon held and did not hand over is now buried, and
+            // leaving it in the file would bury it twice on the next start.
+            state.roster = survivors
+                .into_iter()
+                .map(|entry| (SessionId::new(entry.id.clone()), entry))
+                .collect();
         }
-        // The roster starts empty for this daemon: whatever the last one held is
-        // now buried, and leaving the file behind would bury it twice on the
-        // next start.
         graveyard.persist_roster()?;
         graveyard.persist_graves()?;
         Ok(graveyard)
@@ -437,7 +451,7 @@ mod tests {
     #[test]
     fn a_session_that_exits_is_buried_with_its_status() {
         let dir = temp_dir("exit");
-        let graveyard = Graveyard::open(&dir).unwrap();
+        let graveyard = Graveyard::open_retaining(&dir, &[]).unwrap();
         graveyard.note_live(&info("a"));
         graveyard.bury(&info("a"), EndReason::Exited, Some(0));
 
@@ -456,7 +470,7 @@ mod tests {
     #[test]
     fn a_replaced_executable_survives_in_the_durable_record() {
         let dir = temp_dir("replaced");
-        let graveyard = Graveyard::open(&dir).unwrap();
+        let graveyard = Graveyard::open_retaining(&dir, &[]).unwrap();
         let mut dying = info("a");
         dying.alive = false;
         dying.child_executable_replaced = true;
@@ -466,7 +480,7 @@ mod tests {
 
         // Reopened, so this reads the field back off disk rather than out of
         // the in-memory copy that bury() just wrote.
-        let graves = Graveyard::open(&dir).unwrap().all();
+        let graves = Graveyard::open_retaining(&dir, &[]).unwrap().all();
         assert_eq!(graves.len(), 1);
         assert!(
             graves[0].child_executable_replaced,
@@ -487,7 +501,7 @@ mod tests {
         )
         .unwrap();
 
-        let graves = Graveyard::open(&dir).unwrap().all();
+        let graves = Graveyard::open_retaining(&dir, &[]).unwrap().all();
         assert_eq!(graves.len(), 1);
         assert!(
             !graves[0].child_executable_replaced,
@@ -500,11 +514,11 @@ mod tests {
     #[test]
     fn a_session_the_daemon_died_under_is_adopted_as_lost() {
         let dir = temp_dir("crash");
-        let first = Graveyard::open(&dir).unwrap();
+        let first = Graveyard::open_retaining(&dir, &[]).unwrap();
         first.note_live(&info("a"));
         drop(first); // no bury — the daemon vanished
 
-        let second = Graveyard::open(&dir).unwrap();
+        let second = Graveyard::open_retaining(&dir, &[]).unwrap();
         let graves = second.all();
         assert_eq!(graves.len(), 1);
         assert_eq!(graves[0].id, "a");
@@ -520,12 +534,12 @@ mod tests {
     #[test]
     fn a_buried_session_is_not_mourned_twice() {
         let dir = temp_dir("once");
-        let first = Graveyard::open(&dir).unwrap();
+        let first = Graveyard::open_retaining(&dir, &[]).unwrap();
         first.note_live(&info("a"));
         first.bury(&info("a"), EndReason::Killed, Some(137));
         drop(first);
 
-        let graves = Graveyard::open(&dir).unwrap().all();
+        let graves = Graveyard::open_retaining(&dir, &[]).unwrap().all();
         assert_eq!(graves.len(), 1);
         assert_eq!(graves[0].reason, "killed");
     }
@@ -537,7 +551,7 @@ mod tests {
     #[test]
     fn the_index_is_capped_with_the_graves() {
         let dir = temp_dir("index-cap");
-        let graveyard = Graveyard::open(&dir).unwrap();
+        let graveyard = Graveyard::open_retaining(&dir, &[]).unwrap();
         for index in 0..MAX_GRAVES + 50 {
             let mut ended = info(&format!("s{index}"));
             ended.created_unix = 1000 + index as u64;
@@ -554,7 +568,7 @@ mod tests {
     #[test]
     fn a_late_reaper_does_not_replace_the_shutdown_reason() {
         let dir = temp_dir("shutdown-race");
-        let graveyard = Graveyard::open(&dir).unwrap();
+        let graveyard = Graveyard::open_retaining(&dir, &[]).unwrap();
         graveyard.note_live(&info("a"));
         graveyard
             .bury_remaining(EndReason::DaemonStopped)
@@ -571,12 +585,12 @@ mod tests {
     #[test]
     fn adoption_is_not_repeated_on_every_restart() {
         let dir = temp_dir("idempotent");
-        let first = Graveyard::open(&dir).unwrap();
+        let first = Graveyard::open_retaining(&dir, &[]).unwrap();
         first.note_live(&info("a"));
         drop(first);
 
-        assert_eq!(Graveyard::open(&dir).unwrap().all().len(), 1);
-        assert_eq!(Graveyard::open(&dir).unwrap().all().len(), 1);
+        assert_eq!(Graveyard::open_retaining(&dir, &[]).unwrap().all().len(), 1);
+        assert_eq!(Graveyard::open_retaining(&dir, &[]).unwrap().all().len(), 1);
     }
 
     /// History is bounded, and the cap drops the oldest — a box that has been up
@@ -584,7 +598,7 @@ mod tests {
     #[test]
     fn history_is_capped_and_drops_the_oldest() {
         let dir = temp_dir("cap");
-        let graveyard = Graveyard::open(&dir).unwrap();
+        let graveyard = Graveyard::open_retaining(&dir, &[]).unwrap();
         for index in 0..MAX_GRAVES + 10 {
             graveyard.bury(&info(&format!("s{index}")), EndReason::Exited, Some(0));
         }
@@ -599,11 +613,11 @@ mod tests {
     #[test]
     fn graves_survive_a_restart() {
         let dir = temp_dir("persist");
-        let first = Graveyard::open(&dir).unwrap();
+        let first = Graveyard::open_retaining(&dir, &[]).unwrap();
         first.bury(&info("a"), EndReason::Exited, Some(3));
         drop(first);
 
-        let graves = Graveyard::open(&dir).unwrap().all();
+        let graves = Graveyard::open_retaining(&dir, &[]).unwrap().all();
         assert_eq!(graves.len(), 1);
         assert_eq!(graves[0].exit_status, Some(3));
     }
@@ -616,6 +630,6 @@ mod tests {
         std::fs::write(dir.join("tombstones.json"), b"{not json").unwrap();
         std::fs::write(dir.join("roster.json"), b"[[[").unwrap();
 
-        assert_eq!(Graveyard::open(&dir).unwrap().all().len(), 0);
+        assert_eq!(Graveyard::open_retaining(&dir, &[]).unwrap().all().len(), 0);
     }
 }

--- a/termiod/tests/handoff.rs
+++ b/termiod/tests/handoff.rs
@@ -1,0 +1,264 @@
+//! `termiod handoff` against a real daemon: the claim is that the process, its
+//! children and their PTYs all survive a binary replacement, and the only way
+//! to check that is to run one.
+//!
+//! The load-bearing assertion is not the exit code. It is the counter file: a
+//! shell writing to it every tenth of a second stops the instant its PTY master
+//! closes, because the slave side raises `SIGHUP` and nothing in the session
+//! outlives that. A counter that is still moving after the daemon has replaced
+//! its own image is the whole feature, observed from outside.
+
+use serde_json::Value;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+const BIN: &str = env!("CARGO_BIN_EXE_termiod");
+
+static DIRECTORIES: AtomicUsize = AtomicUsize::new(0);
+
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new() -> TestDir {
+        let nonce = DIRECTORIES.fetch_add(1, Ordering::Relaxed);
+        // Unix-domain socket paths are short on macOS; the per-user temporary
+        // directory can consume most of that limit before the test adds a name.
+        let path = PathBuf::from(format!("/tmp/tho-{}-{nonce}", std::process::id()));
+        std::fs::create_dir(&path).expect("create isolated daemon state directory");
+        TestDir(path)
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct Daemon {
+    child: Child,
+}
+
+impl Daemon {
+    fn start(socket: &Path) -> Daemon {
+        let mut child = Command::new(BIN)
+            .arg("serve")
+            .env("TERMIOD_SOCK", socket)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn isolated daemon");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !socket.exists() {
+            if let Some(status) = child.try_wait().expect("poll daemon startup") {
+                let mut stderr = String::new();
+                if let Some(mut stream) = child.stderr.take() {
+                    let _ = stream.read_to_string(&mut stderr);
+                }
+                panic!("daemon exited {status} before binding its socket: {stderr}");
+            }
+            assert!(Instant::now() < deadline, "daemon never bound its socket");
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        Daemon { child }
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        // The daemon this test kills is the *original* pid, which is still the
+        // pid after a handoff — the whole point. Killing the process group takes
+        // the session's shell with it.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn termiod(socket: &Path, args: &[&str]) -> Output {
+    Command::new(BIN)
+        .args(args)
+        .env("TERMIOD_SOCK", socket)
+        .output()
+        .expect("run termiod")
+}
+
+fn status(socket: &Path) -> Value {
+    let output = termiod(socket, &["status", "--json"]);
+    assert!(output.status.success(), "status failed: {output:?}");
+    serde_json::from_slice(&output.stdout).expect("status is json")
+}
+
+fn counter(path: &Path) -> u64 {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| text.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Block until the session's shell has written at least `target`, so "it is
+/// still running" is read from the process rather than from a sleep.
+fn wait_for_counter(path: &Path, target: u64) -> u64 {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let seen = counter(path);
+        if seen >= target {
+            return seen;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the session stopped writing at {seen}, waiting for {target}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn a_handoff_keeps_the_pid_the_sessions_and_the_screen() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("s");
+    let tally = dir.0.join("tally");
+    let daemon = Daemon::start(&socket);
+
+    // A plain `sh` on the PTY, ticking in the background: the shell keeps
+    // reading stdin — which is what makes "send it something after the
+    // upgrade" a question that can be asked — while the loop keeps writing,
+    // which is what makes "it never got a hangup" a question that can be
+    // answered.
+    let created = termiod(&socket, &["create", "--name", "carried", "--", "sh"]);
+    assert!(created.status.success(), "create failed: {created:?}");
+
+    let before = status(&socket);
+    let daemon_pid = before["daemon"]["pid"].as_i64().expect("daemon pid");
+    let sessions = before["sessions"].as_array().expect("sessions");
+    assert_eq!(sessions.len(), 1, "{before}");
+    let session_id = sessions[0]["id"].as_str().expect("session id").to_string();
+
+    let sent = termiod(
+        &socket,
+        &["send", &session_id, "echo MARKER-BEFORE-HANDOFF"],
+    );
+    assert!(sent.status.success(), "send failed: {sent:?}");
+    let ticker = format!(
+        "(n=0; while :; do n=$((n+1)); echo $n > {}; sleep 0.1; done) &",
+        tally.display()
+    );
+    let sent = termiod(&socket, &["send", &session_id, &ticker]);
+    assert!(sent.status.success(), "send failed: {sent:?}");
+
+    let ticks = wait_for_counter(&tally, 3);
+
+    let handed = termiod(&socket, &["handoff", "--json"]);
+    assert!(
+        handed.status.success(),
+        "handoff failed: {}",
+        String::from_utf8_lossy(&handed.stderr)
+    );
+    let outcome: Value = serde_json::from_slice(&handed.stdout).expect("handoff is json");
+    assert_eq!(outcome["pid"].as_i64(), Some(daemon_pid), "{outcome}");
+    assert_eq!(outcome["sessions"].as_u64(), Some(1), "{outcome}");
+
+    // Same process, not a replacement someone autostarted over the socket.
+    let after = status(&socket);
+    assert_eq!(after["daemon"]["pid"].as_i64(), Some(daemon_pid), "{after}");
+    let carried = after["sessions"].as_array().expect("sessions after");
+    assert_eq!(carried.len(), 1, "{after}");
+    assert_eq!(
+        carried[0]["id"].as_str(),
+        Some(session_id.as_str()),
+        "{after}"
+    );
+    assert_eq!(carried[0]["name"].as_str(), Some("carried"), "{after}");
+
+    // The claim, in one assertion: the shell never saw a hangup.
+    wait_for_counter(&tally, ticks + 5);
+
+    // And it is still reachable — the new image is reading and writing the same
+    // master, not merely holding a descriptor open.
+    let marker = format!("touch {}", dir.0.join("typed").display());
+    let sent = termiod(&socket, &["send", &session_id, &marker]);
+    assert!(sent.status.success(), "send failed: {sent:?}");
+    let typed = dir.0.join("typed");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !typed.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "the carried shell never ran what it was sent"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // The replay ring crossed too: what the session printed before the upgrade
+    // is what a client attaching after it is shown.
+    assert!(
+        observed(&socket, &session_id).contains("MARKER-BEFORE-HANDOFF"),
+        "the screen from before the handoff was not replayed"
+    );
+
+    drop(daemon);
+}
+
+/// What an observer sees on attach — the ring the daemon replays. Read for a
+/// moment and then stopped, because `attach --observe` streams forever.
+fn observed(socket: &Path, session: &str) -> String {
+    let mut child = Command::new(BIN)
+        .args(["attach", session, "--observe", "--no-create"])
+        .env("TERMIOD_SOCK", socket)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn observer");
+    std::thread::sleep(Duration::from_millis(750));
+    let _ = child.kill();
+    let mut seen = String::new();
+    if let Some(mut stdout) = child.stdout.take() {
+        let _ = stdout.read_to_string(&mut seen);
+    }
+    let _ = child.wait();
+    seen
+}
+
+/// A handoff to something that is not a working termiod is refused before the
+/// daemon takes a single session apart — so the refusal costs nothing, and the
+/// daemon that refuses is still the daemon that was running.
+#[test]
+fn a_binary_that_cannot_run_is_refused_and_changes_nothing() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("s");
+    let daemon = Daemon::start(&socket);
+
+    let created = termiod(&socket, &["create", "--name", "kept", "--", "sleep", "300"]);
+    assert!(created.status.success(), "create failed: {created:?}");
+    let before = status(&socket);
+    let daemon_pid = before["daemon"]["pid"].as_i64().expect("daemon pid");
+
+    let impostor = dir.0.join("not-termiod");
+    std::fs::write(&impostor, "#!/bin/sh\nexit 9\n").expect("write impostor");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&impostor, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod impostor");
+    }
+
+    let refused = termiod(
+        &socket,
+        &["handoff", "--binary", impostor.to_str().expect("path")],
+    );
+    assert!(
+        !refused.status.success(),
+        "the impostor was accepted: {refused:?}"
+    );
+
+    let after = status(&socket);
+    assert_eq!(after["daemon"]["pid"].as_i64(), Some(daemon_pid), "{after}");
+    assert_eq!(
+        after["sessions"].as_array().map(Vec::len),
+        Some(1),
+        "the refused handoff cost a session: {after}"
+    );
+
+    drop(daemon);
+}

--- a/termiod/tests/handoff.rs
+++ b/termiod/tests/handoff.rs
@@ -560,10 +560,16 @@ fn a_blob_write_that_fails_after_the_carry_costs_nothing() {
     let ticks = wait_for_counter(&tally, 3);
 
     // The upgrade is asked for, gets as far as carrying every session, and then
-    // cannot write the blob. The reply says nothing about that: it is sent when
-    // the request is accepted, not when the handoff has happened — so the
-    // daemon's own log is what says which way it went.
-    let _ = termiod(&socket, &["handoff", "--json"]);
+    // cannot write the blob. The client learns this the only way it can: its own
+    // connection is still open. A successful handoff execs and takes that
+    // connection with it, so an aborted one is exactly the case where it does
+    // not close — which is why reporting used to be wrong here, and is now the
+    // assertion.
+    let handed = termiod(&socket, &["handoff", "--json"]);
+    assert!(
+        !handed.status.success(),
+        "an aborted handoff reported success: {handed:?}"
+    );
     let deadline = Instant::now() + Duration::from_secs(15);
     loop {
         let said = std::fs::read_to_string(&log).unwrap_or_default();

--- a/termiod/tests/handoff.rs
+++ b/termiod/tests/handoff.rs
@@ -378,12 +378,18 @@ fn a_session_is_either_listed_or_gone_never_both() {
     drop(daemon);
 }
 
-/// A carried session whose ring can no longer draw its own screen must not have
-/// the host claim otherwise. The daemon answers such a snapshot by falling back
-/// to ring replay — the client's terminal interpreting bytes it was handed —
-/// rather than asserting a grid it reconstructed from an incomplete replay.
+/// A handoff that happens while a client is attached leaves the session
+/// driveable afterwards. The client's socket dies with the image, which is the
+/// documented cost; the session behind it must not.
+///
+/// What this does *not* cover is the stale-VT decision — whether an adopted
+/// session declines to reconstruct a screen it cannot know. That needs a real
+/// resize, which an observer cannot perform (`attach --observe` has no tty and
+/// no resize handling), so it is asserted against the session actor directly in
+/// `session::tests::a_resize_makes_the_ring_stop_describing_the_screen` and
+/// `an_unfaithful_ring_comes_back_with_a_vt_that_refuses_snapshots`.
 #[test]
-fn a_resized_session_does_not_come_back_with_a_confidently_wrong_screen() {
+fn a_session_with_a_client_attached_is_still_driveable_afterwards() {
     let dir = TestDir::new();
     let socket = dir.0.join("s");
     let daemon = Daemon::start(&socket);
@@ -399,8 +405,6 @@ fn a_resized_session_does_not_come_back_with_a_confidently_wrong_screen() {
     let sent = termiod(&socket, &["send", &session_id, "echo MARKER-BEFORE-RESIZE"]);
     assert!(sent.status.success(), "send failed: {sent:?}");
 
-    // An observer attaching at a different size is what moves the session off
-    // the geometry its ring was written at.
     let _ = observed(&socket, &session_id);
 
     let handed = termiod(&socket, &["handoff", "--json"]);
@@ -420,6 +424,77 @@ fn a_resized_session_does_not_come_back_with_a_confidently_wrong_screen() {
         );
         std::thread::sleep(Duration::from_millis(50));
     }
+
+    drop(daemon);
+}
+
+/// A candidate that never answers, and one that will not stop answering, are
+/// both refused on a deadline — and the daemon is still there afterwards.
+///
+/// This is the shape that bites: the probe runs on a control task, so a
+/// candidate that hangs does not merely fail its own handoff, it wedges the
+/// verb for everyone. The first version of the timeout read the child's output
+/// before waiting on it, which meant the deadline below was never reached at
+/// all: the read blocked in the kernel on a pipe the sleeping child kept open.
+#[test]
+fn a_probe_that_hangs_or_floods_is_refused_and_leaves_the_daemon_working() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("s");
+    let daemon = Daemon::start(&socket);
+
+    let created = termiod(&socket, &["create", "--name", "kept", "--", "sh"]);
+    assert!(created.status.success(), "create failed: {created:?}");
+    let daemon_pid = status(&socket)["daemon"]["pid"]
+        .as_i64()
+        .expect("daemon pid");
+
+    for (name, script) in [
+        (
+            "hang",
+            "#!/bin/sh\ncase \"$1\" in handoff) sleep 600;; esac\n",
+        ),
+        (
+            "flood",
+            "#!/bin/sh\ncase \"$1\" in handoff) yes termiod-handoff;; esac\n",
+        ),
+    ] {
+        let path = dir.0.join(name);
+        std::fs::write(&path, script).expect("write candidate");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod candidate");
+        }
+        let started = Instant::now();
+        let refused = termiod(
+            &socket,
+            &["handoff", "--binary", path.to_str().expect("path")],
+        );
+        assert!(
+            !refused.status.success(),
+            "{name} was accepted: {refused:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "{name} was refused only after {:?} — the deadline is not being reached",
+            started.elapsed()
+        );
+    }
+
+    // Still the same daemon, still holding its session, still able to hand off
+    // for real.
+    assert_eq!(
+        status(&socket)["daemon"]["pid"].as_i64(),
+        Some(daemon_pid),
+        "a refused probe cost the daemon"
+    );
+    assert_eq!(listed(&socket).len(), 1, "a refused probe cost a session");
+    let handed = termiod(&socket, &["handoff", "--json"]);
+    assert!(
+        handed.status.success(),
+        "the verb was wedged by the refusals: {handed:?}"
+    );
 
     drop(daemon);
 }

--- a/termiod/tests/handoff.rs
+++ b/termiod/tests/handoff.rs
@@ -612,3 +612,80 @@ fn a_blob_write_that_fails_after_the_carry_costs_nothing() {
 
     drop(daemon);
 }
+
+/// Two upgrades asked for at once. Nothing serialised them: both were vetted,
+/// both got `ok`, both reached the accept loop — and the second carried a roster
+/// the first had already emptied.
+#[test]
+fn a_second_handoff_is_refused_while_one_is_under_way() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("s");
+    let log = dir.0.join("daemon.log");
+    // Held at the blob write, so the first handoff is still in flight — which is
+    // the only window in which a second one can be asked for at all.
+    let daemon = Daemon::start_logging(
+        &socket,
+        &[("TERMIOD_HANDOFF_FAIL_AFTER_CARRY", "2500")],
+        Some(&log),
+    );
+
+    let created = termiod(&socket, &["create", "--name", "one", "--", "sh"]);
+    assert!(created.status.success(), "create failed: {created:?}");
+    let before = status(&socket);
+    let session_id = before["sessions"].as_array().expect("sessions")[0]["id"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    // Two, back to back. At most one may be accepted; the daemon must answer the
+    // other rather than run it.
+    // Both at once, on two connections. Sequentially they cannot race at all:
+    // the accept loop is inside the handoff, so a second client simply waits for
+    // it to come back and is then served normally. The window that matters is
+    // the one where both requests are *already* being handled — both vetted,
+    // both about to be accepted — which only two connections in flight can
+    // reach.
+    let (a, b) = (socket.clone(), socket.clone());
+    let left = std::thread::spawn(move || termiod(&a, &["handoff", "--json"]));
+    let right = std::thread::spawn(move || termiod(&b, &["handoff", "--json"]));
+    let first = left.join().expect("first handoff thread");
+    let second = right.join().expect("second handoff thread");
+    // The replies say nothing: `termiod handoff` composes its success message on
+    // the client from a status it fetched, so both calls print the same thing
+    // whatever the daemon decided. That is its own gap — reporting a handoff
+    // that has only been *accepted* as one that happened — and it is why the
+    // daemon's log is what answers here.
+    let _ = (&first, &second);
+
+    // One request reached the accept loop, so one handoff settled. Two would
+    // mean the second carried a roster the first had already emptied.
+    let deadline = Instant::now() + Duration::from_secs(25);
+    loop {
+        let said = std::fs::read_to_string(&log).unwrap_or_default();
+        let settled = said.matches("aborted").count();
+        assert!(settled <= 1, "both handoffs ran:\n{said}");
+        if settled == 1 {
+            // Long enough for a second one to have shown up if it were coming.
+            std::thread::sleep(Duration::from_millis(1500));
+            let said = std::fs::read_to_string(&log).unwrap_or_default();
+            assert_eq!(said.matches("aborted").count(), 1, "a second handoff ran:\n{said}");
+            break;
+        }
+        assert!(Instant::now() < deadline, "no handoff ever settled: {said}");
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let after = status(&socket);
+    assert_eq!(
+        after["sessions"].as_array().expect("sessions after").len(),
+        1,
+        "{after}"
+    );
+    let marker = dir.0.join("typed-after-race");
+    let sent = termiod(
+        &socket,
+        &["send", &session_id, &format!("touch {}", marker.display())],
+    );
+    assert!(sent.status.success(), "send after the race failed: {sent:?}");
+
+    drop(daemon);
+}

--- a/termiod/tests/handoff.rs
+++ b/termiod/tests/handoff.rs
@@ -44,11 +44,31 @@ struct Daemon {
 
 impl Daemon {
     fn start(socket: &Path) -> Daemon {
-        let mut child = Command::new(BIN)
+        Daemon::start_with(socket, &[])
+    }
+
+    fn start_with(socket: &Path, env: &[(&str, &str)]) -> Daemon {
+        Daemon::start_logging(socket, env, None)
+    }
+
+    /// `log` sends the daemon's stderr to a file the test can read while it is
+    /// still running — the only way to see what the daemon decided, since the
+    /// `handoff` reply is sent when the request is accepted rather than when it
+    /// has happened.
+    fn start_logging(socket: &Path, env: &[(&str, &str)], log: Option<&Path>) -> Daemon {
+        let mut command = Command::new(BIN);
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        let errors = match log {
+            Some(path) => Stdio::from(std::fs::File::create(path).expect("daemon log")),
+            None => Stdio::piped(),
+        };
+        let mut child = command
             .arg("serve")
             .env("TERMIOD_SOCK", socket)
             .stdout(Stdio::null())
-            .stderr(Stdio::piped())
+            .stderr(errors)
             .spawn()
             .expect("spawn isolated daemon");
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -495,6 +515,100 @@ fn a_probe_that_hangs_or_floods_is_refused_and_leaves_the_daemon_working() {
         handed.status.success(),
         "the verb was wedged by the refusals: {handed:?}"
     );
+
+    drop(daemon);
+}
+
+/// The claim the rollback exists to make: a blob write that fails *after* every
+/// actor has handed over its PTY costs nothing at all.
+///
+/// This is the one path that cannot be reached by asking the daemon nicely — a
+/// real ENOSPC mid-write is not arrangeable — so the daemon carries a gate for
+/// it. Before the rollback, this failure dropped every carried master at once
+/// and the daemon exited: every shell on the box took SIGHUP together, which is
+/// precisely the loss the feature promises to prevent.
+#[test]
+fn a_blob_write_that_fails_after_the_carry_costs_nothing() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("s");
+    let tally = dir.0.join("tally");
+    let log = dir.0.join("daemon.log");
+    let daemon = Daemon::start_logging(
+        &socket,
+        &[("TERMIOD_HANDOFF_FAIL_AFTER_CARRY", "1")],
+        Some(&log),
+    );
+
+    let created = termiod(&socket, &["create", "--name", "survivor", "--", "sh"]);
+    assert!(created.status.success(), "create failed: {created:?}");
+
+    let before = status(&socket);
+    let daemon_pid = before["daemon"]["pid"].as_i64().expect("daemon pid");
+    let session_id = before["sessions"].as_array().expect("sessions")[0]["id"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    // A ticker, so "it never saw a hangup" is a question with an answer rather
+    // than an absence of evidence.
+    let ticker = format!(
+        "(n=0; while :; do n=$((n+1)); echo $n > {}; sleep 0.1; done) &",
+        tally.display()
+    );
+    let sent = termiod(&socket, &["send", &session_id, &ticker]);
+    assert!(sent.status.success(), "send failed: {sent:?}");
+    let ticks = wait_for_counter(&tally, 3);
+
+    // The upgrade is asked for, gets as far as carrying every session, and then
+    // cannot write the blob. The reply says nothing about that: it is sent when
+    // the request is accepted, not when the handoff has happened — so the
+    // daemon's own log is what says which way it went.
+    let _ = termiod(&socket, &["handoff", "--json"]);
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let said = std::fs::read_to_string(&log).unwrap_or_default();
+        if said.contains("aborted") {
+            assert!(
+                said.contains("every session is still here"),
+                "the daemon aborted without putting the sessions back: {said}"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the daemon never reported an aborted handoff: {said}"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    // The daemon is the same process, still answering, with the session still
+    // in its roster.
+    let after = status(&socket);
+    assert_eq!(
+        after["daemon"]["pid"].as_i64(),
+        Some(daemon_pid),
+        "the daemon exited or was replaced: {after}"
+    );
+    let kept = after["sessions"].as_array().expect("sessions after");
+    assert_eq!(kept.len(), 1, "the session was dropped: {after}");
+    assert_eq!(kept[0]["id"].as_str(), Some(session_id.as_str()), "{after}");
+
+    // The shell behind it never noticed.
+    wait_for_counter(&tally, ticks + 5);
+
+    // And it is still driveable — the master went back to a live actor, not
+    // merely back into a roster entry.
+    let marker = dir.0.join("typed-after-abort");
+    let sent = termiod(&socket, &["send", &session_id, &format!("touch {}", marker.display())]);
+    assert!(sent.status.success(), "send after the abort failed: {sent:?}");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !marker.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "the restored session never ran what it was sent"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
 
     drop(daemon);
 }

--- a/termiod/tests/handoff.rs
+++ b/termiod/tests/handoff.rs
@@ -91,6 +91,22 @@ fn status(socket: &Path) -> Value {
     serde_json::from_slice(&output.stdout).expect("status is json")
 }
 
+/// `list --json` — `SessionInfo`, which carries the pid that `status` omits.
+fn listed(socket: &Path) -> Vec<Value> {
+    let output = termiod(socket, &["list", "--json"]);
+    assert!(output.status.success(), "list failed: {output:?}");
+    let parsed: Value = serde_json::from_slice(&output.stdout).expect("list is json");
+    match parsed {
+        Value::Array(sessions) => sessions,
+        Value::Object(ref map) => map
+            .get("sessions")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
 fn counter(path: &Path) -> u64 {
     std::fs::read_to_string(path)
         .ok()
@@ -223,8 +239,14 @@ fn observed(socket: &Path, session: &str) -> String {
 /// A handoff to something that is not a working termiod is refused before the
 /// daemon takes a single session apart — so the refusal costs nothing, and the
 /// daemon that refuses is still the daemon that was running.
+///
+/// The impostor here is the dangerous shape, not the obvious one: it exits 0
+/// and prints a plausible version, which is all `--version` ever proved. Only
+/// the handoff contract itself tells it apart from a real termiod — and an
+/// older termiod, which answers `--version` and has never heard of
+/// `serve --handoff`, is the same case wearing the right name.
 #[test]
-fn a_binary_that_cannot_run_is_refused_and_changes_nothing() {
+fn a_binary_that_cannot_adopt_is_refused_and_changes_nothing() {
     let dir = TestDir::new();
     let socket = dir.0.join("s");
     let daemon = Daemon::start(&socket);
@@ -235,7 +257,11 @@ fn a_binary_that_cannot_run_is_refused_and_changes_nothing() {
     let daemon_pid = before["daemon"]["pid"].as_i64().expect("daemon pid");
 
     let impostor = dir.0.join("not-termiod");
-    std::fs::write(&impostor, "#!/bin/sh\nexit 9\n").expect("write impostor");
+    std::fs::write(
+        &impostor,
+        "#!/bin/sh\ncase \"$1\" in --version) echo 'termiod 9.9.9+9999'; exit 0;; esac\nexit 0\n",
+    )
+    .expect("write impostor");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -259,6 +285,141 @@ fn a_binary_that_cannot_run_is_refused_and_changes_nothing() {
         Some(1),
         "the refused handoff cost a session: {after}"
     );
+
+    drop(daemon);
+}
+
+/// The vet's contract, stated as the thing it actually checks. A binary that
+/// answers `--version` convincingly and knows nothing about handing off is
+/// refused; the real one is accepted.
+#[test]
+fn the_probe_is_what_separates_a_termiod_from_a_convincing_impostor() {
+    let dir = TestDir::new();
+    let impostor = dir.0.join("impostor");
+    std::fs::write(
+        &impostor,
+        "#!/bin/sh\ncase \"$1\" in --version) echo 'termiod 9.9.9+9999'; exit 0;; esac\nexit 0\n",
+    )
+    .expect("write impostor");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&impostor, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod impostor");
+    }
+    let version = Command::new(&impostor)
+        .arg("--version")
+        .output()
+        .expect("run impostor");
+    assert!(
+        version.status.success(),
+        "the impostor should pass --version"
+    );
+
+    let probe = Command::new(BIN)
+        .args(["handoff", "--probe"])
+        .output()
+        .expect("probe the real binary");
+    assert!(probe.status.success());
+    let token = String::from_utf8_lossy(&probe.stdout).trim().to_string();
+    assert!(token.starts_with("termiod-handoff "), "{token}");
+
+    let impostor_probe = Command::new(&impostor)
+        .args(["handoff", "--probe"])
+        .output()
+        .expect("probe the impostor");
+    assert_ne!(
+        String::from_utf8_lossy(&impostor_probe.stdout).trim(),
+        token,
+        "the impostor answered the handoff contract"
+    );
+}
+
+/// The invariant that must hold however a handoff goes: a session is either in
+/// the roster or its process is gone. Never both absent.
+///
+/// A carried master that reaches the new image without a session around it
+/// would break exactly this — the program would keep running, un-hung-up, in a
+/// session nothing can list, attach to, or kill. That is why the descriptor is
+/// handed over owned; dropping it is what turns a session that cannot be
+/// carried into an ordinary loss.
+#[test]
+fn a_session_is_either_listed_or_gone_never_both() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("s");
+    let daemon = Daemon::start(&socket);
+
+    let created = termiod(&socket, &["create", "--name", "kept", "--", "sh"]);
+    assert!(created.status.success(), "create failed: {created:?}");
+    let session_pid = listed(&socket)[0]["pid"].as_i64().expect("session pid");
+    let daemon_pid = status(&socket)["daemon"]["pid"]
+        .as_i64()
+        .expect("daemon pid");
+
+    let handed = termiod(&socket, &["handoff", "--json"]);
+    assert!(handed.status.success(), "handoff failed: {handed:?}");
+    assert_eq!(
+        status(&socket)["daemon"]["pid"].as_i64(),
+        Some(daemon_pid),
+        "the daemon was replaced rather than handed off"
+    );
+
+    let sessions = listed(&socket);
+    let accounted = sessions
+        .iter()
+        .any(|session| session["pid"].as_i64() == Some(session_pid));
+    let alive = unsafe { libc::kill(session_pid as i32, 0) } == 0;
+    assert!(
+        accounted || !alive,
+        "pid {session_pid} is running but no session accounts for it: {sessions:?}"
+    );
+    assert!(accounted, "the session should have survived: {sessions:?}");
+
+    drop(daemon);
+}
+
+/// A carried session whose ring can no longer draw its own screen must not have
+/// the host claim otherwise. The daemon answers such a snapshot by falling back
+/// to ring replay — the client's terminal interpreting bytes it was handed —
+/// rather than asserting a grid it reconstructed from an incomplete replay.
+#[test]
+fn a_resized_session_does_not_come_back_with_a_confidently_wrong_screen() {
+    let dir = TestDir::new();
+    let socket = dir.0.join("s");
+    let daemon = Daemon::start(&socket);
+
+    let created = termiod(&socket, &["create", "--name", "resized", "--", "sh"]);
+    assert!(created.status.success(), "create failed: {created:?}");
+    let before = status(&socket);
+    let session_id = before["sessions"][0]["id"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let sent = termiod(&socket, &["send", &session_id, "echo MARKER-BEFORE-RESIZE"]);
+    assert!(sent.status.success(), "send failed: {sent:?}");
+
+    // An observer attaching at a different size is what moves the session off
+    // the geometry its ring was written at.
+    let _ = observed(&socket, &session_id);
+
+    let handed = termiod(&socket, &["handoff", "--json"]);
+    assert!(handed.status.success(), "handoff failed: {handed:?}");
+
+    // The session is still there and still driveable — degrading the snapshot
+    // must not degrade the session.
+    let marker = format!("touch {}", dir.0.join("after-resize").display());
+    let sent = termiod(&socket, &["send", &session_id, &marker]);
+    assert!(sent.status.success(), "send failed: {sent:?}");
+    let typed = dir.0.join("after-resize");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !typed.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "the carried shell stopped responding after the handoff"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
 
     drop(daemon);
 }


### PR DESCRIPTION
Upgrading a box used to cost the work running on it. `termiod deploy` staged the
new binary, asked the daemon to stop, and every PTY master closed with the
process — SIGHUP, and the agents mid-task went with it. A box with work in
progress was left permanently `staged` instead, waiting for someone to decide
whose session to end.

`execve` is the way out. It replaces the process *image* while keeping the
*process*: same pid, same children, same open descriptors, same session and
process group. The PTY masters stay open, the shells never see a hangup, and
the only thing that changes is which code is on the other end of the descriptor.

## What crosses

Nothing in memory survives an exec, so whatever the new image needs is written
down first and handed over by descriptor number:

- **The PTY masters**, duplicated so the old actor can drop its own copy normally.
- **The replay rings**, so the screen is rebuilt rather than redrawn.
- **The already-bound Unix listener.** Re-binding would mean unlinking and
  re-creating the socket, and a client connecting in that window would autostart
  a second daemon over a state directory this one still owns. Carried, connects
  queue in the kernel backlog instead.

The blob is written to a file that is unlinked before a byte goes into it: it
holds raw terminal output, and a handoff must not become a way of writing that
to disk behind the user's back.

What does not cross: client connections (they reconnect and reattach by session
id, to find the session alive), the WebSocket listener, and the VT sidecar.

## Descriptor ownership is the invariant

Everything handed over stays *owned* until the crossing is certain. A session's
master is an `OwnedFd` from the moment the actor duplicates it, and `pack`
releases ownership only after the last fallible step has succeeded. Two things
fall out of that, and both were bugs before it:

- A session that misses the carry deadline has its master **closed**, so it is
  hung up like any other loss — not left running, un-hung-up, inside a session
  the new daemon has no handle for.
- A write failure partway through packing drops every master rather than
  scattering raw descriptors nothing owns.

## Order, and what it does not buy

Everything fallible that does not need the sessions runs first: resolving the
state directory, creating and unlinking the blob file, duplicating the listener.
Only then are the actors asked for their PTYs.

That does not make the rest safe, and the code no longer claims it does. Writing
the blob can still fail, and the new image can still fail to start. The far side
answers that by degrading rather than exiting — the runtime directory, the
WebSocket configuration and the tombstone log all log and carry on, because on
this path refusing to start means killing what you were just handed. The host id
is carried in the blob rather than re-read, which removes that failure outright
and states that identity does not change across a handoff.

## Vetting the candidate

`--version` is not the question. Every termiod ever built answers it, including
the ones that have never heard of `serve --handoff`; exec one of those and the
daemon is replaced by a program that exits. The candidate now has to answer
`handoff --probe` with the exact format token, on a five-second deadline with a
capped reply, so a candidate that hangs or floods cannot wedge the verb.

**This is still self-attestation.** A binary that answers correctly and then
fails to start takes every session with it, and nothing short of running
`serve --handoff` for real would prove otherwise — which is the step that cannot
be taken back. The residual is written down in the module docs rather than
implied away. What it closes is the case that actually happens: a staged binary
too old to know the verb.

## Screens

A carried session whose ring can no longer draw its own screen — it evicted
output, or was resized after those bytes were written — comes back with its VT
stale, so snapshots fall back to ring replay instead of the host asserting a
grid it reconstructed from bytes it has been told are wrong.

## Deploy

`deploy` reaches for `handoff` first and falls back to `stop` for a daemon too
old to advertise the capability. A busy box is now upgraded rather than staged.
An explicit `--binary` is verified against that binary's own version, so a
deliberate rollback is not reported as a failure.

## Verification

191 unit tests and 6 integration tests in `tests/handoff.rs`. The load-bearing
assertion is a counter file: a shell writing to it every tenth of a second stops
the instant its PTY master closes, so a counter still moving after the daemon has
replaced its own image is the feature, observed from outside. The rest cover the
convincing impostor, the hanging and flooding probes, the listed-or-gone
invariant, and — against the session actor, where a real client holds the write
token — the resize that makes a ring stop describing its screen.

Two rounds of adversarial review found eleven defects between them; the commits
say which. `tests/join_invariant.rs` fails on this branch and on `main` alike —
pre-existing, not touched here.

Release Notes:

- termiod can now replace its own binary in place. Upgrading a machine keeps its
  sessions, their scrollback and everything running in them; clients reconnect.