### PR TITLE
Make a doc's status mean something again

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,12 @@ from the real front matter).
 | archived | design | [Sandbox VM —— 原生 per-project 容器（Apple Containerization）](design/20260629-sandbox-vm.md) |
 | archived | essay | ["From IDE to ADE: Sixty Years of Development Environments, and Why the Era Is Ending"](essays/from-ide-to-ade.md) |
 | archived | plan | [Fix — defer the PTY spawn to the first real layout size so the agent banner boots at pane width](plan/terminal-narrow-grid-frozen-banner-fix.md) |
+| archived | rfc | ["Adversarial review: One workspace source — the inspector reads the session's device"](design/20260818-one-workspace-source.review-codex.md) |
+| archived | rfc | ["Adversarial review: Retire remote — every machine is a device"](design/20260814-remote-to-device.review-codex.md) |
+| archived | rfc | ["RFC: Per-project agent sandbox (Apple Seatbelt)"](design/20260630-sandbox-seatbelt.md) |
+| archived | rfc | [Adversarial review — Retire "remote", every machine is a device](design/20260814-remote-to-device.review-claude.md) |
+| archived | rfc | [Device RFC blocking decisions](design/20260814-remote-to-device.decisions.md) |
+| archived | rfc | [Review — One path, local sessions run through termiod too](design/20260817-one-path-local-through-termiod.review-claude.md) |
 | done | bug | ["HANDOFF: terminal content does not reflow on window resize"](bug/terminal-resize-no-reflow-HANDOFF.md) |
 | done | bug | [Agent welcome banner frozen into a narrow column when a session opens in a wide window](bug/terminal-narrow-grid-frozen-banner-on-open.md) |
 | done | bug | [iOS terminal fails "unauthorized" while the session list works (companion over tunnel)](bug/companion-terminal-unauthorized-over-tunnel.md) |
@@ -73,6 +79,9 @@ from the real front matter).
 | done | design | [Agent Abstraction & Configuration](design/20260718-agent-abstraction-and-configuration.md) |
 | done | design | [Config-driven agent resume](design/20260720-config-driven-agent-resume.md) |
 | done | design | [Quick theme switching from the command palette](design/20260727-command-palette-theme-switching.md) |
+| done | design | [Session deep links (termio:// addresses)](design/20260801-session-deep-link.md) |
+| done | design | [Sessions CLI v3 — command design (better than tmux)](design/20260808-sessions-cli-v3-command-design.md) |
+| done | design | [Sidebar scroll performance — per-session runtime state](design/20260724-sidebar-scroll-performance.md) |
 | done | design | [Vibe Island 式 Agent 状态层（Claude Code hooks）](design/20260719-vibe-island-status.md) |
 | done | research | ["ADE 赛道全景表（2026-07）：开源 + 闭源一张表，Termio 亮点"](competitive-analysis/10-landscape-table-2026-07.md) |
 | done | research | ["Competitive analysis: claude-squad"](competitive-analysis/05-claude-squad.md) |
@@ -85,6 +94,11 @@ from the real front matter).
 | done | research | ["Competitive analysis: Vibe Island family (status monitors)"](competitive-analysis/07-vibe-island.md) |
 | done | research | ["Competitive analysis: Warp (alternative paradigm)"](competitive-analysis/08-warp.md) |
 | done | research | ["Termio differentiation, gaps, and risks"](competitive-analysis/09-differentiation-and-gaps.md) |
+| done | rfc | [A project carries its machine — delete the host container](design/20260818-one-workspace-source.md) |
+| done | rfc | [Companion Wire Protocol](design/20260810-companion-wire-protocol.md) |
+| done | rfc | [Fork libghostty-spm — own the wrapper, rent the engine?](design/20260703-fork-libghostty-spm.md) |
+| done | rfc | [Loose terminals as first-class entities](design/20260713-loose-terminal-entity.md) |
+| done | rfc | [Remote git — the pane's verbs run on the device](design/20260818-remote-git-plane.md) |
 | draft | design | [分享 Agent 会话（带密码的实时分享链接）](design/20260628-session-share.md) |
 | draft | design | [调研：下一批 AgentAdapter 的落盘格式（OpenCode / Pi / Amp / Cursor / Kimi）](design/20260711-agent-transcript-survey.md) |
 | draft | design | ["Markdown preview — Apple-grade reading typography"](design/20260718-markdown-preview-reading-typography.md) |
@@ -98,32 +112,19 @@ from the real front matter).
 | draft | design | [Mac retention analytics (no app changes)](design/20260715-mac-retention-analytics.md) |
 | draft | design | [Remote Projects (open an SSH/VPS box like a local project)](design/20260708-remote-projects.md) |
 | draft | design | [Session Daemon Architecture (termiod — one model for local, remote, mobile)](design/20260708-session-daemon-architecture.md) |
-| draft | design | [Session deep links (termio:// addresses)](design/20260801-session-deep-link.md) |
 | draft | design | [Session guests — three deltas, not a sharing subsystem](design/20260818-session-guests.md) |
-| draft | design | [Sessions CLI v3 — command design (better than tmux)](design/20260808-sessions-cli-v3-command-design.md) |
-| draft | design | [Sidebar scroll performance — per-session runtime state](design/20260724-sidebar-scroll-performance.md) |
 | draft | design | [Superlogical research brief (Codex / competitive)](design/20260805-_research-superlogical-codex-brief.md) |
 | draft | design | [termiod — Agent-native session mux](design/20260730-termiod-session-mux.md) |
 | draft | design | [termiod Session Protocol](design/20260730-termiod-session-protocol.md) |
 | draft | design | [远程访问与中转策略（tunelo / BYO-tunnel）](design/20260705-remote-access-relay-strategy.md) |
 | draft | essay | ["How Claude Code Got the Mouse: Reverse-Engineering the Clickable Terminal"](essays/how-claude-code-got-the-mouse.md) |
 | draft | rfc | [零前置远程访问：把 dev tunnels 的形状搬到 termio](design/20260827-remote-access-dev-tunnels-model.md) |
-| draft | rfc | ["Adversarial review: One workspace source — the inspector reads the session's device"](design/20260818-one-workspace-source.review-codex.md) |
-| draft | rfc | ["Adversarial review: Retire remote — every machine is a device"](design/20260814-remote-to-device.review-codex.md) |
-| draft | rfc | ["RFC: Per-project agent sandbox (Apple Seatbelt)"](design/20260630-sandbox-seatbelt.md) |
-| draft | rfc | [A project carries its machine — delete the host container](design/20260818-one-workspace-source.md) |
-| draft | rfc | [Adversarial review — Retire "remote", every machine is a device](design/20260814-remote-to-device.review-claude.md) |
 | draft | rfc | [Automation — scheduled agent runs](design/20260702-automation-scheduled-agent-runs.md) |
-| draft | rfc | [Companion Wire Protocol](design/20260810-companion-wire-protocol.md) |
-| draft | rfc | [Device RFC blocking decisions](design/20260814-remote-to-device.decisions.md) |
 | draft | rfc | [Feature cut after Superlogical's 28 Aug demo](design/20260829-feature-cut-after-superlogical-demo.md) |
-| draft | rfc | [Fork libghostty-spm — own the wrapper, rent the engine?](design/20260703-fork-libghostty-spm.md) |
 | draft | rfc | [Installing termio's agent integration on a device](design/20260824-agent-integration-on-a-device.md) |
 | draft | rfc | [iOS as a device client](design/20260824-ios-as-device-client.md) |
-| draft | rfc | [Loose terminals as first-class entities](design/20260713-loose-terminal-entity.md) |
 | draft | rfc | [Onboarding —— 首次启动体验设计](design/20260630-onboarding.md) |
-| draft | rfc | [Remote git — the pane's verbs run on the device](design/20260818-remote-git-plane.md) |
-| draft | rfc | [Review — One path, local sessions run through termiod too](design/20260817-one-path-local-through-termiod.review-claude.md) |
+| draft | rfc | [Session identity survives the agent](design/20260830-session-identity-survives-the-agent.md) |
 | draft | rfc | [Settings that know which machine they mean](design/20260824-settings-that-know-which-machine.md) |
 | draft | rfc | [Termiod web client on official Ghostty WASM (Linux first)](design/20260818-termiod-web-client-ghostty-wasm.md) |
 | draft | rfc | [The tab strip is the collapsed sidebar](design/20260829-tab-strip-is-the-collapsed-sidebar.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ from the real front matter).
 | active | design | [Research brief — termiod Session Protocol (for design agent)](design/20260730-_research-session-protocol-brief.md) |
 | active | design | [Sessions CLI v2 — reliability & command design](design/20260724-sessions-cli-v2.md) |
 | active | research | ["Reading list: PTYs, SSH, and detachable remote terminals"](READING.md) |
+| active | rfc | [可扩展 Agent —— 配置化定义 + 配置化 Hook](design/20260707-agent-extensibility.md) |
 | active | rfc | [Agent integration moves into termiod](design/20260825-agent-integration-moves-to-termiod.md) |
 | active | rfc | [Push-to-talk voice dictation — hold the space bar (iOS shipped, OpenAI)](design/20260704-push-to-talk-voice-dictation.md) |
 | active | rfc | [Unify the server plane in Rust, reduce the Mac app to a viewer](design/20260819-unify-server-plane.md) |
@@ -57,13 +58,17 @@ from the real front matter).
 | approved | design | [Worktree information architecture](design/20260628-worktree-information-architecture.md) |
 | approved | rfc | [Theme store — browse 50, install on demand, library is truth](design/20260814-theme-store.md) |
 | archived | design | [移动端 Agent UI 协议 —— PTY 之上的旁路结构面（ACP 词汇）](design/20260711-mobile-agent-ui-protocol.md) |
+| archived | design | [Agent permission questions on the phone](design/20260803-agent-permission-questions.md) |
 | archived | design | [iOS scroll-draw coalescing (vsync-capped surface draws)](design/20260706-ios-scroll-renderer-health.md) |
 | archived | design | [Sandbox VM —— 原生 per-project 容器（Apple Containerization）](design/20260629-sandbox-vm.md) |
 | archived | essay | ["From IDE to ADE: Sixty Years of Development Environments, and Why the Era Is Ending"](essays/from-ide-to-ade.md) |
 | archived | plan | [Fix — defer the PTY spawn to the first real layout size so the agent banner boots at pane width](plan/terminal-narrow-grid-frozen-banner-fix.md) |
-| built, measured, shelved | design | [Agent permission questions on the phone](design/20260803-agent-permission-questions.md) |
 | done | bug | ["HANDOFF: terminal content does not reflow on window resize"](bug/terminal-resize-no-reflow-HANDOFF.md) |
 | done | bug | [Agent welcome banner frozen into a narrow column when a session opens in a wide window](bug/terminal-narrow-grid-frozen-banner-on-open.md) |
+| done | bug | [iOS terminal fails "unauthorized" while the session list works (companion over tunnel)](bug/companion-terminal-unauthorized-over-tunnel.md) |
+| done | bug | [New terminal opens unfocused (hollow cursor, beeps until clicked)](bug/terminal-focus-loss-on-new-session-mount.md) |
+| done | bug | [Terminal loses focus after window deactivation](bug/terminal-focus-loss-on-window-key.md) |
+| done | bug | [Terminal loses focus while the window stays key — sibling-render trigger](bug/terminal-focus-loss-on-sibling-render.md) |
 | done | design | ["Sandbox removal & restoration (Apple Seatbelt subsystem)"](design/20260718-sandbox-removal-and-restoration.md) |
 | done | design | [Agent Abstraction & Configuration](design/20260718-agent-abstraction-and-configuration.md) |
 | done | design | [Config-driven agent resume](design/20260720-config-driven-agent-resume.md) |
@@ -122,14 +127,9 @@ from the real front matter).
 | draft | rfc | [Settings that know which machine they mean](design/20260824-settings-that-know-which-machine.md) |
 | draft | rfc | [Termiod web client on official Ghostty WASM (Linux first)](design/20260818-termiod-web-client-ghostty-wasm.md) |
 | draft | rfc | [The tab strip is the collapsed sidebar](design/20260829-tab-strip-is-the-collapsed-sidebar.md) |
-| fixed | bug | [New terminal opens unfocused (hollow cursor, beeps until clicked)](bug/terminal-focus-loss-on-new-session-mount.md) |
-| fixed | bug | [Terminal loses focus after window deactivation](bug/terminal-focus-loss-on-window-key.md) |
-| fixed | bug | [Terminal loses focus while the window stays key — sibling-render trigger](bug/terminal-focus-loss-on-sibling-render.md) |
-| in-progress | rfc | [可扩展 Agent —— 配置化定义 + 配置化 Hook](design/20260707-agent-extensibility.md) |
 | in-review | design | [Workspace switch latency](design/20260819-workspace-switch-latency.md) |
 | in-review | rfc | [Every machine is a device, every place you work is a project](design/20260814-remote-to-device.md) |
 | in-review | rfc | [One path — local sessions run through termiod too](design/20260817-one-path-local-through-termiod.md) |
 | in-review | rfc | [Split panes — Ghostty-style splits in the terminal column](design/20260702-split-panes.md) |
 | in-review | rfc | [termiod lifecycle — install and update as one reconcile loop](design/20260827-termiod-lifecycle-reconcile.md) |
-| resolved | bug | [iOS terminal fails "unauthorized" while the session list works (companion over tunnel)](bug/companion-terminal-unauthorized-over-tunnel.md) |
 <!-- END docs-index -->

--- a/docs/bug/companion-terminal-unauthorized-over-tunnel.md
+++ b/docs/bug/companion-terminal-unauthorized-over-tunnel.md
@@ -1,6 +1,6 @@
 ---
 title: iOS terminal fails "unauthorized" while the session list works (companion over tunnel)
-status: resolved
+status: done
 type: bug
 created: 2026-07-04
 updated: 2026-07-04

--- a/docs/bug/terminal-focus-loss-on-new-session-mount.md
+++ b/docs/bug/terminal-focus-loss-on-new-session-mount.md
@@ -1,6 +1,6 @@
 ---
 title: New terminal opens unfocused (hollow cursor, beeps until clicked)
-status: fixed
+status: done
 type: bug
 created: 2026-07-14
 updated: 2026-07-14

--- a/docs/bug/terminal-focus-loss-on-sibling-render.md
+++ b/docs/bug/terminal-focus-loss-on-sibling-render.md
@@ -1,6 +1,6 @@
 ---
 title: Terminal loses focus while the window stays key — sibling-render trigger
-status: fixed
+status: done
 type: bug
 created: 2026-07-14
 updated: 2026-07-14

--- a/docs/bug/terminal-focus-loss-on-window-key.md
+++ b/docs/bug/terminal-focus-loss-on-window-key.md
@@ -1,6 +1,6 @@
 ---
 title: Terminal loses focus after window deactivation
-status: fixed
+status: done
 type: bug
 created: 2026-07-02
 updated: 2026-07-14

--- a/docs/design/20260630-sandbox-seatbelt.md
+++ b/docs/design/20260630-sandbox-seatbelt.md
@@ -1,9 +1,9 @@
 ---
 title: "RFC: Per-project agent sandbox (Apple Seatbelt)"
-status: draft
+status: archived
 type: rfc
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-08-31
 related:
   - 20260629-sandbox-vm.md
   - 20260707-agent-extensibility.md

--- a/docs/design/20260703-fork-libghostty-spm.md
+++ b/docs/design/20260703-fork-libghostty-spm.md
@@ -1,9 +1,9 @@
 ---
 title: Fork libghostty-spm — own the wrapper, rent the engine?
-status: draft
+status: done
 type: rfc
 created: 2026-07-03
-updated: 2026-07-03
+updated: 2026-08-31
 ---
 
 # Fork libghostty-spm — own the wrapper, rent the engine?

--- a/docs/design/20260707-agent-extensibility.md
+++ b/docs/design/20260707-agent-extensibility.md
@@ -1,6 +1,6 @@
 ---
 title: 可扩展 Agent —— 配置化定义 + 配置化 Hook
-status: in-progress
+status: active
 type: rfc
 updated: 2026-07-07
 related:

--- a/docs/design/20260713-loose-terminal-entity.md
+++ b/docs/design/20260713-loose-terminal-entity.md
@@ -1,9 +1,9 @@
 ---
 title: Loose terminals as first-class entities
-status: draft
+status: done
 type: rfc
 created: 2026-07-13
-updated: 2026-07-13
+updated: 2026-08-31
 related:
   - 20260628-worktree-information-architecture.md
   - 20260630-sandbox-seatbelt.md

--- a/docs/design/20260724-sidebar-scroll-performance.md
+++ b/docs/design/20260724-sidebar-scroll-performance.md
@@ -1,9 +1,9 @@
 ---
 title: Sidebar scroll performance — per-session runtime state
-status: draft
+status: done
 type: design
 created: 2026-07-24
-updated: 2026-07-24
+updated: 2026-08-31
 related:
   - 20260713-loose-terminal-entity.md
 ---

--- a/docs/design/20260801-session-deep-link.md
+++ b/docs/design/20260801-session-deep-link.md
@@ -1,9 +1,9 @@
 ---
 title: Session deep links (termio:// addresses)
-status: draft
+status: done
 type: design
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-31
 ---
 
 # Session deep links (termio:// addresses)

--- a/docs/design/20260803-agent-permission-questions.md
+++ b/docs/design/20260803-agent-permission-questions.md
@@ -1,6 +1,6 @@
 ---
 title: Agent permission questions on the phone
-status: built, measured, shelved
+status: archived
 type: design
 created: 2026-08-03
 updated: 2026-08-03

--- a/docs/design/20260808-sessions-cli-v3-command-design.md
+++ b/docs/design/20260808-sessions-cli-v3-command-design.md
@@ -1,9 +1,9 @@
 ---
 title: Sessions CLI v3 — command design (better than tmux)
-status: draft
+status: done
 type: design
 created: 2026-08-08
-updated: 2026-08-08
+updated: 2026-08-31
 related:
   - 20260724-sessions-cli-v2.md
   - 20260730-termiod-session-protocol.md

--- a/docs/design/20260810-companion-wire-protocol.md
+++ b/docs/design/20260810-companion-wire-protocol.md
@@ -1,9 +1,9 @@
 ---
 title: Companion Wire Protocol
-status: draft
+status: done
 type: rfc
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-31
 related:
   - mobile-agent-ui-protocol.md
   - termiod-session-protocol.md

--- a/docs/design/20260814-remote-to-device.decisions.md
+++ b/docs/design/20260814-remote-to-device.decisions.md
@@ -1,9 +1,9 @@
 ---
 title: Device RFC blocking decisions
-status: draft
+status: archived
 type: rfc
 created: 2026-08-16
-updated: 2026-08-16
+updated: 2026-08-31
 ---
 
 # Device RFC blocking decisions

--- a/docs/design/20260814-remote-to-device.review-claude.md
+++ b/docs/design/20260814-remote-to-device.review-claude.md
@@ -1,9 +1,9 @@
 ---
 title: Adversarial review — Retire "remote", every machine is a device
-status: draft
+status: archived
 type: rfc
 created: 2026-08-15
-updated: 2026-08-15
+updated: 2026-08-31
 related:
   - 20260814-remote-to-device.md
   - 20260805-termiod-device-architecture.md

--- a/docs/design/20260814-remote-to-device.review-codex.md
+++ b/docs/design/20260814-remote-to-device.review-codex.md
@@ -1,9 +1,9 @@
 ---
 title: "Adversarial review: Retire remote — every machine is a device"
-status: draft
+status: archived
 type: rfc
 created: 2026-08-15
-updated: 2026-08-15
+updated: 2026-08-31
 ---
 
 # Adversarial review: Retire remote — every machine is a device

--- a/docs/design/20260817-one-path-local-through-termiod.review-claude.md
+++ b/docs/design/20260817-one-path-local-through-termiod.review-claude.md
@@ -1,9 +1,9 @@
 ---
 title: Review — One path, local sessions run through termiod too
-status: draft
+status: archived
 type: rfc
 created: 2026-08-17
-updated: 2026-08-17
+updated: 2026-08-31
 related:
   - 20260817-one-path-local-through-termiod.md
   - 20260805-termiod-device-architecture.md

--- a/docs/design/20260818-one-workspace-source.md
+++ b/docs/design/20260818-one-workspace-source.md
@@ -1,9 +1,9 @@
 ---
 title: A project carries its machine — delete the host container
-status: draft
+status: done
 type: rfc
 created: 2026-08-18
-updated: 2026-08-18
+updated: 2026-08-31
 related:
   - 20260818-one-workspace-source.review-codex.md
   - 20260818-remote-git-plane.md

--- a/docs/design/20260818-one-workspace-source.review-codex.md
+++ b/docs/design/20260818-one-workspace-source.review-codex.md
@@ -1,9 +1,9 @@
 ---
 title: "Adversarial review: One workspace source — the inspector reads the session's device"
-status: draft
+status: archived
 type: rfc
 created: 2026-08-18
-updated: 2026-08-18
+updated: 2026-08-31
 ---
 
 # Adversarial review: One workspace source — the inspector reads the session's device

--- a/docs/design/20260818-remote-git-plane.md
+++ b/docs/design/20260818-remote-git-plane.md
@@ -1,9 +1,9 @@
 ---
 title: Remote git — the pane's verbs run on the device
-status: draft
+status: done
 type: rfc
 created: 2026-08-18
-updated: 2026-08-18
+updated: 2026-08-31
 related:
   - 20260818-one-workspace-source.md
   - 20260818-one-workspace-source.review-codex.md

--- a/docs/design/20260830-session-identity-survives-the-agent.md
+++ b/docs/design/20260830-session-identity-survives-the-agent.md
@@ -1,0 +1,235 @@
+---
+title: Session identity survives the agent
+status: draft
+type: rfc
+created: 2026-08-30
+updated: 2026-08-30
+related:
+  - 20260829-tab-strip-is-the-collapsed-sidebar.md
+  - 20260827-termiod-lifecycle-reconcile.md
+---
+
+# Session identity survives the agent
+
+> A session the app created must never reappear under "Also Running". This RFC
+> fixes issue #528 by making destroy name-addressed, agent exit visible, and the
+> stranger filter honest — following the identity model tmux and herdr both use.
+
+## The bug (#528)
+
+A built-in Claude Code or Codex session runs as:
+
+```text
+termiod
+└─ /bin/zsh -il
+   └─ codex | claude
+```
+
+The user exits the agent normally. The outer login shell survives, and the
+session's sidebar row disappears — replaced by an entry under **Also Running**
+named `zsh`. The user must reattach and `exit` a second time to be rid of it.
+The reporter's complaint is exact: the session changed identity silently, so a
+finished task reads as a process leak.
+
+## Three root causes
+
+These are separate defects that compound. All file references are current as of
+this writing.
+
+### 1. Destroy depends on a lazily-created link
+
+`closeSession` kills the daemon-side session through exactly one line
+(`Sources/termio/TermioStore/TermioStore+ProjectActions.swift:1003`):
+
+```swift
+termiodLinks[id]?.killAndClose()
+termiodLinks[id] = nil
+```
+
+The `?.` is the bug. A `TermiodSessionLink` is created only when a pane
+actually renders (`surface(for:)` →
+`makeTermiodLink` in `TermioStore+TerminalSurface.swift:287`), and it is
+cleared in several places — first thing in `applyTermiodExit`
+(`TermioStore+Termiod.swift:375`), on connection loss, and wholesale on app
+quit. So every one of these closes silently kills nothing:
+
+- a row restored after app relaunch that was never selected,
+- a close from the CLI or the phone for a row never viewed this run,
+- any close after the exit/connection-lost paths nil'd the link.
+
+The same pattern repeats at `removeProject`
+(`TermioStore+ProjectActions.swift:857`) and `relaunchSession` (`:1063`).
+`relaunchSession` is the worst case: its comment promises "a respawn-in-place
+must not leave the old daemon-side process running under the same name", but on
+the revert-to-shell path the kill is *always* a no-op, because
+`applyTermiodExit` already nil'd the link before calling it.
+
+The irony: `killAndClose()` itself already kills by name
+(`Terminal/Termiod/TermiodClient.swift:1292`), and `closeDeviceSessions`
+already does a link-free kill for stranger rows
+(`TermioStore+Termiod.swift:770`). The capability exists; `closeSession` just
+doesn't use it when the link is gone.
+
+### 2. Agent exit inside a surviving shell is invisible
+
+The launch wrapper is `[shell, "-ilc", "exec \(command)"]`
+(`TermioStore+TerminalSurface.swift:502`). When the `exec` actually replaces
+the shell, agent exit ends the daemon session, `link.onExit` fires, and
+`applyTermiodExit` reverts the row to a shell in place — the designed behavior.
+
+The issue's process tree shows a shell that did **not** exec: the agent ran as
+a child of `zsh -il`. (A `claude`/`codex` that resolves to a shell function or
+alias shim in the user's zshrc is enough — `exec` of a function cannot replace
+the process.) In that tree the daemon session never exits, so no exit event
+ever fires. And the app deliberately never demotes a declared agent row from
+foreground data — `applyTermiodInformation` is wired with
+`identifiesAgent: isPlainTerminal` (`TermioStore+Termiod.swift:135`). Net
+effect: no code path in the app can notice the agent left.
+
+termiod, for its part, already reports everything needed: the foreground
+sampler (`termiod/src/session/foreground.rs`, 2s cadence) publishes
+`foreground_pid` / `foreground_argv` per session, and `zsh` in an Also Running
+row is precisely that sampler reporting an idle login shell.
+
+### 3. The stranger filter can't tell strangers from our own orphans
+
+"Also Running" was designed (tab-strip RFC) as *sessions the device reports
+that no row accounts for* — the adoption affordance for sessions started from
+the `termiod` CLI. The filter (`TermioStore/DeviceContext.swift:205`) is:
+
+```swift
+guard information.alive else { return false }
+guard !mine.contains(where: { daemonSessionName(for: $0) == information.name }) else { return false }
+if isLocal, information.attachedClients > 0 { return false }
+```
+
+An app-created session whose row was closed link-lessly satisfies all three
+within one roster refresh. The filter checks *live* rows only; the app keeps no
+record of sessions it closed, so its own orphan is indistinguishable from a
+genuine CLI-started stranger.
+
+## What tmux and herdr do
+
+Both competitors converge on one principle: **identity belongs to the session
+object; the foreground process is an attribute of it.**
+
+- **tmux** — a pane's identity never changes when its process exits. Default:
+  the pane dies with the process. With `remain-on-exit`, the pane stays *in
+  place*, explicitly marked dead ("Pane is dead"), and `respawn-pane` revives
+  it in the same spot. There is no path on which a pane migrates to a
+  different list under a different name.
+- **herdr** — the pane is the stable identity and the agent is *detected
+  inside* it ("each agent stays in a real terminal pane with its shell").
+  Agent exit rolls the pane's state back to idle/unknown; the pane stays where
+  it is. There is no orphan bucket at all. External sessions are handled by
+  detection and state roll-up, not by a separate section.
+
+Termio's revert-to-shell is already the right call by this standard — it is
+tmux's `remain-on-exit` with a live shell instead of a dead pane. The bug is
+that on the non-exec tree the revert never runs, and that close can leak the
+daemon session into a bucket that changes its identity.
+
+## Design
+
+### D1. Destroy is name-addressed, never link-addressed
+
+The `(daemon name, route)` pair is the destroy capability. The link is a live
+attachment — an optimization, never a prerequisite.
+
+`closeSession`, `removeProject`, and `relaunchSession` kill unconditionally by
+name, exactly as `closeDeviceSessions` already does:
+
+```swift
+if let link = termiodLinks[id] {
+    link.killAndClose()
+} else {
+    Termiod.killSession(
+        target: daemonSessionName(for: session),
+        route: TermiodRoute(sshAlias: session.termiodRemoteHost))
+}
+termiodLinks[id] = nil
+```
+
+`closeSession` already reads the session before mutating (`locate(id)` at
+`:998`), so name and route are available. "No such session" stays a benign
+answer, as it already is in `TermiodClient.swift:829`.
+
+If the route is unreachable at close time (remote host offline), record the
+`(name, route)` pair as a pending kill and retry on the next successful roster
+refresh for that route. A small persisted ring is enough; this also closes the
+close-while-offline hole that no link-based scheme could.
+
+### D2. Agent exit is detected by foreground, not only by process exit
+
+Keep both exit shapes converging on the same UX — the row stays in place:
+
+- **Exec'd tree** (daemon child *is* the agent): unchanged —
+  `applyTermiodExit` → revert to shell in place. D1 fixes `relaunchSession` so
+  the respawn actually replaces the old daemon session instead of reattaching
+  to it.
+- **Wrapped tree** (agent is a child of a surviving shell): let foreground data
+  demote a declared agent row. When a declared-agent session's
+  `foreground_argv` has reported the shell for a stable streak (same streak
+  machinery status promotion already uses), transition the row in place:
+  status → idle, subtitle → "Claude Code exited — shell". The
+  `identifiesAgent: isPlainTerminal` asymmetry stays for *promotion* (a
+  declared row never gets re-identified as a different agent), but demotion to
+  "agent gone, shell remains" becomes an explicit, visible state.
+
+The issue asks for one of: kill the outer shell too, keep the shell clearly
+labeled in place, or a setting. This RFC picks **labeled in place** as the only
+behavior — it is tmux's `remain-on-exit` semantics and herdr's idle roll-back,
+it preserves scrollback, and it matches "the session lives on the box". A
+setting is surface area we don't need until someone asks for the kill
+behavior.
+
+### D3. "Also Running" shows true strangers only
+
+The app remembers the daemon names of sessions it has closed (the same ring
+that D1's pending kills use — a closed-session journal keyed by daemon name,
+bounded, persisted in `StateFile`). At roster refresh:
+
+- live daemon session whose name matches a **current row** → accounted for
+  (already the case),
+- name matches a **journaled close** → not a stranger: kill it on sight.
+  D1 should have killed it; this sweep is the belt-and-braces that makes the
+  invariant hold even across crashes and offline closes,
+- anything else → a genuine stranger; show it for adoption as designed.
+
+The journal, not name shape, decides "mine": two Termio installs share one
+per-uid daemon roster, so a UUID-shaped name alone proves nothing about whose
+session it is.
+
+### The verdict on the section itself
+
+Keep the mechanism, fix its diet. Adopting `termiod`-CLI sessions into the
+sidebar is real product surface — it is the "one roster, any client" half of
+the positioning, and herdr validates external-session detection as the
+category norm. What #528 shows is not that the section is a bad idea but that
+it was fed sessions whose identity the app already owned. After D1–D3 it
+appears only when someone genuinely started a session outside the app — which
+for most users is never, and that is the correct frequency for it.
+
+## Testing
+
+- `Tests/termioTests/TermiodDestroyIntegrationTests.swift` installs the link by
+  hand (`:104`), so the link-present path is the only one ever exercised — the
+  #528 close path has zero coverage. Add the link-less cases: close of a
+  restored row, close after `applyTermiodExit`, close from the CLI path.
+- Unit-test the D3 filter with a journaled close: roster row matching a
+  journaled name must be killed, not listed.
+- The D2 demotion streak is pure logic over `SessionInfo` sequences — testable
+  without a window, same shape as `StallProbeTests`.
+- Manual: reproduce the issue's tree by shadowing `claude` with a zsh function
+  in a probe channel (`TERMIO_CHANNEL=probe`), exit the agent, confirm the row
+  demotes in place; close it, confirm the daemon roster is empty.
+
+## Non-goals
+
+- #526/#527 (connect-failure daemon spawning) are a different root cause and
+  tracked separately.
+- No daemon-side "owner" metadata. termiod stays client-agnostic; ownership is
+  the app's bookkeeping (the journal), which also keeps two installs sharing a
+  roster honest.
+- No change to revert-to-shell as the designed outcome of agent exit, and no
+  nested window manager anywhere in the host.


### PR DESCRIPTION
Half the docs corpus was created and never touched again, so `status` had stopped carrying information: 42 of 105 docs sat at `draft`, which is supposed to mean "being written, nothing committed to".

That is not tidiness. Every agent that greps `docs/` weighs all 99 front-matter docs equally, and one of the `draft` ones was an RFC for a per-project Seatbelt sandbox that was removed from the tree entirely. The next agent to ask whether Termio sandboxes its agents gets a confident wrong answer out of our own repo.

Headers only — no document body is edited, because the dates and the reasoning are the whole value of a design doc.

Six docs went back on the vocabulary. `fixed`, `resolved`, `in-progress` and `built, measured, shelved` are not statuses the index or any query understands, so those docs sorted into their own buckets and answered nothing. The shelved doc's own opening paragraph still says it was built and measured, which is where that nuance belongs.

Fourteen write-once drafts were re-stated against the code. Eight move to `done`, each verified by grepping for the thing the doc proposes — the libghostty fork pinned in `Package.swift`, `SessionRuntime`, `termio://session`, `WireProtocol.swift`, `scripts/termio sessions`, `termiod/src/git.rs`, `struct Checkout`, loose terminals. The Seatbelt RFC moves to `archived`. So do five adversarial-review artifacts: a review of another document is finished the day it is written and will never leave `draft` on its own.

`draft` is now 29, and those 29 are genuinely open questions.

Release Notes:
* None — documentation only.