### PR TITLE
Make the pair CLI adopt and revoke legacy state

### DIFF
--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -422,7 +422,40 @@ pub fn load_or_create_pair_token() -> Result<String> {
 pub fn rotate_pair_token() -> Result<String> {
     let token = encode_base64url(&random_bytes(24)?);
     replace_secret(&pair_token_path()?, &token)?;
+    // Rotation is revocation, and the legacy copy beside the socket is still a
+    // live credential: a pre-split daemon reads it per handshake, and it would
+    // keep admitting the old secret until a restart while `--rotate` reports
+    // everyone signed out. Removing it is part of the rotation, not cleanup.
+    remove_legacy_runtime_file("pair.token");
     Ok(token)
+}
+
+/// Best-effort removal of the copy an older daemon kept beside the socket.
+/// Only for writers that must not leave a stale twin behind (`--rotate`,
+/// `--wss-off`); readers go through adoption instead.
+fn remove_legacy_runtime_file(name: &str) {
+    let (Ok(legacy_dir), Ok(durable)) = (state_dir(), durable_state_dir()) else {
+        return;
+    };
+    if legacy_dir == durable {
+        return;
+    }
+    let _ = std::fs::remove_file(legacy_dir.join(name));
+}
+
+/// Disarm the WSS listener durably: both the durable bind and any legacy copy
+/// beside the socket go. Removing only the durable file re-armed the listener
+/// on the next daemon start, because startup adoption dutifully promoted the
+/// legacy bind the operator thought they had turned off.
+pub fn remove_wss_bind() -> Result<()> {
+    let path = wss_bind_path()?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error).with_context(|| format!("removing {}", path.display())),
+    }
+    remove_legacy_runtime_file("wss.bind");
+    Ok(())
 }
 
 /// Root of the per-session upload scratch dirs (§C.12 `temp:` dests). Lives

--- a/termiod/src/paths.rs
+++ b/termiod/src/paths.rs
@@ -236,6 +236,13 @@ fn adopt_runtime_file(name: &str) {
     if legacy_dir == durable {
         return;
     }
+    // Adoption's decision (legacy present, target absent) and `--wss-off`'s
+    // deletion must not interleave: an adopter that read the legacy bind
+    // before the deletion would publish it *after*, resurrecting the listener
+    // the operator just turned off. Both sides serialize on the same flock;
+    // losing the lock file falls back to unlocked best effort, which is the
+    // pre-lock behaviour, not a new failure mode.
+    let _lock = adoption_lock(&durable);
     let legacy = legacy_dir.join(name);
     let target = durable.join(name);
     if target.exists() || !legacy.exists() {
@@ -443,11 +450,34 @@ fn remove_legacy_runtime_file(name: &str) {
     let _ = std::fs::remove_file(legacy_dir.join(name));
 }
 
+/// The flock every adopter and every legacy-removing writer holds while it
+/// decides. The file itself is meaningless; only the lock matters, so it is
+/// created on demand in the durable dir and never removed. `None` (no durable
+/// dir, or flock failing) degrades to the unlocked behaviour.
+fn adoption_lock(durable: &Path) -> Option<std::fs::File> {
+    use std::os::fd::AsRawFd;
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .mode(0o600)
+        .open(durable.join(".adopt.lock"))
+        .ok()?;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        return None;
+    }
+    Some(file)
+}
+
 /// Disarm the WSS listener durably: both the durable bind and any legacy copy
 /// beside the socket go. Removing only the durable file re-armed the listener
 /// on the next daemon start, because startup adoption dutifully promoted the
-/// legacy bind the operator thought they had turned off.
+/// legacy bind the operator thought they had turned off. Holding the adoption
+/// lock closes the other resurrection path: an adopter that read the legacy
+/// bind before this deletion but would have published it after.
 pub fn remove_wss_bind() -> Result<()> {
+    let lock_dir = durable_state_dir()?;
+    let _lock = adoption_lock(&lock_dir);
     let path = wss_bind_path()?;
     match std::fs::remove_file(&path) {
         Ok(()) => {}

--- a/termiod/src/wss.rs
+++ b/termiod/src/wss.rs
@@ -747,6 +747,12 @@ pub struct PairOptions {
 /// a terminal on the box runs `--qr` and scans the screen in front of them.
 pub fn run_pair(options: PairOptions) -> Result<()> {
     paths::ensure_runtime_dir()?;
+    // `pair` runs in its own process, usually before the upgraded daemon has
+    // restarted — so the files an older build kept beside the socket may not
+    // have been adopted yet. Reading (`--json`/`--qr` needs `wss.origin`) or
+    // writing around them here would answer from, or leave behind, state the
+    // next daemon start will contradict.
+    paths::adopt_runtime_state();
 
     let token = if options.rotate {
         let token = paths::rotate_pair_token()?;
@@ -757,14 +763,7 @@ pub fn run_pair(options: PairOptions) -> Result<()> {
     };
 
     if options.wss_off {
-        let path = paths::wss_bind_path()?;
-        match std::fs::remove_file(&path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(error).with_context(|| format!("removing {}", path.display()))
-            }
-        }
+        paths::remove_wss_bind()?;
         eprintln!("termiod: wss off — the next `termiod serve` binds the Unix socket only");
     }
 

--- a/termiod/tests/pair_state.rs
+++ b/termiod/tests/pair_state.rs
@@ -137,3 +137,41 @@ fn invite_adopts_the_legacy_origin() {
         "the origin must have moved into durable state"
     );
 }
+
+/// The resurrection race: an adopter that read the legacy bind before
+/// `--wss-off` deleted it must not publish it afterwards. Both sides hold the
+/// adoption flock, so however the two processes interleave, off means off.
+/// (Probabilistic by nature — the unlocked code only loses this race in a
+/// narrow window — but it exercises the lock path on every round.)
+#[test]
+fn wss_off_wins_against_a_concurrent_adopter() {
+    let sandbox = Sandbox::new("race");
+    for round in 0..12 {
+        sandbox.seed_legacy("wss.bind", "127.0.0.1:8790");
+        let _ = fs::remove_file(sandbox.durable_dir().join("wss.bind"));
+
+        let adopter = {
+            let home = sandbox.home();
+            let runtime = sandbox.runtime();
+            std::thread::spawn(move || {
+                Command::new(BIN)
+                    .arg("pair")
+                    .env_clear()
+                    .env("HOME", home)
+                    .env("XDG_RUNTIME_DIR", runtime)
+                    .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+                    .output()
+                    .expect("running the adopting pair")
+            })
+        };
+        let off = sandbox.pair(&["--wss-off"]);
+        assert!(off.status.success(), "round {round}: --wss-off failed: {off:?}");
+        let _ = adopter.join().expect("adopter thread");
+
+        assert!(
+            !sandbox.durable_dir().join("wss.bind").exists()
+                && !sandbox.legacy_dir().join("wss.bind").exists(),
+            "round {round}: wss.bind resurrected after --wss-off"
+        );
+    }
+}

--- a/termiod/tests/pair_state.rs
+++ b/termiod/tests/pair_state.rs
@@ -1,0 +1,139 @@
+//! `termiod pair` runs in its own process, usually before the upgraded daemon
+//! restarts, so the files an older build kept beside the socket may not have
+//! been adopted yet. These tests pin the three CLI paths that used to bypass
+//! that: `--rotate` left the legacy token valid, `--wss-off` left a legacy
+//! bind for the next startup adoption to re-arm, and `--json` refused an
+//! invite whose origin only existed beside the socket.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_termiod");
+
+/// A sandboxed home + runtime dir pair, mirroring the daemon's own
+/// derivations: the legacy dir is `$XDG_RUNTIME_DIR/termiod`, the durable dir
+/// is the platform state dir under `$HOME` (`durable_state_base` in
+/// `src/paths.rs`).
+struct Sandbox {
+    root: PathBuf,
+}
+
+impl Sandbox {
+    fn new(tag: &str) -> Self {
+        let root = std::env::temp_dir().join(format!("termiod-pair-state-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        let sandbox = Self { root };
+        fs::create_dir_all(sandbox.legacy_dir()).expect("legacy dir");
+        fs::create_dir_all(sandbox.home()).expect("home dir");
+        sandbox
+    }
+
+    fn home(&self) -> PathBuf {
+        self.root.join("home")
+    }
+
+    fn runtime(&self) -> PathBuf {
+        self.root.join("run")
+    }
+
+    fn legacy_dir(&self) -> PathBuf {
+        self.runtime().join("termiod")
+    }
+
+    fn durable_dir(&self) -> PathBuf {
+        if cfg!(target_os = "macos") {
+            self.home().join("Library").join("Application Support").join("termio")
+        } else {
+            self.home().join(".local").join("state").join("termio")
+        }
+    }
+
+    fn seed_legacy(&self, name: &str, contents: &str) {
+        fs::write(self.legacy_dir().join(name), contents).expect("seeding legacy file");
+    }
+
+    fn pair(&self, args: &[&str]) -> std::process::Output {
+        Command::new(BIN)
+            .arg("pair")
+            .args(args)
+            .env_clear()
+            .env("HOME", self.home())
+            .env("XDG_RUNTIME_DIR", self.runtime())
+            .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+            .output()
+            .expect("running termiod pair")
+    }
+}
+
+impl Drop for Sandbox {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_default().trim().to_string()
+}
+
+/// Rotation is revocation: after `--rotate`, no copy of the old secret may
+/// remain anywhere a daemon reads — including beside the socket, where a
+/// pre-split daemon still answers handshakes from.
+#[test]
+fn rotate_revokes_the_legacy_token() {
+    let sandbox = Sandbox::new("rotate");
+    sandbox.seed_legacy("pair.token", "old-secret");
+
+    let output = sandbox.pair(&["--rotate"]);
+    assert!(output.status.success(), "pair --rotate failed: {output:?}");
+
+    let durable = read(&sandbox.durable_dir().join("pair.token"));
+    assert!(!durable.is_empty(), "rotation must mint a durable token");
+    assert_ne!(durable, "old-secret", "rotation must replace the old secret");
+    assert!(
+        !sandbox.legacy_dir().join("pair.token").exists(),
+        "the legacy copy is a live credential and must go with the rotation"
+    );
+}
+
+/// `--wss-off` must silence the listener durably: leaving the legacy bind
+/// behind meant the next daemon start adopted it and re-armed WSS.
+#[test]
+fn wss_off_removes_the_legacy_bind_too() {
+    let sandbox = Sandbox::new("wssoff");
+    sandbox.seed_legacy("wss.bind", "127.0.0.1:8790");
+
+    let output = sandbox.pair(&["--wss-off"]);
+    assert!(output.status.success(), "pair --wss-off failed: {output:?}");
+
+    assert!(
+        !sandbox.durable_dir().join("wss.bind").exists(),
+        "no durable bind may survive --wss-off"
+    );
+    assert!(
+        !sandbox.legacy_dir().join("wss.bind").exists(),
+        "a legacy bind left behind re-arms WSS on the next daemon start"
+    );
+}
+
+/// An invite must find an origin that so far only exists beside the socket:
+/// `pair --json` often runs right after an upgrade, before any daemon restart
+/// has adopted the legacy files.
+#[test]
+fn invite_adopts_the_legacy_origin() {
+    let sandbox = Sandbox::new("invite");
+    sandbox.seed_legacy("wss.origin", "https://box.example.ts.net");
+
+    let output = sandbox.pair(&["--json"]);
+    assert!(output.status.success(), "pair --json failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("box.example.ts.net"),
+        "the invite must carry the adopted origin, got: {stdout}"
+    );
+    assert_eq!(
+        read(&sandbox.durable_dir().join("wss.origin")),
+        "https://box.example.ts.net",
+        "the origin must have moved into durable state"
+    );
+}


### PR DESCRIPTION
Closes out the review findings on #534 (merged): three `termiod pair` paths still bypassed the durable-state split's adoption.

- `--rotate` wrote the new durable token but left the legacy copy beside the socket — a live credential a pre-split daemon keeps honouring per handshake, while the command reports every client signed out. Rotation now removes it as part of the revocation.
- `--wss-off` removed only the durable bind; the next daemon start adopted the legacy one and re-armed the listener the operator had turned off. Both copies now go through one `paths::remove_wss_bind` helper.
- `--json`/`--qr` read `wss.origin` without adoption and refused an invite whose origin only existed beside the socket. `run_pair` now adopts up front.

Verification: three new integration tests in `termiod/tests/pair_state.rs` run the real binary in a sandboxed `HOME` + `XDG_RUNTIME_DIR`; all three fail against the unpatched sources and pass with the fix. Full termiod suite: 249 passed, 0 failed.

Release Notes:
- Fixed: `termiod pair --rotate` now revokes the pre-upgrade pairing token everywhere, `--wss-off` stays off across daemon restarts, and invites work before the upgraded daemon's first restart.