### PR TITLE
Bring the README architecture section up to what shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ public beta: [join on TestFlight](https://testflight.apple.com/join/1Arf1UKR).
 
 ## Architecture
 
-Termio is moving every session onto `termiod`, a small Rust daemon that owns the
+Every Termio session runs on `termiod`, a small Rust daemon that owns the
 PTY on whichever machine the work runs on. Each UI — the Mac app, the phone, a
 browser — is a client that attaches to it over one versioned protocol.
 
@@ -176,10 +176,11 @@ a session through another client, which is what stops the phone from being a
 satellite of the Mac — and what makes a session on a VPS the same object as one
 on your laptop.
 
-**Built:** the daemon and its protocol, the `unix` and `ssh` transports,
-snapshot-on-attach, scrollback, and the file and git planes — running behind a
-flag while the Mac app moves onto it. **Not built:** the WSS transport the
-browser and the phone need.
+**Built:** the daemon and its protocol; the `unix`, `ssh`, and `wss`
+transports; snapshot-on-attach; scrollback; the file and git planes; and
+launchd/systemd supervision. The Mac app runs every session through it, and the
+phone attaches to a Mac or a Linux box over WSS. **Not built:** the browser
+client.
 
 The reasoning is in [`termiod/ARCHITECTURE.md`](termiod/ARCHITECTURE.md) and the
 design notes under [`docs/`](docs/README.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -144,7 +144,7 @@ esc、tab、ctrl 和方向键放在键盘上方，按住说话把语音直接转
 
 ## 架构
 
-Termio 正在把每个会话搬到 `termiod` 上——一个小小的 Rust daemon，在活儿实际跑的那台
+Termio 的每个会话都跑在 `termiod` 上——一个小小的 Rust daemon，在活儿实际跑的那台
 机器上持有 PTY。每个界面——Mac 应用、手机、浏览器——都是通过同一套带版本的协议附着
 上去的客户端。
 
@@ -161,9 +161,9 @@ Termio 正在把每个会话搬到 `termiod` 上——一个小小的 Rust daemo
 变的只有管道，每一段上的帧完全一样。没有哪个客户端要穿过另一个客户端才能拿到会话
 ——手机因此不是 Mac 的卫星，VPS 上的会话和笔记本上的会话也因此是同一种东西。
 
-**已经有的：** daemon 和它的协议、`unix` 与 `ssh` 两种传输、附着时的快照、回滚，
-以及文件和 git 平面——目前在一个开关后面跑，Mac 应用正在往上迁。
-**还没有的：** 浏览器和手机需要的 WSS 传输。
+**已经有的：** daemon 和它的协议、`unix`、`ssh`、`wss` 三种传输、附着时的快照、
+回滚、文件和 git 平面，以及 launchd/systemd 托管。Mac 应用的每个会话都跑在它上面，
+手机通过 WSS 附着到 Mac 或 Linux 机器。**还没有的：** 浏览器客户端。
 
 推导过程写在 [`termiod/ARCHITECTURE.md`](termiod/ARCHITECTURE.md) 和
 [`docs/`](docs/README.md) 下的设计笔记里。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -146,7 +146,7 @@ npx skills add termio-sh/termio --skill termio
 
 ## 架構
 
-Termio 正在把每個工作階段搬到 `termiod` 上 — 一個小小的 Rust daemon，在活兒實際跑
+Termio 的每個工作階段都跑在 `termiod` 上 — 一個小小的 Rust daemon，在活兒實際跑
 的那台機器上持有 PTY。每個介面 — Mac 應用程式、手機、瀏覽器 — 都是透過同一套帶版本
 的協定附著上去的用戶端。
 
@@ -164,9 +164,9 @@ Termio 正在把每個工作階段搬到 `termiod` 上 — 一個小小的 Rust 
 階段 — 手機因此不是 Mac 的衛星，VPS 上的工作階段和筆電上的工作階段也因此是同一種
 東西。
 
-**已經有的：** daemon 和它的協定、`unix` 與 `ssh` 兩種傳輸、附著時的快照、回捲，
-以及檔案和 git 平面 — 目前在一個開關後面跑，Mac 應用程式正在往上搬。
-**還沒有的：** 瀏覽器和手機需要的 WSS 傳輸。
+**已經有的：** daemon 和它的協定、`unix`、`ssh`、`wss` 三種傳輸、附著時的快照、
+回捲、檔案和 git 平面，以及 launchd/systemd 託管。Mac 應用的每個工作階段都跑在
+它上面，手機透過 WSS 附著到 Mac 或 Linux 機器。**還沒有的：** 瀏覽器客戶端。
 
 推導過程寫在 [`termiod/ARCHITECTURE.md`](termiod/ARCHITECTURE.md) 和
 [`docs/`](docs/README.md) 底下的設計筆記裡。


### PR DESCRIPTION
The paragraph still said termiod runs behind a flag while the Mac app migrates, and that the WSS transport is not built. Both are stale: termiod has been the only session backend since 2026-08-22, and WSS shipped — the phone attaches to a Mac or a Linux box over it, with launchd/systemd supervision. The browser client is what remains unbuilt, so the paragraph now says that. English, zh-CN, zh-TW; ja/ko have no architecture section.

Release Notes:
- N/A (README only)