### PR TITLE
Keep hidden panes ticking so session supervision stays live

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "618c4e27b8aedb12a95ce833079485730a5bf9e60e8dcea2aa8a3d77ff615e69",
+  "originHash" : "acc0380c528c2a1a81c3cb2f3c187cd38789aa75591291c16e42e5fd9a5e714f",
   "pins" : [
     {
       "identity" : "highlightr",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "84af6e4a766110efa7ceb09a2a02cac4c2ad684f",
-        "version" : "1.0.22"
+        "revision" : "95216959a440f66746f68b8fd3832d32aabde112",
+        "version" : "1.0.23"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "acc0380c528c2a1a81c3cb2f3c187cd38789aa75591291c16e42e5fd9a5e714f",
+  "originHash" : "503222484195d1f3ff9622dd488aad22b05ba5dd569733f566e2a4f20b80cbd4",
   "pins" : [
     {
       "identity" : "highlightr",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/termio-sh/libghostty-swift",
       "state" : {
-        "revision" : "95216959a440f66746f68b8fd3832d32aabde112",
-        "version" : "1.0.23"
+        "revision" : "7f9687529e1f998aa4df882defc3e7abcd4f88c8",
+        "version" : "1.0.24"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // live resize" suspicion that briefly rolled this back to Lakr233 was a
         // misdiagnosis — the real bug was termio's own PTY spawn shape (see
         // docs/bug/terminal-resize-no-reflow-HANDOFF.md §0).
-        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.22"),
+        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.23"),
         // Sparkle powers in-app auto-update (the "Check for Updates…" menu item and
         // background update checks). It reads the appcast published with each GitHub
         // release; the matching EdDSA public key is embedded in packaging/Info.plist.

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // live resize" suspicion that briefly rolled this back to Lakr233 was a
         // misdiagnosis — the real bug was termio's own PTY spawn shape (see
         // docs/bug/terminal-resize-no-reflow-HANDOFF.md §0).
-        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.23"),
+        .package(url: "https://github.com/termio-sh/libghostty-swift", from: "1.0.24"),
         // Sparkle powers in-app auto-update (the "Check for Updates…" menu item and
         // background update checks). It reads the appcast published with each GitHub
         // release; the matching EdDSA public key is embedded in packaging/Info.plist.

--- a/Sources/termio/Terminal/TerminalPane.swift
+++ b/Sources/termio/Terminal/TerminalPane.swift
@@ -533,10 +533,13 @@ private struct ManagedTerminalSurface: View {
 ///
 /// The switch for that lives on the *view*, not the surface. `setSurfaceVisible`
 /// composes with the app-active state the surface coordinator already tracks, stops
-/// the display link, gates the PTY-output wakeups that would otherwise tick a hidden
-/// pane, and asks for an immediate frame on the way back in. Setting ghostty's
-/// occlusion flag directly does none of those, and is overwritten the next time the
-/// coordinator re-asserts its own answer.
+/// the display link, gates the *render* half of a PTY-output wakeup, and asks for an
+/// immediate frame on the way back in. The wakeup's `ghostty_app_tick` is never
+/// gated: it drains the app mailbox that ghostty's stream handler blocks on when
+/// full, and withholding it froze every hidden pane's byte stream — viewport, status
+/// tap and daemon events with it — seconds into a turn (issues #545/#546). Setting
+/// ghostty's occlusion flag directly does none of those, and is overwritten the next
+/// time the coordinator re-asserts its own answer.
 @MainActor
 private func applySurfaceVisibility(_ visible: Bool, for state: TerminalViewState) {
     guard let root = AppDelegate.mainWindow?.contentView,

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -584,8 +584,10 @@ extension TermioStore {
     /// animating after the reply. A 300ms poll always catches the `working` span of a real
     /// turn (an LLM round-trip is far longer). Only a session with no status signal at all
     /// — a plain terminal driven by `send --wait` — falls back to the screen first changing
-    /// and then going still. Each poll awaits off the actor, so a long wait never blocks
-    /// other control requests (§4.2 stays true even mid-wait).
+    /// and then going still; an agent session reaching that fallback (every status channel
+    /// missed the turn) must sit still for the longer `agentSettleWindow` first. Each poll
+    /// awaits off the actor, so a long wait never blocks other control requests (§4.2
+    /// stays true even mid-wait).
     ///
     /// Two failure modes end the wait early instead of burning the whole timeout,
     /// both adopted from herdr's agent-wait design:
@@ -607,6 +609,18 @@ extension TermioStore {
         let started = Date()
         let deadline = started.addingTimeInterval(Double(cap) / 1_000)
         let settleWindow = 1.5
+        // The screen-only settle below is meant for a session with *no status
+        // signal at all* — but it is reached by an agent session too whenever
+        // every status channel missed the turn, and there 1.5s of stillness is
+        // weak evidence: both Codex and Claude Code sit visually still for
+        // spells early in a turn (issue #545 settled on exactly that, seconds
+        // after the send). An agent occupant therefore needs the screen still
+        // for long enough that the promotion path would have flipped the
+        // status to `working` first if a turn were painting anything: past
+        // `userInputQuietWindow` (3s, the send itself counts as input) plus
+        // the two-tick promotion streak. A plain terminal keeps the short
+        // window — a shell prompt going quiet after output *is* the turn end.
+        let agentSettleWindow = 6.0
         let stallWindow = 5.0
 
         let statusAtSend = status(for: session.id)
@@ -673,11 +687,13 @@ extension TermioStore {
 
             guard current != .working else { continue }
             let rested = restingSince.map { now.timeIntervalSince($0) >= settleWindow } ?? false
-            let screenQuiet = now.timeIntervalSince(lastChangeAt) >= settleWindow
+            let quietWindow = occupant == .terminal ? settleWindow : agentSettleWindow
+            let screenQuiet = now.timeIntervalSince(lastChangeAt) >= quietWindow
             // Status-tracked agent: seen working, now rested. (Footer animation can't
             // fool this — it doesn't touch status.)
             if sawWorking, rested { settled = current; break }
-            // No status signal at all (a plain terminal): the screen changed, then stilled.
+            // No status signal at all: the screen changed, then stilled — for the
+            // window the occupant earns (see `agentSettleWindow`).
             if !sawWorking, changedSinceSend, screenQuiet { settled = current; break }
         }
         return await waitReply(request, session: session,

--- a/Sources/termio/TermioStore/TermioStore+SessionControl.swift
+++ b/Sources/termio/TermioStore/TermioStore+SessionControl.swift
@@ -614,12 +614,17 @@ extension TermioStore {
         // every status channel missed the turn, and there 1.5s of stillness is
         // weak evidence: both Codex and Claude Code sit visually still for
         // spells early in a turn (issue #545 settled on exactly that, seconds
-        // after the send). An agent occupant therefore needs the screen still
-        // for long enough that the promotion path would have flipped the
-        // status to `working` first if a turn were painting anything: past
-        // `userInputQuietWindow` (3s, the send itself counts as input) plus
-        // the two-tick promotion streak. A plain terminal keeps the short
-        // window — a shell prompt going quiet after output *is* the turn end.
+        // after the send). An agent occupant therefore holds for a longer
+        // still window — past `userInputQuietWindow` (3s, the send itself
+        // counts as input) plus the promotion streak's two 1s samples, so a
+        // turn that *keeps repainting* is promoted to `working` before this
+        // fallback can settle. That is a trade, not a proof: a turn that goes
+        // screen-silent mid-turn (a long tool call with no spinner repaint)
+        // can still settle early, and no finite window closes that — the
+        // alternative is burning the caller's whole timeout for every
+        // status-less turn that finished quietly. A plain terminal keeps the
+        // short window — a shell prompt going quiet after output *is* the
+        // turn end.
         let agentSettleWindow = 6.0
         let stallWindow = 5.0
 


### PR DESCRIPTION
Fixes #545, fixes #546 — one root cause, plus a hardening on the settle detector.

## Root cause

A hidden pane's byte stream froze wholesale seconds into any agent turn. `setSurfaceVisible(false)` suppressed the ghostty wakeup entirely, so a hidden surface's `ghostty_app` was never ticked. Ghostty's stream handler pushes surface messages — title changes above all, and Claude Code retitles several times a second mid-turn — into a fixed 64-slot queue that only `ghostty_app_tick` empties. Once it filled, the next push parked the producing thread forever inside `ghostty_surface_write_buffer`. That thread is the session's `termiod-read-*` reader, which also delivers the daemon's `E` status frames and feeds the status tap, so one blocked push froze everything supervision depends on:

- the viewport (`sessions read` returned the identical frame for 10+ minutes — the #546 clue),
- screen-streak promotion, screen rules, OSC title and `OSC 9;4` classification,
- hook status arriving over the daemon channel,
- and therefore every `done`/`needs-you` transition `sessions watch` broadcasts (#546), while `send --wait`'s screen-quiet fallback settled on the last stale status seconds after the send (#545).

Reproduced on an isolated `TERMIO_CHANNEL` build with a hidden pane emitting a title change 5×/s: viewport frozen within ~15 s, and a 2-second `sample` shows the reader thread parked in `__ulock_wait2` under `InMemoryTerminalSession.write` → `ghostty_surface_write_buffer` for all 1713 samples.

## Fix

1. **libghostty-swift 1.0.24** (termio-sh/libghostty-swift#6 + #7): `handleWakeup` now always runs `ghostty_app_tick`; visibility gates only the render request, and a burst of wakeups coalesces into at most one queued main-thread hop per controller. Rendering hidden panes stays suppressed (`wakeup render suspended`) — the repro's hidden churning pane sits at 0.2% CPU with a live viewport. Both releases were cut from the same ghostty sha as 1.0.22 (`8867c37`), so no terminal-core drift rides along.
2. **Settle hardening** (#545's remaining weak link): `send --wait`'s screen-only fallback was designed for status-less plain terminals but was reachable by agent sessions whenever every status channel missed the turn, and 1.5 s of screen stillness settled it. An agent occupant now needs the screen still for 6 s — past the input quiet window (3 s) plus the promotion streak's two 1 s samples, so a turn that *keeps repainting* is promoted to `working` before the fallback can settle. This is a trade, not a proof: a turn that goes screen-silent mid-turn (a long tool call with no spinner repaint) can still settle early, and no finite window closes that — the alternative is burning the caller's whole timeout for every status-less turn that finished quietly. Plain terminals keep the 1.5 s window.

## Refutation review

A Codex refutation round reviewed this PR before merge. Disposition:

- **Hidden-wakeup main-thread flood** (confirmed): fixed by wakeup coalescing in 1.0.24 (termio-sh/libghostty-swift#7).
- **Screen stillness cannot prove completion** (confirmed): inherent to the status-less fallback; the code comment now states the trade instead of overclaiming that promotion always intervenes.
- **`prompt_stalled` at 5 s for echo-less turns** and **boot-settle's identical-frames readiness heuristic**: pre-existing behavior, deliberately unchanged here.
- No independent loss found in `E`-frame routing or `SessionWatchHub` — consistent with the one-root claim.

## Verification

Real reproduction on an isolated probe channel (no mocks):

- Before: hidden pane frozen (identical `sessions read` frames 6 s apart), reader thread sampled blocked in `ghostty_surface_write_buffer`.
- After: hidden pane's viewport advances at exactly the writer's rate while renders stay gated.
- `sessions send <hidden claude> "<slow prompt>" --wait` holds for the full real turn (11 s) and returns `status:done`, `timed_out:false`, with the correct transcript range — previously it returned stale `idle` within seconds.
- A concurrent `sessions watch --json --no-snapshot` fired `done` events for two hidden Claude Code sessions' turns — the transitions #546 reported missing.
- `swift build` and `swift test` green (922 tests); libghostty-swift's own suite green (104 tests).

Release Notes:
- Fixed: supervising a session whose pane wasn't on screen — `sessions watch` missing done/needs-you transitions, `send --wait` returning while the agent was still mid-turn, and `sessions read` reporting a frozen screen.
