### PR TITLE
Let termiod own its systemd unit when publishing a device

### DIFF
--- a/Sources/termio/Settings/RemotePairing.swift
+++ b/Sources/termio/Settings/RemotePairing.swift
@@ -60,10 +60,19 @@ enum RemotePairing {
     /// answer at all — the listener binds loopback on purpose, so nothing on the
     /// box can derive a public name it was not given.
     ///
+    /// `pair` is its own process, outside the unit, so the origin the unit
+    /// hands the daemon (`TERMIOD_WSS_ORIGIN` in its drop-in) is handed to
+    /// `pair` here too — the same value, read back through systemd, so the
+    /// address the invite prints and the origin the daemon pins cannot
+    /// disagree. A box with no drop-in falls through to the daemon's own
+    /// `wss.origin`, which is where a hand-run `--wss-origin` persisted it.
+    ///
     /// Runs on a detached task: this forks `ssh`, and a box that is asleep or
     /// behind a slow link would otherwise block whatever called it.
     static func invite(from alias: String, rotate: Bool = false) async throws -> Invite {
-        let command = "\(Termiod.remoteBinary()) pair --json\(rotate ? " --rotate" : "")"
+        let environment = await RemoteTunnelService.listenerOrigin(of: alias)
+            .map { "TERMIOD_WSS_ORIGIN=\(RemoteShell.quoted($0)) " } ?? ""
+        let command = "\(environment)\(Termiod.remoteBinary()) pair --json\(rotate ? " --rotate" : "")"
         let result = try await run(alias: alias, command: command)
         guard result.status == 0 else {
             throw Failure(message: message(from: result))

--- a/Sources/termio/Settings/RemoteTunnel.swift
+++ b/Sources/termio/Settings/RemoteTunnel.swift
@@ -218,6 +218,9 @@ enum RemoteTunnelPaths {
     static let unitDirectory = "$HOME/.config/systemd/user"
     static let tuneloIdentity = "$HOME/.config/tunelo/termio.key"
     static var tunnelLog: String { "\(stateDirectory)/tunnel.log" }
+    /// Where the daemon writes its own log on Linux (`paths::log_path` in
+    /// termiod). Nothing here redirects to it; it is read back only to explain
+    /// a listener that never came up.
     static var daemonLog: String { "\(stateDirectory)/termiod.log" }
 }
 
@@ -265,8 +268,7 @@ extension RemoteTunnelProvider {
     }
 }
 
-/// The two long-running processes publishing a box needs, expressed as
-/// `systemd --user` units.
+/// The tunnel publishing a box, expressed as a `systemd --user` unit.
 ///
 /// A `setsid nohup` outlives the SSH session that started it and nothing else.
 /// That is the wrong lifetime for this: the point of publishing a VPS is that
@@ -279,23 +281,22 @@ extension RemoteTunnelProvider {
 /// command line on the box, including the `bash -c` that ssh spawned to run the
 /// pkill itself, so a pattern general enough to find the tunnel kills the shell
 /// looking for it. `systemctl --user restart` addresses a unit, not a string.
+///
+/// Only the tunnel is written this way. The daemon's unit belongs to
+/// `termiod service install`: this file once wrote its own `termiod.service`
+/// too, and two writers of one unit name with opposite restart policies left a
+/// box restarting a daemon every three seconds, forever, against the one a
+/// client had already autostarted.
 struct RemoteSystemdUnit {
     let name: String
     let title: String
     let executable: String
     let arguments: [String]
     let log: String
-    /// Whether to empty the log at every start.
-    ///
-    /// True for the tunnel, whose log is read as a *value* — the public address
-    /// it prints — so a stale line from the previous provider must never be
-    /// mistaken for this run's answer. False for the daemon, whose log is read
-    /// as *evidence* and is worth keeping across a restart loop.
-    let freshLog: Bool
 
     var text: String {
         let argv = ([executable] + arguments).map(Self.argument).joined(separator: " ")
-        var lines = [
+        let lines = [
             "[Unit]",
             "Description=\(title)",
             "After=network-online.target",
@@ -310,19 +311,19 @@ struct RemoteSystemdUnit {
             "[Service]",
             "Type=simple",
             "ExecStartPre=/bin/mkdir -p \(Self.argument(RemoteTunnelPaths.stateDirectory))",
-        ]
-        if freshLog {
-            // The raw path, not a converted one: `argument` does the conversion
-            // itself, and feeding it output that already says `%h` escapes the
-            // specifier into the literal `%%h` and the unit exits 2.
-            lines.append("ExecStartPre=/bin/sh -c \(Self.argument(": > \(log)"))")
-        }
-        lines += [
+            // The log is emptied at every start because it is read as a
+            // *value* — the public address the tunnel prints — and a stale
+            // line from the previous provider must never be mistaken for this
+            // run's answer. The raw path, not a converted one: `argument` does
+            // the conversion itself, and feeding it output that already says
+            // `%h` escapes the specifier into the literal `%%h` and the unit
+            // exits 2.
+            "ExecStartPre=/bin/sh -c \(Self.argument(": > \(log)"))",
             "ExecStart=\(argv)",
             "StandardOutput=append:\(Self.specifiers(log))",
             "StandardError=append:\(Self.specifiers(log))",
-            // The tunnel and the daemon are both things the user asked to keep
-            // running; a crash is a reason to come back, not to stay down.
+            // The tunnel is something the user asked to keep running; a crash
+            // is a reason to come back, not to stay down.
             "Restart=always",
             "RestartSec=3",
             "",
@@ -377,11 +378,11 @@ enum RemoteTunnelService {
     }
 
     static let tunnelUnit = "termio-tunnel.service"
-    /// The name the daemon already looks for. `termiod service` writes a launchd
-    /// agent and refuses on Linux, but `termiod status` still probes
-    /// `systemctl --user is-active termiod` to name its supervisor
-    /// (`lifecycle.rs`) — so this is the existing convention, not a second one,
-    /// and a box published from here reports `service: systemd --user`.
+    /// The unit `termiod service install` writes on the release channel
+    /// (`service.rs`, `unit_name_for`). Named here only to stop it, to reload
+    /// it, and to place the drop-in beside it — never to write it. The remote
+    /// daemon is always the release build: nothing this app runs over SSH sets
+    /// `TERMIO_CHANNEL`, so there is no `termiod-dev.service` to account for.
     static let daemonUnit = "termiod.service"
 
     /// `uname -m`, mapped to the builds we publish.
@@ -461,8 +462,7 @@ enum RemoteTunnelService {
             title: "Termio tunnel (\(provider.label))",
             executable: binary,
             arguments: provider.arguments(port: port, custom: custom),
-            log: RemoteTunnelPaths.tunnelLog,
-            freshLog: true)
+            log: RemoteTunnelPaths.tunnelLog)
         try await start(unit, on: alias, failing: localized("Couldn’t start \(provider.label) on \(alias)."))
 
         // Polled rather than slept on: a cold tunnel that has to dial a relay
@@ -570,38 +570,42 @@ extension RemoteTunnelService {
         return "\(webScheme)://\(host)\(port)"
     }
 
-    /// Points the daemon at the address the tunnel just published, and restarts
-    /// it so the listener actually exists.
+    /// Points the daemon at the address the tunnel just published and hands it
+    /// to `systemd --user`, so the listener exists now and comes back after a
+    /// crash, a logout and a reboot.
     ///
-    /// Both halves are needed and both need the restart: `--wss` is what opens
-    /// the loopback listener at all, and `--wss-origin` is what lets the phone's
-    /// `Origin` past the CSRF check. Running `serve` explicitly with the two
-    /// flags also *persists* them (`wss.bind`, `wss.origin`, 0600), so a
-    /// client-triggered autostart on a box whose unit was never installed still
-    /// comes back armed.
+    /// The unit is the daemon's own — `termiod service install` writes it,
+    /// with an absolute `ExecStart`, `Restart=on-failure`, and nothing about
+    /// WSS on its command line. The bind and the origin go in a drop-in beside
+    /// it, which is the durable place for them: `wss.bind` and `wss.origin`
+    /// sit in `$XDG_RUNTIME_DIR`, a tmpfs a reboot empties, and a later
+    /// `service install` overwrites the unit file but leaves
+    /// `termiod.service.d/` alone. The daemon reads `TERMIOD_WSS` and
+    /// `TERMIOD_WSS_ORIGIN` from its environment at every start, so a crash
+    /// restart is armed too.
     ///
     /// **This ends every session the daemon is hosting.** The caller asks first;
     /// this does not, because it cannot know whether the caller already did.
     static func arm(alias: String, origin: String, port: Int) async throws {
+        try await retireHandWrittenUnit(on: alias)
+        try await installListenerDropIn(on: alias, origin: origin, port: port)
+
         // `termiod stop`, never `pkill`: the daemon is found by the credential
         // on its socket, so this stops the one actually serving this user and
         // cannot stop anything else — including the ssh wrapper running the
         // command, which is what an unanchored pattern match reaches.
-        // `--force` because the caller has already named what will end.
+        // `--force` because the caller has already named what will end. It has
+        // to run before `service install`, which refuses while a daemon no unit
+        // owns holds the socket.
         _ = await RemoteShell.run(
             alias: alias,
             command: "\(Termiod.remoteBinary()) stop --force > /dev/null 2>&1 || true")
 
-        let unit = RemoteSystemdUnit(
-            name: daemonUnit,
-            title: "termiod session host",
-            executable: Termiod.remoteBinary(),
-            arguments: ["serve", "--wss", "127.0.0.1:\(port)", "--wss-origin", origin],
-            log: RemoteTunnelPaths.daemonLog,
-            freshLog: false)
-        try await start(
-            unit, on: alias,
-            failing: localized("Couldn’t start termiod on \(alias) with a listener."))
+        let installed = await RemoteShell.run(
+            alias: alias, command: "\(Termiod.remoteBinary()) service install")
+        guard installed.succeeded else {
+            throw Failure(message: localized("Couldn’t put termiod on \(alias) under systemd.\n\(installed.failure)"))
+        }
 
         // The daemon binds its socket before it serves; wait for it rather than
         // guessing, so the pair that follows is not answered by a corpse.
@@ -612,6 +616,107 @@ extension RemoteTunnelService {
             if up.stdout.contains("up") { return }
         }
         throw Failure(message: localized("termiod on \(alias) never opened its listener.\n\(await diagnosis(alias: alias, unit: daemonUnit, log: RemoteTunnelPaths.daemonLog))"))
+    }
+
+    /// Migrates a box this app published before the daemon owned its unit.
+    ///
+    /// Earlier versions wrote `termiod.service` themselves, with `--wss` baked
+    /// into `ExecStart` and `Restart=always`. On a box where a client had since
+    /// autostarted a daemon, that unit sat in `activating` forever: its daemon
+    /// exited "already running" every three seconds and systemd started it
+    /// again. `service install` overwrites the file, but a unit that is
+    /// mid-restart when it does keeps its old definition for that restart and
+    /// would beat the install to the socket — so the old unit is stopped first,
+    /// by name. Stopping a unit whose `MainPID` is 0 kills nothing; stopping one
+    /// that is running the daemon ends what the caller already agreed to end.
+    ///
+    /// `--wss` on the unit's own command line is the mark: the unit
+    /// `termiod service install` writes never carries it.
+    private static func retireHandWrittenUnit(on alias: String) async throws {
+        let path = "\(RemoteTunnelPaths.unitDirectory)/\(daemonUnit)"
+        let retired = await RemoteShell.run(
+            alias: alias,
+            command: """
+                if [ -f \(path) ] && grep -q -- --wss \(path); then \
+                systemctl --user stop \(daemonUnit); fi && \
+                { systemctl --user reset-failed \(daemonUnit) 2>/dev/null || true; }
+                """)
+        guard retired.succeeded else {
+            throw Failure(message: localized("Couldn’t stop the termiod unit an earlier Termio wrote on \(alias).\n\(retired.failure)"))
+        }
+    }
+
+    /// Where the bind and the origin live, beside the unit rather than in it.
+    static func listenerDropIn(unit: String) -> String {
+        "\(RemoteTunnelPaths.unitDirectory)/\(unit).d/override.conf"
+    }
+
+    /// The drop-in `systemctl --user edit termiod` would have written by hand,
+    /// as `termiod/DEPLOY.md` documents it. Values are quoted the way unit
+    /// files read words: `%` is a specifier everywhere, and `\` and `"` could
+    /// close the quotes they sit in. `$` is left alone — unlike `ExecStart=`,
+    /// `Environment=` expands no variables.
+    static func listenerDropInText(origin: String, port: Int) -> String {
+        let quote = { (value: String) -> String in
+            let escaped = value
+                .replacingOccurrences(of: "%", with: "%%")
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+            return "\"\(escaped)\""
+        }
+        return [
+            "[Service]",
+            "Environment=\(quote("TERMIOD_WSS=127.0.0.1:\(port)"))",
+            "Environment=\(quote("TERMIOD_WSS_ORIGIN=\(origin)"))",
+            "",
+        ].joined(separator: "\n")
+    }
+
+    /// Writes the drop-in and reloads before anything starts the unit. The
+    /// reload is here rather than left to `service install`: with
+    /// `Restart=on-failure` the daemon `termiod stop` ends can be restarted by
+    /// systemd before the install runs, and a start that happened between the
+    /// write and a reload would run without the listener.
+    private static func installListenerDropIn(
+        on alias: String, origin: String, port: Int
+    ) async throws {
+        let path = listenerDropIn(unit: daemonUnit)
+        let written = await RemoteShell.run(
+            alias: alias,
+            command: """
+                mkdir -p \(RemoteTunnelPaths.unitDirectory)/\(daemonUnit).d && \
+                printf '%s' \(RemoteShell.quoted(listenerDropInText(origin: origin, port: port))) > \(path).new && \
+                mv \(path).new \(path) && \
+                systemctl --user daemon-reload
+                """)
+        guard written.succeeded else {
+            throw Failure(message: localized("Couldn’t point termiod on \(alias) at \(origin).\n\(written.failure)"))
+        }
+    }
+
+    /// The origin the unit hands the daemon, read from the drop-in through
+    /// systemd rather than from the file, so it is the value the daemon
+    /// actually sees. `nil` on a box with no drop-in — one armed by hand with
+    /// `--wss-origin`, whose daemon persisted the origin itself.
+    static func listenerOrigin(of alias: String) async -> String? {
+        let shown = await RemoteShell.run(
+            alias: alias,
+            command: "systemctl --user show \(daemonUnit) -p Environment --value 2>/dev/null")
+        return listenerOrigin(fromEnvironment: shown.stdout)
+    }
+
+    /// `KEY=value` words as `systemctl show -p Environment --value` prints
+    /// them, space-separated and double-quoted only when the value needs it.
+    static func listenerOrigin(fromEnvironment text: String) -> String? {
+        for word in text.split(whereSeparator: \.isWhitespace) {
+            guard word.hasPrefix("TERMIOD_WSS_ORIGIN=") else { continue }
+            var value = String(word.dropFirst("TERMIOD_WSS_ORIGIN=".count))
+            if value.hasPrefix("\""), value.hasSuffix("\""), value.count >= 2 {
+                value = String(value.dropFirst().dropLast())
+            }
+            return value.isEmpty ? nil : value
+        }
+        return nil
     }
 }
 

--- a/Tests/termioTests/RemoteTunnelTests.swift
+++ b/Tests/termioTests/RemoteTunnelTests.swift
@@ -13,4 +13,47 @@ final class RemoteTunnelTests: XCTestCase {
             RemoteTunnelService.originValue(of: "https://relay.example.com:8443/termio"),
             "https://relay.example.com:8443")
     }
+
+    /// The drop-in is the shape `termiod/DEPLOY.md` documents for pinning the
+    /// bind in the unit: both variables, under `[Service]`, and nothing that
+    /// would make it a second writer of the unit file itself.
+    func testListenerDropInCarriesBindAndOriginOnly() {
+        let text = RemoteTunnelService.listenerDropInText(
+            origin: "https://box.example.net", port: 8790)
+        XCTAssertEqual(text, """
+            [Service]
+            Environment="TERMIOD_WSS=127.0.0.1:8790"
+            Environment="TERMIOD_WSS_ORIGIN=https://box.example.net"
+
+            """)
+        XCTAssertFalse(text.contains("ExecStart"))
+        XCTAssertFalse(text.contains("Restart="))
+    }
+
+    /// A `%` in an origin would otherwise be read as a specifier and the unit
+    /// would fail to load — with an error about the drop-in, on the box, that
+    /// nothing on screen would repeat.
+    func testListenerDropInEscapesSpecifiers() {
+        let text = RemoteTunnelService.listenerDropInText(
+            origin: "https://100%.example.net", port: 8790)
+        XCTAssertTrue(text.contains("Environment=\"TERMIOD_WSS_ORIGIN=https://100%%.example.net\""))
+    }
+
+    func testListenerOriginIsReadFromShownEnvironment() {
+        XCTAssertEqual(
+            RemoteTunnelService.listenerOrigin(
+                fromEnvironment: "TERMIOD_WSS=127.0.0.1:8790 TERMIOD_WSS_ORIGIN=https://box.example.net\n"),
+            "https://box.example.net")
+        XCTAssertEqual(
+            RemoteTunnelService.listenerOrigin(
+                fromEnvironment: "TERMIOD_WSS_ORIGIN=\"https://box.example.net\""),
+            "https://box.example.net")
+    }
+
+    /// No drop-in means no answer, not an empty one: `pair` must then fall
+    /// through to the daemon's own `wss.origin`.
+    func testListenerOriginIsAbsentWithoutADropIn() {
+        XCTAssertNil(RemoteTunnelService.listenerOrigin(fromEnvironment: "\n"))
+        XCTAssertNil(RemoteTunnelService.listenerOrigin(fromEnvironment: "TERMIOD_WSS=127.0.0.1:8790"))
+    }
 }


### PR DESCRIPTION
## Why

Publishing a device hand-wrote its own `termiod.service` — `--wss`/`--wss-origin` baked into `ExecStart`, `Restart=always`, `RestartSec=3`. Since #522, `termiod service install` writes the same unit name on Linux with `Restart=on-failure`. Two writers of one unit with opposite policies: on a box where a client had already autostarted the daemon, the hand-written unit sat in a three-second restart loop forever (`ActiveState=activating MainPID=0`, `NRestarts=74332`) against the unsupervised daemon holding the socket.

## What changed

- `RemoteTunnelService.arm` no longer generates a unit for the daemon. It runs `termiod service install` over the existing ssh wrapper and puts the bind in a drop-in, `~/.config/systemd/user/termiod.service.d/override.conf`, with `TERMIOD_WSS=127.0.0.1:8790` and `TERMIOD_WSS_ORIGIN=<origin>` — the shape `termiod/DEPLOY.md` documents under "The durable unit".
- **Why the drop-in, not `wss.bind`:** `wss.bind`/`wss.origin` live beside the socket in `$XDG_RUNTIME_DIR`, a tmpfs a reboot empties; and a later `service install` overwrites the unit file but never touches `termiod.service.d/`. The daemon reads `TERMIOD_WSS`/`TERMIOD_WSS_ORIGIN` from its environment at every start, so the drop-in survives a crash restart, a reinstall and a reboot. Nothing else does all three.
- **Migration is an explicit step** (`retireHandWrittenUnit`): a unit file carrying `--wss` on its own command line is the mark of the old writer — the generated unit never has it. That unit is stopped by name (kills nothing when `MainPID=0`) and `reset-failed` before the install, because a unit mid-restart keeps its old definition for that restart and would beat the install to the socket. The unsupervised daemon is only ever ended through `termiod stop --force`, which the caller already confirmed with the user.
- `pair` runs outside the unit, so `RemotePairing.invite` reads the unit's `TERMIOD_WSS_ORIGIN` back through `systemctl --user show` and hands it to `pair` — the invite and the daemon's origin pin come from one file. A box without a drop-in falls through to the daemon's own `wss.origin` as before.
- `RemoteSystemdUnit` is now tunnel-only; the daemon-log redirection and `freshLog` toggle that existed for the daemon are gone. The tunnel unit is unchanged.

## Verification

`swift build` passes; `swift test` — 879 tests, 0 failures (6 in `RemoteTunnelTests`: drop-in text, specifier escaping, environment parse).

End to end on a VPS (ubuntu, aarch64, `systemd --user`, linger on) that had the stuck hand-written unit and a client-autostarted daemon with 2 idle sessions. The released v0.47.0 `termiod` was staged first (the box ran 0.46.0, which predates Linux `service install`), then the exact command strings `arm` issues, in order:

```
== 1 retireHandWrittenUnit
MainPID=0
ActiveState=inactive                      ← stuck unit stopped; the old daemon is still alive:
daemon:  0.46.0+1597 pid 2970492 (/run/user/1001/termiod/termiod.sock)
== 2 installListenerDropIn
== 3 termiod stop --force
== 4 termiod service install
installed termiod.service → /home/ubuntu/.config/systemd/user/termiod.service
termiod now starts at login, restarts if it crashes, and survives logout.
== 5 listener
up
```

After:

```
$ systemctl --user show termiod -p ActiveState,SubState,MainPID,NRestarts,DropInPaths
MainPID=3204893
NRestarts=0
ActiveState=active
SubState=running
DropInPaths=/home/ubuntu/.config/systemd/user/termiod.service.d/override.conf

$ termiod status
binary:  0.47.0+1639 (/home/ubuntu/.local/bin/termiod)
daemon:  0.47.0+1639 pid 3204893 (/run/user/1001/termiod/termiod.sock)
host:    h_2dd992eedcd43241da3b5aaf3409baf4
service: systemd --user

$ cat ~/.config/systemd/user/termiod.service.d/override.conf
[Service]
Environment="TERMIOD_WSS=127.0.0.1:8790"
Environment="TERMIOD_WSS_ORIGIN=https://4a6c5284842fef36.tunelo.net"

$ journalctl --user -u termiod -n 2
termiod[3204893]: termiod listening on /run/user/1001/termiod/termiod.sock
termiod[3204893]: termiod: wss listening on ws://127.0.0.1:8790/ws (origins: https://4a6c5284842fef36.tunelo.net:443)

$ TERMIOD_WSS_ORIGIN='https://4a6c5284842fef36.tunelo.net' termiod pair --json   # what invite() now runs
{ "host_id": "h_2dd9…", "proto": 1, "token": "…", "url": "https://4a6c5284842fef36.tunelo.net/" }

$ curl … -H 'Origin: https://4a6c5284842fef36.tunelo.net' http://127.0.0.1:8790/ws   → HTTP 101
$ curl … -H 'Origin: https://evil.example.com'             http://127.0.0.1:8790/ws   → HTTP 403
```

`termio-tunnel.service` was not touched (`active`, same MainPID). The two idle sessions ended, as the user agreed before the run.

## Release Notes

- Publishing a device now lets `termiod service install` own the daemon's systemd unit, and keeps the tunnel address in a drop-in beside it; boxes published by an earlier Termio are migrated off the unit it used to write.


Release Notes:

- Publishing a device now hands termiod to systemd via `termiod service install`; the WSS listener lives in a drop-in, so it survives crashes, logouts, and reboots. Boxes with the older hand-written unit are migrated automatically.
