### PR TITLE
Keep SGR mouse format winning in snapshot replay

### DIFF
--- a/termiod/vt/src/lib.rs
+++ b/termiod/vt/src/lib.rs
@@ -155,6 +155,21 @@ const SNAPSHOT_PROLOGUE: &[u8] = concat!(
 )
 .as_bytes();
 
+/// Mouse format is last-writer-wins, but the formatter re-emits mode bits in
+/// enum order — SGR (`?1006h`) before urxvt (`?1015h`). crossterm enables
+/// urxvt then SGR, so replaying its payload flips a client into urxvt, which
+/// crossterm TUIs don't parse (#441). The engine's API can't read the resolved
+/// winner back out, so `format_vt` re-asserts SGR whenever both were emitted:
+/// `?1015h` only ever appears as the fallback written before `?1006h`.
+const SGR_MOUSE_FORMAT: &[u8] = b"\x1b[?1006h";
+const URXVT_MOUSE_FORMAT: &[u8] = b"\x1b[?1015h";
+
+fn last_occurrence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .rposition(|window| window == needle)
+}
+
 /// A terminal plus reusable render iterators. This type is deliberately
 /// `!Send`/`!Sync`; construct and use it on the sidecar thread that owns it.
 pub struct VtTerminal {
@@ -291,6 +306,17 @@ impl VtTerminal {
             )?;
             let bytes = check(formatter.format_alloc(None), "Formatter::format_alloc")?;
             formatted.extend_from_slice(&bytes);
+        }
+
+        // See SGR_MOUSE_FORMAT. Guarded on the actual order so this becomes
+        // a no-op the day the formatter restates the winner itself.
+        if let (Some(sgr), Some(urxvt)) = (
+            last_occurrence(&formatted, SGR_MOUSE_FORMAT),
+            last_occurrence(&formatted, URXVT_MOUSE_FORMAT),
+        ) {
+            if urxvt > sgr {
+                formatted.extend_from_slice(SGR_MOUSE_FORMAT);
+            }
         }
 
         let pending_wrap = check(

--- a/termiod/vt/tests/mouse_format_replay.rs
+++ b/termiod/vt/tests/mouse_format_replay.rs
@@ -1,0 +1,69 @@
+//! A snapshot payload must leave a replaying client in the host's actual
+//! mouse format. The formatter re-emits mode bits in enum order — SGR
+//! (`?1006h`) before urxvt (`?1015h`) — so a host that enabled urxvt then
+//! SGR (crossterm's `EnableMouseCapture`) replayed into urxvt, an encoding
+//! crossterm TUIs don't parse. That was #441: herdr's mouse went dead after
+//! every attach, resize, or resync.
+
+use termiod_vt::VtTerminal;
+
+/// crossterm 0.29 `EnableMouseCapture`, byte for byte.
+const CROSSTERM_ENABLE_MOUSE: &[u8] = b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1015h\x1b[?1006h";
+
+fn last(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .rposition(|window| window == needle)
+}
+
+fn count(haystack: &[u8], needle: &[u8]) -> usize {
+    haystack
+        .windows(needle.len())
+        .filter(|window| *window == needle)
+        .count()
+}
+
+#[test]
+fn sgr_wins_the_replay_when_the_host_set_it_last() {
+    let mut host = VtTerminal::new(15, 50).expect("host terminal");
+    host.vt_write(b"\x1b[?1049h");
+    host.vt_write(CROSSTERM_ENABLE_MOUSE);
+    host.vt_write(b"herdr screen");
+
+    let payload = host.format_vt().expect("format_vt");
+    let sgr = last(&payload, b"\x1b[?1006h").expect("payload restates SGR");
+    let urxvt = last(&payload, b"\x1b[?1015h").expect("payload restates urxvt");
+    assert!(
+        sgr > urxvt,
+        "SGR must land after urxvt or the replaying client reports in urxvt; payload: {}",
+        String::from_utf8_lossy(&payload).replace('\x1b', "<ESC>")
+    );
+}
+
+/// A second hop — a handoff, or a resize after an attach — must not regress.
+#[test]
+fn replayed_client_payload_keeps_sgr_winning() {
+    let mut host = VtTerminal::new(15, 50).expect("host terminal");
+    host.vt_write(b"\x1b[?1049h");
+    host.vt_write(CROSSTERM_ENABLE_MOUSE);
+
+    let payload = host.format_vt().expect("host format_vt");
+    let mut client = VtTerminal::new(15, 50).expect("client terminal");
+    client.vt_write(&payload);
+
+    let second_hop = client.format_vt().expect("client format_vt");
+    let sgr = last(&second_hop, b"\x1b[?1006h").expect("second hop restates SGR");
+    let urxvt = last(&second_hop, b"\x1b[?1015h").expect("second hop restates urxvt");
+    assert!(sgr > urxvt, "SGR must keep winning across hops");
+}
+
+/// A host that only ever set SGR needs no repair.
+#[test]
+fn payload_without_urxvt_is_untouched() {
+    let mut host = VtTerminal::new(15, 50).expect("host terminal");
+    host.vt_write(b"\x1b[?1002h\x1b[?1006h");
+
+    let payload = host.format_vt().expect("format_vt");
+    assert_eq!(count(&payload, b"\x1b[?1006h"), 1, "no redundant re-assert");
+    assert_eq!(count(&payload, b"\x1b[?1015h"), 0);
+}


### PR DESCRIPTION
A snapshot payload re-emits mouse modes from the terminal's mode bits in enum order — SGR (`?1006h`) before urxvt (`?1015h`). crossterm's `EnableMouseCapture` sets urxvt then SGR, so a replaying client landed in urxvt, an encoding crossterm TUIs don't parse. Their mouse went dead after every attach, resize, or backlog resync, and stayed dead because a TUI never re-sends state it believes is already set (#441).

`format_vt` now re-asserts `?1006h` whenever the payload carries both formats with urxvt last. The guard checks the actual byte order, so a formatter that one day restates the winner itself turns this into a no-op. `?1015h` only ever appears in the wild as the compatibility fallback written before `?1006h`, so preferring SGR reconstructs the real state.

Regression tests cover crossterm's exact enable sequence, a second replay hop, and an SGR-only host staying untouched.

Fixes #441

Release Notes:
- Fixed mouse input dying in crossterm TUIs (herdr, lazygit, btop, …) after a resize, reattach, or resync.