### PR TITLE
Say why a device can't be reached, and retry when the app comes back

### DIFF
--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -1687,6 +1687,11 @@ public enum TermiodClientError: LocalizedError {
     /// exactly what a daemon too old for the op does, since unknown ops are
     /// dropped rather than refused (`daemon.rs`, the `Control::Unknown` arm).
     case timedOut(String)
+    /// The pipe to the device closed before the protocol got a word in, and
+    /// `ssh`'s stderr says why. Carries that line verbatim: "Permission denied
+    /// (publickey,password)" names the problem in the words the user can search
+    /// for, and every paraphrase of it is worse than the line itself.
+    case remoteFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -1706,7 +1711,45 @@ public enum TermiodClientError: LocalizedError {
             return message
         case .timedOut(let operation):
             return "the device stopped answering \(operation)"
+        case .remoteFailed(let reason):
+            return reason
         }
+    }
+}
+
+extension Termiod {
+    /// The one line of an `ssh` child's stderr worth showing when its pipe
+    /// closed without a handshake, or `nil` when nothing there explains it.
+    ///
+    /// A connection that dies before `hello_ok` collapses every real cause —
+    /// `BatchMode=yes` refusing to prompt for a password, `termiod` missing on
+    /// the box, a host key mismatch — into the same EOF, and the only witness
+    /// is what ssh or the remote shell printed. The last line is the verdict
+    /// (OpenSSH prints its failure last); lines that narrate rather than
+    /// explain — known-hosts warnings, the "Connection closed" echo of the EOF
+    /// itself — are skipped so they cannot shadow it.
+    ///
+    /// A missing `termiod` is the one cause worth translating: the remote
+    /// shell's "No such file or directory" names a path, not the fix, and the
+    /// fix is this app's to know (opening a terminal on the machine deploys
+    /// the daemon).
+    public static func remoteFailureDiagnosis(stderr: String) -> String? {
+        let verdicts = stderr.split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .filter { !$0.hasPrefix("Warning:") }
+            .filter { !($0.hasPrefix("Connection to ") && $0.hasSuffix("closed.")) }
+        guard let line = verdicts.last else { return nil }
+        // The remote shell failing to exec the daemon's own path — "/…/termiod:
+        // No such file or directory" (bash, path first) or "…: /…/termiod"
+        // (zsh, path last). The path check keeps the daemon complaining about
+        // some *other* missing file out of this arm.
+        let missing = line.localizedCaseInsensitiveContains("no such file or directory")
+            || line.localizedCaseInsensitiveContains("not found")
+        if missing, line.contains("/termiod: ") || line.hasSuffix("/termiod") {
+            return "termiod isn't installed on this machine yet — a new terminal on it sets it up"
+        }
+        return line
     }
 }
 

--- a/Shared/Sources/TermioShared/TermiodProtocol.swift
+++ b/Shared/Sources/TermioShared/TermiodProtocol.swift
@@ -1746,7 +1746,7 @@ extension Termiod {
         // some *other* missing file out of this arm.
         let missing = line.localizedCaseInsensitiveContains("no such file or directory")
             || line.localizedCaseInsensitiveContains("not found")
-        if missing, line.contains("/termiod: ") || line.hasSuffix("/termiod") {
+        if missing, (line.contains("/termiod: ") || line.hasSuffix("/termiod")) {
             return "termiod isn't installed on this machine yet — a new terminal on it sets it up"
         }
         return line

--- a/Sources/termio/App/App.swift
+++ b/Sources/termio/App/App.swift
@@ -511,6 +511,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         false
     }
 
+    /// Coming back to the app is the retry a failed roster never had. A machine
+    /// that refused while the user was away — asleep laptop, network change, an
+    /// ssh problem they just went and fixed — stayed refused on screen until
+    /// something else happened to re-ask (issue #498: the only manual path was
+    /// switching devices). Scoped to the failed state on another machine, so
+    /// ordinary app switching never spawns an ssh.
+    func applicationDidBecomeActive(_ notification: Notification) {
+        if case .failed = store.deviceSessions, !store.currentDevice.isLocal {
+            store.refreshDeviceSessions()
+        }
+    }
+
     /// Dock click (or `open -b sh.termio.app`) with the window closed. The window
     /// survived its close, so it is re-shown rather than rebuilt — the sessions kept
     /// running in its view tree the whole time.

--- a/Sources/termio/Terminal/Termiod/TermiodClient.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodClient.swift
@@ -398,14 +398,48 @@ extension Termiod {
         /// wrong route — the pipe knows where it went.
         let route: TermiodRoute
         private let sshPid: pid_t?
+        /// What the ssh child said on stderr, for the moment its stdout closes
+        /// without explanation. `nil` on the local socket, which has no child
+        /// and no stderr to keep.
+        private let stderrTail: StderrTail?
 
         private init(readDescriptor: Int32, writeDescriptor: Int32,
-                     route: TermiodRoute, sshPid: pid_t?) {
+                     route: TermiodRoute, sshPid: pid_t?,
+                     stderrTail: StderrTail? = nil) {
             self.readDescriptor = readDescriptor
             self.writeDescriptor = writeDescriptor
             self.route = route
             self.sshPid = sshPid
+            self.stderrTail = stderrTail
             Transport.suppressSignalOnBrokenPipe(writeDescriptor)
+        }
+
+        /// The same failure, explained when it can be. A connection that closed
+        /// or lost frame alignment on the SSH road usually means the child
+        /// exited with its reason on stderr — "Permission denied", "No such
+        /// file or directory" — and the generic error is what issue #498 looks
+        /// like from the outside: "my ssh works, Termio says the connection
+        /// closed". Every other error already names its cause and passes
+        /// through untouched.
+        ///
+        /// For a closed connection the child has (all but) exited, so this
+        /// waits briefly for its stderr to finish; a torn frame leaves the
+        /// child alive, so only what has already arrived is consulted.
+        func explained(_ error: TermiodClientError) -> TermiodClientError {
+            guard let stderrTail else { return error }
+            let words: String
+            switch error {
+            case .connectionClosed:
+                words = stderrTail.contents(waitingUpTo: .milliseconds(500))
+            case .malformedFrame:
+                words = stderrTail.contents(waitingUpTo: .zero)
+            default:
+                return error
+            }
+            guard let reason = Termiod.remoteFailureDiagnosis(stderr: words) else {
+                return error
+            }
+            return .remoteFailed(reason)
         }
 
         /// Makes a write to a hung-up peer return `EPIPE` instead of raising
@@ -452,14 +486,23 @@ extension Termiod {
         static func ssh(host: String) throws -> Transport {
             var toChild = [Int32](repeating: -1, count: 2) // app writes [1] → child stdin [0]
             var fromChild = [Int32](repeating: -1, count: 2) // child stdout [1] → app reads [0]
+            var errorPipe = [Int32](repeating: -1, count: 2) // child stderr [1] → tail reads [0]
             guard pipe(&toChild) == 0 else {
                 throw TermiodClientError.daemonUnreachable("ssh:\(host)")
             }
-            // Close the first pair before bailing, or a second-pipe failure (most
-            // likely under fd exhaustion — exactly when it happens) leaks two fds.
+            // Close the earlier pairs before bailing, or a later-pipe failure
+            // (most likely under fd exhaustion — exactly when it happens) leaks
+            // their fds.
             guard pipe(&fromChild) == 0 else {
                 Darwin.close(toChild[0])
                 Darwin.close(toChild[1])
+                throw TermiodClientError.daemonUnreachable("ssh:\(host)")
+            }
+            guard pipe(&errorPipe) == 0 else {
+                Darwin.close(toChild[0])
+                Darwin.close(toChild[1])
+                Darwin.close(fromChild[0])
+                Darwin.close(fromChild[1])
                 throw TermiodClientError.daemonUnreachable("ssh:\(host)")
             }
 
@@ -468,10 +511,14 @@ extension Termiod {
             defer { posix_spawn_file_actions_destroy(&fileActions) }
             posix_spawn_file_actions_adddup2(&fileActions, toChild[0], 0)
             posix_spawn_file_actions_adddup2(&fileActions, fromChild[1], 1)
-            // Child inherits stderr for SSH diagnostics; close the pipe ends it
-            // must not keep open.
+            // stderr is captured, not inherited: it is the only witness when
+            // ssh dies before the handshake, and inherited it went to a console
+            // nobody reads while the UI showed a generic "connection closed".
+            posix_spawn_file_actions_adddup2(&fileActions, errorPipe[1], 2)
+            // Close the pipe ends the child must not keep open.
             posix_spawn_file_actions_addclose(&fileActions, toChild[1])
             posix_spawn_file_actions_addclose(&fileActions, fromChild[0])
+            posix_spawn_file_actions_addclose(&fileActions, errorPipe[0])
 
             let command = "\(remoteBinary()) stdio"
             let arguments = ["ssh", "-o", "ServerAliveInterval=15"]
@@ -484,13 +531,16 @@ extension Termiod {
             let status = posix_spawnp(&pid, "ssh", &fileActions, nil, argv, environ)
             Darwin.close(toChild[0])
             Darwin.close(fromChild[1])
+            Darwin.close(errorPipe[1])
             guard status == 0 else {
                 Darwin.close(toChild[1])
                 Darwin.close(fromChild[0])
+                Darwin.close(errorPipe[0])
                 throw TermiodClientError.daemonSpawnFailed(status)
             }
             return Transport(readDescriptor: fromChild[0], writeDescriptor: toChild[1],
-                             route: .ssh(host), sshPid: pid)
+                             route: .ssh(host), sshPid: pid,
+                             stderrTail: StderrTail(descriptor: errorPipe[0]))
         }
 
         /// Detach: closing the pipe/socket ends the attach without killing the
@@ -520,6 +570,70 @@ extension Termiod {
                 var ignored: Int32 = 0
                 _ = waitpid(sshPid, &ignored, WNOHANG)
             }
+        }
+    }
+
+    /// The last of what an ssh child wrote to stderr, kept so a pipe that
+    /// closes without a handshake can say why.
+    ///
+    /// A dedicated reader thread drains the pipe for the child's whole life —
+    /// draining is not optional, since a child blocked on a full stderr pipe
+    /// would wedge the connection it narrates — but only the newest 4KB are
+    /// kept: the diagnosis is the last line, not the transcript.
+    ///
+    /// `@unchecked Sendable` because every access to the buffer goes through
+    /// `condition`; the lock, not the type system, is what makes this safe.
+    final class StderrTail: @unchecked Sendable {
+        private let condition = NSCondition()
+        private var buffer = Data()
+        private var finished = false
+
+        private static let keep = 4096
+
+        init(descriptor: Int32) {
+            let thread = Thread {
+                var chunk = [UInt8](repeating: 0, count: 1024)
+                while true {
+                    let count = read(descriptor, &chunk, chunk.count)
+                    if count > 0 {
+                        self.condition.lock()
+                        self.buffer.append(contentsOf: chunk[0 ..< count])
+                        if self.buffer.count > Self.keep {
+                            self.buffer.removeFirst(self.buffer.count - Self.keep)
+                        }
+                        self.condition.unlock()
+                    } else if count < 0, errno == EINTR {
+                        continue
+                    } else {
+                        break
+                    }
+                }
+                Darwin.close(descriptor)
+                self.condition.lock()
+                self.finished = true
+                self.condition.broadcast()
+                self.condition.unlock()
+            }
+            thread.name = "sh.termio.termiod.stderr"
+            thread.stackSize = 128 * 1024
+            thread.start()
+        }
+
+        /// Everything kept so far, after giving the child up to `patience` to
+        /// finish saying it. The wait matters on the closed-connection path:
+        /// stdout's EOF and stderr's last line race out of a dying ssh, and
+        /// asking at the instant of the EOF would routinely read an empty pipe
+        /// that is one scheduler tick from holding the answer.
+        func contents(waitingUpTo patience: Duration) -> String {
+            condition.lock()
+            defer { condition.unlock() }
+            if !finished, patience > .zero {
+                let deadline = Date().addingTimeInterval(
+                    Double(patience.components.seconds)
+                        + Double(patience.components.attoseconds) / 1e18)
+                while !finished, condition.wait(until: deadline) {}
+            }
+            return String(decoding: buffer, as: UTF8.self)
         }
     }
 
@@ -660,8 +774,12 @@ extension Termiod {
     ) throws -> Result {
         let transport = try Transport.open(route)
         defer { transport.close() }
-        let handshake = try performHello(transport, role: "control", caps: caps)
-        return try body(transport, handshake)
+        do {
+            let handshake = try performHello(transport, role: "control", caps: caps)
+            return try body(transport, handshake)
+        } catch let error as TermiodClientError {
+            throw transport.explained(error)
+        }
     }
 
     /// Connect, shake hands, hang up: the cheapest question you can ask a route,
@@ -671,7 +789,11 @@ extension Termiod {
     static func probeDevice(route: TermiodRoute) throws -> TermiodDevice {
         let transport = try Transport.open(route)
         defer { transport.close() }
-        return try performHello(transport, role: "control").device
+        do {
+            return try performHello(transport, role: "control").device
+        } catch let error as TermiodClientError {
+            throw transport.explained(error)
+        }
     }
 
     /// The capability the agent plane rides on. A daemon that predates it

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -270,6 +270,9 @@ extension Termiod {
                 self.route = route
                 self.capabilities = handshake.capabilities
                 self.home = handshake.home
+            } catch let error as TermiodClientError {
+                transport.close()
+                throw transport.explained(error)
             } catch {
                 transport.close()
                 throw error

--- a/Tests/termioTests/TermiodRemoteDiagnosisTests.swift
+++ b/Tests/termioTests/TermiodRemoteDiagnosisTests.swift
@@ -1,0 +1,60 @@
+import TermioShared
+import XCTest
+
+/// What the roster shows when `ssh <host> termiod stdio` dies before the
+/// handshake (issue #498): the diagnosis is ssh's own last word, never the
+/// narration around it, and a missing daemon is translated into the fix.
+final class TermiodRemoteDiagnosisTests: XCTestCase {
+    func testPermissionDeniedIsTheVerdict() {
+        // BatchMode=yes against password-only auth: the shape behind "my ssh
+        // works but Termio can't connect" — interactive ssh prompts, ours may not.
+        XCTAssertEqual(
+            Termiod.remoteFailureDiagnosis(
+                stderr: "yqn-14: Permission denied (publickey,password).\n"),
+            "yqn-14: Permission denied (publickey,password).")
+    }
+
+    func testLastLineWinsOverEarlierNoise() {
+        let stderr = """
+        Warning: Permanently added 'yqn-14' (ED25519) to the list of known hosts.
+        yqn-14: Permission denied (publickey,password).
+        """
+        XCTAssertEqual(
+            Termiod.remoteFailureDiagnosis(stderr: stderr),
+            "yqn-14: Permission denied (publickey,password).")
+    }
+
+    func testMissingTermiodNamesTheFix() {
+        for shell in [
+            "bash: line 1: /home/user/.local/bin/termiod: No such file or directory",
+            "zsh:1: no such file or directory: /root/.local/bin/termiod",
+            "sh: 1: /home/user/.local/bin/termiod: not found",
+        ] {
+            XCTAssertEqual(
+                Termiod.remoteFailureDiagnosis(stderr: shell),
+                "termiod isn't installed on this machine yet — a new terminal on it sets it up")
+        }
+    }
+
+    func testAnotherMissingFileIsNotCalledAMissingDaemon() {
+        // The daemon itself complaining about some other path must pass through
+        // verbatim, not be rewritten into an install prompt.
+        let stderr = "termiod: /tmp/nowhere: No such file or directory"
+        XCTAssertEqual(Termiod.remoteFailureDiagnosis(stderr: stderr), stderr)
+    }
+
+    func testNarrationAloneIsNoDiagnosis() {
+        // A tail of only warnings and the EOF's own echo explains nothing; the
+        // caller keeps its generic error instead of showing noise as a reason.
+        let stderr = """
+        Warning: Permanently added 'yqn-14' (ED25519) to the list of known hosts.
+        Connection to yqn-14 closed.
+        """
+        XCTAssertNil(Termiod.remoteFailureDiagnosis(stderr: stderr))
+    }
+
+    func testEmptyStderrIsNoDiagnosis() {
+        XCTAssertNil(Termiod.remoteFailureDiagnosis(stderr: ""))
+        XCTAssertNil(Termiod.remoteFailureDiagnosis(stderr: "\n  \n"))
+    }
+}

--- a/Tests/termioTests/TermiodRemoteDiagnosisTests.swift
+++ b/Tests/termioTests/TermiodRemoteDiagnosisTests.swift
@@ -36,6 +36,14 @@ final class TermiodRemoteDiagnosisTests: XCTestCase {
         }
     }
 
+    func testDeniedDaemonPathIsNotCalledMissing() {
+        // The daemon's own path failing for a reason other than absence — a
+        // noexec mount, wrong permissions — must show that reason, not an
+        // install hint for a binary that is right there.
+        let stderr = "zsh: permission denied: /opt/bin/termiod"
+        XCTAssertEqual(Termiod.remoteFailureDiagnosis(stderr: stderr), stderr)
+    }
+
     func testAnotherMissingFileIsNotCalledAMissingDaemon() {
         // The daemon itself complaining about some other path must pass through
         // verbatim, not be rewritten into an install prompt.


### PR DESCRIPTION
Fixes the shape of #498: the user's interactive SSH works, but Termio shows only **"the termiod connection closed"** with no way to recover short of switching devices.

Three gaps, three fixes:

- **ssh's stderr was invisible.** The `ssh <host> termiod stdio` child inherited stderr into the app's console, so every pre-handshake death — `BatchMode=yes` refusing to prompt for a password, `termiod` missing on the box, a real network failure — collapsed into the same generic EOF error. The transport now captures a bounded stderr tail (dedicated drain thread, newest 4KB) and, when the pipe closes or loses frame alignment without an answer, shows ssh's last meaningful line verbatim: `Can't reach yqn-14: Permission denied (publickey,password).` Known-hosts warnings and the "Connection closed" echo are skipped so they can't shadow the verdict.
- **A missing daemon read as a path error.** The remote shell's "No such file or directory" names a path, not the fix. That one cause is translated: *"termiod isn't installed on this machine yet — a new terminal on it sets it up"* (opening a terminal on the device runs the deploy loop).
- **A failed roster never retried.** Once `.failed`, nothing re-asked until the user switched devices. Reactivating the app now refreshes the roster when the current device is remote and its last answer was a refusal — scoped so ordinary app switching never spawns an ssh.

The diagnosis lives in `TermioShared` as a pure function with unit tests (verdict picking, both shells' missing-binary formats, the false-positive path where termiod complains about some *other* missing file, narration-only tails). One-shot control channels, `probeDevice`, and the pooled channel's handshake all route through the same explanation seam.

Verified with `swift build` and `swift test` (928 tests green). The live-ssh path (real `Permission denied` against a box) follows POSIX plumbing the destroy integration tests already exercise locally; I haven't run it against a real remote from this machine.

Release Notes:
- When a machine can't be reached, the sidebar now shows ssh's actual reason — "Permission denied", "termiod isn't installed on this machine yet" — instead of a generic "connection closed".
- Coming back to Termio retries a machine that refused while you were away.