### PR TITLE
Stop the reattach repaint eating the last line on screen

### DIFF
--- a/termiod/vt/src/lib.rs
+++ b/termiod/vt/src/lib.rs
@@ -251,6 +251,35 @@ impl VtTerminal {
             formatted.extend_from_slice(&bytes);
         }
 
+        let pending_wrap = check(
+            self.terminal.is_cursor_pending_wrap(),
+            "Terminal::is_cursor_pending_wrap",
+        )?;
+
+        // The formatter paints a scrolled primary screen as one newline-joined
+        // flow and stops at the last non-blank row, dropping the blank rows
+        // beneath it — and with them the scroll steps the host has already
+        // taken. A client replaying the payload then holds a screen sitting a
+        // row (or more) behind the host's, so the cursor re-assert below lands
+        // *on* the last painted line instead of the blank row under it, and the
+        // first live byte after the snapshot overwrites that line in place.
+        // This is the reattach seam that ate exactly one line per attach: the
+        // line written in the attach second.
+        //
+        // The engine itself referees: replay the payload into a scratch
+        // terminal of the same grid and, while its screen trails the live one,
+        // feed it the newlines the flow dropped. The padding is adopted only
+        // once the replay converges on the live screen, so a payload the
+        // formatter already positions correctly — an alt-screen frame, a
+        // CUP-addressed repaint, an unscrolled screen — passes through
+        // untouched. Skipped under pending wrap for the same reason the CUP
+        // re-assert is: the formatter's own cell-reprint restore must stand.
+        if !pending_wrap {
+            if let Some(pad) = self.replay_scroll_shortfall(&formatted)? {
+                formatted.extend_from_slice(&pad);
+            }
+        }
+
         // The formatter emits the cursor's CUP *before* the state extras, and
         // some of those move the cursor as a side effect — `tabstops` walks the
         // row with CHA/HTS and leaves it wherever the last stop was, and
@@ -266,10 +295,7 @@ impl VtTerminal {
         // screen diverges from the host's on the very next byte. The formatter's
         // own restore already leaves the cursor in the right place, so this owes
         // nothing further.
-        if !check(
-            self.terminal.is_cursor_pending_wrap(),
-            "Terminal::is_cursor_pending_wrap",
-        )? {
+        if !pending_wrap {
             let cursor_x = check(self.terminal.cursor_x(), "Terminal::cursor_x")?;
             let cursor_y = check(self.terminal.cursor_y(), "Terminal::cursor_y")?;
             formatted.extend_from_slice(
@@ -420,6 +446,61 @@ impl VtTerminal {
             Ok(title) if !title.is_empty() => Some(title.to_string()),
             _ => None,
         })
+    }
+
+    /// How many scroll steps a client replaying `formatted` would end up
+    /// behind this terminal's screen, answered as the `\r\n` padding that
+    /// closes the gap — or `None` when the replay already matches (nothing to
+    /// fix) or never converges within the search bound (nothing this padding
+    /// could fix; the payload ships as-is, which is the pre-existing
+    /// behaviour).
+    ///
+    /// The bound exists because each probe re-reads the scratch grid through
+    /// FFI. A genuine shortfall is the run of blank rows the host's cursor has
+    /// scrolled past — one for a program streaming lines, a handful after a
+    /// burst of bare newlines — so a small cap covers the real cases without
+    /// letting a pathological screen turn a snapshot into a grid crawl.
+    fn replay_scroll_shortfall(&self, formatted: &[u8]) -> Result<Option<Vec<u8>>> {
+        const MAX_SCROLL_SHORTFALL: usize = 8;
+        let rows = check(self.terminal.rows(), "Terminal::rows")?;
+        let cols = check(self.terminal.cols(), "Terminal::cols")?;
+        let live = self.active_codepoints()?;
+        let mut scratch = Self::new(rows, cols)?;
+        scratch.vt_write(formatted);
+        let bound = MAX_SCROLL_SHORTFALL.min(usize::from(rows));
+        for shortfall in 0..=bound {
+            if scratch.active_codepoints()? == live {
+                if shortfall == 0 {
+                    return Ok(None);
+                }
+                return Ok(Some(b"\r\n".repeat(shortfall)));
+            }
+            scratch.vt_write(b"\r\n");
+        }
+        Ok(None)
+    }
+
+    /// The active screen's text, one codepoint per cell in row-major order,
+    /// read through `grid_ref` like `history_cell` — so nothing here touches
+    /// the render state's damage tracking, which `take_damage` owns.
+    fn active_codepoints(&self) -> Result<Vec<u32>> {
+        let rows = check(self.terminal.rows(), "Terminal::rows")?;
+        let cols = check(self.terminal.cols(), "Terminal::cols")?;
+        let mut codepoints = Vec::with_capacity(usize::from(rows) * usize::from(cols));
+        for y in 0..rows {
+            for x in 0..cols {
+                let reference = check(
+                    self.terminal.grid_ref(Point::Active(PointCoordinate {
+                        x,
+                        y: u32::from(y),
+                    })),
+                    "Terminal::grid_ref(active)",
+                )?;
+                let raw_cell = check(reference.cell(), "GridRef::cell(active)")?;
+                codepoints.push(check_at(raw_cell.codepoint(), "Cell::codepoint", "active")?);
+            }
+        }
+        Ok(codepoints)
     }
 
     fn history_cell(&self, x: u16, y: u32) -> Result<Cell> {

--- a/termiod/vt/src/lib.rs
+++ b/termiod/vt/src/lib.rs
@@ -455,19 +455,24 @@ impl VtTerminal {
     /// could fix; the payload ships as-is, which is the pre-existing
     /// behaviour).
     ///
-    /// The bound exists because each probe re-reads the scratch grid through
-    /// FFI. A genuine shortfall is the run of blank rows the host's cursor has
-    /// scrolled past — one for a program streaming lines, a handful after a
-    /// burst of bare newlines — so a small cap covers the real cases without
-    /// letting a pathological screen turn a snapshot into a grid crawl.
+    /// The bound is not a tuning knob: each padding newline scrolls one more
+    /// blank row onto the scratch screen's bottom, so a padded replay can only
+    /// equal the live screen if the live screen ends in at least that many
+    /// blank rows. Probing past the live screen's trailing blank run can
+    /// therefore never converge, and probing up to it costs exactly as much as
+    /// the shortfall that actually exists.
     fn replay_scroll_shortfall(&self, formatted: &[u8]) -> Result<Option<Vec<u8>>> {
-        const MAX_SCROLL_SHORTFALL: usize = 8;
         let rows = check(self.terminal.rows(), "Terminal::rows")?;
         let cols = check(self.terminal.cols(), "Terminal::cols")?;
         let live = self.active_codepoints()?;
         let mut scratch = Self::new(rows, cols)?;
         scratch.vt_write(formatted);
-        let bound = MAX_SCROLL_SHORTFALL.min(usize::from(rows));
+        let blank = |cell: &u32| *cell == 0 || *cell == u32::from(b' ');
+        let bound = live
+            .chunks(usize::from(cols).max(1))
+            .rev()
+            .take_while(|row| row.iter().all(blank))
+            .count();
         for shortfall in 0..=bound {
             if scratch.active_codepoints()? == live {
                 if shortfall == 0 {

--- a/termiod/vt/tests/attach_replay.rs
+++ b/termiod/vt/tests/attach_replay.rs
@@ -1,0 +1,127 @@
+//! A snapshot payload must leave a replaying client on the *same* screen as
+//! the host — including the scroll position. The formatter paints a scrolled
+//! primary screen as one newline-joined flow that stops at the last non-blank
+//! row, so without compensation the client ends up a scroll step behind the
+//! host, the trailing cursor re-assert lands on the last painted line, and the
+//! first live byte after the seam overwrites that line. That was the reattach
+//! bug: quit the app mid-stream, reopen it, and the line written in the attach
+//! second vanished from the screen.
+
+use termiod_vt::VtTerminal;
+
+fn screen(vt: &mut VtTerminal) -> Vec<String> {
+    let snapshot = vt.snapshot().expect("snapshot");
+    let cols = usize::from(snapshot.cols);
+    snapshot
+        .cells
+        .chunks(cols)
+        .map(|row| {
+            row.iter()
+                .map(|cell| char::from_u32(cell.codepoint).unwrap_or(' '))
+                .map(|c| if c == '\0' { ' ' } else { c })
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect()
+}
+
+fn replay(host: &mut VtTerminal, rows: u16, cols: u16) -> VtTerminal {
+    let payload = host.format_vt().expect("format_vt");
+    let mut client = VtTerminal::new(rows, cols).expect("client terminal");
+    client.vt_write(&payload);
+    client
+}
+
+/// The captured bug, end to end: a program has been streaming one line per
+/// tick for long enough to scroll, the client attaches, and the next live
+/// line must append below the last one — not overwrite it.
+#[test]
+fn replayed_stream_keeps_the_hosts_scroll_position() {
+    let mut host = VtTerminal::new(15, 50).expect("host terminal");
+    for i in 1..=40 {
+        host.vt_write(format!("tick  {i:04}\r\n").as_bytes());
+    }
+    let mut client = replay(&mut host, 15, 50);
+    assert_eq!(
+        screen(&mut client),
+        screen(&mut host),
+        "replaying the payload must reproduce the host screen, scroll included"
+    );
+
+    let live = b"tick  0041\r\n";
+    host.vt_write(live);
+    client.vt_write(live);
+    let host_screen = screen(&mut host);
+    assert_eq!(screen(&mut client), host_screen);
+    assert!(
+        host_screen.iter().any(|row| row.contains("tick  0040")),
+        "the line written just before the seam must survive the first live line"
+    );
+}
+
+/// A burst of bare newlines leaves several blank rows above the cursor; the
+/// replay has to make up every one of those scroll steps, not just one.
+#[test]
+fn replayed_stream_recovers_multiple_dropped_scrolls() {
+    let mut host = VtTerminal::new(10, 40).expect("host terminal");
+    for i in 1..=20 {
+        host.vt_write(format!("line {i}\r\n").as_bytes());
+    }
+    host.vt_write(b"\r\n\r\n");
+    let mut client = replay(&mut host, 10, 40);
+    assert_eq!(screen(&mut client), screen(&mut host));
+
+    host.vt_write(b"after");
+    client.vt_write(b"after");
+    assert_eq!(screen(&mut client), screen(&mut host));
+}
+
+/// An unscrolled screen has no shortfall to make up; the payload must pass
+/// through unpadded and still replay exactly.
+#[test]
+fn short_content_replays_without_padding() {
+    let mut host = VtTerminal::new(15, 50).expect("host terminal");
+    host.vt_write(b"one\r\ntwo\r\nthree\r\n");
+    let mut client = replay(&mut host, 15, 50);
+    assert_eq!(screen(&mut client), screen(&mut host));
+
+    host.vt_write(b"four");
+    client.vt_write(b"four");
+    assert_eq!(screen(&mut client), screen(&mut host));
+}
+
+/// Pending wrap is the formatter's own restore (ghostty#13876): the payload
+/// ends by reprinting the final cell, and neither the padding nor the cursor
+/// re-assert may disturb it. The next character must wrap on the client
+/// exactly as it does on the host.
+#[test]
+fn pending_wrap_restore_is_left_alone() {
+    let mut host = VtTerminal::new(10, 20).expect("host terminal");
+    for i in 1..=12 {
+        host.vt_write(format!("row {i}\r\n").as_bytes());
+    }
+    host.vt_write(b"ABCDEFGHIJKLMNOPQRST"); // exactly 20 cols: cursor holds pending wrap
+    let mut client = replay(&mut host, 10, 20);
+    assert_eq!(screen(&mut client), screen(&mut host));
+
+    host.vt_write(b"X");
+    client.vt_write(b"X");
+    assert_eq!(
+        screen(&mut client),
+        screen(&mut host),
+        "the next character must wrap identically on both ends"
+    );
+}
+
+/// An alt-screen frame (vim, top) repaints on the alternate buffer with its
+/// own addressing; the replay must reproduce it and the padding must never
+/// scroll it.
+#[test]
+fn alt_screen_replays_exactly() {
+    let mut host = VtTerminal::new(10, 40).expect("host terminal");
+    host.vt_write(b"shell history line\r\n");
+    host.vt_write(b"\x1b[?1049h\x1b[2J\x1b[H\x1b[3;5Halt content\x1b[7;1Hstatus bar");
+    let mut client = replay(&mut host, 10, 40);
+    assert_eq!(screen(&mut client), screen(&mut host));
+}

--- a/termiod/vt/tests/attach_replay.rs
+++ b/termiod/vt/tests/attach_replay.rs
@@ -60,6 +60,39 @@ fn replayed_stream_keeps_the_hosts_scroll_position() {
     );
 }
 
+/// A long burst of bare newlines — more than any small fixed cap would allow —
+/// still converges: the search bound is the live screen's trailing blank run,
+/// not a constant.
+#[test]
+fn replayed_stream_recovers_a_screenful_of_dropped_scrolls() {
+    let mut host = VtTerminal::new(20, 40).expect("host terminal");
+    for i in 1..=30 {
+        host.vt_write(format!("line {i}\r\n").as_bytes());
+    }
+    host.vt_write(&b"\r\n".repeat(12));
+    let mut client = replay(&mut host, 20, 40);
+    assert_eq!(screen(&mut client), screen(&mut host));
+
+    host.vt_write(b"after");
+    client.vt_write(b"after");
+    assert_eq!(screen(&mut client), screen(&mut host));
+}
+
+/// A screen scrolled fully blank (the cursor parked below a wall of newlines)
+/// is the extreme of the same case.
+#[test]
+fn fully_blank_scrolled_screen_replays_exactly() {
+    let mut host = VtTerminal::new(10, 40).expect("host terminal");
+    host.vt_write(b"only line\r\n");
+    host.vt_write(&b"\r\n".repeat(15));
+    let mut client = replay(&mut host, 10, 40);
+    assert_eq!(screen(&mut client), screen(&mut host));
+
+    host.vt_write(b"back");
+    client.vt_write(b"back");
+    assert_eq!(screen(&mut client), screen(&mut host));
+}
+
 /// A burst of bare newlines leaves several blank rows above the cursor; the
 /// replay has to make up every one of those scroll steps, not just one.
 #[test]


### PR DESCRIPTION
Quit the app while a session streams output, reopen it, and the line written in the attach second vanished from the screen — reproducibly, every attach. The daemon's authoritative VT always had the line (an observer attach showed the full sequence with zero gaps); only the reattached app's screen lost it.

The mechanism, taken from a byte tap between the app and the daemon: the snapshot formatter serialises a scrolled primary screen as one newline-joined flow that stops at the last non-blank row. The blank rows beneath it — the scroll steps the host has already taken — never reach the client, so the replayed screen sits one row behind the host's. The trailing cursor re-assert then lands *on* the last painted line instead of the blank row under it, and the first live byte after the seam overwrites that line in place.

The fix stays in `termiod-vt`'s `format_vt`, and the engine itself referees: replay the payload into a scratch terminal of the same grid, and while its screen trails the live one, feed it the newlines the flow dropped — adopting the padding only once the replay converges on the live screen. Payloads the formatter already positions correctly (alt-screen frames, unscrolled screens, pending-wrap restores) pass through untouched, and the shortfall search is bounded so a pathological screen can't turn a snapshot into a grid crawl. The active-screen reads go through `grid_ref` like history cells, so damage tracking is never touched.

Verified three ways:
- `termiod/vt/tests/attach_replay.rs`: five replay tests, including the captured bug shape; the two scroll cases fail without the fix and pass with it.
- `cargo test` across the termiod workspace: all green.
- Live: with the fixed daemon, five quit-relaunch rounds against a streaming counter session reattached with zero lost lines (the same experiment reproduced the loss on every round before the fix).

Release Notes:
- Fixed: reopening the app no longer loses the line a session printed at the moment of reattach.