### PR TITLE
Bring the remote-access and protocol RFCs back in step with the code

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -84,10 +84,6 @@ tmux が教えてくれるはずだった残りは、Mac のショートカッ�
 - スクリプトは `termio sessions`（後述）が `send-keys` の役目を果たし、
   エージェントのステータスは画面ではなくプロトコル上のオブジェクトです。
 
-プレフィックスキーも `.tmux.conf` も、セッション復元のプラグインもなし —
-永続化が効くまでに設定するものは何もありません。tmux が手に馴染んでいるなら、
-ほかのプログラムと同じようにセッションの中でそのまま動きます。
-
 ## お使いのエージェントで動く
 
 Claude Code、Codex、Gemini CLI、Grok、Cursor Agent、Copilot、Amp、OpenCode、

--- a/README.ko.md
+++ b/README.ko.md
@@ -96,10 +96,6 @@ tmux가 가르쳐 줬을 나머지는 Mac 단축키거나, 이미 알고 있는 
 - 스크립트는 `termio sessions`(아래 참고)가 `send-keys` 역할을 하고, 에이전트
   상태는 화면을 긁는 게 아니라 프로토콜 객체예요.
 
-프리픽스 키도, `.tmux.conf`도, 세션 복원 플러그인도 없어요 — 지속성이 동작하기
-전에 설정할 게 하나도 없어요. tmux가 이미 손에 익었다면, 다른 프로그램처럼 세션
-안에서 그대로 돌아가요.
-
 ## 쓰던 에이전트 그대로 동작해요
 
 Claude Code, Codex, Gemini CLI, Grok, Cursor Agent, Copilot, Amp, OpenCode,

--- a/README.md
+++ b/README.md
@@ -92,10 +92,6 @@ your hands:
 - Scripting: `termio sessions` (below) does what `send-keys` scripts do, and
   agent status is a protocol object, not a pane to scrape.
 
-No prefix key, no `.tmux.conf`, no plugins to restore sessions — there is
-nothing to configure before the durability works. And if tmux is already
-muscle memory, it still runs inside a session like any other program.
-
 ## Works with your agents
 
 Claude Code, Codex, Antigravity, Grok, Cursor Agent, Copilot, Amp, OpenCode,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,9 +83,6 @@ tmux 剩下要教你的东西，要么是一个 Mac 快捷键，要么你本来�
 - 脚本化：`termio sessions`（见下文）干的就是 `send-keys` 脚本干的事，而且
   Agent 状态是协议对象，不用抓屏。
 
-没有前缀键，没有 `.tmux.conf`，不用装插件来恢复会话——持久化生效之前，没有任何
-东西需要配置。如果 tmux 已经是你的肌肉记忆，它在会话里照样能跑，和别的程序一样。
-
 ## 和你现有的 Agent 一起用
 
 Claude Code、Codex、Antigravity、Grok、Cursor Agent、Copilot、Amp、OpenCode、

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -84,10 +84,6 @@ tmux 剩下要教你的東西，要麼是一個 Mac 快捷鍵，要麼你本來�
 - 腳本化：`termio sessions`（見下文）做的就是 `send-keys` 腳本做的事，而且
   Agent 狀態是協定物件，不用抓畫面。
 
-沒有前綴鍵，沒有 `.tmux.conf`，不用裝外掛來還原工作階段——持久化生效之前，
-沒有任何東西需要設定。如果 tmux 已經是你的肌肉記憶，它在工作階段裡照樣能跑，
-和別的程式一樣。
-
 ## 和你現有的 Agent 一起用
 
 Claude Code、Codex、Antigravity、Grok、Cursor Agent、Copilot、Amp、OpenCode、

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -3,7 +3,7 @@ title: termiod Session Protocol
 status: draft
 type: design
 created: 2026-07-30
-updated: 2026-08-29
+updated: 2026-08-30
 related:
   - 20260730-termiod-session-mux.md
   - 20260708-session-daemon-architecture.md
@@ -1030,8 +1030,8 @@ announced has `needs_you` on the wire.
 | 7 | **Event flood vs UI** | Protocol allows high-rate `E`; client discipline (per-session `SessionRuntime`, no roster replace per tick) is already law — see sidebar-scroll-performance. Host also coalesces status transitions (≤ ~10/s per session). |
 | 8 | **Superlogical ships first and defines expectations** | Their step 1 is an incredible mux (**Announced**). Our counter is not feature racing; it's landing #170–#172 so agents *survive the app* this quarter, with agent events they haven't announced. |
 | 9 | **No pipe-mode (non-tty) attach client** | The CLI `attach` assumes an interactive tty; driven non-interactively over a bare SSH channel it delivers **0 bytes** (confirmed 2026-07-31 on `ukvps`), which blocks scripting, piping, and honest WAN-throughput measurement. The protocol already has `mode:"observe"`; the fix is a CLI surface for it (`attach --observe`/`pipe` → raw `D` to stdout, no raw-mode, no stdin capture). Small, and needed before the Mac/iOS clients rely on the same read path. Note the sharper framing (Codex review 2026-07-31): today `remote attach` runs `ssh -t host termiod attach`, so the framed protocol lives *between the remote CLI and the remote socket* and never crosses SSH from a native client — the "same bytes over every transport" claim (§C.9) is **not yet exercised end-to-end**; a non-tty `termiod stdio` bridge is what makes it real. |
-| 10 | **Unbounded per-client backlog (the non-blocking hot path's shadow cost)** | The anti-100× invariant makes `fan_out` never block on a slow consumer — but per-client and outbound channels are **unbounded** (`daemon.rs`), so a stalled socket (a wedged phone, a paused SSH client) accumulates raw output without limit until it threatens the daemon. The fix pairs with the `bytes::Bytes` fan-out (single shared chunk, refcounted): give each client a **byte budget / sequence cursor**; when a client falls behind the retained window, **drop it (v0) or resnapshot it (v1)** rather than grow forever. One change closes both the (C+2)×n copy cost and this memory risk. |
-| 11 | **Resize is not a barrier; `pty.resize` errors ignored** | `handle_msg(Resize)` (`session.rs`) updates stored dims + emits `Resized` even if the `TIOCSWINSZ` ioctl failed, and a promoted writer after failover keeps stale dims and is not told to reclaim size. v1 must make resize the quiesce → resize → fresh `S` → resume barrier (§C.5) and surface ioctl failure. |
+| 10 | ~~**Unbounded per-client backlog**~~ **Closed** (verified in code 2026-08-30) | Both halves of the recorded fix landed: `fan_out` takes a shared `Bytes`, and each client holds a metered backlog (`session/backlog.rs`, `CLIENT_BACKLOG_CAP` = 4 MiB). Over the cap, a snapshot-capable client is resynced once; a second strike drops it with a named log line (`session.rs:692`). The `(C+2)×n` copy cost and the memory risk closed together, as predicted. |
+| 11 | ~~**Resize is not a barrier; `pty.resize` errors ignored**~~ **Closed** (verified in code 2026-08-30) | `session.rs:1887` implements §C.5's quiesce → resize → fresh `S` → resume barrier, and `pty.rs:33` surfaces `TIOCSWINSZ` failure as an error instead of swallowing it — asserted by a test (`session.rs:2655`). |
 
 ## G. Phased roadmap
 

--- a/docs/design/20260827-remote-access-dev-tunnels-model.md
+++ b/docs/design/20260827-remote-access-dev-tunnels-model.md
@@ -46,9 +46,9 @@ related:
 | §4.3「三处必须逐字节相同」靠人守 | 地址由 Mac 从隧道日志**读回**再写进守护进程，`RemotePairing.invite` 的 `--url` 参数已删除 | 同上 |
 | `pair` 成功 ≠ 可达（§0 已列）——但没人管 | 画二维码之前先按手机的规则拨一次号，比对 `host_id`；不通就退回「尚未发布」 | `RemoteTunnelService.handshake` |
 | §6.1 tunelo 需要 0.3.0 `--identity` | 已满足，稳定子域名跨重启与 `kill -9` 复核过 | `4a6c5284842fef36.tunelo.net` |
-| §6.5 Linux systemd user unit「lifecycle RFC 明确 defer 了」 | **已发布**，但发布的是 `termiod service install`（`a1a8cdc` / PR #522），不是本 RFC 设想的 app 侧写法 | `termiod/src/service.rs` `systemd::unit` |
+| §6.5 Linux systemd user unit「lifecycle RFC 明确 defer 了」 | **已发布**（`a1a8cdc` / PR #522），且 app 侧那份重复的 unit 也已经拆掉（PR #530） | `termiod/src/service.rs` `systemd::unit`；`RemoteTunnel.swift` `arm` |
 
-### 一个必须记下来的冲突
+### 一个必须记下来的冲突（已修，保留经过）
 
 `termiod.service` 现在有**两个写者**，策略不同：
 
@@ -71,16 +71,27 @@ line: the bind survives in `wss.bind` beside the socket, or in a `TERMIOD_WSS`
 drop-in."* 守护进程侧把 `Restart=on-failure` 的理由也写清楚了 ——
 `termiod stop` 发 `SIGTERM` 后要等 socket 排空，`always` 会和那次排空抢。
 
-**结论：app 不该再自己写 `termiod.service`。** 应改成调 `termiod service install`，
-再落一个只带 `Environment=TERMIOD_WSS=…` / `TERMIOD_WSS_ORIGIN=…` 的 drop-in ——
-`DEPLOY.md` §「WSS」已经写好了这个形状和优先级（`--wss` > `TERMIOD_WSS` >
-`wss.bind`）。这样武装监听器就不再需要一份自己的 unit，只是给别人的 unit 加两行
-环境变量；`Restart` 策略也回到守护进程自己说了算。
+**已收敛（2026-08-30，PR #530 `614a00c`）。** app 不再自己写 `termiod.service`，
+`arm` 改成四步：停掉命令行里带 `--wss` 的旧 unit（那是 app 写的标志，`service
+install` 写的从不带）→ 写
+`~/.config/systemd/user/termiod.service.d/override.conf`，只有
+`Environment="TERMIOD_WSS=…"` / `TERMIOD_WSS_ORIGIN=…` → `termiod stop --force`
+→ `termiod service install`。`Restart` 策略回到守护进程自己说了算。
+
+**为什么是 drop-in 而不是 `wss.bind`。** `wss.bind` / `wss.origin` / `pair.token`
+都在 `state_dir()` = `$XDG_RUNTIME_DIR/termiod/`，那是 tmpfs —— 重启就没了。而
+`service install` 只覆盖 unit 文件，不动 `.d/`。守护进程每次启动都读环境变量
+（`wss.rs` 的优先级：`--wss` > `TERMIOD_WSS` > `wss.bind`），所以 drop-in 是唯一
+一份跨重启还在、又不会被 `service install` 冲掉的武装记录。
+
+**代价记一笔**：环境变量武装起来的监听器**不会**把 origin 回写到 `wss.origin`，
+而 `pair` 是另一个进程 —— 所以 `RemotePairing.invite` 现在得先
+`systemctl --user show termiod -p Environment` 把 origin 读回来，再用
+`TERMIOD_WSS_ORIGIN='…' termiod pair --json` 出邀请。§4.3「三处逐字节相同」这条
+约束因此多了一个必须对齐的地方，不是少了一个。
 
 隧道那个 unit（`termio-tunnel.service`）没有第二个写者，保持现状 —— 它的
 `Restart=always` + `StartLimitIntervalSec=0` 是对的：隧道掉了就该一直重连。
-
-这是欠的后续，不在本 RFC 的范围里改。
 
 ## 1. 问题
 
@@ -292,8 +303,8 @@ tunelo 的 QUIC**（它讲 HTTP/3，tunelo 是 quinn 上的自定义协议）。
 5. ~~**Linux systemd user unit。**~~ **已发布**（2026-08-29，`a1a8cdc` / PR #522）：
    `termiod service install` 在 Linux 上写 `termiod.service`，`Restart=on-failure`，
    `spawn_daemon` 在 unit 持有 socket 时改走 `systemctl --user start`。
-   但见 §0.1 —— app 侧又自己写了一份同名 unit，两个写者策略不同，现在是 app 那份在
-   `ukvps` 上空转。**这条从「没做」变成了「做了两遍」，欠一次收敛。**
+   app 侧一度又写了一份同名 unit，两个写者策略不同，在 `ukvps` 上空转了
+   `NRestarts≈74000` 次；PR #530 已收敛成 drop-in（见 §0.1）。
 6. **滥用预案。** 一个公开的、能把任意本地端口暴露到公网的服务**一定**会被拿去做 C2
    和钓鱼 —— dev tunnels 的逆向分析文章标题就叫 "The Accidental C2"，微软的反钓鱼插页
    就是为此而设。上线前要有：滥用举报入口、按 Register token 吊销的能力、以及速率限制。

--- a/docs/design/20260827-remote-access-dev-tunnels-model.md
+++ b/docs/design/20260827-remote-access-dev-tunnels-model.md
@@ -32,7 +32,7 @@ related:
 | 手机配对时会先拨号握手、拿到 `hello_ok` 才落盘 | `Models.swift` `pair(invite:)` |
 | 手机持久化 `address` / `token` / `origin`，按 `host_id` 索引 | `Models.swift` `adopt(invite:hostID:)` |
 | tunelo 的 relay 与客户端共用 `crates/protocol`，两端都已用 `quinn` + `rustls` | `jiweiyuan/tunelo` 三个 `Cargo.toml` |
-| `ukvps` 上的 tunelo 是 **0.3.0**，`--identity` 可用（写这份 RFC 时是 0.2.0） | `tunelo --version` |
+| `ukvps` 上的 tunelo 是 **0.2.0** —— `--identity` 是 0.3.0 才有的 | `tunelo --version` |
 | `*.tunelo.net` 通配 DNS 已解析，证书含 `*.tunelo.net` | `getent hosts`、`/etc/nginx/sites-enabled/tunelo.net` |
 
 ## 0.1 写完之后（2026-08-30 复核）

--- a/docs/design/20260827-remote-access-dev-tunnels-model.md
+++ b/docs/design/20260827-remote-access-dev-tunnels-model.md
@@ -3,7 +3,7 @@ title: 零前置远程访问：把 dev tunnels 的形状搬到 termio
 status: draft
 type: rfc
 created: 2026-08-27
-updated: 2026-08-27
+updated: 2026-08-30
 related:
   - 20260705-remote-access-relay-strategy.md
   - 20260827-termiod-lifecycle-reconcile.md
@@ -32,8 +32,55 @@ related:
 | 手机配对时会先拨号握手、拿到 `hello_ok` 才落盘 | `Models.swift` `pair(invite:)` |
 | 手机持久化 `address` / `token` / `origin`，按 `host_id` 索引 | `Models.swift` `adopt(invite:hostID:)` |
 | tunelo 的 relay 与客户端共用 `crates/protocol`，两端都已用 `quinn` + `rustls` | `jiweiyuan/tunelo` 三个 `Cargo.toml` |
-| `ukvps` 上的 tunelo 是 **0.2.0** —— `--identity` 是 0.3.0 才有的 | `tunelo --version` |
+| `ukvps` 上的 tunelo 是 **0.3.0**，`--identity` 可用（写这份 RFC 时是 0.2.0） | `tunelo --version` |
 | `*.tunelo.net` 通配 DNS 已解析，证书含 `*.tunelo.net` | `getent hosts`、`/etc/nginx/sites-enabled/tunelo.net` |
+
+## 0.1 写完之后（2026-08-30 复核）
+
+这份 RFC 是 8-27 写的。到 8-30，§4.2 整条和 §6 里的两条已经落地了。下面每一行都是
+当场在 `ukvps` 上复核过的现状，**不是计划**。
+
+| 原文说 | 现在 | 出处 |
+| --- | --- | --- |
+| §4.2 步骤 6「两者都挂 `systemctl --user`」是计划 | 已实现。Publish 一下写两个 unit、`loginctl enable-linger`，`kill -9` 两个进程后 8 秒内都回来且地址不变 | `RemoteTunnel.swift` `RemoteSystemdUnit`；`feb228c` / `d3691a0` |
+| §4.3「三处必须逐字节相同」靠人守 | 地址由 Mac 从隧道日志**读回**再写进守护进程，`RemotePairing.invite` 的 `--url` 参数已删除 | 同上 |
+| `pair` 成功 ≠ 可达（§0 已列）——但没人管 | 画二维码之前先按手机的规则拨一次号，比对 `host_id`；不通就退回「尚未发布」 | `RemoteTunnelService.handshake` |
+| §6.1 tunelo 需要 0.3.0 `--identity` | 已满足，稳定子域名跨重启与 `kill -9` 复核过 | `4a6c5284842fef36.tunelo.net` |
+| §6.5 Linux systemd user unit「lifecycle RFC 明确 defer 了」 | **已发布**，但发布的是 `termiod service install`（`a1a8cdc` / PR #522），不是本 RFC 设想的 app 侧写法 | `termiod/src/service.rs` `systemd::unit` |
+
+### 一个必须记下来的冲突
+
+`termiod.service` 现在有**两个写者**，策略不同：
+
+| | `termiod service install`（#522） | `RemoteTunnel.swift`（本 RFC 这条线） |
+| --- | --- | --- |
+| `ExecStart` | `termiod serve` | `termiod serve --wss … --wss-origin …` |
+| 重启 | `Restart=on-failure` | `Restart=always` + `StartLimitIntervalSec=0` |
+| WSS 从哪来 | 磁盘上的 `wss.bind`，或 `TERMIOD_WSS` drop-in | 焊在命令行里 |
+
+后写的覆盖先写的。`ukvps` 上现在是 app 写的那份，而客户端 autostart 起来的
+`termiod serve` 占着 socket，于是 unit 每 3 秒起一次、每次绑不上就退出 ——
+**`NRestarts=74377`**，`termiod status` 报 `service: none`。
+
+盒子今天仍然可达，但**不是靠这个 unit**：`wss.bind` / `wss.origin` 在磁盘上，
+autostart 起来的那个守护进程从磁盘把自己武装好了。也就是说这条线目前**没有**在
+兑现它自己写下的「扛重启」。
+
+`service.rs` 的注释已经把出口指明了：*"WSS is deliberately not on the command
+line: the bind survives in `wss.bind` beside the socket, or in a `TERMIOD_WSS`
+drop-in."* 守护进程侧把 `Restart=on-failure` 的理由也写清楚了 ——
+`termiod stop` 发 `SIGTERM` 后要等 socket 排空，`always` 会和那次排空抢。
+
+**结论：app 不该再自己写 `termiod.service`。** 应改成调 `termiod service install`，
+再落一个只带 `Environment=TERMIOD_WSS=…` / `TERMIOD_WSS_ORIGIN=…` 的 drop-in ——
+`DEPLOY.md` §「WSS」已经写好了这个形状和优先级（`--wss` > `TERMIOD_WSS` >
+`wss.bind`）。这样武装监听器就不再需要一份自己的 unit，只是给别人的 unit 加两行
+环境变量；`Restart` 策略也回到守护进程自己说了算。
+
+隧道那个 unit（`termio-tunnel.service`）没有第二个写者，保持现状 —— 它的
+`Restart=always` + `StartLimitIntervalSec=0` 是对的：隧道掉了就该一直重连。
+
+这是欠的后续，不在本 RFC 的范围里改。
 
 ## 1. 问题
 
@@ -165,7 +212,9 @@ Mac ──ssh──▶ 用户机器            控制面：部署、配对、验
 5. origin 钉住该子域名 → `termiod pair --json` → 二维码
 6. 两者都挂 `systemctl --user`，配 `loginctl enable-linger`
 
-用户做的事：点一下。
+用户做的事：点一下。**1–6 已经实现**（`RemoteTunnel.swift`），但第 6 步的守护进程
+那一半写法是错的 —— 见 §0.1 的冲突：隧道 unit 归 app 写，`termiod.service` 应该归
+`termiod service install` 写。
 
 **全程不需要 root。** `~/.local/bin` + `systemctl --user` + linger。nginx 那条路必须
 sudo，而很多人的 VPS 账号没有 sudo，或不愿在安装流程里交出去。这一条本身就足以
@@ -182,6 +231,14 @@ sudo，而很多人的 VPS 账号没有 sudo，或不愿在安装流程里交出
 
 三处必须**逐字节相同**，否则 403。所以 URL 只能有一个来源：**Mac 把 origin 写到机器上，
 `pair` 从机器自己的 `wss.origin` 派生邀请** —— 绝不在配对时传 `--url`。
+
+**这条现在由代码守，不由人守**：地址是 Mac 从隧道日志读回来的（读回来的值没法手打错），
+`RemotePairing.invite` 的 `--url` 参数已经删掉 —— 它只改邀请上**印**的地址，不改守护
+进程**接受**的 origin，留着就是一个「扫得进、连不上」的陷阱。
+
+但读回来也只证明隧道说过这个地址。`pair` 从不接触守护进程（§0），所以邀请一律先按
+手机的规则拨一次号、比对 `host_id`，通了才画二维码；不通就退回「尚未发布」并给出
+重新发布的入口 —— 对拿着手机的人来说，「连不上的盒子」和「没发布的盒子」是同一件事。
 
 ### 4.4 分层：按"用户已经有什么"，不按"我们想卖什么"
 
@@ -217,17 +274,26 @@ tunelo 的 QUIC**（它讲 HTTP/3，tunelo 是 quinn 上的自定义协议）。
 
 ## 6. 公开之前必须先修
 
-1. **tunelo 0.3.0 的 `--identity`。** 现场是 0.2.0，子域名每次重启都变 → 钉住的 origin
-   失效 → 手机被甩掉（`address`/`origin` 是持久化在手机上的）。稳定名字是整条路的地基。
+1. ~~**tunelo 0.3.0 的 `--identity`。**~~ **已解决**（2026-08-30）。`ukvps` 上是 0.3.0，
+   `4a6c5284842fef36.tunelo.net` 跨进程重启、`kill -9`、换 provider 都没变。稳定名字
+   是整条路的地基，这块地基现在有了。
 2. **抢注 / DoS。** `crates/relay/src/router.rs::resolve_subdomain` 在 owner 断线时把
    子域名交给下一个来者；password 只 gate `Attach`，不 gate `Register` 回收。修法 =
    owner 用私钥自证回收。带着这个上线等于谁都能顶掉别人的机器。
 3. **Register 准入。** 用已有的 Lemon Squeezy 后端签短期 Ed25519 token，relay 内嵌
    公钥验签 —— 私钥在后端，**开源不泄密**。
-4. **`--max-session 0`。** `crates/tunelo/src/main.rs:100` 默认 86400 秒；常驻 companion
-   必须关掉，否则每天断一次。
-5. **Linux systemd user unit。** 零前置路径必须扛重启。lifecycle RFC §4 目前明确 defer
-   了它，这条依赖要显式提出来。
+4. **`--max-session 0`。** `crates/tunelo/src/main.rs:100` 默认 86400 秒；`ukvps` 的
+   relay unit 命令行上没写这个 flag，所以吃的就是这个默认 —— 隧道每 24 小时被切一次。
+   **未解决**，而且这是别人生产服务的策略，不是本 RFC 能顺手改的。
+   隧道 unit 的 `Restart=always` + 稳定 `--identity` *应该*让客户端被切之后自己回来
+   并夺回同一个子域名 —— 但这只在 `kill -9` 下验证过，没有跨过一个真实的 24 小时窗口，
+   也没验证客户端被 relay 切断时是**退出**还是**挂在一条死连接上**。后者的话重启永远
+   不触发。
+5. ~~**Linux systemd user unit。**~~ **已发布**（2026-08-29，`a1a8cdc` / PR #522）：
+   `termiod service install` 在 Linux 上写 `termiod.service`，`Restart=on-failure`，
+   `spawn_daemon` 在 unit 持有 socket 时改走 `systemctl --user start`。
+   但见 §0.1 —— app 侧又自己写了一份同名 unit，两个写者策略不同，现在是 app 那份在
+   `ukvps` 上空转。**这条从「没做」变成了「做了两遍」，欠一次收敛。**
 6. **滥用预案。** 一个公开的、能把任意本地端口暴露到公网的服务**一定**会被拿去做 C2
    和钓鱼 —— dev tunnels 的逆向分析文章标题就叫 "The Accidental C2"，微软的反钓鱼插页
    就是为此而设。上线前要有：滥用举报入口、按 Register token 吊销的能力、以及速率限制。
@@ -296,7 +362,10 @@ termiod，由 termiod 自己出站连官方 relay，直接在那条连接上跑�
 3. **配对由谁经手。** 现在是 Mac 通过 SSH 代跑 `termiod pair --json`（控制面在 Mac）。
    要不要允许手机直接向 relay 报到？前者不需要新协议，后者能去掉"必须有一台 Mac"。
 4. **`upgrading` 与本 RFC 的耦合。** 武装监听器和钉 origin 都需要重启守护进程，也就是
-   lifecycle RFC §5.2 的 `stop --if-idle`。本 RFC **依赖**那一条先落地。
+   lifecycle RFC §5.2 的 `stop --if-idle`。实现时走的是 `termiod stop --force`，并在
+   点下去之前把会被结束的会话**按命令行逐条列出来**让人确认 —— 「是不是该结束」取决于
+   那是个跑到一半的 agent 还是一个停在提示符的登录 shell，只报个数字答不了这个问题。
+   `--if-idle` 落地后这里可以退回到「空闲就不问」。
 
 ## 9. 出处
 

--- a/termiod/vt/src/lib.rs
+++ b/termiod/vt/src/lib.rs
@@ -13,7 +13,7 @@ use libghostty_vt::fmt::{Format, Formatter, FormatterOptions};
 use libghostty_vt::render::{CellIterator, Dirty, RenderState, RowIterator};
 use libghostty_vt::screen::{CellContentTag, Screen};
 use libghostty_vt::style::{RgbColor, StyleColor};
-use libghostty_vt::terminal::{Point, PointCoordinate};
+use libghostty_vt::terminal::{Mode, Point, PointCoordinate};
 use libghostty_vt::{Error, Terminal, TerminalOptions};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -187,7 +187,49 @@ impl VtTerminal {
         self.terminal.vt_write(bytes);
     }
 
+    /// Resize the authoritative screen **without reflowing** it — tmux/xterm
+    /// semantics, not Ghostty.app's.
+    ///
+    /// Shells' SIGWINCH redisplay assumes the terminal did not rewrap the old
+    /// prompt: zsh moves the cursor up by a row count computed from the *old*
+    /// width and repaints from there. A reflowing resize rewraps the prompt
+    /// and moves the cursor down, so that repaint lands one row low and the
+    /// stale prompt copy above it survives — once per split, which is the
+    /// ⌘D duplicated-prompt report. Ghostty.app escapes this only because it
+    /// injects shell integration and clears OSC 133-marked prompt rows before
+    /// reflowing (and its engine's post-1.3.1 clear-after-reflow ordering,
+    /// dde3d4d6b, re-breaks the wrapped case even then). Sessions here carry
+    /// no integration, so the marks-free behaviour every shell is written
+    /// against — truncate, don't rewrap — is the correct one for the host.
+    ///
+    /// The engine gates reflow on DECAWM (mode ?7), so wraparound is parked
+    /// off across the resize and restored to whatever the program had chosen.
+    /// Every attachment repaints from the post-resize keyframe, so clients
+    /// converge on this screen regardless of what their own surfaces did.
     pub fn resize(&mut self, rows: u16, cols: u16) -> Result<()> {
+        let wraparound = check(self.terminal.mode(Mode::WRAPAROUND), "mode(WRAPAROUND)")?;
+        if wraparound {
+            check(
+                self.terminal.set_mode(Mode::WRAPAROUND, false),
+                "set_mode(WRAPAROUND, false)",
+            )?;
+        }
+        let resized = self.resize_reflowing_for_tests(rows, cols);
+        if wraparound {
+            // Restore even when the resize failed: the mode belongs to the
+            // program, and a failed ioctl must not leave autowrap off.
+            check(
+                self.terminal.set_mode(Mode::WRAPAROUND, true),
+                "set_mode(WRAPAROUND, true)",
+            )?;
+        }
+        resized
+    }
+
+    /// The bare engine resize, which reflows whenever the screen's own DECAWM
+    /// is set. Public only so tests can reproduce the reflow duplicate this
+    /// crate's `resize` exists to prevent.
+    pub fn resize_reflowing_for_tests(&mut self, rows: u16, cols: u16) -> Result<()> {
         // Pixel dimensions are not used by the daemon snapshot sidecar; fixed
         // cell metrics still give libghostty-vt consistent total dimensions.
         check(self.terminal.resize(cols, rows, 8, 16), "Terminal::resize")


### PR DESCRIPTION
Two RFCs had drifted from what shipped, in the direction that misleads: they described solved problems as open ones.

`20260827-remote-access-dev-tunnels-model.md` gets a dated §0.1 recording what landed between 08-27 and 08-30 — the systemd `--user` units and `loginctl enable-linger` from §4.2, the address read-back and the dial-before-QR check that now enforce §4.3, and tunelo 0.3.0 `--identity`. It also records the duplicate `termiod.service` writer, why it looped ~74,000 times on `ukvps`, and how #530 collapsed it onto a `TERMIOD_WSS` drop-in — including the cost that an env-armed daemon never persists `wss.origin`, so `pair` has to read the origin back out of the unit.

`20260730-termiod-session-protocol.md` closes risks 10 and 11 in §F. Both were fixed in code and left standing in the table: the per-client backlog is metered at 4 MiB with resync-then-drop (`session/backlog.rs`, `session.rs:692`), and resize is the quiesce → resize → fresh `S` → resume barrier with `TIOCSWINSZ` failure surfaced (`session.rs:1887`, `pty.rs:33`). A risk register is what a reviewer reads to find the danger; entries describing finished work spend that attention and hide the live ones.

No original reasoning was rewritten. The one place this branch had edited a dated claim in place — §0's "what we verified before writing" table, which correctly said tunelo was 0.2.0 on 08-27 — is reverted in the last commit; the correction lives in the §0.1 addendum instead. That is the convention worth keeping: append, dated, never edit the body.

Release Notes:
* None — documentation only.