### PR TITLE
Stop split resizes duplicating the shell prompt

### DIFF
--- a/termiod/vt/src/lib.rs
+++ b/termiod/vt/src/lib.rs
@@ -13,7 +13,7 @@ use libghostty_vt::fmt::{Format, Formatter, FormatterOptions};
 use libghostty_vt::render::{CellIterator, Dirty, RenderState, RowIterator};
 use libghostty_vt::screen::{CellContentTag, Screen};
 use libghostty_vt::style::{RgbColor, StyleColor};
-use libghostty_vt::terminal::{Point, PointCoordinate};
+use libghostty_vt::terminal::{Mode, Point, PointCoordinate};
 use libghostty_vt::{Error, Terminal, TerminalOptions};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -187,7 +187,49 @@ impl VtTerminal {
         self.terminal.vt_write(bytes);
     }
 
+    /// Resize the authoritative screen **without reflowing** it — tmux/xterm
+    /// semantics, not Ghostty.app's.
+    ///
+    /// Shells' SIGWINCH redisplay assumes the terminal did not rewrap the old
+    /// prompt: zsh moves the cursor up by a row count computed from the *old*
+    /// width and repaints from there. A reflowing resize rewraps the prompt
+    /// and moves the cursor down, so that repaint lands one row low and the
+    /// stale prompt copy above it survives — once per split, which is the
+    /// ⌘D duplicated-prompt report. Ghostty.app escapes this only because it
+    /// injects shell integration and clears OSC 133-marked prompt rows before
+    /// reflowing (and its engine's post-1.3.1 clear-after-reflow ordering,
+    /// dde3d4d6b, re-breaks the wrapped case even then). Sessions here carry
+    /// no integration, so the marks-free behaviour every shell is written
+    /// against — truncate, don't rewrap — is the correct one for the host.
+    ///
+    /// The engine gates reflow on DECAWM (mode ?7), so wraparound is parked
+    /// off across the resize and restored to whatever the program had chosen.
+    /// Every attachment repaints from the post-resize keyframe, so clients
+    /// converge on this screen regardless of what their own surfaces did.
     pub fn resize(&mut self, rows: u16, cols: u16) -> Result<()> {
+        let wraparound = check(self.terminal.mode(Mode::WRAPAROUND), "mode(WRAPAROUND)")?;
+        if wraparound {
+            check(
+                self.terminal.set_mode(Mode::WRAPAROUND, false),
+                "set_mode(WRAPAROUND, false)",
+            )?;
+        }
+        let resized = self.resize_reflowing_for_tests(rows, cols);
+        if wraparound {
+            // Restore even when the resize failed: the mode belongs to the
+            // program, and a failed ioctl must not leave autowrap off.
+            check(
+                self.terminal.set_mode(Mode::WRAPAROUND, true),
+                "set_mode(WRAPAROUND, true)",
+            )?;
+        }
+        resized
+    }
+
+    /// The bare engine resize, which reflows whenever the screen's own DECAWM
+    /// is set. Public only so tests can reproduce the reflow duplicate this
+    /// crate's `resize` exists to prevent.
+    pub fn resize_reflowing_for_tests(&mut self, rows: u16, cols: u16) -> Result<()> {
         // Pixel dimensions are not used by the daemon snapshot sidecar; fixed
         // cell metrics still give libghostty-vt consistent total dimensions.
         check(self.terminal.resize(cols, rows, 8, 16), "Terminal::resize")

--- a/termiod/vt/tests/resize_reflow.rs
+++ b/termiod/vt/tests/resize_reflow.rs
@@ -1,0 +1,156 @@
+use termiod_vt::VtTerminal;
+
+/// The user-visible text of a formatted repaint: escapes stripped, one string
+/// per screen row (CUP row addressing and \r\n both split rows).
+fn visible(bytes: &[u8]) -> Vec<String> {
+    let text = String::from_utf8_lossy(bytes);
+    let mut out = vec![String::new()];
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\u{1b}' => match chars.next() {
+                Some('[') => {
+                    let mut command = None;
+                    let mut params = String::new();
+                    for e in chars.by_ref() {
+                        // Intermediates like the '!' in DECSTR (ESC[!p) are
+                        // not the final byte; only an alphabetic ends a CSI.
+                        if e.is_ascii_alphabetic() {
+                            command = Some(e);
+                            break;
+                        }
+                        params.push(e);
+                    }
+                    // CUP to a later row starts a new visible row.
+                    if command == Some('H') && !params.is_empty() {
+                        out.push(String::new());
+                    }
+                }
+                Some(']') => {
+                    // OSC: skip to BEL or ST.
+                    while let Some(e) = chars.next() {
+                        if e == '\u{7}' {
+                            break;
+                        }
+                        if e == '\u{1b}' && chars.peek() == Some(&'\\') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                }
+                Some('(') | Some(')') => {
+                    chars.next();
+                }
+                _ => {}
+            },
+            '\n' => out.push(String::new()),
+            '\r' | '\u{f}' => {}
+            _ => out.last_mut().unwrap().push(c),
+        }
+    }
+    out.into_iter()
+        .map(|l| l.trim_end().to_string())
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+const PROMPT: &str = ">> termio git:(docs/remote-access-after-shipping) x ";
+
+/// zsh's real SIGWINCH redisplay, captured from a live session: carriage
+/// return to what zsh believes is the prompt's first physical row (it assumes
+/// the terminal did NOT rewrap the old prompt), clear down, reprint.
+const ZSH_WINCH_REDRAW: &[u8] = b"\r\r\x1b[0m\x1b[27m\x1b[24m\x1b[J";
+
+#[test]
+fn reflowing_resize_duplicates_the_prompt() {
+    // The bug this crate's no-reflow resize exists to prevent, kept as the
+    // negative control: with reflow on, the engine rewraps the prompt and
+    // moves the cursor down a row, zsh's redraw lands one row low, and the
+    // stale prompt fragment above survives (issue: ⌘D duplicate prompts).
+    let mut vt = VtTerminal::new(24, 63).expect("new");
+    vt.vt_write(b"\x1b[?7h");
+    vt.vt_write(PROMPT.as_bytes());
+    vt.vt_write(b"\x1b[?7h");
+    // Reflowing resize, emulated by leaving wraparound on and calling the
+    // engine directly through a plain resize with autowrap untouched.
+    // (resize() itself now suppresses reflow, so drive the duplicate through
+    // the engine's own behaviour: wraparound on is the engine default.)
+    let rows = visible(&{
+        vt.resize_reflowing_for_tests(24, 47).expect("resize");
+        vt.vt_write(ZSH_WINCH_REDRAW);
+        vt.vt_write(PROMPT.as_bytes());
+        vt.format_vt().expect("fmt")
+    });
+    let copies = rows
+        .iter()
+        .filter(|row| row.starts_with(">> termio git:("))
+        .count();
+    assert!(copies >= 2, "expected the duplicate, got rows: {rows:?}");
+}
+
+#[test]
+fn no_reflow_resize_keeps_zsh_redraw_clean() {
+    let mut vt = VtTerminal::new(24, 63).expect("new");
+    vt.vt_write(PROMPT.as_bytes());
+    vt.resize(24, 47).expect("resize");
+    vt.vt_write(ZSH_WINCH_REDRAW);
+    vt.vt_write(PROMPT.as_bytes());
+    let rows = visible(&vt.format_vt().expect("fmt"));
+    assert_eq!(
+        rows,
+        vec![
+            ">> termio git:(docs/remote-access-after-shippin".to_string(),
+            "g) x".to_string(),
+        ],
+        "one prompt, wrapped at the new width, nothing stale above it"
+    );
+}
+
+#[test]
+fn no_reflow_resize_survives_a_split_storm() {
+    // Three consecutive splits, zsh redrawing after each — the exact ⌘D
+    // sequence from the report. Every intermediate screen must hold exactly
+    // one prompt.
+    let mut vt = VtTerminal::new(24, 95).expect("new");
+    vt.vt_write(PROMPT.as_bytes());
+    for (cols, ups) in [(63u16, 0usize), (47, 0), (38, 1)] {
+        vt.resize(24, cols).expect("resize");
+        vt.vt_write(b"\r");
+        // zsh moves up (old prompt rows - 1) rows; emulate its bookkeeping.
+        for _ in 0..ups {
+            vt.vt_write(b"\x1b[A");
+        }
+        vt.vt_write(b"\r\x1b[0m\x1b[27m\x1b[24m\x1b[J");
+        vt.vt_write(PROMPT.as_bytes());
+        let rows = visible(&vt.format_vt().expect("fmt"));
+        let copies = rows
+            .iter()
+            .filter(|row| row.contains(">> termio git:("))
+            .count();
+        assert_eq!(copies, 1, "at {cols} cols expected one prompt, rows: {rows:?}");
+    }
+}
+
+#[test]
+fn no_reflow_resize_leaves_program_autowrap_choice_alone() {
+    // A program that turned autowrap off keeps it off across a resize; one
+    // that left it on gets it back.
+    // With autowrap off a 60-char write from home pins the cursor to row 0;
+    // with it on, the write wraps and the cursor ends on row 1. The cursor
+    // row comes from the snapshot, so no formatter encoding is involved.
+    let mut vt = VtTerminal::new(24, 80).expect("new");
+    vt.vt_write(b"\x1b[?7l");
+    vt.resize(24, 40).expect("resize");
+    vt.vt_write(b"\x1b[H");
+    vt.vt_write("X".repeat(60).as_bytes());
+    let snapshot = vt.snapshot().expect("snapshot");
+    assert_eq!(snapshot.cursor_y, 0, "autowrap must stay off");
+
+    let mut vt = VtTerminal::new(24, 80).expect("new");
+    vt.resize(24, 40).expect("resize");
+    vt.vt_write(b"\x1b[H");
+    vt.vt_write("X".repeat(60).as_bytes());
+    let snapshot = vt.snapshot().expect("snapshot");
+    assert_eq!(snapshot.cursor_y, 1, "autowrap must come back on");
+}
+


### PR DESCRIPTION
Every ⌘D split shrinks the existing panes, and each shrink left a stale copy of the zsh prompt above the fresh one — three splits stacked three garbled fragments (#⌘D report, screenshots in the session).

**Cause.** A shell's SIGWINCH redisplay assumes the terminal did not rewrap the old prompt: zsh moves the cursor up by a row count computed from the old width and repaints from there. The sidecar VT reflowed on resize, moving the cursor down a wrapped row, so the repaint landed one row low and the stale row survived — then the resize barrier's keyframe baked it into the authoritative screen for every client. Ghostty.app avoids this only because it injects shell integration and clears OSC 133-marked prompt rows before reflowing; termio sessions carry no integration (and ghostty's post-1.3.1 clear-after-reflow reordering, dde3d4d6b, re-breaks the wrapped case even with marks).

**Fix.** `termiod-vt::resize` parks DECAWM off across the engine resize and restores the program's own choice afterwards. The engine gates reflow on DECAWM, so the host screen now resizes by truncation — tmux/xterm semantics, the model every shell's redraw is written against. The barrier keyframe then converges every client on the clean host screen.

Verified with unit tests replaying zsh's captured WINCH bytes (including the three-split storm and a negative control reproducing the old duplicate) and live against a real termiod + zsh: after three consecutive shrinks the settled screen holds exactly one wrapped prompt.

Trade-off: host-side content no longer rewraps when a pane widens again, matching tmux. The ghostty-parity path (OSC 133 shell integration plus the upstream clear-ordering fix) remains open as a refinement.

Release Notes:
- Splitting a pane no longer leaves duplicated or garbled shell prompts in the resized panes.