### PR TITLE
Name the app's socket for the process that binds it

### DIFF
--- a/Sources/termio/Agents/SessionControl.swift
+++ b/Sources/termio/Agents/SessionControl.swift
@@ -113,10 +113,10 @@ enum LocalSocket {
 }
 
 /// One request from the `termio sessions …` CLI, sent as a single JSON object
-/// over `SessionControlListener`'s local socket. This is the write/drive
-/// counterpart to `HookListener`'s read-only status stream: where a hook reports
-/// "this session is now working", a control request *acts on* a sibling session
-/// — listing them, sending a prompt, answering a menu, closing or focusing one.
+/// over `AppSocketListener`'s local socket. Where an agent's hook *reports* ("this
+/// session is now working", via `termio agent report`), a request here *acts on* a
+/// sibling session — listing them, sending a prompt, answering a menu, closing or
+/// focusing one.
 ///
 /// - `op` — `list` / `read` / `send` / `answer` / `close` / `focus`.
 /// - `format` — `text` (human-readable lines, the default) or `json`.
@@ -250,23 +250,33 @@ enum SocketIO {
     }
 }
 
-/// A local Unix-domain socket the `termio sessions` CLI connects to. Unlike
-/// `HookListener` (which only receives), this is request/response: it decodes one
-/// `ControlRequest`, runs the handler on the main actor, and writes the handler's
-/// reply back down the same connection before closing — so the CLI can print it.
+/// A local Unix-domain socket the `termio` CLI connects to. Request/response: it
+/// decodes one `ControlRequest`, runs the handler on the main actor, and writes the
+/// handler's reply back down the same connection before closing — so the CLI can
+/// print it.
 ///
 /// This type owns only the transport. Resolving the caller's project, enforcing
 /// project scope, and acting on sessions all live in `TermioStore` (the handler).
 // @unchecked: the handler closures are immutable @MainActor values, and every
 // mutable property is confined to `queue`; the queue is the synchronization the
 // compiler cannot see.
-final class SessionControlListener: @unchecked Sendable {
-    /// The control socket, alongside the status socket and session tree under
-    /// termio's Application Support directory. Deliberately a *different* file from
-    /// `HookListener.socketURL`: this one accepts drive commands, not status pings.
+final class AppSocketListener: @unchecked Sendable {
+    /// Named for the process that binds it, the way `termiod.sock` is: the daemon
+    /// answers there, the app answers here. Not named for the session verbs it
+    /// carries today — those are migrating to the daemon's framed protocol one at a
+    /// time (unify-server-plane Stage 10), and what is left behind is the work only
+    /// a window can do: focusing a pane, posting a notification, placing a split.
     static var socketURL: URL {
-        AppChannel.supportDirectory.appendingPathComponent("session-control.sock")
+        AppChannel.supportDirectory.appendingPathComponent("app.sock")
     }
+
+    // Deliberately the only path bound. Answering on the pre-rename name too would
+    // mean a second listener with its own defer-and-reclaim state, and `bindAndListen`
+    // yields a path to whoever already holds it — so an app could hold one name while
+    // an older instance held the other, and which app a request reached would depend
+    // on which name the client resolved. One path, one owner. A client older than the
+    // rename gets a connection error naming a socket nobody binds, which is a
+    // diagnosable failure rather than a silently misrouted command.
 
     private let onRequest: @MainActor (ControlRequest) async -> Data
     /// Resolves a `watch` subscription: returns the caller's project id to scope the
@@ -275,7 +285,7 @@ final class SessionControlListener: @unchecked Sendable {
     /// not one-shot — the connection stays open and is handed to `SessionWatchHub`
     /// instead of being answered and closed.
     private let onWatch: @MainActor (ControlRequest) -> (UUID?, Data?, [SessionWatchEvent])
-    private let queue = DispatchQueue(label: "com.termio.session-control")
+    private let queue = DispatchQueue(label: "sh.termio.app-socket")
     private var source: DispatchSourceRead?
     private var listenDescriptor: Int32 = -1
     /// Watches the socket *file* we bound, so an instance that loses the path to
@@ -313,7 +323,7 @@ final class SessionControlListener: @unchecked Sendable {
             // and the reader's next move is usually TERMIO_CHANNEL=<name>
             // ./scripts/build-app.sh — which builds no such channel.
             Self.log("""
-                another termio already answers at \(path) — leaving session control \
+                another termio already answers at \(path) — leaving the app socket \
                 to it (relaunch this process with TERMIO_CHANNEL=dev for a channel of \
                 its own; that steers this run, not how a bundle was built)
                 """)
@@ -362,7 +372,7 @@ final class SessionControlListener: @unchecked Sendable {
     private func watchForReplacement(_ path: String) {
         pathWatch = LocalSocket.watchForReplacement(of: path, on: queue) { [weak self] in
             guard let self else { return }
-            Self.log("session control socket was replaced — rebinding")
+            Self.log("app socket was replaced — rebinding")
             self.pathWatch?.cancel()
             self.pathWatch = nil
             self.source?.cancel()
@@ -500,7 +510,7 @@ final class SessionControlListener: @unchecked Sendable {
     }
 
     private static func log(_ message: String) {
-        FileHandle.standardError.write(Data("termio: session control \(message)\n".utf8))
+        FileHandle.standardError.write(Data("termio: app socket \(message)\n".utf8))
     }
 }
 

--- a/Sources/termio/App/Models.swift
+++ b/Sources/termio/App/Models.swift
@@ -407,7 +407,7 @@ enum BrandLogo: Hashable {
 /// A session's live activity, shown as a dot in the sidebar and aggregated into
 /// the menu-bar pulse. Driven by two layers: the zero-config libghostty surface
 /// signals the `TerminalViewState` publishes (bell / desktop notification), and,
-/// when enabled, the per-agent hooks reported into `HookListener`.
+/// when enabled, the per-agent hooks that call `termio agent report`.
 ///
 /// The four states follow the cleanest model among the reference tools
 /// (open-vibe-island): a finished turn is `done`, *not* "needs you" —

--- a/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
+++ b/Sources/termio/TermioStore/TermioStore+AgentStatus.swift
@@ -56,11 +56,11 @@ extension TermioStore {
         syncAgentIntegration()
     }
 
-    /// Brings up the control socket and aligns the agents' awareness note with the
-    /// current setting. Like the hook listener, the socket always runs; only the
-    /// note written into the agent instruction files is toggled.
-    func startSessionControl() {
-        let control = SessionControlListener(
+    /// Brings up the app socket and aligns the agents' awareness note with the
+    /// current setting. The socket always runs; only the note written into the agent
+    /// instruction files is toggled.
+    func startAppSocket() {
+        let control = AppSocketListener(
             onRequest: { [weak self] request in
                 await self?.handleSessionControl(request) ?? Data()
             },
@@ -68,7 +68,7 @@ extension TermioStore {
                 self?.resolveWatchScope(request) ?? (nil, nil, [])
             })
         control.start()
-        sessionControl = control
+        appSocket = control
         installedSessionControlEnabled = settings.sessionControlEnabled
         syncSessionControlInstallation()
     }

--- a/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
+++ b/Sources/termio/TermioStore/TermioStore+TerminalSurface.swift
@@ -251,7 +251,7 @@ extension TermioStore {
         let argv = Self.launchArgv(command: agentCommand)
         var env = Self.sanitizedEnvironment()
         // Stamp the session id so any agent hook running inside can echo it back,
-        // letting `HookListener` correlate events to this exact session.
+        // letting `termio agent report` name this exact session.
         env["TERMIO_SESSION"] = session.id.uuidString
         env["TERM"] = "xterm-256color"
         env["COLORTERM"] = "truecolor"

--- a/Sources/termio/TermioStore/TermioStore.swift
+++ b/Sources/termio/TermioStore/TermioStore.swift
@@ -1095,11 +1095,11 @@ final class TermioStore: ObservableObject {
     /// unrelated appearance change that also fires `objectWillChange`.
     var installedHooksEnabled: Bool?
 
-    /// The control socket the `termio sessions` CLI drives sibling sessions through.
-    /// Runs for the app's lifetime (harmless when the feature is off — the handler
-    /// refuses with "disabled"); only the awareness note installed into the agent
-    /// instruction files is toggled.
-    var sessionControl: SessionControlListener?
+    /// The socket the `termio` CLI drives the app through. Runs for the app's
+    /// lifetime (harmless when the feature is off — the handler refuses with
+    /// "disabled"); only the awareness note installed into the agent instruction
+    /// files is toggled.
+    var appSocket: AppSocketListener?
     var installedSessionControlEnabled: Bool?
 
     /// The agent's own conversation log per session, learned from the hook stream
@@ -1311,7 +1311,7 @@ final class TermioStore: ObservableObject {
         reconcileWorktrees()
 
         startHookMonitoring()
-        startSessionControl()
+        startAppSocket()
     }
 
     /// The live branch label for a folder (a project checkout or a session

--- a/scripts/termio
+++ b/scripts/termio
@@ -234,7 +234,16 @@ EOF
     esac
 }
 
-SOCKET="$HOME/Library/Application Support/$SUPPORT_DIR_NAME/session-control.sock"
+# The app answers on `app.sock`, named for the process that binds it the way the
+# daemon's `termiod.sock` is. An app older than that rename answers only on the
+# name below it, so fall back rather than fail: this script is often a symlink into
+# a checkout, and so can be newer than the app it is driving. Drop the fallback once
+# the rename has shipped in a release — no installed app binds the old name after
+# that.
+SOCKET_DIR="$HOME/Library/Application Support/$SUPPORT_DIR_NAME"
+SOCKET="$SOCKET_DIR/app.sock"
+[ -S "$SOCKET" ] || [ ! -S "$SOCKET_DIR/session-control.sock" ] || \
+    SOCKET="$SOCKET_DIR/session-control.sock"
 
 # The channel this copy of the script is bound to, spelled the way
 # `TERMIO_CHANNEL` spells it. Passed explicitly on every termiod this script

--- a/termiod/src/app_socket.rs
+++ b/termiod/src/app_socket.rs
@@ -1,6 +1,5 @@
-//! The Mac app's session-control socket, spoken the way `scripts/termio`
-//! speaks it: one-line JSON requests over
-//! `~/Library/Application Support/<channel dir>/session-control.sock`, with
+//! The Mac app's own socket, spoken the way `scripts/termio` speaks it: one-line
+//! JSON requests over `~/Library/Application Support/<channel dir>/app.sock`, with
 //! the shell client's exact request shape, error taxonomy, and exit-code
 //! semantics. This module exists so the Rust client can replace the script
 //! wholesale at parity; verbs migrate off this socket onto the daemon's
@@ -9,8 +8,9 @@
 
 use crate::channel::Channel;
 use std::io::{Read, Write};
+use std::os::unix::fs::FileTypeExt;
 use std::os::unix::net::UnixStream;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 /// How a one-shot request ended. `Timeout` is `--wait`'s "still running"
@@ -23,12 +23,46 @@ pub enum Outcome {
     Timeout,
 }
 
+/// The name this socket carried before it was named for the process that binds it.
+/// An app older than that rename answers only here. Delete this and `resolve_in`'s
+/// second branch once the rename has shipped in a release: from then on every
+/// installed app binds `app.sock`, since the app rewrites its own CLI copy on launch
+/// and Sparkle keeps the app current.
+const LEGACY_SOCKET_NAME: &str = "session-control.sock";
+
 pub fn socket_path(channel: &Channel) -> PathBuf {
     let home = std::env::var_os("HOME").unwrap_or_default();
-    PathBuf::from(home)
-        .join("Library/Application Support")
-        .join(&channel.support_dir_name)
-        .join("session-control.sock")
+    resolve_in(
+        &PathBuf::from(home)
+            .join("Library/Application Support")
+            .join(&channel.support_dir_name),
+    )
+}
+
+/// Prefer the current name, but fall back rather than fail: this client ships ahead
+/// of the app it drives (a checkout on `$PATH`, a dev build talking to a released
+/// app), so a missing `app.sock` means an older app, not a missing one. With neither
+/// present the current name is returned, so the connect error names the path a
+/// current app would have bound.
+fn resolve_in(dir: &Path) -> PathBuf {
+    let current = dir.join("app.sock");
+    if is_socket(&current) {
+        return current;
+    }
+    let legacy = dir.join(LEGACY_SOCKET_NAME);
+    if is_socket(&legacy) {
+        return legacy;
+    }
+    current
+}
+
+/// `[ -S ]`, which is what `scripts/termio` asks — not "does a path exist". A plain
+/// file where a socket belongs is not an older app to fall back to, and the two
+/// clients must answer that the same way or they report different paths.
+fn is_socket(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .map(|data| data.file_type().is_socket())
+        .unwrap_or(false)
 }
 
 /// The one-shot read bound in seconds: `TERMIO_CLI_TIMEOUT`, default 15.
@@ -307,6 +341,54 @@ pub fn watch(channel: &Channel, format: &str, states: &str, extra: &str) -> i32 
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    fn bind(path: &std::path::Path) {
+        std::os::unix::net::UnixListener::bind(path).expect("bind");
+    }
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "termiod-app-socket-{name}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    #[test]
+    fn prefers_the_current_socket_name() {
+        let dir = scratch("current");
+        bind(&dir.join("app.sock"));
+        bind(&dir.join("session-control.sock"));
+        assert_eq!(resolve_in(&dir), dir.join("app.sock"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn falls_back_to_the_pre_rename_name_for_an_older_app() {
+        let dir = scratch("legacy");
+        bind(&dir.join("session-control.sock"));
+        assert_eq!(resolve_in(&dir), dir.join("session-control.sock"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_plain_file_is_not_an_older_app() {
+        let dir = scratch("plain");
+        std::fs::write(dir.join("session-control.sock"), b"").unwrap();
+        assert_eq!(resolve_in(&dir), dir.join("app.sock"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn names_the_current_socket_when_no_app_is_running() {
+        let dir = scratch("absent");
+        assert_eq!(resolve_in(&dir), dir.join("app.sock"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     use super::*;
 
     #[test]

--- a/termiod/tests/cli_compat.py
+++ b/termiod/tests/cli_compat.py
@@ -30,7 +30,10 @@ RUST = os.environ.get(
 
 HOME = f"/private/tmp/termio-compat-{os.getpid()}"
 SOCK_DIR = os.path.join(HOME, "Library/Application Support/termio")
-SOCK = os.path.join(SOCK_DIR, "session-control.sock")
+SOCK = os.path.join(SOCK_DIR, "app.sock")
+# The name the app bound before it was named for its binder. Both clients fall back
+# to it so a checkout CLI can drive an older app; they must agree on when.
+LEGACY_SOCK = os.path.join(SOCK_DIR, "session-control.sock")
 
 failures = []
 passes = 0
@@ -238,6 +241,17 @@ def main():
         handle.write("")
     compare("socket is a plain file", ["sessions", "list"], no_server=True)
     os.unlink(SOCK)
+    # An app older than the socket rename: both clients fall back to the name it
+    # binds, and both must name the same path when what sits there is not a socket.
+    legacy = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    legacy.bind(LEGACY_SOCK)
+    legacy.close()
+    compare("falls back to the pre-rename socket", ["sessions", "list"], no_server=True)
+    os.unlink(LEGACY_SOCK)
+    with open(LEGACY_SOCK, "w") as handle:
+        handle.write("")
+    compare("pre-rename plain file is not an older app", ["sessions", "list"], no_server=True)
+    os.unlink(LEGACY_SOCK)
     # A socket file whose listener is gone: connect refused.
     stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     stale.bind(SOCK)


### PR DESCRIPTION
`session-control.sock` named the part that is leaving. Stage 10 moves `list`, `send`, `read` and `close` onto the daemon's framed protocol (`termiod/src/app_socket.rs` says so in its own header), and what stays behind is the work only a window can do: focusing a pane, posting a notification, placing a split.

So name it for its binder, the way `termiod.sock` already is — the daemon answers at `termiod.sock`, the app answers at `app.sock`. The Rust module that speaks it was already called `app_socket`.

Not `termio.sock`: one character from `termiod.sock` is unreadable in an error message, and the containing directory already supplies the scope.

### Only one path is bound

Answering on the old name too would mean a second listener with its own defer-and-reclaim state, and `bindAndListen` yields a path to whoever already holds it. An app could then hold one name while an older instance held the other, and which app a request reached would depend on which name the client resolved — a silent misroute, in the code family that already shipped #526 and #527.

The clients carry the compatibility instead: both prefer `app.sock` and fall back to the old name if it is missing. That is stateless, and it covers the skew that can actually happen — `scripts/termio` is often a symlink into a checkout, so it runs ahead of the app it drives. The reverse cannot: `CommandLineTool.refreshSupportCopy()` rewrites the CLI on PATH from the bundle on every launch, so the installed client upgrades with the app.

A client older than the rename gets `app is not running (no control socket at …/session-control.sock)` — loud, and it names the path.

### Also

Five comments described `HookListener`, a type deleted when agent integration moved into termiod. One of them was the passage justifying why this socket is separate from a status socket that no longer exists. Hooks call `termio agent report` now.

`agent-status.sock` itself is already dead — nothing binds it; `install.rs`'s `SOCKET_MARKER` keeps the literal string only to recognize legacy hooks in dotfiles and to fingerprint generated plugins, and is left alone.

### Verification

- `swift build`, `swift test` — 953 tests, 0 failures
- `cargo build`, `cargo test --lib app_socket` — 6 pass, including three new ones covering prefer / fall back / neither present
- Ran the built app on an isolated probe channel: only `app.sock` appears, a current `termio sessions list` gets a handler reply, and a pre-rename copy of the script fails with the error above

Release Notes: None — internal socket rename.