### PR TITLE
Bundle the Rust termio client in place of the shell script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ swift test                                 # run the unit tests
 ./scripts/build-app.sh                     # ad-hoc-signed .app → ./termio.app
 TERMIO_CHANNEL=dev ./scripts/build-app.sh  # side-by-side dev app → ./termio-dev.app
 ./ios/dev-run.sh                           # build + install iOS app on the device
+cargo build --bin termio                   # (in termiod/) the Rust CLI, for checkout use
 ```
 
 termio is a real foreground AppKit app bootstrapped by an explicit

--- a/Sources/termio/Companion/AppChannel.swift
+++ b/Sources/termio/Companion/AppChannel.swift
@@ -16,22 +16,33 @@ import Foundation
 enum AppChannel {
     /// `"-dev"` for a `*.dev` bundle id, `""` for a release build.
     ///
-    /// `TERMIO_CHANNEL` overrides the bundle reading — the same switch
-    /// `build-app.sh` takes at build time, now honoured at runtime. It exists for
-    /// the unbundled case: `swift run` has no bundle identifier, so without it a
-    /// bare binary falls into the *release* channel and shares the shipped app's
-    /// state directory, control socket and companion port.
+    /// A termio `.app` reads its channel off its own bundle identifier, and
+    /// nothing overrides that: every termio session carries the channel of
+    /// the app that spawned it in `TERMIO_CHANNEL`, and macOS `open`
+    /// propagates the caller's environment — so launching the dev app from a
+    /// release session (or the reverse) would otherwise rebind the app to
+    /// the *other* channel's state directory, control socket, and companion
+    /// port. The `TERMIO_CHANNEL` override exists for the unbundled case
+    /// only: `swift run` has no bundle identifier, so without it a bare
+    /// binary falls into the release channel and shares the shipped app's
+    /// state.
     static let suffix: String = {
         let requested = ProcessInfo.processInfo.environment["TERMIO_CHANNEL"]?
             .trimmingCharacters(in: .whitespaces).lowercased() ?? ""
-        // Only a plain name becomes a path component — anything else is a typo we
-        // must not turn into a stray directory next to the real ones.
-        if !requested.isEmpty, requested != "release",
+        // A custom probe channel is always deliberate — only a test harness
+        // sets one — and only a plain name becomes a path component: anything
+        // else is a typo we must not turn into a stray directory.
+        if !requested.isEmpty, requested != "release", requested != "dev",
            requested.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" }) {
             return "-" + requested
         }
-        if requested == "release" { return "" }
-        return (Bundle.main.bundleIdentifier?.hasSuffix(".dev") ?? false) ? "-dev" : ""
+        // The two real channel names are the ones a session's environment
+        // carries, so for them the app's own identity wins.
+        if let identifier = Bundle.main.bundleIdentifier,
+           identifier == "sh.termio.app" || identifier.hasSuffix(".dev") {
+            return identifier.hasSuffix(".dev") ? "-dev" : ""
+        }
+        return requested == "dev" ? "-dev" : ""
     }()
 
     /// True for the side-by-side dev build. Use this to gate diagnostics that must

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1310,6 +1310,13 @@ final class TermioStore: ObservableObject {
             }
         reconcileWorktrees()
 
+        // The support copy exists to version-update with the app, but the
+        // hook-sync paths refresh it only when a toggle changes or on refocus
+        // with hooks on. Refresh unconditionally here: hooks and the PATH
+        // symlink exec this copy directly, and after an app update it must
+        // carry the new build's client.
+        CommandLineTool.refreshSupportCopy()
+
         startHookMonitoring()
         startSessionControl()
     }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -180,23 +180,30 @@ shopt -u nullglob
 
 # Ship the command-line tool inside the bundle. The app installs it onto the user's
 # PATH by symlinking to this copy, so it version-updates with the app. A dev build
-# ships it as `termio-dev`, rebound to the dev socket + bundle id, so it drives the
-# dev app without clobbering the release `termio`.
+# ships it as `termio-dev`: the Rust client reads its channel off its own program
+# name, so one binary drives the dev app without clobbering the release `termio`.
+# Bundled after the daemon build below, from the same cargo slices — `cargo build`
+# compiles every bin in the crate, so the client costs no second build. A dev
+# build without the Rust toolchain falls back to the shell client, rebound by sed
+# the way every build used to be.
 cli_name="termio"
 [[ "$channel" == "dev" ]] && cli_name="termio-dev"
-echo "==> Bundling $cli_name command-line tool"
-cp "$repo_root/scripts/termio" "$resources_dir/$cli_name"
-if [[ "$channel" == "dev" ]]; then
-    /usr/bin/sed -i '' \
-        -e 's/^SUPPORT_DIR_NAME="termio"/SUPPORT_DIR_NAME="termio-dev"/' \
-        -e 's/^BUNDLE_ID="sh.termio.app"/BUNDLE_ID="sh.termio.app.dev"/' \
-        "$resources_dir/$cli_name"
-fi
-if [[ -n "${TERMIO_VERSION:-}" ]]; then
-    /usr/bin/sed -i '' -e "s/^VERSION=\"dev\"/VERSION=\"$TERMIO_VERSION\"/" \
-        "$resources_dir/$cli_name"
-fi
-chmod +x "$resources_dir/$cli_name"
+
+bundle_shell_client() {
+    echo "==> Bundling $cli_name command-line tool (shell fallback)"
+    cp "$repo_root/scripts/termio" "$resources_dir/$cli_name"
+    if [[ "$channel" == "dev" ]]; then
+        /usr/bin/sed -i '' \
+            -e 's/^SUPPORT_DIR_NAME="termio"/SUPPORT_DIR_NAME="termio-dev"/' \
+            -e 's/^BUNDLE_ID="sh.termio.app"/BUNDLE_ID="sh.termio.app.dev"/' \
+            "$resources_dir/$cli_name"
+    fi
+    if [[ -n "${TERMIO_VERSION:-}" ]]; then
+        /usr/bin/sed -i '' -e "s/^VERSION=\"dev\"/VERSION=\"$TERMIO_VERSION\"/" \
+            "$resources_dir/$cli_name"
+    fi
+    chmod +x "$resources_dir/$cli_name"
+}
 
 # Ship the session daemon inside the bundle, beside the CLI. `termiod` owns the
 # PTY for every session the app opens through it, and the app resolves it out of
@@ -238,6 +245,7 @@ if [[ -n "$daemon_toolchain_missing" ]]; then
         exit 1
     fi
     echo "==> Skipping termiod: $daemon_toolchain_missing not found — this dev build cannot start a daemon"
+    bundle_shell_client
 else
     # Xcode 26's libSystem.tbd advertises arm64e only and Zig cannot link against
     # it (the build dies in a wall of "undefined symbol: _malloc"); the Command
@@ -277,6 +285,29 @@ else
         fi
     done
     echo "==> Bundled $daemon_name architectures: $daemon_archs"
+
+    # The Rust termio client, from the slices the daemon build just produced.
+    # Its name is load-bearing twice: the support copy and PATH symlink keep
+    # the exact per-channel paths installed hooks already reference, and
+    # argv[0] is what binds the binary to this bundle id, support directory,
+    # and daemon socket.
+    echo "==> Bundling $cli_name command-line tool (Rust client)"
+    cli_slices=()
+    for arch in "${architectures[@]}"; do
+        rust_target="$arch-apple-darwin"
+        [[ "$arch" == "arm64" ]] && rust_target="aarch64-apple-darwin"
+        cli_slices+=("$repo_root/termiod/target/$rust_target/release/termio")
+    done
+    lipo -create "${cli_slices[@]}" -output "$resources_dir/$cli_name"
+    chmod +x "$resources_dir/$cli_name"
+    cli_archs="$(lipo -archs "$resources_dir/$cli_name")"
+    for required_arch in "${architectures[@]}"; do
+        if [[ " $cli_archs " != *" $required_arch "* ]]; then
+            echo "error: bundled $cli_name is missing the $required_arch slice — has [$cli_archs]" >&2
+            exit 1
+        fi
+    done
+    echo "==> Bundled $cli_name architectures: $cli_archs"
 
     # The daemons that ship *to* a Linux box. `termiod remote deploy` used to
     # cross-compile one on demand, which needs cargo, the musl target, and this
@@ -398,6 +429,11 @@ codesign "${sign_args[@]}" "$sparkle"
 # outer app for the same reason — and with the same hardened runtime, because
 # notarization rejects any executable inside the bundle that lacks it.
 [[ -e "$daemon_dest" ]] && codesign "${sign_args[@]}" "$daemon_dest"
+# The Rust client is the same shape when it shipped (the shell-script fallback
+# is covered by the outer seal like any other resource file).
+if [[ -e "$resources_dir/$cli_name" ]] && file "$resources_dir/$cli_name" | grep -q "Mach-O"; then
+    codesign "${sign_args[@]}" "$resources_dir/$cli_name"
+fi
 # Seal the outer app last so CodeResources covers the embedded framework. NOT
 # --deep: the framework's components are already individually signed above.
 codesign "${sign_args[@]}" "$app_dir"

--- a/termiod/src/bin/termio.rs
+++ b/termiod/src/bin/termio.rs
@@ -74,6 +74,12 @@ Every one-shot command times out after ${TERMIO_CLI_TIMEOUT:-15}s (TERMIO_CLI_TI
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Rust ignores SIGPIPE and turns a closed pipe into a stdout panic; a CLI
+    // whose output feeds `head` must die silently there, like the shell
+    // client it replaces.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
     let (channel, provenance) = channel::resolve();
     let arguments: Vec<String> = std::env::args().skip(1).collect();
     match arguments.first().map(String::as_str) {


### PR DESCRIPTION
PR 4 of the CLI port (after #556): `build-app.sh` lipos the `termio` bin out of the same cargo slices the daemon build already produces — the client costs no second build — and ships it under the channel's resource name (`termio`/`termio-dev`), sealed with the hardened runtime like the daemon so notarization holds. The sed-rewritten shell client survives only as the dev-without-Rust-toolchain fallback. `CommandLineTool` needed zero changes: the support copy and PATH symlink flow treats a Mach-O like any content, so hooks written by old releases keep resolving on the exact same path.

Two latent bugs became load-bearing and are fixed here:

- **Stale support copy after update**: the copy only refreshed when the hooks toggle changed or on refocus with hooks on — an updated app could leave an old client on the exact path hooks exec. `TermioStore` now refreshes it unconditionally at launch.
- **Channel rebinding via inherited env**: `AppChannel.suffix` let an inherited `TERMIO_CHANNEL` beat the bundle's own identity. Every termio session carries its app's channel in that variable, and macOS `open` propagates the caller's environment — so a dev app launched from inside a release session silently rebound itself to the *release* channel's state directory and sockets. The app's own bundle id now wins for the two real channel names; custom probe channels stay honoured, and unbundled `swift run` keeps the env override.

Also: the client restores default SIGPIPE disposition, dying silently on a closed pipe (`termio version | head`) like the script instead of panicking mid-print.

Verified: dev `.app` built and launched — the support copy becomes the signed Mach-O with 0755 at launch; the installed copy drives the dev app (`sessions list` prints `termio-dev://` links) and passes all 91 compat-harness checks; release support copy untouched; 225 lib tests, integration suites, and `swift test` green.

Release Notes:

- The `termio` command-line tool is now a native binary. Its commands, output, and paths are unchanged.