### PR TITLE
Extract termiod's module tree into a library crate

### DIFF
--- a/termiod/Cargo.toml
+++ b/termiod/Cargo.toml
@@ -2,6 +2,7 @@
 name = "termiod"
 version = "0.1.0"
 edition = "2021"
+publish = false
 description = "termiod — durable PTY session host (POC). Detach ≠ kill."
 license = "MIT"
 
@@ -12,9 +13,13 @@ license = "MIT"
 members = ["vt"]
 default-members = [".", "vt"]
 
+[lib]
+name = "termiod"
+path = "src/lib.rs"
+
 [[bin]]
 name = "termiod"
-path = "src/main.rs"
+path = "src/bin/termiod.rs"
 
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "io-std", "sync", "macros", "signal", "time", "process"] }

--- a/termiod/src/bin/termiod.rs
+++ b/termiod/src/bin/termiod.rs
@@ -7,31 +7,11 @@
 //!
 //! See `ARCHITECTURE.md` and `README.md`.
 
-mod agent;
-mod client;
-mod daemon;
-mod files;
-mod git;
-mod handoff;
-mod id;
-mod keep_awake;
-mod lifecycle;
-mod log;
-mod paths;
-mod proc;
-mod protocol;
-mod pty;
-mod remote;
-mod resource;
-mod service;
-mod session;
-mod tombstone;
-mod wss;
-
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use protocol::CreateSpec;
 use std::net::SocketAddr;
+use termiod::protocol::CreateSpec;
+use termiod::{agent, client, daemon, handoff, lifecycle, log, protocol, remote, service, wss};
 
 #[derive(Parser)]
 #[command(

--- a/termiod/src/lib.rs
+++ b/termiod/src/lib.rs
@@ -1,0 +1,32 @@
+//! Internal library for the `termiod` and `termio` binaries.
+//!
+//! This is not a public API: every module is exported so the two binaries in
+//! `src/bin/` can share one implementation, and nothing here carries a
+//! stability promise. Downstream code lives in this repository only.
+//!
+//! Dependency discipline (docker-lessons RFC §6): the runtime core — PTY
+//! host, session lifecycle, framed protocol — must not import from the
+//! planes (`files`, `git`, `resource`, `agent`). Planes may depend on the
+//! core; the core compiles without them. If this ever needs teeth it becomes
+//! a `termiod-core` crate boundary, the same move as `termiod-vt`.
+
+pub mod agent;
+pub mod client;
+pub mod daemon;
+pub mod files;
+pub mod git;
+pub mod handoff;
+pub mod id;
+pub mod keep_awake;
+pub mod lifecycle;
+pub mod log;
+pub mod paths;
+pub mod proc;
+pub mod protocol;
+pub mod pty;
+pub mod remote;
+pub mod resource;
+pub mod service;
+pub mod session;
+pub mod tombstone;
+pub mod wss;

--- a/termiod/src/lib.rs
+++ b/termiod/src/lib.rs
@@ -1,8 +1,17 @@
 //! Internal library for the `termiod` and `termio` binaries.
 //!
-//! This is not a public API: every module is exported so the two binaries in
-//! `src/bin/` can share one implementation, and nothing here carries a
-//! stability promise. Downstream code lives in this repository only.
+//! Nothing here is a supported interface: every module is exported so the
+//! binaries in `src/bin/` can share one implementation, and nothing carries
+//! a stability promise. `publish = false` keeps the crate off the registry;
+//! it does not stop a path dependency, so the visibility is convenience for
+//! this repository, not a contract.
+//!
+//! One seam to respect when adding a binary: several paths assume the
+//! current executable IS the daemon — `client::connect`'s auto-start spawns
+//! `current_exe()` with `serve`, `lifecycle`'s handoff defaults to it,
+//! `service` installs it, and `remote::shipped_binary()` deploys it to Mac
+//! targets. A client binary must resolve the daemon binary explicitly
+//! before reaching any of them.
 //!
 //! Dependency discipline (docker-lessons RFC §6): the runtime core — PTY
 //! host, session lifecycle, framed protocol — must not import from the

--- a/termiod/src/session/backlog.rs
+++ b/termiod/src/session/backlog.rs
@@ -29,13 +29,13 @@ pub(crate) fn cap_description() -> String {
 /// reservation that let it through, so a forced resync can discard everything
 /// already queued for that client without corrupting the count.
 #[derive(Clone)]
-pub(crate) struct Metered {
+pub struct Metered {
     pub(crate) bytes: Bytes,
     epoch: u64,
 }
 
 /// Counts PTY bytes queued anywhere between a session and its socket writer.
-pub(crate) struct ClientBacklog {
+pub struct ClientBacklog {
     outstanding: AtomicUsize,
     /// Bumped by a forced resync. Everything reserved under an older epoch is
     /// stale: it precedes a snapshot that supersedes it, so it is dropped


### PR DESCRIPTION
The crate had one binary rooted at `src/main.rs` declaring all twenty modules, so a second binary could not import them. This moves the module tree to `src/lib.rs` (every module `pub`; the crate is internal and marked `publish = false`) and makes `src/bin/termiod.rs` a thin entry importing what it uses. `Metered` and `ClientBacklog` become `pub` because public enums in a library may not expose crate-private types.

This is the lib extraction the docker-lessons RFC §1.3 prices as the prerequisite for the Rust `termio` client (unify-server-plane Stage 10, pulled forward per #551). The `termio` binary itself comes in a follow-up; this PR is deliberately mechanical.

Verified no behavior change:

- `--help` output byte-identical to the pre-move build, top level and all eighteen subcommands
- `cargo test` green: 255 tests across the lib and 11 integration suites, including the 8 handoff-contract tests
- `smoke_test.py` and `remote_smoke_test.py` both pass
- `--version` output identical; CI's `TERMIO_TERMIOD_TEST_BIN` path (`target/debug/termiod`) unchanged

Release Notes:

- None (internal refactor).