### PR TITLE
Land the docker/dockerd lessons RFC and restamp the migration stage statuses

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,8 +49,10 @@ from the real front matter).
 | active | research | ["Reading list: PTYs, SSH, and detachable remote terminals"](READING.md) |
 | active | rfc | [可扩展 Agent —— 配置化定义 + 配置化 Hook](design/20260707-agent-extensibility.md) |
 | active | rfc | [Agent integration moves into termiod](design/20260825-agent-integration-moves-to-termiod.md) |
+| active | rfc | [One path — local sessions run through termiod too](design/20260817-one-path-local-through-termiod.md) |
 | active | rfc | [Push-to-talk voice dictation — hold the space bar (iOS shipped, OpenAI)](design/20260704-push-to-talk-voice-dictation.md) |
 | active | rfc | [Unify the server plane in Rust, reduce the Mac app to a viewer](design/20260819-unify-server-plane.md) |
+| active | rfc | [What ten years of docker/dockerd teach the termio/termiod split](design/20260831-docker-dockerd-lessons.md) |
 | approved | design | [会话历史 · 搜索 · 恢复（Session History / Search / Resume）](design/20260628-session-history-search-resume.md) |
 | approved | design | [Agent Resume Identity — keeping the resume pin on the live conversation](design/20260716-agent-resume-identity.md) |
 | approved | design | [Git worktree creation & lifecycle (Codex-aligned)](design/20260706-worktree-creation-lifecycle.md) |
@@ -129,10 +131,8 @@ from the real front matter).
 | draft | rfc | [Settings that know which machine they mean](design/20260824-settings-that-know-which-machine.md) |
 | draft | rfc | [Termiod web client on official Ghostty WASM (Linux first)](design/20260818-termiod-web-client-ghostty-wasm.md) |
 | draft | rfc | [The tab strip is the collapsed sidebar](design/20260829-tab-strip-is-the-collapsed-sidebar.md) |
-| draft | rfc | [What ten years of docker/dockerd teach the termio/termiod split](design/20260831-docker-dockerd-lessons.md) |
 | in-review | design | [Workspace switch latency](design/20260819-workspace-switch-latency.md) |
 | in-review | rfc | [Every machine is a device, every place you work is a project](design/20260814-remote-to-device.md) |
-| in-review | rfc | [One path — local sessions run through termiod too](design/20260817-one-path-local-through-termiod.md) |
 | in-review | rfc | [Split panes — Ghostty-style splits in the terminal column](design/20260702-split-panes.md) |
 | in-review | rfc | [termiod lifecycle — install and update as one reconcile loop](design/20260827-termiod-lifecycle-reconcile.md) |
 <!-- END docs-index -->

--- a/docs/design/20260817-one-path-local-through-termiod.md
+++ b/docs/design/20260817-one-path-local-through-termiod.md
@@ -1,9 +1,9 @@
 ---
 title: One path — local sessions run through termiod too
-status: in-review
+status: active
 type: rfc
 created: 2026-08-17
-updated: 2026-08-24
+updated: 2026-08-31
 related:
   - 20260817-one-path-local-through-termiod.review-claude.md
   - 20260805-termiod-device-architecture.md
@@ -1125,7 +1125,7 @@ Linux/macOS split behind one trait, argv → agent mapping staying on the client
 
 **Rollback:** additive field; an app that ignores it behaves as before.
 
-### Stage 4 — the companion stops depending on `PTYProcess`
+### Stage 4 — the companion stops depending on `PTYProcess` — **done** (PR #404; unify-server-plane Stage 6)
 
 The blocker identified in §1.5, and **the biggest stage in this RFC.** Not "extract
 a protocol both types satisfy": three of `PTYBridge`'s twelve members have no
@@ -1164,7 +1164,7 @@ piece, and the one most likely to change phone behaviour visibly.
 
 **Rollback:** the seam has one other conformer; revert to the concrete type.
 
-### Stage 5 — delete the fork
+### Stage 5 — delete the fork — **done** (`a8b15bd`, 2026-08-22; soak note in unify-server-plane §2 restamp)
 
 Only now. Remove `Termiod.isEnabled` (`TermiodClient.swift:46`) and every branch
 on it, the in-process `PTYProcess` construction
@@ -1193,7 +1193,7 @@ default for a full release cycle. Concretely — **ship Stage 4 with the flag
 defaulting to on and the env var able to force it off**, run one release, then
 delete in Stage 5. The escape hatch is a release rollback, not a runtime flag.
 
-### Stage 6 — the CLI moves, verb by verb (§7)
+### Stage 6 — the CLI moves, verb by verb (§7) — **in progress since 2026-08-31** (as unify-server-plane Stage 10, pulled forward; criteria unchanged)
 
 Order chosen so the verbs the client cannot fix land first (§7.1):
 

--- a/docs/design/20260819-unify-server-plane.md
+++ b/docs/design/20260819-unify-server-plane.md
@@ -3,8 +3,9 @@ title: Unify the server plane in Rust, reduce the Mac app to a viewer
 status: active
 type: rfc
 created: 2026-08-19
-updated: 2026-08-22
+updated: 2026-08-31
 related:
+  - 20260831-docker-dockerd-lessons.md
   - 20260817-one-path-local-through-termiod.md
   - 20260817-one-path-local-through-termiod.review-claude.md
   - 20260818-one-workspace-source.md
@@ -89,6 +90,40 @@ inherited; none is new here.
 The first revision of this document was cut at `7fedc72`. Thirteen commits have
 landed under `termiod/` since, and they move three of its eight stages. What
 follows replaces §1 of that revision wholesale.
+
+> **Restamp, 2026-08-31.** The tree outran this section within hours of the
+> 2026-08-22 stamp, and the doc went nine days without recording it. What is
+> true now:
+>
+> - **Stage 2 is done.** `feat/termiod-session-facts` merged as PR #400 the
+>   same afternoon (2026-08-22T14:46Z); all four of its gates closed —
+>   `termiod.yml` has the ubuntu-24.04-arm job, the wire-order integration
+>   test exists (`TermiodWireOrderIntegrationTests.swift`),
+>   `Tombstone::from_info` carries `child_executable_replaced`
+>   (`tombstone.rs:123`), and `displayLabel` reads `foregroundArgv` first
+>   (`TermiodProtocol.swift:966-977`).
+> - **Stages 7 and 8 collapsed into one step, and the soak was served
+>   retroactively.** `a8b15bd` (2026-08-22, two hours after PR #400) deleted
+>   `PTYProcess.swift` and every `TERMIO_TERMIOD` branch without the
+>   flag-default-on release Stage 7 specified. The sequencing risk was taken,
+>   not mitigated — and then paid off empirically: the daemon-only backend
+>   shipped in every tag from v0.41.0 onward with no rollback. Stage 8's greps
+>   pass on main today.
+> - **Stage 6 is done.** `grep -rn 'PTYProcess' Sources/termio/Companion/` → 0;
+>   `PTYBridge` no longer exists (PR #404 and follow-ups #490, #495, #517).
+> - **Stage 5** items 2 and 3 are done differently than written: Linux systemd
+>   `--user` landed in PR #530; `feat/termiod-remote-install` was superseded by
+>   the reconcile loop (PRs #499, #522, #543). Item 1 (local launchctl
+>   supervision) is still open.
+> - **Stage 3** is half done: `fs.search` shipped and is consumed
+>   (`TermiodFiles.swift:559-644`); the `git.diff` half is untouched.
+> - **Stage 10 is pulled forward, starting 2026-08-31.** Its gate was never
+>   "Stages 3–9 finished"; it was the reason behind the ordering — do not move
+>   the CLI while two session backends exist. That condition has been met since
+>   `a8b15bd`. The still-open stages (3's git half, 4b/4c, 5 item 1, 9) are
+>   orthogonal to CLI verbs and continue independently. Stage 10's own gates —
+>   one-path Stage 6's criteria, plus `20260831-docker-dockerd-lessons.md`
+>   §1.3's additions — are unchanged.
 
 ### 2.1 Landed since the last stamp
 
@@ -369,13 +404,12 @@ One verification remains open and is recorded as open, not claimed: the device
 branch of the pane has not been seen on screen against a second machine running
 `termiod`.
 
-### Stage 2 — foreground parity: the client half
+### Stage 2 — foreground parity: the client half — **done**
 
-Rust's first half shipped in `c4934c2`. The rest — the client decode, the two
-delivery gaps in §2.3, and the group-member scan — is **implemented across two
-worktrees, reviewed and approved, and neither committed nor merged** (§2.4):
-99 Rust tests and 483 Swift tests pass locally. **This stage has not landed**,
-and the gates at the end of this section are what stands between the two.
+Rust's first half shipped in `c4934c2`; the rest merged as **PR #400**
+(2026-08-22), and all four gates below closed since (§2 restamp). The section
+is kept as written because it records the decisions, two of which contradict
+one-path §3.2 and won.
 
 Nothing below is a proposal. It is the shape the implementation settled on,
 recorded because two of the decisions contradict what `20260817-one-path-local-through-termiod.md`
@@ -479,7 +513,7 @@ Two guards make the split safe:
   question. When the group changes, the cached pid and argv are cleared rather
   than carried, so the gap is honest until the next resolution fills it.
 
-#### Remaining gates — all four are open
+#### Remaining gates — all four closed by 2026-08-31 (kept as the record of what they were)
 
 - **Linux `cfg` compilation and runtime.** The `/proc` path has never been
   compiled or run; it waits on `termiod.yml`'s ubuntu-24.04-arm job. Behaviourally:
@@ -559,8 +593,10 @@ byte path.
 
 ### Stage 5 — the daemon is supervised, on both platforms
 
-Items 1 and 2 of the last revision landed in `1746593`. Three remain, and each is
-a release blocker on its own.
+Items 1 and 2 of the last revision landed in `1746593`. Three remained when
+this was written; by 2026-08-31 items 2 and 3 are done (PR #530; the reconcile
+loop of PRs #499/#522/#543 superseding `feat/termiod-remote-install`) and only
+item 1 is open — see the §2 restamp.
 
 1. **The app installs or repairs the launchd job on launch.** Nothing calls
    `launchctl` — `grep -rn 'launchctl' Sources/` → **0**. Until it does,
@@ -589,7 +625,7 @@ or replace it, but do not ship Stage 7 without an answer.
 both slices (true today); a fresh Linux box reachable by alias goes from nothing
 installed to an open session without a terminal, and survives a logout.
 
-### Stage 6 — the companion stops depending on `PTYProcess`
+### Stage 6 — the companion stops depending on `PTYProcess` — **done** (PR #404; gate grep → 0)
 
 one-path §5 Stage 4, and the biggest single stage here. **Not** "extract a
 protocol both types satisfy": `PTYBridge` uses thirteen `PTYProcess` members
@@ -623,7 +659,7 @@ Exit fan-out is inherited from 4b rather than solved here.
 `grep -rn 'PTYProcess' Sources/termio/Companion/` → 0. Verified on a real device,
 not the simulator.
 
-### Stage 7 — default on, for one full release
+### Stage 7 — default on, for one full release — **collapsed into Stage 8; soak served retroactively** (§2 restamp)
 
 Ship with `Termiod.isEnabled` defaulting to **true** and `TERMIO_TERMIOD=0`
 able to force it off. Then run one release and change nothing else in this list.
@@ -640,7 +676,7 @@ by default and no rollback. Concretely: local sessions survive an app quit and
 relaunch reattaching to the same pid; the companion, agent status, and task
 notifications behave as they did with the flag off.
 
-### Stage 8 — delete the local PTY fork
+### Stage 8 — delete the local PTY fork — **done** (`a8b15bd`, 2026-08-22; gates pass on main)
 
 Only now. Remove `Termiod.isEnabled` and every branch on it, the in-process
 `PTYProcess` construction (`TermioStore+TerminalSurface.swift:253`), the flag-off
@@ -686,7 +722,7 @@ bounded before this ships** — a recursive watch plus a full BFS name-index wal
 over `$HOME` or a large monorepo, alive five minutes past the last subscriber, is
 not obviously authorized by "the user let us read this machine" (open question 3).
 
-### Stage 10 — the CLI moves, verb by verb
+### Stage 10 — the CLI moves, verb by verb — **in progress since 2026-08-31, pulled forward** (§2 restamp; gates unchanged)
 
 one-path §7 and its Stage 6, unchanged in content and in internal order: `read`,
 `send`/`answer`, `watch`, `list`, `spawn`/`run`/`close`, then

--- a/docs/design/20260819-unify-server-plane.md
+++ b/docs/design/20260819-unify-server-plane.md
@@ -112,11 +112,14 @@ follows replaces §1 of that revision wholesale.
 > - **Stage 6 is done.** `grep -rn 'PTYProcess' Sources/termio/Companion/` → 0;
 >   `PTYBridge` no longer exists (PR #404 and follow-ups #490, #495, #517).
 > - **Stage 5** items 2 and 3 are done differently than written: Linux systemd
->   `--user` landed in PR #530; `feat/termiod-remote-install` was superseded by
->   the reconcile loop (PRs #499, #522, #543). Item 1 (local launchctl
+>   `--user` supervision landed inside PR #522 (`a1a8cdc`), and PR #530 made
+>   termiod own the unit; `feat/termiod-remote-install` was superseded by the
+>   reconcile loop (PRs #499, #522, #543) and deleted. Item 1 (local launchctl
 >   supervision) is still open.
 > - **Stage 3** is half done: `fs.search` shipped and is consumed
->   (`TermiodFiles.swift:559-644`); the `git.diff` half is untouched.
+>   (`TermiodFiles.swift:559-644`). The daemon's `git.diff` shipped long ago
+>   (`d38f50c`, §2 table below); what is untouched is its Swift consumer —
+>   `grep -rn '"git\.' Sources/` → 0.
 > - **Stage 10 is pulled forward, starting 2026-08-31.** Its gate was never
 >   "Stages 3–9 finished"; it was the reason behind the ordering — do not move
 >   the CLI while two session backends exist. That condition has been met since
@@ -153,6 +156,9 @@ grep -rc 'op = "fs_list"' Sources/                                              
 grep -rn 'PTYProcess(' Sources/ | wc -l                                                                     → 1
 grep -rn 'TermiodConnection' Sources/ | wc -l                                                               → 0
 ```
+
+(Restamp 2026-08-31: the `PTYProcess(` row is now 0 — the constructor went
+with `a8b15bd`. The others are unchanged.)
 
 `FileBrowserView.swift:77-84` now has exactly two branches plus an honest empty
 state: `RemoteFileTreeView` for any checkout with a root on another device, the
@@ -199,10 +205,10 @@ moment it matters and cannot reach any client by either route. This is a
 delivery gap, not a mechanism gap — `proc::ExecutableIdentity::was_replaced()`
 is right and tested (`proc.rs:44-58`, `notices_a_replaced_executable`).
 
-**Half answered.** The event route is built (Stage 2); the tombstone route is
-not. `Tombstone::from_info` still drops the field, so a client that was not
-attached when the session died still cannot learn it. That remains a Stage 2
-gate.
+**Half answered** at the stamp; closed since. `Tombstone::from_info` dropped
+the field then, so a client that was not attached when the session died could
+not learn it. It carries the field now (`tombstone.rs:123`) — the gate closed
+with the rest of Stage 2 (§2 restamp).
 
 **(c) Linux has no live-process-group-member scan.**
 `sample_foreground` reads argv straight off the pgid
@@ -219,9 +225,17 @@ per-platform and belongs with the rest of `proc.rs`'s cfg-gating.
 
 **Answered on both targets** (Stage 2), with the macOS path additionally
 re-checking `pbi_pgid` per candidate so a recycled pid cannot be reported. The
-Linux path has still never been compiled or run — that is a Stage 2 gate.
+Linux path had never been compiled or run at the stamp; the
+`ubuntu-24.04-arm` job closed that gate with the rest of Stage 2 (§2
+restamp).
 
 ### 2.4 Unmerged branches that bear on this plan
+
+(Restamp 2026-08-31: the two `feat/termiod-session-facts` rows merged as
+PR #400 the same afternoon this table was written; `feat/termiod-remote-install`
+was superseded by the reconcile loop and deleted. Only `feat/termiod-wss` is
+still an unmerged branch; `feat/foreground-parity` remains a dead worktree.
+The rows stand as the record of what was measured.)
 
 | Branch | Size | Standing |
 | --- | --- | --- |
@@ -233,8 +247,9 @@ Linux path has still never been compiled or run — that is a Stage 2 gate.
 
 The two completion worktrees were committed separately, then cherry-picked onto
 `feat/termiod-session-facts` at `c69c022` with this RFC. That integration branch
-is the only branch to review or merge for Stage 2. `feat/foreground-parity`
-remains a superseded, uncommitted worktree and must not be combined with it.
+was the only branch to review or merge for Stage 2 (merged as PR #400).
+`feat/foreground-parity` remains a superseded, uncommitted worktree and must
+not be combined with it.
 
 ---
 
@@ -312,7 +327,7 @@ Ordered by how ready the daemon already is. "Daemon state" is measured today.
 | Responsibility | Swift today | Daemon state | Stage |
 | --- | --- | --- | --- |
 | Directory listing, file read | — (deleted) | **Shipped and consumed** | **1 — done** |
-| Foreground job / argv / cwd / executable identity | `PTYProcess.swift:864-930` | **Shipped** (`proc.rs`, `pty.rs:258`); group-member resolution and the client decode written but **unmerged** (§2.4) | **2** |
+| Foreground job / argv / cwd / executable identity | `PTYProcess.swift:864-930` (deleted in `a8b15bd`) | **Shipped** (`proc.rs`, `pty.rs:258`); group-member resolution and the client decode merged as PR #400 | **2 — done** |
 | Content search | `ContentSearch.swift` 144 (`git grep` via `Process`) | **Shipped**, streamed + cancellable | 3 |
 | Git diff for one path | `GitService.diffText` | **Shipped** (`git.diff`) | 3 |
 | Filename fuzzy finder | local walk | **Shipped** (`fs.match`, frizbee scorer); needs a subscription for coverage | 9 (gated on 4b) |
@@ -326,7 +341,7 @@ Ordered by how ready the daemon already is. "Daemon state" is measured today.
 | Fetch / pull / push, askpass | absent | **Absent** — new scope | 11 |
 | Session roster, `read`, `send`, `watch`, `spawn`, `close` | `TermioStore+SessionControl.swift` 1,040 | Verbs exist; the CLI talks to the Swift socket | 10 |
 | Agent hook sink | `HookListener.swift` 944, `agent-status.sock` on this Mac | `set_status` exists; nothing routes a hook into it | 10 |
-| PTY ownership | `PTYProcess.swift` 996 | **Shipped** (`pty.rs`) | 8 |
+| PTY ownership | `PTYProcess.swift` 996 (deleted in `a8b15bd`) | **Shipped** (`pty.rs`) | **8 — done** |
 
 ### 4.3 Deleted outright
 
@@ -593,10 +608,12 @@ byte path.
 
 ### Stage 5 — the daemon is supervised, on both platforms
 
-Items 1 and 2 of the last revision landed in `1746593`. Three remained when
-this was written; by 2026-08-31 items 2 and 3 are done (PR #530; the reconcile
-loop of PRs #499/#522/#543 superseding `feat/termiod-remote-install`) and only
-item 1 is open — see the §2 restamp.
+Items 1 and 2 of the *last revision's* list landed in `1746593`; the three
+numbered below are what remained when this was written. Of those, items 2 and
+3 are done as of 2026-08-31 (systemd inside PR #522, unit ownership in
+PR #530; the reconcile loop of PRs #499/#522/#543 superseding
+`feat/termiod-remote-install`). Item 1 — nothing calls `launchctl` on the
+local Mac — is the one still open. See the §2 restamp.
 
 1. **The app installs or repairs the launchd job on launch.** Nothing calls
    `launchctl` — `grep -rn 'launchctl' Sources/` → **0**. Until it does,

--- a/docs/design/20260831-docker-dockerd-lessons.md
+++ b/docs/design/20260831-docker-dockerd-lessons.md
@@ -1,0 +1,416 @@
+---
+title: What ten years of docker/dockerd teach the termio/termiod split
+status: active
+type: rfc
+created: 2026-08-31
+updated: 2026-08-31
+related:
+  - 20260730-termiod-session-protocol.md
+  - 20260819-unify-server-plane.md
+  - 20260817-one-path-local-through-termiod.md
+  - 20260827-termiod-lifecycle-reconcile.md
+  - 20260827-remote-access-dev-tunnels-model.md
+  - 20260831-docker-dockerd-lessons.review-codex.md
+---
+
+# What ten years of docker/dockerd teach the termio/termiod split
+
+> docker/dockerd is the longest-running client/daemon pair whose scars are
+> public. This RFC mines those scars for changes to the termio/termiod
+> architecture, and settles the one question the pair answers outright:
+> `termio` is the only command a person types; `termiod` is a daemon name,
+> like `dockerd`. Revised after the codex review: the first draft misstated
+> the protocol's negotiation, the WSS listener, and the CLI-migration
+> ordering; this version is written against the tree.
+
+---
+
+## 0. Why docker, and how to read the analogy
+
+The shapes map almost one to one:
+
+| docker | termio | state of the analogy |
+| --- | --- | --- |
+| `docker` CLI | `termio` (today: `scripts/termio`, 779-line shell) | this RFC, §1 |
+| `dockerd` | `termiod` | holds |
+| `docker.sock` | app control socket + termiod Unix socket | §5 |
+| Engine API version negotiation | `hello` `proto`/`min_proto` (§C.3) | mechanism shipped; the policy and tests around it are not, §2 |
+| Engine API support window | none stated | §2 |
+| `docker system dial-stdio` | `termiod stdio` | already identical |
+| `docker context` | `~/.ssh/config` alias | ours is simpler; keep it |
+| containerd/runc extraction | the accretion risk on termiod | §6 |
+| rootless mode (year ten) | systemd `--user` (day one) | already avoided |
+
+Three of their lessons we already banked without paying for them. This
+document exists partly to say so, so nobody re-argues them:
+
+1. An API over an exec'd stdio pipe is the right remote transport.
+   `docker -H ssh://` literally runs `docker system dial-stdio` on the far
+   end. `termiod stdio` is the same mechanism, validated by ten production
+   years. (§H #3 stands: the pipe is OpenSSH's, never ours.)
+2. A root daemon is a decade-long regret. docker shipped rootless in year
+   ten. termiod was born user-scoped. No work here; just don't regress.
+3. A named-endpoint registry is overhead when ssh aliases exist.
+   `docker context` reinvents `~/.ssh/config` because docker predates
+   caring about it. We read the ssh config as authoritative (§A) and need
+   no second registry.
+
+A fourth lesson turned out, on audit, to be banked too: the version
+negotiation §2 of the first draft proposed already exists. What remains of
+it is policy, not mechanism.
+
+The rest of the document covers the places where the analogy still demands
+work. Each section ends with the change it proposes.
+
+---
+
+## 1. The decision this RFC records: one command, two binaries
+
+Nomad's answer (one binary, `nomad agent` mode) fits products where the
+daemon is the product on every node. termio's brain on a Mac is the app,
+and the CLI has a verb class (`open` via LaunchServices, `notify`,
+`focus`) that only means anything where the app lives. docker's answer
+fits us: `termio` is everything a person or an agent types on a machine
+that has the client; `termiod` is the daemon and the machine-invoked
+plumbing. `systemctl status` shows a thing named like `sshd`, because it
+is a thing like `sshd`.
+
+This is a naming and packaging decision, not a merge. The server-plane
+RFC's §7.8 rejection of a single binary stands and is not re-proposed
+here: a daemon named `termio` would land on the support-copy path every
+installed hook names absolutely, and a router named `termio` cannot
+dispatch to a binary with its own name. Two binaries, two names.
+
+### 1.1 The surface being migrated, in full
+
+The first draft treated `termiod remote …` as the whole person-facing
+surface. It is not. What people can type today:
+
+- `scripts/termio` (the shell client): `open`, `sessions
+  list/watch/spawn/run/send/read/close/focus`, `agent report`, `notify`.
+  `agent report` is not purely app-plane: with `TERMIOD_SESSION_ID` set it
+  execs `termiod set-status` (`scripts/termio:670-687`), so it already
+  straddles both planes.
+- `termiod`, top level: `logs`, `serve`, `pair`, `handoff`, `create`,
+  `list`, `kill`, `send`, `set-status`, `agent` (`install`/`uninstall`),
+  `attach`, `watch`, `stdio`, `status`, `stop`, `deploy`, `service`, plus
+  `--host` variants of `deploy`/`list`/`attach` that duplicate the
+  `remote` namespace (`main.rs:53-349`).
+- `termiod remote`: `deploy`, `list`, `attach`, `open`.
+
+The migration therefore needs a destination map for every row above, not
+a passthrough for one namespace. The map this RFC proposes:
+
+| today | destination | notes |
+| --- | --- | --- |
+| `termio sessions …`, `open`, `notify`, `agent report` | stays `termio` | contract frozen; see §4 for which socket serves it when |
+| `termiod remote …` and top-level `--host` twins | `termio remote …`, one spelling | the duplicate top-level forms retire with a deprecation notice, not silently |
+| `termiod create/list/kill/send/attach/watch/status/logs` | `termio …` on machines that have the client; unchanged as `termiod …` when invoked on the box over SSH | see §1.2 |
+| `termiod pair/serve/service/deploy` | stays `termiod` | operator plumbing for the box itself |
+| `termiod stop` | stays `termiod`, on-box only | stops the daemon under it; destructive enough that it should require being on the box, like `systemctl stop` |
+| `termiod handoff`, `termiod stdio`, `termiod set-status` | stays `termiod`, frozen | machine-invoked: the upgrade path, the SSH exec target (its name is in the wire path), and the hook target (hooks exec it by absolute path) |
+| `termiod agent install/uninstall` | stays `termiod` | host integration, written by the deploy loop; a person runs it only to repair a box |
+
+### 1.2 Where each command exists
+
+DEPLOY.md teaches people to run `~/.local/bin/termiod …` on the VPS,
+because on the VPS that is all there is: the reconcile loop installs the
+daemon binary and nothing else. `termio remote open ukvps` is a command
+for machines that have the client; it does not replace the on-box
+spellings, and DEPLOY.md keeps teaching `termiod` for commands an SSH
+user runs on the host itself. The docs change in P1 is scoped to the
+Mac-side examples only. Whether the client binary ever gets installed on
+Linux boxes is the standalone-topology question (§7, curl installer) and
+is out of scope here.
+
+### 1.3 Mechanics, costed honestly
+
+The first draft called a second `[[bin]]` "cheap because the crate
+already builds one bin from shared modules." Wrong: the modules are
+declared from the binary crate root (`main.rs`), so a second bin cannot
+import them. The real shape is a lib extraction (`src/lib.rs` declaring
+the module tree, two thin `src/bin/` entries), which is mechanical but is
+a refactor with a diff, not a one-line change.
+
+Channel binding: today `build-app.sh` rewrites three variables at the top
+of the shell script so `termio-dev` drives the dev app. The Rust client
+selects the channel from argv[0] instead: the dev bundle installs the
+same binary under the name `termio-dev`, which selects the `.dev` bundle
+id, `~/.termio-dev`, and the dev socket. Two paths must be pinned down
+before this ships, because installed hooks name the support-copy path
+absolutely and end `2>/dev/null || true`, so a path mistake fails
+silently: the release app's support copy keeps the exact path
+`CommandLineTool.supportCopyURL` owns today, and the dev app keeps its
+own. The port lands behind the existing paths or it does not land.
+
+### 1.4 Migration order
+
+1. P1, verb collection in shell: `scripts/termio` gains `remote …` by
+   exec'ing the bundled `termiod`, and the Mac-side docs stop teaching
+   `termiod` as a typed command. One prerequisite the script lacks
+   today: a bundled-daemon locator. Its only daemon lookup is `agent
+   report`'s `TERMIOD_BIN`, then `~/.local/bin/termiod`, then `PATH`
+   (`scripts/termio:670-677`), which on a machine with both channels can
+   select a daemon from a different bundle than the app the script
+   drives. P1 adds one helper that resolves the daemon inside the same
+   bundle the script's channel bindings point at, with `TERMIOD_BIN`
+   kept as the explicit override, and `remote …` and `agent report` both
+   use it. With that, shippable now; touches no session backend.
+2. P2, the Rust `termio` client. **Scheduled by the server-plane RFC, not
+   by this one.** Unify-server-plane Stage 10 moves the CLI verb by verb
+   once there is one session backend to route to, precisely so no verb is
+   ported twice; this RFC adds to that stage the lib extraction, the
+   argv[0] channel selection, and the two frozen contracts (`agent
+   report` byte-compatible; `sessions … --json` value-compatible), and
+   removes nothing from its gates. Until Stage 10, the shell script stays
+   the router.
+3. P3: the script becomes a one-line exec shim on its frozen path (hooks
+   reference it absolutely), then disappears when nothing does.
+
+---
+
+## 2. Lesson: a support window is policy, and policy is the hard part
+
+The first draft proposed adding range negotiation to the handshake. It is
+already there in substance: the client's `hello` carries `proto` and
+`min_proto`, the session runs at the highest common version, and no
+overlap returns `hello_err {code:"incompatible", supported:[…]}` with
+immediate close (§C.3; `protocol.rs` `Control::Hello`/`HelloErr`). §C.3
+also already commits the compatibility matrix (old client × new host and
+the reverse, at the intersection, for all of proto:1) and names the test
+shape (golden-file codec tests plus replayed skew transcripts).
+
+One implementation/document gap to record: §C.3 says host and client
+*each* advertise `[min_proto, proto]`, but the implemented `hello_ok`
+carries only the chosen `proto`, with no host minimum
+(`protocol.rs:528-550`), and the daemon today accepts protocol 1 only.
+The gap hasn't bitten because there is one protocol version to choose
+from; before there are two, either `hello_ok` grows the host's range or
+§C.3 is amended to define `hello_ok.proto` as the negotiated result and
+nothing more. Pinning that down belongs with the window work below.
+
+What docker actually has and we do not is everything around the
+mechanism:
+
+- **A stated support window.** §C.3 commits proto:1 additivity but says
+  nothing about how long a payload encoding lives. The payload version
+  bytes (snapshot v3 packed / v2 VT, history v2, grid v2) hard-refuse
+  unknown versions, and §C.3 marks snapshot encoding "deliberately
+  unstable until v1." That instability window has to close: the policy
+  this RFC proposes is that once v1 ships, a new payload version within a
+  supported protocol version ships beside its predecessor for one
+  release window, and a removal (like snapshot v1's) must write down its
+  justification. This amends §C.3's payload-encoding policy; it does not
+  discover a missing mechanism.
+- **The tests §C.3 promises.** "POC smoke tests grow into this" is a
+  roadmap line, not a suite. The skew matrix needs to actually run in CI
+  before the next payload change, because iOS is the client that cannot
+  be re-shipped in a day: App Store review means the phone and the Mac
+  never update atomically, and so far every protocol change has won the
+  ordering gamble by shipping the Mac first. That is a habit, not a
+  mechanism.
+- **An error that names both sides.** `hello_err` carries the host's
+  `supported` list only. A client rendering "phone speaks 3..4, host
+  speaks 5" needs its own range in the message it shows; today it must
+  reconstruct half the sentence. Small, additive, worth doing with the
+  test work.
+
+The reconcile loop keeps skew transient for daemons the Mac owns, and
+that has quietly served as the entire policy. Unowned daemons (a
+pre-baked devbox image, any future non-reconcile install path) and the
+App Store cadence are the two populations it does not cover; the window
+plus the tests are what covers them.
+
+---
+
+## 3. Lesson: make skew visible before making it survivable
+
+`docker version` prints client and server versions in one output. It is
+the first line of every docker bug report and the cheapest support tool
+they built.
+
+We are closer to this than the first draft claimed, but not as close as
+its second draft claimed either: `hello_ok` already returns the daemon's
+build (`version: <app version>+<build>`) exactly so "termiod 0.43 on
+ukvps; this app needs 0.44" can be said, and `termiod status --json`
+already reports local binary and daemon state. But the Mac's device
+registry keeps less than the handshake learns: `TermiodDevice` persists
+`id`, `daemonVersion`, and routes, and the handshake path drops `proto`
+on the floor (`TermiodDevice.swift:62-80`, `TermiodClient.swift:615-634`).
+The remote rows are the Mac client's last-handshake observations, not
+daemon history, and today they contain no protocol number.
+
+So the change is presentation plus one small persistence fix, still no
+new probe: the device registry also records the negotiated `proto` and
+the observation time at each handshake, and `termio version` wraps
+`termiod status` for the local rows and that registry for the remote
+ones, printing one table:
+
+```
+termio        0.34.0+912          (client, dev channel)
+termio.app    0.34.0+912          (running)
+termiod local 0.34.0+912          proto 1
+ukvps         0.34.0+907          proto 1   ← behind, reconciles on next deploy
+```
+
+A host it has never spoken to is absent, not probed. Every remote row is
+stamped from its observation time ("as of last connect, 2h ago"), so a
+stale row announces its staleness instead of posing as live state. No
+new transport calls, no parallel version registry. Ship it before the §2
+policy work: seeing skew is cheaper than surviving it, and tells us
+which windows matter.
+
+---
+
+## 4. Lesson: one API, or no ecosystem
+
+docker's CLI is replaceable because the Engine API is the product.
+Compose, Portainer, and every CI plugin speak the socket, and none of
+them asked docker's permission. There was never a second, easier API to
+grow on.
+
+Our exposure: we have two client-visible surfaces, the framed session
+protocol (documented, versioned, transport-agnostic) and the Mac app's
+control socket (JSON, shell-script consumer, shaped by app internals).
+The unify-server-plane RFC already sentences the app socket to
+absorption. The docker lesson is about the meantime: third parties build
+on whatever surface the examples use.
+
+The policy, with its exceptions named so review can enforce it:
+
+- The framed protocol is the only surface third-party tools may target,
+  and the only one the docs teach for programmatic use.
+- Two public contracts are temporarily served by the app socket and are
+  value-frozen while they migrate: `termio agent report` (already
+  straddling: it execs `termiod set-status` when a daemon session id is
+  present) and `termio sessions … --json` (agents script against it).
+  Their migration to protocol verbs is Stage 10's existing work; the
+  freeze is on observable values, per Stage 10's own gate.
+- Permanently app-plane, by design: `open`, `notify`, `focus` (§4.1 of
+  the server-plane RFC keeps them in Swift). These are not exceptions to
+  the API policy; they are UI verbs with no daemon meaning.
+- Everything else new lands on the framed protocol. A verb that could go
+  either way goes to the daemon, because every verb ported later is
+  migration debt. A new app-socket command outside the lists above is
+  the thing review rejects.
+
+---
+
+## 5. Lesson: decide what the socket is worth before the ecosystem does
+
+docker.sock reachable = root. Everyone knows; nobody can fix it; a decade
+of tooling depends on the socket being all-powerful, so scoping it now
+would break the world. It is the canonical case of a security boundary
+defined by accident and frozen by adoption.
+
+The first draft described a scoped-token tier as if it existed and could
+be documented for free. The tree says otherwise, so this section now does
+the honest half first and prices the second half as engineering.
+
+### 5.1 What is true today, and should be written down as a promise
+
+- The Unix socket is full authority, by design: anything that can open it
+  can inject keystrokes into any session, which is user-equivalent code
+  execution. That is the point (`termio sessions send` driving sibling
+  agents is a feature), and AF_UNIX plus filesystem permissions is the
+  right fence for same-user-same-box (§A: the OS is the security team).
+  No per-verb ACL on the socket will ever be added; a caller you don't
+  trust with your shell must not reach the socket at all.
+- The pairing token is currently daemon-equivalent too. `serve --wss` is
+  a TCP listener that refuses non-loopback binds, carries the same framed
+  protocol onto the daemon socket, and DEPLOY.md already says it plainly:
+  whoever holds the token has full access to the daemon until it is
+  rotated. So the first draft's "No TCP listener, ever" was false against
+  the tree; the true invariants are **no non-loopback bind** (the flag
+  parses the address and refuses otherwise) and **no embedded TLS** (§H
+  #3; TLS belongs to the tunnel in front).
+
+Writing 5.1 into the protocol doc is the prose-only work, and its value
+is docker's negative example: the promise must exist before third-party
+tools shape themselves around an undocumented "the token can do
+everything."
+
+### 5.2 The scoped tier, if and when a phone deserves less than everything
+
+A token tier that grants only session planes (attach, input, files
+within advertised roots, upload) and can never reach `deploy`,
+`service`, or hook installation would need: token claims in the pairing
+payload, an authorization check on every control op in the daemon,
+enforcement on every transport that reaches the socket, and a closed
+catalog in the protocol doc where new privileged verbs are
+loopback-invisible until argued in. That is protocol and daemon work
+with tests, not a documentation pass. It becomes worth scheduling when a
+token holder exists who should not be daemon-equivalent: in practice,
+when device pairing extends beyond the owner's own phone. Until then,
+5.1's honest statement is the security model.
+
+---
+
+## 6. Lesson: the daemon that survives is the boring one
+
+dockerd accreted build, swarm, networking, and plugins, until the
+industry extracted the part it actually needed (containerd/runc) behind a
+narrow interface and Kubernetes dropped dockerd entirely. The daemon was
+punished for being interesting.
+
+termiod will face a steady stream of "the daemon should also…" proposals,
+and some are even right: the deciding rule from the device architecture
+(§4.1: would two people on two machines expect the same answer?) has
+already, correctly, moved git reads and agent integration server-side. So
+the docker lesson here cannot be "keep the daemon tiny"; that would
+contradict §4.1. The lesson is to keep the runtime core extractable:
+
+- The PTY host, session lifecycle, and framed protocol core is the
+  containerd of this system. It must never import from the planes. git,
+  files, upload, and agents may depend on the core; the core compiles
+  without them. Today this is a module-dependency discipline; if it ever
+  needs teeth, it becomes an internal crate boundary (`termiod-core`),
+  the same move as `termiod-vt`. The §1.3 lib extraction is the natural
+  moment to draw the line, since the module tree is being restated
+  anyway.
+- Every plane admission answers both tests, in order: first §4.1 (does it
+  belong server-side at all?), then bytes versus judgment. The daemon
+  moves and reports bytes (a diff, a file, a status string); rendering,
+  ranking, and interpretation stay in clients. A plane that wants the
+  daemon to have opinions is how dockerd got swarm.
+- `HOST_CAPABILITIES` names what accreted, but it mixes plane names
+  (`git`, `files`, `upload`) with feature flags of the core
+  (`send_wait`, `grid_diff`, `handoff`). If the list is to serve as the
+  extraction seam, that distinction gets written down when the core
+  boundary is drawn; until then it is a capability list, not a map.
+
+---
+
+## 7. What we are explicitly not copying
+
+- `docker context`: ssh aliases are our contexts. No registry.
+- Plugin binary discovery (`docker-buildx` on `$PATH`): an extension
+  story is premature until the framed protocol has third-party consumers.
+  Revisit when one exists.
+- A curl installer: separate discussion, gated on a topology (phone to
+  box without a Mac) that doesn't exist yet. When it comes, the script
+  fetches a binary and execs `termiod service install`, so the reconcile
+  loop stays the single writer. It is also the point at which §1.2's
+  "client on a Linux box" question reopens.
+- A single merged binary: rejected in server-plane §7.8 for path and
+  dispatch reasons that this RFC's two-binary shape avoids. Not
+  re-proposed.
+- An HTTP shape for the API: the framed protocol fits PTYs in a way
+  request/response does not. docker's REST shape is an artifact of 2013.
+
+---
+
+## 8. Order of work
+
+Rebased on unify-server-plane's stage order after review; this RFC
+schedules nothing ahead of a stage that RFC already gates.
+
+| # | Change | Cost | When |
+| --- | --- | --- | --- |
+| 1 | `termio version`: persist `proto` + observation time in the device registry, wrap `termiod status` + registry rows (§3) | small | **shipped, PR #543** |
+| 2 | P1 verb collection: bundled-daemon locator, `termio remote …` in the script; Mac-side docs stop teaching `termiod`; deprecation notice on the top-level `--host` twins (§1.1, §1.4) | one to two days | **shipped, PR #543** |
+| 3 | §5.1 written into the protocol doc as the stated security model | prose only | **shipped, PR #543** |
+| 4 | §2 policy: payload support window amending §C.3, the skew test matrix in CI, both-ranges error, `hello_ok` range gap resolved | tests + small protocol additions | before the next payload-format change |
+| 5 | Core-vs-planes import discipline (§6) + single-API policy with its named exceptions (§4) | review discipline | standing, from now |
+| 6 | P2 Rust `termio` client: lib extraction, argv[0] channels, frozen contracts (§1.3) | the real port | **started 2026-08-31** — Stage 10 pulled forward after the one-backend gate was met early (unify-server-plane, restamp of that date); its gates unchanged |
+| 7 | §5.2 scoped token tier | protocol + daemon + tests | when a non-owner token holder exists; not scheduled |

--- a/docs/design/20260831-docker-dockerd-lessons.review-codex.md
+++ b/docs/design/20260831-docker-dockerd-lessons.review-codex.md
@@ -1,0 +1,256 @@
+---
+title: "Adversarial review: What ten years of docker/dockerd teach the termio/termiod split"
+status: archived
+type: rfc
+created: 2026-08-31
+updated: 2026-08-31
+related:
+  - 20260831-docker-dockerd-lessons.md
+  - 20260730-termiod-session-protocol.md
+  - 20260819-unify-server-plane.md
+---
+
+# Adversarial review: What ten years of docker/dockerd teach the termio/termiod split
+
+## Verdict
+
+> Request changes. The command-name direction may be worth discussing, but the
+> RFC misstates the protocol and current listener security model, then schedules
+> a CLI migration ahead of the prerequisites the server-plane RFC explicitly
+> puts before it.
+
+Do not approve the work order as written. Protocol-version range negotiation is
+already present: every `hello` sends `min_proto` and `proto`, and the host
+selects the highest overlap or returns `hello_err`. The proposed work is a
+support-window policy, tests, and client-side handling of the selected version —
+not adding ranges to the handshake.
+
+The security section is more serious. `termiod` already has an opt-in TCP
+listener: `serve --wss` accepts only a loopback address, but it is still TCP and
+is documented as carrying the same framed protocol onto the daemon socket.
+`DEPLOY.md` warns that possession of its pairing token gives “full access to the
+daemon.” The RFC instead calls the token a bounded session-plane credential and
+declares “No TCP listener, ever.” Those are not descriptions of the current
+tree or the cited protocol document; they are a breaking authorization redesign.
+
+Finally, §8 treats P2 as a near-term port after protocol work. The accepted
+server-plane ordering puts the CLI move at Stage 10, after the device connection,
+daemon supervision, companion decoupling, a default-on release, and deletion of
+the local PTY fork. It gives a concrete reason: moving the CLI while two session
+backends remain creates the same work twice. This RFC needs either to preserve
+that dependency order or explicitly supersede it with gates that address the
+same risks.
+
+## Current-tree audit
+
+| RFC claim | Current tree | Finding |
+| --- | --- | --- |
+| `HOST_CAPABILITIES` is an existing string list of planes. | `termiod/src/protocol.rs:27-40` exports a string slice: `events`, `send_wait`, `snapshot`, `scrollback`, `grid_diff`, `resources`, `fs_watch`, `files`, `upload`, `git`, `agents`, `handoff`. | Correct, though it also contains feature-level flags, not only the broad “planes” named in §6. It cannot by itself be the promised extraction seam without defining that distinction. |
+| Snapshot v3, history v2, and grid v2 carry per-payload version bytes and hard-refuse unknown versions. | `protocol.rs:51-64`, `1519-1552`, `1642-1663`, and `1712-1745` encode the leading byte; unknown snapshot, history, and grid versions return an error. | Correct. Snapshot has two accepted current encodings, however: packed cells v3 and VT repaint v2. Calling this simply “snapshot v3” hides that compatibility shape. |
+| The handshake needs protocol ranges added beside capabilities. | `Control::Hello` already has `proto` and `min_proto` (`protocol.rs:520-526`). `20260730-termiod-session-protocol.md` §C.3 already specifies both sides advertise the range and use the highest overlap. | Incorrect. The RFC’s proposed error wording is also not current: `HelloErr` carries `supported: Vec<u32>`, not two named ranges (`protocol.rs:552-555`). |
+| The current shell CLI has the app-plane verbs `sessions`, `agent report`, `notify`, and `open`. | `scripts/termio:17-58,745-779` implements those top-level forms; the script is currently 779 lines. | Correct, with an important qualification: `agent report` now execs `termiod set-status` when `TERMIOD_SESSION_ID` is set (`scripts/termio:662-686`). It is not solely app-plane. |
+| The daemon-plane verbs “today live under `termiod remote …` (`open`, `deploy`, `attach`, `list`).” | `termiod remote` has `deploy`, `list`, `attach`, and `open` (`termiod/src/remote.rs:79-136`). But `termiod deploy --host`, `list --host`, and `attach --host` are also top-level forms (`termiod/src/main.rs:157-177,242-281,325-339`). | Incomplete and misleading. The RFC should inventory both spellings before choosing a public migration, rather than treating `remote` as the whole existing surface. |
+| `termiod` is only for machine invocations today. | Its current public CLI includes `logs`, `pair`, `create`, `list`, `kill`, `send`, `attach`, `watch`, `status`, `deploy`, `remote`, and `service` (`termiod/src/main.rs:51-351`). `DEPLOY.md` teaches people to type many of them. | This is an intended future decision, not current fact. The migration needs a deprecation map for every user-facing subcommand, not only `remote` verbs. |
+| A second Rust `termio` binary is mechanically cheap because the crate can reuse its modules. | `Cargo.toml` declares one `[[bin]]`, `termiod`, rooted at `src/main.rs`. The modules are declared from that binary crate root (`main.rs:14-29`), not a shared library. | Unsupported. A second bin cannot directly import this binary’s private module tree. It requires a library extraction, duplicated module declarations, or another explicit refactor; that may be reasonable, but it is not the claimed one-line `[[bin]]` change. |
+| `DEPLOY.md` examples can simply become `termio remote open ukvps`. | `termiod/DEPLOY.md` is a daemon deployment guide. It instructs remote users to invoke `~/.local/bin/termiod`, including over SSH, and says a bare `termiod` depends on the remote `PATH` (`DEPLOY.md:122-217`). | The proposed example has no established installation or routing story on the VPS. A Mac-bundled `scripts/termio` cannot be assumed to exist on that box. The RFC must distinguish a local client command from commands an SSH user runs on the host. |
+
+## Contradictions with the settled protocol and server-plane RFCs
+
+### The proposed negotiation mechanism already exists
+
+The protocol RFC does not merely suggest versioning. §C.3 specifies the same
+`min_proto..proto` exchange, highest-common selection, and an incompatible
+error. It also commits old-client/new-host and new-client/old-host operation at
+the intersection for `proto:1`. Calling the current model “hard-refuse on
+mismatch” conflates two distinct boundaries:
+
+- Protocol versions correctly hard-refuse when no common range exists.
+- Payload encodings currently refuse unknown bytes, because snapshot encoding is
+  deliberately unstable until v1 and the old snapshot encoding lost necessary
+  theme information.
+
+The RFC can propose a one-version support window, but it must say it changes the
+payload-encoding policy in §C.3 rather than discovering a missing protocol
+mechanism. It also needs a selected-protocol field in `hello_ok` semantics if
+clients are to behave differently by negotiated version; today `HelloOk` has
+`proto`, capabilities, identity, build version, and home, but no explicit
+support range.
+
+### “No TCP listener, ever” directly contradicts both tree and protocol
+
+The protocol RFC says Unix socket only is the **default**, not that TCP is
+forbidden. Its transport table reserves WSS + relay for later. The current tree
+has implemented that later path: `termiod serve --wss` binds only loopback,
+requires a pairing token, and forwards the framed protocol to the local daemon.
+`DEPLOY.md` §“Serving a phone or a browser” documents the tunnel/TLS setup.
+
+The scope claim is also aspirational, not descriptive. `DEPLOY.md` says the QR
+token gives its holder full access to the daemon. The WSS bridge carries the
+same protocol; no token claim enum, per-verb authorization check, or
+loopback-invisible control catalog exists in `protocol.rs`. A closed
+session-plane-only tier needs explicit authorization carried through every
+transport and enforced in the daemon before the docs can promise it. Until
+then, the safe current statement is the opposite: do not disclose the pairing
+token to a party you would not trust with the daemon.
+
+### P1/P2 collide with the server-plane migration
+
+`20260819-unify-server-plane.md` §6 places the CLI move at Stage 10, after:
+
+1. device file reads and foreground parity;
+2. a per-device connection object and reconnect model;
+3. supervision on both platforms;
+4. companion decoupling from `PTYProcess`;
+5. one full default-on release; and
+6. deletion of the local PTY fork.
+
+That RFC says the ordering is deliberate: the CLI should move only once there
+is one session backend, otherwise every port is built twice. §8’s #5 ignores
+that order by placing the Rust CLI port immediately after the handshake change.
+Its #6 “single API policy” is also impossible to enforce as phrased while the
+document retains `termio sessions --json` as a public app-socket contract and
+P1 forwards its new `remote` namespace through `termiod`.
+
+There is a further named-binary conflict. The server-plane RFC §7.8 rejects a
+daemon named `termio`: installed hooks have an absolute `termio` support-copy
+path, and a router named `termio` cannot dispatch to another binary with that
+same name. This RFC does not propose renaming the daemon, but P2’s “Rust
+`termio` bin” plus a script shim has the same path-ownership question. It must
+name the installed binary paths and invocation graph for release and dev before
+claiming `argv[0]` channel selection removes the existing build-time rewrite.
+
+## §8 ordering defects
+
+1. **#1 cannot be a useful skew diagnostic before its data sources exist.** The
+   script can print its own stamped version, but it has no current remote-host
+   registry, no stated source for “recent `remote` targets,” and cannot obtain
+   the running app version or daemon protocol without defining failures and
+   transport calls. `termiod status --json` already knows binary/daemon state
+   locally; decide whether `termio version` wraps that first instead of creating
+   a parallel probe.
+
+2. **#2 changes public documentation before the target command is deployed.**
+   The shell script can proxy a bundled daemon on this Mac, but that does not
+   make `termio remote …` available on Linux boxes, where DEPLOY currently
+   teaches `termiod`. Establish the supported invocation locations and binary
+   layout before rewriting DEPLOY examples.
+
+3. **#3 is not “prose only” if it promises token scoping.** Documenting the
+   current full-authority token is prose. Turning it into a bounded credential
+   needs protocol and daemon authorization work, so it must not be scheduled
+   alongside a doc-only command rename.
+
+4. **#4 should be split.** Range negotiation is already shipped. The remaining
+   tasks are support-window policy, compatibility tests, payload dual-decoding
+   rules, and a structured incompatible error with both advertised ranges. They
+   should precede any payload-format change, not be described as a prerequisite
+   for unrelated CLI packaging.
+
+5. **#5 must wait for the server-plane Stage 10 prerequisites or explicitly
+   replace them.** A Rust client is not inherently blocked on range policy; it
+   is blocked on the two-session-backend fork and unresolved command ownership.
+   Moving it early repeats the work the accepted plan intentionally avoids.
+
+6. **#6 cannot be a standing policy without an exception list.** `open` and
+   `notify` are explicitly app-plane. `sessions --json` remains app-socket
+   backed during the migration. The policy should name these temporary public
+   contracts, their replacement protocol verbs, and deletion gates; otherwise
+   review has no objective way to reject a new app-socket command.
+
+## Required rewrite before approval
+
+- Replace the handshake premise with the actual existing range negotiation and
+  specify only the missing support-window, error-shape, and payload-compatibility
+  work.
+- Reconcile the security section with the shipped loopback WSS listener. Either
+  document its current full authority or design and stage real scoped-token
+  enforcement; do not label the latter as zero-code policy.
+- Inventory every person-facing `termiod` command, including top-level and
+  `remote` aliases, and state its destination, compatibility period, and host
+  installation story.
+- Replace the “second bin is cheap” assertion with the necessary crate/module
+  architecture and a concrete release/dev/hook path plan.
+- Rebase §8 on `unify-server-plane` Stage 10, or explicitly supersede that
+  ordering with prerequisite gates for one session backend, connection
+  ownership, supervision, companion decoupling, and the default-on soak.
+
+## Round 2
+
+The rewrite resolves the first review's central objections: it now treats
+range negotiation as shipped, accurately describes the loopback WSS listener
+and its full-authority token, costs scoped authorization as protocol/daemon
+work, distinguishes Mac-side from on-box documentation, and puts P2 inside
+`unify-server-plane` Stage 10. The lib-extraction correction is also directionally
+right: `Cargo.toml` has one `termiod` bin and `main.rs` owns the module tree, so
+a second client needs a library/module refactor rather than only another
+`[[bin]]` entry. The current build really does rewrite the shell client's three
+top-of-file bindings for the dev bundle (`scripts/build-app.sh:188-198`), and
+`CommandLineTool.supportCopyURL` is the stable hook path the rewrite must keep.
+
+Two factual defects remain, and one new one was introduced.
+
+### 1. §1.1 is still not a full verb inventory
+
+The section labels its list “in full,” but `termiod/src/main.rs` also exposes
+`serve`, `handoff`, `stop`, `set-status`, and `agent` (whose public subcommands
+are `install` and `uninstall`). They are absent from the claimed top-level
+inventory. The destination table mentions most of them later, but that does not
+make the source inventory complete; it even names `daemon`, which is **not** a
+current `termiod` subcommand. The host command is `serve`.
+
+This matters for the stated deprecation map. `stop` is an operator command with
+destructive consequences, `handoff` is the upgrade path, `agent install` owns
+host integration, and `set-status` is the hook target. They need an explicit
+destination and compatibility decision, rather than disappearing between the
+two tables. The `scripts/termio:670-687` citation itself is now sound: those
+lines select and `exec` the daemon for `agent report`.
+
+### 2. §2 overstates what the wire presently sends back
+
+The prose says `hello` carries `proto` and `min_proto` “in both directions.”
+The current Rust wire shape does not: `Control::Hello` carries both fields, but
+`Control::HelloOk` has only `proto` (`termiod/src/protocol.rs:520-555`). The
+daemon currently accepts only protocol 1 (`daemon.rs:1115-1158`), so the
+distinction has not bitten yet, but a genuine range negotiation needs the host
+range represented in its reply or a precisely defined meaning for `HelloOk.proto`.
+
+This is also an unresolved tension between the protocol document and the tree:
+§C.3 says host and client each advertise `[min_proto, proto]`, while the
+implemented `hello_ok` does not carry the host minimum. The RFC should call out
+that implementation/document gap instead of saying the two-direction mechanism
+is already fully present.
+
+### 3. §3's “no new probe” table lacks the retained data
+
+`HelloOk.version` is correctly described as the running daemon's build stamp;
+`termiod status --json` correctly reports the local binary and running daemon
+versions. But the Mac registry does not retain complete `hello_ok` results or a
+protocol value. `TermiodDevice` persists only `id`, `daemonVersion`, and routes
+(`Sources/termio/Terminal/Termiod/TermiodDevice.swift:62-80`); its handshake
+path records `payload.version ?? payload.host` and drops `proto`
+(`TermiodClient.swift:615-634`). Thus “stored `hello_ok` results for remotes the
+daemon has spoken to” is wrong twice: they are stored device observations from
+the **Mac client**'s handshake, not daemon history, and they contain no remote
+protocol number.
+
+Consequently the proposed remote `proto 1` row cannot be produced from the
+claimed sources without either treating protocol 1 as a hard-coded current
+constant, persisting the negotiated protocol/build observation, or making a new
+probe. Pick one and say how staleness is marked. This is the one required-rewrite
+item still materially incomplete: the version display has an inventory/source
+story for builds, but not yet for every displayed field.
+
+### 4. The Stage-10 deference is now correct, with one scope caveat
+
+§1.4 and §8 #6 correctly defer the Rust client to
+`unify-server-plane` Stage 10 and retain that stage's one-backend gate. P1 is
+separately described as a shell-only command collection, so it does not revive
+the rejected early Rust port.
+
+The remaining design decision is implementation-facing rather than a
+contradiction: P1 says the shell will exec “the bundled `termiod`,” but the
+current shell has no bundled-daemon locator; its only daemon lookup in
+`agent report` is `TERMIOD_BIN`, then `~/.local/bin/termiod`, then `PATH`
+(`scripts/termio:670-677`). Define the release/dev resource path or a single
+helper before calling P1 independently shippable. Without that, a PATH-installed
+`termio` can select a different daemon than the app bundle that P1 intends.


### PR DESCRIPTION
The docker/dockerd RFC and its codex review were implemented (PR #543) but the documents themselves were never committed. This lands both, marks the RFC active with its §8 rows 1–3 stamped as shipped, and restamps the two migration RFCs that the tree outran:

- **unify-server-plane**: Stage 2 merged as PR #400 the same afternoon the doc was last stamped; Stage 6 done (PR #404); Stages 7/8 collapsed into `a8b15bd` with the soak served retroactively across v0.41.0–v0.48.0; Stage 5 items 2–3 done via PRs #530/#499/#522. A dated restamp block in §2 records each closure with its evidence, and the stage headings carry the outcome.
- **one-path**: Stages 4 and 5 marked done; Stage 6 marked in progress.
- Both docs record the decision to pull Stage 10 (the CLI move) forward as of 2026-08-31: its ordering existed to prevent porting verbs across two session backends, and there has been one backend since `a8b15bd`. Its gates are unchanged.

Release Notes:

- None (documentation only).