### PR TITLE
Add the termio client binary skeleton

### DIFF
--- a/termiod/Cargo.toml
+++ b/termiod/Cargo.toml
@@ -3,6 +3,7 @@ name = "termiod"
 version = "0.1.0"
 edition = "2021"
 publish = false
+default-run = "termiod"
 description = "termiod — durable PTY session host (POC). Detach ≠ kill."
 license = "MIT"
 
@@ -20,6 +21,10 @@ path = "src/lib.rs"
 [[bin]]
 name = "termiod"
 path = "src/bin/termiod.rs"
+
+[[bin]]
+name = "termio"
+path = "src/bin/termio.rs"
 
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "io-std", "sync", "macros", "signal", "time", "process"] }

--- a/termiod/src/bin/termio.rs
+++ b/termiod/src/bin/termio.rs
@@ -13,7 +13,7 @@
 
 use anyhow::{bail, Context, Result};
 use std::os::unix::process::CommandExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use termiod::channel::{self, Channel};
 use termiod::{lifecycle, version};
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
             println!("{USAGE}");
             Ok(())
         }
-        Some("-V") | Some("--version") => {
+        Some("--version") => {
             println!("termio {} ({})", lifecycle::BUILD_VERSION, channel.name);
             Ok(())
         }
@@ -83,61 +83,10 @@ fn open_project(channel: &Channel, directory: &Path) -> Result<()> {
 /// daemon-sibling fix, not here. `channel::resolve` already pinned
 /// `TERMIO_CHANNEL`, which the exec inherits.
 fn remote_passthrough(channel: &Channel, rest: &[String]) -> Result<()> {
-    let Some(daemon) = locate_termiod(channel) else {
+    let Some(daemon) = channel::daemon_binary(channel) else {
         eprintln!("termio: no termiod binary found — install the termio app, or set TERMIOD_BIN");
         std::process::exit(1);
     };
     let error = Command::new(&daemon).arg("remote").args(rest).exec();
     Err(error).with_context(|| format!("running {}", daemon.display()))
-}
-
-/// The shell client's `locate_termiod()`, same rungs in the same order: the
-/// explicit `TERMIOD_BIN` override; the daemon bundled beside this binary
-/// (`Contents/Resources` in the app, `target/{debug,release}` in a
-/// checkout); the running app's bundle via `lsappinfo`, which only answers
-/// for a live process so it can never name a stale bundle; then the
-/// standalone install locations.
-fn locate_termiod(channel: &Channel) -> Option<PathBuf> {
-    if let Some(explicit) = std::env::var_os("TERMIOD_BIN") {
-        let path = PathBuf::from(explicit);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-    if let Ok(own) = std::env::current_exe() {
-        if let Some(sibling) = own.canonicalize().ok().and_then(|resolved| {
-            let candidate = resolved.parent()?.join("termiod");
-            candidate.is_file().then_some(candidate)
-        }) {
-            return Some(sibling);
-        }
-    }
-    if cfg!(target_os = "macos") {
-        if let Ok(info) = Command::new("lsappinfo")
-            .args(["info", "-only", "bundlepath", &channel.bundle_id])
-            .output()
-        {
-            let stdout = String::from_utf8_lossy(&info.stdout);
-            if let Some(bundle) = stdout
-                .lines()
-                .find_map(|line| line.strip_prefix("\"LSBundlePath\"=\""))
-                .and_then(|rest| rest.strip_suffix('"'))
-            {
-                let candidate = Path::new(bundle).join("Contents/Resources/termiod");
-                if candidate.is_file() {
-                    return Some(candidate);
-                }
-            }
-        }
-    }
-    if let Some(home) = std::env::var_os("HOME") {
-        let candidate = Path::new(&home).join(".local/bin/termiod");
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    let path_variable = std::env::var_os("PATH")?;
-    std::env::split_paths(&path_variable)
-        .map(|directory| directory.join("termiod"))
-        .find(|candidate| candidate.is_file())
 }

--- a/termiod/src/bin/termio.rs
+++ b/termiod/src/bin/termio.rs
@@ -1,0 +1,143 @@
+//! termio — the command a person types. `termiod` is the daemon, like
+//! `dockerd`; this client drives the Mac app and the session host
+//! (docker-lessons RFC §1).
+//!
+//! This binary is the Rust replacement for `scripts/termio`, growing verb by
+//! verb (unify-server-plane Stage 10). Implemented here: `version`,
+//! `remote`, `open`, and the bare-`DIR` shorthand. Until the port completes,
+//! `sessions`, `agent report`, and `notify` stay with the shell client.
+//!
+//! The dispatcher is a hand-rolled match, not clap: `termio [DIR]` must
+//! treat any non-verb first argument as a directory (the `code .` shape),
+//! and `remote` is an argv passthrough whose help belongs to the daemon.
+
+use anyhow::{bail, Context, Result};
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use termiod::channel::{self, Channel};
+use termiod::{lifecycle, version};
+
+const USAGE: &str = "\
+termio — drive the termio app and its session host from the terminal
+
+usage:
+  termio [DIR]           open DIR (default: .) as a project in termio
+  termio open [DIR]      the same, spelled out
+  termio version         every version in one table: client, app, local termiod, known remotes
+  termio remote <verb> … drive a remote box's termiod (deploy, list, attach, open)
+  termio --version       client version and channel
+
+not yet ported from the shell client: sessions, agent, notify";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let (channel, provenance) = channel::resolve();
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    match arguments.first().map(String::as_str) {
+        None => open_project(&channel, Path::new(".")),
+        Some("-h") | Some("--help") | Some("help") => {
+            println!("{USAGE}");
+            Ok(())
+        }
+        Some("-V") | Some("--version") => {
+            println!("termio {} ({})", lifecycle::BUILD_VERSION, channel.name);
+            Ok(())
+        }
+        Some("version") => version::print_table(&channel, provenance).await,
+        Some("remote") => remote_passthrough(&channel, &arguments[1..]),
+        Some("open") => {
+            let directory = arguments.get(1).map(String::as_str).unwrap_or(".");
+            open_project(&channel, Path::new(directory))
+        }
+        // Bare `termio [DIR]` stays as the `code .`-shaped shorthand for `open`.
+        Some(directory) => open_project(&channel, Path::new(directory)),
+    }
+}
+
+/// Resolve to an absolute, symlink-free path so termio keys the project by
+/// the same canonical path it stores, avoiding duplicate sidebar entries.
+fn open_project(channel: &Channel, directory: &Path) -> Result<()> {
+    if !directory.is_dir() {
+        eprintln!("termio: not a directory: {}", directory.display());
+        std::process::exit(1);
+    }
+    let absolute = directory
+        .canonicalize()
+        .with_context(|| format!("resolving {}", directory.display()))?;
+    if !cfg!(target_os = "macos") {
+        bail!("termio open drives the Mac app; there is none on this machine");
+    }
+    let error = Command::new("open")
+        .arg("-b")
+        .arg(&channel.bundle_id)
+        .arg(&absolute)
+        .exec();
+    Err(error).context("running open")
+}
+
+/// `termio remote …` execs the daemon binary rather than calling
+/// `remote::run` in-process: `shipped_binary()` deploys `current_exe()` to
+/// Mac targets, so an in-process call from this client would ship the client
+/// as the remote daemon. The in-process move happens together with a
+/// daemon-sibling fix, not here. `channel::resolve` already pinned
+/// `TERMIO_CHANNEL`, which the exec inherits.
+fn remote_passthrough(channel: &Channel, rest: &[String]) -> Result<()> {
+    let Some(daemon) = locate_termiod(channel) else {
+        eprintln!("termio: no termiod binary found — install the termio app, or set TERMIOD_BIN");
+        std::process::exit(1);
+    };
+    let error = Command::new(&daemon).arg("remote").args(rest).exec();
+    Err(error).with_context(|| format!("running {}", daemon.display()))
+}
+
+/// The shell client's `locate_termiod()`, same rungs in the same order: the
+/// explicit `TERMIOD_BIN` override; the daemon bundled beside this binary
+/// (`Contents/Resources` in the app, `target/{debug,release}` in a
+/// checkout); the running app's bundle via `lsappinfo`, which only answers
+/// for a live process so it can never name a stale bundle; then the
+/// standalone install locations.
+fn locate_termiod(channel: &Channel) -> Option<PathBuf> {
+    if let Some(explicit) = std::env::var_os("TERMIOD_BIN") {
+        let path = PathBuf::from(explicit);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    if let Ok(own) = std::env::current_exe() {
+        if let Some(sibling) = own.canonicalize().ok().and_then(|resolved| {
+            let candidate = resolved.parent()?.join("termiod");
+            candidate.is_file().then_some(candidate)
+        }) {
+            return Some(sibling);
+        }
+    }
+    if cfg!(target_os = "macos") {
+        if let Ok(info) = Command::new("lsappinfo")
+            .args(["info", "-only", "bundlepath", &channel.bundle_id])
+            .output()
+        {
+            let stdout = String::from_utf8_lossy(&info.stdout);
+            if let Some(bundle) = stdout
+                .lines()
+                .find_map(|line| line.strip_prefix("\"LSBundlePath\"=\""))
+                .and_then(|rest| rest.strip_suffix('"'))
+            {
+                let candidate = Path::new(bundle).join("Contents/Resources/termiod");
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let candidate = Path::new(&home).join(".local/bin/termiod");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    let path_variable = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_variable)
+        .map(|directory| directory.join("termiod"))
+        .find(|candidate| candidate.is_file())
+}

--- a/termiod/src/channel.rs
+++ b/termiod/src/channel.rs
@@ -1,0 +1,152 @@
+//! Which channel the `termio` client drives, resolved from its own name.
+//!
+//! The shell client carried three build-time rewritten variables
+//! (`SUPPORT_DIR_NAME`, `BUNDLE_ID`, `VERSION`); this derives the same
+//! bindings from argv[0] instead: the dev bundle installs the binary as
+//! `termio-dev`, which selects the `.dev` bundle id, the `termio-dev`
+//! support directory, and the dev daemon socket. One binary, no sed.
+//!
+//! An inherited `TERMIO_CHANNEL` is deliberately not consulted: the shell
+//! client pinned `TERMIO_CHANNEL="$CHANNEL"` on every daemon exec so a stale
+//! value could not cross channels, and this keeps that rule. The one runtime
+//! override is `TERMIOD_SOCK`, which pins the daemon socket outright
+//! (`paths::socket_path` honors it first) — that is how a hook firing inside
+//! a channel-pinned session reaches the daemon that owns it. `termio
+//! version` prints which of the two answered, so a surprising socket names
+//! its own cause.
+
+/// The bindings the shell client's three rewritten variables carried.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Channel {
+    /// `release`, `dev`, or a custom probe channel name.
+    pub name: String,
+    /// The Mac app this client drives (`open -b`, `lsappinfo`).
+    pub bundle_id: String,
+    /// Directory name under `~/Library/Application Support` holding the
+    /// app's control socket, support copies, and device registry.
+    pub support_dir_name: String,
+}
+
+/// Which rung decided where the daemon socket is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provenance {
+    /// `TERMIOD_SOCK` names the socket directly.
+    ExplicitSocket,
+    /// Derived from the binary's own name (`termio` / `termio-<channel>`).
+    ProgramName,
+}
+
+impl Channel {
+    fn release() -> Channel {
+        Channel {
+            name: "release".to_string(),
+            bundle_id: "sh.termio.app".to_string(),
+            support_dir_name: "termio".to_string(),
+        }
+    }
+
+    /// Same validation rule as `paths::channel_suffix`: a channel name is a
+    /// path component, so anything that isn't lowercase alphanumeric-or-dash
+    /// falls back to the release channel instead of opening a stray
+    /// directory.
+    fn named(candidate: &str) -> Channel {
+        let name = candidate.trim().to_lowercase();
+        if name.is_empty() || name == "release" {
+            return Channel::release();
+        }
+        if !name
+            .chars()
+            .all(|character| character.is_alphanumeric() || character == '-')
+        {
+            return Channel::release();
+        }
+        Channel {
+            bundle_id: format!("sh.termio.app.{name}"),
+            support_dir_name: format!("termio-{name}"),
+            name,
+        }
+    }
+
+    /// `termio` → release; `termio-dev` → dev; `termio-<name>` → `<name>`;
+    /// anything else → release. Takes the bare program name, not a path.
+    pub fn from_program_name(program: &str) -> Channel {
+        match program.strip_prefix("termio-") {
+            Some(rest) => Channel::named(rest),
+            None => Channel::release(),
+        }
+    }
+}
+
+fn program_name() -> String {
+    std::env::args()
+        .next()
+        .as_deref()
+        .map(std::path::Path::new)
+        .and_then(|path| path.file_name())
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "termio".to_string())
+}
+
+fn explicit_socket() -> bool {
+    std::env::var_os("TERMIOD_SOCK").is_some_and(|value| !value.is_empty())
+}
+
+/// Resolve the channel and pin it for everything downstream: sets
+/// `TERMIO_CHANNEL` in this process's environment so `paths::*` and every
+/// exec'd daemon derive the same socket, overwriting any inherited value —
+/// the same pin the shell client applied on every daemon exec.
+pub fn resolve() -> (Channel, Provenance) {
+    let channel = Channel::from_program_name(&program_name());
+    std::env::set_var("TERMIO_CHANNEL", &channel.name);
+    let provenance = if explicit_socket() {
+        Provenance::ExplicitSocket
+    } else {
+        Provenance::ProgramName
+    };
+    (channel, provenance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_plain_name_is_the_release_channel() {
+        let channel = Channel::from_program_name("termio");
+        assert_eq!(channel.name, "release");
+        assert_eq!(channel.bundle_id, "sh.termio.app");
+        assert_eq!(channel.support_dir_name, "termio");
+    }
+
+    #[test]
+    fn a_dev_suffix_selects_the_dev_bundle_and_support_dir() {
+        let channel = Channel::from_program_name("termio-dev");
+        assert_eq!(channel.name, "dev");
+        assert_eq!(channel.bundle_id, "sh.termio.app.dev");
+        assert_eq!(channel.support_dir_name, "termio-dev");
+    }
+
+    #[test]
+    fn a_custom_suffix_is_its_own_probe_channel() {
+        let channel = Channel::from_program_name("termio-smoke2");
+        assert_eq!(channel.name, "smoke2");
+        assert_eq!(channel.support_dir_name, "termio-smoke2");
+    }
+
+    #[test]
+    fn an_explicit_release_suffix_collapses_to_release() {
+        assert_eq!(Channel::from_program_name("termio-release"), Channel::release());
+    }
+
+    #[test]
+    fn an_invalid_suffix_falls_back_to_release_like_paths_does() {
+        assert_eq!(Channel::from_program_name("termio-../evil"), Channel::release());
+        assert_eq!(Channel::from_program_name("termio-a_b"), Channel::release());
+    }
+
+    #[test]
+    fn an_unrelated_program_name_is_release() {
+        assert_eq!(Channel::from_program_name("termiofoo"), Channel::release());
+        assert_eq!(Channel::from_program_name("cargo"), Channel::release());
+    }
+}

--- a/termiod/src/channel.rs
+++ b/termiod/src/channel.rs
@@ -106,6 +106,73 @@ pub fn resolve() -> (Channel, Provenance) {
     (channel, provenance)
 }
 
+/// The shell client's `locate_termiod()`, same rungs in the same order: the
+/// explicit `TERMIOD_BIN` override; the daemon beside this binary, but only
+/// when this binary itself runs out of a bundle's `Contents/Resources` (a
+/// checkout's `target/debug/termio` must not quietly prefer its sibling over
+/// the live app); the running app's bundle via `lsappinfo`, which only
+/// answers for a live process so it can never name a stale bundle; then the
+/// standalone install locations. Every rung requires an executable file,
+/// like the shell's `-x` and `command -v`.
+pub fn daemon_binary(channel: &Channel) -> Option<std::path::PathBuf> {
+    use std::path::{Path, PathBuf};
+    if let Some(explicit) = std::env::var_os("TERMIOD_BIN") {
+        let path = PathBuf::from(explicit);
+        if executable(&path) {
+            return Some(path);
+        }
+    }
+    if let Some(resolved) = std::env::current_exe()
+        .ok()
+        .and_then(|own| own.canonicalize().ok())
+    {
+        if let Some(parent) = resolved.parent() {
+            if parent.ends_with("Contents/Resources") {
+                let candidate = parent.join("termiod");
+                if executable(&candidate) {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    if cfg!(target_os = "macos") {
+        if let Ok(info) = std::process::Command::new("lsappinfo")
+            .args(["info", "-only", "bundlepath", &channel.bundle_id])
+            .output()
+        {
+            let stdout = String::from_utf8_lossy(&info.stdout);
+            if let Some(bundle) = stdout
+                .lines()
+                .find_map(|line| line.strip_prefix("\"LSBundlePath\"=\""))
+                .and_then(|rest| rest.strip_suffix('"'))
+            {
+                let candidate = Path::new(bundle).join("Contents/Resources/termiod");
+                if executable(&candidate) {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let candidate = Path::new(&home).join(".local/bin/termiod");
+        if executable(&candidate) {
+            return Some(candidate);
+        }
+    }
+    let path_variable = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_variable)
+        .map(|directory| directory.join("termiod"))
+        .find(|candidate| executable(candidate))
+}
+
+fn executable(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.is_file()
+        && std::fs::metadata(path)
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/termiod/src/lib.rs
+++ b/termiod/src/lib.rs
@@ -20,6 +20,7 @@
 //! a `termiod-core` crate boundary, the same move as `termiod-vt`.
 
 pub mod agent;
+pub mod channel;
 pub mod client;
 pub mod daemon;
 pub mod files;
@@ -38,4 +39,5 @@ pub mod resource;
 pub mod service;
 pub mod session;
 pub mod tombstone;
+pub mod version;
 pub mod wss;

--- a/termiod/src/version.rs
+++ b/termiod/src/version.rs
@@ -6,12 +6,15 @@
 //! spoken to is absent, and nothing here touches the network.
 //!
 //! Ported from the shell client's `version_table()`, with two deliberate
-//! deviations: the local daemon rows come from `lifecycle::status()`
-//! in-process instead of awk over pretty-printed JSON, and a final line
-//! names the resolved socket and which rung chose it (`TERMIOD_SOCK` or the
-//! program name), so a surprising socket names its own cause.
+//! deviations: the located daemon's `status --json` is parsed into the typed
+//! `lifecycle::NodeStatus` instead of awk over its pretty printing, and a
+//! final line names the resolved socket and which rung chose it
+//! (`TERMIOD_SOCK` or the program name), so a surprising socket names its
+//! own cause. Like the shell client, the daemon rows come from the *located
+//! daemon binary*, not this process — a staged daemon/client skew must show
+//! in this table, and asking ourselves would hide it.
 
-use crate::channel::{Channel, Provenance};
+use crate::channel::{self, Channel, Provenance};
 use crate::{lifecycle, paths};
 use anyhow::Result;
 use std::process::Command;
@@ -35,26 +38,31 @@ pub async fn print_table(channel: &Channel, provenance: Provenance) -> Result<()
         None => row("termio.app", "-", "", "(not running)"),
     }
 
-    match lifecycle::status().await {
-        Ok(status) if status.daemon.running => {
-            let version = status.daemon.version.unwrap_or(status.binary.version);
-            let proto = status
-                .daemon
-                .proto
-                .map(|proto| format!("proto {proto}"))
-                .unwrap_or_default();
-            row("termiod local", &version, &proto, "");
-        }
-        // This binary and the daemon build from one crate, so its own stamp
-        // is the installed daemon's version — the shell client had to locate
-        // and exec the daemon binary to learn the same thing.
-        Ok(status) => row(
-            "termiod local",
-            &status.binary.version,
-            "",
-            "(binary; daemon not running)",
-        ),
-        Err(_) => row("termiod local", "-", "", "(no answer)"),
+    match channel::daemon_binary(channel) {
+        None => row("termiod local", "-", "", "(not installed)"),
+        Some(daemon) => match daemon_status(&daemon) {
+            Some(status) if status.daemon.running => {
+                let version = status.daemon.version.unwrap_or(status.binary.version);
+                let proto = status
+                    .daemon
+                    .proto
+                    .map(|proto| format!("proto {proto}"))
+                    .unwrap_or_default();
+                row("termiod local", &version, &proto, "");
+            }
+            Some(status) if !status.binary.version.is_empty() => row(
+                "termiod local",
+                &status.binary.version,
+                "",
+                "(binary; daemon not running)",
+            ),
+            _ => row(
+                "termiod local",
+                "-",
+                "",
+                &format!("(no answer from {})", daemon.display()),
+            ),
+        },
     }
 
     for remote in remote_rows(&channel.support_dir_name) {
@@ -70,6 +78,19 @@ pub async fn print_table(channel: &Channel, provenance: Provenance) -> Result<()
         println!("socket {} ({why})", socket.display());
     }
     Ok(())
+}
+
+/// The located daemon binary answering for itself, exactly as the shell
+/// client asked it: its own build, the daemon on the canonical socket, and
+/// that daemon's hello — so a staged binary that differs from the running
+/// daemon shows as two different versions. `channel::resolve` already pinned
+/// `TERMIO_CHANNEL`, which the child inherits.
+fn daemon_status(daemon: &std::path::Path) -> Option<lifecycle::NodeStatus> {
+    let output = Command::new(daemon).args(["status", "--json"]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    serde_json::from_slice(&output.stdout).ok()
 }
 
 /// The running app's `CFBundleShortVersionString+CFBundleVersion`, through
@@ -146,10 +167,14 @@ fn remote_rows(support_dir_name: &str) -> Vec<RemoteRow> {
             let version = device
                 .get("daemonVersion")
                 .and_then(|value| value.as_str())
-                .unwrap_or("-");
+                .unwrap_or("");
             let proto = device
                 .get("proto")
-                .and_then(|value| value.as_u64())
+                .and_then(|value| match value {
+                    serde_json::Value::Number(number) => Some(number.to_string()),
+                    serde_json::Value::String(text) => Some(text.clone()),
+                    _ => None,
+                })
                 .map(|proto| format!("proto {proto}"))
                 .unwrap_or_default();
             let stamp = device
@@ -196,14 +221,15 @@ fn parse_utc_timestamp(stamp: &str) -> Option<i64> {
     let number = |range: std::ops::Range<usize>| stamp.get(range)?.parse::<i64>().ok();
     let (year, month, day) = (number(0..4)?, number(5..7)?, number(8..10)?);
     let (hour, minute, second) = (number(11..13)?, number(14..16)?, number(17..19)?);
-    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+    if !(1..=12).contains(&month) || day < 1 || day > days_in_month(year, month) {
         return None;
     }
     if !(0..24).contains(&hour) || !(0..60).contains(&minute) || !(0..60).contains(&second) {
         return None;
     }
     // Days-from-civil (Howard Hinnant's algorithm), avoiding a time crate for
-    // one fixed-format field.
+    // one fixed-format field. The month-length check above matters because
+    // the algorithm normalizes impossible dates instead of rejecting them.
     let year_adjusted = if month <= 2 { year - 1 } else { year };
     let era = year_adjusted.div_euclid(400);
     let year_of_era = year_adjusted - era * 400;
@@ -212,6 +238,21 @@ fn parse_utc_timestamp(stamp: &str) -> Option<i64> {
     let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
     let days = era * 146_097 + day_of_era - 719_468;
     Some(days * 86_400 + hour * 3_600 + minute * 60 + second)
+}
+
+fn days_in_month(year: i64, month: i64) -> i64 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) {
+                29
+            } else {
+                28
+            }
+        }
+        _ => 0,
+    }
 }
 
 #[cfg(test)]
@@ -230,6 +271,18 @@ mod tests {
         assert_eq!(parse_utc_timestamp("2026-08-31 00:00:00"), None);
         assert_eq!(parse_utc_timestamp("2026-08-31T00:00:00.123Z"), None);
         assert_eq!(parse_utc_timestamp("2026-13-01T00:00:00Z"), None);
+    }
+
+    #[test]
+    fn impossible_calendar_dates_are_rejected_not_normalized() {
+        assert_eq!(parse_utc_timestamp("2026-02-31T00:00:00Z"), None);
+        assert_eq!(parse_utc_timestamp("2026-02-29T00:00:00Z"), None);
+        assert_eq!(parse_utc_timestamp("2026-04-31T00:00:00Z"), None);
+        // 2024-02-29 is real: a leap day, one day after the 28th.
+        assert_eq!(
+            parse_utc_timestamp("2024-02-29T00:00:00Z"),
+            parse_utc_timestamp("2024-02-28T00:00:00Z").map(|epoch| epoch + 86_400)
+        );
     }
 
     #[test]

--- a/termiod/src/version.rs
+++ b/termiod/src/version.rs
@@ -1,0 +1,245 @@
+//! `termio version` — every version in one table: this client, the running
+//! app, the local termiod, and one row per known remote from the device
+//! registry the app writes at each handshake (`devices.json`). A remote row
+//! is what the last connect observed, stamped so a stale row announces its
+//! staleness instead of posing as live state; a host this Mac has never
+//! spoken to is absent, and nothing here touches the network.
+//!
+//! Ported from the shell client's `version_table()`, with two deliberate
+//! deviations: the local daemon rows come from `lifecycle::status()`
+//! in-process instead of awk over pretty-printed JSON, and a final line
+//! names the resolved socket and which rung chose it (`TERMIOD_SOCK` or the
+//! program name), so a surprising socket names its own cause.
+
+use crate::channel::{Channel, Provenance};
+use crate::{lifecycle, paths};
+use anyhow::Result;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn row(name: &str, version: &str, proto: &str, note: &str) {
+    let line = format!("{name:<14} {version:<22} {proto:<9} {note}");
+    println!("{}", line.trim_end());
+}
+
+pub async fn print_table(channel: &Channel, provenance: Provenance) -> Result<()> {
+    row(
+        "termio",
+        lifecycle::BUILD_VERSION,
+        "",
+        &format!("(client, {} channel)", channel.name),
+    );
+
+    match running_app_version(&channel.bundle_id) {
+        Some(version) => row("termio.app", &version, "", "(running)"),
+        None => row("termio.app", "-", "", "(not running)"),
+    }
+
+    match lifecycle::status().await {
+        Ok(status) if status.daemon.running => {
+            let version = status.daemon.version.unwrap_or(status.binary.version);
+            let proto = status
+                .daemon
+                .proto
+                .map(|proto| format!("proto {proto}"))
+                .unwrap_or_default();
+            row("termiod local", &version, &proto, "");
+        }
+        // This binary and the daemon build from one crate, so its own stamp
+        // is the installed daemon's version — the shell client had to locate
+        // and exec the daemon binary to learn the same thing.
+        Ok(status) => row(
+            "termiod local",
+            &status.binary.version,
+            "",
+            "(binary; daemon not running)",
+        ),
+        Err(_) => row("termiod local", "-", "", "(no answer)"),
+    }
+
+    for remote in remote_rows(&channel.support_dir_name) {
+        row(&remote.alias, &remote.version, &remote.proto, &remote.stamp);
+    }
+
+    if let Ok(socket) = paths::socket_path() {
+        let why = match provenance {
+            Provenance::ExplicitSocket => "via TERMIOD_SOCK",
+            Provenance::ProgramName => "via program name",
+        };
+        println!();
+        println!("socket {} ({why})", socket.display());
+    }
+    Ok(())
+}
+
+/// The running app's `CFBundleShortVersionString+CFBundleVersion`, through
+/// `lsappinfo` so only a live process answers — a stale bundle on disk never
+/// poses as running. macOS only; anywhere else there is no app.
+fn running_app_version(bundle_id: &str) -> Option<String> {
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    let info = Command::new("lsappinfo")
+        .args(["info", "-only", "bundlepath", bundle_id])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&info.stdout);
+    let bundle = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("\"LSBundlePath\"=\""))
+        .and_then(|rest| rest.strip_suffix('"'))?;
+    let plist = format!("{bundle}/Contents/Info.plist");
+    let read = |key: &str| -> Option<String> {
+        let output = Command::new("/usr/libexec/PlistBuddy")
+            .args(["-c", &format!("Print :{key}"), &plist])
+            .output()
+            .ok()?;
+        output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+            .filter(|value| !value.is_empty())
+    };
+    let version = read("CFBundleShortVersionString").unwrap_or_else(|| "?".to_string());
+    match read("CFBundleVersion") {
+        Some(build) => Some(format!("{version}+{build}")),
+        None => Some(version),
+    }
+}
+
+struct RemoteRow {
+    alias: String,
+    version: String,
+    proto: String,
+    stamp: String,
+}
+
+/// One record per device that has been reached over SSH, labeled by its most
+/// recently used alias. Devices only ever seen locally are the local row.
+fn remote_rows(support_dir_name: &str) -> Vec<RemoteRow> {
+    let Some(home) = std::env::var_os("HOME") else {
+        return Vec::new();
+    };
+    let path = std::path::Path::new(&home)
+        .join("Library/Application Support")
+        .join(support_dir_name)
+        .join("devices.json");
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let Ok(devices) = serde_json::from_str::<Vec<serde_json::Value>>(&raw) else {
+        return Vec::new();
+    };
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or(0);
+    devices
+        .iter()
+        .filter_map(|device| {
+            let alias = device
+                .get("routes")?
+                .as_array()?
+                .iter()
+                .filter_map(|route| route.as_str())
+                .find_map(|route| route.strip_prefix("ssh:"))?;
+            let version = device
+                .get("daemonVersion")
+                .and_then(|value| value.as_str())
+                .unwrap_or("-");
+            let proto = device
+                .get("proto")
+                .and_then(|value| value.as_u64())
+                .map(|proto| format!("proto {proto}"))
+                .unwrap_or_default();
+            let stamp = device
+                .get("observedAt")
+                .and_then(|value| value.as_str())
+                .and_then(parse_utc_timestamp)
+                .map(|observed| {
+                    format!("(as of last connect, {})", age(now.saturating_sub(observed)))
+                })
+                .unwrap_or_else(|| "(as of an earlier connect)".to_string());
+            Some(RemoteRow {
+                alias: alias.to_string(),
+                version: version.to_string(),
+                proto,
+                stamp,
+            })
+        })
+        .collect()
+}
+
+fn age(seconds: i64) -> String {
+    let seconds = seconds.max(0);
+    if seconds < 60 {
+        "just now".to_string()
+    } else if seconds < 3600 {
+        format!("{}m ago", seconds / 60)
+    } else if seconds < 86400 {
+        format!("{}h ago", seconds / 3600)
+    } else {
+        format!("{}d ago", seconds / 86400)
+    }
+}
+
+/// `2026-08-31T12:34:56Z` → Unix seconds. The registry writes exactly this
+/// shape; anything else reads as "an earlier connect" rather than guessing.
+fn parse_utc_timestamp(stamp: &str) -> Option<i64> {
+    let bytes = stamp.as_bytes();
+    if bytes.len() != 20 || bytes[4] != b'-' || bytes[7] != b'-' || bytes[10] != b'T' {
+        return None;
+    }
+    if bytes[13] != b':' || bytes[16] != b':' || bytes[19] != b'Z' {
+        return None;
+    }
+    let number = |range: std::ops::Range<usize>| stamp.get(range)?.parse::<i64>().ok();
+    let (year, month, day) = (number(0..4)?, number(5..7)?, number(8..10)?);
+    let (hour, minute, second) = (number(11..13)?, number(14..16)?, number(17..19)?);
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    if !(0..24).contains(&hour) || !(0..60).contains(&minute) || !(0..60).contains(&second) {
+        return None;
+    }
+    // Days-from-civil (Howard Hinnant's algorithm), avoiding a time crate for
+    // one fixed-format field.
+    let year_adjusted = if month <= 2 { year - 1 } else { year };
+    let era = year_adjusted.div_euclid(400);
+    let year_of_era = year_adjusted - era * 400;
+    let month_shifted = if month > 2 { month - 3 } else { month + 9 };
+    let day_of_year = (153 * month_shifted + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    let days = era * 146_097 + day_of_era - 719_468;
+    Some(days * 86_400 + hour * 3_600 + minute * 60 + second)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_registry_timestamp_shape_parses_to_unix_seconds() {
+        assert_eq!(parse_utc_timestamp("1970-01-01T00:00:00Z"), Some(0));
+        assert_eq!(parse_utc_timestamp("2026-08-31T00:00:00Z"), Some(1_788_134_400));
+    }
+
+    #[test]
+    fn anything_else_reads_as_an_earlier_connect() {
+        assert_eq!(parse_utc_timestamp(""), None);
+        assert_eq!(parse_utc_timestamp("2026-08-31 00:00:00"), None);
+        assert_eq!(parse_utc_timestamp("2026-08-31T00:00:00.123Z"), None);
+        assert_eq!(parse_utc_timestamp("2026-13-01T00:00:00Z"), None);
+    }
+
+    #[test]
+    fn ages_bucket_like_the_shell_client() {
+        assert_eq!(age(0), "just now");
+        assert_eq!(age(59), "just now");
+        assert_eq!(age(60), "1m ago");
+        assert_eq!(age(3_599), "59m ago");
+        assert_eq!(age(3_600), "1h ago");
+        assert_eq!(age(86_400 * 3 + 5), "3d ago");
+        assert_eq!(age(-5), "just now");
+    }
+}


### PR DESCRIPTION
Stacked on #553. The first slice of the Rust `termio` client (unify-server-plane Stage 10, pulled forward per #551): a second bin built from the extracted library, carrying the verbs that need no app socket — `version`, `remote`, `open`, and the bare `DIR` shorthand. `sessions`, `agent report`, and `notify` stay with the shell client until the parity PR.

- **argv[0] channel selection** replaces `build-app.sh`'s three sed rewrites: `termio-dev` selects `sh.termio.app.dev`, the `termio-dev` support dir, and the dev socket (`channel.rs`, unit-tested including the invalid-suffix fallback). An inherited `TERMIO_CHANNEL` is deliberately overwritten — the shell client pinned `TERMIO_CHANNEL="$CHANNEL"` on every daemon exec so a stale value can't cross channels, and `TERMIOD_SOCK` remains the one runtime override (that's how hooks inside a pinned session reach the owning daemon). `termio version` prints the resolved socket and which rung chose it.
- **`termio version`** ports `version_table()` with local rows from `lifecycle::status()` in-process (typed structs, no awk over pretty JSON — the proto column now always answers), the app row via `lsappinfo`/`PlistBuddy`, and remote rows serde-parsed from `devices.json` with the same age buckets.
- **`termio remote`** stays an exec of the located daemon binary (the shell client's four locator rungs, ported): `shipped_binary()` deploys `current_exe()` to Mac targets, so an in-process `remote::run` from the client would ship the *client* as the remote daemon. The in-process move lands with a daemon-sibling fix once both bins are bundled side by side.
- `default-run = "termiod"` keeps bare `cargo run` meaning the daemon.

Verified: 263 tests green (three full runs; one unrelated timing flake on the first run, absent on both re-runs); `termio --version` / `version` / `open` (not-a-directory error, exit 1) / `remote --help` passthrough exercised against the live release-channel daemon; `termio-dev` symlink selects the dev channel; output diffed against `scripts/termio version` — the two deliberate deviations are the compiled-in version stamp and the trailing socket-provenance line.

Release Notes:

- None (the binary is not yet bundled; it ships to users in a later PR).