### PR TITLE
Stop telling users that quitting asks before ending sessions

### DIFF
--- a/web/landing/content/docs/first-session.mdx
+++ b/web/landing/content/docs/first-session.mdx
@@ -82,10 +82,9 @@ reattaches to the session it left rather than starting a new one — same proces
 same output.
 
 <Callout type="note">
-  Ending a session is a deliberate act: `⌘W` closes the focused one, and
-  quitting asks first when something is still running. Everything else —
-  closing the window, losing an SSH connection, relaunching the app — detaches
-  rather than kills.
+  Ending a session is a deliberate act: `⌘W` closes the focused one. Everything
+  else — closing the window, quitting Termio, losing an SSH connection,
+  relaunching the app — detaches rather than kills.
 </Callout>
 
 ## Next steps

--- a/web/landing/content/docs/first-session.zh-CN.mdx
+++ b/web/landing/content/docs/first-session.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 你的第一个会话
 description: 打开项目，在真实终端里启动 Agent，再拆分窗口，让开发服务器和一个 shell 并排待在旁边。
 x-i18n:
   source_path: first-session.mdx
-  source_hash: 4f8d82daa5964141b286df4e81d87a244bf7655c245df4396ebc10e5f0eca77c
-  generated_at: 2026-08-27
+  source_hash: 395c8354c979418f0041e94af38c5d118c949edb653aee712c61d674fb10552a
+  generated_at: 2026-08-30
 ---
 
 Termio 里的*会话*就是一个真实终端，跑着一件事——一个 Agent、一个开发服务器，或者
@@ -75,8 +75,8 @@ Termio 里的*会话*就是一个真实终端，跑着一件事——一个 Agen
 一个——同一个进程，同样的输出。
 
 <Callout type="note">
-  结束会话是一件需要你明确去做的事：`⌘W` 关闭当前会话，退出应用时如果还有东西在跑会
-  先问一句。其余情况——关掉窗口、SSH 断线、重启应用——都只是分离，不会杀掉任何东西。
+  结束会话是一件需要你明确去做的事：`⌘W` 关闭当前会话。其余情况——关掉窗口、退出
+  Termio、SSH 断线、重启应用——都只是分离，不会杀掉任何东西。
 </Callout>
 
 ## 下一步

--- a/web/landing/content/docs/machines.mdx
+++ b/web/landing/content/docs/machines.mdx
@@ -104,8 +104,8 @@ That’s why closing the window leaves everything running, and why a remote
 session isn’t tied to the SSH connection that opened it: dropping the link
 detaches you, it doesn’t kill the agent. Reattaching restores the screen.
 
-Only **Close Session** (`⌘W`) ends a session on purpose. `⌘Q` asks first when
-something is still running.
+Only **Close Session** (`⌘W`) ends a session on purpose. Quitting Termio detaches
+instead, and the next launch reattaches.
 
 ## What reaches across
 

--- a/web/landing/content/docs/machines.zh-CN.mdx
+++ b/web/landing/content/docs/machines.zh-CN.mdx
@@ -3,8 +3,8 @@ title: 工作区与设备
 description: 工作区是侧栏的作用域，它属于某一台设备——本机，或者你用 SSH 能连上的机器。Termio 会在那台机器上装好会话宿主，会话是否附着都照跑不误。
 x-i18n:
   source_path: machines.mdx
-  source_hash: 15dc0d327b0b7d6fce84dd959dce8b5b644f01f5def72c62e055d92cb7deef6b
-  generated_at: 2026-08-27
+  source_hash: ff1e70ecff4e002162d6a735a0b22f67d09afbdcd63d6e42f66675d09bd61832
+  generated_at: 2026-08-30
 ---
 
 Termio 把 Agent 跑在你自己的机器上：本机、同一张桌子上的 Mac mini、你自己付钱的
@@ -86,7 +86,8 @@ daemon 中。应用只是一个负责附着和分离的查看器。
 所以关掉窗口，一切照跑；所以远程会话并不绑在开启它的那条 SSH 连接上：链路断了只是把你
 分离，不会杀掉 Agent。重新附着，屏幕就回来了。
 
-只有**关闭会话**（`⌘W`）才是有意结束一个会话。`⌘Q` 在还有东西在跑时会先问一句。
+只有**关闭会话**（`⌘W`）才是有意结束一个会话。退出 Termio 只是把你分离，下次启动会重新
+附着。
 
 ## 哪些能力跨得过去
 


### PR DESCRIPTION
The user-facing half of #520. Two pages still described the quit confirmation that PR deleted, and both carried the false premise under it — that quitting is a way to end a session.

- `first-session.mdx` — “`⌘W` closes the focused one, and quitting asks first when something is still running.” Quitting now sits on the other list, beside closing the window and losing an SSH link.
- `machines.mdx` — “`⌘Q` asks first when something is still running.” Replaced with what actually happens: it detaches, and the next launch reattaches.

Both Chinese pages retranslated from the new English and restamped. `docs:stamp` also bumps `generated_at` on the 14 untouched translations; those were dropped from the commit, since nothing about them was regenerated.

Verified: `sync-keybindings --check` and `docs-check` both pass (16 pages × 1 locale in step, 104 links resolve).

Release Notes:
- None — docs only.