### PR TITLE
Supervise termiod with a systemd --user unit on Linux

### DIFF
--- a/docs/design/20260827-termiod-lifecycle-reconcile.md
+++ b/docs/design/20260827-termiod-lifecycle-reconcile.md
@@ -3,7 +3,7 @@ title: termiod lifecycle — install and update as one reconcile loop
 status: in-review
 type: rfc
 created: 2026-08-27
-updated: 2026-08-27
+updated: 2026-08-29
 related:
   - 20260825-agent-integration-moves-to-termiod.md
   - 20260824-agent-integration-on-a-device.md
@@ -144,8 +144,8 @@ stays as a developer fallback and is never reached from the app.
 
 **The daemon is handed to the OS supervisor when there is one.** `service.rs`
 does this for launchd. The Linux half — a systemd `--user` unit plus
-`loginctl enable-linger` — is specified there and not built. This RFC does not
-build it either; it records that `status.supervisor` is the field that will
+`loginctl enable-linger` — is specified there and was built after this RFC
+(2026-08-29); it records that `status.supervisor` is the field that will
 tell the loop whether "restart" means `systemctl --user restart termiod` or
 "stop it and let the next client autostart it". Both paths converge on the same
 loop; only the activate step differs.
@@ -377,9 +377,10 @@ the text above, the code is right and the reason is recorded here:
   itself has the daemon between builds keeps its spinner instead of turning
   into an unreachable row.
 
-Not built here: the systemd `--user` unit (question 4) and the holder
-process (§9). `status.supervisor` is the field that lets both land without
-touching the loop.
+Not built here: the holder process (§9). The systemd `--user` unit (question
+4) landed on 2026-08-29 without touching the loop: `Restart=on-failure` leaves
+a cleanly stopped unit inactive, and the verify handshake's reconnect starts
+the unit again instead of forking a `setsid` daemon beside it.
 
 ## 12. Open questions for review
 

--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -159,24 +159,50 @@ it survives the SSH channel closing — that's the whole durability trick.
 
 ### Optional: a user systemd unit
 
-If you want the daemon always up (so `list` is instant and sessions predate any
-attach), drop a `--user` unit on the host:
+If you want the daemon always up (so `list` is instant, sessions predate any
+attach, and a crash or a reboot brings it back), let it install its own
+`--user` unit:
+
+```sh
+ssh my-vps ~/.local/bin/termiod service install
+ssh my-vps ~/.local/bin/termiod service status
+```
+
+`service install` writes the unit below to `~/.config/systemd/user/`, runs
+`systemctl --user enable --now` on it, and tries `loginctl enable-linger` for
+you. Linger is what keeps the daemon alive **after you log out**: without it
+systemd stops the user's manager — and every unit in it — when the last
+session closes, so sessions would vanish silently between SSH connections.
+Enabling linger over SSH is sometimes refused by polkit; when that happens the
+install still succeeds and prints the one command left to run:
+
+```sh
+ssh my-vps loginctl enable-linger $USER
+```
+
+The unit is generated from the absolute path of the binary that installed it,
+so it never depends on `PATH`:
 
 ```ini
-# ~/.config/systemd/user/termiod.service
+# ~/.config/systemd/user/termiod.service — what `termiod service install` writes
 [Unit]
 Description=termiod session host
+
 [Service]
-ExecStart=%h/.local/bin/termiod serve
+ExecStart="/home/you/.local/bin/termiod" serve
 Restart=on-failure
+
 [Install]
 WantedBy=default.target
 ```
 
-```sh
-ssh my-vps loginctl enable-linger $USER   # keep it running after you log out
-ssh my-vps systemctl --user enable --now termiod
-```
+`Restart=on-failure` rather than `always`: `termiod stop` (and `deploy`) sends
+`SIGTERM` and waits for the socket to stay gone, and the next client contact
+starts the unit again — a client never forks a second daemon beside a unit
+systemd owns. A dev build (`TERMIO_CHANNEL=dev`) installs `termiod-dev.service`
+with the channel pinned, so it and the release unit never fight over one
+socket. `service uninstall` disables and removes the unit and leaves linger as
+it was.
 
 This is strictly optional; on-demand start is the supported default.
 
@@ -241,27 +267,28 @@ if you do, rotate.
 ### The durable unit
 
 A flag that lives only on one foreground argv dies on the next crash restart —
-the daemon auto-starts as bare `termiod serve`. So an explicit `--wss` with a
-token in place writes `wss.bind` (`0600`) beside the socket, and the unit sets
-`TERMIOD_WSS` as well. Either one alone is enough; the pair is what survives
-both a restart and a client-triggered autostart.
+the daemon auto-starts as bare `termiod serve`, and so does the unit
+`termiod service install` writes. So an explicit `--wss` with a token in place
+writes `wss.bind` (`0600`) beside the socket, and every later bare start reads
+it back. That is the whole durable path; the generated unit deliberately puts
+nothing about WSS on its command line.
+
+To pin the bind in the unit as well, use a drop-in rather than editing the
+generated file — a drop-in survives a later `service install`:
+
+```sh
+ssh my-vps systemctl --user edit termiod
+```
 
 ```ini
-# ~/.config/systemd/user/termiod.service
-[Unit]
-Description=termiod session host
+# ~/.config/systemd/user/termiod.service.d/override.conf
 [Service]
-ExecStart=%h/.local/bin/termiod serve --wss 127.0.0.1:8790 --wss-origin https://box.tailnet.ts.net
 Environment=TERMIOD_WSS=127.0.0.1:8790
 Environment=TERMIOD_WSS_ORIGIN=https://box.tailnet.ts.net
-Restart=on-failure
-[Install]
-WantedBy=default.target
 ```
 
 ```sh
-ssh my-vps loginctl enable-linger $USER
-ssh my-vps systemctl --user enable --now termiod
+ssh my-vps ~/.local/bin/termiod service install
 ```
 
 The bind is resolved in this order, first valid loopback address winning:

--- a/termiod/src/client.rs
+++ b/termiod/src/client.rs
@@ -73,6 +73,13 @@ pub async fn stdio() -> Result<()> {
 }
 
 fn spawn_daemon() -> Result<()> {
+    // A box whose unit systemd owns gets its daemon back from systemd. After a
+    // clean `termiod stop` the unit is merely inactive, and a `setsid` fork
+    // here would take the socket the unit binds next — leaving the unit
+    // failing at every later start and the daemon unsupervised again.
+    if crate::service::systemd_unit_owns_daemon() {
+        return crate::service::start_systemd_unit();
+    }
     let exe = std::env::current_exe().context("locating termiod binary")?;
     use std::os::unix::process::CommandExt;
     let mut cmd = std::process::Command::new(exe);

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -352,13 +352,15 @@ async fn detect_supervisor() -> Supervisor {
             Supervisor::None
         };
     }
-    let active = tokio::process::Command::new("systemctl")
-        .args(["--user", "is-active", "--quiet", "termiod"])
-        .output()
+    // Enabled counts as well as active: after a clean `stop` the unit is
+    // inactive (`Restart=on-failure` does not restart a clean exit), but the
+    // next client contact starts it again through systemd, so systemd still
+    // owns whatever runs next. Mirrors "loaded" on launchd, which likewise
+    // says nothing about a pid.
+    let owned = tokio::task::spawn_blocking(crate::service::systemd_unit_owns_daemon)
         .await
-        .map(|output| output.status.success())
         .unwrap_or(false);
-    if active {
+    if owned {
         Supervisor::SystemdUser
     } else {
         Supervisor::None
@@ -715,6 +717,13 @@ async fn run_loop<N: Node>(node: &N, desired: &str, options: Options) -> Result<
             .and_then(Version::parse)
             .map_or(true, |have| have < want);
     if daemon_is_stale {
+        // The bounce is the same under every supervisor: `stop` SIGTERMs the
+        // daemon and waits for the socket to go, and `verify` reconnects, which
+        // autostarts the staged binary. Under launchd `KeepAlive` respawns it;
+        // under systemd a clean exit leaves the unit inactive
+        // (`Restart=on-failure`) and the reconnect's `spawn_daemon` starts the
+        // unit again, so the new daemon comes up supervised rather than as a
+        // `setsid` orphan.
         eprintln!("[deploy] asking the daemon on {label} to stop…");
         let command = format!(
             "{} stop --json{}",

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -308,7 +308,8 @@ enum Cmd {
         cmd: remote::RemoteCmd,
     },
 
-    /// Keep the daemon running across logins and crashes (launchd, macOS).
+    /// Keep the daemon running across logins and crashes (launchd on macOS,
+    /// systemd --user on Linux).
     Service {
         #[command(subcommand)]
         cmd: service::ServiceCmd,

--- a/termiod/src/service.rs
+++ b/termiod/src/service.rs
@@ -7,16 +7,19 @@
 //! logs out.
 //!
 //! macOS answers this with a **launchd user agent**: `RunAtLoad` starts it at
-//! login, `KeepAlive` restarts it if it dies. Linux's answer is a systemd
-//! `--user` unit plus `loginctl enable-linger` — without linger a user daemon is
-//! killed at logout, so sessions would vanish silently between SSH connections.
-//! Only macOS is implemented here; Linux boxes are reached over SSH, which
-//! autostarts the daemon on contact, so the gap is a durability limit rather
-//! than an outage.
+//! login, `KeepAlive` restarts it if it dies. Linux answers with a **systemd
+//! `--user` unit**: `WantedBy=default.target` starts it at login,
+//! `Restart=on-failure` brings it back after a crash, and `loginctl
+//! enable-linger` keeps the user's manager — and so the daemon — alive across
+//! logouts. Without linger a user daemon is killed at logout, so sessions would
+//! vanish silently between SSH connections; install asks for linger and says
+//! so when it cannot get it. The same three verbs do the same three things on
+//! both, from the same clap surface.
 //!
-//! Installing is never automatic. It writes into the user's `LaunchAgents` and
-//! makes the daemon outlive every termio process, which is the user's decision
-//! to make, not a side effect of running a command.
+//! Installing is never automatic. It writes into the user's `LaunchAgents` or
+//! `~/.config/systemd/user` and makes the daemon outlive every termio process,
+//! which is the user's decision to make, not a side effect of running a
+//! command.
 
 use anyhow::{bail, Context, Result};
 use std::path::PathBuf;
@@ -42,18 +45,19 @@ pub fn label() -> String {
 
 #[derive(clap::Subcommand)]
 pub enum ServiceCmd {
-    /// Install and start the launchd user agent (macOS).
+    /// Install and start the user service: a launchd agent on macOS, a
+    /// systemd --user unit on Linux.
     Install,
-    /// Stop and remove the launchd user agent.
+    /// Stop and remove the user service.
     Uninstall,
-    /// Report whether the agent is installed and loaded.
+    /// Report whether the service is installed and running.
     Status,
 }
 
 fn home() -> Result<PathBuf> {
     std::env::var_os("HOME")
         .map(PathBuf::from)
-        .context("HOME is not set, so the user's LaunchAgents directory can't be found")
+        .context("HOME is not set, so the user's service directory can't be found")
 }
 
 fn plist_path() -> Result<PathBuf> {
@@ -157,17 +161,20 @@ fn domain_target() -> String {
 }
 
 pub fn run(cmd: ServiceCmd) -> Result<()> {
-    if !cfg!(target_os = "macos") {
-        bail!(
-            "`termiod service` manages a launchd agent and is macOS-only. \
-             On Linux use a systemd --user unit with `loginctl enable-linger` \
-             (without linger the daemon is killed at logout)."
-        );
-    }
-    match cmd {
-        ServiceCmd::Install => install(),
-        ServiceCmd::Uninstall => uninstall(),
-        ServiceCmd::Status => status(),
+    if cfg!(target_os = "macos") {
+        match cmd {
+            ServiceCmd::Install => install(),
+            ServiceCmd::Uninstall => uninstall(),
+            ServiceCmd::Status => status(),
+        }
+    } else if cfg!(target_os = "linux") {
+        match cmd {
+            ServiceCmd::Install => systemd::install(),
+            ServiceCmd::Uninstall => systemd::uninstall(),
+            ServiceCmd::Status => systemd::status(),
+        }
+    } else {
+        bail!("`termiod service` needs launchd (macOS) or systemd (Linux) to supervise the daemon");
     }
 }
 
@@ -250,8 +257,362 @@ fn status() -> Result<()> {
     Ok(())
 }
 
+/// The channel this build serves, as the value `TERMIO_CHANNEL` must carry:
+/// `None` on the release channel, which is the absence of one.
+fn channel() -> Option<String> {
+    paths::channel_suffix()
+        .strip_prefix('-')
+        .map(str::to_string)
+}
+
+/// Whether systemd owns the daemon for *this caller's* socket: a unit exists,
+/// it serves the socket this process would connect to, and it is enabled or
+/// active. The unit file is read before `systemctl` is asked anything, so an
+/// unsupervised box — the default — never spawns a process to find that out.
+///
+/// The socket check is the guard that keeps a `TERMIOD_SOCK`-pinned caller
+/// (the test suite, a side-by-side daemon) from starting the real unit in
+/// place of its own daemon: a daemon pointed at its own socket is its own
+/// daemon, the same rule `paths::log_path` follows.
+pub fn systemd_unit_owns_daemon() -> bool {
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
+    let Ok(path) = systemd::unit_path() else {
+        return false;
+    };
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    let socket_override = std::env::var("TERMIOD_SOCK").ok();
+    let serves_this_socket = match socket_override.as_deref() {
+        None => !text.contains("TERMIOD_SOCK="),
+        Some(socket) => text.contains(&systemd::environment_line("TERMIOD_SOCK", socket)),
+    };
+    if !serves_this_socket {
+        return false;
+    }
+    let unit = systemd::unit_name();
+    let query = |verb: &str| {
+        systemd::systemctl(&["--user", verb, "--quiet", &unit])
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    };
+    query("is-enabled") || query("is-active")
+}
+
+/// Start the daemon through its unit, for a client that found the socket dead
+/// while [`systemd_unit_owns_daemon`] is true. A `setsid` fork here would win
+/// the socket and leave the unit failing at every later start — which demotes
+/// the box from supervised to unsupervised without anyone asking for it.
+pub fn start_systemd_unit() -> Result<()> {
+    let unit = systemd::unit_name();
+    let output = systemd::systemctl(&["--user", "start", &unit])?;
+    if !output.status.success() {
+        bail!(
+            "the daemon is supervised by systemd, but `systemctl --user start {unit}` failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// The Linux half: a systemd `--user` unit under `~/.config/systemd/user`.
+mod systemd {
+    use anyhow::{bail, Context, Result};
+    use std::path::PathBuf;
+
+    use crate::paths;
+
+    const UNIT_BASE: &str = "termiod";
+
+    /// The unit name, scoped by channel for the same reason as the launchd
+    /// label: `termiod.service` for a release build, `termiod-dev.service` for
+    /// the dev build beside it. `-dev` rather than `.dev` because a dot in a
+    /// unit name is a template instance to systemd.
+    pub fn unit_name() -> String {
+        unit_name_for(super::channel().as_deref())
+    }
+
+    pub fn unit_name_for(channel: Option<&str>) -> String {
+        match channel {
+            Some(channel) => format!("{UNIT_BASE}-{channel}.service"),
+            None => format!("{UNIT_BASE}.service"),
+        }
+    }
+
+    /// `$XDG_CONFIG_HOME/systemd/user`, which is where `systemctl --user`
+    /// looks, with `~/.config` as the base systemd itself assumes when the
+    /// variable is unset.
+    fn unit_dir() -> Result<PathBuf> {
+        let config = match std::env::var_os("XDG_CONFIG_HOME") {
+            Some(config) if !config.is_empty() => PathBuf::from(config),
+            _ => super::home()?.join(".config"),
+        };
+        Ok(config.join("systemd").join("user"))
+    }
+
+    pub fn unit_path() -> Result<PathBuf> {
+        Ok(unit_dir()?.join(unit_name()))
+    }
+
+    /// One word, quoted the way unit files read words. `%` is a specifier
+    /// everywhere and `$` is a variable reference in `ExecStart=`, so both are
+    /// doubled to stay literal; `\` and `"` are escaped so the path cannot
+    /// close the quotes it sits in, and a newline becomes its escape because
+    /// a unit line ends at the first one.
+    fn quote(value: &str) -> String {
+        let mut quoted = String::with_capacity(value.len() + 2);
+        quoted.push('"');
+        for character in value.chars() {
+            match character {
+                '%' => quoted.push_str("%%"),
+                '$' => quoted.push_str("$$"),
+                '\\' => quoted.push_str("\\\\"),
+                '"' => quoted.push_str("\\\""),
+                '\n' => quoted.push_str("\\n"),
+                other => quoted.push(other),
+            }
+        }
+        quoted.push('"');
+        quoted
+    }
+
+    /// `Environment="KEY=value"`, the exact line [`unit`] writes, so a reader
+    /// can look for the value it would have written rather than parse.
+    pub fn environment_line(key: &str, value: &str) -> String {
+        format!("Environment={}", quote(&format!("{key}={value}")))
+    }
+
+    /// The unit definition. The environment rules are `plist()`'s: `TERMIOD_SOCK`
+    /// only if the caller had it set, `TERMIO_CHANNEL` whenever there is one —
+    /// systemd starts the daemon from the manager's environment, not the
+    /// shell's, so an unpinned dev unit would serve the release socket.
+    ///
+    /// `Restart=on-failure`, not `always`: `termiod stop` sends `SIGTERM` and
+    /// waits for the socket to stay gone, and a unit that restarted on a clean
+    /// exit would race that drain. The next client contact starts the unit
+    /// again (`client::spawn_daemon`), which is the bounce path an update
+    /// takes. WSS is deliberately not on the command line: the bind survives in
+    /// `wss.bind` beside the socket, or in a `TERMIOD_WSS` drop-in.
+    pub fn unit(binary: &str, socket_override: Option<&str>, channel: Option<&str>) -> String {
+        let mut environment = String::new();
+        if let Some(channel) = channel {
+            environment.push_str(&environment_line("TERMIO_CHANNEL", channel));
+            environment.push('\n');
+        }
+        if let Some(socket) = socket_override {
+            environment.push_str(&environment_line("TERMIOD_SOCK", socket));
+            environment.push('\n');
+        }
+        let description = match channel {
+            Some(channel) => format!("termiod session host ({channel})"),
+            None => "termiod session host".to_string(),
+        };
+        format!(
+            "[Unit]\n\
+             Description={description}\n\
+             \n\
+             [Service]\n\
+             ExecStart={binary} serve\n\
+             Restart=on-failure\n\
+             {environment}\
+             \n\
+             [Install]\n\
+             WantedBy=default.target\n",
+            binary = quote(binary),
+        )
+    }
+
+    /// A missing `systemctl` is an answer — this is not a systemd box — and is
+    /// reported as one rather than as an opaque spawn failure.
+    pub fn systemctl(args: &[&str]) -> Result<std::process::Output> {
+        std::process::Command::new("systemctl")
+            .args(args)
+            .output()
+            .context("running systemctl — is this user session managed by systemd?")
+    }
+
+    fn loginctl(args: &[&str]) -> Result<std::process::Output> {
+        std::process::Command::new("loginctl")
+            .args(args)
+            .output()
+            .context("running loginctl — is this user session managed by systemd?")
+    }
+
+    fn checked(output: std::process::Output, what: &str) -> Result<()> {
+        if output.status.success() {
+            return Ok(());
+        }
+        bail!(
+            "{what} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    fn is_active(unit: &str) -> Result<bool> {
+        Ok(systemctl(&["--user", "is-active", "--quiet", unit])?
+            .status
+            .success())
+    }
+
+    /// Whether a daemon already answers on the socket. Sync on purpose: the
+    /// service verbs are one-shot commands with no runtime.
+    fn socket_answers() -> bool {
+        paths::socket_path()
+            .ok()
+            .map(|socket| std::os::unix::net::UnixStream::connect(socket).is_ok())
+            .unwrap_or(false)
+    }
+
+    pub fn install() -> Result<()> {
+        let path = unit_path()?;
+        let name = unit_name();
+        // A daemon some client autostarted holds the socket the unit is about
+        // to bind. The unit's daemon would exit "already running", systemd
+        // would retry it until the start limit tripped, and the operator would
+        // be left with a failed unit and the same unsupervised daemon. Stop is
+        // the user's call: it declines while sessions are busy.
+        if socket_answers() && !is_active(&name)? {
+            bail!(
+                "a daemon is already running unsupervised on {}; run `termiod stop` first, then install again",
+                paths::socket_path()?.display()
+            );
+        }
+        let directory = unit_dir()?;
+        std::fs::create_dir_all(&directory)
+            .with_context(|| format!("creating {}", directory.display()))?;
+        let socket_override = std::env::var("TERMIOD_SOCK").ok();
+        let contents = unit(
+            &super::resolved_binary()?,
+            socket_override.as_deref(),
+            super::channel().as_deref(),
+        );
+        std::fs::write(&path, contents).with_context(|| format!("writing {}", path.display()))?;
+
+        let was_active = is_active(&name)?;
+        checked(
+            systemctl(&["--user", "daemon-reload"])?,
+            "systemctl --user daemon-reload",
+        )?;
+        checked(
+            systemctl(&["--user", "enable", "--now", &name])?,
+            &format!("systemctl --user enable --now {name}"),
+        )?;
+        println!("installed {name} → {}", path.display());
+        if was_active {
+            // `enable --now` leaves a running unit alone, and restarting it here
+            // would end its sessions without being asked to.
+            println!("the unit was already running; the definition on disk applies at its next start.");
+        }
+
+        // Linger is what makes "survives logout" true, and it changes the box's
+        // logout behavior, so a refusal (polkit over ssh, typically) is a next
+        // step for the operator rather than a failed install.
+        let linger = loginctl(&["enable-linger"])?;
+        if linger.status.success() {
+            println!("termiod now starts at login, restarts if it crashes, and survives logout.");
+        } else {
+            println!("termiod now starts at login and restarts if it crashes.");
+            println!(
+                "linger could not be enabled ({}); to keep the daemon alive after logout, run:\n    loginctl enable-linger $USER",
+                String::from_utf8_lossy(&linger.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+
+    pub fn uninstall() -> Result<()> {
+        let path = unit_path()?;
+        let name = unit_name();
+        // Read before disabling: after `--now` the unit is inactive whether or
+        // not it ever ran, and the message below has to say which.
+        let was_active = is_active(&name).unwrap_or(false);
+        let _ = systemctl(&["--user", "disable", "--now", &name])?;
+        match std::fs::remove_file(&path) {
+            Ok(()) => println!("removed {}", path.display()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                println!("{name} was not installed");
+            }
+            Err(error) => return Err(error).with_context(|| format!("removing {}", path.display())),
+        }
+        let _ = systemctl(&["--user", "daemon-reload"])?;
+        // Linger is left as it was: it is a property of the account, not of
+        // this unit, and the operator may have enabled it for other reasons.
+        if was_active {
+            println!("the daemon and its running sessions were stopped; it will not restart.");
+        } else {
+            println!("no supervised daemon was running; anything already running is untouched.");
+        }
+        Ok(())
+    }
+
+    pub fn status() -> Result<()> {
+        let path = unit_path()?;
+        let name = unit_name();
+        println!(
+            "unit:    {} ({})",
+            path.display(),
+            if path.exists() { "present" } else { "absent" }
+        );
+        println!("socket:  {}", paths::socket_path()?.display());
+
+        let output = systemctl(&[
+            "--user",
+            "show",
+            &name,
+            "--property=LoadState,ActiveState,UnitFileState,MainPID",
+        ])?;
+        if !output.status.success() {
+            bail!(
+                "systemctl --user show failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        let property = |key: &str| -> String {
+            text.lines()
+                .find_map(|line| line.strip_prefix(key).and_then(|rest| rest.strip_prefix('=')))
+                .unwrap_or_default()
+                .trim()
+                .to_string()
+        };
+        let state = if property("LoadState") == "not-found" {
+            "not installed".to_string()
+        } else {
+            let active = property("ActiveState");
+            let pid = property("MainPID");
+            let enabled = property("UnitFileState");
+            match (active.as_str(), pid.as_str()) {
+                ("active", pid) if pid != "0" && !pid.is_empty() => format!("active (pid {pid})"),
+                (active, _) if enabled.is_empty() => active.to_string(),
+                (active, _) => format!("{active} ({enabled})"),
+            }
+        };
+        println!("service: {state}");
+
+        let uid = unsafe { libc::getuid() }.to_string();
+        let linger = loginctl(&["show-user", &uid, "--property=Linger", "--value"])?;
+        if linger.status.success() {
+            let value = String::from_utf8_lossy(&linger.stdout).trim().to_string();
+            if value == "yes" {
+                println!("linger:  yes");
+            } else {
+                println!("linger:  {value} — the daemon dies at logout; run `loginctl enable-linger $USER`");
+            }
+        } else {
+            println!(
+                "linger:  unknown ({})",
+                String::from_utf8_lossy(&linger.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::systemd::{unit, unit_name_for};
     use super::{plist, LABEL_BASE};
 
     /// The two keys that make this a *supervised* daemon rather than a one-shot
@@ -324,5 +685,74 @@ mod tests {
     fn paths_with_xml_metacharacters_stay_inside_their_element() {
         let text = plist("/opt/a&b/<termiod>", None, LABEL_BASE, None);
         assert!(text.contains("<string>/opt/a&amp;b/&lt;termiod&gt;</string>"), "{text}");
+    }
+
+    // MARK: systemd
+
+    /// The two lines that make the unit a *supervised* daemon rather than a
+    /// one-shot: come back after a crash, and start when the user's manager
+    /// does. `on-failure` and not `always`, so a clean `termiod stop` stays
+    /// stopped.
+    #[test]
+    fn the_unit_starts_at_login_and_restarts_after_a_crash() {
+        let text = unit("/usr/local/bin/termiod", None, None);
+        assert!(text.contains("\nRestart=on-failure\n"), "{text}");
+        assert!(!text.contains("Restart=always"), "{text}");
+        assert!(text.contains("\nWantedBy=default.target\n"), "{text}");
+        assert!(text.contains("\nExecStart=\"/usr/local/bin/termiod\" serve\n"), "{text}");
+        assert!(!text.contains("--wss"), "{text}");
+    }
+
+    #[test]
+    fn no_socket_is_pinned_in_the_unit_unless_the_user_pinned_one() {
+        assert!(!unit("/usr/local/bin/termiod", None, None).contains("TERMIOD_SOCK"));
+
+        let pinned = unit("/usr/local/bin/termiod", Some("/tmp/custom/termiod.sock"), None);
+        assert!(
+            pinned.contains("\nEnvironment=\"TERMIOD_SOCK=/tmp/custom/termiod.sock\"\n"),
+            "{pinned}"
+        );
+    }
+
+    /// Same two axes as the launchd agent: a dev unit is a different unit,
+    /// and it pins its channel, or the daemon systemd starts serves the
+    /// release socket.
+    #[test]
+    fn a_dev_unit_is_a_different_unit_pinned_to_its_own_channel() {
+        assert_eq!(unit_name_for(None), "termiod.service");
+        assert_eq!(unit_name_for(Some("dev")), "termiod-dev.service");
+
+        let release = unit("/usr/local/bin/termiod", None, None);
+        assert!(!release.contains("TERMIO_CHANNEL"), "{release}");
+
+        let dev = unit("/usr/local/bin/termiod", None, Some("dev"));
+        assert!(dev.contains("\nEnvironment=\"TERMIO_CHANNEL=dev\"\n"), "{dev}");
+    }
+
+    /// Every environment line lands inside `[Service]`, before `[Install]`;
+    /// systemd reads a key under the wrong section as an error.
+    #[test]
+    fn a_pinned_socket_and_channel_both_sit_in_the_service_section() {
+        let text = unit("/usr/local/bin/termiod", Some("/tmp/custom/termiod.sock"), Some("dev"));
+        let service = text.find("[Service]").unwrap_or(usize::MAX);
+        let install = text.find("[Install]").unwrap_or(0);
+        let channel = text.find("TERMIO_CHANNEL=").unwrap_or(0);
+        let socket = text.find("TERMIOD_SOCK=").unwrap_or(0);
+        assert!(service < channel && channel < install, "{text}");
+        assert!(service < socket && socket < install, "{text}");
+    }
+
+    /// A path with unit-file metacharacters must not be able to break the
+    /// unit: a space would split the word, `"` would close it, `%` is a
+    /// specifier and `$` a variable to systemd, and any of them yields a unit
+    /// that fails to load with a message that explains nothing.
+    #[test]
+    fn paths_with_unit_metacharacters_stay_inside_their_word() {
+        let text = unit("/opt/a b/100%/$HOME/\"q\"\\termiod", Some("/tmp/50%/x.sock"), None);
+        assert!(
+            text.contains("\nExecStart=\"/opt/a b/100%%/$$HOME/\\\"q\\\"\\\\termiod\" serve\n"),
+            "{text}"
+        );
+        assert!(text.contains("\nEnvironment=\"TERMIOD_SOCK=/tmp/50%%/x.sock\"\n"), "{text}");
     }
 }


### PR DESCRIPTION
Making termiod the only PTY owner makes it a single point of failure. macOS has had `termiod service install` (a launchd agent) for that; Linux bailed with "macOS-only" and pointed at a hand-written unit, so a VPS reboot or an SSH logout could take every session with it.

## What changes

- `termiod service install | uninstall | status` work on Linux with the same clap surface. `install` writes `~/.config/systemd/user/termiod.service` (`termiod-dev.service` on the dev channel) with an absolute `ExecStart`, `Restart=on-failure`, `WantedBy=default.target`, runs `enable --now`, and tries `loginctl enable-linger` — printing `loginctl enable-linger $USER` as the next step when polkit refuses it over SSH. `TERMIO_CHANNEL` is pinned off the release channel and `TERMIOD_SOCK` only if the caller had it set, the same rules as the plist. No `--wss` in the unit; the bind survives in `wss.bind` or a drop-in.
- `uninstall` disables and removes the unit and leaves linger as it was; it says whether sessions were stopped. `status` is dense like the launchd one: unit file, socket, `active (pid N)` / `inactive (enabled)` / `not installed`, linger.
- **No dual start.** When a unit owns the caller's socket, `spawn_daemon` runs `systemctl --user start` instead of forking a `setsid` daemon. After a clean `termiod stop` the unit is merely inactive (`Restart=on-failure` does not restart a clean exit), and a fork would take the socket and leave the unit failing at every later start — demoting the box to unsupervised without anyone asking. The check reads the unit file first, so an unsupervised box spawns no process, and a `TERMIOD_SOCK`-pinned caller (tests, a side-by-side daemon) never starts the real unit.
- `detect_supervisor` uses that same check and the channel-scoped name; it hardcoded `termiod` before. `deploy` keeps SIGTERM as its stop; the bounce path is documented at the stop step.
- `install` refuses while an unsupervised daemon holds the socket, since the unit's daemon would exit "already running" until the start limit tripped.
- Metacharacters in the binary path cannot break the unit (`%`, `$`, `"`, `\`, space, newline are quoted/escaped).

## Docs

`service.rs` module header, `DEPLOY.md` (the hand-written unit becomes `termiod service install`; the WSS section uses a `systemctl --user edit` drop-in), and one sentence each in the lifecycle RFC §4 and §11.

## Verification

- `cargo build` and `cargo build --target aarch64-unknown-linux-musl`: clean (the 8 warnings are pre-existing, in untouched files).
- `cargo test --bin termiod -- service:: lifecycle::`: 20 passed, including 5 new unit tests mirroring the plist ones.
- Exercised on a real box (Ubuntu aarch64, `systemd --user` running, linger already on) with this PR's musl build on the dev channel, so the release daemon and its sessions were never touched:
  - `service install` wrote `termiod-dev.service` with the absolute `ExecStart`, `Restart=on-failure` and `Environment="TERMIO_CHANNEL=dev"`; `status` reported `active (pid 3194178)`, `linger: yes`; `termiod status` reported `service: systemd --user`.
  - `termiod stop` → `systemctl --user is-active` = `inactive`, `is-enabled` = `enabled`; `status` still says `systemd --user` with no daemon running.
  - `termiod list` on the dead socket brought the daemon back with its pid equal to the unit's `MainPID` (3194516) — started through `systemctl --user start`, not a `setsid` fork.
  - `service uninstall` removed the unit and reported the stop; a following `list` autostarted an unsupervised daemon, and `service install` then refused with "a daemon is already running unsupervised on …; run `termiod stop` first" (exit 1). After `stop`, install and uninstall ran clean and `status` reported `not installed`.

Release Notes:

- `termiod service install` now supervises the daemon on Linux with a systemd `--user` unit, so sessions survive a crash, a logout (with linger), and a reboot.

