### PR TITLE
Keep the Mac awake while a session is busy

### DIFF
--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -313,6 +313,10 @@ impl Manager {
         let _ = self.events.send(event);
     }
 
+    pub(crate) fn subscribe_events(&self) -> broadcast::Receiver<Event> {
+        self.events.subscribe()
+    }
+
     async fn info(&self, handle: &SessionHandle) -> Option<SessionInfo> {
         let (tx, rx) = oneshot::channel();
         if handle.send(SessionMsg::Info { reply: tx }) {
@@ -347,7 +351,7 @@ impl Manager {
         });
     }
 
-    async fn list(&self) -> Vec<SessionInfo> {
+    pub(crate) async fn list(&self) -> Vec<SessionInfo> {
         let handles = self.handles();
         let mut infos = Vec::new();
         for handle in handles {
@@ -493,6 +497,7 @@ pub async fn serve(
     wss_bind: Option<std::net::SocketAddr>,
     wss_origins: Vec<crate::wss::Origin>,
     handoff_fd: Option<std::os::fd::RawFd>,
+    keep_awake: bool,
 ) -> Result<()> {
     // First, before anything that can fail: whoever spawned this daemon most
     // likely pointed its stderr at /dev/null, and a startup error is exactly the
@@ -709,6 +714,12 @@ pub async fn serve(
             }
             Err(error) => return Err(error),
         }
+    }
+
+    // Other platforms never spawn this: the boxes termiod serves there are
+    // servers that do not idle-sleep, and the mechanism is caffeinate anyway.
+    if keep_awake && cfg!(target_os = "macos") {
+        tokio::spawn(crate::keep_awake::run(manager.clone()));
     }
 
     let mut terminate =

--- a/termiod/src/keep_awake.rs
+++ b/termiod/src/keep_awake.rs
@@ -11,7 +11,7 @@
 //! see that method for why attachment is deliberately not the test.
 //!
 //! The assertion is a lease, not a held lock. While any session is busy, a
-//! short-lived `caffeinate -i -s -t LEASE` child is renewed on a timer; when
+//! short-lived `caffeinate -i -t LEASE` process is renewed on a timer; when
 //! nothing is busy the last lease simply runs out, which is also the grace
 //! period. Nothing is ever released, so every exit path is covered by the same
 //! non-mechanism: a crash, `termiod stop`, and the `execve` handoff (which
@@ -77,6 +77,7 @@ impl Renewal {
 pub async fn run(manager: Manager) {
     let mut events = manager.subscribe_events();
     let mut renewal = Renewal::new();
+    let mut failure_reported = false;
     let mut tick = tokio::time::interval(RENEW);
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -106,8 +107,18 @@ pub async fn run(manager: Manager) {
         if busy && !on_alternating_current().await {
             continue;
         }
-        if renewal.should_renew(busy, Instant::now()) && !renew_lease() {
-            return;
+        if renewal.should_renew(busy, Instant::now()) {
+            // A failed spawn is not the end of keep-awake: the clock it just
+            // recorded makes the next due wake — the tick at the latest —
+            // retry, and a transient fork failure will have cleared by then.
+            // Reported only on the transition into failure, so a machine
+            // where it never recovers logs once, not once a minute.
+            if renew_lease().await {
+                failure_reported = false;
+            } else if !failure_reported {
+                eprintln!("termiod: keep-awake lease did not start; will keep retrying");
+                failure_reported = true;
+            }
         }
     }
 }
@@ -132,25 +143,27 @@ async fn on_alternating_current() -> bool {
     }
 }
 
-/// Spawn one lease. The child is dropped, not awaited: tokio reaps dropped
-/// children in the background, and `-t` bounds its life without any release
-/// path here. Returns false when spawning failed — a machine where
-/// `/usr/bin/caffeinate` cannot run gets the failure reported once, not once
-/// a minute for as long as an agent works.
-fn renew_lease() -> bool {
-    let spawned = tokio::process::Command::new("/usr/bin/caffeinate")
-        .args(["-i", "-t"])
-        .arg(LEASE.as_secs().to_string())
+/// Spawn one lease, detached from this process tree. `caffeinate` must not be
+/// this daemon's child: the `execve` handoff keeps the pid but replaces every
+/// in-memory child handle, so a lease inherited across it would sit unreaped
+/// as a zombie until the daemon exits. Backgrounding it from a shell that
+/// exits immediately reparents it to launchd, which reaps everything, and the
+/// shell itself is waited on right here. `-t` bounds the lease's life either
+/// way.
+async fn renew_lease() -> bool {
+    let spawned = tokio::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(format!(
+            "/usr/bin/caffeinate -i -t {} >/dev/null 2>&1 &",
+            LEASE.as_secs()
+        ))
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn();
     match spawned {
-        Ok(_) => true,
-        Err(error) => {
-            eprintln!("termiod: keep-awake disabled: caffeinate did not start: {error:#}");
-            false
-        }
+        Ok(mut shell) => matches!(shell.wait().await, Ok(status) if status.success()),
+        Err(_) => false,
     }
 }
 

--- a/termiod/src/keep_awake.rs
+++ b/termiod/src/keep_awake.rs
@@ -1,0 +1,193 @@
+//! Hold the machine out of idle sleep while stopping the daemon would take
+//! work from someone.
+//!
+//! The failure this exists for: an agent prints a permission prompt and goes
+//! quiet. While it was streaming, its pty counted as an active tty and
+//! `pmset`'s default `ttyskeepawake` kept the machine up for free; the moment
+//! it stops to wait, that cover lapses, the idle-sleep timer runs out, and the
+//! phone that was supposed to answer the prompt can no longer reach the box.
+//! The predicate is therefore [`SessionSummary::busy`] — the same "would
+//! stopping take work" test the update path uses — not "is anyone attached";
+//! see that method for why attachment is deliberately not the test.
+//!
+//! The assertion is a lease, not a held lock. While any session is busy, a
+//! short-lived `caffeinate -i -s -t LEASE` child is renewed on a timer; when
+//! nothing is busy the last lease simply runs out, which is also the grace
+//! period. Nothing is ever released, so every exit path is covered by the same
+//! non-mechanism: a crash, `termiod stop`, and the `execve` handoff (which
+//! runs no destructors and would orphan any long-lived child this module kept)
+//! all leave at most one lease that expires on its own. `-i` limits the
+//! assertion to idle system sleep — the display still sleeps.
+//!
+//! On battery no lease is taken at all. That has to be this module's own
+//! check (`pmset -g batt` before each renewal): caffeinate's `-i` assertion
+//! is honored on battery power, and `-s` does not scope it to AC — it only
+//! adds a second, AC-only assertion. Unplugging mid-lease costs at most one
+//! [`LEASE`] of battery-powered wakefulness.
+
+use std::time::{Duration, Instant};
+
+use crate::daemon::Manager;
+use crate::lifecycle::SessionSummary;
+use crate::protocol::Event;
+
+/// How long one `caffeinate` child asserts for. Also the grace period: the
+/// machine stays awake this long after the last session goes quiet.
+const LEASE: Duration = Duration::from_secs(120);
+
+/// How often a lease is renewed while sessions stay busy. Shorter than
+/// [`LEASE`] so coverage is continuous across a missed tick.
+const RENEW: Duration = Duration::from_secs(60);
+
+/// When a wake decides to spawn a new lease.
+///
+/// Kept apart from the renewal loop because it has a real failure mode the
+/// loop would hide: status events arrive in bursts, and a decision that
+/// renewed on every wake would spawn a `caffeinate` per event instead of one
+/// per [`RENEW`].
+struct Renewal {
+    last_lease: Option<Instant>,
+}
+
+impl Renewal {
+    fn new() -> Renewal {
+        Renewal { last_lease: None }
+    }
+
+    fn should_renew(&mut self, busy: bool, now: Instant) -> bool {
+        if !busy {
+            return false;
+        }
+        let due = match self.last_lease {
+            None => true,
+            // Strictly-greater keeps the periodic tick itself renewing: it
+            // fires at exactly RENEW, and jitter only pushes it later.
+            Some(last) => now.duration_since(last) >= RENEW,
+        };
+        if due {
+            self.last_lease = Some(now);
+        }
+        due
+    }
+}
+
+/// Runs for the daemon's life. Spawned only on macOS and only when keep-awake
+/// is enabled; on every other platform the boxes termiod runs on do not
+/// idle-sleep and no assertion is needed.
+pub async fn run(manager: Manager) {
+    let mut events = manager.subscribe_events();
+    let mut renewal = Renewal::new();
+    let mut tick = tokio::time::interval(RENEW);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = tick.tick() => {}
+            event = events.recv() => match event {
+                // Status flips are the wakes that matter: they are how a
+                // session becomes busy between ticks, and the first lease
+                // should start then, not up to RENEW later. Roster changes
+                // and exits only ever end busyness, which the running lease
+                // already covers, but recomputing on them is free.
+                Ok(Event::Status { .. })
+                | Ok(Event::Roster { .. })
+                | Ok(Event::SessionExited { .. }) => {}
+                Ok(_) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+            }
+        }
+
+        let busy = manager
+            .list()
+            .await
+            .into_iter()
+            .any(|info| SessionSummary::from(info).busy());
+        if busy && !on_alternating_current().await {
+            continue;
+        }
+        if renewal.should_renew(busy, Instant::now()) && !renew_lease() {
+            return;
+        }
+    }
+}
+
+/// Whether the machine is on AC power. An answer that cannot be read is
+/// treated as AC: the feature exists to keep the box reachable, and the only
+/// cost of guessing wrong on a machine where `pmset` is broken is a bounded
+/// assertion, not a drained battery on a healthy one.
+async fn on_alternating_current() -> bool {
+    let output = tokio::process::Command::new("/usr/bin/pmset")
+        .args(["-g", "batt"])
+        .output()
+        .await;
+    match output {
+        Ok(output) => !String::from_utf8_lossy(&output.stdout).contains("Battery Power"),
+        Err(error) => {
+            eprintln!(
+                "termiod: keep-awake could not read the power source, assuming AC: {error:#}"
+            );
+            true
+        }
+    }
+}
+
+/// Spawn one lease. The child is dropped, not awaited: tokio reaps dropped
+/// children in the background, and `-t` bounds its life without any release
+/// path here. Returns false when spawning failed — a machine where
+/// `/usr/bin/caffeinate` cannot run gets the failure reported once, not once
+/// a minute for as long as an agent works.
+fn renew_lease() -> bool {
+    let spawned = tokio::process::Command::new("/usr/bin/caffeinate")
+        .args(["-i", "-t"])
+        .arg(LEASE.as_secs().to_string())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+    match spawned {
+        Ok(_) => true,
+        Err(error) => {
+            eprintln!("termiod: keep-awake disabled: caffeinate did not start: {error:#}");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_busy_wake_leases_immediately() {
+        let mut renewal = Renewal::new();
+        assert!(renewal.should_renew(true, Instant::now()));
+    }
+
+    #[test]
+    fn a_burst_of_busy_wakes_costs_one_lease() {
+        let mut renewal = Renewal::new();
+        let start = Instant::now();
+        assert!(renewal.should_renew(true, start));
+        assert!(!renewal.should_renew(true, start + Duration::from_millis(5)));
+        assert!(!renewal.should_renew(true, start + RENEW - Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn the_periodic_tick_renews() {
+        let mut renewal = Renewal::new();
+        let start = Instant::now();
+        assert!(renewal.should_renew(true, start));
+        assert!(renewal.should_renew(true, start + RENEW));
+    }
+
+    #[test]
+    fn quiet_sessions_never_lease_and_do_not_reset_the_clock() {
+        let mut renewal = Renewal::new();
+        let start = Instant::now();
+        assert!(!renewal.should_renew(false, start));
+        assert!(renewal.should_renew(true, start + Duration::from_secs(1)));
+        assert!(!renewal.should_renew(false, start + Duration::from_secs(2)));
+        assert!(renewal.should_renew(true, start + Duration::from_secs(1) + RENEW));
+    }
+}

--- a/termiod/src/main.rs
+++ b/termiod/src/main.rs
@@ -14,6 +14,7 @@ mod files;
 mod git;
 mod handoff;
 mod id;
+mod keep_awake;
 mod lifecycle;
 mod log;
 mod paths;
@@ -90,6 +91,17 @@ enum Cmd {
         /// `execve`.
         #[arg(long = "handoff", value_name = "FD", hide = true)]
         handoff_fd: Option<std::os::fd::RawFd>,
+
+        /// Let the machine idle-sleep even while an agent is working or
+        /// waiting on its user.
+        ///
+        /// By default (macOS, on AC power only) the daemon renews a short
+        /// `caffeinate` assertion while any session is busy, so the box stays
+        /// reachable for the phone that has to answer a waiting agent. The
+        /// display sleeps either way. `TERMIOD_KEEP_AWAKE=off` in the daemon's
+        /// environment does the same as this flag.
+        #[arg(long)]
+        no_keep_awake: bool,
     },
 
     /// Print the pairing token that lets a phone or a browser attach.
@@ -494,7 +506,15 @@ async fn main() -> Result<()> {
             wss,
             wss_origin,
             handoff_fd,
-        } => daemon::serve(wss, wss_origin, handoff_fd).await,
+            no_keep_awake,
+        } => {
+            let keep_awake = !no_keep_awake
+                && !matches!(
+                    std::env::var("TERMIOD_KEEP_AWAKE").as_deref(),
+                    Ok("off") | Ok("false") | Ok("0")
+                );
+            daemon::serve(wss, wss_origin, handoff_fd, keep_awake).await
+        }
 
         Cmd::Handoff {
             json,

--- a/termiod/tests/attach_barrier.rs
+++ b/termiod/tests/attach_barrier.rs
@@ -58,6 +58,7 @@ fn start_daemon(tag: &str) -> Daemon {
     let child = Command::new(BIN)
         .arg("serve")
         .env("TERMIOD_SOCK", &socket)
+        .env("TERMIOD_KEEP_AWAKE", "off")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/termiod/tests/graceful_shutdown.rs
+++ b/termiod/tests/graceful_shutdown.rs
@@ -38,6 +38,7 @@ impl Daemon {
         let mut child = Command::new(BIN)
             .arg("serve")
             .env("TERMIOD_SOCK", socket)
+            .env("TERMIOD_KEEP_AWAKE", "off")
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()

--- a/termiod/tests/handoff.rs
+++ b/termiod/tests/handoff.rs
@@ -67,6 +67,7 @@ impl Daemon {
         let mut child = command
             .arg("serve")
             .env("TERMIOD_SOCK", socket)
+            .env("TERMIOD_KEEP_AWAKE", "off")
             .stdout(Stdio::null())
             .stderr(errors)
             .spawn()

--- a/termiod/tests/join_invariant.rs
+++ b/termiod/tests/join_invariant.rs
@@ -63,6 +63,7 @@ fn start_daemon(tag: &str) -> Daemon {
     let child = Command::new(BIN)
         .arg("serve")
         .env("TERMIOD_SOCK", &socket)
+        .env("TERMIOD_KEEP_AWAKE", "off")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/termiod/tests/lifecycle.rs
+++ b/termiod/tests/lifecycle.rs
@@ -45,6 +45,7 @@ impl Daemon {
         let mut child = Command::new(BIN)
             .arg("serve")
             .env("TERMIOD_SOCK", socket)
+            .env("TERMIOD_KEEP_AWAKE", "off")
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()

--- a/termiod/tests/stdio_bridge.rs
+++ b/termiod/tests/stdio_bridge.rs
@@ -45,6 +45,7 @@ fn start_daemon(tag: &str) -> Daemon {
     let child = Command::new(BIN)
         .arg("serve")
         .env("TERMIOD_SOCK", &socket)
+        .env("TERMIOD_KEEP_AWAKE", "off")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/termiod/tests/wss_bridge.rs
+++ b/termiod/tests/wss_bridge.rs
@@ -98,6 +98,7 @@ fn start_daemon(tag: &str, token: Option<&str>, inherited: bool) -> Daemon {
     }
     let mut command = Command::new(BIN);
     command.arg("serve").env("TERMIOD_SOCK", &socket);
+    command.env("TERMIOD_KEEP_AWAKE", "off");
     if inherited {
         command.env("TERMIOD_WSS", format!("127.0.0.1:{port}"));
     } else {


### PR DESCRIPTION
While an agent streams, its pty counts as an active tty and pmset's default `ttyskeepawake` keeps the machine up for free. The moment it prints a permission prompt and goes quiet, that cover lapses, the idle-sleep timer runs out (`sleep 1` is a common default — one minute after display sleep), and the phone that was supposed to answer the prompt can no longer reach the box. The agent that most needs the machine reachable is exactly the one that can't keep it awake.

## What this does

`termiod` now renews a short `caffeinate -i -t 120` lease every 60 seconds while any session is busy — the same `SessionSummary::busy()` predicate the update path uses (`running || working || needs_you`), protocol status rather than attachment. The first lease lands on the status event itself, not the next tick.

The assertion is a lease, not a held lock. Nothing is ever released: a crash, `termiod stop`, and the `execve` handoff (which runs no destructors and would orphan any long-lived child) all leave at most one lease that expires on its own. The lease tail doubles as the ~2-minute grace period after the last session goes quiet.

Policy edges:

- **Battery**: no lease is taken at all. This has to be the daemon's own `pmset -g batt` check — `caffeinate -i` is honored on battery, and `-s` only adds a second AC-only assertion rather than scoping `-i`.
- **Display**: sleeps either way; `-i` touches idle *system* sleep only.
- **Lid**: a user-space assertion cannot stop clamshell sleep. Out of scope.
- **Linux**: never spawned — the boxes termiod serves there don't idle-sleep.
- **Opt-out**: `serve --no-keep-awake`, or `TERMIOD_KEEP_AWAKE=off` in the daemon's environment. The flag rides through the handoff via `serve_arguments()`.

Integration tests set `TERMIOD_KEEP_AWAKE=off` on every long-lived `serve` they spawn, so test daemons never take real power assertions on developer machines or CI.

## Verification

- `cargo test`: all green, including 4 new unit tests on the renewal decision (a burst of status events costs one lease, not one per event).
- Live smoke on an isolated channel: `working` produced a `caffeinate -i -t 120` child of the daemon within 3s; 70s after `done`, the same (expiring) lease and no renewal; `stop` left nothing behind.

Release Notes:

- The Mac now stays reachable while an agent is working or waiting on you: termiod holds a short idle-sleep assertion (AC power only, display still sleeps) and lets it lapse a couple of minutes after the last session goes quiet. Opt out with `termiod serve --no-keep-awake` or `TERMIOD_KEEP_AWAKE=off`.