### PR TITLE
Keep termiod's identity and pairing state across reboots

### DIFF
--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -56,11 +56,28 @@ extension Termiod {
 
     /// The directory the daemon keeps everything that belongs to *one host* in
     /// — `host.id`, the pairing token, the durable wss settings. Mirrors
-    /// `state_dir()` in termiod/src/paths.rs, which is the configured socket's
-    /// own directory precisely so a channel-scoped socket takes its identity
-    /// with it.
-    static func stateDirectory() -> String {
-        (socketPath() as NSString).deletingLastPathComponent
+    /// `durable_state_dir()` in termiod/src/paths.rs: on macOS that is
+    /// `~/Library/Application Support/termio<suffix>`, deliberately not the
+    /// socket's temp directory, which the OS may clear and a reboot forgets.
+    /// A `TERMIOD_SOCK` override keeps it beside the socket — the same
+    /// isolation rule the Rust side follows for a daemon pointed at its own
+    /// socket.
+    static func durableStateDirectory() -> String {
+        durableStateDirectory(channelSuffix: AppChannel.suffix,
+                              environment: ProcessInfo.processInfo.environment,
+                              home: NSHomeDirectory())
+    }
+
+    /// Separate from the caller above for the same reason as `socketPath`:
+    /// the mirror to termiod/src/paths.rs drifts silently, so it has to be
+    /// testable without a bundle.
+    static func durableStateDirectory(channelSuffix: String,
+                                      environment: [String: String],
+                                      home: String) -> String {
+        if let explicit = environment["TERMIOD_SOCK"], !explicit.isEmpty {
+            return (explicit as NSString).deletingLastPathComponent
+        }
+        return home + "/Library/Application Support/termio" + channelSuffix
     }
 
     /// The pairing secret that authenticates a WebSocket pipe to this daemon —
@@ -71,8 +88,17 @@ extension Termiod {
     /// on their next dial, and a cached copy would keep letting them in until
     /// the app was relaunched. nil means nothing has ever paired with this
     /// daemon.
+    /// The socket-side path is a fallback, not a second home: a daemon from
+    /// before the durable split keeps its token beside the socket until its
+    /// next start adopts it, and pairing must keep working across that window.
     static func pairToken() -> String? {
-        let path = stateDirectory() + "/pair.token"
+        if let token = readToken(at: durableStateDirectory() + "/pair.token") {
+            return token
+        }
+        return readToken(at: (socketPath() as NSString).deletingLastPathComponent + "/pair.token")
+    }
+
+    private static func readToken(at path: String) -> String? {
         guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
             return nil
         }

--- a/Sources/termio/Terminal/Termiod/TermiodDevice.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodDevice.swift
@@ -57,7 +57,7 @@ enum TermiodRoute: Hashable, Codable, CustomStringConvertible {
 
 /// One machine running one `termiod`. Its identity is the daemon's `host_id` —
 /// a stable random 128-bit value minted on the daemon's first run and persisted
-/// beside its socket (termiod/src/paths.rs). Everything else about a device,
+/// in its durable state dir (termiod/src/paths.rs). Everything else about a device,
 /// routes included, is discovered by connecting and can change underneath it.
 struct TermiodDevice: Codable, Identifiable, Hashable {
     /// The daemon's `host_id`, e.g. `h_3f0a…`.

--- a/Tests/termioTests/TermiodDaemonBinaryTests.swift
+++ b/Tests/termioTests/TermiodDaemonBinaryTests.swift
@@ -144,4 +144,25 @@ final class TermiodDaemonBinaryTests: XCTestCase {
     func testTheReleaseChannelIsNamedNotOmitted() {
         XCTAssertFalse(Termiod.channelName.isEmpty)
     }
+
+    /// The durable-state mirror of termiod/src/paths.rs: per channel, under
+    /// Application Support — and back beside the socket the moment
+    /// `TERMIOD_SOCK` pins one, so a test daemon's token never shadows the
+    /// real one's.
+    func testDurableStateDirectoryIsChannelScoped() {
+        let release = Termiod.durableStateDirectory(
+            channelSuffix: "", environment: [:], home: "/Users/u")
+        let dev = Termiod.durableStateDirectory(
+            channelSuffix: "-dev", environment: [:], home: "/Users/u")
+        XCTAssertEqual(release, "/Users/u/Library/Application Support/termio")
+        XCTAssertEqual(dev, "/Users/u/Library/Application Support/termio-dev")
+    }
+
+    func testPinnedSocketKeepsDurableStateBesideIt() {
+        let pinned = Termiod.durableStateDirectory(
+            channelSuffix: "",
+            environment: ["TERMIOD_SOCK": "/tmp/test-daemon/termiod.sock"],
+            home: "/Users/u")
+        XCTAssertEqual(pinned, "/tmp/test-daemon")
+    }
 }

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -143,7 +143,7 @@ Host 1 ──< Workspace 1 ──< Session 1 ──? Workstream   (workstream = 
 
 | Noun | What it is | Identity | Lifetime |
 | --- | --- | --- | --- |
-| **Host** | One `termiod` process on one machine; owns every PTY and the session table | `host_id`: stable random 128-bit, minted on first run, stored beside the socket | Daemon process (launchd/systemd `--user`); survives all clients |
+| **Host** | One `termiod` process on one machine; owns every PTY and the session table | `host_id`: stable random 128-bit, minted on first run, stored in durable per-user state | Daemon process (launchd/systemd `--user`); survives all clients |
 | **Session** | Durable runtime: PTY + process + (v1) vt state + ring/scrollback | `session_id`: host-scoped ULID; `name` is a mutable human alias, never an identity | From `create` until process exit or `kill`. **Detach never ends it** |
 | **Workstream** | Agent metadata over a session: `agent_id`, project/worktree, `status` (`working·idle·needs_you·done·failed·unknown`), pending approval, title | Same `session_id`; workstream fields are session attributes, not a second object to address | Attached at create or promoted later (agent detection); removed on demotion to plain shell |
 | **Workspace** | A directory root on the host that sessions and non-terminal state are scoped to (a project or worktree). Not a container for processes — a *scope* for filesystem, git, and watch state | Canonicalised absolute path; two spellings of one root are one workspace | Implicit: exists while anything references it. Never created or destroyed explicitly |

--- a/docs/design/20260805-termiod-device-architecture.md
+++ b/docs/design/20260805-termiod-device-architecture.md
@@ -121,7 +121,7 @@ the target; today the phone still reaches sessions through the Mac.
 
 | Concept | What it is | Source of truth |
 | --- | --- | --- |
-| **Device** | A machine running `termiod` | `host_id`, minted on the daemon's first run, persisted beside its socket |
+| **Device** | A machine running `termiod` | `host_id`, minted on the daemon's first run, persisted in its durable state dir |
 | **Route** | A way to reach that device | `~/.ssh/config` for SSH routes; the socket path for local |
 | **Readiness** | Reachable? `termiod` installed? version? | Runtime probe, never configuration |
 

--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -250,7 +250,9 @@ running both does not have them fight.
 ### The token
 
 `termiod pair` mints 24 random bytes as base64url and stores them `0600` at
-`pair.token`, beside `host.id`. `--wss` never mints one: a listener that cannot
+`pair.token`, beside `host.id` in the state dir (`~/.local/state/termio` on
+Linux), so both survive a reboot — the socket's tmpfs does not. `--wss` never
+mints one: a listener that cannot
 authenticate is not something to start by accident.
 
 | Command | What it does |
@@ -278,8 +280,8 @@ if you do, rotate.
 A flag that lives only on one foreground argv dies on the next crash restart —
 the daemon auto-starts as bare `termiod serve`, and so does the unit
 `termiod service install` writes. So an explicit `--wss` with a token in place
-writes `wss.bind` (`0600`) beside the socket, and every later bare start reads
-it back. That is the whole durable path; the generated unit deliberately puts
+writes `wss.bind` (`0600`) into the state dir, and every later bare start —
+including the first one after a reboot — reads it back. That is the whole durable path; the generated unit deliberately puts
 nothing about WSS on its command line.
 
 To pin the bind in the unit as well, use a drop-in rather than editing the
@@ -331,7 +333,7 @@ Session survives: SSH disconnects, laptop sleep, network drops. It ends only on
 | Listener | Unix socket under `$XDG_RUNTIME_DIR/termiod/` (or uid-tmp), mode 0600. **No public port.** The opt-in WebSocket binds loopback and nothing else; TLS and reachability are the proxy's job. |
 | Auth / ACL | **SSH.** Whoever can `ssh my-vps` as your user can reach your daemon — same trust as a shell. Over the WebSocket it is the `pair.token`, and anyone holding it has the same access. |
 | Credentials | Your ssh-agent / `~/.ssh` keys. termiod stores and transmits none. `pair.token` is the one secret it writes, `0600`, and it never leaves the box except in an invite you hand out. |
-| Multi-user | Socket is per-uid and 0600; another user on the box can't connect. A user who can read `pair.token` can, which is why it is `0600` beside the socket. |
+| Multi-user | Socket is per-uid and 0600; another user on the box can't connect. A user who can read `pair.token` can, which is why it is `0600` in a `0700` dir. |
 | Transport crypto | Entirely SSH's, or entirely the front proxy's. termiod adds no crypto and no bespoke protocol on the wire beyond the framed session stream inside the channel. |
 | Browser CSRF | An `Origin` allowlist (`--wss-origin`), defaulting to same-origin. It constrains pages; the token is what authenticates the pipe. There is no exemption for clients that "look native". |
 | Revocation | `termiod pair --rotate`. It drops every attached WebSocket and refuses the old secret from then on. Sessions keep running — a rotation is a detach, not a kill. |

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -541,6 +541,9 @@ pub async fn serve(
         }
         Err(error) => return Err(error),
     }
+    // Before anything reads identity, token, bind or graveyard: a box upgraded
+    // from a build that kept them beside the socket still has them there.
+    paths::adopt_runtime_state();
 
     let mut listener = match &inherited {
         Some((blob, _)) => adopt_listener(blob.listener_fd)?,
@@ -613,7 +616,7 @@ pub async fn serve(
         .flat_map(|(blob, _)| blob.sessions.iter().map(|session| session.id.clone()))
         .collect();
     let graveyard = Arc::new(
-        match paths::state_dir().and_then(|dir| Graveyard::open_retaining(&dir, &carried_ids)) {
+        match paths::durable_state_dir().and_then(|dir| Graveyard::open_retaining(&dir, &carried_ids)) {
             Ok(graveyard) => graveyard,
             Err(error) if adopted => {
                 eprintln!("termiod: the tombstone log did not open after the handoff: {error:#}");

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -316,11 +316,7 @@ pub async fn status() -> Result<NodeStatus> {
             .map(|path| path.display().to_string())
             .unwrap_or_default(),
     };
-    let host_id = paths::host_id_path()
-        .ok()
-        .and_then(|path| std::fs::read_to_string(path).ok())
-        .map(|text| text.trim().to_string())
-        .filter(|text| !text.is_empty());
+    let host_id = paths::stored_host_id();
     let mut daemon = DaemonStatus {
         running: false,
         version: None,

--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -259,24 +259,29 @@ fn adopt_runtime_file(name: &str) {
         std::process::id(),
         ADOPTING.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     ));
-    let published = (|| -> std::io::Result<()> {
+    // A leftover under this exact name is a crashed adopter on a since-reused
+    // pid — ours to clear, and no live adopter's, since live pids are unique.
+    let _ = std::fs::remove_file(&staged);
+    let staged_written = (|| -> std::io::Result<()> {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .mode(0o600)
             .open(&staged)?;
         file.write_all(&contents)?;
-        file.sync_all()?;
-        std::fs::hard_link(&staged, &target)
+        file.sync_all()
     })();
+    // `AlreadyExists` means "another adopter published a complete file" only
+    // when it comes from the link itself and the target is really there —
+    // conflating a staging failure with it would delete the legacy original
+    // without anything ever having been published.
+    let published = staged_written.and_then(|()| std::fs::hard_link(&staged, &target));
     let _ = std::fs::remove_file(&staged);
     match published {
         Ok(()) => {
             let _ = std::fs::remove_file(&legacy);
         }
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            // Another adopter published first; its file is complete, so the
-            // legacy copy has served its purpose either way.
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists && target.exists() => {
             let _ = std::fs::remove_file(&legacy);
         }
         Err(_) => {}

--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -234,14 +234,22 @@ fn adopt_runtime_file(name: &str) {
     let Ok(contents) = std::fs::read(&legacy) else {
         return;
     };
+    // Through a staged name and a rename, so the durable file only ever
+    // appears complete: a crash mid-copy would otherwise leave a torn
+    // `target` that the `target.exists()` check above then treats as the
+    // adopted value forever. A stale staged file from such a crash is
+    // overwritten on the next attempt.
+    let staged = durable.join(format!("{name}.adopting"));
+    let _ = std::fs::remove_file(&staged);
     let written = (|| -> std::io::Result<()> {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .mode(0o600)
-            .open(&target)?;
+            .open(&staged)?;
         file.write_all(&contents)?;
-        file.sync_all()
+        file.sync_all()?;
+        std::fs::rename(&staged, &target)
     })();
     if written.is_ok() {
         let _ = std::fs::remove_file(&legacy);

--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -8,7 +8,7 @@ use crate::id::SessionId;
 use anyhow::{bail, Context, Result};
 use std::io::{Read, Write};
 use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// `"-dev"` for a side-by-side dev build, `""` for a release one.
 ///
@@ -63,9 +63,8 @@ pub fn runtime_dir() -> Result<PathBuf> {
 /// `RemoteTunnelPaths.daemonLog` names for a published Linux box.
 ///
 /// An explicit `TERMIOD_SOCK` overrides that and puts the log beside the socket,
-/// for the same reason `host_id_path` and the graveyard hang off `state_dir`: a
-/// daemon pointed at its own socket is its own daemon, and its files must not
-/// land on the real one's. Without this the test suite — which gives each daemon
+/// the same rule `durable_state_dir` follows: a daemon pointed at its own socket
+/// is its own daemon, and its files must not land on the real one's. Without this the test suite — which gives each daemon
 /// a temp socket but no channel — appends its runs to the installed app's log.
 /// That is the same accident `AppChannel.isRunningTests` exists to prevent on the
 /// Swift side, where it once overwrote a real user's session tree.
@@ -145,10 +144,10 @@ pub fn socket_path() -> Result<PathBuf> {
 }
 
 /// The directory the *configured* socket lives in — which is not always
-/// `runtime_dir()`, because `TERMIOD_SOCK` may point anywhere. Anything that
-/// belongs to one daemon (its identity, its graveyard) must hang off this, or
-/// two daemons on two sockets silently share one file and report each other's
-/// sessions as their own.
+/// `runtime_dir()`, because `TERMIOD_SOCK` may point anywhere. Everything with
+/// the socket's lifetime hangs off this: the serve lock, session scratch, the
+/// handoff blob. What must outlive the socket — identity, pairing secret,
+/// graveyard — hangs off `durable_state_dir` instead.
 pub fn state_dir() -> Result<PathBuf> {
     Ok(socket_path()?
         .parent()
@@ -156,22 +155,124 @@ pub fn state_dir() -> Result<PathBuf> {
         .unwrap_or_else(|| PathBuf::from(".")))
 }
 
-/// Stable host identity, persisted beside the configured socket.
+/// Durable per-daemon state: identity, pairing secret, WSS bind, graveyard.
+///
+/// **Not** beside the socket, unlike everything above. On Linux the canonical
+/// socket lives in `$XDG_RUNTIME_DIR`, a tmpfs a reboot empties — and the first
+/// reboot drill renamed a fifteen-week-old box and silently disarmed its WSS
+/// listener, because identity, secret and graveyard were all riding the
+/// socket's lifetime. sshd survives the same reboot because its host keys live
+/// in `/etc/ssh`; this is that split, per user: files with the socket's
+/// lifetime stay in `state_dir`, files with the *host's* lifetime live here,
+/// in the directory the log already proved durable (macOS: `Application
+/// Support`, where state belongs rather than `Logs`).
+///
+/// An explicit `TERMIOD_SOCK` keeps everything beside the socket — a daemon
+/// pointed at its own socket is its own daemon, and its identity must not land
+/// on the real one's. No `$HOME` falls back the same way rather than refusing
+/// to start.
+pub fn durable_state_dir() -> Result<PathBuf> {
+    if std::env::var_os("TERMIOD_SOCK").is_some() {
+        return state_dir();
+    }
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return state_dir();
+    };
+    let dir = durable_state_base(&home, std::env::var_os("XDG_STATE_HOME"), &channel_suffix());
+    if !dir.exists() {
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&dir)
+            .with_context(|| format!("creating state dir {}", dir.display()))?;
+    }
+    Ok(dir)
+}
+
+fn durable_state_base(home: &Path, xdg_state: Option<std::ffi::OsString>, suffix: &str) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home.join("Library")
+            .join("Application Support")
+            .join(format!("termio{suffix}"))
+    } else if let Some(state) = xdg_state.filter(|value| !value.is_empty()) {
+        PathBuf::from(state).join(format!("termio{suffix}"))
+    } else {
+        home.join(".local").join("state").join(format!("termio{suffix}"))
+    }
+}
+
+/// Bring the files an older daemon kept beside the socket into the durable
+/// dir — at startup, before anything reads them, so an upgrade keeps the
+/// identity and the token the box already has. Copy then remove rather than
+/// rename: `/run` and `$HOME` are different filesystems. Best-effort per
+/// file; one that cannot move is left where the next start can try again.
+pub fn adopt_runtime_state() {
+    for name in [
+        "host.id",
+        "pair.token",
+        "wss.bind",
+        "wss.origin",
+        "tombstones.json",
+        "roster.json",
+    ] {
+        adopt_runtime_file(name);
+    }
+}
+
+fn adopt_runtime_file(name: &str) {
+    let (Ok(legacy_dir), Ok(durable)) = (state_dir(), durable_state_dir()) else {
+        return;
+    };
+    if legacy_dir == durable {
+        return;
+    }
+    let legacy = legacy_dir.join(name);
+    let target = durable.join(name);
+    if target.exists() || !legacy.exists() {
+        return;
+    }
+    let Ok(contents) = std::fs::read(&legacy) else {
+        return;
+    };
+    let written = (|| -> std::io::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&target)?;
+        file.write_all(&contents)?;
+        file.sync_all()
+    })();
+    if written.is_ok() {
+        let _ = std::fs::remove_file(&legacy);
+    }
+}
+
+/// Stable host identity. Durable on purpose: a host id that changes on every
+/// reboot is not an identity, and every pairing invite embeds it.
 pub fn host_id_path() -> Result<PathBuf> {
-    Ok(state_dir()?.join("host.id"))
+    Ok(durable_state_dir()?.join("host.id"))
+}
+
+/// The persisted host identity, if any — for read-only callers (`status`).
+/// Only the daemon mints one.
+pub fn stored_host_id() -> Option<String> {
+    adopt_runtime_file("host.id");
+    read_host_id(&host_id_path().ok()?).ok()
 }
 
 /// The pairing secret that authenticates a WebSocket pipe — never the session
 /// write token, which arbitrates who may type into a PTY. Beside `host.id`
-/// because two daemons on two sockets must not share a secret.
+/// because two daemons on two sockets must not share a secret, and durable
+/// because losing it disarms the listener until the phone re-pairs.
 pub fn pair_token_path() -> Result<PathBuf> {
-    Ok(state_dir()?.join("pair.token"))
+    Ok(durable_state_dir()?.join("pair.token"))
 }
 
-/// The durable WSS bind, so a crash restart or a `spawn_daemon` child that
-/// execs bare `termiod serve` keeps listening.
+/// The durable WSS bind, so a crash restart, a reboot, or a `spawn_daemon`
+/// child that execs bare `termiod serve` keeps listening.
 pub fn wss_bind_path() -> Result<PathBuf> {
-    Ok(state_dir()?.join("wss.bind"))
+    Ok(durable_state_dir()?.join("wss.bind"))
 }
 
 /// The durable allowed origin. Not in the web-client RFC's file table, but
@@ -179,7 +280,7 @@ pub fn wss_bind_path() -> Result<PathBuf> {
 /// binds loopback by design, so without this the reachable name is knowable
 /// only to whoever typed the daemon's argv.
 pub fn wss_origin_path() -> Result<PathBuf> {
-    Ok(state_dir()?.join("wss.origin"))
+    Ok(durable_state_dir()?.join("wss.origin"))
 }
 
 /// 24 random bytes as base64url. No padding: 24 is a multiple of 3.
@@ -244,6 +345,7 @@ pub fn replace_secret(path: &std::path::Path, value: &str) -> Result<()> {
 /// separate from minting on purpose: `serve --wss` must never mint one, or an
 /// operator who forgot to pair gets a listener with a secret nobody has seen.
 pub fn read_pair_token() -> Result<Option<String>> {
+    adopt_runtime_file("pair.token");
     let path = pair_token_path()?;
     match std::fs::read_to_string(&path) {
         Ok(contents) => {
@@ -320,6 +422,7 @@ fn read_host_id(path: &std::path::Path) -> Result<String> {
 
 /// Load the daemon's stable random 128-bit identity, minting it on first run.
 pub fn load_or_create_host_id() -> Result<String> {
+    adopt_runtime_file("host.id");
     let path = host_id_path()?;
     if path.exists() {
         return read_host_id(&path);
@@ -389,5 +492,41 @@ mod serve_lock_tests {
         drop(held);
         super::flock_exclusive(&path).expect("claim after release");
         let _ = std::fs::remove_file(&path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::durable_state_base;
+    use std::path::Path;
+
+    /// One durable dir per channel, or the dev daemon's identity overwrites the
+    /// release one's — the same two-axis scoping the socket and the unit have.
+    #[test]
+    fn durable_state_is_scoped_by_channel() {
+        let home = Path::new("/home/u");
+        let release = durable_state_base(home, None, "");
+        let dev = durable_state_base(home, None, "-dev");
+        assert_ne!(release, dev);
+        assert!(dev.to_string_lossy().ends_with("termio-dev"), "{dev:?}");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn xdg_state_home_outranks_the_default() {
+        let dir = durable_state_base(Path::new("/home/u"), Some("/var/state".into()), "");
+        assert_eq!(dir, Path::new("/var/state/termio"));
+        let fallback = durable_state_base(Path::new("/home/u"), None, "");
+        assert_eq!(fallback, Path::new("/home/u/.local/state/termio"));
+        // An empty variable is unset, not a root-relative state dir.
+        let empty = durable_state_base(Path::new("/home/u"), Some("".into()), "");
+        assert_eq!(empty, fallback);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_state_lives_in_application_support() {
+        let dir = durable_state_base(Path::new("/Users/u"), None, "");
+        assert_eq!(dir, Path::new("/Users/u/Library/Application Support/termio"));
     }
 }

--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -41,6 +41,12 @@ pub fn channel_suffix() -> String {
 /// whole session table, so sharing one between the release app and a dev build
 /// beside it makes them one device: each is handed the other's entire roster,
 /// draws every row of it as a session nothing accounts for, and can kill it.
+/// Whether the caller pinned its own socket — the axis every "beside the
+/// socket or not" decision in this file turns on. Empty counts as unset.
+fn socket_is_pinned() -> bool {
+    std::env::var_os("TERMIOD_SOCK").is_some_and(|value| !value.is_empty())
+}
+
 pub fn runtime_dir() -> Result<PathBuf> {
     let suffix = channel_suffix();
     let base = if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR") {
@@ -75,7 +81,7 @@ pub fn log_path() -> Result<PathBuf> {
     if let Some(explicit) = std::env::var_os("TERMIOD_LOG") {
         return Ok(PathBuf::from(explicit));
     }
-    if std::env::var_os("TERMIOD_SOCK").is_some() {
+    if socket_is_pinned() {
         return Ok(state_dir()?.join("termiod.log"));
     }
     durable_log_dir(&channel_suffix())?.map_or_else(
@@ -137,7 +143,11 @@ fn flock_exclusive(path: &std::path::Path) -> Result<std::fs::File> {
 }
 
 pub fn socket_path() -> Result<PathBuf> {
-    if let Some(explicit) = std::env::var_os("TERMIOD_SOCK") {
+    // An empty value is unset, not a socket in the current directory — the
+    // Swift mirror (`Termiod.socketPath`) already reads it that way, and the
+    // two sides deriving different sockets from one environment is the drift
+    // this file exists to prevent.
+    if let Some(explicit) = std::env::var_os("TERMIOD_SOCK").filter(|value| !value.is_empty()) {
         return Ok(PathBuf::from(explicit));
     }
     Ok(runtime_dir()?.join("termiod.sock"))
@@ -172,7 +182,7 @@ pub fn state_dir() -> Result<PathBuf> {
 /// on the real one's. No `$HOME` falls back the same way rather than refusing
 /// to start.
 pub fn durable_state_dir() -> Result<PathBuf> {
-    if std::env::var_os("TERMIOD_SOCK").is_some() {
+    if socket_is_pinned() {
         return state_dir();
     }
     let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
@@ -234,14 +244,22 @@ fn adopt_runtime_file(name: &str) {
     let Ok(contents) = std::fs::read(&legacy) else {
         return;
     };
-    // Through a staged name and a rename, so the durable file only ever
-    // appears complete: a crash mid-copy would otherwise leave a torn
-    // `target` that the `target.exists()` check above then treats as the
-    // adopted value forever. A stale staged file from such a crash is
-    // overwritten on the next attempt.
-    let staged = durable.join(format!("{name}.adopting"));
-    let _ = std::fs::remove_file(&staged);
-    let written = (|| -> std::io::Result<()> {
+    // Staged under a name unique to this adopter, then published with
+    // `hard_link`, which refuses an existing target. Both halves matter. A
+    // shared staged name lets two concurrent adopters (`serve()` and a
+    // client's lazy read) unlink each other's staging and `rename` would then
+    // publish whatever half-written file the *pathname* resolves to. And
+    // `rename` replaces, so even unique staging could clobber a finished
+    // target with a slower copy. With link-as-publish the durable file only
+    // ever appears complete, and losing the race is success: the winner's
+    // file is whole, because only whole files get published.
+    static ADOPTING: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let staged = durable.join(format!(
+        "{name}.adopting.{}.{}",
+        std::process::id(),
+        ADOPTING.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    let published = (|| -> std::io::Result<()> {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -249,10 +267,19 @@ fn adopt_runtime_file(name: &str) {
             .open(&staged)?;
         file.write_all(&contents)?;
         file.sync_all()?;
-        std::fs::rename(&staged, &target)
+        std::fs::hard_link(&staged, &target)
     })();
-    if written.is_ok() {
-        let _ = std::fs::remove_file(&legacy);
+    let _ = std::fs::remove_file(&staged);
+    match published {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&legacy);
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Another adopter published first; its file is complete, so the
+            // legacy copy has served its purpose either way.
+            let _ = std::fs::remove_file(&legacy);
+        }
+        Err(_) => {}
     }
 }
 
@@ -469,11 +496,8 @@ pub fn load_or_create_host_id() -> Result<String> {
 
 /// Create the runtime dir with 0700 permissions if it does not exist.
 pub fn ensure_runtime_dir() -> Result<PathBuf> {
-    let dir = if let Some(explicit) = std::env::var_os("TERMIOD_SOCK") {
-        PathBuf::from(explicit)
-            .parent()
-            .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| PathBuf::from("."))
+    let dir = if socket_is_pinned() {
+        state_dir()?
     } else {
         runtime_dir()?
     };

--- a/termiod/src/service.rs
+++ b/termiod/src/service.rs
@@ -394,7 +394,7 @@ mod systemd {
     /// exit would race that drain. The next client contact starts the unit
     /// again (`client::spawn_daemon`), which is the bounce path an update
     /// takes. WSS is deliberately not on the command line: the bind survives in
-    /// `wss.bind` beside the socket, or in a `TERMIOD_WSS` drop-in.
+    /// `wss.bind` in the daemon's durable state, or in a `TERMIOD_WSS` drop-in.
     pub fn unit(binary: &str, socket_override: Option<&str>, channel: Option<&str>) -> String {
         let mut environment = String::new();
         if let Some(channel) = channel {

--- a/termiod/src/tombstone.rs
+++ b/termiod/src/tombstone.rs
@@ -7,7 +7,8 @@
 //! rather than "everything was lost".
 //!
 //! Sessions cannot be resurrected; the PTYs are gone. They must not vanish
-//! silently either. So two records are kept beside the socket:
+//! silently either. So two records are kept in the daemon's durable state
+//! dir — not beside the socket, whose tmpfs a reboot empties:
 //!
 //! - a **roster** of the sessions currently alive, rewritten as they come and
 //!   go. It exists solely so the *next* daemon can see what the last one was
@@ -241,8 +242,9 @@ impl State {
     }
 }
 
-/// The on-disk record of what died. One per daemon, living beside the socket so
-/// it shares the socket's lifetime and permissions.
+/// The on-disk record of what died. One per daemon, in `durable_state_dir` —
+/// a record whose whole purpose is to explain a loss must survive the reboot
+/// that caused it.
 pub struct Graveyard {
     graves_path: PathBuf,
     roster_path: PathBuf,

--- a/termiod/src/wss.rs
+++ b/termiod/src/wss.rs
@@ -684,8 +684,14 @@ fn start_rotation_watch() -> Rotation {
 }
 
 fn install_watch(sender: watch::Sender<u64>) -> Result<RecommendedWatcher> {
-    let directory = paths::state_dir()?;
-    let token_name = paths::pair_token_path()?
+    // Derived from the token's own path, not `state_dir`: the token lives in
+    // the durable dir, and a watch on the socket dir would never see a rotate.
+    let token_path = paths::pair_token_path()?;
+    let directory = token_path
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .ok_or_else(|| anyhow::anyhow!("the pairing token has no parent directory"))?;
+    let token_name = token_path
         .file_name()
         .map(std::ffi::OsString::from)
         .ok_or_else(|| anyhow::anyhow!("the pairing token has no file name"))?;


### PR DESCRIPTION
The reboot drill on a real VPS found that everything termiod must remember — `host.id`, `pair.token`, `wss.bind`, `wss.origin`, the graveyard (`tombstones.json` + `roster.json`) — lived beside the socket in `$XDG_RUNTIME_DIR`: a tmpfs the reboot empties. One reboot renamed a fifteen-week-old box (fresh `host.id`, so device lists see a new machine, and invites embed the wrong identity) and silently disarmed the WSS listener (`wss skipped: no pair.token`), even though systemd brought the daemon itself back correctly.

## What changes

- **State is split by lifetime**, the way sshd keeps host keys in `/etc/ssh` while its runtime lives in `/run`. `state_dir` (beside the socket) keeps the serve lock, session scratch, and the handoff blob. A new `durable_state_dir` holds the six files that must outlive the socket: `~/Library/Application Support/termio{-suffix}` on macOS, `$XDG_STATE_HOME`/`~/.local/state/termio{-suffix}` elsewhere — the directory the daemon log already proved durable. Channel-scoped like everything else.
- **`TERMIOD_SOCK` still pins everything beside the socket** — a daemon pointed at its own socket is its own daemon; the whole test suite runs on that rule and passes unchanged.
- **Upgrades adopt.** At `serve()` startup (and lazily in the token/host-id readers, for a `pair` or `status` run before the daemon restarts), files an older build kept beside the socket are copied into the durable dir — copy then remove, because `/run` and `$HOME` are different filesystems — so a box keeps the identity and token it already has.
- The pairing-token **rotation watcher** follows the token's own parent directory instead of assuming `state_dir`.
- `DEPLOY.md` names the new locations.

## Verification

- `cargo test`: 235 passed, 0 failed (the 201 integration tests all pin `TERMIOD_SOCK`, exercising the isolation rule).
- `cargo build` and `cargo build --target aarch64-unknown-linux-musl`: clean.
- Live on a Linux box (dev channel, release daemon untouched): seeded legacy files in the runtime dir → daemon adopted all six (runtime dir left holding only socket + lock), `status` reported the seeded host id, `pair` answered with the seeded token, and the listener armed from the adopted bind. Then wiped the runtime dir and restarted — a reboot in miniature — and the identity and listener both survived.

Release Notes:

- A reboot no longer changes a Linux box's identity or forgets its pairing: termiod now keeps `host.id`, the pairing token, the WSS bind, and session tombstones in durable state (`~/.local/state/termio`), and upgrades migrate the files automatically.
