### PR TITLE
Add the 0.47.0 changelog entry

### DIFF
--- a/web/landing/src/data/changelog.ts
+++ b/web/landing/src/data/changelog.ts
@@ -17,6 +17,26 @@ export type ChangelogEntry = {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: "0.47.0",
+    date: "2026-08-30",
+    title: "Upgrading the session host no longer costs you your sessions",
+    changes: {
+      new: [
+        "Updating a machine's session host replaces the binary in place. Agents keep running, scrollback survives, and an upgrade that cannot go ahead puts everything back and carries on rather than taking your work with it.",
+        "The file tree for a remote project updates itself when files change on that machine, instead of reloading every time you switch back to the window.",
+        "Linux: the session host is supervised by a systemd --user unit, so it comes back after a reboot.",
+      ],
+      improved: [
+        "Opening a remote file and expanding a folder ask the machine for only what changed, so a checkout an agent is writing to no longer costs a full listing on every glance.",
+      ],
+      fixed: [
+        "Quitting no longer warns that it will end every session — it hasn't for some time.",
+        "A finished agent could freeze the app for seconds while its transcript was counted. The count happens off the main thread now, and is cached.",
+        "iPhone: an observer's screen could stay blank or letterboxed after the Mac resized, cursor reports could be read as typing, and F3 with a modifier was dropped.",
+      ],
+    },
+  },
+  {
     version: "0.46.1",
     date: "2026-08-29",
     title: "A stalled session no longer freezes the app",


### PR DESCRIPTION
Covers the 35 commits on `main` since `v0.46.1`, so the tag can be cut without the `Docs` workflow failing on a changelog that trails the releases.

Headline is the session-host handoff: updating a machine's `termiod` now replaces the binary in place, keeping agents running and scrollback intact, and an upgrade that cannot go ahead restores everything rather than dropping it.

`pnpm docs:check` passes: `changelog: newest entry 0.47.0 covers v0.46.1`.

Release Notes: none — the changelog entry is itself the release note for 0.47.0.