### PR TITLE
Port sessions, notify, and agent report to the termio client

### DIFF
--- a/.github/workflows/termiod.yml
+++ b/.github/workflows/termiod.yml
@@ -138,6 +138,14 @@ jobs:
           pkill -9 -f "target/debug/[t]ermiod|deps/[t]ermiod-" || true
           python3 remote_smoke_test.py
 
+      # The Rust termio client against the shell client it replaces: request
+      # bytes, stdout, stderr, and exit codes must be identical on every verb
+      # (unify-server-plane Stage 10's freeze). macOS only — the shell client
+      # itself depends on macOS nc semantics, so a Linux run would diff the
+      # script's own platform drift, not the port.
+      - name: CLI compat harness
+        run: python3 tests/cli_compat.py
+
       # The Swift client's half of the files plane. These tests spawn a real
       # daemon on a private socket, so `swift test` skips them unless
       # TERMIO_TERMIOD_TEST_BIN names a binary — and the Swift workflow's runner

--- a/termiod/src/app_socket.rs
+++ b/termiod/src/app_socket.rs
@@ -1,0 +1,336 @@
+//! The Mac app's session-control socket, spoken the way `scripts/termio`
+//! speaks it: one-line JSON requests over
+//! `~/Library/Application Support/<channel dir>/session-control.sock`, with
+//! the shell client's exact request shape, error taxonomy, and exit-code
+//! semantics. This module exists so the Rust client can replace the script
+//! wholesale at parity; verbs migrate off this socket onto the daemon's
+//! framed protocol one at a time (unify-server-plane Stage 10), and each
+//! migrated verb stops calling into here.
+
+use crate::channel::Channel;
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// How a one-shot request ended. `Timeout` is `--wait`'s "still running"
+/// outcome, exit code 3 — distinct from success and from hard errors so
+/// scripts can branch without parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    Ok,
+    Error,
+    Timeout,
+}
+
+pub fn socket_path(channel: &Channel) -> PathBuf {
+    let home = std::env::var_os("HOME").unwrap_or_default();
+    PathBuf::from(home)
+        .join("Library/Application Support")
+        .join(&channel.support_dir_name)
+        .join("session-control.sock")
+}
+
+/// The one-shot read bound in seconds: `TERMIO_CLI_TIMEOUT`, default 15.
+pub fn client_timeout() -> u64 {
+    std::env::var("TERMIO_CLI_TIMEOUT")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(15)
+}
+
+/// Whether the caller set an explicit `TERMIO_CLI_TIMEOUT` — the escape
+/// hatch that wins over the widened `--wait` read bound.
+pub fn explicit_client_timeout() -> bool {
+    std::env::var_os("TERMIO_CLI_TIMEOUT").is_some_and(|value| !value.is_empty())
+}
+
+/// JSON-escape a string for embedding in a request, byte-for-byte the shell
+/// client's `json_escape`: backslashes, double quotes, tabs, and newlines.
+/// ESC survives as a JSON `\u001b` escape — an escape sequence is exactly the kind of
+/// keypress `send --no-enter` exists to deliver. Every other C0 byte
+/// (carriage returns included) is stripped outright: they are never
+/// intentional in a prompt, and one raw byte would make the whole request
+/// undecodable.
+pub fn json_escape(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for character in input.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\t' => escaped.push_str("\\t"),
+            '\u{1b}' => escaped.push_str("\\u001b"),
+            '\n' => escaped.push_str("\\n"),
+            '\u{00}'..='\u{1f}' => {}
+            _ => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+/// Whether a token addresses a session rather than prompt text: a
+/// `termio://` deep link, or a bare id (full UUID or an 8+ char hex
+/// prefix). Deliberately permissive — an unknown address fails loudly as
+/// `not_found` on the server, whereas an unrecognized one would silently
+/// become the first words of a prompt to a freshly spawned agent.
+pub fn is_address(token: &str) -> bool {
+    if let Some(scheme_end) = token.find("://") {
+        let scheme = &token[..scheme_end];
+        let rest = &token[scheme_end + 3..];
+        return scheme.starts_with("termio")
+            && scheme[6..].chars().all(|c| c.is_ascii_lowercase() || c == '-')
+            && !rest.is_empty()
+            && !rest.contains(' ');
+    }
+    let bytes = token.as_bytes();
+    if bytes.len() < 8 || bytes.len() > 36 {
+        return false;
+    }
+    bytes[..8].iter().all(|byte| byte.is_ascii_hexdigit())
+        && bytes[8..]
+            .iter()
+            .all(|byte| byte.is_ascii_hexdigit() || *byte == b'-')
+}
+
+/// The one-line JSON control request shared by the one-shot and streaming
+/// paths, in the shell client's exact field order. `extra` is raw JSON
+/// (`"key":value`) appended verbatim, for the rare per-verb field that
+/// doesn't earn a slot in every request.
+pub fn build_request(op: &str, format: &str, target: &str, agent: &str, text: &str, extra: &str) -> String {
+    let caller_session = std::env::var("TERMIO_SESSION").unwrap_or_default();
+    // $PWD the way a shell provides it: the inherited logical path when it
+    // still names the current directory (sh validates this at startup), the
+    // physical path otherwise.
+    let physical = std::env::current_dir().ok();
+    let caller_cwd = std::env::var("PWD")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .filter(|value| std::fs::canonicalize(value).ok() == physical)
+        .or_else(|| physical.map(|directory| directory.display().to_string()))
+        .unwrap_or_default();
+    let mut request = format!(
+        "{{\"op\":\"{op}\",\"format\":\"{format}\",\"caller_session\":\"{}\",\"caller_cwd\":\"{}\",\"target\":\"{}\",\"agent\":\"{}\",\"text\":\"{}\"",
+        json_escape(&caller_session),
+        json_escape(&caller_cwd),
+        json_escape(target),
+        json_escape(agent),
+        json_escape(text),
+    );
+    if !extra.is_empty() {
+        request.push(',');
+        request.push_str(extra);
+    }
+    request.push('}');
+    request
+}
+
+/// The shell client's pre-flight: `sessions` and `notify` refuse before
+/// building a request when there is no control socket at all.
+pub fn require_socket(channel: &Channel) -> PathBuf {
+    let socket = socket_path(channel);
+    let is_socket = std::fs::metadata(&socket)
+        .map(|metadata| std::os::unix::fs::FileTypeExt::is_socket(&metadata.file_type()))
+        .unwrap_or(false);
+    if !is_socket {
+        eprintln!(
+            "termio: app is not running (no control socket at {})",
+            socket.display()
+        );
+        std::process::exit(1);
+    }
+    socket
+}
+
+/// One request/response round-trip: prints the app's reply and reports the
+/// outcome through the return value so callers surface it as an exit code —
+/// agents check `$?`, not prose. An empty reply is a hard error, never a
+/// silent success: a control CLI must fail loud.
+pub fn request_once(
+    channel: &Channel,
+    timeout_seconds: u64,
+    op: &str,
+    format: &str,
+    target: &str,
+    agent: &str,
+    text: &str,
+    extra: &str,
+) -> Outcome {
+    let socket = socket_path(channel);
+    let request = build_request(op, format, target, agent, text, extra);
+    let response = exchange(&socket, &request, timeout_seconds);
+    let response = match response {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            // A refused connect and a live-but-silent app are different
+            // failures with different fixes: EPERM is a sandbox denying this
+            // process, not a stale socket, and "restart termio" sends that
+            // reader the wrong way.
+            match error.kind() {
+                std::io::ErrorKind::PermissionDenied => eprintln!(
+                    "termio: the OS denied the connection to {} — this process is likely sandboxed (Codex workspace-write blocks unix sockets); termio itself is fine and restarting it will not help — run the command outside the sandbox",
+                    socket.display()
+                ),
+                std::io::ErrorKind::NotFound => eprintln!(
+                    "termio: no socket at {} — termio isn't running; start it first",
+                    socket.display()
+                ),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut => eprintln!(
+                    "termio: no reply from the app within {timeout_seconds}s — it may be busy or wedged; check the app, or raise TERMIO_CLI_TIMEOUT"
+                ),
+                _ => eprintln!(
+                    "termio: nothing is listening at {} (connection refused) — the socket file outlived the app that made it; restart termio",
+                    socket.display()
+                ),
+            }
+            return Outcome::Error;
+        }
+    };
+    let response = String::from_utf8_lossy(&response);
+    let response = response.trim_end_matches('\n');
+    if response.is_empty() {
+        eprintln!(
+            "termio: no reply from the app within {timeout_seconds}s — it may be busy or wedged; check the app, or raise TERMIO_CLI_TIMEOUT"
+        );
+        return Outcome::Error;
+    }
+    println!("{response}");
+    if response.starts_with("error:") || response.contains("\"ok\":false") {
+        return Outcome::Error;
+    }
+    // A --wait that expired is its own outcome, on its own exit code (3).
+    // JSON mode keys off the contract field, text mode off the headline;
+    // both checks are scoped to wait requests (never `read`, whose payload
+    // is an arbitrary screen) so no other reply can trip them.
+    if extra.contains("\"wait\":true") {
+        if format == "json" {
+            if response.contains("\"timed_out\":true") {
+                return Outcome::Timeout;
+            }
+        } else if response.lines().next().unwrap_or("").contains("— timed out") {
+            return Outcome::Timeout;
+        }
+    }
+    Outcome::Ok
+}
+
+fn exchange(socket: &std::path::Path, request: &str, timeout_seconds: u64) -> std::io::Result<Vec<u8>> {
+    let mut stream = UnixStream::connect(socket)?;
+    let timeout = Duration::from_secs(timeout_seconds);
+    // Both timeouts are armed before the request goes out, and never again:
+    // once the app has replied and closed its end, macOS refuses setsockopt
+    // on the socket (EINVAL) even though the reply is still readable — so a
+    // per-read re-arm would turn every fast reply into a phantom failure.
+    stream.set_write_timeout(Some(timeout))?;
+    stream.set_read_timeout(Some(timeout))?;
+    stream.write_all(request.as_bytes())?;
+    let deadline = Instant::now() + timeout;
+    let mut response = Vec::new();
+    let mut buffer = [0u8; 16 * 1024];
+    loop {
+        match stream.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(count) => {
+                response.extend_from_slice(&buffer[..count]);
+                if Instant::now() >= deadline {
+                    break;
+                }
+            }
+            Err(error)
+                if error.kind() == std::io::ErrorKind::WouldBlock
+                    || error.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                if response.is_empty() {
+                    return Err(std::io::ErrorKind::TimedOut.into());
+                }
+                break;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(response)
+}
+
+/// Streaming: the app holds the connection open and pushes one line per
+/// scoped status transition until interrupted. No read bound here — watch
+/// is *supposed* to sit open, and its liveness signal is the app's 30s
+/// heartbeat line in `--json` mode. Returns the exit code: an immediate
+/// error reply is 1; the stream reaching EOF means the *app* closed it —
+/// 2, "termio died", the case to escalate. Ctrl-C is handled by the caller
+/// installing a handler that exits 0 (the normal end of supervision).
+pub fn watch(channel: &Channel, format: &str, states: &str, extra: &str) -> i32 {
+    let socket = socket_path(channel);
+    let request = build_request("watch", format, "", "", states, extra);
+    let mut stream = match UnixStream::connect(&socket) {
+        Ok(stream) => stream,
+        Err(_) => return 2,
+    };
+    if stream.write_all(request.as_bytes()).is_err() {
+        return 2;
+    }
+    let reader = std::io::BufReader::new(stream);
+    let mut first = true;
+    use std::io::BufRead;
+    for line in reader.lines() {
+        let Ok(line) = line else { break };
+        println!("{line}");
+        use std::io::Write as _;
+        let _ = std::io::stdout().flush();
+        if first {
+            first = false;
+            if line.starts_with("error:") || line.contains("\"ok\":false") {
+                return 1;
+            }
+        }
+    }
+    if first {
+        // EOF before any line: still the app closing the stream.
+        return 2;
+    }
+    2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escaping_matches_the_shell_clients_rules() {
+        assert_eq!(json_escape(r#"a\b"c"#), r#"a\\b\"c"#);
+        assert_eq!(json_escape("a\tb"), r"a\tb");
+        assert_eq!(json_escape("a\nb"), r"a\nb");
+        assert_eq!(json_escape("a\u{1b}[A"), r"a\u001b[A");
+        // Other C0 bytes — carriage returns included — are stripped outright.
+        assert_eq!(json_escape("a\rb\u{07}c"), "abc");
+    }
+
+    #[test]
+    fn addresses_are_links_or_hex_ids() {
+        assert!(is_address("termio://session/8de0b387-485a-4016-8990-cbcbfff03199"));
+        assert!(is_address("termio-dev://session/x"));
+        assert!(is_address("8de0b387"));
+        assert!(is_address("8de0b387-485a-4016-8990-cbcbfff03199"));
+        assert!(is_address("DEADBEEF"));
+        assert!(!is_address("fix the build"));
+        assert!(!is_address("deadbee"));
+        assert!(!is_address("termio://has space"));
+        assert!(!is_address("https://example.com"));
+        assert!(!is_address("8de0b387-485a-4016-8990-cbcbfff03199-and-more-tail"));
+    }
+
+    #[test]
+    fn requests_carry_the_shell_clients_field_order() {
+        std::env::remove_var("TERMIO_SESSION");
+        // A PWD that does not name the actual cwd is distrusted, sh-style,
+        // so the physical directory is what lands in caller_cwd.
+        std::env::set_var("PWD", "/tmp/not-the-cwd");
+        let physical = std::env::current_dir().unwrap().display().to_string();
+        let request = build_request("send", "json", "8de0b387", "", "hi", "\"enter\":false");
+        assert_eq!(
+            request,
+            format!(
+                "{{\"op\":\"send\",\"format\":\"json\",\"caller_session\":\"\",\"caller_cwd\":\"{}\",\"target\":\"8de0b387\",\"agent\":\"\",\"text\":\"hi\",\"enter\":false}}",
+                json_escape(&physical)
+            )
+        );
+    }
+}

--- a/termiod/src/app_socket.rs
+++ b/termiod/src/app_socket.rs
@@ -51,21 +51,26 @@ pub fn explicit_client_timeout() -> bool {
 /// keypress `send --no-enter` exists to deliver. Every other C0 byte
 /// (carriage returns included) is stripped outright: they are never
 /// intentional in a prompt, and one raw byte would make the whole request
-/// undecodable.
+/// undecodable. One trailing newline is dropped — the shell's awk join eats
+/// it — while interior newlines survive as escapes.
 pub fn json_escape(input: &str) -> String {
-    let mut escaped = String::with_capacity(input.len());
+    let mut kept = String::with_capacity(input.len());
     for character in input.chars() {
         match character {
-            '\\' => escaped.push_str("\\\\"),
-            '"' => escaped.push_str("\\\""),
-            '\t' => escaped.push_str("\\t"),
-            '\u{1b}' => escaped.push_str("\\u001b"),
-            '\n' => escaped.push_str("\\n"),
+            '\\' => kept.push_str("\\\\"),
+            '"' => kept.push_str("\\\""),
+            '\t' => kept.push_str("\\t"),
+            '\u{1b}' => kept.push_str("\\u001b"),
+            '\n' => kept.push('\n'),
             '\u{00}'..='\u{1f}' => {}
-            _ => escaped.push(character),
+            _ => kept.push(character),
         }
     }
-    escaped
+    // The shell pipeline ends in awk joining records with \n, which eats
+    // exactly one trailing newline from the input; every interior newline
+    // survives as an escape.
+    let kept = kept.strip_suffix('\n').unwrap_or(&kept);
+    kept.replace('\n', "\\n")
 }
 
 /// Whether a token addresses a session rather than prompt text: a
@@ -267,24 +272,35 @@ pub fn watch(channel: &Channel, format: &str, states: &str, extra: &str) -> i32 
     if stream.write_all(request.as_bytes()).is_err() {
         return 2;
     }
-    let reader = std::io::BufReader::new(stream);
-    let mut first = true;
+    // First line via the shell's `read` semantics: a line is only a line
+    // once its newline arrives — an unterminated EOF fragment is not
+    // printed, and the stream still counts as closed by the app (2). The
+    // rest streams raw like `cat`, flushed per line so a supervisor sees
+    // events as they happen, with an unterminated final fragment passed
+    // through byte-for-byte.
+    let mut reader = std::io::BufReader::new(stream);
+    let mut stdout = std::io::stdout();
+    let mut line: Vec<u8> = Vec::new();
     use std::io::BufRead;
-    for line in reader.lines() {
-        let Ok(line) = line else { break };
-        println!("{line}");
-        use std::io::Write as _;
-        let _ = std::io::stdout().flush();
-        if first {
-            first = false;
-            if line.starts_with("error:") || line.contains("\"ok\":false") {
-                return 1;
-            }
-        }
-    }
-    if first {
-        // EOF before any line: still the app closing the stream.
+    if reader.read_until(b'\n', &mut line).unwrap_or(0) == 0 || !line.ends_with(b"\n") {
         return 2;
+    }
+    let _ = stdout.write_all(&line);
+    let _ = stdout.flush();
+    let first_line = String::from_utf8_lossy(&line);
+    if first_line.starts_with("error:") || first_line.contains("\"ok\":false") {
+        return 1;
+    }
+    loop {
+        line.clear();
+        match reader.read_until(b'\n', &mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                let _ = stdout.write_all(&line);
+                let _ = stdout.flush();
+            }
+            Err(_) => break,
+        }
     }
     2
 }
@@ -301,6 +317,11 @@ mod tests {
         assert_eq!(json_escape("a\u{1b}[A"), r"a\u001b[A");
         // Other C0 bytes — carriage returns included — are stripped outright.
         assert_eq!(json_escape("a\rb\u{07}c"), "abc");
+        // awk's record join eats exactly one trailing newline.
+        assert_eq!(json_escape("hello\n"), "hello");
+        assert_eq!(json_escape("a\n\n"), r"a\n");
+        assert_eq!(json_escape("\n"), "");
+        assert_eq!(json_escape("a\nb\n"), r"a\nb");
     }
 
     #[test]

--- a/termiod/src/bin/termio.rs
+++ b/termiod/src/bin/termio.rs
@@ -184,6 +184,11 @@ fn sessions(channel: &Channel, arguments: &[String]) -> Result<()> {
             "--wait" => wait = true,
             "--timeout" => {
                 let raw = value("--timeout", "termio: --timeout needs a value in ms");
+                // Digits only, like the script's case pattern — `parse` alone
+                // would also take a leading `+`.
+                if raw.is_empty() || !raw.bytes().all(|byte| byte.is_ascii_digit()) {
+                    fail("termio: --timeout needs whole milliseconds");
+                }
                 let Ok(parsed) = raw.parse::<u64>() else {
                     fail("termio: --timeout needs whole milliseconds");
                 };
@@ -366,9 +371,12 @@ fn sessions(channel: &Channel, arguments: &[String]) -> Result<()> {
 
     if op == "close" {
         // One request per tab; any failure fails the whole command, but every
-        // target still gets its attempt and its own reply line.
+        // target still gets its attempt and its own reply line. The script
+        // expands its accumulated list unquoted, so the emptiness check reads
+        // the raw string while whitespace inside one argument splits into
+        // separate targets.
         let mut failed = 0;
-        for target in &targets {
+        for target in target.split_whitespace() {
             if app_socket::request_once(channel, client_timeout, "close", format, target, "", "", "")
                 != Outcome::Ok
             {
@@ -457,7 +465,11 @@ fn agent_report(channel: &Channel, arguments: &[String]) -> Result<()> {
                 }
                 forwarded.push(argument.to_string());
                 cursor += 1;
-                forwarded.push(rest[cursor].clone());
+                // The script accumulates these into one string and expands it
+                // unquoted, so whitespace inside a value word-splits into
+                // separate argv items. Kept for argv parity; the script's
+                // accidental glob expansion of such values is not.
+                forwarded.extend(rest[cursor].split_whitespace().map(str::to_string));
             }
             "working" | "attention" | "done" | "idle" => state = argument.to_string(),
             _ => fail(&format!("termio: unknown agent report argument '{argument}'")),

--- a/termiod/src/bin/termio.rs
+++ b/termiod/src/bin/termio.rs
@@ -2,33 +2,75 @@
 //! `dockerd`; this client drives the Mac app and the session host
 //! (docker-lessons RFC §1).
 //!
-//! This binary is the Rust replacement for `scripts/termio`, growing verb by
-//! verb (unify-server-plane Stage 10). Implemented here: `version`,
-//! `remote`, `open`, and the bare-`DIR` shorthand. Until the port completes,
-//! `sessions`, `agent report`, and `notify` stay with the shell client.
+//! This binary replaces `scripts/termio` at parity: every `sessions` verb,
+//! `notify`, and `agent report` behave as the shell client did, down to help
+//! text, request bytes, stderr diagnoses, and exit codes — the compat
+//! harness (`termiod/tests/cli_compat.py`) holds the diff at zero. The
+//! session verbs still speak the app's control socket; they migrate onto
+//! the daemon's framed protocol one verb at a time (unify-server-plane
+//! Stage 10), each flip retiring its Swift handler.
 //!
 //! The dispatcher is a hand-rolled match, not clap: `termio [DIR]` must
 //! treat any non-verb first argument as a directory (the `code .` shape),
-//! and `remote` is an argv passthrough whose help belongs to the daemon.
+//! `remote` is an argv passthrough whose help belongs to the daemon, and
+//! the help text is the shell client's, verbatim.
 
 use anyhow::{bail, Context, Result};
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
+use termiod::app_socket::{self, Outcome};
 use termiod::channel::{self, Channel};
 use termiod::{lifecycle, version};
 
-const USAGE: &str = "\
-termio — drive the termio app and its session host from the terminal
+const USAGE: &str = r#"usage:
+  termio open [DIR]                          open DIR (default: cwd) as a project
+  termio [DIR]                               shorthand for `termio open DIR`
 
-usage:
-  termio [DIR]           open DIR (default: .) as a project in termio
-  termio open [DIR]      the same, spelled out
-  termio version         every version in one table: client, app, local termiod, known remotes
-  termio remote <verb> … drive a remote box's termiod (deploy, list, attach, open)
-  termio --version       client version and channel
+  termio sessions list                       sessions in this project + status
+  termio sessions watch [--state <s,…>]      stream status transitions until Ctrl-C (default: done,needs-you)
+  termio sessions spawn "<prompt>"           start a NEW agent session on the prompt
+  termio sessions run "<command>"            start a NEW terminal session running a shell command
+  termio sessions send <session> "<text>"        type a prompt (or menu answer) into a session
+  termio sessions read <session> [--lines N]     print a session's current screen
+  termio sessions close <session> [...]      close session tabs
+  termio sessions focus <session>            select the session in the app
 
-not yet ported from the shell client: sessions, agent, notify";
+  termio notify [--title T] "<message>"      post a macOS notification (e.g. "I'm done")
+
+  termio remote <verb> [...]                 drive a box's termiod over SSH (deploy, list,
+                                             attach, open — `termio remote --help` lists them)
+  termio version                             one table: this client, the running app, the local
+                                             termiod, and every known remote as of last connect
+
+  termio agent report <state>                report this agent's activity (hook contract)
+
+options:
+  --json           machine-readable output (any `sessions` command)
+  --agent <id>     agent for `spawn` (e.g. claudeCode, codex, grok, pi; default: caller's kind)
+  --direction <d>  for `spawn`/`run`: where the new pane lands relative to yours — right or down
+  --ratio <0..1>   for `spawn`/`run`: the new pane's share of the split (e.g. 0.25);
+                   a stated ratio holds against later spawns
+  --wait           for `spawn`/`run`/`send`: block until the turn settles; the reply carries
+                   the final status and the transcript line range to read
+                   (exit 0 settled, 1 error — including a stalled/vanished session, 3 timed out)
+  --timeout <ms>   cap for --wait (default 300000, clamped 1000–600000); implies --wait
+  --no-enter       for `send`: deliver the text as-is, with no Return after it —
+                   the way to answer a gate that wants a bare keypress
+  --key <name>     for `send`: press a named key (escape, up, tab, ctrl-c, f2, …)
+                   after the text; repeatable, in order. Any --key suppresses the
+                   implicit Return
+  --lines <n>      for `read`: keep only the last n screen rows
+  --state <s,…>    for `watch`: comma-separated states to report (working, idle, done,
+                   needs-you, stalled; default done,needs-you)
+  --no-snapshot    for `watch`: skip the initial per-session status snapshot
+  --help, --version
+
+`termio sessions <verb> --help` prints focused help for one verb.
+<session> = a termio://session/<uuid> link or a bare id/prefix — printed by
+`termio sessions list` / a `spawn` reply.
+`answer` is a deprecated, agent-only alias of `send`; `send` with no target aliases `spawn`.
+Every one-shot command times out after ${TERMIO_CLI_TIMEOUT:-15}s (TERMIO_CLI_TIMEOUT overrides)."#;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -46,6 +88,9 @@ async fn main() -> Result<()> {
         }
         Some("version") => version::print_table(&channel, provenance).await,
         Some("remote") => remote_passthrough(&channel, &arguments[1..]),
+        Some("sessions") => sessions(&channel, &arguments[1..]),
+        Some("agent") => agent_report(&channel, &arguments[1..]),
+        Some("notify") => notify(&channel, &arguments[1..]),
         Some("open") => {
             let directory = arguments.get(1).map(String::as_str).unwrap_or(".");
             open_project(&channel, Path::new(directory))
@@ -53,6 +98,452 @@ async fn main() -> Result<()> {
         // Bare `termio [DIR]` stays as the `code .`-shaped shorthand for `open`.
         Some(directory) => open_project(&channel, Path::new(directory)),
     }
+}
+
+fn fail(message: &str) -> ! {
+    eprintln!("{message}");
+    std::process::exit(1);
+}
+
+fn exit_outcome(outcome: Outcome) -> ! {
+    std::process::exit(match outcome {
+        Outcome::Ok => 0,
+        Outcome::Error => 1,
+        Outcome::Timeout => 3,
+    })
+}
+
+fn sessions(channel: &Channel, arguments: &[String]) -> Result<()> {
+    let op = arguments.first().map(String::as_str).unwrap_or("list");
+    let rest = if arguments.is_empty() { &[][..] } else { &arguments[1..] };
+
+    match op {
+        "list" | "watch" | "spawn" | "run" | "send" | "answer" | "read" | "close" | "focus" => {}
+        "-h" | "--help" | "help" => {
+            println!("{USAGE}");
+            std::process::exit(0);
+        }
+        _ => {
+            eprintln!("termio: unknown sessions command '{op}'");
+            eprintln!("{USAGE}");
+            std::process::exit(1);
+        }
+    }
+
+    // Per-verb help never needs the app: dispatch it before the socket check.
+    if rest.iter().any(|argument| argument == "-h" || argument == "--help") {
+        println!("{}", verb_usage(op));
+        std::process::exit(0);
+    }
+
+    app_socket::require_socket(channel);
+
+    let mut format = "text";
+    let mut agent = String::new();
+    let mut direction = String::new();
+    let mut ratio = String::new();
+    let mut targets: Vec<String> = Vec::new();
+    let mut text = String::new();
+    let mut states = String::new();
+    let mut no_snapshot = false;
+    let mut no_enter = false;
+    let mut keys_json = String::new();
+    let mut wait = false;
+    let mut timeout_ms: Option<u64> = None;
+    let mut lines = String::new();
+    let mut seen_positional = false;
+
+    let mut cursor = 0;
+    while cursor < rest.len() {
+        let argument = rest[cursor].as_str();
+        let mut value = |name: &str, missing: &str| -> String {
+            if cursor + 1 >= rest.len() {
+                fail(missing);
+            }
+            let _ = name;
+            cursor += 1;
+            rest[cursor].clone()
+        };
+        match argument {
+            "--json" => format = "json",
+            "--no-snapshot" => no_snapshot = true,
+            "--no-enter" => no_enter = true,
+            "--key" => {
+                let key = value("--key", "termio: --key needs a key name (e.g. escape, ctrl-c)");
+                // Order matters — the app presses them in the order named — so
+                // they accumulate into a JSON array rather than a set. The name
+                // itself is validated by the app, the one place that knows the
+                // vocabulary.
+                if !keys_json.is_empty() {
+                    keys_json.push(',');
+                }
+                keys_json.push('"');
+                keys_json.push_str(&app_socket::json_escape(&key));
+                keys_json.push('"');
+            }
+            "--wait" => wait = true,
+            "--timeout" => {
+                let raw = value("--timeout", "termio: --timeout needs a value in ms");
+                let Ok(parsed) = raw.parse::<u64>() else {
+                    fail("termio: --timeout needs whole milliseconds");
+                };
+                timeout_ms = Some(parsed);
+                wait = true;
+            }
+            "--agent" => agent = value("--agent", "termio: --agent needs a value"),
+            "--direction" => {
+                let parsed = value("--direction", "termio: --direction needs right or down");
+                if parsed != "right" && parsed != "down" {
+                    fail("termio: --direction is right or down");
+                }
+                direction = parsed;
+            }
+            "--ratio" => {
+                let parsed = value(
+                    "--ratio",
+                    "termio: --ratio needs a number between 0 and 1 (e.g. 0.25)",
+                );
+                // Strictly `0.<digits>` — anything else (".5", "0.", "50%")
+                // would land on the wire as invalid JSON or a share the app
+                // rejects.
+                let fraction = parsed.strip_prefix("0.");
+                let valid = fraction
+                    .is_some_and(|digits| !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()));
+                if !valid {
+                    fail("termio: --ratio needs a number between 0 and 1 (e.g. 0.25)");
+                }
+                ratio = parsed;
+            }
+            "--state" => states = value("--state", "termio: --state needs a value"),
+            "--lines" => {
+                let parsed = value("--lines", "termio: --lines needs a value");
+                if parsed.is_empty() || !parsed.bytes().all(|b| b.is_ascii_digit()) {
+                    fail("termio: --lines needs a whole number");
+                }
+                lines = parsed;
+            }
+            positional => {
+                if op == "close" {
+                    // Every positional is a tab to close.
+                    targets.push(positional.to_string());
+                } else if op == "spawn" || op == "run" {
+                    // `spawn`/`run` take no target — every positional is the payload.
+                    push_word(&mut text, positional);
+                } else if !seen_positional && (op == "answer" || op == "focus" || op == "read") {
+                    targets = vec![positional.to_string()];
+                } else if !seen_positional && op == "send" && app_socket::is_address(positional) {
+                    // A leading address targets an existing session. Without
+                    // one, `send` is a back-compat alias for `spawn`; the
+                    // strict is_address shape check keeps a prompt that merely
+                    // opens with a word from being mistaken for an address.
+                    targets = vec![positional.to_string()];
+                } else {
+                    push_word(&mut text, positional);
+                }
+                seen_positional = true;
+            }
+        }
+        cursor += 1;
+    }
+    let target = targets.join(" ");
+
+    match op {
+        "answer" | "focus" | "read" => {
+            if target.is_empty() {
+                fail(&format!(
+                    "termio: {op} needs a session link or id (see `termio sessions list`)"
+                ));
+            }
+        }
+        "close" => {
+            if target.is_empty() {
+                fail("termio: close needs at least one session link or id");
+            }
+        }
+        "spawn" => {
+            if text.is_empty() {
+                fail("termio: spawn needs a prompt (e.g. `termio sessions spawn \"fix the build\" --agent codex`)");
+            }
+            // One job, one entry point: spawn creates agents, run creates
+            // terminals. The wire cannot tell `spawn --agent terminal` from
+            // `run` (both arrive as an empty-target send with the shell
+            // pinned), so the split is enforced here, where the user's intent
+            // is still visible.
+            if agent.eq_ignore_ascii_case("terminal") || agent.eq_ignore_ascii_case("shell") {
+                fail("termio: spawn starts agents — for a plain terminal running a command, use `termio sessions run \"<command>\"`");
+            }
+        }
+        "run" => {
+            if text.is_empty() {
+                fail("termio: run needs a command (e.g. `termio sessions run \"pnpm dev\"`)");
+            }
+        }
+        _ => {}
+    }
+
+    // One sync vocabulary: --wait/--timeout mean the same thing on every verb
+    // that accepts them (spawn/run + send), and nothing else silently ignores
+    // them.
+    let mut extra_json = String::new();
+    let mut client_timeout = app_socket::client_timeout();
+    if wait {
+        match op {
+            "spawn" | "run" | "send" | "answer" => {}
+            _ => fail("termio: --wait applies to spawn, run, and send only"),
+        }
+        extra_json.push_str("\"wait\":true");
+        if let Some(milliseconds) = timeout_ms {
+            extra_json.push_str(&format!(",\"timeout_ms\":{milliseconds}"));
+        }
+        // The client read bound must outlive the server-side wait (which the
+        // app clamps to 1s–600s), or the read would hang up mid-wait and
+        // report a false timeout. An explicit TERMIO_CLI_TIMEOUT still wins —
+        // the escape hatch.
+        if !app_socket::explicit_client_timeout() {
+            client_timeout = timeout_ms.unwrap_or(300_000) / 1000 + 30;
+        }
+    }
+
+    // Placement flags only mean something on a verb that creates a pane.
+    if !direction.is_empty() || !ratio.is_empty() {
+        match op {
+            "spawn" | "run" => {}
+            _ => fail("termio: --direction/--ratio apply to spawn and run only"),
+        }
+        if !direction.is_empty() {
+            push_extra(&mut extra_json, &format!("\"direction\":\"{direction}\""));
+        }
+        if !ratio.is_empty() {
+            push_extra(&mut extra_json, &format!("\"ratio\":{ratio}"));
+        }
+    }
+
+    // --no-enter only reads on a send to an existing session: a spawn's prompt
+    // has to be submitted or the fresh agent just sits on a filled composer.
+    if no_enter {
+        match op {
+            "send" | "answer" => {
+                if target.is_empty() {
+                    fail("termio: --no-enter needs a session to send to");
+                }
+            }
+            _ => fail("termio: --no-enter applies to send only"),
+        }
+        push_extra(&mut extra_json, "\"enter\":false");
+    }
+
+    // --key, like --no-enter, only reads on a send to an existing session: a
+    // key is pressed against a TUI that is already drawn, and a booting agent
+    // has none.
+    if !keys_json.is_empty() {
+        match op {
+            "send" | "answer" => {
+                if target.is_empty() {
+                    fail("termio: --key needs a session to press it in");
+                }
+            }
+            _ => fail("termio: --key applies to send only"),
+        }
+        push_extra(&mut extra_json, &format!("\"keys\":[{keys_json}]"));
+    }
+
+    if op == "watch" {
+        // Exit codes tell a supervising agent how the watch ended: Ctrl-C is
+        // the normal end of supervision (0, via the handler); an immediate
+        // error reply (control disabled, no scope) is 1; the stream reaching
+        // EOF means the *app* closed it — 2, "termio died", the case to
+        // escalate.
+        unsafe {
+            libc::signal(libc::SIGINT, watch_interrupted as usize);
+        }
+        let extra = if no_snapshot { "\"snapshot\":false" } else { "" };
+        let code = app_socket::watch(channel, format, &states, extra);
+        if code == 2 {
+            eprintln!("termio: watch stream closed by the app (termio quit or died)");
+        }
+        std::process::exit(code);
+    }
+
+    if op == "close" {
+        // One request per tab; any failure fails the whole command, but every
+        // target still gets its attempt and its own reply line.
+        let mut failed = 0;
+        for target in &targets {
+            if app_socket::request_once(channel, client_timeout, "close", format, target, "", "", "")
+                != Outcome::Ok
+            {
+                failed = 1;
+            }
+        }
+        std::process::exit(failed);
+    }
+
+    // `spawn` and the no-target `send` alias both start a fresh session: the
+    // app spawns whenever a `send` request carries an empty target. `run` is
+    // the same spawn with the agent pinned to the plain shell — the payload is
+    // a command line, not a prompt. `answer` is a thin alias for sending to an
+    // existing session. All fold onto the wire `send`; every other verb maps
+    // straight through.
+    let wire_op = match op {
+        "spawn" | "answer" => "send",
+        "run" => {
+            agent = "terminal".to_string();
+            "send"
+        }
+        "read" => {
+            if !lines.is_empty() {
+                extra_json = format!("\"lines\":{lines}");
+            }
+            "read"
+        }
+        other => other,
+    };
+    exit_outcome(app_socket::request_once(
+        channel,
+        client_timeout,
+        wire_op,
+        format,
+        &target,
+        &agent,
+        &text,
+        &extra_json,
+    ));
+}
+
+extern "C" fn watch_interrupted(_: libc::c_int) {
+    unsafe { libc::_exit(0) }
+}
+
+fn push_word(text: &mut String, word: &str) {
+    if !text.is_empty() {
+        text.push(' ');
+    }
+    text.push_str(word);
+}
+
+fn push_extra(extra: &mut String, fragment: &str) {
+    if !extra.is_empty() {
+        extra.push(',');
+    }
+    extra.push_str(fragment);
+}
+
+/// The public hook contract: `termio agent report <state> …` keeps its name,
+/// its states and every flag, because users hand-write hooks against it. The
+/// report forwards to `termiod set-status`, which takes the same flag names
+/// and reads the same stdin blob, so the payload is parsed once, by
+/// whichever binary the hook actually invoked.
+fn agent_report(channel: &Channel, arguments: &[String]) -> Result<()> {
+    let op = arguments.first().map(String::as_str).unwrap_or("");
+    let rest = if arguments.is_empty() { &[][..] } else { &arguments[1..] };
+    if op != "report" {
+        eprintln!("termio: unknown agent command '{op}'");
+        eprintln!("usage: termio agent report <working|attention|done|idle> [--transcript] [--conversation <id>] [--conversation-from <field>] [--tool-from <field>] [--prompt-title-from <field>] [--reply]");
+        std::process::exit(1);
+    }
+
+    let mut state = String::new();
+    let mut forwarded: Vec<String> = Vec::new();
+    let mut reply = false;
+    let mut cursor = 0;
+    while cursor < rest.len() {
+        let argument = rest[cursor].as_str();
+        match argument {
+            "--transcript" => forwarded.push("--transcript".to_string()),
+            "--reply" => reply = true,
+            "--conversation" | "--conversation-from" | "--tool-from" | "--prompt-title-from" => {
+                if cursor + 1 >= rest.len() {
+                    fail(&format!("termio: {argument} needs a value"));
+                }
+                forwarded.push(argument.to_string());
+                cursor += 1;
+                forwarded.push(rest[cursor].clone());
+            }
+            "working" | "attention" | "done" | "idle" => state = argument.to_string(),
+            _ => fail(&format!("termio: unknown agent report argument '{argument}'")),
+        }
+        cursor += 1;
+    }
+    if state.is_empty() {
+        fail("termio: agent report needs a state (working|attention|done|idle)");
+    }
+
+    // A hook outside a termiod session has nothing to report to, and
+    // reporting with an empty target is a call the daemon rejects. Silent,
+    // because hooks fire constantly and a hook that talks is worse than one
+    // that does not.
+    let session = std::env::var("TERMIOD_SESSION_ID").unwrap_or_default();
+    if session.is_empty() {
+        if reply {
+            print!("{{}}");
+        }
+        return Ok(());
+    }
+    let Some(daemon) = channel::daemon_binary(channel) else {
+        if reply {
+            print!("{{}}");
+        }
+        return Ok(());
+    };
+
+    // `--reply` is handled by the daemon binary, which prints `{}` itself
+    // even when the report could not be delivered — one implementation of
+    // Cursor's stdout contract rather than two. `channel::resolve` already
+    // pinned `TERMIO_CHANNEL`, which the exec inherits.
+    let mut command = Command::new(&daemon);
+    command.arg("set-status").arg(&session).arg(&state).args(&forwarded);
+    if reply {
+        command.arg("--reply");
+    }
+    let error = command.exec();
+    Err(error).with_context(|| format!("running {}", daemon.display()))
+}
+
+/// `termio notify [--title T] "<message>"` — post a macOS notification on
+/// demand, routed through the running app so the banner wears termio's
+/// identity and a click focuses the calling session.
+fn notify(channel: &Channel, arguments: &[String]) -> Result<()> {
+    let mut format = "text";
+    let mut title = String::new();
+    let mut body = String::new();
+    let mut cursor = 0;
+    while cursor < arguments.len() {
+        match arguments[cursor].as_str() {
+            "--json" => format = "json",
+            "--title" => {
+                if cursor + 1 >= arguments.len() {
+                    fail("termio: --title needs a value");
+                }
+                cursor += 1;
+                title = arguments[cursor].clone();
+            }
+            "-h" | "--help" => {
+                println!("{}", NOTIFY_USAGE);
+                std::process::exit(0);
+            }
+            word => push_word(&mut body, word),
+        }
+        cursor += 1;
+    }
+    if body.is_empty() {
+        fail("termio: notify needs a message (e.g. `termio notify \"tests passed\"`)");
+    }
+    app_socket::require_socket(channel);
+    let extra = if title.is_empty() {
+        String::new()
+    } else {
+        format!("\"title\":\"{}\"", app_socket::json_escape(&title))
+    };
+    exit_outcome(app_socket::request_once(
+        channel,
+        app_socket::client_timeout(),
+        "notify",
+        format,
+        "",
+        "",
+        &body,
+        &extra,
+    ));
 }
 
 /// Resolve to an absolute, symlink-free path so termio keys the project by
@@ -89,4 +580,163 @@ fn remote_passthrough(channel: &Channel, rest: &[String]) -> Result<()> {
     };
     let error = Command::new(&daemon).arg("remote").args(rest).exec();
     Err(error).with_context(|| format!("running {}", daemon.display()))
+}
+
+const NOTIFY_USAGE: &str = r#"usage: termio notify [--title T] "<message>" [--json]
+
+Post a macOS notification from the running app. The agent uses this to ping you
+directly — "build finished", "need a decision" — regardless of whether termio is
+frontmost (unlike the automatic completion banner). --title overrides the default
+(the calling agent's name); the banner's subtitle is the project, and clicking it
+focuses the session that posted it."#;
+
+fn verb_usage(op: &str) -> &'static str {
+    match op {
+        "list" => {
+            r#"usage: termio sessions list [--json]
+
+List the sessions in this project with their live status (working / idle /
+done / needs-you). `--json` adds each session's transcript path once its
+agent has reported one."#
+        }
+        "watch" => {
+            r#"usage: termio sessions watch [--state <s,…>] [--no-snapshot] [--json]
+
+Block and stream one line per session status transition until interrupted.
+On attach it first prints a snapshot line per session with its current
+status (tagged "snapshot":true in --json); --no-snapshot skips that.
+--state takes a comma-separated filter (working, idle, done, needs-you,
+stalled); the default reports the two states a supervisor acts on: done,
+needs-you.
+In --json mode the app writes {"heartbeat":true} after 30s of silence so a
+dead stream is distinguishable from a quiet one.
+
+`stalled` is a watch-plane signal, not a real status: the session is still
+working, but for 20+ minutes has made no repo change and next-to-no
+transcript growth — the unattended-runaway pattern. Sustained output (a
+long build streaming logs) suppresses it. The event carries the reasoning
+in `evidence` ("working 42m, no repo change, transcript +3 lines"), fires
+once per quiet stretch, and re-arms when progress resumes. Opt in with
+--state stalled; it is not in the default filter.
+
+exit codes: 0 after Ctrl-C (normal end of supervision), 2 when the stream
+closes from the app side (termio quit or died)."#
+        }
+        "spawn" => {
+            r#"usage: termio sessions spawn "<prompt>" [--agent <id>] [--direction right|down]
+                                        [--ratio <0..1>] [--wait [--timeout <ms>]] [--json]
+
+Start a NEW agent session on the prompt. Replies immediately with the new
+session's termio://session link; the prompt is
+typed in once the agent finishes booting. --agent picks the agent (e.g. claudeCode, codex, grok,
+pi); the default is the calling agent's own kind.
+
+--direction places the new pane relative to yours (right or down) instead of
+the automatic stack; --ratio is the new pane's share of the split (e.g. 0.25
+for a short strip) and holds against later spawns. Panes without a stated
+ratio share their run evenly.
+
+Readiness is judged from the screen, so an agent sitting on a startup gate —
+a trust prompt, a usage notice, a first-run dialog — looks ready while it is
+actually waiting for a keypress, and swallows the prompt as its answer. The
+reply cannot know this; it has already been sent. When it happens the session
+is flagged in `sessions list` (`prompt_undelivered` in --json), so check there
+before waiting on a reply that will never come, then resend with
+`sessions send`.
+
+--wait holds the reply until the spawned agent's first turn settles (or
+--timeout ms elapse; default 300000, clamped 1000–600000). The reply then
+carries the final status, the transcript path, and the cursor..cursor_end
+line range holding the response. A session that stops to ask you something
+returns immediately as needs-you, with the on-screen question in `prompt`.
+
+A prompt that shows no effect within 5s fails fast as prompt_stalled (the
+input was eaten) rather than burning the timeout; a session that closes or
+whose agent exits mid-wait fails as session_closed / agent_gone.
+
+exit codes: 0 settled, 1 error (including stalled/vanished), 3 timed out."#
+        }
+        "run" => {
+            r#"usage: termio sessions run "<command>" [--direction right|down] [--ratio <0..1>]
+                                       [--wait [--timeout <ms>]] [--json]
+
+Start a NEW plain terminal session and type the shell command into it — a
+dev server, a test run, a build — visible in a split pane, no LLM involved.
+Replies immediately with the session's address; drive it further with
+`send`, read its output with `read` (a plain command has no
+transcript; its screen is the result), close it with `close`.
+
+--direction places the pane relative to yours (right or down); --ratio is its
+share of the split — `--direction down --ratio 0.25` is a log strip under
+your pane, not a column beside it.
+
+--wait settles when the screen goes still after the command's output (or
+returns needs-you / times out, exactly as with send).
+
+exit codes: 0 settled, 1 error (including stalled/vanished), 3 timed out."#
+        }
+        "read" => {
+            r#"usage: termio sessions read <session> [--lines N] [--json]
+
+Print the session's current screen (its viewport, right-trimmed, trailing
+blank rows dropped) without focusing it. The result channel for `run`
+sessions, and a quick peek at any agent's live TUI. --lines keeps only
+the last N rows. Scrollback is not included."#
+        }
+        "send" | "answer" => {
+            r#"usage: termio sessions send <session> "<text>" [--key <name>]... [--no-enter]
+                            [--wait [--timeout <ms>]] [--json]
+
+Type text into an existing session and submit it with a real Return
+keypress — a prompt to drive it, or a menu choice ("1", "yes") to answer a
+permission prompt. Addresses come from `termio sessions list` or a `spawn`
+reply — a termio://session link or bare id, copied verbatim.
+
+The text reaches the terminal verbatim, so --no-enter (no Return after it)
+delivers a bare keypress: the lone `t` a trust gate waits for.
+
+--key presses a NAMED key, repeatable and in order, after the text:
+`send <session> --key escape` to back out of a menu, `--key up --key enter`
+to rerun the last entry. Use it instead of writing escape bytes yourself —
+a key's bytes depend on the mode the program negotiated (Up is ESC[A in
+normal mode, ESC O A in application mode), so only the terminal's own key
+encoder can get them right. Any --key suppresses the implicit Return; name
+`--key enter` when you want one. An unknown name is an error, never text.
+
+Key names follow kitty and tmux, both spellings accepted: enter, escape,
+tab, space, backspace, delete, insert, up, down, left, right, home, end,
+pageup, pagedown, f1–f12, and single characters — prefixed with ctrl-/c-
+or shift-/s- for chords (ctrl-c, c-c, shift-tab). Ctrl and Shift are the
+modifiers a program sees: macOS spends Option composing text (option-b is
+∫, not meta-b) and Command drives the app, so those chords are refused
+rather than silently dropped. A meta chord is ESC then the key:
+`--key escape --key b`.
+
+--wait holds the reply until the turn the text kicked off settles (or
+--timeout ms elapse; default 300000, clamped 1000–600000). The reply then
+carries the final status, the transcript path, and the cursor..cursor_end
+line range holding the response. A session that stops to ask you something
+returns immediately as needs-you, with the on-screen question in `prompt`.
+
+A prompt that shows no effect within 5s fails fast as prompt_stalled (the
+input was eaten) rather than burning the timeout; a session that closes or
+whose agent exits mid-wait fails as session_closed / agent_gone.
+
+exit codes: 0 settled, 1 error (including stalled/vanished), 3 timed out.
+
+`answer` is a deprecated, agent-only alias; `send` without a target aliases `spawn`."#
+        }
+        "close" => {
+            r#"usage: termio sessions close <session> [...] [--json]
+
+Close one or more session tabs. Each target gets its own attempt and reply
+line; any failure fails the whole command."#
+        }
+        "focus" => {
+            r#"usage: termio sessions focus <session> [--json]
+
+Select the session in the app and bring termio to the front."#
+        }
+        _ => USAGE,
+    }
 }

--- a/termiod/src/lib.rs
+++ b/termiod/src/lib.rs
@@ -20,6 +20,7 @@
 //! a `termiod-core` crate boundary, the same move as `termiod-vt`.
 
 pub mod agent;
+pub mod app_socket;
 pub mod channel;
 pub mod client;
 pub mod daemon;

--- a/termiod/tests/cli_compat.py
+++ b/termiod/tests/cli_compat.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Byte-compatibility harness: the Rust `termio` client against `scripts/termio`.
+
+Runs both clients against a mock app-control socket (and against no socket at
+all) and diffs four surfaces per case: the request bytes each client puts on
+the wire, stdout, stderr, and the exit code. The shell client is the frozen
+contract; any divergence fails the run. Cases that need no server (validation
+errors, help text) diff the client surfaces only.
+
+The mock lives under a short /private/tmp home because AF_UNIX paths cap at
+104 bytes, and /private/tmp (not /tmp) keeps $PWD logical-path semantics
+identical between sh and the Rust client.
+"""
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SCRIPT = os.path.join(REPO, "scripts", "termio")
+RUST = os.environ.get(
+    "TERMIO_CLI_TEST_BIN",
+    os.path.join(REPO, "termiod", "target", "debug", "termio"),
+)
+
+HOME = f"/private/tmp/termio-compat-{os.getpid()}"
+SOCK_DIR = os.path.join(HOME, "Library/Application Support/termio")
+SOCK = os.path.join(SOCK_DIR, "session-control.sock")
+
+failures = []
+passes = 0
+
+
+def check(name, condition, detail=""):
+    global passes
+    if condition:
+        passes += 1
+        print(f"  [PASS] {name}")
+    else:
+        failures.append(name)
+        print(f"  [FAIL] {name}\n{detail}")
+
+
+class MockApp:
+    """One listener; each connection reads a request, replies from a queue."""
+
+    def __init__(self, replies, hold=False):
+        os.makedirs(SOCK_DIR, exist_ok=True)
+        if os.path.exists(SOCK):
+            os.unlink(SOCK)
+        self.server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.server.bind(SOCK)
+        self.server.listen(8)
+        self.replies = list(replies)
+        self.hold = hold
+        self.requests = []
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+        self.thread.start()
+
+    def _serve(self):
+        while True:
+            try:
+                connection, _ = self.server.accept()
+            except OSError:
+                return
+            connection.settimeout(3)
+            data = b""
+            try:
+                while not data.endswith(b"}"):
+                    chunk = connection.recv(65536)
+                    if not chunk:
+                        break
+                    data += chunk
+            except socket.timeout:
+                pass
+            self.requests.append(data)
+            if self.hold:
+                time.sleep(3)
+                connection.close()
+                continue
+            reply = self.replies.pop(0) if self.replies else b'{"ok":true}'
+            try:
+                connection.sendall(reply)
+            except OSError:
+                pass
+            connection.close()
+
+    def close(self):
+        self.server.close()
+        if os.path.exists(SOCK):
+            os.unlink(SOCK)
+
+
+def run(client, args, env_extra=None):
+    env = {
+        "HOME": HOME,
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "PWD": HOME,
+        "TERMIO_SESSION": "TEST-SESSION",
+    }
+    if env_extra:
+        env.update(env_extra)
+    completed = subprocess.run(
+        [client] + args, env=env, cwd=HOME, capture_output=True, text=True, timeout=30
+    )
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def compare(name, args, replies=None, env_extra=None, hold=False, no_server=False):
+    """Run both clients; diff request bytes, stdout, stderr, and exit code."""
+    surfaces = []
+    for client in (SCRIPT, RUST):
+        mock = None if no_server else MockApp(replies or [b'{"ok":true}'], hold=hold)
+        code, out, err = run(client, args, env_extra)
+        requests = [] if mock is None else list(mock.requests)
+        if mock:
+            mock.close()
+        surfaces.append((code, out, err, requests))
+    (s_code, s_out, s_err, s_req), (r_code, r_out, r_err, r_req) = surfaces
+    detail = (
+        f"    exit: script={s_code} rust={r_code}\n"
+        f"    stdout: script={s_out!r}\n            rust={r_out!r}\n"
+        f"    stderr: script={s_err!r}\n            rust={r_err!r}\n"
+        f"    requests: script={s_req!r}\n              rust={r_req!r}"
+    )
+    check(
+        name,
+        (s_code, s_out, s_err, s_req) == (r_code, r_out, r_err, r_req),
+        detail,
+    )
+
+
+def main():
+    shutil.rmtree(HOME, ignore_errors=True)
+    os.makedirs(SOCK_DIR)
+    if not os.path.exists(RUST):
+        print(f"missing rust client at {RUST}; cargo build first", file=sys.stderr)
+        return 2
+
+    ok = b'{"ok":true,"schema_version":1,"sessions":[]}'
+    err = b'{"error":"no_scope","message":"Couldn\xe2\x80\x99t tell.","ok":false,"schema_version":1}'
+
+    print("== requests and replies ==")
+    compare("list text", ["sessions", "list"], [ok])
+    compare("list json", ["sessions", "list", "--json"], [ok])
+    compare("list default op", ["sessions"], [ok])
+    compare("error reply exits 1", ["sessions", "list", "--json"], [err])
+    compare("text error prefix exits 1", ["sessions", "list"], [b"error: nope\n"])
+    compare("send to target", ["sessions", "send", "8de0b387", "hello", "world"], [ok])
+    compare("send full link", ["sessions", "send", "termio://session/8de0b387-485a-4016-8990-cbcbfff03199", "hi"], [ok])
+    compare("send no-enter with key", ["sessions", "send", "8de0b387", "t", "--no-enter", "--key", "escape", "--key", "enter"], [ok])
+    compare("send no target aliases spawn", ["sessions", "send", "fix", "the", "build"], [ok])
+    compare("send 7-hex token is text", ["sessions", "send", "deadbee", "tail"], [ok])
+    compare("answer", ["sessions", "answer", "8de0b387", "yes"], [ok])
+    compare("spawn with placement", ["sessions", "spawn", "fix it", "--agent", "codex", "--direction", "down", "--ratio", "0.25"], [ok])
+    compare("run", ["sessions", "run", "pnpm dev", "--direction", "right"], [ok])
+    compare("read with lines", ["sessions", "read", "8de0b387", "--lines", "12"], [ok])
+    compare("focus", ["sessions", "focus", "8de0b387"], [ok])
+    compare("close two targets", ["sessions", "close", "8de0b387", "deadbeef"], [ok, ok])
+    compare("close second fails", ["sessions", "close", "8de0b387", "deadbeef"], [ok, err])
+    compare("notify", ["notify", "tests", "passed"], [ok])
+    compare("notify with title", ["notify", "--title", "ci", "done", "--json"], [ok])
+
+    print("== --wait ==")
+    waited = b'{"ok":true,"status":"done","timed_out":false}'
+    timed = b'{"ok":true,"status":"working","timed_out":true}'
+    compare("wait settled", ["sessions", "send", "8de0b387", "go", "--wait", "--timeout", "5000", "--json"], [waited])
+    compare("wait timeout exits 3 json", ["sessions", "send", "8de0b387", "go", "--wait", "--timeout", "5000", "--json"], [timed])
+    compare("wait timeout exits 3 text", ["sessions", "spawn", "go", "--wait"], [b"working \xe2\x80\x94 timed out after 300s\ndetail\n"])
+
+    print("== watch ==")
+    stream = b'{"snapshot":true,"session":"a"}\n{"session":"a","status":"done"}\n'
+    compare("watch stream then eof", ["sessions", "watch", "--json"], [stream])
+    compare("watch error first line", ["sessions", "watch"], [b'error: control disabled\n'])
+    compare("watch no-snapshot state filter", ["sessions", "watch", "--state", "done,stalled", "--no-snapshot", "--json"], [stream])
+
+    print("== validation (no server contact) ==")
+    for name, args in [
+        ("spawn empty", ["sessions", "spawn"]),
+        ("spawn terminal refused", ["sessions", "spawn", "x", "--agent", "terminal"]),
+        ("spawn Shell refused", ["sessions", "spawn", "x", "--agent", "Shell"]),
+        ("run empty", ["sessions", "run"]),
+        ("read no target", ["sessions", "read"]),
+        ("answer no target", ["sessions", "answer"]),
+        ("focus no target", ["sessions", "focus"]),
+        ("close no target", ["sessions", "close"]),
+        ("ratio bare5", ["sessions", "spawn", "x", "--ratio", ".5"]),
+        ("ratio trailing dot", ["sessions", "spawn", "x", "--ratio", "0."]),
+        ("ratio percent", ["sessions", "spawn", "x", "--ratio", "50%"]),
+        ("direction bad", ["sessions", "spawn", "x", "--direction", "left"]),
+        ("timeout not ms", ["sessions", "send", "8de0b387", "x", "--timeout", "5s"]),
+        ("lines not number", ["sessions", "read", "8de0b387", "--lines", "two"]),
+        ("wait on list", ["sessions", "list", "--wait"]),
+        ("placement on send", ["sessions", "send", "8de0b387", "x", "--direction", "down"]),
+        ("no-enter on spawn", ["sessions", "spawn", "x", "--no-enter"]),
+        ("no-enter without target", ["sessions", "send", "x", "--no-enter"]),
+        ("key without target", ["sessions", "send", "x", "--key", "escape"]),
+        ("key missing value", ["sessions", "send", "8de0b387", "--key"]),
+        ("agent missing value", ["sessions", "spawn", "x", "--agent"]),
+        ("state missing value", ["sessions", "watch", "--state"]),
+        ("title missing value", ["notify", "--title"]),
+        ("notify empty", ["notify"]),
+    ]:
+        compare(name, args, [ok])
+    compare("unknown sessions cmd", ["sessions", "bogus"], no_server=True)
+
+    print("== error taxonomy ==")
+    compare("no socket at all", ["sessions", "list"], no_server=True)
+    compare("notify no socket", ["notify", "hi"], no_server=True)
+    # A plain file where the socket should be: the -S pre-check refuses.
+    with open(SOCK, "w") as handle:
+        handle.write("")
+    compare("socket is a plain file", ["sessions", "list"], no_server=True)
+    os.unlink(SOCK)
+    # A socket file whose listener is gone: connect refused.
+    stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    stale.bind(SOCK)
+    stale.close()
+    compare("stale socket refused", ["sessions", "list"], no_server=True)
+    os.unlink(SOCK)
+    compare(
+        "silent app times out",
+        ["sessions", "list"],
+        hold=True,
+        env_extra={"TERMIO_CLI_TIMEOUT": "1"},
+    )
+
+    print("== agent report ==")
+    compare("report outside session", ["agent", "report", "done"], no_server=True)
+    compare("report outside session reply", ["agent", "report", "done", "--reply"], no_server=True)
+    compare("report no state", ["agent", "report"], no_server=True)
+    compare("report unknown flag", ["agent", "report", "done", "--bogus"], no_server=True)
+    compare("unknown agent cmd", ["agent", "bogus"], no_server=True)
+    # With a session id and a recorder daemon: both clients must exec the
+    # daemon with identical argv.
+    recorder = os.path.join(HOME, "record-termiod")
+    argv_log = os.path.join(HOME, "argv")
+    with open(recorder, "w") as handle:
+        handle.write(f'#!/bin/sh\nprintf \'%s\\n\' "$@" > "{argv_log}"\n')
+    os.chmod(recorder, 0o755)
+    argvs = []
+    for client in (SCRIPT, RUST):
+        if os.path.exists(argv_log):
+            os.unlink(argv_log)
+        code, out, err = run(
+            client,
+            ["agent", "report", "working", "--transcript", "--tool-from", "tool_name", "--reply"],
+            {"TERMIOD_SESSION_ID": "S1", "TERMIOD_BIN": recorder},
+        )
+        argv = open(argv_log).read() if os.path.exists(argv_log) else "(none)"
+        argvs.append((code, out, err, argv))
+    check(
+        "report execs identical set-status argv",
+        argvs[0] == argvs[1],
+        f"    script={argvs[0]!r}\n    rust={argvs[1]!r}",
+    )
+
+    print("== help ==")
+    for name, args in [
+        ("usage", ["--help"]),
+        ("usage via help", ["help"]),
+        ("sessions usage", ["sessions", "--help"]),
+        ("list help", ["sessions", "list", "--help"]),
+        ("watch help", ["sessions", "watch", "--help"]),
+        ("spawn help", ["sessions", "spawn", "--help"]),
+        ("run help", ["sessions", "run", "--help"]),
+        ("send help", ["sessions", "send", "--help"]),
+        ("answer help", ["sessions", "answer", "--help"]),
+        ("read help", ["sessions", "read", "--help"]),
+        ("close help", ["sessions", "close", "--help"]),
+        ("focus help", ["sessions", "focus", "--help"]),
+        ("notify help", ["notify", "--help"]),
+        ("not a directory", ["/nonexistent-dir"]),
+        ("open not a directory", ["open", "/nonexistent-dir"]),
+    ]:
+        compare(name, args, no_server=True)
+
+    shutil.rmtree(HOME, ignore_errors=True)
+    print()
+    if failures:
+        print(f"{passes} passed, {len(failures)} FAILED: {failures}")
+        return 1
+    print(f"ALL {passes} CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/termiod/tests/cli_compat.py
+++ b/termiod/tests/cli_compat.py
@@ -70,14 +70,20 @@ class MockApp:
                 return
             connection.settimeout(3)
             data = b""
-            try:
-                while not data.endswith(b"}"):
-                    chunk = connection.recv(65536)
-                    if not chunk:
+            while True:
+                if data:
+                    try:
+                        json.loads(data)
                         break
-                    data += chunk
-            except socket.timeout:
-                pass
+                    except ValueError:
+                        pass
+                try:
+                    chunk = connection.recv(65536)
+                except socket.timeout:
+                    break
+                if not chunk:
+                    break
+                data += chunk
             self.requests.append(data)
             if self.hold:
                 time.sleep(3)
@@ -164,6 +170,16 @@ def main():
     compare("close two targets", ["sessions", "close", "8de0b387", "deadbeef"], [ok, ok])
     compare("close second fails", ["sessions", "close", "8de0b387", "deadbeef"], [ok, err])
     compare("notify", ["notify", "tests", "passed"], [ok])
+    compare("timeout leading plus", ["sessions", "send", "8de0b387", "x", "--timeout", "+5"], [ok])
+    compare("timeout negative", ["sessions", "send", "8de0b387", "x", "--timeout", "-5"], [ok])
+    compare("trailing newline eaten", ["sessions", "spawn", "hello\n"], [ok])
+    compare("interior newline survives", ["sessions", "spawn", "a\nb"], [ok])
+    compare("two trailing newlines keep one", ["sessions", "spawn", "a\n\n"], [ok])
+    compare("close splits one argument", ["sessions", "close", "one two"], [ok, ok])
+    compare("close whitespace-only argument", ["sessions", "close", "  "], [ok])
+    compare("send text then address is all text", ["sessions", "send", "fix", "8de0b387aa", "please"], [ok])
+    compare("json after positionals", ["sessions", "send", "8de0b387", "hi", "--json"], [ok])
+    compare("ok-false inside text reply", ["sessions", "list"], [b'something "ok":false something\n'])
     compare("notify with title", ["notify", "--title", "ci", "done", "--json"], [ok])
 
     print("== --wait ==")
@@ -172,12 +188,15 @@ def main():
     compare("wait settled", ["sessions", "send", "8de0b387", "go", "--wait", "--timeout", "5000", "--json"], [waited])
     compare("wait timeout exits 3 json", ["sessions", "send", "8de0b387", "go", "--wait", "--timeout", "5000", "--json"], [timed])
     compare("wait timeout exits 3 text", ["sessions", "spawn", "go", "--wait"], [b"working \xe2\x80\x94 timed out after 300s\ndetail\n"])
+    compare("wait timeout marker on later line", ["sessions", "spawn", "go", "--wait"], [b"working\nlater \xe2\x80\x94 timed out\n"])
 
     print("== watch ==")
     stream = b'{"snapshot":true,"session":"a"}\n{"session":"a","status":"done"}\n'
     compare("watch stream then eof", ["sessions", "watch", "--json"], [stream])
     compare("watch error first line", ["sessions", "watch"], [b'error: control disabled\n'])
     compare("watch no-snapshot state filter", ["sessions", "watch", "--state", "done,stalled", "--no-snapshot", "--json"], [stream])
+    compare("watch unterminated final line", ["sessions", "watch", "--json"], [b'{"snapshot":true}\n{"session":"a","status":"done"}'])
+    compare("watch unterminated first line", ["sessions", "watch", "--json"], [b'{"snapshot":true}'])
 
     print("== validation (no server contact) ==")
     for name, args in [
@@ -211,6 +230,8 @@ def main():
 
     print("== error taxonomy ==")
     compare("no socket at all", ["sessions", "list"], no_server=True)
+    compare("socket error before flag validation", ["sessions", "spawn", "x", "--ratio", "bad"], no_server=True)
+    compare("notify body error before socket check", ["notify"], no_server=True)
     compare("notify no socket", ["notify", "hi"], no_server=True)
     # A plain file where the socket should be: the -S pre-check refuses.
     with open(SOCK, "w") as handle:
@@ -249,7 +270,7 @@ def main():
             os.unlink(argv_log)
         code, out, err = run(
             client,
-            ["agent", "report", "working", "--transcript", "--tool-from", "tool_name", "--reply"],
+            ["agent", "report", "working", "--transcript", "--tool-from", "tool name", "--reply"],
             {"TERMIOD_SESSION_ID": "S1", "TERMIOD_BIN": recorder},
         )
         argv = open(argv_log).read() if os.path.exists(argv_log) else "(none)"


### PR DESCRIPTION
The parity slice of the Rust `termio` client (unify-server-plane Stage 10, following #551/#553/#555): every `sessions` verb, `notify`, and `agent report` move into the binary, still speaking the app's control socket. Backends change one verb at a time in later PRs, each flip retiring its Swift handler; this PR is the byte-compat heavy-lifting that makes those flips diffable.

- **`app_socket.rs`** reproduces the shell client's request shape byte for byte — field order, its exact `json_escape` semantics (C0 stripping, ESC surviving as a JSON u001b escape), the `is_address` heuristic — plus its error taxonomy (sandbox denial / missing socket / stale socket / silent app), the `--wait` exit-code contract (0/1/3), and watch's stream semantics (0 on Ctrl-C, 1 on an error first line, 2 on EOF with the escalation message).
- Two load-bearing macOS traps found while porting, documented in place: the app treats a half-closed request socket as the client leaving (`nc` never shuts down its write side, so neither do we), and **setsockopt is refused with EINVAL once the peer has closed** — both timeouts are armed before the request goes out and never re-armed, or every fast reply becomes a phantom "connection refused".
- `$PWD` is validated against the physical cwd the way `sh` validates it before being trusted as `caller_cwd`.
- `agent report` execs the located daemon's `set-status` with the script's exact argv and keeps both silent-success shapes (`{}` under `--reply`).
- **`tests/cli_compat.py`**: both clients run against a mock app socket; request bytes, stdout, stderr, and exit codes are diffed across **76 cases** — every verb in both formats, `--wait` settle/timeout, watch stream/error/EOF, all validation errors, the error taxonomy, the hook contract (argv-recording fake daemon), and every help text. Wired into the macOS CI job (Linux would diff the script's own `nc` platform drift, not the port).

Verified: all 76 harness checks pass; 267 tests green across the lib and integration suites; `list`/`read`/`focus` additionally diffed byte-identical against the live app in both formats, including error paths.

Release Notes:

- None (the binary is not yet bundled; it ships to users in a later PR).