### PR TITLE
Read a device's checkout in the Changes pane

### DIFF
--- a/Sources/termio/FileBrowser/FileBrowserView.swift
+++ b/Sources/termio/FileBrowser/FileBrowserView.swift
@@ -271,7 +271,19 @@ struct FileBrowserView: View {
                 noProject
             }
         case .changes:
-            if let deviceCheckout {
+            if let deviceCheckout, let root = deviceCheckout.root {
+                // The device runs git on its own checkout with its own config and
+                // credentials, and publishes status as it moves; this pane
+                // subscribes. Fresh identity per (machine, root) so no state
+                // leaks between boxes.
+                GitChangesView(
+                    repoRoot: root,
+                    device: deviceCheckout.device.route,
+                    changeCount: $store.gitChangeCount,
+                    isPaneVisible: { [weak store] in store?.inspectorVisible ?? true }
+                )
+                .id(deviceCheckout.deviceIdentity + "\u{1f}" + root)
+            } else if let deviceCheckout {
                 unavailable(pane: localized("Changes"), on: deviceCheckout)
             } else if let repoRoot = projectPath {
                 // Fresh identity per repo, so the panel model (selection, draft message,

--- a/Sources/termio/Git/DiffSource.swift
+++ b/Sources/termio/Git/DiffSource.swift
@@ -1,0 +1,64 @@
+import TermioShared
+import Foundation
+
+/// Where a diff comes from — this Mac's `git`, or the device the checkout lives
+/// on. The one place in the pane that decides which machine runs the command.
+///
+/// It is a *provider swap and nothing more*: both roads produce unified-diff
+/// **text**, and `DiffParser` / `DiffDocument` / `DiffTextView` already consume
+/// text, so a device diff renders through the identical stack — same fold, same
+/// intraline word diff, same syntax pass. That was the whole bet in
+/// `docs/rfcs/remote-git-plane.md` §2 and it holds.
+enum DiffSource {
+    /// Rendered rows for one changed file. `device` nil means this Mac.
+    static func rows(
+        for change: GitChange,
+        in repoRoot: String,
+        device: TermiodRoute?,
+        commit: String? = nil,
+        range: String? = nil
+    ) async -> [DiffRow] {
+        guard let device else {
+            return await GitService.diffRows(
+                for: change, in: repoRoot, commit: commit, range: range)
+        }
+        // `git.diff` answers the working-tree diff for one path. A commit or a
+        // range is the read tier's `git.show` / `git.log`, which this pane does
+        // not ask a device for yet — and inventing a local answer for a remote
+        // path would diff the wrong machine's file.
+        guard commit == nil, range == nil else { return [] }
+        // Full context, exactly as the local path asks for it: the overlay holds
+        // the whole file and collapses the unchanged runs into bands the reader
+        // can expand. `GitService.diffRows` falls back to git's default context
+        // when the row count is pathological; the device caps at 1 MiB instead,
+        // and says so.
+        let text = await text(
+            for: change, in: repoRoot, device: device, context: 999_999)
+        return await GitService.parseDiffText(text)
+    }
+
+    /// The raw unified-diff text — what "Copy Diff" puts on the pasteboard.
+    static func text(
+        for change: GitChange, in repoRoot: String, device: TermiodRoute?,
+        context: Int? = nil
+    ) async -> String {
+        guard let device else {
+            return await GitService.diffText(for: change, in: repoRoot)
+        }
+        do {
+            // A fully staged change has nothing in the worktree to diff, so the
+            // index is what the row is about — the same choice the local path
+            // makes by diffing against `HEAD`.
+            let diff = try await Termiod.gitDiff(
+                route: device, root: repoRoot, path: change.path,
+                staged: change.isStaged, context: context)
+            return diff.text
+        } catch {
+            Log.termiod.error("""
+            device diff for \(change.path, privacy: .public) failed: \
+            \(String(describing: error), privacy: .public)
+            """)
+            return ""
+        }
+    }
+}

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -279,9 +279,15 @@ struct GitChangesView: View {
         if !model.changes.isEmpty {
             let additions = model.changes.reduce(0) { $0 + $1.additions }
             let deletions = model.changes.reduce(0) { $0 + $1.deletions }
-            Text(model.changes.count == 1
-                ? localized("\(model.changes.count) file")
-                : localized("\(model.changes.count) files"))
+            // The device cuts a flooded status list at its cap, so the count is
+            // the head of the list rather than the whole of it. Said here
+            // because this number is the one that would otherwise be a claim
+            // about the working tree that isn't true.
+            Text(model.deviceListTruncated
+                ? localized("first \(model.changes.count) files")
+                : (model.changes.count == 1
+                    ? localized("\(model.changes.count) file")
+                    : localized("\(model.changes.count) files")))
                 .foregroundStyle(.secondary)
             if additions > 0 { Text("+\(additions)").foregroundStyle(.green) }
             if deletions > 0 { Text("−\(deletions)").foregroundStyle(.red) }

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -282,12 +282,14 @@ struct GitChangesView: View {
             // The device cuts a flooded status list at its cap, so the count is
             // the head of the list rather than the whole of it. Said here
             // because this number is the one that would otherwise be a claim
-            // about the working tree that isn't true.
-            Text(model.deviceListTruncated
-                ? localized("first \(model.changes.count) files")
-                : (model.changes.count == 1
-                    ? localized("\(model.changes.count) file")
-                    : localized("\(model.changes.count) files")))
+            // about the working tree that isn't true — and said with the real
+            // total, since "first 5,000" and "first 5,000 of 41,900" are
+            // different answers.
+            Text(model.deviceListTotal.map {
+                localized("first \(model.changes.count) of \($0) files")
+            } ?? (model.changes.count == 1
+                ? localized("\(model.changes.count) file")
+                : localized("\(model.changes.count) files")))
                 .foregroundStyle(.secondary)
             if additions > 0 { Text("+\(additions)").foregroundStyle(.green) }
             if deletions > 0 { Text("−\(deletions)").foregroundStyle(.red) }

--- a/Sources/termio/Git/GitChangesView.swift
+++ b/Sources/termio/Git/GitChangesView.swift
@@ -16,6 +16,11 @@ struct GitChangesView: View {
     @Environment(\.colorScheme) private var colorScheme
 
     let repoRoot: String
+    /// The machine `repoRoot` is a path on, when it is not this Mac. A device
+    /// checkout reads: the pane subscribes to that box's git status and asks it
+    /// for diffs, and offers no action it cannot honestly perform there (see
+    /// `docs/rfcs/remote-git-plane.md` — the mutation tier is staged separately).
+    var device: TermiodRoute? = nil
     /// Lifted up to `FileBrowserView` so the switcher's Changes badge stays in step.
     @Binding var changeCount: Int
 
@@ -49,11 +54,18 @@ struct GitChangesView: View {
     /// it was (the Issues list's rule).
     @State private var lastOpenedPath: String?
 
-    init(repoRoot: String, changeCount: Binding<Int>, isPaneVisible: (() -> Bool)? = nil) {
+    init(
+        repoRoot: String,
+        device: TermiodRoute? = nil,
+        changeCount: Binding<Int>,
+        isPaneVisible: (() -> Bool)? = nil
+    ) {
         self.repoRoot = repoRoot
+        self.device = device
         self._changeCount = changeCount
         self._model = StateObject(
-            wrappedValue: GitPanelModel(repoRoot: repoRoot, isPaneVisible: isPaneVisible))
+            wrappedValue: GitPanelModel(
+                repoRoot: repoRoot, device: device, isPaneVisible: isPaneVisible))
     }
 
     private var chrome: ChromeTheme? { settings.chromeTheme(for: colorScheme) }
@@ -100,8 +112,17 @@ struct GitChangesView: View {
         // moment the pane is actually shown again (either signal can fire first
         // depending on how the view was re-attached).
         .onAppear { model.flushDeferredRefresh() }
+        .onDisappear { model.stopDeviceWatch() }
         .onChange(of: store.inspectorVisible) { _, visible in
-            if visible { model.flushDeferredRefresh() }
+            if visible {
+                model.flushDeferredRefresh()
+                model.startDeviceWatch()
+            } else {
+                // A hidden pane stops watching: the device retires an unwatched
+                // resource on its own, so nothing keeps running over there for a
+                // pane nobody can see.
+                model.stopDeviceWatch()
+            }
         }
         .onChange(of: model.changes.count) { _, count in changeCount = count }
         .onChange(of: selection) { _, selected in
@@ -191,8 +212,14 @@ struct GitChangesView: View {
     private var modeSwitch: some View {
         HStack(spacing: 0) {
             segment(localized("Changes"), .changes)
-            segment(localized("Compare"), .compare)
-            segment(localized("History"), .history)
+            // Compare and History are the device's read tier (`git.log`,
+            // `git.branches`), which this pane does not ask for yet. Hidden
+            // rather than shown empty: a tab that answers nothing is worse than
+            // a tab that isn't there.
+            if device == nil {
+                segment(localized("Compare"), .compare)
+                segment(localized("History"), .history)
+            }
         }
         // The selection pill rides behind the active segment and slides across on switch.
         .background { selectionPill }
@@ -269,6 +296,16 @@ struct GitChangesView: View {
             ProgressView()
                 .controlSize(.small)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let problem = model.deviceProblem {
+            // The device's own words. "No Changes" would be a different claim
+            // from "that directory isn't a repository", and the pane must not
+            // make the second look like the first.
+            PaneEmptyState(
+                localized("No Changes to Show"),
+                icon: .serverStack,
+                message: problem
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if model.changes.isEmpty {
             // Fill the pane (like the loading state) rather than sizing to the compact empty
             // view — otherwise the enclosing `VStack` shrinks to content height and the host
@@ -300,7 +337,9 @@ struct GitChangesView: View {
                 // multi-selection takes over the moment one exists.
                 isSelected: selection.contains(change.path)
                     || (selection.isEmpty && lastOpenedPath == change.path),
-                onDiscard: { pendingDiscard = [change] }
+                // Discard writes to the checkout, which a device's file plane
+                // does not do. The button is absent there rather than inert.
+                onDiscard: device == nil ? { pendingDiscard = [change] } : nil
             )
             .contextMenu { contextMenu(for: change) }
         }
@@ -326,15 +365,20 @@ struct GitChangesView: View {
         let targets = targets(for: change)
         let fileExtension = (change.path as NSString).pathExtension.lowercased()
         if targets.count == 1 {
-            Button(localized("Open in Editor")) { openInEditor(change) }
-            Button(localized("Reveal in Finder")) { revealInFinder(change) }
-            Divider()
-            Button(localized("Copy Path")) { copyPath(change) }
+            // Opening in the editor and revealing in the Finder are both about a
+            // file on *this* Mac; for a device checkout the path names a file
+            // this machine does not have.
+            if device == nil {
+                Button(localized("Open in Editor")) { openInEditor(change) }
+                Button(localized("Reveal in Finder")) { revealInFinder(change) }
+                Divider()
+                Button(localized("Copy Path")) { copyPath(change) }
+            }
             Button(localized("Copy Relative Path")) { copyToPasteboard(change.path) }
             Button(localized("Copy Diff")) { copyDiff(targets) }
             // GitHub Desktop's two ignore actions, verbatim — the by-extension form is
             // what clears a build-products flood one file type at a time.
-            if change.isUntracked {
+            if change.isUntracked, device == nil {
                 Divider()
                 Button(localized("Ignore File (Add to .gitignore)")) { addToGitignore(paths: [change.path]) }
                 if !fileExtension.isEmpty {
@@ -343,8 +387,10 @@ struct GitChangesView: View {
                     }
                 }
             }
-            Divider()
-            Button(localized("Discard Changes…"), role: .destructive) { pendingDiscard = targets }
+            if device == nil {
+                Divider()
+                Button(localized("Discard Changes…"), role: .destructive) { pendingDiscard = targets }
+            }
         } else {
             Button(localized("Copy Paths")) {
                 copyToPasteboard(targets.map { fileURL(for: $0).path }.joined(separator: "\n"))
@@ -355,14 +401,16 @@ struct GitChangesView: View {
             Button(localized("Copy Diff")) { copyDiff(targets) }
             // GitHub Desktop acts on the whole selection here too.
             let untracked = targets.filter(\.isUntracked)
-            if !untracked.isEmpty {
+            if !untracked.isEmpty, device == nil {
                 Divider()
                 Button(localized("Ignore \(untracked.count) Selected Files (Add to .gitignore)")) {
                     addToGitignore(paths: untracked.map(\.path))
                 }
             }
-            Divider()
-            Button(localized("Discard \(targets.count) Files…"), role: .destructive) { pendingDiscard = targets }
+            if device == nil {
+                Divider()
+                Button(localized("Discard \(targets.count) Files…"), role: .destructive) { pendingDiscard = targets }
+            }
         }
     }
 
@@ -412,7 +460,8 @@ struct GitChangesView: View {
         if FileActivation.previewsRatherThanDiff(url), FileManager.default.fileExists(atPath: url.path) {
             store.openFileInEditor(url)
         } else {
-            store.openDiff = GitDiffRequest(repoRoot: repoRoot, change: change, siblings: model.changes)
+            store.openDiff = GitDiffRequest(
+                repoRoot: repoRoot, device: device, change: change, siblings: model.changes)
         }
     }
 
@@ -438,7 +487,8 @@ struct GitChangesView: View {
         Task {
             var parts: [String] = []
             for change in changes {
-                parts.append(await GitService.diffText(for: change, in: repoRoot))
+                parts.append(await DiffSource.text(
+                    for: change, in: repoRoot, device: device))
             }
             copyToPasteboard(parts.joined())
         }
@@ -506,7 +556,9 @@ private struct GitChangeRow: View {
     let chrome: ChromeTheme?
     let isSelected: Bool
     /// Fires the discard confirmation for this row (owned by `GitChangesView`).
-    let onDiscard: () -> Void
+    /// `nil` where discarding is not on offer — a checkout on another machine,
+    /// whose file plane reads and does not write.
+    let onDiscard: (() -> Void)?
 
     @State private var isHovering = false
 
@@ -533,7 +585,7 @@ private struct GitChangeRow: View {
             // On hover the trailing counts give way to a single discard button — the
             // one destructive action worth a one-click affordance (everything else lives
             // in the right-click menu). The counts return when the pointer leaves.
-            if isHovering {
+            if isHovering, let onDiscard {
                 Button(action: onDiscard) {
                     Image(systemName: "arrow.uturn.backward")
                         .font(.system(size: 11, weight: .medium))

--- a/Sources/termio/Git/GitDiffView.swift
+++ b/Sources/termio/Git/GitDiffView.swift
@@ -279,8 +279,9 @@ struct GitDiffView: View {
     // MARK: Loading + syntax colors
 
     private func load() async {
-        let parsed = await GitService.diffRows(
-            for: request.change, in: request.repoRoot, commit: request.commit, range: request.range)
+        let parsed = await DiffSource.rows(
+            for: request.change, in: request.repoRoot, device: request.device,
+            commit: request.commit, range: request.range)
         rows = parsed
         rebuildDocument()
         isLoading = false
@@ -332,7 +333,7 @@ extension GitDiffRequest {
             let candidate = siblings[next]
             let url = URL(fileURLWithPath: repoRoot).appendingPathComponent(candidate.path)
             if !FileActivation.previewsRatherThanDiff(url) {
-                return GitDiffRequest(repoRoot: repoRoot, change: candidate,
+                return GitDiffRequest(repoRoot: repoRoot, device: device, change: candidate,
                                       commit: commit, range: range, siblings: siblings)
             }
             next += delta

--- a/Sources/termio/Git/GitModels.swift
+++ b/Sources/termio/Git/GitModels.swift
@@ -42,6 +42,58 @@ struct GitChange: Identifiable, Hashable, Sendable {
     var directory: String { (path as NSString).deletingLastPathComponent }
 }
 
+/// Reading a device's status into the pane's own row type. An extension, not a
+/// member, so `GitChange` keeps its memberwise initializer.
+extension GitChange {
+    /// One row of a device's `git_changed` batch, in the pane's own vocabulary.
+    ///
+    /// `nil` for a status the row cannot draw: an ignored file, which the local
+    /// parser drops for the same reason, and a status this build does not know.
+    /// The two-axis form is what decides `isStaged` — the worktree axis wins
+    /// when it moved, exactly as `GitService.make(xy:path:untracked:)` reads
+    /// porcelain v2 on this Mac, so a row means the same thing on either road.
+    init?(device entry: Termiod.GitStatusEntryPayload) {
+        let status: GitFileStatus
+        var staged = false
+        switch entry.status {
+        case .untracked:
+            status = .untracked
+        case .unmerged:
+            status = .conflicted
+        case .ignored, .unknown:
+            return nil
+        case .tracked(let index, let worktree):
+            let primary = worktree == "unmodified" ? index : worktree
+            status = GitFileStatus(code: Self.letter(for: primary))
+            staged = index != "unmodified" && worktree == "unmodified"
+        }
+        self.init(
+            path: entry.path,
+            status: status,
+            isUntracked: status == .untracked,
+            additions: entry.additions,
+            deletions: entry.deletions,
+            originalPath: entry.originalPath,
+            isStaged: staged,
+            isBinary: entry.binary)
+    }
+
+    /// `git.rs`'s `GitStatusCode`, back to the porcelain letter `GitFileStatus`
+    /// already reads. Going through the letter rather than adding a second
+    /// mapping keeps one definition of what a status means.
+    private static func letter(for code: String) -> Character {
+        switch code {
+        case "modified": return "M"
+        case "type_changed": return "T"
+        case "added": return "A"
+        case "deleted": return "D"
+        case "renamed": return "R"
+        case "copied": return "C"
+        default: return "M"
+        }
+    }
+}
+
 /// One commit in the branch's history, parsed from `git log`. Shown as a row in
 /// the git pane's History tab; selecting it lists the files it touched, each of
 /// which opens that commit's diff over the terminal.
@@ -118,6 +170,10 @@ enum GitFileStatus: Hashable, Sendable {
 /// can run `git diff` for the file without re-deriving it.
 struct GitDiffRequest: Hashable, Sendable {
     let repoRoot: String
+    /// The machine `repoRoot` is a path on, when it is not this one. The overlay
+    /// asks that device for the diff instead of running `git` here — a path from
+    /// another box means nothing to this one's filesystem.
+    var device: TermiodRoute? = nil
     let change: GitChange
     /// When set, the overlay shows the file's diff *as of that commit*
     /// (`git show <sha>`) rather than the working-tree diff — the History tab's

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -142,11 +142,23 @@ final class GitPanelModel: ObservableObject {
     /// Starts (or resumes) the device subscription. Idempotent: the pane calls
     /// it on appear and whenever it becomes visible again.
     func startDeviceWatch() {
-        guard let device, gitWatch == nil, !resubscribing else { return }
+        guard let device, gitWatch == nil else { return }
+        guard !resubscribing else {
+            // A stop followed immediately by an appear can land while the old
+            // subscribe still awaits its acknowledgement. Supersede that
+            // handshake and have its cleanup begin the new one.
+            watchLedger.requestRestart()
+            return
+        }
         resubscribing = true
         let generation = watchLedger.begin()
         Task { [repoRoot] in
-            defer { resubscribing = false }
+            defer {
+                resubscribing = false
+                if watchLedger.consumeRestartRequest() {
+                    startDeviceWatch()
+                }
+            }
             do {
                 let (subscription, gap, seq) = try await Termiod.watchGit(
                     route: device,
@@ -227,6 +239,7 @@ final class GitPanelModel: ObservableObject {
         Task {
             // Let the drop settle before the next request reopens the channel.
             try? await Task.sleep(for: .seconds(1))
+            guard watchLedger.isCurrent(generation) else { return }
             startDeviceWatch()
         }
     }
@@ -471,6 +484,7 @@ struct DeviceWatchLedger {
     private(set) var generation = 0
     private var awaitingBaseline = false
     private var held: [Termiod.GitChangedPayload] = []
+    private var restartRequested = false
 
     /// A new subscribe attempt begins; everything older is dead.
     mutating func begin() -> Int {
@@ -485,6 +499,30 @@ struct DeviceWatchLedger {
         generation += 1
         awaitingBaseline = false
         held = []
+        restartRequested = false
+    }
+
+    /// A newer visible pane wants a watch while an older handshake is still
+    /// pending. The old acknowledgement must not install, but its cleanup is
+    /// responsible for starting the replacement once it has released the
+    /// in-flight slot.
+    mutating func requestRestart() {
+        generation += 1
+        awaitingBaseline = false
+        held = []
+        restartRequested = true
+    }
+
+    /// Returns whether the caller's generation still owns the watch.
+    func isCurrent(_ generation: Int) -> Bool {
+        generation == self.generation
+    }
+
+    /// Takes the one deferred replacement request after its predecessor has
+    /// completed its handshake.
+    mutating func consumeRestartRequest() -> Bool {
+        defer { restartRequested = false }
+        return restartRequested
     }
 
     /// Admits one arriving batch: returns it when the watch is settled and the

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -134,10 +134,11 @@ final class GitPanelModel: ObservableObject {
     /// What the device says the checkout's branch is, for a pane that wants to
     /// name it. Absent until the first batch lands.
     @Published private(set) var deviceBranch: String?
-    /// The device cut the status list at its cap. The rows shown are real; the
-    /// list is not all of them, and the pane has to say so rather than let a
+    /// How many paths the device's checkout really has changed, when it cut
+    /// the list below that. The rows shown are real; the list is not all of
+    /// them, and the pane says how many are missing rather than let a
     /// head-of-list read as the working tree.
-    @Published private(set) var deviceListTruncated = false
+    @Published private(set) var deviceListTotal: Int?
 
     /// Starts (or resumes) the device subscription. Idempotent: the pane calls
     /// it on appear and whenever it becomes visible again.
@@ -188,7 +189,7 @@ final class GitPanelModel: ObservableObject {
                 // by its own gap reset.
                 if gap {
                     deviceStatuses = [:]
-                    deviceListTruncated = false
+                    deviceListTotal = nil
                     gitCursor = nil
                 } else {
                     gitCursor = max(gitCursor ?? 0, seq)
@@ -259,7 +260,7 @@ final class GitPanelModel: ObservableObject {
             }
         }
         deviceBranch = batch.branch
-        deviceListTruncated = batch.truncated
+        deviceListTotal = batch.total
         deviceProblem = nil
         changes = Self.sorted(Array(deviceStatuses.values))
         isLoading = false

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -134,6 +134,10 @@ final class GitPanelModel: ObservableObject {
     /// What the device says the checkout's branch is, for a pane that wants to
     /// name it. Absent until the first batch lands.
     @Published private(set) var deviceBranch: String?
+    /// The device cut the status list at its cap. The rows shown are real; the
+    /// list is not all of them, and the pane has to say so rather than let a
+    /// head-of-list read as the working tree.
+    @Published private(set) var deviceListTruncated = false
 
     /// Starts (or resumes) the device subscription. Idempotent: the pane calls
     /// it on appear and whenever it becomes visible again.
@@ -172,6 +176,7 @@ final class GitPanelModel: ObservableObject {
                 // by its own gap reset.
                 if gap {
                     deviceStatuses = [:]
+                    deviceListTruncated = false
                     gitCursor = nil
                 } else {
                     gitCursor = max(gitCursor ?? 0, seq)
@@ -241,6 +246,7 @@ final class GitPanelModel: ObservableObject {
             }
         }
         deviceBranch = batch.branch
+        deviceListTruncated = batch.truncated
         deviceProblem = nil
         changes = Self.sorted(Array(deviceStatuses.values))
         isLoading = false

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -125,6 +125,9 @@ final class GitPanelModel: ObservableObject {
     private var gitWatch: Termiod.ResourceSubscription?
     private var gitCursor: UInt64?
     private var resubscribing = false
+    /// Orders the pieces of a subscribe handshake that reach the main actor on
+    /// different paths — see `DeviceWatchLedger`.
+    private var watchLedger = DeviceWatchLedger()
     /// The status the device has published so far, keyed by path. The batches
     /// are **deltas**, so the pane holds the baseline they apply to.
     private var deviceStatuses: [String: GitChange] = [:]
@@ -137,6 +140,7 @@ final class GitPanelModel: ObservableObject {
     func startDeviceWatch() {
         guard let device, gitWatch == nil, !resubscribing else { return }
         resubscribing = true
+        let generation = watchLedger.begin()
         Task { [repoRoot] in
             defer { resubscribing = false }
             do {
@@ -145,21 +149,34 @@ final class GitPanelModel: ObservableObject {
                     root: repoRoot,
                     since: gitCursor,
                     onBatch: { [weak self] batch in
-                        Task { @MainActor in self?.apply(batch) }
+                        Task { @MainActor in self?.receive(batch, generation: generation) }
                     },
                     onInterrupted: { [weak self] in
-                        Task { @MainActor in self?.deviceWatchInterrupted() }
+                        Task { @MainActor in
+                            self?.deviceWatchInterrupted(generation: generation)
+                        }
                     })
+                guard let earlyBatches = watchLedger.settle(generation: generation) else {
+                    // The pane stopped (or restarted) the watch while this
+                    // handshake was in flight; the subscription must not
+                    // outlive the interest that asked for it.
+                    subscription.cancel()
+                    return
+                }
                 gitWatch = subscription
                 // A gap means the ring could not replay from this cursor, so the
                 // baseline is not trustworthy: drop it and let the device's
-                // synthesized full batch rebuild it.
+                // synthesized full batch rebuild it. The reset lands *before*
+                // any batch applies — batches that raced the ack sat in the
+                // ledger and apply below, so the full batch can never be erased
+                // by its own gap reset.
                 if gap {
                     deviceStatuses = [:]
                     gitCursor = nil
                 } else {
                     gitCursor = max(gitCursor ?? 0, seq)
                 }
+                for batch in earlyBatches { apply(batch) }
                 // The ack only says the device accepted the subscription; the
                 // baseline follows a beat later (measured at 2 ms behind it).
                 // Waiting for it is what keeps a repo with changes from flashing
@@ -168,9 +185,11 @@ final class GitPanelModel: ObservableObject {
                 // pane's answer to a clean tree. So: wait briefly, then settle.
                 Task { [weak self] in
                     try? await Task.sleep(for: .seconds(1))
-                    self?.isLoading = false
+                    guard let self, self.watchLedger.generation == generation else { return }
+                    self.isLoading = false
                 }
             } catch {
+                guard watchLedger.generation == generation else { return }
                 isLoading = false
                 deviceProblem = Self.message(for: error)
             }
@@ -178,8 +197,17 @@ final class GitPanelModel: ObservableObject {
     }
 
     func stopDeviceWatch() {
+        watchLedger.stop()
         gitWatch?.cancel()
         gitWatch = nil
+    }
+
+    /// Routes one arriving batch through the ledger: applied when the watch is
+    /// settled, held when the handshake's baseline decision is still in
+    /// flight, dropped when it belongs to a watch that was stopped.
+    private func receive(_ batch: Termiod.GitChangedPayload, generation: Int) {
+        guard let ready = watchLedger.admit(batch, generation: generation) else { return }
+        apply(ready)
     }
 
     /// Why the device's git pane is empty, when it is empty for a reason. Held
@@ -187,7 +215,8 @@ final class GitPanelModel: ObservableObject {
     /// read as the same thing.
     @Published private(set) var deviceProblem: String?
 
-    private func deviceWatchInterrupted() {
+    private func deviceWatchInterrupted(generation: Int) {
+        guard watchLedger.generation == generation else { return }
         gitWatch = nil
         guard !resubscribing else { return }
         Task {
@@ -416,5 +445,63 @@ final class GitPanelModel: ObservableObject {
                 await self.loadCompare()
             }
         }
+    }
+}
+
+// MARK: - Device-watch ordering
+
+/// The ordering ledger for one device git watch.
+///
+/// A subscribe handshake resolves on two paths that both land on the main
+/// actor: the ack (with its gap → reset-the-baseline decision) comes back
+/// through the async call, while the first batches arrive through the
+/// subscription handler — and the daemon queues the synthesized full batch
+/// right behind the ack, so a batch can be applied *before* the gap reset that
+/// would erase it, rendering a changed checkout clean. The ledger holds batches
+/// until the baseline decision has landed, and stamps every attempt with a
+/// generation so a watch that was stopped — or restarted — while its handshake
+/// was in flight can neither install its subscription nor apply its batches.
+struct DeviceWatchLedger {
+    private(set) var generation = 0
+    private var awaitingBaseline = false
+    private var held: [Termiod.GitChangedPayload] = []
+
+    /// A new subscribe attempt begins; everything older is dead.
+    mutating func begin() -> Int {
+        generation += 1
+        awaitingBaseline = true
+        held = []
+        return generation
+    }
+
+    /// The watch was stopped; an in-flight attempt must not land.
+    mutating func stop() {
+        generation += 1
+        awaitingBaseline = false
+        held = []
+    }
+
+    /// Admits one arriving batch: returns it when the watch is settled and the
+    /// batch may apply now, or nil when it was held for `settle` or belongs to
+    /// a dead generation.
+    mutating func admit(
+        _ batch: Termiod.GitChangedPayload, generation: Int
+    ) -> Termiod.GitChangedPayload? {
+        guard generation == self.generation else { return nil }
+        guard !awaitingBaseline else {
+            held.append(batch)
+            return nil
+        }
+        return batch
+    }
+
+    /// The ack landed and the caller is about to make the baseline decision.
+    /// Returns the batches that raced ahead, in arrival order, to apply after
+    /// that decision — or nil when the attempt is stale and must be abandoned.
+    mutating func settle(generation: Int) -> [Termiod.GitChangedPayload]? {
+        guard generation == self.generation else { return nil }
+        awaitingBaseline = false
+        defer { held = [] }
+        return held
     }
 }

--- a/Sources/termio/Git/GitPanelModel.swift
+++ b/Sources/termio/Git/GitPanelModel.swift
@@ -1,3 +1,4 @@
+import TermioShared
 import AppKit
 import Combine
 import SwiftUI
@@ -15,6 +16,13 @@ import SwiftUI
 @MainActor
 final class GitPanelModel: ObservableObject {
     let repoRoot: String
+    /// The machine `repoRoot` lives on, when it is not this Mac. A device
+    /// checkout is driven the other way round from a local one: the box already
+    /// watches its own workspace and publishes status deltas, so the pane
+    /// subscribes and applies them instead of running `git status` on a timer.
+    /// This is the shape Zed pushes as `UpdateRepository` and VS Code gets by
+    /// running the git extension on the remote — nobody polls a remote checkout.
+    let device: TermiodRoute?
 
     @Published var changes: [GitChange] = []
     @Published var isLoading = true
@@ -93,17 +101,144 @@ final class GitPanelModel: ObservableObject {
         return false
     }
 
-    init(repoRoot: String, isPaneVisible: (() -> Bool)? = nil) {
+    init(repoRoot: String, device: TermiodRoute? = nil, isPaneVisible: (() -> Bool)? = nil) {
         self.repoRoot = repoRoot
+        self.device = device
         self.isPaneVisible = isPaneVisible
         // Re-activation catches whatever happened while termio was in the background
         // (a rebase in another app, a pull on another machine's shared folder…).
+        // A device checkout needs no such catch-all: its watch runs on the box
+        // and kept publishing while this app was not even in front.
+        guard device == nil else { return }
         appActiveObserver = NotificationCenter.default
             .publisher(for: NSApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in self?.scheduleRefresh(includeHistory: true) }
     }
 
     deinit { refreshDebounce?.cancel() }
+
+    // MARK: The device's own status
+
+    /// The subscription to `git:<root>` on the device, and the cursor into its
+    /// batches — so a dropped channel resumes from the replay ring rather than
+    /// re-reading a whole status.
+    private var gitWatch: Termiod.ResourceSubscription?
+    private var gitCursor: UInt64?
+    private var resubscribing = false
+    /// The status the device has published so far, keyed by path. The batches
+    /// are **deltas**, so the pane holds the baseline they apply to.
+    private var deviceStatuses: [String: GitChange] = [:]
+    /// What the device says the checkout's branch is, for a pane that wants to
+    /// name it. Absent until the first batch lands.
+    @Published private(set) var deviceBranch: String?
+
+    /// Starts (or resumes) the device subscription. Idempotent: the pane calls
+    /// it on appear and whenever it becomes visible again.
+    func startDeviceWatch() {
+        guard let device, gitWatch == nil, !resubscribing else { return }
+        resubscribing = true
+        Task { [repoRoot] in
+            defer { resubscribing = false }
+            do {
+                let (subscription, gap, seq) = try await Termiod.watchGit(
+                    route: device,
+                    root: repoRoot,
+                    since: gitCursor,
+                    onBatch: { [weak self] batch in
+                        Task { @MainActor in self?.apply(batch) }
+                    },
+                    onInterrupted: { [weak self] in
+                        Task { @MainActor in self?.deviceWatchInterrupted() }
+                    })
+                gitWatch = subscription
+                // A gap means the ring could not replay from this cursor, so the
+                // baseline is not trustworthy: drop it and let the device's
+                // synthesized full batch rebuild it.
+                if gap {
+                    deviceStatuses = [:]
+                    gitCursor = nil
+                } else {
+                    gitCursor = max(gitCursor ?? 0, seq)
+                }
+                // The ack only says the device accepted the subscription; the
+                // baseline follows a beat later (measured at 2 ms behind it).
+                // Waiting for it is what keeps a repo with changes from flashing
+                // "No Changes" — but a checkout that has nothing to say sends no
+                // batch at all, and a spinner that never stops would be the
+                // pane's answer to a clean tree. So: wait briefly, then settle.
+                Task { [weak self] in
+                    try? await Task.sleep(for: .seconds(1))
+                    self?.isLoading = false
+                }
+            } catch {
+                isLoading = false
+                deviceProblem = Self.message(for: error)
+            }
+        }
+    }
+
+    func stopDeviceWatch() {
+        gitWatch?.cancel()
+        gitWatch = nil
+    }
+
+    /// Why the device's git pane is empty, when it is empty for a reason. Held
+    /// apart from the list so "no changes" and "not a git repository" cannot
+    /// read as the same thing.
+    @Published private(set) var deviceProblem: String?
+
+    private func deviceWatchInterrupted() {
+        gitWatch = nil
+        guard !resubscribing else { return }
+        Task {
+            // Let the drop settle before the next request reopens the channel.
+            try? await Task.sleep(for: .seconds(1))
+            startDeviceWatch()
+        }
+    }
+
+    /// Applies one `git_changed` delta to the baseline the pane holds.
+    private func apply(_ batch: Termiod.GitChangedPayload) {
+        gitCursor = max(gitCursor ?? 0, batch.seq)
+        for path in batch.removedPaths {
+            deviceStatuses.removeValue(forKey: path)
+        }
+        for entry in batch.updatedStatuses {
+            if let change = GitChange(device: entry) {
+                deviceStatuses[entry.path] = change
+            } else {
+                // Ignored, or a status this build cannot draw: not a row.
+                deviceStatuses.removeValue(forKey: entry.path)
+            }
+        }
+        deviceBranch = batch.branch
+        deviceProblem = nil
+        changes = Self.sorted(Array(deviceStatuses.values))
+        isLoading = false
+    }
+
+    /// Conflicts first — the one status that must be acted on — then by path, so
+    /// siblings cluster the way the file tree shows them. The same order
+    /// `GitService.loadChanges` puts a local list in.
+    private static func sorted(_ changes: [GitChange]) -> [GitChange] {
+        changes.sorted { first, second in
+            if (first.status == .conflicted) != (second.status == .conflicted) {
+                return first.status == .conflicted
+            }
+            return first.path.localizedCaseInsensitiveCompare(second.path) == .orderedAscending
+        }
+    }
+
+    private static func message(for error: Error) -> String {
+        switch error {
+        case DeviceGitError.unsupported:
+            return localized("This device’s termiod is too old to read git.")
+        case TermiodClientError.requestFailed(let detail) where !detail.isEmpty:
+            return detail
+        default:
+            return localized("The device couldn’t read this checkout.")
+        }
+    }
 
     // MARK: Loading
 
@@ -122,6 +257,13 @@ final class GitPanelModel: ObservableObject {
     /// we publish anyway and hand off to a debounced refresh instead of looping here,
     /// so the pane can never livelock (spinning `git status`, `isLoading` stuck on).
     func load() async {
+        // A device checkout is not loaded, it is subscribed to: running `git` here
+        // against a path on another machine would either fail or — worse — answer
+        // about a same-named directory on this one.
+        if device != nil {
+            startDeviceWatch()
+            return
+        }
         if loading {
             loadReentered = true
             loadGeneration += 1   // supersede the in-flight pass's stale snapshot
@@ -154,6 +296,10 @@ final class GitPanelModel: ObservableObject {
     /// Loads the commit history on demand (first time the History tab opens); re-run
     /// with `force` when the git dir reports a change.
     func loadHistory(force: Bool = false) async {
+        // History and Compare are the device's read tier (`git.log`,
+        // `git.branches`), which this pane does not ask for yet — so for a
+        // device checkout their tabs are hidden rather than shown empty.
+        guard device == nil else { return }
         guard force || !didLoadHistory else { return }
         didLoadHistory = true
         isLoadingHistory = commits.isEmpty
@@ -166,6 +312,7 @@ final class GitPanelModel: ObservableObject {
     /// Re-reads the branch and the bases it can be compared against. Cheap enough to run
     /// on every history refresh: three `git` reads of refs, no diff.
     func loadCompareContext() async {
+        guard device == nil else { return }
         compareContext = await GitService.compareContext(in: repoRoot)
     }
 
@@ -217,6 +364,7 @@ final class GitPanelModel: ObservableObject {
     /// git dirs are watched separately because a linked worktree's metadata lives
     /// outside the checkout — see `GitService.watchPaths`.
     private func armWatcher() async {
+        guard device == nil else { return }
         let (tree, gitDirs) = await GitService.watchPaths(for: repoRoot)
         guard watcher == nil, !gitDirs.isEmpty else { return }
         // The primary checkout's `.git` sits inside the tree and needs no second watch.

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -7779,12 +7779,12 @@
         }
       }
     },
-    "first %lld files": {
+    "first %1$lld of %2$lld files": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "前 %lld 个文件"
+            "value": "%2$lld 个文件中的前 %1$lld 个"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -4004,6 +4004,16 @@
         }
       }
     },
+    "No Changes to Show": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可显示的更改"
+          }
+        }
+      }
+    },
     "No Common History": {
       "localizations": {
         "zh-Hans": {
@@ -6588,6 +6598,16 @@
         }
       }
     },
+    "The device couldn’t read this checkout.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该设备无法读取这个检出。"
+          }
+        }
+      }
+    },
     "The devices in your ~/.ssh/config, and the keys that reach them": {
       "localizations": {
         "zh-Hans": {
@@ -6964,6 +6984,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "该设备上的 termiod 版本过旧，无法安装 Agent 集成。"
+          }
+        }
+      }
+    },
+    "This device’s termiod is too old to read git.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该设备上的 termiod 版本过旧，无法读取 git。"
           }
         }
       }

--- a/Sources/termio/Resources/Localizable.xcstrings
+++ b/Sources/termio/Resources/Localizable.xcstrings
@@ -7779,6 +7779,16 @@
         }
       }
     },
+    "first %lld files": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前 %lld 个文件"
+          }
+        }
+      }
+    },
     "git couldn’t check “%@” for changes, so it was not removed.": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1570,6 +1570,8 @@
 	<string>devices</string>
 	<key>e.g. JetBrains Mono</key>
 	<string>e.g. JetBrains Mono</string>
+	<key>first %lld files</key>
+	<string>first %lld files</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git couldn’t check “%@” for changes, so it was not removed.</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -814,6 +814,8 @@
 	<string>No Base Branch</string>
 	<key>No Changes</key>
 	<string>No Changes</string>
+	<key>No Changes to Show</key>
+	<string>No Changes to Show</string>
 	<key>No Common History</key>
 	<string>No Common History</string>
 	<key>No Diff</key>
@@ -1332,6 +1334,8 @@
 	<string>The clone runs on %@ and opens as a project there.</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>The coding agents offered when you start a session</string>
+	<key>The device couldn’t read this checkout.</key>
+	<string>The device couldn’t read this checkout.</string>
 	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>
 	<string>The devices in your ~/.ssh/config, and the keys that reach them</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
@@ -1408,6 +1412,8 @@
 	<string>This device’s termiod is too old to browse files.</string>
 	<key>This device’s termiod is too old to install agent integration.</key>
 	<string>This device’s termiod is too old to install agent integration.</string>
+	<key>This device’s termiod is too old to read git.</key>
+	<string>This device’s termiod is too old to read git.</string>
 	<key>This device’s termiod is too old to report its agents.</key>
 	<string>This device’s termiod is too old to report its agents.</string>
 	<key>This diff is too large to show here — open the file on GitHub.</key>

--- a/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/en.lproj/Localizable.strings
@@ -1570,8 +1570,8 @@
 	<string>devices</string>
 	<key>e.g. JetBrains Mono</key>
 	<string>e.g. JetBrains Mono</string>
-	<key>first %lld files</key>
-	<string>first %lld files</string>
+	<key>first %1$lld of %2$lld files</key>
+	<string>first %1$lld of %2$lld files</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git couldn’t check “%@” for changes, so it was not removed.</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1570,6 +1570,8 @@
 	<string>台设备</string>
 	<key>e.g. JetBrains Mono</key>
 	<string>例如 JetBrains Mono</string>
+	<key>first %lld files</key>
+	<string>前 %lld 个文件</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git 无法检查“%@”是否有更改，因此未将其移除。</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -814,6 +814,8 @@
 	<string>未选择基础分支</string>
 	<key>No Changes</key>
 	<string>没有更改</string>
+	<key>No Changes to Show</key>
+	<string>没有可显示的更改</string>
 	<key>No Common History</key>
 	<string>没有共同历史</string>
 	<key>No Diff</key>
@@ -1332,6 +1334,8 @@
 	<string>克隆在 %@ 上执行，并作为那台机器上的项目打开。</string>
 	<key>The coding agents offered when you start a session</key>
 	<string>新建会话时可以选用的编程 Agent</string>
+	<key>The device couldn’t read this checkout.</key>
+	<string>该设备无法读取这个检出。</string>
 	<key>The devices in your ~/.ssh/config, and the keys that reach them</key>
 	<string>~/.ssh/config 里的设备，以及连上它们的密钥</string>
 	<key>The folder was removed, but git couldn’t prune its stale worktree metadata.</key>
@@ -1408,6 +1412,8 @@
 	<string>该设备上的 termiod 版本过旧，无法浏览文件。</string>
 	<key>This device’s termiod is too old to install agent integration.</key>
 	<string>该设备上的 termiod 版本过旧，无法安装 Agent 集成。</string>
+	<key>This device’s termiod is too old to read git.</key>
+	<string>该设备上的 termiod 版本过旧，无法读取 git。</string>
 	<key>This device’s termiod is too old to report its agents.</key>
 	<string>该设备上的 termiod 版本过旧，无法查询其 Agent。</string>
 	<key>This diff is too large to show here — open the file on GitHub.</key>

--- a/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/termio/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1570,8 +1570,8 @@
 	<string>台设备</string>
 	<key>e.g. JetBrains Mono</key>
 	<string>例如 JetBrains Mono</string>
-	<key>first %lld files</key>
-	<string>前 %lld 个文件</string>
+	<key>first %1$lld of %2$lld files</key>
+	<string>%2$lld 个文件中的前 %1$lld 个</string>
 	<key>git couldn’t check “%@” for changes, so it was not removed.</key>
 	<string>git 无法检查“%@”是否有更改，因此未将其移除。</string>
 	<key>git couldn’t create a worktree for “%@”. Is it a git repository with at least one commit?</key>

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -376,7 +376,7 @@ extension Termiod {
         /// Drops the subscription, and reports whether it was the last one filed
         /// under its resource — the only removal that may tell the device to
         /// retire the watch.
-        fileprivate func unregister(_ subscription: ResourceSubscription) -> Bool {
+        fileprivate func unregister(_ subscription: ObjectIdentifier) -> Bool {
             stateLock.lock()
             defer { stateLock.unlock() }
             lastUsed = .now
@@ -562,7 +562,13 @@ extension Termiod {
     ///
     /// Held by whoever is drawing from it; releasing the last reference drops
     /// the interest on the device, so a pane that goes away cannot leave a watch
-    /// running on someone's box.
+    /// running on someone's box. That is a real guarantee rather than a
+    /// convention: the channel's routing table files subscriptions *weakly*, so
+    /// the owner is the only strong reference and `deinit` is what retires the
+    /// watch. A strong entry there would make the two hold each other up —
+    /// a subscribed channel is never reaped — and the pane's `.onDisappear`
+    /// would be the only thing standing between a released pane and a `git
+    /// status` loop that ran on the box forever.
     final class ResourceSubscription: @unchecked Sendable {
         /// The resource id this subscription is filed under. Starts as the
         /// caller's spelling and is re-keyed to the device's canonical id when
@@ -624,7 +630,7 @@ extension Termiod {
             let currentResource = resource
             lock.unlock()
             guard !alreadyCancelled, let channel else { return }
-            guard channel.unregister(self) else { return }
+            guard channel.unregister(ObjectIdentifier(self)) else { return }
             // Best effort: a channel that is already gone has no watch left to
             // retire, and the device retires an unwatched resource on its own.
             let seq = channel.nextRequestID()
@@ -647,9 +653,20 @@ extension Termiod {
     /// the daemon canonicalises roots and stamps events with the canonical id
     /// only.
     struct ResourceRoutingTable<Subscriber: AnyObject> {
-        private var byResource: [String: [ObjectIdentifier: Subscriber]] = [:]
+        /// Subscribers are held **weakly**. The subscription is owned by
+        /// whoever is drawing from it, and its `deinit` is what retires the
+        /// watch on the device; a strong entry here would keep every
+        /// subscription — and, through `idleDuration`, the channel carrying it
+        /// — alive for as long as the connection did, so a pane released
+        /// without an explicit cancel would leave a `git status` loop running
+        /// on someone's box forever.
+        private struct WeakSubscriber {
+            weak var subscriber: Subscriber?
+        }
+        private var byResource: [String: [ObjectIdentifier: WeakSubscriber]] = [:]
         /// Each subscriber's current key, so unregistering never depends on
-        /// reading mutable state off the subscriber itself.
+        /// reading mutable state off the subscriber itself — and still works
+        /// from `deinit`, where the weak entry above has already been zeroed.
         private var keys: [ObjectIdentifier: String] = [:]
         /// Subscribers whose ack has not come back yet, by the request carrying
         /// them.
@@ -660,7 +677,7 @@ extension Termiod {
         mutating func register(_ subscriber: Subscriber, resource: String, request: UInt64) {
             let id = ObjectIdentifier(subscriber)
             keys[id] = resource
-            byResource[resource, default: [:]][id] = subscriber
+            byResource[resource, default: [:]][id] = WeakSubscriber(subscriber: subscriber)
             pendingAcks[request] = id
         }
 
@@ -674,7 +691,7 @@ extension Termiod {
         mutating func acknowledged(request: UInt64, canonical: String) -> Subscriber? {
             guard let id = pendingAcks.removeValue(forKey: request),
                   let previous = keys[id],
-                  let subscriber = byResource[previous]?[id],
+                  let subscriber = byResource[previous]?[id]?.subscriber,
                   previous != canonical
             else { return nil }
             byResource[previous]?.removeValue(forKey: id)
@@ -682,15 +699,18 @@ extension Termiod {
                 byResource.removeValue(forKey: previous)
             }
             keys[id] = canonical
-            byResource[canonical, default: [:]][id] = subscriber
+            byResource[canonical, default: [:]][id] = WeakSubscriber(subscriber: subscriber)
             return subscriber
         }
 
         /// Drops the subscriber, and reports whether it was the last one filed
         /// under its resource. Unknown subscribers — already swept by
         /// `removeAll` — report false, so a late cancel sends nothing.
-        mutating func unregister(_ subscriber: Subscriber) -> Bool {
-            let id = ObjectIdentifier(subscriber)
+        ///
+        /// Keyed by identity rather than by a strong reference so `deinit` can
+        /// call it: retaining a deinitializing object to pass it here is what
+        /// the identity is for.
+        mutating func unregister(_ id: ObjectIdentifier) -> Bool {
             if let request = pendingAcks.first(where: { $0.value == id })?.key {
                 pendingAcks.removeValue(forKey: request)
             }
@@ -701,8 +721,11 @@ extension Termiod {
             return true
         }
 
+        /// The live subscribers for a resource. A weak entry reads nil only
+        /// between the owner's release and the `deinit` that unregisters it —
+        /// a window an event may land in, and one that is not a listener.
         func listeners(for resource: String) -> [Subscriber] {
-            byResource[resource].map { Array($0.values) } ?? []
+            byResource[resource]?.values.compactMap(\.subscriber) ?? []
         }
 
         mutating func removeAll() -> [Subscriber] {
@@ -711,7 +734,7 @@ extension Termiod {
                 keys = [:]
                 pendingAcks = [:]
             }
-            return byResource.values.flatMap(\.values)
+            return byResource.values.flatMap { $0.values.compactMap(\.subscriber) }
         }
     }
 
@@ -1055,7 +1078,12 @@ extension Termiod {
                     }
                 }
             } catch {
-                _ = channel.unregister(subscription)
+                // `cancel`, not a bare unregister: the request may have reached
+                // a device that armed the watch and only the reply was lost, so
+                // the interest has to be retired over there too — otherwise a
+                // timed-out subscribe leaves a `git status` loop running for a
+                // subscriber that no longer exists.
+                subscription.cancel()
                 guard attempt == 0, reused, !call.hasDelivered, isConnectionLoss(error) else {
                     throw error
                 }

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -243,7 +243,7 @@ extension Termiod {
         /// addressed to a *resource*, not to a request, so it cannot ride an
         /// inbox: the reply that armed the subscription is long finished by the
         /// time the batches arrive.
-        private var subscribers: [String: [ObjectIdentifier: ResourceSubscription]] = [:]
+        private var subscriptions = ResourceRoutingTable<ResourceSubscription>()
         private var nextSeq: UInt64 = 1
         private var dead = false
         private var lastUsed = ContinuousClock.now
@@ -266,7 +266,7 @@ extension Termiod {
         fileprivate var idleDuration: Duration {
             stateLock.lock()
             defer { stateLock.unlock() }
-            guard inboxes.isEmpty, subscribers.isEmpty else { return .zero }
+            guard inboxes.isEmpty, subscriptions.isEmpty else { return .zero }
             return lastUsed.duration(to: .now)
         }
 
@@ -361,24 +361,26 @@ extension Termiod {
             return eventObservers.count
         }
 
-        fileprivate func register(_ subscription: ResourceSubscription) -> Bool {
+        /// Files the subscription under the resource id the caller asked for,
+        /// remembering the request that carries it — the ack to that request is
+        /// what names the canonical id to re-key under.
+        fileprivate func register(_ subscription: ResourceSubscription, request: UInt64) -> Bool {
             stateLock.lock()
             defer { stateLock.unlock() }
             guard !dead else { return false }
-            subscribers[subscription.resource, default: [:]][
-                ObjectIdentifier(subscription)] = subscription
+            subscriptions.register(
+                subscription, resource: subscription.resource, request: request)
             return true
         }
 
-        fileprivate func unregister(_ subscription: ResourceSubscription) {
+        /// Drops the subscription, and reports whether it was the last one filed
+        /// under its resource — the only removal that may tell the device to
+        /// retire the watch.
+        fileprivate func unregister(_ subscription: ResourceSubscription) -> Bool {
             stateLock.lock()
-            subscribers[subscription.resource]?
-                .removeValue(forKey: ObjectIdentifier(subscription))
-            if subscribers[subscription.resource]?.isEmpty == true {
-                subscribers.removeValue(forKey: subscription.resource)
-            }
+            defer { stateLock.unlock() }
             lastUsed = .now
-            stateLock.unlock()
+            return subscriptions.unregister(subscription)
         }
 
         fileprivate func release(_ seq: UInt64) {
@@ -416,8 +418,7 @@ extension Termiod {
             inboxes.removeAll()
             let observers = eventObservers
             eventObservers.removeAll()
-            let orphaned = subscribers.values.flatMap(\.values)
-            subscribers.removeAll()
+            let orphaned = subscriptions.removeAll()
             stateLock.unlock()
             // `dead` is set before this lock is taken, so no further write can
             // start; taking it waits out the one that may already be running.
@@ -454,6 +455,9 @@ extension Termiod {
                         deliverResourceEvent(frame)
                         continue
                     }
+                    if frame.kind == .control {
+                        rekeyOnAcknowledgement(seq, frame.payload)
+                    }
                     stateLock.lock()
                     let inbox = inboxes[seq]
                     stateLock.unlock()
@@ -482,6 +486,29 @@ extension Termiod {
             for observer in observers.values { observer(.event(event)) }
         }
 
+        /// Re-keys a pending subscription under the canonical id the device
+        /// acknowledged. The daemon canonicalises the root (resource.rs
+        /// `resource_id`) and stamps every event with the canonical id, so a
+        /// subscription left under the caller's spelling — a symlinked
+        /// checkout, a trailing slash — would never hear a single event.
+        ///
+        /// Done on the reader thread, not by the caller: the daemon writes the
+        /// ack before any replayed batch, so re-keying here, before the ack is
+        /// even handed to the caller's inbox, means no event carrying the
+        /// canonical id can arrive ahead of the re-key.
+        private func rekeyOnAcknowledgement(_ seq: UInt64, _ payload: Data) {
+            stateLock.lock()
+            let awaited = subscriptions.isAwaiting(request: seq)
+            stateLock.unlock()
+            guard awaited,
+                  case .subscribed(let ack) = try? decodeControl(payload)
+            else { return }
+            stateLock.lock()
+            let rekeyed = subscriptions.acknowledged(request: seq, canonical: ack.resource)
+            stateLock.unlock()
+            rekeyed?.adopt(resource: ack.resource)
+        }
+
         /// Fans one resource event out to whoever subscribed to that resource.
         ///
         /// Run on the reader thread, like the inbox delivery beside it — but a
@@ -495,7 +522,7 @@ extension Termiod {
                   let resource = Self.resourceID(of: frame.payload)
             else { return }
             stateLock.lock()
-            let listeners = subscribers[resource].map { Array($0.values) } ?? []
+            let listeners = subscriptions.listeners(for: resource)
             stateLock.unlock()
             for subscription in listeners { subscription.deliver(frame.payload) }
         }
@@ -537,7 +564,10 @@ extension Termiod {
     /// the interest on the device, so a pane that goes away cannot leave a watch
     /// running on someone's box.
     final class ResourceSubscription: @unchecked Sendable {
-        let resource: String
+        /// The resource id this subscription is filed under. Starts as the
+        /// caller's spelling and is re-keyed to the device's canonical id when
+        /// the ack names one — the id every event carries.
+        private(set) var resource: String
         private let onEvent: @Sendable (Data) -> Void
         /// Fired when the channel underneath dies. The device keeps the resource
         /// and its replay ring for its linger window, so the owner re-subscribes
@@ -575,25 +605,114 @@ extension Termiod {
             onInterrupted()
         }
 
-        /// Drops the interest, and tells the device so it can retire the watch.
+        fileprivate func adopt(resource: String) {
+            lock.lock()
+            self.resource = resource
+            lock.unlock()
+        }
+
+        /// Drops the interest, and tells the device so it can retire the watch —
+        /// but only when this was the channel's last subscription to the
+        /// resource. The daemon tracks interest per *connection*, so an
+        /// unsubscribe sent while another pane still reads the same resource on
+        /// this pooled channel would take that pane's events with it.
         /// Idempotent, and safe on a channel that has already died.
         func cancel() {
             lock.lock()
             let alreadyCancelled = cancelled
             cancelled = true
+            let currentResource = resource
             lock.unlock()
             guard !alreadyCancelled, let channel else { return }
-            channel.unregister(self)
+            guard channel.unregister(self) else { return }
             // Best effort: a channel that is already gone has no watch left to
             // retire, and the device retires an unwatched resource on its own.
             let seq = channel.nextRequestID()
             try? channel.write(
                 kind: .control,
                 payload: encodeControl(
-                    UnsubscribeResourceOperation(resource: resource, seq: seq)))
+                    UnsubscribeResourceOperation(resource: currentResource, seq: seq)))
         }
 
         deinit { cancel() }
+    }
+
+    /// A pooled channel's index of live resource subscriptions: which
+    /// subscribers an event's resource id routes to, and when a removal is the
+    /// last interest in a resource. Pure bookkeeping, kept apart from the
+    /// channel so both decisions stay pinned by tests without a connection.
+    ///
+    /// A subscription is filed under the caller's spelling of the resource
+    /// until the device's ack names the canonical id (`acknowledged`), because
+    /// the daemon canonicalises roots and stamps events with the canonical id
+    /// only.
+    struct ResourceRoutingTable<Subscriber: AnyObject> {
+        private var byResource: [String: [ObjectIdentifier: Subscriber]] = [:]
+        /// Each subscriber's current key, so unregistering never depends on
+        /// reading mutable state off the subscriber itself.
+        private var keys: [ObjectIdentifier: String] = [:]
+        /// Subscribers whose ack has not come back yet, by the request carrying
+        /// them.
+        private var pendingAcks: [UInt64: ObjectIdentifier] = [:]
+
+        var isEmpty: Bool { byResource.isEmpty }
+
+        mutating func register(_ subscriber: Subscriber, resource: String, request: UInt64) {
+            let id = ObjectIdentifier(subscriber)
+            keys[id] = resource
+            byResource[resource, default: [:]][id] = subscriber
+            pendingAcks[request] = id
+        }
+
+        func isAwaiting(request: UInt64) -> Bool {
+            pendingAcks[request] != nil
+        }
+
+        /// Re-keys the subscriber awaiting `request` under the canonical id,
+        /// returning it so the caller can update the subscriber's own label —
+        /// or nil when nothing needed to move.
+        mutating func acknowledged(request: UInt64, canonical: String) -> Subscriber? {
+            guard let id = pendingAcks.removeValue(forKey: request),
+                  let previous = keys[id],
+                  let subscriber = byResource[previous]?[id],
+                  previous != canonical
+            else { return nil }
+            byResource[previous]?.removeValue(forKey: id)
+            if byResource[previous]?.isEmpty == true {
+                byResource.removeValue(forKey: previous)
+            }
+            keys[id] = canonical
+            byResource[canonical, default: [:]][id] = subscriber
+            return subscriber
+        }
+
+        /// Drops the subscriber, and reports whether it was the last one filed
+        /// under its resource. Unknown subscribers — already swept by
+        /// `removeAll` — report false, so a late cancel sends nothing.
+        mutating func unregister(_ subscriber: Subscriber) -> Bool {
+            let id = ObjectIdentifier(subscriber)
+            if let request = pendingAcks.first(where: { $0.value == id })?.key {
+                pendingAcks.removeValue(forKey: request)
+            }
+            guard let key = keys.removeValue(forKey: id) else { return false }
+            byResource[key]?.removeValue(forKey: id)
+            guard byResource[key]?.isEmpty == true else { return false }
+            byResource.removeValue(forKey: key)
+            return true
+        }
+
+        func listeners(for resource: String) -> [Subscriber] {
+            byResource[resource].map { Array($0.values) } ?? []
+        }
+
+        mutating func removeAll() -> [Subscriber] {
+            defer {
+                byResource = [:]
+                keys = [:]
+                pendingAcks = [:]
+            }
+            return byResource.values.flatMap(\.values)
+        }
     }
 
     /// The channels themselves, keyed by the device they reach and what they
@@ -907,7 +1026,12 @@ extension Termiod {
             let subscription = ResourceSubscription(
                 resource: resource, channel: channel,
                 onEvent: onEvent, onInterrupted: onInterrupted)
-            guard channel.register(subscription), let call = channel.begin() else {
+            guard let call = channel.begin() else {
+                stale = channel
+                continue
+            }
+            guard channel.register(subscription, request: call.seq) else {
+                call.finish()
                 stale = channel
                 continue
             }
@@ -931,7 +1055,7 @@ extension Termiod {
                     }
                 }
             } catch {
-                channel.unregister(subscription)
+                _ = channel.unregister(subscription)
                 guard attempt == 0, reused, !call.hasDelivered, isConnectionLoss(error) else {
                     throw error
                 }

--- a/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodControlPool.swift
@@ -239,6 +239,11 @@ extension Termiod {
         /// request on it, which is why they need a second delivery path rather
         /// than a long-lived fake request.
         private var eventObservers: [UUID: ChannelObserver] = [:]
+        /// Live resource subscriptions, by resource id. A `fs:`/`git:` event is
+        /// addressed to a *resource*, not to a request, so it cannot ride an
+        /// inbox: the reply that armed the subscription is long finished by the
+        /// time the batches arrive.
+        private var subscribers: [String: [ObjectIdentifier: ResourceSubscription]] = [:]
         private var nextSeq: UInt64 = 1
         private var dead = false
         private var lastUsed = ContinuousClock.now
@@ -253,10 +258,16 @@ extension Termiod {
             return dead
         }
 
+        /// A channel is idle only when nothing is riding it. A subscription is
+        /// riding it — that is the whole point of holding the connection — so a
+        /// subscribed channel is never reaped, however long since its last
+        /// request. Hanging one up would silently stop the updates the pane is
+        /// drawing from, which reads as "the device stopped changing".
         fileprivate var idleDuration: Duration {
             stateLock.lock()
             defer { stateLock.unlock() }
-            return inboxes.isEmpty ? lastUsed.duration(to: .now) : .zero
+            guard inboxes.isEmpty, subscribers.isEmpty else { return .zero }
+            return lastUsed.duration(to: .now)
         }
 
         fileprivate init(route: TermiodRoute, caps: [String]) throws {
@@ -350,6 +361,26 @@ extension Termiod {
             return eventObservers.count
         }
 
+        fileprivate func register(_ subscription: ResourceSubscription) -> Bool {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            guard !dead else { return false }
+            subscribers[subscription.resource, default: [:]][
+                ObjectIdentifier(subscription)] = subscription
+            return true
+        }
+
+        fileprivate func unregister(_ subscription: ResourceSubscription) {
+            stateLock.lock()
+            subscribers[subscription.resource]?
+                .removeValue(forKey: ObjectIdentifier(subscription))
+            if subscribers[subscription.resource]?.isEmpty == true {
+                subscribers.removeValue(forKey: subscription.resource)
+            }
+            lastUsed = .now
+            stateLock.unlock()
+        }
+
         fileprivate func release(_ seq: UInt64) {
             stateLock.lock()
             inboxes.removeValue(forKey: seq)
@@ -385,6 +416,8 @@ extension Termiod {
             inboxes.removeAll()
             let observers = eventObservers
             eventObservers.removeAll()
+            let orphaned = subscribers.values.flatMap(\.values)
+            subscribers.removeAll()
             stateLock.unlock()
             // `dead` is set before this lock is taken, so no further write can
             // start; taking it waits out the one that may already be running.
@@ -398,6 +431,9 @@ extension Termiod {
             // cannot land on this same corpse: `dead` is already set, so its
             // request for a channel opens a fresh one.
             for observer in observers.values { observer(.closed) }
+            // The device keeps the resource and its replay ring, so a subscriber
+            // told the pipe died can resume from its cursor rather than rebuild.
+            for subscription in orphaned { subscription.interrupted() }
         }
 
         /// Dedicated blocking-read thread, the same shape a session link uses:
@@ -415,6 +451,7 @@ extension Termiod {
                     }
                     guard let seq = Self.requestID(of: frame) else {
                         deliverUnaddressed(frame)
+                        deliverResourceEvent(frame)
                         continue
                     }
                     stateLock.lock()
@@ -445,6 +482,32 @@ extension Termiod {
             for observer in observers.values { observer(.event(event)) }
         }
 
+        /// Fans one resource event out to whoever subscribed to that resource.
+        ///
+        /// Run on the reader thread, like the inbox delivery beside it — but a
+        /// subscriber's handler *is* caller code, which the inbox path
+        /// deliberately never runs. So a handler must do nothing but hand the
+        /// payload on; the two consumers here hop to the main actor immediately.
+        /// The alternative, a queue per subscription, buys nothing while that
+        /// holds and costs a hop on every batch.
+        private func deliverResourceEvent(_ frame: (kind: FrameKind, payload: Data)) {
+            guard frame.kind == .event,
+                  let resource = Self.resourceID(of: frame.payload)
+            else { return }
+            stateLock.lock()
+            let listeners = subscribers[resource].map { Array($0.values) } ?? []
+            stateLock.unlock()
+            for subscription in listeners { subscription.deliver(frame.payload) }
+        }
+
+        /// The resource a `fs_changed` / `git_changed` event belongs to. Decoded
+        /// off the one field they share rather than through the event enum, so a
+        /// resource kind this build has never heard of still routes.
+        private static func resourceID(of payload: Data) -> String? {
+            struct Tagged: Decodable { let resource: String? }
+            return (try? JSONDecoder().decode(Tagged.self, from: payload))?.resource
+        }
+
         /// Which request a frame answers, or `nil` for one that answers nobody.
         ///
         /// Three shapes, because the protocol has three: a control reply carries
@@ -466,6 +529,71 @@ extension Termiod {
                 return nil
             }
         }
+    }
+
+    /// A live subscription to one device resource (`fs:<root>`, `git:<root>`).
+    ///
+    /// Held by whoever is drawing from it; releasing the last reference drops
+    /// the interest on the device, so a pane that goes away cannot leave a watch
+    /// running on someone's box.
+    final class ResourceSubscription: @unchecked Sendable {
+        let resource: String
+        private let onEvent: @Sendable (Data) -> Void
+        /// Fired when the channel underneath dies. The device keeps the resource
+        /// and its replay ring for its linger window, so the owner re-subscribes
+        /// with the last `seq` it applied rather than rebuilding from nothing.
+        private let onInterrupted: @Sendable () -> Void
+        private weak var channel: PooledChannel?
+        private let lock = NSLock()
+        private var cancelled = false
+
+        fileprivate init(
+            resource: String,
+            channel: PooledChannel,
+            onEvent: @escaping @Sendable (Data) -> Void,
+            onInterrupted: @escaping @Sendable () -> Void
+        ) {
+            self.resource = resource
+            self.channel = channel
+            self.onEvent = onEvent
+            self.onInterrupted = onInterrupted
+        }
+
+        fileprivate func deliver(_ payload: Data) {
+            lock.lock()
+            let stopped = cancelled
+            lock.unlock()
+            guard !stopped else { return }
+            onEvent(payload)
+        }
+
+        fileprivate func interrupted() {
+            lock.lock()
+            let stopped = cancelled
+            lock.unlock()
+            guard !stopped else { return }
+            onInterrupted()
+        }
+
+        /// Drops the interest, and tells the device so it can retire the watch.
+        /// Idempotent, and safe on a channel that has already died.
+        func cancel() {
+            lock.lock()
+            let alreadyCancelled = cancelled
+            cancelled = true
+            lock.unlock()
+            guard !alreadyCancelled, let channel else { return }
+            channel.unregister(self)
+            // Best effort: a channel that is already gone has no watch left to
+            // retire, and the device retires an unwatched resource on its own.
+            let seq = channel.nextRequestID()
+            try? channel.write(
+                kind: .control,
+                payload: encodeControl(
+                    UnsubscribeResourceOperation(resource: resource, seq: seq)))
+        }
+
+        deinit { cancel() }
     }
 
     /// The channels themselves, keyed by the device they reach and what they
@@ -747,6 +875,66 @@ extension Termiod {
                 pooled \(caps.joined(separator: ","), privacy: .public) channel to \
                 \(route.description, privacy: .public) was stale; reconnecting
                 """)
+                stale = channel
+            }
+        }
+        throw TermiodClientError.connectionClosed
+    }
+
+    /// Subscribes to a device resource over the pooled channel, and returns once
+    /// the device has acknowledged.
+    ///
+    /// The handler is registered *before* the request goes out, because the
+    /// first batch can arrive before the ack is read — measured at 2 ms behind
+    /// it against a real device. Registering after would drop the baseline and
+    /// leave the pane empty until something next changed.
+    ///
+    /// `since` resumes an interrupted subscription from the last `seq` applied;
+    /// the reply's `gap` says whether the device could replay from there.
+    ///
+    /// Blocking; call it off the main thread.
+    static func subscribeResource(
+        route: TermiodRoute,
+        caps: [String],
+        resource: String,
+        since: UInt64? = nil,
+        onEvent: @escaping @Sendable (Data) -> Void,
+        onInterrupted: @escaping @Sendable () -> Void = {}
+    ) throws -> (subscription: ResourceSubscription, gap: Bool, seq: UInt64) {
+        var stale: PooledChannel?
+        for attempt in 0 ... 1 {
+            let channel = try ControlPool.channel(route: route, caps: caps, discarding: stale)
+            let subscription = ResourceSubscription(
+                resource: resource, channel: channel,
+                onEvent: onEvent, onInterrupted: onInterrupted)
+            guard channel.register(subscription), let call = channel.begin() else {
+                stale = channel
+                continue
+            }
+            let reused = call.wasReused
+            defer { call.finish() }
+            do {
+                try call.send(payload: encodeControl(SubscribeResourceOperation(
+                    resource: resource, since: since, seq: call.seq)))
+                while true {
+                    let frame = try call.next(
+                        timeoutSeconds: connectTimeoutSeconds,
+                        operation: "subscribe \(resource)")
+                    guard frame.kind == .control else { continue }
+                    switch try decodeControl(frame.payload) {
+                    case .subscribed(let ack):
+                        return (subscription, ack.gap, ack.seq)
+                    case .error(let failure):
+                        throw TermiodClientError.requestFailed(failure.message)
+                    default:
+                        continue
+                    }
+                }
+            } catch {
+                channel.unregister(subscription)
+                guard attempt == 0, reused, !call.hasDelivered, isConnectionLoss(error) else {
+                    throw error
+                }
                 stale = channel
             }
         }

--- a/Sources/termio/Terminal/Termiod/TermiodGit.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodGit.swift
@@ -38,9 +38,10 @@ extension Termiod {
         let ahead: Int
         let behind: Int
         let conflicts: [String]
-        /// The device cut the status list at its cap (`git.rs` `STATUS_CAP`),
-        /// so what arrived is the head of the list and not the whole of it.
-        let truncated: Bool
+        /// How many paths the device's status run named, when it cut the list
+        /// below that (`git.rs` `STATUS_CAP`) — so the pane can say how much
+        /// of it is missing, not merely that some is.
+        let total: Int?
     }
 
     /// One changed path. The two-axis `status` is the porcelain-v2 vocabulary
@@ -178,11 +179,11 @@ extension Termiod {
         let head: String?
         let aheadBehind: [Int]?
         let conflicts: [String]
-        let truncated: Bool
+        let total: Int?
 
         private enum CodingKeys: String, CodingKey {
             case seq, updatedStatuses, removedPaths, branch, head, aheadBehind, conflicts
-            case truncated
+            case total
         }
 
         init(from decoder: Decoder) throws {
@@ -196,7 +197,7 @@ extension Termiod {
             head = try container.decodeIfPresent(String.self, forKey: .head)
             aheadBehind = try container.decodeIfPresent([Int].self, forKey: .aheadBehind)
             conflicts = try container.decodeIfPresent([String].self, forKey: .conflicts) ?? []
-            truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+            total = try container.decodeIfPresent(Int.self, forKey: .total)
         }
 
         var payload: GitChangedPayload {
@@ -209,7 +210,7 @@ extension Termiod {
                 ahead: aheadBehind?.first ?? 0,
                 behind: aheadBehind?.dropFirst().first ?? 0,
                 conflicts: conflicts,
-                truncated: truncated)
+                total: total)
         }
     }
 

--- a/Sources/termio/Terminal/Termiod/TermiodGit.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodGit.swift
@@ -1,0 +1,293 @@
+import TermioShared
+import Foundation
+
+/// The git plane: reading a device's checkout through the `git:` resource and
+/// the `git.*` verbs (`termiod/src/git.rs`).
+///
+/// Status is a **subscription**, not a poll. The device already watches the
+/// workspace, so it knows when status moved and the client does not have to ask;
+/// what arrives is a delta against what the subscriber holds. Zed publishes the
+/// same object under a different name (`UpdateRepository`: `updated_statuses`,
+/// `removed_statuses`, `branch_summary`), and VS Code arrives at it from the
+/// other side by running the git extension itself on the remote. A client that
+/// polled would be the only one of the three doing so.
+///
+/// Everything here reads. Stage, commit, discard and push are a separate tier
+/// that needs the prompt-forwarding channel (`docs/rfcs/remote-git-plane.md` §3)
+/// and are deliberately absent — a remote checkout's Changes pane offers no
+/// action it cannot honestly perform.
+extension Termiod {
+    /// What a git channel negotiates. The pool keys channels by capability set,
+    /// so this is also what decides whether the Changes pane shares a connection
+    /// with the file tree or gets its own — deliberately its own, because the
+    /// tree's `["files"]` channel could not answer a `git` verb and handing it
+    /// one would hang on a reply the daemon will never send.
+    static let gitCapabilities = ["resources", "git"]
+
+    /// The `git:` resource id for a checkout — `resource.rs` `GIT_PREFIX`.
+    static func gitResource(root: String) -> String { "git:\(root)" }
+
+    /// One `git_changed` batch: a delta against the subscriber's baseline, with
+    /// branch metadata carried whole so a client never merges it.
+    struct GitChangedPayload: Sendable {
+        let seq: UInt64
+        let updatedStatuses: [GitStatusEntryPayload]
+        let removedPaths: [String]
+        let branch: String?
+        let head: String?
+        let ahead: Int
+        let behind: Int
+        let conflicts: [String]
+    }
+
+    /// One changed path. The two-axis `status` is the porcelain-v2 vocabulary
+    /// the device and the Mac's own parser both speak, so the pane's row reads
+    /// the same either way.
+    struct GitStatusEntryPayload: Sendable {
+        let path: String
+        let status: WireGitStatus
+        let originalPath: String?
+        let additions: Int
+        let deletions: Int
+        let binary: Bool
+    }
+
+    /// `git.rs`'s `GitFileStatus`, as it arrives. Kept as the wire's own shape
+    /// rather than flattened on decode: which axis moved is what says whether a
+    /// change is staged, and collapsing that here would throw it away.
+    enum WireGitStatus: Sendable {
+        case untracked
+        case ignored
+        case tracked(index: String, worktree: String)
+        case unmerged
+        /// A status this build has never heard of. Additive evolution applies to
+        /// the *batch* — one unreadable row must not sink the list — but not to
+        /// the row itself, which is dropped rather than drawn as a guess.
+        case unknown
+    }
+
+    static func decodeGitChanged(_ payload: Data) throws -> GitChangedPayload {
+        try gitDecoder().decode(WireGitChanged.self, from: payload).payload
+    }
+
+    /// The unified diff for one path, rendered client-side.
+    ///
+    /// `staged` is a hint about where the change lives; the device walks the
+    /// same ladder the Mac's local path does either way, so an untracked file
+    /// and a fully-staged one both answer. `context` is the `-U`: the overlay
+    /// asks for the whole file so it can fold unchanged runs into expandable
+    /// bands, which git's default three lines cannot support.
+    static func gitDiff(
+        route: TermiodRoute, root: String, path: String, staged: Bool, context: Int? = nil
+    ) async throws -> (text: String, truncated: Bool) {
+        try await offMain {
+            try withPooledRequest(route: route, caps: gitCapabilities) { call, channel in
+                guard channel.capabilities.contains("git") else {
+                    throw DeviceGitError.unsupported
+                }
+                try call.send(payload: encodeControl(GitDiffOperation(
+                    root: root, path: path, staged: staged,
+                    context: context.map(UInt64.init), seq: call.seq)))
+                while true {
+                    let frame = try call.next(
+                        timeoutSeconds: connectTimeoutSeconds, operation: "git diff \(path)")
+                    guard frame.kind == .control else { continue }
+                    let reply = try decodeControl(frame.payload)
+                    if case .error(let failure) = reply {
+                        throw TermiodClientError.requestFailed(failure.message)
+                    }
+                    guard case .unknown = reply else { continue }
+                    // `git_diff_result` is not in the shared decode table: it is
+                    // this plane's own reply and nothing else consumes it, so it
+                    // is decoded here rather than grown into an enum every other
+                    // channel would carry.
+                    let result = try gitDecoder().decode(GitDiffResult.self, from: frame.payload)
+                    return (result.diff, result.truncated)
+                }
+            }
+        }
+    }
+
+    /// Runs a blocking pooled request off the main thread. Every verb here is
+    /// blocking by construction — the pool hands out a frame reader, not a
+    /// future — and the panes calling them are on the main actor.
+    private static func offMain<Value: Sendable>(
+        _ body: @escaping @Sendable () throws -> Value
+    ) async throws -> Value {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(with: Result { try body() })
+            }
+        }
+    }
+
+    /// Subscribes to the checkout's status. The first batch is the whole state
+    /// — the device synthesizes it for a subscriber with no cursor — so the
+    /// caller starts from empty and applies what arrives.
+    static func watchGit(
+        route: TermiodRoute,
+        root: String,
+        since: UInt64? = nil,
+        onBatch: @escaping @Sendable (GitChangedPayload) -> Void,
+        onInterrupted: @escaping @Sendable () -> Void
+    ) async throws -> (subscription: ResourceSubscription, gap: Bool, seq: UInt64) {
+        try await offMain {
+            try subscribeResource(
+                route: route,
+                caps: gitCapabilities,
+                resource: gitResource(root: root),
+                since: since,
+                onEvent: { payload in
+                    guard let batch = try? decodeGitChanged(payload) else { return }
+                    onBatch(batch)
+                },
+                onInterrupted: onInterrupted)
+        }
+    }
+
+    private struct GitDiffOperation: Encodable {
+        let op = "git_diff"
+        let root: String
+        let path: String
+        let staged: Bool
+        let context: UInt64?
+        let seq: UInt64
+    }
+
+    private struct GitDiffResult: Decodable {
+        let diff: String
+        let truncated: Bool
+
+        private enum CodingKeys: String, CodingKey { case diff, truncated }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            diff = try container.decodeIfPresent(String.self, forKey: .diff) ?? ""
+            truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+        }
+    }
+
+    private struct WireGitChanged: Decodable {
+        let seq: UInt64
+        let updatedStatuses: [WireStatusEntry]
+        let removedPaths: [String]
+        let branch: String?
+        let head: String?
+        let aheadBehind: [Int]?
+        let conflicts: [String]
+
+        private enum CodingKeys: String, CodingKey {
+            case seq, updatedStatuses, removedPaths, branch, head, aheadBehind, conflicts
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            seq = try container.decodeIfPresent(UInt64.self, forKey: .seq) ?? 0
+            updatedStatuses = try container.decodeIfPresent(
+                [WireStatusEntry].self, forKey: .updatedStatuses) ?? []
+            removedPaths = try container.decodeIfPresent(
+                [String].self, forKey: .removedPaths) ?? []
+            branch = try container.decodeIfPresent(String.self, forKey: .branch)
+            head = try container.decodeIfPresent(String.self, forKey: .head)
+            aheadBehind = try container.decodeIfPresent([Int].self, forKey: .aheadBehind)
+            conflicts = try container.decodeIfPresent([String].self, forKey: .conflicts) ?? []
+        }
+
+        var payload: GitChangedPayload {
+            GitChangedPayload(
+                seq: seq,
+                updatedStatuses: updatedStatuses.map(\.payload),
+                removedPaths: removedPaths,
+                branch: branch,
+                head: head,
+                ahead: aheadBehind?.first ?? 0,
+                behind: aheadBehind?.dropFirst().first ?? 0,
+                conflicts: conflicts)
+        }
+    }
+
+    private struct WireStatusEntry: Decodable {
+        let path: String
+        let status: WireStatusValue
+        let originalPath: String?
+        let additions: Int
+        let deletions: Int
+        let binary: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case path, status, originalPath, additions, deletions, binary
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            path = try container.decode(String.self, forKey: .path)
+            status = try container.decode(WireStatusValue.self, forKey: .status)
+            originalPath = try container.decodeIfPresent(String.self, forKey: .originalPath)
+            additions = try container.decodeIfPresent(Int.self, forKey: .additions) ?? 0
+            deletions = try container.decodeIfPresent(Int.self, forKey: .deletions) ?? 0
+            binary = try container.decodeIfPresent(Bool.self, forKey: .binary) ?? false
+        }
+
+        var payload: GitStatusEntryPayload {
+            GitStatusEntryPayload(
+                path: path, status: status.status, originalPath: originalPath,
+                additions: additions, deletions: deletions, binary: binary)
+        }
+    }
+
+    /// Serde's externally-tagged enum: `"untracked"` for a unit case, and
+    /// `{"tracked": {...}}` for one with fields. Decoded by hand because the two
+    /// shapes are a string and an object, which no synthesized initializer will
+    /// accept as one type.
+    private struct WireStatusValue: Decodable {
+        let status: WireGitStatus
+
+        init(from decoder: Decoder) throws {
+            if let single = try? decoder.singleValueContainer(),
+               let name = try? single.decode(String.self) {
+                switch name {
+                case "untracked": status = .untracked
+                case "ignored": status = .ignored
+                default: status = .unknown
+                }
+                return
+            }
+            guard let container = try? decoder.container(keyedBy: Key.self) else {
+                status = .unknown
+                return
+            }
+            if let tracked = try? container.decode(
+                TrackedAxes.self, forKey: Key(stringValue: "tracked")) {
+                status = .tracked(index: tracked.indexStatus, worktree: tracked.worktreeStatus)
+            } else if container.contains(Key(stringValue: "unmerged")) {
+                status = .unmerged
+            } else {
+                status = .unknown
+            }
+        }
+
+        private struct TrackedAxes: Decodable {
+            let indexStatus: String
+            let worktreeStatus: String
+        }
+
+        private struct Key: CodingKey {
+            var stringValue: String
+            var intValue: Int? { nil }
+            init(stringValue: String) { self.stringValue = stringValue }
+            init?(intValue: Int) { return nil }
+        }
+    }
+
+    private static func gitDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }
+}
+
+/// What can go wrong reading a device's git, in the pane's vocabulary.
+enum DeviceGitError: Error, Equatable {
+    /// The daemon did not grant `git` — too old, or built without it.
+    case unsupported
+}

--- a/Sources/termio/Terminal/Termiod/TermiodGit.swift
+++ b/Sources/termio/Terminal/Termiod/TermiodGit.swift
@@ -38,6 +38,9 @@ extension Termiod {
         let ahead: Int
         let behind: Int
         let conflicts: [String]
+        /// The device cut the status list at its cap (`git.rs` `STATUS_CAP`),
+        /// so what arrived is the head of the list and not the whole of it.
+        let truncated: Bool
     }
 
     /// One changed path. The two-axis `status` is the porcelain-v2 vocabulary
@@ -175,9 +178,11 @@ extension Termiod {
         let head: String?
         let aheadBehind: [Int]?
         let conflicts: [String]
+        let truncated: Bool
 
         private enum CodingKeys: String, CodingKey {
             case seq, updatedStatuses, removedPaths, branch, head, aheadBehind, conflicts
+            case truncated
         }
 
         init(from decoder: Decoder) throws {
@@ -191,6 +196,7 @@ extension Termiod {
             head = try container.decodeIfPresent(String.self, forKey: .head)
             aheadBehind = try container.decodeIfPresent([Int].self, forKey: .aheadBehind)
             conflicts = try container.decodeIfPresent([String].self, forKey: .conflicts) ?? []
+            truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
         }
 
         var payload: GitChangedPayload {
@@ -202,7 +208,8 @@ extension Termiod {
                 head: head,
                 ahead: aheadBehind?.first ?? 0,
                 behind: aheadBehind?.dropFirst().first ?? 0,
-                conflicts: conflicts)
+                conflicts: conflicts,
+                truncated: truncated)
         }
     }
 

--- a/Tests/termioTests/DeviceGitStatusTests.swift
+++ b/Tests/termioTests/DeviceGitStatusTests.swift
@@ -1,0 +1,134 @@
+import TermioShared
+import XCTest
+@testable import termio
+
+/// The device's `git_changed` batch, decoded into the rows the Changes pane
+/// draws.
+///
+/// This is the seam where a remote pane could silently lie: the wire carries the
+/// two-axis porcelain-v2 status, and the row shows one letter, a `+N −M`, and a
+/// staged dot. Get the collapse wrong and the pane looks plausible and says the
+/// wrong thing about someone's working tree. The fixtures below are what
+/// `termiod/src/git.rs` actually serializes.
+final class DeviceGitStatusTests: XCTestCase {
+    private func batch(_ json: String) throws -> Termiod.GitChangedPayload {
+        try Termiod.decodeGitChanged(Data(json.utf8))
+    }
+
+    func testATrackedWorktreeEditReadsAsModified() throws {
+        let payload = try batch("""
+        {"ev":"git_changed","resource":"git:/repo","seq":3,"updated_statuses":[
+          {"path":"src/main.rs",
+           "status":{"tracked":{"index_status":"unmodified","worktree_status":"modified"}},
+           "additions":12,"deletions":3}
+        ]}
+        """)
+        let change = try XCTUnwrap(GitChange(device: payload.updatedStatuses[0]))
+        XCTAssertEqual(change.path, "src/main.rs")
+        XCTAssertEqual(change.status, .modified)
+        XCTAssertEqual(change.additions, 12)
+        XCTAssertEqual(change.deletions, 3)
+        XCTAssertFalse(change.isStaged, "the worktree still holds the edit")
+        XCTAssertFalse(change.isUntracked)
+    }
+
+    /// The dot on the row means "a `git commit` in the terminal would take this
+    /// file". That is exactly index-moved and worktree-clean, and nothing else.
+    func testOnlyAnIndexOnlyChangeCountsAsStaged() throws {
+        let payload = try batch("""
+        {"ev":"git_changed","seq":1,"updated_statuses":[
+          {"path":"staged.rs",
+           "status":{"tracked":{"index_status":"modified","worktree_status":"unmodified"}}},
+          {"path":"both.rs",
+           "status":{"tracked":{"index_status":"modified","worktree_status":"modified"}}}
+        ]}
+        """)
+        let staged = try XCTUnwrap(GitChange(device: payload.updatedStatuses[0]))
+        let both = try XCTUnwrap(GitChange(device: payload.updatedStatuses[1]))
+        XCTAssertTrue(staged.isStaged)
+        XCTAssertFalse(both.isStaged, "a file with more in the worktree is not staged")
+    }
+
+    /// The worktree axis wins when it moved — a file added to the index and then
+    /// deleted on disk is a deletion, which is what the letter has to say.
+    func testTheWorktreeAxisWinsWhenItMoved() throws {
+        let payload = try batch("""
+        {"ev":"git_changed","seq":1,"updated_statuses":[
+          {"path":"gone.rs",
+           "status":{"tracked":{"index_status":"added","worktree_status":"deleted"}}}
+        ]}
+        """)
+        let change = try XCTUnwrap(GitChange(device: payload.updatedStatuses[0]))
+        XCTAssertEqual(change.status, .deleted)
+    }
+
+    func testUntrackedAndConflictedAndRenamedSurvive() throws {
+        let payload = try batch("""
+        {"ev":"git_changed","seq":1,"updated_statuses":[
+          {"path":"fresh.txt","status":"untracked","additions":4},
+          {"path":"clash.rs","status":{"unmerged":{"first_head":"updated","second_head":"updated"}}},
+          {"path":"new-name.rs","original_path":"old-name.rs",
+           "status":{"tracked":{"index_status":"renamed","worktree_status":"unmodified"}}}
+        ]}
+        """)
+        let fresh = try XCTUnwrap(GitChange(device: payload.updatedStatuses[0]))
+        XCTAssertEqual(fresh.status, .untracked)
+        XCTAssertTrue(fresh.isUntracked)
+        XCTAssertEqual(fresh.additions, 4)
+
+        let clash = try XCTUnwrap(GitChange(device: payload.updatedStatuses[1]))
+        XCTAssertEqual(clash.status, .conflicted)
+
+        let renamed = try XCTUnwrap(GitChange(device: payload.updatedStatuses[2]))
+        XCTAssertEqual(renamed.status, .renamed)
+        XCTAssertEqual(renamed.originalPath, "old-name.rs",
+                       "the row's `old → new` tooltip needs where it came from")
+    }
+
+    /// An ignored file is not a row — the local parser drops `!` records for the
+    /// same reason — and neither is a status this build has never heard of. A
+    /// guess would be drawn as fact.
+    func testIgnoredAndUnknownStatusesAreNotRows() throws {
+        let payload = try batch("""
+        {"ev":"git_changed","seq":1,"updated_statuses":[
+          {"path":"target/debug","status":"ignored"},
+          {"path":"future.rs","status":"teleported"}
+        ]}
+        """)
+        XCTAssertNil(GitChange(device: payload.updatedStatuses[0]))
+        XCTAssertNil(GitChange(device: payload.updatedStatuses[1]))
+    }
+
+    /// One unreadable row must not sink the batch: the rest of the list, the
+    /// branch, and the removals still have to arrive.
+    func testTheRestOfABatchSurvivesAnUnreadableRow() throws {
+        let payload = try batch("""
+        {"ev":"git_changed","seq":9,"updated_statuses":[
+          {"path":"future.rs","status":"teleported"},
+          {"path":"real.rs","status":{"tracked":{"index_status":"unmodified","worktree_status":"modified"}}}
+        ],"removed_paths":["fixed.rs"],"branch":"main","head":"abc123","ahead_behind":[2,1],
+        "conflicts":["clash.rs"]}
+        """)
+        XCTAssertEqual(payload.seq, 9)
+        XCTAssertEqual(payload.branch, "main")
+        XCTAssertEqual(payload.ahead, 2)
+        XCTAssertEqual(payload.behind, 1)
+        XCTAssertEqual(payload.removedPaths, ["fixed.rs"])
+        XCTAssertEqual(payload.conflicts, ["clash.rs"])
+        XCTAssertNotNil(GitChange(device: payload.updatedStatuses[1]))
+    }
+
+    /// Counts are left off the wire when they are zero, and a binary file has no
+    /// numbers at all rather than `+0 −0`.
+    func testAbsentCountsAreZeroAndBinaryIsCarried() throws {
+        let payload = try batch("""
+        {"ev":"git_changed","seq":1,"updated_statuses":[
+          {"path":"blob.bin","status":"untracked","binary":true}
+        ]}
+        """)
+        let change = try XCTUnwrap(GitChange(device: payload.updatedStatuses[0]))
+        XCTAssertTrue(change.isBinary)
+        XCTAssertEqual(change.additions, 0)
+        XCTAssertEqual(change.deletions, 0)
+    }
+}

--- a/Tests/termioTests/DeviceGitWatchTests.swift
+++ b/Tests/termioTests/DeviceGitWatchTests.swift
@@ -58,6 +58,31 @@ final class DeviceGitWatchTests: XCTestCase {
         XCTAssertNil(ledger.settle(generation: old))
     }
 
+    func testAnInterruptedRetryCannotOutliveAStoppedWatch() {
+        var ledger = DeviceWatchLedger()
+        let interrupted = ledger.begin()
+        ledger.stop()
+
+        XCTAssertFalse(ledger.isCurrent(interrupted))
+    }
+
+    func testAStartDuringAnOldHandshakeRequestsAReplacementWatch() {
+        var ledger = DeviceWatchLedger()
+        let old = ledger.begin()
+        ledger.stop()
+
+        // `startDeviceWatch()` cannot open another subscription until the old
+        // async call leaves its defer, so it invalidates the old one and asks
+        // that cleanup to begin the visible pane's replacement.
+        ledger.requestRestart()
+        XCTAssertNil(ledger.settle(generation: old))
+        XCTAssertTrue(ledger.consumeRestartRequest())
+        XCTAssertFalse(ledger.consumeRestartRequest())
+
+        let replacement = ledger.begin()
+        XCTAssertNotNil(ledger.settle(generation: replacement))
+    }
+
     // MARK: - ResourceRoutingTable
 
     private final class Subscriber {}

--- a/Tests/termioTests/DeviceGitWatchTests.swift
+++ b/Tests/termioTests/DeviceGitWatchTests.swift
@@ -9,10 +9,11 @@ import TermioShared
 /// subscriber.
 final class DeviceGitWatchTests: XCTestCase {
 
-    private func batch(seq: UInt64) -> Termiod.GitChangedPayload {
+    private func batch(seq: UInt64, truncated: Bool = false) -> Termiod.GitChangedPayload {
         Termiod.GitChangedPayload(
             seq: seq, updatedStatuses: [], removedPaths: [],
-            branch: nil, head: nil, ahead: 0, behind: 0, conflicts: [])
+            branch: nil, head: nil, ahead: 0, behind: 0, conflicts: [],
+            truncated: truncated)
     }
 
     // MARK: - DeviceWatchLedger
@@ -91,8 +92,8 @@ final class DeviceGitWatchTests: XCTestCase {
         table.register(second, resource: "git:/repo", request: 2)
         // The daemon tracks interest per connection: an unsubscribe sent while
         // the second pane still reads would take its events too.
-        XCTAssertFalse(table.unregister(first))
-        XCTAssertTrue(table.unregister(second))
+        XCTAssertFalse(table.unregister(ObjectIdentifier(first)))
+        XCTAssertTrue(table.unregister(ObjectIdentifier(second)))
     }
 
     func testTwoSpellingsOfOneRepoConvergeAfterTheirAcks() {
@@ -104,8 +105,8 @@ final class DeviceGitWatchTests: XCTestCase {
         _ = table.acknowledged(request: 1, canonical: "git:/real/repo")
         _ = table.acknowledged(request: 2, canonical: "git:/real/repo")
         XCTAssertEqual(table.listeners(for: "git:/real/repo").count, 2)
-        XCTAssertFalse(table.unregister(first))
-        XCTAssertTrue(table.unregister(second))
+        XCTAssertFalse(table.unregister(ObjectIdentifier(first)))
+        XCTAssertTrue(table.unregister(ObjectIdentifier(second)))
     }
 
     func testASubscriberSweptByCloseReportsNotLast() {
@@ -115,16 +116,53 @@ final class DeviceGitWatchTests: XCTestCase {
         XCTAssertTrue(table.removeAll().first === subscriber)
         XCTAssertTrue(table.isEmpty)
         // A cancel arriving after the channel died has nothing to retire.
-        XCTAssertFalse(table.unregister(subscriber))
+        XCTAssertFalse(table.unregister(ObjectIdentifier(subscriber)))
     }
 
     func testAFailedSubscribeClearsItsPendingAck() {
         var table = Termiod.ResourceRoutingTable<Subscriber>()
         let subscriber = Subscriber()
         table.register(subscriber, resource: "git:/repo", request: 9)
-        XCTAssertTrue(table.unregister(subscriber))
+        XCTAssertTrue(table.unregister(ObjectIdentifier(subscriber)))
         XCTAssertFalse(table.isAwaiting(request: 9))
         // A late ack for the dead request must not resurrect anything.
         XCTAssertNil(table.acknowledged(request: 9, canonical: "git:/real"))
+    }
+
+    /// The table routes events; it does not own subscriptions. Owning them
+    /// would keep every one alive as long as the channel — and the channel
+    /// alive as long as the subscription, since a subscribed channel is never
+    /// reaped — so a pane released without an explicit cancel would leave a
+    /// `git status` loop running on the device with nobody reading it.
+    func testTheTableDoesNotKeepASubscriberAlive() {
+        var table = Termiod.ResourceRoutingTable<Subscriber>()
+        weak var released: Subscriber?
+        do {
+            let subscriber = Subscriber()
+            released = subscriber
+            table.register(subscriber, resource: "git:/repo", request: 1)
+            XCTAssertNotNil(released)
+        }
+        XCTAssertNil(released, "the routing table must hold subscribers weakly")
+        XCTAssertTrue(table.listeners(for: "git:/repo").isEmpty)
+    }
+
+    /// A subscriber that deallocated still has to be removable, because the
+    /// removal is what tells the device to retire the watch — and it runs from
+    /// `deinit`, by which point every weak reference to it already reads nil.
+    func testADeallocatedSubscriberStillUnregistersByIdentity() {
+        var table = Termiod.ResourceRoutingTable<Subscriber>()
+        let survivor = Subscriber()
+        var identity: ObjectIdentifier?
+        do {
+            let subscriber = Subscriber()
+            identity = ObjectIdentifier(subscriber)
+            table.register(subscriber, resource: "git:/repo", request: 1)
+            table.register(survivor, resource: "git:/repo", request: 2)
+        }
+        guard let identity else { return XCTFail("no identity recorded") }
+        XCTAssertFalse(table.unregister(identity), "the survivor still reads it")
+        XCTAssertTrue(table.unregister(ObjectIdentifier(survivor)))
+        XCTAssertTrue(table.isEmpty)
     }
 }

--- a/Tests/termioTests/DeviceGitWatchTests.swift
+++ b/Tests/termioTests/DeviceGitWatchTests.swift
@@ -9,11 +9,11 @@ import TermioShared
 /// subscriber.
 final class DeviceGitWatchTests: XCTestCase {
 
-    private func batch(seq: UInt64, truncated: Bool = false) -> Termiod.GitChangedPayload {
+    private func batch(seq: UInt64, total: Int? = nil) -> Termiod.GitChangedPayload {
         Termiod.GitChangedPayload(
             seq: seq, updatedStatuses: [], removedPaths: [],
             branch: nil, head: nil, ahead: 0, behind: 0, conflicts: [],
-            truncated: truncated)
+            total: total)
     }
 
     // MARK: - DeviceWatchLedger

--- a/Tests/termioTests/DeviceGitWatchTests.swift
+++ b/Tests/termioTests/DeviceGitWatchTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+import TermioShared
+@testable import termio
+
+/// The ordering and routing rules a device git watch lives by, pinned without
+/// a connection: the ledger that keeps a racing batch from being erased by its
+/// own gap reset, and the routing table that re-keys a subscription under the
+/// device's canonical resource id and retires a watch only with its last
+/// subscriber.
+final class DeviceGitWatchTests: XCTestCase {
+
+    private func batch(seq: UInt64) -> Termiod.GitChangedPayload {
+        Termiod.GitChangedPayload(
+            seq: seq, updatedStatuses: [], removedPaths: [],
+            branch: nil, head: nil, ahead: 0, behind: 0, conflicts: [])
+    }
+
+    // MARK: - DeviceWatchLedger
+
+    func testABatchRacingTheAckIsHeldUntilTheBaselineDecision() {
+        var ledger = DeviceWatchLedger()
+        let generation = ledger.begin()
+        // The daemon queues the synthesized full batch right behind the ack;
+        // applied immediately, the gap reset that follows would erase it.
+        XCTAssertNil(ledger.admit(batch(seq: 7), generation: generation))
+        let held = ledger.settle(generation: generation)
+        XCTAssertEqual(held?.map(\.seq), [7])
+        // Settled: later batches apply as they arrive.
+        XCTAssertEqual(ledger.admit(batch(seq: 8), generation: generation)?.seq, 8)
+    }
+
+    func testHeldBatchesComeBackInArrivalOrder() {
+        var ledger = DeviceWatchLedger()
+        let generation = ledger.begin()
+        XCTAssertNil(ledger.admit(batch(seq: 1), generation: generation))
+        XCTAssertNil(ledger.admit(batch(seq: 2), generation: generation))
+        XCTAssertEqual(ledger.settle(generation: generation)?.map(\.seq), [1, 2])
+    }
+
+    func testStoppingMidHandshakeAbandonsTheAttempt() {
+        var ledger = DeviceWatchLedger()
+        let generation = ledger.begin()
+        ledger.stop()
+        // The pane went away before the ack: the subscription must not install.
+        XCTAssertNil(ledger.settle(generation: generation))
+        // And a batch from that attempt must not apply.
+        XCTAssertNil(ledger.admit(batch(seq: 3), generation: generation))
+    }
+
+    func testARestartedWatchDropsTheOldGenerationsBatches() {
+        var ledger = DeviceWatchLedger()
+        let old = ledger.begin()
+        let current = ledger.begin()
+        XCTAssertNil(ledger.admit(batch(seq: 4), generation: old))
+        // The stale batch was dropped, not held for the new attempt.
+        XCTAssertEqual(ledger.settle(generation: current)?.map(\.seq), [])
+        XCTAssertNil(ledger.settle(generation: old))
+    }
+
+    // MARK: - ResourceRoutingTable
+
+    private final class Subscriber {}
+
+    func testTheAckReKeysUnderTheCanonicalId() {
+        var table = Termiod.ResourceRoutingTable<Subscriber>()
+        let subscriber = Subscriber()
+        // The caller spelled the root through a symlink; the daemon
+        // canonicalises and stamps every event with the canonical id.
+        table.register(subscriber, resource: "git:/link/repo", request: 5)
+        XCTAssertTrue(table.isAwaiting(request: 5))
+        XCTAssertTrue(table.acknowledged(request: 5, canonical: "git:/real/repo") === subscriber)
+        XCTAssertFalse(table.isAwaiting(request: 5))
+        XCTAssertTrue(table.listeners(for: "git:/real/repo").first === subscriber)
+        XCTAssertTrue(table.listeners(for: "git:/link/repo").isEmpty)
+    }
+
+    func testAnAckNamingTheSameIdMovesNothing() {
+        var table = Termiod.ResourceRoutingTable<Subscriber>()
+        let subscriber = Subscriber()
+        table.register(subscriber, resource: "git:/repo", request: 5)
+        XCTAssertNil(table.acknowledged(request: 5, canonical: "git:/repo"))
+        XCTAssertTrue(table.listeners(for: "git:/repo").first === subscriber)
+        XCTAssertFalse(table.isAwaiting(request: 5))
+    }
+
+    func testOnlyTheLastUnregisterForAResourceReportsLast() {
+        var table = Termiod.ResourceRoutingTable<Subscriber>()
+        let first = Subscriber()
+        let second = Subscriber()
+        table.register(first, resource: "git:/repo", request: 1)
+        table.register(second, resource: "git:/repo", request: 2)
+        // The daemon tracks interest per connection: an unsubscribe sent while
+        // the second pane still reads would take its events too.
+        XCTAssertFalse(table.unregister(first))
+        XCTAssertTrue(table.unregister(second))
+    }
+
+    func testTwoSpellingsOfOneRepoConvergeAfterTheirAcks() {
+        var table = Termiod.ResourceRoutingTable<Subscriber>()
+        let first = Subscriber()
+        let second = Subscriber()
+        table.register(first, resource: "git:/link/repo", request: 1)
+        table.register(second, resource: "git:/real/repo", request: 2)
+        _ = table.acknowledged(request: 1, canonical: "git:/real/repo")
+        _ = table.acknowledged(request: 2, canonical: "git:/real/repo")
+        XCTAssertEqual(table.listeners(for: "git:/real/repo").count, 2)
+        XCTAssertFalse(table.unregister(first))
+        XCTAssertTrue(table.unregister(second))
+    }
+
+    func testASubscriberSweptByCloseReportsNotLast() {
+        var table = Termiod.ResourceRoutingTable<Subscriber>()
+        let subscriber = Subscriber()
+        table.register(subscriber, resource: "git:/repo", request: 1)
+        XCTAssertTrue(table.removeAll().first === subscriber)
+        XCTAssertTrue(table.isEmpty)
+        // A cancel arriving after the channel died has nothing to retire.
+        XCTAssertFalse(table.unregister(subscriber))
+    }
+
+    func testAFailedSubscribeClearsItsPendingAck() {
+        var table = Termiod.ResourceRoutingTable<Subscriber>()
+        let subscriber = Subscriber()
+        table.register(subscriber, resource: "git:/repo", request: 9)
+        XCTAssertTrue(table.unregister(subscriber))
+        XCTAssertFalse(table.isAwaiting(request: 9))
+        // A late ack for the dead request must not resurrect anything.
+        XCTAssertNil(table.acknowledged(request: 9, canonical: "git:/real"))
+    }
+}

--- a/termiod/src/daemon.rs
+++ b/termiod/src/daemon.rs
@@ -1748,6 +1748,7 @@ async fn process_control(
             root,
             path,
             staged,
+            context,
             seq,
         } => {
             if let Some(denied) = git_denied(connection, seq) {
@@ -1755,7 +1756,8 @@ async fn process_control(
             } else {
                 let out = out.clone();
                 tokio::spawn(async move {
-                    let response = match crate::git::run_diff(&root, &path, staged).await {
+                    let response = match crate::git::run_diff(&root, &path, staged, context).await
+                    {
                         Ok((diff, truncated)) => Control::GitDiffResult {
                             diff,
                             truncated,

--- a/termiod/src/git.rs
+++ b/termiod/src/git.rs
@@ -261,9 +261,22 @@ const STATUS_PATH_BYTES_CAP: usize = 1024 * 1024;
 /// deterministic — two consecutive runs over an unchanged flooded tree keep the
 /// same rows and produce no delta.
 fn cap_statuses(snapshot: &mut GitSnapshot) {
-    if snapshot.statuses.len() <= STATUS_CAP {
+    // Both bounds are checked before the fast path: five thousand entries is
+    // not the only way past a frame, and neither is a million bytes of path.
+    // A rename spends its budget twice — the row names where the file came
+    // from as well as where it is.
+    let cost = |state: &FileState, path: &String| {
+        path.len() + state.original_path.as_ref().map_or(0, String::len)
+    };
+    let total: usize = snapshot
+        .statuses
+        .iter()
+        .map(|(path, state)| cost(state, path))
+        .sum();
+    if snapshot.statuses.len() <= STATUS_CAP && total <= STATUS_PATH_BYTES_CAP {
         return;
     }
+
     let mut paths: Vec<&String> = snapshot.statuses.keys().collect();
     paths.sort_by_key(|path| {
         let tier = match snapshot.statuses[*path].status {
@@ -276,7 +289,7 @@ fn cap_statuses(snapshot: &mut GitSnapshot) {
     let mut bytes = 0usize;
     let mut keep: HashSet<String> = HashSet::new();
     for path in paths.into_iter().take(STATUS_CAP) {
-        bytes += path.len();
+        bytes += cost(&snapshot.statuses[path], path);
         if bytes > STATUS_PATH_BYTES_CAP {
             break;
         }
@@ -1393,6 +1406,38 @@ mod tests {
             "a conflict must act on outlives everything, whatever it sorts as"
         );
         assert_eq!(snapshot.conflicts(), vec!["zzz/conflicted.rs".to_string()]);
+    }
+
+    /// The entry count is not the only way past a frame. Few enough rows to
+    /// clear `STATUS_CAP` can still carry megabytes of path — and a rename
+    /// spends its budget twice, for where the file came from as well as where
+    /// it is.
+    #[test]
+    fn a_short_list_of_very_long_paths_is_cut_too() {
+        let mut snapshot = GitSnapshot::default();
+        let long = "d".repeat(3_000);
+        for index in 0..600 {
+            let mut state = FileState::new(GitFileStatus::Tracked {
+                index_status: GitStatusCode::Renamed,
+                worktree_status: GitStatusCode::Unmodified,
+            });
+            state.original_path = Some(format!("{long}/was-{index}.rs"));
+            snapshot
+                .statuses
+                .insert(format!("{long}/now-{index}.rs"), state);
+        }
+        assert!(snapshot.statuses.len() < STATUS_CAP, "the entry cap is clear");
+        cap_statuses(&mut snapshot);
+
+        assert!(snapshot.truncated, "the byte budget has to bind on its own");
+        let spent: usize = snapshot
+            .statuses
+            .iter()
+            .map(|(path, state)| {
+                path.len() + state.original_path.as_ref().map_or(0, String::len)
+            })
+            .sum();
+        assert!(spent <= STATUS_PATH_BYTES_CAP, "spent {spent}");
     }
 
     /// The cut has to be deterministic, or two runs over an unchanged flooded

--- a/termiod/src/git.rs
+++ b/termiod/src/git.rs
@@ -104,6 +104,10 @@ pub struct GitSnapshot {
     pub branch: Option<String>,
     pub head: Option<String>,
     pub ahead_behind: Option<(u32, u32)>,
+    /// The status run said more than [`STATUS_CAP`] and the list was
+    /// cut. Carried on every batch so the pane can say the list is partial
+    /// rather than let a cut list read as the whole truth.
+    pub truncated: bool,
 }
 
 impl GitSnapshot {
@@ -134,6 +138,7 @@ impl GitSnapshot {
             head: self.head.clone(),
             ahead_behind: self.ahead_behind,
             conflicts: self.conflicts(),
+            truncated: self.truncated,
         }
     }
 
@@ -157,7 +162,8 @@ impl GitSnapshot {
 
         let metadata_moved = self.branch != previous.branch
             || self.head != previous.head
-            || self.ahead_behind != previous.ahead_behind;
+            || self.ahead_behind != previous.ahead_behind
+            || self.truncated != previous.truncated;
         if updated.is_empty() && removed.is_empty() && !metadata_moved {
             return None;
         }
@@ -168,6 +174,7 @@ impl GitSnapshot {
             head: self.head.clone(),
             ahead_behind: self.ahead_behind,
             conflicts: self.conflicts(),
+            truncated: self.truncated,
         })
     }
 }
@@ -181,6 +188,8 @@ pub struct GitBatch {
     pub head: Option<String>,
     pub ahead_behind: Option<(u32, u32)>,
     pub conflicts: Vec<String>,
+    /// The status list was cut — see [`STATUS_CAP`].
+    pub truncated: bool,
 }
 
 impl GitBatch {
@@ -194,6 +203,7 @@ impl GitBatch {
             head: self.head,
             ahead_behind: self.ahead_behind,
             conflicts: self.conflicts,
+            truncated: self.truncated,
         }
     }
 }
@@ -219,8 +229,58 @@ pub async fn run_status(root: &str) -> Result<GitSnapshot> {
         );
     }
     let mut snapshot = parse_porcelain_v2(&output.stdout)?;
+    cap_statuses(&mut snapshot);
     apply_counts(root, &mut snapshot).await;
     Ok(snapshot)
+}
+
+/// The most changed paths one `git_changed` batch will ever carry.
+///
+/// A batch is one frame, and a frame over `protocol::MAX_FRAME_SIZE` is a write
+/// error that takes the whole connection down with it — the file tree and agent
+/// status ride the same channel. `--untracked-files=all` over a checkout with a
+/// missing `.gitignore` reaches that easily: a `node_modules` tree is hundreds
+/// of thousands of paths. So the list is cut here, at a size no reviewer reads
+/// past, and the batch says it was cut.
+pub const STATUS_CAP: usize = 5_000;
+
+/// And the most path bytes, because the entry count alone does not bound a
+/// frame — a deeply nested tree can carry very long paths.
+const STATUS_PATH_BYTES_CAP: usize = 2 * 1024 * 1024;
+
+/// Cut an oversized status list down to what a batch may carry.
+///
+/// Tracked changes are kept first and untracked ones fill what is left: the
+/// flood case is always untracked build output, and the edits a person is
+/// reviewing are the rows that must survive it. Within each half the order is
+/// by path, so the cut is deterministic — two consecutive runs of an unchanged
+/// flooded tree keep the same rows and produce no delta.
+fn cap_statuses(snapshot: &mut GitSnapshot) {
+    if snapshot.statuses.len() <= STATUS_CAP {
+        return;
+    }
+    let mut paths: Vec<&String> = snapshot.statuses.keys().collect();
+    paths.sort_by_key(|path| {
+        let untracked = matches!(
+            snapshot.statuses[*path].status,
+            Some(GitFileStatus::Untracked) | Some(GitFileStatus::Ignored)
+        );
+        (untracked, *path)
+    });
+    let mut bytes = 0usize;
+    let mut keep: HashSet<String> = HashSet::new();
+    for path in paths.into_iter().take(STATUS_CAP) {
+        bytes += path.len();
+        if bytes > STATUS_PATH_BYTES_CAP {
+            break;
+        }
+        keep.insert(path.clone());
+    }
+    if keep.len() == snapshot.statuses.len() {
+        return;
+    }
+    snapshot.statuses.retain(|path, _| keep.contains(path));
+    snapshot.truncated = true;
 }
 
 /// Above this many untracked files the per-file line counts are skipped
@@ -280,21 +340,52 @@ async fn apply_counts(root: &str, snapshot: &mut GitSnapshot) {
         > UNTRACKED_COUNT_LIMIT;
 
     for (path, state) in snapshot.statuses.iter_mut() {
-        if state.status == Some(GitFileStatus::Untracked) {
-            if untracked_flood {
-                continue;
-            }
-            match untracked_line_count(&Path::new(root).join(path)) {
-                UntrackedCount::Lines(lines) => state.additions = lines,
-                UntrackedCount::Binary => state.binary = true,
-                UntrackedCount::Skip => {}
-            }
-        } else {
+        if state.status != Some(GitFileStatus::Untracked) {
             if let Some((added, deleted)) = counts.get(path) {
                 state.additions = *added;
                 state.deletions = *deleted;
             }
             state.binary = binaries.contains(path);
+        }
+    }
+
+    if untracked_flood {
+        return;
+    }
+    let untracked: Vec<String> = snapshot
+        .statuses
+        .iter()
+        .filter(|(_, state)| state.status == Some(GitFileStatus::Untracked))
+        .map(|(path, _)| path.clone())
+        .collect();
+    if untracked.is_empty() {
+        return;
+    }
+    // Counting lines is bounded but blocking — up to `UNTRACKED_COUNT_LIMIT`
+    // files of `UNTRACKED_SIZE_LIMIT` each, read synchronously. Doing that on a
+    // runtime worker parks whatever else that worker was carrying, including a
+    // connection's writes; `files.rs` moves its directory reads off the runtime
+    // for the same reason, and this is the larger read of the two.
+    let root_path = Path::new(root).to_path_buf();
+    let counted = tokio::task::spawn_blocking(move || {
+        untracked
+            .into_iter()
+            .map(|path| {
+                let count = untracked_line_count(&root_path.join(&path));
+                (path, count)
+            })
+            .collect::<Vec<_>>()
+    })
+    .await;
+    let Ok(counted) = counted else { return };
+    for (path, count) in counted {
+        let Some(state) = snapshot.statuses.get_mut(&path) else {
+            continue;
+        };
+        match count {
+            UntrackedCount::Lines(lines) => state.additions = lines,
+            UntrackedCount::Binary => state.binary = true,
+            UntrackedCount::Skip => {}
         }
     }
 }
@@ -1147,6 +1238,7 @@ mod tests {
             head: None,
             ahead_behind: Some((1, 0)),
             conflicts: vec![],
+            truncated: false,
         }
         .into_event("git:/repo".to_string(), 7);
         let json = serde_json::to_value(&event).unwrap();
@@ -1254,6 +1346,72 @@ mod tests {
             snapshot.statuses["blob.bin"].binary,
             "a NUL in the first chunk is binary, and +N would be a lie"
         );
+    }
+
+    /// A batch is one frame, and a frame past `MAX_FRAME_SIZE` kills the whole
+    /// connection — the file tree and agent status ride the same channel. So a
+    /// flooded checkout is cut here, and the cut is announced.
+    #[test]
+    fn an_oversized_status_list_is_cut_and_says_so() {
+        let mut snapshot = GitSnapshot::default();
+        snapshot.statuses.insert(
+            "src/edited.rs".to_string(),
+            FileState::new(GitFileStatus::Tracked {
+                index_status: GitStatusCode::Unmodified,
+                worktree_status: GitStatusCode::Modified,
+            }),
+        );
+        for index in 0..STATUS_CAP + 10 {
+            snapshot.statuses.insert(
+                format!("node_modules/pkg/{index}.js"),
+                FileState::new(GitFileStatus::Untracked),
+            );
+        }
+        cap_statuses(&mut snapshot);
+
+        assert!(snapshot.truncated, "a cut list must announce that it was cut");
+        assert_eq!(snapshot.statuses.len(), STATUS_CAP);
+        assert!(
+            snapshot.statuses.contains_key("src/edited.rs"),
+            "the tracked edit is the row a person is reviewing; the flood is not"
+        );
+    }
+
+    /// The cut has to be deterministic, or two runs over an unchanged flooded
+    /// tree would keep different rows and publish a delta on every tick.
+    #[test]
+    fn the_cut_keeps_the_same_rows_across_runs() {
+        let build = || {
+            let mut snapshot = GitSnapshot::default();
+            for index in 0..STATUS_CAP + 50 {
+                snapshot.statuses.insert(
+                    format!("build/{index}.o"),
+                    FileState::new(GitFileStatus::Untracked),
+                );
+            }
+            cap_statuses(&mut snapshot);
+            snapshot
+        };
+        let first = build();
+        let second = build();
+        assert!(first.truncated);
+        assert_eq!(first, second);
+        assert_eq!(second.delta_from(&first), None, "an unchanged tree is quiet");
+    }
+
+    /// A list under the cap is untouched, and never claims to be partial.
+    #[test]
+    fn an_ordinary_status_list_is_not_cut() {
+        let mut snapshot = GitSnapshot::default();
+        for index in 0..10 {
+            snapshot.statuses.insert(
+                format!("src/{index}.rs"),
+                FileState::new(GitFileStatus::Untracked),
+            );
+        }
+        cap_statuses(&mut snapshot);
+        assert!(!snapshot.truncated);
+        assert_eq!(snapshot.statuses.len(), 10);
     }
 
     /// Every state a Changes row can be in has to produce a diff. `git diff --

--- a/termiod/src/git.rs
+++ b/termiod/src/git.rs
@@ -104,10 +104,12 @@ pub struct GitSnapshot {
     pub branch: Option<String>,
     pub head: Option<String>,
     pub ahead_behind: Option<(u32, u32)>,
-    /// The status run said more than [`STATUS_CAP`] and the list was
-    /// cut. Carried on every batch so the pane can say the list is partial
-    /// rather than let a cut list read as the whole truth.
-    pub truncated: bool,
+    /// How many paths the status run actually named, when the list was cut
+    /// below that (see [`STATUS_CAP`]). Carried on every batch so the pane can
+    /// say how much is missing rather than let a cut list read as the whole
+    /// truth — with five thousand conflicts, "first 5,000" and "first 5,000 of
+    /// 41,900" are different answers.
+    pub total: Option<u64>,
 }
 
 impl GitSnapshot {
@@ -138,7 +140,7 @@ impl GitSnapshot {
             head: self.head.clone(),
             ahead_behind: self.ahead_behind,
             conflicts: self.conflicts(),
-            truncated: self.truncated,
+            total: self.total,
         }
     }
 
@@ -163,7 +165,7 @@ impl GitSnapshot {
         let metadata_moved = self.branch != previous.branch
             || self.head != previous.head
             || self.ahead_behind != previous.ahead_behind
-            || self.truncated != previous.truncated;
+            || self.total != previous.total;
         if updated.is_empty() && removed.is_empty() && !metadata_moved {
             return None;
         }
@@ -174,7 +176,7 @@ impl GitSnapshot {
             head: self.head.clone(),
             ahead_behind: self.ahead_behind,
             conflicts: self.conflicts(),
-            truncated: self.truncated,
+            total: self.total,
         })
     }
 }
@@ -188,8 +190,9 @@ pub struct GitBatch {
     pub head: Option<String>,
     pub ahead_behind: Option<(u32, u32)>,
     pub conflicts: Vec<String>,
-    /// The status list was cut — see [`STATUS_CAP`].
-    pub truncated: bool,
+    /// How many paths there really are, when the list was cut — see
+    /// [`STATUS_CAP`].
+    pub total: Option<u64>,
 }
 
 impl GitBatch {
@@ -203,7 +206,7 @@ impl GitBatch {
             head: self.head,
             ahead_behind: self.ahead_behind,
             conflicts: self.conflicts,
-            truncated: self.truncated,
+            total: self.total,
         }
     }
 }
@@ -245,11 +248,30 @@ pub async fn run_status(root: &str) -> Result<GitSnapshot> {
 pub const STATUS_CAP: usize = 5_000;
 
 /// And the most path bytes, because the entry count alone does not bound a
-/// frame — a deeply nested tree can carry very long paths. One batch spends
-/// its paths three times (updated, removed, conflicts) and JSON can double a
-/// path that is all quotes, so the headroom under `MAX_FRAME_SIZE` is what
-/// this number buys: 6 × 1 MiB, plus at most `STATUS_CAP` entry envelopes.
+/// frame — a deeply nested tree can carry very long paths.
+///
+/// Counted as *encoded* bytes, not raw ones: a byte a filename may legally
+/// hold and JSON may not — POSIX forbids only NUL and `/` — becomes six
+/// characters (`\u0001`), so a raw-byte budget is a sixth of the bound it
+/// looks like. One batch spends its paths three times (updated, removed,
+/// conflicts), which puts the worst frame at 3 MiB plus at most `STATUS_CAP`
+/// entry envelopes — clear of `MAX_FRAME_SIZE` with room that does not depend
+/// on what a path happens to contain.
 const STATUS_PATH_BYTES_CAP: usize = 1024 * 1024;
+
+/// What one string costs inside a JSON document. Control bytes escape to six
+/// characters, a quote or a backslash to two, and everything else — UTF-8
+/// included — passes through as itself.
+fn json_cost(text: &str) -> usize {
+    text.bytes()
+        .map(|byte| match byte {
+            b'"' | b'\\' => 2,
+            0x08 | 0x09 | 0x0a | 0x0c | 0x0d => 2,
+            0x00..=0x1f => 6,
+            _ => 1,
+        })
+        .sum()
+}
 
 /// Cut an oversized status list down to what a batch may carry.
 ///
@@ -266,14 +288,14 @@ fn cap_statuses(snapshot: &mut GitSnapshot) {
     // A rename spends its budget twice — the row names where the file came
     // from as well as where it is.
     let cost = |state: &FileState, path: &String| {
-        path.len() + state.original_path.as_ref().map_or(0, String::len)
+        json_cost(path) + state.original_path.as_deref().map_or(0, json_cost)
     };
-    let total: usize = snapshot
+    let encoded: usize = snapshot
         .statuses
         .iter()
         .map(|(path, state)| cost(state, path))
         .sum();
-    if snapshot.statuses.len() <= STATUS_CAP && total <= STATUS_PATH_BYTES_CAP {
+    if snapshot.statuses.len() <= STATUS_CAP && encoded <= STATUS_PATH_BYTES_CAP {
         return;
     }
 
@@ -298,8 +320,8 @@ fn cap_statuses(snapshot: &mut GitSnapshot) {
     if keep.len() == snapshot.statuses.len() {
         return;
     }
+    snapshot.total = Some(snapshot.statuses.len() as u64);
     snapshot.statuses.retain(|path, _| keep.contains(path));
-    snapshot.truncated = true;
 }
 
 /// Above this many untracked files the per-file line counts are skipped
@@ -1257,7 +1279,7 @@ mod tests {
             head: None,
             ahead_behind: Some((1, 0)),
             conflicts: vec![],
-            truncated: false,
+            total: None,
         }
         .into_event("git:/repo".to_string(), 7);
         let json = serde_json::to_value(&event).unwrap();
@@ -1395,7 +1417,11 @@ mod tests {
         }
         cap_statuses(&mut snapshot);
 
-        assert!(snapshot.truncated, "a cut list must announce that it was cut");
+        assert_eq!(
+            snapshot.total,
+            Some(STATUS_CAP as u64 + 12),
+            "a cut list must name how many there really were"
+        );
         assert_eq!(snapshot.statuses.len(), STATUS_CAP);
         assert!(
             snapshot.statuses.contains_key("src/edited.rs"),
@@ -1429,7 +1455,11 @@ mod tests {
         assert!(snapshot.statuses.len() < STATUS_CAP, "the entry cap is clear");
         cap_statuses(&mut snapshot);
 
-        assert!(snapshot.truncated, "the byte budget has to bind on its own");
+        assert_eq!(
+            snapshot.total,
+            Some(600),
+            "the byte budget has to bind on its own, and still name the total"
+        );
         let spent: usize = snapshot
             .statuses
             .iter()
@@ -1457,7 +1487,7 @@ mod tests {
         };
         let first = build();
         let second = build();
-        assert!(first.truncated);
+        assert!(first.total.is_some());
         assert_eq!(first, second);
         assert_eq!(second.delta_from(&first), None, "an unchanged tree is quiet");
     }
@@ -1473,7 +1503,7 @@ mod tests {
             );
         }
         cap_statuses(&mut snapshot);
-        assert!(!snapshot.truncated);
+        assert_eq!(snapshot.total, None);
         assert_eq!(snapshot.statuses.len(), 10);
     }
 

--- a/termiod/src/git.rs
+++ b/termiod/src/git.rs
@@ -20,6 +20,7 @@ use crate::protocol::{
 };
 use anyhow::{bail, Context, Result};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 /// A `git.diff` reply is cut here — the same preview budget as `fs.read`.
 pub const DIFF_CAP: usize = 1024 * 1024;
@@ -65,9 +66,41 @@ fn validate_revision(revision: &str) -> Result<()> {
 /// Everything one status run said. The live copy backs the synthetic
 /// full-state batch a gap subscriber receives — only the host can "rescan"
 /// git status, so on gap it does the scan for the client.
+/// What one status run said about one path. Kept apart from the wire entry so
+/// the snapshot can be diffed by value: a file whose line counts moved has
+/// changed as far as the row is concerned, even when its status letter did not.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FileState {
+    pub status: Option<GitFileStatus>,
+    pub original_path: Option<String>,
+    pub additions: u64,
+    pub deletions: u64,
+    pub binary: bool,
+}
+
+impl FileState {
+    fn new(status: GitFileStatus) -> FileState {
+        FileState {
+            status: Some(status),
+            ..FileState::default()
+        }
+    }
+
+    fn entry(&self, path: &str) -> Option<GitStatusEntry> {
+        Some(GitStatusEntry {
+            path: path.to_string(),
+            status: self.status?,
+            original_path: self.original_path.clone(),
+            additions: self.additions,
+            deletions: self.deletions,
+            binary: self.binary,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct GitSnapshot {
-    pub statuses: HashMap<String, GitFileStatus>,
+    pub statuses: HashMap<String, FileState>,
     pub branch: Option<String>,
     pub head: Option<String>,
     pub ahead_behind: Option<(u32, u32)>,
@@ -78,7 +111,7 @@ impl GitSnapshot {
         let mut paths: Vec<String> = self
             .statuses
             .iter()
-            .filter(|(_, status)| matches!(status, GitFileStatus::Unmerged { .. }))
+            .filter(|(_, state)| matches!(state.status, Some(GitFileStatus::Unmerged { .. })))
             .map(|(path, _)| path.clone())
             .collect();
         paths.sort();
@@ -91,10 +124,7 @@ impl GitSnapshot {
         let mut updated: Vec<GitStatusEntry> = self
             .statuses
             .iter()
-            .map(|(path, status)| GitStatusEntry {
-                path: path.clone(),
-                status: *status,
-            })
+            .filter_map(|(path, state)| state.entry(path))
             .collect();
         updated.sort_by(|a, b| a.path.cmp(&b.path));
         GitBatch {
@@ -113,11 +143,8 @@ impl GitSnapshot {
         let mut updated: Vec<GitStatusEntry> = self
             .statuses
             .iter()
-            .filter(|(path, status)| previous.statuses.get(*path) != Some(status))
-            .map(|(path, status)| GitStatusEntry {
-                path: path.clone(),
-                status: *status,
-            })
+            .filter(|(path, state)| previous.statuses.get(*path) != Some(state))
+            .filter_map(|(path, state)| state.entry(path))
             .collect();
         updated.sort_by(|a, b| a.path.cmp(&b.path));
         let mut removed: Vec<String> = previous
@@ -191,7 +218,133 @@ pub async fn run_status(root: &str) -> Result<GitSnapshot> {
             String::from_utf8_lossy(&output.stderr).trim()
         );
     }
-    parse_porcelain_v2(&output.stdout)
+    let mut snapshot = parse_porcelain_v2(&output.stdout)?;
+    apply_counts(root, &mut snapshot).await;
+    Ok(snapshot)
+}
+
+/// Above this many untracked files the per-file line counts are skipped
+/// wholesale — the flood case, almost always a missing `.gitignore` over a
+/// build directory. The Mac client degrades at the same number for the same
+/// reason, and so does VS Code at its `git.statusLimit`.
+const UNTRACKED_COUNT_LIMIT: usize = 500;
+
+/// An untracked file bigger than this is never line-counted: nobody reviews a
+/// multi-megabyte file by its `+N` badge.
+const UNTRACKED_SIZE_LIMIT: u64 = 4_000_000;
+
+/// Fills each changed path's `+N −M`: `git diff --numstat` merged with
+/// `--cached` for tracked files, and a line count for untracked ones.
+///
+/// This mirrors the Mac client's local pass field for field, deliberately — the
+/// Changes pane must read the same whether the checkout is on this box or
+/// another one, and "the same" includes what the numbers mean and when they are
+/// withheld.
+async fn apply_counts(root: &str, snapshot: &mut GitSnapshot) {
+    let mut counts: HashMap<String, (u64, u64)> = HashMap::new();
+    let mut binaries: HashSet<String> = HashSet::new();
+    for cached in [false, true] {
+        let mut command = git_command(root);
+        command.arg("diff").arg("--numstat");
+        if cached {
+            command.arg("--cached");
+        }
+        let Ok(output) = command.output().await else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let mut fields = line.splitn(3, '\t');
+            let (Some(added), Some(deleted), Some(path)) =
+                (fields.next(), fields.next(), fields.next())
+            else {
+                continue;
+            };
+            if added == "-" {
+                binaries.insert(path.to_string());
+                continue;
+            }
+            let entry = counts.entry(path.to_string()).or_insert((0, 0));
+            entry.0 += added.parse::<u64>().unwrap_or(0);
+            entry.1 += deleted.parse::<u64>().unwrap_or(0);
+        }
+    }
+
+    let untracked_flood = snapshot
+        .statuses
+        .values()
+        .filter(|state| state.status == Some(GitFileStatus::Untracked))
+        .count()
+        > UNTRACKED_COUNT_LIMIT;
+
+    for (path, state) in snapshot.statuses.iter_mut() {
+        if state.status == Some(GitFileStatus::Untracked) {
+            if untracked_flood {
+                continue;
+            }
+            match untracked_line_count(&Path::new(root).join(path)) {
+                UntrackedCount::Lines(lines) => state.additions = lines,
+                UntrackedCount::Binary => state.binary = true,
+                UntrackedCount::Skip => {}
+            }
+        } else {
+            if let Some((added, deleted)) = counts.get(path) {
+                state.additions = *added;
+                state.deletions = *deleted;
+            }
+            state.binary = binaries.contains(path);
+        }
+    }
+}
+
+enum UntrackedCount {
+    Lines(u64),
+    Binary,
+    Skip,
+}
+
+/// The `+N` for one untracked file: bounded chunked reads counting newlines,
+/// never a whole-file decode. A NUL in the first chunk marks it binary, which
+/// is git's own sniff; crossing the size cap gives up rather than paying for it.
+fn untracked_line_count(path: &Path) -> UntrackedCount {
+    use std::io::Read;
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return UntrackedCount::Skip;
+    };
+    let mut buffer = vec![0u8; 262_144];
+    let mut lines = 0u64;
+    let mut total = 0u64;
+    let mut last_byte = b'\n';
+    let mut first_chunk = true;
+    loop {
+        let read = match file.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(_) => return UntrackedCount::Skip,
+        };
+        let chunk = &buffer[..read];
+        if first_chunk {
+            if chunk[..chunk.len().min(8000)].contains(&0) {
+                return UntrackedCount::Binary;
+            }
+            first_chunk = false;
+        }
+        total += read as u64;
+        if total > UNTRACKED_SIZE_LIMIT {
+            return UntrackedCount::Skip;
+        }
+        lines += chunk.iter().filter(|byte| **byte == b'\n').count() as u64;
+        last_byte = *chunk.last().unwrap_or(&last_byte);
+    }
+    if first_chunk {
+        return UntrackedCount::Skip; // empty, or vanished mid-read: no badge
+    }
+    if last_byte != b'\n' {
+        lines += 1;
+    }
+    UntrackedCount::Lines(lines)
 }
 
 /// Parse `--porcelain=v2 -z` output. Records are NUL-terminated; a rename
@@ -219,7 +372,9 @@ pub fn parse_porcelain_v2(bytes: &[u8]) -> Result<GitSnapshot> {
                 let xy = columns.next().unwrap_or_default();
                 let path = columns.nth(6).unwrap_or_default();
                 if let (Some(status), false) = (tracked_status(xy), path.is_empty()) {
-                    snapshot.statuses.insert(path.to_string(), status);
+                    snapshot
+                        .statuses
+                        .insert(path.to_string(), FileState::new(status));
                 }
             }
             "2" => {
@@ -227,10 +382,17 @@ pub fn parse_porcelain_v2(bytes: &[u8]) -> Result<GitSnapshot> {
                 let mut columns = rest.splitn(9, ' ');
                 let xy = columns.next().unwrap_or_default();
                 let path = columns.nth(7).unwrap_or_default();
-                // Consume the origPath field so it is not read as a record.
-                let _orig = fields.next();
+                // The origPath field must be consumed either way, or it is read
+                // as the next record. It is also what the row's `old → new`
+                // tooltip is made of, so it is kept rather than dropped.
+                let original = fields
+                    .next()
+                    .map(|field| String::from_utf8_lossy(field).into_owned())
+                    .filter(|field| !field.is_empty());
                 if let (Some(status), false) = (tracked_status(xy), path.is_empty()) {
-                    snapshot.statuses.insert(path.to_string(), status);
+                    let mut state = FileState::new(status);
+                    state.original_path = original;
+                    snapshot.statuses.insert(path.to_string(), state);
                 }
             }
             "u" => {
@@ -239,18 +401,20 @@ pub fn parse_porcelain_v2(bytes: &[u8]) -> Result<GitSnapshot> {
                 let xy = columns.next().unwrap_or_default();
                 let path = columns.nth(8).unwrap_or_default();
                 if let (Some(status), false) = (unmerged_status(xy), path.is_empty()) {
-                    snapshot.statuses.insert(path.to_string(), status);
+                    snapshot
+                        .statuses
+                        .insert(path.to_string(), FileState::new(status));
                 }
             }
             "?" => {
                 snapshot
                     .statuses
-                    .insert(rest.to_string(), GitFileStatus::Untracked);
+                    .insert(rest.to_string(), FileState::new(GitFileStatus::Untracked));
             }
             "!" => {
                 snapshot
                     .statuses
-                    .insert(rest.to_string(), GitFileStatus::Ignored);
+                    .insert(rest.to_string(), FileState::new(GitFileStatus::Ignored));
             }
             _ => {}
         }
@@ -329,21 +493,86 @@ fn unmerged_status(xy: &str) -> Option<GitFileStatus> {
 
 /// `git.diff` (§C.13): a unified diff for one path, worktree-vs-index by
 /// default, index-vs-HEAD with `staged`. Capped at [`DIFF_CAP`].
-pub async fn run_diff(root: &str, path: &str, staged: bool) -> Result<(String, bool)> {
-    let mut command = git_command(root);
-    command.arg("diff");
-    if staged {
-        command.arg("--cached");
+/// `git.diff` (§C.13): the unified diff for one working-tree path.
+///
+/// `git diff -- <path>` alone answers for exactly one of the four cases a
+/// Changes row can be in, and empty for the rest — an untracked file has no
+/// diff at all, and a fully-staged change lives in the index. So this walks the
+/// same ladder the Mac's local `GitService.loadDiffText` walks, in the same
+/// order, because a row must show the same diff whichever machine the checkout
+/// is on. Measured against a real device before it did: 44 rows, every one of
+/// them an empty diff.
+///
+/// `context` is the `-U` the client wants. The overlay asks for a very large one
+/// so it holds the whole file and can fold unchanged runs into bands the reader
+/// expands; without it a remote diff renders with git's default three lines and
+/// silently loses that.
+pub async fn run_diff(
+    root: &str,
+    path: &str,
+    staged: bool,
+    context: Option<u64>,
+) -> Result<(String, bool)> {
+    let unified: Vec<String> = context
+        .map(|lines| vec![format!("-U{lines}")])
+        .unwrap_or_default();
+
+    // An untracked file is not in the index and not in HEAD, so every ordinary
+    // form of `git diff` says nothing about it. `--no-index` against /dev/null
+    // is what makes it read as one big addition — and it exits non-zero when the
+    // two differ, which is the normal case, so its status is not an error.
+    let mut against_nothing = git_command(root);
+    against_nothing.arg("diff").arg("--no-index");
+    for argument in &unified {
+        against_nothing.arg(argument);
     }
-    command.arg("--").arg(path);
-    let output = command.output().await.context("running git diff")?;
-    if !output.status.success() {
+    against_nothing.arg("--").arg("/dev/null").arg(path);
+
+    // `diff HEAD` shows staged and unstaged together, which is what the row is
+    // about; the split forms are the fallback for a repo with no commit yet and
+    // for a change that is entirely in the index.
+    let mut ladder: Vec<Vec<String>> = Vec::new();
+    if staged {
+        ladder.push(vec!["--cached".into()]);
+    }
+    ladder.push(vec!["HEAD".into()]);
+    ladder.push(vec![]);
+    ladder.push(vec!["--cached".into()]);
+
+    for revision in ladder {
+        let mut command = git_command(root);
+        command.arg("diff");
+        for argument in &unified {
+            command.arg(argument);
+        }
+        for argument in &revision {
+            command.arg(argument);
+        }
+        command.arg("--").arg(path);
+        let output = command.output().await.context("running git diff")?;
+        // A form that does not apply here (no HEAD yet, a path git will not
+        // diff that way) is not a failure — it is the reason there is a ladder.
+        if !output.status.success() {
+            continue;
+        }
+        let diff = String::from_utf8_lossy(&output.stdout).into_owned();
+        if !diff.is_empty() {
+            return Ok(cap_diff(diff));
+        }
+    }
+
+    let output = against_nothing
+        .output()
+        .await
+        .context("running git diff --no-index")?;
+    let diff = String::from_utf8_lossy(&output.stdout).into_owned();
+    if diff.is_empty() && !output.status.success() {
         bail!(
             "git diff failed: {}",
             String::from_utf8_lossy(&output.stderr).trim()
         );
     }
-    Ok(cap_diff(String::from_utf8_lossy(&output.stdout).into_owned()))
+    Ok(cap_diff(diff))
 }
 
 /// Cut a diff at [`DIFF_CAP`] on a character boundary, reporting that it was
@@ -770,7 +999,7 @@ mod tests {
         assert_eq!(snapshot.branch.as_deref(), Some("main"));
         assert_eq!(snapshot.head.as_deref(), Some("1234567890abcdef"));
         assert_eq!(snapshot.ahead_behind, Some((2, 1)));
-        let status = |path: &str| snapshot.statuses[path];
+        let status = |path: &str| snapshot.statuses[path].status.unwrap();
         assert_eq!(
             status("staged.rs"),
             GitFileStatus::Tracked {
@@ -809,6 +1038,11 @@ mod tests {
         assert!(
             !snapshot.statuses.contains_key("old-name.rs"),
             "a rename's origin path is a field, not a record"
+        );
+        assert_eq!(
+            snapshot.statuses["new-name.rs"].original_path.as_deref(),
+            Some("old-name.rs"),
+            "the origin is kept: it is what the row's `old → new` is made of"
         );
         assert_eq!(
             status("conflicted.rs"),
@@ -894,10 +1128,18 @@ mod tests {
                         index_status: GitStatusCode::Modified,
                         worktree_status: GitStatusCode::Unmodified,
                     },
+                    original_path: None,
+                    additions: 12,
+                    deletions: 3,
+                    binary: false,
                 },
                 GitStatusEntry {
                     path: "b.rs".to_string(),
                     status: GitFileStatus::Untracked,
+                    original_path: None,
+                    additions: 0,
+                    deletions: 0,
+                    binary: false,
                 },
             ],
             removed_paths: vec![],
@@ -916,6 +1158,12 @@ mod tests {
         );
         assert_eq!(json["updated_statuses"][1]["status"], "untracked");
         assert_eq!(json["ahead_behind"][0], 1);
+        assert_eq!(json["updated_statuses"][0]["additions"], 12);
+        assert_eq!(json["updated_statuses"][0]["deletions"], 3);
+        assert!(
+            json["updated_statuses"][1].get("additions").is_none(),
+            "a zero count is left off the wire, not sent as 0"
+        );
     }
 
     // The read tier is tested against a real repository built here, not
@@ -965,6 +1213,86 @@ mod tests {
         run_git(dir, &["add", "-A"]);
         run_git(dir, &["commit", "-q", "-m", message]);
         run_git(dir, &["rev-parse", "HEAD"])
+    }
+
+    /// The Changes row shows `+N −M` beside the path, so the status run has to
+    /// carry those numbers — for a tracked edit, for a staged one, and for an
+    /// untracked file, which has no diff to count and is measured by its lines.
+    #[tokio::test]
+    async fn status_carries_the_line_counts_the_row_shows() {
+        let dir = scratch_repo("counts");
+        write(&dir, "tracked.txt", "one\ntwo\nthree\n");
+        commit(&dir, "first");
+        write(&dir, "tracked.txt", "one\ntwo\nthree\nfour\n");
+        write(&dir, "staged.txt", "a\nb\n");
+        run_git(&dir, &["add", "staged.txt"]);
+        write(&dir, "fresh.txt", "x\ny\nz\n");
+        std::fs::write(dir.join("blob.bin"), [0u8, 1, 2, 3]).unwrap();
+
+        let root = dir.to_string_lossy().into_owned();
+        let snapshot = run_status(&root).await.unwrap();
+
+        let tracked = &snapshot.statuses["tracked.txt"];
+        assert_eq!((tracked.additions, tracked.deletions), (1, 0));
+        assert!(!tracked.binary);
+
+        let staged = &snapshot.statuses["staged.txt"];
+        assert_eq!(
+            (staged.additions, staged.deletions),
+            (2, 0),
+            "a staged file's numbers come from --cached"
+        );
+
+        let untracked = &snapshot.statuses["fresh.txt"];
+        assert_eq!(
+            (untracked.additions, untracked.deletions),
+            (3, 0),
+            "an untracked file is counted by its lines"
+        );
+
+        assert!(
+            snapshot.statuses["blob.bin"].binary,
+            "a NUL in the first chunk is binary, and +N would be a lie"
+        );
+    }
+
+    /// Every state a Changes row can be in has to produce a diff. `git diff --
+    /// <path>` alone answers for one of them and returns empty for the rest,
+    /// which shipped as a pane full of rows that all opened blank.
+    #[tokio::test]
+    async fn every_kind_of_working_tree_change_has_a_diff() {
+        let dir = scratch_repo("diff");
+        write(&dir, "tracked.txt", "one\ntwo\n");
+        commit(&dir, "first");
+        let root = dir.to_string_lossy().into_owned();
+
+        write(&dir, "fresh.txt", "brand\nnew\n");
+        let (untracked, _) = run_diff(&root, "fresh.txt", false, None).await.unwrap();
+        assert!(
+            untracked.contains("+brand"),
+            "an untracked file reads as one big addition, not as nothing: {untracked:?}"
+        );
+
+        write(&dir, "tracked.txt", "one\ntwo\nthree\n");
+        let (unstaged, _) = run_diff(&root, "tracked.txt", false, None).await.unwrap();
+        assert!(unstaged.contains("+three"), "a worktree edit: {unstaged:?}");
+
+        run_git(&dir, &["add", "tracked.txt"]);
+        let (staged, _) = run_diff(&root, "tracked.txt", true, None).await.unwrap();
+        assert!(
+            staged.contains("+three"),
+            "a change that is entirely in the index still has a diff: {staged:?}"
+        );
+
+        // The overlay folds unchanged runs into expandable bands, which needs the
+        // whole file rather than git's three lines of context.
+        let (wide, _) = run_diff(&root, "tracked.txt", true, Some(999_999))
+            .await
+            .unwrap();
+        assert!(
+            wide.contains(" one") && wide.contains(" two"),
+            "a large -U carries the unchanged lines too: {wide:?}"
+        );
     }
 
     #[tokio::test]

--- a/termiod/src/git.rs
+++ b/termiod/src/git.rs
@@ -245,27 +245,33 @@ pub async fn run_status(root: &str) -> Result<GitSnapshot> {
 pub const STATUS_CAP: usize = 5_000;
 
 /// And the most path bytes, because the entry count alone does not bound a
-/// frame — a deeply nested tree can carry very long paths.
-const STATUS_PATH_BYTES_CAP: usize = 2 * 1024 * 1024;
+/// frame — a deeply nested tree can carry very long paths. One batch spends
+/// its paths three times (updated, removed, conflicts) and JSON can double a
+/// path that is all quotes, so the headroom under `MAX_FRAME_SIZE` is what
+/// this number buys: 6 × 1 MiB, plus at most `STATUS_CAP` entry envelopes.
+const STATUS_PATH_BYTES_CAP: usize = 1024 * 1024;
 
 /// Cut an oversized status list down to what a batch may carry.
 ///
-/// Tracked changes are kept first and untracked ones fill what is left: the
+/// Conflicts survive first — the one status that must be acted on — then the
+/// rest of the tracked changes, and untracked paths fill what is left: the
 /// flood case is always untracked build output, and the edits a person is
-/// reviewing are the rows that must survive it. Within each half the order is
-/// by path, so the cut is deterministic — two consecutive runs of an unchanged
-/// flooded tree keep the same rows and produce no delta.
+/// reviewing are the rows that must outlive it. That is the order the pane
+/// already sorts rows in. Within each tier the order is by path, so the cut is
+/// deterministic — two consecutive runs over an unchanged flooded tree keep the
+/// same rows and produce no delta.
 fn cap_statuses(snapshot: &mut GitSnapshot) {
     if snapshot.statuses.len() <= STATUS_CAP {
         return;
     }
     let mut paths: Vec<&String> = snapshot.statuses.keys().collect();
     paths.sort_by_key(|path| {
-        let untracked = matches!(
-            snapshot.statuses[*path].status,
-            Some(GitFileStatus::Untracked) | Some(GitFileStatus::Ignored)
-        );
-        (untracked, *path)
+        let tier = match snapshot.statuses[*path].status {
+            Some(GitFileStatus::Unmerged { .. }) => 0,
+            Some(GitFileStatus::Untracked) | Some(GitFileStatus::Ignored) => 2,
+            _ => 1,
+        };
+        (tier, *path)
     });
     let mut bytes = 0usize;
     let mut keep: HashSet<String> = HashSet::new();
@@ -1361,6 +1367,13 @@ mod tests {
                 worktree_status: GitStatusCode::Modified,
             }),
         );
+        snapshot.statuses.insert(
+            "zzz/conflicted.rs".to_string(),
+            FileState::new(GitFileStatus::Unmerged {
+                first_head: GitUnmergedCode::Updated,
+                second_head: GitUnmergedCode::Updated,
+            }),
+        );
         for index in 0..STATUS_CAP + 10 {
             snapshot.statuses.insert(
                 format!("node_modules/pkg/{index}.js"),
@@ -1375,6 +1388,11 @@ mod tests {
             snapshot.statuses.contains_key("src/edited.rs"),
             "the tracked edit is the row a person is reviewing; the flood is not"
         );
+        assert!(
+            snapshot.statuses.contains_key("zzz/conflicted.rs"),
+            "a conflict must act on outlives everything, whatever it sorts as"
+        );
+        assert_eq!(snapshot.conflicts(), vec!["zzz/conflicted.rs".to_string()]);
     }
 
     /// The cut has to be deterministic, or two runs over an unchanged flooded

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -1271,13 +1271,14 @@ pub enum Event {
         ahead_behind: Option<(u32, u32)>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         conflicts: Vec<String>,
-        /// The status list was cut at `git::STATUS_CAP` — a batch is
-        /// one frame, and an uncapped `--untracked-files=all` over a tree with
-        /// no `.gitignore` would exceed `MAX_FRAME_SIZE` and take the whole
-        /// connection with it. Carried so a partial list cannot read as a
-        /// complete one.
-        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-        truncated: bool,
+        /// How many paths the status run named, when the list was cut below
+        /// that (`git::STATUS_CAP`) — a batch is one frame, and an uncapped
+        /// `--untracked-files=all` over a tree with no `.gitignore` would
+        /// exceed `MAX_FRAME_SIZE` and take the whole connection with it.
+        /// Carried so a partial list cannot read as a complete one, and so the
+        /// pane can say how much of it is missing.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        total: Option<u64>,
     },
     /// Roster delta used by control-channel `subscribe`.
     Roster {

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -1271,6 +1271,13 @@ pub enum Event {
         ahead_behind: Option<(u32, u32)>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         conflicts: Vec<String>,
+        /// The status list was cut at `git::STATUS_CAP` — a batch is
+        /// one frame, and an uncapped `--untracked-files=all` over a tree with
+        /// no `.gitignore` would exceed `MAX_FRAME_SIZE` and take the whole
+        /// connection with it. Carried so a partial list cannot read as a
+        /// complete one.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        truncated: bool,
     },
     /// Roster delta used by control-channel `subscribe`.
     Roster {

--- a/termiod/src/protocol.rs
+++ b/termiod/src/protocol.rs
@@ -281,10 +281,28 @@ pub enum GitFileStatus {
     },
 }
 
+/// One changed path in a `git_changed` batch (§C.13).
+///
+/// The line counts ride the status rather than waiting for a diff, because the
+/// row that shows the path shows `+N −M` beside it — a client that had to ask
+/// per file would need one round trip per row to draw one list. Zed carries the
+/// same numbers on the same message (`git.proto` `StatusEntry.diff_stat_added`),
+/// for the same reason.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GitStatusEntry {
     pub path: String,
     pub status: GitFileStatus,
+    /// Where a renamed file came from, for the row that says `old → new`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_path: Option<String>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub additions: u64,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub deletions: u64,
+    /// The counts are not numbers for this file — git reported `-`, or it is an
+    /// untracked file that sniffs as binary. `+0 −0` would be a lie, not a zero.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub binary: bool,
 }
 
 /// One commit row (§C.13 read tier), as `git.log` and `git.show` report it.
@@ -729,6 +747,11 @@ pub enum Control {
         path: String,
         #[serde(default)]
         staged: bool,
+        /// The `-U` the client wants. A pane that folds unchanged runs into
+        /// expandable bands needs the whole file, not git's default three lines
+        /// of context; absent means git's default.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
     },

--- a/termiod/src/resource.rs
+++ b/termiod/src/resource.rs
@@ -631,6 +631,9 @@ fn absorb(
         seen.clear();
         return;
     }
+    if is_read_only_access(&event.kind) {
+        return;
+    }
     for path in event.paths {
         match classify(&path) {
             Classified::Ignored => {}
@@ -650,6 +653,29 @@ fn absorb(
                 }
             }
         }
+    }
+}
+
+/// Reading a directory is not a change to it — and on Linux, saying otherwise
+/// is a closed loop. `notify`'s inotify backend watches `IN_OPEN`
+/// (notify-8.2.0 `inotify.rs`, `WatchMask::OPEN`), so the name index's own
+/// `read_dir` of a directory in a batch is reported back as that directory
+/// changing, which produces the next batch, which re-walks it. Measured against
+/// a Linux host: one lap per `DEBOUNCE` on an empty, untouched directory,
+/// forever — and since the watch only retires on its idle tick, which never
+/// fires while it is chattering, it never stops. Every batch also drives a
+/// `git status` run (`git_loop`), so the cost lands on the user's box, not just
+/// on the wire.
+///
+/// Closing a file after *writing* it (`IN_CLOSE_WRITE`) is a change and stays.
+/// macOS never saw this: FSEvents does not report reads at all, which is why
+/// the loop is invisible on the platform the daemon is developed on.
+fn is_read_only_access(kind: &notify::EventKind) -> bool {
+    use notify::event::{AccessKind, AccessMode};
+    match kind {
+        notify::EventKind::Access(AccessKind::Close(AccessMode::Write)) => false,
+        notify::EventKind::Access(_) => true,
+        _ => false,
     }
 }
 
@@ -738,6 +764,43 @@ mod tests {
         }
         assert!(pending.full_rescan, "storm must set full_rescan");
         assert!(pending.paths.is_empty(), "paths are dropped once rescanning");
+    }
+
+    /// The index re-walks every directory a batch names, and on Linux that read
+    /// comes back as an `IN_OPEN` on the same directory. Treating it as a change
+    /// makes the watch feed itself forever, so a read must produce no batch at
+    /// all — while a write that closes still must.
+    #[test]
+    fn reading_a_directory_is_not_a_change_but_closing_a_written_file_is() {
+        use notify::event::{AccessKind, AccessMode};
+        let mut pending = FsBatch::default();
+        let mut seen = std::collections::HashSet::new();
+
+        for kind in [
+            notify::EventKind::Access(AccessKind::Open(AccessMode::Any)),
+            notify::EventKind::Access(AccessKind::Read),
+            notify::EventKind::Access(AccessKind::Close(AccessMode::Read)),
+        ] {
+            absorb(
+                Ok(notify::Event::new(kind).add_path(PathBuf::from("/repo/src/main.rs"))),
+                &mut pending,
+                &mut seen,
+            );
+        }
+        assert!(pending.paths.is_empty(), "a read is not a change");
+        assert!(!pending.full_rescan);
+
+        absorb(
+            Ok(
+                notify::Event::new(notify::EventKind::Access(AccessKind::Close(
+                    AccessMode::Write,
+                )))
+                .add_path(PathBuf::from("/repo/src/main.rs")),
+            ),
+            &mut pending,
+            &mut seen,
+        );
+        assert_eq!(pending.paths, vec!["/repo/src".to_string()]);
     }
 
     /// A watch with no OS watcher behind it, so the ring and replay rules can


### PR DESCRIPTION
Stage 9 of the unify-server-plane RFC (docs/design/20260819-unify-server-plane.md): the git pane reads a device.

The pane short-circuited to "Changes isn't available on this device yet" for any checkout on another machine, because it is built on `GitService`, which shells out to `/usr/bin/git` against a local path. The daemon has served the git read tier since d38f50c; nothing on the Mac ever asked.

- **Daemon**: the git read tier answers the way a changes row reads it, and the workspace watch no longer feeds itself on Linux.
- **Pool**: resource subscriptions ride the pooled channel. The handler is registered before the request goes out — the first batch can arrive ahead of the ack (measured 2 ms behind it) — and a subscribed channel is never reaped, however long since its last request. A channel that dies tells its subscribers, and the device keeps the replay ring so they resume from their cursor.
- **Pane**: status is a subscription, not a poll — the device publishes deltas the way Zed's `UpdateRepository` does. Diffs are a provider swap: both roads produce unified-diff text, so a device diff renders through the identical parser, fold, word-diff and syntax stack. Read-only on purpose: Discard, Ignore, Open in Editor and Reveal in Finder act on files this Mac does not have, so they are absent rather than shown inert.

Rebase note: main landed the `fs:` live tree on channel observers (cedbca4) while this branch carried resource subscriptions, so the reader thread now has both delivery paths — `fs:` on observers, `git:` on subscriptions — and the shared `SubscribeResourceOperation` / `SubscribedPayload` definitions are used by both. Folding `fs:` onto subscriptions is follow-up work.

Release Notes:
- The Changes pane now works for checkouts on a device: live git status over the daemon and diffs rendered through the same viewer. Read-only for now.

---

Review round (four commits since the first read):

- **A flooded checkout no longer takes the connection down.** A batch is one frame, and `--untracked-files=all` over a tree with no `.gitignore` cleared `MAX_FRAME_SIZE` — which the writer treats as a dead socket, so the file tree and agent status went with it. The status list is cut at `STATUS_CAP`, conflicts first and untracked last, bounded by encoded path bytes as well as entry count (a control byte a filename may hold costs six characters in JSON). The batch carries the real path count, so the pane reads "first 5,000 of 41,900 files" rather than a number that isn't the working tree.
- **Counting untracked lines moved to `spawn_blocking`.** It ran on a runtime worker on every status refresh — up to 500 files of 4 MB — parking whatever else that worker carried. `files.rs` already puts its directory reads off the runtime for the same reason.
- **A released pane retires its watch.** The routing table held subscriptions strongly, so `ResourceSubscription.deinit` could never run: a pane released without `.onDisappear` left a `git status` loop running on the box and pinned the channel, which is never reaped while subscribed. The table files subscribers weakly and unregisters by identity. A subscribe that fails after the request went out cancels rather than dropping its local registration, since the device may have armed the watch and only the reply was lost.
- **Two watch-lifecycle races.** A delayed reconnect no longer resurrects a stopped watch, and a hide/show during an in-flight handshake no longer leaves a visible pane permanently unwatched.
