### PR TITLE
Add termio version and termio remote, deprecate the daemon's --host twins

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -578,6 +578,10 @@ public enum Termiod {
         public let hostId: String
         public let host: String
         public let clientId: String
+        /// The protocol version the handshake settled on — the highest the two
+        /// ranges share (§C.3). Decoded tolerantly for replayed captures, but
+        /// every real daemon sends it.
+        public let proto: Int?
         /// Capabilities the daemon accepted. Absent on an older daemon, so it
         /// defaults rather than failing the handshake — negotiate, never lockstep.
         public let caps: [String]
@@ -596,7 +600,7 @@ public enum Termiod {
         public var homeDirectory: String { home.hasPrefix("/") ? home : "/" }
 
         private enum CodingKeys: String, CodingKey {
-            case hostId, host, clientId, caps, home, version
+            case hostId, host, clientId, proto, caps, home, version
         }
 
         public init(from decoder: Decoder) throws {
@@ -604,6 +608,7 @@ public enum Termiod {
             hostId = try container.decode(String.self, forKey: .hostId)
             host = try container.decode(String.self, forKey: .host)
             clientId = try container.decode(String.self, forKey: .clientId)
+            proto = try container.decodeIfPresent(Int.self, forKey: .proto)
             caps = try container.decodeIfPresent([String].self, forKey: .caps) ?? []
             home = try container.decodeIfPresent(String.self, forKey: .home) ?? ""
             version = try container.decodeIfPresent(String.self, forKey: .version)

--- a/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
+++ b/Sources/termio/Terminal/Termiod/TermioStore+Termiod.swift
@@ -1010,7 +1010,9 @@ extension TermioStore {
                 state: .failed,
                 message: "The termiod binary to deploy wasn't found at \(localBinary)."))
         }
-        var arguments = ["deploy", "--host", host, "--json"]
+        // The `remote` spelling, not `deploy --host`: the top-level twin is
+        // deprecated and warns on stderr, which this side reads as a diagnosis.
+        var arguments = ["remote", "deploy", host, "--json"]
         if force { arguments.append("--force") }
         guard let run = runProcess(localBinary, arguments) else {
             return .failure(RemoteSetupError(

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -622,7 +622,7 @@ extension Termiod {
             // sent (`termiod/0.1.0 linux-aarch64`) for one that predates it.
             let device = TermiodDeviceRegistry.shared.record(
                 hostID: payload.hostId, daemonVersion: payload.version ?? payload.host,
-                route: transport.route)
+                negotiatedProtocol: payload.proto, route: transport.route)
             // An offer the daemon dropped is not an error — negotiate, never
             // lockstep — but it does change what this connection can expect, so
             // it is worth saying out loud once per channel.

--- a/Sources/termio/Terminal/Termiod/TermiodDevice.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodDevice.swift
@@ -70,6 +70,14 @@ struct TermiodDevice: Codable, Identifiable, Hashable {
     var daemonVersion: String
     /// Every route this device has been seen on, most recently used first.
     var routes: [TermiodRoute]
+    /// The protocol version the last handshake with the device negotiated —
+    /// `hello_ok.proto`. `nil` for a device recorded before the field existed.
+    var negotiatedProtocol: Int? = nil
+    /// When the last handshake completed, persisted. Unlike `lastSeen` this
+    /// never claims reachability: it stamps *when the facts above were learned*,
+    /// so `termio version` can say "as of last connect, 2h ago" instead of
+    /// presenting a stale row as live state.
+    var observedAt: Date? = nil
     /// When *this run* of the app last completed a handshake with the device.
     /// Deliberately not persisted: a timestamp restored from disk would claim
     /// reachability the app has not verified since launch.
@@ -77,6 +85,8 @@ struct TermiodDevice: Codable, Identifiable, Hashable {
 
     private enum CodingKeys: String, CodingKey {
         case id, daemonVersion, routes
+        case negotiatedProtocol = "proto"
+        case observedAt
     }
 }
 
@@ -111,7 +121,10 @@ final class TermiodDeviceRegistry: @unchecked Sendable {
     /// Records what a completed handshake just revealed. Returns the merged
     /// device so the caller can log or act on the identity it actually reached.
     @discardableResult
-    func record(hostID: String, daemonVersion: String, route: TermiodRoute) -> TermiodDevice {
+    func record(
+        hostID: String, daemonVersion: String, negotiatedProtocol: Int? = nil,
+        route: TermiodRoute
+    ) -> TermiodDevice {
         lock.lock()
         defer { lock.unlock() }
 
@@ -125,10 +138,16 @@ final class TermiodDeviceRegistry: @unchecked Sendable {
         var device = devicesByID[hostID]
             ?? TermiodDevice(id: hostID, daemonVersion: daemonVersion, routes: [], lastSeen: nil)
         device.daemonVersion = daemonVersion
+        // A handshake that did not carry the version keeps the last one that
+        // did: overwriting a known protocol with `nil` would only unlearn it.
+        if let negotiatedProtocol {
+            device.negotiatedProtocol = negotiatedProtocol
+        }
         // Most recently used first: the route that just worked is the one to try
         // again before probing the others.
         device.routes.removeAll { $0 == route }
         device.routes.insert(route, at: 0)
+        device.observedAt = Date()
         device.lastSeen = Date()
         devicesByID[hostID] = device
 
@@ -182,6 +201,9 @@ final class TermiodDeviceRegistry: @unchecked Sendable {
                 at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            // ISO 8601, not the Foundation reference-date float: `devices.json`
+            // reads like configuration, and `termio version` parses it in shell.
+            encoder.dateEncodingStrategy = .iso8601
             let devices = devicesByID.values.sorted { $0.id < $1.id }
             try encoder.encode(devices).write(to: fileURL, options: .atomic)
         } catch {
@@ -192,8 +214,10 @@ final class TermiodDeviceRegistry: @unchecked Sendable {
     }
 
     private func load() {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
         guard let data = try? Data(contentsOf: fileURL),
-              let devices = try? JSONDecoder().decode([TermiodDevice].self, from: data)
+              let devices = try? decoder.decode([TermiodDevice].self, from: data)
         else { return }
         for device in devices {
             devicesByID[device.id] = device

--- a/Tests/termioTests/TermiodDeviceRegistryTests.swift
+++ b/Tests/termioTests/TermiodDeviceRegistryTests.swift
@@ -135,6 +135,7 @@ final class TermiodDeviceRegistryTests: XCTestCase {
         XCTAssertEqual(payload.host, macDaemon)
         XCTAssertEqual(payload.clientId, "c_1")
         XCTAssertEqual(payload.caps, ["snapshot"])
+        XCTAssertEqual(payload.proto, 1)
     }
 
     /// A daemon that predates a field must still shake hands — negotiate, never
@@ -163,5 +164,19 @@ final class TermiodDeviceRegistryTests: XCTestCase {
                               encoding: .utf8)
         XCTAssertTrue(text.contains("\"ssh:vps-lan\""), text)
         XCTAssertTrue(text.contains("\"unix\""), text)
+    }
+
+    /// What `termio version` reads for its remote rows: the negotiated protocol
+    /// and the observation time survive a relaunch, and a later handshake that
+    /// carries no protocol keeps the last one that did instead of unlearning it.
+    func testNegotiatedProtocolAndObservationTimePersist() {
+        let first = makeRegistry()
+        first.record(hostID: "h_aaaa", daemonVersion: linuxDaemon,
+                     negotiatedProtocol: 1, route: .ssh("vps"))
+        first.record(hostID: "h_aaaa", daemonVersion: linuxDaemon, route: .ssh("vps"))
+
+        let device = makeRegistry().device(id: "h_aaaa")
+        XCTAssertEqual(device?.negotiatedProtocol, 1)
+        XCTAssertNotNil(device?.observedAt)
     }
 }

--- a/docs/design/20260730-termiod-session-protocol.md
+++ b/docs/design/20260730-termiod-session-protocol.md
@@ -3,7 +3,7 @@ title: termiod Session Protocol
 status: draft
 type: design
 created: 2026-07-30
-updated: 2026-08-30
+updated: 2026-08-31
 related:
   - 20260730-termiod-session-mux.md
   - 20260708-session-daemon-architecture.md
@@ -61,7 +61,12 @@ mutate".
 2026-08-22: reserved the `tunnel` capability name (§C.3, new §C.14 — VS Code
 Remote's raw-pipe tunnel shape, deferred until a non-SSH pipe needs it) and
 added §H #11 (never require agent cooperation), from a design pass against VS
-Code Remote's public architecture record. -->
+Code Remote's public architecture record.
+2026-08-31: wrote the stated security model into §C.8 (Unix socket = full
+authority by design; the pairing token is daemon-equivalent until rotated; the
+invariants are no non-loopback bind and no embedded TLS — not "no TCP ever"),
+per the docker-dockerd-lessons RFC §5.1, and aligned §D's WSS auth cell with
+it. -->
 
 
 # Design: termiod Session Protocol
@@ -527,6 +532,33 @@ Baseline stance (unchanged from the mux doc): default listen is **Unix socket
 only**, `0700` runtime dir; no TCP bind by default; relays are optional and
 blind (§D.4).
 
+**The stated security model** (recorded here per the docker-dockerd-lessons
+RFC §5.1, before third-party tools shape themselves around an undocumented
+one):
+
+- **The Unix socket is full authority, by design.** Anything that can open it
+  can inject keystrokes into any session, which is user-equivalent code
+  execution. That is the point — `termio sessions send` driving sibling agents
+  is a feature — and AF_UNIX plus filesystem permissions is the right fence
+  for same-user-same-box (§A: the OS is the security team). No per-verb ACL
+  on the socket will ever be added; a caller you don't trust with your shell
+  must not reach the socket at all.
+- **The pairing token is currently daemon-equivalent too.** `serve --wss` is a
+  TCP listener that refuses non-loopback binds and carries the same framed
+  protocol onto the daemon socket, and DEPLOY.md says it plainly: whoever
+  holds the token has full access to the daemon until it is rotated. Do not
+  hand the token to a party you would not trust with the daemon.
+- **The invariants are precise.** They are **no non-loopback bind** (the
+  `--wss` flag parses its address and refuses anything not loopback) and
+  **no embedded TLS** (§H #3: TLS belongs to the tunnel in front) — not
+  "no TCP ever".
+- A scoped token tier — one that reaches the session planes but never
+  `deploy`, `service`, or hook installation — is protocol and daemon work
+  with tests, not a documentation pass. It gets scheduled when a token holder
+  exists who should not be daemon-equivalent (pairing beyond the owner's own
+  phone); until then, the statements above are the security model
+  (docker-dockerd-lessons RFC §5.2).
+
 ### C.9 Wire example — same messages, three pipes
 
 ```
@@ -819,7 +851,7 @@ output parsing as the Remote-SSH default.
 
 | | Unix socket | SSH stdio | QUIC (later) | WSS + relay (later) |
 | --- | --- | --- | --- | --- |
-| **Auth** | Filesystem perms on `$XDG_RUNTIME_DIR/termiod/` (0700); peer-cred check optional | ssh-agent / `~/.ssh/config` — user's existing identity, keys never touch Termio | Borrowed identity only: Tailscale tailnet, or pairing-pinned host cert (TOFU like SSH). **No DIY PKI** | Pairing token (companion model), scoped per device; tokens gate every connection |
+| **Auth** | Filesystem perms on `$XDG_RUNTIME_DIR/termiod/` (0700); peer-cred check optional | ssh-agent / `~/.ssh/config` — user's existing identity, keys never touch Termio | Borrowed identity only: Tailscale tailnet, or pairing-pinned host cert (TOFU like SSH). **No DIY PKI** | Pairing token (companion model) — today daemon-equivalent until rotated (§C.8); tokens gate every connection |
 | **Channel mapping** | 1 connection = 1 channel | 1 exec (`termiod stdio`) = 1 channel; ControlMaster **would** multiplex execs over one TCP+auth session — **not implemented**, see the note below the table | 1 QUIC connection per (client, host); stream 0 = control, one bidi stream per attach — the roles were designed for this | 1 WebSocket = 1 channel (matches today's companion shape) |
 | **Failure / reconnect** | Retry connect; host down = launchd/systemd restarts it | TCP drop = detach, never kill; reattach replays ring / snapshot; ControlMaster + `ServerAliveInterval` for fast resume | Connection migration = roaming survives network flips; 0-RTT resume | Relay drop = detach; client re-pairs/reconnects; tiered ReconnectPolicy already exists on iOS |
 | **When (product)** | Local, always — the default | Remote VPS/devbox — the default remote through v1 | Only after measured pain: the §D p95 criterion, or a supersedable plane the browser needs | **The web client's transport** (a Replica over WSS), plus a phone with no tailnet behind hostile NAT |

--- a/scripts/termio
+++ b/scripts/termio
@@ -725,12 +725,14 @@ agent() {
 
     # `--reply` is handled by the daemon binary, which prints `{}` itself even
     # when the report could not be delivered — one implementation of Cursor's
-    # stdout contract rather than two.
+    # stdout contract rather than two. The channel is pinned like every other
+    # daemon exec in this script: a dev-located daemon with a stale or absent
+    # inherited channel would otherwise report to the release socket.
     # shellcheck disable=SC2086
     if [ "$reply" -eq 1 ]; then
-        exec "$daemon" set-status "$TERMIOD_SESSION_ID" "$state" $forwarded --reply
+        TERMIO_CHANNEL="$CHANNEL" exec "$daemon" set-status "$TERMIOD_SESSION_ID" "$state" $forwarded --reply
     fi
-    exec "$daemon" set-status "$TERMIOD_SESSION_ID" "$state" $forwarded
+    TERMIO_CHANNEL="$CHANNEL" exec "$daemon" set-status "$TERMIOD_SESSION_ID" "$state" $forwarded
 }
 
 # `termio notify [--title T] "<message>"` — post a macOS notification on demand.

--- a/scripts/termio
+++ b/scripts/termio
@@ -37,6 +37,11 @@ usage:
 
   termio notify [--title T] "<message>"      post a macOS notification (e.g. "I'm done")
 
+  termio remote <verb> [...]                 drive a box's termiod over SSH (deploy, list,
+                                             attach, open — `termio remote --help` lists them)
+  termio version                             one table: this client, the running app, the local
+                                             termiod, and every known remote as of last connect
+
   termio agent report <state>                report this agent's activity (hook contract)
 
 options:
@@ -230,6 +235,51 @@ EOF
 }
 
 SOCKET="$HOME/Library/Application Support/$SUPPORT_DIR_NAME/session-control.sock"
+
+# The channel this copy of the script is bound to, spelled the way
+# `TERMIO_CHANNEL` spells it. Passed explicitly on every termiod this script
+# execs (mirroring the app), so a stale value inherited from whatever launched
+# the shell cannot land a daemon command on the other channel's socket.
+CHANNEL="release"
+[ "$SUPPORT_DIR_NAME" != "termio" ] && CHANNEL="${SUPPORT_DIR_NAME#termio-}"
+
+# The termiod that belongs to this script's channel. The old lookup (used only
+# by `agent report`) went ~/.local/bin then PATH, which on a machine with both
+# channels installed can select a daemon from a different bundle than the app
+# this script drives. Resolution order:
+#   1. TERMIOD_BIN — the explicit override, when it names an executable.
+#   2. The bundle this script was exec'd out of (the daemon is a sibling
+#      resource in Contents/Resources).
+#   3. The running app for this channel's bundle id — lsappinfo answers only
+#      for a live process, so it can never name a stale, moved bundle.
+#   4. ~/.local/bin/termiod, then PATH — the old fallbacks, kept last so a
+#      box-style install without any app still works.
+# Prints nothing when no daemon exists; callers decide whether that is fatal.
+locate_termiod() {
+    if [ -n "${TERMIOD_BIN:-}" ] && [ -x "$TERMIOD_BIN" ]; then
+        printf '%s\n' "$TERMIOD_BIN"
+        return 0
+    fi
+    script_dir=$(dirname "$(readlink -f "$0" 2>/dev/null || printf '%s' "$0")")
+    case "$script_dir" in
+        */Contents/Resources)
+            if [ -x "$script_dir/termiod" ]; then
+                printf '%s\n' "$script_dir/termiod"
+                return 0
+            fi ;;
+    esac
+    bundle=$(lsappinfo info -only bundlepath "$BUNDLE_ID" 2>/dev/null \
+        | sed -n 's/^"LSBundlePath"="\(.*\)"$/\1/p')
+    if [ -n "$bundle" ] && [ -x "$bundle/Contents/Resources/termiod" ]; then
+        printf '%s\n' "$bundle/Contents/Resources/termiod"
+        return 0
+    fi
+    if [ -x "$HOME/.local/bin/termiod" ]; then
+        printf '%s\n' "$HOME/.local/bin/termiod"
+        return 0
+    fi
+    command -v termiod 2>/dev/null || true
+}
 
 # JSON-escape a string for embedding in a request: backslashes, double quotes,
 # tabs, and newlines (which would otherwise break the single-line JSON object).
@@ -667,10 +717,7 @@ agent() {
         return 0
     fi
 
-    daemon="${TERMIOD_BIN:-$HOME/.local/bin/termiod}"
-    if [ ! -x "$daemon" ]; then
-        daemon=$(command -v termiod 2>/dev/null || echo "")
-    fi
+    daemon=$(locate_termiod)
     if [ -z "$daemon" ]; then
         if [ "$reply" -eq 1 ]; then printf '{}'; fi
         return 0
@@ -730,6 +777,118 @@ EOF
     request_once notify "$format" "" "" "$body" "$extra"
 }
 
+# `termio remote <verb>` — one spelling for driving another box's termiod
+# (deploy, list, attach, open). Pure passthrough: the daemon binary owns the
+# verbs, their flags, and their help; this side only picks the right binary —
+# the one bundled beside this script's channel — and pins the channel so the
+# daemon commands land on this app's socket.
+remote_command() {
+    daemon=$(locate_termiod)
+    if [ -z "$daemon" ]; then
+        echo "termio: no termiod binary found — install the termio app, or set TERMIOD_BIN" >&2
+        exit 1
+    fi
+    TERMIO_CHANNEL="$CHANNEL" exec "$daemon" remote "$@"
+}
+
+# `termio version` — every version in one table: this client, the running app,
+# the local termiod (wrapping `termiod status --json`), and one row per known
+# remote from the device registry the app writes at each handshake
+# (`devices.json`). A remote row is what the last connect observed, stamped so
+# a stale row announces its staleness instead of posing as live state; a host
+# this Mac has never spoken to is absent, and nothing here touches the network.
+version_table() {
+    row() { printf '%-14s %-22s %-9s %s\n' "$1" "$2" "$3" "$4" | sed 's/ *$//'; }
+
+    row "termio" "$VERSION" "" "(client, $CHANNEL channel)"
+
+    bundle=$(lsappinfo info -only bundlepath "$BUNDLE_ID" 2>/dev/null \
+        | sed -n 's/^"LSBundlePath"="\(.*\)"$/\1/p')
+    if [ -n "$bundle" ] && [ -f "$bundle/Contents/Info.plist" ]; then
+        app_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" \
+            "$bundle/Contents/Info.plist" 2>/dev/null || echo "")
+        app_build=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" \
+            "$bundle/Contents/Info.plist" 2>/dev/null || echo "")
+        row "termio.app" "${app_version:-?}${app_build:++$app_build}" "" "(running)"
+    else
+        row "termio.app" "-" "" "(not running)"
+    fi
+
+    daemon=$(locate_termiod)
+    if [ -z "$daemon" ]; then
+        row "termiod local" "-" "" "(not installed)"
+    else
+        # The keys live in known sections of a stable shape; tracking the
+        # section is what keeps a session's own command line, echoed in the
+        # sessions array, from ever matching.
+        parsed=$(TERMIO_CHANNEL="$CHANNEL" "$daemon" status --json 2>/dev/null | awk '
+            function value(line) {
+                sub(/^[^:]*: */, "", line); gsub(/^"|",?$|,$/, "", line)
+                gsub(/\\\//, "/", line); return line
+            }
+            /^  "binary": \{/ { section = "binary"; next }
+            /^  "daemon": \{/ { section = "daemon"; next }
+            /^  \},?$/        { section = ""; next }
+            section == "binary" && /^    "version":/ { binary_version = value($0) }
+            section == "daemon" && /^    "version":/ { daemon_version = value($0) }
+            section == "daemon" && /^    "running":/ { running = value($0) }
+            section == "daemon" && /^    "proto":/   { proto = value($0) }
+            END { printf "%s|%s|%s|%s", binary_version, running, daemon_version, proto }
+        ' || true)
+        binary_version=${parsed%%"|"*}; rest=${parsed#*"|"}
+        running=${rest%%"|"*}; rest=${rest#*"|"}
+        daemon_version=${rest%%"|"*}; proto=${rest##*"|"}
+        if [ "$running" = "true" ]; then
+            row "termiod local" "${daemon_version:-$binary_version}" \
+                "${proto:+proto $proto}" ""
+        elif [ -n "$binary_version" ]; then
+            row "termiod local" "$binary_version" "" "(binary; daemon not running)"
+        else
+            row "termiod local" "-" "" "(no answer from $daemon)"
+        fi
+    fi
+
+    devices="$HOME/Library/Application Support/$SUPPORT_DIR_NAME/devices.json"
+    [ -f "$devices" ] || return 0
+    tab=$(printf '\t')
+    # One record per device that has been reached over SSH, labeled by its most
+    # recently used alias. Devices only ever seen locally are the row above.
+    awk '
+        function value(line) {
+            sub(/^[^:]*: */, "", line); gsub(/^"|",?$|,$/, "", line)
+            gsub(/\\\//, "/", line); return line
+        }
+        /"daemonVersion"/ { version = value($0) }
+        /"proto"/         { proto = value($0) }
+        /"observedAt"/    { observed = value($0) }
+        /"routes"/        { in_routes = 1; next }
+        in_routes && /"ssh:/ {
+            if (alias == "") { alias = value($0); sub(/^ssh:/, "", alias) }
+            next
+        }
+        in_routes && /\]/ { in_routes = 0; next }
+        /^  \},?$/ {
+            if (alias != "") printf "%s\t%s\t%s\t%s\n", alias, version, proto, observed
+            alias = version = proto = observed = ""
+        }
+    ' "$devices" | while IFS="$tab" read -r alias device_version proto observed; do
+        stamp="as of an earlier connect"
+        if [ -n "$observed" ]; then
+            connected=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$observed" +%s 2>/dev/null || echo "")
+            if [ -n "$connected" ]; then
+                seconds=$(( $(date +%s) - connected ))
+                [ "$seconds" -lt 0 ] && seconds=0
+                if [ "$seconds" -lt 60 ]; then age="just now"
+                elif [ "$seconds" -lt 3600 ]; then age="$((seconds / 60))m ago"
+                elif [ "$seconds" -lt 86400 ]; then age="$((seconds / 3600))h ago"
+                else age="$((seconds / 86400))d ago"; fi
+                stamp="as of last connect, $age"
+            fi
+        fi
+        row "$alias" "$device_version" "${proto:+proto $proto}" "($stamp)"
+    done
+}
+
 open_project() {
     dir="${1:-.}"
     if [ ! -d "$dir" ]; then
@@ -748,10 +907,16 @@ case "${1:-}" in
         exit 0
         ;;
     --version)
-        channel="release"
-        [ "$SUPPORT_DIR_NAME" != "termio" ] && channel="${SUPPORT_DIR_NAME#termio-}"
-        echo "termio $VERSION ($channel)"
+        echo "termio $VERSION ($CHANNEL)"
         exit 0
+        ;;
+    version)
+        version_table
+        exit 0
+        ;;
+    remote)
+        shift
+        remote_command "$@"
         ;;
     sessions)
         shift

--- a/termiod/DEPLOY.md
+++ b/termiod/DEPLOY.md
@@ -64,17 +64,21 @@ lands (see the protocol doc's roadmap).
 ## The one-liner
 
 ```sh
-termiod remote open my-vps            # deploy if needed, create a session, attach
+termio remote open my-vps             # deploy if needed, create a session, attach
 ```
 
-`my-vps` is any `~/.ssh/config` alias (or `user@host`). Behind that:
+`termio remote …` is the spelling on a machine that has the client — the
+script execs the daemon bundled beside it, so it always matches the app's
+channel. On the box itself there is only `termiod`, which is why the SSH
+examples below keep that name. `my-vps` is any `~/.ssh/config` alias (or
+`user@host`). Behind that:
 
 1. `ssh my-vps test -x ~/.local/bin/termiod` — installed? If not, deploy.
 2. `ssh my-vps termiod create …` — create a durable session; capture its id.
 3. `ssh -t my-vps termiod attach <id>` — attach over an SSH PTY.
 
 Close your laptop mid-session; the daemon on the VPS owns the PTY, so the agent
-keeps running. Reconnect with `termiod remote attach my-vps <id>` (or `open`).
+keeps running. Reconnect with `termio remote attach my-vps <id>` (or `open`).
 
 ## Cross-compiling on the Mac
 
@@ -101,7 +105,7 @@ rustup target add aarch64-unknown-linux-musl   # ARM VPS (Graviton, Ampere, Pi)
 rustup target add x86_64-unknown-linux-musl     # Intel/AMD VPS
 ```
 
-`termiod deploy --host <host>` runs `uname -sm` on the host, picks the matching
+`termio remote deploy <host>` runs `uname -sm` on the host, picks the matching
 target — the slice bundled beside the binary when there is one, a cross-compile
 otherwise — and installs. Manual build:
 
@@ -116,7 +120,7 @@ install one and override `linker` in `.cargo/config.toml`, or build on the host
 and deploy the prebuilt binary:
 
 ```sh
-termiod remote deploy my-vps --bin path/to/linux/termiod
+termio remote deploy my-vps --bin path/to/linux/termiod
 ```
 
 ## What deploy does
@@ -125,7 +129,7 @@ One reconcile loop (`src/lifecycle.rs`; the design is
 `docs/design/20260827-termiod-lifecycle-reconcile.md`):
 
 ```sh
-termiod deploy --host my-vps
+termio remote deploy my-vps
 #  ssh  my-vps ~/.local/bin/termiod status --json   # observe: binary, daemon, sessions
 #  scp  <bundled slice>  my-vps:.local/bin/termiod.new
 #  ssh  my-vps 'chmod +x … && mv termiod termiod.prev && mv termiod.new termiod'   # stage
@@ -316,9 +320,9 @@ Missing `pair.token` splits by where the bind came from:
 ## Reconnect workflow
 
 ```sh
-termiod remote list my-vps               # what's running on the VPS
-termiod remote attach my-vps <id|name>   # reattach; Ctrl-\ detaches
-termiod remote attach my-vps build -- npm run dev   # attach-or-create by name
+termio remote list my-vps               # what's running on the VPS
+termio remote attach my-vps <id|name>   # reattach; Ctrl-\ detaches
+termio remote attach my-vps build -- npm run dev   # attach-or-create by name
 ```
 
 Session survives: SSH disconnects, laptop sleep, network drops. It ends only on

--- a/termiod/src/lifecycle.rs
+++ b/termiod/src/lifecycle.rs
@@ -82,6 +82,8 @@ pub struct DaemonHello {
     /// Absent on a daemon that predates the field — older than anything that
     /// reports one, which is how the loop reads it.
     pub version: Option<String>,
+    /// The protocol version this handshake negotiated (`hello_ok.proto`).
+    pub proto: u32,
     pub host_id: String,
     /// What the daemon can do, from its own `hello_ok`. Read for one thing: a
     /// daemon that does not list `handoff` has to be stopped to be upgraded,
@@ -123,12 +125,14 @@ where
     .await?;
     match read_frame(reader).await? {
         Some(Frame::Control(Control::HelloOk {
+            proto,
             version,
             host_id,
             caps,
             ..
         })) => Ok(DaemonHello {
             version: version.filter(|value| !value.is_empty()),
+            proto,
             host_id,
             caps,
         }),
@@ -244,6 +248,11 @@ pub struct DaemonStatus {
     /// is the state the loop most needs to see. `None` on a daemon too old to
     /// say, or none running.
     pub version: Option<String>,
+    /// The protocol version this probe's own handshake with the daemon
+    /// negotiated — what `termio version` reports for the local daemon.
+    /// `None` when no daemon is running.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proto: Option<u32>,
     pub pid: Option<i32>,
     pub socket: String,
 }
@@ -324,6 +333,7 @@ pub async fn status() -> Result<NodeStatus> {
     let mut daemon = DaemonStatus {
         running: false,
         version: None,
+        proto: None,
         pid: None,
         socket: socket.display().to_string(),
     };
@@ -339,7 +349,10 @@ pub async fn status() -> Result<NodeStatus> {
         })
         .await;
         if let Ok((hello, list)) = asked {
-            daemon.version = hello.ok().and_then(|hello| hello.version);
+            if let Ok(hello) = hello {
+                daemon.version = hello.version;
+                daemon.proto = Some(hello.proto);
+            }
             sessions = list
                 .unwrap_or_default()
                 .into_iter()
@@ -1316,6 +1329,7 @@ mod tests {
             daemon: DaemonStatus {
                 running,
                 version: daemon.map(str::to_string),
+                proto: running.then_some(1),
                 pid: running.then_some(4242),
                 socket: "/run/user/1001/termiod/termiod.sock".to_string(),
             },
@@ -1329,6 +1343,7 @@ mod tests {
     fn hello(version: Option<&str>) -> Result<DaemonHello> {
         Ok(DaemonHello {
             version: version.map(str::to_string),
+            proto: 1,
             host_id: "h_1".to_string(),
             caps: vec![HANDOFF_CAPABILITY.to_string()],
         })

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -546,6 +546,12 @@ async fn main() -> Result<()> {
             host,
             no_local,
         } => {
+            // The top-level `--host` twins of the `remote` namespace retire
+            // (docker-dockerd-lessons RFC §1.1): one spelling, announced
+            // rather than dropped, on stderr so `--json` consumers never see it.
+            if !host.is_empty() {
+                eprintln!("warning: `termiod list --host` is deprecated — use `termio remote list <host>`");
+            }
             // A cloud fleet is many hosts. Sweep them concurrently so the view
             // costs one slow host, not the sum of all of them.
             let mut fleet: Vec<(String, anyhow::Result<Vec<_>>)> = Vec::new();
@@ -697,6 +703,9 @@ async fn main() -> Result<()> {
             host,
             argv,
         } => {
+            if host.is_some() {
+                eprintln!("warning: `termiod attach --host` is deprecated — use `termio remote attach <host> <session>`");
+            }
             // Raw stays the default on every transport, including remote.
             // Measured against a real VPS (2026-08-05, 300-line burst): raw
             // 50 KB vs grid 436 KB — 8.6× *worse* for grid. Scrolling output
@@ -772,7 +781,10 @@ async fn main() -> Result<()> {
         } => {
             let options = lifecycle::Options { force, stage_only };
             let report = match host {
-                Some(host) => remote::reconcile(&remote::SshNode::new(host), options).await,
+                Some(host) => {
+                    eprintln!("warning: `termiod deploy --host` is deprecated — use `termio remote deploy <host>`");
+                    remote::reconcile(&remote::SshNode::new(host), options).await
+                }
                 None => {
                     lifecycle::reconcile(&lifecycle::LocalNode, lifecycle::BUILD_VERSION, options)
                         .await

--- a/termiod/src/remote.rs
+++ b/termiod/src/remote.rs
@@ -78,7 +78,7 @@ fn batch_args() -> Vec<String> {
 
 #[derive(Subcommand)]
 pub enum RemoteCmd {
-    /// Install or update `termiod` on a host over SSH — `termiod deploy --host`.
+    /// Install or update `termiod` on a host over SSH.
     Deploy {
         /// SSH host alias from `~/.ssh/config` (or user@host).
         host: String,


### PR DESCRIPTION
Implements items 1–3 of the docker-dockerd-lessons RFC's near-term work order (§8): make version skew visible, collect the person-typed daemon verbs behind `termio`, and write the current security model down.

## What changed

**`termio version` (§3).** One table: this client, the running app, the local termiod (wrapping `termiod status --json`), and one row per known remote from the device registry. To source it honestly, the handshake path stops dropping `hello_ok.proto`: `TermiodDevice` now persists the negotiated protocol and an observation timestamp (ISO 8601, so `devices.json` stays shell-readable), and `termiod status --json` gains the daemon's `proto`. Remote rows are stamped from their observation time ("as of last connect, 2h ago"); a host never spoken to is absent, and nothing probes the network.

```
termio         0.46.1                 (client, release channel)
termio.app     0.46.1+1602            (running)
termiod local  0.46.1+1602            proto 1
ukvps          0.34.0+907             proto 1   (as of last connect, 2h ago)
```

**P1 verb collection (§1.1, §1.4).** `scripts/termio` gains one bundled-daemon locator — `TERMIOD_BIN` as the explicit override, then the bundle the script was exec'd from, then the running app for its channel's bundle id, then the old fallbacks — and both `agent report` and the new `termio remote …` passthrough resolve through it, so a machine with both channels installed can no longer pick the other bundle's daemon. The top-level `--host` twins of `deploy`/`list`/`attach` print a one-line deprecation notice on stderr (stdout stays clean for `--json`); the app's own deploy call moves to the `remote` spelling. `DEPLOY.md`'s Mac-side examples now teach `termio remote …`; the on-box SSH examples keep `termiod`.

**Security model (§5.1).** The protocol doc's §C.8 now states it as a promise: the Unix socket is full authority by design (no per-verb ACL, ever), the pairing token is currently daemon-equivalent until rotated, and the invariants are no non-loopback bind and no embedded TLS — not "no TCP ever". §D's WSS auth cell no longer claims a per-device scope that does not exist.

## Verification

- `swift build` and `swift test` pass (887 tests, 1 expected failure).
- `cargo test` passes (199 tests; one unrelated `serve_lock` file-lock test flaked once under a parallel run and passes on rerun and in isolation).
- `termio agent report` byte-compatibility checked by hand: silent + exit 0 outside a termiod session, `{}` with `--reply`, unchanged argv to `termiod set-status`.
- `termio version` run against the live machine and against a fixture registry covering `observedAt`/`proto`, escaped `\/`, unix-only and route-less devices.

## Release Notes

- `termio version` prints every version in one table: the client, the running app, the local termiod, and each known remote as of its last connect.
- `termio remote <verb>` drives a box's termiod (deploy, list, attach, open) through the daemon bundled with the app. `termiod deploy/list/attach --host` still work but print a deprecation notice.
- `termio agent report` now prefers the daemon bundled with its own app, so a machine with release and dev builds installed reports through the right one.