### PR TITLE
Never treat a denied connect as a dead daemon

### DIFF
--- a/scripts/termio
+++ b/scripts/termio
@@ -295,7 +295,21 @@ request_once() {
         # a wedged app that is in fact running fine behind a socket file whose
         # owner is gone — raising TERMIO_CLI_TIMEOUT can never help.
         if [ "$reach" -ne 0 ]; then
-            echo "termio: nothing is listening at $SOCKET (connection refused) — the socket file outlived the app that made it; restart termio" >&2
+            # nc says nothing about *why* a unix connect failed, and the why
+            # decides the advice: EPERM is a sandbox denying this process, not
+            # a stale socket, and "restart termio" sends that reader the wrong
+            # way. zsh's zsocket names the errno and ships on every macOS; the
+            # probe runs under the same sandbox as the failed connect, so it
+            # reproduces the same denial.
+            reason=$(/bin/zsh -c 'zmodload zsh/net/socket 2>/dev/null || exit 9; zsocket "$1" 2>&1' zsocket "$SOCKET" 2>&1) || true
+            case "$reason" in
+                *"operation not permitted"*|*"permission denied"*)
+                    echo "termio: the OS denied the connection to $SOCKET — this process is likely sandboxed (Codex workspace-write blocks unix sockets); termio itself is fine and restarting it will not help — run the command outside the sandbox" >&2 ;;
+                *"no such file"*)
+                    echo "termio: no socket at $SOCKET — termio isn't running; start it first" >&2 ;;
+                *)
+                    echo "termio: nothing is listening at $SOCKET (connection refused) — the socket file outlived the app that made it; restart termio" >&2 ;;
+            esac
         else
             echo "termio: no reply from the app within ${CLIENT_TIMEOUT}s — it may be busy or wedged; check the app, or raise TERMIO_CLI_TIMEOUT" >&2
         fi

--- a/skills/termio/SKILL.md
+++ b/skills/termio/SKILL.md
@@ -9,6 +9,14 @@ If `TERMIO_SESSION` is not set in your environment, you are not running inside
 a Termio-managed session — say so and stop instead of trying to drive sessions
 you cannot see.
 
+A sandboxed command cannot reach the CLI: seatbelt profiles that deny network
+access (Codex `workspace-write` is one) refuse unix-socket connects with
+EPERM, so `termio sessions …` fails with "the OS denied the connection". The
+socket and the app are fine — do not restart Termio; run the command outside
+the sandbox (in Codex, request escalated permissions for it). The link is
+one-directional there: siblings can still drive the sandboxed session, but it
+cannot drive back.
+
 You are running inside Termio alongside other agent sessions in this same
 project. Coordinate with them through the `termio sessions` CLI. Every command
 is scoped to this project automatically; add `--json` for machine-readable

--- a/termiod/src/client.rs
+++ b/termiod/src/client.rs
@@ -21,8 +21,21 @@ const DETACH_KEY: u8 = 0x1c;
 /// Connect to the daemon, auto-starting it if the socket is dead/missing.
 pub async fn connect() -> Result<UnixStream> {
     let sock = paths::socket_path()?;
-    if let Ok(s) = UnixStream::connect(&sock).await {
-        return Ok(s);
+    let error = match UnixStream::connect(&sock).await {
+        Ok(s) => return Ok(s),
+        Err(error) => error,
+    };
+    // Only a connect failure that proves nothing is serving may recover by
+    // spawning. Anything else — EPERM from a sandbox above all — can be a
+    // healthy daemon this process is not allowed to reach, and the daemon a
+    // spawn starts here would unlink the live socket and displace it (#526,
+    // #527).
+    if !absent_daemon(error.raw_os_error()) {
+        bail!(
+            "connecting to termiod at {} failed: {error}{}",
+            sock.display(),
+            denial_hint(error.raw_os_error())
+        );
     }
     // No live daemon — spawn one detached and wait for it to bind.
     spawn_daemon()?;
@@ -70,6 +83,23 @@ pub async fn stdio() -> Result<()> {
         _ = downstream => {}
     }
     Ok(())
+}
+
+/// Whether a connect failure proves nothing is serving the socket. `ENOENT`
+/// (no file) and `ECONNREFUSED` (a file no listener backs) do; every other
+/// errno describes this client's situation, not the daemon's.
+fn absent_daemon(errno: Option<i32>) -> bool {
+    matches!(errno, Some(libc::ENOENT) | Some(libc::ECONNREFUSED))
+}
+
+fn denial_hint(errno: Option<i32>) -> &'static str {
+    match errno {
+        Some(libc::EPERM) | Some(libc::EACCES) => {
+            " — the OS denied the connection, most likely a sandbox; \
+             the daemon may be running fine, and restarting it will not help"
+        }
+        _ => "",
+    }
 }
 
 fn spawn_daemon() -> Result<()> {
@@ -854,4 +884,17 @@ async fn render_cells<W: AsyncWriteExt + Unpin>(
     output.write_all(&rendered).await?;
     output.flush().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod autostart_tests {
+    #[test]
+    fn only_a_provably_absent_daemon_recovers_by_spawning() {
+        assert!(super::absent_daemon(Some(libc::ENOENT)));
+        assert!(super::absent_daemon(Some(libc::ECONNREFUSED)));
+        assert!(!super::absent_daemon(Some(libc::EPERM)));
+        assert!(!super::absent_daemon(Some(libc::EACCES)));
+        assert!(!super::absent_daemon(Some(libc::ETIMEDOUT)));
+        assert!(!super::absent_daemon(None));
+    }
 }

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -516,6 +516,21 @@ pub async fn serve(
     // less with no WebSocket listener or no tombstone log; it is worth nothing
     // to the person whose agent was mid-task if it exits instead.
     let adopted = inherited.is_some();
+    // The claim on the channel, held for the daemon's life. Two cold starts
+    // racing the socket probe could each decide the path was theirs, and the
+    // loser kept a listener bound to an unlinked file forever (#526); with the
+    // lock, the loser exits here. A handoff's `execve` closes the descriptor
+    // (it is CLOEXEC), which releases the lock for the incoming image — and a
+    // failure to re-take it is, like everything on the handoff path, something
+    // to log and go without rather than exit over.
+    let _serve_lock = match paths::acquire_serve_lock() {
+        Ok(lock) => Some(lock),
+        Err(error) if adopted => {
+            eprintln!("termiod: could not take the serve lock after the handoff: {error:#}");
+            None
+        }
+        Err(error) => return Err(error),
+    };
     match paths::ensure_runtime_dir() {
         Ok(_) => {}
         // The directory is already there and already holds the socket this
@@ -527,7 +542,7 @@ pub async fn serve(
         Err(error) => return Err(error),
     }
 
-    let listener = match &inherited {
+    let mut listener = match &inherited {
         Some((blob, _)) => adopt_listener(blob.listener_fd)?,
         None => {
             if sock_path.exists() {
@@ -535,8 +550,18 @@ pub async fn serve(
                     Ok(_) => {
                         anyhow::bail!("termiod already running at {}", sock_path.display());
                     }
-                    Err(_) => {
+                    // Only these errnos prove the file is a corpse. An EPERM
+                    // here is a sandbox denying *this* process, not a dead
+                    // daemon: unlinking on it displaced healthy daemons and
+                    // left them as the unreachable orphans of #526.
+                    Err(error) if socket_is_stale(error.raw_os_error()) => {
                         let _ = std::fs::remove_file(&sock_path);
+                    }
+                    Err(error) => {
+                        anyhow::bail!(
+                            "probing {} failed: {error} — refusing to replace a socket that may still be served",
+                            sock_path.display()
+                        );
                     }
                 }
             }
@@ -697,6 +722,17 @@ pub async fn serve(
     };
     tokio::pin!(shutdown_signal);
 
+    // The socket file's identity at bind time. macOS sweeps $TMPDIR entries it
+    // considers stale, and a raced start used to replace the file — either way
+    // a daemon serving an unlinked path is unreachable and must not keep
+    // pretending otherwise. The periodic check below re-binds a vanished path
+    // and stands down from a replaced one.
+    let mut bound_inode = socket_identity(&sock_path);
+    let mut displacement_reported = false;
+    let mut socket_check = tokio::time::interval(std::time::Duration::from_secs(30));
+    socket_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    socket_check.tick().await;
+
     // Serving is a loop around the accept loop, not the accept loop itself: a
     // handoff that cannot go ahead puts its sessions back and comes out here to
     // carry on serving them. Only a shutdown, or a handoff that lost sessions,
@@ -723,6 +759,48 @@ pub async fn serve(
                             eprintln!("termiod: connection error: {e:#}");
                         }
                     });
+                }
+                _ = socket_check.tick() => {
+                    let identity = socket_identity(&sock_path);
+                    if identity == bound_inode {
+                        displacement_reported = false;
+                    } else if identity.is_none() {
+                        // The file is gone but nothing replaced it — re-bind
+                        // in place. Established connections ride the old
+                        // listener's descriptors and never notice.
+                        match UnixListener::bind(&sock_path) {
+                            Ok(rebound) => {
+                                use std::os::unix::fs::PermissionsExt;
+                                let _ = std::fs::set_permissions(
+                                    &sock_path, std::fs::Permissions::from_mode(0o600));
+                                listener = rebound;
+                                bound_inode = socket_identity(&sock_path);
+                                eprintln!(
+                                    "termiod: {} had vanished; re-bound it",
+                                    sock_path.display());
+                            }
+                            Err(error) => {
+                                eprintln!(
+                                    "termiod: {} is gone and re-binding failed: {error:#}",
+                                    sock_path.display());
+                            }
+                        }
+                    } else if manager.handles().is_empty() {
+                        // Another daemon owns the path and this one holds
+                        // nothing — lingering is how the #526 orphans lived
+                        // for a week. With sessions it stays: they outrank
+                        // reachability, and killing them to tidy a process
+                        // table is the wrong trade.
+                        eprintln!(
+                            "termiod: {} now belongs to another daemon and no sessions are held here; exiting",
+                            sock_path.display());
+                        std::process::exit(0);
+                    } else if !displacement_reported {
+                        displacement_reported = true;
+                        eprintln!(
+                            "termiod: {} now belongs to another daemon; keeping the sessions held here alive",
+                            sock_path.display());
+                    }
                 }
             }
         }
@@ -767,6 +845,18 @@ pub async fn serve(
         Err(error) => eprintln!("termiod: could not remove socket during shutdown: {error}"),
     }
     drained
+}
+
+/// Whether a failed probe connect proves no daemon is behind the socket file.
+fn socket_is_stale(errno: Option<i32>) -> bool {
+    matches!(errno, Some(libc::ECONNREFUSED) | Some(libc::ENOENT))
+}
+
+/// The inode currently at `path`, or `None` when nothing is.
+fn socket_identity(path: &std::path::Path) -> Option<u64> {
+    std::fs::metadata(path)
+        .ok()
+        .map(|metadata| std::os::unix::fs::MetadataExt::ino(&metadata))
 }
 
 /// Re-establish a `UnixListener` on a descriptor that crossed an `execve`.
@@ -2758,5 +2848,17 @@ fn error(re: Option<u64>, code: ErrorCode, message: impl Into<String>, retryable
         code,
         message: message.into(),
         retryable,
+    }
+}
+
+#[cfg(test)]
+mod bind_probe_tests {
+    #[test]
+    fn only_refused_and_missing_mean_a_stale_socket() {
+        assert!(super::socket_is_stale(Some(libc::ECONNREFUSED)));
+        assert!(super::socket_is_stale(Some(libc::ENOENT)));
+        assert!(!super::socket_is_stale(Some(libc::EPERM)));
+        assert!(!super::socket_is_stale(Some(libc::EACCES)));
+        assert!(!super::socket_is_stale(None));
     }
 }

--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -104,6 +104,39 @@ fn durable_log_dir(suffix: &str) -> Result<Option<PathBuf>> {
 
 /// Full path to the control socket. Overridable with `TERMIOD_SOCK` so tests
 /// (and side-by-side daemons) can isolate.
+/// Claims the exclusive right to serve this channel's socket. The returned
+/// file *is* the claim — hold it for the daemon's life; dropping it (or the
+/// process ending, however it ends) releases it.
+pub fn acquire_serve_lock() -> Result<std::fs::File> {
+    // Beside the socket, not in `runtime_dir()`: a `TERMIOD_SOCK` override
+    // moves the socket, and a lock guarding a different directory would
+    // serialize nothing.
+    let dir = state_dir()?;
+    let _ = std::fs::create_dir_all(&dir);
+    flock_exclusive(&dir.join("termiod.lock"))
+}
+
+fn flock_exclusive(path: &std::path::Path) -> Result<std::fs::File> {
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    let taken = unsafe {
+        libc::flock(
+            std::os::fd::AsRawFd::as_raw_fd(&file),
+            libc::LOCK_EX | libc::LOCK_NB,
+        )
+    };
+    if taken != 0 {
+        bail!(
+            "another termiod is starting or serving this channel (lock held at {})",
+            path.display()
+        );
+    }
+    Ok(file)
+}
+
 pub fn socket_path() -> Result<PathBuf> {
     if let Some(explicit) = std::env::var_os("TERMIOD_SOCK") {
         return Ok(PathBuf::from(explicit));
@@ -341,4 +374,20 @@ pub fn ensure_runtime_dir() -> Result<PathBuf> {
             .with_context(|| format!("creating runtime dir {}", dir.display()))?;
     }
     Ok(dir)
+}
+
+#[cfg(test)]
+mod serve_lock_tests {
+    #[test]
+    fn the_serve_lock_is_exclusive_and_released_on_drop() {
+        let path = std::env::temp_dir().join(format!(
+            "termiod-lock-test-{}",
+            std::process::id()
+        ));
+        let held = super::flock_exclusive(&path).expect("first claim");
+        assert!(super::flock_exclusive(&path).is_err(), "second claim must fail");
+        drop(held);
+        super::flock_exclusive(&path).expect("claim after release");
+        let _ = std::fs::remove_file(&path);
+    }
 }


### PR DESCRIPTION
## Summary

`termiod`'s autostart recovered from **any** connect failure as if no daemon existed: the client spawned a new daemon, and a starting daemon that could not connect to an existing socket file unlinked it before binding. Neither side inspected the errno.

Under a sandbox (Codex `workspace-write` denies unix-socket connects with EPERM) this displaced healthy daemons: a sandboxed `termiod list` spawned a daemon inside the sandbox, that daemon unlinked the live socket and then died on `bind` (also denied), and the next unsandboxed client spawned a replacement — leaving the original daemon resident forever with one stale listener fd and no connections, the exact `lsof` signature in #526. The CLI compounded it by reporting EPERM as "connection refused — restart termio" (#527).

Reproduced end-to-end on an isolated channel (`TERMIO_CHANNEL=probe` + `sandbox-exec '(deny network*)'`) before the fix; after it, the sandboxed client refuses without touching the socket and the daemon keeps serving.

## Changes

- **Errno-gated recovery, both sides**: only ENOENT and ECONNREFUSED prove nothing is serving. Any other errno makes the client fail with the real reason (EPERM/EACCES name the sandbox) and makes a starting daemon refuse to replace the socket.
- **Serve lock**: startup takes a `flock` beside the socket, held for the daemon's life, so racing cold starts exit instead of lingering with a listener bound to an unlinked path. `execve` releases it for a handoff's incoming image; on the handoff path a lock failure is logged, never fatal.
- **Displaced-socket self-check** (every 30s): re-binds the path if the OS swept it (macOS prunes stale $TMPDIR entries — the likely story behind the 7-day orphan); a daemon holding no sessions whose path now belongs to another daemon exits instead of lingering; one holding sessions stays and says so.
- **CLI**: on a failed `nc` connect, a `zsocket` probe (ships with macOS) names the errno — denied by the OS (sandbox; restarting will not help), no socket file (app not running), or genuinely refused (the old message, now only when true).
- **Skill**: documents that the sandbox link is one-directional — siblings can drive a sandboxed session; it cannot drive back.

## Verification

- `cargo test`: 199 passed, including new unit tests for both errno classifications and lock exclusivity; `cargo build` clean (the 9 warnings pre-exist on `main`).
- Live smoke test on an isolated probe channel: sandboxed `list` fails with the denial message, socket inode unchanged, daemon still answers; a second `serve` exits on the lock with no resident process.
- `sh -n scripts/termio`; sandboxed `termio sessions list` prints the sandbox message and exits 1; unsandboxed behavior unchanged.

Fixes #526
Fixes #527

## Release Notes

- Fixed: a sandboxed `termiod` call (e.g. from a Codex session) could knock the running daemon off its socket, leaving orphaned `termiod serve` processes and unreachable sessions.
- Fixed: daemon startup is now serialized, so concurrent autostarts no longer leave resident loser processes.
- Fixed: `termio` CLI now says when a connection was denied by a sandbox instead of advising a pointless restart.