### PR TITLE
Inherit Ghostty themes the way Ghostty parses them

### DIFF
--- a/Sources/termio/Settings/GhosttyUserConfig.swift
+++ b/Sources/termio/Settings/GhosttyUserConfig.swift
@@ -15,7 +15,7 @@ struct GhosttyUserConfig {
     /// (termio honors both slots verbatim, even when the two names are equal).
     enum ThemeSetting: Equatable {
         case bare(String)
-        case split(light: String?, dark: String?)
+        case split(light: String, dark: String)
     }
 
     /// `font-family` values in declaration order — Ghostty treats repeats as a fallback chain
@@ -26,31 +26,50 @@ struct GhosttyUserConfig {
 
     var isEmpty: Bool { fontFamilies.isEmpty && fontSize == nil && themeSetting == nil }
 
-    static func parseThemeSetting(_ value: String) -> ThemeSetting {
+    /// Mirrors Ghostty's `Theme.parseCLI`: a comma, colon, or equals sign switches to the
+    /// light/dark pair form, and the pair form is all-or-nothing — every part must be a
+    /// `light:`/`dark:` pair and both slots must end up named, or Ghostty rejects the whole
+    /// line as a config error. Returning nil mirrors that rejection, and it matters as much
+    /// as the parse: a line Ghostty errors on paints nothing there, so termio must not
+    /// inherit it either.
+    static func parseThemeSetting(_ value: String) -> ThemeSetting? {
+        guard value.contains(",") || value.contains(":") || value.contains("=") else {
+            return .bare(value)
+        }
         var light: String?
         var dark: String?
-        var sawSplitForm = false
         for part in value.split(separator: ",") {
             let pair = part.split(separator: ":", maxSplits: 1)
-            guard pair.count == 2 else { continue }
-            let mode = pair[0].trimmingCharacters(in: .whitespaces).lowercased()
-            let name = pair[1].trimmingCharacters(in: .whitespaces)
-            if mode == "light" { light = name; sawSplitForm = true }
-            if mode == "dark" { dark = name; sawSplitForm = true }
+            guard pair.count == 2 else { return nil }
+            let mode = pair[0].trimmingCharacters(in: .whitespaces)
+            var name = pair[1].trimmingCharacters(in: .whitespaces)
+            if name.count >= 2, name.hasPrefix("\""), name.hasSuffix("\"") {
+                name = String(name.dropFirst().dropLast())
+            }
+            switch mode {
+            case "light": light = name
+            case "dark": dark = name
+            default: return nil
+            }
         }
-        return sawSplitForm ? .split(light: light, dark: dark) : .bare(value)
+        guard let light, let dark else { return nil }
+        return .split(light: light, dark: dark)
     }
 
-    /// Reads the files Ghostty itself loads on macOS, in Ghostty's order — the XDG file first,
-    /// the Application Support file after, so the latter wins for single-value keys while
-    /// `font-family` keeps accumulating across both.
+    /// Reads the files Ghostty itself loads on macOS, in Ghostty's order — XDG before
+    /// Application Support, and in each place the legacy `config` before the `config.ghostty`
+    /// name Ghostty prefers since 1.3 — so later files win for single-value keys while
+    /// `font-family` keeps accumulating across all of them.
     static func load(home: URL = FileManager.default.homeDirectoryForCurrentUser,
                      environment: [String: String] = ProcessInfo.processInfo.environment) -> GhosttyUserConfig {
         let xdgBase = environment["XDG_CONFIG_HOME"].map { URL(fileURLWithPath: $0) }
             ?? home.appendingPathComponent(".config")
+        let appSupportBase = home.appendingPathComponent("Library/Application Support/com.mitchellh.ghostty")
         let paths = [
             xdgBase.appendingPathComponent("ghostty/config"),
-            home.appendingPathComponent("Library/Application Support/com.mitchellh.ghostty/config"),
+            xdgBase.appendingPathComponent("ghostty/config.ghostty"),
+            appSupportBase.appendingPathComponent("config"),
+            appSupportBase.appendingPathComponent("config.ghostty"),
         ]
         var config = GhosttyUserConfig()
         for path in paths {
@@ -63,11 +82,14 @@ struct GhosttyUserConfig {
     /// Folds one config file's text into the receiver: later lines win for single-value keys,
     /// `font-family` accumulates, comments and unknown keys are skipped.
     mutating func merge(parsing text: String) {
-        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
+        // Split on `isNewline`, not "\n": Swift folds "\r\n" into one grapheme cluster, so a
+        // CRLF-saved config would otherwise never split into lines at all.
+        for rawLine in text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline) {
+            // Keys stay case-sensitive because Ghostty's are.
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !line.isEmpty, !line.hasPrefix("#") else { continue }
             guard let equals = line.firstIndex(of: "=") else { continue }
-            let key = line[..<equals].trimmingCharacters(in: .whitespaces).lowercased()
+            let key = line[..<equals].trimmingCharacters(in: .whitespaces)
             var value = line[line.index(after: equals)...].trimmingCharacters(in: .whitespaces)
             if value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"") {
                 value = String(value.dropFirst().dropLast())
@@ -84,7 +106,13 @@ struct GhosttyUserConfig {
             case "font-size":
                 fontSize = Double(value)
             case "theme":
-                themeSetting = value.isEmpty ? nil : Self.parseThemeSetting(value)
+                if value.isEmpty {
+                    themeSetting = nil
+                } else if let setting = Self.parseThemeSetting(value) {
+                    themeSetting = setting
+                }
+                // An unparsable value keeps the previous one: Ghostty rejects the bad
+                // line as a config error and the earlier setting stays in effect.
             default:
                 break
             }

--- a/Sources/termio/Settings/Settings.swift
+++ b/Sources/termio/Settings/Settings.swift
@@ -491,10 +491,10 @@ final class AppSettings: ObservableObject {
                 overrides[definition.isDark ? Key.darkThemeName : Key.lightThemeName] = definition.name
             }
         case .split(let light, let dark):
-            if let light, let definition = ThemeLibrary.catalogTheme(matching: light) {
+            if let definition = ThemeLibrary.catalogTheme(matching: light) {
                 overrides[Key.lightThemeName] = definition.name
             }
-            if let dark, let definition = ThemeLibrary.catalogTheme(matching: dark) {
+            if let definition = ThemeLibrary.catalogTheme(matching: dark) {
                 overrides[Key.darkThemeName] = definition.name
             }
         case nil:

--- a/Tests/termioTests/GhosttyUserConfigTests.swift
+++ b/Tests/termioTests/GhosttyUserConfigTests.swift
@@ -72,6 +72,46 @@ final class GhosttyUserConfigTests: XCTestCase {
         )
     }
 
+    func testOneSidedSplitIsRejectedLikeGhostty() {
+        // Ghostty's pair form requires both slots; `theme = light:Nord` is a config
+        // error there, so the previous value must stand here too.
+        let config = parsed("""
+        theme = Dracula
+        theme = light:Nord
+        """)
+        XCTAssertEqual(config.themeSetting, .bare("Dracula"))
+    }
+
+    func testMalformedSplitPartRejectsWholeLine() {
+        XCTAssertNil(parsed("theme = light:Nord,dark:Dracula,typo").themeSetting)
+        XCTAssertNil(parsed("theme = Light:Nord,dark:Dracula").themeSetting)
+    }
+
+    func testEmptyThemeResetsToDefault() {
+        let config = parsed("""
+        theme = Dracula
+        theme =
+        """)
+        XCTAssertNil(config.themeSetting)
+    }
+
+    func testQuotedSplitNamesAreUnquoted() {
+        XCTAssertEqual(
+            parsed("theme = light:\"Solarized Light\",dark:\"Nord\"").themeSetting,
+            .split(light: "Solarized Light", dark: "Nord")
+        )
+    }
+
+    func testCRLFLinesParseClean() {
+        let config = parsed("font-family = Menlo\r\ntheme = Nord\r\n")
+        XCTAssertEqual(config.fontFamilies, ["Menlo"])
+        XCTAssertEqual(config.themeSetting, .bare("Nord"))
+    }
+
+    func testKeysAreCaseSensitiveLikeGhostty() {
+        XCTAssertNil(parsed("Theme = Nord").themeSetting)
+    }
+
     func testDuplicateFontFamiliesCollapse() {
         var config = parsed("font-family = Berkeley Mono")
         config.merge(parsing: "font-family = Berkeley Mono")
@@ -89,6 +129,24 @@ final class GhosttyUserConfigTests: XCTestCase {
         """)
         XCTAssertEqual(config.fontFamilies, ["Menlo", "Sarasa Mono SC"])
         XCTAssertEqual(config.fontSize, 14)
+    }
+
+    func testConfigGhosttyFileIsReadAndWins() throws {
+        // Ghostty ≥1.3 prefers `config.ghostty` beside the legacy `config` name and
+        // loads both, the new name after — so its values must win here too.
+        let home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ghostty-config-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let xdg = home.appendingPathComponent(".config/ghostty")
+        try FileManager.default.createDirectory(at: xdg, withIntermediateDirectories: true)
+        try "theme = Dracula\nfont-size = 12\n".write(
+            to: xdg.appendingPathComponent("config"), atomically: true, encoding: .utf8)
+        try "theme = Nord\n".write(
+            to: xdg.appendingPathComponent("config.ghostty"), atomically: true, encoding: .utf8)
+
+        let config = GhosttyUserConfig.load(home: home, environment: [:])
+        XCTAssertEqual(config.themeSetting, .bare("Nord"))
+        XCTAssertEqual(config.fontSize, 12)
     }
 
     func testMissingFilesYieldEmptyConfig() {


### PR DESCRIPTION
termio inherits font and theme from the user's Ghostty config as launch-time defaults. Auditing that parser against Ghostty 1.3.1's actual source (`Config.zig`, `cli/args.zig`, `config/file_load.zig`) turned up one real gap and a family of divergences where termio would inherit values Ghostty itself rejects.

- Read the `config.ghostty` files Ghostty prefers since 1.3, beside the legacy `config` names, in Ghostty's load order (XDG legacy → XDG new → App Support legacy → App Support new). A Ghostty install migrated to the new filename previously got silently zero inheritance.
- Mirror Ghostty's `Theme.parseCLI` for the `light:Name,dark:Name` pair form: any `,` `:` `=` enters pair parsing, every part must be a `light:`/`dark:` pair, both slots are required, quoted names are unquoted. An invalid line is rejected and the previous value stands, matching Ghostty's error-and-continue — so termio never paints a theme Ghostty is erroring on.
- Parse CRLF-saved configs. Swift folds `\r\n` into one grapheme cluster, so splitting on `"\n"` treated an entire CRLF file as a single line; splitting on `isNewline` fixes it.
- Match Ghostty's case-sensitive config keys.

Eight new tests pin each behavior; `swift build` and the full suite pass.

Release Notes:
- Termio now reads Ghostty 1.3's `config.ghostty` files when inheriting font and theme defaults, and only inherits theme values Ghostty itself accepts.